### PR TITLE
Unity D3D11 fence support

### DIFF
--- a/src/xrt/compositor/d3d11/comp_d3d11_compositor.cpp
+++ b/src/xrt/compositor/d3d11/comp_d3d11_compositor.cpp
@@ -1038,22 +1038,45 @@ d3d11_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 		}
 	}
 
-	// Flush and wait for GPU to finish processing all prior commands.
-	// Multi-threaded engines (e.g. Unity) submit draw commands from worker threads.
-	// The GPU may still be executing those commands when we read the swapchain
-	// textures. This is the D3D11 equivalent of D3D12's gpu_wait_idle().
+	// Wait for GPU completion of all projection swapchain textures before reading.
+	//
+	// barrier_image(TO_COMP) at xrReleaseSwapchainImage inserts a Flush() then
+	// signals an ID3D11Fence.  Waiting here blocks until the GPU has processed
+	// all commands up to that release point — no spinning, no per-frame allocs.
+	// Falls back to Flush+D3D11_QUERY_EVENT spin-wait on pre-D3D11.4 hardware.
+	//
+	// Deduplicates swapchains so two eyes on one swapchain only wait once.
 	{
-		c->context->Flush();
-		ID3D11Query *event_query = nullptr;
-		D3D11_QUERY_DESC qd = {};
-		qd.Query = D3D11_QUERY_EVENT;
-		if (SUCCEEDED(c->device->CreateQuery(&qd, &event_query))) {
-			c->context->End(event_query);
-			BOOL query_done = FALSE;
-			while (c->context->GetData(event_query, &query_done, sizeof(query_done), 0) == S_FALSE) {
-				// Spin-wait for GPU to drain
+		struct xrt_swapchain *waited[XRT_MAX_LAYERS * XRT_MAX_VIEWS] = {};
+		uint32_t wait_count = 0;
+
+		for (uint32_t li = 0; li < c->layer_accum.layer_count; li++) {
+			struct comp_layer *layer = &c->layer_accum.layers[li];
+			if (layer->data.type != XRT_LAYER_PROJECTION &&
+			    layer->data.type != XRT_LAYER_PROJECTION_DEPTH) {
+				continue;
 			}
-			event_query->Release();
+			uint32_t vc = layer->data.view_count < XRT_MAX_VIEWS
+			                  ? layer->data.view_count
+			                  : XRT_MAX_VIEWS;
+			for (uint32_t v = 0; v < vc; v++) {
+				struct xrt_swapchain *xsc = layer->sc_array[v];
+				if (xsc == nullptr) {
+					continue;
+				}
+				// Skip if already waited on this swapchain this frame.
+				bool seen = false;
+				for (uint32_t w = 0; w < wait_count; w++) {
+					if (waited[w] == xsc) {
+						seen = true;
+						break;
+					}
+				}
+				if (!seen && wait_count < ARRAY_SIZE(waited)) {
+					waited[wait_count++] = xsc;
+					comp_d3d11_swapchain_wait_gpu_complete(xsc, 100);
+				}
+			}
 		}
 	}
 

--- a/src/xrt/compositor/d3d11/comp_d3d11_swapchain.cpp
+++ b/src/xrt/compositor/d3d11/comp_d3d11_swapchain.cpp
@@ -61,6 +61,16 @@ struct comp_d3d11_swapchain
 
 	//! Last released image index (for round-robin).
 	uint32_t last_released_index;
+
+	//! D3D11.4 fence for efficient GPU→CPU release notification.
+	//! Signaled at xrReleaseSwapchainImage; waited in layer_commit.
+	ID3D11Fence *release_fence;
+
+	//! Auto-reset Win32 event; fired when GPU reaches release_fence.
+	HANDLE release_event;
+
+	//! Monotonic counter; incremented on each release.
+	uint64_t release_fence_value;
 };
 
 // Access compositor internals
@@ -193,13 +203,27 @@ d3d11_swapchain_barrier_image(struct xrt_swapchain *xsc, enum xrt_barrier_direct
 {
 	struct comp_d3d11_swapchain *sc = d3d11_sc(xsc);
 
-	// When transitioning from app to compositor, flush pending GPU commands.
-	// Multi-threaded engines (e.g. Unity) may submit draw commands from worker
-	// threads that haven't been fully processed when xrEndFrame reads the texture.
-	// Flush ensures all prior immediate-context commands are submitted to the GPU.
+	// When transitioning from app to compositor, flush pending GPU commands then
+	// signal a fence so layer_commit can wait efficiently via WaitForSingleObject.
 	if (direction == XRT_BARRIER_TO_COMP && sc->c != nullptr) {
 		auto internals = get_internals(sc->c);
+
+		// Flush all pending immediate-context commands to the GPU.
 		internals->context->Flush();
+
+		// Signal fence after the flush.  When the GPU reaches this signal,
+		// release_event fires and layer_commit's WaitForSingleObject returns,
+		// guaranteeing all commands submitted up to this release are complete.
+		if (sc->release_fence != nullptr && sc->release_event != nullptr) {
+			ID3D11DeviceContext4 *ctx4 = nullptr;
+			if (SUCCEEDED(internals->context->QueryInterface(
+			        __uuidof(ID3D11DeviceContext4), (void **)&ctx4))) {
+				uint64_t val = ++sc->release_fence_value;
+				ctx4->Signal(sc->release_fence, val);
+				sc->release_fence->SetEventOnCompletion(val, sc->release_event);
+				ctx4->Release();
+			}
+		}
 	}
 
 	return XRT_SUCCESS;
@@ -244,6 +268,13 @@ d3d11_swapchain_destroy(struct xrt_swapchain *xsc)
 		}
 	}
 
+	if (sc->release_event != nullptr) {
+		CloseHandle(sc->release_event);
+	}
+	if (sc->release_fence != nullptr) {
+		sc->release_fence->Release();
+	}
+
 	delete sc;
 }
 
