### PR TITLE
Shell Phase 3: 3D window positioning, rotation, dynamic layouts, #108 fix

### DIFF
--- a/docs/roadmap/shell-phase3-plan.md
+++ b/docs/roadmap/shell-phase3-plan.md
@@ -1,5 +1,8 @@
 # Shell Phase 3: 3D Window Positioning
 
+> **Status: COMPLETE** (2026-04-03). All 3A/3B/3C tasks implemented and tested on Leia display.
+> See `shell-phase3-status.md` for full implementation details and controls reference.
+
 ## Prerequisites
 
 Phase 2 is complete on branch `feature/shell-phase2-ci`. All features working:

--- a/docs/roadmap/shell-phase3-status.md
+++ b/docs/roadmap/shell-phase3-status.md
@@ -2,6 +2,30 @@
 
 Last updated: 2026-04-03 (branch `feature/shell-phase3-ci`)
 
+## Phase 3+ Dynamic Spatial Layouts (Experimental)
+
+Exploratory dynamic layout system — continuously-driven window poses with auto-animation and interactive drag. These are UI experiments; the interaction model needs deeper design work before productization.
+
+### Dynamic Layouts
+| Key | Mode | Description |
+|-----|------|-------------|
+| Ctrl+5 | Carousel | Full 360° circle, auto-spins ~10°/s. Title bar drag controls rotation with momentum. Content click pauses rotation + forwards to app. TAB snaps focused to front + 5s pause. Scroll adjusts radius. |
+| Ctrl+6 | Orbital | Elliptical multi-orbit. Focused window on inner orbit (largest). Others orbit at increasing radii with different speeds. |
+| Ctrl+7 | Helix | Vertical spiral staircase. Windows rotate + move up/down cyclically. |
+| Ctrl+8 | Expose | Grid overview (Mission Control style). Click a window to select and return to previous layout. |
+
+### Architecture
+- `dynamic_layout` state on `d3d11_multi_compositor`: mode, angle_offset, angular_velocity, drag state, pause_until_ns
+- `dynamic_layout_tick()`: called every frame, computes poses from layout math, updates pixel rects
+- Per-layout compute functions: `carousel_compute_pose()`, `orbital_compute_pose()`, `helix_compute_pose()`, `expose_compute_pose()`
+- Z-depth comfort: all layouts clamp Z within ±zmax where zmax = max(display_w, display_h) / 5
+
+### Other Changes
+- **Z-depth render order**: painter's algorithm (back-to-front by Z), replaces focus-based ordering
+- **Focus border in Z-order**: drawn inside per-slot render loop, not as separate post-pass
+- **Animation system**: `slot_animate_to()` + `slot_animate_tick()` with ease-out cubic, 300ms for layout transitions, 400ms for window entry
+- **Input forwarding**: rect updated every frame in dynamic mode (windows move continuously)
+
 ## What Works (from Phase 2)
 
 All Phase 2 features are on branch `feature/shell-phase2-ci`:

--- a/docs/roadmap/shell-phase3-status.md
+++ b/docs/roadmap/shell-phase3-status.md
@@ -134,8 +134,8 @@ Shell apps connect via IPC → the Kooima eye transform runs in `ipc_server_hand
 
 ## Known Issues (Inherited)
 
-### Intermittent crash with two apps (#108)
-Service crashes intermittently when two apps run simultaneously. Race condition or D3D11 threading issue.
+### Service crash with 3+ apps (#108) — Open
+Inter-app launch delay reduced from 3s to 100ms. **2-app launch is stable.** **3+ apps crash the service** — log ends abruptly (segfault) a few frames after clients register. The `render_mutex` from Phase 2 handles the 2-client case but there's a deeper threading/D3D11 issue with 3+ simultaneous clients. Needs debugger session with 3-app repro.
 
 ### Apps don't survive shell exit (Phase 1A deferred)
 ESC dismisses shell, apps become invisible. Must relaunch apps after shell revival.

--- a/docs/roadmap/shell-phase3-status.md
+++ b/docs/roadmap/shell-phase3-status.md
@@ -134,8 +134,10 @@ Shell apps connect via IPC → the Kooima eye transform runs in `ipc_server_hand
 
 ## Known Issues (Inherited)
 
-### Service crash with 3+ apps (#108) — Open
-Inter-app launch delay reduced from 3s to 100ms. **2-app launch is stable.** **3+ apps crash the service** — log ends abruptly (segfault) a few frames after clients register. The `render_mutex` from Phase 2 handles the 2-client case but there's a deeper threading/D3D11 issue with 3+ simultaneous clients. Needs debugger session with 3-app repro.
+### Service crash with 3+ apps (#108) — FIXED
+**Root cause:** D3D11 device shared across multiple IPC client threads without multithread protection. Concurrent API calls from 3+ threads corrupted internal state.
+**Fix:** `ID3D11Multithread::SetMultithreadProtected(TRUE)` after device creation. Tested stable with 4 simultaneous apps. Inter-app launch delay reduced from 3s to 100ms.
+**Remaining:** Occasional black flashes during multi-app rendering (atlas texture briefly not ready). Cosmetic, not a crash.
 
 ### Apps don't survive shell exit (Phase 1A deferred)
 ESC dismisses shell, apps become invisible. Must relaunch apps after shell revival.

--- a/docs/roadmap/shell-phase3-status.md
+++ b/docs/roadmap/shell-phase3-status.md
@@ -1,12 +1,12 @@
 # Shell Phase 3 — Implementation Status
 
-Last updated: 2026-04-02 (branch `feature/shell-phase2-ci`)
+Last updated: 2026-04-03 (branch `feature/shell-phase3-ci`)
 
 ## What Works (from Phase 2)
 
 All Phase 2 features are on branch `feature/shell-phase2-ci`:
 - Window chrome: title bars with app name, close (X) and minimize (—) buttons, button hover highlights
-- Layout presets: Ctrl+1 side-by-side, Ctrl+2 stacked, Ctrl+3 fullscreen, Ctrl+4 cascade
+- Layout presets: Ctrl+1 side-by-side, Ctrl+2 stacked (Phase 3 replaced Ctrl+3-4, added Ctrl+5)
 - Edge/corner resize: asymmetric (only dragged edge moves), continuous HWND update, mouse suppression during resize
 - Minimize/maximize: minimize button, taskbar with indicators, double-click title bar maximize toggle
 - Persistence: `%LOCALAPPDATA%\DisplayXR\shell_layout.json` with numbered app instance names
@@ -15,79 +15,136 @@ All Phase 2 features are on branch `feature/shell-phase2-ci`:
 - Cursor feedback: arrow/move/resize arrows via `WM_SETCURSOR` on window thread
 - Right-click forwards to app (focus on RMB down)
 - All UI dimensions in meters (rendering converts to tile pixels, hit-testing uses meters directly)
-- App instance numbering: "AppName", "AppName (2)" for duplicates
-- Title text: strip subtitle after " - ", replace non-ASCII, 16x32 glyph rendering
-
-See `shell-phase2-status.md` for full design decisions and lessons learned.
 
 ## Phase 3 Progress
 
 ### Phase 3A: Z-Depth Positioning
-**Status:** Not started
+**Status:** Done (locally tested on Leia display, 2026-04-03)
 
 Windows at arbitrary Z depths with per-eye parallax.
 
 | Task | Status | Notes |
 |------|--------|-------|
-| 3A.1 Per-eye parallax in slot_pose_to_pixel_rect | | Project window through eye to display plane |
-| 3A.2 Different blit positions in left/right SBS halves | | Parallax offset from eye separation |
-| 3A.3 Apparent size scaling by Z | | Similar triangles: closer = larger |
-| 3A.4 Raycast with non-zero Z | | Already implemented, needs testing |
-| 3A.5 Z-depth controls | | Mouse wheel + modifier, --pose z arg |
-| 3A.6 Chrome at window Z | | Title bar/buttons follow window depth |
+| 3A.1 Per-eye parallax in slot_pose_to_pixel_rect | ✅ | `slot_pose_to_pixel_rect_for_eye()`: projects window through eye to Z=0 plane, scale = eye_z / (eye_z - win_z) |
+| 3A.2 Different blit positions in left/right SBS halves | ✅ | `eye_rect[2]` arrays computed per slot, used in per-view blit loop. Left/right eyes see window at different positions. |
+| 3A.3 Apparent size scaling by Z | ✅ | Built into the projection math: closer windows appear larger (scale > 1) |
+| 3A.4 Raycast with non-zero Z | ✅ | Already implemented in Phase 2, verified working with Z != 0 |
+| 3A.5 Z-depth controls | ✅ | Shift+Scroll (2mm/notch), [/] keys (5mm steps), range ±50mm |
+| 3A.6 Chrome at window Z | ✅ | Title bar, buttons, text, focus border all use per-eye projected rects |
 
 ### Phase 3B: Angled Windows
-**Status:** Not started
+**Status:** Done (locally tested on Leia display, 2026-04-03)
 
 Windows with non-identity orientation (tilted/rotated).
 
 | Task | Status | Notes |
 |------|--------|-------|
-| 3B.1 Perspective-correct quad blit | | Replace axis-aligned blit with projected quad |
-| 3B.2 Quad corner computation | | Apply orientation quaternion, project per-eye |
-| 3B.3 Shader update for arbitrary quads | | Pass 4 corner positions to VS |
-| 3B.4 Raycast with rotated planes | | Plane normal from quaternion |
-| 3B.5 Chrome on rotated plane | | Title bar follows window tilt |
+| 3B.1 Perspective-correct quad blit | ✅ | Extended `BlitConstants` with `quad_mode`, `quad_corners_01/23`, `quad_w`. VS branches: axis-aligned (w=1) vs perspective quad (w=depth). |
+| 3B.2 Quad corner computation | ✅ | `compute_projected_quad_corners()`: rotate 4 corners by quaternion, project per-eye to Z=0 plane. `project_local_rect_for_eye()` for arbitrary local-space rects. |
+| 3B.3 Shader update for arbitrary quads | ✅ | Blit VS uses `output.position = float4(ndc * w, 0, w)` for perspective-correct UV interpolation. D3D11 rasterizer auto-divides by w. |
+| 3B.4 Raycast with rotated planes | ✅ | Plane normal from `math_quat_rotate_vec3(q, (0,0,1))`, ray-plane intersection via dot product, hit→local coords via inverse rotation. |
+| 3B.5 Chrome on rotated plane | ✅ | All chrome elements (title bar bg, close/minimize buttons, text glyphs, focus border) rendered as perspective quads via `CHROME_BLIT_POS` macro + `project_local_rect_for_eye`. |
+
+**Rotation controls:**
+- Title bar RMB drag: horizontal = yaw ±30°, vertical = pitch ±15° (~1°/10px)
+- Rising-edge detection (`rmb_held && !prev_rmb_held`) avoids GetAsyncKeyState press-bit consumption
+
+**Window-local Kooima eyes:**
+- Added `window_orientation` (quaternion) and `window_center_offset_z_m` to `xrt_window_metrics`
+- IPC server handler (`ipc_server_handler.c`): transforms eye positions to window-local frame via `local_eye = Q_inv * (eye - window_pos)`
+- Apps receive correct Kooima projection for rotated/translated windows
 
 ### Phase 3C: 3D Layout Presets
-**Status:** Not started
+**Status:** Done (locally tested on Leia display, 2026-04-03)
 
 Layout presets exploiting depth and angle.
 
 | Task | Status | Notes |
 |------|--------|-------|
-| 3C.1 Theater layout | | Focused at Z=0, others recessed + angled |
-| 3C.2 Carousel layout | | Semicircle at varying Z |
-| 3C.3 Stack layout | | Increasing Z depths, offset |
-| 3C.4 Key bindings | | Ctrl+5/6/7 or replace 2D presets |
+| 3C.1 Theater layout (Ctrl+3) | ✅ | Focused: Z=0, 60% display. Others: Z=-3cm, ±15° yaw inward, 40% width, flanking left/right. |
+| 3C.2 Stack layout (Ctrl+4) | ✅ | Card pile: focused at Z=+2cm, others behind with 5mm XY offset per layer. TAB reorders Z. |
+| 3C.3 Carousel layout (Ctrl+5) | ✅ | Semicircle: 60° arc, 15cm radius. Center window slightly forward. Yaw to face center. |
+| 3C.4 Key bindings | ✅ | Ctrl+3=Theater, Ctrl+4=Stack, Ctrl+5=Carousel. Ctrl+1-2 unchanged (SBS, stacked). `current_layout` field tracks active preset for TAB Z-reorder. |
+
+## Key Architecture Decisions
+
+### Perspective Quad Rendering Pipeline
+```
+Per window, per eye:
+  1. If rotated: compute 4 world-space corners (rotate local by quaternion + translate)
+  2. Project each corner through eye to Z=0 plane (similar triangles)
+  3. Compute per-corner W = eye_z - corner_z (for perspective-correct UV)
+  4. Convert to SBS tile pixel coordinates
+  5. Pass as quad_corners_01/23 + quad_w in BlitConstants
+  6. VS: output.position = float4(ndc * w, 0, w) → D3D11 perspective-correct interpolation
+```
+
+### HLSL Constant Buffer Alignment
+`float2[4]` in HLSL has 16-byte-per-element stride (array padding), but C `float[8]` is tightly packed. Fixed by packing as two `float4` values: `quad_corners_01` (TL.xy, BL.xy) and `quad_corners_23` (TR.xy, BR.xy).
+
+### IPC vs In-Process Eye Transform
+Shell apps connect via IPC → the Kooima eye transform runs in `ipc_server_handler.c`, NOT `oxr_session.c`. Both paths now apply the same `Q_inv * (eye - window_pos)` transform.
+
+## Shell Controls (Updated)
+
+| Input | Action |
+|-------|--------|
+| Left-click | Focus window (cyan border, z-order on top). Click title bar buttons: close (X), minimize (—) |
+| Left-click-drag title bar | Move window in display plane (move cursor shown) |
+| Left-click-drag edge/corner | Resize window (resize cursor shown, asymmetric) |
+| **Right-click-drag title bar** | **Rotate window: horizontal=yaw ±30°, vertical=pitch ±15°** |
+| Right-click content | Focus window + forward to app |
+| Double-click title bar | Toggle maximize / restore |
+| Scroll wheel | Resize focused window (~5% per notch) |
+| **Shift+Scroll** | **Z-depth: ±2mm per notch (range ±50mm)** |
+| **[ / ]** | **Z-depth: ±5mm steps** |
+| Ctrl+1 | Layout: side-by-side |
+| Ctrl+2 | Layout: stacked |
+| **Ctrl+3** | **Layout: Theater (focused at Z=0, others recessed + angled)** |
+| **Ctrl+4** | **Layout: Stack (card pile, TAB reorders Z)** |
+| **Ctrl+5** | **Layout: Carousel (semicircle arrangement)** |
+| TAB | Cycle focus (+ reorder Z in Stack layout) |
+| DELETE | Close focused app |
+| ESC | Dismiss shell (2D mode) |
+| V | Toggle 2D/3D display mode |
 
 ## Known Issues (Inherited)
 
 ### Intermittent crash with two apps (#108)
-Service crashes intermittently when two apps run simultaneously. Race condition or D3D11 threading issue. Needs debugger session.
+Service crashes intermittently when two apps run simultaneously. Race condition or D3D11 threading issue.
 
 ### Apps don't survive shell exit (Phase 1A deferred)
 ESC dismisses shell, apps become invisible. Must relaunch apps after shell revival.
 
-## How to Launch the Shell
+## Key Source Files
 
-See `shell-phase2-status.md` for full launch instructions. Summary:
+| File | Role |
+|------|------|
+| `src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp` | Multi-comp, render loop, spatial raycast, per-eye parallax, perspective quad projection, rotation drag, 3D presets, chrome rendering |
+| `src/xrt/compositor/d3d11_service/d3d11_service_shaders.h` | Blit shaders: `BlitConstants` (quad_mode, quad_corners, quad_w), perspective-correct VS |
+| `src/xrt/compositor/d3d11/comp_d3d11_window.cpp` | Window WndProc, WM_SETCURSOR, input forwarding |
+| `src/xrt/ipc/server/ipc_server_handler.c` | IPC Kooima: window-local eye transform (Q_inv * (eye - pos)) |
+| `src/xrt/include/xrt/xrt_display_metrics.h` | `xrt_window_metrics`: window_orientation, window_center_offset_z_m |
+| `src/xrt/state_trackers/oxr/oxr_session.c` | In-process Kooima: window-local eye transform (same math) |
+| `src/xrt/targets/shell/main.c` | Shell launcher, persistence, --pose args |
+| `src/xrt/auxiliary/math/m_display3d_view.h` | Kooima projection math |
+
+## How to Test
 
 ```bash
 scripts\build_windows.bat build && scripts\build_windows.bat test-apps
 _package\bin\displayxr-shell.exe test_apps\cube_handle_d3d11_win\build\cube_handle_d3d11_win.exe test_apps\cube_handle_d3d11_win\build\cube_handle_d3d11_win.exe
 ```
 
-### Key source files
+**Z-depth test:** Shift+Scroll or [/] to move window forward/back. Window shows stereo parallax on Leia display.
 
-| File | Role |
-|------|------|
-| `src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp` | Multi-comp, render loop, `shell_raycast_hit_test()`, spatial UI, layout presets, resize, chrome |
-| `src/xrt/compositor/d3d11_service/d3d11_service_shaders.h` | Blit + border shaders |
-| `src/xrt/compositor/d3d11_service/d3d11_bitmap_font.h` | 8x16 bitmap font atlas |
-| `src/xrt/compositor/d3d11/comp_d3d11_window.cpp` | WndProc, WM_SETCURSOR, input forwarding |
-| `src/xrt/ipc/shared/proto.json` | IPC protocol (shell_set_window_pose, shell_set_visibility, shell_get_window_pose) |
-| `src/xrt/targets/shell/main.c` | Shell launcher, persistence, numbered instance tracking |
-| `src/xrt/auxiliary/math/m_display3d_view.h` | Kooima projection math |
+**Rotation test:** Right-click-drag on title bar to rotate. Content, chrome, and border all rotate together. App content updates Kooima projection for the rotated viewing angle.
+
+**Preset test:** Ctrl+3 Theater, Ctrl+4 Stack (TAB to cycle focus + reorder Z), Ctrl+5 Carousel.
+
+**Pose CLI test:**
+```bash
+_package\bin\displayxr-shell.exe --pose -0.1,0.05,0.03,0.14,0.08 app1.exe --pose 0.1,0.05,-0.02,0.14,0.08 app2.exe
+```
 
 Logs: `%LOCALAPPDATA%\DisplayXR\*.log`

