### PR TITLE
Shell 5: Spatial App Launcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,6 @@ LeiaSR-SDK-*/
 vcpkg/
 local_build*.log
 openxr_sdk/
+
+# Shell smoke test outputs (screenshots + logs)
+scripts/test/out/

--- a/docs/roadmap/shell-phase5-agent-prompt.md
+++ b/docs/roadmap/shell-phase5-agent-prompt.md
@@ -1,0 +1,130 @@
+# Shell Phase 5: Agent Prompt — Spatial App Launcher
+
+Use this prompt to start a new Claude Code session for implementing Phase 5 on branch `feature/shell-phase5`.
+
+---
+
+## Prompt
+
+```
+I'm working on the DisplayXR shell — a spatial window manager for 3D lenticular displays. We're implementing Phase 5: the Spatial App Launcher. This adds a proper 3D UI panel for browsing and launching DisplayXR apps, replacing the Phase 4C minimal Ctrl+L stub (which just launches the first registered app).
+
+## Context
+
+Read these docs first (in order):
+1. `CLAUDE.md` — project overview, build commands, architecture
+2. `docs/roadmap/shell-phase5-plan.md` — **the plan you're implementing** (exploration phase + launcher UI)
+3. `docs/roadmap/shell-phase5-status.md` — task checklist (update as you complete tasks)
+4. `docs/roadmap/shell-phase4c-status.md` — what Phase 4C delivered (the foundation you build on)
+5. `docs/roadmap/shell-runtime-contract.md` — IPC protocol boundary (runtime vs shell)
+6. `docs/reference/window-drag-rendering.md` — how the multi-compositor handles windows (useful for launcher panel rendering)
+7. `docs/roadmap/3d-shell.md` and `docs/roadmap/spatial-desktop-prd.md` — product vision for the shell
+
+## Branch
+
+You are on `feature/shell-phase5`, branched from `main` after Phase 4C was merged (PR #138). All work goes here. Commits should reference #43 (Spatial OS tracking issue) or add #44 if shell-specific.
+
+## What Phase 5 needs
+
+Phase 5 has TWO parts. Start with Part 1 (discovery exploration) — do NOT jump straight to UI work.
+
+### Part 1: App Discovery — start with exploration
+
+Phase 4C shipped `registered_apps.json` at `%LOCALAPPDATA%\DisplayXR\registered_apps.json` with manually-listed apps. Phase 5 needs to **auto-discover installed DisplayXR apps** so users don't have to hand-edit JSON.
+
+**Your first task is an exploration phase.** Before writing any code:
+
+1. Read `docs/roadmap/shell-phase5-plan.md` Part 1 thoroughly.
+2. Research the five exploration questions listed there:
+   - Can we detect OpenXR apps by scanning PE imports?
+   - Is a `.displayxr.json` sidecar convention viable?
+   - What install locations should we scan?
+   - How do other XR ecosystems (SteamVR, Oculus, WMR) handle this?
+   - What can the runtime tell us about known apps?
+3. Look at the existing Phase 4C launcher code in `src/xrt/targets/shell/main.c` — specifically the `registered_app` struct, `registered_apps_load/save`, `shell_launch_registered_app`, and the Ctrl+L handler. Understand what's already there.
+4. Look at existing demo/test app layouts: `test_apps/cube_handle_*_win/`, `demos/*/`.
+5. Write a ~500-word report at `docs/roadmap/shell-phase5-discovery-findings.md` with:
+   - Summary of findings for each exploration question
+   - A concrete **recommendation** for the discovery strategy (probably a hybrid)
+   - A proposed `.displayxr.json` spec if that's part of the recommendation
+   - Open questions that need the user's input before implementation
+
+**Stop after writing the exploration report. Ask the user to review it before implementing anything.** The user explicitly wants the exploration to happen first.
+
+### Part 2: Spatial Launcher UI
+
+Only start Part 2 after exploration is approved.
+
+The launcher is a spatial window rendered inside the multi-compositor shell window. It shows:
+- **Running section**: apps currently connected as IPC clients (highlight tiles)
+- **Installed section**: apps from the scanned registry + `registered_apps.json`
+- **Browse for app**: file dialog to add an arbitrary exe
+
+**Rendering approach:** Extend the existing multi-compositor's drawing code (title bars, buttons, bitmap font atlas in `d3d11_bitmap_font.h`) to draw a panel with a grid of tiles. Start with the simplest possible layout — grid of colored quads with text labels — then iterate.
+
+**Interaction:**
+- `Ctrl+L` opens the launcher (replacing current Phase 4C behavior of launching first app)
+- `Esc` closes it
+- Mouse hover + click to launch
+- Arrow keys + Enter for keyboard nav
+- Right-click tile for context menu (remove)
+
+**Launch path:** Reuse the existing `shell_launch_registered_app()` from Phase 4C. Don't duplicate the env-var-setting CreateProcess logic.
+
+**Running detection:** Already available via `ipc_call_system_get_clients` + `ipc_call_system_get_client_info` (used in Phase 4C's polling loop). The launcher queries this when it opens and highlights matching tiles.
+
+## What Phase 5 is NOT
+
+- Not a Steam-style app store
+- Not cloud app sync
+- Not arbitrary icon extraction from exe resources (sidecar + fallback for v1)
+- Not multi-display launcher positioning
+- Not localization
+
+Keep the scope tight. Ship a working grid with discovery in a reasonable number of commits.
+
+## Key files to reference
+
+- `src/xrt/targets/shell/main.c` — existing launcher code (`registered_app`, `shell_launch_registered_app`, Ctrl+L handler)
+- `src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp` — multi-compositor rendering; find `render_title_bar_*` and the blit shader usage for an example of drawing UI in the shell window
+- `src/xrt/compositor/d3d11_service/d3d11_bitmap_font.h` and the glyph atlas setup — for rendering tile labels
+- `src/xrt/compositor/d3d11_service/d3d11_service_shaders.h` — existing `BlitConstants` struct (already supports rounded corners, glow, etc.)
+
+## Commit style
+
+- Commit per task (or small group of related tasks) — not one big blob
+- Reference #43 (or #44 if shell-specific) in every commit
+- Use `Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>` in the commit footer
+
+## Testing
+
+Build locally: `scripts\build_windows.bat build`. Launch the shell with a cube app for running-app testing:
+```
+_package\bin\displayxr-shell.exe test_apps\cube_handle_d3d11_win\build\cube_handle_d3d11_win.exe
+```
+
+Press Ctrl+Space to activate shell, then Ctrl+L to open the launcher.
+
+## When to ask the user
+
+- After the exploration report is written — before implementing the discovery scanner
+- Before making UI layout decisions that could be "bikeshed" — provide options and ask
+- When you hit any deadlock, cross-process issue, or scope question — Phase 4C had many of these, don't power through without asking
+
+## Deliverables
+
+- `docs/roadmap/shell-phase5-discovery-findings.md` — the exploration report
+- Working discovery scanner + populated `registered_apps.json` on first launch
+- Working spatial launcher panel (Ctrl+L) with grid, running indicator, launch dispatch
+- Updated `shell-phase5-status.md` with tasks checked off
+- Clean commits on `feature/shell-phase5`
+```
+
+---
+
+## Notes for the user running the agent
+
+- Phase 5 explicitly starts with an exploration phase. Don't approve a jump straight to implementation — the agent should produce `shell-phase5-discovery-findings.md` first.
+- The "automatic app discovery" problem is not fully solved by any XR ecosystem; a hybrid approach is expected (sidecar + scan + manual registry merge).
+- The launcher UI should reuse Phase 4A-4C infrastructure (multi-compositor drawing, bitmap font atlas, title bar rendering, slot-based rendering) — resist temptation to add a new windowing layer.
+- Test with the existing `test_apps/cube_handle_*_win` apps — they're the most diverse set for validating discovery.

--- a/docs/roadmap/shell-phase5-discovery-findings.md
+++ b/docs/roadmap/shell-phase5-discovery-findings.md
@@ -1,0 +1,85 @@
+# Shell Phase 5 — App Discovery Findings
+
+**Status:** Exploration deliverable (Task 5.1). Pre-implementation. Awaiting user review before Step 2.
+**Date:** 2026-04-10
+**Branch:** `feature/shell-phase5`
+
+## Goal
+
+Decide how the shell should auto-populate `registered_apps.json` so users don't hand-edit JSON. The launcher must answer: *which executables on this machine are DisplayXR / OpenXR apps, and what should I show for each?*
+
+## Findings
+
+### 1. PE import scan — feasible, no DisplayXR-only signal
+
+Windows ships `Dbghelp.dll` with `ImageDirectoryEntryToDataEx`, which can read a PE's import table without `LoadLibrary`. No PE-parsing code exists in the repo today; it would be a new ~150 LOC module.
+
+We can reliably detect **OpenXR** apps by scanning imports for `openxr_loader.dll` — every test app and demo links it.
+
+We **cannot** detect "DisplayXR app" specifically. There is no `DisplayXRClient.dll` and no DisplayXR-only DLL/symbol. `XR_EXT_win32_window_binding` is an OpenXR extension, not a DisplayXR marker. Conclusion: PE scan tells us "is OpenXR," nothing more.
+
+### 2. Sidecar `.displayxr.json` is the cleanest authoritative metadata source
+
+A per-app sidecar lets developers ship name, icon, category, and preferred display mode without resource hacks. Other XR ecosystems (SteamVR `appmanifest_*.acf`, Oculus library JSON, WMR AppX) all use the same per-app-manifest pattern. Sidecar is the strongest signal "this app intends to run on DisplayXR."
+
+**Proposed schema:**
+
+```json
+{
+  "name": "Cube D3D11",
+  "icon": "icon.png",
+  "type": "3d",
+  "category": "test",
+  "display_mode": "auto"
+}
+```
+
+`type` matches the existing Phase 4C `registered_app.type` field (`"3d"` / `"2d"`). `icon` is relative to the sidecar. All fields except `name` are optional.
+
+### 3. Existing test apps already carry usable metadata in VERSIONINFO
+
+11 of the 12 cube test apps populate `FileDescription` in `resource.rc` (e.g. *"SR Cube OpenXR Ext Test Application"*). `GetFileVersionInfoW` + `VerQueryValueW` gives us a no-touch fallback display name, so a sidecar-less app still gets a sensible label.
+
+No `.ico` files exist anywhere in the repo. Icon extraction via `PrivateExtractIconsW` would work but is fiddly — defer to a v2. v1 tiles render text-only when no sidecar `icon` is provided.
+
+### 4. Scan paths
+
+Walk these (relative to the shell exe, then absolute fallbacks):
+
+| Path | Why |
+|---|---|
+| `test_apps/*/build/*.exe` | Dev scenario — 12 cube variants live here |
+| `demos/*/build/*.exe` | Gaussian splatting, spatial OS demos |
+| `_package/bin/*.exe` | Installed runtime layout |
+| `%PROGRAMFILES%\DisplayXR\apps\` | Future production install (currently empty — harmless) |
+
+### 5. Runtime knows running clients but not exe paths
+
+`ipc_call_system_get_clients` + `ipc_call_system_get_client_info` returns `struct ipc_app_state` with `pid`, `info.application_name`, and session flags — but **no exe path**. To match a running client to a registry entry we either:
+
+- match by `application_name` string (simple; what Phase 4C already does), or
+- resolve `pid` → exe via `QueryFullProcessImageNameW` (more robust but needs `PROCESS_QUERY_LIMITED_INFORMATION` access).
+
+Recommend starting with name match and adding PID→path as a fallback only if collisions show up.
+
+## Recommended hybrid strategy
+
+1. **Sidecar `.displayxr.json` (preferred).** Authoritative metadata. Developers add it to test_apps and demos in Step 2.
+2. **Filesystem scan with PE import gate.** For each `.exe` under the scan paths, check `openxr_loader.dll` import. If matched: use sidecar if present, else `VERSIONINFO.FileDescription`, else exe filename.
+3. **Merge with `registered_apps.json`.** Existing user entries get `source: "user"` and are never overwritten. Scan-discovered entries get `source: "scan"`. User-removed scan entries get `hidden: true` (sticky tombstone) so the next scan doesn't re-add them.
+4. **Running tag at launcher open.** Query `ipc_call_system_get_clients` and tag matching tiles. Click on a running tile = focus existing instance, not relaunch.
+
+This avoids requiring sidecars (so existing test apps "just work") while giving developers a clean upgrade path for richer metadata.
+
+## Open questions for the user
+
+Please answer before Step 2 starts:
+
+1. **Sidecar location** — next to the `.exe`, or in `%LOCALAPPDATA%\DisplayXR\app-metadata\<hash>.json`? Next-to-exe is simpler and lets the app's own installer ship it; central dir lets the shell own metadata for apps it doesn't control.
+2. **v1 strictness** — require sidecars (cleaner registry, fewer false positives) or accept VERSIONINFO + generic-icon fallback (existing test apps just work, but any random OpenXR app a user installs will appear)?
+3. **Scan timing** — every shell startup, or once-on-first-run plus an explicit "Refresh" button in the launcher?
+4. **Right-click "Remove"** — permanent (`hidden: true` tombstone in JSON) or session-only (re-appears on next start)?
+5. **Layout persistence** — should grid order / pinned apps survive across sessions, or always sort alphabetically?
+6. **Scope check** — is "OpenXR app discovered, no sidecar" something we want to **show** in the launcher, or **filter out** until the developer ships a sidecar?
+
+Once these are answered I'll proceed to Step 2 (scanner + merge implementation) per the plan in `.claude/plans/sorted-painting-stroustrup.md`.

--- a/docs/roadmap/shell-phase5-plan.md
+++ b/docs/roadmap/shell-phase5-plan.md
@@ -1,0 +1,175 @@
+# Shell Phase 5 Plan: Spatial App Launcher
+
+**Branch:** `feature/shell-phase5`
+**Tracking issue:** #43 (Spatial OS) / #44 (3D Shell)
+**Depends on:** Phase 4C complete (merged to main)
+
+## Overview
+
+Phase 4C shipped a minimal app launcher — `Ctrl+L` launches the first registered app from `%LOCALAPPDATA%\DisplayXR\registered_apps.json`. There is no visual UI for browsing apps, no auto-discovery of installed DisplayXR apps, and no way to tell running-in-shell apps apart from not-yet-launched apps.
+
+Phase 5 delivers the **Spatial App Launcher**: a 3D panel inside the shell that shows installed DisplayXR apps as tiles with icons, a "currently running" section, and a "quick launch" flow. The launcher is summoned by Ctrl+L (or a new hotkey), rendered as a spatial window in the multi-compositor, and supports mouse navigation + keyboard focus.
+
+**Phase 5 has two main deliverables:**
+
+1. **App discovery** — figure out which apps on the system are DisplayXR / OpenXR apps, without requiring the user to hand-edit JSON.
+2. **Spatial launcher UI** — render an app grid in the shell window, handle input, launch selected apps.
+
+Phase 5 starts with an **exploration phase** on app discovery before committing to an implementation.
+
+## Part 1: App Discovery (Exploration → Design → Implementation)
+
+### Exploration phase
+
+Before writing code, the agent must explore and report on these questions. The Phase 4C research already produced a summary — the exploration should validate and extend it:
+
+1. **Can we reliably detect OpenXR apps from their executable?** Options:
+   - Scan PE imports for `openxr_loader.dll`
+   - Scan for DisplayXR-specific imports or strings
+   - Parse embedded manifests / version resources
+   - None of the above (rely on user registration)
+
+2. **Is a `.displayxr.json` sidecar convention viable?** Design:
+   - File format (name, icon path, display mode requirements, category, etc.)
+   - Discovery locations (next to .exe, in `%LOCALAPPDATA%\DisplayXR\apps\`, etc.)
+   - Who writes it: app developer, installer, or the launcher scanner on first run
+   - Fallback when no sidecar exists
+
+3. **What existing DisplayXR install locations should we scan?**
+   - `_package/bin/` (installed runtime dir)
+   - `test_apps/*/build/` (dev builds — shell dev scenario)
+   - `%PROGRAMFILES%\DisplayXR\apps\` (hypothetical production install)
+   - `demos/*/build/` (demo repo install)
+
+4. **How do other XR ecosystems handle this?**
+   - SteamVR: `steamapps.vdf`, `appmanifest_*.acf`
+   - Oculus: library JSON in `%APPDATA%\Oculus`
+   - Windows Mixed Reality: AppX manifest
+   - Is there a lightweight pattern we can borrow without adopting a full app store?
+
+5. **What can the RUNTIME tell us about apps?** Even without discovery, the runtime knows:
+   - Running IPC clients (name, PID, display mode index, extensions used) via `system_get_client_info`
+   - Apps that have called `xrCreateInstance` in the past (does the runtime log this? should it?)
+
+**Exploration deliverables:**
+- A short report (~500 words) in `docs/roadmap/shell-phase5-discovery-findings.md`
+- A **recommendation** for the discovery strategy (or a hybrid of strategies)
+- A proposed `.displayxr.json` spec if that's part of the recommendation
+
+### Design phase (after exploration approval)
+
+Based on the exploration findings, draft the concrete design:
+
+- App metadata schema (what fields per app)
+- Discovery scan logic (when, what paths, how often)
+- Cache format (update `registered_apps.json` or new format)
+- Manual add/remove UI from the launcher
+
+### Implementation tasks
+
+Depends on the design outcome. Likely tasks:
+
+| Task | Description |
+|------|-------------|
+| 5.1 | Exploration report + recommendation |
+| 5.2 | Define `.displayxr.json` sidecar spec (if adopted) — add to test_apps/ and demos/ |
+| 5.3 | Filesystem scanner — walk a set of paths, find executables, read sidecars / extract metadata |
+| 5.4 | Icon extraction — from sidecar, from `.exe` via `PrivateExtractIconsW`, or placeholder |
+| 5.5 | Merge scanned results with existing `registered_apps.json` (preserve user edits) |
+| 5.6 | Running-app detection via existing `system_get_client_info` — tag entries as "running" |
+
+## Part 2: Spatial Launcher UI
+
+The launcher is a spatial window rendered by the multi-compositor, similar to how app windows are rendered. It appears when the user presses Ctrl+L (or whatever trigger we decide), floats in front of the user, and supports click-to-launch.
+
+### UI layout (initial design — refine during implementation)
+
+```
+┌──────────────────────────────────────────────┐
+│  DisplayXR Launcher                      [x] │
+├──────────────────────────────────────────────┤
+│                                              │
+│  Running (2)                                 │
+│  ┌────┐ ┌────┐                               │
+│  │ C  │ │ V  │   (running apps — click to    │
+│  │Cube│ │ VK │    bring to focus)            │
+│  └────┘ └────┘                               │
+│                                              │
+│  Installed (5)                               │
+│  ┌────┐ ┌────┐ ┌────┐ ┌────┐ ┌────┐          │
+│  │ D11│ │ D12│ │ GL │ │ VK │ │Demo│          │
+│  │Cube│ │Cube│ │Cube│ │Cube│ │ GS │          │
+│  └────┘ └────┘ └────┘ └────┘ └────┘          │
+│                                              │
+│  [Browse for app...]                         │
+└──────────────────────────────────────────────┘
+```
+
+### Rendering approach
+
+The launcher can be rendered in one of two ways:
+
+- **Option A: Native multi-compositor UI** — extend the multi-compositor shell window chrome (which already draws title bars, borders, buttons) to draw a launcher panel directly. Uses existing `d3d11_service` drawing primitives. Fastest to implement, no new windowing.
+- **Option B: Dedicated launcher HWND via runtime-owned window** — a small child window created by the service for the launcher, captured into the shell like any other window. More flexible but heavier.
+
+**Recommendation:** Start with Option A. The shell already has title bars, text rendering via the bitmap font atlas (see `d3d11_bitmap_font.h`), and button hit-testing. A panel of tiles is the same primitives, just laid out differently.
+
+### Interaction
+
+| Action | Trigger |
+|--------|---------|
+| Open launcher | `Ctrl+L` (replacing current minimal "launch first app" behavior) |
+| Close launcher | `Esc` / click outside / click [x] |
+| Navigate tiles | Mouse hover + click; arrow keys + Enter |
+| Launch app | Click tile or Enter |
+| Browse for exe | Click "Browse for app..." → file dialog → add to registry |
+| Remove from launcher | Right-click tile → "Remove" |
+
+### Tasks
+
+| Task | Description |
+|------|-------------|
+| 5.7 | Launcher panel render — quad in multi-comp at a fixed position, drawn with existing blit shader |
+| 5.8 | Tile layout — grid of thumbnails, text labels from app metadata |
+| 5.9 | Hit testing — mouse ray → tile index, hover highlight, click dispatch |
+| 5.10 | Launch dispatch — click tile → spawn process with correct env vars (reuse Phase 4C `shell_launch_registered_app`) |
+| 5.11 | Running indicator — highlight tiles whose app is currently an IPC client |
+| 5.12 | Keyboard navigation — arrow keys + Enter, tab out to shell |
+| 5.13 | Remove / reorder via right-click context menu |
+| 5.14 | Browse-for-app file dialog integration (reuses existing Ctrl+O plumbing where applicable) |
+
+## Out of scope for Phase 5
+
+- Steam/Oculus-style app store
+- Cloud app sync
+- Icons extracted from arbitrary exe resources (use sidecar or fallback for v1)
+- Custom app categories / tags beyond "running" vs "installed"
+- Multi-monitor launcher positioning (single display for v1)
+- Localization
+
+## Critical files
+
+| File | Expected changes |
+|------|------------------|
+| `src/xrt/targets/shell/main.c` | Ctrl+L now opens launcher panel instead of launching first app; add scanner call on startup |
+| `src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp` | Launcher panel rendering + hit testing |
+| `src/xrt/compositor/d3d11_service/d3d11_bitmap_font.h` | Reused for tile labels |
+| `test_apps/*/build/*.displayxr.json` | New sidecar files if convention is adopted |
+| `docs/roadmap/shell-phase5-discovery-findings.md` | NEW — exploration report |
+| `docs/roadmap/shell-phase5-status.md` | Task checklist, updated as work progresses |
+
+## Verification
+
+1. **Discovery scan** — Launch shell with no `registered_apps.json`. Verify scanner finds all `cube_handle_*` test apps in `test_apps/` and populates the registry.
+2. **Launcher opens** — Ctrl+L opens the panel, shows all scanned apps + "Browse for app..." button.
+3. **Running indicator** — Launch cube_handle_d3d11_win. Open launcher. Verify the cube tile shows as "running."
+4. **Click to launch** — Click a tile, verify the app launches and the panel closes.
+5. **Bring to front** — Click a "running" tile, verify the existing instance gets focus (not a second instance).
+6. **Close via Esc** — Panel closes, shell continues.
+7. **Round-trip with Ctrl+Space** — Open launcher, deactivate shell, re-activate, reopen launcher, state persists.
+
+## Risks
+
+- **Discovery false positives:** scanning exe imports could classify any OpenXR app as a DisplayXR app (not necessarily wrong, but could clutter the launcher). Mitigation: prefer sidecar files, use exe scan only as fallback.
+- **UI complexity creep:** keyboard nav + hit testing + animations in the multi-compositor is non-trivial. Start with the simplest possible grid and iterate.
+- **Icon quality:** extracting icons from exes is fiddly. Use a fallback icon for v1 if sidecar doesn't provide one.

--- a/docs/roadmap/shell-phase5-status.md
+++ b/docs/roadmap/shell-phase5-status.md
@@ -1,0 +1,66 @@
+# Shell Phase 5 Status: Spatial App Launcher
+
+**Branch:** `feature/shell-phase5`
+**Status:** Not started — exploration phase pending
+**Date:** 2026-04-10
+
+## Scope
+
+Phase 5 delivers a proper spatial launcher panel in the shell, replacing the Phase 4C minimal Ctrl+L (launch-first-app) stub. Two main deliverables:
+
+1. **App discovery** — figure out which apps on the system are DisplayXR / OpenXR apps without requiring the user to hand-edit JSON.
+2. **Spatial launcher UI** — render an app grid inside the multi-compositor shell window, handle input, launch selected apps.
+
+**Full plan:** [shell-phase5-plan.md](shell-phase5-plan.md)
+
+## Part 1: App Discovery
+
+### Exploration phase
+
+| Status | Task | Description |
+|--------|------|-------------|
+| [ ] | 5.1 | Exploration report — `shell-phase5-discovery-findings.md` with recommendation |
+
+### Design + implementation (after exploration approval)
+
+| Status | Task | Description |
+|--------|------|-------------|
+| [ ] | 5.2 | `.displayxr.json` sidecar spec (if adopted) — add to test_apps and demos |
+| [ ] | 5.3 | Filesystem scanner — walks paths, finds exes, reads sidecars |
+| [ ] | 5.4 | Icon extraction — sidecar, PE resource, or fallback |
+| [ ] | 5.5 | Merge scanned results with user-edited `registered_apps.json` |
+| [ ] | 5.6 | Running-app detection via `system_get_client_info` |
+
+## Part 2: Spatial Launcher UI
+
+| Status | Task | Description |
+|--------|------|-------------|
+| [ ] | 5.7 | Launcher panel render — quad in multi-comp, blit shader |
+| [ ] | 5.8 | Tile layout — grid with icons and labels |
+| [ ] | 5.9 | Hit testing — mouse ray → tile index, hover highlight |
+| [ ] | 5.10 | Launch dispatch — click → `shell_launch_registered_app` |
+| [ ] | 5.11 | Running indicator — highlight tiles for running clients |
+| [ ] | 5.12 | Keyboard navigation — arrow keys + Enter |
+| [ ] | 5.13 | Right-click context menu (remove, reorder) |
+| [ ] | 5.14 | Browse-for-app file dialog |
+
+## Commits
+
+_(none yet)_
+
+## Design Decisions
+
+_(to be filled in during exploration and implementation)_
+
+## Known Issues
+
+_(to be filled in during implementation)_
+
+## Open Questions (for exploration)
+
+- Is there a reliable way to detect OpenXR apps by scanning their PE imports?
+- Should we adopt a `.displayxr.json` sidecar convention, and who writes it?
+- Which filesystem paths should the scanner walk by default?
+- How do we handle icons — sidecar-provided, exe-extracted, or fallback-only for v1?
+- Should the launcher persist its layout across sessions (grid order, pinned apps)?
+- Should right-click remove delete from `registered_apps.json` permanently, or just hide for this session?

--- a/docs/specs/displayxr-app-manifest.md
+++ b/docs/specs/displayxr-app-manifest.md
@@ -1,0 +1,161 @@
+# DisplayXR App Manifest (`.displayxr.json`)
+
+| Field | Value |
+|---|---|
+| **Spec** | DisplayXR App Manifest |
+| **Version** | 1.0 (draft) |
+| **Status** | Phase 5 — spatial launcher discovery |
+| **Owner** | Shell team |
+| **Applies to** | Any application that wants to appear in the DisplayXR shell launcher |
+
+## 1. Purpose
+
+The DisplayXR shell's spatial launcher discovers installable apps by scanning a small set of filesystem locations and reading per-app **manifest sidecar files** named `.displayxr.json`. The manifest is the authoritative source of an app's display name, icons, category, and display-mode preferences.
+
+**Discovery is manifest-gated.** An executable with no manifest is NOT shown in the launcher, even if it imports `openxr_loader.dll`. This is intentional: it keeps the launcher curated, avoids false positives from unrelated OpenXR apps, and gives developers a single explicit contract to satisfy. Users can still manually add any executable through the launcher's **Browse for app…** entry; those entries bypass the manifest requirement.
+
+DisplayXR Unity and Unreal plugins are expected to generate a manifest automatically as part of their build/export pipelines. Native app developers author the manifest by hand.
+
+**Not every executable in a DisplayXR SDK install ships a manifest.** In particular, test-only variants (`cube_hosted_legacy_*`, `cube_texture_*`, `cube_hosted_*`, and similar) intentionally omit a sidecar so they do not appear in the launcher — they exist to exercise runtime paths that are not meaningful to end users. Only apps that a user would plausibly launch from the shell should ship a manifest. Inside this repo, only the `cube_handle_*_win` reference apps carry sidecars.
+
+## 2. File location
+
+The manifest lives **next to the executable** it describes, with the filename stem matching the executable:
+
+```
+my_app/
+├── my_app.exe
+├── my_app.displayxr.json     ← manifest
+├── icon.png                  ← referenced from manifest
+└── icon_sbs.png              ← optional 3D icon
+```
+
+- The scanner looks for `<exe_basename>.displayxr.json` in the same directory as each discovered `.exe`.
+- All paths inside the manifest are resolved **relative to the manifest file**, not the CWD.
+- The scanner never writes to the manifest. It is developer-owned.
+
+## 3. Schema (v1.0)
+
+```json
+{
+  "schema_version": 1,
+  "name": "Cube D3D11",
+  "type": "3d",
+  "icon": "icon.png",
+  "icon_3d": "icon_sbs.png",
+  "icon_3d_layout": "sbs-lr",
+  "category": "test",
+  "display_mode": "auto",
+  "description": "Reference cube demonstrating XR_EXT_win32_window_binding on D3D11."
+}
+```
+
+### 3.1 Required fields
+
+| Field | Type | Notes |
+|---|---|---|
+| `schema_version` | integer | Must be `1` for v1.0. Allows future schema migrations. |
+| `name` | string | Display name shown on the tile. 1–64 characters. UTF-8. |
+| `type` | string | `"3d"` for extension/hosted apps that create an OpenXR session, `"2d"` for legacy Win32 apps the shell captures by HWND. Must match one of these values. |
+
+### 3.2 Optional fields
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `icon` | string | *none* | Relative path to a 2D icon image. PNG or JPEG. Recommended 512×512. When absent, the tile is rendered with the app name as a text label on a category-colored background. |
+| `icon_3d` | string | *none* | Relative path to a stereoscopic icon image. When present, the shell renders the tile stereoscopically. Resolution matches `icon` aspect but doubled along the layout axis (e.g. 1024×512 for `sbs-lr`). Requires `icon` to also be set (as the 2D fallback). |
+| `icon_3d_layout` | string | `"sbs-lr"` | How the stereo pair is packed in `icon_3d`. One of `"sbs-lr"` (left-right), `"sbs-rl"` (right-left), `"tb"` (top-bottom, left eye on top), `"bt"` (bottom-top). Ignored if `icon_3d` is absent. |
+| `category` | string | `"app"` | Free-form tag used for grouping. Reserved values: `"test"`, `"demo"`, `"app"`, `"tool"`. Unknown values are accepted and displayed as-is. |
+| `display_mode` | string | `"auto"` | Preferred display mode at launch. `"auto"` lets the runtime choose. Other values are forwarded to the runtime's mode selection. |
+| `description` | string | `""` | One-line description shown in tooltips. Max 256 characters. |
+
+### 3.3 Reserved for future versions
+
+Names the shell may consume in later schema versions — do not use for custom data:
+
+`version`, `publisher`, `homepage`, `min_runtime`, `required_extensions`, `screenshots`, `trailer`, `pose`, `window_size`.
+
+## 4. 3D icons
+
+The launcher's key visual hook is that app tiles are themselves 3D. A high-quality `icon_3d` is the single biggest contributor to the launcher "wow" moment.
+
+### 4.1 Generating 3D icons
+
+- **Unity / Unreal plugin** — the recommended path. Render two viewpoints from the runtime's stereo camera pair at a fixed convergence plane (typically 0.5–1.0 m), composited as specified by `icon_3d_layout`. A single gameplay snapshot is sufficient; no animation.
+- **Native apps** — render two offset views with asymmetric frustums matching the target convergence, save as side-by-side PNG.
+- **No 3D icon** — omit `icon_3d`. The tile falls back to `icon` rendered as a flat quad. The launcher still looks good, but without the 3D payoff.
+
+### 4.2 Convergence guidance
+
+The shell renders launcher tiles at ~40 cm in front of the viewer. Stereo icons should be authored for a comfortable convergence at roughly that distance. Parallax budget: ±2% of image width.
+
+## 5. Discovery behavior
+
+The shell scanner walks a fixed set of paths (see `shell-phase5-plan.md` Part 1):
+
+```
+<shell-exe>/../test_apps/*/build/
+<shell-exe>/../demos/*/build/
+<shell-exe>/../_package/bin/
+%PROGRAMFILES%\DisplayXR\apps\
+```
+
+For each `.exe` found:
+
+1. Look for `<exe_basename>.displayxr.json` in the same directory.
+2. If absent → **skip the exe entirely**.
+3. If present → parse, validate against this spec, resolve icon paths, add to the registry with `source: "scan"`.
+4. Sanity check: verify the exe imports `openxr_loader.dll` (PE import scan). If not, log a warning and still add the entry (the manifest is authoritative — a 2D `type` app wouldn't import OpenXR anyway).
+
+Manifest parse errors are logged to the shell log and the entry is dropped. Malformed manifests do not crash the scanner.
+
+## 6. Validation rules
+
+The scanner rejects a manifest if any of the following are true:
+
+- `schema_version` is missing or not `1`.
+- `name` is missing, empty, or longer than 64 characters.
+- `type` is missing or not one of `"3d"` / `"2d"`.
+- `icon` is specified but the referenced file does not exist or is not a readable PNG/JPEG.
+- `icon_3d` is specified but the file does not exist or is not a readable PNG/JPEG, or `icon` is not also set.
+- `icon_3d_layout` is specified but not one of the four allowed values.
+
+Rejected manifests are logged as warnings. The shell does not attempt to recover partial data.
+
+## 7. Example: minimal manifest
+
+```json
+{
+  "schema_version": 1,
+  "name": "My App",
+  "type": "3d"
+}
+```
+
+This is enough for the launcher to show a named tile. Without `icon` the tile renders as a text label on a category-colored background.
+
+## 8. Example: full manifest with 3D icon
+
+```json
+{
+  "schema_version": 1,
+  "name": "Gaussian Splatting Demo",
+  "type": "3d",
+  "icon": "icon.png",
+  "icon_3d": "icon_sbs.png",
+  "icon_3d_layout": "sbs-lr",
+  "category": "demo",
+  "display_mode": "auto",
+  "description": "Real-time 3D Gaussian splatting rendered on a tracked 3D display."
+}
+```
+
+## 9. Versioning
+
+Breaking changes bump `schema_version`. The shell will refuse to parse manifests with a `schema_version` it does not understand, and log the unsupported version. Additive changes (new optional fields) keep `schema_version: 1`.
+
+## 10. Relationship to `registered_apps.json`
+
+`registered_apps.json` at `%LOCALAPPDATA%\DisplayXR\registered_apps.json` is the shell's local registry — the cached result of scanning plus any user-added entries. Entries discovered from sidecars are written there with `source: "scan"`; entries added via **Browse for app…** get `source: "user"`. The registry is rebuilt from sidecars on each shell startup; `source: "user"` entries are preserved across rebuilds.
+
+Developers should never edit `registered_apps.json` directly — edit the sidecar next to your app and relaunch the shell.

--- a/docs/specs/displayxr-app-manifest.md
+++ b/docs/specs/displayxr-app-manifest.md
@@ -18,6 +18,8 @@ DisplayXR Unity and Unreal plugins are expected to generate a manifest automatic
 
 **Not every executable in a DisplayXR SDK install ships a manifest.** In particular, test-only variants (`cube_hosted_legacy_*`, `cube_texture_*`, `cube_hosted_*`, and similar) intentionally omit a sidecar so they do not appear in the launcher — they exist to exercise runtime paths that are not meaningful to end users. Only apps that a user would plausibly launch from the shell should ship a manifest. Inside this repo, only the `cube_handle_*_win` reference apps carry sidecars.
 
+**The shell ships no built-in default apps.** When `registered_apps.json` does not exist (first run), the registry starts empty. The scanner immediately populates whatever it finds via sidecars; if it finds nothing, the launcher renders the empty-state hint instead of a tile grid. There is no pre-seeded "Notepad" or other system app — the launcher is exclusively a curated DisplayXR app surface, never a generic Windows app drawer.
+
 ## 2. File location
 
 The manifest lives **next to the executable** it describes, with the filename stem matching the executable:

--- a/scripts/test/_capture_shell.ps1
+++ b/scripts/test/_capture_shell.ps1
@@ -1,0 +1,133 @@
+# Capture the DisplayXR shell compositor window to a PNG.
+#
+# The shell window is created on a background thread by displayxr-service.exe,
+# so Get-Process ... MainWindowHandle returns 0. Instead we enumerate ALL
+# top-level windows, filter to ones owned by displayxr-service, and pick the
+# one whose title contains "DisplayXR" (falling back to the largest visible
+# window owned by the service if no match).
+#
+# Uses PrintWindow API with PW_RENDERFULLCONTENT (2) so DWM-backed windows
+# render correctly.
+#
+# Arg: absolute Windows path for the output PNG.
+#
+# Exit codes:
+#   0  success
+#   1  no shell window found
+#   2  capture failed
+
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$OutPath
+)
+
+Add-Type -ReferencedAssemblies System.Drawing @'
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Runtime.InteropServices;
+using System.Text;
+
+public class WCap {
+    public delegate bool EnumWindowsProc(IntPtr h, IntPtr l);
+
+    [DllImport("user32.dll")] public static extern bool EnumWindows(EnumWindowsProc cb, IntPtr l);
+    [DllImport("user32.dll")] public static extern uint GetWindowThreadProcessId(IntPtr h, out uint pid);
+    [DllImport("user32.dll", CharSet=CharSet.Auto, SetLastError=true)]
+    public static extern int GetWindowTextW(IntPtr h, StringBuilder s, int n);
+    [DllImport("user32.dll")] public static extern bool IsWindowVisible(IntPtr h);
+    [DllImport("user32.dll")] public static extern bool GetWindowRect(IntPtr h, out RECT r);
+    [DllImport("user32.dll")] public static extern bool PrintWindow(IntPtr h, IntPtr dc, uint f);
+
+    [StructLayout(LayoutKind.Sequential)] public struct RECT { public int L, T, R, B; }
+
+    public static List<IntPtr> Find(uint targetPid) {
+        var result = new List<IntPtr>();
+        EnumWindows((h, l) => {
+            if (!IsWindowVisible(h)) return true;
+            uint pid;
+            GetWindowThreadProcessId(h, out pid);
+            if (pid != targetPid) return true;
+            result.Add(h);
+            return true;
+        }, IntPtr.Zero);
+        return result;
+    }
+
+    public static string Title(IntPtr h) {
+        var sb = new StringBuilder(512);
+        GetWindowTextW(h, sb, sb.Capacity);
+        return sb.ToString();
+    }
+
+    public static bool Cap(IntPtr h, string path) {
+        RECT r; GetWindowRect(h, out r);
+        int w = r.R - r.L, ht = r.B - r.T;
+        if (w <= 0 || ht <= 0) return false;
+        var b = new Bitmap(w, ht);
+        var g = Graphics.FromImage(b);
+        IntPtr dc = g.GetHdc();
+        PrintWindow(h, dc, 2);
+        g.ReleaseHdc(dc);
+        b.Save(path);
+        g.Dispose(); b.Dispose();
+        return true;
+    }
+}
+'@
+
+$proc = Get-Process displayxr-service -ErrorAction SilentlyContinue | Select-Object -First 1
+if ($null -eq $proc) {
+    Write-Host "no displayxr-service process"
+    exit 1
+}
+
+$targetPid = [uint32]$proc.Id
+$hwnds = [WCap]::Find($targetPid)
+if ($hwnds.Count -eq 0) {
+    Write-Host "displayxr-service PID $targetPid has no visible windows"
+    exit 1
+}
+
+# Prefer a window whose title contains "DisplayXR".
+$chosen = [IntPtr]::Zero
+$chosenTitle = ""
+foreach ($h in $hwnds) {
+    $t = [WCap]::Title($h)
+    if ($t -match "DisplayXR") {
+        $chosen = $h
+        $chosenTitle = $t
+        break
+    }
+}
+
+# Fallback: largest visible window owned by the process.
+if ($chosen -eq [IntPtr]::Zero) {
+    $bestArea = 0
+    foreach ($h in $hwnds) {
+        $r = New-Object WCap+RECT
+        if ([WCap]::GetWindowRect($h, [ref]$r)) {
+            $area = ($r.R - $r.L) * ($r.B - $r.T)
+            if ($area -gt $bestArea) {
+                $bestArea = $area
+                $chosen = $h
+                $chosenTitle = [WCap]::Title($h)
+            }
+        }
+    }
+}
+
+if ($chosen -eq [IntPtr]::Zero) {
+    Write-Host "no candidate window"
+    exit 1
+}
+
+Write-Host "target: [$chosenTitle] hwnd=$chosen"
+
+if ([WCap]::Cap($chosen, $OutPath)) {
+    Write-Host "captured: $OutPath"
+    exit 0
+} else {
+    Write-Host "capture failed"
+    exit 2
+}

--- a/scripts/test/_send_keys.ps1
+++ b/scripts/test/_send_keys.ps1
@@ -1,0 +1,31 @@
+# Send a key combo via user32!keybd_event.
+#
+# Args: one or more hex VK codes (e.g. 0x11 0x4C for Ctrl+L).
+# Presses keys in argument order, waits briefly, then releases in reverse.
+#
+# Used by scripts/test/shell_launcher_smoke.sh.
+
+param(
+    [Parameter(ValueFromRemainingArguments=$true)]
+    [string[]]$VkHex
+)
+
+Add-Type -Name SendKey -Namespace Test -MemberDefinition @'
+[System.Runtime.InteropServices.DllImport("user32.dll")]
+public static extern void keybd_event(byte bVk, byte bScan, uint dwFlags, uint dwExtraInfo);
+'@
+
+$codes = @()
+foreach ($h in $VkHex) {
+    $codes += [byte]([Convert]::ToInt32($h, 16))
+}
+
+# Press in forward order.
+foreach ($c in $codes) {
+    [Test.SendKey]::keybd_event($c, 0, 0, 0)
+}
+Start-Sleep -Milliseconds 60
+# Release in reverse order.
+for ($i = $codes.Length - 1; $i -ge 0; $i--) {
+    [Test.SendKey]::keybd_event($codes[$i], 0, 2, 0)
+}

--- a/scripts/test/shell_launcher_smoke.sh
+++ b/scripts/test/shell_launcher_smoke.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Shell launcher smoke test — autonomous end-to-end exerciser for Phase 5 tasks.
+#
+# Launches displayxr-shell + cube_handle_d3d11_win, activates the shell via
+# Ctrl+Space, captures a screenshot, toggles Ctrl+L to show the launcher panel,
+# captures again, toggles Ctrl+L to hide, captures a third time, cleans up.
+#
+# Outputs under scripts/test/out/:
+#   shell_pre.png       — shell active, no launcher
+#   shell_launcher.png  — launcher panel ON
+#   shell_post.png      — launcher panel OFF again (should match pre)
+#   shell_test.log      — shell stdout/stderr
+#
+# Intended for iterative development of Phase 5 launcher UI. Edit code,
+# rebuild, re-run this script, Read the screenshots.
+#
+# Usage:
+#   bash scripts/test/shell_launcher_smoke.sh
+#
+# Requires a successful `scripts\build_windows.bat build` first.
+
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+OUT_DIR="scripts/test/out"
+mkdir -p "$OUT_DIR"
+
+SHELL_EXE="_package\\bin\\displayxr-shell.exe"
+CUBE_EXE="test_apps\\cube_handle_d3d11_win\\build\\cube_handle_d3d11_win.exe"
+LOG="$OUT_DIR/shell_test.log"
+
+SEND_KEYS_PS1="scripts/test/_send_keys.ps1"
+CAPTURE_PS1="scripts/test/_capture_shell.ps1"
+
+echo "=== shell_launcher_smoke.sh ==="
+echo "repo: $REPO_ROOT"
+
+# -----------------------------------------------------------------------------
+# Helpers
+# -----------------------------------------------------------------------------
+
+kill_all() {
+    cmd.exe //c "taskkill /F /IM displayxr-shell.exe" >/dev/null 2>&1 || true
+    cmd.exe //c "taskkill /F /IM displayxr-service.exe" >/dev/null 2>&1 || true
+    cmd.exe //c "taskkill /F /IM cube_handle_d3d11_win.exe" >/dev/null 2>&1 || true
+}
+
+# Send a key combo. Args: hex VK codes. Example: send_combo 0x11 0x4C
+send_combo() {
+    powershell -NoProfile -ExecutionPolicy Bypass -File "$SEND_KEYS_PS1" "$@"
+}
+
+# Capture the shell compositor window to an absolute path. Arg: output PNG path
+# relative to repo root.
+capture_shell() {
+    local out="$1"
+    local abs_out
+    abs_out="$(cygpath -w "$REPO_ROOT/$out" 2>/dev/null || echo "$REPO_ROOT/$out")"
+    powershell -NoProfile -ExecutionPolicy Bypass -File "$CAPTURE_PS1" -OutPath "$abs_out"
+}
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+
+trap kill_all EXIT
+
+echo "[1/10] cleaning up prior runs..."
+kill_all
+sleep 1
+# Clear previous outputs so old files don't confuse debugging.
+rm -f "$OUT_DIR"/*.png "$LOG" 2>/dev/null || true
+
+echo "[2/10] preflight..."
+if [ ! -f "$SHELL_EXE" ]; then
+    echo "ERROR: $SHELL_EXE not found. Run scripts\\build_windows.bat build first."
+    exit 1
+fi
+if [ ! -f "$CUBE_EXE" ]; then
+    echo "ERROR: $CUBE_EXE not found. Run scripts\\build_windows.bat test-apps first."
+    exit 1
+fi
+
+echo "[3/10] launching shell + cube (log: $LOG)..."
+cmd.exe //c "$SHELL_EXE $CUBE_EXE > $LOG 2>&1" &
+SHELL_PID=$!
+echo "  shell wrapper pid=$SHELL_PID"
+
+echo "[4/10] waiting 20s for service + shell activation + eye-tracking warmup..."
+# When launched with an app arg, displayxr-shell auto-activates the shell
+# mode and launches the cube. Eye tracking takes several seconds to stabilize
+# after activation — during the warmup window the shell shows the left eye
+# stretched to full screen, which makes screenshots misleading. Wait long
+# enough for eye tracking to be fully online before capturing.
+sleep 20
+
+echo "[5/10] capturing shell_pre.png (no launcher)..."
+capture_shell "$OUT_DIR/shell_pre.png"
+sleep 1
+
+echo "[7/10] sending Ctrl+L (launcher ON)..."
+send_combo 0x11 0x4C
+sleep 2
+
+echo "[8/10] capturing shell_launcher.png (launcher ON)..."
+capture_shell "$OUT_DIR/shell_launcher.png"
+sleep 1
+
+echo "[9/10] sending Ctrl+L (launcher OFF) + capturing shell_post.png..."
+send_combo 0x11 0x4C
+sleep 2
+capture_shell "$OUT_DIR/shell_post.png"
+sleep 1
+
+echo "[10/10] cleaning up..."
+
+kill_all
+wait $SHELL_PID 2>/dev/null || true
+
+echo ""
+echo "=== outputs ==="
+ls -la "$OUT_DIR" 2>/dev/null
+echo ""
+echo "=== shell log (last 25 lines) ==="
+tail -25 "$LOG" 2>/dev/null || echo "(no log)"

--- a/src/external/stb/stb_image.h
+++ b/src/external/stb/stb_image.h
@@ -1,0 +1,7988 @@
+/* stb_image - v2.30 - public domain image loader - http://nothings.org/stb
+                                  no warranty implied; use at your own risk
+
+   Do this:
+      #define STB_IMAGE_IMPLEMENTATION
+   before you include this file in *one* C or C++ file to create the implementation.
+
+   // i.e. it should look like this:
+   #include ...
+   #include ...
+   #include ...
+   #define STB_IMAGE_IMPLEMENTATION
+   #include "stb_image.h"
+
+   You can #define STBI_ASSERT(x) before the #include to avoid using assert.h.
+   And #define STBI_MALLOC, STBI_REALLOC, and STBI_FREE to avoid using malloc,realloc,free
+
+
+   QUICK NOTES:
+      Primarily of interest to game developers and other people who can
+          avoid problematic images and only need the trivial interface
+
+      JPEG baseline & progressive (12 bpc/arithmetic not supported, same as stock IJG lib)
+      PNG 1/2/4/8/16-bit-per-channel
+
+      TGA (not sure what subset, if a subset)
+      BMP non-1bpp, non-RLE
+      PSD (composited view only, no extra channels, 8/16 bit-per-channel)
+
+      GIF (*comp always reports as 4-channel)
+      HDR (radiance rgbE format)
+      PIC (Softimage PIC)
+      PNM (PPM and PGM binary only)
+
+      Animated GIF still needs a proper API, but here's one way to do it:
+          http://gist.github.com/urraka/685d9a6340b26b830d49
+
+      - decode from memory or through FILE (define STBI_NO_STDIO to remove code)
+      - decode from arbitrary I/O callbacks
+      - SIMD acceleration on x86/x64 (SSE2) and ARM (NEON)
+
+   Full documentation under "DOCUMENTATION" below.
+
+
+LICENSE
+
+  See end of file for license information.
+
+RECENT REVISION HISTORY:
+
+      2.30  (2024-05-31) avoid erroneous gcc warning
+      2.29  (2023-05-xx) optimizations
+      2.28  (2023-01-29) many error fixes, security errors, just tons of stuff
+      2.27  (2021-07-11) document stbi_info better, 16-bit PNM support, bug fixes
+      2.26  (2020-07-13) many minor fixes
+      2.25  (2020-02-02) fix warnings
+      2.24  (2020-02-02) fix warnings; thread-local failure_reason and flip_vertically
+      2.23  (2019-08-11) fix clang static analysis warning
+      2.22  (2019-03-04) gif fixes, fix warnings
+      2.21  (2019-02-25) fix typo in comment
+      2.20  (2019-02-07) support utf8 filenames in Windows; fix warnings and platform ifdefs
+      2.19  (2018-02-11) fix warning
+      2.18  (2018-01-30) fix warnings
+      2.17  (2018-01-29) bugfix, 1-bit BMP, 16-bitness query, fix warnings
+      2.16  (2017-07-23) all functions have 16-bit variants; optimizations; bugfixes
+      2.15  (2017-03-18) fix png-1,2,4; all Imagenet JPGs; no runtime SSE detection on GCC
+      2.14  (2017-03-03) remove deprecated STBI_JPEG_OLD; fixes for Imagenet JPGs
+      2.13  (2016-12-04) experimental 16-bit API, only for PNG so far; fixes
+      2.12  (2016-04-02) fix typo in 2.11 PSD fix that caused crashes
+      2.11  (2016-04-02) 16-bit PNGS; enable SSE2 in non-gcc x64
+                         RGB-format JPEG; remove white matting in PSD;
+                         allocate large structures on the stack;
+                         correct channel count for PNG & BMP
+      2.10  (2016-01-22) avoid warning introduced in 2.09
+      2.09  (2016-01-16) 16-bit TGA; comments in PNM files; STBI_REALLOC_SIZED
+
+   See end of file for full revision history.
+
+
+ ============================    Contributors    =========================
+
+ Image formats                          Extensions, features
+    Sean Barrett (jpeg, png, bmp)          Jetro Lauha (stbi_info)
+    Nicolas Schulz (hdr, psd)              Martin "SpartanJ" Golini (stbi_info)
+    Jonathan Dummer (tga)                  James "moose2000" Brown (iPhone PNG)
+    Jean-Marc Lienher (gif)                Ben "Disch" Wenger (io callbacks)
+    Tom Seddon (pic)                       Omar Cornut (1/2/4-bit PNG)
+    Thatcher Ulrich (psd)                  Nicolas Guillemot (vertical flip)
+    Ken Miller (pgm, ppm)                  Richard Mitton (16-bit PSD)
+    github:urraka (animated gif)           Junggon Kim (PNM comments)
+    Christopher Forseth (animated gif)     Daniel Gibson (16-bit TGA)
+                                           socks-the-fox (16-bit PNG)
+                                           Jeremy Sawicki (handle all ImageNet JPGs)
+ Optimizations & bugfixes                  Mikhail Morozov (1-bit BMP)
+    Fabian "ryg" Giesen                    Anael Seghezzi (is-16-bit query)
+    Arseny Kapoulkine                      Simon Breuss (16-bit PNM)
+    John-Mark Allen
+    Carmelo J Fdez-Aguera
+
+ Bug & warning fixes
+    Marc LeBlanc            David Woo          Guillaume George     Martins Mozeiko
+    Christpher Lloyd        Jerry Jansson      Joseph Thomson       Blazej Dariusz Roszkowski
+    Phil Jordan                                Dave Moore           Roy Eltham
+    Hayaki Saito            Nathan Reed        Won Chun
+    Luke Graham             Johan Duparc       Nick Verigakis       the Horde3D community
+    Thomas Ruf              Ronny Chevalier                         github:rlyeh
+    Janez Zemva             John Bartholomew   Michal Cichon        github:romigrou
+    Jonathan Blow           Ken Hamada         Tero Hanninen        github:svdijk
+    Eugene Golushkov        Laurent Gomila     Cort Stratton        github:snagar
+    Aruelien Pocheville     Sergio Gonzalez    Thibault Reuille     github:Zelex
+    Cass Everitt            Ryamond Barbiero                        github:grim210
+    Paul Du Bois            Engin Manap        Aldo Culquicondor    github:sammyhw
+    Philipp Wiesemann       Dale Weiler        Oriol Ferrer Mesia   github:phprus
+    Josh Tobin              Neil Bickford      Matthew Gregan       github:poppolopoppo
+    Julian Raschke          Gregory Mullen     Christian Floisand   github:darealshinji
+    Baldur Karlsson         Kevin Schmidt      JR Smith             github:Michaelangel007
+                            Brad Weinberger    Matvey Cherevko      github:mosra
+    Luca Sas                Alexander Veselov  Zack Middleton       [reserved]
+    Ryan C. Gordon          [reserved]                              [reserved]
+                     DO NOT ADD YOUR NAME HERE
+
+                     Jacko Dirks
+
+  To add your name to the credits, pick a random blank space in the middle and fill it.
+  80% of merge conflicts on stb PRs are due to people adding their name at the end
+  of the credits.
+*/
+
+#ifndef STBI_INCLUDE_STB_IMAGE_H
+#define STBI_INCLUDE_STB_IMAGE_H
+
+// DOCUMENTATION
+//
+// Limitations:
+//    - no 12-bit-per-channel JPEG
+//    - no JPEGs with arithmetic coding
+//    - GIF always returns *comp=4
+//
+// Basic usage (see HDR discussion below for HDR usage):
+//    int x,y,n;
+//    unsigned char *data = stbi_load(filename, &x, &y, &n, 0);
+//    // ... process data if not NULL ...
+//    // ... x = width, y = height, n = # 8-bit components per pixel ...
+//    // ... replace '0' with '1'..'4' to force that many components per pixel
+//    // ... but 'n' will always be the number that it would have been if you said 0
+//    stbi_image_free(data);
+//
+// Standard parameters:
+//    int *x                 -- outputs image width in pixels
+//    int *y                 -- outputs image height in pixels
+//    int *channels_in_file  -- outputs # of image components in image file
+//    int desired_channels   -- if non-zero, # of image components requested in result
+//
+// The return value from an image loader is an 'unsigned char *' which points
+// to the pixel data, or NULL on an allocation failure or if the image is
+// corrupt or invalid. The pixel data consists of *y scanlines of *x pixels,
+// with each pixel consisting of N interleaved 8-bit components; the first
+// pixel pointed to is top-left-most in the image. There is no padding between
+// image scanlines or between pixels, regardless of format. The number of
+// components N is 'desired_channels' if desired_channels is non-zero, or
+// *channels_in_file otherwise. If desired_channels is non-zero,
+// *channels_in_file has the number of components that _would_ have been
+// output otherwise. E.g. if you set desired_channels to 4, you will always
+// get RGBA output, but you can check *channels_in_file to see if it's trivially
+// opaque because e.g. there were only 3 channels in the source image.
+//
+// An output image with N components has the following components interleaved
+// in this order in each pixel:
+//
+//     N=#comp     components
+//       1           grey
+//       2           grey, alpha
+//       3           red, green, blue
+//       4           red, green, blue, alpha
+//
+// If image loading fails for any reason, the return value will be NULL,
+// and *x, *y, *channels_in_file will be unchanged. The function
+// stbi_failure_reason() can be queried for an extremely brief, end-user
+// unfriendly explanation of why the load failed. Define STBI_NO_FAILURE_STRINGS
+// to avoid compiling these strings at all, and STBI_FAILURE_USERMSG to get slightly
+// more user-friendly ones.
+//
+// Paletted PNG, BMP, GIF, and PIC images are automatically depalettized.
+//
+// To query the width, height and component count of an image without having to
+// decode the full file, you can use the stbi_info family of functions:
+//
+//   int x,y,n,ok;
+//   ok = stbi_info(filename, &x, &y, &n);
+//   // returns ok=1 and sets x, y, n if image is a supported format,
+//   // 0 otherwise.
+//
+// Note that stb_image pervasively uses ints in its public API for sizes,
+// including sizes of memory buffers. This is now part of the API and thus
+// hard to change without causing breakage. As a result, the various image
+// loaders all have certain limits on image size; these differ somewhat
+// by format but generally boil down to either just under 2GB or just under
+// 1GB. When the decoded image would be larger than this, stb_image decoding
+// will fail.
+//
+// Additionally, stb_image will reject image files that have any of their
+// dimensions set to a larger value than the configurable STBI_MAX_DIMENSIONS,
+// which defaults to 2**24 = 16777216 pixels. Due to the above memory limit,
+// the only way to have an image with such dimensions load correctly
+// is for it to have a rather extreme aspect ratio. Either way, the
+// assumption here is that such larger images are likely to be malformed
+// or malicious. If you do need to load an image with individual dimensions
+// larger than that, and it still fits in the overall size limit, you can
+// #define STBI_MAX_DIMENSIONS on your own to be something larger.
+//
+// ===========================================================================
+//
+// UNICODE:
+//
+//   If compiling for Windows and you wish to use Unicode filenames, compile
+//   with
+//       #define STBI_WINDOWS_UTF8
+//   and pass utf8-encoded filenames. Call stbi_convert_wchar_to_utf8 to convert
+//   Windows wchar_t filenames to utf8.
+//
+// ===========================================================================
+//
+// Philosophy
+//
+// stb libraries are designed with the following priorities:
+//
+//    1. easy to use
+//    2. easy to maintain
+//    3. good performance
+//
+// Sometimes I let "good performance" creep up in priority over "easy to maintain",
+// and for best performance I may provide less-easy-to-use APIs that give higher
+// performance, in addition to the easy-to-use ones. Nevertheless, it's important
+// to keep in mind that from the standpoint of you, a client of this library,
+// all you care about is #1 and #3, and stb libraries DO NOT emphasize #3 above all.
+//
+// Some secondary priorities arise directly from the first two, some of which
+// provide more explicit reasons why performance can't be emphasized.
+//
+//    - Portable ("ease of use")
+//    - Small source code footprint ("easy to maintain")
+//    - No dependencies ("ease of use")
+//
+// ===========================================================================
+//
+// I/O callbacks
+//
+// I/O callbacks allow you to read from arbitrary sources, like packaged
+// files or some other source. Data read from callbacks are processed
+// through a small internal buffer (currently 128 bytes) to try to reduce
+// overhead.
+//
+// The three functions you must define are "read" (reads some bytes of data),
+// "skip" (skips some bytes of data), "eof" (reports if the stream is at the end).
+//
+// ===========================================================================
+//
+// SIMD support
+//
+// The JPEG decoder will try to automatically use SIMD kernels on x86 when
+// supported by the compiler. For ARM Neon support, you must explicitly
+// request it.
+//
+// (The old do-it-yourself SIMD API is no longer supported in the current
+// code.)
+//
+// On x86, SSE2 will automatically be used when available based on a run-time
+// test; if not, the generic C versions are used as a fall-back. On ARM targets,
+// the typical path is to have separate builds for NEON and non-NEON devices
+// (at least this is true for iOS and Android). Therefore, the NEON support is
+// toggled by a build flag: define STBI_NEON to get NEON loops.
+//
+// If for some reason you do not want to use any of SIMD code, or if
+// you have issues compiling it, you can disable it entirely by
+// defining STBI_NO_SIMD.
+//
+// ===========================================================================
+//
+// HDR image support   (disable by defining STBI_NO_HDR)
+//
+// stb_image supports loading HDR images in general, and currently the Radiance
+// .HDR file format specifically. You can still load any file through the existing
+// interface; if you attempt to load an HDR file, it will be automatically remapped
+// to LDR, assuming gamma 2.2 and an arbitrary scale factor defaulting to 1;
+// both of these constants can be reconfigured through this interface:
+//
+//     stbi_hdr_to_ldr_gamma(2.2f);
+//     stbi_hdr_to_ldr_scale(1.0f);
+//
+// (note, do not use _inverse_ constants; stbi_image will invert them
+// appropriately).
+//
+// Additionally, there is a new, parallel interface for loading files as
+// (linear) floats to preserve the full dynamic range:
+//
+//    float *data = stbi_loadf(filename, &x, &y, &n, 0);
+//
+// If you load LDR images through this interface, those images will
+// be promoted to floating point values, run through the inverse of
+// constants corresponding to the above:
+//
+//     stbi_ldr_to_hdr_scale(1.0f);
+//     stbi_ldr_to_hdr_gamma(2.2f);
+//
+// Finally, given a filename (or an open file or memory block--see header
+// file for details) containing image data, you can query for the "most
+// appropriate" interface to use (that is, whether the image is HDR or
+// not), using:
+//
+//     stbi_is_hdr(char *filename);
+//
+// ===========================================================================
+//
+// iPhone PNG support:
+//
+// We optionally support converting iPhone-formatted PNGs (which store
+// premultiplied BGRA) back to RGB, even though they're internally encoded
+// differently. To enable this conversion, call
+// stbi_convert_iphone_png_to_rgb(1).
+//
+// Call stbi_set_unpremultiply_on_load(1) as well to force a divide per
+// pixel to remove any premultiplied alpha *only* if the image file explicitly
+// says there's premultiplied data (currently only happens in iPhone images,
+// and only if iPhone convert-to-rgb processing is on).
+//
+// ===========================================================================
+//
+// ADDITIONAL CONFIGURATION
+//
+//  - You can suppress implementation of any of the decoders to reduce
+//    your code footprint by #defining one or more of the following
+//    symbols before creating the implementation.
+//
+//        STBI_NO_JPEG
+//        STBI_NO_PNG
+//        STBI_NO_BMP
+//        STBI_NO_PSD
+//        STBI_NO_TGA
+//        STBI_NO_GIF
+//        STBI_NO_HDR
+//        STBI_NO_PIC
+//        STBI_NO_PNM   (.ppm and .pgm)
+//
+//  - You can request *only* certain decoders and suppress all other ones
+//    (this will be more forward-compatible, as addition of new decoders
+//    doesn't require you to disable them explicitly):
+//
+//        STBI_ONLY_JPEG
+//        STBI_ONLY_PNG
+//        STBI_ONLY_BMP
+//        STBI_ONLY_PSD
+//        STBI_ONLY_TGA
+//        STBI_ONLY_GIF
+//        STBI_ONLY_HDR
+//        STBI_ONLY_PIC
+//        STBI_ONLY_PNM   (.ppm and .pgm)
+//
+//   - If you use STBI_NO_PNG (or _ONLY_ without PNG), and you still
+//     want the zlib decoder to be available, #define STBI_SUPPORT_ZLIB
+//
+//  - If you define STBI_MAX_DIMENSIONS, stb_image will reject images greater
+//    than that size (in either width or height) without further processing.
+//    This is to let programs in the wild set an upper bound to prevent
+//    denial-of-service attacks on untrusted data, as one could generate a
+//    valid image of gigantic dimensions and force stb_image to allocate a
+//    huge block of memory and spend disproportionate time decoding it. By
+//    default this is set to (1 << 24), which is 16777216, but that's still
+//    very big.
+
+#ifndef STBI_NO_STDIO
+#include <stdio.h>
+#endif // STBI_NO_STDIO
+
+#define STBI_VERSION 1
+
+enum
+{
+   STBI_default = 0, // only used for desired_channels
+
+   STBI_grey       = 1,
+   STBI_grey_alpha = 2,
+   STBI_rgb        = 3,
+   STBI_rgb_alpha  = 4
+};
+
+#include <stdlib.h>
+typedef unsigned char stbi_uc;
+typedef unsigned short stbi_us;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef STBIDEF
+#ifdef STB_IMAGE_STATIC
+#define STBIDEF static
+#else
+#define STBIDEF extern
+#endif
+#endif
+
+//////////////////////////////////////////////////////////////////////////////
+//
+// PRIMARY API - works on images of any type
+//
+
+//
+// load image by filename, open file, or memory buffer
+//
+
+typedef struct
+{
+   int      (*read)  (void *user,char *data,int size);   // fill 'data' with 'size' bytes.  return number of bytes actually read
+   void     (*skip)  (void *user,int n);                 // skip the next 'n' bytes, or 'unget' the last -n bytes if negative
+   int      (*eof)   (void *user);                       // returns nonzero if we are at end of file/data
+} stbi_io_callbacks;
+
+////////////////////////////////////
+//
+// 8-bits-per-channel interface
+//
+
+STBIDEF stbi_uc *stbi_load_from_memory   (stbi_uc           const *buffer, int len   , int *x, int *y, int *channels_in_file, int desired_channels);
+STBIDEF stbi_uc *stbi_load_from_callbacks(stbi_io_callbacks const *clbk  , void *user, int *x, int *y, int *channels_in_file, int desired_channels);
+
+#ifndef STBI_NO_STDIO
+STBIDEF stbi_uc *stbi_load            (char const *filename, int *x, int *y, int *channels_in_file, int desired_channels);
+STBIDEF stbi_uc *stbi_load_from_file  (FILE *f, int *x, int *y, int *channels_in_file, int desired_channels);
+// for stbi_load_from_file, file pointer is left pointing immediately after image
+#endif
+
+#ifndef STBI_NO_GIF
+STBIDEF stbi_uc *stbi_load_gif_from_memory(stbi_uc const *buffer, int len, int **delays, int *x, int *y, int *z, int *comp, int req_comp);
+#endif
+
+#ifdef STBI_WINDOWS_UTF8
+STBIDEF int stbi_convert_wchar_to_utf8(char *buffer, size_t bufferlen, const wchar_t* input);
+#endif
+
+////////////////////////////////////
+//
+// 16-bits-per-channel interface
+//
+
+STBIDEF stbi_us *stbi_load_16_from_memory   (stbi_uc const *buffer, int len, int *x, int *y, int *channels_in_file, int desired_channels);
+STBIDEF stbi_us *stbi_load_16_from_callbacks(stbi_io_callbacks const *clbk, void *user, int *x, int *y, int *channels_in_file, int desired_channels);
+
+#ifndef STBI_NO_STDIO
+STBIDEF stbi_us *stbi_load_16          (char const *filename, int *x, int *y, int *channels_in_file, int desired_channels);
+STBIDEF stbi_us *stbi_load_from_file_16(FILE *f, int *x, int *y, int *channels_in_file, int desired_channels);
+#endif
+
+////////////////////////////////////
+//
+// float-per-channel interface
+//
+#ifndef STBI_NO_LINEAR
+   STBIDEF float *stbi_loadf_from_memory     (stbi_uc const *buffer, int len, int *x, int *y, int *channels_in_file, int desired_channels);
+   STBIDEF float *stbi_loadf_from_callbacks  (stbi_io_callbacks const *clbk, void *user, int *x, int *y,  int *channels_in_file, int desired_channels);
+
+   #ifndef STBI_NO_STDIO
+   STBIDEF float *stbi_loadf            (char const *filename, int *x, int *y, int *channels_in_file, int desired_channels);
+   STBIDEF float *stbi_loadf_from_file  (FILE *f, int *x, int *y, int *channels_in_file, int desired_channels);
+   #endif
+#endif
+
+#ifndef STBI_NO_HDR
+   STBIDEF void   stbi_hdr_to_ldr_gamma(float gamma);
+   STBIDEF void   stbi_hdr_to_ldr_scale(float scale);
+#endif // STBI_NO_HDR
+
+#ifndef STBI_NO_LINEAR
+   STBIDEF void   stbi_ldr_to_hdr_gamma(float gamma);
+   STBIDEF void   stbi_ldr_to_hdr_scale(float scale);
+#endif // STBI_NO_LINEAR
+
+// stbi_is_hdr is always defined, but always returns false if STBI_NO_HDR
+STBIDEF int    stbi_is_hdr_from_callbacks(stbi_io_callbacks const *clbk, void *user);
+STBIDEF int    stbi_is_hdr_from_memory(stbi_uc const *buffer, int len);
+#ifndef STBI_NO_STDIO
+STBIDEF int      stbi_is_hdr          (char const *filename);
+STBIDEF int      stbi_is_hdr_from_file(FILE *f);
+#endif // STBI_NO_STDIO
+
+
+// get a VERY brief reason for failure
+// on most compilers (and ALL modern mainstream compilers) this is threadsafe
+STBIDEF const char *stbi_failure_reason  (void);
+
+// free the loaded image -- this is just free()
+STBIDEF void     stbi_image_free      (void *retval_from_stbi_load);
+
+// get image dimensions & components without fully decoding
+STBIDEF int      stbi_info_from_memory(stbi_uc const *buffer, int len, int *x, int *y, int *comp);
+STBIDEF int      stbi_info_from_callbacks(stbi_io_callbacks const *clbk, void *user, int *x, int *y, int *comp);
+STBIDEF int      stbi_is_16_bit_from_memory(stbi_uc const *buffer, int len);
+STBIDEF int      stbi_is_16_bit_from_callbacks(stbi_io_callbacks const *clbk, void *user);
+
+#ifndef STBI_NO_STDIO
+STBIDEF int      stbi_info               (char const *filename,     int *x, int *y, int *comp);
+STBIDEF int      stbi_info_from_file     (FILE *f,                  int *x, int *y, int *comp);
+STBIDEF int      stbi_is_16_bit          (char const *filename);
+STBIDEF int      stbi_is_16_bit_from_file(FILE *f);
+#endif
+
+
+
+// for image formats that explicitly notate that they have premultiplied alpha,
+// we just return the colors as stored in the file. set this flag to force
+// unpremultiplication. results are undefined if the unpremultiply overflow.
+STBIDEF void stbi_set_unpremultiply_on_load(int flag_true_if_should_unpremultiply);
+
+// indicate whether we should process iphone images back to canonical format,
+// or just pass them through "as-is"
+STBIDEF void stbi_convert_iphone_png_to_rgb(int flag_true_if_should_convert);
+
+// flip the image vertically, so the first pixel in the output array is the bottom left
+STBIDEF void stbi_set_flip_vertically_on_load(int flag_true_if_should_flip);
+
+// as above, but only applies to images loaded on the thread that calls the function
+// this function is only available if your compiler supports thread-local variables;
+// calling it will fail to link if your compiler doesn't
+STBIDEF void stbi_set_unpremultiply_on_load_thread(int flag_true_if_should_unpremultiply);
+STBIDEF void stbi_convert_iphone_png_to_rgb_thread(int flag_true_if_should_convert);
+STBIDEF void stbi_set_flip_vertically_on_load_thread(int flag_true_if_should_flip);
+
+// ZLIB client - used by PNG, available for other purposes
+
+STBIDEF char *stbi_zlib_decode_malloc_guesssize(const char *buffer, int len, int initial_size, int *outlen);
+STBIDEF char *stbi_zlib_decode_malloc_guesssize_headerflag(const char *buffer, int len, int initial_size, int *outlen, int parse_header);
+STBIDEF char *stbi_zlib_decode_malloc(const char *buffer, int len, int *outlen);
+STBIDEF int   stbi_zlib_decode_buffer(char *obuffer, int olen, const char *ibuffer, int ilen);
+
+STBIDEF char *stbi_zlib_decode_noheader_malloc(const char *buffer, int len, int *outlen);
+STBIDEF int   stbi_zlib_decode_noheader_buffer(char *obuffer, int olen, const char *ibuffer, int ilen);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+//
+//
+////   end header file   /////////////////////////////////////////////////////
+#endif // STBI_INCLUDE_STB_IMAGE_H
+
+#ifdef STB_IMAGE_IMPLEMENTATION
+
+#if defined(STBI_ONLY_JPEG) || defined(STBI_ONLY_PNG) || defined(STBI_ONLY_BMP) \
+  || defined(STBI_ONLY_TGA) || defined(STBI_ONLY_GIF) || defined(STBI_ONLY_PSD) \
+  || defined(STBI_ONLY_HDR) || defined(STBI_ONLY_PIC) || defined(STBI_ONLY_PNM) \
+  || defined(STBI_ONLY_ZLIB)
+   #ifndef STBI_ONLY_JPEG
+   #define STBI_NO_JPEG
+   #endif
+   #ifndef STBI_ONLY_PNG
+   #define STBI_NO_PNG
+   #endif
+   #ifndef STBI_ONLY_BMP
+   #define STBI_NO_BMP
+   #endif
+   #ifndef STBI_ONLY_PSD
+   #define STBI_NO_PSD
+   #endif
+   #ifndef STBI_ONLY_TGA
+   #define STBI_NO_TGA
+   #endif
+   #ifndef STBI_ONLY_GIF
+   #define STBI_NO_GIF
+   #endif
+   #ifndef STBI_ONLY_HDR
+   #define STBI_NO_HDR
+   #endif
+   #ifndef STBI_ONLY_PIC
+   #define STBI_NO_PIC
+   #endif
+   #ifndef STBI_ONLY_PNM
+   #define STBI_NO_PNM
+   #endif
+#endif
+
+#if defined(STBI_NO_PNG) && !defined(STBI_SUPPORT_ZLIB) && !defined(STBI_NO_ZLIB)
+#define STBI_NO_ZLIB
+#endif
+
+
+#include <stdarg.h>
+#include <stddef.h> // ptrdiff_t on osx
+#include <stdlib.h>
+#include <string.h>
+#include <limits.h>
+
+#if !defined(STBI_NO_LINEAR) || !defined(STBI_NO_HDR)
+#include <math.h>  // ldexp, pow
+#endif
+
+#ifndef STBI_NO_STDIO
+#include <stdio.h>
+#endif
+
+#ifndef STBI_ASSERT
+#include <assert.h>
+#define STBI_ASSERT(x) assert(x)
+#endif
+
+#ifdef __cplusplus
+#define STBI_EXTERN extern "C"
+#else
+#define STBI_EXTERN extern
+#endif
+
+
+#ifndef _MSC_VER
+   #ifdef __cplusplus
+   #define stbi_inline inline
+   #else
+   #define stbi_inline
+   #endif
+#else
+   #define stbi_inline __forceinline
+#endif
+
+#ifndef STBI_NO_THREAD_LOCALS
+   #if defined(__cplusplus) &&  __cplusplus >= 201103L
+      #define STBI_THREAD_LOCAL       thread_local
+   #elif defined(__GNUC__) && __GNUC__ < 5
+      #define STBI_THREAD_LOCAL       __thread
+   #elif defined(_MSC_VER)
+      #define STBI_THREAD_LOCAL       __declspec(thread)
+   #elif defined (__STDC_VERSION__) && __STDC_VERSION__ >= 201112L && !defined(__STDC_NO_THREADS__)
+      #define STBI_THREAD_LOCAL       _Thread_local
+   #endif
+
+   #ifndef STBI_THREAD_LOCAL
+      #if defined(__GNUC__)
+        #define STBI_THREAD_LOCAL       __thread
+      #endif
+   #endif
+#endif
+
+#if defined(_MSC_VER) || defined(__SYMBIAN32__)
+typedef unsigned short stbi__uint16;
+typedef   signed short stbi__int16;
+typedef unsigned int   stbi__uint32;
+typedef   signed int   stbi__int32;
+#else
+#include <stdint.h>
+typedef uint16_t stbi__uint16;
+typedef int16_t  stbi__int16;
+typedef uint32_t stbi__uint32;
+typedef int32_t  stbi__int32;
+#endif
+
+// should produce compiler error if size is wrong
+typedef unsigned char validate_uint32[sizeof(stbi__uint32)==4 ? 1 : -1];
+
+#ifdef _MSC_VER
+#define STBI_NOTUSED(v)  (void)(v)
+#else
+#define STBI_NOTUSED(v)  (void)sizeof(v)
+#endif
+
+#ifdef _MSC_VER
+#define STBI_HAS_LROTL
+#endif
+
+#ifdef STBI_HAS_LROTL
+   #define stbi_lrot(x,y)  _lrotl(x,y)
+#else
+   #define stbi_lrot(x,y)  (((x) << (y)) | ((x) >> (-(y) & 31)))
+#endif
+
+#if defined(STBI_MALLOC) && defined(STBI_FREE) && (defined(STBI_REALLOC) || defined(STBI_REALLOC_SIZED))
+// ok
+#elif !defined(STBI_MALLOC) && !defined(STBI_FREE) && !defined(STBI_REALLOC) && !defined(STBI_REALLOC_SIZED)
+// ok
+#else
+#error "Must define all or none of STBI_MALLOC, STBI_FREE, and STBI_REALLOC (or STBI_REALLOC_SIZED)."
+#endif
+
+#ifndef STBI_MALLOC
+#define STBI_MALLOC(sz)           malloc(sz)
+#define STBI_REALLOC(p,newsz)     realloc(p,newsz)
+#define STBI_FREE(p)              free(p)
+#endif
+
+#ifndef STBI_REALLOC_SIZED
+#define STBI_REALLOC_SIZED(p,oldsz,newsz) STBI_REALLOC(p,newsz)
+#endif
+
+// x86/x64 detection
+#if defined(__x86_64__) || defined(_M_X64)
+#define STBI__X64_TARGET
+#elif defined(__i386) || defined(_M_IX86)
+#define STBI__X86_TARGET
+#endif
+
+#if defined(__GNUC__) && defined(STBI__X86_TARGET) && !defined(__SSE2__) && !defined(STBI_NO_SIMD)
+// gcc doesn't support sse2 intrinsics unless you compile with -msse2,
+// which in turn means it gets to use SSE2 everywhere. This is unfortunate,
+// but previous attempts to provide the SSE2 functions with runtime
+// detection caused numerous issues. The way architecture extensions are
+// exposed in GCC/Clang is, sadly, not really suited for one-file libs.
+// New behavior: if compiled with -msse2, we use SSE2 without any
+// detection; if not, we don't use it at all.
+#define STBI_NO_SIMD
+#endif
+
+#if defined(__MINGW32__) && defined(STBI__X86_TARGET) && !defined(STBI_MINGW_ENABLE_SSE2) && !defined(STBI_NO_SIMD)
+// Note that __MINGW32__ doesn't actually mean 32-bit, so we have to avoid STBI__X64_TARGET
+//
+// 32-bit MinGW wants ESP to be 16-byte aligned, but this is not in the
+// Windows ABI and VC++ as well as Windows DLLs don't maintain that invariant.
+// As a result, enabling SSE2 on 32-bit MinGW is dangerous when not
+// simultaneously enabling "-mstackrealign".
+//
+// See https://github.com/nothings/stb/issues/81 for more information.
+//
+// So default to no SSE2 on 32-bit MinGW. If you've read this far and added
+// -mstackrealign to your build settings, feel free to #define STBI_MINGW_ENABLE_SSE2.
+#define STBI_NO_SIMD
+#endif
+
+#if !defined(STBI_NO_SIMD) && (defined(STBI__X86_TARGET) || defined(STBI__X64_TARGET))
+#define STBI_SSE2
+#include <emmintrin.h>
+
+#ifdef _MSC_VER
+
+#if _MSC_VER >= 1400  // not VC6
+#include <intrin.h> // __cpuid
+static int stbi__cpuid3(void)
+{
+   int info[4];
+   __cpuid(info,1);
+   return info[3];
+}
+#else
+static int stbi__cpuid3(void)
+{
+   int res;
+   __asm {
+      mov  eax,1
+      cpuid
+      mov  res,edx
+   }
+   return res;
+}
+#endif
+
+#define STBI_SIMD_ALIGN(type, name) __declspec(align(16)) type name
+
+#if !defined(STBI_NO_JPEG) && defined(STBI_SSE2)
+static int stbi__sse2_available(void)
+{
+   int info3 = stbi__cpuid3();
+   return ((info3 >> 26) & 1) != 0;
+}
+#endif
+
+#else // assume GCC-style if not VC++
+#define STBI_SIMD_ALIGN(type, name) type name __attribute__((aligned(16)))
+
+#if !defined(STBI_NO_JPEG) && defined(STBI_SSE2)
+static int stbi__sse2_available(void)
+{
+   // If we're even attempting to compile this on GCC/Clang, that means
+   // -msse2 is on, which means the compiler is allowed to use SSE2
+   // instructions at will, and so are we.
+   return 1;
+}
+#endif
+
+#endif
+#endif
+
+// ARM NEON
+#if defined(STBI_NO_SIMD) && defined(STBI_NEON)
+#undef STBI_NEON
+#endif
+
+#ifdef STBI_NEON
+#include <arm_neon.h>
+#ifdef _MSC_VER
+#define STBI_SIMD_ALIGN(type, name) __declspec(align(16)) type name
+#else
+#define STBI_SIMD_ALIGN(type, name) type name __attribute__((aligned(16)))
+#endif
+#endif
+
+#ifndef STBI_SIMD_ALIGN
+#define STBI_SIMD_ALIGN(type, name) type name
+#endif
+
+#ifndef STBI_MAX_DIMENSIONS
+#define STBI_MAX_DIMENSIONS (1 << 24)
+#endif
+
+///////////////////////////////////////////////
+//
+//  stbi__context struct and start_xxx functions
+
+// stbi__context structure is our basic context used by all images, so it
+// contains all the IO context, plus some basic image information
+typedef struct
+{
+   stbi__uint32 img_x, img_y;
+   int img_n, img_out_n;
+
+   stbi_io_callbacks io;
+   void *io_user_data;
+
+   int read_from_callbacks;
+   int buflen;
+   stbi_uc buffer_start[128];
+   int callback_already_read;
+
+   stbi_uc *img_buffer, *img_buffer_end;
+   stbi_uc *img_buffer_original, *img_buffer_original_end;
+} stbi__context;
+
+
+static void stbi__refill_buffer(stbi__context *s);
+
+// initialize a memory-decode context
+static void stbi__start_mem(stbi__context *s, stbi_uc const *buffer, int len)
+{
+   s->io.read = NULL;
+   s->read_from_callbacks = 0;
+   s->callback_already_read = 0;
+   s->img_buffer = s->img_buffer_original = (stbi_uc *) buffer;
+   s->img_buffer_end = s->img_buffer_original_end = (stbi_uc *) buffer+len;
+}
+
+// initialize a callback-based context
+static void stbi__start_callbacks(stbi__context *s, stbi_io_callbacks *c, void *user)
+{
+   s->io = *c;
+   s->io_user_data = user;
+   s->buflen = sizeof(s->buffer_start);
+   s->read_from_callbacks = 1;
+   s->callback_already_read = 0;
+   s->img_buffer = s->img_buffer_original = s->buffer_start;
+   stbi__refill_buffer(s);
+   s->img_buffer_original_end = s->img_buffer_end;
+}
+
+#ifndef STBI_NO_STDIO
+
+static int stbi__stdio_read(void *user, char *data, int size)
+{
+   return (int) fread(data,1,size,(FILE*) user);
+}
+
+static void stbi__stdio_skip(void *user, int n)
+{
+   int ch;
+   fseek((FILE*) user, n, SEEK_CUR);
+   ch = fgetc((FILE*) user);  /* have to read a byte to reset feof()'s flag */
+   if (ch != EOF) {
+      ungetc(ch, (FILE *) user);  /* push byte back onto stream if valid. */
+   }
+}
+
+static int stbi__stdio_eof(void *user)
+{
+   return feof((FILE*) user) || ferror((FILE *) user);
+}
+
+static stbi_io_callbacks stbi__stdio_callbacks =
+{
+   stbi__stdio_read,
+   stbi__stdio_skip,
+   stbi__stdio_eof,
+};
+
+static void stbi__start_file(stbi__context *s, FILE *f)
+{
+   stbi__start_callbacks(s, &stbi__stdio_callbacks, (void *) f);
+}
+
+//static void stop_file(stbi__context *s) { }
+
+#endif // !STBI_NO_STDIO
+
+static void stbi__rewind(stbi__context *s)
+{
+   // conceptually rewind SHOULD rewind to the beginning of the stream,
+   // but we just rewind to the beginning of the initial buffer, because
+   // we only use it after doing 'test', which only ever looks at at most 92 bytes
+   s->img_buffer = s->img_buffer_original;
+   s->img_buffer_end = s->img_buffer_original_end;
+}
+
+enum
+{
+   STBI_ORDER_RGB,
+   STBI_ORDER_BGR
+};
+
+typedef struct
+{
+   int bits_per_channel;
+   int num_channels;
+   int channel_order;
+} stbi__result_info;
+
+#ifndef STBI_NO_JPEG
+static int      stbi__jpeg_test(stbi__context *s);
+static void    *stbi__jpeg_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri);
+static int      stbi__jpeg_info(stbi__context *s, int *x, int *y, int *comp);
+#endif
+
+#ifndef STBI_NO_PNG
+static int      stbi__png_test(stbi__context *s);
+static void    *stbi__png_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri);
+static int      stbi__png_info(stbi__context *s, int *x, int *y, int *comp);
+static int      stbi__png_is16(stbi__context *s);
+#endif
+
+#ifndef STBI_NO_BMP
+static int      stbi__bmp_test(stbi__context *s);
+static void    *stbi__bmp_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri);
+static int      stbi__bmp_info(stbi__context *s, int *x, int *y, int *comp);
+#endif
+
+#ifndef STBI_NO_TGA
+static int      stbi__tga_test(stbi__context *s);
+static void    *stbi__tga_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri);
+static int      stbi__tga_info(stbi__context *s, int *x, int *y, int *comp);
+#endif
+
+#ifndef STBI_NO_PSD
+static int      stbi__psd_test(stbi__context *s);
+static void    *stbi__psd_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri, int bpc);
+static int      stbi__psd_info(stbi__context *s, int *x, int *y, int *comp);
+static int      stbi__psd_is16(stbi__context *s);
+#endif
+
+#ifndef STBI_NO_HDR
+static int      stbi__hdr_test(stbi__context *s);
+static float   *stbi__hdr_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri);
+static int      stbi__hdr_info(stbi__context *s, int *x, int *y, int *comp);
+#endif
+
+#ifndef STBI_NO_PIC
+static int      stbi__pic_test(stbi__context *s);
+static void    *stbi__pic_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri);
+static int      stbi__pic_info(stbi__context *s, int *x, int *y, int *comp);
+#endif
+
+#ifndef STBI_NO_GIF
+static int      stbi__gif_test(stbi__context *s);
+static void    *stbi__gif_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri);
+static void    *stbi__load_gif_main(stbi__context *s, int **delays, int *x, int *y, int *z, int *comp, int req_comp);
+static int      stbi__gif_info(stbi__context *s, int *x, int *y, int *comp);
+#endif
+
+#ifndef STBI_NO_PNM
+static int      stbi__pnm_test(stbi__context *s);
+static void    *stbi__pnm_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri);
+static int      stbi__pnm_info(stbi__context *s, int *x, int *y, int *comp);
+static int      stbi__pnm_is16(stbi__context *s);
+#endif
+
+static
+#ifdef STBI_THREAD_LOCAL
+STBI_THREAD_LOCAL
+#endif
+const char *stbi__g_failure_reason;
+
+STBIDEF const char *stbi_failure_reason(void)
+{
+   return stbi__g_failure_reason;
+}
+
+#ifndef STBI_NO_FAILURE_STRINGS
+static int stbi__err(const char *str)
+{
+   stbi__g_failure_reason = str;
+   return 0;
+}
+#endif
+
+static void *stbi__malloc(size_t size)
+{
+    return STBI_MALLOC(size);
+}
+
+// stb_image uses ints pervasively, including for offset calculations.
+// therefore the largest decoded image size we can support with the
+// current code, even on 64-bit targets, is INT_MAX. this is not a
+// significant limitation for the intended use case.
+//
+// we do, however, need to make sure our size calculations don't
+// overflow. hence a few helper functions for size calculations that
+// multiply integers together, making sure that they're non-negative
+// and no overflow occurs.
+
+// return 1 if the sum is valid, 0 on overflow.
+// negative terms are considered invalid.
+static int stbi__addsizes_valid(int a, int b)
+{
+   if (b < 0) return 0;
+   // now 0 <= b <= INT_MAX, hence also
+   // 0 <= INT_MAX - b <= INTMAX.
+   // And "a + b <= INT_MAX" (which might overflow) is the
+   // same as a <= INT_MAX - b (no overflow)
+   return a <= INT_MAX - b;
+}
+
+// returns 1 if the product is valid, 0 on overflow.
+// negative factors are considered invalid.
+static int stbi__mul2sizes_valid(int a, int b)
+{
+   if (a < 0 || b < 0) return 0;
+   if (b == 0) return 1; // mul-by-0 is always safe
+   // portable way to check for no overflows in a*b
+   return a <= INT_MAX/b;
+}
+
+#if !defined(STBI_NO_JPEG) || !defined(STBI_NO_PNG) || !defined(STBI_NO_TGA) || !defined(STBI_NO_HDR)
+// returns 1 if "a*b + add" has no negative terms/factors and doesn't overflow
+static int stbi__mad2sizes_valid(int a, int b, int add)
+{
+   return stbi__mul2sizes_valid(a, b) && stbi__addsizes_valid(a*b, add);
+}
+#endif
+
+// returns 1 if "a*b*c + add" has no negative terms/factors and doesn't overflow
+static int stbi__mad3sizes_valid(int a, int b, int c, int add)
+{
+   return stbi__mul2sizes_valid(a, b) && stbi__mul2sizes_valid(a*b, c) &&
+      stbi__addsizes_valid(a*b*c, add);
+}
+
+// returns 1 if "a*b*c*d + add" has no negative terms/factors and doesn't overflow
+#if !defined(STBI_NO_LINEAR) || !defined(STBI_NO_HDR) || !defined(STBI_NO_PNM)
+static int stbi__mad4sizes_valid(int a, int b, int c, int d, int add)
+{
+   return stbi__mul2sizes_valid(a, b) && stbi__mul2sizes_valid(a*b, c) &&
+      stbi__mul2sizes_valid(a*b*c, d) && stbi__addsizes_valid(a*b*c*d, add);
+}
+#endif
+
+#if !defined(STBI_NO_JPEG) || !defined(STBI_NO_PNG) || !defined(STBI_NO_TGA) || !defined(STBI_NO_HDR)
+// mallocs with size overflow checking
+static void *stbi__malloc_mad2(int a, int b, int add)
+{
+   if (!stbi__mad2sizes_valid(a, b, add)) return NULL;
+   return stbi__malloc(a*b + add);
+}
+#endif
+
+static void *stbi__malloc_mad3(int a, int b, int c, int add)
+{
+   if (!stbi__mad3sizes_valid(a, b, c, add)) return NULL;
+   return stbi__malloc(a*b*c + add);
+}
+
+#if !defined(STBI_NO_LINEAR) || !defined(STBI_NO_HDR) || !defined(STBI_NO_PNM)
+static void *stbi__malloc_mad4(int a, int b, int c, int d, int add)
+{
+   if (!stbi__mad4sizes_valid(a, b, c, d, add)) return NULL;
+   return stbi__malloc(a*b*c*d + add);
+}
+#endif
+
+// returns 1 if the sum of two signed ints is valid (between -2^31 and 2^31-1 inclusive), 0 on overflow.
+static int stbi__addints_valid(int a, int b)
+{
+   if ((a >= 0) != (b >= 0)) return 1; // a and b have different signs, so no overflow
+   if (a < 0 && b < 0) return a >= INT_MIN - b; // same as a + b >= INT_MIN; INT_MIN - b cannot overflow since b < 0.
+   return a <= INT_MAX - b;
+}
+
+// returns 1 if the product of two ints fits in a signed short, 0 on overflow.
+static int stbi__mul2shorts_valid(int a, int b)
+{
+   if (b == 0 || b == -1) return 1; // multiplication by 0 is always 0; check for -1 so SHRT_MIN/b doesn't overflow
+   if ((a >= 0) == (b >= 0)) return a <= SHRT_MAX/b; // product is positive, so similar to mul2sizes_valid
+   if (b < 0) return a <= SHRT_MIN / b; // same as a * b >= SHRT_MIN
+   return a >= SHRT_MIN / b;
+}
+
+// stbi__err - error
+// stbi__errpf - error returning pointer to float
+// stbi__errpuc - error returning pointer to unsigned char
+
+#ifdef STBI_NO_FAILURE_STRINGS
+   #define stbi__err(x,y)  0
+#elif defined(STBI_FAILURE_USERMSG)
+   #define stbi__err(x,y)  stbi__err(y)
+#else
+   #define stbi__err(x,y)  stbi__err(x)
+#endif
+
+#define stbi__errpf(x,y)   ((float *)(size_t) (stbi__err(x,y)?NULL:NULL))
+#define stbi__errpuc(x,y)  ((unsigned char *)(size_t) (stbi__err(x,y)?NULL:NULL))
+
+STBIDEF void stbi_image_free(void *retval_from_stbi_load)
+{
+   STBI_FREE(retval_from_stbi_load);
+}
+
+#ifndef STBI_NO_LINEAR
+static float   *stbi__ldr_to_hdr(stbi_uc *data, int x, int y, int comp);
+#endif
+
+#ifndef STBI_NO_HDR
+static stbi_uc *stbi__hdr_to_ldr(float   *data, int x, int y, int comp);
+#endif
+
+static int stbi__vertically_flip_on_load_global = 0;
+
+STBIDEF void stbi_set_flip_vertically_on_load(int flag_true_if_should_flip)
+{
+   stbi__vertically_flip_on_load_global = flag_true_if_should_flip;
+}
+
+#ifndef STBI_THREAD_LOCAL
+#define stbi__vertically_flip_on_load  stbi__vertically_flip_on_load_global
+#else
+static STBI_THREAD_LOCAL int stbi__vertically_flip_on_load_local, stbi__vertically_flip_on_load_set;
+
+STBIDEF void stbi_set_flip_vertically_on_load_thread(int flag_true_if_should_flip)
+{
+   stbi__vertically_flip_on_load_local = flag_true_if_should_flip;
+   stbi__vertically_flip_on_load_set = 1;
+}
+
+#define stbi__vertically_flip_on_load  (stbi__vertically_flip_on_load_set       \
+                                         ? stbi__vertically_flip_on_load_local  \
+                                         : stbi__vertically_flip_on_load_global)
+#endif // STBI_THREAD_LOCAL
+
+static void *stbi__load_main(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri, int bpc)
+{
+   memset(ri, 0, sizeof(*ri)); // make sure it's initialized if we add new fields
+   ri->bits_per_channel = 8; // default is 8 so most paths don't have to be changed
+   ri->channel_order = STBI_ORDER_RGB; // all current input & output are this, but this is here so we can add BGR order
+   ri->num_channels = 0;
+
+   // test the formats with a very explicit header first (at least a FOURCC
+   // or distinctive magic number first)
+   #ifndef STBI_NO_PNG
+   if (stbi__png_test(s))  return stbi__png_load(s,x,y,comp,req_comp, ri);
+   #endif
+   #ifndef STBI_NO_BMP
+   if (stbi__bmp_test(s))  return stbi__bmp_load(s,x,y,comp,req_comp, ri);
+   #endif
+   #ifndef STBI_NO_GIF
+   if (stbi__gif_test(s))  return stbi__gif_load(s,x,y,comp,req_comp, ri);
+   #endif
+   #ifndef STBI_NO_PSD
+   if (stbi__psd_test(s))  return stbi__psd_load(s,x,y,comp,req_comp, ri, bpc);
+   #else
+   STBI_NOTUSED(bpc);
+   #endif
+   #ifndef STBI_NO_PIC
+   if (stbi__pic_test(s))  return stbi__pic_load(s,x,y,comp,req_comp, ri);
+   #endif
+
+   // then the formats that can end up attempting to load with just 1 or 2
+   // bytes matching expectations; these are prone to false positives, so
+   // try them later
+   #ifndef STBI_NO_JPEG
+   if (stbi__jpeg_test(s)) return stbi__jpeg_load(s,x,y,comp,req_comp, ri);
+   #endif
+   #ifndef STBI_NO_PNM
+   if (stbi__pnm_test(s))  return stbi__pnm_load(s,x,y,comp,req_comp, ri);
+   #endif
+
+   #ifndef STBI_NO_HDR
+   if (stbi__hdr_test(s)) {
+      float *hdr = stbi__hdr_load(s, x,y,comp,req_comp, ri);
+      return stbi__hdr_to_ldr(hdr, *x, *y, req_comp ? req_comp : *comp);
+   }
+   #endif
+
+   #ifndef STBI_NO_TGA
+   // test tga last because it's a crappy test!
+   if (stbi__tga_test(s))
+      return stbi__tga_load(s,x,y,comp,req_comp, ri);
+   #endif
+
+   return stbi__errpuc("unknown image type", "Image not of any known type, or corrupt");
+}
+
+static stbi_uc *stbi__convert_16_to_8(stbi__uint16 *orig, int w, int h, int channels)
+{
+   int i;
+   int img_len = w * h * channels;
+   stbi_uc *reduced;
+
+   reduced = (stbi_uc *) stbi__malloc(img_len);
+   if (reduced == NULL) return stbi__errpuc("outofmem", "Out of memory");
+
+   for (i = 0; i < img_len; ++i)
+      reduced[i] = (stbi_uc)((orig[i] >> 8) & 0xFF); // top half of each byte is sufficient approx of 16->8 bit scaling
+
+   STBI_FREE(orig);
+   return reduced;
+}
+
+static stbi__uint16 *stbi__convert_8_to_16(stbi_uc *orig, int w, int h, int channels)
+{
+   int i;
+   int img_len = w * h * channels;
+   stbi__uint16 *enlarged;
+
+   enlarged = (stbi__uint16 *) stbi__malloc(img_len*2);
+   if (enlarged == NULL) return (stbi__uint16 *) stbi__errpuc("outofmem", "Out of memory");
+
+   for (i = 0; i < img_len; ++i)
+      enlarged[i] = (stbi__uint16)((orig[i] << 8) + orig[i]); // replicate to high and low byte, maps 0->0, 255->0xffff
+
+   STBI_FREE(orig);
+   return enlarged;
+}
+
+static void stbi__vertical_flip(void *image, int w, int h, int bytes_per_pixel)
+{
+   int row;
+   size_t bytes_per_row = (size_t)w * bytes_per_pixel;
+   stbi_uc temp[2048];
+   stbi_uc *bytes = (stbi_uc *)image;
+
+   for (row = 0; row < (h>>1); row++) {
+      stbi_uc *row0 = bytes + row*bytes_per_row;
+      stbi_uc *row1 = bytes + (h - row - 1)*bytes_per_row;
+      // swap row0 with row1
+      size_t bytes_left = bytes_per_row;
+      while (bytes_left) {
+         size_t bytes_copy = (bytes_left < sizeof(temp)) ? bytes_left : sizeof(temp);
+         memcpy(temp, row0, bytes_copy);
+         memcpy(row0, row1, bytes_copy);
+         memcpy(row1, temp, bytes_copy);
+         row0 += bytes_copy;
+         row1 += bytes_copy;
+         bytes_left -= bytes_copy;
+      }
+   }
+}
+
+#ifndef STBI_NO_GIF
+static void stbi__vertical_flip_slices(void *image, int w, int h, int z, int bytes_per_pixel)
+{
+   int slice;
+   int slice_size = w * h * bytes_per_pixel;
+
+   stbi_uc *bytes = (stbi_uc *)image;
+   for (slice = 0; slice < z; ++slice) {
+      stbi__vertical_flip(bytes, w, h, bytes_per_pixel);
+      bytes += slice_size;
+   }
+}
+#endif
+
+static unsigned char *stbi__load_and_postprocess_8bit(stbi__context *s, int *x, int *y, int *comp, int req_comp)
+{
+   stbi__result_info ri;
+   void *result = stbi__load_main(s, x, y, comp, req_comp, &ri, 8);
+
+   if (result == NULL)
+      return NULL;
+
+   // it is the responsibility of the loaders to make sure we get either 8 or 16 bit.
+   STBI_ASSERT(ri.bits_per_channel == 8 || ri.bits_per_channel == 16);
+
+   if (ri.bits_per_channel != 8) {
+      result = stbi__convert_16_to_8((stbi__uint16 *) result, *x, *y, req_comp == 0 ? *comp : req_comp);
+      ri.bits_per_channel = 8;
+   }
+
+   // @TODO: move stbi__convert_format to here
+
+   if (stbi__vertically_flip_on_load) {
+      int channels = req_comp ? req_comp : *comp;
+      stbi__vertical_flip(result, *x, *y, channels * sizeof(stbi_uc));
+   }
+
+   return (unsigned char *) result;
+}
+
+static stbi__uint16 *stbi__load_and_postprocess_16bit(stbi__context *s, int *x, int *y, int *comp, int req_comp)
+{
+   stbi__result_info ri;
+   void *result = stbi__load_main(s, x, y, comp, req_comp, &ri, 16);
+
+   if (result == NULL)
+      return NULL;
+
+   // it is the responsibility of the loaders to make sure we get either 8 or 16 bit.
+   STBI_ASSERT(ri.bits_per_channel == 8 || ri.bits_per_channel == 16);
+
+   if (ri.bits_per_channel != 16) {
+      result = stbi__convert_8_to_16((stbi_uc *) result, *x, *y, req_comp == 0 ? *comp : req_comp);
+      ri.bits_per_channel = 16;
+   }
+
+   // @TODO: move stbi__convert_format16 to here
+   // @TODO: special case RGB-to-Y (and RGBA-to-YA) for 8-bit-to-16-bit case to keep more precision
+
+   if (stbi__vertically_flip_on_load) {
+      int channels = req_comp ? req_comp : *comp;
+      stbi__vertical_flip(result, *x, *y, channels * sizeof(stbi__uint16));
+   }
+
+   return (stbi__uint16 *) result;
+}
+
+#if !defined(STBI_NO_HDR) && !defined(STBI_NO_LINEAR)
+static void stbi__float_postprocess(float *result, int *x, int *y, int *comp, int req_comp)
+{
+   if (stbi__vertically_flip_on_load && result != NULL) {
+      int channels = req_comp ? req_comp : *comp;
+      stbi__vertical_flip(result, *x, *y, channels * sizeof(float));
+   }
+}
+#endif
+
+#ifndef STBI_NO_STDIO
+
+#if defined(_WIN32) && defined(STBI_WINDOWS_UTF8)
+STBI_EXTERN __declspec(dllimport) int __stdcall MultiByteToWideChar(unsigned int cp, unsigned long flags, const char *str, int cbmb, wchar_t *widestr, int cchwide);
+STBI_EXTERN __declspec(dllimport) int __stdcall WideCharToMultiByte(unsigned int cp, unsigned long flags, const wchar_t *widestr, int cchwide, char *str, int cbmb, const char *defchar, int *used_default);
+#endif
+
+#if defined(_WIN32) && defined(STBI_WINDOWS_UTF8)
+STBIDEF int stbi_convert_wchar_to_utf8(char *buffer, size_t bufferlen, const wchar_t* input)
+{
+	return WideCharToMultiByte(65001 /* UTF8 */, 0, input, -1, buffer, (int) bufferlen, NULL, NULL);
+}
+#endif
+
+static FILE *stbi__fopen(char const *filename, char const *mode)
+{
+   FILE *f;
+#if defined(_WIN32) && defined(STBI_WINDOWS_UTF8)
+   wchar_t wMode[64];
+   wchar_t wFilename[1024];
+	if (0 == MultiByteToWideChar(65001 /* UTF8 */, 0, filename, -1, wFilename, sizeof(wFilename)/sizeof(*wFilename)))
+      return 0;
+
+	if (0 == MultiByteToWideChar(65001 /* UTF8 */, 0, mode, -1, wMode, sizeof(wMode)/sizeof(*wMode)))
+      return 0;
+
+#if defined(_MSC_VER) && _MSC_VER >= 1400
+	if (0 != _wfopen_s(&f, wFilename, wMode))
+		f = 0;
+#else
+   f = _wfopen(wFilename, wMode);
+#endif
+
+#elif defined(_MSC_VER) && _MSC_VER >= 1400
+   if (0 != fopen_s(&f, filename, mode))
+      f=0;
+#else
+   f = fopen(filename, mode);
+#endif
+   return f;
+}
+
+
+STBIDEF stbi_uc *stbi_load(char const *filename, int *x, int *y, int *comp, int req_comp)
+{
+   FILE *f = stbi__fopen(filename, "rb");
+   unsigned char *result;
+   if (!f) return stbi__errpuc("can't fopen", "Unable to open file");
+   result = stbi_load_from_file(f,x,y,comp,req_comp);
+   fclose(f);
+   return result;
+}
+
+STBIDEF stbi_uc *stbi_load_from_file(FILE *f, int *x, int *y, int *comp, int req_comp)
+{
+   unsigned char *result;
+   stbi__context s;
+   stbi__start_file(&s,f);
+   result = stbi__load_and_postprocess_8bit(&s,x,y,comp,req_comp);
+   if (result) {
+      // need to 'unget' all the characters in the IO buffer
+      fseek(f, - (int) (s.img_buffer_end - s.img_buffer), SEEK_CUR);
+   }
+   return result;
+}
+
+STBIDEF stbi__uint16 *stbi_load_from_file_16(FILE *f, int *x, int *y, int *comp, int req_comp)
+{
+   stbi__uint16 *result;
+   stbi__context s;
+   stbi__start_file(&s,f);
+   result = stbi__load_and_postprocess_16bit(&s,x,y,comp,req_comp);
+   if (result) {
+      // need to 'unget' all the characters in the IO buffer
+      fseek(f, - (int) (s.img_buffer_end - s.img_buffer), SEEK_CUR);
+   }
+   return result;
+}
+
+STBIDEF stbi_us *stbi_load_16(char const *filename, int *x, int *y, int *comp, int req_comp)
+{
+   FILE *f = stbi__fopen(filename, "rb");
+   stbi__uint16 *result;
+   if (!f) return (stbi_us *) stbi__errpuc("can't fopen", "Unable to open file");
+   result = stbi_load_from_file_16(f,x,y,comp,req_comp);
+   fclose(f);
+   return result;
+}
+
+
+#endif //!STBI_NO_STDIO
+
+STBIDEF stbi_us *stbi_load_16_from_memory(stbi_uc const *buffer, int len, int *x, int *y, int *channels_in_file, int desired_channels)
+{
+   stbi__context s;
+   stbi__start_mem(&s,buffer,len);
+   return stbi__load_and_postprocess_16bit(&s,x,y,channels_in_file,desired_channels);
+}
+
+STBIDEF stbi_us *stbi_load_16_from_callbacks(stbi_io_callbacks const *clbk, void *user, int *x, int *y, int *channels_in_file, int desired_channels)
+{
+   stbi__context s;
+   stbi__start_callbacks(&s, (stbi_io_callbacks *)clbk, user);
+   return stbi__load_and_postprocess_16bit(&s,x,y,channels_in_file,desired_channels);
+}
+
+STBIDEF stbi_uc *stbi_load_from_memory(stbi_uc const *buffer, int len, int *x, int *y, int *comp, int req_comp)
+{
+   stbi__context s;
+   stbi__start_mem(&s,buffer,len);
+   return stbi__load_and_postprocess_8bit(&s,x,y,comp,req_comp);
+}
+
+STBIDEF stbi_uc *stbi_load_from_callbacks(stbi_io_callbacks const *clbk, void *user, int *x, int *y, int *comp, int req_comp)
+{
+   stbi__context s;
+   stbi__start_callbacks(&s, (stbi_io_callbacks *) clbk, user);
+   return stbi__load_and_postprocess_8bit(&s,x,y,comp,req_comp);
+}
+
+#ifndef STBI_NO_GIF
+STBIDEF stbi_uc *stbi_load_gif_from_memory(stbi_uc const *buffer, int len, int **delays, int *x, int *y, int *z, int *comp, int req_comp)
+{
+   unsigned char *result;
+   stbi__context s;
+   stbi__start_mem(&s,buffer,len);
+
+   result = (unsigned char*) stbi__load_gif_main(&s, delays, x, y, z, comp, req_comp);
+   if (stbi__vertically_flip_on_load) {
+      stbi__vertical_flip_slices( result, *x, *y, *z, *comp );
+   }
+
+   return result;
+}
+#endif
+
+#ifndef STBI_NO_LINEAR
+static float *stbi__loadf_main(stbi__context *s, int *x, int *y, int *comp, int req_comp)
+{
+   unsigned char *data;
+   #ifndef STBI_NO_HDR
+   if (stbi__hdr_test(s)) {
+      stbi__result_info ri;
+      float *hdr_data = stbi__hdr_load(s,x,y,comp,req_comp, &ri);
+      if (hdr_data)
+         stbi__float_postprocess(hdr_data,x,y,comp,req_comp);
+      return hdr_data;
+   }
+   #endif
+   data = stbi__load_and_postprocess_8bit(s, x, y, comp, req_comp);
+   if (data)
+      return stbi__ldr_to_hdr(data, *x, *y, req_comp ? req_comp : *comp);
+   return stbi__errpf("unknown image type", "Image not of any known type, or corrupt");
+}
+
+STBIDEF float *stbi_loadf_from_memory(stbi_uc const *buffer, int len, int *x, int *y, int *comp, int req_comp)
+{
+   stbi__context s;
+   stbi__start_mem(&s,buffer,len);
+   return stbi__loadf_main(&s,x,y,comp,req_comp);
+}
+
+STBIDEF float *stbi_loadf_from_callbacks(stbi_io_callbacks const *clbk, void *user, int *x, int *y, int *comp, int req_comp)
+{
+   stbi__context s;
+   stbi__start_callbacks(&s, (stbi_io_callbacks *) clbk, user);
+   return stbi__loadf_main(&s,x,y,comp,req_comp);
+}
+
+#ifndef STBI_NO_STDIO
+STBIDEF float *stbi_loadf(char const *filename, int *x, int *y, int *comp, int req_comp)
+{
+   float *result;
+   FILE *f = stbi__fopen(filename, "rb");
+   if (!f) return stbi__errpf("can't fopen", "Unable to open file");
+   result = stbi_loadf_from_file(f,x,y,comp,req_comp);
+   fclose(f);
+   return result;
+}
+
+STBIDEF float *stbi_loadf_from_file(FILE *f, int *x, int *y, int *comp, int req_comp)
+{
+   stbi__context s;
+   stbi__start_file(&s,f);
+   return stbi__loadf_main(&s,x,y,comp,req_comp);
+}
+#endif // !STBI_NO_STDIO
+
+#endif // !STBI_NO_LINEAR
+
+// these is-hdr-or-not is defined independent of whether STBI_NO_LINEAR is
+// defined, for API simplicity; if STBI_NO_LINEAR is defined, it always
+// reports false!
+
+STBIDEF int stbi_is_hdr_from_memory(stbi_uc const *buffer, int len)
+{
+   #ifndef STBI_NO_HDR
+   stbi__context s;
+   stbi__start_mem(&s,buffer,len);
+   return stbi__hdr_test(&s);
+   #else
+   STBI_NOTUSED(buffer);
+   STBI_NOTUSED(len);
+   return 0;
+   #endif
+}
+
+#ifndef STBI_NO_STDIO
+STBIDEF int      stbi_is_hdr          (char const *filename)
+{
+   FILE *f = stbi__fopen(filename, "rb");
+   int result=0;
+   if (f) {
+      result = stbi_is_hdr_from_file(f);
+      fclose(f);
+   }
+   return result;
+}
+
+STBIDEF int stbi_is_hdr_from_file(FILE *f)
+{
+   #ifndef STBI_NO_HDR
+   long pos = ftell(f);
+   int res;
+   stbi__context s;
+   stbi__start_file(&s,f);
+   res = stbi__hdr_test(&s);
+   fseek(f, pos, SEEK_SET);
+   return res;
+   #else
+   STBI_NOTUSED(f);
+   return 0;
+   #endif
+}
+#endif // !STBI_NO_STDIO
+
+STBIDEF int      stbi_is_hdr_from_callbacks(stbi_io_callbacks const *clbk, void *user)
+{
+   #ifndef STBI_NO_HDR
+   stbi__context s;
+   stbi__start_callbacks(&s, (stbi_io_callbacks *) clbk, user);
+   return stbi__hdr_test(&s);
+   #else
+   STBI_NOTUSED(clbk);
+   STBI_NOTUSED(user);
+   return 0;
+   #endif
+}
+
+#ifndef STBI_NO_LINEAR
+static float stbi__l2h_gamma=2.2f, stbi__l2h_scale=1.0f;
+
+STBIDEF void   stbi_ldr_to_hdr_gamma(float gamma) { stbi__l2h_gamma = gamma; }
+STBIDEF void   stbi_ldr_to_hdr_scale(float scale) { stbi__l2h_scale = scale; }
+#endif
+
+static float stbi__h2l_gamma_i=1.0f/2.2f, stbi__h2l_scale_i=1.0f;
+
+STBIDEF void   stbi_hdr_to_ldr_gamma(float gamma) { stbi__h2l_gamma_i = 1/gamma; }
+STBIDEF void   stbi_hdr_to_ldr_scale(float scale) { stbi__h2l_scale_i = 1/scale; }
+
+
+//////////////////////////////////////////////////////////////////////////////
+//
+// Common code used by all image loaders
+//
+
+enum
+{
+   STBI__SCAN_load=0,
+   STBI__SCAN_type,
+   STBI__SCAN_header
+};
+
+static void stbi__refill_buffer(stbi__context *s)
+{
+   int n = (s->io.read)(s->io_user_data,(char*)s->buffer_start,s->buflen);
+   s->callback_already_read += (int) (s->img_buffer - s->img_buffer_original);
+   if (n == 0) {
+      // at end of file, treat same as if from memory, but need to handle case
+      // where s->img_buffer isn't pointing to safe memory, e.g. 0-byte file
+      s->read_from_callbacks = 0;
+      s->img_buffer = s->buffer_start;
+      s->img_buffer_end = s->buffer_start+1;
+      *s->img_buffer = 0;
+   } else {
+      s->img_buffer = s->buffer_start;
+      s->img_buffer_end = s->buffer_start + n;
+   }
+}
+
+stbi_inline static stbi_uc stbi__get8(stbi__context *s)
+{
+   if (s->img_buffer < s->img_buffer_end)
+      return *s->img_buffer++;
+   if (s->read_from_callbacks) {
+      stbi__refill_buffer(s);
+      return *s->img_buffer++;
+   }
+   return 0;
+}
+
+#if defined(STBI_NO_JPEG) && defined(STBI_NO_HDR) && defined(STBI_NO_PIC) && defined(STBI_NO_PNM)
+// nothing
+#else
+stbi_inline static int stbi__at_eof(stbi__context *s)
+{
+   if (s->io.read) {
+      if (!(s->io.eof)(s->io_user_data)) return 0;
+      // if feof() is true, check if buffer = end
+      // special case: we've only got the special 0 character at the end
+      if (s->read_from_callbacks == 0) return 1;
+   }
+
+   return s->img_buffer >= s->img_buffer_end;
+}
+#endif
+
+#if defined(STBI_NO_JPEG) && defined(STBI_NO_PNG) && defined(STBI_NO_BMP) && defined(STBI_NO_PSD) && defined(STBI_NO_TGA) && defined(STBI_NO_GIF) && defined(STBI_NO_PIC)
+// nothing
+#else
+static void stbi__skip(stbi__context *s, int n)
+{
+   if (n == 0) return;  // already there!
+   if (n < 0) {
+      s->img_buffer = s->img_buffer_end;
+      return;
+   }
+   if (s->io.read) {
+      int blen = (int) (s->img_buffer_end - s->img_buffer);
+      if (blen < n) {
+         s->img_buffer = s->img_buffer_end;
+         (s->io.skip)(s->io_user_data, n - blen);
+         return;
+      }
+   }
+   s->img_buffer += n;
+}
+#endif
+
+#if defined(STBI_NO_PNG) && defined(STBI_NO_TGA) && defined(STBI_NO_HDR) && defined(STBI_NO_PNM)
+// nothing
+#else
+static int stbi__getn(stbi__context *s, stbi_uc *buffer, int n)
+{
+   if (s->io.read) {
+      int blen = (int) (s->img_buffer_end - s->img_buffer);
+      if (blen < n) {
+         int res, count;
+
+         memcpy(buffer, s->img_buffer, blen);
+
+         count = (s->io.read)(s->io_user_data, (char*) buffer + blen, n - blen);
+         res = (count == (n-blen));
+         s->img_buffer = s->img_buffer_end;
+         return res;
+      }
+   }
+
+   if (s->img_buffer+n <= s->img_buffer_end) {
+      memcpy(buffer, s->img_buffer, n);
+      s->img_buffer += n;
+      return 1;
+   } else
+      return 0;
+}
+#endif
+
+#if defined(STBI_NO_JPEG) && defined(STBI_NO_PNG) && defined(STBI_NO_PSD) && defined(STBI_NO_PIC)
+// nothing
+#else
+static int stbi__get16be(stbi__context *s)
+{
+   int z = stbi__get8(s);
+   return (z << 8) + stbi__get8(s);
+}
+#endif
+
+#if defined(STBI_NO_PNG) && defined(STBI_NO_PSD) && defined(STBI_NO_PIC)
+// nothing
+#else
+static stbi__uint32 stbi__get32be(stbi__context *s)
+{
+   stbi__uint32 z = stbi__get16be(s);
+   return (z << 16) + stbi__get16be(s);
+}
+#endif
+
+#if defined(STBI_NO_BMP) && defined(STBI_NO_TGA) && defined(STBI_NO_GIF)
+// nothing
+#else
+static int stbi__get16le(stbi__context *s)
+{
+   int z = stbi__get8(s);
+   return z + (stbi__get8(s) << 8);
+}
+#endif
+
+#ifndef STBI_NO_BMP
+static stbi__uint32 stbi__get32le(stbi__context *s)
+{
+   stbi__uint32 z = stbi__get16le(s);
+   z += (stbi__uint32)stbi__get16le(s) << 16;
+   return z;
+}
+#endif
+
+#define STBI__BYTECAST(x)  ((stbi_uc) ((x) & 255))  // truncate int to byte without warnings
+
+#if defined(STBI_NO_JPEG) && defined(STBI_NO_PNG) && defined(STBI_NO_BMP) && defined(STBI_NO_PSD) && defined(STBI_NO_TGA) && defined(STBI_NO_GIF) && defined(STBI_NO_PIC) && defined(STBI_NO_PNM)
+// nothing
+#else
+//////////////////////////////////////////////////////////////////////////////
+//
+//  generic converter from built-in img_n to req_comp
+//    individual types do this automatically as much as possible (e.g. jpeg
+//    does all cases internally since it needs to colorspace convert anyway,
+//    and it never has alpha, so very few cases ). png can automatically
+//    interleave an alpha=255 channel, but falls back to this for other cases
+//
+//  assume data buffer is malloced, so malloc a new one and free that one
+//  only failure mode is malloc failing
+
+static stbi_uc stbi__compute_y(int r, int g, int b)
+{
+   return (stbi_uc) (((r*77) + (g*150) +  (29*b)) >> 8);
+}
+#endif
+
+#if defined(STBI_NO_PNG) && defined(STBI_NO_BMP) && defined(STBI_NO_PSD) && defined(STBI_NO_TGA) && defined(STBI_NO_GIF) && defined(STBI_NO_PIC) && defined(STBI_NO_PNM)
+// nothing
+#else
+static unsigned char *stbi__convert_format(unsigned char *data, int img_n, int req_comp, unsigned int x, unsigned int y)
+{
+   int i,j;
+   unsigned char *good;
+
+   if (req_comp == img_n) return data;
+   STBI_ASSERT(req_comp >= 1 && req_comp <= 4);
+
+   good = (unsigned char *) stbi__malloc_mad3(req_comp, x, y, 0);
+   if (good == NULL) {
+      STBI_FREE(data);
+      return stbi__errpuc("outofmem", "Out of memory");
+   }
+
+   for (j=0; j < (int) y; ++j) {
+      unsigned char *src  = data + j * x * img_n   ;
+      unsigned char *dest = good + j * x * req_comp;
+
+      #define STBI__COMBO(a,b)  ((a)*8+(b))
+      #define STBI__CASE(a,b)   case STBI__COMBO(a,b): for(i=x-1; i >= 0; --i, src += a, dest += b)
+      // convert source image with img_n components to one with req_comp components;
+      // avoid switch per pixel, so use switch per scanline and massive macros
+      switch (STBI__COMBO(img_n, req_comp)) {
+         STBI__CASE(1,2) { dest[0]=src[0]; dest[1]=255;                                     } break;
+         STBI__CASE(1,3) { dest[0]=dest[1]=dest[2]=src[0];                                  } break;
+         STBI__CASE(1,4) { dest[0]=dest[1]=dest[2]=src[0]; dest[3]=255;                     } break;
+         STBI__CASE(2,1) { dest[0]=src[0];                                                  } break;
+         STBI__CASE(2,3) { dest[0]=dest[1]=dest[2]=src[0];                                  } break;
+         STBI__CASE(2,4) { dest[0]=dest[1]=dest[2]=src[0]; dest[3]=src[1];                  } break;
+         STBI__CASE(3,4) { dest[0]=src[0];dest[1]=src[1];dest[2]=src[2];dest[3]=255;        } break;
+         STBI__CASE(3,1) { dest[0]=stbi__compute_y(src[0],src[1],src[2]);                   } break;
+         STBI__CASE(3,2) { dest[0]=stbi__compute_y(src[0],src[1],src[2]); dest[1] = 255;    } break;
+         STBI__CASE(4,1) { dest[0]=stbi__compute_y(src[0],src[1],src[2]);                   } break;
+         STBI__CASE(4,2) { dest[0]=stbi__compute_y(src[0],src[1],src[2]); dest[1] = src[3]; } break;
+         STBI__CASE(4,3) { dest[0]=src[0];dest[1]=src[1];dest[2]=src[2];                    } break;
+         default: STBI_ASSERT(0); STBI_FREE(data); STBI_FREE(good); return stbi__errpuc("unsupported", "Unsupported format conversion");
+      }
+      #undef STBI__CASE
+   }
+
+   STBI_FREE(data);
+   return good;
+}
+#endif
+
+#if defined(STBI_NO_PNG) && defined(STBI_NO_PSD)
+// nothing
+#else
+static stbi__uint16 stbi__compute_y_16(int r, int g, int b)
+{
+   return (stbi__uint16) (((r*77) + (g*150) +  (29*b)) >> 8);
+}
+#endif
+
+#if defined(STBI_NO_PNG) && defined(STBI_NO_PSD)
+// nothing
+#else
+static stbi__uint16 *stbi__convert_format16(stbi__uint16 *data, int img_n, int req_comp, unsigned int x, unsigned int y)
+{
+   int i,j;
+   stbi__uint16 *good;
+
+   if (req_comp == img_n) return data;
+   STBI_ASSERT(req_comp >= 1 && req_comp <= 4);
+
+   good = (stbi__uint16 *) stbi__malloc(req_comp * x * y * 2);
+   if (good == NULL) {
+      STBI_FREE(data);
+      return (stbi__uint16 *) stbi__errpuc("outofmem", "Out of memory");
+   }
+
+   for (j=0; j < (int) y; ++j) {
+      stbi__uint16 *src  = data + j * x * img_n   ;
+      stbi__uint16 *dest = good + j * x * req_comp;
+
+      #define STBI__COMBO(a,b)  ((a)*8+(b))
+      #define STBI__CASE(a,b)   case STBI__COMBO(a,b): for(i=x-1; i >= 0; --i, src += a, dest += b)
+      // convert source image with img_n components to one with req_comp components;
+      // avoid switch per pixel, so use switch per scanline and massive macros
+      switch (STBI__COMBO(img_n, req_comp)) {
+         STBI__CASE(1,2) { dest[0]=src[0]; dest[1]=0xffff;                                     } break;
+         STBI__CASE(1,3) { dest[0]=dest[1]=dest[2]=src[0];                                     } break;
+         STBI__CASE(1,4) { dest[0]=dest[1]=dest[2]=src[0]; dest[3]=0xffff;                     } break;
+         STBI__CASE(2,1) { dest[0]=src[0];                                                     } break;
+         STBI__CASE(2,3) { dest[0]=dest[1]=dest[2]=src[0];                                     } break;
+         STBI__CASE(2,4) { dest[0]=dest[1]=dest[2]=src[0]; dest[3]=src[1];                     } break;
+         STBI__CASE(3,4) { dest[0]=src[0];dest[1]=src[1];dest[2]=src[2];dest[3]=0xffff;        } break;
+         STBI__CASE(3,1) { dest[0]=stbi__compute_y_16(src[0],src[1],src[2]);                   } break;
+         STBI__CASE(3,2) { dest[0]=stbi__compute_y_16(src[0],src[1],src[2]); dest[1] = 0xffff; } break;
+         STBI__CASE(4,1) { dest[0]=stbi__compute_y_16(src[0],src[1],src[2]);                   } break;
+         STBI__CASE(4,2) { dest[0]=stbi__compute_y_16(src[0],src[1],src[2]); dest[1] = src[3]; } break;
+         STBI__CASE(4,3) { dest[0]=src[0];dest[1]=src[1];dest[2]=src[2];                       } break;
+         default: STBI_ASSERT(0); STBI_FREE(data); STBI_FREE(good); return (stbi__uint16*) stbi__errpuc("unsupported", "Unsupported format conversion");
+      }
+      #undef STBI__CASE
+   }
+
+   STBI_FREE(data);
+   return good;
+}
+#endif
+
+#ifndef STBI_NO_LINEAR
+static float   *stbi__ldr_to_hdr(stbi_uc *data, int x, int y, int comp)
+{
+   int i,k,n;
+   float *output;
+   if (!data) return NULL;
+   output = (float *) stbi__malloc_mad4(x, y, comp, sizeof(float), 0);
+   if (output == NULL) { STBI_FREE(data); return stbi__errpf("outofmem", "Out of memory"); }
+   // compute number of non-alpha components
+   if (comp & 1) n = comp; else n = comp-1;
+   for (i=0; i < x*y; ++i) {
+      for (k=0; k < n; ++k) {
+         output[i*comp + k] = (float) (pow(data[i*comp+k]/255.0f, stbi__l2h_gamma) * stbi__l2h_scale);
+      }
+   }
+   if (n < comp) {
+      for (i=0; i < x*y; ++i) {
+         output[i*comp + n] = data[i*comp + n]/255.0f;
+      }
+   }
+   STBI_FREE(data);
+   return output;
+}
+#endif
+
+#ifndef STBI_NO_HDR
+#define stbi__float2int(x)   ((int) (x))
+static stbi_uc *stbi__hdr_to_ldr(float   *data, int x, int y, int comp)
+{
+   int i,k,n;
+   stbi_uc *output;
+   if (!data) return NULL;
+   output = (stbi_uc *) stbi__malloc_mad3(x, y, comp, 0);
+   if (output == NULL) { STBI_FREE(data); return stbi__errpuc("outofmem", "Out of memory"); }
+   // compute number of non-alpha components
+   if (comp & 1) n = comp; else n = comp-1;
+   for (i=0; i < x*y; ++i) {
+      for (k=0; k < n; ++k) {
+         float z = (float) pow(data[i*comp+k]*stbi__h2l_scale_i, stbi__h2l_gamma_i) * 255 + 0.5f;
+         if (z < 0) z = 0;
+         if (z > 255) z = 255;
+         output[i*comp + k] = (stbi_uc) stbi__float2int(z);
+      }
+      if (k < comp) {
+         float z = data[i*comp+k] * 255 + 0.5f;
+         if (z < 0) z = 0;
+         if (z > 255) z = 255;
+         output[i*comp + k] = (stbi_uc) stbi__float2int(z);
+      }
+   }
+   STBI_FREE(data);
+   return output;
+}
+#endif
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//  "baseline" JPEG/JFIF decoder
+//
+//    simple implementation
+//      - doesn't support delayed output of y-dimension
+//      - simple interface (only one output format: 8-bit interleaved RGB)
+//      - doesn't try to recover corrupt jpegs
+//      - doesn't allow partial loading, loading multiple at once
+//      - still fast on x86 (copying globals into locals doesn't help x86)
+//      - allocates lots of intermediate memory (full size of all components)
+//        - non-interleaved case requires this anyway
+//        - allows good upsampling (see next)
+//    high-quality
+//      - upsampled channels are bilinearly interpolated, even across blocks
+//      - quality integer IDCT derived from IJG's 'slow'
+//    performance
+//      - fast huffman; reasonable integer IDCT
+//      - some SIMD kernels for common paths on targets with SSE2/NEON
+//      - uses a lot of intermediate memory, could cache poorly
+
+#ifndef STBI_NO_JPEG
+
+// huffman decoding acceleration
+#define FAST_BITS   9  // larger handles more cases; smaller stomps less cache
+
+typedef struct
+{
+   stbi_uc  fast[1 << FAST_BITS];
+   // weirdly, repacking this into AoS is a 10% speed loss, instead of a win
+   stbi__uint16 code[256];
+   stbi_uc  values[256];
+   stbi_uc  size[257];
+   unsigned int maxcode[18];
+   int    delta[17];   // old 'firstsymbol' - old 'firstcode'
+} stbi__huffman;
+
+typedef struct
+{
+   stbi__context *s;
+   stbi__huffman huff_dc[4];
+   stbi__huffman huff_ac[4];
+   stbi__uint16 dequant[4][64];
+   stbi__int16 fast_ac[4][1 << FAST_BITS];
+
+// sizes for components, interleaved MCUs
+   int img_h_max, img_v_max;
+   int img_mcu_x, img_mcu_y;
+   int img_mcu_w, img_mcu_h;
+
+// definition of jpeg image component
+   struct
+   {
+      int id;
+      int h,v;
+      int tq;
+      int hd,ha;
+      int dc_pred;
+
+      int x,y,w2,h2;
+      stbi_uc *data;
+      void *raw_data, *raw_coeff;
+      stbi_uc *linebuf;
+      short   *coeff;   // progressive only
+      int      coeff_w, coeff_h; // number of 8x8 coefficient blocks
+   } img_comp[4];
+
+   stbi__uint32   code_buffer; // jpeg entropy-coded buffer
+   int            code_bits;   // number of valid bits
+   unsigned char  marker;      // marker seen while filling entropy buffer
+   int            nomore;      // flag if we saw a marker so must stop
+
+   int            progressive;
+   int            spec_start;
+   int            spec_end;
+   int            succ_high;
+   int            succ_low;
+   int            eob_run;
+   int            jfif;
+   int            app14_color_transform; // Adobe APP14 tag
+   int            rgb;
+
+   int scan_n, order[4];
+   int restart_interval, todo;
+
+// kernels
+   void (*idct_block_kernel)(stbi_uc *out, int out_stride, short data[64]);
+   void (*YCbCr_to_RGB_kernel)(stbi_uc *out, const stbi_uc *y, const stbi_uc *pcb, const stbi_uc *pcr, int count, int step);
+   stbi_uc *(*resample_row_hv_2_kernel)(stbi_uc *out, stbi_uc *in_near, stbi_uc *in_far, int w, int hs);
+} stbi__jpeg;
+
+static int stbi__build_huffman(stbi__huffman *h, int *count)
+{
+   int i,j,k=0;
+   unsigned int code;
+   // build size list for each symbol (from JPEG spec)
+   for (i=0; i < 16; ++i) {
+      for (j=0; j < count[i]; ++j) {
+         h->size[k++] = (stbi_uc) (i+1);
+         if(k >= 257) return stbi__err("bad size list","Corrupt JPEG");
+      }
+   }
+   h->size[k] = 0;
+
+   // compute actual symbols (from jpeg spec)
+   code = 0;
+   k = 0;
+   for(j=1; j <= 16; ++j) {
+      // compute delta to add to code to compute symbol id
+      h->delta[j] = k - code;
+      if (h->size[k] == j) {
+         while (h->size[k] == j)
+            h->code[k++] = (stbi__uint16) (code++);
+         if (code-1 >= (1u << j)) return stbi__err("bad code lengths","Corrupt JPEG");
+      }
+      // compute largest code + 1 for this size, preshifted as needed later
+      h->maxcode[j] = code << (16-j);
+      code <<= 1;
+   }
+   h->maxcode[j] = 0xffffffff;
+
+   // build non-spec acceleration table; 255 is flag for not-accelerated
+   memset(h->fast, 255, 1 << FAST_BITS);
+   for (i=0; i < k; ++i) {
+      int s = h->size[i];
+      if (s <= FAST_BITS) {
+         int c = h->code[i] << (FAST_BITS-s);
+         int m = 1 << (FAST_BITS-s);
+         for (j=0; j < m; ++j) {
+            h->fast[c+j] = (stbi_uc) i;
+         }
+      }
+   }
+   return 1;
+}
+
+// build a table that decodes both magnitude and value of small ACs in
+// one go.
+static void stbi__build_fast_ac(stbi__int16 *fast_ac, stbi__huffman *h)
+{
+   int i;
+   for (i=0; i < (1 << FAST_BITS); ++i) {
+      stbi_uc fast = h->fast[i];
+      fast_ac[i] = 0;
+      if (fast < 255) {
+         int rs = h->values[fast];
+         int run = (rs >> 4) & 15;
+         int magbits = rs & 15;
+         int len = h->size[fast];
+
+         if (magbits && len + magbits <= FAST_BITS) {
+            // magnitude code followed by receive_extend code
+            int k = ((i << len) & ((1 << FAST_BITS) - 1)) >> (FAST_BITS - magbits);
+            int m = 1 << (magbits - 1);
+            if (k < m) k += (~0U << magbits) + 1;
+            // if the result is small enough, we can fit it in fast_ac table
+            if (k >= -128 && k <= 127)
+               fast_ac[i] = (stbi__int16) ((k * 256) + (run * 16) + (len + magbits));
+         }
+      }
+   }
+}
+
+static void stbi__grow_buffer_unsafe(stbi__jpeg *j)
+{
+   do {
+      unsigned int b = j->nomore ? 0 : stbi__get8(j->s);
+      if (b == 0xff) {
+         int c = stbi__get8(j->s);
+         while (c == 0xff) c = stbi__get8(j->s); // consume fill bytes
+         if (c != 0) {
+            j->marker = (unsigned char) c;
+            j->nomore = 1;
+            return;
+         }
+      }
+      j->code_buffer |= b << (24 - j->code_bits);
+      j->code_bits += 8;
+   } while (j->code_bits <= 24);
+}
+
+// (1 << n) - 1
+static const stbi__uint32 stbi__bmask[17]={0,1,3,7,15,31,63,127,255,511,1023,2047,4095,8191,16383,32767,65535};
+
+// decode a jpeg huffman value from the bitstream
+stbi_inline static int stbi__jpeg_huff_decode(stbi__jpeg *j, stbi__huffman *h)
+{
+   unsigned int temp;
+   int c,k;
+
+   if (j->code_bits < 16) stbi__grow_buffer_unsafe(j);
+
+   // look at the top FAST_BITS and determine what symbol ID it is,
+   // if the code is <= FAST_BITS
+   c = (j->code_buffer >> (32 - FAST_BITS)) & ((1 << FAST_BITS)-1);
+   k = h->fast[c];
+   if (k < 255) {
+      int s = h->size[k];
+      if (s > j->code_bits)
+         return -1;
+      j->code_buffer <<= s;
+      j->code_bits -= s;
+      return h->values[k];
+   }
+
+   // naive test is to shift the code_buffer down so k bits are
+   // valid, then test against maxcode. To speed this up, we've
+   // preshifted maxcode left so that it has (16-k) 0s at the
+   // end; in other words, regardless of the number of bits, it
+   // wants to be compared against something shifted to have 16;
+   // that way we don't need to shift inside the loop.
+   temp = j->code_buffer >> 16;
+   for (k=FAST_BITS+1 ; ; ++k)
+      if (temp < h->maxcode[k])
+         break;
+   if (k == 17) {
+      // error! code not found
+      j->code_bits -= 16;
+      return -1;
+   }
+
+   if (k > j->code_bits)
+      return -1;
+
+   // convert the huffman code to the symbol id
+   c = ((j->code_buffer >> (32 - k)) & stbi__bmask[k]) + h->delta[k];
+   if(c < 0 || c >= 256) // symbol id out of bounds!
+       return -1;
+   STBI_ASSERT((((j->code_buffer) >> (32 - h->size[c])) & stbi__bmask[h->size[c]]) == h->code[c]);
+
+   // convert the id to a symbol
+   j->code_bits -= k;
+   j->code_buffer <<= k;
+   return h->values[c];
+}
+
+// bias[n] = (-1<<n) + 1
+static const int stbi__jbias[16] = {0,-1,-3,-7,-15,-31,-63,-127,-255,-511,-1023,-2047,-4095,-8191,-16383,-32767};
+
+// combined JPEG 'receive' and JPEG 'extend', since baseline
+// always extends everything it receives.
+stbi_inline static int stbi__extend_receive(stbi__jpeg *j, int n)
+{
+   unsigned int k;
+   int sgn;
+   if (j->code_bits < n) stbi__grow_buffer_unsafe(j);
+   if (j->code_bits < n) return 0; // ran out of bits from stream, return 0s intead of continuing
+
+   sgn = j->code_buffer >> 31; // sign bit always in MSB; 0 if MSB clear (positive), 1 if MSB set (negative)
+   k = stbi_lrot(j->code_buffer, n);
+   j->code_buffer = k & ~stbi__bmask[n];
+   k &= stbi__bmask[n];
+   j->code_bits -= n;
+   return k + (stbi__jbias[n] & (sgn - 1));
+}
+
+// get some unsigned bits
+stbi_inline static int stbi__jpeg_get_bits(stbi__jpeg *j, int n)
+{
+   unsigned int k;
+   if (j->code_bits < n) stbi__grow_buffer_unsafe(j);
+   if (j->code_bits < n) return 0; // ran out of bits from stream, return 0s intead of continuing
+   k = stbi_lrot(j->code_buffer, n);
+   j->code_buffer = k & ~stbi__bmask[n];
+   k &= stbi__bmask[n];
+   j->code_bits -= n;
+   return k;
+}
+
+stbi_inline static int stbi__jpeg_get_bit(stbi__jpeg *j)
+{
+   unsigned int k;
+   if (j->code_bits < 1) stbi__grow_buffer_unsafe(j);
+   if (j->code_bits < 1) return 0; // ran out of bits from stream, return 0s intead of continuing
+   k = j->code_buffer;
+   j->code_buffer <<= 1;
+   --j->code_bits;
+   return k & 0x80000000;
+}
+
+// given a value that's at position X in the zigzag stream,
+// where does it appear in the 8x8 matrix coded as row-major?
+static const stbi_uc stbi__jpeg_dezigzag[64+15] =
+{
+    0,  1,  8, 16,  9,  2,  3, 10,
+   17, 24, 32, 25, 18, 11,  4,  5,
+   12, 19, 26, 33, 40, 48, 41, 34,
+   27, 20, 13,  6,  7, 14, 21, 28,
+   35, 42, 49, 56, 57, 50, 43, 36,
+   29, 22, 15, 23, 30, 37, 44, 51,
+   58, 59, 52, 45, 38, 31, 39, 46,
+   53, 60, 61, 54, 47, 55, 62, 63,
+   // let corrupt input sample past end
+   63, 63, 63, 63, 63, 63, 63, 63,
+   63, 63, 63, 63, 63, 63, 63
+};
+
+// decode one 64-entry block--
+static int stbi__jpeg_decode_block(stbi__jpeg *j, short data[64], stbi__huffman *hdc, stbi__huffman *hac, stbi__int16 *fac, int b, stbi__uint16 *dequant)
+{
+   int diff,dc,k;
+   int t;
+
+   if (j->code_bits < 16) stbi__grow_buffer_unsafe(j);
+   t = stbi__jpeg_huff_decode(j, hdc);
+   if (t < 0 || t > 15) return stbi__err("bad huffman code","Corrupt JPEG");
+
+   // 0 all the ac values now so we can do it 32-bits at a time
+   memset(data,0,64*sizeof(data[0]));
+
+   diff = t ? stbi__extend_receive(j, t) : 0;
+   if (!stbi__addints_valid(j->img_comp[b].dc_pred, diff)) return stbi__err("bad delta","Corrupt JPEG");
+   dc = j->img_comp[b].dc_pred + diff;
+   j->img_comp[b].dc_pred = dc;
+   if (!stbi__mul2shorts_valid(dc, dequant[0])) return stbi__err("can't merge dc and ac", "Corrupt JPEG");
+   data[0] = (short) (dc * dequant[0]);
+
+   // decode AC components, see JPEG spec
+   k = 1;
+   do {
+      unsigned int zig;
+      int c,r,s;
+      if (j->code_bits < 16) stbi__grow_buffer_unsafe(j);
+      c = (j->code_buffer >> (32 - FAST_BITS)) & ((1 << FAST_BITS)-1);
+      r = fac[c];
+      if (r) { // fast-AC path
+         k += (r >> 4) & 15; // run
+         s = r & 15; // combined length
+         if (s > j->code_bits) return stbi__err("bad huffman code", "Combined length longer than code bits available");
+         j->code_buffer <<= s;
+         j->code_bits -= s;
+         // decode into unzigzag'd location
+         zig = stbi__jpeg_dezigzag[k++];
+         data[zig] = (short) ((r >> 8) * dequant[zig]);
+      } else {
+         int rs = stbi__jpeg_huff_decode(j, hac);
+         if (rs < 0) return stbi__err("bad huffman code","Corrupt JPEG");
+         s = rs & 15;
+         r = rs >> 4;
+         if (s == 0) {
+            if (rs != 0xf0) break; // end block
+            k += 16;
+         } else {
+            k += r;
+            // decode into unzigzag'd location
+            zig = stbi__jpeg_dezigzag[k++];
+            data[zig] = (short) (stbi__extend_receive(j,s) * dequant[zig]);
+         }
+      }
+   } while (k < 64);
+   return 1;
+}
+
+static int stbi__jpeg_decode_block_prog_dc(stbi__jpeg *j, short data[64], stbi__huffman *hdc, int b)
+{
+   int diff,dc;
+   int t;
+   if (j->spec_end != 0) return stbi__err("can't merge dc and ac", "Corrupt JPEG");
+
+   if (j->code_bits < 16) stbi__grow_buffer_unsafe(j);
+
+   if (j->succ_high == 0) {
+      // first scan for DC coefficient, must be first
+      memset(data,0,64*sizeof(data[0])); // 0 all the ac values now
+      t = stbi__jpeg_huff_decode(j, hdc);
+      if (t < 0 || t > 15) return stbi__err("can't merge dc and ac", "Corrupt JPEG");
+      diff = t ? stbi__extend_receive(j, t) : 0;
+
+      if (!stbi__addints_valid(j->img_comp[b].dc_pred, diff)) return stbi__err("bad delta", "Corrupt JPEG");
+      dc = j->img_comp[b].dc_pred + diff;
+      j->img_comp[b].dc_pred = dc;
+      if (!stbi__mul2shorts_valid(dc, 1 << j->succ_low)) return stbi__err("can't merge dc and ac", "Corrupt JPEG");
+      data[0] = (short) (dc * (1 << j->succ_low));
+   } else {
+      // refinement scan for DC coefficient
+      if (stbi__jpeg_get_bit(j))
+         data[0] += (short) (1 << j->succ_low);
+   }
+   return 1;
+}
+
+// @OPTIMIZE: store non-zigzagged during the decode passes,
+// and only de-zigzag when dequantizing
+static int stbi__jpeg_decode_block_prog_ac(stbi__jpeg *j, short data[64], stbi__huffman *hac, stbi__int16 *fac)
+{
+   int k;
+   if (j->spec_start == 0) return stbi__err("can't merge dc and ac", "Corrupt JPEG");
+
+   if (j->succ_high == 0) {
+      int shift = j->succ_low;
+
+      if (j->eob_run) {
+         --j->eob_run;
+         return 1;
+      }
+
+      k = j->spec_start;
+      do {
+         unsigned int zig;
+         int c,r,s;
+         if (j->code_bits < 16) stbi__grow_buffer_unsafe(j);
+         c = (j->code_buffer >> (32 - FAST_BITS)) & ((1 << FAST_BITS)-1);
+         r = fac[c];
+         if (r) { // fast-AC path
+            k += (r >> 4) & 15; // run
+            s = r & 15; // combined length
+            if (s > j->code_bits) return stbi__err("bad huffman code", "Combined length longer than code bits available");
+            j->code_buffer <<= s;
+            j->code_bits -= s;
+            zig = stbi__jpeg_dezigzag[k++];
+            data[zig] = (short) ((r >> 8) * (1 << shift));
+         } else {
+            int rs = stbi__jpeg_huff_decode(j, hac);
+            if (rs < 0) return stbi__err("bad huffman code","Corrupt JPEG");
+            s = rs & 15;
+            r = rs >> 4;
+            if (s == 0) {
+               if (r < 15) {
+                  j->eob_run = (1 << r);
+                  if (r)
+                     j->eob_run += stbi__jpeg_get_bits(j, r);
+                  --j->eob_run;
+                  break;
+               }
+               k += 16;
+            } else {
+               k += r;
+               zig = stbi__jpeg_dezigzag[k++];
+               data[zig] = (short) (stbi__extend_receive(j,s) * (1 << shift));
+            }
+         }
+      } while (k <= j->spec_end);
+   } else {
+      // refinement scan for these AC coefficients
+
+      short bit = (short) (1 << j->succ_low);
+
+      if (j->eob_run) {
+         --j->eob_run;
+         for (k = j->spec_start; k <= j->spec_end; ++k) {
+            short *p = &data[stbi__jpeg_dezigzag[k]];
+            if (*p != 0)
+               if (stbi__jpeg_get_bit(j))
+                  if ((*p & bit)==0) {
+                     if (*p > 0)
+                        *p += bit;
+                     else
+                        *p -= bit;
+                  }
+         }
+      } else {
+         k = j->spec_start;
+         do {
+            int r,s;
+            int rs = stbi__jpeg_huff_decode(j, hac); // @OPTIMIZE see if we can use the fast path here, advance-by-r is so slow, eh
+            if (rs < 0) return stbi__err("bad huffman code","Corrupt JPEG");
+            s = rs & 15;
+            r = rs >> 4;
+            if (s == 0) {
+               if (r < 15) {
+                  j->eob_run = (1 << r) - 1;
+                  if (r)
+                     j->eob_run += stbi__jpeg_get_bits(j, r);
+                  r = 64; // force end of block
+               } else {
+                  // r=15 s=0 should write 16 0s, so we just do
+                  // a run of 15 0s and then write s (which is 0),
+                  // so we don't have to do anything special here
+               }
+            } else {
+               if (s != 1) return stbi__err("bad huffman code", "Corrupt JPEG");
+               // sign bit
+               if (stbi__jpeg_get_bit(j))
+                  s = bit;
+               else
+                  s = -bit;
+            }
+
+            // advance by r
+            while (k <= j->spec_end) {
+               short *p = &data[stbi__jpeg_dezigzag[k++]];
+               if (*p != 0) {
+                  if (stbi__jpeg_get_bit(j))
+                     if ((*p & bit)==0) {
+                        if (*p > 0)
+                           *p += bit;
+                        else
+                           *p -= bit;
+                     }
+               } else {
+                  if (r == 0) {
+                     *p = (short) s;
+                     break;
+                  }
+                  --r;
+               }
+            }
+         } while (k <= j->spec_end);
+      }
+   }
+   return 1;
+}
+
+// take a -128..127 value and stbi__clamp it and convert to 0..255
+stbi_inline static stbi_uc stbi__clamp(int x)
+{
+   // trick to use a single test to catch both cases
+   if ((unsigned int) x > 255) {
+      if (x < 0) return 0;
+      if (x > 255) return 255;
+   }
+   return (stbi_uc) x;
+}
+
+#define stbi__f2f(x)  ((int) (((x) * 4096 + 0.5)))
+#define stbi__fsh(x)  ((x) * 4096)
+
+// derived from jidctint -- DCT_ISLOW
+#define STBI__IDCT_1D(s0,s1,s2,s3,s4,s5,s6,s7) \
+   int t0,t1,t2,t3,p1,p2,p3,p4,p5,x0,x1,x2,x3; \
+   p2 = s2;                                    \
+   p3 = s6;                                    \
+   p1 = (p2+p3) * stbi__f2f(0.5411961f);       \
+   t2 = p1 + p3*stbi__f2f(-1.847759065f);      \
+   t3 = p1 + p2*stbi__f2f( 0.765366865f);      \
+   p2 = s0;                                    \
+   p3 = s4;                                    \
+   t0 = stbi__fsh(p2+p3);                      \
+   t1 = stbi__fsh(p2-p3);                      \
+   x0 = t0+t3;                                 \
+   x3 = t0-t3;                                 \
+   x1 = t1+t2;                                 \
+   x2 = t1-t2;                                 \
+   t0 = s7;                                    \
+   t1 = s5;                                    \
+   t2 = s3;                                    \
+   t3 = s1;                                    \
+   p3 = t0+t2;                                 \
+   p4 = t1+t3;                                 \
+   p1 = t0+t3;                                 \
+   p2 = t1+t2;                                 \
+   p5 = (p3+p4)*stbi__f2f( 1.175875602f);      \
+   t0 = t0*stbi__f2f( 0.298631336f);           \
+   t1 = t1*stbi__f2f( 2.053119869f);           \
+   t2 = t2*stbi__f2f( 3.072711026f);           \
+   t3 = t3*stbi__f2f( 1.501321110f);           \
+   p1 = p5 + p1*stbi__f2f(-0.899976223f);      \
+   p2 = p5 + p2*stbi__f2f(-2.562915447f);      \
+   p3 = p3*stbi__f2f(-1.961570560f);           \
+   p4 = p4*stbi__f2f(-0.390180644f);           \
+   t3 += p1+p4;                                \
+   t2 += p2+p3;                                \
+   t1 += p2+p4;                                \
+   t0 += p1+p3;
+
+static void stbi__idct_block(stbi_uc *out, int out_stride, short data[64])
+{
+   int i,val[64],*v=val;
+   stbi_uc *o;
+   short *d = data;
+
+   // columns
+   for (i=0; i < 8; ++i,++d, ++v) {
+      // if all zeroes, shortcut -- this avoids dequantizing 0s and IDCTing
+      if (d[ 8]==0 && d[16]==0 && d[24]==0 && d[32]==0
+           && d[40]==0 && d[48]==0 && d[56]==0) {
+         //    no shortcut                 0     seconds
+         //    (1|2|3|4|5|6|7)==0          0     seconds
+         //    all separate               -0.047 seconds
+         //    1 && 2|3 && 4|5 && 6|7:    -0.047 seconds
+         int dcterm = d[0]*4;
+         v[0] = v[8] = v[16] = v[24] = v[32] = v[40] = v[48] = v[56] = dcterm;
+      } else {
+         STBI__IDCT_1D(d[ 0],d[ 8],d[16],d[24],d[32],d[40],d[48],d[56])
+         // constants scaled things up by 1<<12; let's bring them back
+         // down, but keep 2 extra bits of precision
+         x0 += 512; x1 += 512; x2 += 512; x3 += 512;
+         v[ 0] = (x0+t3) >> 10;
+         v[56] = (x0-t3) >> 10;
+         v[ 8] = (x1+t2) >> 10;
+         v[48] = (x1-t2) >> 10;
+         v[16] = (x2+t1) >> 10;
+         v[40] = (x2-t1) >> 10;
+         v[24] = (x3+t0) >> 10;
+         v[32] = (x3-t0) >> 10;
+      }
+   }
+
+   for (i=0, v=val, o=out; i < 8; ++i,v+=8,o+=out_stride) {
+      // no fast case since the first 1D IDCT spread components out
+      STBI__IDCT_1D(v[0],v[1],v[2],v[3],v[4],v[5],v[6],v[7])
+      // constants scaled things up by 1<<12, plus we had 1<<2 from first
+      // loop, plus horizontal and vertical each scale by sqrt(8) so together
+      // we've got an extra 1<<3, so 1<<17 total we need to remove.
+      // so we want to round that, which means adding 0.5 * 1<<17,
+      // aka 65536. Also, we'll end up with -128 to 127 that we want
+      // to encode as 0..255 by adding 128, so we'll add that before the shift
+      x0 += 65536 + (128<<17);
+      x1 += 65536 + (128<<17);
+      x2 += 65536 + (128<<17);
+      x3 += 65536 + (128<<17);
+      // tried computing the shifts into temps, or'ing the temps to see
+      // if any were out of range, but that was slower
+      o[0] = stbi__clamp((x0+t3) >> 17);
+      o[7] = stbi__clamp((x0-t3) >> 17);
+      o[1] = stbi__clamp((x1+t2) >> 17);
+      o[6] = stbi__clamp((x1-t2) >> 17);
+      o[2] = stbi__clamp((x2+t1) >> 17);
+      o[5] = stbi__clamp((x2-t1) >> 17);
+      o[3] = stbi__clamp((x3+t0) >> 17);
+      o[4] = stbi__clamp((x3-t0) >> 17);
+   }
+}
+
+#ifdef STBI_SSE2
+// sse2 integer IDCT. not the fastest possible implementation but it
+// produces bit-identical results to the generic C version so it's
+// fully "transparent".
+static void stbi__idct_simd(stbi_uc *out, int out_stride, short data[64])
+{
+   // This is constructed to match our regular (generic) integer IDCT exactly.
+   __m128i row0, row1, row2, row3, row4, row5, row6, row7;
+   __m128i tmp;
+
+   // dot product constant: even elems=x, odd elems=y
+   #define dct_const(x,y)  _mm_setr_epi16((x),(y),(x),(y),(x),(y),(x),(y))
+
+   // out(0) = c0[even]*x + c0[odd]*y   (c0, x, y 16-bit, out 32-bit)
+   // out(1) = c1[even]*x + c1[odd]*y
+   #define dct_rot(out0,out1, x,y,c0,c1) \
+      __m128i c0##lo = _mm_unpacklo_epi16((x),(y)); \
+      __m128i c0##hi = _mm_unpackhi_epi16((x),(y)); \
+      __m128i out0##_l = _mm_madd_epi16(c0##lo, c0); \
+      __m128i out0##_h = _mm_madd_epi16(c0##hi, c0); \
+      __m128i out1##_l = _mm_madd_epi16(c0##lo, c1); \
+      __m128i out1##_h = _mm_madd_epi16(c0##hi, c1)
+
+   // out = in << 12  (in 16-bit, out 32-bit)
+   #define dct_widen(out, in) \
+      __m128i out##_l = _mm_srai_epi32(_mm_unpacklo_epi16(_mm_setzero_si128(), (in)), 4); \
+      __m128i out##_h = _mm_srai_epi32(_mm_unpackhi_epi16(_mm_setzero_si128(), (in)), 4)
+
+   // wide add
+   #define dct_wadd(out, a, b) \
+      __m128i out##_l = _mm_add_epi32(a##_l, b##_l); \
+      __m128i out##_h = _mm_add_epi32(a##_h, b##_h)
+
+   // wide sub
+   #define dct_wsub(out, a, b) \
+      __m128i out##_l = _mm_sub_epi32(a##_l, b##_l); \
+      __m128i out##_h = _mm_sub_epi32(a##_h, b##_h)
+
+   // butterfly a/b, add bias, then shift by "s" and pack
+   #define dct_bfly32o(out0, out1, a,b,bias,s) \
+      { \
+         __m128i abiased_l = _mm_add_epi32(a##_l, bias); \
+         __m128i abiased_h = _mm_add_epi32(a##_h, bias); \
+         dct_wadd(sum, abiased, b); \
+         dct_wsub(dif, abiased, b); \
+         out0 = _mm_packs_epi32(_mm_srai_epi32(sum_l, s), _mm_srai_epi32(sum_h, s)); \
+         out1 = _mm_packs_epi32(_mm_srai_epi32(dif_l, s), _mm_srai_epi32(dif_h, s)); \
+      }
+
+   // 8-bit interleave step (for transposes)
+   #define dct_interleave8(a, b) \
+      tmp = a; \
+      a = _mm_unpacklo_epi8(a, b); \
+      b = _mm_unpackhi_epi8(tmp, b)
+
+   // 16-bit interleave step (for transposes)
+   #define dct_interleave16(a, b) \
+      tmp = a; \
+      a = _mm_unpacklo_epi16(a, b); \
+      b = _mm_unpackhi_epi16(tmp, b)
+
+   #define dct_pass(bias,shift) \
+      { \
+         /* even part */ \
+         dct_rot(t2e,t3e, row2,row6, rot0_0,rot0_1); \
+         __m128i sum04 = _mm_add_epi16(row0, row4); \
+         __m128i dif04 = _mm_sub_epi16(row0, row4); \
+         dct_widen(t0e, sum04); \
+         dct_widen(t1e, dif04); \
+         dct_wadd(x0, t0e, t3e); \
+         dct_wsub(x3, t0e, t3e); \
+         dct_wadd(x1, t1e, t2e); \
+         dct_wsub(x2, t1e, t2e); \
+         /* odd part */ \
+         dct_rot(y0o,y2o, row7,row3, rot2_0,rot2_1); \
+         dct_rot(y1o,y3o, row5,row1, rot3_0,rot3_1); \
+         __m128i sum17 = _mm_add_epi16(row1, row7); \
+         __m128i sum35 = _mm_add_epi16(row3, row5); \
+         dct_rot(y4o,y5o, sum17,sum35, rot1_0,rot1_1); \
+         dct_wadd(x4, y0o, y4o); \
+         dct_wadd(x5, y1o, y5o); \
+         dct_wadd(x6, y2o, y5o); \
+         dct_wadd(x7, y3o, y4o); \
+         dct_bfly32o(row0,row7, x0,x7,bias,shift); \
+         dct_bfly32o(row1,row6, x1,x6,bias,shift); \
+         dct_bfly32o(row2,row5, x2,x5,bias,shift); \
+         dct_bfly32o(row3,row4, x3,x4,bias,shift); \
+      }
+
+   __m128i rot0_0 = dct_const(stbi__f2f(0.5411961f), stbi__f2f(0.5411961f) + stbi__f2f(-1.847759065f));
+   __m128i rot0_1 = dct_const(stbi__f2f(0.5411961f) + stbi__f2f( 0.765366865f), stbi__f2f(0.5411961f));
+   __m128i rot1_0 = dct_const(stbi__f2f(1.175875602f) + stbi__f2f(-0.899976223f), stbi__f2f(1.175875602f));
+   __m128i rot1_1 = dct_const(stbi__f2f(1.175875602f), stbi__f2f(1.175875602f) + stbi__f2f(-2.562915447f));
+   __m128i rot2_0 = dct_const(stbi__f2f(-1.961570560f) + stbi__f2f( 0.298631336f), stbi__f2f(-1.961570560f));
+   __m128i rot2_1 = dct_const(stbi__f2f(-1.961570560f), stbi__f2f(-1.961570560f) + stbi__f2f( 3.072711026f));
+   __m128i rot3_0 = dct_const(stbi__f2f(-0.390180644f) + stbi__f2f( 2.053119869f), stbi__f2f(-0.390180644f));
+   __m128i rot3_1 = dct_const(stbi__f2f(-0.390180644f), stbi__f2f(-0.390180644f) + stbi__f2f( 1.501321110f));
+
+   // rounding biases in column/row passes, see stbi__idct_block for explanation.
+   __m128i bias_0 = _mm_set1_epi32(512);
+   __m128i bias_1 = _mm_set1_epi32(65536 + (128<<17));
+
+   // load
+   row0 = _mm_load_si128((const __m128i *) (data + 0*8));
+   row1 = _mm_load_si128((const __m128i *) (data + 1*8));
+   row2 = _mm_load_si128((const __m128i *) (data + 2*8));
+   row3 = _mm_load_si128((const __m128i *) (data + 3*8));
+   row4 = _mm_load_si128((const __m128i *) (data + 4*8));
+   row5 = _mm_load_si128((const __m128i *) (data + 5*8));
+   row6 = _mm_load_si128((const __m128i *) (data + 6*8));
+   row7 = _mm_load_si128((const __m128i *) (data + 7*8));
+
+   // column pass
+   dct_pass(bias_0, 10);
+
+   {
+      // 16bit 8x8 transpose pass 1
+      dct_interleave16(row0, row4);
+      dct_interleave16(row1, row5);
+      dct_interleave16(row2, row6);
+      dct_interleave16(row3, row7);
+
+      // transpose pass 2
+      dct_interleave16(row0, row2);
+      dct_interleave16(row1, row3);
+      dct_interleave16(row4, row6);
+      dct_interleave16(row5, row7);
+
+      // transpose pass 3
+      dct_interleave16(row0, row1);
+      dct_interleave16(row2, row3);
+      dct_interleave16(row4, row5);
+      dct_interleave16(row6, row7);
+   }
+
+   // row pass
+   dct_pass(bias_1, 17);
+
+   {
+      // pack
+      __m128i p0 = _mm_packus_epi16(row0, row1); // a0a1a2a3...a7b0b1b2b3...b7
+      __m128i p1 = _mm_packus_epi16(row2, row3);
+      __m128i p2 = _mm_packus_epi16(row4, row5);
+      __m128i p3 = _mm_packus_epi16(row6, row7);
+
+      // 8bit 8x8 transpose pass 1
+      dct_interleave8(p0, p2); // a0e0a1e1...
+      dct_interleave8(p1, p3); // c0g0c1g1...
+
+      // transpose pass 2
+      dct_interleave8(p0, p1); // a0c0e0g0...
+      dct_interleave8(p2, p3); // b0d0f0h0...
+
+      // transpose pass 3
+      dct_interleave8(p0, p2); // a0b0c0d0...
+      dct_interleave8(p1, p3); // a4b4c4d4...
+
+      // store
+      _mm_storel_epi64((__m128i *) out, p0); out += out_stride;
+      _mm_storel_epi64((__m128i *) out, _mm_shuffle_epi32(p0, 0x4e)); out += out_stride;
+      _mm_storel_epi64((__m128i *) out, p2); out += out_stride;
+      _mm_storel_epi64((__m128i *) out, _mm_shuffle_epi32(p2, 0x4e)); out += out_stride;
+      _mm_storel_epi64((__m128i *) out, p1); out += out_stride;
+      _mm_storel_epi64((__m128i *) out, _mm_shuffle_epi32(p1, 0x4e)); out += out_stride;
+      _mm_storel_epi64((__m128i *) out, p3); out += out_stride;
+      _mm_storel_epi64((__m128i *) out, _mm_shuffle_epi32(p3, 0x4e));
+   }
+
+#undef dct_const
+#undef dct_rot
+#undef dct_widen
+#undef dct_wadd
+#undef dct_wsub
+#undef dct_bfly32o
+#undef dct_interleave8
+#undef dct_interleave16
+#undef dct_pass
+}
+
+#endif // STBI_SSE2
+
+#ifdef STBI_NEON
+
+// NEON integer IDCT. should produce bit-identical
+// results to the generic C version.
+static void stbi__idct_simd(stbi_uc *out, int out_stride, short data[64])
+{
+   int16x8_t row0, row1, row2, row3, row4, row5, row6, row7;
+
+   int16x4_t rot0_0 = vdup_n_s16(stbi__f2f(0.5411961f));
+   int16x4_t rot0_1 = vdup_n_s16(stbi__f2f(-1.847759065f));
+   int16x4_t rot0_2 = vdup_n_s16(stbi__f2f( 0.765366865f));
+   int16x4_t rot1_0 = vdup_n_s16(stbi__f2f( 1.175875602f));
+   int16x4_t rot1_1 = vdup_n_s16(stbi__f2f(-0.899976223f));
+   int16x4_t rot1_2 = vdup_n_s16(stbi__f2f(-2.562915447f));
+   int16x4_t rot2_0 = vdup_n_s16(stbi__f2f(-1.961570560f));
+   int16x4_t rot2_1 = vdup_n_s16(stbi__f2f(-0.390180644f));
+   int16x4_t rot3_0 = vdup_n_s16(stbi__f2f( 0.298631336f));
+   int16x4_t rot3_1 = vdup_n_s16(stbi__f2f( 2.053119869f));
+   int16x4_t rot3_2 = vdup_n_s16(stbi__f2f( 3.072711026f));
+   int16x4_t rot3_3 = vdup_n_s16(stbi__f2f( 1.501321110f));
+
+#define dct_long_mul(out, inq, coeff) \
+   int32x4_t out##_l = vmull_s16(vget_low_s16(inq), coeff); \
+   int32x4_t out##_h = vmull_s16(vget_high_s16(inq), coeff)
+
+#define dct_long_mac(out, acc, inq, coeff) \
+   int32x4_t out##_l = vmlal_s16(acc##_l, vget_low_s16(inq), coeff); \
+   int32x4_t out##_h = vmlal_s16(acc##_h, vget_high_s16(inq), coeff)
+
+#define dct_widen(out, inq) \
+   int32x4_t out##_l = vshll_n_s16(vget_low_s16(inq), 12); \
+   int32x4_t out##_h = vshll_n_s16(vget_high_s16(inq), 12)
+
+// wide add
+#define dct_wadd(out, a, b) \
+   int32x4_t out##_l = vaddq_s32(a##_l, b##_l); \
+   int32x4_t out##_h = vaddq_s32(a##_h, b##_h)
+
+// wide sub
+#define dct_wsub(out, a, b) \
+   int32x4_t out##_l = vsubq_s32(a##_l, b##_l); \
+   int32x4_t out##_h = vsubq_s32(a##_h, b##_h)
+
+// butterfly a/b, then shift using "shiftop" by "s" and pack
+#define dct_bfly32o(out0,out1, a,b,shiftop,s) \
+   { \
+      dct_wadd(sum, a, b); \
+      dct_wsub(dif, a, b); \
+      out0 = vcombine_s16(shiftop(sum_l, s), shiftop(sum_h, s)); \
+      out1 = vcombine_s16(shiftop(dif_l, s), shiftop(dif_h, s)); \
+   }
+
+#define dct_pass(shiftop, shift) \
+   { \
+      /* even part */ \
+      int16x8_t sum26 = vaddq_s16(row2, row6); \
+      dct_long_mul(p1e, sum26, rot0_0); \
+      dct_long_mac(t2e, p1e, row6, rot0_1); \
+      dct_long_mac(t3e, p1e, row2, rot0_2); \
+      int16x8_t sum04 = vaddq_s16(row0, row4); \
+      int16x8_t dif04 = vsubq_s16(row0, row4); \
+      dct_widen(t0e, sum04); \
+      dct_widen(t1e, dif04); \
+      dct_wadd(x0, t0e, t3e); \
+      dct_wsub(x3, t0e, t3e); \
+      dct_wadd(x1, t1e, t2e); \
+      dct_wsub(x2, t1e, t2e); \
+      /* odd part */ \
+      int16x8_t sum15 = vaddq_s16(row1, row5); \
+      int16x8_t sum17 = vaddq_s16(row1, row7); \
+      int16x8_t sum35 = vaddq_s16(row3, row5); \
+      int16x8_t sum37 = vaddq_s16(row3, row7); \
+      int16x8_t sumodd = vaddq_s16(sum17, sum35); \
+      dct_long_mul(p5o, sumodd, rot1_0); \
+      dct_long_mac(p1o, p5o, sum17, rot1_1); \
+      dct_long_mac(p2o, p5o, sum35, rot1_2); \
+      dct_long_mul(p3o, sum37, rot2_0); \
+      dct_long_mul(p4o, sum15, rot2_1); \
+      dct_wadd(sump13o, p1o, p3o); \
+      dct_wadd(sump24o, p2o, p4o); \
+      dct_wadd(sump23o, p2o, p3o); \
+      dct_wadd(sump14o, p1o, p4o); \
+      dct_long_mac(x4, sump13o, row7, rot3_0); \
+      dct_long_mac(x5, sump24o, row5, rot3_1); \
+      dct_long_mac(x6, sump23o, row3, rot3_2); \
+      dct_long_mac(x7, sump14o, row1, rot3_3); \
+      dct_bfly32o(row0,row7, x0,x7,shiftop,shift); \
+      dct_bfly32o(row1,row6, x1,x6,shiftop,shift); \
+      dct_bfly32o(row2,row5, x2,x5,shiftop,shift); \
+      dct_bfly32o(row3,row4, x3,x4,shiftop,shift); \
+   }
+
+   // load
+   row0 = vld1q_s16(data + 0*8);
+   row1 = vld1q_s16(data + 1*8);
+   row2 = vld1q_s16(data + 2*8);
+   row3 = vld1q_s16(data + 3*8);
+   row4 = vld1q_s16(data + 4*8);
+   row5 = vld1q_s16(data + 5*8);
+   row6 = vld1q_s16(data + 6*8);
+   row7 = vld1q_s16(data + 7*8);
+
+   // add DC bias
+   row0 = vaddq_s16(row0, vsetq_lane_s16(1024, vdupq_n_s16(0), 0));
+
+   // column pass
+   dct_pass(vrshrn_n_s32, 10);
+
+   // 16bit 8x8 transpose
+   {
+// these three map to a single VTRN.16, VTRN.32, and VSWP, respectively.
+// whether compilers actually get this is another story, sadly.
+#define dct_trn16(x, y) { int16x8x2_t t = vtrnq_s16(x, y); x = t.val[0]; y = t.val[1]; }
+#define dct_trn32(x, y) { int32x4x2_t t = vtrnq_s32(vreinterpretq_s32_s16(x), vreinterpretq_s32_s16(y)); x = vreinterpretq_s16_s32(t.val[0]); y = vreinterpretq_s16_s32(t.val[1]); }
+#define dct_trn64(x, y) { int16x8_t x0 = x; int16x8_t y0 = y; x = vcombine_s16(vget_low_s16(x0), vget_low_s16(y0)); y = vcombine_s16(vget_high_s16(x0), vget_high_s16(y0)); }
+
+      // pass 1
+      dct_trn16(row0, row1); // a0b0a2b2a4b4a6b6
+      dct_trn16(row2, row3);
+      dct_trn16(row4, row5);
+      dct_trn16(row6, row7);
+
+      // pass 2
+      dct_trn32(row0, row2); // a0b0c0d0a4b4c4d4
+      dct_trn32(row1, row3);
+      dct_trn32(row4, row6);
+      dct_trn32(row5, row7);
+
+      // pass 3
+      dct_trn64(row0, row4); // a0b0c0d0e0f0g0h0
+      dct_trn64(row1, row5);
+      dct_trn64(row2, row6);
+      dct_trn64(row3, row7);
+
+#undef dct_trn16
+#undef dct_trn32
+#undef dct_trn64
+   }
+
+   // row pass
+   // vrshrn_n_s32 only supports shifts up to 16, we need
+   // 17. so do a non-rounding shift of 16 first then follow
+   // up with a rounding shift by 1.
+   dct_pass(vshrn_n_s32, 16);
+
+   {
+      // pack and round
+      uint8x8_t p0 = vqrshrun_n_s16(row0, 1);
+      uint8x8_t p1 = vqrshrun_n_s16(row1, 1);
+      uint8x8_t p2 = vqrshrun_n_s16(row2, 1);
+      uint8x8_t p3 = vqrshrun_n_s16(row3, 1);
+      uint8x8_t p4 = vqrshrun_n_s16(row4, 1);
+      uint8x8_t p5 = vqrshrun_n_s16(row5, 1);
+      uint8x8_t p6 = vqrshrun_n_s16(row6, 1);
+      uint8x8_t p7 = vqrshrun_n_s16(row7, 1);
+
+      // again, these can translate into one instruction, but often don't.
+#define dct_trn8_8(x, y) { uint8x8x2_t t = vtrn_u8(x, y); x = t.val[0]; y = t.val[1]; }
+#define dct_trn8_16(x, y) { uint16x4x2_t t = vtrn_u16(vreinterpret_u16_u8(x), vreinterpret_u16_u8(y)); x = vreinterpret_u8_u16(t.val[0]); y = vreinterpret_u8_u16(t.val[1]); }
+#define dct_trn8_32(x, y) { uint32x2x2_t t = vtrn_u32(vreinterpret_u32_u8(x), vreinterpret_u32_u8(y)); x = vreinterpret_u8_u32(t.val[0]); y = vreinterpret_u8_u32(t.val[1]); }
+
+      // sadly can't use interleaved stores here since we only write
+      // 8 bytes to each scan line!
+
+      // 8x8 8-bit transpose pass 1
+      dct_trn8_8(p0, p1);
+      dct_trn8_8(p2, p3);
+      dct_trn8_8(p4, p5);
+      dct_trn8_8(p6, p7);
+
+      // pass 2
+      dct_trn8_16(p0, p2);
+      dct_trn8_16(p1, p3);
+      dct_trn8_16(p4, p6);
+      dct_trn8_16(p5, p7);
+
+      // pass 3
+      dct_trn8_32(p0, p4);
+      dct_trn8_32(p1, p5);
+      dct_trn8_32(p2, p6);
+      dct_trn8_32(p3, p7);
+
+      // store
+      vst1_u8(out, p0); out += out_stride;
+      vst1_u8(out, p1); out += out_stride;
+      vst1_u8(out, p2); out += out_stride;
+      vst1_u8(out, p3); out += out_stride;
+      vst1_u8(out, p4); out += out_stride;
+      vst1_u8(out, p5); out += out_stride;
+      vst1_u8(out, p6); out += out_stride;
+      vst1_u8(out, p7);
+
+#undef dct_trn8_8
+#undef dct_trn8_16
+#undef dct_trn8_32
+   }
+
+#undef dct_long_mul
+#undef dct_long_mac
+#undef dct_widen
+#undef dct_wadd
+#undef dct_wsub
+#undef dct_bfly32o
+#undef dct_pass
+}
+
+#endif // STBI_NEON
+
+#define STBI__MARKER_none  0xff
+// if there's a pending marker from the entropy stream, return that
+// otherwise, fetch from the stream and get a marker. if there's no
+// marker, return 0xff, which is never a valid marker value
+static stbi_uc stbi__get_marker(stbi__jpeg *j)
+{
+   stbi_uc x;
+   if (j->marker != STBI__MARKER_none) { x = j->marker; j->marker = STBI__MARKER_none; return x; }
+   x = stbi__get8(j->s);
+   if (x != 0xff) return STBI__MARKER_none;
+   while (x == 0xff)
+      x = stbi__get8(j->s); // consume repeated 0xff fill bytes
+   return x;
+}
+
+// in each scan, we'll have scan_n components, and the order
+// of the components is specified by order[]
+#define STBI__RESTART(x)     ((x) >= 0xd0 && (x) <= 0xd7)
+
+// after a restart interval, stbi__jpeg_reset the entropy decoder and
+// the dc prediction
+static void stbi__jpeg_reset(stbi__jpeg *j)
+{
+   j->code_bits = 0;
+   j->code_buffer = 0;
+   j->nomore = 0;
+   j->img_comp[0].dc_pred = j->img_comp[1].dc_pred = j->img_comp[2].dc_pred = j->img_comp[3].dc_pred = 0;
+   j->marker = STBI__MARKER_none;
+   j->todo = j->restart_interval ? j->restart_interval : 0x7fffffff;
+   j->eob_run = 0;
+   // no more than 1<<31 MCUs if no restart_interal? that's plenty safe,
+   // since we don't even allow 1<<30 pixels
+}
+
+static int stbi__parse_entropy_coded_data(stbi__jpeg *z)
+{
+   stbi__jpeg_reset(z);
+   if (!z->progressive) {
+      if (z->scan_n == 1) {
+         int i,j;
+         STBI_SIMD_ALIGN(short, data[64]);
+         int n = z->order[0];
+         // non-interleaved data, we just need to process one block at a time,
+         // in trivial scanline order
+         // number of blocks to do just depends on how many actual "pixels" this
+         // component has, independent of interleaved MCU blocking and such
+         int w = (z->img_comp[n].x+7) >> 3;
+         int h = (z->img_comp[n].y+7) >> 3;
+         for (j=0; j < h; ++j) {
+            for (i=0; i < w; ++i) {
+               int ha = z->img_comp[n].ha;
+               if (!stbi__jpeg_decode_block(z, data, z->huff_dc+z->img_comp[n].hd, z->huff_ac+ha, z->fast_ac[ha], n, z->dequant[z->img_comp[n].tq])) return 0;
+               z->idct_block_kernel(z->img_comp[n].data+z->img_comp[n].w2*j*8+i*8, z->img_comp[n].w2, data);
+               // every data block is an MCU, so countdown the restart interval
+               if (--z->todo <= 0) {
+                  if (z->code_bits < 24) stbi__grow_buffer_unsafe(z);
+                  // if it's NOT a restart, then just bail, so we get corrupt data
+                  // rather than no data
+                  if (!STBI__RESTART(z->marker)) return 1;
+                  stbi__jpeg_reset(z);
+               }
+            }
+         }
+         return 1;
+      } else { // interleaved
+         int i,j,k,x,y;
+         STBI_SIMD_ALIGN(short, data[64]);
+         for (j=0; j < z->img_mcu_y; ++j) {
+            for (i=0; i < z->img_mcu_x; ++i) {
+               // scan an interleaved mcu... process scan_n components in order
+               for (k=0; k < z->scan_n; ++k) {
+                  int n = z->order[k];
+                  // scan out an mcu's worth of this component; that's just determined
+                  // by the basic H and V specified for the component
+                  for (y=0; y < z->img_comp[n].v; ++y) {
+                     for (x=0; x < z->img_comp[n].h; ++x) {
+                        int x2 = (i*z->img_comp[n].h + x)*8;
+                        int y2 = (j*z->img_comp[n].v + y)*8;
+                        int ha = z->img_comp[n].ha;
+                        if (!stbi__jpeg_decode_block(z, data, z->huff_dc+z->img_comp[n].hd, z->huff_ac+ha, z->fast_ac[ha], n, z->dequant[z->img_comp[n].tq])) return 0;
+                        z->idct_block_kernel(z->img_comp[n].data+z->img_comp[n].w2*y2+x2, z->img_comp[n].w2, data);
+                     }
+                  }
+               }
+               // after all interleaved components, that's an interleaved MCU,
+               // so now count down the restart interval
+               if (--z->todo <= 0) {
+                  if (z->code_bits < 24) stbi__grow_buffer_unsafe(z);
+                  if (!STBI__RESTART(z->marker)) return 1;
+                  stbi__jpeg_reset(z);
+               }
+            }
+         }
+         return 1;
+      }
+   } else {
+      if (z->scan_n == 1) {
+         int i,j;
+         int n = z->order[0];
+         // non-interleaved data, we just need to process one block at a time,
+         // in trivial scanline order
+         // number of blocks to do just depends on how many actual "pixels" this
+         // component has, independent of interleaved MCU blocking and such
+         int w = (z->img_comp[n].x+7) >> 3;
+         int h = (z->img_comp[n].y+7) >> 3;
+         for (j=0; j < h; ++j) {
+            for (i=0; i < w; ++i) {
+               short *data = z->img_comp[n].coeff + 64 * (i + j * z->img_comp[n].coeff_w);
+               if (z->spec_start == 0) {
+                  if (!stbi__jpeg_decode_block_prog_dc(z, data, &z->huff_dc[z->img_comp[n].hd], n))
+                     return 0;
+               } else {
+                  int ha = z->img_comp[n].ha;
+                  if (!stbi__jpeg_decode_block_prog_ac(z, data, &z->huff_ac[ha], z->fast_ac[ha]))
+                     return 0;
+               }
+               // every data block is an MCU, so countdown the restart interval
+               if (--z->todo <= 0) {
+                  if (z->code_bits < 24) stbi__grow_buffer_unsafe(z);
+                  if (!STBI__RESTART(z->marker)) return 1;
+                  stbi__jpeg_reset(z);
+               }
+            }
+         }
+         return 1;
+      } else { // interleaved
+         int i,j,k,x,y;
+         for (j=0; j < z->img_mcu_y; ++j) {
+            for (i=0; i < z->img_mcu_x; ++i) {
+               // scan an interleaved mcu... process scan_n components in order
+               for (k=0; k < z->scan_n; ++k) {
+                  int n = z->order[k];
+                  // scan out an mcu's worth of this component; that's just determined
+                  // by the basic H and V specified for the component
+                  for (y=0; y < z->img_comp[n].v; ++y) {
+                     for (x=0; x < z->img_comp[n].h; ++x) {
+                        int x2 = (i*z->img_comp[n].h + x);
+                        int y2 = (j*z->img_comp[n].v + y);
+                        short *data = z->img_comp[n].coeff + 64 * (x2 + y2 * z->img_comp[n].coeff_w);
+                        if (!stbi__jpeg_decode_block_prog_dc(z, data, &z->huff_dc[z->img_comp[n].hd], n))
+                           return 0;
+                     }
+                  }
+               }
+               // after all interleaved components, that's an interleaved MCU,
+               // so now count down the restart interval
+               if (--z->todo <= 0) {
+                  if (z->code_bits < 24) stbi__grow_buffer_unsafe(z);
+                  if (!STBI__RESTART(z->marker)) return 1;
+                  stbi__jpeg_reset(z);
+               }
+            }
+         }
+         return 1;
+      }
+   }
+}
+
+static void stbi__jpeg_dequantize(short *data, stbi__uint16 *dequant)
+{
+   int i;
+   for (i=0; i < 64; ++i)
+      data[i] *= dequant[i];
+}
+
+static void stbi__jpeg_finish(stbi__jpeg *z)
+{
+   if (z->progressive) {
+      // dequantize and idct the data
+      int i,j,n;
+      for (n=0; n < z->s->img_n; ++n) {
+         int w = (z->img_comp[n].x+7) >> 3;
+         int h = (z->img_comp[n].y+7) >> 3;
+         for (j=0; j < h; ++j) {
+            for (i=0; i < w; ++i) {
+               short *data = z->img_comp[n].coeff + 64 * (i + j * z->img_comp[n].coeff_w);
+               stbi__jpeg_dequantize(data, z->dequant[z->img_comp[n].tq]);
+               z->idct_block_kernel(z->img_comp[n].data+z->img_comp[n].w2*j*8+i*8, z->img_comp[n].w2, data);
+            }
+         }
+      }
+   }
+}
+
+static int stbi__process_marker(stbi__jpeg *z, int m)
+{
+   int L;
+   switch (m) {
+      case STBI__MARKER_none: // no marker found
+         return stbi__err("expected marker","Corrupt JPEG");
+
+      case 0xDD: // DRI - specify restart interval
+         if (stbi__get16be(z->s) != 4) return stbi__err("bad DRI len","Corrupt JPEG");
+         z->restart_interval = stbi__get16be(z->s);
+         return 1;
+
+      case 0xDB: // DQT - define quantization table
+         L = stbi__get16be(z->s)-2;
+         while (L > 0) {
+            int q = stbi__get8(z->s);
+            int p = q >> 4, sixteen = (p != 0);
+            int t = q & 15,i;
+            if (p != 0 && p != 1) return stbi__err("bad DQT type","Corrupt JPEG");
+            if (t > 3) return stbi__err("bad DQT table","Corrupt JPEG");
+
+            for (i=0; i < 64; ++i)
+               z->dequant[t][stbi__jpeg_dezigzag[i]] = (stbi__uint16)(sixteen ? stbi__get16be(z->s) : stbi__get8(z->s));
+            L -= (sixteen ? 129 : 65);
+         }
+         return L==0;
+
+      case 0xC4: // DHT - define huffman table
+         L = stbi__get16be(z->s)-2;
+         while (L > 0) {
+            stbi_uc *v;
+            int sizes[16],i,n=0;
+            int q = stbi__get8(z->s);
+            int tc = q >> 4;
+            int th = q & 15;
+            if (tc > 1 || th > 3) return stbi__err("bad DHT header","Corrupt JPEG");
+            for (i=0; i < 16; ++i) {
+               sizes[i] = stbi__get8(z->s);
+               n += sizes[i];
+            }
+            if(n > 256) return stbi__err("bad DHT header","Corrupt JPEG"); // Loop over i < n would write past end of values!
+            L -= 17;
+            if (tc == 0) {
+               if (!stbi__build_huffman(z->huff_dc+th, sizes)) return 0;
+               v = z->huff_dc[th].values;
+            } else {
+               if (!stbi__build_huffman(z->huff_ac+th, sizes)) return 0;
+               v = z->huff_ac[th].values;
+            }
+            for (i=0; i < n; ++i)
+               v[i] = stbi__get8(z->s);
+            if (tc != 0)
+               stbi__build_fast_ac(z->fast_ac[th], z->huff_ac + th);
+            L -= n;
+         }
+         return L==0;
+   }
+
+   // check for comment block or APP blocks
+   if ((m >= 0xE0 && m <= 0xEF) || m == 0xFE) {
+      L = stbi__get16be(z->s);
+      if (L < 2) {
+         if (m == 0xFE)
+            return stbi__err("bad COM len","Corrupt JPEG");
+         else
+            return stbi__err("bad APP len","Corrupt JPEG");
+      }
+      L -= 2;
+
+      if (m == 0xE0 && L >= 5) { // JFIF APP0 segment
+         static const unsigned char tag[5] = {'J','F','I','F','\0'};
+         int ok = 1;
+         int i;
+         for (i=0; i < 5; ++i)
+            if (stbi__get8(z->s) != tag[i])
+               ok = 0;
+         L -= 5;
+         if (ok)
+            z->jfif = 1;
+      } else if (m == 0xEE && L >= 12) { // Adobe APP14 segment
+         static const unsigned char tag[6] = {'A','d','o','b','e','\0'};
+         int ok = 1;
+         int i;
+         for (i=0; i < 6; ++i)
+            if (stbi__get8(z->s) != tag[i])
+               ok = 0;
+         L -= 6;
+         if (ok) {
+            stbi__get8(z->s); // version
+            stbi__get16be(z->s); // flags0
+            stbi__get16be(z->s); // flags1
+            z->app14_color_transform = stbi__get8(z->s); // color transform
+            L -= 6;
+         }
+      }
+
+      stbi__skip(z->s, L);
+      return 1;
+   }
+
+   return stbi__err("unknown marker","Corrupt JPEG");
+}
+
+// after we see SOS
+static int stbi__process_scan_header(stbi__jpeg *z)
+{
+   int i;
+   int Ls = stbi__get16be(z->s);
+   z->scan_n = stbi__get8(z->s);
+   if (z->scan_n < 1 || z->scan_n > 4 || z->scan_n > (int) z->s->img_n) return stbi__err("bad SOS component count","Corrupt JPEG");
+   if (Ls != 6+2*z->scan_n) return stbi__err("bad SOS len","Corrupt JPEG");
+   for (i=0; i < z->scan_n; ++i) {
+      int id = stbi__get8(z->s), which;
+      int q = stbi__get8(z->s);
+      for (which = 0; which < z->s->img_n; ++which)
+         if (z->img_comp[which].id == id)
+            break;
+      if (which == z->s->img_n) return 0; // no match
+      z->img_comp[which].hd = q >> 4;   if (z->img_comp[which].hd > 3) return stbi__err("bad DC huff","Corrupt JPEG");
+      z->img_comp[which].ha = q & 15;   if (z->img_comp[which].ha > 3) return stbi__err("bad AC huff","Corrupt JPEG");
+      z->order[i] = which;
+   }
+
+   {
+      int aa;
+      z->spec_start = stbi__get8(z->s);
+      z->spec_end   = stbi__get8(z->s); // should be 63, but might be 0
+      aa = stbi__get8(z->s);
+      z->succ_high = (aa >> 4);
+      z->succ_low  = (aa & 15);
+      if (z->progressive) {
+         if (z->spec_start > 63 || z->spec_end > 63  || z->spec_start > z->spec_end || z->succ_high > 13 || z->succ_low > 13)
+            return stbi__err("bad SOS", "Corrupt JPEG");
+      } else {
+         if (z->spec_start != 0) return stbi__err("bad SOS","Corrupt JPEG");
+         if (z->succ_high != 0 || z->succ_low != 0) return stbi__err("bad SOS","Corrupt JPEG");
+         z->spec_end = 63;
+      }
+   }
+
+   return 1;
+}
+
+static int stbi__free_jpeg_components(stbi__jpeg *z, int ncomp, int why)
+{
+   int i;
+   for (i=0; i < ncomp; ++i) {
+      if (z->img_comp[i].raw_data) {
+         STBI_FREE(z->img_comp[i].raw_data);
+         z->img_comp[i].raw_data = NULL;
+         z->img_comp[i].data = NULL;
+      }
+      if (z->img_comp[i].raw_coeff) {
+         STBI_FREE(z->img_comp[i].raw_coeff);
+         z->img_comp[i].raw_coeff = 0;
+         z->img_comp[i].coeff = 0;
+      }
+      if (z->img_comp[i].linebuf) {
+         STBI_FREE(z->img_comp[i].linebuf);
+         z->img_comp[i].linebuf = NULL;
+      }
+   }
+   return why;
+}
+
+static int stbi__process_frame_header(stbi__jpeg *z, int scan)
+{
+   stbi__context *s = z->s;
+   int Lf,p,i,q, h_max=1,v_max=1,c;
+   Lf = stbi__get16be(s);         if (Lf < 11) return stbi__err("bad SOF len","Corrupt JPEG"); // JPEG
+   p  = stbi__get8(s);            if (p != 8) return stbi__err("only 8-bit","JPEG format not supported: 8-bit only"); // JPEG baseline
+   s->img_y = stbi__get16be(s);   if (s->img_y == 0) return stbi__err("no header height", "JPEG format not supported: delayed height"); // Legal, but we don't handle it--but neither does IJG
+   s->img_x = stbi__get16be(s);   if (s->img_x == 0) return stbi__err("0 width","Corrupt JPEG"); // JPEG requires
+   if (s->img_y > STBI_MAX_DIMENSIONS) return stbi__err("too large","Very large image (corrupt?)");
+   if (s->img_x > STBI_MAX_DIMENSIONS) return stbi__err("too large","Very large image (corrupt?)");
+   c = stbi__get8(s);
+   if (c != 3 && c != 1 && c != 4) return stbi__err("bad component count","Corrupt JPEG");
+   s->img_n = c;
+   for (i=0; i < c; ++i) {
+      z->img_comp[i].data = NULL;
+      z->img_comp[i].linebuf = NULL;
+   }
+
+   if (Lf != 8+3*s->img_n) return stbi__err("bad SOF len","Corrupt JPEG");
+
+   z->rgb = 0;
+   for (i=0; i < s->img_n; ++i) {
+      static const unsigned char rgb[3] = { 'R', 'G', 'B' };
+      z->img_comp[i].id = stbi__get8(s);
+      if (s->img_n == 3 && z->img_comp[i].id == rgb[i])
+         ++z->rgb;
+      q = stbi__get8(s);
+      z->img_comp[i].h = (q >> 4);  if (!z->img_comp[i].h || z->img_comp[i].h > 4) return stbi__err("bad H","Corrupt JPEG");
+      z->img_comp[i].v = q & 15;    if (!z->img_comp[i].v || z->img_comp[i].v > 4) return stbi__err("bad V","Corrupt JPEG");
+      z->img_comp[i].tq = stbi__get8(s);  if (z->img_comp[i].tq > 3) return stbi__err("bad TQ","Corrupt JPEG");
+   }
+
+   if (scan != STBI__SCAN_load) return 1;
+
+   if (!stbi__mad3sizes_valid(s->img_x, s->img_y, s->img_n, 0)) return stbi__err("too large", "Image too large to decode");
+
+   for (i=0; i < s->img_n; ++i) {
+      if (z->img_comp[i].h > h_max) h_max = z->img_comp[i].h;
+      if (z->img_comp[i].v > v_max) v_max = z->img_comp[i].v;
+   }
+
+   // check that plane subsampling factors are integer ratios; our resamplers can't deal with fractional ratios
+   // and I've never seen a non-corrupted JPEG file actually use them
+   for (i=0; i < s->img_n; ++i) {
+      if (h_max % z->img_comp[i].h != 0) return stbi__err("bad H","Corrupt JPEG");
+      if (v_max % z->img_comp[i].v != 0) return stbi__err("bad V","Corrupt JPEG");
+   }
+
+   // compute interleaved mcu info
+   z->img_h_max = h_max;
+   z->img_v_max = v_max;
+   z->img_mcu_w = h_max * 8;
+   z->img_mcu_h = v_max * 8;
+   // these sizes can't be more than 17 bits
+   z->img_mcu_x = (s->img_x + z->img_mcu_w-1) / z->img_mcu_w;
+   z->img_mcu_y = (s->img_y + z->img_mcu_h-1) / z->img_mcu_h;
+
+   for (i=0; i < s->img_n; ++i) {
+      // number of effective pixels (e.g. for non-interleaved MCU)
+      z->img_comp[i].x = (s->img_x * z->img_comp[i].h + h_max-1) / h_max;
+      z->img_comp[i].y = (s->img_y * z->img_comp[i].v + v_max-1) / v_max;
+      // to simplify generation, we'll allocate enough memory to decode
+      // the bogus oversized data from using interleaved MCUs and their
+      // big blocks (e.g. a 16x16 iMCU on an image of width 33); we won't
+      // discard the extra data until colorspace conversion
+      //
+      // img_mcu_x, img_mcu_y: <=17 bits; comp[i].h and .v are <=4 (checked earlier)
+      // so these muls can't overflow with 32-bit ints (which we require)
+      z->img_comp[i].w2 = z->img_mcu_x * z->img_comp[i].h * 8;
+      z->img_comp[i].h2 = z->img_mcu_y * z->img_comp[i].v * 8;
+      z->img_comp[i].coeff = 0;
+      z->img_comp[i].raw_coeff = 0;
+      z->img_comp[i].linebuf = NULL;
+      z->img_comp[i].raw_data = stbi__malloc_mad2(z->img_comp[i].w2, z->img_comp[i].h2, 15);
+      if (z->img_comp[i].raw_data == NULL)
+         return stbi__free_jpeg_components(z, i+1, stbi__err("outofmem", "Out of memory"));
+      // align blocks for idct using mmx/sse
+      z->img_comp[i].data = (stbi_uc*) (((size_t) z->img_comp[i].raw_data + 15) & ~15);
+      if (z->progressive) {
+         // w2, h2 are multiples of 8 (see above)
+         z->img_comp[i].coeff_w = z->img_comp[i].w2 / 8;
+         z->img_comp[i].coeff_h = z->img_comp[i].h2 / 8;
+         z->img_comp[i].raw_coeff = stbi__malloc_mad3(z->img_comp[i].w2, z->img_comp[i].h2, sizeof(short), 15);
+         if (z->img_comp[i].raw_coeff == NULL)
+            return stbi__free_jpeg_components(z, i+1, stbi__err("outofmem", "Out of memory"));
+         z->img_comp[i].coeff = (short*) (((size_t) z->img_comp[i].raw_coeff + 15) & ~15);
+      }
+   }
+
+   return 1;
+}
+
+// use comparisons since in some cases we handle more than one case (e.g. SOF)
+#define stbi__DNL(x)         ((x) == 0xdc)
+#define stbi__SOI(x)         ((x) == 0xd8)
+#define stbi__EOI(x)         ((x) == 0xd9)
+#define stbi__SOF(x)         ((x) == 0xc0 || (x) == 0xc1 || (x) == 0xc2)
+#define stbi__SOS(x)         ((x) == 0xda)
+
+#define stbi__SOF_progressive(x)   ((x) == 0xc2)
+
+static int stbi__decode_jpeg_header(stbi__jpeg *z, int scan)
+{
+   int m;
+   z->jfif = 0;
+   z->app14_color_transform = -1; // valid values are 0,1,2
+   z->marker = STBI__MARKER_none; // initialize cached marker to empty
+   m = stbi__get_marker(z);
+   if (!stbi__SOI(m)) return stbi__err("no SOI","Corrupt JPEG");
+   if (scan == STBI__SCAN_type) return 1;
+   m = stbi__get_marker(z);
+   while (!stbi__SOF(m)) {
+      if (!stbi__process_marker(z,m)) return 0;
+      m = stbi__get_marker(z);
+      while (m == STBI__MARKER_none) {
+         // some files have extra padding after their blocks, so ok, we'll scan
+         if (stbi__at_eof(z->s)) return stbi__err("no SOF", "Corrupt JPEG");
+         m = stbi__get_marker(z);
+      }
+   }
+   z->progressive = stbi__SOF_progressive(m);
+   if (!stbi__process_frame_header(z, scan)) return 0;
+   return 1;
+}
+
+static stbi_uc stbi__skip_jpeg_junk_at_end(stbi__jpeg *j)
+{
+   // some JPEGs have junk at end, skip over it but if we find what looks
+   // like a valid marker, resume there
+   while (!stbi__at_eof(j->s)) {
+      stbi_uc x = stbi__get8(j->s);
+      while (x == 0xff) { // might be a marker
+         if (stbi__at_eof(j->s)) return STBI__MARKER_none;
+         x = stbi__get8(j->s);
+         if (x != 0x00 && x != 0xff) {
+            // not a stuffed zero or lead-in to another marker, looks
+            // like an actual marker, return it
+            return x;
+         }
+         // stuffed zero has x=0 now which ends the loop, meaning we go
+         // back to regular scan loop.
+         // repeated 0xff keeps trying to read the next byte of the marker.
+      }
+   }
+   return STBI__MARKER_none;
+}
+
+// decode image to YCbCr format
+static int stbi__decode_jpeg_image(stbi__jpeg *j)
+{
+   int m;
+   for (m = 0; m < 4; m++) {
+      j->img_comp[m].raw_data = NULL;
+      j->img_comp[m].raw_coeff = NULL;
+   }
+   j->restart_interval = 0;
+   if (!stbi__decode_jpeg_header(j, STBI__SCAN_load)) return 0;
+   m = stbi__get_marker(j);
+   while (!stbi__EOI(m)) {
+      if (stbi__SOS(m)) {
+         if (!stbi__process_scan_header(j)) return 0;
+         if (!stbi__parse_entropy_coded_data(j)) return 0;
+         if (j->marker == STBI__MARKER_none ) {
+         j->marker = stbi__skip_jpeg_junk_at_end(j);
+            // if we reach eof without hitting a marker, stbi__get_marker() below will fail and we'll eventually return 0
+         }
+         m = stbi__get_marker(j);
+         if (STBI__RESTART(m))
+            m = stbi__get_marker(j);
+      } else if (stbi__DNL(m)) {
+         int Ld = stbi__get16be(j->s);
+         stbi__uint32 NL = stbi__get16be(j->s);
+         if (Ld != 4) return stbi__err("bad DNL len", "Corrupt JPEG");
+         if (NL != j->s->img_y) return stbi__err("bad DNL height", "Corrupt JPEG");
+         m = stbi__get_marker(j);
+      } else {
+         if (!stbi__process_marker(j, m)) return 1;
+         m = stbi__get_marker(j);
+      }
+   }
+   if (j->progressive)
+      stbi__jpeg_finish(j);
+   return 1;
+}
+
+// static jfif-centered resampling (across block boundaries)
+
+typedef stbi_uc *(*resample_row_func)(stbi_uc *out, stbi_uc *in0, stbi_uc *in1,
+                                    int w, int hs);
+
+#define stbi__div4(x) ((stbi_uc) ((x) >> 2))
+
+static stbi_uc *resample_row_1(stbi_uc *out, stbi_uc *in_near, stbi_uc *in_far, int w, int hs)
+{
+   STBI_NOTUSED(out);
+   STBI_NOTUSED(in_far);
+   STBI_NOTUSED(w);
+   STBI_NOTUSED(hs);
+   return in_near;
+}
+
+static stbi_uc* stbi__resample_row_v_2(stbi_uc *out, stbi_uc *in_near, stbi_uc *in_far, int w, int hs)
+{
+   // need to generate two samples vertically for every one in input
+   int i;
+   STBI_NOTUSED(hs);
+   for (i=0; i < w; ++i)
+      out[i] = stbi__div4(3*in_near[i] + in_far[i] + 2);
+   return out;
+}
+
+static stbi_uc*  stbi__resample_row_h_2(stbi_uc *out, stbi_uc *in_near, stbi_uc *in_far, int w, int hs)
+{
+   // need to generate two samples horizontally for every one in input
+   int i;
+   stbi_uc *input = in_near;
+
+   if (w == 1) {
+      // if only one sample, can't do any interpolation
+      out[0] = out[1] = input[0];
+      return out;
+   }
+
+   out[0] = input[0];
+   out[1] = stbi__div4(input[0]*3 + input[1] + 2);
+   for (i=1; i < w-1; ++i) {
+      int n = 3*input[i]+2;
+      out[i*2+0] = stbi__div4(n+input[i-1]);
+      out[i*2+1] = stbi__div4(n+input[i+1]);
+   }
+   out[i*2+0] = stbi__div4(input[w-2]*3 + input[w-1] + 2);
+   out[i*2+1] = input[w-1];
+
+   STBI_NOTUSED(in_far);
+   STBI_NOTUSED(hs);
+
+   return out;
+}
+
+#define stbi__div16(x) ((stbi_uc) ((x) >> 4))
+
+static stbi_uc *stbi__resample_row_hv_2(stbi_uc *out, stbi_uc *in_near, stbi_uc *in_far, int w, int hs)
+{
+   // need to generate 2x2 samples for every one in input
+   int i,t0,t1;
+   if (w == 1) {
+      out[0] = out[1] = stbi__div4(3*in_near[0] + in_far[0] + 2);
+      return out;
+   }
+
+   t1 = 3*in_near[0] + in_far[0];
+   out[0] = stbi__div4(t1+2);
+   for (i=1; i < w; ++i) {
+      t0 = t1;
+      t1 = 3*in_near[i]+in_far[i];
+      out[i*2-1] = stbi__div16(3*t0 + t1 + 8);
+      out[i*2  ] = stbi__div16(3*t1 + t0 + 8);
+   }
+   out[w*2-1] = stbi__div4(t1+2);
+
+   STBI_NOTUSED(hs);
+
+   return out;
+}
+
+#if defined(STBI_SSE2) || defined(STBI_NEON)
+static stbi_uc *stbi__resample_row_hv_2_simd(stbi_uc *out, stbi_uc *in_near, stbi_uc *in_far, int w, int hs)
+{
+   // need to generate 2x2 samples for every one in input
+   int i=0,t0,t1;
+
+   if (w == 1) {
+      out[0] = out[1] = stbi__div4(3*in_near[0] + in_far[0] + 2);
+      return out;
+   }
+
+   t1 = 3*in_near[0] + in_far[0];
+   // process groups of 8 pixels for as long as we can.
+   // note we can't handle the last pixel in a row in this loop
+   // because we need to handle the filter boundary conditions.
+   for (; i < ((w-1) & ~7); i += 8) {
+#if defined(STBI_SSE2)
+      // load and perform the vertical filtering pass
+      // this uses 3*x + y = 4*x + (y - x)
+      __m128i zero  = _mm_setzero_si128();
+      __m128i farb  = _mm_loadl_epi64((__m128i *) (in_far + i));
+      __m128i nearb = _mm_loadl_epi64((__m128i *) (in_near + i));
+      __m128i farw  = _mm_unpacklo_epi8(farb, zero);
+      __m128i nearw = _mm_unpacklo_epi8(nearb, zero);
+      __m128i diff  = _mm_sub_epi16(farw, nearw);
+      __m128i nears = _mm_slli_epi16(nearw, 2);
+      __m128i curr  = _mm_add_epi16(nears, diff); // current row
+
+      // horizontal filter works the same based on shifted vers of current
+      // row. "prev" is current row shifted right by 1 pixel; we need to
+      // insert the previous pixel value (from t1).
+      // "next" is current row shifted left by 1 pixel, with first pixel
+      // of next block of 8 pixels added in.
+      __m128i prv0 = _mm_slli_si128(curr, 2);
+      __m128i nxt0 = _mm_srli_si128(curr, 2);
+      __m128i prev = _mm_insert_epi16(prv0, t1, 0);
+      __m128i next = _mm_insert_epi16(nxt0, 3*in_near[i+8] + in_far[i+8], 7);
+
+      // horizontal filter, polyphase implementation since it's convenient:
+      // even pixels = 3*cur + prev = cur*4 + (prev - cur)
+      // odd  pixels = 3*cur + next = cur*4 + (next - cur)
+      // note the shared term.
+      __m128i bias  = _mm_set1_epi16(8);
+      __m128i curs = _mm_slli_epi16(curr, 2);
+      __m128i prvd = _mm_sub_epi16(prev, curr);
+      __m128i nxtd = _mm_sub_epi16(next, curr);
+      __m128i curb = _mm_add_epi16(curs, bias);
+      __m128i even = _mm_add_epi16(prvd, curb);
+      __m128i odd  = _mm_add_epi16(nxtd, curb);
+
+      // interleave even and odd pixels, then undo scaling.
+      __m128i int0 = _mm_unpacklo_epi16(even, odd);
+      __m128i int1 = _mm_unpackhi_epi16(even, odd);
+      __m128i de0  = _mm_srli_epi16(int0, 4);
+      __m128i de1  = _mm_srli_epi16(int1, 4);
+
+      // pack and write output
+      __m128i outv = _mm_packus_epi16(de0, de1);
+      _mm_storeu_si128((__m128i *) (out + i*2), outv);
+#elif defined(STBI_NEON)
+      // load and perform the vertical filtering pass
+      // this uses 3*x + y = 4*x + (y - x)
+      uint8x8_t farb  = vld1_u8(in_far + i);
+      uint8x8_t nearb = vld1_u8(in_near + i);
+      int16x8_t diff  = vreinterpretq_s16_u16(vsubl_u8(farb, nearb));
+      int16x8_t nears = vreinterpretq_s16_u16(vshll_n_u8(nearb, 2));
+      int16x8_t curr  = vaddq_s16(nears, diff); // current row
+
+      // horizontal filter works the same based on shifted vers of current
+      // row. "prev" is current row shifted right by 1 pixel; we need to
+      // insert the previous pixel value (from t1).
+      // "next" is current row shifted left by 1 pixel, with first pixel
+      // of next block of 8 pixels added in.
+      int16x8_t prv0 = vextq_s16(curr, curr, 7);
+      int16x8_t nxt0 = vextq_s16(curr, curr, 1);
+      int16x8_t prev = vsetq_lane_s16(t1, prv0, 0);
+      int16x8_t next = vsetq_lane_s16(3*in_near[i+8] + in_far[i+8], nxt0, 7);
+
+      // horizontal filter, polyphase implementation since it's convenient:
+      // even pixels = 3*cur + prev = cur*4 + (prev - cur)
+      // odd  pixels = 3*cur + next = cur*4 + (next - cur)
+      // note the shared term.
+      int16x8_t curs = vshlq_n_s16(curr, 2);
+      int16x8_t prvd = vsubq_s16(prev, curr);
+      int16x8_t nxtd = vsubq_s16(next, curr);
+      int16x8_t even = vaddq_s16(curs, prvd);
+      int16x8_t odd  = vaddq_s16(curs, nxtd);
+
+      // undo scaling and round, then store with even/odd phases interleaved
+      uint8x8x2_t o;
+      o.val[0] = vqrshrun_n_s16(even, 4);
+      o.val[1] = vqrshrun_n_s16(odd,  4);
+      vst2_u8(out + i*2, o);
+#endif
+
+      // "previous" value for next iter
+      t1 = 3*in_near[i+7] + in_far[i+7];
+   }
+
+   t0 = t1;
+   t1 = 3*in_near[i] + in_far[i];
+   out[i*2] = stbi__div16(3*t1 + t0 + 8);
+
+   for (++i; i < w; ++i) {
+      t0 = t1;
+      t1 = 3*in_near[i]+in_far[i];
+      out[i*2-1] = stbi__div16(3*t0 + t1 + 8);
+      out[i*2  ] = stbi__div16(3*t1 + t0 + 8);
+   }
+   out[w*2-1] = stbi__div4(t1+2);
+
+   STBI_NOTUSED(hs);
+
+   return out;
+}
+#endif
+
+static stbi_uc *stbi__resample_row_generic(stbi_uc *out, stbi_uc *in_near, stbi_uc *in_far, int w, int hs)
+{
+   // resample with nearest-neighbor
+   int i,j;
+   STBI_NOTUSED(in_far);
+   for (i=0; i < w; ++i)
+      for (j=0; j < hs; ++j)
+         out[i*hs+j] = in_near[i];
+   return out;
+}
+
+// this is a reduced-precision calculation of YCbCr-to-RGB introduced
+// to make sure the code produces the same results in both SIMD and scalar
+#define stbi__float2fixed(x)  (((int) ((x) * 4096.0f + 0.5f)) << 8)
+static void stbi__YCbCr_to_RGB_row(stbi_uc *out, const stbi_uc *y, const stbi_uc *pcb, const stbi_uc *pcr, int count, int step)
+{
+   int i;
+   for (i=0; i < count; ++i) {
+      int y_fixed = (y[i] << 20) + (1<<19); // rounding
+      int r,g,b;
+      int cr = pcr[i] - 128;
+      int cb = pcb[i] - 128;
+      r = y_fixed +  cr* stbi__float2fixed(1.40200f);
+      g = y_fixed + (cr*-stbi__float2fixed(0.71414f)) + ((cb*-stbi__float2fixed(0.34414f)) & 0xffff0000);
+      b = y_fixed                                     +   cb* stbi__float2fixed(1.77200f);
+      r >>= 20;
+      g >>= 20;
+      b >>= 20;
+      if ((unsigned) r > 255) { if (r < 0) r = 0; else r = 255; }
+      if ((unsigned) g > 255) { if (g < 0) g = 0; else g = 255; }
+      if ((unsigned) b > 255) { if (b < 0) b = 0; else b = 255; }
+      out[0] = (stbi_uc)r;
+      out[1] = (stbi_uc)g;
+      out[2] = (stbi_uc)b;
+      out[3] = 255;
+      out += step;
+   }
+}
+
+#if defined(STBI_SSE2) || defined(STBI_NEON)
+static void stbi__YCbCr_to_RGB_simd(stbi_uc *out, stbi_uc const *y, stbi_uc const *pcb, stbi_uc const *pcr, int count, int step)
+{
+   int i = 0;
+
+#ifdef STBI_SSE2
+   // step == 3 is pretty ugly on the final interleave, and i'm not convinced
+   // it's useful in practice (you wouldn't use it for textures, for example).
+   // so just accelerate step == 4 case.
+   if (step == 4) {
+      // this is a fairly straightforward implementation and not super-optimized.
+      __m128i signflip  = _mm_set1_epi8(-0x80);
+      __m128i cr_const0 = _mm_set1_epi16(   (short) ( 1.40200f*4096.0f+0.5f));
+      __m128i cr_const1 = _mm_set1_epi16( - (short) ( 0.71414f*4096.0f+0.5f));
+      __m128i cb_const0 = _mm_set1_epi16( - (short) ( 0.34414f*4096.0f+0.5f));
+      __m128i cb_const1 = _mm_set1_epi16(   (short) ( 1.77200f*4096.0f+0.5f));
+      __m128i y_bias = _mm_set1_epi8((char) (unsigned char) 128);
+      __m128i xw = _mm_set1_epi16(255); // alpha channel
+
+      for (; i+7 < count; i += 8) {
+         // load
+         __m128i y_bytes = _mm_loadl_epi64((__m128i *) (y+i));
+         __m128i cr_bytes = _mm_loadl_epi64((__m128i *) (pcr+i));
+         __m128i cb_bytes = _mm_loadl_epi64((__m128i *) (pcb+i));
+         __m128i cr_biased = _mm_xor_si128(cr_bytes, signflip); // -128
+         __m128i cb_biased = _mm_xor_si128(cb_bytes, signflip); // -128
+
+         // unpack to short (and left-shift cr, cb by 8)
+         __m128i yw  = _mm_unpacklo_epi8(y_bias, y_bytes);
+         __m128i crw = _mm_unpacklo_epi8(_mm_setzero_si128(), cr_biased);
+         __m128i cbw = _mm_unpacklo_epi8(_mm_setzero_si128(), cb_biased);
+
+         // color transform
+         __m128i yws = _mm_srli_epi16(yw, 4);
+         __m128i cr0 = _mm_mulhi_epi16(cr_const0, crw);
+         __m128i cb0 = _mm_mulhi_epi16(cb_const0, cbw);
+         __m128i cb1 = _mm_mulhi_epi16(cbw, cb_const1);
+         __m128i cr1 = _mm_mulhi_epi16(crw, cr_const1);
+         __m128i rws = _mm_add_epi16(cr0, yws);
+         __m128i gwt = _mm_add_epi16(cb0, yws);
+         __m128i bws = _mm_add_epi16(yws, cb1);
+         __m128i gws = _mm_add_epi16(gwt, cr1);
+
+         // descale
+         __m128i rw = _mm_srai_epi16(rws, 4);
+         __m128i bw = _mm_srai_epi16(bws, 4);
+         __m128i gw = _mm_srai_epi16(gws, 4);
+
+         // back to byte, set up for transpose
+         __m128i brb = _mm_packus_epi16(rw, bw);
+         __m128i gxb = _mm_packus_epi16(gw, xw);
+
+         // transpose to interleave channels
+         __m128i t0 = _mm_unpacklo_epi8(brb, gxb);
+         __m128i t1 = _mm_unpackhi_epi8(brb, gxb);
+         __m128i o0 = _mm_unpacklo_epi16(t0, t1);
+         __m128i o1 = _mm_unpackhi_epi16(t0, t1);
+
+         // store
+         _mm_storeu_si128((__m128i *) (out + 0), o0);
+         _mm_storeu_si128((__m128i *) (out + 16), o1);
+         out += 32;
+      }
+   }
+#endif
+
+#ifdef STBI_NEON
+   // in this version, step=3 support would be easy to add. but is there demand?
+   if (step == 4) {
+      // this is a fairly straightforward implementation and not super-optimized.
+      uint8x8_t signflip = vdup_n_u8(0x80);
+      int16x8_t cr_const0 = vdupq_n_s16(   (short) ( 1.40200f*4096.0f+0.5f));
+      int16x8_t cr_const1 = vdupq_n_s16( - (short) ( 0.71414f*4096.0f+0.5f));
+      int16x8_t cb_const0 = vdupq_n_s16( - (short) ( 0.34414f*4096.0f+0.5f));
+      int16x8_t cb_const1 = vdupq_n_s16(   (short) ( 1.77200f*4096.0f+0.5f));
+
+      for (; i+7 < count; i += 8) {
+         // load
+         uint8x8_t y_bytes  = vld1_u8(y + i);
+         uint8x8_t cr_bytes = vld1_u8(pcr + i);
+         uint8x8_t cb_bytes = vld1_u8(pcb + i);
+         int8x8_t cr_biased = vreinterpret_s8_u8(vsub_u8(cr_bytes, signflip));
+         int8x8_t cb_biased = vreinterpret_s8_u8(vsub_u8(cb_bytes, signflip));
+
+         // expand to s16
+         int16x8_t yws = vreinterpretq_s16_u16(vshll_n_u8(y_bytes, 4));
+         int16x8_t crw = vshll_n_s8(cr_biased, 7);
+         int16x8_t cbw = vshll_n_s8(cb_biased, 7);
+
+         // color transform
+         int16x8_t cr0 = vqdmulhq_s16(crw, cr_const0);
+         int16x8_t cb0 = vqdmulhq_s16(cbw, cb_const0);
+         int16x8_t cr1 = vqdmulhq_s16(crw, cr_const1);
+         int16x8_t cb1 = vqdmulhq_s16(cbw, cb_const1);
+         int16x8_t rws = vaddq_s16(yws, cr0);
+         int16x8_t gws = vaddq_s16(vaddq_s16(yws, cb0), cr1);
+         int16x8_t bws = vaddq_s16(yws, cb1);
+
+         // undo scaling, round, convert to byte
+         uint8x8x4_t o;
+         o.val[0] = vqrshrun_n_s16(rws, 4);
+         o.val[1] = vqrshrun_n_s16(gws, 4);
+         o.val[2] = vqrshrun_n_s16(bws, 4);
+         o.val[3] = vdup_n_u8(255);
+
+         // store, interleaving r/g/b/a
+         vst4_u8(out, o);
+         out += 8*4;
+      }
+   }
+#endif
+
+   for (; i < count; ++i) {
+      int y_fixed = (y[i] << 20) + (1<<19); // rounding
+      int r,g,b;
+      int cr = pcr[i] - 128;
+      int cb = pcb[i] - 128;
+      r = y_fixed + cr* stbi__float2fixed(1.40200f);
+      g = y_fixed + cr*-stbi__float2fixed(0.71414f) + ((cb*-stbi__float2fixed(0.34414f)) & 0xffff0000);
+      b = y_fixed                                   +   cb* stbi__float2fixed(1.77200f);
+      r >>= 20;
+      g >>= 20;
+      b >>= 20;
+      if ((unsigned) r > 255) { if (r < 0) r = 0; else r = 255; }
+      if ((unsigned) g > 255) { if (g < 0) g = 0; else g = 255; }
+      if ((unsigned) b > 255) { if (b < 0) b = 0; else b = 255; }
+      out[0] = (stbi_uc)r;
+      out[1] = (stbi_uc)g;
+      out[2] = (stbi_uc)b;
+      out[3] = 255;
+      out += step;
+   }
+}
+#endif
+
+// set up the kernels
+static void stbi__setup_jpeg(stbi__jpeg *j)
+{
+   j->idct_block_kernel = stbi__idct_block;
+   j->YCbCr_to_RGB_kernel = stbi__YCbCr_to_RGB_row;
+   j->resample_row_hv_2_kernel = stbi__resample_row_hv_2;
+
+#ifdef STBI_SSE2
+   if (stbi__sse2_available()) {
+      j->idct_block_kernel = stbi__idct_simd;
+      j->YCbCr_to_RGB_kernel = stbi__YCbCr_to_RGB_simd;
+      j->resample_row_hv_2_kernel = stbi__resample_row_hv_2_simd;
+   }
+#endif
+
+#ifdef STBI_NEON
+   j->idct_block_kernel = stbi__idct_simd;
+   j->YCbCr_to_RGB_kernel = stbi__YCbCr_to_RGB_simd;
+   j->resample_row_hv_2_kernel = stbi__resample_row_hv_2_simd;
+#endif
+}
+
+// clean up the temporary component buffers
+static void stbi__cleanup_jpeg(stbi__jpeg *j)
+{
+   stbi__free_jpeg_components(j, j->s->img_n, 0);
+}
+
+typedef struct
+{
+   resample_row_func resample;
+   stbi_uc *line0,*line1;
+   int hs,vs;   // expansion factor in each axis
+   int w_lores; // horizontal pixels pre-expansion
+   int ystep;   // how far through vertical expansion we are
+   int ypos;    // which pre-expansion row we're on
+} stbi__resample;
+
+// fast 0..255 * 0..255 => 0..255 rounded multiplication
+static stbi_uc stbi__blinn_8x8(stbi_uc x, stbi_uc y)
+{
+   unsigned int t = x*y + 128;
+   return (stbi_uc) ((t + (t >>8)) >> 8);
+}
+
+static stbi_uc *load_jpeg_image(stbi__jpeg *z, int *out_x, int *out_y, int *comp, int req_comp)
+{
+   int n, decode_n, is_rgb;
+   z->s->img_n = 0; // make stbi__cleanup_jpeg safe
+
+   // validate req_comp
+   if (req_comp < 0 || req_comp > 4) return stbi__errpuc("bad req_comp", "Internal error");
+
+   // load a jpeg image from whichever source, but leave in YCbCr format
+   if (!stbi__decode_jpeg_image(z)) { stbi__cleanup_jpeg(z); return NULL; }
+
+   // determine actual number of components to generate
+   n = req_comp ? req_comp : z->s->img_n >= 3 ? 3 : 1;
+
+   is_rgb = z->s->img_n == 3 && (z->rgb == 3 || (z->app14_color_transform == 0 && !z->jfif));
+
+   if (z->s->img_n == 3 && n < 3 && !is_rgb)
+      decode_n = 1;
+   else
+      decode_n = z->s->img_n;
+
+   // nothing to do if no components requested; check this now to avoid
+   // accessing uninitialized coutput[0] later
+   if (decode_n <= 0) { stbi__cleanup_jpeg(z); return NULL; }
+
+   // resample and color-convert
+   {
+      int k;
+      unsigned int i,j;
+      stbi_uc *output;
+      stbi_uc *coutput[4] = { NULL, NULL, NULL, NULL };
+
+      stbi__resample res_comp[4];
+
+      for (k=0; k < decode_n; ++k) {
+         stbi__resample *r = &res_comp[k];
+
+         // allocate line buffer big enough for upsampling off the edges
+         // with upsample factor of 4
+         z->img_comp[k].linebuf = (stbi_uc *) stbi__malloc(z->s->img_x + 3);
+         if (!z->img_comp[k].linebuf) { stbi__cleanup_jpeg(z); return stbi__errpuc("outofmem", "Out of memory"); }
+
+         r->hs      = z->img_h_max / z->img_comp[k].h;
+         r->vs      = z->img_v_max / z->img_comp[k].v;
+         r->ystep   = r->vs >> 1;
+         r->w_lores = (z->s->img_x + r->hs-1) / r->hs;
+         r->ypos    = 0;
+         r->line0   = r->line1 = z->img_comp[k].data;
+
+         if      (r->hs == 1 && r->vs == 1) r->resample = resample_row_1;
+         else if (r->hs == 1 && r->vs == 2) r->resample = stbi__resample_row_v_2;
+         else if (r->hs == 2 && r->vs == 1) r->resample = stbi__resample_row_h_2;
+         else if (r->hs == 2 && r->vs == 2) r->resample = z->resample_row_hv_2_kernel;
+         else                               r->resample = stbi__resample_row_generic;
+      }
+
+      // can't error after this so, this is safe
+      output = (stbi_uc *) stbi__malloc_mad3(n, z->s->img_x, z->s->img_y, 1);
+      if (!output) { stbi__cleanup_jpeg(z); return stbi__errpuc("outofmem", "Out of memory"); }
+
+      // now go ahead and resample
+      for (j=0; j < z->s->img_y; ++j) {
+         stbi_uc *out = output + n * z->s->img_x * j;
+         for (k=0; k < decode_n; ++k) {
+            stbi__resample *r = &res_comp[k];
+            int y_bot = r->ystep >= (r->vs >> 1);
+            coutput[k] = r->resample(z->img_comp[k].linebuf,
+                                     y_bot ? r->line1 : r->line0,
+                                     y_bot ? r->line0 : r->line1,
+                                     r->w_lores, r->hs);
+            if (++r->ystep >= r->vs) {
+               r->ystep = 0;
+               r->line0 = r->line1;
+               if (++r->ypos < z->img_comp[k].y)
+                  r->line1 += z->img_comp[k].w2;
+            }
+         }
+         if (n >= 3) {
+            stbi_uc *y = coutput[0];
+            if (z->s->img_n == 3) {
+               if (is_rgb) {
+                  for (i=0; i < z->s->img_x; ++i) {
+                     out[0] = y[i];
+                     out[1] = coutput[1][i];
+                     out[2] = coutput[2][i];
+                     out[3] = 255;
+                     out += n;
+                  }
+               } else {
+                  z->YCbCr_to_RGB_kernel(out, y, coutput[1], coutput[2], z->s->img_x, n);
+               }
+            } else if (z->s->img_n == 4) {
+               if (z->app14_color_transform == 0) { // CMYK
+                  for (i=0; i < z->s->img_x; ++i) {
+                     stbi_uc m = coutput[3][i];
+                     out[0] = stbi__blinn_8x8(coutput[0][i], m);
+                     out[1] = stbi__blinn_8x8(coutput[1][i], m);
+                     out[2] = stbi__blinn_8x8(coutput[2][i], m);
+                     out[3] = 255;
+                     out += n;
+                  }
+               } else if (z->app14_color_transform == 2) { // YCCK
+                  z->YCbCr_to_RGB_kernel(out, y, coutput[1], coutput[2], z->s->img_x, n);
+                  for (i=0; i < z->s->img_x; ++i) {
+                     stbi_uc m = coutput[3][i];
+                     out[0] = stbi__blinn_8x8(255 - out[0], m);
+                     out[1] = stbi__blinn_8x8(255 - out[1], m);
+                     out[2] = stbi__blinn_8x8(255 - out[2], m);
+                     out += n;
+                  }
+               } else { // YCbCr + alpha?  Ignore the fourth channel for now
+                  z->YCbCr_to_RGB_kernel(out, y, coutput[1], coutput[2], z->s->img_x, n);
+               }
+            } else
+               for (i=0; i < z->s->img_x; ++i) {
+                  out[0] = out[1] = out[2] = y[i];
+                  out[3] = 255; // not used if n==3
+                  out += n;
+               }
+         } else {
+            if (is_rgb) {
+               if (n == 1)
+                  for (i=0; i < z->s->img_x; ++i)
+                     *out++ = stbi__compute_y(coutput[0][i], coutput[1][i], coutput[2][i]);
+               else {
+                  for (i=0; i < z->s->img_x; ++i, out += 2) {
+                     out[0] = stbi__compute_y(coutput[0][i], coutput[1][i], coutput[2][i]);
+                     out[1] = 255;
+                  }
+               }
+            } else if (z->s->img_n == 4 && z->app14_color_transform == 0) {
+               for (i=0; i < z->s->img_x; ++i) {
+                  stbi_uc m = coutput[3][i];
+                  stbi_uc r = stbi__blinn_8x8(coutput[0][i], m);
+                  stbi_uc g = stbi__blinn_8x8(coutput[1][i], m);
+                  stbi_uc b = stbi__blinn_8x8(coutput[2][i], m);
+                  out[0] = stbi__compute_y(r, g, b);
+                  out[1] = 255;
+                  out += n;
+               }
+            } else if (z->s->img_n == 4 && z->app14_color_transform == 2) {
+               for (i=0; i < z->s->img_x; ++i) {
+                  out[0] = stbi__blinn_8x8(255 - coutput[0][i], coutput[3][i]);
+                  out[1] = 255;
+                  out += n;
+               }
+            } else {
+               stbi_uc *y = coutput[0];
+               if (n == 1)
+                  for (i=0; i < z->s->img_x; ++i) out[i] = y[i];
+               else
+                  for (i=0; i < z->s->img_x; ++i) { *out++ = y[i]; *out++ = 255; }
+            }
+         }
+      }
+      stbi__cleanup_jpeg(z);
+      *out_x = z->s->img_x;
+      *out_y = z->s->img_y;
+      if (comp) *comp = z->s->img_n >= 3 ? 3 : 1; // report original components, not output
+      return output;
+   }
+}
+
+static void *stbi__jpeg_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri)
+{
+   unsigned char* result;
+   stbi__jpeg* j = (stbi__jpeg*) stbi__malloc(sizeof(stbi__jpeg));
+   if (!j) return stbi__errpuc("outofmem", "Out of memory");
+   memset(j, 0, sizeof(stbi__jpeg));
+   STBI_NOTUSED(ri);
+   j->s = s;
+   stbi__setup_jpeg(j);
+   result = load_jpeg_image(j, x,y,comp,req_comp);
+   STBI_FREE(j);
+   return result;
+}
+
+static int stbi__jpeg_test(stbi__context *s)
+{
+   int r;
+   stbi__jpeg* j = (stbi__jpeg*)stbi__malloc(sizeof(stbi__jpeg));
+   if (!j) return stbi__err("outofmem", "Out of memory");
+   memset(j, 0, sizeof(stbi__jpeg));
+   j->s = s;
+   stbi__setup_jpeg(j);
+   r = stbi__decode_jpeg_header(j, STBI__SCAN_type);
+   stbi__rewind(s);
+   STBI_FREE(j);
+   return r;
+}
+
+static int stbi__jpeg_info_raw(stbi__jpeg *j, int *x, int *y, int *comp)
+{
+   if (!stbi__decode_jpeg_header(j, STBI__SCAN_header)) {
+      stbi__rewind( j->s );
+      return 0;
+   }
+   if (x) *x = j->s->img_x;
+   if (y) *y = j->s->img_y;
+   if (comp) *comp = j->s->img_n >= 3 ? 3 : 1;
+   return 1;
+}
+
+static int stbi__jpeg_info(stbi__context *s, int *x, int *y, int *comp)
+{
+   int result;
+   stbi__jpeg* j = (stbi__jpeg*) (stbi__malloc(sizeof(stbi__jpeg)));
+   if (!j) return stbi__err("outofmem", "Out of memory");
+   memset(j, 0, sizeof(stbi__jpeg));
+   j->s = s;
+   result = stbi__jpeg_info_raw(j, x, y, comp);
+   STBI_FREE(j);
+   return result;
+}
+#endif
+
+// public domain zlib decode    v0.2  Sean Barrett 2006-11-18
+//    simple implementation
+//      - all input must be provided in an upfront buffer
+//      - all output is written to a single output buffer (can malloc/realloc)
+//    performance
+//      - fast huffman
+
+#ifndef STBI_NO_ZLIB
+
+// fast-way is faster to check than jpeg huffman, but slow way is slower
+#define STBI__ZFAST_BITS  9 // accelerate all cases in default tables
+#define STBI__ZFAST_MASK  ((1 << STBI__ZFAST_BITS) - 1)
+#define STBI__ZNSYMS 288 // number of symbols in literal/length alphabet
+
+// zlib-style huffman encoding
+// (jpegs packs from left, zlib from right, so can't share code)
+typedef struct
+{
+   stbi__uint16 fast[1 << STBI__ZFAST_BITS];
+   stbi__uint16 firstcode[16];
+   int maxcode[17];
+   stbi__uint16 firstsymbol[16];
+   stbi_uc  size[STBI__ZNSYMS];
+   stbi__uint16 value[STBI__ZNSYMS];
+} stbi__zhuffman;
+
+stbi_inline static int stbi__bitreverse16(int n)
+{
+  n = ((n & 0xAAAA) >>  1) | ((n & 0x5555) << 1);
+  n = ((n & 0xCCCC) >>  2) | ((n & 0x3333) << 2);
+  n = ((n & 0xF0F0) >>  4) | ((n & 0x0F0F) << 4);
+  n = ((n & 0xFF00) >>  8) | ((n & 0x00FF) << 8);
+  return n;
+}
+
+stbi_inline static int stbi__bit_reverse(int v, int bits)
+{
+   STBI_ASSERT(bits <= 16);
+   // to bit reverse n bits, reverse 16 and shift
+   // e.g. 11 bits, bit reverse and shift away 5
+   return stbi__bitreverse16(v) >> (16-bits);
+}
+
+static int stbi__zbuild_huffman(stbi__zhuffman *z, const stbi_uc *sizelist, int num)
+{
+   int i,k=0;
+   int code, next_code[16], sizes[17];
+
+   // DEFLATE spec for generating codes
+   memset(sizes, 0, sizeof(sizes));
+   memset(z->fast, 0, sizeof(z->fast));
+   for (i=0; i < num; ++i)
+      ++sizes[sizelist[i]];
+   sizes[0] = 0;
+   for (i=1; i < 16; ++i)
+      if (sizes[i] > (1 << i))
+         return stbi__err("bad sizes", "Corrupt PNG");
+   code = 0;
+   for (i=1; i < 16; ++i) {
+      next_code[i] = code;
+      z->firstcode[i] = (stbi__uint16) code;
+      z->firstsymbol[i] = (stbi__uint16) k;
+      code = (code + sizes[i]);
+      if (sizes[i])
+         if (code-1 >= (1 << i)) return stbi__err("bad codelengths","Corrupt PNG");
+      z->maxcode[i] = code << (16-i); // preshift for inner loop
+      code <<= 1;
+      k += sizes[i];
+   }
+   z->maxcode[16] = 0x10000; // sentinel
+   for (i=0; i < num; ++i) {
+      int s = sizelist[i];
+      if (s) {
+         int c = next_code[s] - z->firstcode[s] + z->firstsymbol[s];
+         stbi__uint16 fastv = (stbi__uint16) ((s << 9) | i);
+         z->size [c] = (stbi_uc     ) s;
+         z->value[c] = (stbi__uint16) i;
+         if (s <= STBI__ZFAST_BITS) {
+            int j = stbi__bit_reverse(next_code[s],s);
+            while (j < (1 << STBI__ZFAST_BITS)) {
+               z->fast[j] = fastv;
+               j += (1 << s);
+            }
+         }
+         ++next_code[s];
+      }
+   }
+   return 1;
+}
+
+// zlib-from-memory implementation for PNG reading
+//    because PNG allows splitting the zlib stream arbitrarily,
+//    and it's annoying structurally to have PNG call ZLIB call PNG,
+//    we require PNG read all the IDATs and combine them into a single
+//    memory buffer
+
+typedef struct
+{
+   stbi_uc *zbuffer, *zbuffer_end;
+   int num_bits;
+   int hit_zeof_once;
+   stbi__uint32 code_buffer;
+
+   char *zout;
+   char *zout_start;
+   char *zout_end;
+   int   z_expandable;
+
+   stbi__zhuffman z_length, z_distance;
+} stbi__zbuf;
+
+stbi_inline static int stbi__zeof(stbi__zbuf *z)
+{
+   return (z->zbuffer >= z->zbuffer_end);
+}
+
+stbi_inline static stbi_uc stbi__zget8(stbi__zbuf *z)
+{
+   return stbi__zeof(z) ? 0 : *z->zbuffer++;
+}
+
+static void stbi__fill_bits(stbi__zbuf *z)
+{
+   do {
+      if (z->code_buffer >= (1U << z->num_bits)) {
+        z->zbuffer = z->zbuffer_end;  /* treat this as EOF so we fail. */
+        return;
+      }
+      z->code_buffer |= (unsigned int) stbi__zget8(z) << z->num_bits;
+      z->num_bits += 8;
+   } while (z->num_bits <= 24);
+}
+
+stbi_inline static unsigned int stbi__zreceive(stbi__zbuf *z, int n)
+{
+   unsigned int k;
+   if (z->num_bits < n) stbi__fill_bits(z);
+   k = z->code_buffer & ((1 << n) - 1);
+   z->code_buffer >>= n;
+   z->num_bits -= n;
+   return k;
+}
+
+static int stbi__zhuffman_decode_slowpath(stbi__zbuf *a, stbi__zhuffman *z)
+{
+   int b,s,k;
+   // not resolved by fast table, so compute it the slow way
+   // use jpeg approach, which requires MSbits at top
+   k = stbi__bit_reverse(a->code_buffer, 16);
+   for (s=STBI__ZFAST_BITS+1; ; ++s)
+      if (k < z->maxcode[s])
+         break;
+   if (s >= 16) return -1; // invalid code!
+   // code size is s, so:
+   b = (k >> (16-s)) - z->firstcode[s] + z->firstsymbol[s];
+   if (b >= STBI__ZNSYMS) return -1; // some data was corrupt somewhere!
+   if (z->size[b] != s) return -1;  // was originally an assert, but report failure instead.
+   a->code_buffer >>= s;
+   a->num_bits -= s;
+   return z->value[b];
+}
+
+stbi_inline static int stbi__zhuffman_decode(stbi__zbuf *a, stbi__zhuffman *z)
+{
+   int b,s;
+   if (a->num_bits < 16) {
+      if (stbi__zeof(a)) {
+         if (!a->hit_zeof_once) {
+            // This is the first time we hit eof, insert 16 extra padding btis
+            // to allow us to keep going; if we actually consume any of them
+            // though, that is invalid data. This is caught later.
+            a->hit_zeof_once = 1;
+            a->num_bits += 16; // add 16 implicit zero bits
+         } else {
+            // We already inserted our extra 16 padding bits and are again
+            // out, this stream is actually prematurely terminated.
+            return -1;
+         }
+      } else {
+         stbi__fill_bits(a);
+      }
+   }
+   b = z->fast[a->code_buffer & STBI__ZFAST_MASK];
+   if (b) {
+      s = b >> 9;
+      a->code_buffer >>= s;
+      a->num_bits -= s;
+      return b & 511;
+   }
+   return stbi__zhuffman_decode_slowpath(a, z);
+}
+
+static int stbi__zexpand(stbi__zbuf *z, char *zout, int n)  // need to make room for n bytes
+{
+   char *q;
+   unsigned int cur, limit, old_limit;
+   z->zout = zout;
+   if (!z->z_expandable) return stbi__err("output buffer limit","Corrupt PNG");
+   cur   = (unsigned int) (z->zout - z->zout_start);
+   limit = old_limit = (unsigned) (z->zout_end - z->zout_start);
+   if (UINT_MAX - cur < (unsigned) n) return stbi__err("outofmem", "Out of memory");
+   while (cur + n > limit) {
+      if(limit > UINT_MAX / 2) return stbi__err("outofmem", "Out of memory");
+      limit *= 2;
+   }
+   q = (char *) STBI_REALLOC_SIZED(z->zout_start, old_limit, limit);
+   STBI_NOTUSED(old_limit);
+   if (q == NULL) return stbi__err("outofmem", "Out of memory");
+   z->zout_start = q;
+   z->zout       = q + cur;
+   z->zout_end   = q + limit;
+   return 1;
+}
+
+static const int stbi__zlength_base[31] = {
+   3,4,5,6,7,8,9,10,11,13,
+   15,17,19,23,27,31,35,43,51,59,
+   67,83,99,115,131,163,195,227,258,0,0 };
+
+static const int stbi__zlength_extra[31]=
+{ 0,0,0,0,0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3,4,4,4,4,5,5,5,5,0,0,0 };
+
+static const int stbi__zdist_base[32] = { 1,2,3,4,5,7,9,13,17,25,33,49,65,97,129,193,
+257,385,513,769,1025,1537,2049,3073,4097,6145,8193,12289,16385,24577,0,0};
+
+static const int stbi__zdist_extra[32] =
+{ 0,0,0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7,8,8,9,9,10,10,11,11,12,12,13,13};
+
+static int stbi__parse_huffman_block(stbi__zbuf *a)
+{
+   char *zout = a->zout;
+   for(;;) {
+      int z = stbi__zhuffman_decode(a, &a->z_length);
+      if (z < 256) {
+         if (z < 0) return stbi__err("bad huffman code","Corrupt PNG"); // error in huffman codes
+         if (zout >= a->zout_end) {
+            if (!stbi__zexpand(a, zout, 1)) return 0;
+            zout = a->zout;
+         }
+         *zout++ = (char) z;
+      } else {
+         stbi_uc *p;
+         int len,dist;
+         if (z == 256) {
+            a->zout = zout;
+            if (a->hit_zeof_once && a->num_bits < 16) {
+               // The first time we hit zeof, we inserted 16 extra zero bits into our bit
+               // buffer so the decoder can just do its speculative decoding. But if we
+               // actually consumed any of those bits (which is the case when num_bits < 16),
+               // the stream actually read past the end so it is malformed.
+               return stbi__err("unexpected end","Corrupt PNG");
+            }
+            return 1;
+         }
+         if (z >= 286) return stbi__err("bad huffman code","Corrupt PNG"); // per DEFLATE, length codes 286 and 287 must not appear in compressed data
+         z -= 257;
+         len = stbi__zlength_base[z];
+         if (stbi__zlength_extra[z]) len += stbi__zreceive(a, stbi__zlength_extra[z]);
+         z = stbi__zhuffman_decode(a, &a->z_distance);
+         if (z < 0 || z >= 30) return stbi__err("bad huffman code","Corrupt PNG"); // per DEFLATE, distance codes 30 and 31 must not appear in compressed data
+         dist = stbi__zdist_base[z];
+         if (stbi__zdist_extra[z]) dist += stbi__zreceive(a, stbi__zdist_extra[z]);
+         if (zout - a->zout_start < dist) return stbi__err("bad dist","Corrupt PNG");
+         if (len > a->zout_end - zout) {
+            if (!stbi__zexpand(a, zout, len)) return 0;
+            zout = a->zout;
+         }
+         p = (stbi_uc *) (zout - dist);
+         if (dist == 1) { // run of one byte; common in images.
+            stbi_uc v = *p;
+            if (len) { do *zout++ = v; while (--len); }
+         } else {
+            if (len) { do *zout++ = *p++; while (--len); }
+         }
+      }
+   }
+}
+
+static int stbi__compute_huffman_codes(stbi__zbuf *a)
+{
+   static const stbi_uc length_dezigzag[19] = { 16,17,18,0,8,7,9,6,10,5,11,4,12,3,13,2,14,1,15 };
+   stbi__zhuffman z_codelength;
+   stbi_uc lencodes[286+32+137];//padding for maximum single op
+   stbi_uc codelength_sizes[19];
+   int i,n;
+
+   int hlit  = stbi__zreceive(a,5) + 257;
+   int hdist = stbi__zreceive(a,5) + 1;
+   int hclen = stbi__zreceive(a,4) + 4;
+   int ntot  = hlit + hdist;
+
+   memset(codelength_sizes, 0, sizeof(codelength_sizes));
+   for (i=0; i < hclen; ++i) {
+      int s = stbi__zreceive(a,3);
+      codelength_sizes[length_dezigzag[i]] = (stbi_uc) s;
+   }
+   if (!stbi__zbuild_huffman(&z_codelength, codelength_sizes, 19)) return 0;
+
+   n = 0;
+   while (n < ntot) {
+      int c = stbi__zhuffman_decode(a, &z_codelength);
+      if (c < 0 || c >= 19) return stbi__err("bad codelengths", "Corrupt PNG");
+      if (c < 16)
+         lencodes[n++] = (stbi_uc) c;
+      else {
+         stbi_uc fill = 0;
+         if (c == 16) {
+            c = stbi__zreceive(a,2)+3;
+            if (n == 0) return stbi__err("bad codelengths", "Corrupt PNG");
+            fill = lencodes[n-1];
+         } else if (c == 17) {
+            c = stbi__zreceive(a,3)+3;
+         } else if (c == 18) {
+            c = stbi__zreceive(a,7)+11;
+         } else {
+            return stbi__err("bad codelengths", "Corrupt PNG");
+         }
+         if (ntot - n < c) return stbi__err("bad codelengths", "Corrupt PNG");
+         memset(lencodes+n, fill, c);
+         n += c;
+      }
+   }
+   if (n != ntot) return stbi__err("bad codelengths","Corrupt PNG");
+   if (!stbi__zbuild_huffman(&a->z_length, lencodes, hlit)) return 0;
+   if (!stbi__zbuild_huffman(&a->z_distance, lencodes+hlit, hdist)) return 0;
+   return 1;
+}
+
+static int stbi__parse_uncompressed_block(stbi__zbuf *a)
+{
+   stbi_uc header[4];
+   int len,nlen,k;
+   if (a->num_bits & 7)
+      stbi__zreceive(a, a->num_bits & 7); // discard
+   // drain the bit-packed data into header
+   k = 0;
+   while (a->num_bits > 0) {
+      header[k++] = (stbi_uc) (a->code_buffer & 255); // suppress MSVC run-time check
+      a->code_buffer >>= 8;
+      a->num_bits -= 8;
+   }
+   if (a->num_bits < 0) return stbi__err("zlib corrupt","Corrupt PNG");
+   // now fill header the normal way
+   while (k < 4)
+      header[k++] = stbi__zget8(a);
+   len  = header[1] * 256 + header[0];
+   nlen = header[3] * 256 + header[2];
+   if (nlen != (len ^ 0xffff)) return stbi__err("zlib corrupt","Corrupt PNG");
+   if (a->zbuffer + len > a->zbuffer_end) return stbi__err("read past buffer","Corrupt PNG");
+   if (a->zout + len > a->zout_end)
+      if (!stbi__zexpand(a, a->zout, len)) return 0;
+   memcpy(a->zout, a->zbuffer, len);
+   a->zbuffer += len;
+   a->zout += len;
+   return 1;
+}
+
+static int stbi__parse_zlib_header(stbi__zbuf *a)
+{
+   int cmf   = stbi__zget8(a);
+   int cm    = cmf & 15;
+   /* int cinfo = cmf >> 4; */
+   int flg   = stbi__zget8(a);
+   if (stbi__zeof(a)) return stbi__err("bad zlib header","Corrupt PNG"); // zlib spec
+   if ((cmf*256+flg) % 31 != 0) return stbi__err("bad zlib header","Corrupt PNG"); // zlib spec
+   if (flg & 32) return stbi__err("no preset dict","Corrupt PNG"); // preset dictionary not allowed in png
+   if (cm != 8) return stbi__err("bad compression","Corrupt PNG"); // DEFLATE required for png
+   // window = 1 << (8 + cinfo)... but who cares, we fully buffer output
+   return 1;
+}
+
+static const stbi_uc stbi__zdefault_length[STBI__ZNSYMS] =
+{
+   8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8, 8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,
+   8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8, 8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,
+   8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8, 8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,
+   8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8, 8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,
+   8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8, 9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,
+   9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9, 9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,
+   9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9, 9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,
+   9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9, 9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,
+   7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7, 7,7,7,7,7,7,7,7,8,8,8,8,8,8,8,8
+};
+static const stbi_uc stbi__zdefault_distance[32] =
+{
+   5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5
+};
+/*
+Init algorithm:
+{
+   int i;   // use <= to match clearly with spec
+   for (i=0; i <= 143; ++i)     stbi__zdefault_length[i]   = 8;
+   for (   ; i <= 255; ++i)     stbi__zdefault_length[i]   = 9;
+   for (   ; i <= 279; ++i)     stbi__zdefault_length[i]   = 7;
+   for (   ; i <= 287; ++i)     stbi__zdefault_length[i]   = 8;
+
+   for (i=0; i <=  31; ++i)     stbi__zdefault_distance[i] = 5;
+}
+*/
+
+static int stbi__parse_zlib(stbi__zbuf *a, int parse_header)
+{
+   int final, type;
+   if (parse_header)
+      if (!stbi__parse_zlib_header(a)) return 0;
+   a->num_bits = 0;
+   a->code_buffer = 0;
+   a->hit_zeof_once = 0;
+   do {
+      final = stbi__zreceive(a,1);
+      type = stbi__zreceive(a,2);
+      if (type == 0) {
+         if (!stbi__parse_uncompressed_block(a)) return 0;
+      } else if (type == 3) {
+         return 0;
+      } else {
+         if (type == 1) {
+            // use fixed code lengths
+            if (!stbi__zbuild_huffman(&a->z_length  , stbi__zdefault_length  , STBI__ZNSYMS)) return 0;
+            if (!stbi__zbuild_huffman(&a->z_distance, stbi__zdefault_distance,  32)) return 0;
+         } else {
+            if (!stbi__compute_huffman_codes(a)) return 0;
+         }
+         if (!stbi__parse_huffman_block(a)) return 0;
+      }
+   } while (!final);
+   return 1;
+}
+
+static int stbi__do_zlib(stbi__zbuf *a, char *obuf, int olen, int exp, int parse_header)
+{
+   a->zout_start = obuf;
+   a->zout       = obuf;
+   a->zout_end   = obuf + olen;
+   a->z_expandable = exp;
+
+   return stbi__parse_zlib(a, parse_header);
+}
+
+STBIDEF char *stbi_zlib_decode_malloc_guesssize(const char *buffer, int len, int initial_size, int *outlen)
+{
+   stbi__zbuf a;
+   char *p = (char *) stbi__malloc(initial_size);
+   if (p == NULL) return NULL;
+   a.zbuffer = (stbi_uc *) buffer;
+   a.zbuffer_end = (stbi_uc *) buffer + len;
+   if (stbi__do_zlib(&a, p, initial_size, 1, 1)) {
+      if (outlen) *outlen = (int) (a.zout - a.zout_start);
+      return a.zout_start;
+   } else {
+      STBI_FREE(a.zout_start);
+      return NULL;
+   }
+}
+
+STBIDEF char *stbi_zlib_decode_malloc(char const *buffer, int len, int *outlen)
+{
+   return stbi_zlib_decode_malloc_guesssize(buffer, len, 16384, outlen);
+}
+
+STBIDEF char *stbi_zlib_decode_malloc_guesssize_headerflag(const char *buffer, int len, int initial_size, int *outlen, int parse_header)
+{
+   stbi__zbuf a;
+   char *p = (char *) stbi__malloc(initial_size);
+   if (p == NULL) return NULL;
+   a.zbuffer = (stbi_uc *) buffer;
+   a.zbuffer_end = (stbi_uc *) buffer + len;
+   if (stbi__do_zlib(&a, p, initial_size, 1, parse_header)) {
+      if (outlen) *outlen = (int) (a.zout - a.zout_start);
+      return a.zout_start;
+   } else {
+      STBI_FREE(a.zout_start);
+      return NULL;
+   }
+}
+
+STBIDEF int stbi_zlib_decode_buffer(char *obuffer, int olen, char const *ibuffer, int ilen)
+{
+   stbi__zbuf a;
+   a.zbuffer = (stbi_uc *) ibuffer;
+   a.zbuffer_end = (stbi_uc *) ibuffer + ilen;
+   if (stbi__do_zlib(&a, obuffer, olen, 0, 1))
+      return (int) (a.zout - a.zout_start);
+   else
+      return -1;
+}
+
+STBIDEF char *stbi_zlib_decode_noheader_malloc(char const *buffer, int len, int *outlen)
+{
+   stbi__zbuf a;
+   char *p = (char *) stbi__malloc(16384);
+   if (p == NULL) return NULL;
+   a.zbuffer = (stbi_uc *) buffer;
+   a.zbuffer_end = (stbi_uc *) buffer+len;
+   if (stbi__do_zlib(&a, p, 16384, 1, 0)) {
+      if (outlen) *outlen = (int) (a.zout - a.zout_start);
+      return a.zout_start;
+   } else {
+      STBI_FREE(a.zout_start);
+      return NULL;
+   }
+}
+
+STBIDEF int stbi_zlib_decode_noheader_buffer(char *obuffer, int olen, const char *ibuffer, int ilen)
+{
+   stbi__zbuf a;
+   a.zbuffer = (stbi_uc *) ibuffer;
+   a.zbuffer_end = (stbi_uc *) ibuffer + ilen;
+   if (stbi__do_zlib(&a, obuffer, olen, 0, 0))
+      return (int) (a.zout - a.zout_start);
+   else
+      return -1;
+}
+#endif
+
+// public domain "baseline" PNG decoder   v0.10  Sean Barrett 2006-11-18
+//    simple implementation
+//      - only 8-bit samples
+//      - no CRC checking
+//      - allocates lots of intermediate memory
+//        - avoids problem of streaming data between subsystems
+//        - avoids explicit window management
+//    performance
+//      - uses stb_zlib, a PD zlib implementation with fast huffman decoding
+
+#ifndef STBI_NO_PNG
+typedef struct
+{
+   stbi__uint32 length;
+   stbi__uint32 type;
+} stbi__pngchunk;
+
+static stbi__pngchunk stbi__get_chunk_header(stbi__context *s)
+{
+   stbi__pngchunk c;
+   c.length = stbi__get32be(s);
+   c.type   = stbi__get32be(s);
+   return c;
+}
+
+static int stbi__check_png_header(stbi__context *s)
+{
+   static const stbi_uc png_sig[8] = { 137,80,78,71,13,10,26,10 };
+   int i;
+   for (i=0; i < 8; ++i)
+      if (stbi__get8(s) != png_sig[i]) return stbi__err("bad png sig","Not a PNG");
+   return 1;
+}
+
+typedef struct
+{
+   stbi__context *s;
+   stbi_uc *idata, *expanded, *out;
+   int depth;
+} stbi__png;
+
+
+enum {
+   STBI__F_none=0,
+   STBI__F_sub=1,
+   STBI__F_up=2,
+   STBI__F_avg=3,
+   STBI__F_paeth=4,
+   // synthetic filter used for first scanline to avoid needing a dummy row of 0s
+   STBI__F_avg_first
+};
+
+static stbi_uc first_row_filter[5] =
+{
+   STBI__F_none,
+   STBI__F_sub,
+   STBI__F_none,
+   STBI__F_avg_first,
+   STBI__F_sub // Paeth with b=c=0 turns out to be equivalent to sub
+};
+
+static int stbi__paeth(int a, int b, int c)
+{
+   // This formulation looks very different from the reference in the PNG spec, but is
+   // actually equivalent and has favorable data dependencies and admits straightforward
+   // generation of branch-free code, which helps performance significantly.
+   int thresh = c*3 - (a + b);
+   int lo = a < b ? a : b;
+   int hi = a < b ? b : a;
+   int t0 = (hi <= thresh) ? lo : c;
+   int t1 = (thresh <= lo) ? hi : t0;
+   return t1;
+}
+
+static const stbi_uc stbi__depth_scale_table[9] = { 0, 0xff, 0x55, 0, 0x11, 0,0,0, 0x01 };
+
+// adds an extra all-255 alpha channel
+// dest == src is legal
+// img_n must be 1 or 3
+static void stbi__create_png_alpha_expand8(stbi_uc *dest, stbi_uc *src, stbi__uint32 x, int img_n)
+{
+   int i;
+   // must process data backwards since we allow dest==src
+   if (img_n == 1) {
+      for (i=x-1; i >= 0; --i) {
+         dest[i*2+1] = 255;
+         dest[i*2+0] = src[i];
+      }
+   } else {
+      STBI_ASSERT(img_n == 3);
+      for (i=x-1; i >= 0; --i) {
+         dest[i*4+3] = 255;
+         dest[i*4+2] = src[i*3+2];
+         dest[i*4+1] = src[i*3+1];
+         dest[i*4+0] = src[i*3+0];
+      }
+   }
+}
+
+// create the png data from post-deflated data
+static int stbi__create_png_image_raw(stbi__png *a, stbi_uc *raw, stbi__uint32 raw_len, int out_n, stbi__uint32 x, stbi__uint32 y, int depth, int color)
+{
+   int bytes = (depth == 16 ? 2 : 1);
+   stbi__context *s = a->s;
+   stbi__uint32 i,j,stride = x*out_n*bytes;
+   stbi__uint32 img_len, img_width_bytes;
+   stbi_uc *filter_buf;
+   int all_ok = 1;
+   int k;
+   int img_n = s->img_n; // copy it into a local for later
+
+   int output_bytes = out_n*bytes;
+   int filter_bytes = img_n*bytes;
+   int width = x;
+
+   STBI_ASSERT(out_n == s->img_n || out_n == s->img_n+1);
+   a->out = (stbi_uc *) stbi__malloc_mad3(x, y, output_bytes, 0); // extra bytes to write off the end into
+   if (!a->out) return stbi__err("outofmem", "Out of memory");
+
+   // note: error exits here don't need to clean up a->out individually,
+   // stbi__do_png always does on error.
+   if (!stbi__mad3sizes_valid(img_n, x, depth, 7)) return stbi__err("too large", "Corrupt PNG");
+   img_width_bytes = (((img_n * x * depth) + 7) >> 3);
+   if (!stbi__mad2sizes_valid(img_width_bytes, y, img_width_bytes)) return stbi__err("too large", "Corrupt PNG");
+   img_len = (img_width_bytes + 1) * y;
+
+   // we used to check for exact match between raw_len and img_len on non-interlaced PNGs,
+   // but issue #276 reported a PNG in the wild that had extra data at the end (all zeros),
+   // so just check for raw_len < img_len always.
+   if (raw_len < img_len) return stbi__err("not enough pixels","Corrupt PNG");
+
+   // Allocate two scan lines worth of filter workspace buffer.
+   filter_buf = (stbi_uc *) stbi__malloc_mad2(img_width_bytes, 2, 0);
+   if (!filter_buf) return stbi__err("outofmem", "Out of memory");
+
+   // Filtering for low-bit-depth images
+   if (depth < 8) {
+      filter_bytes = 1;
+      width = img_width_bytes;
+   }
+
+   for (j=0; j < y; ++j) {
+      // cur/prior filter buffers alternate
+      stbi_uc *cur = filter_buf + (j & 1)*img_width_bytes;
+      stbi_uc *prior = filter_buf + (~j & 1)*img_width_bytes;
+      stbi_uc *dest = a->out + stride*j;
+      int nk = width * filter_bytes;
+      int filter = *raw++;
+
+      // check filter type
+      if (filter > 4) {
+         all_ok = stbi__err("invalid filter","Corrupt PNG");
+         break;
+      }
+
+      // if first row, use special filter that doesn't sample previous row
+      if (j == 0) filter = first_row_filter[filter];
+
+      // perform actual filtering
+      switch (filter) {
+      case STBI__F_none:
+         memcpy(cur, raw, nk);
+         break;
+      case STBI__F_sub:
+         memcpy(cur, raw, filter_bytes);
+         for (k = filter_bytes; k < nk; ++k)
+            cur[k] = STBI__BYTECAST(raw[k] + cur[k-filter_bytes]);
+         break;
+      case STBI__F_up:
+         for (k = 0; k < nk; ++k)
+            cur[k] = STBI__BYTECAST(raw[k] + prior[k]);
+         break;
+      case STBI__F_avg:
+         for (k = 0; k < filter_bytes; ++k)
+            cur[k] = STBI__BYTECAST(raw[k] + (prior[k]>>1));
+         for (k = filter_bytes; k < nk; ++k)
+            cur[k] = STBI__BYTECAST(raw[k] + ((prior[k] + cur[k-filter_bytes])>>1));
+         break;
+      case STBI__F_paeth:
+         for (k = 0; k < filter_bytes; ++k)
+            cur[k] = STBI__BYTECAST(raw[k] + prior[k]); // prior[k] == stbi__paeth(0,prior[k],0)
+         for (k = filter_bytes; k < nk; ++k)
+            cur[k] = STBI__BYTECAST(raw[k] + stbi__paeth(cur[k-filter_bytes], prior[k], prior[k-filter_bytes]));
+         break;
+      case STBI__F_avg_first:
+         memcpy(cur, raw, filter_bytes);
+         for (k = filter_bytes; k < nk; ++k)
+            cur[k] = STBI__BYTECAST(raw[k] + (cur[k-filter_bytes] >> 1));
+         break;
+      }
+
+      raw += nk;
+
+      // expand decoded bits in cur to dest, also adding an extra alpha channel if desired
+      if (depth < 8) {
+         stbi_uc scale = (color == 0) ? stbi__depth_scale_table[depth] : 1; // scale grayscale values to 0..255 range
+         stbi_uc *in = cur;
+         stbi_uc *out = dest;
+         stbi_uc inb = 0;
+         stbi__uint32 nsmp = x*img_n;
+
+         // expand bits to bytes first
+         if (depth == 4) {
+            for (i=0; i < nsmp; ++i) {
+               if ((i & 1) == 0) inb = *in++;
+               *out++ = scale * (inb >> 4);
+               inb <<= 4;
+            }
+         } else if (depth == 2) {
+            for (i=0; i < nsmp; ++i) {
+               if ((i & 3) == 0) inb = *in++;
+               *out++ = scale * (inb >> 6);
+               inb <<= 2;
+            }
+         } else {
+            STBI_ASSERT(depth == 1);
+            for (i=0; i < nsmp; ++i) {
+               if ((i & 7) == 0) inb = *in++;
+               *out++ = scale * (inb >> 7);
+               inb <<= 1;
+            }
+         }
+
+         // insert alpha=255 values if desired
+         if (img_n != out_n)
+            stbi__create_png_alpha_expand8(dest, dest, x, img_n);
+      } else if (depth == 8) {
+         if (img_n == out_n)
+            memcpy(dest, cur, x*img_n);
+         else
+            stbi__create_png_alpha_expand8(dest, cur, x, img_n);
+      } else if (depth == 16) {
+         // convert the image data from big-endian to platform-native
+         stbi__uint16 *dest16 = (stbi__uint16*)dest;
+         stbi__uint32 nsmp = x*img_n;
+
+         if (img_n == out_n) {
+            for (i = 0; i < nsmp; ++i, ++dest16, cur += 2)
+               *dest16 = (cur[0] << 8) | cur[1];
+         } else {
+            STBI_ASSERT(img_n+1 == out_n);
+            if (img_n == 1) {
+               for (i = 0; i < x; ++i, dest16 += 2, cur += 2) {
+                  dest16[0] = (cur[0] << 8) | cur[1];
+                  dest16[1] = 0xffff;
+               }
+            } else {
+               STBI_ASSERT(img_n == 3);
+               for (i = 0; i < x; ++i, dest16 += 4, cur += 6) {
+                  dest16[0] = (cur[0] << 8) | cur[1];
+                  dest16[1] = (cur[2] << 8) | cur[3];
+                  dest16[2] = (cur[4] << 8) | cur[5];
+                  dest16[3] = 0xffff;
+               }
+            }
+         }
+      }
+   }
+
+   STBI_FREE(filter_buf);
+   if (!all_ok) return 0;
+
+   return 1;
+}
+
+static int stbi__create_png_image(stbi__png *a, stbi_uc *image_data, stbi__uint32 image_data_len, int out_n, int depth, int color, int interlaced)
+{
+   int bytes = (depth == 16 ? 2 : 1);
+   int out_bytes = out_n * bytes;
+   stbi_uc *final;
+   int p;
+   if (!interlaced)
+      return stbi__create_png_image_raw(a, image_data, image_data_len, out_n, a->s->img_x, a->s->img_y, depth, color);
+
+   // de-interlacing
+   final = (stbi_uc *) stbi__malloc_mad3(a->s->img_x, a->s->img_y, out_bytes, 0);
+   if (!final) return stbi__err("outofmem", "Out of memory");
+   for (p=0; p < 7; ++p) {
+      int xorig[] = { 0,4,0,2,0,1,0 };
+      int yorig[] = { 0,0,4,0,2,0,1 };
+      int xspc[]  = { 8,8,4,4,2,2,1 };
+      int yspc[]  = { 8,8,8,4,4,2,2 };
+      int i,j,x,y;
+      // pass1_x[4] = 0, pass1_x[5] = 1, pass1_x[12] = 1
+      x = (a->s->img_x - xorig[p] + xspc[p]-1) / xspc[p];
+      y = (a->s->img_y - yorig[p] + yspc[p]-1) / yspc[p];
+      if (x && y) {
+         stbi__uint32 img_len = ((((a->s->img_n * x * depth) + 7) >> 3) + 1) * y;
+         if (!stbi__create_png_image_raw(a, image_data, image_data_len, out_n, x, y, depth, color)) {
+            STBI_FREE(final);
+            return 0;
+         }
+         for (j=0; j < y; ++j) {
+            for (i=0; i < x; ++i) {
+               int out_y = j*yspc[p]+yorig[p];
+               int out_x = i*xspc[p]+xorig[p];
+               memcpy(final + out_y*a->s->img_x*out_bytes + out_x*out_bytes,
+                      a->out + (j*x+i)*out_bytes, out_bytes);
+            }
+         }
+         STBI_FREE(a->out);
+         image_data += img_len;
+         image_data_len -= img_len;
+      }
+   }
+   a->out = final;
+
+   return 1;
+}
+
+static int stbi__compute_transparency(stbi__png *z, stbi_uc tc[3], int out_n)
+{
+   stbi__context *s = z->s;
+   stbi__uint32 i, pixel_count = s->img_x * s->img_y;
+   stbi_uc *p = z->out;
+
+   // compute color-based transparency, assuming we've
+   // already got 255 as the alpha value in the output
+   STBI_ASSERT(out_n == 2 || out_n == 4);
+
+   if (out_n == 2) {
+      for (i=0; i < pixel_count; ++i) {
+         p[1] = (p[0] == tc[0] ? 0 : 255);
+         p += 2;
+      }
+   } else {
+      for (i=0; i < pixel_count; ++i) {
+         if (p[0] == tc[0] && p[1] == tc[1] && p[2] == tc[2])
+            p[3] = 0;
+         p += 4;
+      }
+   }
+   return 1;
+}
+
+static int stbi__compute_transparency16(stbi__png *z, stbi__uint16 tc[3], int out_n)
+{
+   stbi__context *s = z->s;
+   stbi__uint32 i, pixel_count = s->img_x * s->img_y;
+   stbi__uint16 *p = (stbi__uint16*) z->out;
+
+   // compute color-based transparency, assuming we've
+   // already got 65535 as the alpha value in the output
+   STBI_ASSERT(out_n == 2 || out_n == 4);
+
+   if (out_n == 2) {
+      for (i = 0; i < pixel_count; ++i) {
+         p[1] = (p[0] == tc[0] ? 0 : 65535);
+         p += 2;
+      }
+   } else {
+      for (i = 0; i < pixel_count; ++i) {
+         if (p[0] == tc[0] && p[1] == tc[1] && p[2] == tc[2])
+            p[3] = 0;
+         p += 4;
+      }
+   }
+   return 1;
+}
+
+static int stbi__expand_png_palette(stbi__png *a, stbi_uc *palette, int len, int pal_img_n)
+{
+   stbi__uint32 i, pixel_count = a->s->img_x * a->s->img_y;
+   stbi_uc *p, *temp_out, *orig = a->out;
+
+   p = (stbi_uc *) stbi__malloc_mad2(pixel_count, pal_img_n, 0);
+   if (p == NULL) return stbi__err("outofmem", "Out of memory");
+
+   // between here and free(out) below, exitting would leak
+   temp_out = p;
+
+   if (pal_img_n == 3) {
+      for (i=0; i < pixel_count; ++i) {
+         int n = orig[i]*4;
+         p[0] = palette[n  ];
+         p[1] = palette[n+1];
+         p[2] = palette[n+2];
+         p += 3;
+      }
+   } else {
+      for (i=0; i < pixel_count; ++i) {
+         int n = orig[i]*4;
+         p[0] = palette[n  ];
+         p[1] = palette[n+1];
+         p[2] = palette[n+2];
+         p[3] = palette[n+3];
+         p += 4;
+      }
+   }
+   STBI_FREE(a->out);
+   a->out = temp_out;
+
+   STBI_NOTUSED(len);
+
+   return 1;
+}
+
+static int stbi__unpremultiply_on_load_global = 0;
+static int stbi__de_iphone_flag_global = 0;
+
+STBIDEF void stbi_set_unpremultiply_on_load(int flag_true_if_should_unpremultiply)
+{
+   stbi__unpremultiply_on_load_global = flag_true_if_should_unpremultiply;
+}
+
+STBIDEF void stbi_convert_iphone_png_to_rgb(int flag_true_if_should_convert)
+{
+   stbi__de_iphone_flag_global = flag_true_if_should_convert;
+}
+
+#ifndef STBI_THREAD_LOCAL
+#define stbi__unpremultiply_on_load  stbi__unpremultiply_on_load_global
+#define stbi__de_iphone_flag  stbi__de_iphone_flag_global
+#else
+static STBI_THREAD_LOCAL int stbi__unpremultiply_on_load_local, stbi__unpremultiply_on_load_set;
+static STBI_THREAD_LOCAL int stbi__de_iphone_flag_local, stbi__de_iphone_flag_set;
+
+STBIDEF void stbi_set_unpremultiply_on_load_thread(int flag_true_if_should_unpremultiply)
+{
+   stbi__unpremultiply_on_load_local = flag_true_if_should_unpremultiply;
+   stbi__unpremultiply_on_load_set = 1;
+}
+
+STBIDEF void stbi_convert_iphone_png_to_rgb_thread(int flag_true_if_should_convert)
+{
+   stbi__de_iphone_flag_local = flag_true_if_should_convert;
+   stbi__de_iphone_flag_set = 1;
+}
+
+#define stbi__unpremultiply_on_load  (stbi__unpremultiply_on_load_set           \
+                                       ? stbi__unpremultiply_on_load_local      \
+                                       : stbi__unpremultiply_on_load_global)
+#define stbi__de_iphone_flag  (stbi__de_iphone_flag_set                         \
+                                ? stbi__de_iphone_flag_local                    \
+                                : stbi__de_iphone_flag_global)
+#endif // STBI_THREAD_LOCAL
+
+static void stbi__de_iphone(stbi__png *z)
+{
+   stbi__context *s = z->s;
+   stbi__uint32 i, pixel_count = s->img_x * s->img_y;
+   stbi_uc *p = z->out;
+
+   if (s->img_out_n == 3) {  // convert bgr to rgb
+      for (i=0; i < pixel_count; ++i) {
+         stbi_uc t = p[0];
+         p[0] = p[2];
+         p[2] = t;
+         p += 3;
+      }
+   } else {
+      STBI_ASSERT(s->img_out_n == 4);
+      if (stbi__unpremultiply_on_load) {
+         // convert bgr to rgb and unpremultiply
+         for (i=0; i < pixel_count; ++i) {
+            stbi_uc a = p[3];
+            stbi_uc t = p[0];
+            if (a) {
+               stbi_uc half = a / 2;
+               p[0] = (p[2] * 255 + half) / a;
+               p[1] = (p[1] * 255 + half) / a;
+               p[2] = ( t   * 255 + half) / a;
+            } else {
+               p[0] = p[2];
+               p[2] = t;
+            }
+            p += 4;
+         }
+      } else {
+         // convert bgr to rgb
+         for (i=0; i < pixel_count; ++i) {
+            stbi_uc t = p[0];
+            p[0] = p[2];
+            p[2] = t;
+            p += 4;
+         }
+      }
+   }
+}
+
+#define STBI__PNG_TYPE(a,b,c,d)  (((unsigned) (a) << 24) + ((unsigned) (b) << 16) + ((unsigned) (c) << 8) + (unsigned) (d))
+
+static int stbi__parse_png_file(stbi__png *z, int scan, int req_comp)
+{
+   stbi_uc palette[1024], pal_img_n=0;
+   stbi_uc has_trans=0, tc[3]={0};
+   stbi__uint16 tc16[3];
+   stbi__uint32 ioff=0, idata_limit=0, i, pal_len=0;
+   int first=1,k,interlace=0, color=0, is_iphone=0;
+   stbi__context *s = z->s;
+
+   z->expanded = NULL;
+   z->idata = NULL;
+   z->out = NULL;
+
+   if (!stbi__check_png_header(s)) return 0;
+
+   if (scan == STBI__SCAN_type) return 1;
+
+   for (;;) {
+      stbi__pngchunk c = stbi__get_chunk_header(s);
+      switch (c.type) {
+         case STBI__PNG_TYPE('C','g','B','I'):
+            is_iphone = 1;
+            stbi__skip(s, c.length);
+            break;
+         case STBI__PNG_TYPE('I','H','D','R'): {
+            int comp,filter;
+            if (!first) return stbi__err("multiple IHDR","Corrupt PNG");
+            first = 0;
+            if (c.length != 13) return stbi__err("bad IHDR len","Corrupt PNG");
+            s->img_x = stbi__get32be(s);
+            s->img_y = stbi__get32be(s);
+            if (s->img_y > STBI_MAX_DIMENSIONS) return stbi__err("too large","Very large image (corrupt?)");
+            if (s->img_x > STBI_MAX_DIMENSIONS) return stbi__err("too large","Very large image (corrupt?)");
+            z->depth = stbi__get8(s);  if (z->depth != 1 && z->depth != 2 && z->depth != 4 && z->depth != 8 && z->depth != 16)  return stbi__err("1/2/4/8/16-bit only","PNG not supported: 1/2/4/8/16-bit only");
+            color = stbi__get8(s);  if (color > 6)         return stbi__err("bad ctype","Corrupt PNG");
+            if (color == 3 && z->depth == 16)                  return stbi__err("bad ctype","Corrupt PNG");
+            if (color == 3) pal_img_n = 3; else if (color & 1) return stbi__err("bad ctype","Corrupt PNG");
+            comp  = stbi__get8(s);  if (comp) return stbi__err("bad comp method","Corrupt PNG");
+            filter= stbi__get8(s);  if (filter) return stbi__err("bad filter method","Corrupt PNG");
+            interlace = stbi__get8(s); if (interlace>1) return stbi__err("bad interlace method","Corrupt PNG");
+            if (!s->img_x || !s->img_y) return stbi__err("0-pixel image","Corrupt PNG");
+            if (!pal_img_n) {
+               s->img_n = (color & 2 ? 3 : 1) + (color & 4 ? 1 : 0);
+               if ((1 << 30) / s->img_x / s->img_n < s->img_y) return stbi__err("too large", "Image too large to decode");
+            } else {
+               // if paletted, then pal_n is our final components, and
+               // img_n is # components to decompress/filter.
+               s->img_n = 1;
+               if ((1 << 30) / s->img_x / 4 < s->img_y) return stbi__err("too large","Corrupt PNG");
+            }
+            // even with SCAN_header, have to scan to see if we have a tRNS
+            break;
+         }
+
+         case STBI__PNG_TYPE('P','L','T','E'):  {
+            if (first) return stbi__err("first not IHDR", "Corrupt PNG");
+            if (c.length > 256*3) return stbi__err("invalid PLTE","Corrupt PNG");
+            pal_len = c.length / 3;
+            if (pal_len * 3 != c.length) return stbi__err("invalid PLTE","Corrupt PNG");
+            for (i=0; i < pal_len; ++i) {
+               palette[i*4+0] = stbi__get8(s);
+               palette[i*4+1] = stbi__get8(s);
+               palette[i*4+2] = stbi__get8(s);
+               palette[i*4+3] = 255;
+            }
+            break;
+         }
+
+         case STBI__PNG_TYPE('t','R','N','S'): {
+            if (first) return stbi__err("first not IHDR", "Corrupt PNG");
+            if (z->idata) return stbi__err("tRNS after IDAT","Corrupt PNG");
+            if (pal_img_n) {
+               if (scan == STBI__SCAN_header) { s->img_n = 4; return 1; }
+               if (pal_len == 0) return stbi__err("tRNS before PLTE","Corrupt PNG");
+               if (c.length > pal_len) return stbi__err("bad tRNS len","Corrupt PNG");
+               pal_img_n = 4;
+               for (i=0; i < c.length; ++i)
+                  palette[i*4+3] = stbi__get8(s);
+            } else {
+               if (!(s->img_n & 1)) return stbi__err("tRNS with alpha","Corrupt PNG");
+               if (c.length != (stbi__uint32) s->img_n*2) return stbi__err("bad tRNS len","Corrupt PNG");
+               has_trans = 1;
+               // non-paletted with tRNS = constant alpha. if header-scanning, we can stop now.
+               if (scan == STBI__SCAN_header) { ++s->img_n; return 1; }
+               if (z->depth == 16) {
+                  for (k = 0; k < s->img_n && k < 3; ++k) // extra loop test to suppress false GCC warning
+                     tc16[k] = (stbi__uint16)stbi__get16be(s); // copy the values as-is
+               } else {
+                  for (k = 0; k < s->img_n && k < 3; ++k)
+                     tc[k] = (stbi_uc)(stbi__get16be(s) & 255) * stbi__depth_scale_table[z->depth]; // non 8-bit images will be larger
+               }
+            }
+            break;
+         }
+
+         case STBI__PNG_TYPE('I','D','A','T'): {
+            if (first) return stbi__err("first not IHDR", "Corrupt PNG");
+            if (pal_img_n && !pal_len) return stbi__err("no PLTE","Corrupt PNG");
+            if (scan == STBI__SCAN_header) {
+               // header scan definitely stops at first IDAT
+               if (pal_img_n)
+                  s->img_n = pal_img_n;
+               return 1;
+            }
+            if (c.length > (1u << 30)) return stbi__err("IDAT size limit", "IDAT section larger than 2^30 bytes");
+            if ((int)(ioff + c.length) < (int)ioff) return 0;
+            if (ioff + c.length > idata_limit) {
+               stbi__uint32 idata_limit_old = idata_limit;
+               stbi_uc *p;
+               if (idata_limit == 0) idata_limit = c.length > 4096 ? c.length : 4096;
+               while (ioff + c.length > idata_limit)
+                  idata_limit *= 2;
+               STBI_NOTUSED(idata_limit_old);
+               p = (stbi_uc *) STBI_REALLOC_SIZED(z->idata, idata_limit_old, idata_limit); if (p == NULL) return stbi__err("outofmem", "Out of memory");
+               z->idata = p;
+            }
+            if (!stbi__getn(s, z->idata+ioff,c.length)) return stbi__err("outofdata","Corrupt PNG");
+            ioff += c.length;
+            break;
+         }
+
+         case STBI__PNG_TYPE('I','E','N','D'): {
+            stbi__uint32 raw_len, bpl;
+            if (first) return stbi__err("first not IHDR", "Corrupt PNG");
+            if (scan != STBI__SCAN_load) return 1;
+            if (z->idata == NULL) return stbi__err("no IDAT","Corrupt PNG");
+            // initial guess for decoded data size to avoid unnecessary reallocs
+            bpl = (s->img_x * z->depth + 7) / 8; // bytes per line, per component
+            raw_len = bpl * s->img_y * s->img_n /* pixels */ + s->img_y /* filter mode per row */;
+            z->expanded = (stbi_uc *) stbi_zlib_decode_malloc_guesssize_headerflag((char *) z->idata, ioff, raw_len, (int *) &raw_len, !is_iphone);
+            if (z->expanded == NULL) return 0; // zlib should set error
+            STBI_FREE(z->idata); z->idata = NULL;
+            if ((req_comp == s->img_n+1 && req_comp != 3 && !pal_img_n) || has_trans)
+               s->img_out_n = s->img_n+1;
+            else
+               s->img_out_n = s->img_n;
+            if (!stbi__create_png_image(z, z->expanded, raw_len, s->img_out_n, z->depth, color, interlace)) return 0;
+            if (has_trans) {
+               if (z->depth == 16) {
+                  if (!stbi__compute_transparency16(z, tc16, s->img_out_n)) return 0;
+               } else {
+                  if (!stbi__compute_transparency(z, tc, s->img_out_n)) return 0;
+               }
+            }
+            if (is_iphone && stbi__de_iphone_flag && s->img_out_n > 2)
+               stbi__de_iphone(z);
+            if (pal_img_n) {
+               // pal_img_n == 3 or 4
+               s->img_n = pal_img_n; // record the actual colors we had
+               s->img_out_n = pal_img_n;
+               if (req_comp >= 3) s->img_out_n = req_comp;
+               if (!stbi__expand_png_palette(z, palette, pal_len, s->img_out_n))
+                  return 0;
+            } else if (has_trans) {
+               // non-paletted image with tRNS -> source image has (constant) alpha
+               ++s->img_n;
+            }
+            STBI_FREE(z->expanded); z->expanded = NULL;
+            // end of PNG chunk, read and skip CRC
+            stbi__get32be(s);
+            return 1;
+         }
+
+         default:
+            // if critical, fail
+            if (first) return stbi__err("first not IHDR", "Corrupt PNG");
+            if ((c.type & (1 << 29)) == 0) {
+               #ifndef STBI_NO_FAILURE_STRINGS
+               // not threadsafe
+               static char invalid_chunk[] = "XXXX PNG chunk not known";
+               invalid_chunk[0] = STBI__BYTECAST(c.type >> 24);
+               invalid_chunk[1] = STBI__BYTECAST(c.type >> 16);
+               invalid_chunk[2] = STBI__BYTECAST(c.type >>  8);
+               invalid_chunk[3] = STBI__BYTECAST(c.type >>  0);
+               #endif
+               return stbi__err(invalid_chunk, "PNG not supported: unknown PNG chunk type");
+            }
+            stbi__skip(s, c.length);
+            break;
+      }
+      // end of PNG chunk, read and skip CRC
+      stbi__get32be(s);
+   }
+}
+
+static void *stbi__do_png(stbi__png *p, int *x, int *y, int *n, int req_comp, stbi__result_info *ri)
+{
+   void *result=NULL;
+   if (req_comp < 0 || req_comp > 4) return stbi__errpuc("bad req_comp", "Internal error");
+   if (stbi__parse_png_file(p, STBI__SCAN_load, req_comp)) {
+      if (p->depth <= 8)
+         ri->bits_per_channel = 8;
+      else if (p->depth == 16)
+         ri->bits_per_channel = 16;
+      else
+         return stbi__errpuc("bad bits_per_channel", "PNG not supported: unsupported color depth");
+      result = p->out;
+      p->out = NULL;
+      if (req_comp && req_comp != p->s->img_out_n) {
+         if (ri->bits_per_channel == 8)
+            result = stbi__convert_format((unsigned char *) result, p->s->img_out_n, req_comp, p->s->img_x, p->s->img_y);
+         else
+            result = stbi__convert_format16((stbi__uint16 *) result, p->s->img_out_n, req_comp, p->s->img_x, p->s->img_y);
+         p->s->img_out_n = req_comp;
+         if (result == NULL) return result;
+      }
+      *x = p->s->img_x;
+      *y = p->s->img_y;
+      if (n) *n = p->s->img_n;
+   }
+   STBI_FREE(p->out);      p->out      = NULL;
+   STBI_FREE(p->expanded); p->expanded = NULL;
+   STBI_FREE(p->idata);    p->idata    = NULL;
+
+   return result;
+}
+
+static void *stbi__png_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri)
+{
+   stbi__png p;
+   p.s = s;
+   return stbi__do_png(&p, x,y,comp,req_comp, ri);
+}
+
+static int stbi__png_test(stbi__context *s)
+{
+   int r;
+   r = stbi__check_png_header(s);
+   stbi__rewind(s);
+   return r;
+}
+
+static int stbi__png_info_raw(stbi__png *p, int *x, int *y, int *comp)
+{
+   if (!stbi__parse_png_file(p, STBI__SCAN_header, 0)) {
+      stbi__rewind( p->s );
+      return 0;
+   }
+   if (x) *x = p->s->img_x;
+   if (y) *y = p->s->img_y;
+   if (comp) *comp = p->s->img_n;
+   return 1;
+}
+
+static int stbi__png_info(stbi__context *s, int *x, int *y, int *comp)
+{
+   stbi__png p;
+   p.s = s;
+   return stbi__png_info_raw(&p, x, y, comp);
+}
+
+static int stbi__png_is16(stbi__context *s)
+{
+   stbi__png p;
+   p.s = s;
+   if (!stbi__png_info_raw(&p, NULL, NULL, NULL))
+	   return 0;
+   if (p.depth != 16) {
+      stbi__rewind(p.s);
+      return 0;
+   }
+   return 1;
+}
+#endif
+
+// Microsoft/Windows BMP image
+
+#ifndef STBI_NO_BMP
+static int stbi__bmp_test_raw(stbi__context *s)
+{
+   int r;
+   int sz;
+   if (stbi__get8(s) != 'B') return 0;
+   if (stbi__get8(s) != 'M') return 0;
+   stbi__get32le(s); // discard filesize
+   stbi__get16le(s); // discard reserved
+   stbi__get16le(s); // discard reserved
+   stbi__get32le(s); // discard data offset
+   sz = stbi__get32le(s);
+   r = (sz == 12 || sz == 40 || sz == 56 || sz == 108 || sz == 124);
+   return r;
+}
+
+static int stbi__bmp_test(stbi__context *s)
+{
+   int r = stbi__bmp_test_raw(s);
+   stbi__rewind(s);
+   return r;
+}
+
+
+// returns 0..31 for the highest set bit
+static int stbi__high_bit(unsigned int z)
+{
+   int n=0;
+   if (z == 0) return -1;
+   if (z >= 0x10000) { n += 16; z >>= 16; }
+   if (z >= 0x00100) { n +=  8; z >>=  8; }
+   if (z >= 0x00010) { n +=  4; z >>=  4; }
+   if (z >= 0x00004) { n +=  2; z >>=  2; }
+   if (z >= 0x00002) { n +=  1;/* >>=  1;*/ }
+   return n;
+}
+
+static int stbi__bitcount(unsigned int a)
+{
+   a = (a & 0x55555555) + ((a >>  1) & 0x55555555); // max 2
+   a = (a & 0x33333333) + ((a >>  2) & 0x33333333); // max 4
+   a = (a + (a >> 4)) & 0x0f0f0f0f; // max 8 per 4, now 8 bits
+   a = (a + (a >> 8)); // max 16 per 8 bits
+   a = (a + (a >> 16)); // max 32 per 8 bits
+   return a & 0xff;
+}
+
+// extract an arbitrarily-aligned N-bit value (N=bits)
+// from v, and then make it 8-bits long and fractionally
+// extend it to full full range.
+static int stbi__shiftsigned(unsigned int v, int shift, int bits)
+{
+   static unsigned int mul_table[9] = {
+      0,
+      0xff/*0b11111111*/, 0x55/*0b01010101*/, 0x49/*0b01001001*/, 0x11/*0b00010001*/,
+      0x21/*0b00100001*/, 0x41/*0b01000001*/, 0x81/*0b10000001*/, 0x01/*0b00000001*/,
+   };
+   static unsigned int shift_table[9] = {
+      0, 0,0,1,0,2,4,6,0,
+   };
+   if (shift < 0)
+      v <<= -shift;
+   else
+      v >>= shift;
+   STBI_ASSERT(v < 256);
+   v >>= (8-bits);
+   STBI_ASSERT(bits >= 0 && bits <= 8);
+   return (int) ((unsigned) v * mul_table[bits]) >> shift_table[bits];
+}
+
+typedef struct
+{
+   int bpp, offset, hsz;
+   unsigned int mr,mg,mb,ma, all_a;
+   int extra_read;
+} stbi__bmp_data;
+
+static int stbi__bmp_set_mask_defaults(stbi__bmp_data *info, int compress)
+{
+   // BI_BITFIELDS specifies masks explicitly, don't override
+   if (compress == 3)
+      return 1;
+
+   if (compress == 0) {
+      if (info->bpp == 16) {
+         info->mr = 31u << 10;
+         info->mg = 31u <<  5;
+         info->mb = 31u <<  0;
+      } else if (info->bpp == 32) {
+         info->mr = 0xffu << 16;
+         info->mg = 0xffu <<  8;
+         info->mb = 0xffu <<  0;
+         info->ma = 0xffu << 24;
+         info->all_a = 0; // if all_a is 0 at end, then we loaded alpha channel but it was all 0
+      } else {
+         // otherwise, use defaults, which is all-0
+         info->mr = info->mg = info->mb = info->ma = 0;
+      }
+      return 1;
+   }
+   return 0; // error
+}
+
+static void *stbi__bmp_parse_header(stbi__context *s, stbi__bmp_data *info)
+{
+   int hsz;
+   if (stbi__get8(s) != 'B' || stbi__get8(s) != 'M') return stbi__errpuc("not BMP", "Corrupt BMP");
+   stbi__get32le(s); // discard filesize
+   stbi__get16le(s); // discard reserved
+   stbi__get16le(s); // discard reserved
+   info->offset = stbi__get32le(s);
+   info->hsz = hsz = stbi__get32le(s);
+   info->mr = info->mg = info->mb = info->ma = 0;
+   info->extra_read = 14;
+
+   if (info->offset < 0) return stbi__errpuc("bad BMP", "bad BMP");
+
+   if (hsz != 12 && hsz != 40 && hsz != 56 && hsz != 108 && hsz != 124) return stbi__errpuc("unknown BMP", "BMP type not supported: unknown");
+   if (hsz == 12) {
+      s->img_x = stbi__get16le(s);
+      s->img_y = stbi__get16le(s);
+   } else {
+      s->img_x = stbi__get32le(s);
+      s->img_y = stbi__get32le(s);
+   }
+   if (stbi__get16le(s) != 1) return stbi__errpuc("bad BMP", "bad BMP");
+   info->bpp = stbi__get16le(s);
+   if (hsz != 12) {
+      int compress = stbi__get32le(s);
+      if (compress == 1 || compress == 2) return stbi__errpuc("BMP RLE", "BMP type not supported: RLE");
+      if (compress >= 4) return stbi__errpuc("BMP JPEG/PNG", "BMP type not supported: unsupported compression"); // this includes PNG/JPEG modes
+      if (compress == 3 && info->bpp != 16 && info->bpp != 32) return stbi__errpuc("bad BMP", "bad BMP"); // bitfields requires 16 or 32 bits/pixel
+      stbi__get32le(s); // discard sizeof
+      stbi__get32le(s); // discard hres
+      stbi__get32le(s); // discard vres
+      stbi__get32le(s); // discard colorsused
+      stbi__get32le(s); // discard max important
+      if (hsz == 40 || hsz == 56) {
+         if (hsz == 56) {
+            stbi__get32le(s);
+            stbi__get32le(s);
+            stbi__get32le(s);
+            stbi__get32le(s);
+         }
+         if (info->bpp == 16 || info->bpp == 32) {
+            if (compress == 0) {
+               stbi__bmp_set_mask_defaults(info, compress);
+            } else if (compress == 3) {
+               info->mr = stbi__get32le(s);
+               info->mg = stbi__get32le(s);
+               info->mb = stbi__get32le(s);
+               info->extra_read += 12;
+               // not documented, but generated by photoshop and handled by mspaint
+               if (info->mr == info->mg && info->mg == info->mb) {
+                  // ?!?!?
+                  return stbi__errpuc("bad BMP", "bad BMP");
+               }
+            } else
+               return stbi__errpuc("bad BMP", "bad BMP");
+         }
+      } else {
+         // V4/V5 header
+         int i;
+         if (hsz != 108 && hsz != 124)
+            return stbi__errpuc("bad BMP", "bad BMP");
+         info->mr = stbi__get32le(s);
+         info->mg = stbi__get32le(s);
+         info->mb = stbi__get32le(s);
+         info->ma = stbi__get32le(s);
+         if (compress != 3) // override mr/mg/mb unless in BI_BITFIELDS mode, as per docs
+            stbi__bmp_set_mask_defaults(info, compress);
+         stbi__get32le(s); // discard color space
+         for (i=0; i < 12; ++i)
+            stbi__get32le(s); // discard color space parameters
+         if (hsz == 124) {
+            stbi__get32le(s); // discard rendering intent
+            stbi__get32le(s); // discard offset of profile data
+            stbi__get32le(s); // discard size of profile data
+            stbi__get32le(s); // discard reserved
+         }
+      }
+   }
+   return (void *) 1;
+}
+
+
+static void *stbi__bmp_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri)
+{
+   stbi_uc *out;
+   unsigned int mr=0,mg=0,mb=0,ma=0, all_a;
+   stbi_uc pal[256][4];
+   int psize=0,i,j,width;
+   int flip_vertically, pad, target;
+   stbi__bmp_data info;
+   STBI_NOTUSED(ri);
+
+   info.all_a = 255;
+   if (stbi__bmp_parse_header(s, &info) == NULL)
+      return NULL; // error code already set
+
+   flip_vertically = ((int) s->img_y) > 0;
+   s->img_y = abs((int) s->img_y);
+
+   if (s->img_y > STBI_MAX_DIMENSIONS) return stbi__errpuc("too large","Very large image (corrupt?)");
+   if (s->img_x > STBI_MAX_DIMENSIONS) return stbi__errpuc("too large","Very large image (corrupt?)");
+
+   mr = info.mr;
+   mg = info.mg;
+   mb = info.mb;
+   ma = info.ma;
+   all_a = info.all_a;
+
+   if (info.hsz == 12) {
+      if (info.bpp < 24)
+         psize = (info.offset - info.extra_read - 24) / 3;
+   } else {
+      if (info.bpp < 16)
+         psize = (info.offset - info.extra_read - info.hsz) >> 2;
+   }
+   if (psize == 0) {
+      // accept some number of extra bytes after the header, but if the offset points either to before
+      // the header ends or implies a large amount of extra data, reject the file as malformed
+      int bytes_read_so_far = s->callback_already_read + (int)(s->img_buffer - s->img_buffer_original);
+      int header_limit = 1024; // max we actually read is below 256 bytes currently.
+      int extra_data_limit = 256*4; // what ordinarily goes here is a palette; 256 entries*4 bytes is its max size.
+      if (bytes_read_so_far <= 0 || bytes_read_so_far > header_limit) {
+         return stbi__errpuc("bad header", "Corrupt BMP");
+      }
+      // we established that bytes_read_so_far is positive and sensible.
+      // the first half of this test rejects offsets that are either too small positives, or
+      // negative, and guarantees that info.offset >= bytes_read_so_far > 0. this in turn
+      // ensures the number computed in the second half of the test can't overflow.
+      if (info.offset < bytes_read_so_far || info.offset - bytes_read_so_far > extra_data_limit) {
+         return stbi__errpuc("bad offset", "Corrupt BMP");
+      } else {
+         stbi__skip(s, info.offset - bytes_read_so_far);
+      }
+   }
+
+   if (info.bpp == 24 && ma == 0xff000000)
+      s->img_n = 3;
+   else
+      s->img_n = ma ? 4 : 3;
+   if (req_comp && req_comp >= 3) // we can directly decode 3 or 4
+      target = req_comp;
+   else
+      target = s->img_n; // if they want monochrome, we'll post-convert
+
+   // sanity-check size
+   if (!stbi__mad3sizes_valid(target, s->img_x, s->img_y, 0))
+      return stbi__errpuc("too large", "Corrupt BMP");
+
+   out = (stbi_uc *) stbi__malloc_mad3(target, s->img_x, s->img_y, 0);
+   if (!out) return stbi__errpuc("outofmem", "Out of memory");
+   if (info.bpp < 16) {
+      int z=0;
+      if (psize == 0 || psize > 256) { STBI_FREE(out); return stbi__errpuc("invalid", "Corrupt BMP"); }
+      for (i=0; i < psize; ++i) {
+         pal[i][2] = stbi__get8(s);
+         pal[i][1] = stbi__get8(s);
+         pal[i][0] = stbi__get8(s);
+         if (info.hsz != 12) stbi__get8(s);
+         pal[i][3] = 255;
+      }
+      stbi__skip(s, info.offset - info.extra_read - info.hsz - psize * (info.hsz == 12 ? 3 : 4));
+      if (info.bpp == 1) width = (s->img_x + 7) >> 3;
+      else if (info.bpp == 4) width = (s->img_x + 1) >> 1;
+      else if (info.bpp == 8) width = s->img_x;
+      else { STBI_FREE(out); return stbi__errpuc("bad bpp", "Corrupt BMP"); }
+      pad = (-width)&3;
+      if (info.bpp == 1) {
+         for (j=0; j < (int) s->img_y; ++j) {
+            int bit_offset = 7, v = stbi__get8(s);
+            for (i=0; i < (int) s->img_x; ++i) {
+               int color = (v>>bit_offset)&0x1;
+               out[z++] = pal[color][0];
+               out[z++] = pal[color][1];
+               out[z++] = pal[color][2];
+               if (target == 4) out[z++] = 255;
+               if (i+1 == (int) s->img_x) break;
+               if((--bit_offset) < 0) {
+                  bit_offset = 7;
+                  v = stbi__get8(s);
+               }
+            }
+            stbi__skip(s, pad);
+         }
+      } else {
+         for (j=0; j < (int) s->img_y; ++j) {
+            for (i=0; i < (int) s->img_x; i += 2) {
+               int v=stbi__get8(s),v2=0;
+               if (info.bpp == 4) {
+                  v2 = v & 15;
+                  v >>= 4;
+               }
+               out[z++] = pal[v][0];
+               out[z++] = pal[v][1];
+               out[z++] = pal[v][2];
+               if (target == 4) out[z++] = 255;
+               if (i+1 == (int) s->img_x) break;
+               v = (info.bpp == 8) ? stbi__get8(s) : v2;
+               out[z++] = pal[v][0];
+               out[z++] = pal[v][1];
+               out[z++] = pal[v][2];
+               if (target == 4) out[z++] = 255;
+            }
+            stbi__skip(s, pad);
+         }
+      }
+   } else {
+      int rshift=0,gshift=0,bshift=0,ashift=0,rcount=0,gcount=0,bcount=0,acount=0;
+      int z = 0;
+      int easy=0;
+      stbi__skip(s, info.offset - info.extra_read - info.hsz);
+      if (info.bpp == 24) width = 3 * s->img_x;
+      else if (info.bpp == 16) width = 2*s->img_x;
+      else /* bpp = 32 and pad = 0 */ width=0;
+      pad = (-width) & 3;
+      if (info.bpp == 24) {
+         easy = 1;
+      } else if (info.bpp == 32) {
+         if (mb == 0xff && mg == 0xff00 && mr == 0x00ff0000 && ma == 0xff000000)
+            easy = 2;
+      }
+      if (!easy) {
+         if (!mr || !mg || !mb) { STBI_FREE(out); return stbi__errpuc("bad masks", "Corrupt BMP"); }
+         // right shift amt to put high bit in position #7
+         rshift = stbi__high_bit(mr)-7; rcount = stbi__bitcount(mr);
+         gshift = stbi__high_bit(mg)-7; gcount = stbi__bitcount(mg);
+         bshift = stbi__high_bit(mb)-7; bcount = stbi__bitcount(mb);
+         ashift = stbi__high_bit(ma)-7; acount = stbi__bitcount(ma);
+         if (rcount > 8 || gcount > 8 || bcount > 8 || acount > 8) { STBI_FREE(out); return stbi__errpuc("bad masks", "Corrupt BMP"); }
+      }
+      for (j=0; j < (int) s->img_y; ++j) {
+         if (easy) {
+            for (i=0; i < (int) s->img_x; ++i) {
+               unsigned char a;
+               out[z+2] = stbi__get8(s);
+               out[z+1] = stbi__get8(s);
+               out[z+0] = stbi__get8(s);
+               z += 3;
+               a = (easy == 2 ? stbi__get8(s) : 255);
+               all_a |= a;
+               if (target == 4) out[z++] = a;
+            }
+         } else {
+            int bpp = info.bpp;
+            for (i=0; i < (int) s->img_x; ++i) {
+               stbi__uint32 v = (bpp == 16 ? (stbi__uint32) stbi__get16le(s) : stbi__get32le(s));
+               unsigned int a;
+               out[z++] = STBI__BYTECAST(stbi__shiftsigned(v & mr, rshift, rcount));
+               out[z++] = STBI__BYTECAST(stbi__shiftsigned(v & mg, gshift, gcount));
+               out[z++] = STBI__BYTECAST(stbi__shiftsigned(v & mb, bshift, bcount));
+               a = (ma ? stbi__shiftsigned(v & ma, ashift, acount) : 255);
+               all_a |= a;
+               if (target == 4) out[z++] = STBI__BYTECAST(a);
+            }
+         }
+         stbi__skip(s, pad);
+      }
+   }
+
+   // if alpha channel is all 0s, replace with all 255s
+   if (target == 4 && all_a == 0)
+      for (i=4*s->img_x*s->img_y-1; i >= 0; i -= 4)
+         out[i] = 255;
+
+   if (flip_vertically) {
+      stbi_uc t;
+      for (j=0; j < (int) s->img_y>>1; ++j) {
+         stbi_uc *p1 = out +      j     *s->img_x*target;
+         stbi_uc *p2 = out + (s->img_y-1-j)*s->img_x*target;
+         for (i=0; i < (int) s->img_x*target; ++i) {
+            t = p1[i]; p1[i] = p2[i]; p2[i] = t;
+         }
+      }
+   }
+
+   if (req_comp && req_comp != target) {
+      out = stbi__convert_format(out, target, req_comp, s->img_x, s->img_y);
+      if (out == NULL) return out; // stbi__convert_format frees input on failure
+   }
+
+   *x = s->img_x;
+   *y = s->img_y;
+   if (comp) *comp = s->img_n;
+   return out;
+}
+#endif
+
+// Targa Truevision - TGA
+// by Jonathan Dummer
+#ifndef STBI_NO_TGA
+// returns STBI_rgb or whatever, 0 on error
+static int stbi__tga_get_comp(int bits_per_pixel, int is_grey, int* is_rgb16)
+{
+   // only RGB or RGBA (incl. 16bit) or grey allowed
+   if (is_rgb16) *is_rgb16 = 0;
+   switch(bits_per_pixel) {
+      case 8:  return STBI_grey;
+      case 16: if(is_grey) return STBI_grey_alpha;
+               // fallthrough
+      case 15: if(is_rgb16) *is_rgb16 = 1;
+               return STBI_rgb;
+      case 24: // fallthrough
+      case 32: return bits_per_pixel/8;
+      default: return 0;
+   }
+}
+
+static int stbi__tga_info(stbi__context *s, int *x, int *y, int *comp)
+{
+    int tga_w, tga_h, tga_comp, tga_image_type, tga_bits_per_pixel, tga_colormap_bpp;
+    int sz, tga_colormap_type;
+    stbi__get8(s);                   // discard Offset
+    tga_colormap_type = stbi__get8(s); // colormap type
+    if( tga_colormap_type > 1 ) {
+        stbi__rewind(s);
+        return 0;      // only RGB or indexed allowed
+    }
+    tga_image_type = stbi__get8(s); // image type
+    if ( tga_colormap_type == 1 ) { // colormapped (paletted) image
+        if (tga_image_type != 1 && tga_image_type != 9) {
+            stbi__rewind(s);
+            return 0;
+        }
+        stbi__skip(s,4);       // skip index of first colormap entry and number of entries
+        sz = stbi__get8(s);    //   check bits per palette color entry
+        if ( (sz != 8) && (sz != 15) && (sz != 16) && (sz != 24) && (sz != 32) ) {
+            stbi__rewind(s);
+            return 0;
+        }
+        stbi__skip(s,4);       // skip image x and y origin
+        tga_colormap_bpp = sz;
+    } else { // "normal" image w/o colormap - only RGB or grey allowed, +/- RLE
+        if ( (tga_image_type != 2) && (tga_image_type != 3) && (tga_image_type != 10) && (tga_image_type != 11) ) {
+            stbi__rewind(s);
+            return 0; // only RGB or grey allowed, +/- RLE
+        }
+        stbi__skip(s,9); // skip colormap specification and image x/y origin
+        tga_colormap_bpp = 0;
+    }
+    tga_w = stbi__get16le(s);
+    if( tga_w < 1 ) {
+        stbi__rewind(s);
+        return 0;   // test width
+    }
+    tga_h = stbi__get16le(s);
+    if( tga_h < 1 ) {
+        stbi__rewind(s);
+        return 0;   // test height
+    }
+    tga_bits_per_pixel = stbi__get8(s); // bits per pixel
+    stbi__get8(s); // ignore alpha bits
+    if (tga_colormap_bpp != 0) {
+        if((tga_bits_per_pixel != 8) && (tga_bits_per_pixel != 16)) {
+            // when using a colormap, tga_bits_per_pixel is the size of the indexes
+            // I don't think anything but 8 or 16bit indexes makes sense
+            stbi__rewind(s);
+            return 0;
+        }
+        tga_comp = stbi__tga_get_comp(tga_colormap_bpp, 0, NULL);
+    } else {
+        tga_comp = stbi__tga_get_comp(tga_bits_per_pixel, (tga_image_type == 3) || (tga_image_type == 11), NULL);
+    }
+    if(!tga_comp) {
+      stbi__rewind(s);
+      return 0;
+    }
+    if (x) *x = tga_w;
+    if (y) *y = tga_h;
+    if (comp) *comp = tga_comp;
+    return 1;                   // seems to have passed everything
+}
+
+static int stbi__tga_test(stbi__context *s)
+{
+   int res = 0;
+   int sz, tga_color_type;
+   stbi__get8(s);      //   discard Offset
+   tga_color_type = stbi__get8(s);   //   color type
+   if ( tga_color_type > 1 ) goto errorEnd;   //   only RGB or indexed allowed
+   sz = stbi__get8(s);   //   image type
+   if ( tga_color_type == 1 ) { // colormapped (paletted) image
+      if (sz != 1 && sz != 9) goto errorEnd; // colortype 1 demands image type 1 or 9
+      stbi__skip(s,4);       // skip index of first colormap entry and number of entries
+      sz = stbi__get8(s);    //   check bits per palette color entry
+      if ( (sz != 8) && (sz != 15) && (sz != 16) && (sz != 24) && (sz != 32) ) goto errorEnd;
+      stbi__skip(s,4);       // skip image x and y origin
+   } else { // "normal" image w/o colormap
+      if ( (sz != 2) && (sz != 3) && (sz != 10) && (sz != 11) ) goto errorEnd; // only RGB or grey allowed, +/- RLE
+      stbi__skip(s,9); // skip colormap specification and image x/y origin
+   }
+   if ( stbi__get16le(s) < 1 ) goto errorEnd;      //   test width
+   if ( stbi__get16le(s) < 1 ) goto errorEnd;      //   test height
+   sz = stbi__get8(s);   //   bits per pixel
+   if ( (tga_color_type == 1) && (sz != 8) && (sz != 16) ) goto errorEnd; // for colormapped images, bpp is size of an index
+   if ( (sz != 8) && (sz != 15) && (sz != 16) && (sz != 24) && (sz != 32) ) goto errorEnd;
+
+   res = 1; // if we got this far, everything's good and we can return 1 instead of 0
+
+errorEnd:
+   stbi__rewind(s);
+   return res;
+}
+
+// read 16bit value and convert to 24bit RGB
+static void stbi__tga_read_rgb16(stbi__context *s, stbi_uc* out)
+{
+   stbi__uint16 px = (stbi__uint16)stbi__get16le(s);
+   stbi__uint16 fiveBitMask = 31;
+   // we have 3 channels with 5bits each
+   int r = (px >> 10) & fiveBitMask;
+   int g = (px >> 5) & fiveBitMask;
+   int b = px & fiveBitMask;
+   // Note that this saves the data in RGB(A) order, so it doesn't need to be swapped later
+   out[0] = (stbi_uc)((r * 255)/31);
+   out[1] = (stbi_uc)((g * 255)/31);
+   out[2] = (stbi_uc)((b * 255)/31);
+
+   // some people claim that the most significant bit might be used for alpha
+   // (possibly if an alpha-bit is set in the "image descriptor byte")
+   // but that only made 16bit test images completely translucent..
+   // so let's treat all 15 and 16bit TGAs as RGB with no alpha.
+}
+
+static void *stbi__tga_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri)
+{
+   //   read in the TGA header stuff
+   int tga_offset = stbi__get8(s);
+   int tga_indexed = stbi__get8(s);
+   int tga_image_type = stbi__get8(s);
+   int tga_is_RLE = 0;
+   int tga_palette_start = stbi__get16le(s);
+   int tga_palette_len = stbi__get16le(s);
+   int tga_palette_bits = stbi__get8(s);
+   int tga_x_origin = stbi__get16le(s);
+   int tga_y_origin = stbi__get16le(s);
+   int tga_width = stbi__get16le(s);
+   int tga_height = stbi__get16le(s);
+   int tga_bits_per_pixel = stbi__get8(s);
+   int tga_comp, tga_rgb16=0;
+   int tga_inverted = stbi__get8(s);
+   // int tga_alpha_bits = tga_inverted & 15; // the 4 lowest bits - unused (useless?)
+   //   image data
+   unsigned char *tga_data;
+   unsigned char *tga_palette = NULL;
+   int i, j;
+   unsigned char raw_data[4] = {0};
+   int RLE_count = 0;
+   int RLE_repeating = 0;
+   int read_next_pixel = 1;
+   STBI_NOTUSED(ri);
+   STBI_NOTUSED(tga_x_origin); // @TODO
+   STBI_NOTUSED(tga_y_origin); // @TODO
+
+   if (tga_height > STBI_MAX_DIMENSIONS) return stbi__errpuc("too large","Very large image (corrupt?)");
+   if (tga_width > STBI_MAX_DIMENSIONS) return stbi__errpuc("too large","Very large image (corrupt?)");
+
+   //   do a tiny bit of precessing
+   if ( tga_image_type >= 8 )
+   {
+      tga_image_type -= 8;
+      tga_is_RLE = 1;
+   }
+   tga_inverted = 1 - ((tga_inverted >> 5) & 1);
+
+   //   If I'm paletted, then I'll use the number of bits from the palette
+   if ( tga_indexed ) tga_comp = stbi__tga_get_comp(tga_palette_bits, 0, &tga_rgb16);
+   else tga_comp = stbi__tga_get_comp(tga_bits_per_pixel, (tga_image_type == 3), &tga_rgb16);
+
+   if(!tga_comp) // shouldn't really happen, stbi__tga_test() should have ensured basic consistency
+      return stbi__errpuc("bad format", "Can't find out TGA pixelformat");
+
+   //   tga info
+   *x = tga_width;
+   *y = tga_height;
+   if (comp) *comp = tga_comp;
+
+   if (!stbi__mad3sizes_valid(tga_width, tga_height, tga_comp, 0))
+      return stbi__errpuc("too large", "Corrupt TGA");
+
+   tga_data = (unsigned char*)stbi__malloc_mad3(tga_width, tga_height, tga_comp, 0);
+   if (!tga_data) return stbi__errpuc("outofmem", "Out of memory");
+
+   // skip to the data's starting position (offset usually = 0)
+   stbi__skip(s, tga_offset );
+
+   if ( !tga_indexed && !tga_is_RLE && !tga_rgb16 ) {
+      for (i=0; i < tga_height; ++i) {
+         int row = tga_inverted ? tga_height -i - 1 : i;
+         stbi_uc *tga_row = tga_data + row*tga_width*tga_comp;
+         stbi__getn(s, tga_row, tga_width * tga_comp);
+      }
+   } else  {
+      //   do I need to load a palette?
+      if ( tga_indexed)
+      {
+         if (tga_palette_len == 0) {  /* you have to have at least one entry! */
+            STBI_FREE(tga_data);
+            return stbi__errpuc("bad palette", "Corrupt TGA");
+         }
+
+         //   any data to skip? (offset usually = 0)
+         stbi__skip(s, tga_palette_start );
+         //   load the palette
+         tga_palette = (unsigned char*)stbi__malloc_mad2(tga_palette_len, tga_comp, 0);
+         if (!tga_palette) {
+            STBI_FREE(tga_data);
+            return stbi__errpuc("outofmem", "Out of memory");
+         }
+         if (tga_rgb16) {
+            stbi_uc *pal_entry = tga_palette;
+            STBI_ASSERT(tga_comp == STBI_rgb);
+            for (i=0; i < tga_palette_len; ++i) {
+               stbi__tga_read_rgb16(s, pal_entry);
+               pal_entry += tga_comp;
+            }
+         } else if (!stbi__getn(s, tga_palette, tga_palette_len * tga_comp)) {
+               STBI_FREE(tga_data);
+               STBI_FREE(tga_palette);
+               return stbi__errpuc("bad palette", "Corrupt TGA");
+         }
+      }
+      //   load the data
+      for (i=0; i < tga_width * tga_height; ++i)
+      {
+         //   if I'm in RLE mode, do I need to get a RLE stbi__pngchunk?
+         if ( tga_is_RLE )
+         {
+            if ( RLE_count == 0 )
+            {
+               //   yep, get the next byte as a RLE command
+               int RLE_cmd = stbi__get8(s);
+               RLE_count = 1 + (RLE_cmd & 127);
+               RLE_repeating = RLE_cmd >> 7;
+               read_next_pixel = 1;
+            } else if ( !RLE_repeating )
+            {
+               read_next_pixel = 1;
+            }
+         } else
+         {
+            read_next_pixel = 1;
+         }
+         //   OK, if I need to read a pixel, do it now
+         if ( read_next_pixel )
+         {
+            //   load however much data we did have
+            if ( tga_indexed )
+            {
+               // read in index, then perform the lookup
+               int pal_idx = (tga_bits_per_pixel == 8) ? stbi__get8(s) : stbi__get16le(s);
+               if ( pal_idx >= tga_palette_len ) {
+                  // invalid index
+                  pal_idx = 0;
+               }
+               pal_idx *= tga_comp;
+               for (j = 0; j < tga_comp; ++j) {
+                  raw_data[j] = tga_palette[pal_idx+j];
+               }
+            } else if(tga_rgb16) {
+               STBI_ASSERT(tga_comp == STBI_rgb);
+               stbi__tga_read_rgb16(s, raw_data);
+            } else {
+               //   read in the data raw
+               for (j = 0; j < tga_comp; ++j) {
+                  raw_data[j] = stbi__get8(s);
+               }
+            }
+            //   clear the reading flag for the next pixel
+            read_next_pixel = 0;
+         } // end of reading a pixel
+
+         // copy data
+         for (j = 0; j < tga_comp; ++j)
+           tga_data[i*tga_comp+j] = raw_data[j];
+
+         //   in case we're in RLE mode, keep counting down
+         --RLE_count;
+      }
+      //   do I need to invert the image?
+      if ( tga_inverted )
+      {
+         for (j = 0; j*2 < tga_height; ++j)
+         {
+            int index1 = j * tga_width * tga_comp;
+            int index2 = (tga_height - 1 - j) * tga_width * tga_comp;
+            for (i = tga_width * tga_comp; i > 0; --i)
+            {
+               unsigned char temp = tga_data[index1];
+               tga_data[index1] = tga_data[index2];
+               tga_data[index2] = temp;
+               ++index1;
+               ++index2;
+            }
+         }
+      }
+      //   clear my palette, if I had one
+      if ( tga_palette != NULL )
+      {
+         STBI_FREE( tga_palette );
+      }
+   }
+
+   // swap RGB - if the source data was RGB16, it already is in the right order
+   if (tga_comp >= 3 && !tga_rgb16)
+   {
+      unsigned char* tga_pixel = tga_data;
+      for (i=0; i < tga_width * tga_height; ++i)
+      {
+         unsigned char temp = tga_pixel[0];
+         tga_pixel[0] = tga_pixel[2];
+         tga_pixel[2] = temp;
+         tga_pixel += tga_comp;
+      }
+   }
+
+   // convert to target component count
+   if (req_comp && req_comp != tga_comp)
+      tga_data = stbi__convert_format(tga_data, tga_comp, req_comp, tga_width, tga_height);
+
+   //   the things I do to get rid of an error message, and yet keep
+   //   Microsoft's C compilers happy... [8^(
+   tga_palette_start = tga_palette_len = tga_palette_bits =
+         tga_x_origin = tga_y_origin = 0;
+   STBI_NOTUSED(tga_palette_start);
+   //   OK, done
+   return tga_data;
+}
+#endif
+
+// *************************************************************************************************
+// Photoshop PSD loader -- PD by Thatcher Ulrich, integration by Nicolas Schulz, tweaked by STB
+
+#ifndef STBI_NO_PSD
+static int stbi__psd_test(stbi__context *s)
+{
+   int r = (stbi__get32be(s) == 0x38425053);
+   stbi__rewind(s);
+   return r;
+}
+
+static int stbi__psd_decode_rle(stbi__context *s, stbi_uc *p, int pixelCount)
+{
+   int count, nleft, len;
+
+   count = 0;
+   while ((nleft = pixelCount - count) > 0) {
+      len = stbi__get8(s);
+      if (len == 128) {
+         // No-op.
+      } else if (len < 128) {
+         // Copy next len+1 bytes literally.
+         len++;
+         if (len > nleft) return 0; // corrupt data
+         count += len;
+         while (len) {
+            *p = stbi__get8(s);
+            p += 4;
+            len--;
+         }
+      } else if (len > 128) {
+         stbi_uc   val;
+         // Next -len+1 bytes in the dest are replicated from next source byte.
+         // (Interpret len as a negative 8-bit int.)
+         len = 257 - len;
+         if (len > nleft) return 0; // corrupt data
+         val = stbi__get8(s);
+         count += len;
+         while (len) {
+            *p = val;
+            p += 4;
+            len--;
+         }
+      }
+   }
+
+   return 1;
+}
+
+static void *stbi__psd_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri, int bpc)
+{
+   int pixelCount;
+   int channelCount, compression;
+   int channel, i;
+   int bitdepth;
+   int w,h;
+   stbi_uc *out;
+   STBI_NOTUSED(ri);
+
+   // Check identifier
+   if (stbi__get32be(s) != 0x38425053)   // "8BPS"
+      return stbi__errpuc("not PSD", "Corrupt PSD image");
+
+   // Check file type version.
+   if (stbi__get16be(s) != 1)
+      return stbi__errpuc("wrong version", "Unsupported version of PSD image");
+
+   // Skip 6 reserved bytes.
+   stbi__skip(s, 6 );
+
+   // Read the number of channels (R, G, B, A, etc).
+   channelCount = stbi__get16be(s);
+   if (channelCount < 0 || channelCount > 16)
+      return stbi__errpuc("wrong channel count", "Unsupported number of channels in PSD image");
+
+   // Read the rows and columns of the image.
+   h = stbi__get32be(s);
+   w = stbi__get32be(s);
+
+   if (h > STBI_MAX_DIMENSIONS) return stbi__errpuc("too large","Very large image (corrupt?)");
+   if (w > STBI_MAX_DIMENSIONS) return stbi__errpuc("too large","Very large image (corrupt?)");
+
+   // Make sure the depth is 8 bits.
+   bitdepth = stbi__get16be(s);
+   if (bitdepth != 8 && bitdepth != 16)
+      return stbi__errpuc("unsupported bit depth", "PSD bit depth is not 8 or 16 bit");
+
+   // Make sure the color mode is RGB.
+   // Valid options are:
+   //   0: Bitmap
+   //   1: Grayscale
+   //   2: Indexed color
+   //   3: RGB color
+   //   4: CMYK color
+   //   7: Multichannel
+   //   8: Duotone
+   //   9: Lab color
+   if (stbi__get16be(s) != 3)
+      return stbi__errpuc("wrong color format", "PSD is not in RGB color format");
+
+   // Skip the Mode Data.  (It's the palette for indexed color; other info for other modes.)
+   stbi__skip(s,stbi__get32be(s) );
+
+   // Skip the image resources.  (resolution, pen tool paths, etc)
+   stbi__skip(s, stbi__get32be(s) );
+
+   // Skip the reserved data.
+   stbi__skip(s, stbi__get32be(s) );
+
+   // Find out if the data is compressed.
+   // Known values:
+   //   0: no compression
+   //   1: RLE compressed
+   compression = stbi__get16be(s);
+   if (compression > 1)
+      return stbi__errpuc("bad compression", "PSD has an unknown compression format");
+
+   // Check size
+   if (!stbi__mad3sizes_valid(4, w, h, 0))
+      return stbi__errpuc("too large", "Corrupt PSD");
+
+   // Create the destination image.
+
+   if (!compression && bitdepth == 16 && bpc == 16) {
+      out = (stbi_uc *) stbi__malloc_mad3(8, w, h, 0);
+      ri->bits_per_channel = 16;
+   } else
+      out = (stbi_uc *) stbi__malloc(4 * w*h);
+
+   if (!out) return stbi__errpuc("outofmem", "Out of memory");
+   pixelCount = w*h;
+
+   // Initialize the data to zero.
+   //memset( out, 0, pixelCount * 4 );
+
+   // Finally, the image data.
+   if (compression) {
+      // RLE as used by .PSD and .TIFF
+      // Loop until you get the number of unpacked bytes you are expecting:
+      //     Read the next source byte into n.
+      //     If n is between 0 and 127 inclusive, copy the next n+1 bytes literally.
+      //     Else if n is between -127 and -1 inclusive, copy the next byte -n+1 times.
+      //     Else if n is 128, noop.
+      // Endloop
+
+      // The RLE-compressed data is preceded by a 2-byte data count for each row in the data,
+      // which we're going to just skip.
+      stbi__skip(s, h * channelCount * 2 );
+
+      // Read the RLE data by channel.
+      for (channel = 0; channel < 4; channel++) {
+         stbi_uc *p;
+
+         p = out+channel;
+         if (channel >= channelCount) {
+            // Fill this channel with default data.
+            for (i = 0; i < pixelCount; i++, p += 4)
+               *p = (channel == 3 ? 255 : 0);
+         } else {
+            // Read the RLE data.
+            if (!stbi__psd_decode_rle(s, p, pixelCount)) {
+               STBI_FREE(out);
+               return stbi__errpuc("corrupt", "bad RLE data");
+            }
+         }
+      }
+
+   } else {
+      // We're at the raw image data.  It's each channel in order (Red, Green, Blue, Alpha, ...)
+      // where each channel consists of an 8-bit (or 16-bit) value for each pixel in the image.
+
+      // Read the data by channel.
+      for (channel = 0; channel < 4; channel++) {
+         if (channel >= channelCount) {
+            // Fill this channel with default data.
+            if (bitdepth == 16 && bpc == 16) {
+               stbi__uint16 *q = ((stbi__uint16 *) out) + channel;
+               stbi__uint16 val = channel == 3 ? 65535 : 0;
+               for (i = 0; i < pixelCount; i++, q += 4)
+                  *q = val;
+            } else {
+               stbi_uc *p = out+channel;
+               stbi_uc val = channel == 3 ? 255 : 0;
+               for (i = 0; i < pixelCount; i++, p += 4)
+                  *p = val;
+            }
+         } else {
+            if (ri->bits_per_channel == 16) {    // output bpc
+               stbi__uint16 *q = ((stbi__uint16 *) out) + channel;
+               for (i = 0; i < pixelCount; i++, q += 4)
+                  *q = (stbi__uint16) stbi__get16be(s);
+            } else {
+               stbi_uc *p = out+channel;
+               if (bitdepth == 16) {  // input bpc
+                  for (i = 0; i < pixelCount; i++, p += 4)
+                     *p = (stbi_uc) (stbi__get16be(s) >> 8);
+               } else {
+                  for (i = 0; i < pixelCount; i++, p += 4)
+                     *p = stbi__get8(s);
+               }
+            }
+         }
+      }
+   }
+
+   // remove weird white matte from PSD
+   if (channelCount >= 4) {
+      if (ri->bits_per_channel == 16) {
+         for (i=0; i < w*h; ++i) {
+            stbi__uint16 *pixel = (stbi__uint16 *) out + 4*i;
+            if (pixel[3] != 0 && pixel[3] != 65535) {
+               float a = pixel[3] / 65535.0f;
+               float ra = 1.0f / a;
+               float inv_a = 65535.0f * (1 - ra);
+               pixel[0] = (stbi__uint16) (pixel[0]*ra + inv_a);
+               pixel[1] = (stbi__uint16) (pixel[1]*ra + inv_a);
+               pixel[2] = (stbi__uint16) (pixel[2]*ra + inv_a);
+            }
+         }
+      } else {
+         for (i=0; i < w*h; ++i) {
+            unsigned char *pixel = out + 4*i;
+            if (pixel[3] != 0 && pixel[3] != 255) {
+               float a = pixel[3] / 255.0f;
+               float ra = 1.0f / a;
+               float inv_a = 255.0f * (1 - ra);
+               pixel[0] = (unsigned char) (pixel[0]*ra + inv_a);
+               pixel[1] = (unsigned char) (pixel[1]*ra + inv_a);
+               pixel[2] = (unsigned char) (pixel[2]*ra + inv_a);
+            }
+         }
+      }
+   }
+
+   // convert to desired output format
+   if (req_comp && req_comp != 4) {
+      if (ri->bits_per_channel == 16)
+         out = (stbi_uc *) stbi__convert_format16((stbi__uint16 *) out, 4, req_comp, w, h);
+      else
+         out = stbi__convert_format(out, 4, req_comp, w, h);
+      if (out == NULL) return out; // stbi__convert_format frees input on failure
+   }
+
+   if (comp) *comp = 4;
+   *y = h;
+   *x = w;
+
+   return out;
+}
+#endif
+
+// *************************************************************************************************
+// Softimage PIC loader
+// by Tom Seddon
+//
+// See http://softimage.wiki.softimage.com/index.php/INFO:_PIC_file_format
+// See http://ozviz.wasp.uwa.edu.au/~pbourke/dataformats/softimagepic/
+
+#ifndef STBI_NO_PIC
+static int stbi__pic_is4(stbi__context *s,const char *str)
+{
+   int i;
+   for (i=0; i<4; ++i)
+      if (stbi__get8(s) != (stbi_uc)str[i])
+         return 0;
+
+   return 1;
+}
+
+static int stbi__pic_test_core(stbi__context *s)
+{
+   int i;
+
+   if (!stbi__pic_is4(s,"\x53\x80\xF6\x34"))
+      return 0;
+
+   for(i=0;i<84;++i)
+      stbi__get8(s);
+
+   if (!stbi__pic_is4(s,"PICT"))
+      return 0;
+
+   return 1;
+}
+
+typedef struct
+{
+   stbi_uc size,type,channel;
+} stbi__pic_packet;
+
+static stbi_uc *stbi__readval(stbi__context *s, int channel, stbi_uc *dest)
+{
+   int mask=0x80, i;
+
+   for (i=0; i<4; ++i, mask>>=1) {
+      if (channel & mask) {
+         if (stbi__at_eof(s)) return stbi__errpuc("bad file","PIC file too short");
+         dest[i]=stbi__get8(s);
+      }
+   }
+
+   return dest;
+}
+
+static void stbi__copyval(int channel,stbi_uc *dest,const stbi_uc *src)
+{
+   int mask=0x80,i;
+
+   for (i=0;i<4; ++i, mask>>=1)
+      if (channel&mask)
+         dest[i]=src[i];
+}
+
+static stbi_uc *stbi__pic_load_core(stbi__context *s,int width,int height,int *comp, stbi_uc *result)
+{
+   int act_comp=0,num_packets=0,y,chained;
+   stbi__pic_packet packets[10];
+
+   // this will (should...) cater for even some bizarre stuff like having data
+    // for the same channel in multiple packets.
+   do {
+      stbi__pic_packet *packet;
+
+      if (num_packets==sizeof(packets)/sizeof(packets[0]))
+         return stbi__errpuc("bad format","too many packets");
+
+      packet = &packets[num_packets++];
+
+      chained = stbi__get8(s);
+      packet->size    = stbi__get8(s);
+      packet->type    = stbi__get8(s);
+      packet->channel = stbi__get8(s);
+
+      act_comp |= packet->channel;
+
+      if (stbi__at_eof(s))          return stbi__errpuc("bad file","file too short (reading packets)");
+      if (packet->size != 8)  return stbi__errpuc("bad format","packet isn't 8bpp");
+   } while (chained);
+
+   *comp = (act_comp & 0x10 ? 4 : 3); // has alpha channel?
+
+   for(y=0; y<height; ++y) {
+      int packet_idx;
+
+      for(packet_idx=0; packet_idx < num_packets; ++packet_idx) {
+         stbi__pic_packet *packet = &packets[packet_idx];
+         stbi_uc *dest = result+y*width*4;
+
+         switch (packet->type) {
+            default:
+               return stbi__errpuc("bad format","packet has bad compression type");
+
+            case 0: {//uncompressed
+               int x;
+
+               for(x=0;x<width;++x, dest+=4)
+                  if (!stbi__readval(s,packet->channel,dest))
+                     return 0;
+               break;
+            }
+
+            case 1://Pure RLE
+               {
+                  int left=width, i;
+
+                  while (left>0) {
+                     stbi_uc count,value[4];
+
+                     count=stbi__get8(s);
+                     if (stbi__at_eof(s))   return stbi__errpuc("bad file","file too short (pure read count)");
+
+                     if (count > left)
+                        count = (stbi_uc) left;
+
+                     if (!stbi__readval(s,packet->channel,value))  return 0;
+
+                     for(i=0; i<count; ++i,dest+=4)
+                        stbi__copyval(packet->channel,dest,value);
+                     left -= count;
+                  }
+               }
+               break;
+
+            case 2: {//Mixed RLE
+               int left=width;
+               while (left>0) {
+                  int count = stbi__get8(s), i;
+                  if (stbi__at_eof(s))  return stbi__errpuc("bad file","file too short (mixed read count)");
+
+                  if (count >= 128) { // Repeated
+                     stbi_uc value[4];
+
+                     if (count==128)
+                        count = stbi__get16be(s);
+                     else
+                        count -= 127;
+                     if (count > left)
+                        return stbi__errpuc("bad file","scanline overrun");
+
+                     if (!stbi__readval(s,packet->channel,value))
+                        return 0;
+
+                     for(i=0;i<count;++i, dest += 4)
+                        stbi__copyval(packet->channel,dest,value);
+                  } else { // Raw
+                     ++count;
+                     if (count>left) return stbi__errpuc("bad file","scanline overrun");
+
+                     for(i=0;i<count;++i, dest+=4)
+                        if (!stbi__readval(s,packet->channel,dest))
+                           return 0;
+                  }
+                  left-=count;
+               }
+               break;
+            }
+         }
+      }
+   }
+
+   return result;
+}
+
+static void *stbi__pic_load(stbi__context *s,int *px,int *py,int *comp,int req_comp, stbi__result_info *ri)
+{
+   stbi_uc *result;
+   int i, x,y, internal_comp;
+   STBI_NOTUSED(ri);
+
+   if (!comp) comp = &internal_comp;
+
+   for (i=0; i<92; ++i)
+      stbi__get8(s);
+
+   x = stbi__get16be(s);
+   y = stbi__get16be(s);
+
+   if (y > STBI_MAX_DIMENSIONS) return stbi__errpuc("too large","Very large image (corrupt?)");
+   if (x > STBI_MAX_DIMENSIONS) return stbi__errpuc("too large","Very large image (corrupt?)");
+
+   if (stbi__at_eof(s))  return stbi__errpuc("bad file","file too short (pic header)");
+   if (!stbi__mad3sizes_valid(x, y, 4, 0)) return stbi__errpuc("too large", "PIC image too large to decode");
+
+   stbi__get32be(s); //skip `ratio'
+   stbi__get16be(s); //skip `fields'
+   stbi__get16be(s); //skip `pad'
+
+   // intermediate buffer is RGBA
+   result = (stbi_uc *) stbi__malloc_mad3(x, y, 4, 0);
+   if (!result) return stbi__errpuc("outofmem", "Out of memory");
+   memset(result, 0xff, x*y*4);
+
+   if (!stbi__pic_load_core(s,x,y,comp, result)) {
+      STBI_FREE(result);
+      result=0;
+   }
+   *px = x;
+   *py = y;
+   if (req_comp == 0) req_comp = *comp;
+   result=stbi__convert_format(result,4,req_comp,x,y);
+
+   return result;
+}
+
+static int stbi__pic_test(stbi__context *s)
+{
+   int r = stbi__pic_test_core(s);
+   stbi__rewind(s);
+   return r;
+}
+#endif
+
+// *************************************************************************************************
+// GIF loader -- public domain by Jean-Marc Lienher -- simplified/shrunk by stb
+
+#ifndef STBI_NO_GIF
+typedef struct
+{
+   stbi__int16 prefix;
+   stbi_uc first;
+   stbi_uc suffix;
+} stbi__gif_lzw;
+
+typedef struct
+{
+   int w,h;
+   stbi_uc *out;                 // output buffer (always 4 components)
+   stbi_uc *background;          // The current "background" as far as a gif is concerned
+   stbi_uc *history;
+   int flags, bgindex, ratio, transparent, eflags;
+   stbi_uc  pal[256][4];
+   stbi_uc lpal[256][4];
+   stbi__gif_lzw codes[8192];
+   stbi_uc *color_table;
+   int parse, step;
+   int lflags;
+   int start_x, start_y;
+   int max_x, max_y;
+   int cur_x, cur_y;
+   int line_size;
+   int delay;
+} stbi__gif;
+
+static int stbi__gif_test_raw(stbi__context *s)
+{
+   int sz;
+   if (stbi__get8(s) != 'G' || stbi__get8(s) != 'I' || stbi__get8(s) != 'F' || stbi__get8(s) != '8') return 0;
+   sz = stbi__get8(s);
+   if (sz != '9' && sz != '7') return 0;
+   if (stbi__get8(s) != 'a') return 0;
+   return 1;
+}
+
+static int stbi__gif_test(stbi__context *s)
+{
+   int r = stbi__gif_test_raw(s);
+   stbi__rewind(s);
+   return r;
+}
+
+static void stbi__gif_parse_colortable(stbi__context *s, stbi_uc pal[256][4], int num_entries, int transp)
+{
+   int i;
+   for (i=0; i < num_entries; ++i) {
+      pal[i][2] = stbi__get8(s);
+      pal[i][1] = stbi__get8(s);
+      pal[i][0] = stbi__get8(s);
+      pal[i][3] = transp == i ? 0 : 255;
+   }
+}
+
+static int stbi__gif_header(stbi__context *s, stbi__gif *g, int *comp, int is_info)
+{
+   stbi_uc version;
+   if (stbi__get8(s) != 'G' || stbi__get8(s) != 'I' || stbi__get8(s) != 'F' || stbi__get8(s) != '8')
+      return stbi__err("not GIF", "Corrupt GIF");
+
+   version = stbi__get8(s);
+   if (version != '7' && version != '9')    return stbi__err("not GIF", "Corrupt GIF");
+   if (stbi__get8(s) != 'a')                return stbi__err("not GIF", "Corrupt GIF");
+
+   stbi__g_failure_reason = "";
+   g->w = stbi__get16le(s);
+   g->h = stbi__get16le(s);
+   g->flags = stbi__get8(s);
+   g->bgindex = stbi__get8(s);
+   g->ratio = stbi__get8(s);
+   g->transparent = -1;
+
+   if (g->w > STBI_MAX_DIMENSIONS) return stbi__err("too large","Very large image (corrupt?)");
+   if (g->h > STBI_MAX_DIMENSIONS) return stbi__err("too large","Very large image (corrupt?)");
+
+   if (comp != 0) *comp = 4;  // can't actually tell whether it's 3 or 4 until we parse the comments
+
+   if (is_info) return 1;
+
+   if (g->flags & 0x80)
+      stbi__gif_parse_colortable(s,g->pal, 2 << (g->flags & 7), -1);
+
+   return 1;
+}
+
+static int stbi__gif_info_raw(stbi__context *s, int *x, int *y, int *comp)
+{
+   stbi__gif* g = (stbi__gif*) stbi__malloc(sizeof(stbi__gif));
+   if (!g) return stbi__err("outofmem", "Out of memory");
+   if (!stbi__gif_header(s, g, comp, 1)) {
+      STBI_FREE(g);
+      stbi__rewind( s );
+      return 0;
+   }
+   if (x) *x = g->w;
+   if (y) *y = g->h;
+   STBI_FREE(g);
+   return 1;
+}
+
+static void stbi__out_gif_code(stbi__gif *g, stbi__uint16 code)
+{
+   stbi_uc *p, *c;
+   int idx;
+
+   // recurse to decode the prefixes, since the linked-list is backwards,
+   // and working backwards through an interleaved image would be nasty
+   if (g->codes[code].prefix >= 0)
+      stbi__out_gif_code(g, g->codes[code].prefix);
+
+   if (g->cur_y >= g->max_y) return;
+
+   idx = g->cur_x + g->cur_y;
+   p = &g->out[idx];
+   g->history[idx / 4] = 1;
+
+   c = &g->color_table[g->codes[code].suffix * 4];
+   if (c[3] > 128) { // don't render transparent pixels;
+      p[0] = c[2];
+      p[1] = c[1];
+      p[2] = c[0];
+      p[3] = c[3];
+   }
+   g->cur_x += 4;
+
+   if (g->cur_x >= g->max_x) {
+      g->cur_x = g->start_x;
+      g->cur_y += g->step;
+
+      while (g->cur_y >= g->max_y && g->parse > 0) {
+         g->step = (1 << g->parse) * g->line_size;
+         g->cur_y = g->start_y + (g->step >> 1);
+         --g->parse;
+      }
+   }
+}
+
+static stbi_uc *stbi__process_gif_raster(stbi__context *s, stbi__gif *g)
+{
+   stbi_uc lzw_cs;
+   stbi__int32 len, init_code;
+   stbi__uint32 first;
+   stbi__int32 codesize, codemask, avail, oldcode, bits, valid_bits, clear;
+   stbi__gif_lzw *p;
+
+   lzw_cs = stbi__get8(s);
+   if (lzw_cs > 12) return NULL;
+   clear = 1 << lzw_cs;
+   first = 1;
+   codesize = lzw_cs + 1;
+   codemask = (1 << codesize) - 1;
+   bits = 0;
+   valid_bits = 0;
+   for (init_code = 0; init_code < clear; init_code++) {
+      g->codes[init_code].prefix = -1;
+      g->codes[init_code].first = (stbi_uc) init_code;
+      g->codes[init_code].suffix = (stbi_uc) init_code;
+   }
+
+   // support no starting clear code
+   avail = clear+2;
+   oldcode = -1;
+
+   len = 0;
+   for(;;) {
+      if (valid_bits < codesize) {
+         if (len == 0) {
+            len = stbi__get8(s); // start new block
+            if (len == 0)
+               return g->out;
+         }
+         --len;
+         bits |= (stbi__int32) stbi__get8(s) << valid_bits;
+         valid_bits += 8;
+      } else {
+         stbi__int32 code = bits & codemask;
+         bits >>= codesize;
+         valid_bits -= codesize;
+         // @OPTIMIZE: is there some way we can accelerate the non-clear path?
+         if (code == clear) {  // clear code
+            codesize = lzw_cs + 1;
+            codemask = (1 << codesize) - 1;
+            avail = clear + 2;
+            oldcode = -1;
+            first = 0;
+         } else if (code == clear + 1) { // end of stream code
+            stbi__skip(s, len);
+            while ((len = stbi__get8(s)) > 0)
+               stbi__skip(s,len);
+            return g->out;
+         } else if (code <= avail) {
+            if (first) {
+               return stbi__errpuc("no clear code", "Corrupt GIF");
+            }
+
+            if (oldcode >= 0) {
+               p = &g->codes[avail++];
+               if (avail > 8192) {
+                  return stbi__errpuc("too many codes", "Corrupt GIF");
+               }
+
+               p->prefix = (stbi__int16) oldcode;
+               p->first = g->codes[oldcode].first;
+               p->suffix = (code == avail) ? p->first : g->codes[code].first;
+            } else if (code == avail)
+               return stbi__errpuc("illegal code in raster", "Corrupt GIF");
+
+            stbi__out_gif_code(g, (stbi__uint16) code);
+
+            if ((avail & codemask) == 0 && avail <= 0x0FFF) {
+               codesize++;
+               codemask = (1 << codesize) - 1;
+            }
+
+            oldcode = code;
+         } else {
+            return stbi__errpuc("illegal code in raster", "Corrupt GIF");
+         }
+      }
+   }
+}
+
+// this function is designed to support animated gifs, although stb_image doesn't support it
+// two back is the image from two frames ago, used for a very specific disposal format
+static stbi_uc *stbi__gif_load_next(stbi__context *s, stbi__gif *g, int *comp, int req_comp, stbi_uc *two_back)
+{
+   int dispose;
+   int first_frame;
+   int pi;
+   int pcount;
+   STBI_NOTUSED(req_comp);
+
+   // on first frame, any non-written pixels get the background colour (non-transparent)
+   first_frame = 0;
+   if (g->out == 0) {
+      if (!stbi__gif_header(s, g, comp,0)) return 0; // stbi__g_failure_reason set by stbi__gif_header
+      if (!stbi__mad3sizes_valid(4, g->w, g->h, 0))
+         return stbi__errpuc("too large", "GIF image is too large");
+      pcount = g->w * g->h;
+      g->out = (stbi_uc *) stbi__malloc(4 * pcount);
+      g->background = (stbi_uc *) stbi__malloc(4 * pcount);
+      g->history = (stbi_uc *) stbi__malloc(pcount);
+      if (!g->out || !g->background || !g->history)
+         return stbi__errpuc("outofmem", "Out of memory");
+
+      // image is treated as "transparent" at the start - ie, nothing overwrites the current background;
+      // background colour is only used for pixels that are not rendered first frame, after that "background"
+      // color refers to the color that was there the previous frame.
+      memset(g->out, 0x00, 4 * pcount);
+      memset(g->background, 0x00, 4 * pcount); // state of the background (starts transparent)
+      memset(g->history, 0x00, pcount);        // pixels that were affected previous frame
+      first_frame = 1;
+   } else {
+      // second frame - how do we dispose of the previous one?
+      dispose = (g->eflags & 0x1C) >> 2;
+      pcount = g->w * g->h;
+
+      if ((dispose == 3) && (two_back == 0)) {
+         dispose = 2; // if I don't have an image to revert back to, default to the old background
+      }
+
+      if (dispose == 3) { // use previous graphic
+         for (pi = 0; pi < pcount; ++pi) {
+            if (g->history[pi]) {
+               memcpy( &g->out[pi * 4], &two_back[pi * 4], 4 );
+            }
+         }
+      } else if (dispose == 2) {
+         // restore what was changed last frame to background before that frame;
+         for (pi = 0; pi < pcount; ++pi) {
+            if (g->history[pi]) {
+               memcpy( &g->out[pi * 4], &g->background[pi * 4], 4 );
+            }
+         }
+      } else {
+         // This is a non-disposal case eithe way, so just
+         // leave the pixels as is, and they will become the new background
+         // 1: do not dispose
+         // 0:  not specified.
+      }
+
+      // background is what out is after the undoing of the previou frame;
+      memcpy( g->background, g->out, 4 * g->w * g->h );
+   }
+
+   // clear my history;
+   memset( g->history, 0x00, g->w * g->h );        // pixels that were affected previous frame
+
+   for (;;) {
+      int tag = stbi__get8(s);
+      switch (tag) {
+         case 0x2C: /* Image Descriptor */
+         {
+            stbi__int32 x, y, w, h;
+            stbi_uc *o;
+
+            x = stbi__get16le(s);
+            y = stbi__get16le(s);
+            w = stbi__get16le(s);
+            h = stbi__get16le(s);
+            if (((x + w) > (g->w)) || ((y + h) > (g->h)))
+               return stbi__errpuc("bad Image Descriptor", "Corrupt GIF");
+
+            g->line_size = g->w * 4;
+            g->start_x = x * 4;
+            g->start_y = y * g->line_size;
+            g->max_x   = g->start_x + w * 4;
+            g->max_y   = g->start_y + h * g->line_size;
+            g->cur_x   = g->start_x;
+            g->cur_y   = g->start_y;
+
+            // if the width of the specified rectangle is 0, that means
+            // we may not see *any* pixels or the image is malformed;
+            // to make sure this is caught, move the current y down to
+            // max_y (which is what out_gif_code checks).
+            if (w == 0)
+               g->cur_y = g->max_y;
+
+            g->lflags = stbi__get8(s);
+
+            if (g->lflags & 0x40) {
+               g->step = 8 * g->line_size; // first interlaced spacing
+               g->parse = 3;
+            } else {
+               g->step = g->line_size;
+               g->parse = 0;
+            }
+
+            if (g->lflags & 0x80) {
+               stbi__gif_parse_colortable(s,g->lpal, 2 << (g->lflags & 7), g->eflags & 0x01 ? g->transparent : -1);
+               g->color_table = (stbi_uc *) g->lpal;
+            } else if (g->flags & 0x80) {
+               g->color_table = (stbi_uc *) g->pal;
+            } else
+               return stbi__errpuc("missing color table", "Corrupt GIF");
+
+            o = stbi__process_gif_raster(s, g);
+            if (!o) return NULL;
+
+            // if this was the first frame,
+            pcount = g->w * g->h;
+            if (first_frame && (g->bgindex > 0)) {
+               // if first frame, any pixel not drawn to gets the background color
+               for (pi = 0; pi < pcount; ++pi) {
+                  if (g->history[pi] == 0) {
+                     g->pal[g->bgindex][3] = 255; // just in case it was made transparent, undo that; It will be reset next frame if need be;
+                     memcpy( &g->out[pi * 4], &g->pal[g->bgindex], 4 );
+                  }
+               }
+            }
+
+            return o;
+         }
+
+         case 0x21: // Comment Extension.
+         {
+            int len;
+            int ext = stbi__get8(s);
+            if (ext == 0xF9) { // Graphic Control Extension.
+               len = stbi__get8(s);
+               if (len == 4) {
+                  g->eflags = stbi__get8(s);
+                  g->delay = 10 * stbi__get16le(s); // delay - 1/100th of a second, saving as 1/1000ths.
+
+                  // unset old transparent
+                  if (g->transparent >= 0) {
+                     g->pal[g->transparent][3] = 255;
+                  }
+                  if (g->eflags & 0x01) {
+                     g->transparent = stbi__get8(s);
+                     if (g->transparent >= 0) {
+                        g->pal[g->transparent][3] = 0;
+                     }
+                  } else {
+                     // don't need transparent
+                     stbi__skip(s, 1);
+                     g->transparent = -1;
+                  }
+               } else {
+                  stbi__skip(s, len);
+                  break;
+               }
+            }
+            while ((len = stbi__get8(s)) != 0) {
+               stbi__skip(s, len);
+            }
+            break;
+         }
+
+         case 0x3B: // gif stream termination code
+            return (stbi_uc *) s; // using '1' causes warning on some compilers
+
+         default:
+            return stbi__errpuc("unknown code", "Corrupt GIF");
+      }
+   }
+}
+
+static void *stbi__load_gif_main_outofmem(stbi__gif *g, stbi_uc *out, int **delays)
+{
+   STBI_FREE(g->out);
+   STBI_FREE(g->history);
+   STBI_FREE(g->background);
+
+   if (out) STBI_FREE(out);
+   if (delays && *delays) STBI_FREE(*delays);
+   return stbi__errpuc("outofmem", "Out of memory");
+}
+
+static void *stbi__load_gif_main(stbi__context *s, int **delays, int *x, int *y, int *z, int *comp, int req_comp)
+{
+   if (stbi__gif_test(s)) {
+      int layers = 0;
+      stbi_uc *u = 0;
+      stbi_uc *out = 0;
+      stbi_uc *two_back = 0;
+      stbi__gif g;
+      int stride;
+      int out_size = 0;
+      int delays_size = 0;
+
+      STBI_NOTUSED(out_size);
+      STBI_NOTUSED(delays_size);
+
+      memset(&g, 0, sizeof(g));
+      if (delays) {
+         *delays = 0;
+      }
+
+      do {
+         u = stbi__gif_load_next(s, &g, comp, req_comp, two_back);
+         if (u == (stbi_uc *) s) u = 0;  // end of animated gif marker
+
+         if (u) {
+            *x = g.w;
+            *y = g.h;
+            ++layers;
+            stride = g.w * g.h * 4;
+
+            if (out) {
+               void *tmp = (stbi_uc*) STBI_REALLOC_SIZED( out, out_size, layers * stride );
+               if (!tmp)
+                  return stbi__load_gif_main_outofmem(&g, out, delays);
+               else {
+                   out = (stbi_uc*) tmp;
+                   out_size = layers * stride;
+               }
+
+               if (delays) {
+                  int *new_delays = (int*) STBI_REALLOC_SIZED( *delays, delays_size, sizeof(int) * layers );
+                  if (!new_delays)
+                     return stbi__load_gif_main_outofmem(&g, out, delays);
+                  *delays = new_delays;
+                  delays_size = layers * sizeof(int);
+               }
+            } else {
+               out = (stbi_uc*)stbi__malloc( layers * stride );
+               if (!out)
+                  return stbi__load_gif_main_outofmem(&g, out, delays);
+               out_size = layers * stride;
+               if (delays) {
+                  *delays = (int*) stbi__malloc( layers * sizeof(int) );
+                  if (!*delays)
+                     return stbi__load_gif_main_outofmem(&g, out, delays);
+                  delays_size = layers * sizeof(int);
+               }
+            }
+            memcpy( out + ((layers - 1) * stride), u, stride );
+            if (layers >= 2) {
+               two_back = out - 2 * stride;
+            }
+
+            if (delays) {
+               (*delays)[layers - 1U] = g.delay;
+            }
+         }
+      } while (u != 0);
+
+      // free temp buffer;
+      STBI_FREE(g.out);
+      STBI_FREE(g.history);
+      STBI_FREE(g.background);
+
+      // do the final conversion after loading everything;
+      if (req_comp && req_comp != 4)
+         out = stbi__convert_format(out, 4, req_comp, layers * g.w, g.h);
+
+      *z = layers;
+      return out;
+   } else {
+      return stbi__errpuc("not GIF", "Image was not as a gif type.");
+   }
+}
+
+static void *stbi__gif_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri)
+{
+   stbi_uc *u = 0;
+   stbi__gif g;
+   memset(&g, 0, sizeof(g));
+   STBI_NOTUSED(ri);
+
+   u = stbi__gif_load_next(s, &g, comp, req_comp, 0);
+   if (u == (stbi_uc *) s) u = 0;  // end of animated gif marker
+   if (u) {
+      *x = g.w;
+      *y = g.h;
+
+      // moved conversion to after successful load so that the same
+      // can be done for multiple frames.
+      if (req_comp && req_comp != 4)
+         u = stbi__convert_format(u, 4, req_comp, g.w, g.h);
+   } else if (g.out) {
+      // if there was an error and we allocated an image buffer, free it!
+      STBI_FREE(g.out);
+   }
+
+   // free buffers needed for multiple frame loading;
+   STBI_FREE(g.history);
+   STBI_FREE(g.background);
+
+   return u;
+}
+
+static int stbi__gif_info(stbi__context *s, int *x, int *y, int *comp)
+{
+   return stbi__gif_info_raw(s,x,y,comp);
+}
+#endif
+
+// *************************************************************************************************
+// Radiance RGBE HDR loader
+// originally by Nicolas Schulz
+#ifndef STBI_NO_HDR
+static int stbi__hdr_test_core(stbi__context *s, const char *signature)
+{
+   int i;
+   for (i=0; signature[i]; ++i)
+      if (stbi__get8(s) != signature[i])
+          return 0;
+   stbi__rewind(s);
+   return 1;
+}
+
+static int stbi__hdr_test(stbi__context* s)
+{
+   int r = stbi__hdr_test_core(s, "#?RADIANCE\n");
+   stbi__rewind(s);
+   if(!r) {
+       r = stbi__hdr_test_core(s, "#?RGBE\n");
+       stbi__rewind(s);
+   }
+   return r;
+}
+
+#define STBI__HDR_BUFLEN  1024
+static char *stbi__hdr_gettoken(stbi__context *z, char *buffer)
+{
+   int len=0;
+   char c = '\0';
+
+   c = (char) stbi__get8(z);
+
+   while (!stbi__at_eof(z) && c != '\n') {
+      buffer[len++] = c;
+      if (len == STBI__HDR_BUFLEN-1) {
+         // flush to end of line
+         while (!stbi__at_eof(z) && stbi__get8(z) != '\n')
+            ;
+         break;
+      }
+      c = (char) stbi__get8(z);
+   }
+
+   buffer[len] = 0;
+   return buffer;
+}
+
+static void stbi__hdr_convert(float *output, stbi_uc *input, int req_comp)
+{
+   if ( input[3] != 0 ) {
+      float f1;
+      // Exponent
+      f1 = (float) ldexp(1.0f, input[3] - (int)(128 + 8));
+      if (req_comp <= 2)
+         output[0] = (input[0] + input[1] + input[2]) * f1 / 3;
+      else {
+         output[0] = input[0] * f1;
+         output[1] = input[1] * f1;
+         output[2] = input[2] * f1;
+      }
+      if (req_comp == 2) output[1] = 1;
+      if (req_comp == 4) output[3] = 1;
+   } else {
+      switch (req_comp) {
+         case 4: output[3] = 1; /* fallthrough */
+         case 3: output[0] = output[1] = output[2] = 0;
+                 break;
+         case 2: output[1] = 1; /* fallthrough */
+         case 1: output[0] = 0;
+                 break;
+      }
+   }
+}
+
+static float *stbi__hdr_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri)
+{
+   char buffer[STBI__HDR_BUFLEN];
+   char *token;
+   int valid = 0;
+   int width, height;
+   stbi_uc *scanline;
+   float *hdr_data;
+   int len;
+   unsigned char count, value;
+   int i, j, k, c1,c2, z;
+   const char *headerToken;
+   STBI_NOTUSED(ri);
+
+   // Check identifier
+   headerToken = stbi__hdr_gettoken(s,buffer);
+   if (strcmp(headerToken, "#?RADIANCE") != 0 && strcmp(headerToken, "#?RGBE") != 0)
+      return stbi__errpf("not HDR", "Corrupt HDR image");
+
+   // Parse header
+   for(;;) {
+      token = stbi__hdr_gettoken(s,buffer);
+      if (token[0] == 0) break;
+      if (strcmp(token, "FORMAT=32-bit_rle_rgbe") == 0) valid = 1;
+   }
+
+   if (!valid)    return stbi__errpf("unsupported format", "Unsupported HDR format");
+
+   // Parse width and height
+   // can't use sscanf() if we're not using stdio!
+   token = stbi__hdr_gettoken(s,buffer);
+   if (strncmp(token, "-Y ", 3))  return stbi__errpf("unsupported data layout", "Unsupported HDR format");
+   token += 3;
+   height = (int) strtol(token, &token, 10);
+   while (*token == ' ') ++token;
+   if (strncmp(token, "+X ", 3))  return stbi__errpf("unsupported data layout", "Unsupported HDR format");
+   token += 3;
+   width = (int) strtol(token, NULL, 10);
+
+   if (height > STBI_MAX_DIMENSIONS) return stbi__errpf("too large","Very large image (corrupt?)");
+   if (width > STBI_MAX_DIMENSIONS) return stbi__errpf("too large","Very large image (corrupt?)");
+
+   *x = width;
+   *y = height;
+
+   if (comp) *comp = 3;
+   if (req_comp == 0) req_comp = 3;
+
+   if (!stbi__mad4sizes_valid(width, height, req_comp, sizeof(float), 0))
+      return stbi__errpf("too large", "HDR image is too large");
+
+   // Read data
+   hdr_data = (float *) stbi__malloc_mad4(width, height, req_comp, sizeof(float), 0);
+   if (!hdr_data)
+      return stbi__errpf("outofmem", "Out of memory");
+
+   // Load image data
+   // image data is stored as some number of sca
+   if ( width < 8 || width >= 32768) {
+      // Read flat data
+      for (j=0; j < height; ++j) {
+         for (i=0; i < width; ++i) {
+            stbi_uc rgbe[4];
+           main_decode_loop:
+            stbi__getn(s, rgbe, 4);
+            stbi__hdr_convert(hdr_data + j * width * req_comp + i * req_comp, rgbe, req_comp);
+         }
+      }
+   } else {
+      // Read RLE-encoded data
+      scanline = NULL;
+
+      for (j = 0; j < height; ++j) {
+         c1 = stbi__get8(s);
+         c2 = stbi__get8(s);
+         len = stbi__get8(s);
+         if (c1 != 2 || c2 != 2 || (len & 0x80)) {
+            // not run-length encoded, so we have to actually use THIS data as a decoded
+            // pixel (note this can't be a valid pixel--one of RGB must be >= 128)
+            stbi_uc rgbe[4];
+            rgbe[0] = (stbi_uc) c1;
+            rgbe[1] = (stbi_uc) c2;
+            rgbe[2] = (stbi_uc) len;
+            rgbe[3] = (stbi_uc) stbi__get8(s);
+            stbi__hdr_convert(hdr_data, rgbe, req_comp);
+            i = 1;
+            j = 0;
+            STBI_FREE(scanline);
+            goto main_decode_loop; // yes, this makes no sense
+         }
+         len <<= 8;
+         len |= stbi__get8(s);
+         if (len != width) { STBI_FREE(hdr_data); STBI_FREE(scanline); return stbi__errpf("invalid decoded scanline length", "corrupt HDR"); }
+         if (scanline == NULL) {
+            scanline = (stbi_uc *) stbi__malloc_mad2(width, 4, 0);
+            if (!scanline) {
+               STBI_FREE(hdr_data);
+               return stbi__errpf("outofmem", "Out of memory");
+            }
+         }
+
+         for (k = 0; k < 4; ++k) {
+            int nleft;
+            i = 0;
+            while ((nleft = width - i) > 0) {
+               count = stbi__get8(s);
+               if (count > 128) {
+                  // Run
+                  value = stbi__get8(s);
+                  count -= 128;
+                  if ((count == 0) || (count > nleft)) { STBI_FREE(hdr_data); STBI_FREE(scanline); return stbi__errpf("corrupt", "bad RLE data in HDR"); }
+                  for (z = 0; z < count; ++z)
+                     scanline[i++ * 4 + k] = value;
+               } else {
+                  // Dump
+                  if ((count == 0) || (count > nleft)) { STBI_FREE(hdr_data); STBI_FREE(scanline); return stbi__errpf("corrupt", "bad RLE data in HDR"); }
+                  for (z = 0; z < count; ++z)
+                     scanline[i++ * 4 + k] = stbi__get8(s);
+               }
+            }
+         }
+         for (i=0; i < width; ++i)
+            stbi__hdr_convert(hdr_data+(j*width + i)*req_comp, scanline + i*4, req_comp);
+      }
+      if (scanline)
+         STBI_FREE(scanline);
+   }
+
+   return hdr_data;
+}
+
+static int stbi__hdr_info(stbi__context *s, int *x, int *y, int *comp)
+{
+   char buffer[STBI__HDR_BUFLEN];
+   char *token;
+   int valid = 0;
+   int dummy;
+
+   if (!x) x = &dummy;
+   if (!y) y = &dummy;
+   if (!comp) comp = &dummy;
+
+   if (stbi__hdr_test(s) == 0) {
+       stbi__rewind( s );
+       return 0;
+   }
+
+   for(;;) {
+      token = stbi__hdr_gettoken(s,buffer);
+      if (token[0] == 0) break;
+      if (strcmp(token, "FORMAT=32-bit_rle_rgbe") == 0) valid = 1;
+   }
+
+   if (!valid) {
+       stbi__rewind( s );
+       return 0;
+   }
+   token = stbi__hdr_gettoken(s,buffer);
+   if (strncmp(token, "-Y ", 3)) {
+       stbi__rewind( s );
+       return 0;
+   }
+   token += 3;
+   *y = (int) strtol(token, &token, 10);
+   while (*token == ' ') ++token;
+   if (strncmp(token, "+X ", 3)) {
+       stbi__rewind( s );
+       return 0;
+   }
+   token += 3;
+   *x = (int) strtol(token, NULL, 10);
+   *comp = 3;
+   return 1;
+}
+#endif // STBI_NO_HDR
+
+#ifndef STBI_NO_BMP
+static int stbi__bmp_info(stbi__context *s, int *x, int *y, int *comp)
+{
+   void *p;
+   stbi__bmp_data info;
+
+   info.all_a = 255;
+   p = stbi__bmp_parse_header(s, &info);
+   if (p == NULL) {
+      stbi__rewind( s );
+      return 0;
+   }
+   if (x) *x = s->img_x;
+   if (y) *y = s->img_y;
+   if (comp) {
+      if (info.bpp == 24 && info.ma == 0xff000000)
+         *comp = 3;
+      else
+         *comp = info.ma ? 4 : 3;
+   }
+   return 1;
+}
+#endif
+
+#ifndef STBI_NO_PSD
+static int stbi__psd_info(stbi__context *s, int *x, int *y, int *comp)
+{
+   int channelCount, dummy, depth;
+   if (!x) x = &dummy;
+   if (!y) y = &dummy;
+   if (!comp) comp = &dummy;
+   if (stbi__get32be(s) != 0x38425053) {
+       stbi__rewind( s );
+       return 0;
+   }
+   if (stbi__get16be(s) != 1) {
+       stbi__rewind( s );
+       return 0;
+   }
+   stbi__skip(s, 6);
+   channelCount = stbi__get16be(s);
+   if (channelCount < 0 || channelCount > 16) {
+       stbi__rewind( s );
+       return 0;
+   }
+   *y = stbi__get32be(s);
+   *x = stbi__get32be(s);
+   depth = stbi__get16be(s);
+   if (depth != 8 && depth != 16) {
+       stbi__rewind( s );
+       return 0;
+   }
+   if (stbi__get16be(s) != 3) {
+       stbi__rewind( s );
+       return 0;
+   }
+   *comp = 4;
+   return 1;
+}
+
+static int stbi__psd_is16(stbi__context *s)
+{
+   int channelCount, depth;
+   if (stbi__get32be(s) != 0x38425053) {
+       stbi__rewind( s );
+       return 0;
+   }
+   if (stbi__get16be(s) != 1) {
+       stbi__rewind( s );
+       return 0;
+   }
+   stbi__skip(s, 6);
+   channelCount = stbi__get16be(s);
+   if (channelCount < 0 || channelCount > 16) {
+       stbi__rewind( s );
+       return 0;
+   }
+   STBI_NOTUSED(stbi__get32be(s));
+   STBI_NOTUSED(stbi__get32be(s));
+   depth = stbi__get16be(s);
+   if (depth != 16) {
+       stbi__rewind( s );
+       return 0;
+   }
+   return 1;
+}
+#endif
+
+#ifndef STBI_NO_PIC
+static int stbi__pic_info(stbi__context *s, int *x, int *y, int *comp)
+{
+   int act_comp=0,num_packets=0,chained,dummy;
+   stbi__pic_packet packets[10];
+
+   if (!x) x = &dummy;
+   if (!y) y = &dummy;
+   if (!comp) comp = &dummy;
+
+   if (!stbi__pic_is4(s,"\x53\x80\xF6\x34")) {
+      stbi__rewind(s);
+      return 0;
+   }
+
+   stbi__skip(s, 88);
+
+   *x = stbi__get16be(s);
+   *y = stbi__get16be(s);
+   if (stbi__at_eof(s)) {
+      stbi__rewind( s);
+      return 0;
+   }
+   if ( (*x) != 0 && (1 << 28) / (*x) < (*y)) {
+      stbi__rewind( s );
+      return 0;
+   }
+
+   stbi__skip(s, 8);
+
+   do {
+      stbi__pic_packet *packet;
+
+      if (num_packets==sizeof(packets)/sizeof(packets[0]))
+         return 0;
+
+      packet = &packets[num_packets++];
+      chained = stbi__get8(s);
+      packet->size    = stbi__get8(s);
+      packet->type    = stbi__get8(s);
+      packet->channel = stbi__get8(s);
+      act_comp |= packet->channel;
+
+      if (stbi__at_eof(s)) {
+          stbi__rewind( s );
+          return 0;
+      }
+      if (packet->size != 8) {
+          stbi__rewind( s );
+          return 0;
+      }
+   } while (chained);
+
+   *comp = (act_comp & 0x10 ? 4 : 3);
+
+   return 1;
+}
+#endif
+
+// *************************************************************************************************
+// Portable Gray Map and Portable Pixel Map loader
+// by Ken Miller
+//
+// PGM: http://netpbm.sourceforge.net/doc/pgm.html
+// PPM: http://netpbm.sourceforge.net/doc/ppm.html
+//
+// Known limitations:
+//    Does not support comments in the header section
+//    Does not support ASCII image data (formats P2 and P3)
+
+#ifndef STBI_NO_PNM
+
+static int      stbi__pnm_test(stbi__context *s)
+{
+   char p, t;
+   p = (char) stbi__get8(s);
+   t = (char) stbi__get8(s);
+   if (p != 'P' || (t != '5' && t != '6')) {
+       stbi__rewind( s );
+       return 0;
+   }
+   return 1;
+}
+
+static void *stbi__pnm_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri)
+{
+   stbi_uc *out;
+   STBI_NOTUSED(ri);
+
+   ri->bits_per_channel = stbi__pnm_info(s, (int *)&s->img_x, (int *)&s->img_y, (int *)&s->img_n);
+   if (ri->bits_per_channel == 0)
+      return 0;
+
+   if (s->img_y > STBI_MAX_DIMENSIONS) return stbi__errpuc("too large","Very large image (corrupt?)");
+   if (s->img_x > STBI_MAX_DIMENSIONS) return stbi__errpuc("too large","Very large image (corrupt?)");
+
+   *x = s->img_x;
+   *y = s->img_y;
+   if (comp) *comp = s->img_n;
+
+   if (!stbi__mad4sizes_valid(s->img_n, s->img_x, s->img_y, ri->bits_per_channel / 8, 0))
+      return stbi__errpuc("too large", "PNM too large");
+
+   out = (stbi_uc *) stbi__malloc_mad4(s->img_n, s->img_x, s->img_y, ri->bits_per_channel / 8, 0);
+   if (!out) return stbi__errpuc("outofmem", "Out of memory");
+   if (!stbi__getn(s, out, s->img_n * s->img_x * s->img_y * (ri->bits_per_channel / 8))) {
+      STBI_FREE(out);
+      return stbi__errpuc("bad PNM", "PNM file truncated");
+   }
+
+   if (req_comp && req_comp != s->img_n) {
+      if (ri->bits_per_channel == 16) {
+         out = (stbi_uc *) stbi__convert_format16((stbi__uint16 *) out, s->img_n, req_comp, s->img_x, s->img_y);
+      } else {
+         out = stbi__convert_format(out, s->img_n, req_comp, s->img_x, s->img_y);
+      }
+      if (out == NULL) return out; // stbi__convert_format frees input on failure
+   }
+   return out;
+}
+
+static int      stbi__pnm_isspace(char c)
+{
+   return c == ' ' || c == '\t' || c == '\n' || c == '\v' || c == '\f' || c == '\r';
+}
+
+static void     stbi__pnm_skip_whitespace(stbi__context *s, char *c)
+{
+   for (;;) {
+      while (!stbi__at_eof(s) && stbi__pnm_isspace(*c))
+         *c = (char) stbi__get8(s);
+
+      if (stbi__at_eof(s) || *c != '#')
+         break;
+
+      while (!stbi__at_eof(s) && *c != '\n' && *c != '\r' )
+         *c = (char) stbi__get8(s);
+   }
+}
+
+static int      stbi__pnm_isdigit(char c)
+{
+   return c >= '0' && c <= '9';
+}
+
+static int      stbi__pnm_getinteger(stbi__context *s, char *c)
+{
+   int value = 0;
+
+   while (!stbi__at_eof(s) && stbi__pnm_isdigit(*c)) {
+      value = value*10 + (*c - '0');
+      *c = (char) stbi__get8(s);
+      if((value > 214748364) || (value == 214748364 && *c > '7'))
+          return stbi__err("integer parse overflow", "Parsing an integer in the PPM header overflowed a 32-bit int");
+   }
+
+   return value;
+}
+
+static int      stbi__pnm_info(stbi__context *s, int *x, int *y, int *comp)
+{
+   int maxv, dummy;
+   char c, p, t;
+
+   if (!x) x = &dummy;
+   if (!y) y = &dummy;
+   if (!comp) comp = &dummy;
+
+   stbi__rewind(s);
+
+   // Get identifier
+   p = (char) stbi__get8(s);
+   t = (char) stbi__get8(s);
+   if (p != 'P' || (t != '5' && t != '6')) {
+       stbi__rewind(s);
+       return 0;
+   }
+
+   *comp = (t == '6') ? 3 : 1;  // '5' is 1-component .pgm; '6' is 3-component .ppm
+
+   c = (char) stbi__get8(s);
+   stbi__pnm_skip_whitespace(s, &c);
+
+   *x = stbi__pnm_getinteger(s, &c); // read width
+   if(*x == 0)
+       return stbi__err("invalid width", "PPM image header had zero or overflowing width");
+   stbi__pnm_skip_whitespace(s, &c);
+
+   *y = stbi__pnm_getinteger(s, &c); // read height
+   if (*y == 0)
+       return stbi__err("invalid width", "PPM image header had zero or overflowing width");
+   stbi__pnm_skip_whitespace(s, &c);
+
+   maxv = stbi__pnm_getinteger(s, &c);  // read max value
+   if (maxv > 65535)
+      return stbi__err("max value > 65535", "PPM image supports only 8-bit and 16-bit images");
+   else if (maxv > 255)
+      return 16;
+   else
+      return 8;
+}
+
+static int stbi__pnm_is16(stbi__context *s)
+{
+   if (stbi__pnm_info(s, NULL, NULL, NULL) == 16)
+	   return 1;
+   return 0;
+}
+#endif
+
+static int stbi__info_main(stbi__context *s, int *x, int *y, int *comp)
+{
+   #ifndef STBI_NO_JPEG
+   if (stbi__jpeg_info(s, x, y, comp)) return 1;
+   #endif
+
+   #ifndef STBI_NO_PNG
+   if (stbi__png_info(s, x, y, comp))  return 1;
+   #endif
+
+   #ifndef STBI_NO_GIF
+   if (stbi__gif_info(s, x, y, comp))  return 1;
+   #endif
+
+   #ifndef STBI_NO_BMP
+   if (stbi__bmp_info(s, x, y, comp))  return 1;
+   #endif
+
+   #ifndef STBI_NO_PSD
+   if (stbi__psd_info(s, x, y, comp))  return 1;
+   #endif
+
+   #ifndef STBI_NO_PIC
+   if (stbi__pic_info(s, x, y, comp))  return 1;
+   #endif
+
+   #ifndef STBI_NO_PNM
+   if (stbi__pnm_info(s, x, y, comp))  return 1;
+   #endif
+
+   #ifndef STBI_NO_HDR
+   if (stbi__hdr_info(s, x, y, comp))  return 1;
+   #endif
+
+   // test tga last because it's a crappy test!
+   #ifndef STBI_NO_TGA
+   if (stbi__tga_info(s, x, y, comp))
+       return 1;
+   #endif
+   return stbi__err("unknown image type", "Image not of any known type, or corrupt");
+}
+
+static int stbi__is_16_main(stbi__context *s)
+{
+   #ifndef STBI_NO_PNG
+   if (stbi__png_is16(s))  return 1;
+   #endif
+
+   #ifndef STBI_NO_PSD
+   if (stbi__psd_is16(s))  return 1;
+   #endif
+
+   #ifndef STBI_NO_PNM
+   if (stbi__pnm_is16(s))  return 1;
+   #endif
+   return 0;
+}
+
+#ifndef STBI_NO_STDIO
+STBIDEF int stbi_info(char const *filename, int *x, int *y, int *comp)
+{
+    FILE *f = stbi__fopen(filename, "rb");
+    int result;
+    if (!f) return stbi__err("can't fopen", "Unable to open file");
+    result = stbi_info_from_file(f, x, y, comp);
+    fclose(f);
+    return result;
+}
+
+STBIDEF int stbi_info_from_file(FILE *f, int *x, int *y, int *comp)
+{
+   int r;
+   stbi__context s;
+   long pos = ftell(f);
+   stbi__start_file(&s, f);
+   r = stbi__info_main(&s,x,y,comp);
+   fseek(f,pos,SEEK_SET);
+   return r;
+}
+
+STBIDEF int stbi_is_16_bit(char const *filename)
+{
+    FILE *f = stbi__fopen(filename, "rb");
+    int result;
+    if (!f) return stbi__err("can't fopen", "Unable to open file");
+    result = stbi_is_16_bit_from_file(f);
+    fclose(f);
+    return result;
+}
+
+STBIDEF int stbi_is_16_bit_from_file(FILE *f)
+{
+   int r;
+   stbi__context s;
+   long pos = ftell(f);
+   stbi__start_file(&s, f);
+   r = stbi__is_16_main(&s);
+   fseek(f,pos,SEEK_SET);
+   return r;
+}
+#endif // !STBI_NO_STDIO
+
+STBIDEF int stbi_info_from_memory(stbi_uc const *buffer, int len, int *x, int *y, int *comp)
+{
+   stbi__context s;
+   stbi__start_mem(&s,buffer,len);
+   return stbi__info_main(&s,x,y,comp);
+}
+
+STBIDEF int stbi_info_from_callbacks(stbi_io_callbacks const *c, void *user, int *x, int *y, int *comp)
+{
+   stbi__context s;
+   stbi__start_callbacks(&s, (stbi_io_callbacks *) c, user);
+   return stbi__info_main(&s,x,y,comp);
+}
+
+STBIDEF int stbi_is_16_bit_from_memory(stbi_uc const *buffer, int len)
+{
+   stbi__context s;
+   stbi__start_mem(&s,buffer,len);
+   return stbi__is_16_main(&s);
+}
+
+STBIDEF int stbi_is_16_bit_from_callbacks(stbi_io_callbacks const *c, void *user)
+{
+   stbi__context s;
+   stbi__start_callbacks(&s, (stbi_io_callbacks *) c, user);
+   return stbi__is_16_main(&s);
+}
+
+#endif // STB_IMAGE_IMPLEMENTATION
+
+/*
+   revision history:
+      2.20  (2019-02-07) support utf8 filenames in Windows; fix warnings and platform ifdefs
+      2.19  (2018-02-11) fix warning
+      2.18  (2018-01-30) fix warnings
+      2.17  (2018-01-29) change sbti__shiftsigned to avoid clang -O2 bug
+                         1-bit BMP
+                         *_is_16_bit api
+                         avoid warnings
+      2.16  (2017-07-23) all functions have 16-bit variants;
+                         STBI_NO_STDIO works again;
+                         compilation fixes;
+                         fix rounding in unpremultiply;
+                         optimize vertical flip;
+                         disable raw_len validation;
+                         documentation fixes
+      2.15  (2017-03-18) fix png-1,2,4 bug; now all Imagenet JPGs decode;
+                         warning fixes; disable run-time SSE detection on gcc;
+                         uniform handling of optional "return" values;
+                         thread-safe initialization of zlib tables
+      2.14  (2017-03-03) remove deprecated STBI_JPEG_OLD; fixes for Imagenet JPGs
+      2.13  (2016-11-29) add 16-bit API, only supported for PNG right now
+      2.12  (2016-04-02) fix typo in 2.11 PSD fix that caused crashes
+      2.11  (2016-04-02) allocate large structures on the stack
+                         remove white matting for transparent PSD
+                         fix reported channel count for PNG & BMP
+                         re-enable SSE2 in non-gcc 64-bit
+                         support RGB-formatted JPEG
+                         read 16-bit PNGs (only as 8-bit)
+      2.10  (2016-01-22) avoid warning introduced in 2.09 by STBI_REALLOC_SIZED
+      2.09  (2016-01-16) allow comments in PNM files
+                         16-bit-per-pixel TGA (not bit-per-component)
+                         info() for TGA could break due to .hdr handling
+                         info() for BMP to shares code instead of sloppy parse
+                         can use STBI_REALLOC_SIZED if allocator doesn't support realloc
+                         code cleanup
+      2.08  (2015-09-13) fix to 2.07 cleanup, reading RGB PSD as RGBA
+      2.07  (2015-09-13) fix compiler warnings
+                         partial animated GIF support
+                         limited 16-bpc PSD support
+                         #ifdef unused functions
+                         bug with < 92 byte PIC,PNM,HDR,TGA
+      2.06  (2015-04-19) fix bug where PSD returns wrong '*comp' value
+      2.05  (2015-04-19) fix bug in progressive JPEG handling, fix warning
+      2.04  (2015-04-15) try to re-enable SIMD on MinGW 64-bit
+      2.03  (2015-04-12) extra corruption checking (mmozeiko)
+                         stbi_set_flip_vertically_on_load (nguillemot)
+                         fix NEON support; fix mingw support
+      2.02  (2015-01-19) fix incorrect assert, fix warning
+      2.01  (2015-01-17) fix various warnings; suppress SIMD on gcc 32-bit without -msse2
+      2.00b (2014-12-25) fix STBI_MALLOC in progressive JPEG
+      2.00  (2014-12-25) optimize JPG, including x86 SSE2 & NEON SIMD (ryg)
+                         progressive JPEG (stb)
+                         PGM/PPM support (Ken Miller)
+                         STBI_MALLOC,STBI_REALLOC,STBI_FREE
+                         GIF bugfix -- seemingly never worked
+                         STBI_NO_*, STBI_ONLY_*
+      1.48  (2014-12-14) fix incorrectly-named assert()
+      1.47  (2014-12-14) 1/2/4-bit PNG support, both direct and paletted (Omar Cornut & stb)
+                         optimize PNG (ryg)
+                         fix bug in interlaced PNG with user-specified channel count (stb)
+      1.46  (2014-08-26)
+              fix broken tRNS chunk (colorkey-style transparency) in non-paletted PNG
+      1.45  (2014-08-16)
+              fix MSVC-ARM internal compiler error by wrapping malloc
+      1.44  (2014-08-07)
+              various warning fixes from Ronny Chevalier
+      1.43  (2014-07-15)
+              fix MSVC-only compiler problem in code changed in 1.42
+      1.42  (2014-07-09)
+              don't define _CRT_SECURE_NO_WARNINGS (affects user code)
+              fixes to stbi__cleanup_jpeg path
+              added STBI_ASSERT to avoid requiring assert.h
+      1.41  (2014-06-25)
+              fix search&replace from 1.36 that messed up comments/error messages
+      1.40  (2014-06-22)
+              fix gcc struct-initialization warning
+      1.39  (2014-06-15)
+              fix to TGA optimization when req_comp != number of components in TGA;
+              fix to GIF loading because BMP wasn't rewinding (whoops, no GIFs in my test suite)
+              add support for BMP version 5 (more ignored fields)
+      1.38  (2014-06-06)
+              suppress MSVC warnings on integer casts truncating values
+              fix accidental rename of 'skip' field of I/O
+      1.37  (2014-06-04)
+              remove duplicate typedef
+      1.36  (2014-06-03)
+              convert to header file single-file library
+              if de-iphone isn't set, load iphone images color-swapped instead of returning NULL
+      1.35  (2014-05-27)
+              various warnings
+              fix broken STBI_SIMD path
+              fix bug where stbi_load_from_file no longer left file pointer in correct place
+              fix broken non-easy path for 32-bit BMP (possibly never used)
+              TGA optimization by Arseny Kapoulkine
+      1.34  (unknown)
+              use STBI_NOTUSED in stbi__resample_row_generic(), fix one more leak in tga failure case
+      1.33  (2011-07-14)
+              make stbi_is_hdr work in STBI_NO_HDR (as specified), minor compiler-friendly improvements
+      1.32  (2011-07-13)
+              support for "info" function for all supported filetypes (SpartanJ)
+      1.31  (2011-06-20)
+              a few more leak fixes, bug in PNG handling (SpartanJ)
+      1.30  (2011-06-11)
+              added ability to load files via callbacks to accomidate custom input streams (Ben Wenger)
+              removed deprecated format-specific test/load functions
+              removed support for installable file formats (stbi_loader) -- would have been broken for IO callbacks anyway
+              error cases in bmp and tga give messages and don't leak (Raymond Barbiero, grisha)
+              fix inefficiency in decoding 32-bit BMP (David Woo)
+      1.29  (2010-08-16)
+              various warning fixes from Aurelien Pocheville
+      1.28  (2010-08-01)
+              fix bug in GIF palette transparency (SpartanJ)
+      1.27  (2010-08-01)
+              cast-to-stbi_uc to fix warnings
+      1.26  (2010-07-24)
+              fix bug in file buffering for PNG reported by SpartanJ
+      1.25  (2010-07-17)
+              refix trans_data warning (Won Chun)
+      1.24  (2010-07-12)
+              perf improvements reading from files on platforms with lock-heavy fgetc()
+              minor perf improvements for jpeg
+              deprecated type-specific functions so we'll get feedback if they're needed
+              attempt to fix trans_data warning (Won Chun)
+      1.23    fixed bug in iPhone support
+      1.22  (2010-07-10)
+              removed image *writing* support
+              stbi_info support from Jetro Lauha
+              GIF support from Jean-Marc Lienher
+              iPhone PNG-extensions from James Brown
+              warning-fixes from Nicolas Schulz and Janez Zemva (i.stbi__err. Janez (U+017D)emva)
+      1.21    fix use of 'stbi_uc' in header (reported by jon blow)
+      1.20    added support for Softimage PIC, by Tom Seddon
+      1.19    bug in interlaced PNG corruption check (found by ryg)
+      1.18  (2008-08-02)
+              fix a threading bug (local mutable static)
+      1.17    support interlaced PNG
+      1.16    major bugfix - stbi__convert_format converted one too many pixels
+      1.15    initialize some fields for thread safety
+      1.14    fix threadsafe conversion bug
+              header-file-only version (#define STBI_HEADER_FILE_ONLY before including)
+      1.13    threadsafe
+      1.12    const qualifiers in the API
+      1.11    Support installable IDCT, colorspace conversion routines
+      1.10    Fixes for 64-bit (don't use "unsigned long")
+              optimized upsampling by Fabian "ryg" Giesen
+      1.09    Fix format-conversion for PSD code (bad global variables!)
+      1.08    Thatcher Ulrich's PSD code integrated by Nicolas Schulz
+      1.07    attempt to fix C++ warning/errors again
+      1.06    attempt to fix C++ warning/errors again
+      1.05    fix TGA loading to return correct *comp and use good luminance calc
+      1.04    default float alpha is 1, not 255; use 'void *' for stbi_image_free
+      1.03    bugfixes to STBI_NO_STDIO, STBI_NO_HDR
+      1.02    support for (subset of) HDR files, float interface for preferred access to them
+      1.01    fix bug: possible bug in handling right-side up bmps... not sure
+              fix bug: the stbi__bmp_load() and stbi__tga_load() functions didn't work at all
+      1.00    interface to zlib that skips zlib header
+      0.99    correct handling of alpha in palette
+      0.98    TGA loader by lonesock; dynamically add loaders (untested)
+      0.97    jpeg errors on too large a file; also catch another malloc failure
+      0.96    fix detection of invalid v value - particleman@mollyrocket forum
+      0.95    during header scan, seek to markers in case of padding
+      0.94    STBI_NO_STDIO to disable stdio usage; rename all #defines the same
+      0.93    handle jpegtran output; verbose errors
+      0.92    read 4,8,16,24,32-bit BMP files of several formats
+      0.91    output 24-bit Windows 3.0 BMP files
+      0.90    fix a few more warnings; bump version number to approach 1.0
+      0.61    bugfixes due to Marc LeBlanc, Christopher Lloyd
+      0.60    fix compiling as c++
+      0.59    fix warnings: merge Dave Moore's -Wall fixes
+      0.58    fix bug: zlib uncompressed mode len/nlen was wrong endian
+      0.57    fix bug: jpg last huffman symbol before marker was >9 bits but less than 16 available
+      0.56    fix bug: zlib uncompressed mode len vs. nlen
+      0.55    fix bug: restart_interval not initialized to 0
+      0.54    allow NULL for 'int *comp'
+      0.53    fix bug in png 3->4; speedup png decoding
+      0.52    png handles req_comp=3,4 directly; minor cleanup; jpeg comments
+      0.51    obey req_comp requests, 1-component jpegs return as 1-component,
+              on 'test' only check type, not whether we support this variant
+      0.50  (2006-11-19)
+              first released version
+*/
+
+
+/*
+------------------------------------------------------------------------------
+This software is available under 2 licenses -- choose whichever you prefer.
+------------------------------------------------------------------------------
+ALTERNATIVE A - MIT License
+Copyright (c) 2017 Sean Barrett
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+------------------------------------------------------------------------------
+ALTERNATIVE B - Public Domain (www.unlicense.org)
+This is free and unencumbered software released into the public domain.
+Anyone is free to copy, modify, publish, use, compile, sell, or distribute this
+software, either in source code form or as a compiled binary, for any purpose,
+commercial or non-commercial, and by any means.
+In jurisdictions that recognize copyright laws, the author or authors of this
+software dedicate any and all copyright interest in the software to the public
+domain. We make this dedication for the benefit of the public at large and to
+the detriment of our heirs and successors. We intend this dedication to be an
+overt act of relinquishment in perpetuity of all present and future rights to
+this software under copyright law.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+------------------------------------------------------------------------------
+*/

--- a/src/external/stb/stb_image.h.license
+++ b/src/external/stb/stb_image.h.license
@@ -1,0 +1,3 @@
+Copyright (c) 2017 Sean Barrett
+
+SPDX-License-Identifier: MIT OR Unlicense

--- a/src/xrt/compositor/d3d11/comp_d3d11_window.cpp
+++ b/src/xrt/compositor/d3d11/comp_d3d11_window.cpp
@@ -531,7 +531,17 @@ wnd_proc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 			return 0;
 		}
 
-		// Normal mode (no forwarding): pass all keys to qwerty
+		// Normal mode (no forwarding): pass all keys to qwerty.
+		// ESC → close window: Phase 4C made ESC a no-op in qwerty to
+		// prevent it from killing the shell, but that also broke non-shell
+		// ESC (WebXR, standalone IPC clients). Handle ESC here before
+		// qwerty sees it. Shell mode never reaches this block because
+		// input_forward_hwnd != NULL takes the forwarding path above.
+		if (message == WM_KEYDOWN && wParam == VK_ESCAPE) {
+			U_LOG_W("D3D11 window: ESC pressed — closing (non-shell mode)");
+			PostMessageW(hWnd, WM_CLOSE, 0, 0);
+			return 0;
+		}
 #ifdef XRT_BUILD_DRIVER_QWERTY
 		if (w->qwerty_enabled && w->xsysd != NULL) {
 			bool handled = false;

--- a/src/xrt/compositor/d3d11/comp_d3d11_window.cpp
+++ b/src/xrt/compositor/d3d11/comp_d3d11_window.cpp
@@ -156,6 +156,13 @@ struct comp_d3d11_window
 	//! Set by compositor thread, read by WndProc thread.
 	volatile LONG input_suppress;
 
+	//! Phase 5.12: grace period for input_suppress after the launcher closes.
+	//! Holds a GetTickCount() value; while GetTickCount() < input_suppress_until_tick
+	//! the WndProc treats input as suppressed even when input_suppress=0. Prevents
+	//! the Esc-that-closes-the-launcher from leaking into the focused app on the
+	//! next message-queue drain (render thread vs window thread race).
+	volatile LONG input_suppress_until_tick;
+
 	//! True when a mouse button press originated inside the app content rect.
 	//! Used to prevent title bar clicks from being forwarded as app drags.
 	//! Set on button-down inside rect, cleared on button-up.
@@ -327,6 +334,11 @@ set_fullscreen(HWND hWnd, bool fullscreen)
 	}
 }
 
+// Forward declaration — defined later in this file alongside the suppress
+// setters so the logic lives in one place. Used by wnd_proc to gate key
+// and mouse forwarding.
+static bool input_is_suppressed(struct comp_d3d11_window *w);
+
 /*!
  * Window procedure — runs on the window thread.
  *
@@ -431,6 +443,14 @@ wnd_proc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 	case WM_SYSKEYUP:
 	case WM_CHAR:
 	case WM_SYSCHAR: {
+		// Phase 5.12: when the shell is suppressing input (launcher visible,
+		// resize drag, or within the post-launcher grace period) we eat the
+		// key entirely — don't forward, don't run qwerty. Otherwise the
+		// launcher's Esc / arrows / Enter leak through and close the app.
+		if (input_is_suppressed(w)) {
+			return 0;
+		}
+
 		// Shell input forwarding: all keys go to BOTH qwerty and the app.
 		// Qwerty processes first (mode toggles, camera controls), then
 		// the key is forwarded to the focused app's HWND.
@@ -499,8 +519,9 @@ wnd_proc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 	case WM_MBUTTONUP:
 	case WM_MOUSEMOVE:
 	case WM_MOUSEWHEEL: {
-		// Skip forwarding when shell drag/resize is active
-		if (InterlockedCompareExchange(&w->input_suppress, 0, 0)) {
+		// Skip forwarding when shell drag/resize is active or within the
+		// launcher grace period.
+		if (input_is_suppressed(w)) {
 			break; // fall through to qwerty/default handling
 		}
 
@@ -1095,6 +1116,27 @@ comp_d3d11_window_set_input_forward(struct comp_d3d11_window *window,
 	} else {
 		U_LOG_W("D3D11 window: input forwarding disabled");
 	}
+}
+
+// Returns true if input forwarding should currently be suppressed, considering
+// both the immediate flag and the tick-count grace period (Phase 5.12).
+static bool
+input_is_suppressed(struct comp_d3d11_window *w)
+{
+	if (InterlockedCompareExchange(&w->input_suppress, 0, 0)) return true;
+	LONG until = InterlockedCompareExchange(&w->input_suppress_until_tick, 0, 0);
+	if (until == 0) return false;
+	// GetTickCount() wraps every ~49 days; use signed diff for wrap-safety.
+	LONG now = (LONG)GetTickCount();
+	return (LONG)(until - now) > 0;
+}
+
+extern "C" void
+comp_d3d11_window_set_input_suppress_grace_ms(struct comp_d3d11_window *window, uint32_t ms)
+{
+	if (window == NULL) return;
+	LONG until = (LONG)(GetTickCount() + ms);
+	InterlockedExchange(&window->input_suppress_until_tick, until);
 }
 
 extern "C" void

--- a/src/xrt/compositor/d3d11/comp_d3d11_window.cpp
+++ b/src/xrt/compositor/d3d11/comp_d3d11_window.cpp
@@ -339,6 +339,13 @@ set_fullscreen(HWND hWnd, bool fullscreen)
 // and mouse forwarding.
 static bool input_is_suppressed(struct comp_d3d11_window *w);
 
+// Phase 5.13: private message ID for "show launcher context menu". Sent by
+// the render thread via comp_d3d11_window_show_launcher_context_menu so the
+// window thread actually runs TrackPopupMenu — that API only works on the
+// thread that owns the target window. Defined up here so both wnd_proc and
+// the exported helper can reference it.
+#define WM_LAUNCHER_CTX_MENU (WM_USER + 110)
+
 /*!
  * Window procedure — runs on the window thread.
  *
@@ -419,6 +426,35 @@ wnd_proc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 	case WM_DESTROY:
 		PostQuitMessage(0);
 		break;
+
+	case WM_LAUNCHER_CTX_MENU: {
+		// Phase 5.13: synchronously show the launcher tile context menu
+		// on THIS thread (the window thread). TrackPopupMenu only works
+		// from the thread that owns the target window — calling it from
+		// the render thread silently returns 0. Caller (render thread)
+		// uses SendMessage so we block until the user picks / cancels.
+		HMENU menu = CreatePopupMenu();
+		if (menu == NULL) {
+			return 0;
+		}
+		AppendMenuW(menu, MF_STRING, 1, L"Launch");
+		AppendMenuW(menu, MF_STRING, 2, L"Remove from launcher (this session)");
+		AppendMenuW(menu, MF_SEPARATOR, 0, NULL);
+		AppendMenuW(menu, MF_STRING, 3, L"Cancel");
+
+		POINT pt;
+		GetCursorPos(&pt);
+		SetForegroundWindow(hWnd);
+		UINT cmd = TrackPopupMenu(menu,
+		                          TPM_RETURNCMD | TPM_NONOTIFY,
+		                          pt.x, pt.y, 0, hWnd, NULL);
+		DestroyMenu(menu);
+		PostMessageW(hWnd, WM_NULL, 0, 0);
+		// Map to public result codes (1=launch, 2=remove, 0=cancel).
+		if (cmd == 1) return LAUNCHER_CTX_MENU_RESULT_LAUNCH;
+		if (cmd == 2) return LAUNCHER_CTX_MENU_RESULT_REMOVE;
+		return 0;
+	}
 
 	case WM_KEYDOWN:
 		// F11: toggle fullscreen for non-shell (single app) windows.
@@ -1137,6 +1173,14 @@ comp_d3d11_window_set_input_suppress_grace_ms(struct comp_d3d11_window *window, 
 	if (window == NULL) return;
 	LONG until = (LONG)(GetTickCount() + ms);
 	InterlockedExchange(&window->input_suppress_until_tick, until);
+}
+
+extern "C" uint32_t
+comp_d3d11_window_show_launcher_context_menu(struct comp_d3d11_window *window)
+{
+	if (window == NULL || window->hwnd == NULL) return 0;
+	LRESULT r = SendMessageW(window->hwnd, WM_LAUNCHER_CTX_MENU, 0, 0);
+	return (uint32_t)r;
 }
 
 extern "C" void

--- a/src/xrt/compositor/d3d11/comp_d3d11_window.h
+++ b/src/xrt/compositor/d3d11/comp_d3d11_window.h
@@ -229,6 +229,21 @@ void
 comp_d3d11_window_set_input_suppress_grace_ms(struct comp_d3d11_window *window, uint32_t ms);
 
 /*!
+ * Phase 5.13: show a Win32 popup menu for a launcher tile right-click.
+ * Must be called from the shell's render thread — internally dispatches to
+ * the window thread via SendMessage since TrackPopupMenu only works from
+ * the thread that owns the target window.
+ *
+ * @return one of LAUNCHER_CTX_MENU_RESULT_* (see below), or 0 if no
+ *         selection (cancel).
+ */
+#define LAUNCHER_CTX_MENU_RESULT_LAUNCH 1
+#define LAUNCHER_CTX_MENU_RESULT_REMOVE 2
+
+uint32_t
+comp_d3d11_window_show_launcher_context_menu(struct comp_d3d11_window *window);
+
+/*!
  * Read and reset accumulated scroll wheel delta (for shell window resize).
  *
  * @param window The window object

--- a/src/xrt/compositor/d3d11/comp_d3d11_window.h
+++ b/src/xrt/compositor/d3d11/comp_d3d11_window.h
@@ -212,10 +212,21 @@ comp_d3d11_window_set_input_forward(struct comp_d3d11_window *window,
 
 /*!
  * Suppress or resume input forwarding (for shell drag/resize operations).
- * When suppressed, the WndProc does not forward mouse events to the app.
+ * When suppressed, the WndProc does not forward mouse or keyboard events to
+ * the app.
  */
 void
 comp_d3d11_window_set_input_suppress(struct comp_d3d11_window *window, bool suppress);
+
+/*!
+ * Phase 5.12: extend input suppression for @p ms milliseconds from now,
+ * regardless of the immediate `input_suppress` flag. Used when closing the
+ * launcher: any WM_KEYDOWN messages still sitting in the window thread's
+ * queue (e.g. the Esc that triggered the close) get swallowed instead of
+ * leaking through to the focused app.
+ */
+void
+comp_d3d11_window_set_input_suppress_grace_ms(struct comp_d3d11_window *window, uint32_t ms);
 
 /*!
  * Read and reset accumulated scroll wheel delta (for shell window resize).

--- a/src/xrt/compositor/d3d11_service/CMakeLists.txt
+++ b/src/xrt/compositor/d3d11_service/CMakeLists.txt
@@ -16,6 +16,8 @@ add_library(
 	d3d11_service_shaders.h
 	d3d11_capture.cpp
 	d3d11_capture.h
+	d3d11_icon_loader.cpp
+	d3d11_icon_loader.h
 	# Include layer accumulator directly (it has no Vulkan dependencies)
 	../util/comp_layer_accum.c
 	../util/comp_layer_accum.h
@@ -39,7 +41,11 @@ target_link_libraries(
 		windowsapp  # C++/WinRT runtime for Windows.Graphics.Capture
 	)
 
-target_include_directories(comp_d3d11_service PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/.. ${CMAKE_CURRENT_SOURCE_DIR}/../d3d11)
+target_include_directories(comp_d3d11_service PRIVATE
+	${CMAKE_CURRENT_SOURCE_DIR}/..
+	${CMAKE_CURRENT_SOURCE_DIR}/../d3d11
+	${CMAKE_CURRENT_SOURCE_DIR}/../../../external/stb  # stb_image.h
+)
 
 # Qwerty include path for stereo state polling in HUD overlay
 if(XRT_BUILD_DRIVER_QWERTY)

--- a/src/xrt/compositor/d3d11_service/CMakeLists.txt
+++ b/src/xrt/compositor/d3d11_service/CMakeLists.txt
@@ -44,6 +44,7 @@ target_link_libraries(
 target_include_directories(comp_d3d11_service PRIVATE
 	${CMAKE_CURRENT_SOURCE_DIR}/..
 	${CMAKE_CURRENT_SOURCE_DIR}/../d3d11
+	${CMAKE_CURRENT_SOURCE_DIR}/../../ipc          # shared/ipc_protocol.h (launcher app list)
 	${CMAKE_CURRENT_SOURCE_DIR}/../../../external/stb  # stb_image.h
 )
 

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -307,6 +307,15 @@ struct d3d11_service_system
 	//! The render pass draws a glow border around set tiles.
 	uint64_t running_tile_mask = 0;
 
+	//! Phase 5.12: visible-space selection index for the launcher grid.
+	//! -1 = nothing selected. Reset to 0 when the launcher becomes visible.
+	int32_t launcher_selected_index = -1;
+
+	//! Phase 5.13: bitmask of tiles the user has hidden this session via
+	//! right-click → Remove. Bit i = launcher_apps[i] is hidden. Cleared on
+	//! every shell registry re-push so the state is session-only.
+	uint64_t hidden_tile_mask = 0;
+
 	//! Multi-compositor control interface for session state management
 	struct xrt_multi_compositor_control xmcc;
 
@@ -4241,20 +4250,88 @@ struct shell_hit_result
 	int edge_flags;      //!< RESIZE_LEFT|RIGHT|TOP|BOTTOM if near edge
 };
 
+// Phase 5.12: toggle launcher visibility AND the window's input-suppress
+// flag in one place. When the launcher is up we want keyboard input to
+// drive the launcher itself (arrows / Enter / Esc) rather than leaking
+// through to the focused app; mirror the existing resize/drag pattern
+// which uses `comp_d3d11_window_set_input_suppress` for the same purpose.
+static void
+launcher_set_visible(struct d3d11_service_system *sys,
+                     struct d3d11_multi_compositor *mc, bool visible)
+{
+	if (mc == nullptr) return;
+	if (mc->launcher_visible == visible) return;
+
+	mc->launcher_visible = visible;
+	if (mc->window != nullptr) {
+		if (visible) {
+			comp_d3d11_window_set_input_suppress(mc->window, true);
+		} else {
+			// Phase 5.12: set the grace-period timestamp BEFORE clearing
+			// the immediate flag. If we cleared the flag first and then
+			// set the grace, the window thread could sample between the
+			// two writes and see neither active → forward the Esc that
+			// triggered the close. 200ms covers any WM_KEYDOWN queued on
+			// the window thread before the render thread got here.
+			comp_d3d11_window_set_input_suppress_grace_ms(mc->window, 200);
+			comp_d3d11_window_set_input_suppress(mc->window, false);
+		}
+	}
+	// Phase 5.12: when opening, force keyboard focus onto the compositor
+	// window. Without this, keys still route to whichever app previously
+	// had focus (the cube) and never reach the WndProc that the launcher's
+	// input-suppress gate lives in. The shell process grants us
+	// foreground-activation permission via AllowSetForegroundWindow before
+	// firing this IPC.
+	if (visible && mc->hwnd != nullptr) {
+		SetForegroundWindow(mc->hwnd);
+		SetFocus(mc->hwnd);
+	}
+	if (visible) {
+		sys->launcher_selected_index = 0;
+	} else {
+		sys->launcher_selected_index = -1;
+	}
+}
+
+// Phase 5.12+5.13+5.14: build the compacted visible-tile remap for the
+// launcher. Walks sys->launcher_apps skipping any bit set in hidden_tile_mask
+// and writes the full-space indices into @p out. The render pass and hit
+// test share this so the grid positions agree across the frame.
+//
+// Returns the number of visible tiles written. Does NOT include the virtual
+// "Add app…" Browse tile — that gets slot [n_visible] in both the render and
+// hit-test code paths.
+static uint32_t
+launcher_build_visible_list(const struct d3d11_service_system *sys,
+                            int out_visible_to_full[IPC_LAUNCHER_MAX_APPS])
+{
+	uint32_t n_apps = sys->launcher_app_count;
+	if (n_apps > IPC_LAUNCHER_MAX_APPS) n_apps = IPC_LAUNCHER_MAX_APPS;
+	uint32_t n_visible = 0;
+	for (uint32_t i = 0; i < n_apps; i++) {
+		if ((sys->hidden_tile_mask & (1ULL << i)) != 0) continue;
+		out_visible_to_full[n_visible++] = (int)i;
+	}
+	return n_visible;
+}
+
 /*!
- * Phase 5.9: hit test the launcher tile grid against a cursor position.
+ * Phase 5.9 / 5.13 / 5.14: hit test the launcher grid against a cursor.
  *
  * The launcher panel sits at z=0 in display coordinates (zero-disparity plane),
  * so the cursor position on the shell window converts directly to display
  * meters — no eye-projection raycast needed. Mirrors the layout math used by
  * the render pass so the visible tiles align with the hit boxes.
  *
- * Returns the tile index hit (0..launcher_app_count-1), -1 if cursor is over
- * the panel but not on a tile (used to suppress click-through), or -2 if the
- * cursor is outside the panel entirely (caller should dismiss the launcher).
+ * Returns:
+ *   - 0..n_visible-1      real tile hit (visible-space index, caller maps to full)
+ *   - n_visible           the virtual "Add app…" Browse tile
+ *   - -1                  inside panel but on a gap / title / header
+ *   - -2                  outside panel entirely (caller treats as dismiss)
  */
 static int
-launcher_hit_test(struct d3d11_service_system *sys, POINT cursor_px)
+launcher_hit_test(struct d3d11_service_system *sys, POINT cursor_px, uint32_t n_visible)
 {
 	float disp_w_m = sys->base.info.display_width_m;
 	float disp_h_m = sys->base.info.display_height_m;
@@ -4304,11 +4381,10 @@ launcher_hit_test(struct d3d11_service_system *sys, POINT cursor_px)
 	// (section_h_px * 0.65 / font_glyph_h) * 0.85 → in meters: section_h * 0.65 * 0.85.
 	float label_h = section_text_h * 0.85f;
 
-	uint32_t n_apps = sys->launcher_app_count;
-	if (n_apps > IPC_LAUNCHER_MAX_APPS) {
-		n_apps = IPC_LAUNCHER_MAX_APPS;
-	}
-	for (uint32_t i = 0; i < n_apps; i++) {
+	// Walk the visible tile grid PLUS one virtual Browse tile at position n_visible.
+	uint32_t n_total = n_visible + 1;
+	if (n_total > IPC_LAUNCHER_MAX_APPS + 1) n_total = IPC_LAUNCHER_MAX_APPS + 1;
+	for (uint32_t i = 0; i < n_total; i++) {
 		int tcol = (int)(i % LAUNCHER_GRID_COLS);
 		int trow = (int)(i / LAUNCHER_GRID_COLS);
 		float tx = margin + (float)tcol * (tile_w + margin);
@@ -5166,6 +5242,64 @@ multi_compositor_render(struct d3d11_service_system *sys)
 		return;
 	}
 
+	// Phase 5.12: launcher keyboard navigation.
+	// When the launcher is visible the arrow keys move selection, Enter
+	// fires the selected tile (or the Browse tile), and Esc dismisses the
+	// launcher. The normal TAB/DELETE/F11/Ctrl+1-3 shortcuts are gated
+	// out so e.g. Enter while launcher is open doesn't also toggle layout.
+	if (mc->launcher_visible) {
+		const int LAUNCHER_GRID_COLS = 4;
+		int visible_to_full[IPC_LAUNCHER_MAX_APPS];
+		uint32_t n_visible = launcher_build_visible_list(sys, visible_to_full);
+		// Addressable range includes the Browse tile at index n_visible.
+		int n_selectable = (int)n_visible + 1;
+
+		if (sys->launcher_selected_index < 0) sys->launcher_selected_index = 0;
+		if (sys->launcher_selected_index >= n_selectable) {
+			sys->launcher_selected_index = n_selectable - 1;
+		}
+
+		if (GetAsyncKeyState(VK_RIGHT) & 1) {
+			sys->launcher_selected_index =
+			    (sys->launcher_selected_index + 1) % n_selectable;
+		}
+		if (GetAsyncKeyState(VK_LEFT) & 1) {
+			sys->launcher_selected_index =
+			    (sys->launcher_selected_index - 1 + n_selectable) % n_selectable;
+		}
+		if (GetAsyncKeyState(VK_DOWN) & 1) {
+			int next = sys->launcher_selected_index + LAUNCHER_GRID_COLS;
+			if (next < n_selectable) {
+				sys->launcher_selected_index = next;
+			}
+		}
+		if (GetAsyncKeyState(VK_UP) & 1) {
+			int prev = sys->launcher_selected_index - LAUNCHER_GRID_COLS;
+			if (prev >= 0) {
+				sys->launcher_selected_index = prev;
+			}
+		}
+		if (GetAsyncKeyState(VK_RETURN) & 1) {
+			int sel = sys->launcher_selected_index;
+			if (sel == (int)n_visible) {
+				sys->pending_launcher_click_index = IPC_LAUNCHER_ACTION_BROWSE;
+				launcher_set_visible(sys, mc, false);
+				U_LOG_W("Launcher: Enter on Browse tile");
+			} else if (sel >= 0 && sel < (int)n_visible) {
+				sys->pending_launcher_click_index = visible_to_full[sel];
+				launcher_set_visible(sys, mc, false);
+				U_LOG_W("Launcher: Enter on tile vis=%d full=%d",
+				        sel, visible_to_full[sel]);
+			}
+		}
+		if (GetAsyncKeyState(VK_ESCAPE) & 1) {
+			launcher_set_visible(sys, mc, false);
+			U_LOG_W("Launcher: Esc dismissed");
+		}
+
+		goto after_key_shortcuts;
+	}
+
 	// TAB: cycle focus — includes unfocused state (-1)
 	// Cycle: slot 0 → slot 1 → ... → -1 (unfocused) → slot 0
 	// Ignore ALT+TAB (system task switcher) — only process bare TAB.
@@ -5267,6 +5401,9 @@ multi_compositor_render(struct d3d11_service_system *sys)
 			enter_dynamic_layout(sys, mc, 0); // carousel
 		}
 	}
+
+after_key_shortcuts:
+	(void)0; // label target for the launcher-visible fast-path above.
 
 	// Update cursor via window thread (compositor thread can't call SetCursor directly).
 	// Cursor IDs: 0=arrow, 1=sizewe, 2=sizens, 3=sizenwse, 4=sizenesw, 5=sizeall
@@ -5406,19 +5543,26 @@ multi_compositor_render(struct d3d11_service_system *sys)
 			GetCursorPos(&pt);
 			ScreenToClient(mc->hwnd, &pt);
 
-			// Phase 5.9/5.10: launcher takes click priority when visible.
-			// Hit a tile → store the index for the shell to consume + hide
-			// the launcher. Click outside the panel → just hide (dismiss).
-			// Click inside panel but not on a tile → swallow (no dismiss,
-			// no launch).
+			// Phase 5.9/5.10/5.14: launcher takes click priority when visible.
+			// - vis_tile in [0, n_visible-1]  → real tile, store full index
+			// - vis_tile == n_visible         → Browse-for-app virtual tile
+			// - vis_tile == -1                → gap/title/header, swallow
+			// - vis_tile == -2                → outside panel, dismiss
 			if (mc->launcher_visible) {
-				int tile = launcher_hit_test(sys, pt);
-				if (tile >= 0) {
-					sys->pending_launcher_click_index = tile;
-					mc->launcher_visible = false;
-					U_LOG_W("Launcher: tile %d clicked", tile);
-				} else if (tile == -2) {
-					mc->launcher_visible = false;
+				int visible_to_full[IPC_LAUNCHER_MAX_APPS];
+				uint32_t n_visible = launcher_build_visible_list(sys, visible_to_full);
+				int vis_tile = launcher_hit_test(sys, pt, n_visible);
+				if (vis_tile >= 0 && vis_tile < (int)n_visible) {
+					sys->pending_launcher_click_index = visible_to_full[vis_tile];
+					launcher_set_visible(sys, mc, false);
+					U_LOG_W("Launcher: tile vis=%d full=%d clicked",
+					        vis_tile, visible_to_full[vis_tile]);
+				} else if (vis_tile == (int)n_visible) {
+					sys->pending_launcher_click_index = IPC_LAUNCHER_ACTION_BROWSE;
+					launcher_set_visible(sys, mc, false);
+					U_LOG_W("Launcher: Browse tile clicked");
+				} else if (vis_tile == -2) {
+					launcher_set_visible(sys, mc, false);
 					U_LOG_W("Launcher: dismissed by click outside panel");
 				}
 				// Either way, do not propagate this click to window logic.
@@ -6861,10 +7005,9 @@ multi_compositor_render(struct d3d11_service_system *sys)
 		// the shell completes its first registered_apps_load + push; empty-
 		// state branch below handles that.
 		const struct ipc_launcher_app *apps = sys->launcher_apps;
-		uint32_t n_apps = sys->launcher_app_count;
-		if (n_apps > IPC_LAUNCHER_MAX_APPS) {
-			n_apps = IPC_LAUNCHER_MAX_APPS;
-		}
+		int visible_to_full[IPC_LAUNCHER_MAX_APPS];
+		uint32_t n_visible = launcher_build_visible_list(sys, visible_to_full);
+		uint32_t n_apps = n_visible; // rest of this block treats the list as compacted
 
 		// Pipeline setup once — then per-eye scissor + draw. Bind the font
 		// atlas SRV for text glyph sampling; solid-color draws ignore it.
@@ -7136,89 +7279,136 @@ multi_compositor_render(struct d3d11_service_system *sys)
 			float label_h = (float)mc->font_glyph_h * label_scale;
 			float grid_top = section_y + (float)mc->font_glyph_h * section_scale + margin * 0.5f;
 
+			// Render real tiles (compacted via visible_to_full) + the virtual
+			// "Add app…" Browse tile at position n_visible. When there are no
+			// real tiles we still draw the Browse tile plus the empty-state
+			// hint above it so the launcher is never completely blank.
 			if (n_apps == 0) {
 				const char *empty_line1 = "No apps discovered";
-				const char *empty_line2 = "Add a .displayxr.json sidecar next to your exe.";
+				const char *empty_line2 = "Add a .displayxr.json sidecar next to your exe, or use the tile below.";
 				float empty_scale_1 = section_scale * 0.95f;
-				float empty_scale_2 = section_scale * 0.65f;
+				float empty_scale_2 = section_scale * 0.60f;
 				float w1 = measure_text(empty_line1, empty_scale_1);
 				float w2 = measure_text(empty_line2, empty_scale_2);
 				float ex1 = panel_x + (panel_w_px - w1) * 0.5f;
 				float ex2 = panel_x + (panel_w_px - w2) * 0.5f;
-				float ey1 = grid_top + tile_h * 0.30f;
+				float ey1 = grid_top + tile_h * 0.15f;
 				float ey2 = ey1 + (float)mc->font_glyph_h * empty_scale_1 + margin * 0.4f;
 				draw_text(empty_line1, ex1, ey1, empty_scale_1);
 				draw_text(empty_line2, ex2, ey2, empty_scale_2);
-			} else {
-				for (uint32_t i = 0; i < n_apps; i++) {
-					int tcol = (int)(i % LAUNCHER_GRID_COLS);
-					int trow = (int)(i / LAUNCHER_GRID_COLS);
-					float tx = panel_x + margin + (float)tcol * (tile_w + margin);
-					float ty = grid_top + (float)trow * (tile_h + label_h + margin);
+			}
 
-					bool tile_running = (sys->running_tile_mask & (1ULL << i)) != 0;
+			for (uint32_t vi = 0; vi < n_apps; vi++) {
+				int full_idx = visible_to_full[vi];
+				int tcol = (int)(vi % LAUNCHER_GRID_COLS);
+				int trow = (int)(vi / LAUNCHER_GRID_COLS);
+				float tx = panel_x + margin + (float)tcol * (tile_w + margin);
+				float ty = grid_top + (float)trow * (tile_h + label_h + margin);
 
-					// Phase 5.11: glow border for running tiles. Draw an
-					// oversized quad in glow mode (convert_srgb=3.0) so the
-					// shader fades the inner rect into the surrounding margin.
-					if (tile_running) {
-						float glow_margin = tile_h * 0.18f;
-						float gx = tx - glow_margin;
-						float gy = ty - glow_margin;
-						float gw = tile_w + 2.0f * glow_margin;
-						float gh = tile_h + 2.0f * glow_margin;
-						float glow_ext = glow_margin / gh;
+				bool tile_running = (sys->running_tile_mask & (1ULL << full_idx)) != 0;
+				bool tile_selected = (sys->launcher_selected_index == (int32_t)vi);
 
-						D3D11_MAPPED_SUBRESOURCE gm;
-						if (SUCCEEDED(sys->context->Map(sys->blit_constant_buffer.get(), 0,
-						                                D3D11_MAP_WRITE_DISCARD, 0, &gm))) {
-							BlitConstants *cb = static_cast<BlitConstants *>(gm.pData);
-							cb->src_rect[0] = 0; cb->src_rect[1] = 0;
-							cb->src_rect[2] = 1; cb->src_rect[3] = 1;
-							cb->src_size[0] = 1; cb->src_size[1] = 1;
-							cb->dst_size[0] = (float)ca_w;
-							cb->dst_size[1] = (float)ca_h;
-							cb->convert_srgb = 3.0f; // glow mode
-							cb->corner_radius = 0.0f;
-							cb->corner_aspect = 0.0f;
-							cb->edge_feather = 0.0f;
-							cb->glow_intensity = 0.85f;
-							cb->glow_extent = glow_ext;
-							cb->glow_falloff = 8.0f;
-							cb->glow_color[0] = 0.30f;
-							cb->glow_color[1] = 0.85f;
-							cb->glow_color[2] = 1.00f;
-							cb->glow_color[3] = 1.0f;
-							cb->quad_mode = 0;
-							cb->dst_offset[0] = gx;
-							cb->dst_offset[1] = gy;
-							cb->dst_rect_wh[0] = gw;
-							cb->dst_rect_wh[1] = gh;
-							memset(cb->quad_corners_01, 0, sizeof(cb->quad_corners_01));
-							memset(cb->quad_corners_23, 0, sizeof(cb->quad_corners_23));
-							sys->context->Unmap(sys->blit_constant_buffer.get(), 0);
-							// Glow mode uses premultiplied alpha — switch
-							// blend state for this draw, then restore.
-							sys->context->OMSetBlendState(sys->blend_premul.get(), nullptr, 0xFFFFFFFF);
-							sys->context->Draw(4, 0);
-							sys->context->OMSetBlendState(sys->blend_alpha.get(), nullptr, 0xFFFFFFFF);
-						}
+				// Phase 5.11: glow border for running tiles. Draw an
+				// oversized quad in glow mode (convert_srgb=3.0) so the
+				// shader fades the inner rect into the surrounding margin.
+				if (tile_running) {
+					float glow_margin = tile_h * 0.18f;
+					float gx = tx - glow_margin;
+					float gy = ty - glow_margin;
+					float gw = tile_w + 2.0f * glow_margin;
+					float gh = tile_h + 2.0f * glow_margin;
+					float glow_ext = glow_margin / gh;
+
+					D3D11_MAPPED_SUBRESOURCE gm;
+					if (SUCCEEDED(sys->context->Map(sys->blit_constant_buffer.get(), 0,
+					                                D3D11_MAP_WRITE_DISCARD, 0, &gm))) {
+						BlitConstants *cb = static_cast<BlitConstants *>(gm.pData);
+						cb->src_rect[0] = 0; cb->src_rect[1] = 0;
+						cb->src_rect[2] = 1; cb->src_rect[3] = 1;
+						cb->src_size[0] = 1; cb->src_size[1] = 1;
+						cb->dst_size[0] = (float)ca_w;
+						cb->dst_size[1] = (float)ca_h;
+						cb->convert_srgb = 3.0f; // glow mode
+						cb->corner_radius = 0.0f;
+						cb->corner_aspect = 0.0f;
+						cb->edge_feather = 0.0f;
+						cb->glow_intensity = 0.85f;
+						cb->glow_extent = glow_ext;
+						cb->glow_falloff = 8.0f;
+						cb->glow_color[0] = 0.30f;
+						cb->glow_color[1] = 0.85f;
+						cb->glow_color[2] = 1.00f;
+						cb->glow_color[3] = 1.0f;
+						cb->quad_mode = 0;
+						cb->dst_offset[0] = gx;
+						cb->dst_offset[1] = gy;
+						cb->dst_rect_wh[0] = gw;
+						cb->dst_rect_wh[1] = gh;
+						memset(cb->quad_corners_01, 0, sizeof(cb->quad_corners_01));
+						memset(cb->quad_corners_23, 0, sizeof(cb->quad_corners_23));
+						sys->context->Unmap(sys->blit_constant_buffer.get(), 0);
+						// Glow mode uses premultiplied alpha — switch
+						// blend state for this draw, then restore.
+						sys->context->OMSetBlendState(sys->blend_premul.get(), nullptr, 0xFFFFFFFF);
+						sys->context->Draw(4, 0);
+						sys->context->OMSetBlendState(sys->blend_alpha.get(), nullptr, 0xFFFFFFFF);
 					}
-
-					// Tile background — slightly lighter than panel, rounded.
-					// Running tiles get a brighter background to reinforce the glow.
-					float bg_r = tile_running ? 0.20f : 0.16f;
-					float bg_g = tile_running ? 0.27f : 0.19f;
-					float bg_b = tile_running ? 0.36f : 0.26f;
-					draw_solid_rect(tx, ty, tile_w, tile_h,
-					                bg_r, bg_g, bg_b, 0.95f, 0.18f, 0.0f);
-
-					// Label centered horizontally below tile, ellipsis-truncated
-					// if it would overflow into the neighbouring tile.
-					const char *label = apps[i].name;
-					float label_y = ty + tile_h + margin * 0.15f;
-					draw_label_centered(label, tx, label_y, tile_w, label_scale);
 				}
+
+				// Phase 5.12: keyboard selection outline. Draw a slightly
+				// oversized white rect behind the tile; the tile background
+				// covers the middle, leaving a thin visible ring.
+				if (tile_selected) {
+					float sm = tile_h * 0.045f;
+					draw_solid_rect(tx - sm, ty - sm,
+					                tile_w + 2.0f * sm, tile_h + 2.0f * sm,
+					                1.00f, 1.00f, 1.00f, 0.90f, 0.20f, 0.0f);
+				}
+
+				// Tile background — slightly lighter than panel, rounded.
+				// Running tiles get a brighter background to reinforce the glow.
+				float bg_r = tile_running ? 0.20f : 0.16f;
+				float bg_g = tile_running ? 0.27f : 0.19f;
+				float bg_b = tile_running ? 0.36f : 0.26f;
+				draw_solid_rect(tx, ty, tile_w, tile_h,
+				                bg_r, bg_g, bg_b, 0.95f, 0.18f, 0.0f);
+
+				// Label centered horizontally below tile, ellipsis-truncated
+				// if it would overflow into the neighbouring tile.
+				const char *label = apps[full_idx].name;
+				float label_y = ty + tile_h + margin * 0.15f;
+				draw_label_centered(label, tx, label_y, tile_w, label_scale);
+			}
+
+			// Phase 5.14: virtual "Add app…" Browse tile at position n_apps.
+			// Distinct styling (lighter, more translucent) + "+" glyph +
+			// "Add app…" label. Click here → IPC_LAUNCHER_ACTION_BROWSE.
+			{
+				uint32_t vi = n_apps;
+				int tcol = (int)(vi % LAUNCHER_GRID_COLS);
+				int trow = (int)(vi / LAUNCHER_GRID_COLS);
+				float tx = panel_x + margin + (float)tcol * (tile_w + margin);
+				float ty = grid_top + (float)trow * (tile_h + label_h + margin);
+				bool browse_selected = (sys->launcher_selected_index == (int32_t)vi);
+
+				if (browse_selected) {
+					float sm = tile_h * 0.045f;
+					draw_solid_rect(tx - sm, ty - sm,
+					                tile_w + 2.0f * sm, tile_h + 2.0f * sm,
+					                1.00f, 1.00f, 1.00f, 0.90f, 0.20f, 0.0f);
+				}
+
+				draw_solid_rect(tx, ty, tile_w, tile_h,
+				                0.20f, 0.22f, 0.28f, 0.75f, 0.18f, 0.0f);
+
+				float plus_scale = section_scale * 1.6f;
+				float plus_h = (float)mc->font_glyph_h * plus_scale;
+				draw_label_centered("+", tx, ty + (tile_h - plus_h) * 0.5f,
+				                    tile_w, plus_scale);
+
+				float browse_label_y = ty + tile_h + margin * 0.15f;
+				draw_label_centered("Add app...", tx, browse_label_y,
+				                    tile_w, label_scale);
 			}
 		}
 
@@ -9974,6 +10164,11 @@ comp_d3d11_service_clear_launcher_apps(struct xrt_system_compositor *xsysc)
 	std::lock_guard<std::recursive_mutex> lock(sys->render_mutex);
 
 	sys->launcher_app_count = 0;
+	// Phase 5.13: the hidden-tile state is session-only and indices refer
+	// to positions in launcher_apps, so it only makes sense while that list
+	// is stable. Wipe it whenever a fresh push starts.
+	sys->hidden_tile_mask = 0;
+	sys->launcher_selected_index = -1;
 }
 
 // Phase 5.8: append one app to the launcher's tile grid. Silently dropped if
@@ -10071,11 +10266,7 @@ comp_d3d11_service_set_launcher_visible(struct xrt_system_compositor *xsysc, boo
 		return;
 	}
 
-	if (mc->launcher_visible == visible) {
-		return;
-	}
-
-	mc->launcher_visible = visible;
+	launcher_set_visible(sys, mc, visible);
 	U_LOG_W("Launcher: %s", visible ? "shown" : "hidden");
 
 	// Wake the render thread so the next frame reflects the new state even

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -302,6 +302,11 @@ struct d3d11_service_system
 	//! ipc_call_shell_poll_launcher_click(). -1 means no pending click.
 	int32_t pending_launcher_click_index = -1;
 
+	//! Phase 5.11: bitmask of running tiles (bit i = launcher_apps[i] has a
+	//! matching IPC client). Pushed by the shell from its client-poll loop.
+	//! The render pass draws a glow border around set tiles.
+	uint64_t running_tile_mask = 0;
+
 	//! Multi-compositor control interface for session state management
 	struct xrt_multi_compositor_control xmcc;
 
@@ -7151,9 +7156,62 @@ multi_compositor_render(struct d3d11_service_system *sys)
 					float tx = panel_x + margin + (float)tcol * (tile_w + margin);
 					float ty = grid_top + (float)trow * (tile_h + label_h + margin);
 
+					bool tile_running = (sys->running_tile_mask & (1ULL << i)) != 0;
+
+					// Phase 5.11: glow border for running tiles. Draw an
+					// oversized quad in glow mode (convert_srgb=3.0) so the
+					// shader fades the inner rect into the surrounding margin.
+					if (tile_running) {
+						float glow_margin = tile_h * 0.18f;
+						float gx = tx - glow_margin;
+						float gy = ty - glow_margin;
+						float gw = tile_w + 2.0f * glow_margin;
+						float gh = tile_h + 2.0f * glow_margin;
+						float glow_ext = glow_margin / gh;
+
+						D3D11_MAPPED_SUBRESOURCE gm;
+						if (SUCCEEDED(sys->context->Map(sys->blit_constant_buffer.get(), 0,
+						                                D3D11_MAP_WRITE_DISCARD, 0, &gm))) {
+							BlitConstants *cb = static_cast<BlitConstants *>(gm.pData);
+							cb->src_rect[0] = 0; cb->src_rect[1] = 0;
+							cb->src_rect[2] = 1; cb->src_rect[3] = 1;
+							cb->src_size[0] = 1; cb->src_size[1] = 1;
+							cb->dst_size[0] = (float)ca_w;
+							cb->dst_size[1] = (float)ca_h;
+							cb->convert_srgb = 3.0f; // glow mode
+							cb->corner_radius = 0.0f;
+							cb->corner_aspect = 0.0f;
+							cb->edge_feather = 0.0f;
+							cb->glow_intensity = 0.85f;
+							cb->glow_extent = glow_ext;
+							cb->glow_falloff = 8.0f;
+							cb->glow_color[0] = 0.30f;
+							cb->glow_color[1] = 0.85f;
+							cb->glow_color[2] = 1.00f;
+							cb->glow_color[3] = 1.0f;
+							cb->quad_mode = 0;
+							cb->dst_offset[0] = gx;
+							cb->dst_offset[1] = gy;
+							cb->dst_rect_wh[0] = gw;
+							cb->dst_rect_wh[1] = gh;
+							memset(cb->quad_corners_01, 0, sizeof(cb->quad_corners_01));
+							memset(cb->quad_corners_23, 0, sizeof(cb->quad_corners_23));
+							sys->context->Unmap(sys->blit_constant_buffer.get(), 0);
+							// Glow mode uses premultiplied alpha — switch
+							// blend state for this draw, then restore.
+							sys->context->OMSetBlendState(sys->blend_premul.get(), nullptr, 0xFFFFFFFF);
+							sys->context->Draw(4, 0);
+							sys->context->OMSetBlendState(sys->blend_alpha.get(), nullptr, 0xFFFFFFFF);
+						}
+					}
+
 					// Tile background — slightly lighter than panel, rounded.
+					// Running tiles get a brighter background to reinforce the glow.
+					float bg_r = tile_running ? 0.20f : 0.16f;
+					float bg_g = tile_running ? 0.27f : 0.19f;
+					float bg_b = tile_running ? 0.36f : 0.26f;
 					draw_solid_rect(tx, ty, tile_w, tile_h,
-					                0.16f, 0.19f, 0.26f, 0.95f, 0.18f, 0.0f);
+					                bg_r, bg_g, bg_b, 0.95f, 0.18f, 0.0f);
 
 					// Label centered horizontally below tile, ellipsis-truncated
 					// if it would overflow into the neighbouring tile.
@@ -9941,6 +9999,33 @@ comp_d3d11_service_add_launcher_app(struct xrt_system_compositor *xsysc,
 
 	// Wake the compositor window if it exists and the launcher is on-screen,
 	// so the next frame picks up the new tile.
+	struct d3d11_multi_compositor *mc = sys->multi_comp;
+	if (mc != nullptr && mc->hwnd != nullptr && mc->launcher_visible) {
+		InvalidateRect(mc->hwnd, nullptr, FALSE);
+	}
+}
+
+// Phase 5.11: set the running-tile bitmask. Bit i set means launcher_apps[i]
+// has at least one matching IPC client connected. The render pass draws a
+// glow border around any tile whose bit is set. Pushed by the shell from its
+// client-poll loop whenever the running set changes.
+void
+comp_d3d11_service_set_running_tile_mask(struct xrt_system_compositor *xsysc, uint64_t mask)
+{
+	if (xsysc == nullptr) {
+		return;
+	}
+
+	struct d3d11_service_system *sys = d3d11_service_system_from_xrt(xsysc);
+	std::lock_guard<std::recursive_mutex> lock(sys->render_mutex);
+
+	if (sys->running_tile_mask == mask) {
+		return;
+	}
+	sys->running_tile_mask = mask;
+
+	// Wake the compositor if the launcher is on-screen so the new glow
+	// state shows up immediately.
 	struct d3d11_multi_compositor *mc = sys->multi_comp;
 	if (mc != nullptr && mc->hwnd != nullptr && mc->launcher_visible) {
 		InvalidateRect(mc->hwnd, nullptr, FALSE);

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -602,6 +602,11 @@ struct d3d11_multi_compositor
 	//! Unlike window_dismissed, the multi-comp structure stays alive for re-activation.
 	bool suspended;
 
+	//! Phase 5.7: spatial launcher panel visible.
+	//! Toggled by Ctrl+L via ipc_call_shell_set_launcher_visible. When true, the
+	//! render loop draws a rounded-corner panel at the zero-disparity plane.
+	bool launcher_visible;
+
 	//! Debounced re-grid: when > 0, apply grid layout after this timestamp.
 	//! Set by client registration, consumed by render loop.
 	uint64_t regrid_pending_ns;
@@ -6684,6 +6689,247 @@ multi_compositor_render(struct d3d11_service_system *sys)
 		}
 	}
 
+	// Phase 5.7 + 5.8: spatial launcher panel.
+	// Drawn at (0,0,0) in display coordinates — zero-disparity plane — so it
+	// appears on the physical display surface, which maximizes viewing comfort.
+	// At z=0 there is no parallax, so the panel lands at the same pixel
+	// position for every eye; we just center-draw into each tile.
+	//
+	// Layout (5.8): title bar text "DisplayXR Launcher" → "Installed" header
+	// → tile grid (4-column, wraps to additional rows). Hard-coded placeholder
+	// app names for now; real apps come over IPC in a follow-up task.
+	if (mc->launcher_visible) {
+		uint32_t ca_w = sys->base.info.display_pixel_width;
+		uint32_t ca_h = sys->base.info.display_pixel_height;
+		if (ca_w == 0) ca_w = 3840;
+		if (ca_h == 0) ca_h = 2160;
+		uint32_t half_w = ca_w / sys->tile_columns;
+		uint32_t half_h = ca_h / sys->tile_rows;
+		uint32_t num_views = sys->tile_columns * sys->tile_rows;
+
+		// Panel size as a fraction of the physical display — resolution-
+		// and aspect-independent. Using fractions of display_{width,height}_m
+		// instead of absolute meters ensures the panel scales correctly across
+		// laptop, tablet, and desktop displays.
+		float disp_w_m = sys->base.info.display_width_m;
+		float disp_h_m = sys->base.info.display_height_m;
+		if (disp_w_m <= 0.0f) disp_w_m = 0.700f;
+		if (disp_h_m <= 0.0f) disp_h_m = 0.394f;
+
+		const float panel_w_frac = 0.60f;
+		const float panel_h_frac = 0.55f;
+		float panel_w_m = disp_w_m * panel_w_frac;
+		float panel_h_m = disp_h_m * panel_h_frac;
+
+		float panel_w_px = ui_m_to_tile_px_x(panel_w_m, sys);
+		float panel_h_px = ui_m_to_tile_px_y(panel_h_m, sys);
+
+		// Tile grid layout (panel-relative). 4 columns wraps to additional
+		// rows when more apps are present. All sizes derived from panel
+		// dimensions so the layout scales with display size.
+		const int LAUNCHER_GRID_COLS = 4;
+		float margin = panel_w_px * 0.04f;
+		float title_h = panel_h_px * 0.13f;
+		float section_h = panel_h_px * 0.07f;
+		float tile_w = (panel_w_px - (LAUNCHER_GRID_COLS + 1) * margin) /
+		               (float)LAUNCHER_GRID_COLS;
+		float tile_h = tile_w * 0.65f;
+
+		// Hard-coded placeholder apps. The real app list will arrive via IPC
+		// in a follow-up task; this proves the layout + text rendering path.
+		const char *placeholder_apps[] = {
+			"Cube D3D11", "Cube D3D12", "Cube OpenGL", "Cube Vulkan",
+		};
+		const int n_apps = (int)(sizeof(placeholder_apps) / sizeof(placeholder_apps[0]));
+
+		// Pipeline setup once — then per-eye scissor + draw. Bind the font
+		// atlas SRV for text glyph sampling; solid-color draws ignore it.
+		sys->context->VSSetShader(sys->blit_vs.get(), nullptr, 0);
+		sys->context->PSSetShader(sys->blit_ps.get(), nullptr, 0);
+		sys->context->VSSetConstantBuffers(0, 1, sys->blit_constant_buffer.addressof());
+		sys->context->PSSetConstantBuffers(0, 1, sys->blit_constant_buffer.addressof());
+		ID3D11RenderTargetView *launcher_rtvs[] = {mc->combined_atlas_rtv.get()};
+		sys->context->OMSetRenderTargets(1, launcher_rtvs, nullptr);
+		sys->context->OMSetBlendState(sys->blend_alpha.get(), nullptr, 0xFFFFFFFF);
+		sys->context->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
+		sys->context->IASetInputLayout(nullptr);
+		sys->context->RSSetState(sys->rasterizer_state.get());
+		sys->context->OMSetDepthStencilState(sys->depth_disabled.get(), 0);
+		D3D11_VIEWPORT launcher_vp = {};
+		launcher_vp.Width = (float)ca_w;
+		launcher_vp.Height = (float)ca_h;
+		launcher_vp.MaxDepth = 1.0f;
+		sys->context->RSSetViewports(1, &launcher_vp);
+		if (mc->font_atlas_srv) {
+			ID3D11ShaderResourceView *font_srv = mc->font_atlas_srv.get();
+			sys->context->PSSetShaderResources(0, 1, &font_srv);
+			sys->context->PSSetSamplers(0, 1, sys->sampler_linear.addressof());
+		}
+
+		// Helper: draw a solid-color rounded rect at (dx,dy,dw,dh) in atlas
+		// pixels with the given RGBA. Used for the panel background and tile
+		// backgrounds. Updates the constant buffer and issues a single Draw.
+		auto draw_solid_rect = [&](float dx, float dy, float dw, float dh,
+		                           float r, float g, float b, float a,
+		                           float corner_radius, float glow_intensity) {
+			D3D11_MAPPED_SUBRESOURCE m;
+			if (FAILED(sys->context->Map(sys->blit_constant_buffer.get(), 0,
+			                             D3D11_MAP_WRITE_DISCARD, 0, &m))) {
+				return;
+			}
+			BlitConstants *cb = static_cast<BlitConstants *>(m.pData);
+			cb->src_rect[0] = r;
+			cb->src_rect[1] = g;
+			cb->src_rect[2] = b;
+			cb->src_rect[3] = a;
+			cb->src_size[0] = 1;
+			cb->src_size[1] = 1;
+			cb->dst_size[0] = (float)ca_w;
+			cb->dst_size[1] = (float)ca_h;
+			cb->convert_srgb = 2.0f; // solid-color mode
+			cb->corner_radius = corner_radius;
+			cb->corner_aspect = (dh > 0.0f) ? (dw / dh) : 1.0f;
+			cb->edge_feather = (dh > 0.0f) ? (2.0f / dh) : 0.0f;
+			cb->glow_intensity = glow_intensity;
+			cb->quad_mode = 0;
+			cb->dst_offset[0] = dx;
+			cb->dst_offset[1] = dy;
+			cb->dst_rect_wh[0] = dw;
+			cb->dst_rect_wh[1] = dh;
+			memset(cb->quad_corners_01, 0, sizeof(cb->quad_corners_01));
+			memset(cb->quad_corners_23, 0, sizeof(cb->quad_corners_23));
+			sys->context->Unmap(sys->blit_constant_buffer.get(), 0);
+			sys->context->Draw(4, 0);
+		};
+
+		// Helper: width of a string in atlas pixels at the given scale.
+		auto measure_text = [&](const char *text, float scale) -> float {
+			float w = 0.0f;
+			for (const char *p = text; *p != '\0'; p++) {
+				unsigned char ch = (unsigned char)*p;
+				if (ch < 0x20 || ch > 0x7E) ch = '?';
+				int gi = ch - 0x20;
+				w += mc->glyph_advances[gi] * scale;
+			}
+			return w;
+		};
+
+		// Helper: draw a string starting at (dx, dy) (top-left, atlas px) at
+		// the given scale, sampling the font atlas. One Draw call per glyph.
+		auto draw_text = [&](const char *text, float dx, float dy, float scale) {
+			float cursor = 0.0f;
+			float dst_gh = (float)mc->font_glyph_h * scale;
+			for (const char *p = text; *p != '\0'; p++) {
+				unsigned char ch = (unsigned char)*p;
+				if (ch < 0x20 || ch > 0x7E) ch = '?';
+				int gi = ch - 0x20;
+				float src_gw = mc->glyph_advances[gi];
+				float src_x = 0.0f;
+				for (int i = 0; i < gi; i++) {
+					src_x += mc->glyph_advances[i];
+				}
+				float dst_gw = src_gw * scale;
+
+				D3D11_MAPPED_SUBRESOURCE m;
+				if (SUCCEEDED(sys->context->Map(sys->blit_constant_buffer.get(), 0,
+				                                D3D11_MAP_WRITE_DISCARD, 0, &m))) {
+					BlitConstants *cb = static_cast<BlitConstants *>(m.pData);
+					cb->src_rect[0] = src_x;
+					cb->src_rect[1] = 0.0f;
+					cb->src_rect[2] = src_gw;
+					cb->src_rect[3] = (float)mc->font_glyph_h;
+					cb->src_size[0] = (float)mc->font_atlas_w;
+					cb->src_size[1] = (float)mc->font_atlas_h;
+					cb->dst_size[0] = (float)ca_w;
+					cb->dst_size[1] = (float)ca_h;
+					cb->convert_srgb = 0.0f; // textured (font atlas is linear)
+					cb->corner_radius = 0.0f;
+					cb->corner_aspect = 0.0f;
+					cb->edge_feather = 0.0f;
+					cb->glow_intensity = 0.0f;
+					cb->quad_mode = 0;
+					cb->dst_offset[0] = dx + cursor;
+					cb->dst_offset[1] = dy;
+					cb->dst_rect_wh[0] = dst_gw;
+					cb->dst_rect_wh[1] = dst_gh;
+					memset(cb->quad_corners_01, 0, sizeof(cb->quad_corners_01));
+					memset(cb->quad_corners_23, 0, sizeof(cb->quad_corners_23));
+					sys->context->Unmap(sys->blit_constant_buffer.get(), 0);
+					sys->context->Draw(4, 0);
+				}
+				cursor += dst_gw;
+			}
+		};
+
+		for (uint32_t v = 0; v < num_views && v < XRT_MAX_VIEWS; v++) {
+			uint32_t col = v % sys->tile_columns;
+			uint32_t row = v / sys->tile_columns;
+
+			// Scissor clips to this tile's bounds so the solid quad cannot
+			// bleed into neighbouring eyes.
+			D3D11_RECT scissor;
+			scissor.left = (LONG)(col * half_w);
+			scissor.top = (LONG)(row * half_h);
+			scissor.right = (LONG)((col + 1) * half_w);
+			scissor.bottom = (LONG)((row + 1) * half_h);
+			sys->context->RSSetScissorRects(1, &scissor);
+
+			// Tile-local center — z=0 means no parallax, identical for both eyes.
+			float tile_cx = (float)(col * half_w) + (float)half_w * 0.5f;
+			float tile_cy = (float)(row * half_h) + (float)half_h * 0.5f;
+			float panel_x = tile_cx - panel_w_px * 0.5f;
+			float panel_y = tile_cy - panel_h_px * 0.5f;
+
+			// 1) Panel background — dark slate with ~92% alpha.
+			draw_solid_rect(panel_x, panel_y, panel_w_px, panel_h_px,
+			                0.08f, 0.10f, 0.14f, 0.92f, 0.08f, 0.0f);
+
+			// 2) Title bar text "DisplayXR Launcher", centered horizontally
+			// in the title strip.
+			const char *title_text = "DisplayXR Launcher";
+			float title_scale = (title_h * 0.55f) / (float)mc->font_glyph_h;
+			float title_w = measure_text(title_text, title_scale);
+			float title_x = panel_x + (panel_w_px - title_w) * 0.5f;
+			float title_y = panel_y + (title_h - mc->font_glyph_h * title_scale) * 0.5f;
+			draw_text(title_text, title_x, title_y, title_scale);
+
+			// 3) "Installed" section header, left-aligned with grid margin.
+			const char *installed_text = "Installed";
+			float section_scale = (section_h * 0.65f) / (float)mc->font_glyph_h;
+			float section_x = panel_x + margin;
+			float section_y = panel_y + title_h + margin * 0.5f;
+			draw_text(installed_text, section_x, section_y, section_scale);
+
+			// 4) Tile grid — 4-column wrapping. Each row also reserves space
+			// below the tile for its label.
+			float label_scale = section_scale * 0.85f;
+			float label_h = (float)mc->font_glyph_h * label_scale;
+			float grid_top = section_y + (float)mc->font_glyph_h * section_scale + margin * 0.5f;
+			for (int i = 0; i < n_apps; i++) {
+				int tcol = i % LAUNCHER_GRID_COLS;
+				int trow = i / LAUNCHER_GRID_COLS;
+				float tx = panel_x + margin + tcol * (tile_w + margin);
+				float ty = grid_top + trow * (tile_h + label_h + margin);
+
+				// Tile background — slightly lighter than panel, rounded.
+				draw_solid_rect(tx, ty, tile_w, tile_h,
+				                0.16f, 0.19f, 0.26f, 0.95f, 0.18f, 0.0f);
+
+				// Label centered horizontally below tile, clipped if too wide.
+				const char *label = placeholder_apps[i];
+				float label_w = measure_text(label, label_scale);
+				float label_x = tx + (tile_w - label_w) * 0.5f;
+				if (label_x < tx) label_x = tx;
+				float label_y = ty + tile_h + margin * 0.15f;
+				draw_text(label, label_x, label_y, label_scale);
+			}
+		}
+
+		// Clear scissor so downstream passes aren't affected.
+		D3D11_RECT full_scissor = {0, 0, (LONG)ca_w, (LONG)ca_h};
+		sys->context->RSSetScissorRects(1, &full_scissor);
+	}
+
 	// Send full combined atlas to DP — content is placed at sub-rect positions,
 	// background is dark gray. The DP interlaces the entire image.
 	// View width/height = full atlas divided by tile layout (not sub-rect).
@@ -9415,4 +9661,38 @@ comp_d3d11_service_deactivate_shell(struct xrt_system_compositor *xsysc)
 
 	U_LOG_W("Shell deactivate: complete — captures stopped, multi-comp suspended, "
 	        "IPC clients will lazy-switch to standalone on next frame");
+}
+
+// Phase 5.7: spatial launcher visibility toggle. Just flips the render-thread
+// bool; the render loop picks it up on the next frame and draws (or skips) the
+// launcher panel overlay. No-op if there's no multi-comp yet (shell not active).
+void
+comp_d3d11_service_set_launcher_visible(struct xrt_system_compositor *xsysc, bool visible)
+{
+	if (xsysc == nullptr) {
+		return;
+	}
+
+	struct d3d11_service_system *sys = d3d11_service_system_from_xrt(xsysc);
+	std::lock_guard<std::recursive_mutex> lock(sys->render_mutex);
+
+	struct d3d11_multi_compositor *mc = sys->multi_comp;
+	if (mc == nullptr || mc->suspended) {
+		U_LOG_W("Launcher: set_visible %s ignored — multi-comp not active",
+		        visible ? "true" : "false");
+		return;
+	}
+
+	if (mc->launcher_visible == visible) {
+		return;
+	}
+
+	mc->launcher_visible = visible;
+	U_LOG_W("Launcher: %s", visible ? "shown" : "hidden");
+
+	// Wake the render thread so the next frame reflects the new state even
+	// if the render loop is idling on a timer.
+	if (mc->hwnd != nullptr) {
+		InvalidateRect(mc->hwnd, nullptr, FALSE);
+	}
 }

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -297,6 +297,11 @@ struct d3d11_service_system
 	struct ipc_launcher_app launcher_apps[IPC_LAUNCHER_MAX_APPS];
 	uint32_t launcher_app_count;
 
+	//! Phase 5.9/5.10: pending launcher tile click. Set by the WM_LBUTTONDOWN
+	//! handler when the user clicks a tile, consumed by the shell via
+	//! ipc_call_shell_poll_launcher_click(). -1 means no pending click.
+	int32_t pending_launcher_click_index = -1;
+
 	//! Multi-compositor control interface for session state management
 	struct xrt_multi_compositor_control xmcc;
 
@@ -4232,6 +4237,88 @@ struct shell_hit_result
 };
 
 /*!
+ * Phase 5.9: hit test the launcher tile grid against a cursor position.
+ *
+ * The launcher panel sits at z=0 in display coordinates (zero-disparity plane),
+ * so the cursor position on the shell window converts directly to display
+ * meters — no eye-projection raycast needed. Mirrors the layout math used by
+ * the render pass so the visible tiles align with the hit boxes.
+ *
+ * Returns the tile index hit (0..launcher_app_count-1), -1 if cursor is over
+ * the panel but not on a tile (used to suppress click-through), or -2 if the
+ * cursor is outside the panel entirely (caller should dismiss the launcher).
+ */
+static int
+launcher_hit_test(struct d3d11_service_system *sys, POINT cursor_px)
+{
+	float disp_w_m = sys->base.info.display_width_m;
+	float disp_h_m = sys->base.info.display_height_m;
+	uint32_t disp_px_w = sys->base.info.display_pixel_width;
+	uint32_t disp_px_h = sys->base.info.display_pixel_height;
+	if (disp_w_m <= 0.0f) disp_w_m = 0.700f;
+	if (disp_h_m <= 0.0f) disp_h_m = 0.394f;
+	if (disp_px_w == 0) disp_px_w = 3840;
+	if (disp_px_h == 0) disp_px_h = 2160;
+
+	// Cursor → display-surface meters (origin = display center, +x right, +y up).
+	// Same formula as the existing taskbar hit-test path.
+	float cursor_x_m = ((float)cursor_px.x - (float)disp_px_w / 2.0f) *
+	                   disp_w_m / (float)disp_px_w;
+	float cursor_y_m = ((float)disp_px_h / 2.0f - (float)cursor_px.y) *
+	                   disp_h_m / (float)disp_px_h;
+
+	// Panel geometry — must mirror the render block exactly.
+	const float panel_w_frac = 0.60f;
+	const float panel_h_frac = 0.55f;
+	float panel_w_m = disp_w_m * panel_w_frac;
+	float panel_h_m = disp_h_m * panel_h_frac;
+
+	// Outside panel → caller treats as dismiss.
+	if (cursor_x_m < -panel_w_m * 0.5f || cursor_x_m > panel_w_m * 0.5f ||
+	    cursor_y_m < -panel_h_m * 0.5f || cursor_y_m > panel_h_m * 0.5f) {
+		return -2;
+	}
+
+	// Convert to panel-local meters (origin top-left).
+	float lx = cursor_x_m + panel_w_m * 0.5f;
+	float ly = panel_h_m * 0.5f - cursor_y_m;
+
+	// Tile layout — mirrors the render pass, but in meters instead of pixels.
+	// All ratios are unit-independent so the same fractions work in either.
+	const int LAUNCHER_GRID_COLS = 4;
+	float margin = panel_w_m * 0.04f;
+	float title_h = panel_h_m * 0.13f;
+	float section_h = panel_h_m * 0.07f;
+	float tile_w = (panel_w_m - (LAUNCHER_GRID_COLS + 1) * margin) /
+	               (float)LAUNCHER_GRID_COLS;
+	float tile_h = tile_w * 0.65f;
+	float section_text_h = section_h * 0.65f;
+	float section_y = title_h + margin * 0.5f;
+	float grid_top = section_y + section_text_h + margin * 0.5f;
+	// Label height = font_glyph_h * label_scale where label_scale =
+	// (section_h_px * 0.65 / font_glyph_h) * 0.85 → in meters: section_h * 0.65 * 0.85.
+	float label_h = section_text_h * 0.85f;
+
+	uint32_t n_apps = sys->launcher_app_count;
+	if (n_apps > IPC_LAUNCHER_MAX_APPS) {
+		n_apps = IPC_LAUNCHER_MAX_APPS;
+	}
+	for (uint32_t i = 0; i < n_apps; i++) {
+		int tcol = (int)(i % LAUNCHER_GRID_COLS);
+		int trow = (int)(i / LAUNCHER_GRID_COLS);
+		float tx = margin + (float)tcol * (tile_w + margin);
+		float ty = grid_top + (float)trow * (tile_h + label_h + margin);
+		if (lx >= tx && lx <= tx + tile_w &&
+		    ly >= ty && ly <= ty + tile_h) {
+			return (int)i;
+		}
+	}
+
+	// Inside panel but not on a tile (e.g. title bar, gaps).
+	return -1;
+}
+
+/*!
  * Spatial raycast hit-test: cast a ray from the user's eye through the mouse
  * cursor position on the display surface, and intersect with shell window planes.
  *
@@ -5313,6 +5400,25 @@ multi_compositor_render(struct d3d11_service_system *sys)
 			POINT pt;
 			GetCursorPos(&pt);
 			ScreenToClient(mc->hwnd, &pt);
+
+			// Phase 5.9/5.10: launcher takes click priority when visible.
+			// Hit a tile → store the index for the shell to consume + hide
+			// the launcher. Click outside the panel → just hide (dismiss).
+			// Click inside panel but not on a tile → swallow (no dismiss,
+			// no launch).
+			if (mc->launcher_visible) {
+				int tile = launcher_hit_test(sys, pt);
+				if (tile >= 0) {
+					sys->pending_launcher_click_index = tile;
+					mc->launcher_visible = false;
+					U_LOG_W("Launcher: tile %d clicked", tile);
+				} else if (tile == -2) {
+					mc->launcher_visible = false;
+					U_LOG_W("Launcher: dismissed by click outside panel");
+				}
+				// Either way, do not propagate this click to window logic.
+				goto after_lmb_handling;
+			}
 
 			// Spatial raycast: cast ray from eye through cursor on display surface
 			struct shell_hit_result hit = shell_raycast_hit_test(sys, mc, pt);
@@ -9839,6 +9945,25 @@ comp_d3d11_service_add_launcher_app(struct xrt_system_compositor *xsysc,
 	if (mc != nullptr && mc->hwnd != nullptr && mc->launcher_visible) {
 		InvalidateRect(mc->hwnd, nullptr, FALSE);
 	}
+}
+
+// Phase 5.9/5.10: poll-and-clear the pending launcher tile click. The
+// WM_LBUTTONDOWN handler stores the tile index when the user clicks; the
+// shell calls this from its poll loop, gets the index, and dispatches a
+// CreateProcess via shell_launch_registered_app on its end.
+int32_t
+comp_d3d11_service_poll_launcher_click(struct xrt_system_compositor *xsysc)
+{
+	if (xsysc == nullptr) {
+		return -1;
+	}
+
+	struct d3d11_service_system *sys = d3d11_service_system_from_xrt(xsysc);
+	std::lock_guard<std::recursive_mutex> lock(sys->render_mutex);
+
+	int32_t idx = sys->pending_launcher_click_index;
+	sys->pending_launcher_click_index = -1;
+	return idx;
 }
 
 // Phase 5.7: spatial launcher visibility toggle. Just flips the render-thread

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -12,6 +12,8 @@
 #include "d3d11_bitmap_font.h"
 #include "d3d11_capture.h"
 
+#include "shared/ipc_protocol.h" // struct ipc_launcher_app_list
+
 #include "xrt/xrt_handles.h"
 #include "xrt/xrt_limits.h"
 #include "xrt/xrt_session.h"
@@ -287,6 +289,13 @@ struct d3d11_service_system
 {
 	//! Base system compositor - must be first!
 	struct xrt_system_compositor base;
+
+	//! Phase 5.8: spatial launcher app registry, pushed from the shell
+	//! process via clear+add IPC calls. Lives on the service (not the
+	//! multi-comp) so it survives multi-comp create/destroy cycles —
+	//! the shell can push at any time, even before shell_activate.
+	struct ipc_launcher_app launcher_apps[IPC_LAUNCHER_MAX_APPS];
+	uint32_t launcher_app_count;
 
 	//! Multi-compositor control interface for session state management
 	struct xrt_multi_compositor_control xmcc;
@@ -605,6 +614,7 @@ struct d3d11_multi_compositor
 	//! Phase 5.7: spatial launcher panel visible.
 	//! Toggled by Ctrl+L via ipc_call_shell_set_launcher_visible. When true, the
 	//! render loop draws a rounded-corner panel at the zero-disparity plane.
+	//! The app list it renders lives on d3d11_service_system (sys->launcher_apps).
 	bool launcher_visible;
 
 	//! Debounced re-grid: when > 0, apply grid layout after this timestamp.
@@ -6735,12 +6745,15 @@ multi_compositor_render(struct d3d11_service_system *sys)
 		               (float)LAUNCHER_GRID_COLS;
 		float tile_h = tile_w * 0.65f;
 
-		// Hard-coded placeholder apps. The real app list will arrive via IPC
-		// in a follow-up task; this proves the layout + text rendering path.
-		const char *placeholder_apps[] = {
-			"Cube D3D11", "Cube D3D12", "Cube OpenGL", "Cube Vulkan",
-		};
-		const int n_apps = (int)(sizeof(placeholder_apps) / sizeof(placeholder_apps[0]));
+		// App list pushed from the shell process via clear+add IPC calls.
+		// Stored on sys so it survives multi-comp create/destroy. Empty until
+		// the shell completes its first registered_apps_load + push; empty-
+		// state branch below handles that.
+		const struct ipc_launcher_app *apps = sys->launcher_apps;
+		uint32_t n_apps = sys->launcher_app_count;
+		if (n_apps > IPC_LAUNCHER_MAX_APPS) {
+			n_apps = IPC_LAUNCHER_MAX_APPS;
+		}
 
 		// Pipeline setup once — then per-eye scissor + draw. Bind the font
 		// atlas SRV for text glyph sampling; solid-color draws ignore it.
@@ -6812,6 +6825,110 @@ multi_compositor_render(struct d3d11_service_system *sys)
 				w += mc->glyph_advances[gi] * scale;
 			}
 			return w;
+		};
+
+		// Helper: draw a label centered horizontally within a (tx, tile_w)
+		// box, ellipsis-truncated if it doesn't fit. Used for tile labels
+		// where long sidecar names like "Cube D3D11 (Handle)" would
+		// otherwise overflow into adjacent tiles.
+		auto draw_label_centered = [&](const char *text, float tx, float ty,
+		                               float box_w, float scale) {
+			float full_w = 0.0f;
+			for (const char *p = text; *p != '\0'; p++) {
+				unsigned char ch = (unsigned char)*p;
+				if (ch < 0x20 || ch > 0x7E) ch = '?';
+				full_w += mc->glyph_advances[ch - 0x20] * scale;
+			}
+			if (full_w <= box_w) {
+				float cx = tx + (box_w - full_w) * 0.5f;
+				// Inline draw to avoid the lambda forward-decl problem.
+				float cursor = 0.0f;
+				float dst_gh = (float)mc->font_glyph_h * scale;
+				for (const char *p = text; *p != '\0'; p++) {
+					unsigned char ch = (unsigned char)*p;
+					if (ch < 0x20 || ch > 0x7E) ch = '?';
+					int gi = ch - 0x20;
+					float src_gw = mc->glyph_advances[gi];
+					float src_x = 0.0f;
+					for (int j = 0; j < gi; j++) src_x += mc->glyph_advances[j];
+					float dst_gw = src_gw * scale;
+					D3D11_MAPPED_SUBRESOURCE mm;
+					if (SUCCEEDED(sys->context->Map(sys->blit_constant_buffer.get(), 0,
+					                                D3D11_MAP_WRITE_DISCARD, 0, &mm))) {
+						BlitConstants *cb = static_cast<BlitConstants *>(mm.pData);
+						cb->src_rect[0] = src_x; cb->src_rect[1] = 0.0f;
+						cb->src_rect[2] = src_gw; cb->src_rect[3] = (float)mc->font_glyph_h;
+						cb->src_size[0] = (float)mc->font_atlas_w;
+						cb->src_size[1] = (float)mc->font_atlas_h;
+						cb->dst_size[0] = (float)ca_w; cb->dst_size[1] = (float)ca_h;
+						cb->convert_srgb = 0.0f;
+						cb->corner_radius = 0.0f; cb->corner_aspect = 0.0f;
+						cb->edge_feather = 0.0f; cb->glow_intensity = 0.0f;
+						cb->quad_mode = 0;
+						cb->dst_offset[0] = cx + cursor; cb->dst_offset[1] = ty;
+						cb->dst_rect_wh[0] = dst_gw; cb->dst_rect_wh[1] = dst_gh;
+						memset(cb->quad_corners_01, 0, sizeof(cb->quad_corners_01));
+						memset(cb->quad_corners_23, 0, sizeof(cb->quad_corners_23));
+						sys->context->Unmap(sys->blit_constant_buffer.get(), 0);
+						sys->context->Draw(4, 0);
+					}
+					cursor += dst_gw;
+				}
+				return;
+			}
+
+			// Doesn't fit — build a truncated version with trailing "..".
+			// Greedy: walk chars while (width + ".."_width) <= box_w.
+			float dot_w = mc->glyph_advances['.' - 0x20] * scale;
+			float ellipsis_w = dot_w * 2.0f;
+			char buf[160];
+			int n = 0;
+			float w = 0.0f;
+			for (const char *p = text; *p != '\0' && n < (int)sizeof(buf) - 3; p++) {
+				unsigned char ch = (unsigned char)*p;
+				if (ch < 0x20 || ch > 0x7E) ch = '?';
+				float gw = mc->glyph_advances[ch - 0x20] * scale;
+				if (w + gw + ellipsis_w > box_w) break;
+				buf[n++] = (char)ch;
+				w += gw;
+			}
+			buf[n++] = '.'; buf[n++] = '.';
+			buf[n] = '\0';
+			float total_w = w + ellipsis_w;
+			float cx = tx + (box_w - total_w) * 0.5f;
+			if (cx < tx) cx = tx;
+
+			// Draw the truncated buffer (same inline glyph loop).
+			float cursor = 0.0f;
+			float dst_gh = (float)mc->font_glyph_h * scale;
+			for (int i = 0; i < n; i++) {
+				int gi = (unsigned char)buf[i] - 0x20;
+				float src_gw = mc->glyph_advances[gi];
+				float src_x = 0.0f;
+				for (int j = 0; j < gi; j++) src_x += mc->glyph_advances[j];
+				float dst_gw = src_gw * scale;
+				D3D11_MAPPED_SUBRESOURCE mm;
+				if (SUCCEEDED(sys->context->Map(sys->blit_constant_buffer.get(), 0,
+				                                D3D11_MAP_WRITE_DISCARD, 0, &mm))) {
+					BlitConstants *cb = static_cast<BlitConstants *>(mm.pData);
+					cb->src_rect[0] = src_x; cb->src_rect[1] = 0.0f;
+					cb->src_rect[2] = src_gw; cb->src_rect[3] = (float)mc->font_glyph_h;
+					cb->src_size[0] = (float)mc->font_atlas_w;
+					cb->src_size[1] = (float)mc->font_atlas_h;
+					cb->dst_size[0] = (float)ca_w; cb->dst_size[1] = (float)ca_h;
+					cb->convert_srgb = 0.0f;
+					cb->corner_radius = 0.0f; cb->corner_aspect = 0.0f;
+					cb->edge_feather = 0.0f; cb->glow_intensity = 0.0f;
+					cb->quad_mode = 0;
+					cb->dst_offset[0] = cx + cursor; cb->dst_offset[1] = ty;
+					cb->dst_rect_wh[0] = dst_gw; cb->dst_rect_wh[1] = dst_gh;
+					memset(cb->quad_corners_01, 0, sizeof(cb->quad_corners_01));
+					memset(cb->quad_corners_23, 0, sizeof(cb->quad_corners_23));
+					sys->context->Unmap(sys->blit_constant_buffer.get(), 0);
+					sys->context->Draw(4, 0);
+				}
+				cursor += dst_gw;
+			}
 		};
 
 		// Helper: draw a string starting at (dx, dy) (top-left, atlas px) at
@@ -6901,27 +7018,43 @@ multi_compositor_render(struct d3d11_service_system *sys)
 			draw_text(installed_text, section_x, section_y, section_scale);
 
 			// 4) Tile grid — 4-column wrapping. Each row also reserves space
-			// below the tile for its label.
+			// below the tile for its label. If the registry is empty (e.g.
+			// scanner found no sidecars and shell hasn't pushed yet), show
+			// an empty-state hint instead of a blank grid.
 			float label_scale = section_scale * 0.85f;
 			float label_h = (float)mc->font_glyph_h * label_scale;
 			float grid_top = section_y + (float)mc->font_glyph_h * section_scale + margin * 0.5f;
-			for (int i = 0; i < n_apps; i++) {
-				int tcol = i % LAUNCHER_GRID_COLS;
-				int trow = i / LAUNCHER_GRID_COLS;
-				float tx = panel_x + margin + tcol * (tile_w + margin);
-				float ty = grid_top + trow * (tile_h + label_h + margin);
 
-				// Tile background — slightly lighter than panel, rounded.
-				draw_solid_rect(tx, ty, tile_w, tile_h,
-				                0.16f, 0.19f, 0.26f, 0.95f, 0.18f, 0.0f);
+			if (n_apps == 0) {
+				const char *empty_line1 = "No apps discovered";
+				const char *empty_line2 = "Add a .displayxr.json sidecar next to your exe.";
+				float empty_scale_1 = section_scale * 0.95f;
+				float empty_scale_2 = section_scale * 0.65f;
+				float w1 = measure_text(empty_line1, empty_scale_1);
+				float w2 = measure_text(empty_line2, empty_scale_2);
+				float ex1 = panel_x + (panel_w_px - w1) * 0.5f;
+				float ex2 = panel_x + (panel_w_px - w2) * 0.5f;
+				float ey1 = grid_top + tile_h * 0.30f;
+				float ey2 = ey1 + (float)mc->font_glyph_h * empty_scale_1 + margin * 0.4f;
+				draw_text(empty_line1, ex1, ey1, empty_scale_1);
+				draw_text(empty_line2, ex2, ey2, empty_scale_2);
+			} else {
+				for (uint32_t i = 0; i < n_apps; i++) {
+					int tcol = (int)(i % LAUNCHER_GRID_COLS);
+					int trow = (int)(i / LAUNCHER_GRID_COLS);
+					float tx = panel_x + margin + (float)tcol * (tile_w + margin);
+					float ty = grid_top + (float)trow * (tile_h + label_h + margin);
 
-				// Label centered horizontally below tile, clipped if too wide.
-				const char *label = placeholder_apps[i];
-				float label_w = measure_text(label, label_scale);
-				float label_x = tx + (tile_w - label_w) * 0.5f;
-				if (label_x < tx) label_x = tx;
-				float label_y = ty + tile_h + margin * 0.15f;
-				draw_text(label, label_x, label_y, label_scale);
+					// Tile background — slightly lighter than panel, rounded.
+					draw_solid_rect(tx, ty, tile_w, tile_h,
+					                0.16f, 0.19f, 0.26f, 0.95f, 0.18f, 0.0f);
+
+					// Label centered horizontally below tile, ellipsis-truncated
+					// if it would overflow into the neighbouring tile.
+					const char *label = apps[i].name;
+					float label_y = ty + tile_h + margin * 0.15f;
+					draw_label_centered(label, tx, label_y, tile_w, label_scale);
+				}
 			}
 		}
 
@@ -9661,6 +9794,51 @@ comp_d3d11_service_deactivate_shell(struct xrt_system_compositor *xsysc)
 
 	U_LOG_W("Shell deactivate: complete — captures stopped, multi-comp suspended, "
 	        "IPC clients will lazy-switch to standalone on next frame");
+}
+
+// Phase 5.8: empty the launcher's app list. The shell calls this before
+// pushing a fresh registry so the tile grid never carries stale entries.
+// Stored on the system (not the multi-comp) so it survives across activations.
+void
+comp_d3d11_service_clear_launcher_apps(struct xrt_system_compositor *xsysc)
+{
+	if (xsysc == nullptr) {
+		return;
+	}
+
+	struct d3d11_service_system *sys = d3d11_service_system_from_xrt(xsysc);
+	std::lock_guard<std::recursive_mutex> lock(sys->render_mutex);
+
+	sys->launcher_app_count = 0;
+}
+
+// Phase 5.8: append one app to the launcher's tile grid. Silently dropped if
+// the array is already full. The shell loops over its registry calling this
+// once per entry after a clear. Lives on the system, not the multi-comp.
+void
+comp_d3d11_service_add_launcher_app(struct xrt_system_compositor *xsysc,
+                                    const struct ipc_launcher_app *app)
+{
+	if (xsysc == nullptr || app == nullptr) {
+		return;
+	}
+
+	struct d3d11_service_system *sys = d3d11_service_system_from_xrt(xsysc);
+	std::lock_guard<std::recursive_mutex> lock(sys->render_mutex);
+
+	if (sys->launcher_app_count >= IPC_LAUNCHER_MAX_APPS) {
+		return;
+	}
+
+	sys->launcher_apps[sys->launcher_app_count] = *app;
+	sys->launcher_app_count++;
+
+	// Wake the compositor window if it exists and the launcher is on-screen,
+	// so the next frame picks up the new tile.
+	struct d3d11_multi_compositor *mc = sys->multi_comp;
+	if (mc != nullptr && mc->hwnd != nullptr && mc->launcher_visible) {
+		InvalidateRect(mc->hwnd, nullptr, FALSE);
+	}
 }
 
 // Phase 5.7: spatial launcher visibility toggle. Just flips the render-thread

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -4250,6 +4250,47 @@ struct shell_hit_result
 	int edge_flags;      //!< RESIZE_LEFT|RIGHT|TOP|BOTTOM if near edge
 };
 
+static void launcher_set_visible(struct d3d11_service_system *sys,
+                                 struct d3d11_multi_compositor *mc, bool visible);
+
+// Phase 5.13: pop a Win32 context menu at the cursor for a launcher tile.
+// Launch fires the tile like a click; Remove sets hidden_tile_mask so the
+// tile disappears from the grid until the shell re-pushes its registry.
+//
+// TrackPopupMenu only runs on the thread that owns the target window, so
+// we dispatch via comp_d3d11_window_show_launcher_context_menu which
+// SendMessages across to the window thread. The render thread blocks
+// until the user picks or cancels.
+static void
+launcher_show_context_menu(struct d3d11_service_system *sys,
+                           struct d3d11_multi_compositor *mc,
+                           POINT client_pt, int full_idx)
+{
+	(void)client_pt;
+	if (mc == nullptr || mc->window == nullptr) return;
+
+	uint32_t result = comp_d3d11_window_show_launcher_context_menu(mc->window);
+	switch (result) {
+	case LAUNCHER_CTX_MENU_RESULT_LAUNCH:
+		sys->pending_launcher_click_index = full_idx;
+		launcher_set_visible(sys, mc, false);
+		U_LOG_W("Launcher: context menu launch full=%d", full_idx);
+		break;
+	case LAUNCHER_CTX_MENU_RESULT_REMOVE:
+		sys->hidden_tile_mask |= (1ULL << full_idx);
+		U_LOG_W("Launcher: context menu remove full=%d", full_idx);
+		// Launcher stays open so the user can remove more tiles. Clamp
+		// the selection in case we just removed the selected tile from
+		// the compacted visible list — next render re-builds it.
+		if (sys->launcher_selected_index > 0) {
+			sys->launcher_selected_index = 0;
+		}
+		break;
+	default:
+		break;
+	}
+}
+
 // Phase 5.12: toggle launcher visibility AND the window's input-suppress
 // flag in one place. When the launcher is up we want keyboard input to
 // drive the launcher itself (arrows / Enter / Esc) rather than leaking
@@ -5882,6 +5923,28 @@ after_key_shortcuts:
 		bool rmb_just_pressed = rmb_held && !mc->prev_rmb_held;
 		mc->prev_rmb_held = rmb_held;
 
+		// Phase 5.13: launcher RMB context menu. When the launcher is
+		// visible, right-click on a tile pops a Win32 menu with Launch +
+		// Remove (session-only) + Cancel. Branch before the existing
+		// window-drag handling so it doesn't try to start a rotation drag
+		// on a tile. Suppress Launch/Remove visual hit routing to the
+		// window below.
+		if (mc->launcher_visible && rmb_just_pressed) {
+			POINT pt;
+			GetCursorPos(&pt);
+			ScreenToClient(mc->hwnd, &pt);
+			int visible_to_full[IPC_LAUNCHER_MAX_APPS];
+			uint32_t n_visible = launcher_build_visible_list(sys, visible_to_full);
+			int vis_tile = launcher_hit_test(sys, pt, n_visible);
+			if (vis_tile >= 0 && vis_tile < (int)n_visible) {
+				int full_idx = visible_to_full[vis_tile];
+				launcher_show_context_menu(sys, mc, pt, full_idx);
+			}
+			// Eat the RMB regardless of hit so it doesn't start a drag
+			// on a window that might be peeking through the panel.
+			goto after_rmb_handling;
+		}
+
 		if (rmb_held) {
 			if (!mc->title_rmb_drag.active && rmb_just_pressed) {
 				// RMB just pressed — check if on title bar to start rotation drag
@@ -5939,6 +6002,9 @@ after_key_shortcuts:
 				POINT p; GetCursorPos(&p); SetCursorPos(p.x, p.y);
 			}
 		}
+
+	after_rmb_handling:
+		(void)0; // label target for the launcher-visible fast-path above.
 	}
 
 	// Scroll wheel: Shift+Scroll = Z-depth, plain scroll = resize.

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -4374,6 +4374,9 @@ launcher_build_visible_list(const struct d3d11_service_system *sys,
 static int
 launcher_hit_test(struct d3d11_service_system *sys, POINT cursor_px, uint32_t n_visible)
 {
+	// Cursor is in compositor-window client pixels, which we map to
+	// display meters via the same formula the taskbar hit-test uses
+	// (pt.x and pt.y are assumed to span the full atlas pixel dimensions).
 	float disp_w_m = sys->base.info.display_width_m;
 	float disp_h_m = sys->base.info.display_height_m;
 	uint32_t disp_px_w = sys->base.info.display_pixel_width;
@@ -4383,14 +4386,12 @@ launcher_hit_test(struct d3d11_service_system *sys, POINT cursor_px, uint32_t n_
 	if (disp_px_w == 0) disp_px_w = 3840;
 	if (disp_px_h == 0) disp_px_h = 2160;
 
-	// Cursor → display-surface meters (origin = display center, +x right, +y up).
-	// Same formula as the existing taskbar hit-test path.
 	float cursor_x_m = ((float)cursor_px.x - (float)disp_px_w / 2.0f) *
 	                   disp_w_m / (float)disp_px_w;
 	float cursor_y_m = ((float)disp_px_h / 2.0f - (float)cursor_px.y) *
 	                   disp_h_m / (float)disp_px_h;
 
-	// Panel geometry — must mirror the render block exactly.
+	// Panel geometry — the fractions below must match the render block.
 	const float panel_w_frac = 0.60f;
 	const float panel_h_frac = 0.55f;
 	float panel_w_m = disp_w_m * panel_w_frac;
@@ -4402,25 +4403,39 @@ launcher_hit_test(struct d3d11_service_system *sys, POINT cursor_px, uint32_t n_
 		return -2;
 	}
 
-	// Convert to panel-local meters (origin top-left).
+	// Panel-local meters, origin top-left.
 	float lx = cursor_x_m + panel_w_m * 0.5f;
 	float ly = panel_h_m * 0.5f - cursor_y_m;
 
-	// Tile layout — mirrors the render pass, but in meters instead of pixels.
-	// All ratios are unit-independent so the same fractions work in either.
 	const int LAUNCHER_GRID_COLS = 4;
 	float margin = panel_w_m * 0.04f;
 	float title_h = panel_h_m * 0.13f;
 	float section_h = panel_h_m * 0.07f;
 	float tile_w = (panel_w_m - (LAUNCHER_GRID_COLS + 1) * margin) /
 	               (float)LAUNCHER_GRID_COLS;
-	float tile_h = tile_w * 0.65f;
+
+	// Phase 5.14: the render computes tile_h in render-pixel terms
+	// (`tile_h_px = tile_w_px * 0.65`). Because ui_m_to_tile_px_x and
+	// ui_m_to_tile_px_y use different px-per-meter ratios (tile_px_w =
+	// display_pixel_width/tile_columns, but tile_px_h = display_pixel_height
+	// /tile_rows), converting that back to meters requires an aspect-ratio
+	// correction or the hit test and render disagree on row positions.
+	float tile_px_w_eff = (float)(disp_px_w / (sys->tile_columns ? sys->tile_columns : 1));
+	float tile_px_h_eff = (float)(disp_px_h / (sys->tile_rows    ? sys->tile_rows    : 1));
+	float px_per_m_x = tile_px_w_eff / disp_w_m;
+	float px_per_m_y = tile_px_h_eff / disp_h_m;
+	float y_ratio = (px_per_m_y > 0.0f) ? (px_per_m_x / px_per_m_y) : 1.0f;
+	float tile_h = tile_w * 0.65f * y_ratio;
+
+	// Section header + label heights: render uses
+	// `font_glyph_h * section_scale` where section_scale = (section_h_px * 0.65)
+	// / font_glyph_h. In meters that's section_h_m * 0.65, unaffected by the
+	// X/Y ratio (section_h is panel_h-derived, so y-based).
 	float section_text_h = section_h * 0.65f;
+	float label_h = section_text_h * 0.85f;
+
 	float section_y = title_h + margin * 0.5f;
 	float grid_top = section_y + section_text_h + margin * 0.5f;
-	// Label height = font_glyph_h * label_scale where label_scale =
-	// (section_h_px * 0.65 / font_glyph_h) * 0.85 → in meters: section_h * 0.65 * 0.85.
-	float label_h = section_text_h * 0.85f;
 
 	// Walk the visible tile grid PLUS one virtual Browse tile at position n_visible.
 	uint32_t n_total = n_visible + 1;
@@ -5325,6 +5340,10 @@ multi_compositor_render(struct d3d11_service_system *sys)
 			if (sel == (int)n_visible) {
 				sys->pending_launcher_click_index = IPC_LAUNCHER_ACTION_BROWSE;
 				launcher_set_visible(sys, mc, false);
+				// Phase 5.14: see corresponding AllowSetForegroundWindow
+				// call in the LMB click path — grants the shell's file
+				// dialog permission to pop to the front.
+				AllowSetForegroundWindow(ASFW_ANY);
 				U_LOG_W("Launcher: Enter on Browse tile");
 			} else if (sel >= 0 && sel < (int)n_visible) {
 				sys->pending_launcher_click_index = visible_to_full[sel];
@@ -5601,6 +5620,11 @@ after_key_shortcuts:
 				} else if (vis_tile == (int)n_visible) {
 					sys->pending_launcher_click_index = IPC_LAUNCHER_ACTION_BROWSE;
 					launcher_set_visible(sys, mc, false);
+					// Phase 5.14: grant any process foreground-activation
+					// permission so the shell's GetOpenFileNameA dialog can
+					// pop to the front. The service currently has foreground
+					// from the click, so it has the right to grant this.
+					AllowSetForegroundWindow(ASFW_ANY);
 					U_LOG_W("Launcher: Browse tile clicked");
 				} else if (vis_tile == -2) {
 					launcher_set_visible(sys, mc, false);

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.h
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.h
@@ -347,6 +347,20 @@ comp_d3d11_service_add_launcher_app(struct xrt_system_compositor *xsysc,
 int32_t
 comp_d3d11_service_poll_launcher_click(struct xrt_system_compositor *xsysc);
 
+/*!
+ * Phase 5.11: set the bitmask of currently-running tiles. Bit @c i set means
+ * the registered app at index @c i has at least one matching IPC client
+ * connected to the service. The launcher draws a glow border around tiles
+ * whose bit is set so the user can tell which apps are already open.
+ *
+ * Pushed by the shell whenever its computed running set changes (typically
+ * after each client connect/disconnect poll).
+ *
+ * @ingroup comp_d3d11_service
+ */
+void
+comp_d3d11_service_set_running_tile_mask(struct xrt_system_compositor *xsysc, uint64_t mask);
+
 /*! @} */
 
 

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.h
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.h
@@ -336,6 +336,17 @@ void
 comp_d3d11_service_add_launcher_app(struct xrt_system_compositor *xsysc,
                                     const struct ipc_launcher_app *app);
 
+/*!
+ * Phase 5.9/5.10: poll-and-clear the pending launcher tile click. Returns the
+ * tile index the user clicked since the last poll, or -1 if none. Called by
+ * the shell from its main poll loop; on a hit the shell looks up the
+ * corresponding registered app and launches it via shell_launch_registered_app.
+ *
+ * @ingroup comp_d3d11_service
+ */
+int32_t
+comp_d3d11_service_poll_launcher_click(struct xrt_system_compositor *xsysc);
+
 /*! @} */
 
 

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.h
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.h
@@ -299,6 +299,19 @@ comp_d3d11_service_ensure_shell_window(struct xrt_system_compositor *xsysc);
 void
 comp_d3d11_service_deactivate_shell(struct xrt_system_compositor *xsysc);
 
+/*!
+ * Show or hide the spatial launcher panel. When visible, the multi-compositor
+ * draws a rounded-corner launcher overlay at the zero-disparity plane
+ * (z = 0 in display coordinates). Called by
+ * ipc_handle_shell_set_launcher_visible() in response to Ctrl+L from the shell.
+ *
+ * No-op if the shell is not currently active.
+ *
+ * @ingroup comp_d3d11_service
+ */
+void
+comp_d3d11_service_set_launcher_visible(struct xrt_system_compositor *xsysc, bool visible);
+
 /*! @} */
 
 

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.h
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.h
@@ -25,6 +25,9 @@
 extern "C" {
 #endif
 
+// Forward decl from ipc_protocol.h — full definition is included by callers.
+struct ipc_launcher_app;
+
 
 /*!
  * @defgroup comp_d3d11_service D3D11 Service Compositor
@@ -311,6 +314,27 @@ comp_d3d11_service_deactivate_shell(struct xrt_system_compositor *xsysc);
  */
 void
 comp_d3d11_service_set_launcher_visible(struct xrt_system_compositor *xsysc, bool visible);
+
+/*!
+ * Empty the spatial launcher's app list. Called by the shell at the start of
+ * each registry push (clear-then-add-N pattern keeps each IPC message under
+ * the per-message buffer cap).
+ *
+ * @ingroup comp_d3d11_service
+ */
+void
+comp_d3d11_service_clear_launcher_apps(struct xrt_system_compositor *xsysc);
+
+/*!
+ * Append one app to the spatial launcher's tile grid. Silently dropped if the
+ * list is already full (IPC_LAUNCHER_MAX_APPS). Called by the shell once per
+ * registered app after a clear.
+ *
+ * @ingroup comp_d3d11_service
+ */
+void
+comp_d3d11_service_add_launcher_app(struct xrt_system_compositor *xsysc,
+                                    const struct ipc_launcher_app *app);
 
 /*! @} */
 

--- a/src/xrt/compositor/d3d11_service/d3d11_icon_loader.cpp
+++ b/src/xrt/compositor/d3d11_service/d3d11_icon_loader.cpp
@@ -1,0 +1,113 @@
+// Copyright 2026, Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  PNG/JPEG → D3D11 texture loader implementation (stb_image-backed).
+ * @ingroup comp_d3d11_service
+ */
+
+#include "d3d11_icon_loader.h"
+
+#include "util/u_logging.h"
+
+#include <d3d11.h>
+#include <cstring>
+
+// This is the single translation unit that instantiates stb_image.
+// STBI_NO_STDIO is deliberately NOT defined — we want stbi_load(path).
+#define STB_IMAGE_IMPLEMENTATION
+#define STBI_ONLY_PNG
+#define STBI_ONLY_JPEG
+#define STBI_NO_HDR
+#define STBI_NO_LINEAR
+#include "stb_image.h"
+
+bool
+d3d11_icon_load_from_file(ID3D11Device *device,
+                          const char *path,
+                          ID3D11ShaderResourceView **out_srv,
+                          uint32_t *out_width,
+                          uint32_t *out_height)
+{
+	if (out_srv != nullptr) {
+		*out_srv = nullptr;
+	}
+	if (out_width != nullptr) {
+		*out_width = 0;
+	}
+	if (out_height != nullptr) {
+		*out_height = 0;
+	}
+
+	if (device == nullptr || path == nullptr || out_srv == nullptr) {
+		return false;
+	}
+
+	int w = 0;
+	int h = 0;
+	int channels_in_file = 0;
+	// Force RGBA8 output regardless of source channel count.
+	stbi_uc *pixels = stbi_load(path, &w, &h, &channels_in_file, 4);
+	if (pixels == nullptr) {
+		U_LOG_W("d3d11_icon_load_from_file: stbi_load failed for '%s': %s", path,
+		        stbi_failure_reason());
+		return false;
+	}
+	if (w <= 0 || h <= 0) {
+		stbi_image_free(pixels);
+		U_LOG_W("d3d11_icon_load_from_file: invalid dims for '%s'", path);
+		return false;
+	}
+
+	D3D11_TEXTURE2D_DESC desc = {};
+	desc.Width = static_cast<UINT>(w);
+	desc.Height = static_cast<UINT>(h);
+	desc.MipLevels = 1;
+	desc.ArraySize = 1;
+	desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM_SRGB;
+	desc.SampleDesc.Count = 1;
+	desc.Usage = D3D11_USAGE_IMMUTABLE;
+	desc.BindFlags = D3D11_BIND_SHADER_RESOURCE;
+	desc.CPUAccessFlags = 0;
+	desc.MiscFlags = 0;
+
+	D3D11_SUBRESOURCE_DATA init = {};
+	init.pSysMem = pixels;
+	init.SysMemPitch = static_cast<UINT>(w) * 4u;
+	init.SysMemSlicePitch = 0;
+
+	ID3D11Texture2D *tex = nullptr;
+	HRESULT hr = device->CreateTexture2D(&desc, &init, &tex);
+	stbi_image_free(pixels);
+
+	if (FAILED(hr) || tex == nullptr) {
+		U_LOG_W("d3d11_icon_load_from_file: CreateTexture2D failed 0x%08lX for '%s'",
+		        static_cast<unsigned long>(hr), path);
+		return false;
+	}
+
+	D3D11_SHADER_RESOURCE_VIEW_DESC srv_desc = {};
+	srv_desc.Format = desc.Format;
+	srv_desc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
+	srv_desc.Texture2D.MostDetailedMip = 0;
+	srv_desc.Texture2D.MipLevels = 1;
+
+	ID3D11ShaderResourceView *srv = nullptr;
+	hr = device->CreateShaderResourceView(tex, &srv_desc, &srv);
+	tex->Release();
+
+	if (FAILED(hr) || srv == nullptr) {
+		U_LOG_W("d3d11_icon_load_from_file: CreateShaderResourceView failed 0x%08lX for '%s'",
+		        static_cast<unsigned long>(hr), path);
+		return false;
+	}
+
+	*out_srv = srv;
+	if (out_width != nullptr) {
+		*out_width = static_cast<uint32_t>(w);
+	}
+	if (out_height != nullptr) {
+		*out_height = static_cast<uint32_t>(h);
+	}
+	return true;
+}

--- a/src/xrt/compositor/d3d11_service/d3d11_icon_loader.h
+++ b/src/xrt/compositor/d3d11_service/d3d11_icon_loader.h
@@ -1,0 +1,45 @@
+// Copyright 2026, Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  PNG/JPEG → D3D11 texture loader for the shell launcher tiles.
+ *
+ * Decodes an image file via stb_image and creates a shader resource view bound
+ * to an ID3D11Texture2D. Used by the shell's spatial launcher to load app
+ * tile icons (both 2D `icon` and stereoscopic `icon_3d`).
+ *
+ * The loader does not interpret side-by-side / top-bottom layouts — it always
+ * produces a single 2D texture matching the source image dimensions. The
+ * launcher render shader samples per-eye sub-rects at draw time based on the
+ * sidecar's `icon_3d_layout`.
+ *
+ * @ingroup comp_d3d11_service
+ */
+
+#pragma once
+
+#include <cstdint>
+
+struct ID3D11Device;
+struct ID3D11ShaderResourceView;
+
+/*!
+ * Load an image file (PNG, JPEG, BMP, TGA — whatever stb_image supports) into
+ * a newly-created D3D11 2D texture and shader resource view.
+ *
+ * On success returns true and writes the SRV pointer to @p out_srv (the caller
+ * owns the reference and must call Release). Also writes the source
+ * dimensions in pixels to @p out_width and @p out_height if non-null.
+ *
+ * On failure returns false; @p out_srv is set to nullptr.
+ *
+ * The texture is created as DXGI_FORMAT_R8G8B8A8_UNORM_SRGB so that sampling
+ * applies the standard sRGB → linear conversion, matching the rest of the
+ * compositor's color pipeline.
+ */
+bool
+d3d11_icon_load_from_file(ID3D11Device *device,
+                          const char *path,
+                          ID3D11ShaderResourceView **out_srv,
+                          uint32_t *out_width,
+                          uint32_t *out_height);

--- a/src/xrt/ipc/server/ipc_server_handler.c
+++ b/src/xrt/ipc/server/ipc_server_handler.c
@@ -2027,6 +2027,44 @@ ipc_handle_shell_set_launcher_visible(volatile struct ipc_client_state *_ics, bo
 }
 
 xrt_result_t
+ipc_handle_shell_clear_launcher_apps(volatile struct ipc_client_state *_ics)
+{
+	struct ipc_server *s = _ics->server;
+
+#if defined(XRT_HAVE_D3D11_SERVICE_COMPOSITOR)
+	if (s->xsysc == NULL) {
+		return XRT_ERROR_IPC_FAILURE;
+	}
+
+	comp_d3d11_service_clear_launcher_apps(s->xsysc);
+	return XRT_SUCCESS;
+#else
+	(void)s;
+	return XRT_ERROR_IPC_FAILURE;
+#endif
+}
+
+xrt_result_t
+ipc_handle_shell_add_launcher_app(volatile struct ipc_client_state *_ics,
+                                   const struct ipc_launcher_app *app)
+{
+	struct ipc_server *s = _ics->server;
+
+#if defined(XRT_HAVE_D3D11_SERVICE_COMPOSITOR)
+	if (s->xsysc == NULL || app == NULL) {
+		return XRT_ERROR_IPC_FAILURE;
+	}
+
+	comp_d3d11_service_add_launcher_app(s->xsysc, app);
+	return XRT_SUCCESS;
+#else
+	(void)s;
+	(void)app;
+	return XRT_ERROR_IPC_FAILURE;
+#endif
+}
+
+xrt_result_t
 ipc_handle_shell_set_window_pose(volatile struct ipc_client_state *_ics,
                                   uint32_t client_id,
                                   const struct xrt_pose *pose,

--- a/src/xrt/ipc/server/ipc_server_handler.c
+++ b/src/xrt/ipc/server/ipc_server_handler.c
@@ -2065,6 +2065,25 @@ ipc_handle_shell_add_launcher_app(volatile struct ipc_client_state *_ics,
 }
 
 xrt_result_t
+ipc_handle_shell_set_running_tile_mask(volatile struct ipc_client_state *_ics, uint64_t mask)
+{
+	struct ipc_server *s = _ics->server;
+
+#if defined(XRT_HAVE_D3D11_SERVICE_COMPOSITOR)
+	if (s->xsysc == NULL) {
+		return XRT_ERROR_IPC_FAILURE;
+	}
+
+	comp_d3d11_service_set_running_tile_mask(s->xsysc, mask);
+	return XRT_SUCCESS;
+#else
+	(void)s;
+	(void)mask;
+	return XRT_ERROR_IPC_FAILURE;
+#endif
+}
+
+xrt_result_t
 ipc_handle_shell_poll_launcher_click(volatile struct ipc_client_state *_ics,
                                       int64_t *out_tile_index)
 {

--- a/src/xrt/ipc/server/ipc_server_handler.c
+++ b/src/xrt/ipc/server/ipc_server_handler.c
@@ -2065,6 +2065,26 @@ ipc_handle_shell_add_launcher_app(volatile struct ipc_client_state *_ics,
 }
 
 xrt_result_t
+ipc_handle_shell_poll_launcher_click(volatile struct ipc_client_state *_ics,
+                                      int64_t *out_tile_index)
+{
+	struct ipc_server *s = _ics->server;
+
+#if defined(XRT_HAVE_D3D11_SERVICE_COMPOSITOR)
+	if (s->xsysc == NULL || out_tile_index == NULL) {
+		return XRT_ERROR_IPC_FAILURE;
+	}
+
+	*out_tile_index = (int64_t)comp_d3d11_service_poll_launcher_click(s->xsysc);
+	return XRT_SUCCESS;
+#else
+	(void)s;
+	if (out_tile_index != NULL) *out_tile_index = -1;
+	return XRT_ERROR_IPC_FAILURE;
+#endif
+}
+
+xrt_result_t
 ipc_handle_shell_set_window_pose(volatile struct ipc_client_state *_ics,
                                   uint32_t client_id,
                                   const struct xrt_pose *pose,

--- a/src/xrt/ipc/server/ipc_server_handler.c
+++ b/src/xrt/ipc/server/ipc_server_handler.c
@@ -2007,6 +2007,26 @@ ipc_handle_shell_get_state(volatile struct ipc_client_state *_ics, bool *out_act
 }
 
 xrt_result_t
+ipc_handle_shell_set_launcher_visible(volatile struct ipc_client_state *_ics, bool visible)
+{
+	struct ipc_server *s = _ics->server;
+
+#if defined(XRT_HAVE_D3D11_SERVICE_COMPOSITOR)
+	if (s->xsysc == NULL) {
+		return XRT_ERROR_IPC_FAILURE;
+	}
+
+	IPC_INFO(s, "Shell: set_launcher_visible %s", visible ? "true" : "false");
+	comp_d3d11_service_set_launcher_visible(s->xsysc, visible);
+	return XRT_SUCCESS;
+#else
+	(void)s;
+	(void)visible;
+	return XRT_ERROR_IPC_FAILURE;
+#endif
+}
+
+xrt_result_t
 ipc_handle_shell_set_window_pose(volatile struct ipc_client_state *_ics,
                                   uint32_t client_id,
                                   const struct xrt_pose *pose,

--- a/src/xrt/ipc/shared/ipc_protocol.h
+++ b/src/xrt/ipc/shared/ipc_protocol.h
@@ -304,6 +304,28 @@ struct ipc_client_list
 };
 
 /*!
+ * Phase 5.8: registered-app record shipped one-at-a-time from the shell
+ * process to the service for the spatial launcher panel. Sized to fit a
+ * single ipc message under IPC_BUF_SIZE — the shell calls
+ * ipc_call_shell_clear_launcher_apps then loops over its registry calling
+ * ipc_call_shell_add_launcher_app per entry whenever the registry changes.
+ *
+ * @ingroup ipc
+ */
+
+#define IPC_LAUNCHER_MAX_APPS 32
+#define IPC_LAUNCHER_NAME_MAX 96
+#define IPC_LAUNCHER_PATH_MAX 256
+#define IPC_LAUNCHER_TYPE_MAX 8
+
+struct ipc_launcher_app
+{
+	char name[IPC_LAUNCHER_NAME_MAX];
+	char exe_path[IPC_LAUNCHER_PATH_MAX];
+	char type[IPC_LAUNCHER_TYPE_MAX]; // "3d" or "2d"
+};
+
+/*!
  * State for a connected application.
  *
  * @ingroup ipc

--- a/src/xrt/ipc/shared/ipc_protocol.h
+++ b/src/xrt/ipc/shared/ipc_protocol.h
@@ -318,6 +318,11 @@ struct ipc_client_list
 #define IPC_LAUNCHER_PATH_MAX 256
 #define IPC_LAUNCHER_TYPE_MAX 8
 
+// Phase 5.14: sentinel returned via ipc_call_shell_poll_launcher_click to mean
+// "the user clicked the Browse-for-app virtual tile" rather than a real tile.
+// Real tile indices are >= 0; -1 means no pending action.
+#define IPC_LAUNCHER_ACTION_BROWSE (-100)
+
 struct ipc_launcher_app
 {
 	char name[IPC_LAUNCHER_NAME_MAX];

--- a/src/xrt/ipc/shared/proto.json
+++ b/src/xrt/ipc/shared/proto.json
@@ -88,6 +88,14 @@
 		]
 	},
 
+	"shell_clear_launcher_apps": {},
+
+	"shell_add_launcher_app": {
+		"in": [
+			{"name": "app", "type": "struct ipc_launcher_app"}
+		]
+	},
+
 	"shell_get_window_pose": {
 		"in": [
 			{"name": "client_id", "type": "uint32_t"}

--- a/src/xrt/ipc/shared/proto.json
+++ b/src/xrt/ipc/shared/proto.json
@@ -102,6 +102,12 @@
 		]
 	},
 
+	"shell_set_running_tile_mask": {
+		"in": [
+			{"name": "mask", "type": "uint64_t"}
+		]
+	},
+
 	"shell_get_window_pose": {
 		"in": [
 			{"name": "client_id", "type": "uint32_t"}

--- a/src/xrt/ipc/shared/proto.json
+++ b/src/xrt/ipc/shared/proto.json
@@ -96,6 +96,12 @@
 		]
 	},
 
+	"shell_poll_launcher_click": {
+		"out": [
+			{"name": "tile_index", "type": "int64_t"}
+		]
+	},
+
 	"shell_get_window_pose": {
 		"in": [
 			{"name": "client_id", "type": "uint32_t"}

--- a/src/xrt/ipc/shared/proto.json
+++ b/src/xrt/ipc/shared/proto.json
@@ -82,6 +82,12 @@
 		]
 	},
 
+	"shell_set_launcher_visible": {
+		"in": [
+			{"name": "visible", "type": "bool"}
+		]
+	},
+
 	"shell_get_window_pose": {
 		"in": [
 			{"name": "client_id", "type": "uint32_t"}

--- a/src/xrt/targets/shell/CMakeLists.txt
+++ b/src/xrt/targets/shell/CMakeLists.txt
@@ -1,11 +1,22 @@
 # Copyright 2026, Leia Inc.
 # SPDX-License-Identifier: BSL-1.0
 
-add_executable(displayxr-shell WIN32 main.c)
+add_executable(displayxr-shell WIN32
+    main.c
+    shell_pe_scan.c
+    shell_pe_scan.h
+    shell_app_scan.c
+    shell_app_scan.h
+)
 add_sanitizers(displayxr-shell)
 
 target_include_directories(displayxr-shell PRIVATE ipc)
 
 target_link_libraries(displayxr-shell PRIVATE aux_util ipc_client)
+
+if(WIN32)
+    # Dbghelp: ImageDirectoryEntryToData (PE import scan)
+    target_link_libraries(displayxr-shell PRIVATE dbghelp)
+endif()
 
 install(TARGETS displayxr-shell RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/xrt/targets/shell/CMakeLists.txt
+++ b/src/xrt/targets/shell/CMakeLists.txt
@@ -16,7 +16,8 @@ target_link_libraries(displayxr-shell PRIVATE aux_util ipc_client)
 
 if(WIN32)
     # Dbghelp: ImageDirectoryEntryToData (PE import scan)
-    target_link_libraries(displayxr-shell PRIVATE dbghelp)
+    # Comdlg32: GetOpenFileNameA (Phase 5.14 Browse-for-app tile)
+    target_link_libraries(displayxr-shell PRIVATE dbghelp comdlg32)
 endif()
 
 install(TARGETS displayxr-shell RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/xrt/targets/shell/main.c
+++ b/src/xrt/targets/shell/main.c
@@ -24,6 +24,8 @@
 #include "xrt/xrt_defines.h"
 #include "util/u_logging.h"
 
+#include "shell_app_scan.h"
+
 #include <cjson/cJSON.h>
 
 #include <stdio.h>
@@ -244,7 +246,7 @@ shell_config_update(struct shell_config *cfg, const char *app_name,
 	sw->width_m = w; sw->height_m = h;
 }
 
-// --- 4C.9: Registered apps config ---
+// --- 4C.9 / 5.5: Registered apps config ---
 
 #define MAX_REGISTERED_APPS 32
 
@@ -252,7 +254,14 @@ struct registered_app
 {
 	char name[128];
 	char exe_path[MAX_PATH];
-	char type[8]; // "3d", "2d", or "" (unknown)
+	char type[8];          // "3d", "2d", or "" (unknown)
+	char source[8];        // "user" | "scan"  (5.5)
+	char category[32];     // sidecar "category", default "app"
+	char description[256]; // sidecar "description"
+	char display_mode[16]; // sidecar "display_mode", default "auto"
+	char icon_path[MAX_PATH];     // resolved 2D icon (absolute) or ""
+	char icon_3d_path[MAX_PATH];  // resolved SBS icon (absolute) or ""
+	char icon_3d_layout[8];       // "sbs-lr"|"sbs-rl"|"tb"|"bt"|""
 };
 
 static struct registered_app g_registered_apps[MAX_REGISTERED_APPS];
@@ -278,6 +287,113 @@ get_registered_apps_path(char *buf, size_t buf_size)
 #endif
 }
 
+// Case-insensitive exe_path comparison. Normalizes forward slashes to
+// backslashes before comparing so "test_apps/x/build/x.exe" matches
+// "test_apps\x\build\x.exe".
+static bool
+exe_path_equal(const char *a, const char *b)
+{
+	if (a == NULL || b == NULL) return a == b;
+	while (*a && *b) {
+		int ca = (unsigned char)*a;
+		int cb = (unsigned char)*b;
+		if (ca == '/') ca = '\\';
+		if (cb == '/') cb = '\\';
+		if (ca >= 'A' && ca <= 'Z') ca += 32;
+		if (cb >= 'A' && cb <= 'Z') cb += 32;
+		if (ca != cb) return false;
+		a++; b++;
+	}
+	return *a == '\0' && *b == '\0';
+}
+
+// Read a string field from a cJSON object into a fixed buffer. If the field
+// is missing or not a string, dst is left untouched.
+static void
+json_copy_str(char *dst, size_t dst_size, const cJSON *obj, const char *key)
+{
+	const cJSON *j = cJSON_GetObjectItemCaseSensitive(obj, key);
+	if (cJSON_IsString(j) && j->valuestring != NULL) {
+		snprintf(dst, dst_size, "%s", j->valuestring);
+	}
+}
+
+static void
+registered_app_zero(struct registered_app *app)
+{
+	memset(app, 0, sizeof(*app));
+}
+
+// Merge a single scanned app into the in-memory registry. If an existing
+// entry has a matching exe_path it is replaced; otherwise the entry is
+// appended.
+static void
+merge_scanned_app(const struct shell_scanned_app *s)
+{
+	// Replace any existing entry (user or scan) with the same exe_path.
+	for (int i = 0; i < g_registered_app_count; i++) {
+		if (exe_path_equal(g_registered_apps[i].exe_path, s->exe_path)) {
+			struct registered_app *app = &g_registered_apps[i];
+			registered_app_zero(app);
+			snprintf(app->name, sizeof(app->name), "%s", s->name);
+			snprintf(app->exe_path, sizeof(app->exe_path), "%s", s->exe_path);
+			snprintf(app->type, sizeof(app->type), "%s", s->type);
+			snprintf(app->source, sizeof(app->source), "scan");
+			snprintf(app->category, sizeof(app->category), "%s", s->category);
+			snprintf(app->description, sizeof(app->description), "%s", s->description);
+			snprintf(app->display_mode, sizeof(app->display_mode), "%s", s->display_mode);
+			snprintf(app->icon_path, sizeof(app->icon_path), "%s", s->icon_path);
+			snprintf(app->icon_3d_path, sizeof(app->icon_3d_path), "%s", s->icon_3d_path);
+			snprintf(app->icon_3d_layout, sizeof(app->icon_3d_layout), "%s", s->icon_3d_layout);
+			return;
+		}
+	}
+
+	// Append as a new entry.
+	if (g_registered_app_count >= MAX_REGISTERED_APPS) {
+		PE("registry full — dropping scanned app '%s'\n", s->name);
+		return;
+	}
+	struct registered_app *app = &g_registered_apps[g_registered_app_count++];
+	registered_app_zero(app);
+	snprintf(app->name, sizeof(app->name), "%s", s->name);
+	snprintf(app->exe_path, sizeof(app->exe_path), "%s", s->exe_path);
+	snprintf(app->type, sizeof(app->type), "%s", s->type);
+	snprintf(app->source, sizeof(app->source), "scan");
+	snprintf(app->category, sizeof(app->category), "%s", s->category);
+	snprintf(app->description, sizeof(app->description), "%s", s->description);
+	snprintf(app->display_mode, sizeof(app->display_mode), "%s", s->display_mode);
+	snprintf(app->icon_path, sizeof(app->icon_path), "%s", s->icon_path);
+	snprintf(app->icon_3d_path, sizeof(app->icon_3d_path), "%s", s->icon_3d_path);
+	snprintf(app->icon_3d_layout, sizeof(app->icon_3d_layout), "%s", s->icon_3d_layout);
+}
+
+// Remove every entry whose source == "scan". Called before re-running the
+// scanner so stale scan results from previous runs don't linger.
+static void
+drop_scan_entries(void)
+{
+	int dst = 0;
+	for (int i = 0; i < g_registered_app_count; i++) {
+		if (strcmp(g_registered_apps[i].source, "scan") != 0) {
+			if (dst != i) {
+				g_registered_apps[dst] = g_registered_apps[i];
+			}
+			dst++;
+		}
+	}
+	g_registered_app_count = dst;
+}
+
+// Forward declarations — these are called from registered_apps_load but
+// defined later in this file.
+static void
+registered_apps_save(void);
+#ifdef _WIN32
+static void
+get_exe_dir(char *buf, size_t buf_size);
+#endif
+
 static void
 registered_apps_load(void)
 {
@@ -286,101 +402,107 @@ registered_apps_load(void)
 	char path[512];
 	get_registered_apps_path(path, sizeof(path));
 
-	FILE *f = fopen(path, "rb");
-	if (!f) {
-		// First run: create default config
-		P("No registered_apps.json found — creating defaults.\n");
 #ifdef _WIN32
-		{
-			char dir[512];
-			snprintf(dir, sizeof(dir), "%s", path);
-			char *last = strrchr(dir, '\\');
-			if (last) { *last = '\0'; CreateDirectoryA(dir, NULL); }
-		}
-#endif
-		// Add demo entries
-		snprintf(g_registered_apps[0].name, sizeof(g_registered_apps[0].name), "cube_handle_d3d11_win");
-		snprintf(g_registered_apps[0].exe_path, sizeof(g_registered_apps[0].exe_path),
-		         "test_apps\\cube_handle_d3d11_win\\build\\cube_handle_d3d11_win.exe");
-		snprintf(g_registered_apps[0].type, sizeof(g_registered_apps[0].type), "3d");
-
-		snprintf(g_registered_apps[1].name, sizeof(g_registered_apps[1].name), "Notepad");
-		snprintf(g_registered_apps[1].exe_path, sizeof(g_registered_apps[1].exe_path), "notepad.exe");
-		snprintf(g_registered_apps[1].type, sizeof(g_registered_apps[1].type), "2d");
-
-		g_registered_app_count = 2;
-		// Save to disk
-		goto save_and_return;
-	}
-
 	{
+		// Make sure the parent directory exists before we try to write.
+		char dir[512];
+		snprintf(dir, sizeof(dir), "%s", path);
+		char *last = strrchr(dir, '\\');
+		if (last) { *last = '\0'; CreateDirectoryA(dir, NULL); }
+	}
+#endif
+
+	// -------- 1) Load existing JSON, if present. --------
+	FILE *f = fopen(path, "rb");
+	if (f != NULL) {
 		fseek(f, 0, SEEK_END);
 		long len = ftell(f);
 		fseek(f, 0, SEEK_SET);
-		if (len <= 0 || len > 64 * 1024) { fclose(f); return; }
+		if (len > 0 && len <= 256 * 1024) {
+			char *data = (char *)malloc((size_t)len + 1);
+			if (data != NULL) {
+				fread(data, 1, (size_t)len, f);
+				data[len] = '\0';
 
-		char *data = (char *)malloc(len + 1);
-		fread(data, 1, len, f);
-		data[len] = '\0';
+				cJSON *root = cJSON_Parse(data);
+				free(data);
+				if (root && cJSON_IsArray(root)) {
+					cJSON *entry = NULL;
+					cJSON_ArrayForEach(entry, root)
+					{
+						if (g_registered_app_count >= MAX_REGISTERED_APPS) break;
+						struct registered_app *app =
+						    &g_registered_apps[g_registered_app_count];
+						registered_app_zero(app);
+
+						json_copy_str(app->name, sizeof(app->name), entry, "name");
+						json_copy_str(app->exe_path, sizeof(app->exe_path), entry, "exe_path");
+						json_copy_str(app->type, sizeof(app->type), entry, "type");
+						json_copy_str(app->source, sizeof(app->source), entry, "source");
+						json_copy_str(app->category, sizeof(app->category), entry, "category");
+						json_copy_str(app->description, sizeof(app->description), entry, "description");
+						json_copy_str(app->display_mode, sizeof(app->display_mode), entry, "display_mode");
+						json_copy_str(app->icon_path, sizeof(app->icon_path), entry, "icon_path");
+						json_copy_str(app->icon_3d_path, sizeof(app->icon_3d_path), entry, "icon_3d_path");
+						json_copy_str(app->icon_3d_layout, sizeof(app->icon_3d_layout), entry, "icon_3d_layout");
+
+						// Back-compat: a Phase 4C JSON has no `source` field.
+						// Treat pre-existing entries as user-added.
+						if (app->source[0] == '\0') {
+							snprintf(app->source, sizeof(app->source), "user");
+						}
+
+						g_registered_app_count++;
+					}
+				}
+				cJSON_Delete(root);
+			}
+		}
 		fclose(f);
-
-		cJSON *root = cJSON_Parse(data);
-		free(data);
-		if (!root || !cJSON_IsArray(root)) {
-			cJSON_Delete(root);
-			return;
-		}
-
-		cJSON *entry = NULL;
-		cJSON_ArrayForEach(entry, root)
-		{
-			if (g_registered_app_count >= MAX_REGISTERED_APPS) break;
-			struct registered_app *app = &g_registered_apps[g_registered_app_count];
-
-			cJSON *jname = cJSON_GetObjectItemCaseSensitive(entry, "name");
-			cJSON *jpath = cJSON_GetObjectItemCaseSensitive(entry, "exe_path");
-			cJSON *jtype = cJSON_GetObjectItemCaseSensitive(entry, "type");
-
-			if (cJSON_IsString(jname))
-				snprintf(app->name, sizeof(app->name), "%s", jname->valuestring);
-			if (cJSON_IsString(jpath))
-				snprintf(app->exe_path, sizeof(app->exe_path), "%s", jpath->valuestring);
-			if (cJSON_IsString(jtype))
-				snprintf(app->type, sizeof(app->type), "%s", jtype->valuestring);
-
-			g_registered_app_count++;
-		}
-		cJSON_Delete(root);
+	} else {
+		P("No registered_apps.json found — seeding defaults.\n");
+		// Minimal first-run defaults. The scanner will populate DisplayXR apps;
+		// we only seed a single 2D fallback so the launcher isn't empty on
+		// systems with no installed sidecars yet.
+#ifdef _WIN32
+		struct registered_app *np = &g_registered_apps[g_registered_app_count++];
+		registered_app_zero(np);
+		snprintf(np->name, sizeof(np->name), "Notepad");
+		snprintf(np->exe_path, sizeof(np->exe_path), "notepad.exe");
+		snprintf(np->type, sizeof(np->type), "2d");
+		snprintf(np->source, sizeof(np->source), "user");
+		snprintf(np->category, sizeof(np->category), "tool");
+#endif
 	}
 
-	P("Loaded %d registered app(s).\n", g_registered_app_count);
-	return;
+	// -------- 2) Drop stale scan entries, re-run scanner, merge. --------
+	drop_scan_entries();
 
-save_and_return:
-	; // fallthrough to save
+#ifdef _WIN32
 	{
-		char spath[512];
-		get_registered_apps_path(spath, sizeof(spath));
-
-		cJSON *arr = cJSON_CreateArray();
-		for (int i = 0; i < g_registered_app_count; i++) {
-			cJSON *obj = cJSON_CreateObject();
-			cJSON_AddStringToObject(obj, "name", g_registered_apps[i].name);
-			cJSON_AddStringToObject(obj, "exe_path", g_registered_apps[i].exe_path);
-			cJSON_AddStringToObject(obj, "type", g_registered_apps[i].type);
-			cJSON_AddItemToArray(arr, obj);
+		char exe_dir[MAX_PATH] = {0};
+		get_exe_dir(exe_dir, sizeof(exe_dir));
+		size_t edl = strlen(exe_dir);
+		if (edl > 0 && (exe_dir[edl - 1] == '\\' || exe_dir[edl - 1] == '/')) {
+			exe_dir[edl - 1] = '\0';
 		}
-		char *json_str = cJSON_Print(arr);
-		cJSON_Delete(arr);
 
-		FILE *sf = fopen(spath, "wb");
-		if (sf) {
-			fwrite(json_str, 1, strlen(json_str), sf);
-			fclose(sf);
-			P("Created default registered_apps.json with %d entries.\n", g_registered_app_count);
+		struct shell_scanned_app scanned[MAX_REGISTERED_APPS];
+		int n = shell_scan_apps(exe_dir, scanned, MAX_REGISTERED_APPS);
+		for (int i = 0; i < n; i++) {
+			merge_scanned_app(&scanned[i]);
 		}
-		free(json_str);
 	}
+#endif
+
+	P("Registry: %d app(s) after merge.\n", g_registered_app_count);
+	for (int i = 0; i < g_registered_app_count; i++) {
+		P("  [%s] %s  (%s)\n", g_registered_apps[i].source, g_registered_apps[i].name,
+		  g_registered_apps[i].exe_path);
+	}
+
+	// -------- 3) Persist merged registry so users can hand-edit later. --------
+	registered_apps_save();
 }
 
 static void
@@ -392,9 +514,17 @@ registered_apps_save(void)
 	cJSON *arr = cJSON_CreateArray();
 	for (int i = 0; i < g_registered_app_count; i++) {
 		cJSON *obj = cJSON_CreateObject();
-		cJSON_AddStringToObject(obj, "name", g_registered_apps[i].name);
-		cJSON_AddStringToObject(obj, "exe_path", g_registered_apps[i].exe_path);
-		cJSON_AddStringToObject(obj, "type", g_registered_apps[i].type);
+		const struct registered_app *app = &g_registered_apps[i];
+		cJSON_AddStringToObject(obj, "name", app->name);
+		cJSON_AddStringToObject(obj, "exe_path", app->exe_path);
+		cJSON_AddStringToObject(obj, "type", app->type);
+		cJSON_AddStringToObject(obj, "source", app->source[0] ? app->source : "user");
+		if (app->category[0])       cJSON_AddStringToObject(obj, "category", app->category);
+		if (app->description[0])    cJSON_AddStringToObject(obj, "description", app->description);
+		if (app->display_mode[0])   cJSON_AddStringToObject(obj, "display_mode", app->display_mode);
+		if (app->icon_path[0])      cJSON_AddStringToObject(obj, "icon_path", app->icon_path);
+		if (app->icon_3d_path[0])   cJSON_AddStringToObject(obj, "icon_3d_path", app->icon_3d_path);
+		if (app->icon_3d_layout[0]) cJSON_AddStringToObject(obj, "icon_3d_layout", app->icon_3d_layout);
 		cJSON_AddItemToArray(arr, obj);
 	}
 	char *json_str = cJSON_Print(arr);
@@ -918,6 +1048,80 @@ cleanup_closed_captures(struct ipc_connection *ipc_c,
 	}
 }
 
+// --- 5.6: Running-app set (for launcher "running" tag) ---
+
+#define SHELL_RUNNING_NAMES_MAX 32
+
+struct shell_running_set
+{
+	int count;
+	char names[SHELL_RUNNING_NAMES_MAX][128];
+};
+
+/*!
+ * Snapshot the set of application_name strings for every IPC client currently
+ * connected to the service. Used by the launcher to highlight tiles whose app
+ * is already running.
+ *
+ * Wraps ipc_call_system_get_clients + ipc_call_system_get_client_info so the
+ * launcher UI doesn't have to speak IPC directly. Cheap enough to call every
+ * time the launcher opens; not intended for per-frame use.
+ *
+ * On IPC failure, returns an empty set — the launcher should degrade to "no
+ * running apps" rather than failing to open.
+ */
+static void
+shell_get_running_app_set(struct ipc_connection *ipc_c, struct shell_running_set *out)
+{
+	out->count = 0;
+
+	struct ipc_client_list clients;
+	xrt_result_t r = ipc_call_system_get_clients(ipc_c, &clients);
+	if (r != XRT_SUCCESS) {
+		return;
+	}
+
+	for (uint32_t c = 0; c < clients.id_count; c++) {
+		if (clients.ids[c] == 0) continue;
+		if (out->count >= SHELL_RUNNING_NAMES_MAX) break;
+
+		struct ipc_app_state ias;
+		xrt_result_t ir = ipc_call_system_get_client_info(ipc_c, clients.ids[c], &ias);
+		if (ir != XRT_SUCCESS) continue;
+		if (ias.info.application_name[0] == '\0') continue;
+
+		// Deduplicate — two instances of the same app are one tile in the
+		// launcher (for highlight purposes).
+		bool already = false;
+		for (int i = 0; i < out->count; i++) {
+			if (strcmp(out->names[i], ias.info.application_name) == 0) {
+				already = true;
+				break;
+			}
+		}
+		if (already) continue;
+
+		snprintf(out->names[out->count], sizeof(out->names[0]), "%s",
+		         ias.info.application_name);
+		out->count++;
+	}
+}
+
+/*!
+ * True if @p app_name matches any currently-running client in @p set. The
+ * comparison is case-sensitive and expects the application_name as passed to
+ * xrCreateInstance.
+ */
+static bool
+shell_running_set_contains(const struct shell_running_set *set, const char *app_name)
+{
+	if (set == NULL || app_name == NULL || !*app_name) return false;
+	for (int i = 0; i < set->count; i++) {
+		if (strcmp(set->names[i], app_name) == 0) return true;
+	}
+	return false;
+}
+
 // --- 4C.10+4C.11: App launch from shell + auto-detect type ---
 
 /*!
@@ -1206,7 +1410,7 @@ main(int argc, char *argv[])
 
 	P("Connected to service.\n");
 
-	// Load registered apps config (4C.9)
+	// Load registered apps config (Phase 4C.9 + Phase 5.5 scanner merge)
 	registered_apps_load();
 
 #ifdef _WIN32

--- a/src/xrt/targets/shell/main.c
+++ b/src/xrt/targets/shell/main.c
@@ -38,6 +38,7 @@
 #include <process.h>
 #include <tlhelp32.h> // For process enumeration (service PID lookup)
 #include <shellapi.h> // For Shell_NotifyIcon (system tray)
+#include <commdlg.h>  // For GetOpenFileNameA (Phase 5.14 Browse tile)
 #else
 #include <unistd.h>
 #endif
@@ -1259,6 +1260,79 @@ shell_push_registered_apps_to_service(struct ipc_connection *ipc_c)
 	P("Pushed %d app(s) to launcher.\n", pushed);
 }
 
+#ifdef _WIN32
+/*!
+ * Phase 5.14: prompt the user for an executable via GetOpenFileNameA,
+ * append it to g_registered_apps as a user entry, persist to JSON, and
+ * re-push the registry to the service. Mirrors the OPENFILENAMEA idiom
+ * used by comp_d3d11_window.cpp's Ctrl+O launch flow.
+ *
+ * Called from the launcher click-poll branch when the service signals a
+ * Browse-tile hit (IPC_LAUNCHER_ACTION_BROWSE). The dialog is modal and
+ * blocks the shell's message loop; on return the launcher is re-shown so
+ * the user sees their new tile at the end of the grid.
+ */
+static void
+shell_browse_and_add_app(struct ipc_connection *ipc_c)
+{
+	// Phase 5.14: open the file dialog as a top-level window
+	// (hwndOwner=NULL). The service granted ASFW_ANY foreground permission
+	// when it processed the Browse click, so Windows lets the modal dialog
+	// activate normally. Using the hidden HWND_MESSAGE g_msg_hwnd as owner
+	// doesn't help — message-only windows can't be focused, so the dialog
+	// would still hide behind the compositor.
+	char path[MAX_PATH] = {0};
+	OPENFILENAMEA ofn = {0};
+	ofn.lStructSize = sizeof(ofn);
+	ofn.hwndOwner = NULL;
+	ofn.lpstrFilter = "Executables (*.exe)\0*.exe\0All Files (*.*)\0*.*\0";
+	ofn.lpstrFile = path;
+	ofn.nMaxFile = MAX_PATH;
+	ofn.lpstrTitle = "Add app to DisplayXR launcher";
+	ofn.Flags = OFN_FILEMUSTEXIST | OFN_PATHMUSTEXIST | OFN_NOCHANGEDIR;
+
+	if (!GetOpenFileNameA(&ofn)) {
+		P("Browse: canceled\n");
+		return;
+	}
+
+	if (g_registered_app_count >= MAX_REGISTERED_APPS) {
+		PE("Registry full (%d) — cannot add '%s'\n",
+		   g_registered_app_count, path);
+		return;
+	}
+
+	// Derive a display name from the exe basename (strip path and .exe).
+	const char *base = strrchr(path, '\\');
+	if (base == NULL) base = strrchr(path, '/');
+	base = base ? base + 1 : path;
+	char name[128];
+	snprintf(name, sizeof(name), "%s", base);
+	size_t nlen = strlen(name);
+	if (nlen >= 4 && _stricmp(name + nlen - 4, ".exe") == 0) {
+		name[nlen - 4] = '\0';
+	}
+
+	struct registered_app *app = &g_registered_apps[g_registered_app_count++];
+	registered_app_zero(app);
+	snprintf(app->name, sizeof(app->name), "%s", name);
+	snprintf(app->exe_path, sizeof(app->exe_path), "%s", path);
+	snprintf(app->type, sizeof(app->type), "3d");   // assume 3d; user can edit JSON
+	snprintf(app->source, sizeof(app->source), "user");
+	snprintf(app->category, sizeof(app->category), "app");
+
+	registered_apps_save();
+	shell_push_registered_apps_to_service(ipc_c);
+	P("Browse: added '%s' from %s\n", name, path);
+}
+#else
+static void
+shell_browse_and_add_app(struct ipc_connection *ipc_c)
+{
+	(void)ipc_c;
+}
+#endif
+
 // --- 4C.10+4C.11: App launch from shell + auto-detect type ---
 
 /*!
@@ -1883,9 +1957,24 @@ main(int argc, char *argv[])
 		if (g_shell_active && g_launcher_visible) {
 			int64_t tile_index = -1;
 			if (ipc_call_shell_poll_launcher_click(&ipc_c, &tile_index) == XRT_SUCCESS &&
-			    tile_index >= 0) {
-				g_launcher_visible = false; // service already hid it
-				if (tile_index < (int64_t)g_registered_app_count) {
+			    tile_index != -1) {
+				// Service already hid the launcher when the click registered.
+				g_launcher_visible = false;
+
+				if (tile_index == IPC_LAUNCHER_ACTION_BROWSE) {
+					// Phase 5.14: Browse tile → open file dialog, add to
+					// registry, re-push, re-show launcher so the user sees
+					// their new tile.
+					shell_browse_and_add_app(&ipc_c);
+#ifdef _WIN32
+					if (service_pid != 0) {
+						AllowSetForegroundWindow(service_pid);
+					}
+#endif
+					if (ipc_call_shell_set_launcher_visible(&ipc_c, true) == XRT_SUCCESS) {
+						g_launcher_visible = true;
+					}
+				} else if (tile_index >= 0 && tile_index < (int64_t)g_registered_app_count) {
 					struct registered_app *rapp = &g_registered_apps[tile_index];
 
 					// Phase 5.11: if a matching client is already running,

--- a/src/xrt/targets/shell/main.c
+++ b/src/xrt/targets/shell/main.c
@@ -461,19 +461,11 @@ registered_apps_load(void)
 		}
 		fclose(f);
 	} else {
-		P("No registered_apps.json found — seeding defaults.\n");
-		// Minimal first-run defaults. The scanner will populate DisplayXR apps;
-		// we only seed a single 2D fallback so the launcher isn't empty on
-		// systems with no installed sidecars yet.
-#ifdef _WIN32
-		struct registered_app *np = &g_registered_apps[g_registered_app_count++];
-		registered_app_zero(np);
-		snprintf(np->name, sizeof(np->name), "Notepad");
-		snprintf(np->exe_path, sizeof(np->exe_path), "notepad.exe");
-		snprintf(np->type, sizeof(np->type), "2d");
-		snprintf(np->source, sizeof(np->source), "user");
-		snprintf(np->category, sizeof(np->category), "tool");
-#endif
+		P("No registered_apps.json found — starting with empty registry.\n");
+		// Per the spec, the launcher is manifest-gated: only apps with a
+		// .displayxr.json sidecar (or apps the user explicitly adds via
+		// Browse-for-app) appear. No built-in defaults. The scanner runs
+		// next and populates anything it finds.
 	}
 
 	// -------- 2) Drop stale scan entries, re-run scanner, merge. --------
@@ -1749,6 +1741,35 @@ main(int argc, char *argv[])
 					g_shell_active = false;
 					g_launcher_visible = false;
 					tray_update_tooltip(false);
+				}
+			}
+		}
+
+		// Phase 5.10: poll for launcher tile clicks. The service-side
+		// WM_LBUTTONDOWN handler stores a tile index when the user clicks
+		// inside the launcher; we look up the registered app and dispatch
+		// the launch on this side because we own the env vars + CreateProcess
+		// path. The launcher panel was already hidden by the service when
+		// the click landed, so we just need to sync our local state and run
+		// the launch. Only poll while the launcher is actually visible to
+		// keep IPC traffic minimal.
+		if (g_shell_active && g_launcher_visible) {
+			int64_t tile_index = -1;
+			if (ipc_call_shell_poll_launcher_click(&ipc_c, &tile_index) == XRT_SUCCESS &&
+			    tile_index >= 0) {
+				g_launcher_visible = false; // service already hid it
+				if (tile_index < (int64_t)g_registered_app_count) {
+					struct registered_app *rapp = &g_registered_apps[tile_index];
+					P("Launcher: launching tile %lld → '%s'\n",
+					  (long long)tile_index, rapp->name);
+					shell_launch_registered_app(
+					    &ipc_c, rapp,
+					    have_json ? runtime_json : NULL,
+					    apps, &app_count,
+					    captures, &capture_count);
+				} else {
+					PE("Launcher click: tile %lld out of range (count=%d)\n",
+					   (long long)tile_index, g_registered_app_count);
 				}
 			}
 		}

--- a/src/xrt/targets/shell/main.c
+++ b/src/xrt/targets/shell/main.c
@@ -1116,6 +1116,110 @@ shell_running_set_contains(const struct shell_running_set *set, const char *app_
 }
 
 /*!
+ * Phase 5.11: case-insensitive normalized exe-path equality. Treats
+ * forward slashes as backslashes so registry-stored paths match what
+ * QueryFullProcessImageNameW returns.
+ */
+static bool
+shell_exe_paths_equal(const char *a, const char *b)
+{
+	if (a == NULL || b == NULL) return a == b;
+	while (*a && *b) {
+		int ca = (unsigned char)*a;
+		int cb = (unsigned char)*b;
+		if (ca == '/') ca = '\\';
+		if (cb == '/') cb = '\\';
+		if (ca >= 'A' && ca <= 'Z') ca += 32;
+		if (cb >= 'A' && cb <= 'Z') cb += 32;
+		if (ca != cb) return false;
+		a++; b++;
+	}
+	return *a == '\0' && *b == '\0';
+}
+
+#ifdef _WIN32
+/*!
+ * Phase 5.11: resolve a PID to its absolute exe path via
+ * QueryFullProcessImageNameW. Writes a UTF-8 path into @p out, returns true
+ * on success.
+ */
+static bool
+shell_pid_to_exe_path(DWORD pid, char *out, size_t out_size)
+{
+	if (pid == 0 || out == NULL || out_size == 0) return false;
+
+	HANDLE h = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
+	if (h == NULL) return false;
+
+	wchar_t wpath[MAX_PATH] = {0};
+	DWORD wlen = MAX_PATH;
+	BOOL ok = QueryFullProcessImageNameW(h, 0, wpath, &wlen);
+	CloseHandle(h);
+	if (!ok || wlen == 0) return false;
+
+	int n = WideCharToMultiByte(CP_UTF8, 0, wpath, (int)wlen, out, (int)out_size - 1, NULL, NULL);
+	if (n <= 0) return false;
+	out[n] = '\0';
+	return true;
+}
+#endif
+
+/*!
+ * Phase 5.11: build a bitmask of registered apps that have at least one
+ * matching IPC client currently connected. Bit @c i set means
+ * g_registered_apps[i].exe_path equals (case-insensitive, slash-normalized)
+ * the exe path of some IPC client's PID.
+ *
+ * Returns 0 on Windows if no clients are connected; non-Windows always 0.
+ */
+static uint64_t
+shell_compute_running_tile_mask(struct ipc_connection *ipc_c)
+{
+#ifdef _WIN32
+	uint64_t mask = 0;
+
+	struct ipc_client_list clients;
+	if (ipc_call_system_get_clients(ipc_c, &clients) != XRT_SUCCESS) {
+		return 0;
+	}
+
+	// Collect each connected client's exe path once.
+	char client_exes[IPC_MAX_CLIENTS][MAX_PATH];
+	int client_exe_count = 0;
+	for (uint32_t c = 0; c < clients.id_count; c++) {
+		if (clients.ids[c] == 0) continue;
+		struct ipc_app_state ias;
+		if (ipc_call_system_get_client_info(ipc_c, clients.ids[c], &ias) != XRT_SUCCESS)
+			continue;
+		if (ias.pid == 0) continue;
+		if (shell_pid_to_exe_path((DWORD)ias.pid, client_exes[client_exe_count],
+		                          sizeof(client_exes[0]))) {
+			client_exe_count++;
+			if (client_exe_count >= IPC_MAX_CLIENTS) break;
+		}
+	}
+
+	// Match each registered app against the connected exe set.
+	int cap = g_registered_app_count;
+	if (cap > 64) cap = 64; // mask is uint64_t
+	for (int i = 0; i < cap; i++) {
+		const char *reg_exe = g_registered_apps[i].exe_path;
+		for (int j = 0; j < client_exe_count; j++) {
+			if (shell_exe_paths_equal(reg_exe, client_exes[j])) {
+				mask |= (1ULL << i);
+				break;
+			}
+		}
+	}
+
+	return mask;
+#else
+	(void)ipc_c;
+	return 0;
+#endif
+}
+
+/*!
  * Phase 5.8: ship the current g_registered_apps[] array to the service so
  * the spatial launcher panel can render its tile grid. Uses a clear+add
  * pattern (one IPC call per app) so each message stays under IPC_BUF_SIZE.
@@ -1745,6 +1849,18 @@ main(int argc, char *argv[])
 			}
 		}
 
+		// Phase 5.11: refresh the running-tile mask and push to service if
+		// it has changed. Cheap to compute (one IPC list call + per-PID
+		// QueryFullProcessImageNameW), and we only push on diff.
+		if (g_shell_active) {
+			static uint64_t s_last_running_mask = (uint64_t)-1;
+			uint64_t mask = shell_compute_running_tile_mask(&ipc_c);
+			if (mask != s_last_running_mask) {
+				ipc_call_shell_set_running_tile_mask(&ipc_c, mask);
+				s_last_running_mask = mask;
+			}
+		}
+
 		// Phase 5.10: poll for launcher tile clicks. The service-side
 		// WM_LBUTTONDOWN handler stores a tile index when the user clicks
 		// inside the launcher; we look up the registered app and dispatch
@@ -1760,13 +1876,40 @@ main(int argc, char *argv[])
 				g_launcher_visible = false; // service already hid it
 				if (tile_index < (int64_t)g_registered_app_count) {
 					struct registered_app *rapp = &g_registered_apps[tile_index];
-					P("Launcher: launching tile %lld → '%s'\n",
-					  (long long)tile_index, rapp->name);
-					shell_launch_registered_app(
-					    &ipc_c, rapp,
-					    have_json ? runtime_json : NULL,
-					    apps, &app_count,
-					    captures, &capture_count);
+
+					// Phase 5.11: if a matching client is already running,
+					// focus it instead of spawning a second instance.
+					bool focused_existing = false;
+#ifdef _WIN32
+					struct ipc_client_list clist;
+					if (ipc_call_system_get_clients(&ipc_c, &clist) == XRT_SUCCESS) {
+						for (uint32_t c = 0; c < clist.id_count && !focused_existing; c++) {
+							if (clist.ids[c] == 0) continue;
+							struct ipc_app_state ias;
+							if (ipc_call_system_get_client_info(&ipc_c, clist.ids[c], &ias) != XRT_SUCCESS)
+								continue;
+							char client_exe[MAX_PATH];
+							if (!shell_pid_to_exe_path((DWORD)ias.pid, client_exe, sizeof(client_exe)))
+								continue;
+							if (shell_exe_paths_equal(client_exe, rapp->exe_path)) {
+								if (ipc_call_system_set_focused_client(&ipc_c, clist.ids[c]) == XRT_SUCCESS) {
+									P("Launcher: focused running client %u → '%s'\n",
+									  clist.ids[c], rapp->name);
+									focused_existing = true;
+								}
+							}
+						}
+					}
+#endif
+					if (!focused_existing) {
+						P("Launcher: launching tile %lld → '%s'\n",
+						  (long long)tile_index, rapp->name);
+						shell_launch_registered_app(
+						    &ipc_c, rapp,
+						    have_json ? runtime_json : NULL,
+						    apps, &app_count,
+						    captures, &capture_count);
+					}
 				} else {
 					PE("Launcher click: tile %lld out of range (count=%d)\n",
 					   (long long)tile_index, g_registered_app_count);

--- a/src/xrt/targets/shell/main.c
+++ b/src/xrt/targets/shell/main.c
@@ -61,6 +61,7 @@
 static volatile int g_running = 1;
 #ifdef _WIN32
 static bool g_shell_active = false;
+static bool g_launcher_visible = false; // Phase 5.7: spatial launcher panel toggle (Ctrl+L)
 static HWND g_msg_hwnd = NULL;
 #endif
 
@@ -1549,6 +1550,7 @@ main(int argc, char *argv[])
 						client_name_count = 0;
 
 						g_shell_active = false;
+						g_launcher_visible = false;
 						tray_update_tooltip(false);
 						P("Shell deactivated — waiting in tray.\n");
 					} else {
@@ -1586,15 +1588,20 @@ main(int argc, char *argv[])
 						P("Shell activated.\n");
 					}
 				} else if (msg.message == WM_HOTKEY && msg.wParam == HOTKEY_LAUNCH) {
-					// --- Ctrl+L: Launch registered app ---
+					// --- Ctrl+L: Toggle spatial launcher panel (Phase 5.7) ---
+					// The Phase 4C MessageBox path is gone — the service-side
+					// multi-compositor renders the panel in its own window when
+					// launcher_visible is true. Tile grid + launch dispatch
+					// come in later Phase 5 tasks.
 					if (g_shell_active) {
-						int idx = shell_show_launcher_dialog();
-						if (idx >= 0 && idx < g_registered_app_count) {
-							shell_launch_registered_app(
-							    &ipc_c, &g_registered_apps[idx],
-							    have_json ? runtime_json : NULL,
-							    apps, &app_count,
-							    captures, &capture_count);
+						g_launcher_visible = !g_launcher_visible;
+						xrt_result_t lret = ipc_call_shell_set_launcher_visible(
+						    &ipc_c, g_launcher_visible);
+						if (lret != XRT_SUCCESS) {
+							PE("ipc_call_shell_set_launcher_visible failed: %d\n", lret);
+							g_launcher_visible = !g_launcher_visible; // roll back
+						} else {
+							P("Launcher %s\n", g_launcher_visible ? "shown" : "hidden");
 						}
 					}
 				} else if (msg.message == WM_TRAYICON) {
@@ -1696,6 +1703,7 @@ main(int argc, char *argv[])
 					capture_count = 0;
 					client_name_count = 0;
 					g_shell_active = false;
+					g_launcher_visible = false;
 					tray_update_tooltip(false);
 				}
 			}

--- a/src/xrt/targets/shell/main.c
+++ b/src/xrt/targets/shell/main.c
@@ -1123,6 +1123,46 @@ shell_running_set_contains(const struct shell_running_set *set, const char *app_
 	return false;
 }
 
+/*!
+ * Phase 5.8: ship the current g_registered_apps[] array to the service so
+ * the spatial launcher panel can render its tile grid. Uses a clear+add
+ * pattern (one IPC call per app) so each message stays under IPC_BUF_SIZE.
+ * The shell must re-call this whenever the registry changes (browse-for-app,
+ * remove, refresh).
+ */
+static void
+shell_push_registered_apps_to_service(struct ipc_connection *ipc_c)
+{
+	xrt_result_t r = ipc_call_shell_clear_launcher_apps(ipc_c);
+	if (r != XRT_SUCCESS) {
+		PE("ipc_call_shell_clear_launcher_apps failed: %d\n", r);
+		return;
+	}
+
+	int pushed = 0;
+	int cap = g_registered_app_count;
+	if (cap > IPC_LAUNCHER_MAX_APPS) {
+		cap = IPC_LAUNCHER_MAX_APPS;
+	}
+	for (int i = 0; i < cap; i++) {
+		const struct registered_app *src = &g_registered_apps[i];
+
+		struct ipc_launcher_app msg;
+		memset(&msg, 0, sizeof(msg));
+		snprintf(msg.name, sizeof(msg.name), "%s", src->name);
+		snprintf(msg.exe_path, sizeof(msg.exe_path), "%s", src->exe_path);
+		snprintf(msg.type, sizeof(msg.type), "%s", src->type);
+
+		r = ipc_call_shell_add_launcher_app(ipc_c, &msg);
+		if (r != XRT_SUCCESS) {
+			PE("ipc_call_shell_add_launcher_app[%d] failed: %d\n", i, r);
+			return;
+		}
+		pushed++;
+	}
+	P("Pushed %d app(s) to launcher.\n", pushed);
+}
+
 // --- 4C.10+4C.11: App launch from shell + auto-detect type ---
 
 /*!
@@ -1413,6 +1453,10 @@ main(int argc, char *argv[])
 
 	// Load registered apps config (Phase 4C.9 + Phase 5.5 scanner merge)
 	registered_apps_load();
+
+	// Phase 5.8: push the merged registry to the service so the spatial
+	// launcher panel can render its tile grid.
+	shell_push_registered_apps_to_service(&ipc_c);
 
 #ifdef _WIN32
 	// --- Resolve runtime JSON path (needed for app launches) ---

--- a/src/xrt/targets/shell/main.c
+++ b/src/xrt/targets/shell/main.c
@@ -1735,6 +1735,17 @@ main(int argc, char *argv[])
 					// come in later Phase 5 tasks.
 					if (g_shell_active) {
 						g_launcher_visible = !g_launcher_visible;
+
+						// Phase 5.12: when opening, hand the service process
+						// foreground-activation permission so it can pull its
+						// compositor window into focus. Otherwise keys like
+						// Esc stay routed to whichever app previously had
+						// focus and never reach the compositor WndProc that
+						// the launcher keyboard handler depends on.
+						if (g_launcher_visible && service_pid != 0) {
+							AllowSetForegroundWindow(service_pid);
+						}
+
 						xrt_result_t lret = ipc_call_shell_set_launcher_visible(
 						    &ipc_c, g_launcher_visible);
 						if (lret != XRT_SUCCESS) {

--- a/src/xrt/targets/shell/shell_app_scan.c
+++ b/src/xrt/targets/shell/shell_app_scan.c
@@ -1,0 +1,453 @@
+// Copyright 2026, Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  DisplayXR shell app-discovery scanner implementation.
+ *
+ * Walks filesystem paths, finds .exe files with a matching .displayxr.json
+ * sidecar, parses the sidecar via cJSON, and populates an array of
+ * shell_scanned_app structs.
+ *
+ * @ingroup shell
+ */
+
+#include "shell_app_scan.h"
+#include "shell_pe_scan.h"
+
+#include <cjson/cJSON.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdbool.h>
+
+#define LOG_W(...) fprintf(stderr, "[shell_scan] " __VA_ARGS__)
+#define LOG_I(...) fprintf(stdout, "[shell_scan] " __VA_ARGS__)
+
+#ifdef _WIN32
+
+#include <windows.h>
+
+// -----------------------------------------------------------------------------
+// Sidecar parsing
+// -----------------------------------------------------------------------------
+
+static void
+copy_str(char *dst, size_t dst_size, const char *src)
+{
+	if (!dst || dst_size == 0) return;
+	if (!src) {
+		dst[0] = '\0';
+		return;
+	}
+	snprintf(dst, dst_size, "%s", src);
+}
+
+// Read the entire file into a heap buffer. Caller frees. Returns NULL on error.
+static char *
+read_file_text(const char *path, long max_bytes)
+{
+	FILE *f = fopen(path, "rb");
+	if (!f) return NULL;
+
+	fseek(f, 0, SEEK_END);
+	long len = ftell(f);
+	fseek(f, 0, SEEK_SET);
+
+	if (len <= 0 || len > max_bytes) {
+		fclose(f);
+		return NULL;
+	}
+
+	char *data = (char *)malloc((size_t)len + 1);
+	if (!data) {
+		fclose(f);
+		return NULL;
+	}
+
+	size_t got = fread(data, 1, (size_t)len, f);
+	fclose(f);
+
+	if (got != (size_t)len) {
+		free(data);
+		return NULL;
+	}
+
+	data[len] = '\0';
+	return data;
+}
+
+// Resolve an icon path from the sidecar — relative paths are resolved against
+// sidecar_dir. Writes "" to out if the resolved file doesn't exist.
+static void
+resolve_icon_path(const char *sidecar_dir, const char *rel, char *out, size_t out_size)
+{
+	if (!rel || !*rel) {
+		if (out_size) out[0] = '\0';
+		return;
+	}
+
+	char candidate[SHELL_PATH_MAX];
+	// Treat the sidecar value as relative unless it already looks absolute.
+	if (rel[0] == '\\' || rel[0] == '/' || (rel[0] && rel[1] == ':')) {
+		snprintf(candidate, sizeof(candidate), "%s", rel);
+	} else {
+		snprintf(candidate, sizeof(candidate), "%s\\%s", sidecar_dir, rel);
+	}
+
+	DWORD attrs = GetFileAttributesA(candidate);
+	if (attrs == INVALID_FILE_ATTRIBUTES || (attrs & FILE_ATTRIBUTE_DIRECTORY)) {
+		if (out_size) out[0] = '\0';
+		return;
+	}
+
+	copy_str(out, out_size, candidate);
+}
+
+// Validate and populate a scanned_app from a parsed sidecar JSON object.
+// Returns true on success.
+static bool
+parse_sidecar(const cJSON *root, const char *exe_path, const char *sidecar_dir,
+              struct shell_scanned_app *app)
+{
+	memset(app, 0, sizeof(*app));
+
+	const cJSON *j_schema = cJSON_GetObjectItemCaseSensitive(root, "schema_version");
+	if (!cJSON_IsNumber(j_schema) || j_schema->valueint != 1) {
+		LOG_W("rejecting %s: schema_version missing or unsupported\n", exe_path);
+		return false;
+	}
+
+	const cJSON *j_name = cJSON_GetObjectItemCaseSensitive(root, "name");
+	if (!cJSON_IsString(j_name) || !j_name->valuestring || !*j_name->valuestring) {
+		LOG_W("rejecting %s: name missing\n", exe_path);
+		return false;
+	}
+	if (strlen(j_name->valuestring) >= SHELL_APP_NAME_MAX) {
+		LOG_W("rejecting %s: name too long\n", exe_path);
+		return false;
+	}
+	copy_str(app->name, sizeof(app->name), j_name->valuestring);
+
+	const cJSON *j_type = cJSON_GetObjectItemCaseSensitive(root, "type");
+	if (!cJSON_IsString(j_type) || !j_type->valuestring) {
+		LOG_W("rejecting %s: type missing\n", exe_path);
+		return false;
+	}
+	if (strcmp(j_type->valuestring, "3d") != 0 && strcmp(j_type->valuestring, "2d") != 0) {
+		LOG_W("rejecting %s: type must be '3d' or '2d' (got '%s')\n", exe_path,
+		      j_type->valuestring);
+		return false;
+	}
+	copy_str(app->type, sizeof(app->type), j_type->valuestring);
+
+	// Optional: category (default "app")
+	const cJSON *j_cat = cJSON_GetObjectItemCaseSensitive(root, "category");
+	if (cJSON_IsString(j_cat) && j_cat->valuestring) {
+		copy_str(app->category, sizeof(app->category), j_cat->valuestring);
+	} else {
+		copy_str(app->category, sizeof(app->category), "app");
+	}
+
+	// Optional: display_mode (default "auto")
+	const cJSON *j_mode = cJSON_GetObjectItemCaseSensitive(root, "display_mode");
+	if (cJSON_IsString(j_mode) && j_mode->valuestring) {
+		copy_str(app->display_mode, sizeof(app->display_mode), j_mode->valuestring);
+	} else {
+		copy_str(app->display_mode, sizeof(app->display_mode), "auto");
+	}
+
+	// Optional: description
+	const cJSON *j_desc = cJSON_GetObjectItemCaseSensitive(root, "description");
+	if (cJSON_IsString(j_desc) && j_desc->valuestring) {
+		copy_str(app->description, sizeof(app->description), j_desc->valuestring);
+	}
+
+	// Optional: icon (2D)
+	const cJSON *j_icon = cJSON_GetObjectItemCaseSensitive(root, "icon");
+	if (cJSON_IsString(j_icon) && j_icon->valuestring) {
+		resolve_icon_path(sidecar_dir, j_icon->valuestring, app->icon_path,
+		                  sizeof(app->icon_path));
+		if (!app->icon_path[0]) {
+			LOG_W("rejecting %s: icon file not found ('%s')\n", exe_path,
+			      j_icon->valuestring);
+			return false;
+		}
+	}
+
+	// Optional: icon_3d (stereo) — requires icon to also be set.
+	const cJSON *j_icon3d = cJSON_GetObjectItemCaseSensitive(root, "icon_3d");
+	if (cJSON_IsString(j_icon3d) && j_icon3d->valuestring) {
+		if (!app->icon_path[0]) {
+			LOG_W("rejecting %s: icon_3d requires icon to also be set\n", exe_path);
+			return false;
+		}
+		resolve_icon_path(sidecar_dir, j_icon3d->valuestring, app->icon_3d_path,
+		                  sizeof(app->icon_3d_path));
+		if (!app->icon_3d_path[0]) {
+			LOG_W("rejecting %s: icon_3d file not found ('%s')\n", exe_path,
+			      j_icon3d->valuestring);
+			return false;
+		}
+
+		const cJSON *j_layout = cJSON_GetObjectItemCaseSensitive(root, "icon_3d_layout");
+		const char *layout = "sbs-lr"; // default
+		if (cJSON_IsString(j_layout) && j_layout->valuestring) {
+			layout = j_layout->valuestring;
+		}
+		if (strcmp(layout, "sbs-lr") != 0 && strcmp(layout, "sbs-rl") != 0 &&
+		    strcmp(layout, "tb") != 0 && strcmp(layout, "bt") != 0) {
+			LOG_W("rejecting %s: icon_3d_layout must be sbs-lr|sbs-rl|tb|bt (got '%s')\n",
+			      exe_path, layout);
+			return false;
+		}
+		copy_str(app->icon_3d_layout, sizeof(app->icon_3d_layout), layout);
+	}
+
+	copy_str(app->exe_path, sizeof(app->exe_path), exe_path);
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+// Sidecar lookup per executable
+// -----------------------------------------------------------------------------
+
+// Given an exe path, look for "<basename>.displayxr.json" next to it.
+// On success, parses and writes into @p app. Returns true on success.
+static bool
+try_load_app_from_exe(const char *exe_path, struct shell_scanned_app *app)
+{
+	// Derive sidecar_path by stripping .exe and appending .displayxr.json.
+	char sidecar_path[SHELL_PATH_MAX];
+	snprintf(sidecar_path, sizeof(sidecar_path), "%s", exe_path);
+
+	size_t len = strlen(sidecar_path);
+	if (len > 4 && _stricmp(sidecar_path + len - 4, ".exe") == 0) {
+		sidecar_path[len - 4] = '\0';
+	}
+	if (strlen(sidecar_path) + strlen(".displayxr.json") + 1 > sizeof(sidecar_path)) {
+		return false;
+	}
+	strcat(sidecar_path, ".displayxr.json");
+
+	DWORD attrs = GetFileAttributesA(sidecar_path);
+	if (attrs == INVALID_FILE_ATTRIBUTES || (attrs & FILE_ATTRIBUTE_DIRECTORY)) {
+		// No sidecar — silently skip.
+		return false;
+	}
+
+	char *text = read_file_text(sidecar_path, 64 * 1024);
+	if (!text) {
+		LOG_W("failed to read sidecar: %s\n", sidecar_path);
+		return false;
+	}
+
+	cJSON *root = cJSON_Parse(text);
+	free(text);
+
+	if (!root) {
+		LOG_W("invalid JSON in sidecar: %s\n", sidecar_path);
+		return false;
+	}
+
+	// Derive sidecar_dir for resolving relative icon paths.
+	char sidecar_dir[SHELL_PATH_MAX];
+	copy_str(sidecar_dir, sizeof(sidecar_dir), sidecar_path);
+	char *last_sep = strrchr(sidecar_dir, '\\');
+	if (!last_sep) last_sep = strrchr(sidecar_dir, '/');
+	if (last_sep) *last_sep = '\0';
+
+	bool ok = parse_sidecar(root, exe_path, sidecar_dir, app);
+	cJSON_Delete(root);
+
+	if (!ok) return false;
+
+	// Sanity: for "3d" apps, warn if the PE doesn't import openxr_loader.dll.
+	// This is not fatal — the sidecar is authoritative — but a mismatch
+	// usually means the sidecar was placed next to the wrong binary.
+	if (strcmp(app->type, "3d") == 0) {
+		if (!shell_pe_exe_imports(exe_path, "openxr_loader.dll")) {
+			LOG_W("warning: %s has type=3d but does not import openxr_loader.dll\n",
+			      exe_path);
+		}
+	}
+
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+// Directory walks
+// -----------------------------------------------------------------------------
+
+// Enumerate .exe files in a directory (non-recursive). For each, try to load
+// the sidecar and append a scanned_app to @p out.
+static void
+scan_dir_for_exes(const char *dir, struct shell_scanned_app *out, int max_out, int *count)
+{
+	if (*count >= max_out) return;
+
+	char glob[SHELL_PATH_MAX];
+	snprintf(glob, sizeof(glob), "%s\\*.exe", dir);
+
+	WIN32_FIND_DATAA fd;
+	HANDLE h = FindFirstFileA(glob, &fd);
+	if (h == INVALID_HANDLE_VALUE) return;
+
+	do {
+		if (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) continue;
+
+		char exe_path[SHELL_PATH_MAX];
+		snprintf(exe_path, sizeof(exe_path), "%s\\%s", dir, fd.cFileName);
+
+		if (*count >= max_out) break;
+
+		if (try_load_app_from_exe(exe_path, &out[*count])) {
+			(*count)++;
+		}
+	} while (FindNextFileA(h, &fd));
+
+	FindClose(h);
+}
+
+// Enumerate immediate subdirectories of @p parent and scan each child's build/
+// directory for executables. Matches the test_apps/*/build/ and demos/*/build/
+// repo layouts.
+static void
+scan_parent_build_dirs(const char *parent, struct shell_scanned_app *out, int max_out,
+                       int *count)
+{
+	if (*count >= max_out) return;
+
+	char glob[SHELL_PATH_MAX];
+	snprintf(glob, sizeof(glob), "%s\\*", parent);
+
+	WIN32_FIND_DATAA fd;
+	HANDLE h = FindFirstFileA(glob, &fd);
+	if (h == INVALID_HANDLE_VALUE) return;
+
+	do {
+		if (!(fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)) continue;
+		if (strcmp(fd.cFileName, ".") == 0 || strcmp(fd.cFileName, "..") == 0) continue;
+
+		char build_dir[SHELL_PATH_MAX];
+		snprintf(build_dir, sizeof(build_dir), "%s\\%s\\build", parent, fd.cFileName);
+
+		DWORD attrs = GetFileAttributesA(build_dir);
+		if (attrs == INVALID_FILE_ATTRIBUTES || !(attrs & FILE_ATTRIBUTE_DIRECTORY)) {
+			continue;
+		}
+
+		scan_dir_for_exes(build_dir, out, max_out, count);
+
+		if (*count >= max_out) break;
+	} while (FindNextFileA(h, &fd));
+
+	FindClose(h);
+}
+
+// -----------------------------------------------------------------------------
+// Repo-root resolution
+// -----------------------------------------------------------------------------
+
+// Starting from @p start, walk up the directory tree (up to max_levels) looking
+// for a directory that contains a "test_apps" subdirectory. Writes the match
+// into @p out and returns true. Returns false if not found.
+static bool
+find_repo_root(const char *start, int max_levels, char *out, size_t out_size)
+{
+	char cur[SHELL_PATH_MAX];
+	copy_str(cur, sizeof(cur), start);
+
+	for (int i = 0; i <= max_levels; i++) {
+		char probe[SHELL_PATH_MAX];
+		snprintf(probe, sizeof(probe), "%s\\test_apps", cur);
+
+		DWORD attrs = GetFileAttributesA(probe);
+		if (attrs != INVALID_FILE_ATTRIBUTES && (attrs & FILE_ATTRIBUTE_DIRECTORY)) {
+			copy_str(out, out_size, cur);
+			return true;
+		}
+
+		// Walk up one level.
+		char *last_sep = strrchr(cur, '\\');
+		if (!last_sep) last_sep = strrchr(cur, '/');
+		if (!last_sep) return false;
+		*last_sep = '\0';
+		if (!cur[0]) return false;
+	}
+	return false;
+}
+
+// -----------------------------------------------------------------------------
+// Public entry point
+// -----------------------------------------------------------------------------
+
+int
+shell_scan_apps(const char *shell_exe_dir, struct shell_scanned_app *out, int max_out)
+{
+	if (!out || max_out <= 0) return 0;
+
+	int count = 0;
+
+	// 1) Dev-repo layout — walk up from the shell exe dir looking for test_apps/.
+	char repo_root[SHELL_PATH_MAX] = {0};
+	bool have_repo = false;
+	if (shell_exe_dir && *shell_exe_dir) {
+		have_repo = find_repo_root(shell_exe_dir, 6, repo_root, sizeof(repo_root));
+	}
+	// Also honor an explicit env override.
+	const char *env_root = getenv("DISPLAYXR_REPO_ROOT");
+	if (env_root && *env_root) {
+		copy_str(repo_root, sizeof(repo_root), env_root);
+		have_repo = true;
+	}
+
+	if (have_repo) {
+		LOG_I("scanning repo root: %s\n", repo_root);
+
+		char test_apps[SHELL_PATH_MAX];
+		snprintf(test_apps, sizeof(test_apps), "%s\\test_apps", repo_root);
+		scan_parent_build_dirs(test_apps, out, max_out, &count);
+
+		char demos[SHELL_PATH_MAX];
+		snprintf(demos, sizeof(demos), "%s\\demos", repo_root);
+		scan_parent_build_dirs(demos, out, max_out, &count);
+
+		char pkg_bin[SHELL_PATH_MAX];
+		snprintf(pkg_bin, sizeof(pkg_bin), "%s\\_package\\bin", repo_root);
+		scan_dir_for_exes(pkg_bin, out, max_out, &count);
+	} else {
+		LOG_I("no repo root found — skipping dev paths\n");
+	}
+
+	// 2) Production install path.
+	const char *pf = getenv("ProgramFiles");
+	if (pf && *pf) {
+		char prod[SHELL_PATH_MAX];
+		snprintf(prod, sizeof(prod), "%s\\DisplayXR\\apps", pf);
+		DWORD attrs = GetFileAttributesA(prod);
+		if (attrs != INVALID_FILE_ATTRIBUTES && (attrs & FILE_ATTRIBUTE_DIRECTORY)) {
+			LOG_I("scanning production path: %s\n", prod);
+			// v1: flat layout — exes directly under DisplayXR\apps\. Future
+			// installer shape (per-app subdirectories) can be added when it
+			// exists.
+			scan_dir_for_exes(prod, out, max_out, &count);
+		}
+	}
+
+	LOG_I("scan complete: %d app(s) found\n", count);
+	return count;
+}
+
+#else // !_WIN32
+
+int
+shell_scan_apps(const char *shell_exe_dir, struct shell_scanned_app *out, int max_out)
+{
+	(void)shell_exe_dir;
+	(void)out;
+	(void)max_out;
+	return 0;
+}
+
+#endif

--- a/src/xrt/targets/shell/shell_app_scan.h
+++ b/src/xrt/targets/shell/shell_app_scan.h
@@ -1,0 +1,68 @@
+// Copyright 2026, Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  DisplayXR shell app-discovery scanner.
+ *
+ * Walks a fixed set of filesystem locations looking for executables that ship a
+ * @c .displayxr.json sidecar. Parses the sidecar, resolves icon paths, and
+ * returns an array of scanned apps for the launcher.
+ *
+ * See docs/specs/displayxr-app-manifest.md for the sidecar contract.
+ *
+ * @ingroup shell
+ */
+
+#pragma once
+
+#ifdef _WIN32
+#include <windows.h>
+#define SHELL_PATH_MAX MAX_PATH
+#else
+#define SHELL_PATH_MAX 4096
+#endif
+
+#define SHELL_APP_NAME_MAX 128
+#define SHELL_APP_TYPE_MAX 8
+#define SHELL_APP_CATEGORY_MAX 32
+#define SHELL_APP_DESCRIPTION_MAX 256
+#define SHELL_APP_DISPLAY_MODE_MAX 16
+#define SHELL_APP_ICON_LAYOUT_MAX 8
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*!
+ * A single app discovered by the scanner. Populated from the sidecar manifest
+ * plus filesystem resolution. All string fields are NUL-terminated.
+ */
+struct shell_scanned_app
+{
+	char name[SHELL_APP_NAME_MAX];                    // sidecar "name"
+	char exe_path[SHELL_PATH_MAX];                    // absolute path to the .exe
+	char type[SHELL_APP_TYPE_MAX];                    // "3d" or "2d"
+	char category[SHELL_APP_CATEGORY_MAX];            // sidecar "category", default "app"
+	char description[SHELL_APP_DESCRIPTION_MAX];      // sidecar "description"
+	char display_mode[SHELL_APP_DISPLAY_MODE_MAX];    // sidecar "display_mode", default "auto"
+	char icon_path[SHELL_PATH_MAX];                   // absolute path or "" if none
+	char icon_3d_path[SHELL_PATH_MAX];                // absolute path or "" if none
+	char icon_3d_layout[SHELL_APP_ICON_LAYOUT_MAX];   // "sbs-lr"|"sbs-rl"|"tb"|"bt", empty if no icon_3d
+};
+
+/*!
+ * Scan the standard DisplayXR app-discovery paths and populate @p out.
+ *
+ * @p shell_exe_dir is the directory containing the shell binary; relative scan
+ * paths are resolved against it (e.g. @c <shell_exe_dir>/../test_apps/).
+ *
+ * Returns the number of apps written to @p out (at most @p max_out). Rejected
+ * manifests (missing required fields, schema_version mismatch, unreadable icon
+ * files) are logged and skipped.
+ */
+int
+shell_scan_apps(const char *shell_exe_dir, struct shell_scanned_app *out, int max_out);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/xrt/targets/shell/shell_pe_scan.c
+++ b/src/xrt/targets/shell/shell_pe_scan.c
@@ -1,0 +1,98 @@
+// Copyright 2026, Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  PE import table scanner implementation.
+ *
+ * Uses LoadLibraryEx(LOAD_LIBRARY_AS_DATAFILE) + Dbghelp ImageDirectoryEntryToData
+ * to walk the import directory without executing any code from the target binary.
+ *
+ * @ingroup shell
+ */
+
+#include "shell_pe_scan.h"
+
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+
+#ifdef _WIN32
+
+#include <windows.h>
+#include <dbghelp.h>
+
+static int
+stricmp_safe(const char *a, const char *b)
+{
+	if (!a || !b) return a == b ? 0 : (a ? 1 : -1);
+	while (*a && *b) {
+		int ca = (unsigned char)*a;
+		int cb = (unsigned char)*b;
+		if (ca >= 'A' && ca <= 'Z') ca += 32;
+		if (cb >= 'A' && cb <= 'Z') cb += 32;
+		if (ca != cb) return ca - cb;
+		a++; b++;
+	}
+	return (unsigned char)*a - (unsigned char)*b;
+}
+
+bool
+shell_pe_exe_imports(const char *exe_path, const char *dll_name)
+{
+	if (!exe_path || !dll_name || !*exe_path || !*dll_name) {
+		return false;
+	}
+
+	// LOAD_LIBRARY_AS_IMAGE_RESOURCE maps the file as an image (sections placed
+	// at their VAs) without resolving imports or running DllMain — safe for
+	// untrusted binaries, and lets ImageDirectoryEntryToData treat the base as
+	// a mapped image (MappedAsImage=TRUE). The returned HMODULE has the low
+	// bits set to mark it as a resource mapping; mask them off to get a usable
+	// image base.
+	HMODULE mod = LoadLibraryExA(exe_path, NULL, LOAD_LIBRARY_AS_IMAGE_RESOURCE);
+	if (!mod) {
+		return false;
+	}
+
+	uintptr_t base = (uintptr_t)mod & ~(uintptr_t)0xF;
+
+	bool found = false;
+
+	ULONG dir_size = 0;
+	PIMAGE_IMPORT_DESCRIPTOR import_dir = (PIMAGE_IMPORT_DESCRIPTOR)ImageDirectoryEntryToData(
+	    (PVOID)base, TRUE, IMAGE_DIRECTORY_ENTRY_IMPORT, &dir_size);
+
+	if (import_dir && dir_size > 0) {
+		for (PIMAGE_IMPORT_DESCRIPTOR desc = import_dir;
+		     desc->Name != 0 || desc->FirstThunk != 0;
+		     desc++) {
+
+			const char *imported = (const char *)(base + desc->Name);
+			// Compare basename only (no path separator expected in PE import names,
+			// but tolerate "./foo.dll" just in case).
+			const char *slash = strrchr(imported, '\\');
+			if (!slash) slash = strrchr(imported, '/');
+			const char *base_name = slash ? slash + 1 : imported;
+
+			if (stricmp_safe(base_name, dll_name) == 0) {
+				found = true;
+				break;
+			}
+		}
+	}
+
+	FreeLibrary(mod);
+	return found;
+}
+
+#else // !_WIN32
+
+bool
+shell_pe_exe_imports(const char *exe_path, const char *dll_name)
+{
+	(void)exe_path;
+	(void)dll_name;
+	return false;
+}
+
+#endif

--- a/src/xrt/targets/shell/shell_pe_scan.h
+++ b/src/xrt/targets/shell/shell_pe_scan.h
@@ -1,0 +1,35 @@
+// Copyright 2026, Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  PE import table scanner — check if a Windows executable imports a given DLL.
+ *
+ * Used by the shell's app discovery scanner to sanity-check that a sidecar-declared
+ * DisplayXR app actually links against openxr_loader.dll.
+ *
+ * @ingroup shell
+ */
+
+#pragma once
+
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*!
+ * Returns true if the PE image at @p exe_path has @p dll_name in its import
+ * directory. The comparison is case-insensitive on the DLL basename.
+ *
+ * Returns false on any parse error, if the file is not a valid PE, or if the
+ * import is not present.
+ *
+ * Windows only. On non-Windows builds this is a no-op that always returns false.
+ */
+bool
+shell_pe_exe_imports(const char *exe_path, const char *dll_name);
+
+#ifdef __cplusplus
+}
+#endif

--- a/test_apps/common/displayxr_manifest.cmake
+++ b/test_apps/common/displayxr_manifest.cmake
@@ -1,0 +1,36 @@
+# Copyright 2026, Leia Inc.
+# SPDX-License-Identifier: BSL-1.0
+#
+# displayxr_install_manifest(target manifest_dir)
+#
+# Copies every file in manifest_dir (e.g. the app's displayxr/ sub-directory)
+# next to the built executable so the DisplayXR shell launcher can discover it.
+#
+# Expected layout in manifest_dir:
+#   <exe_basename>.displayxr.json   (required — the sidecar)
+#   icon.png                        (optional — 2D tile image)
+#   icon_sbs.png                    (optional — side-by-side stereo tile image)
+#
+# The shell scanner looks for `<exe_basename>.displayxr.json` next to each
+# discovered executable. See docs/specs/displayxr-app-manifest.md.
+
+function(displayxr_install_manifest target manifest_dir)
+    if(NOT IS_DIRECTORY "${manifest_dir}")
+        message(WARNING "displayxr_install_manifest: directory not found: ${manifest_dir}")
+        return()
+    endif()
+
+    file(GLOB _displayxr_files "${manifest_dir}/*")
+    if(NOT _displayxr_files)
+        message(WARNING "displayxr_install_manifest: no files in ${manifest_dir}")
+        return()
+    endif()
+
+    add_custom_command(TARGET ${target} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            ${_displayxr_files}
+            "$<TARGET_FILE_DIR:${target}>/"
+        COMMENT "Copying DisplayXR manifest files for ${target}"
+        VERBATIM
+    )
+endfunction()

--- a/test_apps/cube_handle_d3d11_win/CMakeLists.txt
+++ b/test_apps/cube_handle_d3d11_win/CMakeLists.txt
@@ -111,6 +111,10 @@ if(TEXTURE_FILES)
     )
 endif()
 
+# DisplayXR shell manifest sidecar
+include(${CMAKE_CURRENT_SOURCE_DIR}/../common/displayxr_manifest.cmake)
+displayxr_install_manifest(cube_handle_d3d11_win "${CMAKE_CURRENT_SOURCE_DIR}/displayxr")
+
 # Copy runtime DLLs
 if(TARGET OpenXR::openxr_loader)
     get_target_property(_loader_location OpenXR::openxr_loader IMPORTED_LOCATION)

--- a/test_apps/cube_handle_d3d11_win/displayxr/cube_handle_d3d11_win.displayxr.json
+++ b/test_apps/cube_handle_d3d11_win/displayxr/cube_handle_d3d11_win.displayxr.json
@@ -1,0 +1,8 @@
+{
+  "schema_version": 1,
+  "name": "Cube D3D11 (Handle)",
+  "type": "3d",
+  "category": "test",
+  "display_mode": "auto",
+  "description": "Reference spinning cube demonstrating XR_EXT_win32_window_binding on Direct3D 11."
+}

--- a/test_apps/cube_handle_d3d12_win/CMakeLists.txt
+++ b/test_apps/cube_handle_d3d12_win/CMakeLists.txt
@@ -120,4 +120,8 @@ if(TEXTURE_FILES)
     )
 endif()
 
+# DisplayXR shell manifest sidecar
+include(${CMAKE_CURRENT_SOURCE_DIR}/../common/displayxr_manifest.cmake)
+displayxr_install_manifest(cube_handle_d3d12_win "${CMAKE_CURRENT_SOURCE_DIR}/displayxr")
+
 

--- a/test_apps/cube_handle_d3d12_win/displayxr/cube_handle_d3d12_win.displayxr.json
+++ b/test_apps/cube_handle_d3d12_win/displayxr/cube_handle_d3d12_win.displayxr.json
@@ -1,0 +1,8 @@
+{
+  "schema_version": 1,
+  "name": "Cube D3D12 (Handle)",
+  "type": "3d",
+  "category": "test",
+  "display_mode": "auto",
+  "description": "Reference spinning cube demonstrating XR_EXT_win32_window_binding on Direct3D 12."
+}

--- a/test_apps/cube_handle_gl_win/CMakeLists.txt
+++ b/test_apps/cube_handle_gl_win/CMakeLists.txt
@@ -120,4 +120,8 @@ if(TEXTURE_FILES)
     )
 endif()
 
+# DisplayXR shell manifest sidecar
+include(${CMAKE_CURRENT_SOURCE_DIR}/../common/displayxr_manifest.cmake)
+displayxr_install_manifest(cube_handle_gl_win "${CMAKE_CURRENT_SOURCE_DIR}/displayxr")
+
 

--- a/test_apps/cube_handle_gl_win/displayxr/cube_handle_gl_win.displayxr.json
+++ b/test_apps/cube_handle_gl_win/displayxr/cube_handle_gl_win.displayxr.json
@@ -1,0 +1,8 @@
+{
+  "schema_version": 1,
+  "name": "Cube OpenGL (Handle)",
+  "type": "3d",
+  "category": "test",
+  "display_mode": "auto",
+  "description": "Reference spinning cube demonstrating XR_EXT_win32_window_binding on OpenGL."
+}

--- a/test_apps/cube_handle_vk_win/CMakeLists.txt
+++ b/test_apps/cube_handle_vk_win/CMakeLists.txt
@@ -136,3 +136,7 @@ if(EXISTS "${VK_WEAVER_DLL}")
             "$<TARGET_FILE_DIR:cube_handle_vk_win>/SimulatedRealityVulkanBeta.dll"
     )
 endif()
+
+# DisplayXR shell manifest sidecar
+include(${CMAKE_CURRENT_SOURCE_DIR}/../common/displayxr_manifest.cmake)
+displayxr_install_manifest(cube_handle_vk_win "${CMAKE_CURRENT_SOURCE_DIR}/displayxr")

--- a/test_apps/cube_handle_vk_win/displayxr/cube_handle_vk_win.displayxr.json
+++ b/test_apps/cube_handle_vk_win/displayxr/cube_handle_vk_win.displayxr.json
@@ -1,0 +1,8 @@
+{
+  "schema_version": 1,
+  "name": "Cube Vulkan (Handle)",
+  "type": "3d",
+  "category": "test",
+  "display_mode": "auto",
+  "description": "Reference spinning cube demonstrating XR_EXT_win32_window_binding on Vulkan."
+}


### PR DESCRIPTION
## Summary

- **App discovery**: `.displayxr.json` sidecar spec + PE import scanner + filesystem walk + merge with `registered_apps.json`
- **Spatial launcher panel**: rendered at ZDP in the multi-compositor, toggled via Ctrl+L
- **Tile grid**: 4-column wrapping layout, real app names from sidecar metadata, ellipsis-truncated labels
- **Click-to-launch**: spatial hit-test → IPC poll → `shell_launch_registered_app` with env vars
- **Running-app indicator**: cyan glow border on tiles whose exe matches a connected IPC client; click-to-focus instead of relaunch
- **Keyboard navigation**: arrow keys + Enter + Esc, with input-suppress so keys don't leak to focused app
- **Right-click context menu**: Launch / Remove (session-only) / Cancel via `TrackPopupMenu` on the window thread
- **Browse-for-app**: virtual "+" tile → `GetOpenFileNameA` → append to registry → persist to JSON → re-push + re-show launcher
- **D3D11 icon loader**: `stb_image` vendored, `d3d11_icon_load_from_file()` ready for tile icon textures (not yet wired into render — placeholder for when sidecars carry `icon`/`icon_3d`)

## Test plan

- [ ] Build: `scripts\build_windows.bat build && scripts\build_windows.bat test-apps`
- [ ] Launch: `_package\bin\displayxr-shell.exe test_apps\cube_handle_d3d11_win\build\cube_handle_d3d11_win.exe`
- [ ] Ctrl+Space → shell activates. Ctrl+L → launcher panel at ZDP with 4 cube tiles + "Add app..." tile
- [ ] Click a tile → app launches, panel closes
- [ ] Ctrl+L → running cube tile has cyan glow. Click it → focuses existing instance
- [ ] Arrow keys move selection (white outline). Enter launches. Esc dismisses (cube stays alive)
- [ ] Right-click tile → popup menu → Remove hides tile (session-only)
- [ ] Click "Add app..." → file dialog → pick exe → new tile appears
- [ ] Ctrl+Space deactivate → re-activate → Ctrl+L → removed tiles restored, new tile persisted

🤖 Generated with [Claude Code](https://claude.com/claude-code)