@@ -276,6 +307,30 @@ comp_d3d11_swapchain_create(struct comp_d3d11_compositor *c,
 	sc->acquired_index = -1;
 	sc->waited_index = -1;
 	sc->last_released_index = image_count - 1; // Start so first acquire returns index 0
+	sc->release_fence = nullptr;
+	sc->release_event = nullptr;
+	sc->release_fence_value = 0;
+
+	// Create ID3D11Fence for efficient GPU→CPU sync (D3D11.4 / Windows 10+).
+	// Falls back to D3D11_QUERY_EVENT spin-wait on older hardware.
+	{
+		ID3D11Device5 *dev5 = nullptr;
+		if (SUCCEEDED(internals->device->QueryInterface(__uuidof(ID3D11Device5), (void **)&dev5))) {
+			HRESULT fence_hr = dev5->CreateFence(
+			    0, D3D11_FENCE_FLAG_NONE, __uuidof(ID3D11Fence), (void **)&sc->release_fence);
+			if (SUCCEEDED(fence_hr)) {
+				sc->release_event = CreateEventW(nullptr, FALSE, FALSE, nullptr);
+				if (sc->release_event == nullptr) {
+					sc->release_fence->Release();
+					sc->release_fence = nullptr;
+				}
+			}
+			dev5->Release();
+		}
+		if (sc->release_fence == nullptr) {
+			U_LOG_I("D3D11: ID3D11Fence unavailable — will use D3D11_QUERY_EVENT fallback");
+		}
+	}
 
 	// Convert format
 	DXGI_FORMAT dxgi_format = xrt_format_to_dxgi(info->format);
@@ -470,4 +525,48 @@ comp_d3d11_swapchain_get_dimensions(struct xrt_swapchain *xsc, uint32_t *out_w, 
 	struct comp_d3d11_swapchain *sc = d3d11_sc(xsc);
 	*out_w = sc->info.width;
 	*out_h = sc->info.height;
+}
+
+/*!
+ * Wait for GPU completion of all commands submitted up to the most recent
+ * xrReleaseSwapchainImage for this swapchain.
+ *
+ * Fast path (D3D11.4): OS-level WaitForSingleObject on an ID3D11Fence event —
+ * zero CPU spin, no per-frame allocations.
+ *
+ * Fallback (pre-D3D11.4): Flush + spin-wait on D3D11_QUERY_EVENT.
+ *
+ * @param xsc       The swapchain.
+ * @param timeout_ms Timeout in milliseconds (100 ms is recommended).
+ */
+extern "C" void
+comp_d3d11_swapchain_wait_gpu_complete(struct xrt_swapchain *xsc, uint32_t timeout_ms)
+{
+	struct comp_d3d11_swapchain *sc = d3d11_sc(xsc);
+
+	// Fast path: ID3D11Fence + Win32 auto-reset event (D3D11.4 / Windows 10+).
+	// The fence was signaled in barrier_image(TO_COMP) after Flush(), so waiting
+	// here guarantees all GPU commands up to xrReleaseSwapchainImage are done.
+	if (sc->release_fence != nullptr && sc->release_event != nullptr &&
+	    sc->release_fence_value > 0) {
+		WaitForSingleObject(sc->release_event, timeout_ms);
+		return;
+	}
+
+	// Fallback: Flush + spin-wait on D3D11_QUERY_EVENT.
+	if (sc->c != nullptr) {
+		auto internals = get_internals(sc->c);
+		internals->context->Flush();
+		ID3D11Query *eq = nullptr;
+		D3D11_QUERY_DESC qd = {};
+		qd.Query = D3D11_QUERY_EVENT;
+		if (SUCCEEDED(internals->device->CreateQuery(&qd, &eq))) {
+			internals->context->End(eq);
+			BOOL done = FALSE;
+			while (internals->context->GetData(eq, &done, sizeof(done), 0) == S_FALSE) {
+				// Spin-wait for GPU to drain
+			}
+			eq->Release();
+		}
+	}
 }

--- a/src/xrt/compositor/d3d11/comp_d3d11_swapchain.h
+++ b/src/xrt/compositor/d3d11/comp_d3d11_swapchain.h
@@ -86,6 +86,21 @@ comp_d3d11_swapchain_get_texture(struct xrt_swapchain *xsc, uint32_t index);
 void
 comp_d3d11_swapchain_get_dimensions(struct xrt_swapchain *xsc, uint32_t *out_w, uint32_t *out_h);
 
+/*!
+ * Wait for GPU completion of all commands submitted up to the most recent
+ * xrReleaseSwapchainImage for this swapchain.
+ *
+ * Uses ID3D11Fence + WaitForSingleObject on D3D11.4 (Windows 10+),
+ * falls back to Flush + D3D11_QUERY_EVENT spin-wait on older hardware.
+ *
+ * @param xsc        The swapchain.
+ * @param timeout_ms Maximum wait in milliseconds (100 is recommended).
+ *
+ * @ingroup comp_d3d11
+ */
+void
+comp_d3d11_swapchain_wait_gpu_complete(struct xrt_swapchain *xsc, uint32_t timeout_ms);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
  comp_d3d11_swapchain.cpp (+ comp_d3d11_swapchain.h):

  1. Added release_fence (ID3D11Fence*), release_event (HANDLE), release_fence_value (uint64_t) to the swapchain struct.
  2. In comp_d3d11_swapchain_create: tries to create the fence via ID3D11Device5 (D3D11.4). Logs a message and falls back gracefully on older hardware.
  3. In barrier_image(TO_COMP) (called at xrReleaseSwapchainImage): after the existing Flush(), signals the fence via ID3D11DeviceContext4::Signal and calls SetEventOnCompletion — so the Win32 event fires when the GPU reaches that point.
  4. In d3d11_swapchain_destroy: CloseHandle + Release cleanup.
  5. New function comp_d3d11_swapchain_wait_gpu_complete: either WaitForSingleObject (fast path) or Flush + D3D11_QUERY_EVENT spin-wait (fallback).

  comp_d3d11_compositor.cpp:

  Replaced the old single Flush+spin-wait block in layer_commit with a deduplicated loop over projection swapchains
  calling comp_d3d11_swapchain_wait_gpu_complete. Two eyes on the same swapchain only wait once.

## Description

<!-- What does this PR do? Why is this change needed? -->

## Related Issue

<!-- Link to a related issue, e.g., "Fixes #123" or "Related to #456" -->

## Checklist

- [ ] Target branch is `main`
- [ ] CI passes (Windows + macOS builds)
- [ ] Code formatted with `git clang-format`
- [ ] Tested on: <!-- e.g., Windows 11 with LeiaSR SDK, macOS with sim_display -->

## Test Plan

<!-- How was this tested? What should reviewers verify? -->
