### PR TITLE
Add Windows system tray icon for DisplayXR service

### DIFF
--- a/installer/DisplayXRInstaller.nsi
+++ b/installer/DisplayXRInstaller.nsi
@@ -637,6 +637,22 @@ Section "DisplayXR Runtime" SecRuntime
 	WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\DisplayXR" \
 		"EstimatedSize" "$0"
 
+	; Create a scheduled task to auto-start displayxr-service at user logon.
+	; Chrome's AppContainer sandbox blocks the OpenXR loader from launching the
+	; service on-demand (ACCESS_DENIED), so we pre-launch it at logon (issue #68).
+	; /sc onlogon = runs when any user logs on
+	; /rl highest = full user privileges (needed for GPU/display access)
+	; /f         = overwrite existing task (handles upgrade installs)
+	IfFileExists "$INSTDIR\displayxr-service.exe" 0 skip_service_task
+		DetailPrint "Creating scheduled task for DisplayXR Service..."
+		nsExec::ExecToLog 'schtasks /create /tn "DisplayXR Service" /tr "\"$INSTDIR\displayxr-service.exe\"" /sc onlogon /rl highest /f'
+		Pop $0
+		; Start the service immediately so it's available without relogon
+		DetailPrint "Starting DisplayXR Service..."
+		nsExec::ExecToLog 'schtasks /run /tn "DisplayXR Service"'
+		Pop $0
+	skip_service_task:
+
 	; Save installation log to install directory
 	StrCpy $0 "$INSTDIR\install.log"
 	Push $0
@@ -658,6 +674,13 @@ SectionEnd
 ; Uninstaller Section
 
 Section "Uninstall"
+	; Stop the displayxr-service and remove its scheduled task (issue #68)
+	; Kill any running instance first so we can delete the exe
+	DetailPrint "Stopping DisplayXR Service..."
+	nsExec::ExecToLog 'taskkill /f /im displayxr-service.exe'
+	DetailPrint "Removing DisplayXR Service scheduled task..."
+	nsExec::ExecToLog 'schtasks /delete /tn "DisplayXR Service" /f'
+
 	; Remove files
 	Delete "$INSTDIR\DisplayXRClient.dll"
 	Delete "$INSTDIR\displayxr-service.exe"

--- a/src/xrt/ipc/server/ipc_server_mainloop_windows.cpp
+++ b/src/xrt/ipc/server/ipc_server_mainloop_windows.cpp
@@ -35,7 +35,6 @@
 // NOTE: D3D11 service compositor header was previously needed for window validity checks.
 // With per-client windows, this is no longer needed - each client manages its own window.
 
-#include <conio.h>
 #include <sddl.h>
 
 
@@ -46,6 +45,9 @@
  */
 
 #define ERROR_STR(BUF, ERR) (u_winerror(BUF, ARRAY_SIZE(BUF), ERR, true))
+
+// Shutdown flag set by the tray icon thread in main.c
+extern "C" volatile bool g_service_shutdown_requested;
 
 DEBUG_GET_ONCE_BOOL_OPTION(relaxed, "IPC_RELAXED_CONNECTION_SECURITY", false)
 
@@ -223,18 +225,11 @@ ipc_server_mainloop_poll(struct ipc_server *vs, struct ipc_server_mainloop *ml)
 {
 	IPC_TRACE_MARKER();
 
-	if (_kbhit()) {
-		U_LOG_E("console input! exiting...");
+	if (g_service_shutdown_requested) {
+		U_LOG_I("Shutdown requested via tray icon, exiting...");
 		ipc_server_handle_shutdown_signal(vs);
 		return;
 	}
-
-	// NOTE: With per-client windows, window validity is now handled per-client.
-	// Each client's window lifecycle is managed when the client connects/disconnects.
-	// The IPC service no longer maintains a global window to check.
-	// Window close events are detected in the per-client message loop and trigger
-	// session end for that specific client.
-	(void)vs;  // Suppress unused warning
 
 	if (!ml->pipe_handle) {
 		create_another_pipe_instance(vs, ml);

--- a/src/xrt/targets/service/CMakeLists.txt
+++ b/src/xrt/targets/service/CMakeLists.txt
@@ -25,6 +25,15 @@ if(WIN32)
 		"/DELAYLOAD:SimulatedRealityVulkanBeta.dll"
 	)
 	target_link_libraries(displayxr-service PRIVATE delayimp)
+
+	# Run as GUI app (no console window) with system tray icon
+	set_target_properties(displayxr-service PROPERTIES WIN32_EXECUTABLE TRUE)
+	target_sources(displayxr-service PRIVATE
+		service_tray_win.c
+		service_tray_win.h
+		service_resources.rc
+	)
+	target_link_libraries(displayxr-service PRIVATE shell32)
 endif()
 
 install(TARGETS displayxr-service RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/xrt/targets/service/main.c
+++ b/src/xrt/targets/service/main.c
@@ -1,9 +1,9 @@
 // Copyright 2020, Collabora, Ltd.
-// Copyright 2024-2025, NVIDIA CORPORATION.
+// Copyright 2024-2026, NVIDIA CORPORATION.
 // SPDX-License-Identifier: BSL-1.0
 /*!
  * @file
- * @brief  Main file for Monado service.
+ * @brief  Main file for DisplayXR service.
  * @author Pete Black <pblack@collabora.com>
  * @author Jakob Bornecrantz <jakob@collabora.com>
  * @ingroup ipc
@@ -17,6 +17,8 @@
 
 #ifdef XRT_OS_WINDOWS
 #include "util/u_windows.h"
+#include "service_tray_win.h"
+#include <stdlib.h> // __argc, __argv
 #endif
 
 #include "server/ipc_server_interface.h"
@@ -28,34 +30,85 @@
 U_TRACE_TARGET_SETUP(U_TRACE_WHICH_SERVICE)
 
 
-int
-main(int argc, char *argv[])
-{
 #ifdef XRT_OS_WINDOWS
+
+// Global shutdown flag set by the tray icon's "Exit" menu item.
+// Checked by ipc_server_mainloop_poll() in ipc_server_mainloop_windows.cpp.
+volatile bool g_service_shutdown_requested = false;
+
+static void
+tray_shutdown_callback(void)
+{
+	g_service_shutdown_requested = true;
+}
+
+static void
+setup_dpi_awareness(void)
+{
 	// Enable per-monitor DPI awareness FIRST, before any window/display operations.
 	// This is critical for high-DPI displays like Leia (7680x4320 at 300% scaling).
 	// Without this, Windows reports scaled logical resolution (2560x1440) instead of
 	// physical resolution, breaking SR weaver which needs true pixel dimensions.
 	//
 	// SetProcessDpiAwarenessContext is Win10 1607+ (SDK 10.0.14393+)
-	{
-		// DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 = ((DPI_AWARENESS_CONTEXT)-4)
-		// Define locally to avoid SDK version issues
-		typedef BOOL(WINAPI * PFN_SetProcessDpiAwarenessContext)(HANDLE);
-		HMODULE user32 = GetModuleHandleA("user32.dll");
-		if (user32) {
-			PFN_SetProcessDpiAwarenessContext fn =
-			    (PFN_SetProcessDpiAwarenessContext)GetProcAddress(user32, "SetProcessDpiAwarenessContext");
-			if (fn) {
-				// DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 = -4
-				fn((HANDLE)(intptr_t)-4);
-			}
+	typedef BOOL(WINAPI * PFN_SetProcessDpiAwarenessContext)(HANDLE);
+	HMODULE user32 = GetModuleHandleA("user32.dll");
+	if (user32) {
+		PFN_SetProcessDpiAwarenessContext fn =
+		    (PFN_SetProcessDpiAwarenessContext)GetProcAddress(user32, "SetProcessDpiAwarenessContext");
+		if (fn) {
+			// DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 = -4
+			fn((HANDLE)(intptr_t)-4);
 		}
 	}
+}
+
+// GUI subsystem entry point (no console window).
+int WINAPI
+WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow)
+{
+	(void)hInstance;
+	(void)hPrevInstance;
+	(void)lpCmdLine;
+	(void)nCmdShow;
+
+	setup_dpi_awareness();
+
+	// Use CRT globals for argc/argv (available even in WinMain)
+	int argc = __argc;
+	char **argv = __argv;
 
 	u_win_try_privilege_or_priority_from_args(U_LOGGING_INFO, argc, argv);
-#endif
 
+	// Start the system tray icon
+	service_tray_init(tray_shutdown_callback);
+
+	u_trace_marker_init();
+	u_metrics_init();
+
+	struct ipc_server_main_info ismi = {
+	    .udgci =
+	        {
+	            .window_title = "DisplayXR Service",
+	            .open = U_DEBUG_GUI_OPEN_AUTO,
+	        },
+	};
+
+	int ret = ipc_server_main(argc, argv, &ismi);
+
+	u_metrics_close();
+
+	// Clean up the tray icon
+	service_tray_cleanup();
+
+	return ret;
+}
+
+#else // !XRT_OS_WINDOWS
+
+int
+main(int argc, char *argv[])
+{
 	u_trace_marker_init();
 	u_metrics_init();
 
@@ -73,3 +126,5 @@ main(int argc, char *argv[])
 
 	return ret;
 }
+
+#endif // XRT_OS_WINDOWS

--- a/src/xrt/targets/service/service_resources.rc
+++ b/src/xrt/targets/service/service_resources.rc
@@ -1,0 +1,9 @@
+// Copyright 2026, DisplayXR
+// SPDX-License-Identifier: BSL-1.0
+//
+// DisplayXR Service - Windows resources
+
+#include <windows.h>
+
+// Application icon (used for system tray)
+101 ICON "../../../../doc/displayxr.ico"

--- a/src/xrt/targets/service/service_tray_win.c
+++ b/src/xrt/targets/service/service_tray_win.c
@@ -1,0 +1,155 @@
+// Copyright 2026, DisplayXR
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  Windows system tray icon for DisplayXR service.
+ * @ingroup ipc
+ */
+
+#include "service_tray_win.h"
+
+#include <windows.h>
+#include <shellapi.h>
+
+#define IDI_DISPLAYXR_ICON 101
+#define WM_TRAYICON        (WM_APP + 1)
+#define IDM_EXIT           1001
+
+static HWND s_tray_hwnd = NULL;
+static HANDLE s_tray_thread = NULL;
+static HANDLE s_ready_event = NULL;
+static NOTIFYICONDATAW s_nid;
+static service_tray_shutdown_cb s_shutdown_cb = NULL;
+
+static LRESULT CALLBACK
+tray_wnd_proc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
+{
+	switch (msg) {
+	case WM_TRAYICON:
+		if (LOWORD(lParam) == WM_RBUTTONUP) {
+			POINT pt;
+			GetCursorPos(&pt);
+
+			HMENU menu = CreatePopupMenu();
+			AppendMenuW(menu, MF_STRING, IDM_EXIT, L"Exit DisplayXR Service");
+
+			// Required for TrackPopupMenu to work from a background window
+			SetForegroundWindow(hwnd);
+			TrackPopupMenu(menu, TPM_BOTTOMALIGN | TPM_LEFTALIGN, pt.x, pt.y, 0, hwnd, NULL);
+			PostMessageW(hwnd, WM_NULL, 0, 0);
+
+			DestroyMenu(menu);
+		}
+		return 0;
+
+	case WM_COMMAND:
+		if (LOWORD(wParam) == IDM_EXIT) {
+			if (s_shutdown_cb) {
+				s_shutdown_cb();
+			}
+			PostQuitMessage(0);
+		}
+		return 0;
+
+	case WM_DESTROY:
+		Shell_NotifyIconW(NIM_DELETE, &s_nid);
+		PostQuitMessage(0);
+		return 0;
+
+	default: return DefWindowProcW(hwnd, msg, wParam, lParam);
+	}
+}
+
+static DWORD WINAPI
+tray_thread_func(LPVOID param)
+{
+	(void)param;
+
+	const wchar_t *cls_name = L"DisplayXRServiceTray";
+
+	WNDCLASSEXW wcex = {0};
+	wcex.cbSize = sizeof(WNDCLASSEXW);
+	wcex.lpfnWndProc = tray_wnd_proc;
+	wcex.hInstance = GetModuleHandleW(NULL);
+	wcex.lpszClassName = cls_name;
+	RegisterClassExW(&wcex);
+
+	s_tray_hwnd = CreateWindowExW(0, cls_name, L"DisplayXR Service Tray", 0, 0, 0, 0, 0, HWND_MESSAGE, NULL,
+	                              GetModuleHandleW(NULL), NULL);
+
+	if (!s_tray_hwnd) {
+		SetEvent(s_ready_event);
+		return 1;
+	}
+
+	// Set up the tray icon
+	ZeroMemory(&s_nid, sizeof(s_nid));
+	s_nid.cbSize = sizeof(NOTIFYICONDATAW);
+	s_nid.hWnd = s_tray_hwnd;
+	s_nid.uID = 1;
+	s_nid.uFlags = NIF_ICON | NIF_TIP | NIF_MESSAGE;
+	s_nid.uCallbackMessage = WM_TRAYICON;
+	wcscpy_s(s_nid.szTip, ARRAYSIZE(s_nid.szTip), L"DisplayXR Service");
+
+	// Load icon from embedded resource, fall back to system default
+	s_nid.hIcon = LoadIconW(GetModuleHandleW(NULL), MAKEINTRESOURCEW(IDI_DISPLAYXR_ICON));
+	if (!s_nid.hIcon) {
+		s_nid.hIcon = LoadIconW(NULL, IDI_APPLICATION);
+	}
+
+	Shell_NotifyIconW(NIM_ADD, &s_nid);
+
+	// Signal that we're ready
+	SetEvent(s_ready_event);
+
+	// Message loop
+	MSG msg;
+	while (GetMessageW(&msg, NULL, 0, 0) > 0) {
+		TranslateMessage(&msg);
+		DispatchMessageW(&msg);
+	}
+
+	return 0;
+}
+
+bool
+service_tray_init(service_tray_shutdown_cb shutdown_cb)
+{
+	s_shutdown_cb = shutdown_cb;
+
+	s_ready_event = CreateEventW(NULL, TRUE, FALSE, NULL);
+	if (!s_ready_event) {
+		return false;
+	}
+
+	s_tray_thread = CreateThread(NULL, 0, tray_thread_func, NULL, 0, NULL);
+	if (!s_tray_thread) {
+		CloseHandle(s_ready_event);
+		s_ready_event = NULL;
+		return false;
+	}
+
+	// Wait for the tray thread to finish initialization (up to 5 seconds)
+	WaitForSingleObject(s_ready_event, 5000);
+	CloseHandle(s_ready_event);
+	s_ready_event = NULL;
+
+	return s_tray_hwnd != NULL;
+}
+
+void
+service_tray_cleanup(void)
+{
+	if (s_tray_hwnd) {
+		// Tell the tray thread to exit
+		PostMessageW(s_tray_hwnd, WM_DESTROY, 0, 0);
+	}
+
+	if (s_tray_thread) {
+		WaitForSingleObject(s_tray_thread, 5000);
+		CloseHandle(s_tray_thread);
+		s_tray_thread = NULL;
+	}
+
+	s_tray_hwnd = NULL;
+}

--- a/src/xrt/targets/service/service_tray_win.h
+++ b/src/xrt/targets/service/service_tray_win.h
@@ -1,0 +1,35 @@
+// Copyright 2026, DisplayXR
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  Windows system tray icon for DisplayXR service.
+ * @ingroup ipc
+ */
+
+#pragma once
+
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef void (*service_tray_shutdown_cb)(void);
+
+/*!
+ * Initialize the system tray icon on a dedicated thread.
+ * @param shutdown_cb Called from the tray thread when the user clicks "Exit".
+ * @return true on success.
+ */
+bool
+service_tray_init(service_tray_shutdown_cb shutdown_cb);
+
+/*!
+ * Remove the tray icon and clean up. Blocks until the tray thread exits.
+ */
+void
+service_tray_cleanup(void);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
## Description

This PR adds a Windows system tray icon for the DisplayXR service with a graceful shutdown mechanism. The service now runs as a GUI application (no console window) and displays a system tray icon that allows users to exit the service via a right-click context menu.

### Key Changes:

1. **New system tray implementation** (`service_tray_win.c/h`):
   - Creates a hidden message-only window on a dedicated thread
   - Displays a system tray icon with a right-click context menu
   - Provides a callback mechanism for graceful shutdown

2. **Updated service entry point** (`main.c`):
   - Changed Windows build to use `WinMain` instead of `main` (GUI subsystem)
   - Initializes the tray icon at startup and cleans up on exit
   - Implements a global shutdown flag (`g_service_shutdown_requested`) that the tray thread can set
   - Refactored DPI awareness setup into a separate function

3. **Shutdown signal handling** (`ipc_server_mainloop_windows.cpp`):
   - Replaced console input polling (`_kbhit()`) with tray icon shutdown flag check
   - Logs shutdown request and gracefully exits the IPC server

4. **Build configuration** (`CMakeLists.txt`):
   - Set `WIN32_EXECUTABLE` to run as GUI app without console window
   - Added tray icon source files and shell32 library dependency
   - Added resource file for application icon

5. **Installer updates** (`DisplayXRInstaller.nsi`):
   - Creates a scheduled task to auto-start the service at user logon
   - Handles service cleanup during uninstallation
   - Addresses Chrome AppContainer sandbox issue (#68) that blocks on-demand service launch

6. **Resource file** (`service_resources.rc`):
   - Embeds the DisplayXR icon for use in the system tray

## Related Issue

Fixes #68 (Chrome AppContainer sandbox blocking on-demand service launch)

## Checklist

- [ ] Target branch is `main`
- [ ] CI passes (Windows + macOS builds)
- [ ] Code formatted with `git clang-format`
- [ ] Tested on: Windows 11 with DisplayXR service

## Test Plan

1. Build the service on Windows
2. Run `displayxr-service.exe` and verify:
   - No console window appears
   - System tray icon appears in the notification area
   - Right-clicking the tray icon shows "Exit DisplayXR Service" menu item
   - Clicking "Exit" gracefully shuts down the service
3. Verify installer creates the scheduled task and service auto-starts on logon
4. Verify uninstaller properly stops the service and removes the scheduled task

https://claude.ai/code/session_01DEndEEuEpQ4tt6jq3LVJeH