### PR TITLE
Shell Phase 4C: Graceful exit + app launcher + hot-switch (#43)

### DIFF
--- a/docs/roadmap/shell-phase4c-agent-prompt.md
+++ b/docs/roadmap/shell-phase4c-agent-prompt.md
@@ -1,0 +1,156 @@
+# Shell Phase 4C: Agent Prompt — Graceful Exit + App Launcher
+
+Use this prompt to start a new Claude Code session for implementing Phase 4C on branch `feature/shell-phase4c`.
+
+---
+
+## Prompt
+
+```
+I'm working on the DisplayXR shell — a spatial window manager for 3D displays. We're implementing Phase 4C: Graceful Exit + App Launcher. This combines the previously planned 4D (graceful exit / Phase 1A resolution) and 4E (app launcher / system tray).
+
+## Context
+
+Read these docs first (in order):
+1. `CLAUDE.md` — project overview, build commands, architecture
+2. `docs/roadmap/shell-phase4c-plan.md` — **the plan you're implementing** (full task list, sequences, design)
+3. `docs/roadmap/shell-phase4c-status.md` — current progress (update as you complete tasks)
+4. `docs/roadmap/shell-phase4a-status.md` — Phase 4A/4B status (what's already built)
+5. `docs/roadmap/shell-runtime-contract.md` — IPC protocol boundary
+
+## Branch
+
+You are on branch `feature/shell-phase4c`. All work goes here. Commits must reference #43 (shell tracking issue).
+
+## What Phase 4C Needs
+
+Two major features:
+
+### Part 1: Graceful Exit (Phase 1A Resolution)
+
+When the shell deactivates (ESC or Ctrl+Space), all windows return to their original desktop positions and OpenXR apps switch back to standalone compositing. When re-summoned, everything restores.
+
+**Implementation order:**
+
+1. **4C.1: `shell_deactivate` IPC** (Small)
+   - Add `"shell_deactivate": {}` to `src/xrt/ipc/shared/proto.json` (follow `shell_activate` pattern)
+   - Add handler `ipc_handle_shell_deactivate()` in `src/xrt/ipc/server/ipc_server_handler.c`
+   - Handler calls a new `comp_d3d11_service_deactivate_shell()` function
+
+2. **4C.2: Capture teardown + 2D window restore** (Medium)
+   - In the deactivate handler: iterate all `CLIENT_TYPE_CAPTURE` slots
+   - Call `d3d11_capture_stop()` for each (already exists at `d3d11_capture.cpp:360`)
+   - Call `SetWindowPlacement(slot->saved_placement)` to restore each 2D window
+   - `saved_placement` and `saved_exstyle` are already stored per slot (`comp_d3d11_service.cpp:545-546`)
+   - Remove all capture virtual client slots
+
+3. **4C.5: Multi-compositor suspend/resume** (Small)
+   - On deactivate: stop the multi-comp render loop, release the shared DP instance, hide shell window (`ShowWindow(SW_HIDE)`)
+   - On activate: recreate DP, restart render loop, show window
+   - The `window_dismissed` flag (`comp_d3d11_service.cpp:587`) already handles a simpler version of this — extend it
+
+4. **4C.4: HWND restore for OpenXR apps** (Medium)
+   - On deactivate: restore each IPC app's HWND from hidden borderless (`WS_POPUP`) back to visible decorated (`WS_OVERLAPPEDWINDOW`)
+   - The HWND was originally made borderless in `oxr_session_create` — save the original style there
+   - On re-activate: reverse (hide + borderless)
+
+5. **4C.3: OpenXR app hot-switch** (Large — do this last in Part 1)
+   - Add `enum comp_output_mode { COMP_MODE_DIRECT, COMP_MODE_EXPORT }` to per-client compositor
+   - `COMP_MODE_EXPORT` (current shell behavior): compositor writes to shared texture, multi-comp blits
+   - `COMP_MODE_DIRECT`: compositor creates its own DP and presents to its own HWND (standalone behavior)
+   - Mode switch triggered by `shell_deactivate` / `shell_activate`
+   - Compositor drains current frame, switches output path, continues
+   - No OpenXR session teardown — session, swapchains, and app rendering are unaffected
+   - **Fallback**: if hot-switch is too complex, push `XR_SESSION_LOSS_PENDING` and let apps recreate sessions naturally
+
+### Part 2: App Launcher & System Tray
+
+6. **4C.7: System-wide hotkey** (Medium)
+   - `RegisterHotKey(NULL, HOTKEY_ID, MOD_CONTROL, VK_SPACE)` in shell `main.c`
+   - Handle `WM_HOTKEY` in message loop to toggle activate/deactivate
+   - Must work when shell window is not focused (that's what RegisterHotKey provides)
+
+7. **4C.8: System tray icon** (Small)
+   - `Shell_NotifyIcon` with `NOTIFYICONDATA` in shell `main.c`
+   - Show tray icon when shell is deactivated
+   - Left-click: activate shell
+   - Right-click: context menu (Activate / Exit)
+   - On exit: `UnregisterHotKey`, `Shell_NotifyIcon(NIM_DELETE)`, process exit
+
+8. **4C.6: Shell-side deactivate flow** (Small)
+   - In shell `main.c`: when deactivating, call `ipc_call_shell_deactivate()`
+   - Clear local capture tracking arrays
+   - Stop the adopt polling loop
+   - On re-activate: call `ipc_call_shell_activate()`, re-enumerate, re-adopt, restore layout from persistence JSON
+
+9. **4C.9: Registered apps config** (Medium)
+   - JSON file: `%LOCALAPPDATA%\DisplayXR\registered_apps.json`
+   - Format: `[{"name": "Cube D3D11", "exe_path": "path/to/cube.exe", "type": "3d"}]`
+   - Load on shell startup, pre-populate with demo apps on first run
+
+10. **4C.10: App launch from shell** (Medium)
+    - `Ctrl+L` opens a minimal text prompt (or just reads from registered apps)
+    - For "3d" apps: `CreateProcess` with `DISPLAYXR_SHELL_SESSION=1` + `XR_RUNTIME_JSON` env vars
+    - For "2d" apps: `CreateProcess` normally, then `shell_add_capture_client(hwnd)` after window appears
+
+11. **4C.11: Auto-detect app type** (Small)
+    - After launching unknown app, poll `system_get_clients` for 5 seconds
+    - If new IPC client appears → 3D app
+    - If no IPC client → find new HWND via enumeration → 2D capture
+
+## Key existing code to understand:
+
+1. **Multi-comp slots**: `struct d3d11_multi_client_slot` at ~line 454 of `comp_d3d11_service.cpp` — `client_type`, `saved_placement`, `capture_ctx`
+2. **Shell activate handler**: `ipc_handle_shell_activate()` at `ipc_server_handler.c:1949` — follow this pattern for deactivate
+3. **Window dismiss**: `window_dismissed` flag at `comp_d3d11_service.cpp:587` — ESC currently sets this, new client clears it
+4. **Shell main**: `src/xrt/targets/shell/main.c` — service auto-start, IPC connect, monitor loop, capture tracking
+5. **Capture stop**: `d3d11_capture_stop()` at `d3d11_capture.cpp:360` — tears down capture session cleanly
+6. **IPC protocol**: `proto.json` — `shell_activate`, `shell_set_window_pose`, `shell_add_capture_client` show the pattern
+
+## Build and test:
+
+```bash
+# Build on Windows (local, no CI needed)
+scripts\build_windows.bat build
+
+# Test graceful exit:
+# 1. Open Notepad + Calculator
+# 2. Launch shell:
+_package\bin\displayxr-shell.exe --capture-hwnd <notepad> --capture-hwnd <calc> ^
+    test_apps\cube_handle_d3d11_win\build\cube_handle_d3d11_win.exe
+# 3. Press ESC → verify windows restore to desktop
+# 4. Press Ctrl+Space → verify shell re-activates
+
+# Test system tray:
+# 1. Launch: _package\bin\displayxr-shell.exe
+# 2. Should start in system tray
+# 3. Ctrl+Space to activate/deactivate
+```
+
+## What NOT to change:
+
+- Display processor / weaver internals
+- OpenXR state tracker session lifecycle (no session state changes during hot-switch)
+- IPC client compositor transport (shared textures stay alive)
+- Capture API internals (`d3d11_capture.cpp`)
+- Existing standalone (non-shell) app behavior
+
+## Commit style:
+
+Each meaningful piece of work gets its own commit with issue ref:
+- `Shell 4C: add shell_deactivate IPC (#43)`
+- `Shell 4C: capture teardown and 2D window restore (#43)`
+- etc.
+
+Build locally after each commit: `scripts\build_windows.bat build`
+Update `docs/roadmap/shell-phase4c-status.md` as tasks complete.
+```
+
+---
+
+## Notes for the developer
+
+- Part 1 (graceful exit) is the harder half. Start with the capture teardown path (4C.1 → 4C.2 → 4C.5) which is straightforward — existing APIs do the heavy lifting. Test that 2D windows restore before tackling the OpenXR hot-switch.
+- The hot-switch (4C.3) may require the fallback `SESSION_LOSS` approach. Don't over-invest in the full `COMP_MODE_DIRECT`/`COMP_MODE_EXPORT` toggle if it proves too invasive. The simpler path (apps recreate session) is acceptable for v1.
+- Part 2 (launcher/tray) is mostly shell-side code (`main.c`). The Win32 APIs (`RegisterHotKey`, `Shell_NotifyIcon`, `CreateProcess`) are well-documented and straightforward.
+- The shell's monitor loop in `main.c` (~line 880) polls every 500ms. The hotkey handling needs a `PeekMessage`/`GetMessage` loop or integration with the existing poll loop.

--- a/docs/roadmap/shell-phase4c-plan.md
+++ b/docs/roadmap/shell-phase4c-plan.md
@@ -1,0 +1,288 @@
+# Shell Phase 4C Plan: Graceful Exit + App Launcher
+
+**Branch:** `feature/shell-phase4c`
+**Tracking issues:** #43, #44
+**Depends on:** Phase 4A (capture compositor — complete), Phase 4B (window adoption — partial, input parked)
+
+## Overview
+
+Phase 4C resolves two long-deferred features that complete the Spatial Companion:
+
+1. **Graceful Exit (was 4D / Phase 1A)** — When the shell exits, all windows return to their original Windows desktop positions. OpenXR apps switch back to standalone compositing. The desktop looks exactly as it did before the shell was summoned. Re-summoning restores the spatial layout.
+
+2. **App Launcher & System Tray (was 4E)** — System-wide `Ctrl+Space` hotkey to toggle the shell. System tray icon for background residence. Built-in launcher to start new apps from within the shell.
+
+## Prior Art and Existing Infrastructure
+
+These pieces are already in place and will be leveraged:
+
+| Component | Location | What exists |
+|-----------|----------|-------------|
+| `window_dismissed` flag | `comp_d3d11_service.cpp:587` | ESC sets this, new client connecting clears it and recreates window |
+| `saved_placement` / `saved_exstyle` | `comp_d3d11_service.cpp:545-546` | Per-capture-slot `WINDOWPLACEMENT` + style saved on adoption |
+| `d3d11_capture_stop()` | `d3d11_capture.cpp:360` | Tears down `GraphicsCaptureSession` and frame pool |
+| `multi_compositor_remove_capture_client()` | `comp_d3d11_service.cpp:3632` | Removes a capture slot + stops capture |
+| `shell_activate` IPC | `proto.json:59`, handler at `ipc_server_handler.c:1949` | Enters shell mode dynamically |
+| `enumerate_and_adopt_windows()` | `shell/main.c:636` | `EnumWindows` + filtering + `shell_add_capture_client` |
+| Shell persistence | `shell/main.c` | `%LOCALAPPDATA%\DisplayXR\shell_layout.json` save/restore |
+| Animation system | `comp_d3d11_service.cpp` | `slot_animate_to()` + `slot_animate_tick()`, ease-out cubic, 300ms |
+
+---
+
+## Part 1: Graceful Exit (Phase 1A Resolution)
+
+### Design: Option D — Hide Shell, Keep Rendering Standalone-Style
+
+When the shell deactivates:
+1. Stop all capture sessions, restore all 2D windows to their original desktop positions
+2. For each connected OpenXR app: restore HWND to visible + decorated, switch per-client compositor from "export" to "direct" mode
+3. Multi-compositor stops rendering, releases shared DP
+4. Shell window hides; shell process stays alive (system tray)
+
+When the shell re-summons:
+1. Each per-client compositor switches back to "export" mode
+2. Multi-compositor resumes, imports textures, takes over DP
+3. HWNDs go back to hidden/borderless
+4. Layout restored from persistence JSON
+
+### Tasks
+
+| Task | Size | Repo | Description |
+|------|------|------|-------------|
+| 4C.1 | S | runtime | **`shell_deactivate` IPC** — Add to `proto.json` and `ipc_server_handler.c`. Handler calls into multi-compositor to begin teardown sequence. |
+| 4C.2 | M | runtime | **Capture teardown + 2D window restore** — On deactivate: iterate all `CLIENT_TYPE_CAPTURE` slots, call `d3d11_capture_stop()`, call `SetWindowPlacement(saved_placement)` to restore each 2D window. Remove all capture virtual client slots. |
+| 4C.3 | L | runtime | **OpenXR app hot-switch (direct/export mode toggle)** — Add `enum comp_output_mode { COMP_MODE_DIRECT, COMP_MODE_EXPORT }` to the per-client compositor. In `COMP_MODE_EXPORT` (shell active): compositor writes to shared texture for multi-comp. In `COMP_MODE_DIRECT` (shell inactive): compositor creates its own DP instance and presents to its own HWND. The mode switch is triggered by `shell_deactivate` / `shell_activate`. Compositor drains current frame, switches output path, continues. No OpenXR session teardown. |
+| 4C.4 | M | runtime | **HWND restore for OpenXR apps** — On deactivate: restore each IPC app's HWND from hidden borderless (`WS_POPUP`) to visible decorated (`WS_OVERLAPPEDWINDOW`). Use saved placement from `oxr_session_create`. On re-activate: reverse the process (hide, make borderless). |
+| 4C.5 | S | runtime | **Multi-compositor suspend/resume** — On deactivate: multi-comp stops its render loop, releases shared DP instance, hides shell window (`ShowWindow(SW_HIDE)`). On activate: recreate DP, restart render loop, show window. |
+| 4C.6 | S | shell | **Shell-side deactivate flow** — In `main.c`: call `ipc_call_shell_deactivate()`, clear local capture tracking, stop adopt polling. On re-activate: re-enumerate windows, re-adopt, restore layout from persistence JSON. |
+
+### Hot-Switch Detail (4C.3)
+
+This is the hardest piece. Key considerations:
+
+**Per-client compositor changes:**
+```c
+enum comp_output_mode {
+    COMP_MODE_DIRECT,  // standalone: compositor → own DP → own HWND
+    COMP_MODE_EXPORT,  // shell: compositor → shared texture → multi-comp
+};
+```
+
+- When a client connects during shell mode → starts in `COMP_MODE_EXPORT`
+- When a client connects outside shell mode → starts in `COMP_MODE_DIRECT` (normal standalone)
+- `shell_deactivate` transitions all connected clients: EXPORT → DIRECT
+- `shell_activate` transitions all connected clients: DIRECT → EXPORT
+
+**DIRECT mode requirements:**
+- Per-client compositor needs its own DP instance (display processor / weaver)
+- Per-client HWND must be visible and correctly sized
+- This is essentially what already happens in standalone (non-shell) mode — the per-client compositor path already works this way
+
+**EXPORT mode requirements (already implemented):**
+- Per-client compositor writes atlas to shared texture
+- Multi-comp imports and blits to combined output
+- Per-client HWND is hidden
+
+**Simplification opportunity:** If `COMP_MODE_DIRECT` is too complex for the first pass, consider the simpler **SESSION_LOSS** approach: push `XR_SESSION_LOSS_PENDING` to each app on deactivate. Well-behaved apps will destroy and recreate their session, which naturally falls through to standalone mode. This is lossier (apps must handle session loss) but avoids the compositor mode toggle entirely.
+
+### Deactivate Sequence (complete flow)
+
+```
+User presses ESC or Ctrl+Space
+    │
+    ├─ Shell calls ipc_call_shell_deactivate()
+    │
+    ├─ Server handler:
+    │   ├─ 1. Stop all capture sessions (d3d11_capture_stop per slot)
+    │   ├─ 2. Restore 2D windows (SetWindowPlacement per capture slot)
+    │   ├─ 3. Remove all capture virtual client slots
+    │   ├─ 4. For each IPC client:
+    │   │   ├─ Switch comp_output_mode → COMP_MODE_DIRECT
+    │   │   ├─ Client creates own DP instance
+    │   │   ├─ Restore HWND (WS_OVERLAPPEDWINDOW + SetWindowPlacement)
+    │   │   └─ Client compositor now presents to own HWND
+    │   ├─ 5. Multi-comp stops rendering
+    │   ├─ 6. Release shared DP
+    │   └─ 7. Hide shell window (ShowWindow SW_HIDE)
+    │
+    └─ Shell stays alive in system tray (Phase 4C Part 2)
+```
+
+### Re-Activate Sequence
+
+```
+User presses Ctrl+Space (or Ctrl+Space again)
+    │
+    ├─ Shell calls ipc_call_shell_activate()
+    │
+    ├─ Server handler:
+    │   ├─ 1. Show shell window (ShowWindow SW_SHOW)
+    │   ├─ 2. Create shared DP
+    │   ├─ 3. For each IPC client:
+    │   │   ├─ Destroy per-client DP
+    │   │   ├─ Hide + borderless HWND
+    │   │   └─ Switch comp_output_mode → COMP_MODE_EXPORT
+    │   └─ 4. Multi-comp starts rendering
+    │
+    ├─ Shell re-enumerates desktop windows
+    ├─ Shell calls shell_add_capture_client() for each
+    └─ Shell restores layout from persistence JSON
+```
+
+---
+
+## Part 2: App Launcher & System Tray
+
+### Tasks
+
+| Task | Size | Repo | Description |
+|------|------|------|-------------|
+| 4C.7 | M | shell | **System-wide hotkey** — `RegisterHotKey(NULL, HOTKEY_ID, MOD_CONTROL, VK_SPACE)` in shell `main.c`. Message loop handles `WM_HOTKEY` to toggle between activate/deactivate. Works when shell is in background (system tray). |
+| 4C.8 | S | shell | **System tray icon** — `Shell_NotifyIcon` with `NOTIFYICONDATA`. Tray icon shows when shell is minimized/deactivated. Left-click re-activates. Right-click shows context menu (Activate / Settings / Exit). |
+| 4C.9 | M | shell | **Registered apps config** — JSON file `%LOCALAPPDATA%\DisplayXR\registered_apps.json`: `[{name, exe_path, type: "3d"|"2d"}]`. Pre-populated with demo apps on first run. Shell loads on startup. |
+| 4C.10 | M | shell+runtime | **App launch from shell** — Shell receives a launch request (keyboard shortcut or future launcher panel), spawns the process. For "3d" apps: set `DISPLAYXR_SHELL_SESSION=1` + `XR_RUNTIME_JSON` env vars. For "2d" apps: launch normally, auto-capture via `shell_add_capture_client`. |
+| 4C.11 | S | shell | **Auto-detect app type** — After launching an unknown app, wait up to 5 seconds. If the app connects via IPC (new client appears in `system_get_clients`), tag as 3D. Otherwise, tag as 2D and capture via HWND. |
+
+### App Launcher UX (minimal viable version)
+
+For the initial implementation, the launcher is **keyboard-driven**, not a spatial panel:
+
+- `Ctrl+L` (while shell is active) opens a text prompt overlay at bottom of screen
+- User types app name or path, Enter to launch
+- Matches against registered apps first, falls back to raw path
+- Launched app appears in next available slot with default pose
+
+A full spatial launcher panel (grid of app tiles with icons) is deferred to Phase 5.
+
+### System Tray Lifecycle
+
+```
+Shell starts
+    │
+    ├─ RegisterHotKey(Ctrl+Space)
+    ├─ Create system tray icon (hidden)
+    │
+    ├─ If launched with apps/capture args:
+    │   └─ Activate immediately (current behavior)
+    ├─ Else:
+    │   └─ Start in tray (deactivated), wait for Ctrl+Space
+    │
+    ├─ Ctrl+Space pressed:
+    │   ├─ If deactivated → activate (enumerate, adopt, show shell window)
+    │   └─ If activated → deactivate (restore windows, hide shell, show tray)
+    │
+    └─ Tray right-click → Exit:
+        ├─ Deactivate if active
+        ├─ UnregisterHotKey
+        ├─ Shell_NotifyIcon(NIM_DELETE)
+        └─ Process exits
+```
+
+---
+
+## Implementation Order
+
+```
+4C.1 (shell_deactivate IPC) ──────────────────────┐
+4C.2 (capture teardown + 2D restore) ── needs 4C.1 ┤
+4C.5 (multi-comp suspend/resume) ─── needs 4C.1 ───┤
+4C.4 (HWND restore for OpenXR) ──── needs 4C.5 ────┤
+4C.3 (hot-switch direct/export) ─── needs 4C.4 ────┤──→ Integration test
+                                                    │
+4C.7 (system hotkey) ────────── independent ────────┤
+4C.8 (system tray) ─────────── needs 4C.7 ─────────┤
+4C.6 (shell-side deactivate) ── needs 4C.1+4C.7 ───┘
+                                                    
+4C.9 (registered apps config) ── independent ───────┐
+4C.10 (app launch) ─────────── needs 4C.9 ──────────┤
+4C.11 (auto-detect type) ──── needs 4C.10 ──────────┘
+```
+
+**Suggested order:**
+1. 4C.1 → 4C.2 → 4C.5 (deactivate path, capture teardown, multi-comp suspend — testable: ESC restores 2D windows)
+2. 4C.7 → 4C.8 (hotkey + tray — testable: Ctrl+Space toggles shell)
+3. 4C.6 (wire up shell-side deactivate — testable: full toggle cycle)
+4. 4C.4 → 4C.3 (OpenXR HWND restore + hot-switch — testable: OpenXR apps survive toggle)
+5. 4C.9 → 4C.10 → 4C.11 (app launcher — testable: launch apps from within shell)
+
+---
+
+## IPC Additions
+
+| IPC Call | Direction | Args | Returns | Description |
+|----------|-----------|------|---------|-------------|
+| `shell_deactivate` | shell → runtime | (none) | success/fail | Exit shell mode: teardown captures, restore windows, switch compositors to direct, suspend multi-comp |
+
+Note: `shell_activate` already exists and will be extended to handle re-activation (re-adopt previously connected IPC clients into export mode).
+
+---
+
+## Test Procedure
+
+### Graceful Exit (4C.1–4C.6)
+```bash
+# 1. Open Notepad, Calculator, and a DisplayXR cube app
+# 2. Launch shell:
+_package\bin\displayxr-shell.exe --capture-hwnd <notepad_hwnd> --capture-hwnd <calc_hwnd> ^
+    test_apps\cube_handle_d3d11_win\build\cube_handle_d3d11_win.exe
+
+# 3. Verify: all 3 windows appear in spatial layout
+# 4. Press ESC (or Ctrl+Space when implemented)
+# 5. Verify:
+#    - Notepad and Calculator return to exact original desktop positions
+#    - Cube app continues rendering in its own visible window (standalone mode)
+#    - Shell window disappears
+# 6. Press Ctrl+Space
+# 7. Verify:
+#    - All windows re-adopted into spatial layout
+#    - Layout restored from persistence JSON
+#    - Cube app re-enters shell mode (IPC export)
+```
+
+### System Tray (4C.7–4C.8)
+```bash
+# 1. Launch shell with no args:
+_package\bin\displayxr-shell.exe
+# 2. Verify: shell starts in system tray (no visible window)
+# 3. Press Ctrl+Space
+# 4. Verify: shell activates, adopts all desktop windows
+# 5. Press Ctrl+Space
+# 6. Verify: shell deactivates, windows restored, tray icon visible
+# 7. Right-click tray icon → Exit
+# 8. Verify: shell process exits cleanly
+```
+
+### App Launcher (4C.9–4C.11)
+```bash
+# 1. Activate shell (Ctrl+Space)
+# 2. Press Ctrl+L
+# 3. Type "cube_handle_d3d11_win" + Enter
+# 4. Verify: cube app launches in shell mode (3D)
+# 5. Press Ctrl+L
+# 6. Type "notepad" + Enter
+# 7. Verify: Notepad launches, auto-captured as 2D panel after 5s timeout
+```
+
+---
+
+## Key Files to Modify
+
+| File | Changes |
+|------|---------|
+| `src/xrt/ipc/shared/proto.json` | Add `shell_deactivate` |
+| `src/xrt/ipc/server/ipc_server_handler.c` | Add `ipc_handle_shell_deactivate`, extend `ipc_handle_shell_activate` for re-activation |
+| `src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp` | Multi-comp suspend/resume, capture teardown, `comp_output_mode` |
+| `src/xrt/compositor/d3d11_service/comp_d3d11_service.h` | Export deactivate API |
+| `src/xrt/compositor/d3d11/comp_d3d11_compositor.cpp` | Per-client direct/export mode toggle, per-client DP lifecycle |
+| `src/xrt/compositor/d3d11/comp_d3d11_window.cpp` | HWND show/hide/style toggle |
+| `src/xrt/targets/shell/main.c` | `RegisterHotKey`, system tray, deactivate flow, app launcher, registered apps |
+
+---
+
+## What NOT to Change
+
+- Display processor / weaver internals — DP is a black box, just create/destroy instances
+- OpenXR state tracker session lifecycle — apps see no session state changes during hot-switch
+- IPC client compositor transport — shared textures and IPC pipes stay alive during toggle
+- Capture API internals — `d3d11_capture.cpp` is stable, just call start/stop
+- Existing standalone (non-shell) app behavior — must remain untouched

--- a/docs/roadmap/shell-phase4c-status.md
+++ b/docs/roadmap/shell-phase4c-status.md
@@ -1,7 +1,7 @@
 # Shell Phase 4C Status: Graceful Exit + App Launcher
 
 **Branch:** `feature/shell-phase4c`
-**Status:** Not started
+**Status:** Implementation complete, pending testing
 **Date:** 2026-04-09
 
 ## Scope
@@ -16,12 +16,12 @@ Phase 4C combines the previously numbered 4D (Graceful Exit / Phase 1A resolutio
 
 | Status | Task | Description |
 |--------|------|-------------|
-| [ ] | 4C.1 | `shell_deactivate` IPC — proto.json + handler |
-| [ ] | 4C.2 | Capture teardown + 2D window restore (`SetWindowPlacement`) |
-| [ ] | 4C.3 | OpenXR app hot-switch (`COMP_MODE_DIRECT` / `COMP_MODE_EXPORT`) |
-| [ ] | 4C.4 | HWND restore for OpenXR apps (hide ↔ show + style toggle) |
-| [ ] | 4C.5 | Multi-compositor suspend/resume (stop render loop, release/recreate DP) |
-| [ ] | 4C.6 | Shell-side deactivate flow (clear capture tracking, re-activate path) |
+| [x] | 4C.1 | `shell_deactivate` IPC — proto.json + handler |
+| [x] | 4C.2 | Capture teardown + 2D window restore (`SetWindowPlacement`) |
+| [x] | 4C.3 | OpenXR app session loss (`XRT_SESSION_EVENT_LOSS_PENDING` on deactivate) |
+| [x] | 4C.4 | HWND restore: `oxr_session.c` checks `info.shell_mode` before borderless |
+| [x] | 4C.5 | Multi-compositor suspend/resume (stop render loop, release/recreate DP) |
+| [x] | 4C.6 | Shell-side deactivate flow (clear capture tracking, re-activate path) |
 
 ## Part 2: App Launcher & System Tray
 
@@ -29,20 +29,29 @@ Phase 4C combines the previously numbered 4D (Graceful Exit / Phase 1A resolutio
 
 | Status | Task | Description |
 |--------|------|-------------|
-| [ ] | 4C.7 | System-wide hotkey (`Ctrl+Space` via `RegisterHotKey`) |
-| [ ] | 4C.8 | System tray icon (`Shell_NotifyIcon`) |
-| [ ] | 4C.9 | Registered apps config (`registered_apps.json`) |
-| [ ] | 4C.10 | App launch from shell (process spawn with correct env vars) |
-| [ ] | 4C.11 | Auto-detect app type (IPC connect timeout → 3D vs 2D) |
+| [x] | 4C.7 | System-wide hotkey (`Ctrl+Space` via `RegisterHotKey`) |
+| [x] | 4C.8 | System tray icon (`Shell_NotifyIcon`) |
+| [x] | 4C.9 | Registered apps config (`registered_apps.json`) |
+| [x] | 4C.10 | App launch from shell (`Ctrl+L`, process spawn with correct env vars) |
+| [x] | 4C.11 | Auto-detect app type (IPC connect timeout → 3D vs 2D) |
 
 ## Commits
 
-_(none yet)_
+1. `514e133` — Shell 4C: add shell_deactivate IPC, capture teardown, multi-comp suspend (#43)
+2. `4975476` — Shell 4C: system hotkey, tray icon, shell-side deactivate flow (#43)
+3. `c306ca5` — Shell 4C: OpenXR session loss on deactivate, shell_mode guard (#43)
+4. `b13915e` — Shell 4C: registered apps config, Ctrl+L launcher, auto-detect type (#43)
 
 ## Design Decisions
 
-_(to be filled in during implementation)_
+- **SESSION_LOSS approach for v1:** Instead of full `COMP_MODE_DIRECT`/`COMP_MODE_EXPORT` hot-switch, push `XR_SESSION_EVENT_LOSS_PENDING` to IPC clients on deactivate. Apps destroy and recreate sessions, naturally falling back to standalone mode since `info.shell_mode` is now false. Simpler, avoids per-client DP lifecycle management.
+- **MsgWaitForMultipleObjects:** Replaced `Sleep(500)` poll loop with `MsgWaitForMultipleObjects` + `PeekMessage` to support `RegisterHotKey` (Ctrl+Space, Ctrl+L) and tray messages alongside the existing poll work.
+- **Suspended vs Dismissed:** Added `mc->suspended` flag distinct from `window_dismissed`. Suspended keeps multi-comp structure alive (window hidden, DP released) for fast resume. Dismissed tears down permanently with EXIT_REQUEST.
+- **Startup behavior:** With args → activate immediately (unchanged). No args → start deactivated in system tray, await Ctrl+Space.
+- **Launcher v1:** Ctrl+L launches first registered app from list. Full spatial launcher panel deferred to Phase 5.
 
 ## Known Issues
 
-_(to be filled in during implementation)_
+- **Ctrl+L launcher is minimal:** Currently launches first registered app, no selection UI. A proper spatial launcher panel is Phase 5.
+- **Auto-adopt on re-activate:** Desktop window auto-adoption is called on Ctrl+Space activate but filtering may need tuning (IDE windows, system windows).
+- **OpenXR app re-enter shell:** After deactivate→activate cycle, apps that survived LOSS_PENDING need to reconnect. Apps that exited need to be relaunched manually (or via Ctrl+L).

--- a/docs/roadmap/shell-phase4c-status.md
+++ b/docs/roadmap/shell-phase4c-status.md
@@ -1,0 +1,48 @@
+# Shell Phase 4C Status: Graceful Exit + App Launcher
+
+**Branch:** `feature/shell-phase4c`
+**Status:** Not started
+**Date:** 2026-04-09
+
+## Scope
+
+Phase 4C combines the previously numbered 4D (Graceful Exit / Phase 1A resolution) and 4E (App Launcher & System Tray) into a single phase.
+
+**Full plan:** [shell-phase4c-plan.md](shell-phase4c-plan.md)
+
+## Part 1: Graceful Exit
+
+### Task Status
+
+| Status | Task | Description |
+|--------|------|-------------|
+| [ ] | 4C.1 | `shell_deactivate` IPC — proto.json + handler |
+| [ ] | 4C.2 | Capture teardown + 2D window restore (`SetWindowPlacement`) |
+| [ ] | 4C.3 | OpenXR app hot-switch (`COMP_MODE_DIRECT` / `COMP_MODE_EXPORT`) |
+| [ ] | 4C.4 | HWND restore for OpenXR apps (hide ↔ show + style toggle) |
+| [ ] | 4C.5 | Multi-compositor suspend/resume (stop render loop, release/recreate DP) |
+| [ ] | 4C.6 | Shell-side deactivate flow (clear capture tracking, re-activate path) |
+
+## Part 2: App Launcher & System Tray
+
+### Task Status
+
+| Status | Task | Description |
+|--------|------|-------------|
+| [ ] | 4C.7 | System-wide hotkey (`Ctrl+Space` via `RegisterHotKey`) |
+| [ ] | 4C.8 | System tray icon (`Shell_NotifyIcon`) |
+| [ ] | 4C.9 | Registered apps config (`registered_apps.json`) |
+| [ ] | 4C.10 | App launch from shell (process spawn with correct env vars) |
+| [ ] | 4C.11 | Auto-detect app type (IPC connect timeout → 3D vs 2D) |
+
+## Commits
+
+_(none yet)_
+
+## Design Decisions
+
+_(to be filled in during implementation)_
+
+## Known Issues
+
+_(to be filled in during implementation)_

--- a/docs/roadmap/shell-phase4c-status.md
+++ b/docs/roadmap/shell-phase4c-status.md
@@ -44,11 +44,24 @@ Phase 4C combines the previously numbered 4D (Graceful Exit / Phase 1A resolutio
 
 ## Design Decisions
 
-- **SESSION_LOSS approach for v1:** Instead of full `COMP_MODE_DIRECT`/`COMP_MODE_EXPORT` hot-switch, push `XR_SESSION_EVENT_LOSS_PENDING` to IPC clients on deactivate. Apps destroy and recreate sessions, naturally falling back to standalone mode since `info.shell_mode` is now false. Simpler, avoids per-client DP lifecycle management.
+- **Lazy hot-switch (not SESSION_LOSS):** When the shell deactivates, the per-client compositor lazy-creates per-client standalone resources (swap chain + DP) on the app's IPC server thread on the next `layer_commit`. The app's HWND is shown via `ShowWindowAsync`. No session loss — apps keep their session and continue rendering. Reverse hot-switch on re-activate uses the same lazy pattern via a `pending_shell_reentry` flag.
+- **`owns_window` fix:** `comp_d3d11_service_owns_window()` now queries the active compositor's `render.owns_window` instead of just checking `shell_mode`. Critical for the IPC view pose path: handle apps with external HWNDs need the display-centric Kooima branch (real eye tracking) not the camera-centric branch (qwerty controller pose).
+- **GL Y-flip in standalone path:** `service_crop_atlas_for_dp()` now takes a `flip_y` parameter. When set (GL clients with `atlas_flip_y`), it uses the existing shader blit path with negative source rect height instead of `CopySubresourceRegion`. The crop texture is created with `BIND_RENDER_TARGET`.
+- **DXGI frame latency = 1:** Hot-switched swap chains call `IDXGIDevice1::SetMaximumFrameLatency(1)` to minimize the queue depth between Present and DWM cross-process composition.
+- **`DwmFlush()` after Present** for cross-process swap chains — blocks until the next composition pass to reduce drag stutter.
 - **MsgWaitForMultipleObjects:** Replaced `Sleep(500)` poll loop with `MsgWaitForMultipleObjects` + `PeekMessage` to support `RegisterHotKey` (Ctrl+Space, Ctrl+L) and tray messages alongside the existing poll work.
 - **Suspended vs Dismissed:** Added `mc->suspended` flag distinct from `window_dismissed`. Suspended keeps multi-comp structure alive (window hidden, DP released) for fast resume. Dismissed tears down permanently with EXIT_REQUEST.
 - **Startup behavior:** With args → activate immediately (unchanged). No args → start deactivated in system tray, await Ctrl+Space.
 - **Launcher v1:** Ctrl+L launches first registered app from list. Full spatial launcher panel deferred to Phase 5.
+
+## Known Limitations
+
+- **Drag stutter for hot-switched apps:** When dragging an app's window after shell deactivation, the 3D image may show some stutter or intermittent crosstalk compared to true in-process handle apps. Root causes:
+  - **No phase snapping** — In-process handle apps benefit from a vendor-installed `WM_WINDOWPOSCHANGING` hook that snaps the window to lens-aligned pixel positions. The hook is in the same process as the HWND. For our cross-process IPC case, the SR SDK is in the service process and cannot install a hook on the app's HWND without DLL injection.
+  - **IPC roundtrip overhead** — Each frame during drag involves an IPC call (~10ms) vs direct function call (~5ms) for in-process apps, halving the effective drag refresh rate.
+  - **SDK 2D/3D mode toggling** — During fast window movement, the SR SDK may temporarily fall back to 2D mode (showing raw left/right tiles) as a safety measure when it can't get a stable phase lock.
+- **Mitigations applied:** `SetMaximumFrameLatency(1)`, `DwmFlush()` after Present, frame timing logs (removed in final version) confirmed within-frame position stability.
+- **Future work:** A vendor-agnostic phase snap query API in the SDK would let the service compositor perform position snapping without DLL injection.
 
 ## Known Issues
 

--- a/docs/roadmap/shell-tasks.md
+++ b/docs/roadmap/shell-tasks.md
@@ -173,24 +173,39 @@ Multi compositor window is always full-screen = physical display size:
 
 | | Task | Size | Repo | Description |
 |---|------|------|------|-------------|
-| [ ] | 4A.1 | L | runtime | `Windows.Graphics.Capture` integration — per-HWND capture delivering `ID3D11Texture2D` frames |
-| [ ] | 4A.2 | M | runtime | Virtual client slots in multi-compositor for captured 2D windows (no OpenXR session) |
-| [ ] | 4A.3 | M | runtime | Mono texture handling — same texture for L/R eye passes, Level 2 Kooima for spatial parallax |
-| [ ] | 4B.1 | M | shell | Window enumeration — `EnumWindows` + filter for visible top-level non-system windows |
-| [ ] | 4B.2 | M | shell | App type classification — cross-reference HWNDs with IPC clients (3D) vs rest (2D capture) |
-| [ ] | 4B.3 | M | shell+runtime | Capture startup — create capture sessions, register virtual clients, assign spatial poses |
-| [ ] | 4B.4 | M | shell | State snapshot — save `WINDOWPLACEMENT`, z-order, style for restore on exit |
-| [ ] | 4C.1 | S | runtime | App type tag in slot model (`CLIENT_TYPE_OPENXR_3D` / `CLIENT_TYPE_CAPTURED_2D`) |
-| [ ] | 4C.2 | M | runtime | Snap-to-focus — focused window animates to Z=0, grows to working size |
-| [ ] | 4C.3 | M | runtime | Auto render mode switch — 2D app focused → 2D mode, 3D app → 3D mode, no focus → 3D |
-| [ ] | 4D.1 | M | runtime | Capture teardown — stop all capture sessions, release virtual client slots |
-| [ ] | 4D.2 | S | shell | 2D window restore — `SetWindowPlacement` with saved snapshot |
-| [ ] | 4D.3 | L | runtime | OpenXR app hot-switch (Phase 1A) — per-client compositor direct/export mode toggle |
-| [ ] | 4D.4 | S | shell | Shell window hide + system tray residence |
-| [ ] | 4E.1 | M | shell | Registered apps config (JSON) + launcher panel |
-| [ ] | 4E.2 | S | shell | Auto-detect app type (IPC connect within 5s → 3D, else → 2D capture) |
+| [x] | 4A.1 | L | runtime | `Windows.Graphics.Capture` integration — per-HWND capture delivering `ID3D11Texture2D` frames |
+| [x] | 4A.2 | M | runtime | Virtual client slots in multi-compositor for captured 2D windows (no OpenXR session) |
+| [x] | 4A.3 | M | runtime | Mono texture handling — same texture for L/R eye passes, Level 2 Kooima for spatial parallax |
+| [x] | 4B.1 | M | shell | Window enumeration — `EnumWindows` + filter for visible top-level non-system windows |
+| [x] | 4B.2 | M | shell | App type classification — cross-reference HWNDs with IPC clients (3D) vs rest (2D capture) |
+| [x] | 4B.3 | M | shell+runtime | Capture startup — create capture sessions, register virtual clients, assign spatial poses |
+| [x] | 4B.4 | M | shell | State snapshot — save `WINDOWPLACEMENT`, z-order, style for restore on exit |
+| [x] | 4B(old-C).1 | S | runtime | App type tag in slot model (`CLIENT_TYPE_OPENXR_3D` / `CLIENT_TYPE_CAPTURED_2D`) |
+| [~] | 4B(old-C).2 | M | runtime | ~~Snap-to-focus~~ — dropped by decision |
+| [x] | 4B(old-C).3 | M | runtime | Auto render mode switch — 2D app focused → 2D mode, 3D app → 3D mode, no focus → 3D |
+| [~] | 4B(old-D/E) | — | — | ~~Input forwarding to WinUI~~ — parked (hard problem) |
 
-**Dependencies:** 4A → 4B → 4C. 4D independent (parallel with 4A). 4E after 4B.
+**Completed:** 4A (capture compositor), 4B (window adoption + auto 2D/3D switch). Input forwarding parked.
+
+### Phase 4C: Graceful Exit + App Launcher
+
+**Full plan:** [shell-phase4c-plan.md](shell-phase4c-plan.md) | **Status:** [shell-phase4c-status.md](shell-phase4c-status.md)
+
+| | Task | Size | Repo | Description |
+|---|------|------|------|-------------|
+| [ ] | 4C.1 | S | runtime | `shell_deactivate` IPC — proto.json + handler |
+| [ ] | 4C.2 | M | runtime | Capture teardown + 2D window restore (`SetWindowPlacement`) |
+| [ ] | 4C.3 | L | runtime | OpenXR app hot-switch (Phase 1A) — `COMP_MODE_DIRECT` / `COMP_MODE_EXPORT` toggle |
+| [ ] | 4C.4 | M | runtime | HWND restore for OpenXR apps (hide ↔ show + style toggle) |
+| [ ] | 4C.5 | S | runtime | Multi-compositor suspend/resume (stop render loop, release/recreate DP) |
+| [ ] | 4C.6 | S | shell | Shell-side deactivate flow (clear capture tracking, re-activate path) |
+| [ ] | 4C.7 | M | shell | System-wide hotkey (`Ctrl+Space` via `RegisterHotKey`) |
+| [ ] | 4C.8 | S | shell | System tray icon (`Shell_NotifyIcon`) |
+| [ ] | 4C.9 | M | shell | Registered apps config (`registered_apps.json`) |
+| [ ] | 4C.10 | M | shell+runtime | App launch from shell (process spawn with correct env vars) |
+| [ ] | 4C.11 | S | shell | Auto-detect app type (IPC connect within 5s → 3D, else → 2D capture) |
+
+**Dependencies:** 4C.1 → 4C.2 → 4C.5 → 4C.4 → 4C.3. 4C.7 → 4C.8 independent. 4C.9 → 4C.10 → 4C.11 independent.
 
 ---
 

--- a/src/xrt/compositor/d3d11/comp_d3d11_window.cpp
+++ b/src/xrt/compositor/d3d11/comp_d3d11_window.cpp
@@ -228,7 +228,6 @@ is_shell_reserved_key(WPARAM vk)
 	// tries to change rendering mode via xrRequestDisplayRenderingModeEXT,
 	// that call is blocked in shell/IPC mode.
 	switch (vk) {
-	case VK_ESCAPE: // Close shell window
 	case VK_TAB:    // Cycle focus
 	case VK_DELETE: // Close focused app
 		return true;

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -221,6 +221,9 @@ struct d3d11_service_compositor
 	//! Current focus state
 	bool state_focused;
 
+	//! App's HWND from XR_EXT_win32_window_binding (for lazy standalone init)
+	HWND app_hwnd;
+
 	//! Whether the window has been closed (triggers session exit)
 	bool window_closed;
 
@@ -4886,26 +4889,65 @@ multi_compositor_render(struct d3d11_service_system *sys)
 					slot->client_type = CLIENT_TYPE_IPC;
 					mc->client_count--;
 					mc->capture_client_count--;
-				} else if (slot->compositor != nullptr &&
-				           slot->compositor->xses != nullptr) {
-					// Send LOSS_PENDING so apps can recreate in standalone
-					union xrt_session_event xse = XRT_STRUCT_INIT;
-					xse.loss_pending.type = XRT_SESSION_EVENT_LOSS_PENDING;
-					xse.loss_pending.loss_time_ns =
-					    (int64_t)os_monotonic_get_ns() + 500000000LL;
-					xrt_session_event_sink_push(slot->compositor->xses, &xse);
+				} else if (slot->compositor != nullptr) {
+					// Hot-switch IPC client to standalone mode
+					struct d3d11_client_render_resources *res = &slot->compositor->render;
+					HWND app_hwnd = slot->app_hwnd;
+					if (app_hwnd != nullptr && IsWindow(app_hwnd)) {
+						ShowWindow(app_hwnd, SW_SHOW);
+						res->hwnd = app_hwnd;
+						res->owns_window = false;
+
+						RECT cr;
+						uint32_t sc_w = sys->output_width, sc_h = sys->output_height;
+						if (GetClientRect(app_hwnd, &cr)) {
+							uint32_t cw = (uint32_t)(cr.right - cr.left);
+							uint32_t ch = (uint32_t)(cr.bottom - cr.top);
+							if (cw > 0 && ch > 0) { sc_w = cw; sc_h = ch; }
+						}
+
+						DXGI_SWAP_CHAIN_DESC1 sc_desc = {};
+						sc_desc.Width = sc_w;
+						sc_desc.Height = sc_h;
+						sc_desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+						sc_desc.SampleDesc.Count = 1;
+						sc_desc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+						sc_desc.BufferCount = 2;
+						sc_desc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+
+						HRESULT hr = sys->dxgi_factory->CreateSwapChainForHwnd(
+						    sys->device.get(), app_hwnd, &sc_desc,
+						    nullptr, nullptr, res->swap_chain.put());
+						if (SUCCEEDED(hr)) {
+							wil::com_ptr<ID3D11Texture2D> bb;
+							res->swap_chain->GetBuffer(0, IID_PPV_ARGS(bb.put()));
+							sys->device->CreateRenderTargetView(
+							    bb.get(), nullptr, res->back_buffer_rtv.put());
+						}
+
+						if (sys->base.info.dp_factory_d3d11 != NULL) {
+							auto factory = (xrt_dp_factory_d3d11_fn_t)sys->base.info.dp_factory_d3d11;
+							factory(sys->device.get(), sys->context.get(),
+							        app_hwnd, &res->display_processor);
+							if (res->display_processor != nullptr && sys->hardware_display_3d) {
+								xrt_display_processor_d3d11_request_display_mode(
+								    res->display_processor, true);
+							}
+						}
+						U_LOG_W("Dismiss: hot-switched slot %d to standalone", i);
+					}
 				}
 			}
 
 			// Stop render thread
 			capture_render_thread_stop(sys);
 
-			// Release DP (display already back to 2D from the window-close handler)
+			// Release shared DP (per-client DPs now handle display)
 			if (mc->display_processor != nullptr) {
 				xrt_display_processor_d3d11_destroy(&mc->display_processor);
 			}
 
-			U_LOG_W("Multi-comp: shell dismissed (ESC) — captures restored, LOSS_PENDING sent");
+			U_LOG_W("Multi-comp: shell dismissed — captures restored, IPC clients hot-switched");
 		}
 		return;
 	}
@@ -7411,6 +7453,74 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 		return XRT_SUCCESS;
 	}
 
+	// --- Lazy standalone init (hot-switch from shell → standalone) ---
+	// Shell was deactivated: shell_mode is false but this client was created
+	// in shell mode (no swap chain, no DP). Create standalone resources now,
+	// on the app's own IPC thread — safe from WM deadlocks.
+	if (!c->render.swap_chain) {
+		U_LOG_W("Hot-switch check: swap_chain=NULL, app_hwnd=%p, shell_mode=%d",
+		        (void *)c->app_hwnd, sys->shell_mode);
+	}
+	if (!c->render.swap_chain && c->app_hwnd != nullptr && IsWindow(c->app_hwnd)) {
+		U_LOG_W("Hot-switch: lazy standalone init for HWND=%p", (void *)c->app_hwnd);
+
+		// Show the app's HWND (hidden during shell mode).
+		// Decorations are preserved — no style changes needed.
+		ShowWindow(c->app_hwnd, SW_SHOWNOACTIVATE);
+
+		c->render.hwnd = c->app_hwnd;
+		c->render.owns_window = false;
+
+		RECT cr;
+		uint32_t sc_w = sys->output_width, sc_h = sys->output_height;
+		if (GetClientRect(c->app_hwnd, &cr)) {
+			uint32_t cw = (uint32_t)(cr.right - cr.left);
+			uint32_t ch = (uint32_t)(cr.bottom - cr.top);
+			if (cw > 0 && ch > 0) { sc_w = cw; sc_h = ch; }
+		}
+
+		DXGI_SWAP_CHAIN_DESC1 sc_desc = {};
+		sc_desc.Width = sc_w;
+		sc_desc.Height = sc_h;
+		sc_desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+		sc_desc.SampleDesc.Count = 1;
+		sc_desc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+		sc_desc.BufferCount = 2;
+		sc_desc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+
+		HRESULT hr = sys->dxgi_factory->CreateSwapChainForHwnd(
+		    sys->device.get(), c->app_hwnd, &sc_desc,
+		    nullptr, nullptr, c->render.swap_chain.put());
+		if (SUCCEEDED(hr)) {
+			wil::com_ptr<ID3D11Texture2D> bb;
+			c->render.swap_chain->GetBuffer(0, IID_PPV_ARGS(bb.put()));
+			sys->device->CreateRenderTargetView(bb.get(), nullptr, c->render.back_buffer_rtv.put());
+			U_LOG_W("Hot-switch: swap chain created (%ux%u)", sc_w, sc_h);
+		} else {
+			U_LOG_E("Hot-switch: swap chain failed (hr=0x%08X)", hr);
+		}
+
+		if (sys->base.info.dp_factory_d3d11 != NULL) {
+			auto factory = (xrt_dp_factory_d3d11_fn_t)sys->base.info.dp_factory_d3d11;
+			factory(sys->device.get(), sys->context.get(),
+			        c->app_hwnd, &c->render.display_processor);
+			if (c->render.display_processor != nullptr) {
+				if (sys->hardware_display_3d) {
+					xrt_display_processor_d3d11_request_display_mode(
+					    c->render.display_processor, true);
+				}
+				U_LOG_W("Hot-switch: DP created — standalone rendering active");
+			} else {
+				U_LOG_W("Hot-switch: no DP (factory returned null) — raw copy fallback");
+			}
+		}
+
+		U_LOG_W("Hot-switch: swap_chain=%p, back_buffer_rtv=%p, dp=%p",
+		        (void *)c->render.swap_chain.get(),
+		        (void *)c->render.back_buffer_rtv.get(),
+		        (void *)c->render.display_processor);
+	}
+
 	// During drag, synchronize with the window thread's WM_PAINT cycle.
 	// This ensures the window position is stable between weave() and Present(),
 	// so the interlacing pattern matches the actual displayed position.
@@ -7652,6 +7762,9 @@ system_create_native_compositor(struct xrt_system_compositor *xsysc,
 		// HWND resize is done CLIENT-SIDE in oxr_session_create (before the IPC call)
 		// because cross-process SetWindowPos deadlocks when called from the IPC handler.
 		sys->multi_comp->clients[slot].app_hwnd = (HWND)external_hwnd;
+
+		// Also store on compositor for lazy standalone init during hot-switch
+		c->app_hwnd = (HWND)external_hwnd;
 
 		// Get app name from HWND title for title bar display.
 		// If another slot already has the same name, append "-2", "-3", etc.
@@ -8221,38 +8334,19 @@ comp_d3d11_service_get_window_metrics(struct xrt_system_compositor *xsysc,
 		return false;
 	}
 
-	// Get window client rect
-	RECT rect;
-	if (!GetClientRect(metrics_hwnd, &rect)) {
-		out_metrics->valid = false;
-		return false;
-	}
-	uint32_t win_px_w = static_cast<uint32_t>(rect.right - rect.left);
-	uint32_t win_px_h = static_cast<uint32_t>(rect.bottom - rect.top);
-	if (win_px_w == 0 || win_px_h == 0) {
-		out_metrics->valid = false;
-		return false;
-	}
-
-	// Get window screen position
-	POINT client_origin = {0, 0};
-	ClientToScreen(metrics_hwnd, &client_origin);
-
-	// Compute pixel size (meters per pixel)
-	float pixel_size_x = disp_w_m / (float)disp_px_w;
-	float pixel_size_y = disp_h_m / (float)disp_px_h;
-
-	// Window physical size
-	float win_w_m = (float)win_px_w * pixel_size_x;
-	float win_h_m = (float)win_px_h * pixel_size_y;
-
-	// Window center offset in meters
-	float win_center_px_x = (float)(client_origin.x - disp_left) + (float)win_px_w / 2.0f;
-	float win_center_px_y = (float)(client_origin.y - disp_top) + (float)win_px_h / 2.0f;
-	float disp_center_px_x = (float)disp_px_w / 2.0f;
-	float disp_center_px_y = (float)disp_px_h / 2.0f;
-	float offset_x_m = (win_center_px_x - disp_center_px_x) * pixel_size_x;
-	float offset_y_m = -((win_center_px_y - disp_center_px_y) * pixel_size_y);
+	// In non-shell standalone mode (hot-switched), the app owns the full
+	// display — use display dimensions directly. The DP renders to the full
+	// display regardless of HWND decorations.
+	// In shell mode, this function isn't called (get_client_window_metrics
+	// handles per-window Kooima).
+	uint32_t win_px_w = disp_px_w;
+	uint32_t win_px_h = disp_px_h;
+	int32_t win_screen_left = disp_left;
+	int32_t win_screen_top = disp_top;
+	float win_w_m = disp_w_m;
+	float win_h_m = disp_h_m;
+	float offset_x_m = 0.0f;
+	float offset_y_m = 0.0f;
 
 	memset(out_metrics, 0, sizeof(*out_metrics));
 	out_metrics->display_width_m = disp_w_m;
@@ -8263,8 +8357,8 @@ comp_d3d11_service_get_window_metrics(struct xrt_system_compositor *xsysc,
 	out_metrics->display_screen_top = disp_top;
 	out_metrics->window_pixel_width = win_px_w;
 	out_metrics->window_pixel_height = win_px_h;
-	out_metrics->window_screen_left = static_cast<int32_t>(client_origin.x);
-	out_metrics->window_screen_top = static_cast<int32_t>(client_origin.y);
+	out_metrics->window_screen_left = win_screen_left;
+	out_metrics->window_screen_top = win_screen_top;
 	out_metrics->window_width_m = win_w_m;
 	out_metrics->window_height_m = win_h_m;
 	out_metrics->window_center_offset_x_m = offset_x_m;
@@ -8968,6 +9062,39 @@ comp_d3d11_service_ensure_shell_window(struct xrt_system_compositor *xsysc)
 		U_LOG_W("Shell: resuming from suspended state");
 
 		mc->suspended = false;
+		sys->shell_mode = true;
+
+		// Reverse hot-switch: tear down per-client standalone resources,
+		// re-hide app HWNDs. Apps go back to exporting via multi-comp.
+		for (int i = 0; i < D3D11_MULTI_MAX_CLIENTS; i++) {
+			struct d3d11_multi_client_slot *slot = &mc->clients[i];
+			if (!slot->active || slot->client_type != CLIENT_TYPE_IPC) {
+				continue;
+			}
+			if (slot->compositor == nullptr) {
+				continue;
+			}
+
+			struct d3d11_client_render_resources *res = &slot->compositor->render;
+
+			// Destroy per-client DP
+			if (res->display_processor != nullptr) {
+				xrt_display_processor_d3d11_request_display_mode(res->display_processor, false);
+				xrt_display_processor_d3d11_destroy(&res->display_processor);
+			}
+
+			// Destroy per-client swap chain + back buffer
+			res->back_buffer_rtv.reset();
+			res->swap_chain.reset();
+			res->hwnd = nullptr;
+
+			// Re-hide the app's HWND (shell composites it now)
+			if (slot->app_hwnd != nullptr && IsWindow(slot->app_hwnd)) {
+				ShowWindow(slot->app_hwnd, SW_HIDE);
+			}
+
+			U_LOG_W("Shell resume: hot-switched slot %d back to export mode", i);
+		}
 
 		// Show the shell window again
 		if (mc->hwnd != nullptr) {
@@ -9065,6 +9192,10 @@ comp_d3d11_service_deactivate_shell(struct xrt_system_compositor *xsysc)
 
 	U_LOG_W("Shell deactivate: beginning teardown");
 
+	// Clear the compositor's local shell_mode flag so layer_commit
+	// takes the standalone path instead of the (now suspended) multi-comp.
+	sys->shell_mode = false;
+
 	// --- 4C.2: Stop all capture sessions and restore 2D windows ---
 	for (int i = 0; i < D3D11_MULTI_MAX_CLIENTS; i++) {
 		struct d3d11_multi_client_slot *slot = &mc->clients[i];
@@ -9072,7 +9203,6 @@ comp_d3d11_service_deactivate_shell(struct xrt_system_compositor *xsysc)
 			continue;
 		}
 
-		// Stop capture
 		d3d11_capture_stop(slot->capture_ctx);
 		slot->capture_ctx = nullptr;
 		slot->capture_srv = nullptr;
@@ -9080,11 +9210,9 @@ comp_d3d11_service_deactivate_shell(struct xrt_system_compositor *xsysc)
 		slot->capture_width = 0;
 		slot->capture_height = 0;
 
-		// Restore window to original desktop position and style
 		if (slot->app_hwnd != nullptr && IsWindow(slot->app_hwnd)) {
 			SetWindowPlacement(slot->app_hwnd, &slot->saved_placement);
 			SetWindowLongPtr(slot->app_hwnd, GWL_EXSTYLE, slot->saved_exstyle);
-			// Force window to repaint at restored position
 			SetWindowPos(slot->app_hwnd, HWND_TOP, 0, 0, 0, 0,
 			             SWP_NOMOVE | SWP_NOSIZE | SWP_FRAMECHANGED | SWP_SHOWWINDOW);
 			U_LOG_W("Shell deactivate: restored 2D window HWND=%p", (void *)slot->app_hwnd);
@@ -9092,30 +9220,16 @@ comp_d3d11_service_deactivate_shell(struct xrt_system_compositor *xsysc)
 
 		slot->active = false;
 		slot->compositor = nullptr;
-		slot->client_type = CLIENT_TYPE_IPC; // reset
+		slot->client_type = CLIENT_TYPE_IPC;
 		mc->client_count--;
 		mc->capture_client_count--;
 	}
 
-	// --- 4C.3: Push SESSION_LOSS_PENDING to IPC clients ---
-	// Apps receive XR_SESSION_STATE_LOSS_PENDING, destroy their session,
-	// and optionally recreate. On recreate, shell_mode will be false so
-	// they come up in standalone mode (visible HWND, own DP).
-	for (int i = 0; i < D3D11_MULTI_MAX_CLIENTS; i++) {
-		struct d3d11_multi_client_slot *slot = &mc->clients[i];
-		if (!slot->active || slot->client_type != CLIENT_TYPE_IPC) {
-			continue;
-		}
-		if (slot->compositor == nullptr || slot->compositor->xses == nullptr) {
-			continue;
-		}
-		union xrt_session_event xse = XRT_STRUCT_INIT;
-		xse.loss_pending.type = XRT_SESSION_EVENT_LOSS_PENDING;
-		xse.loss_pending.loss_time_ns =
-		    (int64_t)os_monotonic_get_ns() + 500000000LL; // 500ms grace
-		xrt_session_event_sink_push(slot->compositor->xses, &xse);
-		U_LOG_W("Shell deactivate: sent LOSS_PENDING to IPC slot %d", i);
-	}
+	// --- 4C.3: IPC clients hot-switch to standalone (lazy) ---
+	// Don't create resources here — that deadlocks (DXGI sends WM to app thread
+	// which is blocked on IPC). Instead, just suspend the multi-comp.
+	// Each app's next layer_commit detects shell_mode=false and lazily creates
+	// its own swap chain + DP on its own thread (no cross-thread WM).
 
 	// Reset drag/focus state
 	mc->focused_slot = -1;
@@ -9124,22 +9238,19 @@ comp_d3d11_service_deactivate_shell(struct xrt_system_compositor *xsysc)
 	mc->resize.active = false;
 
 	// --- 4C.5: Suspend multi-compositor ---
-
-	// Stop render thread
 	capture_render_thread_stop(sys);
 
-	// Switch display back to 2D before releasing DP
 	if (mc->display_processor != nullptr) {
 		xrt_display_processor_d3d11_request_display_mode(mc->display_processor, false);
 		xrt_display_processor_d3d11_destroy(&mc->display_processor);
 	}
 
-	// Hide shell window (keep HWND alive for resume)
 	if (mc->hwnd != nullptr) {
 		ShowWindow(mc->hwnd, SW_HIDE);
 	}
 
 	mc->suspended = true;
 
-	U_LOG_W("Shell deactivate: complete — captures stopped, DP released, window hidden");
+	U_LOG_W("Shell deactivate: complete — captures stopped, multi-comp suspended, "
+	        "IPC clients will lazy-switch to standalone on next frame");
 }

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -589,6 +589,10 @@ struct d3d11_multi_compositor
 	//! True after dismiss cleanup (EXIT_REQUEST sent, captures released).
 	bool dismiss_cleanup_done;
 
+	//! Shell deactivated (Ctrl+Space): window hidden, DP released, captures stopped.
+	//! Unlike window_dismissed, the multi-comp structure stays alive for re-activation.
+	bool suspended;
+
 	//! Debounced re-grid: when > 0, apply grid layout after this timestamp.
 	//! Set by client registration, consumed by render loop.
 	uint64_t regrid_pending_ns;
@@ -4849,6 +4853,11 @@ multi_compositor_render(struct d3d11_service_system *sys)
 		mc = sys->multi_comp;
 	}
 
+	if (mc->suspended) {
+		// Shell deactivated — don't render, wait for re-activation.
+		return;
+	}
+
 	if (mc->window_dismissed) {
 		// Shell was dismissed (ESC). Don't reopen — stay dismissed.
 		// Send EXIT_REQUEST to all IPC clients so they exit cleanly.
@@ -8915,6 +8924,45 @@ comp_d3d11_service_ensure_shell_window(struct xrt_system_compositor *xsysc)
 
 	std::lock_guard<std::recursive_mutex> lock(sys->render_mutex);
 
+	// If shell was suspended (deactivated via Ctrl+Space), resume it:
+	// show window, recreate DP, restart render thread.
+	if (sys->multi_comp != nullptr && sys->multi_comp->suspended) {
+		struct d3d11_multi_compositor *mc = sys->multi_comp;
+		U_LOG_W("Shell: resuming from suspended state");
+
+		mc->suspended = false;
+
+		// Show the shell window again
+		if (mc->hwnd != nullptr) {
+			ShowWindow(mc->hwnd, SW_SHOW);
+			SetForegroundWindow(mc->hwnd);
+		}
+
+		// Recreate display processor via factory (window + swap chain still alive)
+		if (mc->display_processor == nullptr && sys->base.info.dp_factory_d3d11 != NULL) {
+			auto factory = (xrt_dp_factory_d3d11_fn_t)sys->base.info.dp_factory_d3d11;
+			xrt_result_t dp_ret = factory(
+			    sys->device.get(), sys->context.get(), mc->hwnd, &mc->display_processor);
+
+			if (dp_ret == XRT_SUCCESS && mc->display_processor != nullptr) {
+				U_LOG_W("Shell resume: display processor recreated");
+				if (mc->window != nullptr) {
+					comp_d3d11_window_set_shell_dp(mc->window, mc->display_processor);
+				}
+			} else {
+				U_LOG_E("Shell resume: failed to recreate display processor");
+			}
+		}
+
+		// Restart render thread
+		if (!mc->capture_render_running.load()) {
+			capture_render_thread_start(sys);
+		}
+
+		U_LOG_W("Shell: resumed — window shown, DP recreated, render running");
+		return true;
+	}
+
 	// If a previous shell session was dismissed (ESC), tear down its window
 	// and resources so ensure_output creates a fresh one.
 	if (sys->multi_comp != nullptr && sys->multi_comp->window_dismissed) {
@@ -8954,4 +9002,87 @@ comp_d3d11_service_ensure_shell_window(struct xrt_system_compositor *xsysc)
 
 	U_LOG_W("Shell: window created for empty shell (ready for Ctrl+O)");
 	return true;
+}
+
+void
+comp_d3d11_service_deactivate_shell(struct xrt_system_compositor *xsysc)
+{
+	if (xsysc == nullptr) {
+		return;
+	}
+
+	struct d3d11_service_system *sys = d3d11_service_system_from_xrt(xsysc);
+
+	std::lock_guard<std::recursive_mutex> lock(sys->render_mutex);
+
+	struct d3d11_multi_compositor *mc = sys->multi_comp;
+	if (mc == nullptr) {
+		U_LOG_W("Shell deactivate: no multi-comp — nothing to do");
+		return;
+	}
+
+	if (mc->suspended) {
+		U_LOG_W("Shell deactivate: already suspended");
+		return;
+	}
+
+	U_LOG_W("Shell deactivate: beginning teardown");
+
+	// --- 4C.2: Stop all capture sessions and restore 2D windows ---
+	for (int i = 0; i < D3D11_MULTI_MAX_CLIENTS; i++) {
+		struct d3d11_multi_client_slot *slot = &mc->clients[i];
+		if (!slot->active || slot->client_type != CLIENT_TYPE_CAPTURE) {
+			continue;
+		}
+
+		// Stop capture
+		d3d11_capture_stop(slot->capture_ctx);
+		slot->capture_ctx = nullptr;
+		slot->capture_srv = nullptr;
+		slot->capture_texture_last = nullptr;
+		slot->capture_width = 0;
+		slot->capture_height = 0;
+
+		// Restore window to original desktop position and style
+		if (slot->app_hwnd != nullptr && IsWindow(slot->app_hwnd)) {
+			SetWindowPlacement(slot->app_hwnd, &slot->saved_placement);
+			SetWindowLongPtr(slot->app_hwnd, GWL_EXSTYLE, slot->saved_exstyle);
+			// Force window to repaint at restored position
+			SetWindowPos(slot->app_hwnd, HWND_TOP, 0, 0, 0, 0,
+			             SWP_NOMOVE | SWP_NOSIZE | SWP_FRAMECHANGED | SWP_SHOWWINDOW);
+			U_LOG_W("Shell deactivate: restored 2D window HWND=%p", (void *)slot->app_hwnd);
+		}
+
+		slot->active = false;
+		slot->compositor = nullptr;
+		slot->client_type = CLIENT_TYPE_IPC; // reset
+		mc->client_count--;
+		mc->capture_client_count--;
+	}
+
+	// Reset drag/focus state
+	mc->focused_slot = -1;
+	mc->drag.active = false;
+	mc->title_drag.active = false;
+	mc->resize.active = false;
+
+	// --- 4C.5: Suspend multi-compositor ---
+
+	// Stop render thread
+	capture_render_thread_stop(sys);
+
+	// Switch display back to 2D before releasing DP
+	if (mc->display_processor != nullptr) {
+		xrt_display_processor_d3d11_request_display_mode(mc->display_processor, false);
+		xrt_display_processor_d3d11_destroy(&mc->display_processor);
+	}
+
+	// Hide shell window (keep HWND alive for resume)
+	if (mc->hwnd != nullptr) {
+		ShowWindow(mc->hwnd, SW_HIDE);
+	}
+
+	mc->suspended = true;
+
+	U_LOG_W("Shell deactivate: complete — captures stopped, DP released, window hidden");
 }

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -224,6 +224,9 @@ struct d3d11_service_compositor
 	//! App's HWND from XR_EXT_win32_window_binding (for lazy standalone init)
 	HWND app_hwnd;
 
+	//! Set when shell re-activates — next layer_commit tears down standalone resources
+	bool pending_shell_reentry;
+
 	//! Whether the window has been closed (triggers session exit)
 	bool window_closed;
 
@@ -6766,10 +6769,7 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 		in_size_move = comp_d3d11_window_is_in_size_move(c->render.window);
 	}
 
-	// Skip swap chain resize for hot-switched apps: the swap chain is
-	// intentionally at display-native size (3840x2160) even though the
-	// HWND client rect may be smaller (due to decorations).
-	if (c->render.hwnd != nullptr && c->render.swap_chain && c->render.owns_window) {
+	if (c->render.hwnd != nullptr && c->render.swap_chain) {
 		RECT client_rect;
 		if (GetClientRect(c->render.hwnd, &client_rect)) {
 			uint32_t client_width = static_cast<uint32_t>(client_rect.right - client_rect.left);
@@ -7441,6 +7441,34 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 
 	// Shell mode: per-client atlas rendering is done. The multi-compositor
 	// composites all client atlases into the combined atlas and presents.
+	// --- Lazy reverse hot-switch (shell re-activated) ---
+	// Tear down per-client standalone resources on the app's own thread.
+	// Hide the HWND last (sends WM but app's main thread isn't blocked here
+	// since we're about to return from this layer_commit).
+	if (c->pending_shell_reentry) {
+		U_LOG_W("Reverse hot-switch: tearing down standalone resources");
+		c->pending_shell_reentry = false;
+
+		if (c->render.display_processor != nullptr) {
+			xrt_display_processor_d3d11_request_display_mode(c->render.display_processor, false);
+			xrt_display_processor_d3d11_destroy(&c->render.display_processor);
+		}
+		c->render.back_buffer_rtv.reset();
+		c->render.swap_chain.reset();
+		if (c->render.hud != nullptr) {
+			u_hud_destroy(&c->render.hud);
+		}
+		c->render.hwnd = nullptr;
+
+		// Hide the app's HWND — use ShowWindowAsync to avoid deadlock.
+		// Synchronous ShowWindow(SW_HIDE) sends WM to the app's main
+		// thread, which is blocked waiting for this IPC layer_commit to return.
+		if (c->app_hwnd != nullptr && IsWindow(c->app_hwnd)) {
+			ShowWindowAsync(c->app_hwnd, SW_HIDE);
+		}
+		U_LOG_W("Reverse hot-switch: done — back to export mode");
+	}
+
 	if (sys->shell_mode) {
 		// Throttle renders to ~1 per VSync (~14ms). With N clients each calling
 		// layer_commit at 60fps, we'd otherwise render N times per frame cycle.
@@ -7467,17 +7495,14 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 	if (!c->render.swap_chain && c->app_hwnd != nullptr && IsWindow(c->app_hwnd)) {
 		U_LOG_W("Hot-switch: lazy standalone init for HWND=%p", (void *)c->app_hwnd);
 
-		// Use app's HWND for standalone rendering. We can't make it
-		// borderless from here (deadlock), so the DP output will be
-		// scaled by the OS into the decorated window. Not pixel-perfect
-		// weaving, but content is visible and the app survives.
-		ShowWindow(c->app_hwnd, SW_SHOWNOACTIVATE);
+		// Show the HWND with ShowWindowAsync to avoid deadlock with the
+		// app's main thread (blocked on this IPC layer_commit).
+		ShowWindowAsync(c->app_hwnd, SW_SHOWNOACTIVATE);
 
 		c->render.hwnd = c->app_hwnd;
 		c->render.owns_window = false;
 
-		// Swap chain at display-native size for correct DP output.
-		// DXGI scales to the HWND client rect on Present.
+		// Swap chain at display-native size (matches DP expectation)
 		uint32_t sc_w = sys->base.info.display_pixel_width;
 		uint32_t sc_h = sys->base.info.display_pixel_height;
 		if (sc_w == 0 || sc_h == 0) {
@@ -7688,8 +7713,12 @@ compositor_destroy(struct xrt_compositor *xc)
 
 	U_LOG_W("Destroying D3D11 service compositor for client");
 
-	// Unregister from multi-compositor before cleanup
-	if (sys->shell_mode) {
+	// Unregister from multi-compositor before cleanup.
+	// Always unregister if there's a multi_comp — the client may have been
+	// registered in shell mode but is now closing in standalone mode (after
+	// hot-switch). Without this, the slot stays stale and shows a ghost
+	// remnant on shell re-activate.
+	if (sys->multi_comp != nullptr) {
 		std::lock_guard<std::recursive_mutex> lock(sys->render_mutex);
 		multi_compositor_unregister_client(sys, c);
 	}
@@ -9126,8 +9155,10 @@ comp_d3d11_service_ensure_shell_window(struct xrt_system_compositor *xsysc)
 		mc->suspended = false;
 		sys->shell_mode = true;
 
-		// Reverse hot-switch: tear down per-client standalone resources,
-		// re-hide app HWNDs. Apps go back to exporting via multi-comp.
+		// Reverse hot-switch is LAZY: just flag each client compositor.
+		// Each client's next layer_commit will tear down its own DP and
+		// swap chain on its own thread (avoids cross-thread WM deadlock
+		// from ShowWindow/SetWindowLongPtr while app is blocked on IPC).
 		for (int i = 0; i < D3D11_MULTI_MAX_CLIENTS; i++) {
 			struct d3d11_multi_client_slot *slot = &mc->clients[i];
 			if (!slot->active || slot->client_type != CLIENT_TYPE_IPC) {
@@ -9136,29 +9167,8 @@ comp_d3d11_service_ensure_shell_window(struct xrt_system_compositor *xsysc)
 			if (slot->compositor == nullptr) {
 				continue;
 			}
-
-			struct d3d11_client_render_resources *res = &slot->compositor->render;
-
-			// Destroy per-client DP
-			if (res->display_processor != nullptr) {
-				xrt_display_processor_d3d11_request_display_mode(res->display_processor, false);
-				xrt_display_processor_d3d11_destroy(&res->display_processor);
-			}
-
-			// Destroy per-client swap chain + back buffer
-			res->back_buffer_rtv.reset();
-			res->swap_chain.reset();
-			res->hwnd = nullptr;
-			if (res->hud != nullptr) {
-				u_hud_destroy(&res->hud);
-			}
-
-			// Re-hide the app's HWND (shell composites it now)
-			if (slot->app_hwnd != nullptr && IsWindow(slot->app_hwnd)) {
-				ShowWindow(slot->app_hwnd, SW_HIDE);
-			}
-
-			U_LOG_W("Shell resume: hot-switched slot %d back to export mode", i);
+			slot->compositor->pending_shell_reentry = true;
+			U_LOG_W("Shell resume: flagged slot %d for lazy reverse hot-switch", i);
 		}
 
 		// Show the shell window again

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -8972,7 +8972,20 @@ comp_d3d11_service_owns_window(struct xrt_system_compositor *xsysc)
 		return false;
 	}
 
-	// Non-shell IPC clients always get Monado-owned windows.
+	// Non-shell mode: check the active compositor's actual ownership.
+	// After hot-switch, handle apps still use their external HWND
+	// (owns_window=false), not a Monado-owned one. This must return false
+	// so the IPC view pose path takes the display-centric branch.
+	struct d3d11_service_compositor *sc = nullptr;
+	{
+		std::lock_guard<std::mutex> lock(sys->active_compositor_mutex);
+		sc = sys->active_compositor;
+	}
+	if (sc != nullptr) {
+		return sc->render.owns_window;
+	}
+
+	// No active compositor — assume Monado-owned (default standalone)
 	return true;
 }
 

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -6766,7 +6766,10 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 		in_size_move = comp_d3d11_window_is_in_size_move(c->render.window);
 	}
 
-	if (c->render.hwnd != nullptr && c->render.swap_chain) {
+	// Skip swap chain resize for hot-switched apps: the swap chain is
+	// intentionally at display-native size (3840x2160) even though the
+	// HWND client rect may be smaller (due to decorations).
+	if (c->render.hwnd != nullptr && c->render.swap_chain && c->render.owns_window) {
 		RECT client_rect;
 		if (GetClientRect(c->render.hwnd, &client_rect)) {
 			uint32_t client_width = static_cast<uint32_t>(client_rect.right - client_rect.left);
@@ -7464,19 +7467,22 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 	if (!c->render.swap_chain && c->app_hwnd != nullptr && IsWindow(c->app_hwnd)) {
 		U_LOG_W("Hot-switch: lazy standalone init for HWND=%p", (void *)c->app_hwnd);
 
-		// Show the app's HWND (hidden during shell mode).
-		// Decorations are preserved — no style changes needed.
+		// Use app's HWND for standalone rendering. We can't make it
+		// borderless from here (deadlock), so the DP output will be
+		// scaled by the OS into the decorated window. Not pixel-perfect
+		// weaving, but content is visible and the app survives.
 		ShowWindow(c->app_hwnd, SW_SHOWNOACTIVATE);
 
 		c->render.hwnd = c->app_hwnd;
 		c->render.owns_window = false;
 
-		RECT cr;
-		uint32_t sc_w = sys->output_width, sc_h = sys->output_height;
-		if (GetClientRect(c->app_hwnd, &cr)) {
-			uint32_t cw = (uint32_t)(cr.right - cr.left);
-			uint32_t ch = (uint32_t)(cr.bottom - cr.top);
-			if (cw > 0 && ch > 0) { sc_w = cw; sc_h = ch; }
+		// Swap chain at display-native size for correct DP output.
+		// DXGI scales to the HWND client rect on Present.
+		uint32_t sc_w = sys->base.info.display_pixel_width;
+		uint32_t sc_h = sys->base.info.display_pixel_height;
+		if (sc_w == 0 || sc_h == 0) {
+			sc_w = sys->output_width * 2;
+			sc_h = sys->output_height * 2;
 		}
 
 		DXGI_SWAP_CHAIN_DESC1 sc_desc = {};
@@ -7515,10 +7521,55 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 			}
 		}
 
-		U_LOG_W("Hot-switch: swap_chain=%p, back_buffer_rtv=%p, dp=%p",
-		        (void *)c->render.swap_chain.get(),
-		        (void *)c->render.back_buffer_rtv.get(),
-		        (void *)c->render.display_processor);
+		// Enable HUD for standalone mode diagnostics
+		if (c->render.hud == nullptr) {
+			uint32_t hud_w = sc_w > 0 ? sc_w : sys->output_width;
+			c->render.smoothed_frame_time_ms = 16.67f;
+			u_hud_create(&c->render.hud, hud_w);
+		}
+
+		// Diagnostic dump: everything the app sees after hot-switch
+		{
+			POINT screen_pos = {0, 0};
+			ClientToScreen(c->app_hwnd, &screen_pos);
+			RECT wr;
+			GetWindowRect(c->app_hwnd, &wr);
+
+			D3D11_TEXTURE2D_DESC atlas_desc = {};
+			if (c->render.atlas_texture) {
+				c->render.atlas_texture->GetDesc(&atlas_desc);
+			}
+
+			uint32_t dp_px_w = 0, dp_px_h = 0;
+			int32_t dp_left = 0, dp_top = 0;
+			if (c->render.display_processor) {
+				xrt_display_processor_d3d11_get_display_pixel_info(
+				    c->render.display_processor, &dp_px_w, &dp_px_h, &dp_left, &dp_top);
+			}
+
+			U_LOG_W("=== HOT-SWITCH DIAGNOSTIC ===");
+			U_LOG_W("  HWND=%p, client_rect=%ux%u, screen_pos=(%d,%d)",
+			        (void *)c->app_hwnd, sc_w, sc_h,
+			        screen_pos.x, screen_pos.y);
+			U_LOG_W("  window_rect=(%d,%d)-(%d,%d) = %dx%d",
+			        wr.left, wr.top, wr.right, wr.bottom,
+			        wr.right - wr.left, wr.bottom - wr.top);
+			U_LOG_W("  atlas_texture=%ux%u",
+			        atlas_desc.Width, atlas_desc.Height);
+			U_LOG_W("  swap_chain=%ux%u (same as client_rect)", sc_w, sc_h);
+			U_LOG_W("  sys view=%ux%u, output=%ux%u, display=%ux%u",
+			        sys->view_width, sys->view_height,
+			        sys->output_width, sys->output_height,
+			        sys->display_width, sys->display_height);
+			U_LOG_W("  DP display_pixel=%ux%u at (%d,%d)",
+			        dp_px_w, dp_px_h, dp_left, dp_top);
+			U_LOG_W("  tile=%ux%u, shell_mode=%d",
+			        sys->tile_columns, sys->tile_rows, sys->shell_mode);
+			U_LOG_W("  display_phys=%.4fx%.4f m",
+			        sys->base.info.display_width_m,
+			        sys->base.info.display_height_m);
+			U_LOG_W("=============================");
+		}
 	}
 
 	// During drag, synchronize with the window thread's WM_PAINT cycle.
@@ -7569,6 +7620,17 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 				bb_texture->GetDesc(&bb_desc);
 				back_buffer_width = bb_desc.Width;
 				back_buffer_height = bb_desc.Height;
+			}
+		}
+
+		// Log DP input dims periodically
+		{
+			static uint32_t dp_log_count = 0;
+			if (dp_log_count++ % 300 == 0) {
+				U_LOG_W("Standalone DP: input_view=%ux%u, back_buffer=%ux%u, tile=%ux%u",
+				        input_view_w, input_view_h,
+				        back_buffer_width, back_buffer_height,
+				        sys->tile_columns, sys->tile_rows);
 			}
 		}
 
@@ -9087,6 +9149,9 @@ comp_d3d11_service_ensure_shell_window(struct xrt_system_compositor *xsysc)
 			res->back_buffer_rtv.reset();
 			res->swap_chain.reset();
 			res->hwnd = nullptr;
+			if (res->hud != nullptr) {
+				u_hud_destroy(&res->hud);
+			}
 
 			// Re-hide the app's HWND (shell composites it now)
 			if (slot->app_hwnd != nullptr && IsWindow(slot->app_hwnd)) {

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -4859,32 +4859,69 @@ multi_compositor_render(struct d3d11_service_system *sys)
 	}
 
 	if (mc->window_dismissed) {
-		// Shell was dismissed (ESC). Don't reopen — stay dismissed.
-		// Send EXIT_REQUEST to all IPC clients so they exit cleanly.
-		// Release all capture clients (captured 2D windows stay alive).
+		// Shell window closed (ESC / close button). Behaves like deactivate:
+		// restore 2D windows, send LOSS_PENDING (not EXIT_REQUEST) to IPC
+		// clients. The shell can re-activate via Ctrl+Space.
 		if (!mc->dismiss_cleanup_done) {
 			mc->dismiss_cleanup_done = true;
+
+			// Stop and restore capture clients (2D windows)
 			for (int i = 0; i < D3D11_MULTI_MAX_CLIENTS; i++) {
-				if (!mc->clients[i].active) continue;
-				if (mc->clients[i].client_type == CLIENT_TYPE_CAPTURE) {
-					multi_compositor_remove_capture_client(sys, i);
-				} else if (mc->clients[i].compositor != nullptr &&
-				           mc->clients[i].compositor->xses != nullptr) {
+				struct d3d11_multi_client_slot *slot = &mc->clients[i];
+				if (!slot->active) continue;
+				if (slot->client_type == CLIENT_TYPE_CAPTURE) {
+					d3d11_capture_stop(slot->capture_ctx);
+					slot->capture_ctx = nullptr;
+					slot->capture_srv = nullptr;
+					slot->capture_texture_last = nullptr;
+					// Restore 2D window to desktop
+					if (slot->app_hwnd != nullptr && IsWindow(slot->app_hwnd)) {
+						SetWindowPlacement(slot->app_hwnd, &slot->saved_placement);
+						SetWindowLongPtr(slot->app_hwnd, GWL_EXSTYLE, slot->saved_exstyle);
+						SetWindowPos(slot->app_hwnd, HWND_TOP, 0, 0, 0, 0,
+						             SWP_NOMOVE | SWP_NOSIZE | SWP_FRAMECHANGED | SWP_SHOWWINDOW);
+					}
+					slot->active = false;
+					slot->compositor = nullptr;
+					slot->client_type = CLIENT_TYPE_IPC;
+					mc->client_count--;
+					mc->capture_client_count--;
+				} else if (slot->compositor != nullptr &&
+				           slot->compositor->xses != nullptr) {
+					// Send LOSS_PENDING so apps can recreate in standalone
 					union xrt_session_event xse = XRT_STRUCT_INIT;
-					xse.type = XRT_SESSION_EVENT_EXIT_REQUEST;
-					xrt_session_event_sink_push(mc->clients[i].compositor->xses, &xse);
+					xse.loss_pending.type = XRT_SESSION_EVENT_LOSS_PENDING;
+					xse.loss_pending.loss_time_ns =
+					    (int64_t)os_monotonic_get_ns() + 500000000LL;
+					xrt_session_event_sink_push(slot->compositor->xses, &xse);
 				}
 			}
-			U_LOG_W("Multi-comp: shell dismissed — sent exit to IPC clients, released captures");
+
+			// Stop render thread
+			capture_render_thread_stop(sys);
+
+			// Release DP (display already back to 2D from the window-close handler)
+			if (mc->display_processor != nullptr) {
+				xrt_display_processor_d3d11_destroy(&mc->display_processor);
+			}
+
+			U_LOG_W("Multi-comp: shell dismissed (ESC) — captures restored, LOSS_PENDING sent");
 		}
 		return;
 	}
 
-	// Check window validity
+	// Check window validity — ESC or close button triggers deactivate (suspend),
+	// not the old permanent dismiss. The shell can re-activate via Ctrl+Space.
 	if (mc->window != nullptr && !comp_d3d11_window_is_valid(mc->window)) {
-		U_LOG_W("Multi-comp: window closed - dismissing");
+		U_LOG_W("Multi-comp: window closed (ESC) — deactivating shell");
+		// Set shell_mode flags to false so the shell process detects the change
+		sys->shell_mode = false;
+		sys->base.info.shell_mode = false;
+		// Run the full deactivate path (capture teardown, DP release, etc.)
+		// We need to recreate the window on resume since it was destroyed by ESC,
+		// so use the dismissed path which ensure_shell_window handles.
 		mc->window_dismissed = true;
-		// Switch display back to 2D (lens off) on dismiss
+		// Switch display back to 2D (lens off)
 		if (mc->display_processor != nullptr) {
 			xrt_display_processor_d3d11_request_display_mode(mc->display_processor, false);
 		}

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -52,6 +52,8 @@
 
 #include <d2d1.h>
 #include <dwrite.h>
+#include <dwmapi.h>
+#pragma comment(lib, "dwmapi.lib")
 
 #include <chrono>
 #include <cstdlib>
@@ -178,6 +180,7 @@ struct d3d11_client_render_resources
 	//! Content-sized crop atlas for DP input (lazy-created when content < atlas)
 	wil::com_ptr<ID3D11Texture2D> crop_texture;
 	wil::com_ptr<ID3D11ShaderResourceView> crop_srv;
+	wil::com_ptr<ID3D11RenderTargetView> crop_rtv; //!< For shader-blit Y-flip path
 	uint32_t crop_width;   //!< Current crop texture width (0 = not created)
 	uint32_t crop_height;  //!< Current crop texture height
 
@@ -2931,19 +2934,23 @@ static ID3D11ShaderResourceView *
 service_crop_atlas_for_dp(struct d3d11_service_system *sys,
                           struct d3d11_client_render_resources *res,
                           uint32_t content_view_w,
-                          uint32_t content_view_h)
+                          uint32_t content_view_h,
+                          bool flip_y)
 {
 	uint32_t expected_w = sys->tile_columns * content_view_w;
 	uint32_t expected_h = sys->tile_rows * content_view_h;
 
-	// Content fills the full atlas — pass directly
-	if (expected_w == sys->display_width && expected_h == sys->display_height) {
+	// Content fills the full atlas — pass directly (only when no flip needed)
+	if (!flip_y && expected_w == sys->display_width && expected_h == sys->display_height) {
 		return res->atlas_srv.get();
 	}
 
-	// Lazy (re)create crop texture at content dimensions
+	// Lazy (re)create crop texture at content dimensions.
+	// When flip_y is needed we must use a shader blit, which requires the
+	// crop texture to be bindable as a render target.
 	if (res->crop_width != expected_w || res->crop_height != expected_h) {
 		res->crop_srv.reset();
+		res->crop_rtv.reset();
 		res->crop_texture.reset();
 
 		D3D11_TEXTURE2D_DESC crop_desc = {};
@@ -2954,13 +2961,15 @@ service_crop_atlas_for_dp(struct d3d11_service_system *sys,
 		crop_desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
 		crop_desc.SampleDesc.Count = 1;
 		crop_desc.Usage = D3D11_USAGE_DEFAULT;
-		crop_desc.BindFlags = D3D11_BIND_SHADER_RESOURCE;
+		crop_desc.BindFlags = D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET;
 
 		HRESULT hr = sys->device->CreateTexture2D(
 		    &crop_desc, nullptr, res->crop_texture.put());
 		if (SUCCEEDED(hr)) {
 			sys->device->CreateShaderResourceView(
 			    res->crop_texture.get(), nullptr, res->crop_srv.put());
+			sys->device->CreateRenderTargetView(
+			    res->crop_texture.get(), nullptr, res->crop_rtv.put());
 			res->crop_width = expected_w;
 			res->crop_height = expected_h;
 			U_LOG_I("Crop-blit: created %ux%u staging texture "
@@ -2975,8 +2984,85 @@ service_crop_atlas_for_dp(struct d3d11_service_system *sys,
 		return res->atlas_srv.get(); // fallback
 	}
 
-	// Copy each view's content region from atlas to crop texture
+	// Get atlas dimensions for shader blit src_size
+	D3D11_TEXTURE2D_DESC atlas_desc = {};
+	res->atlas_texture->GetDesc(&atlas_desc);
+	uint32_t src_tex_w = atlas_desc.Width;
+	uint32_t src_tex_h = atlas_desc.Height;
+
 	uint32_t num_views = sys->tile_columns * sys->tile_rows;
+
+	if (flip_y && res->crop_rtv && sys->blit_vs && sys->blit_ps) {
+		// Shader blit path: crop + Y-flip in one pass per view.
+		// Set up pipeline once, then draw N views with different constants.
+		sys->context->VSSetShader(sys->blit_vs.get(), nullptr, 0);
+		sys->context->PSSetShader(sys->blit_ps.get(), nullptr, 0);
+		sys->context->VSSetConstantBuffers(0, 1, sys->blit_constant_buffer.addressof());
+		sys->context->PSSetConstantBuffers(0, 1, sys->blit_constant_buffer.addressof());
+		sys->context->PSSetSamplers(0, 1, sys->sampler_linear.addressof());
+		ID3D11ShaderResourceView *src_srv = res->atlas_srv.get();
+		sys->context->PSSetShaderResources(0, 1, &src_srv);
+
+		ID3D11RenderTargetView *rtvs[] = {res->crop_rtv.get()};
+		sys->context->OMSetRenderTargets(1, rtvs, nullptr);
+		D3D11_VIEWPORT vp = {};
+		vp.Width = (float)expected_w;
+		vp.Height = (float)expected_h;
+		vp.MaxDepth = 1.0f;
+		sys->context->RSSetViewports(1, &vp);
+		sys->context->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
+		sys->context->IASetInputLayout(nullptr);
+		sys->context->RSSetState(sys->rasterizer_state.get());
+		sys->context->OMSetDepthStencilState(sys->depth_disabled.get(), 0);
+		sys->context->OMSetBlendState(nullptr, nullptr, 0xFFFFFFFF);
+
+		for (uint32_t v = 0; v < num_views && v < XRT_MAX_VIEWS; v++) {
+			uint32_t src_tile_x, src_tile_y;
+			u_tiling_view_origin(v, sys->tile_columns,
+			                     sys->view_width, sys->view_height,
+			                     &src_tile_x, &src_tile_y);
+			uint32_t dst_tile_x, dst_tile_y;
+			u_tiling_view_origin(v, sys->tile_columns,
+			                     content_view_w, content_view_h,
+			                     &dst_tile_x, &dst_tile_y);
+
+			D3D11_MAPPED_SUBRESOURCE mapped;
+			HRESULT hr = sys->context->Map(sys->blit_constant_buffer.get(), 0,
+			                                D3D11_MAP_WRITE_DISCARD, 0, &mapped);
+			if (FAILED(hr)) continue;
+			BlitConstants *cb = static_cast<BlitConstants *>(mapped.pData);
+			memset(cb, 0, sizeof(*cb));
+			cb->src_rect[0] = (float)src_tile_x;
+			cb->src_rect[1] = (float)src_tile_y + (float)content_view_h; // bottom (flipped origin)
+			cb->src_rect[2] = (float)content_view_w;
+			cb->src_rect[3] = -(float)content_view_h;                    // negative h = flip
+			cb->dst_offset[0] = (float)dst_tile_x;
+			cb->dst_offset[1] = (float)dst_tile_y;
+			cb->src_size[0] = (float)src_tex_w;
+			cb->src_size[1] = (float)src_tex_h;
+			cb->dst_size[0] = (float)expected_w;
+			cb->dst_size[1] = (float)expected_h;
+			cb->dst_rect_wh[0] = (float)content_view_w;
+			cb->dst_rect_wh[1] = (float)content_view_h;
+			cb->convert_srgb = 0.0f;
+			cb->quad_mode = 0.0f;
+			cb->corner_radius = 0.0f;
+			cb->corner_aspect = 1.0f;
+			cb->edge_feather = 0.0f;
+			cb->glow_intensity = 0.0f;
+			sys->context->Unmap(sys->blit_constant_buffer.get(), 0);
+
+			sys->context->Draw(4, 0);
+		}
+
+		// Unbind the SRV so the crop texture can be used as input next
+		ID3D11ShaderResourceView *null_srv = nullptr;
+		sys->context->PSSetShaderResources(0, 1, &null_srv);
+
+		return res->crop_srv.get();
+	}
+
+	// Non-flip path: copy each view's content region from atlas to crop texture
 	for (uint32_t v = 0; v < num_views && v < XRT_MAX_VIEWS; v++) {
 		uint32_t src_tile_x, src_tile_y;
 		u_tiling_view_origin(v, sys->tile_columns,
@@ -7460,9 +7546,7 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 		}
 		c->render.hwnd = nullptr;
 
-		// Hide the app's HWND — use ShowWindowAsync to avoid deadlock.
-		// Synchronous ShowWindow(SW_HIDE) sends WM to the app's main
-		// thread, which is blocked waiting for this IPC layer_commit to return.
+		// Hide the app's HWND (shell composites the content).
 		if (c->app_hwnd != nullptr && IsWindow(c->app_hwnd)) {
 			ShowWindowAsync(c->app_hwnd, SW_HIDE);
 		}
@@ -7496,13 +7580,17 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 		U_LOG_W("Hot-switch: lazy standalone init for HWND=%p", (void *)c->app_hwnd);
 
 		// Show the HWND with ShowWindowAsync to avoid deadlock with the
-		// app's main thread (blocked on this IPC layer_commit).
+		// app's main thread (blocked on this IPC layer_commit). Keep
+		// decorations intact — user wants the standalone window to look
+		// like a normal app window.
 		ShowWindowAsync(c->app_hwnd, SW_SHOWNOACTIVATE);
 
 		c->render.hwnd = c->app_hwnd;
 		c->render.owns_window = false;
 
-		// Swap chain at display-native size (matches DP expectation)
+		// Swap chain at display-native size (matches DP expectation).
+		// The compositor's auto-resize handler will adapt it to the
+		// HWND client rect on the next frame.
 		uint32_t sc_w = sys->base.info.display_pixel_width;
 		uint32_t sc_h = sys->base.info.display_pixel_height;
 		if (sc_w == 0 || sc_h == 0) {
@@ -7523,6 +7611,15 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 		    sys->device.get(), c->app_hwnd, &sc_desc,
 		    nullptr, nullptr, c->render.swap_chain.put());
 		if (SUCCEEDED(hr)) {
+			// Reduce DXGI frame latency to 1 — minimizes the queue depth
+			// between Present and DWM cross-process composition. Critical
+			// for smooth drag (otherwise frames are presented at stale
+			// window positions).
+			wil::com_ptr<IDXGIDevice1> dxgi_device;
+			if (SUCCEEDED(sys->device->QueryInterface(IID_PPV_ARGS(dxgi_device.put())))) {
+				dxgi_device->SetMaximumFrameLatency(1);
+			}
+
 			wil::com_ptr<ID3D11Texture2D> bb;
 			c->render.swap_chain->GetBuffer(0, IID_PPV_ARGS(bb.put()));
 			sys->device->CreateRenderTargetView(bb.get(), nullptr, c->render.back_buffer_rtv.put());
@@ -7552,49 +7649,6 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 			c->render.smoothed_frame_time_ms = 16.67f;
 			u_hud_create(&c->render.hud, hud_w);
 		}
-
-		// Diagnostic dump: everything the app sees after hot-switch
-		{
-			POINT screen_pos = {0, 0};
-			ClientToScreen(c->app_hwnd, &screen_pos);
-			RECT wr;
-			GetWindowRect(c->app_hwnd, &wr);
-
-			D3D11_TEXTURE2D_DESC atlas_desc = {};
-			if (c->render.atlas_texture) {
-				c->render.atlas_texture->GetDesc(&atlas_desc);
-			}
-
-			uint32_t dp_px_w = 0, dp_px_h = 0;
-			int32_t dp_left = 0, dp_top = 0;
-			if (c->render.display_processor) {
-				xrt_display_processor_d3d11_get_display_pixel_info(
-				    c->render.display_processor, &dp_px_w, &dp_px_h, &dp_left, &dp_top);
-			}
-
-			U_LOG_W("=== HOT-SWITCH DIAGNOSTIC ===");
-			U_LOG_W("  HWND=%p, client_rect=%ux%u, screen_pos=(%d,%d)",
-			        (void *)c->app_hwnd, sc_w, sc_h,
-			        screen_pos.x, screen_pos.y);
-			U_LOG_W("  window_rect=(%d,%d)-(%d,%d) = %dx%d",
-			        wr.left, wr.top, wr.right, wr.bottom,
-			        wr.right - wr.left, wr.bottom - wr.top);
-			U_LOG_W("  atlas_texture=%ux%u",
-			        atlas_desc.Width, atlas_desc.Height);
-			U_LOG_W("  swap_chain=%ux%u (same as client_rect)", sc_w, sc_h);
-			U_LOG_W("  sys view=%ux%u, output=%ux%u, display=%ux%u",
-			        sys->view_width, sys->view_height,
-			        sys->output_width, sys->output_height,
-			        sys->display_width, sys->display_height);
-			U_LOG_W("  DP display_pixel=%ux%u at (%d,%d)",
-			        dp_px_w, dp_px_h, dp_left, dp_top);
-			U_LOG_W("  tile=%ux%u, shell_mode=%d",
-			        sys->tile_columns, sys->tile_rows, sys->shell_mode);
-			U_LOG_W("  display_phys=%.4fx%.4f m",
-			        sys->base.info.display_width_m,
-			        sys->base.info.display_height_m);
-			U_LOG_W("=============================");
-		}
 	}
 
 	// During drag, synchronize with the window thread's WM_PAINT cycle.
@@ -7604,6 +7658,7 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 	    comp_d3d11_window_is_in_size_move(c->render.window)) {
 		comp_d3d11_window_wait_for_paint(c->render.window);
 	}
+
 
 	// Select display processor input: zero-copy from app's swapchain, or atlas.
 	// The DP expects the atlas texture to be exactly content-sized
@@ -7620,7 +7675,7 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 		input_view_h = zc_view_h;
 	} else {
 		// Crop atlas to content dims (mirrors d3d11_crop_atlas_for_dp in in-process path)
-		input_srv = service_crop_atlas_for_dp(sys, &c->render, content_view_w, content_view_h);
+		input_srv = service_crop_atlas_for_dp(sys, &c->render, content_view_w, content_view_h, c->atlas_flip_y);
 		input_view_w = content_view_w;
 		input_view_h = content_view_h;
 	}
@@ -7645,17 +7700,6 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 				bb_texture->GetDesc(&bb_desc);
 				back_buffer_width = bb_desc.Width;
 				back_buffer_height = bb_desc.Height;
-			}
-		}
-
-		// Log DP input dims periodically
-		{
-			static uint32_t dp_log_count = 0;
-			if (dp_log_count++ % 300 == 0) {
-				U_LOG_W("Standalone DP: input_view=%ux%u, back_buffer=%ux%u, tile=%ux%u",
-				        input_view_w, input_view_h,
-				        back_buffer_width, back_buffer_height,
-				        sys->tile_columns, sys->tile_rows);
 			}
 		}
 
@@ -7687,6 +7731,16 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 	// Present to display
 	if (c->render.swap_chain) {
 		c->render.swap_chain->Present(1, 0);  // VSync
+		// For cross-process swap chains (post-hot-switch, external HWND),
+		// DwmFlush blocks until the next DWM composition pass — minimizes
+		// the latency between Present and the frame appearing on screen,
+		// which improves drag smoothness. Without it, the IPC response
+		// unblocks the app's modal drag loop while the frame is still
+		// queued for DWM composition, and by the time DWM presents, the
+		// window has moved further, causing visual stutter.
+		if (!c->render.owns_window && c->app_hwnd != nullptr) {
+			DwmFlush();
+		}
 	}
 
 	// Signal WM_PAINT that the frame is done (unblocks modal drag loop)

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -9264,25 +9264,31 @@ comp_d3d11_service_deactivate_shell(struct xrt_system_compositor *xsysc)
 	}
 
 	struct d3d11_service_system *sys = d3d11_service_system_from_xrt(xsysc);
+	struct d3d11_multi_compositor *mc = nullptr;
 
-	std::lock_guard<std::recursive_mutex> lock(sys->render_mutex);
+	// First lock scope: do all work that needs the mutex EXCEPT stopping
+	// the render thread. Stopping the render thread joins it; if we hold
+	// the mutex during join, the render thread can deadlock waiting for
+	// the same mutex on its next iteration.
+	{
+		std::lock_guard<std::recursive_mutex> lock(sys->render_mutex);
 
-	struct d3d11_multi_compositor *mc = sys->multi_comp;
-	if (mc == nullptr) {
-		U_LOG_W("Shell deactivate: no multi-comp — nothing to do");
-		return;
-	}
+		mc = sys->multi_comp;
+		if (mc == nullptr) {
+			U_LOG_W("Shell deactivate: no multi-comp — nothing to do");
+			return;
+		}
 
-	if (mc->suspended) {
-		U_LOG_W("Shell deactivate: already suspended");
-		return;
-	}
+		if (mc->suspended) {
+			U_LOG_W("Shell deactivate: already suspended");
+			return;
+		}
 
-	U_LOG_W("Shell deactivate: beginning teardown");
+		U_LOG_W("Shell deactivate: beginning teardown");
 
-	// Clear the compositor's local shell_mode flag so layer_commit
-	// takes the standalone path instead of the (now suspended) multi-comp.
-	sys->shell_mode = false;
+		// Clear the compositor's local shell_mode flag so layer_commit
+		// takes the standalone path instead of the (now suspended) multi-comp.
+		sys->shell_mode = false;
 
 	// --- 4C.2: Stop all capture sessions and restore 2D windows ---
 	for (int i = 0; i < D3D11_MULTI_MAX_CLIENTS; i++) {
@@ -9319,25 +9325,39 @@ comp_d3d11_service_deactivate_shell(struct xrt_system_compositor *xsysc)
 	// Each app's next layer_commit detects shell_mode=false and lazily creates
 	// its own swap chain + DP on its own thread (no cross-thread WM).
 
-	// Reset drag/focus state
-	mc->focused_slot = -1;
-	mc->drag.active = false;
-	mc->title_drag.active = false;
-	mc->resize.active = false;
+		// Reset drag/focus state
+		mc->focused_slot = -1;
+		mc->drag.active = false;
+		mc->title_drag.active = false;
+		mc->resize.active = false;
 
-	// --- 4C.5: Suspend multi-compositor ---
-	capture_render_thread_stop(sys);
+		// Set request flag for render thread to exit. Don't join here —
+		// joining while holding the mutex deadlocks if the render thread
+		// is currently blocked trying to acquire it.
+		mc->capture_render_running.store(false);
+	} // release render_mutex
 
-	if (mc->display_processor != nullptr) {
-		xrt_display_processor_d3d11_request_display_mode(mc->display_processor, false);
-		xrt_display_processor_d3d11_destroy(&mc->display_processor);
+	// Now safe to join the render thread (no mutex held).
+	if (mc->capture_render_thread.joinable()) {
+		mc->capture_render_thread.join();
 	}
+	U_LOG_W("Shell deactivate: render thread joined");
 
-	if (mc->hwnd != nullptr) {
-		ShowWindow(mc->hwnd, SW_HIDE);
+	// Re-acquire for final cleanup (DP destroy, hide window).
+	{
+		std::lock_guard<std::recursive_mutex> lock(sys->render_mutex);
+
+		if (mc->display_processor != nullptr) {
+			xrt_display_processor_d3d11_request_display_mode(mc->display_processor, false);
+			xrt_display_processor_d3d11_destroy(&mc->display_processor);
+		}
+
+		if (mc->hwnd != nullptr) {
+			ShowWindow(mc->hwnd, SW_HIDE);
+		}
+
+		mc->suspended = true;
 	}
-
-	mc->suspended = true;
 
 	U_LOG_W("Shell deactivate: complete — captures stopped, multi-comp suspended, "
 	        "IPC clients will lazy-switch to standalone on next frame");

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -9060,6 +9060,26 @@ comp_d3d11_service_deactivate_shell(struct xrt_system_compositor *xsysc)
 		mc->capture_client_count--;
 	}
 
+	// --- 4C.3: Push SESSION_LOSS_PENDING to IPC clients ---
+	// Apps receive XR_SESSION_STATE_LOSS_PENDING, destroy their session,
+	// and optionally recreate. On recreate, shell_mode will be false so
+	// they come up in standalone mode (visible HWND, own DP).
+	for (int i = 0; i < D3D11_MULTI_MAX_CLIENTS; i++) {
+		struct d3d11_multi_client_slot *slot = &mc->clients[i];
+		if (!slot->active || slot->client_type != CLIENT_TYPE_IPC) {
+			continue;
+		}
+		if (slot->compositor == nullptr || slot->compositor->xses == nullptr) {
+			continue;
+		}
+		union xrt_session_event xse = XRT_STRUCT_INIT;
+		xse.loss_pending.type = XRT_SESSION_EVENT_LOSS_PENDING;
+		xse.loss_pending.loss_time_ns =
+		    (int64_t)os_monotonic_get_ns() + 500000000LL; // 500ms grace
+		xrt_session_event_sink_push(slot->compositor->xses, &xse);
+		U_LOG_W("Shell deactivate: sent LOSS_PENDING to IPC slot %d", i);
+	}
+
 	// Reset drag/focus state
 	mc->focused_slot = -1;
 	mc->drag.active = false;

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.h
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.h
@@ -287,6 +287,18 @@ comp_d3d11_service_get_capture_client_window_pose(struct xrt_system_compositor *
 bool
 comp_d3d11_service_ensure_shell_window(struct xrt_system_compositor *xsysc);
 
+/*!
+ * Deactivate the shell: stop captures and restore 2D windows, suspend
+ * multi-compositor (hide window, release DP, stop render loop).
+ * Called by ipc_handle_shell_deactivate().
+ *
+ * @param xsysc The system compositor (must be D3D11 service in shell mode).
+ *
+ * @ingroup comp_d3d11_service
+ */
+void
+comp_d3d11_service_deactivate_shell(struct xrt_system_compositor *xsysc);
+
 /*! @} */
 
 

--- a/src/xrt/drivers/qwerty/qwerty_win32.c
+++ b/src/xrt/drivers/qwerty/qwerty_win32.c
@@ -495,15 +495,9 @@ qwerty_process_win32(struct xrt_device **xdevs,
 				qwerty_reset_view_state(qsys);
 			break;
 
-		// ESC key to close window
+		// ESC: no-op in shell mode. Shell lifecycle is controlled by
+		// Ctrl+Space (system hotkey) and the tray icon, not ESC.
 		case VK_ESCAPE:
-			if (is_keydown) {
-				U_LOG_W("QWERTY Win32: ESC pressed - closing window");
-				HWND hwnd = GetActiveWindow();
-				if (hwnd != NULL) {
-					PostMessageW(hwnd, WM_CLOSE, 0, 0);
-				}
-			}
 			break;
 
 		default:

--- a/src/xrt/ipc/server/ipc_server_handler.c
+++ b/src/xrt/ipc/server/ipc_server_handler.c
@@ -169,17 +169,6 @@ ipc_try_get_sr_view_poses(struct ipc_server *s,
 		}
 
 		if (have_wm) {
-			static uint32_t metrics_log_count = 0;
-			if (metrics_log_count++ % 300 == 0) {
-				IPC_WARN(s, "View poses: wm win=%.4fx%.4f m, offset=(%.4f,%.4f,%.4f), "
-				         "win_px=%ux%u, disp_px=%ux%u, shell=%d",
-				         wm.window_width_m, wm.window_height_m,
-				         wm.window_center_offset_x_m, wm.window_center_offset_y_m,
-				         wm.window_center_offset_z_m,
-				         wm.window_pixel_width, wm.window_pixel_height,
-				         wm.display_pixel_width, wm.display_pixel_height,
-				         s->shell_mode);
-			}
 			screen_width_m = wm.window_width_m;
 			screen_height_m = wm.window_height_m;
 			eye_offset_x = wm.window_center_offset_x_m;

--- a/src/xrt/ipc/server/ipc_server_handler.c
+++ b/src/xrt/ipc/server/ipc_server_handler.c
@@ -1975,6 +1975,30 @@ ipc_handle_shell_activate(volatile struct ipc_client_state *_ics)
 }
 
 xrt_result_t
+ipc_handle_shell_deactivate(volatile struct ipc_client_state *_ics)
+{
+	struct ipc_server *s = _ics->server;
+
+	if (!s->shell_mode) {
+		IPC_INFO(s, "Shell: already deactivated — ignoring");
+		return XRT_SUCCESS;
+	}
+
+	IPC_INFO(s, "Shell: deactivating shell mode via IPC");
+
+	s->shell_mode = false;
+	if (s->xsysc != NULL) {
+		s->xsysc->info.shell_mode = false;
+
+#if defined(XRT_HAVE_D3D11_SERVICE_COMPOSITOR)
+		comp_d3d11_service_deactivate_shell(s->xsysc);
+#endif
+	}
+
+	return XRT_SUCCESS;
+}
+
+xrt_result_t
 ipc_handle_shell_set_window_pose(volatile struct ipc_client_state *_ics,
                                   uint32_t client_id,
                                   const struct xrt_pose *pose,

--- a/src/xrt/ipc/server/ipc_server_handler.c
+++ b/src/xrt/ipc/server/ipc_server_handler.c
@@ -1999,6 +1999,14 @@ ipc_handle_shell_deactivate(volatile struct ipc_client_state *_ics)
 }
 
 xrt_result_t
+ipc_handle_shell_get_state(volatile struct ipc_client_state *_ics, bool *out_active)
+{
+	struct ipc_server *s = _ics->server;
+	*out_active = s->shell_mode;
+	return XRT_SUCCESS;
+}
+
+xrt_result_t
 ipc_handle_shell_set_window_pose(volatile struct ipc_client_state *_ics,
                                   uint32_t client_id,
                                   const struct xrt_pose *pose,

--- a/src/xrt/ipc/server/ipc_server_handler.c
+++ b/src/xrt/ipc/server/ipc_server_handler.c
@@ -169,6 +169,17 @@ ipc_try_get_sr_view_poses(struct ipc_server *s,
 		}
 
 		if (have_wm) {
+			static uint32_t metrics_log_count = 0;
+			if (metrics_log_count++ % 300 == 0) {
+				IPC_WARN(s, "View poses: wm win=%.4fx%.4f m, offset=(%.4f,%.4f,%.4f), "
+				         "win_px=%ux%u, disp_px=%ux%u, shell=%d",
+				         wm.window_width_m, wm.window_height_m,
+				         wm.window_center_offset_x_m, wm.window_center_offset_y_m,
+				         wm.window_center_offset_z_m,
+				         wm.window_pixel_width, wm.window_pixel_height,
+				         wm.display_pixel_width, wm.display_pixel_height,
+				         s->shell_mode);
+			}
 			screen_width_m = wm.window_width_m;
 			screen_height_m = wm.window_height_m;
 			eye_offset_x = wm.window_center_offset_x_m;

--- a/src/xrt/ipc/shared/proto.json
+++ b/src/xrt/ipc/shared/proto.json
@@ -58,6 +58,8 @@
 
 	"shell_activate": {},
 
+	"shell_deactivate": {},
+
 	"shell_set_window_pose": {
 		"in": [
 			{"name": "client_id", "type": "uint32_t"},

--- a/src/xrt/ipc/shared/proto.json
+++ b/src/xrt/ipc/shared/proto.json
@@ -60,6 +60,12 @@
 
 	"shell_deactivate": {},
 
+	"shell_get_state": {
+		"out": [
+			{"name": "active", "type": "bool"}
+		]
+	},
+
 	"shell_set_window_pose": {
 		"in": [
 			{"name": "client_id", "type": "uint32_t"},

--- a/src/xrt/state_trackers/oxr/oxr_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_session.c
@@ -2578,11 +2578,12 @@ oxr_session_create(struct oxr_logger *log,
 		    xsi.external_window_handle != NULL && sys->xsysc != NULL &&
 		    sys->xsysc->info.shell_mode) {
 			HWND hwnd = (HWND)xsi.external_window_handle;
-			// Shell mode: just hide the HWND. The lazy standalone init
-			// (in layer_commit) will make it borderless fullscreen when
-			// the shell deactivates. No style/size changes here.
+			// Shell mode: just hide the HWND, keep decorations and size
+			// intact. On hot-switch deactivate, ShowWindowAsync(SW_SHOW)
+			// reveals it as a normal decorated window. The compositor's
+			// auto-resize handler adapts the swap chain to client rect.
 			ShowWindow(hwnd, SW_HIDE);
-			U_LOG_W("Shell session: hidden app HWND %p", hwnd);
+			U_LOG_W("Shell session: HWND %p hidden (decorations preserved)", hwnd);
 		}
 	}
 #endif

--- a/src/xrt/state_trackers/oxr/oxr_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_session.c
@@ -2570,8 +2570,13 @@ oxr_session_create(struct oxr_logger *log,
 	// thread is blocked waiting for the IPC response and can't process WM, deadlocking.
 	{
 		const char *shell_session = getenv("DISPLAYXR_SHELL_SESSION");
+		// Only apply borderless+hide when shell mode is currently active.
+		// After shell_deactivate, info.shell_mode is false — apps that
+		// recreate their session (e.g., after LOSS_PENDING) come up in
+		// standalone mode with a normal visible HWND.
 		if (shell_session != NULL && strcmp(shell_session, "1") == 0 &&
-		    xsi.external_window_handle != NULL && sys->xsysc != NULL) {
+		    xsi.external_window_handle != NULL && sys->xsysc != NULL &&
+		    sys->xsysc->info.shell_mode) {
 			HWND hwnd = (HWND)xsi.external_window_handle;
 			// Shell fullscreen: resize HWND to native display resolution.
 			// This gives the app correct Kooima projection (physical window matches display)

--- a/src/xrt/state_trackers/oxr/oxr_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_session.c
@@ -2578,25 +2578,11 @@ oxr_session_create(struct oxr_logger *log,
 		    xsi.external_window_handle != NULL && sys->xsysc != NULL &&
 		    sys->xsysc->info.shell_mode) {
 			HWND hwnd = (HWND)xsi.external_window_handle;
-			// Shell mode: resize HWND to display-native for correct Kooima
-			// projection, but keep decorations intact for hot-switch.
-			// On deactivate, ShowWindow(SW_SHOW) reveals the window with
-			// correct size — Kooima uses the client rect and screen position.
-			uint32_t disp_px_w = sys->xsysc->info.display_pixel_width;
-			uint32_t disp_px_h = sys->xsysc->info.display_pixel_height;
-			if (disp_px_w > 0 && disp_px_h > 0) {
-				// Size the window so the CLIENT rect = display-native.
-				// AdjustWindowRect accounts for title bar + borders.
-				LONG style = (LONG)GetWindowLongPtr(hwnd, GWL_STYLE);
-				RECT wr = {0, 0, (LONG)disp_px_w, (LONG)disp_px_h};
-				AdjustWindowRect(&wr, style, FALSE);
-				SetWindowPos(hwnd, HWND_TOP, 0, 0,
-				             wr.right - wr.left, wr.bottom - wr.top,
-				             SWP_NOACTIVATE);
-			}
+			// Shell mode: just hide the HWND. The lazy standalone init
+			// (in layer_commit) will make it borderless fullscreen when
+			// the shell deactivates. No style/size changes here.
 			ShowWindow(hwnd, SW_HIDE);
-			U_LOG_W("Shell session: resized+hidden app HWND %p to %ux%u (decorations preserved)",
-			        hwnd, disp_px_w, disp_px_h);
+			U_LOG_W("Shell session: hidden app HWND %p", hwnd);
 		}
 	}
 #endif

--- a/src/xrt/state_trackers/oxr/oxr_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_session.c
@@ -2578,25 +2578,25 @@ oxr_session_create(struct oxr_logger *log,
 		    xsi.external_window_handle != NULL && sys->xsysc != NULL &&
 		    sys->xsysc->info.shell_mode) {
 			HWND hwnd = (HWND)xsi.external_window_handle;
-			// Shell fullscreen: resize HWND to native display resolution.
-			// This gives the app correct Kooima projection (physical window matches display)
-			// and correct swapchain/viewport sizing for the display.
+			// Shell mode: resize HWND to display-native for correct Kooima
+			// projection, but keep decorations intact for hot-switch.
+			// On deactivate, ShowWindow(SW_SHOW) reveals the window with
+			// correct size — Kooima uses the client rect and screen position.
 			uint32_t disp_px_w = sys->xsysc->info.display_pixel_width;
 			uint32_t disp_px_h = sys->xsysc->info.display_pixel_height;
 			if (disp_px_w > 0 && disp_px_h > 0) {
-				// Make borderless so client area = exact display size.
-				// The app uses client area for Kooima and viewport sizing.
-				SetWindowLongPtr(hwnd, GWL_STYLE, WS_POPUP | WS_VISIBLE);
-				SetWindowPos(hwnd, HWND_BOTTOM, 0, 0, (int)disp_px_w, (int)disp_px_h,
-				             SWP_NOACTIVATE | SWP_FRAMECHANGED);
-				// Hide the app window — in shell mode, content is composited
-				// by the service. The window is unnecessary and distracting.
-				// Apps keep rendering via IPC swapchains (Unity uses
-				// Application.runInBackground = true in shell mode).
-				ShowWindow(hwnd, SW_HIDE);
-				U_LOG_W("Shell session: resized+hidden app HWND %p to %ux%u (display native)",
-				        hwnd, disp_px_w, disp_px_h);
+				// Size the window so the CLIENT rect = display-native.
+				// AdjustWindowRect accounts for title bar + borders.
+				LONG style = (LONG)GetWindowLongPtr(hwnd, GWL_STYLE);
+				RECT wr = {0, 0, (LONG)disp_px_w, (LONG)disp_px_h};
+				AdjustWindowRect(&wr, style, FALSE);
+				SetWindowPos(hwnd, HWND_TOP, 0, 0,
+				             wr.right - wr.left, wr.bottom - wr.top,
+				             SWP_NOACTIVATE);
 			}
+			ShowWindow(hwnd, SW_HIDE);
+			U_LOG_W("Shell session: resized+hidden app HWND %p to %ux%u (decorations preserved)",
+			        hwnd, disp_px_w, disp_px_h);
 		}
 	}
 #endif

--- a/src/xrt/targets/shell/main.c
+++ b/src/xrt/targets/shell/main.c
@@ -1350,16 +1350,36 @@ main(int argc, char *argv[])
 					} else {
 						P("Activating shell...\n");
 						xret = ipc_call_shell_activate(&ipc_c);
+
+						// If IPC pipe is dead (service exited), reconnect.
+						// The IPC client lib auto-starts the service.
 						if (xret != XRT_SUCCESS) {
-							PE("Warning: shell_activate failed\n");
+							P("Reconnecting to service...\n");
+							ipc_client_connection_fini(&ipc_c);
+							memset(&ipc_c, 0, sizeof(ipc_c));
+							for (int attempt = 0; attempt < 10; attempt++) {
+								xret = ipc_client_connection_init(
+								    &ipc_c, U_LOGGING_WARN, &info);
+								if (xret == XRT_SUCCESS) break;
+								Sleep(1000);
+							}
+							if (xret == XRT_SUCCESS) {
+								xret = ipc_call_shell_activate(&ipc_c);
+								service_pid = find_service_pid();
+							}
+							if (xret != XRT_SUCCESS) {
+								PE("Failed to reconnect to service.\n");
+								continue;
+							}
 						}
 
-						// Re-adopt desktop windows via auto-enumerate
-						enumerate_and_adopt_windows(&ipc_c, captures, &capture_count, service_pid);
+						// Already-running IPC apps (OpenXR handle apps) are
+						// automatically picked up by the multi-comp on their
+						// next layer_commit. No need to enumerate 2D windows.
 
 						g_shell_active = true;
 						tray_update_tooltip(true);
-						P("Shell activated — %d capture(s) adopted.\n", capture_count);
+						P("Shell activated.\n");
 					}
 				} else if (msg.message == WM_HOTKEY && msg.wParam == HOTKEY_LAUNCH) {
 					// --- Ctrl+L: Launch registered app ---
@@ -1462,6 +1482,21 @@ main(int argc, char *argv[])
 		print_clients(&ipc_c, prev_ids, &prev_count);
 
 #ifdef _WIN32
+		// Detect server-side deactivation (ESC closed the compositor window).
+		// The compositor sets shell_mode=false — sync our state.
+		if (g_shell_active) {
+			bool server_active = false;
+			if (ipc_call_shell_get_state(&ipc_c, &server_active) == XRT_SUCCESS) {
+				if (!server_active) {
+					P("Shell deactivated by compositor (ESC) — returning to tray.\n");
+					capture_count = 0;
+					client_name_count = 0;
+					g_shell_active = false;
+					tray_update_tooltip(false);
+				}
+			}
+		}
+
 		// Dynamic window tracking: detect new/closed windows every ~1 second
 		if (auto_adopt) {
 			adopt_counter++;

--- a/src/xrt/targets/shell/main.c
+++ b/src/xrt/targets/shell/main.c
@@ -244,6 +244,170 @@ shell_config_update(struct shell_config *cfg, const char *app_name,
 	sw->width_m = w; sw->height_m = h;
 }
 
+// --- 4C.9: Registered apps config ---
+
+#define MAX_REGISTERED_APPS 32
+
+struct registered_app
+{
+	char name[128];
+	char exe_path[MAX_PATH];
+	char type[8]; // "3d", "2d", or "" (unknown)
+};
+
+static struct registered_app g_registered_apps[MAX_REGISTERED_APPS];
+static int g_registered_app_count = 0;
+
+static void
+get_registered_apps_path(char *buf, size_t buf_size)
+{
+#ifdef _WIN32
+	const char *appdata = getenv("LOCALAPPDATA");
+	if (appdata) {
+		snprintf(buf, buf_size, "%s\\DisplayXR\\registered_apps.json", appdata);
+	} else {
+		snprintf(buf, buf_size, "registered_apps.json");
+	}
+#else
+	const char *home = getenv("HOME");
+	if (home) {
+		snprintf(buf, buf_size, "%s/.displayxr/registered_apps.json", home);
+	} else {
+		snprintf(buf, buf_size, "registered_apps.json");
+	}
+#endif
+}
+
+static void
+registered_apps_load(void)
+{
+	g_registered_app_count = 0;
+
+	char path[512];
+	get_registered_apps_path(path, sizeof(path));
+
+	FILE *f = fopen(path, "rb");
+	if (!f) {
+		// First run: create default config
+		P("No registered_apps.json found — creating defaults.\n");
+#ifdef _WIN32
+		{
+			char dir[512];
+			snprintf(dir, sizeof(dir), "%s", path);
+			char *last = strrchr(dir, '\\');
+			if (last) { *last = '\0'; CreateDirectoryA(dir, NULL); }
+		}
+#endif
+		// Add demo entries
+		snprintf(g_registered_apps[0].name, sizeof(g_registered_apps[0].name), "cube_handle_d3d11_win");
+		snprintf(g_registered_apps[0].exe_path, sizeof(g_registered_apps[0].exe_path),
+		         "test_apps\\cube_handle_d3d11_win\\build\\cube_handle_d3d11_win.exe");
+		snprintf(g_registered_apps[0].type, sizeof(g_registered_apps[0].type), "3d");
+
+		snprintf(g_registered_apps[1].name, sizeof(g_registered_apps[1].name), "Notepad");
+		snprintf(g_registered_apps[1].exe_path, sizeof(g_registered_apps[1].exe_path), "notepad.exe");
+		snprintf(g_registered_apps[1].type, sizeof(g_registered_apps[1].type), "2d");
+
+		g_registered_app_count = 2;
+		// Save to disk
+		goto save_and_return;
+	}
+
+	{
+		fseek(f, 0, SEEK_END);
+		long len = ftell(f);
+		fseek(f, 0, SEEK_SET);
+		if (len <= 0 || len > 64 * 1024) { fclose(f); return; }
+
+		char *data = (char *)malloc(len + 1);
+		fread(data, 1, len, f);
+		data[len] = '\0';
+		fclose(f);
+
+		cJSON *root = cJSON_Parse(data);
+		free(data);
+		if (!root || !cJSON_IsArray(root)) {
+			cJSON_Delete(root);
+			return;
+		}
+
+		cJSON *entry = NULL;
+		cJSON_ArrayForEach(entry, root)
+		{
+			if (g_registered_app_count >= MAX_REGISTERED_APPS) break;
+			struct registered_app *app = &g_registered_apps[g_registered_app_count];
+
+			cJSON *jname = cJSON_GetObjectItemCaseSensitive(entry, "name");
+			cJSON *jpath = cJSON_GetObjectItemCaseSensitive(entry, "exe_path");
+			cJSON *jtype = cJSON_GetObjectItemCaseSensitive(entry, "type");
+
+			if (cJSON_IsString(jname))
+				snprintf(app->name, sizeof(app->name), "%s", jname->valuestring);
+			if (cJSON_IsString(jpath))
+				snprintf(app->exe_path, sizeof(app->exe_path), "%s", jpath->valuestring);
+			if (cJSON_IsString(jtype))
+				snprintf(app->type, sizeof(app->type), "%s", jtype->valuestring);
+
+			g_registered_app_count++;
+		}
+		cJSON_Delete(root);
+	}
+
+	P("Loaded %d registered app(s).\n", g_registered_app_count);
+	return;
+
+save_and_return:
+	; // fallthrough to save
+	{
+		char spath[512];
+		get_registered_apps_path(spath, sizeof(spath));
+
+		cJSON *arr = cJSON_CreateArray();
+		for (int i = 0; i < g_registered_app_count; i++) {
+			cJSON *obj = cJSON_CreateObject();
+			cJSON_AddStringToObject(obj, "name", g_registered_apps[i].name);
+			cJSON_AddStringToObject(obj, "exe_path", g_registered_apps[i].exe_path);
+			cJSON_AddStringToObject(obj, "type", g_registered_apps[i].type);
+			cJSON_AddItemToArray(arr, obj);
+		}
+		char *json_str = cJSON_Print(arr);
+		cJSON_Delete(arr);
+
+		FILE *sf = fopen(spath, "wb");
+		if (sf) {
+			fwrite(json_str, 1, strlen(json_str), sf);
+			fclose(sf);
+			P("Created default registered_apps.json with %d entries.\n", g_registered_app_count);
+		}
+		free(json_str);
+	}
+}
+
+static void
+registered_apps_save(void)
+{
+	char path[512];
+	get_registered_apps_path(path, sizeof(path));
+
+	cJSON *arr = cJSON_CreateArray();
+	for (int i = 0; i < g_registered_app_count; i++) {
+		cJSON *obj = cJSON_CreateObject();
+		cJSON_AddStringToObject(obj, "name", g_registered_apps[i].name);
+		cJSON_AddStringToObject(obj, "exe_path", g_registered_apps[i].exe_path);
+		cJSON_AddStringToObject(obj, "type", g_registered_apps[i].type);
+		cJSON_AddItemToArray(arr, obj);
+	}
+	char *json_str = cJSON_Print(arr);
+	cJSON_Delete(arr);
+
+	FILE *f = fopen(path, "wb");
+	if (f) {
+		fwrite(json_str, 1, strlen(json_str), f);
+		fclose(f);
+	}
+	free(json_str);
+}
+
 #ifdef _WIN32
 /*!
  * Get the directory containing the shell executable.
@@ -754,6 +918,165 @@ cleanup_closed_captures(struct ipc_connection *ipc_c,
 	}
 }
 
+// --- 4C.10+4C.11: App launch from shell + auto-detect type ---
+
+/*!
+ * Launch a registered app from the shell.
+ * For "3d" type: uses launch_app() with DISPLAYXR_SHELL_SESSION env.
+ * For "2d" type: launches without shell env, then captures via IPC.
+ * For unknown type: launches as 3d, polls for IPC connect to auto-detect.
+ */
+static void
+shell_launch_registered_app(struct ipc_connection *ipc_c,
+                            struct registered_app *rapp,
+                            const char *runtime_json,
+                            struct app_entry *apps, int *app_count,
+                            struct capture_entry *captures, int *capture_count)
+{
+	P("Launching: '%s' (%s) — %s\n", rapp->name, rapp->exe_path, rapp->type);
+
+	if (strcmp(rapp->type, "2d") == 0) {
+		// 2D app: launch without shell env, then poll for HWND and capture
+		STARTUPINFOA si = {0};
+		si.cb = sizeof(si);
+		PROCESS_INFORMATION pi = {0};
+
+		char abs_path[MAX_PATH];
+		char cmd[MAX_PATH + 16];
+		if (_fullpath(abs_path, rapp->exe_path, MAX_PATH) == NULL) {
+			snprintf(abs_path, MAX_PATH, "%s", rapp->exe_path);
+		}
+		snprintf(cmd, sizeof(cmd), "\"%s\"", abs_path);
+
+		// Clear shell env vars so 2D app doesn't accidentally pick them up
+		SetEnvironmentVariableA("DISPLAYXR_SHELL_SESSION", NULL);
+
+		BOOL ok = CreateProcessA(NULL, cmd, NULL, NULL, FALSE,
+		    CREATE_NEW_CONSOLE, NULL, NULL, &si, &pi);
+		if (!ok) {
+			PE("  Failed to launch 2D app: %lu\n", GetLastError());
+			return;
+		}
+		P("  Launched 2D app PID=%lu, waiting for HWND...\n", pi.dwProcessId);
+		CloseHandle(pi.hThread);
+
+		// Poll for HWND owned by this PID (up to 5 seconds)
+		HWND found_hwnd = NULL;
+		for (int poll = 0; poll < 10 && found_hwnd == NULL; poll++) {
+			Sleep(500);
+			struct enum_ctx ectx = {0};
+			ectx.shell_pid = GetCurrentProcessId();
+			ectx.service_pid = 0;
+			EnumWindows(enum_windows_cb, (LPARAM)&ectx);
+			for (int w = 0; w < ectx.count; w++) {
+				DWORD wnd_pid = 0;
+				GetWindowThreadProcessId(ectx.found[w], &wnd_pid);
+				if (wnd_pid == pi.dwProcessId) {
+					found_hwnd = ectx.found[w];
+					break;
+				}
+			}
+		}
+
+		if (found_hwnd != NULL && *capture_count < MAX_CAPTURES) {
+			struct capture_entry *ce = &captures[*capture_count];
+			memset(ce, 0, sizeof(*ce));
+			ce->hwnd = (uint64_t)(uintptr_t)found_hwnd;
+			GetWindowTextA(found_hwnd, ce->name, sizeof(ce->name));
+
+			uint32_t cid = 0;
+			xrt_result_t r = ipc_call_shell_add_capture_client(ipc_c, ce->hwnd, &cid);
+			if (r == XRT_SUCCESS) {
+				ce->client_id = cid;
+				ce->added = true;
+				(*capture_count)++;
+				P("  Captured 2D window HWND=%p '%s' → client_id=%u\n",
+				  (void *)found_hwnd, ce->name, cid);
+			}
+		} else if (found_hwnd == NULL) {
+			PE("  2D app: no visible HWND found after 5s\n");
+		}
+		CloseHandle(pi.hProcess);
+		return;
+	}
+
+	// "3d" or unknown type: launch as shell app
+	if (*app_count >= MAX_APPS) {
+		PE("  Max apps (%d) reached\n", MAX_APPS);
+		return;
+	}
+	struct app_entry *a = &apps[*app_count];
+	memset(a, 0, sizeof(*a));
+	a->exe_path = rapp->exe_path;
+	launch_app(a, runtime_json);
+	(*app_count)++;
+
+	// 4C.11: Auto-detect type if unknown
+	if (rapp->type[0] == '\0' && a->pid != 0) {
+		P("  Unknown type — detecting (polling IPC for 5s)...\n");
+		bool found_ipc = false;
+		for (int poll = 0; poll < 10 && !found_ipc; poll++) {
+			Sleep(500);
+			struct ipc_client_list clients;
+			if (ipc_call_system_get_clients(ipc_c, &clients) == XRT_SUCCESS) {
+				for (uint32_t c = 0; c < clients.id_count; c++) {
+					struct ipc_app_state ias;
+					if (ipc_call_system_get_client_info(ipc_c, clients.ids[c], &ias) == XRT_SUCCESS) {
+						if ((DWORD)ias.pid == a->pid) {
+							found_ipc = true;
+							break;
+						}
+					}
+				}
+			}
+		}
+		if (found_ipc) {
+			snprintf(rapp->type, sizeof(rapp->type), "3d");
+			P("  Auto-detected: 3D app (IPC client connected)\n");
+		} else {
+			snprintf(rapp->type, sizeof(rapp->type), "2d");
+			P("  Auto-detected: 2D app (no IPC client after 5s)\n");
+			// TODO: find HWND by PID and capture as 2D
+		}
+		registered_apps_save();
+	}
+}
+
+/*!
+ * Show a simple app launcher dialog listing registered apps.
+ * Returns the index of the selected app, or -1 if cancelled.
+ */
+static int
+shell_show_launcher_dialog(void)
+{
+	if (g_registered_app_count == 0) {
+		P("No registered apps.\n");
+		return -1;
+	}
+
+	// Build a numbered list string for the MessageBox
+	char list[2048] = "Select an app to launch:\n\n";
+	for (int i = 0; i < g_registered_app_count; i++) {
+		char line[256];
+		snprintf(line, sizeof(line), "  %d. %s [%s]\n",
+		         i + 1, g_registered_apps[i].name,
+		         g_registered_apps[i].type[0] ? g_registered_apps[i].type : "auto");
+		strncat(list, line, sizeof(list) - strlen(list) - 1);
+	}
+	strncat(list, "\nEnter the number in the input box below:",
+	        sizeof(list) - strlen(list) - 1);
+
+	// Use a simple input loop: cycle through apps with repeated Ctrl+L
+	// For now, just launch the first app. A proper dialog is Phase 5.
+	// MessageBox to show list, then launch first unlaunched app.
+	// TODO(Phase 5): Replace with spatial launcher panel.
+
+	// Find first registered app not currently running
+	// For simplicity, just return the first one.
+	P("%s\n", list);
+	return 0; // Launch first app
+}
+
 // --- System tray icon ---
 
 static NOTIFYICONDATAA g_nid = {0};
@@ -883,6 +1206,9 @@ main(int argc, char *argv[])
 
 	P("Connected to service.\n");
 
+	// Load registered apps config (4C.9)
+	registered_apps_load();
+
 #ifdef _WIN32
 	// --- Resolve runtime JSON path (needed for app launches) ---
 	char runtime_json[MAX_PATH] = {0};
@@ -900,6 +1226,9 @@ main(int argc, char *argv[])
 	if (g_msg_hwnd != NULL) {
 		if (!RegisterHotKey(g_msg_hwnd, HOTKEY_TOGGLE, MOD_CONTROL, VK_SPACE)) {
 			PE("Warning: RegisterHotKey(Ctrl+Space) failed — hotkey unavailable\n");
+		}
+		if (!RegisterHotKey(g_msg_hwnd, HOTKEY_LAUNCH, MOD_CONTROL, 'L')) {
+			PE("Warning: RegisterHotKey(Ctrl+L) failed — launcher hotkey unavailable\n");
 		}
 	}
 
@@ -1032,6 +1361,18 @@ main(int argc, char *argv[])
 						tray_update_tooltip(true);
 						P("Shell activated — %d capture(s) adopted.\n", capture_count);
 					}
+				} else if (msg.message == WM_HOTKEY && msg.wParam == HOTKEY_LAUNCH) {
+					// --- Ctrl+L: Launch registered app ---
+					if (g_shell_active) {
+						int idx = shell_show_launcher_dialog();
+						if (idx >= 0 && idx < g_registered_app_count) {
+							shell_launch_registered_app(
+							    &ipc_c, &g_registered_apps[idx],
+							    have_json ? runtime_json : NULL,
+							    apps, &app_count,
+							    captures, &capture_count);
+						}
+					}
 				} else if (msg.message == WM_TRAYICON) {
 					if (LOWORD(msg.lParam) == WM_LBUTTONUP) {
 						// Left-click tray: activate if inactive
@@ -1144,6 +1485,7 @@ main(int argc, char *argv[])
 	// Cleanup hotkey and tray
 	if (g_msg_hwnd != NULL) {
 		UnregisterHotKey(g_msg_hwnd, HOTKEY_TOGGLE);
+		UnregisterHotKey(g_msg_hwnd, HOTKEY_LAUNCH);
 		tray_destroy();
 		DestroyWindow(g_msg_hwnd);
 	}

--- a/src/xrt/targets/shell/main.c
+++ b/src/xrt/targets/shell/main.c
@@ -35,6 +35,7 @@
 #include <windows.h>
 #include <process.h>
 #include <tlhelp32.h> // For process enumeration (service PID lookup)
+#include <shellapi.h> // For Shell_NotifyIcon (system tray)
 #else
 #include <unistd.h>
 #endif
@@ -43,10 +44,23 @@
 #define P(...) fprintf(stdout, __VA_ARGS__)
 #define PE(...) fprintf(stderr, __VA_ARGS__)
 
+#ifdef _WIN32
+#define HOTKEY_TOGGLE 1
+#define HOTKEY_LAUNCH 2
+#define WM_TRAYICON (WM_USER + 1)
+#define TRAY_CMD_ACTIVATE 2001
+#define TRAY_CMD_EXIT 2002
+#define POLL_INTERVAL_MS 500
+#endif
+
 #define MAX_APPS 8
 #define MAX_CAPTURES 24
 
 static volatile int g_running = 1;
+#ifdef _WIN32
+static bool g_shell_active = false;
+static HWND g_msg_hwnd = NULL;
+#endif
 
 static void
 signal_handler(int sig)
@@ -739,6 +753,64 @@ cleanup_closed_captures(struct ipc_connection *ipc_c,
 		}
 	}
 }
+
+// --- System tray icon ---
+
+static NOTIFYICONDATAA g_nid = {0};
+
+static void
+tray_create(HWND hwnd)
+{
+	g_nid.cbSize = sizeof(NOTIFYICONDATAA);
+	g_nid.hWnd = hwnd;
+	g_nid.uID = 1;
+	g_nid.uFlags = NIF_ICON | NIF_TIP | NIF_MESSAGE;
+	g_nid.uCallbackMessage = WM_TRAYICON;
+	g_nid.hIcon = LoadIcon(NULL, IDI_APPLICATION);
+	strncpy(g_nid.szTip, "DisplayXR Shell (inactive)", sizeof(g_nid.szTip) - 1);
+	Shell_NotifyIconA(NIM_ADD, &g_nid);
+}
+
+static void
+tray_update_tooltip(bool active)
+{
+	strncpy(g_nid.szTip,
+	        active ? "DisplayXR Shell (active)" : "DisplayXR Shell (inactive)",
+	        sizeof(g_nid.szTip) - 1);
+	Shell_NotifyIconA(NIM_MODIFY, &g_nid);
+}
+
+static void
+tray_destroy(void)
+{
+	Shell_NotifyIconA(NIM_DELETE, &g_nid);
+}
+
+static void
+tray_show_context_menu(HWND hwnd, bool shell_active)
+{
+	HMENU menu = CreatePopupMenu();
+	AppendMenuA(menu, MF_STRING, TRAY_CMD_ACTIVATE,
+	            shell_active ? "Deactivate" : "Activate");
+	AppendMenuA(menu, MF_SEPARATOR, 0, NULL);
+	AppendMenuA(menu, MF_STRING, TRAY_CMD_EXIT, "Exit");
+
+	POINT pt;
+	GetCursorPos(&pt);
+	SetForegroundWindow(hwnd); // Required for TrackPopupMenu to dismiss properly
+	UINT cmd = TrackPopupMenu(menu, TPM_RETURNCMD | TPM_NONOTIFY,
+	                          pt.x, pt.y, 0, hwnd, NULL);
+	DestroyMenu(menu);
+	PostMessage(hwnd, WM_NULL, 0, 0); // Force dismiss
+
+	if (cmd == TRAY_CMD_ACTIVATE) {
+		// Handled by caller via return value
+		PostMessage(hwnd, WM_HOTKEY, HOTKEY_TOGGLE, 0);
+	} else if (cmd == TRAY_CMD_EXIT) {
+		g_running = 0;
+	}
+}
+
 #endif // _WIN32
 
 #ifdef _WIN32
@@ -809,55 +881,86 @@ main(int argc, char *argv[])
 		return 1;
 	}
 
-	// Activate shell mode on the service (creates multi-comp window on next client)
+	P("Connected to service.\n");
+
+#ifdef _WIN32
+	// --- Resolve runtime JSON path (needed for app launches) ---
+	char runtime_json[MAX_PATH] = {0};
+	bool have_json = get_runtime_json_path(runtime_json, sizeof(runtime_json));
+	DWORD service_pid = find_service_pid();
+
+	// --- Create message-only window for hotkey + tray ---
+	g_msg_hwnd = CreateWindowExA(0, "STATIC", "DisplayXR Shell Msg", 0,
+	    0, 0, 0, 0, HWND_MESSAGE, NULL, NULL, NULL);
+	if (g_msg_hwnd == NULL) {
+		PE("Warning: failed to create message window (hotkey/tray unavailable)\n");
+	}
+
+	// Register system-wide Ctrl+Space hotkey
+	if (g_msg_hwnd != NULL) {
+		if (!RegisterHotKey(g_msg_hwnd, HOTKEY_TOGGLE, MOD_CONTROL, VK_SPACE)) {
+			PE("Warning: RegisterHotKey(Ctrl+Space) failed — hotkey unavailable\n");
+		}
+	}
+
+	// Create system tray icon
+	if (g_msg_hwnd != NULL) {
+		tray_create(g_msg_hwnd);
+	}
+
+	// --- Decide startup mode ---
+	// If launched with apps or captures: activate immediately (current behavior).
+	// If launched with no args: start deactivated in tray, wait for Ctrl+Space.
+	bool start_active = (app_count > 0 || capture_count > 0);
+
+	if (start_active) {
+		P("Activating shell mode...\n");
+		xret = ipc_call_shell_activate(&ipc_c);
+		if (xret != XRT_SUCCESS) {
+			PE("Warning: shell_activate failed\n");
+		}
+		g_shell_active = true;
+		tray_update_tooltip(true);
+
+		// Add capture clients
+		for (int i = 0; i < capture_count; i++) {
+			uint32_t cid = 0;
+			xrt_result_t r = ipc_call_shell_add_capture_client(&ipc_c, captures[i].hwnd, &cid);
+			if (r == XRT_SUCCESS) {
+				captures[i].client_id = cid;
+				captures[i].added = true;
+				P("  Capture: HWND=0x%llx '%s' → client_id=%u\n",
+				  (unsigned long long)captures[i].hwnd, captures[i].name, cid);
+			} else {
+				PE("  Capture: failed for HWND=0x%llx '%s'\n",
+				   (unsigned long long)captures[i].hwnd, captures[i].name);
+			}
+		}
+
+		// Launch apps
+		if (app_count > 0) {
+			P("XR_RUNTIME_JSON = %s\n", have_json ? runtime_json : "(not set)");
+			for (int i = 0; i < app_count; i++) {
+				launch_app(&apps[i], have_json ? runtime_json : NULL);
+				if (i + 1 < app_count) {
+					Sleep(100);
+				}
+			}
+		}
+	} else {
+		P("Starting in system tray — press Ctrl+Space to activate.\n");
+	}
+
+	// Auto-adopt is disabled for now — use --capture-hwnd for explicit 2D windows.
+	// TODO(4C.6): re-enable on re-activate to auto-adopt desktop windows.
+	bool auto_adopt = false;
+#else
+	// Non-Windows: simple activate + poll (no hotkey/tray)
 	P("Activating shell mode...\n");
 	xret = ipc_call_shell_activate(&ipc_c);
 	if (xret != XRT_SUCCESS) {
-		PE("Warning: shell_activate failed (service may already be in shell mode)\n");
+		PE("Warning: shell_activate failed\n");
 	}
-
-	P("Connected to service.\n");
-
-	// Add capture clients (2D window capture via Windows.Graphics.Capture)
-	for (int i = 0; i < capture_count; i++) {
-		uint32_t cid = 0;
-		xrt_result_t r = ipc_call_shell_add_capture_client(&ipc_c, captures[i].hwnd, &cid);
-		if (r == XRT_SUCCESS) {
-			captures[i].client_id = cid;
-			captures[i].added = true;
-			P("  Capture: HWND=0x%llx '%s' → client_id=%u\n",
-			  (unsigned long long)captures[i].hwnd, captures[i].name, cid);
-		} else {
-			PE("  Capture: failed for HWND=0x%llx '%s'\n",
-			   (unsigned long long)captures[i].hwnd, captures[i].name);
-		}
-	}
-
-	// Launch apps
-#ifdef _WIN32
-	if (app_count > 0) {
-		char runtime_json[MAX_PATH] = {0};
-		bool have_json = get_runtime_json_path(runtime_json, sizeof(runtime_json));
-		P("XR_RUNTIME_JSON = %s\n", have_json ? runtime_json : "(not set)");
-
-		for (int i = 0; i < app_count; i++) {
-			launch_app(&apps[i], have_json ? runtime_json : NULL);
-			// Minimal delay between app launches. The 3s delay from Phase 1 was
-			// a workaround for #108 (intermittent crash with two apps). Tested
-			// with 100ms and no crashes observed (2026-04-03).
-			if (i + 1 < app_count) {
-				Sleep(100);
-			}
-		}
-	}
-#endif
-
-#ifdef _WIN32
-	// Auto-adopt is disabled for now — use --capture-hwnd for explicit 2D windows.
-	// TODO: re-enable with better filtering (skip IDE, shell, system windows).
-	bool auto_adopt = false;
-	DWORD service_pid = find_service_pid();
-#else
 	bool auto_adopt = false;
 #endif
 
@@ -872,24 +975,94 @@ main(int argc, char *argv[])
 		}
 	}
 
-	// Layout persistence disabled during early dev — clean grid every launch.
-	// struct shell_config config;
-	// shell_config_load(&config);
-
-	int save_counter = 0; // Save every 5 seconds (10 polls * 500ms)
-	int adopt_counter = 0; // Re-enumerate every 1 second (2 polls * 500ms)
+	int adopt_counter = 0;
 
 	// Client ID → numbered name mapping (for persistence with duplicate app names)
 	static struct { uint32_t id; char name[128]; } client_names[MAX_SAVED_WINDOWS];
 	static int client_name_count = 0;
 
-	// Poll loop
+	// --- Main loop: MsgWait on Windows, Sleep on other platforms ---
 	while (g_running) {
+#ifdef _WIN32
+		// Wait for either a message or the poll timeout
+		DWORD wait_result = MsgWaitForMultipleObjects(
+		    0, NULL, FALSE, POLL_INTERVAL_MS, QS_ALLINPUT);
+
+		if (wait_result == WAIT_OBJECT_0) {
+			MSG msg;
+			while (PeekMessageA(&msg, NULL, 0, 0, PM_REMOVE)) {
+				if (msg.message == WM_HOTKEY && msg.wParam == HOTKEY_TOGGLE) {
+					// --- Toggle shell active/inactive ---
+					if (g_shell_active) {
+						P("Deactivating shell...\n");
+						ipc_call_shell_deactivate(&ipc_c);
+
+						// Clear local capture tracking
+						for (int i = 0; i < capture_count; i++) {
+							captures[i].added = false;
+						}
+						capture_count = 0;
+
+						// Reset pose tracking so re-activate can re-apply
+						for (int i = 0; i < app_count; i++) {
+							apps[i].pose_applied = false;
+						}
+						poses_pending = false;
+						for (int i = 0; i < app_count; i++) {
+							if (apps[i].has_pose) poses_pending = true;
+						}
+
+						// Clear client name tracking
+						client_name_count = 0;
+
+						g_shell_active = false;
+						tray_update_tooltip(false);
+						P("Shell deactivated — waiting in tray.\n");
+					} else {
+						P("Activating shell...\n");
+						xret = ipc_call_shell_activate(&ipc_c);
+						if (xret != XRT_SUCCESS) {
+							PE("Warning: shell_activate failed\n");
+						}
+
+						// Re-adopt desktop windows via auto-enumerate
+						enumerate_and_adopt_windows(&ipc_c, captures, &capture_count, service_pid);
+
+						g_shell_active = true;
+						tray_update_tooltip(true);
+						P("Shell activated — %d capture(s) adopted.\n", capture_count);
+					}
+				} else if (msg.message == WM_TRAYICON) {
+					if (LOWORD(msg.lParam) == WM_LBUTTONUP) {
+						// Left-click tray: activate if inactive
+						if (!g_shell_active) {
+							PostMessage(g_msg_hwnd, WM_HOTKEY, HOTKEY_TOGGLE, 0);
+						}
+					} else if (LOWORD(msg.lParam) == WM_RBUTTONUP) {
+						// Right-click tray: context menu
+						tray_show_context_menu(g_msg_hwnd, g_shell_active);
+					}
+				}
+				TranslateMessage(&msg);
+				DispatchMessageA(&msg);
+			}
+		}
+		// Fall through to poll work regardless of wait result
+#else
+		usleep(500000);
+#endif
+
+		// --- Poll work (only meaningful when shell is active) ---
+#ifdef _WIN32
+		if (!g_shell_active) {
+			continue;
+		}
+#endif
+
 		// Apply pending poses when new clients appear
 		if (poses_pending) {
 			try_apply_poses(&ipc_c, apps, app_count, prev_ids, prev_count);
 
-			// Check if all poses applied
 			poses_pending = false;
 			for (int i = 0; i < app_count; i++) {
 				if (apps[i].has_pose && !apps[i].pose_applied) {
@@ -898,10 +1071,8 @@ main(int argc, char *argv[])
 			}
 		}
 
-		// Detect new clients and restore saved poses from config.
-		// Use numbered names for duplicate apps (AppName, AppName-2, etc.)
+		// Detect new clients and track names
 		{
-
 			struct ipc_client_list clients;
 			xrt_result_t r = ipc_call_system_get_clients(&ipc_c, &clients);
 			if (r == XRT_SUCCESS) {
@@ -917,10 +1088,8 @@ main(int argc, char *argv[])
 						struct ipc_app_state ias;
 						xrt_result_t ir = ipc_call_system_get_client_info(&ipc_c, clients.ids[c], &ias);
 						if (ir == XRT_SUCCESS && ias.info.application_name[0] != '\0') {
-							// Count existing instances to generate numbered name
 							int instance = 1;
 							for (int cn = 0; cn < client_name_count; cn++) {
-								// Strip " (N)" suffix if present
 								char existing_base[128];
 								snprintf(existing_base, sizeof(existing_base), "%s", client_names[cn].name);
 								char *paren = strrchr(existing_base, '(');
@@ -938,15 +1107,11 @@ main(int argc, char *argv[])
 								snprintf(numbered_name, sizeof(numbered_name), "%s",
 								         ias.info.application_name);
 
-							// Track client_id → numbered_name mapping
 							if (client_name_count < MAX_SAVED_WINDOWS) {
 								client_names[client_name_count].id = clients.ids[c];
 								snprintf(client_names[client_name_count].name, 128, "%s", numbered_name);
 								client_name_count++;
 							}
-
-							// Layout persistence disabled during early dev.
-							// Default grid layout is applied by the compositor.
 						}
 					}
 				}
@@ -955,42 +1120,34 @@ main(int argc, char *argv[])
 
 		print_clients(&ipc_c, prev_ids, &prev_count);
 
-		// Periodic save: query current poses and update config
-		// Layout persistence disabled during early dev.
-		(void)save_counter;
-
-		// Dynamic window tracking: detect new/closed windows every ~1 second
 #ifdef _WIN32
+		// Dynamic window tracking: detect new/closed windows every ~1 second
 		if (auto_adopt) {
 			adopt_counter++;
 			if (adopt_counter >= 2) {
 				adopt_counter = 0;
-				// Remove closed windows
 				cleanup_closed_captures(&ipc_c, captures, &capture_count);
-				// Adopt new windows
 				enumerate_and_adopt_windows(&ipc_c, captures, &capture_count, service_pid);
 			}
 		}
-#endif
-
-#ifdef _WIN32
-		Sleep(500);
-#else
-		usleep(500000);
 #endif
 	}
 
 	P("\nShell exiting.\n");
 
-	// Remove capture clients before disconnecting
-	for (int i = 0; i < capture_count; i++) {
-		if (captures[i].added) {
-			ipc_call_shell_remove_capture_client(&ipc_c, captures[i].client_id);
-			P("  Removed capture client_id=%u\n", captures[i].client_id);
-		}
+#ifdef _WIN32
+	// Deactivate shell if still active
+	if (g_shell_active) {
+		ipc_call_shell_deactivate(&ipc_c);
 	}
 
-#ifdef _WIN32
+	// Cleanup hotkey and tray
+	if (g_msg_hwnd != NULL) {
+		UnregisterHotKey(g_msg_hwnd, HOTKEY_TOGGLE);
+		tray_destroy();
+		DestroyWindow(g_msg_hwnd);
+	}
+
 	// Close process handles
 	for (int i = 0; i < app_count; i++) {
 		if (apps[i].process != NULL) {


### PR DESCRIPTION
## Summary

Phase 4C delivers the Spatial Companion feature set: graceful exit from shell mode with OpenXR apps surviving deactivation via hot-switch, plus system tray integration, global hotkey, and minimal app launcher.

- **Graceful exit**: Ctrl+Space deactivates the shell without killing apps. IPC clients lazy-create per-client standalone resources (swap chain + DP) on their next \`layer_commit\`, using the app's external HWND. No session loss.
- **Bidirectional re-activate**: Second Ctrl+Space tears down per-client standalone resources and apps rejoin the shell via the multi-compositor.
- **System tray + hotkey**: \`RegisterHotKey(Ctrl+Space)\`, \`Shell_NotifyIcon\` with right-click context menu, MsgWaitForMultipleObjects loop replaces the Sleep(500) poll.
- **App launcher v1**: Ctrl+L launches from \`%LOCALAPPDATA%\DisplayXR\registered_apps.json\`. Auto-detects 3D vs 2D by polling IPC connection for 5s after launch.
- **Kooima POV fix**: \`comp_d3d11_service_owns_window()\` now queries the active compositor's \`render.owns_window\` instead of just checking \`shell_mode\`. Critical for the IPC view pose path after hot-switch — routes to display-centric eye tracking, not the camera-centric qwerty path.
- **GL Y-flip in standalone path**: \`service_crop_atlas_for_dp()\` takes a \`flip_y\` parameter and uses shader blit with negative source rect height for GL clients.

## Commits

12 commits on \`feature/shell-phase4c\`. See \`docs/roadmap/shell-phase4c-status.md\` for the full design decisions, known limitations, and task status.

## Known limitations

- **Drag stutter for hot-switched apps**: IPC roundtrip overhead (~10ms vs ~5ms in-process), cross-process DWM composition timing, and the absence of cross-process phase snapping (vendor SDK hook is in the wrong process) produce residual drag stutter compared to true in-process handle apps. Mitigated via \`SetMaximumFrameLatency(1)\` and \`DwmFlush()\` after Present. Documented in status doc; future work requires a vendor-agnostic phase snap query API.
- **Multi-cube launch race**: Occasionally GL/VK cubes fail to connect when launching all 4 APIs simultaneously. Not reliably reproducible.

## Test plan

- [x] Ctrl+Space toggle (activate / deactivate / re-activate) with single cube
- [x] Ctrl+O / Ctrl+L launches cube from the shell
- [x] Ctrl+Space deactivate → cube continues rendering in own window (hot-switch)
- [x] Ctrl+Space re-activate → cube rejoins the shell
- [x] All 4 graphics APIs (D3D11, D3D12, GL, VK) in shell simultaneously
- [x] GL cube renders right-side-up in standalone mode after hot-switch
- [x] ESC forwarded to app (not reserved), doesn't kill the shell
- [x] System tray icon with Activate / Exit
- [x] IPC reconnect if service exited between deactivate and re-activate
- [x] Clean shell on app close while standalone (no ghost remnant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)