--- a/docs/roadmap/shell-phase3b-plan.md
+++ b/docs/roadmap/shell-phase3b-plan.md
@@ -1,0 +1,183 @@
+# Shell Phase 3B: Cross-API Shell Support
+
+## Prerequisites
+
+Phase 3 is complete on branch `feature/shell-phase3-ci`. The spatial shell (multi-app compositor with 3D window positioning, rotation, animated layouts) works perfectly with D3D11 apps. The D3D11 multithread protection fix (#108) enables 4+ simultaneous apps.
+
+Phase 3B fixes cross-API texture sharing so GL, Vulkan, and D3D12 apps also work in shell/IPC mode.
+
+## Architecture: How Shell Mode Works
+
+```
+App (any API: D3D11, D3D12, GL, VK)
+    ↓ xrCreateSwapchain → IPC → Service
+    ↓
+D3D11 Service Compositor (per-client)
+    ├─ Creates D3D11 shared textures (NT handles + KeyedMutex)
+    ├─ Exports handles back to app via IPC
+    ↓
+App imports shared textures into its native API
+    ├─ D3D11 → OpenSharedResource1 (works ✅)
+    ├─ D3D12 → OpenSharedHandle (fails: protected content flag ❌)
+    ├─ VK → vkAllocateMemory+vkBindImageMemory (fails: size=0 ❌)
+    ├─ GL → ??? (no import path exists ❌)
+    ↓
+App renders to shared texture → KeyedMutex release
+    ↓
+Multi-compositor (D3D11 service)
+    ├─ Imports all clients' atlas textures via D3D11 SRV
+    ├─ Blits per-eye with Kooima projection
+    └─ Presents to display via vendor DP
+```
+
+## Failure Analysis
+
+### Vulkan: Size Mismatch (CRITICAL — one-line fix)
+
+**Error:** `vk_create_image_from_native: size mismatch, exported 0 but requires 33423360`
+
+**Root cause:** When the D3D11 service creates shared textures and exports NT handles, it sets `images[i].size = 0`:
+
+```c
+// comp_d3d11_service.cpp:2175
+sc->base.images[i].size = 0;  // ← BUG: D3D11 doesn't know allocation size
+```
+
+The VK client calls `vkGetImageMemoryRequirements` which returns 33423360 bytes (3840×2160×4 + alignment), then compares against the exported size (0) and fails.
+
+**Fix:** Calculate the actual texture memory size from the D3D11 texture descriptor:
+```c
+// After texture creation:
+D3D11_TEXTURE2D_DESC desc;
+texture->GetDesc(&desc);
+UINT bpp = dxgi_format_bits_per_pixel(desc.Format);
+sc->base.images[i].size = (uint64_t)desc.Width * desc.Height * (bpp / 8);
+// Note: may need row pitch alignment (typically 256-byte for D3D12, varies for D3D11)
+```
+
+**Files:**
+- `src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp` — `compositor_create_swapchain` (~line 2175)
+- May need: `src/xrt/auxiliary/d3d/d3d_helpers.hpp` for `dxgi_format_bits_per_pixel()` utility
+
+**VK import code (for reference):**
+- `src/xrt/auxiliary/vk/vk_helpers.c:1076-1332` — `vk_create_image_from_native`
+- Size check at line 1316: `requirements.size > image_native->size`
+
+### D3D12: Protected Content Flag (small fix)
+
+**Error:** `XRT_ERROR_SWAPCHAIN_FLAG_VALID_BUT_UNSUPPORTED`
+
+**Root cause:** Unity's OpenXR plugin requests `XRT_SWAPCHAIN_CREATE_PROTECTED_CONTENT` flag by default. The D3D12 client rejects it:
+
+```c
+// comp_d3d12_client.cpp:474-478
+if ((info->create & XRT_SWAPCHAIN_CREATE_PROTECTED_CONTENT) != 0) {
+    return XRT_ERROR_SWAPCHAIN_FLAG_VALID_BUT_UNSUPPORTED;
+}
+```
+
+**Fix:** Strip the protected content flag on the server side before creating the swapchain. Content protection is not needed for shell mode — the textures are composited by the service, not sent to a DRM-protected output.
+
+**Files:**
+- `src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp` — `compositor_create_swapchain`, strip `XRT_SWAPCHAIN_CREATE_PROTECTED_CONTENT` from `info->create`
+- OR `src/xrt/ipc/server/ipc_server_handler.c` — strip before forwarding
+
+### OpenGL: No Import Path (larger fix)
+
+**Behavior:** GL app connects, creates swapchain, but then exits silently after a few frames.
+
+**Root cause:** The GL client converts its format to VK format for IPC (`gl_format_to_vk`), then expects a VK-compatible swapchain back. But the service is D3D11 and exports D3D11 NT handles. The GL client has no mechanism to import D3D11 shared textures as GL textures.
+
+**GL client flow (`src/xrt/compositor/client/comp_gl_client.c:456-525`):**
+1. Converts GL format → VK format
+2. Sends swapchain create request via IPC
+3. Receives NT handles back
+4. Tries to import as VK images → fails (GL, not VK)
+
+**Fix options (in order of preference):**
+
+a) **WGL_NV_DX_interop** (NVIDIA + recent AMD/Intel):
+   - GL client creates/opens D3D11 device
+   - Calls `wglDXOpenDeviceNV(d3d11_device)` to register interop
+   - For each shared texture: `wglDXRegisterObjectNV(gl_name, d3d11_texture, GL_TEXTURE_2D, WGL_ACCESS_READ_WRITE_NV)`
+   - GL can then bind and render to the texture normally
+   - Widely supported on Windows (NVIDIA since ~2012, AMD/Intel recent drivers)
+
+b) **CPU staging fallback** (universal but slow):
+   - D3D11 service maps texture to CPU staging buffer
+   - Copies pixels to GL via `glTexSubImage2D`
+   - Functional but too slow for real-time 3D rendering
+
+c) **VK interop on client** (if VK available):
+   - GL client creates a VK device alongside GL
+   - Imports D3D11 shared textures into VK
+   - Uses `GL_EXT_memory_object` + `GL_EXT_semaphore` to import VK images into GL
+   - Complex but doesn't require WGL_NV_DX_interop
+
+**Recommended:** Option (a) — WGL_NV_DX_interop. It's the standard Windows approach, well-supported, and the simplest correct solution.
+
+**Files:**
+- `src/xrt/compositor/client/comp_gl_client.c` — add D3D11 import path
+- New: WGL interop helper (load extension, register textures)
+- `src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp` — may need to adjust shared texture flags for GL compatibility
+
+### Multi-API Compositor Atlas Import
+
+**Potential issue:** When the multi-compositor renders, it accesses each client's `cc->render.atlas_texture` and `cc->render.atlas_srv` as D3D11 SRVs. For D3D11 clients, these are native. For GL/VK/D3D12 clients going through IPC, the textures are shared — the client writes via its API, the service reads via D3D11.
+
+**KeyedMutex synchronization:** The shared textures use `D3D11_RESOURCE_MISC_SHARED_KEYEDMUTEX`. The multi-compositor must acquire the mutex before reading each client's atlas and release after. Currently, the per-client compositor handles this in `compositor_layer_commit`, but the multi-compositor render path may not coordinate correctly for cross-API clients.
+
+**Files to check:**
+- `src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp` — `multi_compositor_render` blit loop
+- Look for KeyedMutex acquire/release around atlas texture access
+
+## Task Checklist
+
+| Task | Priority | Complexity | Description |
+|------|----------|-----------|-------------|
+| 3B.1 | CRITICAL | Small | VK swapchain import: calculate texture memory size from D3D11 desc |
+| 3B.2 | CRITICAL | Small | D3D12 swapchain: strip protected content flag |
+| 3B.3 | HIGH | Medium | GL client: add D3D11 import via WGL_NV_DX_interop |
+| 3B.4 | MEDIUM | Small | Multi-comp: verify KeyedMutex coordination for cross-API clients |
+| 3B.5 | — | — | Smoke test: all 4 APIs in shell simultaneously |
+
+## Implementation Order
+
+1. **3B.1** (VK size) — unblocks Vulkan apps immediately
+2. **3B.2** (D3D12 flag) — unblocks Unity D3D12 apps
+3. **3B.4** (KeyedMutex check) — verify multi-comp handles cross-API correctly
+4. **3B.3** (GL import) — largest task, requires WGL interop
+5. **3B.5** (smoke test) — final validation
+
+## Key Source Files Reference
+
+| File | Role |
+|------|------|
+| `src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp` | Service compositor: swapchain creation, multi-comp render |
+| `src/xrt/compositor/client/comp_d3d11_client.cpp` | D3D11 client: imports shared textures via OpenSharedResource1 |
+| `src/xrt/compositor/client/comp_d3d12_client.cpp` | D3D12 client: swapchain flag check (line 474-478) |
+| `src/xrt/compositor/client/comp_gl_client.c` | GL client: swapchain creation (line 456-525), needs D3D11 import |
+| `src/xrt/auxiliary/vk/vk_helpers.c` | VK helper: image import from native (line 1076-1332) |
+| `src/xrt/ipc/server/ipc_server_handler.c` | IPC server: swapchain handle propagation |
+
+## Related Issues
+
+- #108 (FIXED) — D3D11 multithread protection for 3+ apps
+- #116 — GL app crashes service in multi-client mode
+- #16 — D3D12 swapchain creation in IPC/shell mode
+
+## Test Procedure
+
+```bash
+scripts\build_windows.bat build && scripts\build_windows.bat test-apps
+
+# Single-API smoke tests
+_package\bin\displayxr-shell.exe test_apps\cube_handle_vk_win\build\cube_handle_vk_win.exe
+_package\bin\displayxr-shell.exe test_apps\cube_handle_gl_win\build\cube_handle_gl_win.exe
+_package\bin\displayxr-shell.exe test_apps\cube_handle_d3d12_win\build\cube_handle_d3d12_win.exe
+
+# Multi-API stress test
+_package\bin\displayxr-shell.exe test_apps\cube_handle_d3d11_win\build\cube_handle_d3d11_win.exe test_apps\cube_handle_gl_win\build\cube_handle_gl_win.exe test_apps\cube_handle_vk_win\build\cube_handle_vk_win.exe test_apps\cube_handle_d3d12_win\build\cube_handle_d3d12_win.exe
+```
+
+Expected: all apps connect, render visible content, no service crash. Carousel mode (Ctrl+5) should spin all 4 windows.

--- a/docs/roadmap/shell-phase3b-status.md
+++ b/docs/roadmap/shell-phase3b-status.md
@@ -1,0 +1,79 @@
+# Shell Phase 3B — Implementation Status
+
+Last updated: 2026-04-04 (branch `feature/shell-phase3b-ci`)
+
+## Prerequisites
+
+Phase 3 (3D window positioning) is complete and merged to main. Shell mode works with D3D11 apps (1-4 simultaneous). Phase 3B adds cross-API support (GL, VK, D3D12).
+
+## Current Test Matrix
+
+| API | Shell Mode | Error | Fix |
+|-----|-----------|-------|-----|
+| D3D11 (1-4 apps) | ✅ Stable | — | — |
+| Vulkan | ❌ | `size mismatch, exported 0 but requires 33423360` | 3B.1: Calculate texture size |
+| D3D12 (Unity) | ❌ | `SWAPCHAIN_FLAG_VALID_BUT_UNSUPPORTED` | 3B.2: Strip protected content flag |
+| OpenGL | ❌ | Silent exit — no D3D11 import path in GL client | 3B.3: WGL_NV_DX_interop |
+
+## Phase 3B Progress
+
+### 3B.1: Fix Vulkan swapchain import (size=0)
+**Status:** Not started
+
+| Task | Status | Notes |
+|------|--------|-------|
+| Calculate texture memory size in compositor_create_swapchain | | Set `images[i].size` from D3D11 texture desc instead of 0 |
+| Test: single VK app in shell | | `cube_handle_vk_win.exe` should render |
+| Test: VK + D3D11 together | | Both visible, no crash |
+
+### 3B.2: Fix D3D12 swapchain creation (protected content flag)
+**Status:** Not started
+
+| Task | Status | Notes |
+|------|--------|-------|
+| Strip XRT_SWAPCHAIN_CREATE_PROTECTED_CONTENT in service | | Before creating shared texture |
+| Test: single D3D12 app in shell | | `cube_handle_d3d12_win.exe` should render |
+| Test: Unity D3D12 app in shell | | `DisplayXR-test.exe` should render |
+
+### 3B.3: Fix GL client import (WGL_NV_DX_interop)
+**Status:** Not started
+
+| Task | Status | Notes |
+|------|--------|-------|
+| Add WGL_NV_DX_interop extension loading | | Check driver support, fallback gracefully |
+| GL client: import D3D11 shared textures as GL textures | | wglDXOpenDeviceNV + wglDXRegisterObjectNV |
+| Test: single GL app in shell | | `cube_handle_gl_win.exe` should render |
+| Test: GL + D3D11 together | | Both visible, no crash |
+
+### 3B.4: KeyedMutex coordination
+**Status:** Not started
+
+| Task | Status | Notes |
+|------|--------|-------|
+| Verify multi-comp acquires/releases mutex per client | | Check blit loop in multi_compositor_render |
+| Test: 4-API simultaneous | | D3D11 + GL + VK + D3D12 all rendering |
+
+### 3B.5: Multi-API smoke test
+**Status:** Not started
+
+| Task | Status | Notes |
+|------|--------|-------|
+| All 4 APIs in carousel mode | | Ctrl+5 with 4 different API apps |
+
+## Key Source Files
+
+| File | Role |
+|------|------|
+| `src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp` | Service compositor: swapchain creation (~line 2061), multi-comp render |
+| `src/xrt/compositor/client/comp_d3d12_client.cpp` | D3D12 client: flag check (line 474-478) |
+| `src/xrt/compositor/client/comp_gl_client.c` | GL client: swapchain creation (line 456-525) |
+| `src/xrt/auxiliary/vk/vk_helpers.c` | VK import: `vk_create_image_from_native` (line 1076-1332) |
+
+## How to Build and Test
+
+```bash
+scripts\build_windows.bat build && scripts\build_windows.bat test-apps
+_package\bin\displayxr-shell.exe test_apps\cube_handle_vk_win\build\cube_handle_vk_win.exe
+```
+
+See `shell-phase3b-plan.md` for full test procedure and architecture details.

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -4784,18 +4784,28 @@ multi_compositor_render(struct d3d11_service_system *sys)
 		uint32_t half_w = ca_w / sys->tile_columns;
 		uint32_t half_h = ca_h / sys->tile_rows;
 
