### PR TITLE
Mitigate Vulkan implicit layer crashes (#105)

### DIFF
--- a/installer/DisplayXRInstaller.nsi
+++ b/installer/DisplayXRInstaller.nsi
@@ -580,8 +580,10 @@ Section "DisplayXR Runtime" SecRuntime
 	; Install switcher if available
 	File /nonfatal "${BIN_DIR}\DisplayXRSwitcher.exe"
 
-	; Install runtime DLL dependencies
-	File /nonfatal "${BIN_DIR}\*.dll"
+	; Install runtime DLL dependencies (exclude vulkan-1.dll — the system copy
+	; in SYSTEM32 is sufficient, and shipping our own risks version conflicts
+	; and interaction with third-party Vulkan implicit layers. See issue #105.)
+	File /nonfatal /x "vulkan-1.dll" "${BIN_DIR}\*.dll"
 
 	; Create AppData directories
 	CreateDirectory "$APPDATA\DisplayXR"

--- a/scripts/build_windows.bat
+++ b/scripts/build_windows.bat
@@ -252,7 +252,20 @@ set "RT_JSON=%REPO%build\Release\openxr_displayxr-dev.json"
 set "PKG=%REPO%_package"
 
 :: Run scripts for standalone test apps (each sets XR_RUNTIME_JSON to dev build)
-for %%A in (cube_handle_d3d11_win cube_hosted_d3d11_win cube_handle_d3d12_win cube_handle_gl_win cube_handle_vk_win) do (
+:: Non-Vulkan apps also disable Vulkan implicit layers to prevent crashes from
+:: buggy third-party layers (e.g., FPS Monitor). See issue #105.
+for %%A in (cube_handle_d3d11_win cube_hosted_d3d11_win cube_handle_d3d12_win cube_handle_gl_win) do (
+    if exist "%REPO%test_apps\%%A\build\%%A.exe" (
+        > "%PKG%\run_%%A.bat" (
+            echo @echo off
+            echo set "XR_RUNTIME_JSON=%RT_JSON%"
+            echo set "VK_LOADER_LAYERS_DISABLE=*"
+            echo "%REPO%test_apps\%%A\build\%%A.exe" %%*
+        )
+    )
+)
+:: Vulkan app — don't disable implicit layers (app needs them for its own VkInstance)
+for %%A in (cube_handle_vk_win) do (
     if exist "%REPO%test_apps\%%A\build\%%A.exe" (
         > "%PKG%\run_%%A.bat" (
             echo @echo off

--- a/src/xrt/compositor/null/null_compositor.c
+++ b/src/xrt/compositor/null/null_compositor.c
@@ -38,6 +38,8 @@
 #include <inttypes.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #ifdef XRT_OS_WINDOWS
 #include <windows.h>
@@ -176,12 +178,27 @@ static bool
 compositor_init_vulkan(struct null_compositor *c)
 {
 #ifdef XRT_OS_WINDOWS
+	// Disable Vulkan implicit layers during internal init to prevent crashes
+	// from buggy third-party layers (e.g., FPS Monitor). The runtime's internal
+	// Vulkan instance doesn't need overlay/monitoring layers. See issue #105.
+	// Requires Vulkan loader 1.3.234+; older loaders ignore the env var harmlessly.
+	const char *orig_layers_disable = getenv("VK_LOADER_LAYERS_DISABLE");
+	char *saved_layers_disable = orig_layers_disable ? _strdup(orig_layers_disable) : NULL;
+	_putenv_s("VK_LOADER_LAYERS_DISABLE", "*");
+
 	// Probe for Vulkan availability before attempting init.
 	// With /DELAYLOAD:vulkan-1.dll, calling any Vulkan function when the
 	// DLL is missing would trigger an SEH exception. Check first.
 	HMODULE vk_mod = LoadLibraryA("vulkan-1.dll");
 	if (vk_mod == NULL) {
 		NULL_WARN(c, "vulkan-1.dll not found — Vulkan is not available on this system");
+		// Restore original env var before returning
+		if (saved_layers_disable) {
+			_putenv_s("VK_LOADER_LAYERS_DISABLE", saved_layers_disable);
+			free(saved_layers_disable);
+		} else {
+			_putenv_s("VK_LOADER_LAYERS_DISABLE", "");
+		}
 		return false;
 	}
 	FreeLibrary(vk_mod);
@@ -202,6 +219,14 @@ compositor_init_vulkan(struct null_compositor *c)
 		         vk_result_string(ret));
 		u_string_list_destroy(&required_instance_ext_list);
 		u_string_list_destroy(&optional_instance_ext_list);
+#ifdef XRT_OS_WINDOWS
+		if (saved_layers_disable) {
+			_putenv_s("VK_LOADER_LAYERS_DISABLE", saved_layers_disable);
+			free(saved_layers_disable);
+		} else {
+			_putenv_s("VK_LOADER_LAYERS_DISABLE", "");
+		}
+#endif
 		return ret;
 	}
 
@@ -227,6 +252,17 @@ compositor_init_vulkan(struct null_compositor *c)
 
 	struct comp_vulkan_results vk_res = {0};
 	bool bundle_ret = comp_vulkan_init_bundle(vk, &vk_args, &vk_res);
+
+#ifdef XRT_OS_WINDOWS
+	// Restore original VK_LOADER_LAYERS_DISABLE so that Vulkan apps' own
+	// vkCreateInstance calls get their expected implicit layers. See issue #105.
+	if (saved_layers_disable) {
+		_putenv_s("VK_LOADER_LAYERS_DISABLE", saved_layers_disable);
+		free(saved_layers_disable);
+	} else {
+		_putenv_s("VK_LOADER_LAYERS_DISABLE", "");
+	}
+#endif
 
 	u_string_list_destroy(&required_instance_ext_list);
 	u_string_list_destroy(&optional_instance_ext_list);


### PR DESCRIPTION
## Summary
- Set `VK_LOADER_LAYERS_DISABLE=*` around the null compositor's internal Vulkan init to prevent buggy third-party implicit layers (e.g., FPS Monitor) from crashing the runtime — restores original value afterward so Vulkan apps' own `vkCreateInstance` is unaffected
- Exclude `vulkan-1.dll` from installer packaging (system copy in SYSTEM32 suffices)
- Add `VK_LOADER_LAYERS_DISABLE=*` to non-Vulkan test app run scripts as defense-in-depth

## Test plan
- [x] CI build passes (Windows + macOS)
- [x] Tested on Windows with FPS Monitor installed — D3D12 app no longer crashes

Fixes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)