-		// Per-eye projected rects for focused slot (parallax for Z != 0)
+		int fs = mc->focused_slot;
+		bool fb_rotated = !quat_is_identity(&mc->clients[fs].window_pose.orientation);
+		float fb_hw = mc->clients[fs].window_width_m / 2.0f;
+		float fb_hh = mc->clients[fs].window_height_m / 2.0f;
+		float fb_tb_h = UI_TITLE_BAR_H_M;
+		// Border width in meters (~0.55mm, from 3px at typical display resolution)
+		float disp_w_m_fb = sys->base.info.display_width_m;
+		if (disp_w_m_fb <= 0.0f) disp_w_m_fb = 0.700f;
+		float bw_m = 3.0f * disp_w_m_fb / (float)(ca_w > 0 ? ca_w : 3840);
+		float bw = 3.0f; // border width in pixels (for non-rotated)
+
+		// Per-eye projected rects for non-rotated fallback
 		int32_t fb_eye_x[2], fb_eye_y[2], fb_eye_w[2], fb_eye_h[2];
 		for (int eye = 0; eye < 2; eye++) {
 			int ei = (eye < (int)eye_pos.count) ? eye : 0;
-			slot_pose_to_pixel_rect_for_eye(sys, &mc->clients[mc->focused_slot],
+			slot_pose_to_pixel_rect_for_eye(sys, &mc->clients[fs],
 			    eye_pos.eyes[ei].x, eye_pos.eyes[ei].y, eye_pos.eyes[ei].z,
 			    &fb_eye_x[eye], &fb_eye_y[eye],
 			    &fb_eye_w[eye], &fb_eye_h[eye]);
 		}
-		float bw = 3.0f; // border width in pixels
 
-		// Set up pipeline for solid-color draw (use blit shader with special flag)
+		// Set up pipeline
 		ID3D11RenderTargetView *ca_rtvs[] = {mc->combined_atlas_rtv.get()};
 		sys->context->OMSetRenderTargets(1, ca_rtvs, nullptr);
 		sys->context->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
@@ -4808,25 +4818,23 @@ multi_compositor_render(struct d3d11_service_system *sys)
 		sys->context->PSSetConstantBuffers(0, 1, sys->blit_constant_buffer.addressof());
 		sys->context->PSSetSamplers(0, 1, sys->sampler_linear.addressof());
 
-		// Draw border edges in each atlas half
+		// Full border rect in local space: content + title bar
+		// left=-hw, right=+hw, bottom=-hh, top=+hh+tb_h
+		// 4 border edge rects in local space (thin strips)
+		struct { float l, t, r, b; } border_edges_local[4] = {
+			{-fb_hw,        fb_hh+fb_tb_h,        fb_hw,        fb_hh+fb_tb_h-bw_m}, // top
+			{-fb_hw,        -fb_hh+bw_m,           fb_hw,        -fb_hh},              // bottom
+			{-fb_hw,        fb_hh+fb_tb_h-bw_m,   -fb_hw+bw_m,  -fb_hh+bw_m},        // left
+			{fb_hw-bw_m,    fb_hh+fb_tb_h-bw_m,   fb_hw,        -fb_hh+bw_m},         // right
+		};
+
 		uint32_t nv = sys->tile_columns * sys->tile_rows;
 		for (uint32_t v = 0; v < nv && v < XRT_MAX_VIEWS; v++) {
 			uint32_t col = v % sys->tile_columns;
 			uint32_t row = v / sys->tile_columns;
-			// Per-eye border rect (parallax for Z != 0)
-			int fb_eye_idx = (col < 2) ? (int)col : 0;
-			int32_t border_y = fb_eye_y[fb_eye_idx] - TITLE_BAR_HEIGHT_PX;
-			int32_t border_h = fb_eye_h[fb_eye_idx] + (fb_eye_y[fb_eye_idx] - border_y);
-			float fx = (float)fb_eye_x[fb_eye_idx] / ca_w;
-			float fy = (float)border_y / ca_h;
-			float fw = (float)fb_eye_w[fb_eye_idx] / ca_w;
-			float fh = (float)border_h / ca_h;
-			float ox = col * half_w + fx * half_w;
-			float oy = row * half_h + fy * half_h;
-			float ew = fw * half_w;
-			float eh = fh * half_h;
+			int fb_ei = (col < 2) ? (int)col : 0;
+			int ei_fb = (fb_ei < (int)eye_pos.count) ? fb_ei : 0;
 
-			// Scissor rect clips to tile bounds — uniform overflow on all edges.
 			D3D11_RECT border_scissor;
 			border_scissor.left = (LONG)(col * half_w);
 			border_scissor.top = (LONG)(row * half_h);
@@ -4834,39 +4842,64 @@ multi_compositor_render(struct d3d11_service_system *sys)
 			border_scissor.bottom = (LONG)((row + 1) * half_h);
 			sys->context->RSSetScissorRects(1, &border_scissor);
 
-			// 4 border rects (scissor clips overflow on all edges)
-			struct { float x, y, w, h; } edges[4] = {
-				{ox,          oy,          ew,  bw},          // top
-				{ox,          oy + eh - bw, ew, bw},          // bottom
-				{ox,          oy + bw,      bw,  eh - 2*bw},  // left
-				{ox + ew - bw, oy + bw,     bw,  eh - 2*bw},  // right
+			// Non-rotated axis-aligned edge positions (fallback)
+			int32_t border_y = fb_eye_y[fb_ei] - TITLE_BAR_HEIGHT_PX;
+			int32_t border_h = fb_eye_h[fb_ei] + (fb_eye_y[fb_ei] - border_y);
+			float fx = (float)fb_eye_x[fb_ei] / ca_w;
+			float fy = (float)border_y / ca_h;
+			float fw = (float)fb_eye_w[fb_ei] / ca_w;
+			float fh = (float)border_h / ca_h;
+			float ox = col * half_w + fx * half_w;
+			float oy = row * half_h + fy * half_h;
+			float ew = fw * half_w;
+			float eh = fh * half_h;
+			struct { float x, y, w, h; } edges_aa[4] = {
+				{ox,          oy,          ew,  bw},
+				{ox,          oy + eh - bw, ew, bw},
+				{ox,          oy + bw,      bw,  eh - 2*bw},
+				{ox + ew - bw, oy + bw,     bw,  eh - 2*bw},
 			};
+
+			D3D11_VIEWPORT vp = {};
+			vp.Width = (float)ca_w; vp.Height = (float)ca_h; vp.MaxDepth = 1.0f;
+			sys->context->RSSetViewports(1, &vp);
 
 			for (int e = 0; e < 4; e++) {
 				D3D11_MAPPED_SUBRESOURCE mapped;
 				if (FAILED(sys->context->Map(sys->blit_constant_buffer.get(), 0,
 				           D3D11_MAP_WRITE_DISCARD, 0, &mapped))) continue;
 				BlitConstants *cb = static_cast<BlitConstants *>(mapped.pData);
-				// Solid color mode: src_rect.rgb = color, convert_srgb = 2.0
-				cb->src_rect[0] = 0.0f; cb->src_rect[1] = 1.0f;  // R=0, G=1
-				cb->src_rect[2] = 1.0f; cb->src_rect[3] = 1.0f;  // B=1 → cyan
-				cb->dst_offset[0] = edges[e].x;
-				cb->dst_offset[1] = edges[e].y;
+				cb->src_rect[0] = 0.0f; cb->src_rect[1] = 1.0f;
+				cb->src_rect[2] = 1.0f; cb->src_rect[3] = 1.0f;
 				cb->src_size[0] = 1; cb->src_size[1] = 1;
-				cb->dst_size[0] = (float)ca_w;
-				cb->dst_size[1] = (float)ca_h;
-				cb->convert_srgb = 2.0f; // solid color mode
-				cb->quad_mode = 0;
-				cb->dst_rect_wh[0] = edges[e].w;
-				cb->dst_rect_wh[1] = edges[e].h;
+				cb->dst_size[0] = (float)ca_w; cb->dst_size[1] = (float)ca_h;
+				cb->convert_srgb = 2.0f;
 				cb->padding2[0] = 0; cb->padding2[1] = 0;
-				sys->context->Unmap(sys->blit_constant_buffer.get(), 0);
 
-				D3D11_VIEWPORT vp = {};
-				vp.Width = (float)ca_w;
-				vp.Height = (float)ca_h;
-				vp.MaxDepth = 1.0f;
-				sys->context->RSSetViewports(1, &vp);
+				if (fb_rotated) {
+					float corners[8];
+					project_local_rect_for_eye(sys,
+					    &mc->clients[fs].window_pose.orientation,
+					    mc->clients[fs].window_pose.position.x,
+					    mc->clients[fs].window_pose.position.y,
+					    mc->clients[fs].window_pose.position.z,
+					    border_edges_local[e].l, border_edges_local[e].t,
+					    border_edges_local[e].r, border_edges_local[e].b,
+					    eye_pos.eyes[ei_fb].x, eye_pos.eyes[ei_fb].y, eye_pos.eyes[ei_fb].z,
+					    col, row, half_w, half_h, ca_w, ca_h, corners);
+					blit_set_quad_corners(cb, corners);
+					cb->dst_offset[0] = 0; cb->dst_offset[1] = 0;
+					cb->dst_rect_wh[0] = 0; cb->dst_rect_wh[1] = 0;
+				} else {
+					cb->quad_mode = 0;
+					cb->dst_offset[0] = edges_aa[e].x;
+					cb->dst_offset[1] = edges_aa[e].y;
+					cb->dst_rect_wh[0] = edges_aa[e].w;
+					cb->dst_rect_wh[1] = edges_aa[e].h;
+					memset(cb->quad_corners_01, 0, sizeof(cb->quad_corners_01));
+					memset(cb->quad_corners_23, 0, sizeof(cb->quad_corners_23));
+				}
+				sys->context->Unmap(sys->blit_constant_buffer.get(), 0);
 				sys->context->Draw(4, 0);
 			}
 		}
@@ -7147,6 +7180,7 @@ comp_d3d11_service_get_client_window_metrics(struct xrt_system_compositor *xsysc
 	// pose.position.x: +X right (meters), pose.position.y: +Y up (meters)
 	float offset_x_m = slot->window_pose.position.x;
 	float offset_y_m = slot->window_pose.position.y;
+	float offset_z_m = slot->window_pose.position.z;
 
 	memset(out_metrics, 0, sizeof(*out_metrics));
 	out_metrics->display_width_m = disp_w_m;
@@ -7163,6 +7197,8 @@ comp_d3d11_service_get_client_window_metrics(struct xrt_system_compositor *xsysc
 	out_metrics->window_height_m = slot->window_height_m;
 	out_metrics->window_center_offset_x_m = offset_x_m;
 	out_metrics->window_center_offset_y_m = offset_y_m;
+	out_metrics->window_center_offset_z_m = offset_z_m;
+	out_metrics->window_orientation = slot->window_pose.orientation;
 	out_metrics->valid = true;
 
 	return true;

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -2875,12 +2875,19 @@ multi_compositor_update_input_forward(struct d3d11_multi_compositor *mc)
 	comp_d3d11_window_set_input_forward(mc->window, (void *)target, rx, ry, rw, rh);
 }
 
-// Forward declaration — defined in the external API section below.
+// Forward declarations — defined in the external API section below.
 static void
 slot_pose_to_pixel_rect(const struct d3d11_service_system *sys,
                         const struct d3d11_multi_client_slot *slot,
                         int32_t *out_x, int32_t *out_y,
                         int32_t *out_w, int32_t *out_h);
+
+static void
+slot_pose_to_pixel_rect_for_eye(const struct d3d11_service_system *sys,
+                                const struct d3d11_multi_client_slot *slot,
+                                float eye_x, float eye_y, float eye_z,
+                                int32_t *out_x, int32_t *out_y,
+                                int32_t *out_w, int32_t *out_h);
 
 /*!
  * Register a per-client compositor with the multi-compositor.
@@ -3980,13 +3987,29 @@ multi_compositor_render(struct d3d11_service_system *sys)
 		}
 	}
 
-	// Scroll wheel: resize focused window (~5% per notch).
+	// Scroll wheel: Shift+Scroll = Z-depth, plain scroll = resize.
 	if (mc->window != nullptr && mc->focused_slot >= 0) {
 		int32_t scroll = comp_d3d11_window_consume_scroll(mc->window);
 		if (scroll != 0) {
 			int s = mc->focused_slot;
 			if (s >= 0 && s < D3D11_MULTI_MAX_CLIENTS && mc->clients[s].active) {
-				// WHEEL_DELTA (120) = one notch = ~5% size change
+				bool shift_held = (GetAsyncKeyState(VK_SHIFT) & 0x8000) != 0;
+				if (shift_held) {
+					// Shift+Scroll: move window in Z (~2mm per notch)
+					float dz = (float)scroll / (120.0f * 500.0f); // ~0.002m per notch
+					float new_z = mc->clients[s].window_pose.position.z + dz;
+					if (new_z < -0.05f) new_z = -0.05f;
+					if (new_z >  0.05f) new_z =  0.05f;
+					mc->clients[s].window_pose.position.z = new_z;
+
+					slot_pose_to_pixel_rect(sys, &mc->clients[s],
+					                        &mc->clients[s].window_rect_x,
+					                        &mc->clients[s].window_rect_y,
+					                        &mc->clients[s].window_rect_w,
+					                        &mc->clients[s].window_rect_h);
+					U_LOG_I("Multi-comp: Shift+Scroll Z depth slot %d → Z=%.3fm", s, new_z);
+				} else {
+				// Plain scroll: resize (~5% per notch)
 				float factor = 1.0f + (float)scroll / (120.0f * 20.0f); // 5% per notch
 				if (factor < 0.5f) factor = 0.5f;
 				if (factor > 2.0f) factor = 2.0f;
@@ -3995,7 +4018,6 @@ multi_compositor_render(struct d3d11_service_system *sys)
 				float new_h = mc->clients[s].window_height_m * factor;
 
 				// Clamp to minimum 2cm and maximum 80% of display
-				// (100% would fill the entire SBS half, leaving no room for other windows)
 				float min_dim = 0.02f;
 				float max_w = sys->base.info.display_width_m * 0.8f;
 				float max_h = sys->base.info.display_height_m * 0.8f;
@@ -4018,7 +4040,30 @@ multi_compositor_render(struct d3d11_service_system *sys)
 
 				mc->clients[s].hwnd_resize_pending = true;
 				multi_compositor_update_input_forward(mc);
+				} // end else (plain scroll resize)
 			}
+		}
+	}
+
+	// [ / ] keys: step Z depth ±5mm for focused window.
+	if (mc->focused_slot >= 0 && mc->focused_slot < D3D11_MULTI_MAX_CLIENTS &&
+	    mc->clients[mc->focused_slot].active) {
+		float z_step = 0.0f;
+		if (GetAsyncKeyState(VK_OEM_4) & 1) z_step = -0.005f;  // [ = back
+		if (GetAsyncKeyState(VK_OEM_6) & 1) z_step =  0.005f;  // ] = forward
+		if (z_step != 0.0f) {
+			int s = mc->focused_slot;
+			float new_z = mc->clients[s].window_pose.position.z + z_step;
+			if (new_z < -0.05f) new_z = -0.05f;
+			if (new_z >  0.05f) new_z =  0.05f;
+			mc->clients[s].window_pose.position.z = new_z;
+
+			slot_pose_to_pixel_rect(sys, &mc->clients[s],
+			                        &mc->clients[s].window_rect_x,
+			                        &mc->clients[s].window_rect_y,
+			                        &mc->clients[s].window_rect_w,
+			                        &mc->clients[s].window_rect_h);
+			U_LOG_I("Multi-comp: [/] Z depth slot %d → Z=%.3fm", s, new_z);
 		}
 	}
 
@@ -4128,10 +4173,7 @@ multi_compositor_render(struct d3d11_service_system *sys)
 		if (cc == nullptr || !cc->render.atlas_texture || !cc->render.atlas_srv) {
 			continue;
 		}
-		// Copy client atlas content to the sub-rect position in combined atlas.
-		// The client rendered into view rects matching its HWND size (resized to sub-rect).
-		int32_t dst_x = mc->clients[s].window_rect_x;
-		uint32_t dst_y = mc->clients[s].window_rect_y;
+		// Client content dimensions (source texture size, same for both eyes).
 		uint32_t cvw = mc->clients[s].content_view_w;
 		uint32_t cvh = mc->clients[s].content_view_h;
 		if (cvw == 0 || cvh == 0) {
@@ -4139,10 +4181,7 @@ multi_compositor_render(struct d3d11_service_system *sys)
 			cvh = dp_view_h;
 		}
 
-		// Blit each view from client atlas → combined atlas with scaling.
-		// For SBS: each half of the combined atlas = one eye's full display view.
-		// The app renders at (HWND * scale) but the window occupies a larger area
-		// in the atlas, so we scale up via shader blit.
+		// Combined atlas dimensions.
 		uint32_t ca_w = sys->base.info.display_pixel_width;
 		uint32_t ca_h = sys->base.info.display_pixel_height;
 		if (ca_w == 0) ca_w = 3840;
@@ -4150,11 +4189,17 @@ multi_compositor_render(struct d3d11_service_system *sys)
 		uint32_t half_w = ca_w / sys->tile_columns;
 		uint32_t half_h = ca_h / sys->tile_rows;
 
-		// Window rect as fraction of display → position within each eye's half
-		float win_frac_x = (float)dst_x / (float)ca_w;
-		float win_frac_y = (float)dst_y / (float)ca_h;
-		float win_frac_w = (float)mc->clients[s].window_rect_w / (float)ca_w;
-		float win_frac_h = (float)mc->clients[s].window_rect_h / ca_h;
+		// Per-eye projected pixel rects (parallax shift for windows at Z != 0).
+		// Each eye sees the window at a different position on the display plane,
+		// creating stereo depth on the lenticular display.
+		int32_t eye_rect_x[2], eye_rect_y[2], eye_rect_w[2], eye_rect_h[2];
+		for (int eye = 0; eye < 2; eye++) {
+			int ei = (eye < (int)eye_pos.count) ? eye : 0;
+			slot_pose_to_pixel_rect_for_eye(sys, &mc->clients[s],
+			    eye_pos.eyes[ei].x, eye_pos.eyes[ei].y, eye_pos.eyes[ei].z,
+			    &eye_rect_x[eye], &eye_rect_y[eye],
+			    &eye_rect_w[eye], &eye_rect_h[eye]);
+		}
 
 		// Get client atlas dimensions for SRV
 		D3D11_TEXTURE2D_DESC client_atlas_desc = {};
@@ -4171,7 +4216,12 @@ multi_compositor_render(struct d3d11_service_system *sys)
 			float src_px_x = static_cast<float>(src_col * cvw);
 			float src_px_y = static_cast<float>(src_row * cvh);
 
-			// Destination rect (pixels in combined atlas)
+			// Per-eye destination rect (parallax-shifted for Z != 0)
+			int eye_idx = (src_col < 2) ? (int)src_col : 0;
+			float win_frac_x = (float)eye_rect_x[eye_idx] / (float)ca_w;
+			float win_frac_y = (float)eye_rect_y[eye_idx] / (float)ca_h;
+			float win_frac_w = (float)eye_rect_w[eye_idx] / (float)ca_w;
+			float win_frac_h = (float)eye_rect_h[eye_idx] / (float)ca_h;
 			float dest_px_x = src_col * half_w + win_frac_x * half_w;
 			float dest_px_y = src_row * half_h + win_frac_y * half_h;
 			float dest_px_w = win_frac_w * half_w;
@@ -4238,17 +4288,20 @@ multi_compositor_render(struct d3d11_service_system *sys)
 		// Draw title bar for this slot (inside render_order loop for correct z-order)
 		{
 			float tb_h_frac = (float)TITLE_BAR_HEIGHT_PX / (float)ca_h;
-			float tb_fy = win_frac_y - tb_h_frac;
-			// No clamping — scissor clips overflow uniformly
-			float actual_tb_h_frac = win_frac_y - tb_fy;
-			if (actual_tb_h_frac > 0.0f) {
+			if (tb_h_frac > 0.0f) {
 				for (uint32_t v2 = 0; v2 < num_views && v2 < XRT_MAX_VIEWS; v2++) {
 					uint32_t col2 = v2 % sys->tile_columns;
 					uint32_t row2 = v2 / sys->tile_columns;
-					float tox = col2 * half_w + win_frac_x * half_w;
+					// Per-eye window frac (parallax for Z != 0)
+					int eye_idx2 = (col2 < 2) ? (int)col2 : 0;
+					float wfx = (float)eye_rect_x[eye_idx2] / (float)ca_w;
+					float wfy = (float)eye_rect_y[eye_idx2] / (float)ca_h;
+					float wfw = (float)eye_rect_w[eye_idx2] / (float)ca_w;
+					float tb_fy = wfy - tb_h_frac;
+					float tox = col2 * half_w + wfx * half_w;
 					float toy = row2 * half_h + tb_fy * half_h;
-					float tow = win_frac_w * half_w;
-					float toh = actual_tb_h_frac * half_h;
+					float tow = wfw * half_w;
+					float toh = tb_h_frac * half_h;
 
 					// Scissor rect clips to tile bounds — uniform overflow on all edges.
 					D3D11_RECT tb_scissor;
@@ -4439,14 +4492,15 @@ multi_compositor_render(struct d3d11_service_system *sys)
 		uint32_t half_w = ca_w / sys->tile_columns;
 		uint32_t half_h = ca_h / sys->tile_rows;
 
-		// Border encompasses title bar + content area (no clamping — scissor clips)
-		int32_t border_y = (int32_t)mc->clients[mc->focused_slot].window_rect_y - TITLE_BAR_HEIGHT_PX;
-		uint32_t border_h = mc->clients[mc->focused_slot].window_rect_h +
-		                     (mc->clients[mc->focused_slot].window_rect_y - (uint32_t)border_y);
-		float fx = (float)mc->clients[mc->focused_slot].window_rect_x / ca_w;
-		float fy = (float)border_y / ca_h;
-		float fw = (float)mc->clients[mc->focused_slot].window_rect_w / ca_w;
-		float fh = (float)border_h / ca_h;
+		// Per-eye projected rects for focused slot (parallax for Z != 0)
+		int32_t fb_eye_x[2], fb_eye_y[2], fb_eye_w[2], fb_eye_h[2];
+		for (int eye = 0; eye < 2; eye++) {
+			int ei = (eye < (int)eye_pos.count) ? eye : 0;
+			slot_pose_to_pixel_rect_for_eye(sys, &mc->clients[mc->focused_slot],
+			    eye_pos.eyes[ei].x, eye_pos.eyes[ei].y, eye_pos.eyes[ei].z,
+			    &fb_eye_x[eye], &fb_eye_y[eye],
+			    &fb_eye_w[eye], &fb_eye_h[eye]);
+		}
 		float bw = 3.0f; // border width in pixels
 
 		// Set up pipeline for solid-color draw (use blit shader with special flag)
@@ -4467,6 +4521,14 @@ multi_compositor_render(struct d3d11_service_system *sys)
 		for (uint32_t v = 0; v < nv && v < XRT_MAX_VIEWS; v++) {
 			uint32_t col = v % sys->tile_columns;
 			uint32_t row = v / sys->tile_columns;
+			// Per-eye border rect (parallax for Z != 0)
+			int fb_eye_idx = (col < 2) ? (int)col : 0;
+			int32_t border_y = fb_eye_y[fb_eye_idx] - TITLE_BAR_HEIGHT_PX;
+			int32_t border_h = fb_eye_h[fb_eye_idx] + (fb_eye_y[fb_eye_idx] - border_y);
+			float fx = (float)fb_eye_x[fb_eye_idx] / ca_w;
+			float fy = (float)border_y / ca_h;
+			float fw = (float)fb_eye_w[fb_eye_idx] / ca_w;
+			float fh = (float)border_h / ca_h;
 			float ox = col * half_w + fx * half_w;
 			float oy = row * half_h + fy * half_h;
 			float ew = fw * half_w;
@@ -6372,6 +6434,70 @@ slot_pose_to_pixel_rect(const struct d3d11_service_system *sys,
 	// No clamping — windows can overflow off-screen (standard Windows behavior).
 	// The mouse can't leave the screen, guaranteeing a visible portion.
 	// The blit code clips to the visible area.
+	*out_x = (int32_t)(center_px_x - (float)w_px / 2.0f + 0.5f);
+	*out_y = (int32_t)(center_px_y - (float)h_px / 2.0f + 0.5f);
+	*out_w = w_px;
+	*out_h = h_px;
+}
+
+/*!
+ * Project a window's pixel rect through an eye position to the display plane (Z=0).
+ *
+ * For Z=0 windows, identical to slot_pose_to_pixel_rect().
+ * For Z != 0, computes parallax-shifted position and scale per-eye.
+ * Used for per-eye rendering in SBS atlas (left/right halves get different rects).
+ *
+ * Math: project window center through eye onto Z=0 plane.
+ *   scale = eye_z / (eye_z - win_z)     — closer windows appear larger
+ *   proj_x = eye_x + scale * (win_x - eye_x)  — parallax shift
+ */
+static void
+slot_pose_to_pixel_rect_for_eye(const struct d3d11_service_system *sys,
+                                const struct d3d11_multi_client_slot *slot,
+                                float eye_x, float eye_y, float eye_z,
+                                int32_t *out_x, int32_t *out_y,
+                                int32_t *out_w, int32_t *out_h)
+{
+	float disp_w_m = sys->base.info.display_width_m;
+	float disp_h_m = sys->base.info.display_height_m;
+	uint32_t disp_px_w = sys->base.info.display_pixel_width;
+	uint32_t disp_px_h = sys->base.info.display_pixel_height;
+
+	if (disp_w_m <= 0.0f || disp_h_m <= 0.0f || disp_px_w == 0 || disp_px_h == 0) {
+		disp_px_w = 3840;
+		disp_px_h = 2160;
+		disp_w_m = 0.700f;
+		disp_h_m = 0.394f;
+	}
+
+	float px_per_m_x = (float)disp_px_w / disp_w_m;
+	float px_per_m_y = (float)disp_px_h / disp_h_m;
+
+	float wx = slot->window_pose.position.x;
+	float wy = slot->window_pose.position.y;
+	float wz = slot->window_pose.position.z;
+	float w_m = slot->window_width_m;
+	float h_m = slot->window_height_m;
+
+	// Project through eye to display plane (Z=0) for non-zero window Z
+	if (fabsf(wz) > 0.0001f && eye_z > 0.01f) {
+		float denom = eye_z - wz;
+		if (fabsf(denom) < 0.001f) {
+			denom = (denom >= 0.0f) ? 0.001f : -0.001f;
+		}
+		float scale = eye_z / denom;
+		wx = eye_x + scale * (wx - eye_x);
+		wy = eye_y + scale * (wy - eye_y);
+		w_m *= scale;
+		h_m *= scale;
+	}
+
+	int32_t w_px = (int32_t)(w_m * px_per_m_x + 0.5f);
+	int32_t h_px = (int32_t)(h_m * px_per_m_y + 0.5f);
+
+	float center_px_x = (float)disp_px_w / 2.0f + wx * px_per_m_x;
+	float center_px_y = (float)disp_px_h / 2.0f - wy * px_per_m_y;
+
 	*out_x = (int32_t)(center_px_x - (float)w_px / 2.0f + 0.5f);
 	*out_y = (int32_t)(center_px_y - (float)h_px / 2.0f + 0.5f);
 	*out_w = w_px;

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -2913,7 +2913,7 @@ compute_projected_quad_corners(const struct d3d11_service_system *sys,
                                uint32_t tile_col, uint32_t tile_row,
                                uint32_t half_w, uint32_t half_h,
                                uint32_t ca_w, uint32_t ca_h,
-                               float out_corners[8]);
+                               float out_corners[8], float out_w[4]);
 
 static void
 project_local_rect_for_eye(const struct d3d11_service_system *sys,
@@ -2925,9 +2925,9 @@ project_local_rect_for_eye(const struct d3d11_service_system *sys,
                            uint32_t tile_col, uint32_t tile_row,
                            uint32_t half_w, uint32_t half_h,
                            uint32_t ca_w, uint32_t ca_h,
-                           float out_corners[8]);
+                           float out_corners[8], float out_w[4]);
 
-static inline void blit_set_quad_corners(BlitConstants *cb, const float corners[8]);
+static inline void blit_set_quad_corners(BlitConstants *cb, const float corners[8], const float w[4]);
 
 /*!
  * Register a per-client compositor with the multi-compositor.
@@ -4464,11 +4464,12 @@ multi_compositor_render(struct d3d11_service_system *sys)
 			int ei_for_quad = (src_col < 2) ? (int)src_col : 0;
 			int ei_q = (ei_for_quad < (int)eye_pos.count) ? ei_for_quad : 0;
 			float quad_corners[8] = {};
+			float quad_w_vals[4] = {1, 1, 1, 1};
 			bool use_quad = compute_projected_quad_corners(
 			    sys, &mc->clients[s],
 			    eye_pos.eyes[ei_q].x, eye_pos.eyes[ei_q].y, eye_pos.eyes[ei_q].z,
 			    src_col, src_row, half_w, half_h, ca_w, ca_h,
-			    quad_corners);
+			    quad_corners, quad_w_vals);
 
 			// Update constant buffer
 			D3D11_MAPPED_SUBRESOURCE mapped;
@@ -4493,7 +4494,7 @@ multi_compositor_render(struct d3d11_service_system *sys)
 			cb->padding2[0] = 0.0f;
 			cb->padding2[1] = 0.0f;
 			if (use_quad) {
-				blit_set_quad_corners(cb, quad_corners);
+				blit_set_quad_corners(cb, quad_corners, quad_w_vals);
 			} else {
 				memset(cb->quad_corners_01, 0, sizeof(cb->quad_corners_01));
 				memset(cb->quad_corners_23, 0, sizeof(cb->quad_corners_23));
@@ -4588,11 +4589,11 @@ multi_compositor_render(struct d3d11_service_system *sys)
 					#define CHROME_BLIT_POS(cb_ptr, ll, lt, lr, lb, aa_x, aa_y, aa_w, aa_h) \
 						do { \
 							if (is_rotated) { \
-								float _corners[8]; \
+								float _corners[8], _w[4]; \
 								project_local_rect_for_eye(sys, win_orient, wcx, wcy, wcz, \
 								    (ll), (lt), (lr), (lb), cur_eye_x, cur_eye_y, cur_eye_z, \
-								    col2, row2, half_w, half_h, ca_w, ca_h, _corners); \
-								blit_set_quad_corners(cb_ptr, _corners); \
+								    col2, row2, half_w, half_h, ca_w, ca_h, _corners, _w); \
+								blit_set_quad_corners(cb_ptr, _corners, _w); \
 								(cb_ptr)->dst_offset[0] = 0; (cb_ptr)->dst_offset[1] = 0; \
 								(cb_ptr)->dst_rect_wh[0] = 0; (cb_ptr)->dst_rect_wh[1] = 0; \
 							} else { \
@@ -4877,7 +4878,7 @@ multi_compositor_render(struct d3d11_service_system *sys)
 				cb->padding2[0] = 0; cb->padding2[1] = 0;
 
 				if (fb_rotated) {
-					float corners[8];
+					float corners[8], corner_w[4];
 					project_local_rect_for_eye(sys,
 					    &mc->clients[fs].window_pose.orientation,
 					    mc->clients[fs].window_pose.position.x,
@@ -4886,8 +4887,8 @@ multi_compositor_render(struct d3d11_service_system *sys)
 					    border_edges_local[e].l, border_edges_local[e].t,
 					    border_edges_local[e].r, border_edges_local[e].b,
 					    eye_pos.eyes[ei_fb].x, eye_pos.eyes[ei_fb].y, eye_pos.eyes[ei_fb].z,
-					    col, row, half_w, half_h, ca_w, ca_h, corners);
-					blit_set_quad_corners(cb, corners);
+					    col, row, half_w, half_h, ca_w, ca_h, corners, corner_w);
+					blit_set_quad_corners(cb, corners, corner_w);
 					cb->dst_offset[0] = 0; cb->dst_offset[1] = 0;
 					cb->dst_rect_wh[0] = 0; cb->dst_rect_wh[1] = 0;
 				} else {
@@ -6865,7 +6866,8 @@ compute_projected_quad_corners(const struct d3d11_service_system *sys,
                                uint32_t tile_col, uint32_t tile_row,
                                uint32_t half_w, uint32_t half_h,
                                uint32_t ca_w, uint32_t ca_h,
-                               float out_corners[8])
+                               float out_corners[8],
+                               float out_w[4])
 {
 	if (quat_is_identity(&slot->window_pose.orientation)) {
 		return false; // Use axis-aligned fast path
@@ -6899,14 +6901,17 @@ compute_projected_quad_corners(const struct d3d11_service_system *sys,
 	float wz = slot->window_pose.position.z;
 
 	for (int i = 0; i < 4; i++) {
-		// Rotate corner by orientation, then translate to world position
 		struct xrt_vec3 world;
 		math_quat_rotate_vec3(q, &local[i], &world);
 		world.x += wx;
 		world.y += wy;
 		world.z += wz;
 
-		// Project through eye to display plane (Z=0)
+		// Depth from eye to corner (for perspective-correct interpolation)
+		float depth = eye_z - world.z;
+		if (depth < 0.01f) depth = 0.01f;
+		out_w[i] = depth;
+
 		float dpx, dpy;
 		project_point_for_eye(world.x, world.y, world.z,
 		                      eye_x, eye_y, eye_z,
@@ -6914,7 +6919,6 @@ compute_projected_quad_corners(const struct d3d11_service_system *sys,
 		                      px_per_m_x, px_per_m_y,
 		                      &dpx, &dpy);
 
-		// Convert to SBS tile pixel coordinates
 		float frac_x = dpx / (float)ca_w;
 		float frac_y = dpy / (float)ca_h;
 		out_corners[i * 2 + 0] = tile_col * half_w + frac_x * half_w;
@@ -6938,7 +6942,8 @@ project_local_rect_for_eye(const struct d3d11_service_system *sys,
                            uint32_t tile_col, uint32_t tile_row,
                            uint32_t half_w, uint32_t half_h,
                            uint32_t ca_w, uint32_t ca_h,
-                           float out_corners[8])
+                           float out_corners[8],
+                           float out_w[4])
 {
 	float disp_w_m = sys->base.info.display_width_m;
 	float disp_h_m = sys->base.info.display_height_m;
@@ -6966,6 +6971,11 @@ project_local_rect_for_eye(const struct d3d11_service_system *sys,
 		world.y += win_cy;
 		world.z += win_cz;
 
+		// Depth from eye to corner (for perspective-correct interpolation)
+		float depth = eye_z - world.z;
+		if (depth < 0.01f) depth = 0.01f;
+		if (out_w) out_w[i] = depth;
+
 		float dpx, dpy;
 		project_point_for_eye(world.x, world.y, world.z,
 		                      eye_x, eye_y, eye_z,
@@ -6984,7 +6994,7 @@ project_local_rect_for_eye(const struct d3d11_service_system *sys,
  * Helper: write quad corner data into a BlitConstants struct.
  */
 static inline void
-blit_set_quad_corners(BlitConstants *cb, const float corners[8])
+blit_set_quad_corners(BlitConstants *cb, const float corners[8], const float w[4])
 {
 	cb->quad_mode = 1.0f;
 	cb->quad_corners_01[0] = corners[0]; // TL.x
@@ -6995,6 +7005,14 @@ blit_set_quad_corners(BlitConstants *cb, const float corners[8])
 	cb->quad_corners_23[1] = corners[5]; // TR.y
 	cb->quad_corners_23[2] = corners[6]; // BR.x
 	cb->quad_corners_23[3] = corners[7]; // BR.y
+	if (w) {
+		cb->quad_w[0] = w[0]; // TL
+		cb->quad_w[1] = w[1]; // BL
+		cb->quad_w[2] = w[2]; // TR
+		cb->quad_w[3] = w[3]; // BR
+	} else {
+		cb->quad_w[0] = cb->quad_w[1] = cb->quad_w[2] = cb->quad_w[3] = 1.0f;
+	}
 }
 
 /*!

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -487,6 +487,20 @@ struct d3d11_multi_client_slot
 
 	//! App name for title bar display (from HWND title or fallback).
 	char app_name[128];
+
+	//! Animation state for smooth pose transitions.
+	struct
+	{
+		bool active;               //!< Animation in progress
+		struct xrt_pose start_pose; //!< Pose at animation start
+		struct xrt_pose target_pose; //!< Target pose
+		float start_width_m;       //!< Width at animation start
+		float start_height_m;      //!< Height at animation start
+		float target_width_m;      //!< Target width
+		float target_height_m;     //!< Target height
+		uint64_t start_ns;         //!< Monotonic timestamp at animation start
+		uint64_t duration_ns;      //!< Animation duration in nanoseconds
+	} anim;
 };
 
 /*!
@@ -2962,17 +2976,36 @@ multi_compositor_register_client(struct d3d11_service_system *sys, struct d3d11_
 			float center_x_m = (i == 0) ? (-0.25f * disp_w_m) : (+0.25f * disp_w_m);
 			float center_y_m = 0.25f * disp_h_m;  // +Y up = upper half
 
+			// Entry animation: start from center (small), animate to target position.
+			// Set initial pose at display center, small size.
 			mc->clients[i].window_pose.orientation.x = 0.0f;
 			mc->clients[i].window_pose.orientation.y = 0.0f;
 			mc->clients[i].window_pose.orientation.z = 0.0f;
 			mc->clients[i].window_pose.orientation.w = 1.0f;
-			mc->clients[i].window_pose.position.x = center_x_m;
-			mc->clients[i].window_pose.position.y = center_y_m;
+			mc->clients[i].window_pose.position.x = 0.0f;
+			mc->clients[i].window_pose.position.y = 0.0f;
 			mc->clients[i].window_pose.position.z = 0.0f;
-			mc->clients[i].window_width_m = win_w_m;
-			mc->clients[i].window_height_m = win_h_m;
+			mc->clients[i].window_width_m = win_w_m * 0.3f; // start small
+			mc->clients[i].window_height_m = win_h_m * 0.3f;
 
-			// Compute pixel rect from pose
+			// Entry animation: grow from center to target position
+			struct xrt_pose target = {};
+			target.orientation.w = 1.0f;
+			target.position.x = center_x_m;
+			target.position.y = center_y_m;
+			target.position.z = 0.0f;
+			// Use inline animation setup (slot_animate_to is defined later in file)
+			mc->clients[i].anim.active = true;
+			mc->clients[i].anim.start_pose = mc->clients[i].window_pose;
+			mc->clients[i].anim.target_pose = target;
+			mc->clients[i].anim.start_width_m = win_w_m * 0.3f;
+			mc->clients[i].anim.start_height_m = win_h_m * 0.3f;
+			mc->clients[i].anim.target_width_m = win_w_m;
+			mc->clients[i].anim.target_height_m = win_h_m;
+			mc->clients[i].anim.start_ns = os_monotonic_get_ns();
+			mc->clients[i].anim.duration_ns = 400ULL * 1000000ULL; // 400ms
+
+			// Compute pixel rect from initial (small) pose
 			slot_pose_to_pixel_rect(sys, &mc->clients[i],
 			                        &mc->clients[i].window_rect_x,
 			                        &mc->clients[i].window_rect_y,
@@ -3548,6 +3581,73 @@ quat_is_identity(const struct xrt_quat *q)
 #define M_PI 3.14159265358979323846
 #endif
 
+//! Default animation duration for layout transitions (300ms).
+#define ANIM_DURATION_NS (300ULL * 1000000ULL)
+
+//! Animation duration for initial window entry (400ms).
+#define ANIM_ENTRY_DURATION_NS (400ULL * 1000000ULL)
+
+/*!
+ * Ease-out cubic: fast start, smooth deceleration.
+ * t in [0,1] → result in [0,1].
+ */
+static inline float
+ease_out_cubic(float t)
+{
+	float f = 1.0f - t;
+	return 1.0f - f * f * f;
+}
+
+/*!
+ * Start an animation on a slot toward a target pose + size.
+ */
+static inline void
+slot_animate_to(struct d3d11_multi_client_slot *slot,
+                const struct xrt_pose *target_pose,
+                float target_w, float target_h,
+                uint64_t now_ns, uint64_t duration_ns)
+{
+	slot->anim.active = true;
+	slot->anim.start_pose = slot->window_pose;
+	slot->anim.target_pose = *target_pose;
+	slot->anim.start_width_m = slot->window_width_m;
+	slot->anim.start_height_m = slot->window_height_m;
+	slot->anim.target_width_m = target_w;
+	slot->anim.target_height_m = target_h;
+	slot->anim.start_ns = now_ns;
+	slot->anim.duration_ns = duration_ns;
+}
+
+/*!
+ * Tick animation for a slot. Returns true if animation is still running.
+ * Updates window_pose and window_width/height_m with interpolated values.
+ */
+static inline bool
+slot_animate_tick(struct d3d11_multi_client_slot *slot, uint64_t now_ns)
+{
+	if (!slot->anim.active) return false;
+
+	uint64_t elapsed = now_ns - slot->anim.start_ns;
+	float t = (float)elapsed / (float)slot->anim.duration_ns;
+	if (t >= 1.0f) {
+		t = 1.0f;
+		slot->anim.active = false;
+	}
+	float eased = ease_out_cubic(t);
+
+	// Interpolate pose (lerp position, slerp orientation)
+	math_pose_interpolate(&slot->anim.start_pose, &slot->anim.target_pose,
+	                      eased, &slot->window_pose);
+
+	// Interpolate dimensions
+	slot->window_width_m = slot->anim.start_width_m +
+	    eased * (slot->anim.target_width_m - slot->anim.start_width_m);
+	slot->window_height_m = slot->anim.start_height_m +
+	    eased * (slot->anim.target_height_m - slot->anim.start_height_m);
+
+	return slot->anim.active; // true = still running
+}
+
 /*!
  * Apply a layout preset to all active (non-minimized) windows.
  * layout_id: 0=side-by-side, 1=stacked, 2=theater, 3=stack, 4=carousel
@@ -3671,19 +3771,16 @@ apply_layout(struct d3d11_service_system *sys, struct d3d11_multi_compositor *mc
 			return;
 		}
 
-		mc->clients[s].window_pose.position.x = new_x;
-		mc->clients[s].window_pose.position.y = new_y;
-		mc->clients[s].window_pose.position.z = new_z;
-		mc->clients[s].window_pose.orientation = new_orient;
-		mc->clients[s].window_width_m = new_w;
-		mc->clients[s].window_height_m = new_h;
+		// Animate to target pose instead of instant snap
+		struct xrt_pose target_pose;
+		target_pose.position.x = new_x;
+		target_pose.position.y = new_y;
+		target_pose.position.z = new_z;
+		target_pose.orientation = new_orient;
 
-		slot_pose_to_pixel_rect(sys, &mc->clients[s],
-		                        &mc->clients[s].window_rect_x,
-		                        &mc->clients[s].window_rect_y,
-		                        &mc->clients[s].window_rect_w,
-		                        &mc->clients[s].window_rect_h);
-		mc->clients[s].hwnd_resize_pending = true;
+		uint64_t now_ns = os_monotonic_get_ns();
+		slot_animate_to(&mc->clients[s], &target_pose, new_w, new_h,
+		                now_ns, ANIM_DURATION_NS);
 	}
 
 	multi_compositor_update_input_forward(mc);
@@ -4336,6 +4433,23 @@ multi_compositor_render(struct d3d11_service_system *sys)
 	}
 	(void)display_w_m;
 	(void)display_h_m;
+
+	// Tick animations: smoothly interpolate window poses toward targets.
+	{
+		uint64_t anim_now = os_monotonic_get_ns();
+		for (int s = 0; s < D3D11_MULTI_MAX_CLIENTS; s++) {
+			if (!mc->clients[s].active || !mc->clients[s].anim.active) continue;
+			bool still_running = slot_animate_tick(&mc->clients[s], anim_now);
+			// Recompute pixel rect from interpolated pose
+			slot_pose_to_pixel_rect(sys, &mc->clients[s],
+			                        &mc->clients[s].window_rect_x,
+			                        &mc->clients[s].window_rect_y,
+			                        &mc->clients[s].window_rect_w,
+			                        &mc->clients[s].window_rect_h);
+			mc->clients[s].hwnd_resize_pending = true;
+			(void)still_running;
+		}
+	}
 
 	// Deferred HWND resize: resize app windows to their assigned sub-rects.
 	// Uses SWP_ASYNCWINDOWPOS to avoid cross-process deadlock.

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -567,12 +567,26 @@ struct d3d11_multi_compositor
 	HCURSOR cursor_sizenesw; // NE-SW diagonal
 	HCURSOR cursor_sizeall;  // move/grab (title drag, right-click drag)
 
+	//! Title bar right-click drag state for window rotation.
+	struct
+	{
+		bool active;
+		int32_t slot;
+		POINT start_cursor;
+		float start_yaw;   //!< Yaw (radians) at drag start
+		float start_pitch;  //!< Pitch (radians) at drag start
+	} title_rmb_drag;
+
+	//! Current layout preset (-1=none, 0-4=preset index). Used for TAB Z-reorder in Stack.
+	int32_t current_layout;
+
 	//! Hovered button: 0=none, 1=close, 2=minimize, for the hovered slot.
 	int hover_btn;
 	int hover_btn_slot;
 
-	//! Previous frame LMB state (for rising-edge detection).
+	//! Previous frame LMB/RMB state (for rising-edge detection).
 	bool prev_lmb_held;
+	bool prev_rmb_held;
 
 	//! Double-click detection for title bar maximize toggle.
 	DWORD last_title_click_time;
@@ -1043,7 +1057,7 @@ blit_to_atlas_texture(struct d3d11_service_system *sys,
 	cb->dst_size[0] = static_cast<float>(sys->display_width);
 	cb->dst_size[1] = static_cast<float>(sys->display_height);
 	cb->convert_srgb = is_srgb ? 1.0f : 0.0f;
-	cb->padding = 0.0f;
+	cb->quad_mode = 0.0f;
 	cb->dst_rect_wh[0] = dst_w;
 	cb->dst_rect_wh[1] = dst_h;
 	cb->padding2[0] = 0.0f;
@@ -2875,6 +2889,9 @@ multi_compositor_update_input_forward(struct d3d11_multi_compositor *mc)
 	comp_d3d11_window_set_input_forward(mc->window, (void *)target, rx, ry, rw, rh);
 }
 
+// Forward declarations
+static inline bool quat_is_identity(const struct xrt_quat *q);
+
 // Forward declarations — defined in the external API section below.
 static void
 slot_pose_to_pixel_rect(const struct d3d11_service_system *sys,
@@ -2888,6 +2905,29 @@ slot_pose_to_pixel_rect_for_eye(const struct d3d11_service_system *sys,
                                 float eye_x, float eye_y, float eye_z,
                                 int32_t *out_x, int32_t *out_y,
                                 int32_t *out_w, int32_t *out_h);
+
+static bool
+compute_projected_quad_corners(const struct d3d11_service_system *sys,
+                               const struct d3d11_multi_client_slot *slot,
+                               float eye_x, float eye_y, float eye_z,
+                               uint32_t tile_col, uint32_t tile_row,
+                               uint32_t half_w, uint32_t half_h,
+                               uint32_t ca_w, uint32_t ca_h,
+                               float out_corners[8]);
+
+static void
+project_local_rect_for_eye(const struct d3d11_service_system *sys,
+                           const struct xrt_quat *orientation,
+                           float win_cx, float win_cy, float win_cz,
+                           float local_left, float local_top,
+                           float local_right, float local_bottom,
+                           float eye_x, float eye_y, float eye_z,
+                           uint32_t tile_col, uint32_t tile_row,
+                           uint32_t half_w, uint32_t half_h,
+                           uint32_t ca_w, uint32_t ca_h,
+                           float out_corners[8]);
+
+static inline void blit_set_quad_corners(BlitConstants *cb, const float corners[8]);
 
 /*!
  * Register a per-client compositor with the multi-compositor.
@@ -3377,14 +3417,42 @@ shell_raycast_hit_test(struct d3d11_service_system *sys,
 		float win_z = mc->clients[s].window_pose.position.z;
 		float win_w = mc->clients[s].window_width_m;
 		float win_h = mc->clients[s].window_height_m;
+		const struct xrt_quat *win_q = &mc->clients[s].window_pose.orientation;
+		bool rotated = !quat_is_identity(win_q);
 
-		// Ray-plane intersection: window plane at Z = win_z
-		if (fabsf(ray_dz) < 1e-6f) continue; // Ray parallel to plane
-		float t = (win_z - eye_z) / ray_dz;
-		if (t < 0.0f) continue; // Behind eye
-
-		float hit_x = eye_x + t * ray_dx;
-		float hit_y = eye_y + t * ray_dy;
+		// Ray-plane intersection
+		float t, hit_x, hit_y;
+		if (rotated) {
+			// Rotated window: compute plane normal from orientation
+			struct xrt_vec3 normal_local = {0, 0, 1};
+			struct xrt_vec3 normal;
+			math_quat_rotate_vec3(win_q, &normal_local, &normal);
+			// Plane equation: dot(normal, point - win_pos) = 0
+			float ray_dot_n = ray_dx * normal.x + ray_dy * normal.y + ray_dz * normal.z;
+			if (fabsf(ray_dot_n) < 1e-6f) continue; // Parallel
+			float d = (win_x - eye_x) * normal.x + (win_y - eye_y) * normal.y + (win_z - eye_z) * normal.z;
+			t = d / ray_dot_n;
+			if (t < 0.0f) continue; // Behind eye
+			float world_hit_x = eye_x + t * ray_dx;
+			float world_hit_y = eye_y + t * ray_dy;
+			float world_hit_z = eye_z + t * ray_dz;
+			// Convert world hit to window-local coords via inverse rotation
+			struct xrt_vec3 delta = {world_hit_x - win_x, world_hit_y - win_y, world_hit_z - win_z};
+			struct xrt_quat inv_q;
+			math_quat_invert(win_q, &inv_q);
+			struct xrt_vec3 local_hit;
+			math_quat_rotate_vec3(&inv_q, &delta, &local_hit);
+			// local_hit.x/y are window-local coords centered at window center
+			hit_x = win_x + local_hit.x; // project back to flat coords for bounds check
+			hit_y = win_y + local_hit.y;
+		} else {
+			// Flat window: simple Z-plane intersection
+			if (fabsf(ray_dz) < 1e-6f) continue;
+			t = (win_z - eye_z) / ray_dz;
+			if (t < 0.0f) continue;
+			hit_x = eye_x + t * ray_dx;
+			hit_y = eye_y + t * ray_dy;
+		}
 
 		// Window bounds (content area)
 		float win_left = win_x - win_w / 2.0f;
@@ -3440,8 +3508,49 @@ shell_raycast_hit_test(struct d3d11_service_system *sys,
 }
 
 /*!
+ * Helper: create a quaternion from yaw (Y-axis rotation) in radians.
+ */
+static inline struct xrt_quat
+quat_from_yaw(float yaw_rad)
+{
+	struct xrt_vec3 axis = {0.0f, 1.0f, 0.0f};
+	struct xrt_quat q;
+	math_quat_from_angle_vector(yaw_rad, &axis, &q);
+	return q;
+}
+
+/*!
+ * Helper: create a quaternion from yaw + pitch (Y then X axis) in radians.
+ */
+static inline struct xrt_quat
+quat_from_yaw_pitch(float yaw_rad, float pitch_rad)
+{
+	struct xrt_vec3 y_axis = {0.0f, 1.0f, 0.0f};
+	struct xrt_vec3 x_axis = {1.0f, 0.0f, 0.0f};
+	struct xrt_quat qy, qp, result;
+	math_quat_from_angle_vector(yaw_rad, &y_axis, &qy);
+	math_quat_from_angle_vector(pitch_rad, &x_axis, &qp);
+	math_quat_rotate(&qy, &qp, &result);
+	return result;
+}
+
+/*!
+ * Helper: check if a quaternion is identity (no rotation).
+ */
+static inline bool
+quat_is_identity(const struct xrt_quat *q)
+{
+	return fabsf(q->x) < 0.0001f && fabsf(q->y) < 0.0001f &&
+	       fabsf(q->z) < 0.0001f && fabsf(q->w - 1.0f) < 0.0001f;
+}
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+/*!
  * Apply a layout preset to all active (non-minimized) windows.
- * layout_id: 0=side-by-side, 1=stacked, 2=fullscreen, 3=cascade
+ * layout_id: 0=side-by-side, 1=stacked, 2=theater, 3=stack, 4=carousel
  */
 static void
 apply_layout(struct d3d11_service_system *sys, struct d3d11_multi_compositor *mc, int layout_id)
@@ -3462,12 +3571,15 @@ apply_layout(struct d3d11_service_system *sys, struct d3d11_multi_compositor *mc
 	}
 	if (n == 0) return;
 
-	const char *layout_names[] = {"side-by-side", "stacked", "fullscreen", "cascade"};
+	const char *layout_names[] = {"side-by-side", "stacked", "theater", "stack", "carousel"};
+	if (layout_id < 0 || layout_id > 4) return;
 	U_LOG_W("Multi-comp: layout %s (%d windows)", layout_names[layout_id], n);
+	mc->current_layout = layout_id;
 
 	for (int idx = 0; idx < n; idx++) {
 		int s = active[idx];
-		float new_x = 0, new_y = 0, new_w = 0, new_h = 0;
+		float new_x = 0, new_y = 0, new_z = 0, new_w = 0, new_h = 0;
+		struct xrt_quat new_orient = {0, 0, 0, 1}; // identity
 
 		switch (layout_id) {
 		case 0: // Side-by-side: split width equally
@@ -3484,33 +3596,85 @@ apply_layout(struct d3d11_service_system *sys, struct d3d11_multi_compositor *mc
 			new_y = ((n - 1) / 2.0f - idx) * (disp_h_m * 0.90f / n);
 			break;
 
-		case 2: // Fullscreen: focused fills display, others minimized
-			if (s == mc->focused_slot || (mc->focused_slot < 0 && idx == 0)) {
-				new_w = disp_w_m * 0.95f;
-				new_h = disp_h_m * 0.95f;
+		case 2: { // Theater: focused at Z=0 large, others recessed + angled inward
+			bool is_focused = (s == mc->focused_slot || (mc->focused_slot < 0 && idx == 0));
+			if (is_focused) {
+				new_w = disp_w_m * 0.60f;
+				new_h = disp_h_m * 0.60f;
 				new_x = 0;
 				new_y = 0;
-				mc->clients[s].minimized = false;
+				new_z = 0;
 			} else {
-				mc->clients[s].minimized = true;
-				continue;
+				new_w = disp_w_m * 0.40f;
+				new_h = disp_h_m * 0.40f;
+				new_z = -0.03f; // 3cm behind display
+				// Spread non-focused windows left/right
+				int side_idx = idx;
+				if (s == mc->focused_slot) side_idx = 0; // shouldn't happen
+				int side_count = n - 1;
+				if (side_count <= 0) side_count = 1;
+				float spread = (float)(side_idx - (side_count - 1) / 2.0f);
+				new_x = spread * disp_w_m * 0.35f;
+				new_y = 0;
+				// Angle inward: positive yaw for left windows, negative for right
+				float yaw = (new_x > 0) ? -(float)(15.0 * M_PI / 180.0)
+				                         : (float)(15.0 * M_PI / 180.0);
+				if (fabsf(new_x) < 0.01f) yaw = 0;
+				new_orient = quat_from_yaw(yaw);
 			}
 			break;
+		}
 
-		case 3: { // Cascade: same size, offset per slot
-			new_w = disp_w_m * 0.50f;
-			new_h = disp_h_m * 0.50f;
-			float offset_m = 0.015f; // ~30px equivalent
-			new_x = -disp_w_m * 0.15f + idx * offset_m;
-			new_y = disp_h_m * 0.15f - idx * offset_m;
+		case 3: { // Stack: card pile at varying Z, focused at front
+			new_w = disp_w_m * 0.55f;
+			new_h = disp_h_m * 0.55f;
+			// Focused window at front Z, others behind
+			bool is_focused = (s == mc->focused_slot || (mc->focused_slot < 0 && idx == 0));
+			if (is_focused) {
+				new_z = 0.02f; // 2cm in front
+				new_x = 0;
+				new_y = 0;
+			} else {
+				// Distribute behind, with XY offset for card-stack look
+				float z_step = 0.04f / (n > 1 ? (float)(n - 1) : 1.0f);
+				new_z = 0.02f - (idx + 1) * z_step;
+				if (new_z < -0.02f) new_z = -0.02f;
+				new_x = idx * 0.005f;  // 5mm right per layer
+				new_y = -idx * 0.005f; // 5mm down per layer
+			}
 			break;
 		}
+
+		case 4: { // Carousel: semicircle arrangement
+			float radius_m = 0.15f; // 15cm semicircle radius
+			new_w = disp_w_m * 0.45f;
+			new_h = disp_h_m * 0.45f;
+			if (n == 1) {
+				new_x = 0; new_y = 0; new_z = 0.01f;
+			} else {
+				// Spread across a 60-degree arc centered on 0
+				float total_arc = (float)(60.0 * M_PI / 180.0);
+				float angle_step = total_arc / (float)(n - 1);
+				float angle = -total_arc / 2.0f + idx * angle_step;
+				new_x = sinf(angle) * radius_m;
+				new_z = (cosf(angle) - 1.0f) * radius_m * 0.5f; // slight Z variation
+				new_y = 0;
+				// Center window slightly forward
+				if (idx == n / 2) new_z += 0.01f;
+				// Yaw to face center
+				new_orient = quat_from_yaw(-angle * 0.6f);
+			}
+			break;
+		}
+
 		default:
 			return;
 		}
 
 		mc->clients[s].window_pose.position.x = new_x;
 		mc->clients[s].window_pose.position.y = new_y;
+		mc->clients[s].window_pose.position.z = new_z;
+		mc->clients[s].window_pose.orientation = new_orient;
 		mc->clients[s].window_width_m = new_w;
 		mc->clients[s].window_height_m = new_h;
 
@@ -3610,6 +3774,11 @@ multi_compositor_render(struct d3d11_service_system *sys)
 			U_LOG_W("Multi-comp: TAB → focused slot %d%s", mc->focused_slot,
 			        mc->focused_slot < 0 ? " (unfocused)" : "");
 			multi_compositor_update_input_forward(mc);
+
+			// Stack layout: TAB reorders Z — focused window to front
+			if (mc->current_layout == 3 && mc->focused_slot >= 0) {
+				apply_layout(sys, mc, 3);
+			}
 		}
 	}
 
@@ -3627,9 +3796,9 @@ multi_compositor_render(struct d3d11_service_system *sys)
 		}
 	}
 
-	// Layout presets: Ctrl+1-4
+	// Layout presets: Ctrl+1-5 (1=SBS, 2=stacked, 3=theater, 4=stack, 5=carousel)
 	if (GetAsyncKeyState(VK_CONTROL) & 0x8000) {
-		for (int k = '1'; k <= '4'; k++) {
+		for (int k = '1'; k <= '5'; k++) {
 			if (GetAsyncKeyState(k) & 1) {
 				apply_layout(sys, mc, k - '1');
 				break;
@@ -3975,15 +4144,70 @@ multi_compositor_render(struct d3d11_service_system *sys)
 		}
 	}
 
-	// Right-click: focus window under cursor (RMB events forwarded to app via WndProc)
-	if (GetAsyncKeyState(VK_RBUTTON) & 1) {
-		POINT pt;
-		GetCursorPos(&pt);
-		ScreenToClient(mc->hwnd, &pt);
-		struct shell_hit_result rmb_hit = shell_raycast_hit_test(sys, mc, pt);
-		if (rmb_hit.slot >= 0 && rmb_hit.slot != mc->focused_slot) {
-			mc->focused_slot = rmb_hit.slot;
-			multi_compositor_update_input_forward(mc);
+	// Right-click: title bar RMB drag = rotation, content RMB = focus + forward to app.
+	// Call GetAsyncKeyState ONCE to avoid consuming the & 1 press bit (Phase 2 lesson #4).
+	{
+		SHORT rmb_state = GetAsyncKeyState(VK_RBUTTON);
+		bool rmb_held = (rmb_state & 0x8000) != 0;
+		bool rmb_just_pressed = rmb_held && !mc->prev_rmb_held;
+		mc->prev_rmb_held = rmb_held;
+
+		if (rmb_held) {
+			if (!mc->title_rmb_drag.active && rmb_just_pressed) {
+				// RMB just pressed — check if on title bar to start rotation drag
+				POINT pt;
+				GetCursorPos(&pt);
+				ScreenToClient(mc->hwnd, &pt);
+				struct shell_hit_result rmb_hit = shell_raycast_hit_test(sys, mc, pt);
+				if (rmb_hit.slot >= 0) {
+					if (rmb_hit.slot != mc->focused_slot) {
+						mc->focused_slot = rmb_hit.slot;
+						multi_compositor_update_input_forward(mc);
+					}
+					if (rmb_hit.in_title_bar && !rmb_hit.in_close_btn && !rmb_hit.in_minimize_btn) {
+						// Start rotation drag
+						mc->title_rmb_drag.active = true;
+						mc->title_rmb_drag.slot = rmb_hit.slot;
+						mc->title_rmb_drag.start_cursor = pt;
+						// Extract current yaw/pitch from quaternion
+						struct xrt_vec3 euler;
+						math_quat_to_euler_angles(&mc->clients[rmb_hit.slot].window_pose.orientation, &euler);
+						mc->title_rmb_drag.start_yaw = euler.y;
+						mc->title_rmb_drag.start_pitch = euler.x;
+					}
+				}
+			} else if (mc->title_rmb_drag.active) {
+				// RMB held — update rotation during drag
+				POINT pt;
+				GetCursorPos(&pt);
+				ScreenToClient(mc->hwnd, &pt);
+				int s = mc->title_rmb_drag.slot;
+				if (s >= 0 && s < D3D11_MULTI_MAX_CLIENTS && mc->clients[s].active) {
+					float dx = (float)(pt.x - mc->title_rmb_drag.start_cursor.x);
+					float dy = (float)(pt.y - mc->title_rmb_drag.start_cursor.y);
+					// ~1 degree per 10 pixels
+					float deg_per_px = (float)(M_PI / 180.0) / 10.0f;
+					float yaw = mc->title_rmb_drag.start_yaw + dx * deg_per_px;
+					float pitch = mc->title_rmb_drag.start_pitch + dy * deg_per_px;
+					// Clamp: yaw ±30°, pitch ±15°
+					float max_yaw = (float)(30.0 * M_PI / 180.0);
+					float max_pitch = (float)(15.0 * M_PI / 180.0);
+					if (yaw < -max_yaw) yaw = -max_yaw;
+					if (yaw > max_yaw) yaw = max_yaw;
+					if (pitch < -max_pitch) pitch = -max_pitch;
+					if (pitch > max_pitch) pitch = max_pitch;
+
+					mc->clients[s].window_pose.orientation = quat_from_yaw_pitch(yaw, pitch);
+					mc->current_layout = -1; // Manual rotation breaks layout
+				}
+			}
+		} else {
+			if (mc->title_rmb_drag.active) {
+				mc->title_rmb_drag.active = false;
+				mc->title_rmb_drag.slot = -1;
+				// Nudge cursor to force WM_SETCURSOR update
+				POINT p; GetCursorPos(&p); SetCursorPos(p.x, p.y);
+			}
 		}
 	}
 
@@ -4236,6 +4460,16 @@ multi_compositor_render(struct d3d11_service_system *sys)
 			scissor.bottom = (LONG)((src_row + 1) * half_h);
 			sys->context->RSSetScissorRects(1, &scissor);
 
+			// Check for rotated window → perspective quad mode
+			int ei_for_quad = (src_col < 2) ? (int)src_col : 0;
+			int ei_q = (ei_for_quad < (int)eye_pos.count) ? ei_for_quad : 0;
+			float quad_corners[8] = {};
+			bool use_quad = compute_projected_quad_corners(
+			    sys, &mc->clients[s],
+			    eye_pos.eyes[ei_q].x, eye_pos.eyes[ei_q].y, eye_pos.eyes[ei_q].z,
+			    src_col, src_row, half_w, half_h, ca_w, ca_h,
+			    quad_corners);
+
 			// Update constant buffer
 			D3D11_MAPPED_SUBRESOURCE mapped;
 			HRESULT hr = sys->context->Map(sys->blit_constant_buffer.get(), 0,
@@ -4253,11 +4487,17 @@ multi_compositor_render(struct d3d11_service_system *sys)
 			cb->dst_size[0] = static_cast<float>(ca_w);
 			cb->dst_size[1] = static_cast<float>(ca_h);
 			cb->convert_srgb = 0.0f;
-			cb->padding = 0.0f;
+			cb->quad_mode = use_quad ? 1.0f : 0.0f;
 			cb->dst_rect_wh[0] = dest_px_w;
 			cb->dst_rect_wh[1] = dest_px_h;
 			cb->padding2[0] = 0.0f;
 			cb->padding2[1] = 0.0f;
+			if (use_quad) {
+				blit_set_quad_corners(cb, quad_corners);
+			} else {
+				memset(cb->quad_corners_01, 0, sizeof(cb->quad_corners_01));
+				memset(cb->quad_corners_23, 0, sizeof(cb->quad_corners_23));
+			}
 			sys->context->Unmap(sys->blit_constant_buffer.get(), 0);
 
 			// Pipeline setup
@@ -4288,12 +4528,29 @@ multi_compositor_render(struct d3d11_service_system *sys)
 		// Draw title bar for this slot (inside render_order loop for correct z-order)
 		{
 			float tb_h_frac = (float)TITLE_BAR_HEIGHT_PX / (float)ca_h;
+			// Window local-space dimensions for rotated chrome
+			bool is_rotated = !quat_is_identity(&mc->clients[s].window_pose.orientation);
+			float win_hw = mc->clients[s].window_width_m / 2.0f;
+			float win_hh = mc->clients[s].window_height_m / 2.0f;
+			float tb_h_m = UI_TITLE_BAR_H_M;
+			float btn_w_m_val = UI_BTN_W_M;
+			float glyph_w_m = UI_GLYPH_W_M;
+			float glyph_h_m = UI_GLYPH_H_M;
+			const struct xrt_quat *win_orient = &mc->clients[s].window_pose.orientation;
+			float wcx = mc->clients[s].window_pose.position.x;
+			float wcy = mc->clients[s].window_pose.position.y;
+			float wcz = mc->clients[s].window_pose.position.z;
+
 			if (tb_h_frac > 0.0f) {
 				for (uint32_t v2 = 0; v2 < num_views && v2 < XRT_MAX_VIEWS; v2++) {
 					uint32_t col2 = v2 % sys->tile_columns;
 					uint32_t row2 = v2 / sys->tile_columns;
 					// Per-eye window frac (parallax for Z != 0)
 					int eye_idx2 = (col2 < 2) ? (int)col2 : 0;
+					int ei2 = (eye_idx2 < (int)eye_pos.count) ? eye_idx2 : 0;
+					float cur_eye_x = eye_pos.eyes[ei2].x;
+					float cur_eye_y = eye_pos.eyes[ei2].y;
+					float cur_eye_z = eye_pos.eyes[ei2].z;
 					float wfx = (float)eye_rect_x[eye_idx2] / (float)ca_w;
 					float wfy = (float)eye_rect_y[eye_idx2] / (float)ca_h;
 					float wfw = (float)eye_rect_w[eye_idx2] / (float)ca_w;
@@ -4327,6 +4584,26 @@ multi_compositor_render(struct d3d11_service_system *sys)
 					tb_vp.Width = (float)ca_w; tb_vp.Height = (float)ca_h; tb_vp.MaxDepth = 1.0f;
 					sys->context->RSSetViewports(1, &tb_vp);
 
+					// Helper lambda: fill CB position fields for rotated or axis-aligned chrome blit
+					#define CHROME_BLIT_POS(cb_ptr, ll, lt, lr, lb, aa_x, aa_y, aa_w, aa_h) \
+						do { \
+							if (is_rotated) { \
+								float _corners[8]; \
+								project_local_rect_for_eye(sys, win_orient, wcx, wcy, wcz, \
+								    (ll), (lt), (lr), (lb), cur_eye_x, cur_eye_y, cur_eye_z, \
+								    col2, row2, half_w, half_h, ca_w, ca_h, _corners); \
+								blit_set_quad_corners(cb_ptr, _corners); \
+								(cb_ptr)->dst_offset[0] = 0; (cb_ptr)->dst_offset[1] = 0; \
+								(cb_ptr)->dst_rect_wh[0] = 0; (cb_ptr)->dst_rect_wh[1] = 0; \
+							} else { \
+								(cb_ptr)->quad_mode = 0; \
+								(cb_ptr)->dst_offset[0] = (aa_x); (cb_ptr)->dst_offset[1] = (aa_y); \
+								(cb_ptr)->dst_rect_wh[0] = (aa_w); (cb_ptr)->dst_rect_wh[1] = (aa_h); \
+								memset((cb_ptr)->quad_corners_01, 0, sizeof((cb_ptr)->quad_corners_01)); \
+								memset((cb_ptr)->quad_corners_23, 0, sizeof((cb_ptr)->quad_corners_23)); \
+							} \
+						} while(0)
+
 					// Title bar background
 					{
 						D3D11_MAPPED_SUBRESOURCE mapped;
@@ -4335,62 +4612,62 @@ multi_compositor_render(struct d3d11_service_system *sys)
 							BlitConstants *cb = static_cast<BlitConstants *>(mapped.pData);
 							cb->src_rect[0] = 0.18f; cb->src_rect[1] = 0.20f;
 							cb->src_rect[2] = 0.25f; cb->src_rect[3] = 1.0f;
-							cb->dst_offset[0] = tox; cb->dst_offset[1] = toy;
 							cb->src_size[0] = 1; cb->src_size[1] = 1;
 							cb->dst_size[0] = (float)ca_w; cb->dst_size[1] = (float)ca_h;
-							cb->convert_srgb = 2.0f; cb->padding = 0;
-							cb->dst_rect_wh[0] = tow; cb->dst_rect_wh[1] = toh;
+							cb->convert_srgb = 2.0f;
 							cb->padding2[0] = 0; cb->padding2[1] = 0;
+							// Title bar: full width, above content
+							CHROME_BLIT_POS(cb,
+							    -win_hw, win_hh + tb_h_m, win_hw, win_hh,
+							    tox, toy, tow, toh);
 							sys->context->Unmap(sys->blit_constant_buffer.get(), 0);
 							sys->context->Draw(4, 0);
 						}
 					}
 					// Close button (red)
 					{
-						float btn_x = tox + tow - (float)CLOSE_BTN_WIDTH_PX;
-						if (btn_x >= tox) {
-							D3D11_MAPPED_SUBRESOURCE mapped;
-							if (SUCCEEDED(sys->context->Map(sys->blit_constant_buffer.get(), 0,
-							              D3D11_MAP_WRITE_DISCARD, 0, &mapped))) {
-								BlitConstants *cb = static_cast<BlitConstants *>(mapped.pData);
-								bool close_hover = (mc->hover_btn == 1 && mc->hover_btn_slot == s);
-								cb->src_rect[0] = close_hover ? 0.90f : 0.70f;
-								cb->src_rect[1] = close_hover ? 0.25f : 0.15f;
-								cb->src_rect[2] = close_hover ? 0.25f : 0.15f;
-								cb->src_rect[3] = 1.0f;
-								cb->dst_offset[0] = btn_x; cb->dst_offset[1] = toy;
-								cb->src_size[0] = 1; cb->src_size[1] = 1;
-								cb->dst_size[0] = (float)ca_w; cb->dst_size[1] = (float)ca_h;
-								cb->convert_srgb = 2.0f; cb->padding = 0;
-								cb->dst_rect_wh[0] = (float)CLOSE_BTN_WIDTH_PX; cb->dst_rect_wh[1] = toh;
-								cb->padding2[0] = 0; cb->padding2[1] = 0;
-								sys->context->Unmap(sys->blit_constant_buffer.get(), 0);
-								sys->context->Draw(4, 0);
-							}
+						D3D11_MAPPED_SUBRESOURCE mapped;
+						if (SUCCEEDED(sys->context->Map(sys->blit_constant_buffer.get(), 0,
+						              D3D11_MAP_WRITE_DISCARD, 0, &mapped))) {
+							BlitConstants *cb = static_cast<BlitConstants *>(mapped.pData);
+							bool close_hover = (mc->hover_btn == 1 && mc->hover_btn_slot == s);
+							cb->src_rect[0] = close_hover ? 0.90f : 0.70f;
+							cb->src_rect[1] = close_hover ? 0.25f : 0.15f;
+							cb->src_rect[2] = close_hover ? 0.25f : 0.15f;
+							cb->src_rect[3] = 1.0f;
+							cb->src_size[0] = 1; cb->src_size[1] = 1;
+							cb->dst_size[0] = (float)ca_w; cb->dst_size[1] = (float)ca_h;
+							cb->convert_srgb = 2.0f;
+							cb->padding2[0] = 0; cb->padding2[1] = 0;
+							float btn_x = tox + tow - (float)CLOSE_BTN_WIDTH_PX;
+							CHROME_BLIT_POS(cb,
+							    win_hw - btn_w_m_val, win_hh + tb_h_m, win_hw, win_hh,
+							    btn_x, toy, (float)CLOSE_BTN_WIDTH_PX, toh);
+							sys->context->Unmap(sys->blit_constant_buffer.get(), 0);
+							sys->context->Draw(4, 0);
 						}
 					}
 					// Minimize button (gray)
 					{
-						float min_x = tox + tow - 2.0f * (float)CLOSE_BTN_WIDTH_PX;
-						if (min_x >= tox) {
-							D3D11_MAPPED_SUBRESOURCE mapped;
-							if (SUCCEEDED(sys->context->Map(sys->blit_constant_buffer.get(), 0,
-							              D3D11_MAP_WRITE_DISCARD, 0, &mapped))) {
-								BlitConstants *cb = static_cast<BlitConstants *>(mapped.pData);
-								bool min_hover = (mc->hover_btn == 2 && mc->hover_btn_slot == s);
-								cb->src_rect[0] = min_hover ? 0.45f : 0.30f;
-								cb->src_rect[1] = min_hover ? 0.48f : 0.33f;
-								cb->src_rect[2] = min_hover ? 0.50f : 0.36f;
-								cb->src_rect[3] = 1.0f;
-								cb->dst_offset[0] = min_x; cb->dst_offset[1] = toy;
-								cb->src_size[0] = 1; cb->src_size[1] = 1;
-								cb->dst_size[0] = (float)ca_w; cb->dst_size[1] = (float)ca_h;
-								cb->convert_srgb = 2.0f; cb->padding = 0;
-								cb->dst_rect_wh[0] = (float)CLOSE_BTN_WIDTH_PX; cb->dst_rect_wh[1] = toh;
-								cb->padding2[0] = 0; cb->padding2[1] = 0;
-								sys->context->Unmap(sys->blit_constant_buffer.get(), 0);
-								sys->context->Draw(4, 0);
-							}
+						D3D11_MAPPED_SUBRESOURCE mapped;
+						if (SUCCEEDED(sys->context->Map(sys->blit_constant_buffer.get(), 0,
+						              D3D11_MAP_WRITE_DISCARD, 0, &mapped))) {
+							BlitConstants *cb = static_cast<BlitConstants *>(mapped.pData);
+							bool min_hover = (mc->hover_btn == 2 && mc->hover_btn_slot == s);
+							cb->src_rect[0] = min_hover ? 0.45f : 0.30f;
+							cb->src_rect[1] = min_hover ? 0.48f : 0.33f;
+							cb->src_rect[2] = min_hover ? 0.50f : 0.36f;
+							cb->src_rect[3] = 1.0f;
+							cb->src_size[0] = 1; cb->src_size[1] = 1;
+							cb->dst_size[0] = (float)ca_w; cb->dst_size[1] = (float)ca_h;
+							cb->convert_srgb = 2.0f;
+							cb->padding2[0] = 0; cb->padding2[1] = 0;
+							float min_x = tox + tow - 2.0f * (float)CLOSE_BTN_WIDTH_PX;
+							CHROME_BLIT_POS(cb,
+							    win_hw - 2*btn_w_m_val, win_hh + tb_h_m, win_hw - btn_w_m_val, win_hh,
+							    min_x, toy, (float)CLOSE_BTN_WIDTH_PX, toh);
+							sys->context->Unmap(sys->blit_constant_buffer.get(), 0);
+							sys->context->Draw(4, 0);
 						}
 					}
 					// Text + glyphs
@@ -4405,6 +4682,9 @@ multi_compositor_render(struct d3d11_service_system *sys)
 						float gh = (float)GLYPH_H;
 						float gpad = (toh - gh) / 2.0f; // vertical centering
 						if (gpad < 0) gpad = 0;
+						// Glyph vertical centering in meters (for rotated path)
+						float glyph_vpad_m = (tb_h_m - glyph_h_m) / 2.0f;
+						if (glyph_vpad_m < 0) glyph_vpad_m = 0;
 
 						int max_chars = ((int)tow - (int)gw - 2 * CLOSE_BTN_WIDTH_PX) / (int)gw;
 						if (max_chars < 0) max_chars = 0;
@@ -4419,13 +4699,18 @@ multi_compositor_render(struct d3d11_service_system *sys)
 								BlitConstants *cb = static_cast<BlitConstants *>(mapped.pData);
 								cb->src_rect[0] = (float)(gi * 8); cb->src_rect[1] = 0;
 								cb->src_rect[2] = 8; cb->src_rect[3] = 16;
-								cb->dst_offset[0] = tox + gw + ci * gw;
-								cb->dst_offset[1] = toy + gpad;
 								cb->src_size[0] = 768; cb->src_size[1] = 16;
 								cb->dst_size[0] = (float)ca_w; cb->dst_size[1] = (float)ca_h;
-								cb->convert_srgb = 0.0f; cb->padding = 0;
-								cb->dst_rect_wh[0] = gw; cb->dst_rect_wh[1] = gh;
+								cb->convert_srgb = 0.0f;
 								cb->padding2[0] = 0; cb->padding2[1] = 0;
+								// Glyph local rect: left edge + 1 glyph padding + ci * glyph_w
+								float gl_left = -win_hw + glyph_w_m + ci * glyph_w_m;
+								float gl_top = win_hh + tb_h_m - glyph_vpad_m;
+								float gl_right = gl_left + glyph_w_m;
+								float gl_bottom = gl_top - glyph_h_m;
+								CHROME_BLIT_POS(cb,
+								    gl_left, gl_top, gl_right, gl_bottom,
+								    tox + gw + ci * gw, toy + gpad, gw, gh);
 								sys->context->Unmap(sys->blit_constant_buffer.get(), 0);
 								sys->context->Draw(4, 0);
 							}
@@ -4434,19 +4719,22 @@ multi_compositor_render(struct d3d11_service_system *sys)
 						{
 							int xg = 'X' - 0x20;
 							float bx = tox + tow - (float)CLOSE_BTN_WIDTH_PX + ((float)CLOSE_BTN_WIDTH_PX - gw) / 2.0f;
+							// Local: centered in close button
+							float xg_left = win_hw - btn_w_m_val + (btn_w_m_val - glyph_w_m) / 2.0f;
+							float xg_top = win_hh + tb_h_m - glyph_vpad_m;
 							D3D11_MAPPED_SUBRESOURCE mapped;
 							if (SUCCEEDED(sys->context->Map(sys->blit_constant_buffer.get(), 0,
 							              D3D11_MAP_WRITE_DISCARD, 0, &mapped))) {
 								BlitConstants *cb = static_cast<BlitConstants *>(mapped.pData);
 								cb->src_rect[0] = (float)(xg * 8); cb->src_rect[1] = 0;
 								cb->src_rect[2] = 8; cb->src_rect[3] = 16;
-								cb->dst_offset[0] = bx;
-								cb->dst_offset[1] = toy + gpad;
 								cb->src_size[0] = 768; cb->src_size[1] = 16;
 								cb->dst_size[0] = (float)ca_w; cb->dst_size[1] = (float)ca_h;
-								cb->convert_srgb = 0.0f; cb->padding = 0;
-								cb->dst_rect_wh[0] = gw; cb->dst_rect_wh[1] = gh;
+								cb->convert_srgb = 0.0f;
 								cb->padding2[0] = 0; cb->padding2[1] = 0;
+								CHROME_BLIT_POS(cb,
+								    xg_left, xg_top, xg_left + glyph_w_m, xg_top - glyph_h_m,
+								    bx, toy + gpad, gw, gh);
 								sys->context->Unmap(sys->blit_constant_buffer.get(), 0);
 								sys->context->Draw(4, 0);
 							}
@@ -4455,19 +4743,22 @@ multi_compositor_render(struct d3d11_service_system *sys)
 						{
 							int dg = '-' - 0x20;
 							float mx = tox + tow - 2.0f * (float)CLOSE_BTN_WIDTH_PX + ((float)CLOSE_BTN_WIDTH_PX - gw) / 2.0f;
+							// Local: centered in minimize button
+							float mg_left = win_hw - 2*btn_w_m_val + (btn_w_m_val - glyph_w_m) / 2.0f;
+							float mg_top = win_hh + tb_h_m - glyph_vpad_m;
 							D3D11_MAPPED_SUBRESOURCE mapped;
 							if (SUCCEEDED(sys->context->Map(sys->blit_constant_buffer.get(), 0,
 							              D3D11_MAP_WRITE_DISCARD, 0, &mapped))) {
 								BlitConstants *cb = static_cast<BlitConstants *>(mapped.pData);
 								cb->src_rect[0] = (float)(dg * 8); cb->src_rect[1] = 0;
 								cb->src_rect[2] = 8; cb->src_rect[3] = 16;
-								cb->dst_offset[0] = mx;
-								cb->dst_offset[1] = toy + gpad;
 								cb->src_size[0] = 768; cb->src_size[1] = 16;
 								cb->dst_size[0] = (float)ca_w; cb->dst_size[1] = (float)ca_h;
-								cb->convert_srgb = 0.0f; cb->padding = 0;
-								cb->dst_rect_wh[0] = gw; cb->dst_rect_wh[1] = gh;
+								cb->convert_srgb = 0.0f;
 								cb->padding2[0] = 0; cb->padding2[1] = 0;
+								CHROME_BLIT_POS(cb,
+								    mg_left, mg_top, mg_left + glyph_w_m, mg_top - glyph_h_m,
+								    mx, toy + gpad, gw, gh);
 								sys->context->Unmap(sys->blit_constant_buffer.get(), 0);
 								sys->context->Draw(4, 0);
 							}
@@ -4475,6 +4766,7 @@ multi_compositor_render(struct d3d11_service_system *sys)
 						sys->context->OMSetBlendState(sys->blend_opaque.get(), nullptr, 0xFFFFFFFF);
 						sys->context->PSSetSamplers(0, 1, sys->sampler_linear.addressof());
 					}
+					#undef CHROME_BLIT_POS
 				}
 			}
 		}
@@ -4564,7 +4856,7 @@ multi_compositor_render(struct d3d11_service_system *sys)
 				cb->dst_size[0] = (float)ca_w;
 				cb->dst_size[1] = (float)ca_h;
 				cb->convert_srgb = 2.0f; // solid color mode
-				cb->padding = 0;
+				cb->quad_mode = 0;
 				cb->dst_rect_wh[0] = edges[e].w;
 				cb->dst_rect_wh[1] = edges[e].h;
 				cb->padding2[0] = 0; cb->padding2[1] = 0;
@@ -4648,7 +4940,7 @@ multi_compositor_render(struct d3d11_service_system *sys)
 					cb->dst_size[0] = (float)ca_w;
 					cb->dst_size[1] = (float)ca_h;
 					cb->convert_srgb = 2.0f;
-					cb->padding = 0;
+					cb->quad_mode = 0;
 					cb->dst_rect_wh[0] = (float)half_w;
 					cb->dst_rect_wh[1] = (float)TASKBAR_HEIGHT_PX;
 					cb->padding2[0] = 0; cb->padding2[1] = 0;
@@ -4690,7 +4982,7 @@ multi_compositor_render(struct d3d11_service_system *sys)
 								cb2->dst_size[0] = (float)ca_w;
 								cb2->dst_size[1] = (float)ca_h;
 								cb2->convert_srgb = 2.0f;
-								cb2->padding = 0;
+								cb2->quad_mode = 0;
 								cb2->dst_rect_wh[0] = pill_w;
 								cb2->dst_rect_wh[1] = pill_h;
 								cb2->padding2[0] = 0; cb2->padding2[1] = 0;
@@ -4721,7 +5013,7 @@ multi_compositor_render(struct d3d11_service_system *sys)
 								cb3->dst_size[0] = (float)ca_w;
 								cb3->dst_size[1] = (float)ca_h;
 								cb3->convert_srgb = 0.0f;
-								cb3->padding = 0;
+								cb3->quad_mode = 0;
 								cb3->dst_rect_wh[0] = tgw;
 								cb3->dst_rect_wh[1] = tgh;
 								cb3->padding2[0] = 0; cb3->padding2[1] = 0;
@@ -6502,6 +6794,174 @@ slot_pose_to_pixel_rect_for_eye(const struct d3d11_service_system *sys,
 	*out_y = (int32_t)(center_px_y - (float)h_px / 2.0f + 0.5f);
 	*out_w = w_px;
 	*out_h = h_px;
+}
+
+/*!
+ * Project a single 3D point through an eye to the display plane (Z=0),
+ * returning the result in display pixel coordinates.
+ */
+static inline void
+project_point_for_eye(float px, float py, float pz,
+                      float eye_x, float eye_y, float eye_z,
+                      float disp_px_w, float disp_px_h,
+                      float px_per_m_x, float px_per_m_y,
+                      float *out_px_x, float *out_px_y)
+{
+	if (fabsf(pz) > 0.0001f && eye_z > 0.01f) {
+		float denom = eye_z - pz;
+		if (fabsf(denom) < 0.001f) denom = (denom >= 0.0f) ? 0.001f : -0.001f;
+		float scale = eye_z / denom;
+		px = eye_x + scale * (px - eye_x);
+		py = eye_y + scale * (py - eye_y);
+	}
+	*out_px_x = disp_px_w / 2.0f + px * px_per_m_x;
+	*out_px_y = disp_px_h / 2.0f - py * px_per_m_y;
+}
+
+/*!
+ * Compute 4 projected corner positions (in SBS tile pixel coords) for a rotated window.
+ * Corners are ordered: TL(0,0), BL(0,1), TR(1,0), BR(1,1) matching the blit VS triangle strip.
+ *
+ * For identity orientation, falls back to axis-aligned rect (returns false).
+ * For non-identity, computes perspective-correct quad corners (returns true).
+ */
+static bool
+compute_projected_quad_corners(const struct d3d11_service_system *sys,
+                               const struct d3d11_multi_client_slot *slot,
+                               float eye_x, float eye_y, float eye_z,
+                               uint32_t tile_col, uint32_t tile_row,
+                               uint32_t half_w, uint32_t half_h,
+                               uint32_t ca_w, uint32_t ca_h,
+                               float out_corners[8])
+{
+	if (quat_is_identity(&slot->window_pose.orientation)) {
+		return false; // Use axis-aligned fast path
+	}
+
+	float disp_w_m = sys->base.info.display_width_m;
+	float disp_h_m = sys->base.info.display_height_m;
+	uint32_t disp_px_w = sys->base.info.display_pixel_width;
+	uint32_t disp_px_h = sys->base.info.display_pixel_height;
+	if (disp_w_m <= 0.0f || disp_h_m <= 0.0f || disp_px_w == 0 || disp_px_h == 0) {
+		disp_px_w = 3840; disp_px_h = 2160;
+		disp_w_m = 0.700f; disp_h_m = 0.394f;
+	}
+	float px_per_m_x = (float)disp_px_w / disp_w_m;
+	float px_per_m_y = (float)disp_px_h / disp_h_m;
+
+	float hw = slot->window_width_m / 2.0f;
+	float hh = slot->window_height_m / 2.0f;
+
+	// 4 corners in window-local space: TL, BL, TR, BR
+	struct xrt_vec3 local[4] = {
+		{-hw, +hh, 0}, // TL
+		{-hw, -hh, 0}, // BL
+		{+hw, +hh, 0}, // TR
+		{+hw, -hh, 0}, // BR
+	};
+
+	const struct xrt_quat *q = &slot->window_pose.orientation;
+	float wx = slot->window_pose.position.x;
+	float wy = slot->window_pose.position.y;
+	float wz = slot->window_pose.position.z;
+
+	for (int i = 0; i < 4; i++) {
+		// Rotate corner by orientation, then translate to world position
+		struct xrt_vec3 world;
+		math_quat_rotate_vec3(q, &local[i], &world);
+		world.x += wx;
+		world.y += wy;
+		world.z += wz;
+
+		// Project through eye to display plane (Z=0)
+		float dpx, dpy;
+		project_point_for_eye(world.x, world.y, world.z,
+		                      eye_x, eye_y, eye_z,
+		                      (float)disp_px_w, (float)disp_px_h,
+		                      px_per_m_x, px_per_m_y,
+		                      &dpx, &dpy);
+
+		// Convert to SBS tile pixel coordinates
+		float frac_x = dpx / (float)ca_w;
+		float frac_y = dpy / (float)ca_h;
+		out_corners[i * 2 + 0] = tile_col * half_w + frac_x * half_w;
+		out_corners[i * 2 + 1] = tile_row * half_h + frac_y * half_h;
+	}
+	return true;
+}
+
+/*!
+ * Project an arbitrary local-space rectangle through a rotated window pose + eye to SBS tile pixels.
+ * local coords: (-hw, -hh) = bottom-left, (+hw, +hh) = top-right, relative to window center.
+ * Output corners are in the same order as the blit VS: TL(0), BL(1), TR(2), BR(3).
+ */
+static void
+project_local_rect_for_eye(const struct d3d11_service_system *sys,
+                           const struct xrt_quat *orientation,
+                           float win_cx, float win_cy, float win_cz,
+                           float local_left, float local_top,
+                           float local_right, float local_bottom,
+                           float eye_x, float eye_y, float eye_z,
+                           uint32_t tile_col, uint32_t tile_row,
+                           uint32_t half_w, uint32_t half_h,
+                           uint32_t ca_w, uint32_t ca_h,
+                           float out_corners[8])
+{
+	float disp_w_m = sys->base.info.display_width_m;
+	float disp_h_m = sys->base.info.display_height_m;
+	uint32_t disp_px_w = sys->base.info.display_pixel_width;
+	uint32_t disp_px_h = sys->base.info.display_pixel_height;
+	if (disp_w_m <= 0.0f || disp_h_m <= 0.0f || disp_px_w == 0 || disp_px_h == 0) {
+		disp_px_w = 3840; disp_px_h = 2160;
+		disp_w_m = 0.700f; disp_h_m = 0.394f;
+	}
+	float px_per_m_x = (float)disp_px_w / disp_w_m;
+	float px_per_m_y = (float)disp_px_h / disp_h_m;
+
+	// 4 corners in window-local space: TL, BL, TR, BR
+	struct xrt_vec3 local[4] = {
+		{local_left,  local_top,    0},
+		{local_left,  local_bottom, 0},
+		{local_right, local_top,    0},
+		{local_right, local_bottom, 0},
+	};
+
+	for (int i = 0; i < 4; i++) {
+		struct xrt_vec3 world;
+		math_quat_rotate_vec3(orientation, &local[i], &world);
+		world.x += win_cx;
+		world.y += win_cy;
+		world.z += win_cz;
+
+		float dpx, dpy;
+		project_point_for_eye(world.x, world.y, world.z,
+		                      eye_x, eye_y, eye_z,
+		                      (float)disp_px_w, (float)disp_px_h,
+		                      px_per_m_x, px_per_m_y,
+		                      &dpx, &dpy);
+
+		float frac_x = dpx / (float)ca_w;
+		float frac_y = dpy / (float)ca_h;
+		out_corners[i * 2 + 0] = tile_col * half_w + frac_x * half_w;
+		out_corners[i * 2 + 1] = tile_row * half_h + frac_y * half_h;
+	}
+}
+
+/*!
+ * Helper: write quad corner data into a BlitConstants struct.
+ */
+static inline void
+blit_set_quad_corners(BlitConstants *cb, const float corners[8])
+{
+	cb->quad_mode = 1.0f;
+	cb->quad_corners_01[0] = corners[0]; // TL.x
+	cb->quad_corners_01[1] = corners[1]; // TL.y
+	cb->quad_corners_01[2] = corners[2]; // BL.x
+	cb->quad_corners_01[3] = corners[3]; // BL.y
+	cb->quad_corners_23[0] = corners[4]; // TR.x
+	cb->quad_corners_23[1] = corners[5]; // TR.y
+	cb->quad_corners_23[2] = corners[6]; // BR.x
+	cb->quad_corners_23[3] = corners[7]; // BR.y
 }
 
 /*!

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -6859,6 +6859,18 @@ comp_d3d11_service_create_system(struct xrt_device *xdev,
 		return XRT_ERROR_VULKAN;  // Generic graphics error
 	}
 
+	// Enable D3D11 multithread protection: multiple IPC client threads + render thread
+	// all share the same device. Without this, 3+ simultaneous clients crash (#108).
+	{
+		wil::com_ptr<ID3D11Multithread> mt;
+		if (device_base.try_query_to(mt.put())) {
+			mt->SetMultithreadProtected(TRUE);
+			U_LOG_W("D3D11 multithread protection enabled");
+		} else {
+			U_LOG_W("D3D11 multithread protection not available");
+		}
+	}
+
 	// Get ID3D11Device5 and ID3D11DeviceContext4 for shared resource support
 	if (!device_base.try_query_to(sys->device.put())) {
 		U_LOG_E("Device doesn't support ID3D11Device5");

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -594,6 +594,29 @@ struct d3d11_multi_compositor
 	//! Current layout preset (-1=none, 0-4=preset index). Used for TAB Z-reorder in Stack.
 	int32_t current_layout;
 
+	//! Dynamic layout state (carousel, orbital, helix, expose).
+	//! When mode >= 0, the layout continuously drives window poses each frame.
+	struct
+	{
+		int mode;                //!< -1=inactive, 0=carousel, 1=orbital, 2=helix, 3=expose
+		float angle_offset;      //!< Current rotation angle (radians)
+		float angular_velocity;  //!< Auto-rotation speed (rad/s)
+		bool user_dragging;      //!< Mouse is controlling rotation
+		float drag_start_angle;  //!< angle_offset when drag started
+		POINT drag_start_cursor; //!< Cursor position when drag started
+		uint64_t last_tick_ns;   //!< Last frame timestamp
+		float radius_m;          //!< Layout radius (meters)
+		float base_win_w;        //!< Base window width for this layout
+		float base_win_h;        //!< Base window height for this layout
+		int prev_layout;         //!< Layout before entering dynamic mode (for expose return)
+		// Momentum tracking for drag release
+		float prev_angle_offset; //!< Previous frame's angle_offset (for velocity calculation)
+		uint64_t prev_drag_ns;   //!< Previous frame's timestamp during drag
+		// Pause state: after TAB brings a window to front, pause auto-rotation
+		uint64_t pause_until_ns; //!< Auto-rotation paused until this timestamp (0 = not paused)
+		float target_angle;      //!< Target angle to animate toward (for TAB snap-to-front)
+	} dynamic_layout;
+
 	//! Hovered button: 0=none, 1=close, 2=minimize, for the hovered slot.
 	int hover_btn;
 	int hover_btn_slot;
@@ -3109,6 +3132,7 @@ multi_compositor_ensure_output(struct d3d11_service_system *sys)
 		sys->multi_comp = new d3d11_multi_compositor();
 		std::memset(sys->multi_comp, 0, sizeof(*sys->multi_comp));
 		sys->multi_comp->focused_slot = -1;
+		sys->multi_comp->dynamic_layout.mode = -1; // No dynamic layout at startup
 	}
 
 	struct d3d11_multi_compositor *mc = sys->multi_comp;
@@ -3648,9 +3672,291 @@ slot_animate_tick(struct d3d11_multi_client_slot *slot, uint64_t now_ns)
 	return slot->anim.active; // true = still running
 }
 
+//! Default auto-rotation speed for dynamic layouts (~10 deg/sec).
+#define DYNAMIC_ROTATION_SPEED 0.175f
+//! Friction coefficient for momentum deceleration after drag release.
+#define DYNAMIC_FRICTION 3.0f
+
+/*!
+ * Compute the maximum comfortable Z depth: ±1/5 of max(display_w, display_h).
+ * Windows should stay within this range for comfortable viewing on the lenticular display.
+ */
+static inline float
+compute_zmax(const struct d3d11_service_system *sys)
+{
+	float dw = sys->base.info.display_width_m;
+	float dh = sys->base.info.display_height_m;
+	if (dw <= 0.0f) dw = 0.700f;
+	if (dh <= 0.0f) dh = 0.394f;
+	return (dw > dh ? dw : dh) / 5.0f;
+}
+
+/*!
+ * Compute carousel window pose for a given window index and angle offset.
+ * Full 360° circle, front window near Z=0, back windows recede within ±zmax.
+ */
+static void
+carousel_compute_pose(int idx, int n, float angle_offset, float radius_m,
+                      float base_w, float base_h, float zmax,
+                      struct xrt_pose *out_pose, float *out_w, float *out_h)
+{
+	float base_angle = (2.0f * (float)M_PI / (float)n) * idx;
+	float world_angle = base_angle + angle_offset;
+
+	out_pose->position.x = sinf(world_angle) * radius_m;
+	// Map Z so front is at Z=0, back is at -zmax (not -2*radius)
+	float raw_depth = cosf(world_angle); // +1 = front, -1 = back
+	out_pose->position.z = (raw_depth - 1.0f) * zmax * 0.5f; // front=0, back=-zmax
+	out_pose->position.y = 0.0f;
+
+	// Depth-based scaling: front = full, back = 70%
+	float depth_t = (raw_depth + 1.0f) / 2.0f; // 0=back, 1=front
+	float scale = 0.70f + 0.30f * depth_t;
+
+	*out_w = base_w * scale;
+	*out_h = base_h * scale;
+
+	// Yaw to face center
+	out_pose->orientation = quat_from_yaw(-world_angle);
+}
+
+/*!
+ * Compute orbital window pose — elliptical orbits at different radii.
+ */
+static void
+orbital_compute_pose(int idx, int n, float angle_offset, float base_radius,
+                     float base_w, float base_h, int focused_idx, float zmax,
+                     struct xrt_pose *out_pose, float *out_w, float *out_h)
+{
+	// Focused window gets innermost orbit
+	int orbit_idx = idx;
+	if (idx == focused_idx) orbit_idx = 0;
+	else if (idx < focused_idx) orbit_idx = idx + 1;
+
+	float radius_step = 0.02f;
+	float orbit_radius = base_radius + orbit_idx * radius_step;
+	float orbit_speed = 1.0f / (1.0f + orbit_idx * 0.3f);
+	float angle = angle_offset * orbit_speed + (2.0f * (float)M_PI / (float)n) * idx;
+
+	out_pose->position.x = sinf(angle) * orbit_radius * 1.5f; // wider X
+	// Clamp Z within ±zmax
+	float raw_z = cosf(angle) * orbit_radius * 0.5f - base_radius * 0.3f;
+	if (raw_z < -zmax) raw_z = -zmax;
+	if (raw_z > zmax) raw_z = zmax;
+	out_pose->position.z = raw_z;
+	out_pose->position.y = 0.0f;
+
+	float scale = (orbit_idx == 0) ? 1.0f : (0.85f - orbit_idx * 0.05f);
+	if (scale < 0.5f) scale = 0.5f;
+	*out_w = base_w * scale;
+	*out_h = base_h * scale;
+
+	out_pose->orientation = quat_from_yaw(-angle * 0.5f);
+}
+
+/*!
+ * Compute helix window pose — vertical spiral staircase.
+ */
+static void
+helix_compute_pose(int idx, int n, float angle_offset, float radius_m,
+                   float base_w, float base_h, float zmax,
+                   struct xrt_pose *out_pose, float *out_w, float *out_h)
+{
+	float base_angle = (2.0f * (float)M_PI / (float)n) * idx;
+	float world_angle = base_angle + angle_offset;
+
+	out_pose->position.x = sinf(world_angle) * radius_m;
+	// Map Z within ±zmax like carousel
+	float raw_depth = cosf(world_angle);
+	out_pose->position.z = (raw_depth - 1.0f) * zmax * 0.5f;
+	// Vertical offset: gentle spiral pitch
+	float helix_pitch_m = 0.04f; // 4cm per revolution
+	float raw_y = helix_pitch_m * (world_angle / (2.0f * (float)M_PI));
+	float range = helix_pitch_m * 1.5f;
+	out_pose->position.y = fmodf(raw_y + range / 2.0f, range) - range / 2.0f;
+
+	// Depth-based scaling
+	float depth_t = (raw_depth + 1.0f) / 2.0f;
+	float scale = 0.65f + 0.35f * depth_t;
+	*out_w = base_w * scale;
+	*out_h = base_h * scale;
+
+	out_pose->orientation = quat_from_yaw(-world_angle);
+}
+
+/*!
+ * Compute expose (grid overview) window pose.
+ */
+static void
+expose_compute_pose(int idx, int n, float disp_w_m, float disp_h_m,
+                    struct xrt_pose *out_pose, float *out_w, float *out_h)
+{
+	int cols = (int)ceilf(sqrtf((float)n));
+	if (cols < 1) cols = 1;
+	int rows = (n + cols - 1) / cols;
+	int col = idx % cols;
+	int row = idx / cols;
+
+	float margin = 0.008f; // 8mm gap between windows
+	float total_w = disp_w_m * 0.85f;
+	float total_h = disp_h_m * 0.85f;
+	float cell_w = (total_w - (cols - 1) * margin) / cols;
+	float cell_h = (total_h - (rows - 1) * margin) / rows;
+
+	out_pose->position.x = (col - (cols - 1) / 2.0f) * (cell_w + margin);
+	out_pose->position.y = ((rows - 1) / 2.0f - row) * (cell_h + margin);
+	out_pose->position.z = -0.03f; // slightly behind display
+	out_pose->orientation.x = 0; out_pose->orientation.y = 0;
+	out_pose->orientation.z = 0; out_pose->orientation.w = 1;
+
+	*out_w = cell_w;
+	*out_h = cell_h;
+}
+
+/*!
+ * Tick the dynamic layout: update angle, compute poses, apply to all windows.
+ * Called every frame when dynamic_layout.mode >= 0.
+ */
+static void
+dynamic_layout_tick(struct d3d11_service_system *sys, struct d3d11_multi_compositor *mc, uint64_t now_ns)
+{
+	auto &dl = mc->dynamic_layout;
+	if (dl.mode < 0) return;
+
+	// Compute dt
+	float dt = 0.0f;
+	if (dl.last_tick_ns > 0) {
+		dt = (float)(now_ns - dl.last_tick_ns) / 1e9f;
+		if (dt > 0.1f) dt = 0.1f; // cap at 100ms to avoid jumps
+	}
+	dl.last_tick_ns = now_ns;
+
+	// Update angle: auto-rotation when not dragging
+	if (!dl.user_dragging && dl.mode != 3) { // expose doesn't rotate
+		bool paused = (dl.pause_until_ns > 0 && now_ns < dl.pause_until_ns);
+
+		if (paused) {
+			// Animate toward target angle (TAB snap-to-front), then hold
+			float diff = dl.target_angle - dl.angle_offset;
+			if (fabsf(diff) > 0.001f) {
+				// Ease toward target
+				float snap_speed = diff * 5.0f; // arrive quickly
+				dl.angle_offset += snap_speed * dt;
+				// Don't overshoot
+				if ((diff > 0 && dl.angle_offset > dl.target_angle) ||
+				    (diff < 0 && dl.angle_offset < dl.target_angle)) {
+					dl.angle_offset = dl.target_angle;
+				}
+			} else {
+				dl.angle_offset = dl.target_angle;
+			}
+			dl.angular_velocity = 0.0f;
+		} else {
+			dl.pause_until_ns = 0;
+			dl.angle_offset += dl.angular_velocity * dt;
+			// Apply friction (exponential decay)
+			float friction = DYNAMIC_FRICTION;
+			dl.angular_velocity *= expf(-friction * dt);
+			// Ease toward target auto-rotation speed
+			float target = DYNAMIC_ROTATION_SPEED;
+			float spd_diff = target - dl.angular_velocity;
+			dl.angular_velocity += spd_diff * (1.0f - expf(-1.0f * dt));
+		}
+	}
+
+	// Collect active windows
+	int active[D3D11_MULTI_MAX_CLIENTS];
+	int n = 0;
+	for (int i = 0; i < D3D11_MULTI_MAX_CLIENTS; i++) {
+		if (mc->clients[i].active && !mc->clients[i].minimized) {
+			active[n++] = i;
+		}
+	}
+	if (n == 0) return;
+
+	float disp_w_m = sys->base.info.display_width_m;
+	float disp_h_m = sys->base.info.display_height_m;
+	if (disp_w_m <= 0.0f) disp_w_m = 0.700f;
+	if (disp_h_m <= 0.0f) disp_h_m = 0.394f;
+
+	// Compute comfortable Z range: ±1/5 of max(display_w, display_h)
+	float zmax = compute_zmax(sys);
+
+	// Compute and apply poses for each window
+	for (int idx = 0; idx < n; idx++) {
+		int s = active[idx];
+		struct xrt_pose pose = {};
+		float w_m = 0, h_m = 0;
+
+		switch (dl.mode) {
+		case 0: // Carousel
+			carousel_compute_pose(idx, n, dl.angle_offset, dl.radius_m,
+			                      dl.base_win_w, dl.base_win_h, zmax, &pose, &w_m, &h_m);
+			break;
+		case 1: // Orbital
+			orbital_compute_pose(idx, n, dl.angle_offset, dl.radius_m,
+			                     dl.base_win_w, dl.base_win_h, mc->focused_slot, zmax,
+			                     &pose, &w_m, &h_m);
+			break;
+		case 2: // Helix
+			helix_compute_pose(idx, n, dl.angle_offset, dl.radius_m,
+			                   dl.base_win_w, dl.base_win_h, zmax, &pose, &w_m, &h_m);
+			break;
+		case 3: // Expose
+			expose_compute_pose(idx, n, disp_w_m, disp_h_m, &pose, &w_m, &h_m);
+			break;
+		}
+
+		mc->clients[s].window_pose = pose;
+		mc->clients[s].window_width_m = w_m;
+		mc->clients[s].window_height_m = h_m;
+		mc->clients[s].anim.active = false; // dynamic layout overrides animation
+
+		slot_pose_to_pixel_rect(sys, &mc->clients[s],
+		                        &mc->clients[s].window_rect_x,
+		                        &mc->clients[s].window_rect_y,
+		                        &mc->clients[s].window_rect_w,
+		                        &mc->clients[s].window_rect_h);
+		mc->clients[s].hwnd_resize_pending = true;
+	}
+}
+
+/*!
+ * Enter a dynamic layout mode. Initializes state and starts transition.
+ */
+static void
+enter_dynamic_layout(struct d3d11_service_system *sys, struct d3d11_multi_compositor *mc, int mode)
+{
+	float disp_w_m = sys->base.info.display_width_m;
+	float disp_h_m = sys->base.info.display_height_m;
+	if (disp_w_m <= 0.0f) disp_w_m = 0.700f;
+	if (disp_h_m <= 0.0f) disp_h_m = 0.394f;
+
+	// Un-minimize all windows
+	for (int i = 0; i < D3D11_MULTI_MAX_CLIENTS; i++) {
+		if (mc->clients[i].active) mc->clients[i].minimized = false;
+	}
+
+	mc->dynamic_layout.prev_layout = mc->current_layout;
+	mc->dynamic_layout.mode = mode;
+	mc->dynamic_layout.angle_offset = 0.0f;
+	mc->dynamic_layout.angular_velocity = (mode == 3) ? 0.0f : DYNAMIC_ROTATION_SPEED;
+	mc->dynamic_layout.user_dragging = false;
+	mc->dynamic_layout.last_tick_ns = os_monotonic_get_ns();
+	mc->dynamic_layout.radius_m = 0.12f; // 12cm default radius
+	mc->dynamic_layout.base_win_w = disp_w_m * 0.40f;
+	mc->dynamic_layout.base_win_h = disp_h_m * 0.40f;
+
+	mc->current_layout = 4 + mode; // 4=carousel, 5=orbital, 6=helix, 7=expose
+
+	const char *mode_names[] = {"carousel", "orbital", "helix", "expose"};
+	U_LOG_W("Multi-comp: dynamic layout → %s", mode_names[mode]);
+}
+
 /*!
  * Apply a layout preset to all active (non-minimized) windows.
- * layout_id: 0=side-by-side, 1=stacked, 2=theater, 3=stack, 4=carousel
+ * layout_id: 0=side-by-side, 1=stacked, 2=theater, 3=stack
+ * For dynamic layouts (carousel etc.), use enter_dynamic_layout() instead.
  */
 static void
 apply_layout(struct d3d11_service_system *sys, struct d3d11_multi_compositor *mc, int layout_id)
@@ -3675,6 +3981,7 @@ apply_layout(struct d3d11_service_system *sys, struct d3d11_multi_compositor *mc
 	if (layout_id < 0 || layout_id > 4) return;
 	U_LOG_W("Multi-comp: layout %s (%d windows)", layout_names[layout_id], n);
 	mc->current_layout = layout_id;
+	mc->dynamic_layout.mode = -1; // Exit dynamic mode when entering static layout
 
 	for (int idx = 0; idx < n; idx++) {
 		int s = active[idx];
@@ -3741,28 +4048,6 @@ apply_layout(struct d3d11_service_system *sys, struct d3d11_multi_compositor *mc
 				if (new_z < -0.02f) new_z = -0.02f;
 				new_x = idx * 0.005f;  // 5mm right per layer
 				new_y = -idx * 0.005f; // 5mm down per layer
-			}
-			break;
-		}
-
-		case 4: { // Carousel: semicircle arrangement
-			float radius_m = 0.15f; // 15cm semicircle radius
-			new_w = disp_w_m * 0.45f;
-			new_h = disp_h_m * 0.45f;
-			if (n == 1) {
-				new_x = 0; new_y = 0; new_z = 0.01f;
-			} else {
-				// Spread across a 60-degree arc centered on 0
-				float total_arc = (float)(60.0 * M_PI / 180.0);
-				float angle_step = total_arc / (float)(n - 1);
-				float angle = -total_arc / 2.0f + idx * angle_step;
-				new_x = sinf(angle) * radius_m;
-				new_z = (cosf(angle) - 1.0f) * radius_m * 0.5f; // slight Z variation
-				new_y = 0;
-				// Center window slightly forward
-				if (idx == n / 2) new_z += 0.01f;
-				// Yaw to face center
-				new_orient = quat_from_yaw(-angle * 0.6f);
 			}
 			break;
 		}
@@ -3876,6 +4161,33 @@ multi_compositor_render(struct d3d11_service_system *sys)
 			if (mc->current_layout == 3 && mc->focused_slot >= 0) {
 				apply_layout(sys, mc, 3);
 			}
+
+			// Dynamic carousel/orbital/helix: TAB rotates to bring focused window to front + pause 5s
+			if (mc->dynamic_layout.mode >= 0 && mc->dynamic_layout.mode <= 2 && mc->focused_slot >= 0) {
+				// Find the index of the focused slot among active windows
+				int active_idx = -1;
+				int n_active = 0;
+				for (int i = 0; i < D3D11_MULTI_MAX_CLIENTS; i++) {
+					if (mc->clients[i].active && !mc->clients[i].minimized) {
+						if (i == mc->focused_slot) active_idx = n_active;
+						n_active++;
+					}
+				}
+				if (active_idx >= 0 && n_active > 0) {
+					// Target angle: the angle_offset that places active_idx at the front (angle=0)
+					float base_angle = (2.0f * (float)M_PI / (float)n_active) * active_idx;
+					// We want base_angle + target_offset = 0 (mod 2π) → target_offset = -base_angle
+					float target = -base_angle;
+					// Find shortest rotation from current angle
+					float diff = target - mc->dynamic_layout.angle_offset;
+					// Normalize to [-π, π]
+					while (diff > (float)M_PI) diff -= 2.0f * (float)M_PI;
+					while (diff < -(float)M_PI) diff += 2.0f * (float)M_PI;
+					mc->dynamic_layout.target_angle = mc->dynamic_layout.angle_offset + diff;
+					mc->dynamic_layout.angular_velocity = diff * 3.0f; // arrive in ~0.33s
+					mc->dynamic_layout.pause_until_ns = os_monotonic_get_ns() + 5000000000ULL; // 5 seconds
+				}
+			}
 		}
 	}
 
@@ -3893,11 +4205,16 @@ multi_compositor_render(struct d3d11_service_system *sys)
 		}
 	}
 
-	// Layout presets: Ctrl+1-5 (1=SBS, 2=stacked, 3=theater, 4=stack, 5=carousel)
+	// Layout presets: Ctrl+1-4 static, Ctrl+5-8 dynamic
+	// 1=SBS, 2=stacked, 3=theater, 4=stack, 5=carousel, 6=orbital, 7=helix, 8=expose
 	if (GetAsyncKeyState(VK_CONTROL) & 0x8000) {
-		for (int k = '1'; k <= '5'; k++) {
+		for (int k = '1'; k <= '8'; k++) {
 			if (GetAsyncKeyState(k) & 1) {
-				apply_layout(sys, mc, k - '1');
+				if (k <= '4') {
+					apply_layout(sys, mc, k - '1');
+				} else {
+					enter_dynamic_layout(sys, mc, k - '5'); // 0=carousel, 1=orbital, 2=helix, 3=expose
+				}
 				break;
 			}
 		}
@@ -3958,6 +4275,105 @@ multi_compositor_render(struct d3d11_service_system *sys)
 		bool lmb_just_pressed = lmb_held && !mc->prev_lmb_held;
 		mc->prev_lmb_held = lmb_held;
 
+		// Dynamic layout drag: title bar LMB controls carousel rotation.
+		// Content clicks/drags pause rotation and forward to app normally.
+		if (mc->dynamic_layout.mode >= 0 && mc->dynamic_layout.mode != 3) {
+			if (lmb_just_pressed) {
+				POINT pt;
+				GetCursorPos(&pt);
+				ScreenToClient(mc->hwnd, &pt);
+				struct shell_hit_result hit = shell_raycast_hit_test(sys, mc, pt);
+				// Close/minimize/background/taskbar → normal handler
+				if (hit.slot < 0 || hit.in_close_btn || hit.in_minimize_btn) {
+					goto normal_lmb_handling;
+				}
+				// Content click → pause rotation, focus window.
+				// Mouse events forwarded to app via WndProc input forwarding.
+				if (hit.in_content) {
+					mc->dynamic_layout.angular_velocity = 0.0f;
+					mc->dynamic_layout.pause_until_ns = UINT64_MAX; // pause until release
+					if (hit.slot != mc->focused_slot) {
+						mc->focused_slot = hit.slot;
+						multi_compositor_update_input_forward(mc);
+					}
+				}
+				// Only title bar drag controls carousel rotation
+				if (hit.slot >= 0 && hit.in_title_bar) {
+					// Start drag: capture angle + cursor
+					mc->dynamic_layout.user_dragging = true;
+					mc->dynamic_layout.drag_start_angle = mc->dynamic_layout.angle_offset;
+					mc->dynamic_layout.drag_start_cursor = pt;
+					mc->dynamic_layout.prev_angle_offset = mc->dynamic_layout.angle_offset;
+					mc->dynamic_layout.prev_drag_ns = os_monotonic_get_ns();
+					mc->dynamic_layout.angular_velocity = 0.0f; // stop auto-rotation
+					mc->dynamic_layout.pause_until_ns = 0; // cancel any TAB pause
+					// Focus the clicked window
+					if (hit.slot != mc->focused_slot) {
+						mc->focused_slot = hit.slot;
+						multi_compositor_update_input_forward(mc);
+					}
+				}
+			} else if (lmb_held && mc->dynamic_layout.user_dragging) {
+				// Drag in progress: update angle from horizontal mouse delta
+				POINT pt;
+				GetCursorPos(&pt);
+				ScreenToClient(mc->hwnd, &pt);
+				float dx_px = (float)(pt.x - mc->dynamic_layout.drag_start_cursor.x);
+				// Sensitivity: ~1 radian per half-display-width
+				float disp_px_w = (float)sys->base.info.display_pixel_width;
+				if (disp_px_w <= 0) disp_px_w = 3840;
+				float sensitivity = 2.0f / disp_px_w; // radians per pixel
+				mc->dynamic_layout.angle_offset = mc->dynamic_layout.drag_start_angle + dx_px * sensitivity;
+				// Track velocity for momentum
+				uint64_t now = os_monotonic_get_ns();
+				float drag_dt = (float)(now - mc->dynamic_layout.prev_drag_ns) / 1e9f;
+				if (drag_dt > 0.001f) {
+					float dangle = mc->dynamic_layout.angle_offset - mc->dynamic_layout.prev_angle_offset;
+					mc->dynamic_layout.angular_velocity = dangle / drag_dt;
+					mc->dynamic_layout.prev_angle_offset = mc->dynamic_layout.angle_offset;
+					mc->dynamic_layout.prev_drag_ns = now;
+				}
+			} else if (!lmb_held && mc->dynamic_layout.user_dragging) {
+				// Release: resume with momentum (angular_velocity already set from tracking)
+				mc->dynamic_layout.user_dragging = false;
+				// Clamp momentum to reasonable range
+				if (mc->dynamic_layout.angular_velocity > 3.0f) mc->dynamic_layout.angular_velocity = 3.0f;
+				if (mc->dynamic_layout.angular_velocity < -3.0f) mc->dynamic_layout.angular_velocity = -3.0f;
+			}
+			// When LMB released in dynamic mode: resume rotation after 3s pause
+			if (!lmb_held && !mc->dynamic_layout.user_dragging &&
+			    mc->dynamic_layout.pause_until_ns == UINT64_MAX) {
+				mc->dynamic_layout.pause_until_ns = os_monotonic_get_ns() + 3000000000ULL;
+				mc->dynamic_layout.target_angle = mc->dynamic_layout.angle_offset;
+			}
+			// Only skip normal LMB handling when actively carousel-dragging
+			if (mc->dynamic_layout.user_dragging) {
+				goto after_lmb_handling;
+			}
+		}
+
+		// Expose click: click a window to select it and return to previous layout
+		if (mc->dynamic_layout.mode == 3 && lmb_just_pressed) {
+			POINT pt;
+			GetCursorPos(&pt);
+			ScreenToClient(mc->hwnd, &pt);
+			struct shell_hit_result hit = shell_raycast_hit_test(sys, mc, pt);
+			if (hit.slot >= 0) {
+				mc->focused_slot = hit.slot;
+				multi_compositor_update_input_forward(mc);
+				// Return to previous layout
+				int prev = mc->dynamic_layout.prev_layout;
+				mc->dynamic_layout.mode = -1;
+				if (prev >= 0 && prev <= 3) {
+					apply_layout(sys, mc, prev);
+				} else {
+					apply_layout(sys, mc, 0); // fallback to SBS
+				}
+			}
+			goto after_lmb_handling;
+		}
+
+		normal_lmb_handling:
 		if (lmb_just_pressed && !mc->title_drag.active && !mc->resize.active) {
 			POINT pt;
 			GetCursorPos(&pt);
@@ -4240,6 +4656,20 @@ multi_compositor_render(struct d3d11_service_system *sys)
 			}
 		}
 	}
+	after_lmb_handling:
+
+	// Scroll in dynamic mode: adjust radius
+	if (mc->dynamic_layout.mode >= 0 && mc->dynamic_layout.mode != 3) {
+		if (mc->window != nullptr) {
+			int32_t scroll = comp_d3d11_window_consume_scroll(mc->window);
+			if (scroll != 0) {
+				float delta = (float)scroll / (120.0f * 20.0f); // ~5% per notch
+				mc->dynamic_layout.radius_m *= (1.0f + delta);
+				if (mc->dynamic_layout.radius_m < 0.05f) mc->dynamic_layout.radius_m = 0.05f;
+				if (mc->dynamic_layout.radius_m > 0.30f) mc->dynamic_layout.radius_m = 0.30f;
+			}
+		}
+	}
 
 	// Right-click: title bar RMB drag = rotation, content RMB = focus + forward to app.
 	// Call GetAsyncKeyState ONCE to avoid consuming the & 1 press bit (Phase 2 lesson #4).
@@ -4434,13 +4864,21 @@ multi_compositor_render(struct d3d11_service_system *sys)
 	(void)display_w_m;
 	(void)display_h_m;
 
-	// Tick animations: smoothly interpolate window poses toward targets.
-	{
+	// Tick dynamic layout (carousel/orbital/helix/expose) — continuously drives window poses.
+	if (mc->dynamic_layout.mode >= 0) {
+		dynamic_layout_tick(sys, mc, os_monotonic_get_ns());
+		// Update input forwarding rect every frame — windows move continuously
+		// in dynamic mode, so the forwarding rect from focus-change is stale.
+		multi_compositor_update_input_forward(mc);
+	}
+
+	// Tick per-slot animations (for static layout transitions + entry animations).
+	// Skipped when dynamic layout is active (it drives poses directly).
+	if (mc->dynamic_layout.mode < 0) {
 		uint64_t anim_now = os_monotonic_get_ns();
 		for (int s = 0; s < D3D11_MULTI_MAX_CLIENTS; s++) {
 			if (!mc->clients[s].active || !mc->clients[s].anim.active) continue;
 			bool still_running = slot_animate_tick(&mc->clients[s], anim_now);
-			// Recompute pixel rect from interpolated pose
 			slot_pose_to_pixel_rect(sys, &mc->clients[s],
 			                        &mc->clients[s].window_rect_x,
 			                        &mc->clients[s].window_rect_y,
@@ -4489,18 +4927,26 @@ multi_compositor_render(struct d3d11_service_system *sys)
 	}
 
 	// Copy client atlas → combined atlas, crop to content dims, send to DP.
-	// Render focused slot LAST so it draws on top of overlapping windows.
-	// Build a render order: non-focused first, focused last.
+	// Render order: back-to-front by Z depth (painter's algorithm).
+	// Windows farther from viewer (lower Z) render first, closer windows on top.
 	int render_order[D3D11_MULTI_MAX_CLIENTS];
 	int render_count = 0;
 	for (int s = 0; s < D3D11_MULTI_MAX_CLIENTS; s++) {
-		if (mc->clients[s].active && !mc->clients[s].minimized && s != mc->focused_slot) {
+		if (mc->clients[s].active && !mc->clients[s].minimized) {
 			render_order[render_count++] = s;
 		}
 	}
-	if (mc->focused_slot >= 0 && mc->focused_slot < D3D11_MULTI_MAX_CLIENTS &&
-	    mc->clients[mc->focused_slot].active && !mc->clients[mc->focused_slot].minimized) {
-		render_order[render_count++] = mc->focused_slot;
+	// Sort by Z ascending (farthest first → closest last = on top)
+	for (int i = 0; i < render_count - 1; i++) {
+		for (int j = i + 1; j < render_count; j++) {
+			float zi = mc->clients[render_order[i]].window_pose.position.z;
+			float zj = mc->clients[render_order[j]].window_pose.position.z;
+			if (zi > zj) {
+				int tmp = render_order[i];
+				render_order[i] = render_order[j];
+				render_order[j] = tmp;
+			}
+		}
 	}
 
 	uint32_t dp_view_w = sys->view_width;
@@ -4885,140 +5331,101 @@ multi_compositor_render(struct d3d11_service_system *sys)
 				}
 			}
 		}
-	}
 
-	// (Title bar rendering is now inside the render_order loop above for correct z-ordering)
+		// Draw cyan focus border for this slot if focused (inside render_order loop for Z-depth ordering)
+		if (s == mc->focused_slot && sys->blit_vs && sys->blit_ps) {
+			bool fb_rotated = !quat_is_identity(&mc->clients[s].window_pose.orientation);
+			float fb_hw = mc->clients[s].window_width_m / 2.0f;
+			float fb_hh = mc->clients[s].window_height_m / 2.0f;
+			float fb_tb_h = UI_TITLE_BAR_H_M;
+			float disp_w_m_fb = sys->base.info.display_width_m;
+			if (disp_w_m_fb <= 0.0f) disp_w_m_fb = 0.700f;
+			float bw_m = 3.0f * disp_w_m_fb / (float)(ca_w > 0 ? ca_w : 3840);
+			float bw = 3.0f;
 
-	// Draw cyan focus border around the focused app's window rect
-	if (mc->focused_slot >= 0 && mc->focused_slot < D3D11_MULTI_MAX_CLIENTS &&
-	    mc->clients[mc->focused_slot].active && sys->blit_vs && sys->blit_ps) {
-		uint32_t ca_w = sys->base.info.display_pixel_width;
-		uint32_t ca_h = sys->base.info.display_pixel_height;
-		if (ca_w == 0) ca_w = 3840;
-		if (ca_h == 0) ca_h = 2160;
-		uint32_t half_w = ca_w / sys->tile_columns;
-		uint32_t half_h = ca_h / sys->tile_rows;
-
-		int fs = mc->focused_slot;
-		bool fb_rotated = !quat_is_identity(&mc->clients[fs].window_pose.orientation);
-		float fb_hw = mc->clients[fs].window_width_m / 2.0f;
-		float fb_hh = mc->clients[fs].window_height_m / 2.0f;
-		float fb_tb_h = UI_TITLE_BAR_H_M;
-		// Border width in meters (~0.55mm, from 3px at typical display resolution)
-		float disp_w_m_fb = sys->base.info.display_width_m;
-		if (disp_w_m_fb <= 0.0f) disp_w_m_fb = 0.700f;
-		float bw_m = 3.0f * disp_w_m_fb / (float)(ca_w > 0 ? ca_w : 3840);
-		float bw = 3.0f; // border width in pixels (for non-rotated)
-
-		// Per-eye projected rects for non-rotated fallback
-		int32_t fb_eye_x[2], fb_eye_y[2], fb_eye_w[2], fb_eye_h[2];
-		for (int eye = 0; eye < 2; eye++) {
-			int ei = (eye < (int)eye_pos.count) ? eye : 0;
-			slot_pose_to_pixel_rect_for_eye(sys, &mc->clients[fs],
-			    eye_pos.eyes[ei].x, eye_pos.eyes[ei].y, eye_pos.eyes[ei].z,
-			    &fb_eye_x[eye], &fb_eye_y[eye],
-			    &fb_eye_w[eye], &fb_eye_h[eye]);
-		}
-
-		// Set up pipeline
-		ID3D11RenderTargetView *ca_rtvs[] = {mc->combined_atlas_rtv.get()};
-		sys->context->OMSetRenderTargets(1, ca_rtvs, nullptr);
-		sys->context->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
-		sys->context->IASetInputLayout(nullptr);
-		sys->context->RSSetState(sys->rasterizer_state.get());
-		sys->context->OMSetDepthStencilState(sys->depth_disabled.get(), 0);
-		sys->context->VSSetShader(sys->blit_vs.get(), nullptr, 0);
-		sys->context->PSSetShader(sys->blit_ps.get(), nullptr, 0);
-		sys->context->VSSetConstantBuffers(0, 1, sys->blit_constant_buffer.addressof());
-		sys->context->PSSetConstantBuffers(0, 1, sys->blit_constant_buffer.addressof());
-		sys->context->PSSetSamplers(0, 1, sys->sampler_linear.addressof());
-
-		// Full border rect in local space: content + title bar
-		// left=-hw, right=+hw, bottom=-hh, top=+hh+tb_h
-		// 4 border edge rects in local space (thin strips)
-		struct { float l, t, r, b; } border_edges_local[4] = {
-			{-fb_hw,        fb_hh+fb_tb_h,        fb_hw,        fb_hh+fb_tb_h-bw_m}, // top
-			{-fb_hw,        -fb_hh+bw_m,           fb_hw,        -fb_hh},              // bottom
-			{-fb_hw,        fb_hh+fb_tb_h-bw_m,   -fb_hw+bw_m,  -fb_hh+bw_m},        // left
-			{fb_hw-bw_m,    fb_hh+fb_tb_h-bw_m,   fb_hw,        -fb_hh+bw_m},         // right
-		};
-
-		uint32_t nv = sys->tile_columns * sys->tile_rows;
-		for (uint32_t v = 0; v < nv && v < XRT_MAX_VIEWS; v++) {
-			uint32_t col = v % sys->tile_columns;
-			uint32_t row = v / sys->tile_columns;
-			int fb_ei = (col < 2) ? (int)col : 0;
-			int ei_fb = (fb_ei < (int)eye_pos.count) ? fb_ei : 0;
-
-			D3D11_RECT border_scissor;
-			border_scissor.left = (LONG)(col * half_w);
-			border_scissor.top = (LONG)(row * half_h);
-			border_scissor.right = (LONG)((col + 1) * half_w);
-			border_scissor.bottom = (LONG)((row + 1) * half_h);
-			sys->context->RSSetScissorRects(1, &border_scissor);
-
-			// Non-rotated axis-aligned edge positions (fallback)
-			int32_t border_y = fb_eye_y[fb_ei] - TITLE_BAR_HEIGHT_PX;
-			int32_t border_h = fb_eye_h[fb_ei] + (fb_eye_y[fb_ei] - border_y);
-			float fx = (float)fb_eye_x[fb_ei] / ca_w;
-			float fy = (float)border_y / ca_h;
-			float fw = (float)fb_eye_w[fb_ei] / ca_w;
-			float fh = (float)border_h / ca_h;
-			float ox = col * half_w + fx * half_w;
-			float oy = row * half_h + fy * half_h;
-			float ew = fw * half_w;
-			float eh = fh * half_h;
-			struct { float x, y, w, h; } edges_aa[4] = {
-				{ox,          oy,          ew,  bw},
-				{ox,          oy + eh - bw, ew, bw},
-				{ox,          oy + bw,      bw,  eh - 2*bw},
-				{ox + ew - bw, oy + bw,     bw,  eh - 2*bw},
+			struct { float l, t, r, b; } border_edges_local[4] = {
+				{-fb_hw,        fb_hh+fb_tb_h,        fb_hw,        fb_hh+fb_tb_h-bw_m},
+				{-fb_hw,        -fb_hh+bw_m,           fb_hw,        -fb_hh},
+				{-fb_hw,        fb_hh+fb_tb_h-bw_m,   -fb_hw+bw_m,  -fb_hh+bw_m},
+				{fb_hw-bw_m,    fb_hh+fb_tb_h-bw_m,   fb_hw,        -fb_hh+bw_m},
 			};
 
-			D3D11_VIEWPORT vp = {};
-			vp.Width = (float)ca_w; vp.Height = (float)ca_h; vp.MaxDepth = 1.0f;
-			sys->context->RSSetViewports(1, &vp);
+			sys->context->VSSetShader(sys->blit_vs.get(), nullptr, 0);
+			sys->context->PSSetShader(sys->blit_ps.get(), nullptr, 0);
+			sys->context->VSSetConstantBuffers(0, 1, sys->blit_constant_buffer.addressof());
+			sys->context->PSSetConstantBuffers(0, 1, sys->blit_constant_buffer.addressof());
+			sys->context->PSSetSamplers(0, 1, sys->sampler_linear.addressof());
+			sys->context->OMSetBlendState(sys->blend_opaque.get(), nullptr, 0xFFFFFFFF);
 
-			for (int e = 0; e < 4; e++) {
-				D3D11_MAPPED_SUBRESOURCE mapped;
-				if (FAILED(sys->context->Map(sys->blit_constant_buffer.get(), 0,
-				           D3D11_MAP_WRITE_DISCARD, 0, &mapped))) continue;
-				BlitConstants *cb = static_cast<BlitConstants *>(mapped.pData);
-				cb->src_rect[0] = 0.0f; cb->src_rect[1] = 1.0f;
-				cb->src_rect[2] = 1.0f; cb->src_rect[3] = 1.0f;
-				cb->src_size[0] = 1; cb->src_size[1] = 1;
-				cb->dst_size[0] = (float)ca_w; cb->dst_size[1] = (float)ca_h;
-				cb->convert_srgb = 2.0f;
-				cb->padding2[0] = 0; cb->padding2[1] = 0;
+			for (uint32_t bv = 0; bv < num_views && bv < XRT_MAX_VIEWS; bv++) {
+				uint32_t bcol = bv % sys->tile_columns;
+				uint32_t brow = bv / sys->tile_columns;
+				int bei = (bcol < 2) ? (int)bcol : 0;
+				int bei2 = (bei < (int)eye_pos.count) ? bei : 0;
 
-				if (fb_rotated) {
-					float corners[8], corner_w[4];
-					project_local_rect_for_eye(sys,
-					    &mc->clients[fs].window_pose.orientation,
-					    mc->clients[fs].window_pose.position.x,
-					    mc->clients[fs].window_pose.position.y,
-					    mc->clients[fs].window_pose.position.z,
-					    border_edges_local[e].l, border_edges_local[e].t,
-					    border_edges_local[e].r, border_edges_local[e].b,
-					    eye_pos.eyes[ei_fb].x, eye_pos.eyes[ei_fb].y, eye_pos.eyes[ei_fb].z,
-					    col, row, half_w, half_h, ca_w, ca_h, corners, corner_w);
-					blit_set_quad_corners(cb, corners, corner_w);
-					cb->dst_offset[0] = 0; cb->dst_offset[1] = 0;
-					cb->dst_rect_wh[0] = 0; cb->dst_rect_wh[1] = 0;
-				} else {
-					cb->quad_mode = 0;
-					cb->dst_offset[0] = edges_aa[e].x;
-					cb->dst_offset[1] = edges_aa[e].y;
-					cb->dst_rect_wh[0] = edges_aa[e].w;
-					cb->dst_rect_wh[1] = edges_aa[e].h;
-					memset(cb->quad_corners_01, 0, sizeof(cb->quad_corners_01));
-					memset(cb->quad_corners_23, 0, sizeof(cb->quad_corners_23));
+				D3D11_RECT bsc;
+				bsc.left = (LONG)(bcol * half_w); bsc.top = (LONG)(brow * half_h);
+				bsc.right = (LONG)((bcol+1) * half_w); bsc.bottom = (LONG)((brow+1) * half_h);
+				sys->context->RSSetScissorRects(1, &bsc);
+
+				// Non-rotated fallback positions
+				int32_t brd_y = eye_rect_y[bei] - TITLE_BAR_HEIGHT_PX;
+				int32_t brd_h = eye_rect_h[bei] + (eye_rect_y[bei] - brd_y);
+				float bfx = (float)eye_rect_x[bei] / ca_w;
+				float bfy = (float)brd_y / ca_h;
+				float bfw = (float)eye_rect_w[bei] / ca_w;
+				float bfh = (float)brd_h / ca_h;
+				float box = bcol * half_w + bfx * half_w;
+				float boy = brow * half_h + bfy * half_h;
+				float bew = bfw * half_w;
+				float beh = bfh * half_h;
+				struct { float x, y, w, h; } edges_aa[4] = {
+					{box,          boy,          bew, bw},
+					{box,          boy+beh-bw,   bew, bw},
+					{box,          boy+bw,       bw,  beh-2*bw},
+					{box+bew-bw,   boy+bw,       bw,  beh-2*bw},
+				};
+
+				D3D11_VIEWPORT bvp = {};
+				bvp.Width = (float)ca_w; bvp.Height = (float)ca_h; bvp.MaxDepth = 1.0f;
+				sys->context->RSSetViewports(1, &bvp);
+
+				for (int e = 0; e < 4; e++) {
+					D3D11_MAPPED_SUBRESOURCE mapped;
+					if (FAILED(sys->context->Map(sys->blit_constant_buffer.get(), 0,
+					           D3D11_MAP_WRITE_DISCARD, 0, &mapped))) continue;
+					BlitConstants *cb = static_cast<BlitConstants *>(mapped.pData);
+					cb->src_rect[0] = 0; cb->src_rect[1] = 1; cb->src_rect[2] = 1; cb->src_rect[3] = 1;
+					cb->src_size[0] = 1; cb->src_size[1] = 1;
+					cb->dst_size[0] = (float)ca_w; cb->dst_size[1] = (float)ca_h;
+					cb->convert_srgb = 2.0f; cb->padding2[0] = 0; cb->padding2[1] = 0;
+					if (fb_rotated) {
+						float corners[8], cw[4];
+						project_local_rect_for_eye(sys, &mc->clients[s].window_pose.orientation,
+						    mc->clients[s].window_pose.position.x, mc->clients[s].window_pose.position.y,
+						    mc->clients[s].window_pose.position.z,
+						    border_edges_local[e].l, border_edges_local[e].t,
+						    border_edges_local[e].r, border_edges_local[e].b,
+						    eye_pos.eyes[bei2].x, eye_pos.eyes[bei2].y, eye_pos.eyes[bei2].z,
+						    bcol, brow, half_w, half_h, ca_w, ca_h, corners, cw);
+						blit_set_quad_corners(cb, corners, cw);
+						cb->dst_offset[0] = 0; cb->dst_offset[1] = 0;
+						cb->dst_rect_wh[0] = 0; cb->dst_rect_wh[1] = 0;
+					} else {
+						cb->quad_mode = 0;
+						cb->dst_offset[0] = edges_aa[e].x; cb->dst_offset[1] = edges_aa[e].y;
+						cb->dst_rect_wh[0] = edges_aa[e].w; cb->dst_rect_wh[1] = edges_aa[e].h;
+						memset(cb->quad_corners_01, 0, sizeof(cb->quad_corners_01));
+						memset(cb->quad_corners_23, 0, sizeof(cb->quad_corners_23));
+					}
+					sys->context->Unmap(sys->blit_constant_buffer.get(), 0);
+					sys->context->Draw(4, 0);
 				}
-				sys->context->Unmap(sys->blit_constant_buffer.get(), 0);
-				sys->context->Draw(4, 0);
 			}
 		}
 	}
+
+	// (Title bar + focus border rendering is inside the render_order loop for correct z-ordering)
 
 	// Reset scissor to full atlas for non-tiled draws (taskbar, DP processing)
 	{

--- a/src/xrt/compositor/d3d11_service/d3d11_service_shaders.h
+++ b/src/xrt/compositor/d3d11_service/d3d11_service_shaders.h
@@ -468,28 +468,34 @@ float4 PSMain(VS_OUTPUT input) : SV_Target
 //! Constant buffer layout for projection blit (SRGB conversion)
 struct BlitConstants
 {
-	float src_rect[4];      // x, y, width, height in pixels
-	float dst_offset[2];    // x, y destination offset in pixels
-	float src_size[2];      // source texture size
-	float dst_size[2];      // destination texture size
-	float convert_srgb;     // 1.0 if source is SRGB, 0.0 otherwise
-	float padding;
+	float src_rect[4];       // x, y, width, height in pixels
+	float dst_offset[2];     // x, y destination offset in pixels
+	float src_size[2];       // source texture size
+	float dst_size[2];       // destination texture size
+	float convert_srgb;      // 1.0 if source is SRGB, 0.0 otherwise; 2.0 = solid color mode
+	float quad_mode;         // > 0.5: use quad_corners instead of dst_offset + dst_rect_wh
 	float dst_rect_wh[2];   // destination quad width, height (0 = use src_rect.zw)
 	float padding2[2];
+	// Perspective quad corners packed as two float4s (avoids HLSL array padding).
+	// TL = top-left, BL = bottom-left, TR = top-right, BR = bottom-right.
+	float quad_corners_01[4]; // [TL.x, TL.y, BL.x, BL.y]
+	float quad_corners_23[4]; // [TR.x, TR.y, BR.x, BR.y]
 };
 
 //! Vertex shader for projection blit - draws a quad at specified destination
 static const char *blit_vs_hlsl = R"(
 cbuffer BlitCB : register(b0)
 {
-    float4 src_rect;      // x, y, width, height in pixels
-    float2 dst_offset;    // x, y destination offset in pixels
-    float2 src_size;      // source texture size
-    float2 dst_size;      // destination texture size
-    float convert_srgb;   // 1.0 if source is SRGB
-    float padding;
+    float4 src_rect;       // x, y, width, height in pixels
+    float2 dst_offset;     // x, y destination offset in pixels
+    float2 src_size;       // source texture size
+    float2 dst_size;       // destination texture size
+    float convert_srgb;    // 1.0 if source is SRGB; 2.0 = solid color mode
+    float quad_mode;       // > 0.5: use quad_corners for perspective quad
     float2 dst_rect_wh;   // destination quad width, height (0 = use src_rect.zw)
     float2 padding2;
+    float4 quad_corners_01; // TL.xy, BL.xy (packed as float4 to avoid HLSL array padding)
+    float4 quad_corners_23; // TR.xy, BR.xy
 };
 
 struct VS_OUTPUT
@@ -498,7 +504,7 @@ struct VS_OUTPUT
     float2 uv : TEXCOORD0;
 };
 
-// Fullscreen quad positions
+// Quad vertex positions (also used as UV coords): TL, BL, TR, BR
 static const float2 positions[4] = {
     float2(0, 0),
     float2(0, 1),
@@ -511,12 +517,24 @@ VS_OUTPUT VSMain(uint vertex_id : SV_VertexID)
     VS_OUTPUT output;
 
     float2 uv = positions[vertex_id % 4];
+    uint vid = vertex_id % 4;
 
-    // Destination quad size: use dst_rect_wh if set, else src_rect.zw (1:1)
-    float2 quad_size = (dst_rect_wh.x > 0) ? dst_rect_wh : src_rect.zw;
-
-    // Calculate destination position in NDC
-    float2 dst_pos = dst_offset + uv * quad_size;
+    float2 dst_pos;
+    if (quad_mode > 0.5) {
+        // Perspective quad mode: use pre-projected corner positions.
+        // Unpack from two float4s: TL=01.xy, BL=01.zw, TR=23.xy, BR=23.zw
+        float2 corners[4] = {
+            quad_corners_01.xy,  // TL (vertex 0)
+            quad_corners_01.zw,  // BL (vertex 1)
+            quad_corners_23.xy,  // TR (vertex 2)
+            quad_corners_23.zw   // BR (vertex 3)
+        };
+        dst_pos = corners[vid];
+    } else {
+        // Axis-aligned mode (existing path)
+        float2 quad_size = (dst_rect_wh.x > 0) ? dst_rect_wh : src_rect.zw;
+        dst_pos = dst_offset + uv * quad_size;
+    }
 
     // Convert to NDC [-1, 1]
     float2 ndc = (dst_pos / dst_size) * 2.0 - 1.0;
@@ -541,9 +559,11 @@ cbuffer BlitCB : register(b0)
     float2 src_size;
     float2 dst_size;
     float convert_srgb;
-    float padding;
+    float quad_mode;
     float2 dst_rect_wh;
     float2 padding2;
+    float4 quad_corners_01;
+    float4 quad_corners_23;
 };
 
 Texture2D src_tex : register(t0);

--- a/src/xrt/compositor/d3d11_service/d3d11_service_shaders.h
+++ b/src/xrt/compositor/d3d11_service/d3d11_service_shaders.h
@@ -480,6 +480,11 @@ struct BlitConstants
 	// TL = top-left, BL = bottom-left, TR = top-right, BR = bottom-right.
 	float quad_corners_01[4]; // [TL.x, TL.y, BL.x, BL.y]
 	float quad_corners_23[4]; // [TR.x, TR.y, BR.x, BR.y]
+	// Per-corner W for perspective-correct UV interpolation.
+	// W = depth from eye to corner (eye_z - corner_z). Required because
+	// projecting a 3D quad to 2D produces a trapezoid — linear UV interpolation
+	// distorts straight lines without perspective correction.
+	float quad_w[4];          // [TL_w, BL_w, TR_w, BR_w]
 };
 
 //! Vertex shader for projection blit - draws a quad at specified destination
@@ -496,6 +501,7 @@ cbuffer BlitCB : register(b0)
     float2 padding2;
     float4 quad_corners_01; // TL.xy, BL.xy (packed as float4 to avoid HLSL array padding)
     float4 quad_corners_23; // TR.xy, BR.xy
+    float4 quad_w;          // per-corner W for perspective-correct interpolation: TL, BL, TR, BR
 };
 
 struct VS_OUTPUT
@@ -520,6 +526,7 @@ VS_OUTPUT VSMain(uint vertex_id : SV_VertexID)
     uint vid = vertex_id % 4;
 
     float2 dst_pos;
+    float w = 1.0;
     if (quad_mode > 0.5) {
         // Perspective quad mode: use pre-projected corner positions.
         // Unpack from two float4s: TL=01.xy, BL=01.zw, TR=23.xy, BR=23.zw
@@ -529,7 +536,9 @@ VS_OUTPUT VSMain(uint vertex_id : SV_VertexID)
             quad_corners_23.xy,  // TR (vertex 2)
             quad_corners_23.zw   // BR (vertex 3)
         };
+        float ws[4] = { quad_w.x, quad_w.y, quad_w.z, quad_w.w };
         dst_pos = corners[vid];
+        w = ws[vid];
     } else {
         // Axis-aligned mode (existing path)
         float2 quad_size = (dst_rect_wh.x > 0) ? dst_rect_wh : src_rect.zw;
@@ -540,7 +549,10 @@ VS_OUTPUT VSMain(uint vertex_id : SV_VertexID)
     float2 ndc = (dst_pos / dst_size) * 2.0 - 1.0;
     ndc.y = -ndc.y;  // Flip Y for D3D
 
-    output.position = float4(ndc, 0.0, 1.0);
+    // Set w for perspective-correct UV interpolation.
+    // w=1 for axis-aligned (affine), w=depth for perspective quads.
+    // D3D11 rasterizer automatically divides interpolated attributes by w.
+    output.position = float4(ndc * w, 0.0, w);
 
     // Calculate source UV — always from src_rect (independent of dest size)
     float2 src_pos = src_rect.xy + uv * src_rect.zw;
@@ -564,6 +576,7 @@ cbuffer BlitCB : register(b0)
     float2 padding2;
     float4 quad_corners_01;
     float4 quad_corners_23;
+    float4 quad_w;
 };
 
 Texture2D src_tex : register(t0);

--- a/src/xrt/include/xrt/xrt_display_metrics.h
+++ b/src/xrt/include/xrt/xrt_display_metrics.h
@@ -16,6 +16,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "xrt_defines.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -85,6 +86,12 @@ struct xrt_window_metrics
 	float window_height_m;          //!< Window physical height (meters)
 	float window_center_offset_x_m; //!< Window center offset from display center (meters, +right)
 	float window_center_offset_y_m; //!< Window center offset from display center (meters, +up)
+	float window_center_offset_z_m; //!< Window Z offset from display plane (meters, +toward viewer)
+
+	//! Window orientation in display space (identity = flat on display surface).
+	//! When non-identity, eye positions should be transformed to window-local frame
+	//! for correct Kooima projection: local_eye = Q_inv * (eye - window_pos).
+	struct xrt_quat window_orientation;
 
 	bool valid; //!< True if all metrics are valid
 };

--- a/src/xrt/ipc/server/ipc_server_handler.c
+++ b/src/xrt/ipc/server/ipc_server_handler.c
@@ -150,7 +150,9 @@ ipc_try_get_sr_view_poses(struct ipc_server *s,
 	// Try per-client window metrics first (shell mode dynamic windows),
 	// then fall back to global window metrics, then display dimensions.
 	float screen_width_m, screen_height_m;
-	float eye_offset_x = 0.0f, eye_offset_y = 0.0f;
+	float eye_offset_x = 0.0f, eye_offset_y = 0.0f, eye_offset_z = 0.0f;
+	struct xrt_quat win_orient = {0, 0, 0, 1};
+	bool win_has_orientation = false;
 	{
 		struct xrt_window_metrics wm = {0};
 		bool have_wm = false;
@@ -171,6 +173,12 @@ ipc_try_get_sr_view_poses(struct ipc_server *s,
 			screen_height_m = wm.window_height_m;
 			eye_offset_x = wm.window_center_offset_x_m;
 			eye_offset_y = wm.window_center_offset_y_m;
+			eye_offset_z = wm.window_center_offset_z_m;
+			win_orient = wm.window_orientation;
+			win_has_orientation = (fabsf(win_orient.x) > 0.0001f ||
+			                      fabsf(win_orient.y) > 0.0001f ||
+			                      fabsf(win_orient.z) > 0.0001f ||
+			                      fabsf(win_orient.w - 1.0f) > 0.0001f);
 		} else if (!comp_d3d11_service_get_display_dimensions(s->xsysc, &screen_width_m, &screen_height_m)) {
 			static bool logged_no_dims = false;
 			if (!logged_no_dims) {
@@ -181,10 +189,21 @@ ipc_try_get_sr_view_poses(struct ipc_server *s,
 		}
 	}
 
-	// Shift eyes to be relative to window center (not display center)
+	// Transform eyes to window-local frame:
+	// 1. Subtract window position (eye relative to window center)
+	// 2. If rotated, apply inverse rotation (eye in window's local space)
 	for (uint32_t i = 0; i < eye_count; i++) {
-		raw_eyes[i].x -= eye_offset_x;
-		raw_eyes[i].y -= eye_offset_y;
+		struct xrt_vec3 delta = {
+		    raw_eyes[i].x - eye_offset_x,
+		    raw_eyes[i].y - eye_offset_y,
+		    raw_eyes[i].z - eye_offset_z};
+		if (win_has_orientation) {
+			struct xrt_quat inv_q;
+			math_quat_invert(&win_orient, &inv_q);
+			math_quat_rotate_vec3(&inv_q, &delta, &raw_eyes[i]);
+		} else {
+			raw_eyes[i] = delta;
+		}
 	}
 
 	// Log success on first successful call

--- a/src/xrt/state_trackers/oxr/oxr_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_session.c
@@ -1256,6 +1256,9 @@ oxr_session_locate_views(struct oxr_logger *log,
 			float screen_height_m = 0.0f;
 			float eye_offset_x = 0.0f; // window center offset from display center (meters)
 			float eye_offset_y = 0.0f;
+			float eye_offset_z = 0.0f;
+			struct xrt_quat win_orient = {0, 0, 0, 1}; // identity
+			bool win_has_orientation = false;
 
 			struct xrt_window_metrics wm = {0};
 			bool have_wm = oxr_session_get_window_metrics(sess, &wm);
@@ -1267,12 +1270,20 @@ oxr_session_locate_views(struct oxr_logger *log,
 				screen_height_m = wm.window_height_m;
 				eye_offset_x = wm.window_center_offset_x_m;
 				eye_offset_y = wm.window_center_offset_y_m;
+				eye_offset_z = wm.window_center_offset_z_m;
+				win_orient = wm.window_orientation;
+				// Check if orientation is non-identity
+				win_has_orientation = (fabsf(win_orient.x) > 0.0001f ||
+				                       fabsf(win_orient.y) > 0.0001f ||
+				                       fabsf(win_orient.z) > 0.0001f ||
+				                       fabsf(win_orient.w - 1.0f) > 0.0001f);
 
 				if (should_log) {
 					U_LOG_I("Window-relative Kooima: screen=%.4fx%.4fm, "
-					        "eye_offset=(%.4f,%.4f)m",
+					        "eye_offset=(%.4f,%.4f,%.4f)m, rotated=%d",
 					        screen_width_m, screen_height_m,
-					        eye_offset_x, eye_offset_y);
+					        eye_offset_x, eye_offset_y, eye_offset_z,
+					        win_has_orientation);
 				}
 			} else if (oxr_session_get_display_dimensions(sess, &screen_width_m, &screen_height_m) &&
 			           screen_width_m > 0.0f && screen_height_m > 0.0f) {
@@ -1293,11 +1304,20 @@ oxr_session_locate_views(struct oxr_logger *log,
 				struct xrt_vec3 nominal = {0, si->nominal_viewer_y_m, si->nominal_viewer_z_m};
 				struct xrt_vec3 raw_eyes[XRT_MAX_VIEWS];
 				for (uint32_t ei = 0; ei < eye_count; ei++) {
-					// Shift eyes to be relative to window center (not display center)
-					raw_eyes[ei] = (struct xrt_vec3){
+					// Transform eye to window-local frame:
+					// 1. Subtract window position (eye relative to window center)
+					// 2. If rotated, apply inverse rotation (eye in window's local space)
+					struct xrt_vec3 delta = {
 					    adj_eyes[ei].x - eye_offset_x,
 					    adj_eyes[ei].y - eye_offset_y,
-					    adj_eyes[ei].z};
+					    adj_eyes[ei].z - eye_offset_z};
+					if (win_has_orientation) {
+						struct xrt_quat inv_q;
+						math_quat_invert(&win_orient, &inv_q);
+						math_quat_rotate_vec3(&inv_q, &delta, &raw_eyes[ei]);
+					} else {
+						raw_eyes[ei] = delta;
+					}
 				}
 				Display3DScreen scr = {screen_width_m, screen_height_m};
 				struct xrt_pose display_pose = {

--- a/src/xrt/targets/shell/main.c
+++ b/src/xrt/targets/shell/main.c
@@ -563,10 +563,11 @@ main(int argc, char *argv[])
 
 		for (int i = 0; i < app_count; i++) {
 			launch_app(&apps[i], have_json ? runtime_json : NULL);
-			// Delay between launches so each app has time to connect
-			// before the next one starts (IPC pipe is single-instance)
+			// Minimal delay between app launches. The 3s delay from Phase 1 was
+			// a workaround for #108 (intermittent crash with two apps). Tested
+			// with 100ms and no crashes observed (2026-04-03).
 			if (i + 1 < app_count) {
-				Sleep(3000);
+				Sleep(100);
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

- **Z-depth positioning**: per-eye parallax projection, Shift+Scroll and [/] controls, ±50mm range
- **Window rotation**: perspective-correct quad shader, rotated chrome/border, title bar RMB drag (yaw ±30°, pitch ±15°)
- **Window-local Kooima**: eye positions transformed to rotated window's local frame for correct app projection (IPC + in-process paths)
- **3D layout presets**: Theater (Ctrl+3), Stack (Ctrl+4) with TAB Z-reorder
- **Dynamic layouts**: Carousel (Ctrl+5), Orbital (Ctrl+6), Helix (Ctrl+7), Expose (Ctrl+8) with auto-rotation, drag-to-control, momentum
- **Animation system**: ease-out cubic transitions (300ms presets, 400ms entry)
- **Z-depth render order**: painter's algorithm replaces focus-based ordering
- **D3D11 multithread protection**: fixes #108 — 4+ simultaneous apps stable
- **Launch delay**: reduced from 3s to 100ms
- **Phase 3B plan**: docs for cross-API shell support (GL, VK, D3D12 fixes)

## Test plan

- [ ] 2x D3D11 apps: entry animation, all presets (Ctrl+1-8), rotation, Z-depth
- [ ] 4x D3D11 apps: carousel mode, TAB cycling
- [ ] Title bar RMB drag rotation with Kooima update
- [ ] Shift+Scroll Z-depth, [/] key stepping

🤖 Generated with [Claude Code](https://claude.com/claude-code)