### PR TITLE
MCP Phase A: handle-app introspection (#150)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,10 +102,12 @@ Cross-compiles a curated subset against MinGW-w64 to catch Win32-API typos, miss
 **Caveats — MinGW is NOT a full MSVC substitute:**
 - Compositors using WIL (`wil::com_ptr` in `comp_d3d11_service.cpp`) won't cross-compile. Service-side D3D11 stays MSVC-only.
 - Vulkan / vcpkg-only deps not available; targets requiring them (full openxr_displayxr.dll, comp_d3d11 native) are out of scope.
-- **MinGW ships winpthreads which adds POSIX-like extensions** (`clock_gettime`, `CLOCK_MONOTONIC`, `pid_t`, etc.) that **MSVC does not have**. These bugs only surface in real CI. Workarounds:
+- **MinGW ships winpthreads which adds POSIX-like extensions** (`clock_gettime`, `CLOCK_MONOTONIC`, `pid_t`, `<unistd.h>`, etc.) that **MSVC does not have**. These bugs only surface in real CI. Workarounds:
   - Use `os_monotonic_get_ns()` from `aux/os/os_time.h` instead of `clock_gettime(CLOCK_MONOTONIC, …)`.
   - Use C11 `timespec_get(TIME_UTC)` instead of `clock_gettime(CLOCK_REALTIME, …)`.
   - Use `long` instead of `pid_t` in public headers (don't include `<sys/types.h>` for it).
+  - Avoid `<unistd.h>` in cross-platform code. Use `os_nanosleep()` from `aux/os/os_time.h` instead of `usleep()`. For PIDs, use a wrapper helper like `u_mcp_self_pid()` that does `getpid()` on POSIX and `GetCurrentProcessId()` on Windows.
+  - Avoid C11 `<stdatomic.h>`. MSVC needs `/experimental:c11atomics` and even then `_Atomic(T*)` syntax is unreliable. Use a `pthread_mutex_t` (uncontended is essentially free), or Windows `Interlocked*` APIs behind an `#ifdef`.
 
 What it DOES catch reliably: `windows.h` symbol resolution, missing platform-config includes (`xrt/xrt_config_os.h` so `XRT_OS_WINDOWS` is actually defined), duplicate struct definitions across `#ifdef` branches, mistakes in cross-platform pthread wrapping.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,26 @@ Downloads all dependencies on first run (SR SDK, vcpkg, OpenXR loader). Requires
 
 **When on a Windows machine with a Leia SR display, prefer local builds over CI** — iterate faster with `scripts\build_windows.bat build` and test directly. Run scripts are generated in `_package/` (see Windows Test App section below).
 
+### Windows Compile-Check on macOS / Linux (MinGW-w64)
+```bash
+brew install mingw-w64        # one-time
+./scripts/build-mingw-check.sh                # default targets: aux_util mcp_adapter
+./scripts/build-mingw-check.sh aux_util drv_qwerty  # custom target list
+```
+Cross-compiles a curated subset against MinGW-w64 to catch Win32-API typos, missing `#ifdef XRT_OS_WINDOWS` guards, and wrong-platform symbols **before pushing to CI**. Mirrors the displayxr-unity plugin's `native~/build-win.sh` pattern.
+
+**Caveats — MinGW is NOT a full MSVC substitute:**
+- Compositors using WIL (`wil::com_ptr` in `comp_d3d11_service.cpp`) won't cross-compile. Service-side D3D11 stays MSVC-only.
+- Vulkan / vcpkg-only deps not available; targets requiring them (full openxr_displayxr.dll, comp_d3d11 native) are out of scope.
+- **MinGW ships winpthreads which adds POSIX-like extensions** (`clock_gettime`, `CLOCK_MONOTONIC`, `pid_t`, etc.) that **MSVC does not have**. These bugs only surface in real CI. Workarounds:
+  - Use `os_monotonic_get_ns()` from `aux/os/os_time.h` instead of `clock_gettime(CLOCK_MONOTONIC, …)`.
+  - Use C11 `timespec_get(TIME_UTC)` instead of `clock_gettime(CLOCK_REALTIME, …)`.
+  - Use `long` instead of `pid_t` in public headers (don't include `<sys/types.h>` for it).
+
+What it DOES catch reliably: `windows.h` symbol resolution, missing platform-config includes (`xrt/xrt_config_os.h` so `XRT_OS_WINDOWS` is actually defined), duplicate struct definitions across `#ifdef` branches, mistakes in cross-platform pthread wrapping.
+
+Toolchain: `cmake/toolchain-mingw-w64.cmake`. Output goes to `build-mingw/` (gitignored). Runs in ~30 s after first configure.
+
 ### CI Build (Remote)
 ```bash
 /ci-monitor "your commit message"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,7 @@ Cross-compiles a curated subset against MinGW-w64 to catch Win32-API typos, miss
   - Use `long` instead of `pid_t` in public headers (don't include `<sys/types.h>` for it).
   - Avoid `<unistd.h>` in cross-platform code. Use `os_nanosleep()` from `aux/os/os_time.h` instead of `usleep()`. For PIDs, use a wrapper helper like `u_mcp_self_pid()` that does `getpid()` on POSIX and `GetCurrentProcessId()` on Windows.
   - Avoid C11 `<stdatomic.h>`. MSVC needs `/experimental:c11atomics` and even then `_Atomic(T*)` syntax is unreliable. Use a `pthread_mutex_t` (uncontended is essentially free), or Windows `Interlocked*` APIs behind an `#ifdef`.
+  - `strncasecmp` / `strcasecmp` are POSIX. MSVC has `_strnicmp` / `_stricmp` in `<string.h>`. Add `#ifdef _WIN32 #define strncasecmp _strnicmp #endif` at the top of the TU.
 
 What it DOES catch reliably: `windows.h` symbol resolution, missing platform-config includes (`xrt/xrt_config_os.h` so `XRT_OS_WINDOWS` is actually defined), duplicate struct definitions across `#ifdef` branches, mistakes in cross-platform pthread wrapping.
 

--- a/cmake/toolchain-mingw-w64.cmake
+++ b/cmake/toolchain-mingw-w64.cmake
@@ -1,0 +1,30 @@
+# Copyright 2026, DisplayXR / Leia Inc.
+# SPDX-License-Identifier: BSL-1.0
+#
+# Cross-compile toolchain for compile-checking Windows code from macOS / Linux
+# using MinGW-w64. **This is a compile-only sanity check** — the canonical
+# Windows binary still comes from the MSVC build in CI. Mirrors the pattern
+# DisplayXR/displayxr-unity uses for its native plugin (native~/toolchain-mingw.cmake).
+#
+# Usage:
+#   cmake -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-mingw-w64.cmake -B build-mingw -G Ninja
+#   cmake --build build-mingw --target aux_util mcp_adapter
+#
+# The wrapper script scripts/build-mingw-check.sh selects a curated target
+# subset; many MSVC-only paths (WIL, vcpkg-provided libs) will not build.
+
+set(CMAKE_SYSTEM_NAME Windows)
+set(CMAKE_SYSTEM_PROCESSOR x86_64)
+
+set(CMAKE_C_COMPILER x86_64-w64-mingw32-gcc)
+set(CMAKE_CXX_COMPILER x86_64-w64-mingw32-g++)
+set(CMAKE_RC_COMPILER x86_64-w64-mingw32-windres)
+
+set(CMAKE_FIND_ROOT_PATH /opt/homebrew/x86_64-w64-mingw32 /usr/x86_64-w64-mingw32)
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+
+# Mark MinGW-w64 cross builds so CMakeLists can guard out incompatible
+# pieces (WIL, vcpkg-only deps) without affecting native MSVC builds.
+set(XRT_CROSS_MINGW_CHECK ON CACHE BOOL "Cross-compile compile-check via MinGW-w64" FORCE)

--- a/docs/roadmap/mcp-phase-a-agent-prompt.md
+++ b/docs/roadmap/mcp-phase-a-agent-prompt.md
@@ -1,0 +1,71 @@
+# Agent Prompt — MCP Phase A Implementation
+
+You are picking up work on the DisplayXR MCP Phase A feature on branch `feature/mcp-phase-a-ci`, worktree `.claude/worktrees/mcp-phase-a`.
+
+## Context you need before touching code
+
+Read in this order:
+
+1. `docs/roadmap/mcp-spec-v0.2.md` — full v0.2 spec. §3.1 (handle-app architecture), §4.A (Phase A tool list), §4.C (three-signals model + bug classes) are authoritative.
+2. `docs/roadmap/mcp-phase-a-plan.md` — this plan. Follow the slice sequence exactly; don't merge slices.
+3. `CLAUDE.md` — repo conventions. Relevant: branch naming (`-ci` suffix, already done), issue refs in commits, prefer local builds over CI, worktree rule.
+4. `docs/architecture/separation-of-concerns.md` — layer boundaries. MCP server goes in `auxiliary/util/` so it sits below state tracker and above platform/OS. It must not depend on compositor-API headers directly — swapchain access goes through existing `xrt_swapchain` vtables.
+5. `src/xrt/state_trackers/oxr/oxr_session_frame_end.c` — where the snapshot gets published.
+6. `src/xrt/auxiliary/util/u_logging.{h,c}` — you'll be adding an opt-in ring buffer here for `tail_log`.
+
+## Operating mode
+
+- **Primary platform: macOS.** Iterate with `./scripts/build_macos.sh` and `cube_handle_metal_macos` / `cube_handle_gl_macos` under `sim_display`. Do not touch Windows-specific code until slice 7.
+- **No CI for iteration.** Local builds only. Only use `/ci-monitor` when a slice is ready for PR.
+- **One slice per commit.** Each slice in the plan is its own atomic commit. Don't squash during development; squash at PR time if needed.
+- **Commit messages must include `(#XXX)`** — create or find a GitHub issue for Phase A before first commit and reference it.
+
+## Invariants you must preserve
+
+- **Runtime still works with `DISPLAYXR_MCP` unset.** The MCP server is strictly opt-in and has zero runtime cost when disabled. Verify after every slice.
+- **No blocking on the render thread.** Tool handlers read from atomically-published snapshots; they never lock anything the compositor holds.
+- **No changes to existing tool behavior for non-MCP consumers.** The U_LOG ring buffer, when added, is opt-in and does not change log output for existing readers.
+- **Layer rules (`separation-of-concerns.md`) apply.** MCP tool code must not include vendor SDK headers or graphics-API headers directly. Capture goes through swapchain vtable readback.
+
+## Slice entry/exit criteria
+
+Follow `docs/roadmap/mcp-phase-a-plan.md` §"Delivery slices." For each slice:
+
+1. Before starting: read the slice description, list files you will touch, confirm dependencies from previous slices are landed.
+2. Implement.
+3. Write or update the scripted test in `tests/mcp/`.
+4. Build on macOS, run the test, capture output.
+5. Verify the invariants above.
+6. Commit with an issue ref.
+
+Do not open a PR until all mac-side slices (1–6) are green.
+
+## The "done" demo
+
+Phase A is done when this sequence works on a clean mac build:
+
+```bash
+./scripts/build_macos.sh
+DISPLAYXR_MCP=1 XR_RUNTIME_JSON=./build/openxr_displayxr-dev.json \
+    ./test_apps/cube_handle_metal_macos/build/cube_handle_metal_macos &
+APP_PID=$!
+./build/src/xrt/targets/mcp_adapter/displayxr-mcp --pid $APP_PID
+# then drive via a scripted JSON-RPC session that calls:
+#   list_sessions → get_kooima_params → get_submitted_projection →
+#   diff_projection → capture_frame → tail_log
+```
+
+A short script in `tests/mcp/demo_maya.sh` should run this and print a pass/fail summary.
+
+## When to ask vs when to proceed
+
+- **Proceed without asking** on: file layout inside `auxiliary/util/`, JSON-RPC framing details, which third-party JSON lib (recommend `cJSON`), snapshot struct layout, test scaffolding choices.
+- **Ask first** on: anything that modifies `xrt_compositor` or `xrt_device` vtables; any new cross-cutting lock; dependencies on new third-party libraries beyond `cJSON` and `stb_image_write`; changes to public OpenXR extension headers.
+
+## What "done" looks like at PR time
+
+- All 7 slices committed (6 mac + 1 Windows), each with its test.
+- `docs/roadmap/mcp-phase-a-status.md` authored — mirror the structure of `docs/roadmap/shell-phase7-status.md`.
+- PR body links the spec, the plan, this prompt, and the Phase A issue.
+- Demo script `tests/mcp/demo_maya.sh` included and passing locally on mac; the Windows slice validated on a Leia display with a recorded screenshot.
+- No changes to `docs/roadmap/mcp-spec-v0.2.md` without explicit user discussion — the spec is the contract this work must satisfy, not a doc you update as implementation details change.

--- a/docs/roadmap/mcp-phase-a-plan.md
+++ b/docs/roadmap/mcp-phase-a-plan.md
@@ -1,0 +1,136 @@
+# MCP Phase A — Handle-App Mode Plan
+
+**Branch:** `feature/mcp-phase-a-ci`
+**Worktree:** `.claude/worktrees/mcp-phase-a`
+**Spec:** `docs/roadmap/mcp-spec-v0.2.md` §3.1, §4.A, §4.C
+**Target:** Maya's stereo-debug story runs end-to-end on a handle app.
+
+## Goal
+
+Ship a minimal in-process MCP server inside `libopenxr_displayxr` that exposes five tools over a per-PID socket, plus the `displayxr-mcp` stdio adapter that lets Claude Code / Cursor attach to a running handle app with no service and no IPC.
+
+## Scope (exactly this, nothing more)
+
+### Tools
+
+1. `list_sessions` — returns one entry (`{pid, display_id, api}`) in handle-app mode.
+2. `get_display_info` — wraps existing `XR_EXT_display_info` query.
+3. `get_runtime_metrics` — FPS, predicted display period, tracking confidence.
+4. `get_kooima_params` — display phys size, canvas, viewer pose at last frame, per-eye recommended FoV handed to the app via `xrLocateViews`.
+5. `get_submitted_projection` — per-eye pose, FoV, swapchain subImage rect from the app's most recent `XrCompositionLayerProjectionView`.
+6. `diff_projection` — structured diff + flagged mismatches (see spec §4.C bug-class table).
+7. `capture_frame` — swapchain readback → PNG. Metal and GL on mac; D3D11 on Windows in a later slice.
+8. `tail_log` — streaming U_LOG ring snapshots.
+
+Trivial helpers (`list_sessions`, `get_display_info`, `get_runtime_metrics`) land alongside the stereo tools since they share infra.
+
+### Out of scope for Phase A
+
+- Anything requiring the shell or service (windows, workspaces, recording, focus).
+- `measure_disparity` as a structured histogram — deferred to a Phase A.5 once `capture_frame` is solid.
+- `get_viewer_pose` / any biometric tool — behind a privacy gate, Phase B at earliest.
+- Remote HTTP/SSE transport — stdio-local only.
+
+## Architecture
+
+```
+Claude Code (MCP client)
+    ↕ stdio (JSON-RPC 2.0 framed by Content-Length headers)
+displayxr-mcp   (new binary in src/xrt/targets/mcp_adapter/)
+    ↕ per-PID socket: /tmp/displayxr-mcp-<pid>.sock (macOS)
+                      \\.\pipe\displayxr-mcp-<pid> (Windows, Phase A Windows slice)
+MCP server thread  (new in src/xrt/auxiliary/util/u_mcp_server.{h,c})
+    ↕ direct state reads
+oxr state tracker + active xrt_compositor swapchain
+```
+
+### Lifecycle
+
+- Runtime checks `DISPLAYXR_MCP` env var in `xrInstanceCreate`. If set, spins up a detached thread running the MCP server.
+- Server binds socket named by current PID; no listener = no overhead.
+- Server is best-effort: failure to bind logs a `U_LOG_W` and continues; never blocks app startup.
+- Thread joined at `xrDestroyInstance`; socket unlinked.
+
+### State access
+
+The MCP server thread reads runtime state through a thin **snapshot** API — no locking the render loop:
+
+- `u_mcp_latest_frame_snapshot_t` — published atomically at the end of `oxr_session_frame_end`. Contains last-submitted projection layers, last recommended FoV, predicted display time, head pose used for prediction.
+- `u_mcp_swapchain_capture()` — requests a one-shot readback tag on the swapchain; fulfilled on next frame boundary, not inline. Returns CPU-side pixels.
+
+### `displayxr-mcp` adapter
+
+Separate binary, no runtime link. Speaks MCP stdio to the agent, forwards JSON-RPC to the per-PID socket.
+
+Modes:
+- `--pid auto` — enumerate sockets, pick the single active session, error if 0 or >1.
+- `--pid N` — attach to a specific PID.
+- `--list` — print discovered sessions and exit.
+
+Ships in `src/xrt/targets/mcp_adapter/`.
+
+## Source tree additions
+
+```
+src/xrt/
+├── auxiliary/util/
+│   ├── u_mcp_server.h           # public header — start/stop, tool registration
+│   ├── u_mcp_server.c           # server thread, socket listener, JSON-RPC dispatch
+│   ├── u_mcp_tools_core.c       # list_sessions, get_display_info, get_runtime_metrics
+│   ├── u_mcp_tools_stereo.c     # get_kooima_params, get_submitted_projection, diff_projection
+│   ├── u_mcp_tools_capture.c    # capture_frame (per-API slices)
+│   ├── u_mcp_tools_log.c        # tail_log ring subscription
+│   ├── u_mcp_snapshot.h         # snapshot struct + atomic publish API
+│   └── u_mcp_snapshot.c
+├── state_trackers/oxr/
+│   └── oxr_session_frame_end.c  # +publish snapshot at submit
+└── targets/mcp_adapter/
+    ├── CMakeLists.txt
+    └── displayxr_mcp.c          # stdio ↔ socket adapter
+```
+
+## Delivery slices
+
+Each slice is an independently mergeable commit. Landing order matters.
+
+1. **Slice 1 — plumbing.** Empty MCP server thread, socket bind, JSON-RPC echo tool. `DISPLAYXR_MCP=1 cube_handle_metal_macos` + `displayxr-mcp --pid auto` handshakes. No runtime data yet.
+2. **Slice 2 — core tools.** `list_sessions`, `get_display_info`, `get_runtime_metrics`. No frame-level data.
+3. **Slice 3 — snapshot API.** `u_mcp_snapshot` published from `oxr_session_frame_end`. `get_kooima_params`, `get_submitted_projection` read from it.
+4. **Slice 4 — diff.** `diff_projection` with all four bug classes from spec §4.C.
+5. **Slice 5 — log tail.** `tail_log` streams `u_logging` ring snapshots; SSE-style incremental responses over JSON-RPC.
+6. **Slice 6 — capture (macOS).** `capture_frame` for Metal + GL swapchains via the existing capture paths. PNG encoding via stb_image_write (already vendored).
+7. **Slice 7 — Windows slice.** Named-pipe transport; D3D11 swapchain capture. Real Leia hardware validation.
+
+Slices 1–6 are a mac-only milestone; slice 7 is the Windows port.
+
+## Platform strategy
+
+**Primary dev platform: macOS.** Iteration on mac handle apps (`cube_handle_metal_macos`, `cube_handle_gl_macos`, `cube_handle_vk_macos`) with `sim_display` exercises the full Maya debug flow — the stereo bugs Maya catches are all math bugs, not Leia-specific. Metal and GL swapchain readback paths are straightforward.
+
+**Windows validation: slice 7.** Named pipe transport, D3D11/D3D12 swapchain capture, real Leia display confirms the weaver doesn't perturb any of the signals `diff_projection` reads. Use `scripts\build_windows.bat build` once the mac side is green; do not use CI for iteration.
+
+**Cross-platform code:** transport is the only platform-specific module. Socket/pipe abstraction lives behind `u_mcp_transport.{h,c}`.
+
+## Validation
+
+Each slice lands with at least one scripted test:
+
+- **Slice 1:** `tests/mcp/test_handshake.sh` — launches handle app under `DISPLAYXR_MCP=1`, runs `displayxr-mcp --pid $PID` with a scripted JSON-RPC init + echo.
+- **Slice 3–4:** `tests/mcp/test_diff_projection.sh` — seeds a handle app that deliberately renders with the wrong aspect; asserts `diff_projection` flags `fov_aspect_mismatch`.
+- **Slice 6:** `tests/mcp/test_capture_frame.sh` — captures a frame from `cube_handle_metal_macos`, asserts PNG size > 0 and center pixel non-black.
+
+Final Maya-story demo: a short recorded session where Claude diagnoses the deliberately-broken aspect app in <60 seconds.
+
+## Open implementation questions
+
+- **JSON library.** Pull in `cJSON` (permissive licence, single .c/.h, tiny) or hand-write a minimal JSON-RPC encoder? Recommend `cJSON`.
+- **Thread safety of the U_LOG ring.** `u_logging` currently has no ring buffer — `tail_log` needs one. Cheapest path: lock-free MPSC ring in `u_logging.c`, opt-in via `DISPLAYXR_MCP=1`.
+- **Snapshot double-buffering.** Single writer (compositor thread) / single reader (MCP thread) — atomic pointer swap is sufficient; no mutex needed.
+- **Security.** Socket perms default to 0600; owner only. No auth beyond OS file perms in Phase A.
+
+## References
+
+- Spec: `docs/roadmap/mcp-spec-v0.2.md`
+- OpenXR layer submit path: `state_trackers/oxr/oxr_session_frame_end.c`
+- Existing logging: `src/xrt/auxiliary/util/u_logging.{h,c}`
+- Existing screenshot path (service mode, reference only): `compositor/multi/comp_d3d11_service.cpp`

--- a/docs/roadmap/mcp-phase-a-status.md
+++ b/docs/roadmap/mcp-phase-a-status.md
@@ -22,7 +22,7 @@ Opt-in in-process MCP server inside `libopenxr_displayxr`, a per-PID unix-socket
 | 3 | Snapshot API + per-view tile getters (get_kooima_params, get_submitted_projection) | Done | `tests/mcp/test_snapshot.sh` |
 | 4 | diff_projection bug classifier (3 of 4 bug classes) | Done | `tests/mcp/test_diff_projection.sh` |
 | 5 | tail_log ring buffer | Done | `tests/mcp/test_tail_log.sh` |
-| 6 | capture_frame tool + per-compositor hook API | Done (stub) | `tests/mcp/test_capture_frame.sh` |
+| 6 | capture_frame tool + per-compositor hook API (Metal + GL on mac, D3D11 on Windows) | Done (full via #153) | `tests/mcp/test_capture_frame.sh`, `tests/mcp/test_capture_frame_gl.sh` |
 | 7 | Windows named-pipe transport + portable adapter + Maya demo | Done (code) | `tests/mcp/demo_maya.sh` |
 
 ## Tools shipped
@@ -35,7 +35,7 @@ Opt-in in-process MCP server inside `libopenxr_displayxr`, a per-PID unix-socket
 | `get_kooima_params` | recommended | `oxr_mcp_tools.c` + `u_mcp_snapshot` (inline) |
 | `get_submitted_projection` | declared | `oxr_mcp_tools.c` + `u_mcp_snapshot` (inline) |
 | `diff_projection` | recommended vs declared | `oxr_mcp_tools.c` |
-| `capture_frame` | actual pixels | `oxr_mcp_tools.c` + per-compositor hooks (pending #153) |
+| `capture_frame` | actual pixels | `oxr_mcp_tools.c` + `u_mcp_capture` + per-compositor hooks in Metal / GL / D3D11 native compositors |
 | `tail_log` | — | `u_mcp_server.c` + `u_mcp_log_ring.c` |
 
 Plus `initialize`, `ping`, `tools/list`, `tools/call`, `echo` as MCP protocol scaffolding.
@@ -76,10 +76,10 @@ Plus `initialize`, `ping`, `tools/list`, `tools/call`, `echo` as MCP protocol sc
 
 ## Known follow-ups (not blocking Phase A)
 
-- **#153** — per-compositor `capture_frame` handlers (Metal, GL, D3D11). Tool infra is complete; only the GPU→CPU readback + PNG encode remains per API.
-- **Windows validation** — slice 7 code is in place but needs a run on a Leia SR display. `tests/mcp/demo_maya.sh` is portable; expect it to pass once the Windows build lands.
-- **`measure_disparity`** — deferred to Phase A.5 per the plan, pending `capture_frame`.
+- **Windows validation** — slice 7 transport + slice D D3D11 capture are code-complete but need a run on a Leia SR display. `tests/mcp/demo_maya.sh` is portable; expect it to pass once the Windows build lands.
+- **`measure_disparity`** — deferred to Phase A.5, now unblocked since `capture_frame` returns real PNGs.
 - **Biometric / viewer-pose tools** — Phase B behind a privacy gate, not in scope here.
+- **File-format alignment with shell-phase8** — our `_atlas.png / _L.png / _R.png` naming matches shell-phase8's IPC capture. A future cleanup could factor the shared stride-copy + stb_write helpers into `u_image_write.{h,c}` once both surfaces land.
 
 ## "Done" demo
 
@@ -96,9 +96,9 @@ Output on a clean mac build:
   PASS  list_sessions — api=metal
   PASS  get_kooima_params — view_count=4
   PASS  get_submitted_projection — declared=2 recommended=4
-  PASS  diff_projection — flags=['app_ignores_recommended', 'stale_head_pose'] ok=False
-  PASS  capture_frame (stub ok until #153)
+  PASS  diff_projection — pipeline_consistent=True, uses own projection math (not forwarding xrLocateViews)
+  PASS  capture_frame — wrote ['L.png', 'R.png', 'atlas.png']
   PASS  tail_log — got 8 entries
 ```
 
-Notably, `diff_projection` on the reference `cube_handle_metal_macos` correctly flags `app_ignores_recommended` + `stale_head_pose` — the test app recomputes Kooima client-side instead of forwarding `xrLocateViews`. A real finding from the first run of the tool, not a false positive.
+Notably, `diff_projection` on the reference `cube_handle_metal_macos` reports `uses own projection math` — the test app recomputes Kooima client-side instead of forwarding `xrLocateViews`. A real observation from the first run of the tool (initially classified as a bug; reframed as a neutral observation after user feedback).

--- a/docs/roadmap/mcp-phase-a-status.md
+++ b/docs/roadmap/mcp-phase-a-status.md
@@ -1,0 +1,104 @@
+# MCP Phase A Status: Handle-App Introspection
+
+**Branch:** `feature/mcp-phase-a-ci`
+**Status:** Complete on macOS — Windows transport code-complete, needs validation on a Leia SR display
+**Date:** 2026-04-14
+
+## Scope
+
+Opt-in in-process MCP server inside `libopenxr_displayxr`, a per-PID unix-socket / named-pipe transport, and a `displayxr-mcp` stdio bridge so Claude Code / Cursor can introspect a running handle-app session. Zero runtime cost when the `DISPLAYXR_MCP` env var is unset.
+
+**Spec:** [mcp-spec-v0.2.md](mcp-spec-v0.2.md) §3.1, §4.A, §4.C
+**Plan:** [mcp-phase-a-plan.md](mcp-phase-a-plan.md)
+**Agent prompt:** [mcp-phase-a-agent-prompt.md](mcp-phase-a-agent-prompt.md)
+**Issue:** #150
+
+## Delivery slices
+
+| # | Slice | Status | Test |
+|---|---|---|---|
+| 1 | Server plumbing + stdio adapter | Done | `tests/mcp/test_handshake.sh` |
+| 2 | Core tools (list_sessions, get_display_info, get_runtime_metrics) | Done | `tests/mcp/test_core_tools.sh` |
+| 3 | Snapshot API + per-view tile getters (get_kooima_params, get_submitted_projection) | Done | `tests/mcp/test_snapshot.sh` |
+| 4 | diff_projection bug classifier (3 of 4 bug classes) | Done | `tests/mcp/test_diff_projection.sh` |
+| 5 | tail_log ring buffer | Done | `tests/mcp/test_tail_log.sh` |
+| 6 | capture_frame tool + per-compositor hook API | Done (stub) | `tests/mcp/test_capture_frame.sh` |
+| 7 | Windows named-pipe transport + portable adapter + Maya demo | Done (code) | `tests/mcp/demo_maya.sh` |
+
+## Tools shipped
+
+| Tool | Signal (spec §4.C) | Source |
+|---|---|---|
+| `list_sessions` | — | `oxr_mcp_tools.c` |
+| `get_display_info` | — | `oxr_mcp_tools.c` |
+| `get_runtime_metrics` | — | `oxr_mcp_tools.c` |
+| `get_kooima_params` | recommended | `oxr_mcp_tools.c` + `u_mcp_snapshot` (inline) |
+| `get_submitted_projection` | declared | `oxr_mcp_tools.c` + `u_mcp_snapshot` (inline) |
+| `diff_projection` | recommended vs declared | `oxr_mcp_tools.c` |
+| `capture_frame` | actual pixels | `oxr_mcp_tools.c` + per-compositor hooks (pending #153) |
+| `tail_log` | — | `u_mcp_server.c` + `u_mcp_log_ring.c` |
+
+Plus `initialize`, `ping`, `tools/list`, `tools/call`, `echo` as MCP protocol scaffolding.
+
+## Architecture
+
+- Stdio (Content-Length-framed JSON-RPC 2.0) ↔ `displayxr-mcp` ↔ per-PID unix socket / Windows named pipe ↔ detached MCP server thread inside `libopenxr_displayxr`.
+- Server start/stop hooked from `oxr_instance_create` / `oxr_instance_destroy`; gated on `DISPLAYXR_MCP`.
+- Session attach/detach from `oxr_session_create` / `oxr_session_destroy` so tool handlers have a guarded session pointer.
+- Per-view snapshot (recommended + declared + display context) published atomically from `oxr_xrLocateViews` and `oxr_session_frame_end`'s `submit_projection_layer`. Reader does atomic load + struct copy; no lock on the compositor thread.
+- `u_logging` sink ring installed only when MCP is enabled — existing log consumers unaffected.
+
+## Design decisions
+
+- **Per-view arrays, not stereo pairs.** All snapshot data is sized to `XRT_MAX_VIEWS` (8) with a per-signal view_count, so mono / stereo / quilted (4- and 8-view) displays all report correctly. The tool surface is tile-oriented, not stereo-oriented.
+- **Two view counts per snapshot.** `xrLocateViews` reports the system max across all rendering modes; submit reports the active mode's count. Keeping both means `diff_projection` can pair views correctly in active-mode-dependent configs like Anaglyph vs Quad.
+- **Tool code in the state tracker, not aux_util.** `oxr_mcp_tools.c` lives in `state_trackers/oxr/` because the tools need direct access to `oxr_session`. `aux_util` owns only the transport, server dispatch, and the logging ring — keeping vendor SDK / graphics-API headers out of util.
+- **Atomic double-buffer publish, not a lock.** Two static snapshot slots; writer fills the inactive one and atomically swaps the pointer. Reader takes a consistent copy via memory_order_acquire. Zero latency added to the compositor.
+- **capture_frame is a hook, not a stub.** Tool + `oxr_mcp_tools_set_capture_handler()` registration API are in place; per-compositor implementations (Metal/GL/D3D11) are tracked in #153 as the mechanical next step.
+- **Adapter is a dumb pipe.** No JSON parsing in `displayxr-mcp` — two blocking threads pump bytes. Works on POSIX and Windows with the same logic.
+
+## Commits (in order)
+
+- `9e14f5c32` Fix macOS build: guard Windows-only shell window calls (#152)
+- `9e214d509` Slice 1 — server plumbing + stdio adapter
+- `caa9700f5` Slice 2 — core tools
+- `a330b8a89` Slice 3 — snapshot API + per-view getters
+- `0024f8435` Slice 4 — diff_projection bug classifier
+- `07e3fa4e8` Slice 5 — tail_log ring buffer
+- `13fc09f4d` Slice 6 — capture_frame stub + hook API
+- `a6921fc38` Slice 7 — Windows transport + portable adapter + Maya demo
+
+## Invariants verified
+
+- Runtime with `DISPLAYXR_MCP` unset: normal startup, no socket, no log-ring sink, no extra cost. Confirmed by running `cube_handle_metal_macos` without the env var and observing no `/tmp/displayxr-mcp-*.sock` creation and no change in log output.
+- Compositor render thread: no new locks, no new allocations per frame. Snapshot publish is a single atomic store.
+- Layer separation (`docs/architecture/separation-of-concerns.md`): aux_util takes no new deps on compositor or graphics-API headers. cJSON was already a PUBLIC dep.
+
+## Known follow-ups (not blocking Phase A)
+
+- **#153** — per-compositor `capture_frame` handlers (Metal, GL, D3D11). Tool infra is complete; only the GPU→CPU readback + PNG encode remains per API.
+- **Windows validation** — slice 7 code is in place but needs a run on a Leia SR display. `tests/mcp/demo_maya.sh` is portable; expect it to pass once the Windows build lands.
+- **`measure_disparity`** — deferred to Phase A.5 per the plan, pending `capture_frame`.
+- **Biometric / viewer-pose tools** — Phase B behind a privacy gate, not in scope here.
+
+## "Done" demo
+
+```bash
+./scripts/build_macos.sh
+./tests/mcp/demo_maya.sh
+```
+
+Output on a clean mac build:
+
+```
+=== Maya stereo-debug demo ===
+  PASS  initialize
+  PASS  list_sessions — api=metal
+  PASS  get_kooima_params — view_count=4
+  PASS  get_submitted_projection — declared=2 recommended=4
+  PASS  diff_projection — flags=['app_ignores_recommended', 'stale_head_pose'] ok=False
+  PASS  capture_frame (stub ok until #153)
+  PASS  tail_log — got 8 entries
+```
+
+Notably, `diff_projection` on the reference `cube_handle_metal_macos` correctly flags `app_ignores_recommended` + `stale_head_pose` — the test app recomputes Kooima client-side instead of forwarding `xrLocateViews`. A real finding from the first run of the tool, not a false positive.

--- a/scripts/build-mingw-check.sh
+++ b/scripts/build-mingw-check.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Copyright 2026, DisplayXR / Leia Inc.
+# SPDX-License-Identifier: BSL-1.0
+#
+# Compile-only Windows check from macOS / Linux via MinGW-w64. Catches
+# Win32-API typos, missing #ifdef guards, wrong-platform symbols (e.g.
+# CLOCK_REALTIME) before pushing to CI. Not a substitute for the MSVC
+# CI build — many MSVC-only headers (WIL, vcpkg deps) won't compile
+# under MinGW. Builds a curated subset of targets known to be portable.
+#
+# Usage:  scripts/build-mingw-check.sh [target...]
+# Default targets: aux_util mcp_adapter
+
+set -u
+set -o pipefail
+
+cd "$(dirname "$0")/.."
+ROOT="$(pwd)"
+BUILD="$ROOT/build-mingw"
+
+if ! command -v x86_64-w64-mingw32-gcc >/dev/null 2>&1; then
+	echo "FAIL: x86_64-w64-mingw32-gcc not found. Install with:" >&2
+	echo "      brew install mingw-w64" >&2
+	exit 1
+fi
+
+TARGETS=("$@")
+if [[ ${#TARGETS[@]} -eq 0 ]]; then
+	TARGETS=(aux_util mcp_adapter)
+fi
+
+echo "=== MinGW-w64 compile check ==="
+echo "    targets: ${TARGETS[*]}"
+echo ""
+
+if [[ ! -f "$BUILD/CMakeCache.txt" ]]; then
+	# Minimal config — we only need the targets to *compile*, not link.
+	# OpenXR / compositors / IPC require Vulkan + vcpkg deps that aren't
+	# available under MinGW; turn them off and let CMake skip those
+	# subdirectories. Anything we left on (aux_util, mcp_adapter, comp_d3d11)
+	# either has no external deps or is what we want to verify.
+	cmake -B "$BUILD" -G Ninja \
+	    -DCMAKE_TOOLCHAIN_FILE="$ROOT/cmake/toolchain-mingw-w64.cmake" \
+	    -DCMAKE_BUILD_TYPE=Debug \
+	    -DXRT_FEATURE_OPENXR=OFF \
+	    -DXRT_FEATURE_SERVICE=OFF \
+	    -DXRT_FEATURE_TRACING=OFF \
+	    -DXRT_FEATURE_DEBUG_GUI=OFF \
+	    -DBUILD_TESTING=OFF \
+	    -DXRT_HAVE_LIBUSB=OFF \
+	    -DXRT_HAVE_OPENGL=OFF \
+	    -DXRT_HAVE_VULKAN=OFF \
+	    -DXRT_HAVE_LEIA_SR=OFF \
+	    -DXRT_HAVE_SDL2=OFF \
+	    -DXRT_MODULE_AUX_VK=OFF \
+	    -DXRT_MODULE_COMPOSITOR=OFF \
+	    -DXRT_MODULE_IPC=OFF \
+	    -DXRT_MODULE_OPENXR_STATE_TRACKER=OFF \
+	    -DXRT_HAVE_SYSTEM_CJSON=OFF \
+	    "$ROOT" || {
+		echo "FAIL: cmake configure failed" >&2
+		exit 1
+	}
+fi
+
+cmake --build "$BUILD" --target "${TARGETS[@]}" 2>&1 | tee "$BUILD/build.log"
+RC=${PIPESTATUS[0]}
+
+echo ""
+if [[ $RC -eq 0 ]]; then
+	echo "=== MinGW compile check PASSED for: ${TARGETS[*]} ==="
+	echo "    NOTE: This is compile-only validation. CI MSVC build is canonical."
+else
+	echo "=== MinGW compile check FAILED ==="
+	echo "    See $BUILD/build.log for details."
+	exit $RC
+fi

--- a/src/xrt/auxiliary/util/CMakeLists.txt
+++ b/src/xrt/auxiliary/util/CMakeLists.txt
@@ -69,6 +69,8 @@ add_library(
 	u_live_stats.h
 	u_logging.c
 	u_logging.h
+	u_mcp_capture.c
+	u_mcp_capture.h
 	u_mcp_log_ring.c
 	u_mcp_log_ring.h
 	u_mcp_server.c

--- a/src/xrt/auxiliary/util/CMakeLists.txt
+++ b/src/xrt/auxiliary/util/CMakeLists.txt
@@ -69,6 +69,8 @@ add_library(
 	u_live_stats.h
 	u_logging.c
 	u_logging.h
+	u_mcp_log_ring.c
+	u_mcp_log_ring.h
 	u_mcp_server.c
 	u_mcp_server.h
 	u_mcp_transport.c

--- a/src/xrt/auxiliary/util/CMakeLists.txt
+++ b/src/xrt/auxiliary/util/CMakeLists.txt
@@ -69,6 +69,10 @@ add_library(
 	u_live_stats.h
 	u_logging.c
 	u_logging.h
+	u_mcp_server.c
+	u_mcp_server.h
+	u_mcp_transport.c
+	u_mcp_transport.h
 	u_file_logging.c
 	u_file_logging.h
 	u_metrics.c

--- a/src/xrt/auxiliary/util/u_mcp_capture.c
+++ b/src/xrt/auxiliary/util/u_mcp_capture.c
@@ -11,16 +11,14 @@
 #include <string.h>
 #include <time.h>
 
-// Forward decl from state_trackers/oxr/oxr_mcp_tools.h — we intentionally
-// don't pull in that header (which includes openxr.h) from aux_util.
-// The signature must stay in sync with oxr_mcp_capture_fn there.
+// Forward-decl from state_trackers/oxr/oxr_mcp_tools.h — intentionally
+// don't pull that header (which includes openxr.h) into aux_util.
 typedef bool (*oxr_mcp_capture_fn)(const char *path, void *userdata);
 extern void
 oxr_mcp_tools_set_capture_handler(oxr_mcp_capture_fn fn, void *userdata);
 
-/*! PNG encode of a 3024×1964 atlas is ~80–150 ms per file via stb_image_write
- *  on an M1, and we may emit three (atlas + L + R). 3 s gives enough headroom
- *  while still timing out if the compositor thread has genuinely stalled. */
+/*! PNG encode of a 3024×1964 atlas is ~80–150 ms on an M1; 3 s is
+ *  ample headroom while still tripping on a genuine stall. */
 #define CAPTURE_TIMEOUT_MS 3000
 
 void
@@ -38,33 +36,32 @@ u_mcp_capture_fini(struct u_mcp_capture_request *req)
 	pthread_mutex_destroy(&req->lock);
 }
 
-// Invoked on the MCP server thread. Hands off to the compositor thread
-// and blocks until done or timeout.
+// Invoked on the MCP server thread. Hands off to the compositor and
+// blocks until done or timeout.
 static bool
-handler_adapter(const char *path_prefix, void *userdata)
+handler_adapter(const char *path, void *userdata)
 {
 	struct u_mcp_capture_request *req = userdata;
-	if (req == NULL || path_prefix == NULL) {
+	if (req == NULL || path == NULL) {
 		return false;
 	}
 
 	pthread_mutex_lock(&req->lock);
-	// Truncate safely — path_prefix is caller-bounded but be defensive.
-	size_t n = strlen(path_prefix);
-	if (n >= sizeof(req->path_prefix)) {
-		n = sizeof(req->path_prefix) - 1;
+	size_t n = strlen(path);
+	if (n >= sizeof(req->path)) {
+		n = sizeof(req->path) - 1;
 	}
-	memcpy(req->path_prefix, path_prefix, n);
-	req->path_prefix[n] = '\0';
-	// Default to full atlas + L/R until the tool surfaces a view arg;
-	// once oxr_mcp_tools threads a view through userdata we'll honor it.
-	req->views = U_MCP_CAPTURE_ALL;
+	memcpy(req->path, path, n);
+	req->path[n] = '\0';
 	req->pending = true;
 	req->done = false;
-	req->views_written = 0;
+	req->success = false;
 
+	// Absolute deadline for pthread_cond_timedwait. C11's timespec_get is
+	// portable (POSIX CLOCK_REALTIME / MSVC alike); clock_gettime isn't
+	// — MSVC's <time.h> has no CLOCK_REALTIME symbol.
 	struct timespec deadline;
-	clock_gettime(CLOCK_REALTIME, &deadline);
+	(void)timespec_get(&deadline, TIME_UTC);
 	deadline.tv_sec += CAPTURE_TIMEOUT_MS / 1000;
 	deadline.tv_nsec += (CAPTURE_TIMEOUT_MS % 1000) * 1000000L;
 	if (deadline.tv_nsec >= 1000000000L) {
@@ -75,16 +72,13 @@ handler_adapter(const char *path_prefix, void *userdata)
 	while (!req->done) {
 		int rc = pthread_cond_timedwait(&req->cond, &req->lock, &deadline);
 		if (rc != 0) {
-			// Timed out — abandon; any late completion from the
-			// compositor will find !pending and no-op. We leak
-			// nothing because the buffer is on the struct.
 			req->pending = false;
 			pthread_mutex_unlock(&req->lock);
 			return false;
 		}
 	}
 
-	bool ok = req->views_written != 0;
+	bool ok = req->success;
 	req->pending = false;
 	pthread_mutex_unlock(&req->lock);
 	return ok;
@@ -103,23 +97,22 @@ u_mcp_capture_uninstall(void)
 }
 
 bool
-u_mcp_capture_poll(struct u_mcp_capture_request *req, char *out_path_prefix, uint32_t *out_views)
+u_mcp_capture_poll(struct u_mcp_capture_request *req, char *out_path)
 {
 	pthread_mutex_lock(&req->lock);
 	bool pending = req->pending && !req->done;
 	if (pending) {
-		memcpy(out_path_prefix, req->path_prefix, sizeof(req->path_prefix));
-		*out_views = req->views;
+		memcpy(out_path, req->path, sizeof(req->path));
 	}
 	pthread_mutex_unlock(&req->lock);
 	return pending;
 }
 
 void
-u_mcp_capture_complete(struct u_mcp_capture_request *req, uint32_t views_written)
+u_mcp_capture_complete(struct u_mcp_capture_request *req, bool success)
 {
 	pthread_mutex_lock(&req->lock);
-	req->views_written = views_written;
+	req->success = success;
 	req->done = true;
 	pthread_cond_signal(&req->cond);
 	pthread_mutex_unlock(&req->lock);

--- a/src/xrt/auxiliary/util/u_mcp_capture.c
+++ b/src/xrt/auxiliary/util/u_mcp_capture.c
@@ -18,7 +18,10 @@ typedef bool (*oxr_mcp_capture_fn)(const char *path, void *userdata);
 extern void
 oxr_mcp_tools_set_capture_handler(oxr_mcp_capture_fn fn, void *userdata);
 
-#define CAPTURE_TIMEOUT_MS 500 //!< Give the compositor ~30 frames at 60 Hz.
+/*! PNG encode of a 3024×1964 atlas is ~80–150 ms per file via stb_image_write
+ *  on an M1, and we may emit three (atlas + L + R). 3 s gives enough headroom
+ *  while still timing out if the compositor thread has genuinely stalled. */
+#define CAPTURE_TIMEOUT_MS 3000
 
 void
 u_mcp_capture_init(struct u_mcp_capture_request *req)

--- a/src/xrt/auxiliary/util/u_mcp_capture.c
+++ b/src/xrt/auxiliary/util/u_mcp_capture.c
@@ -1,0 +1,123 @@
+// Copyright 2026, DisplayXR / Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  MCP capture_frame cross-thread hand-off.
+ * @ingroup aux_util
+ */
+
+#include "u_mcp_capture.h"
+
+#include <string.h>
+#include <time.h>
+
+// Forward decl from state_trackers/oxr/oxr_mcp_tools.h — we intentionally
+// don't pull in that header (which includes openxr.h) from aux_util.
+// The signature must stay in sync with oxr_mcp_capture_fn there.
+typedef bool (*oxr_mcp_capture_fn)(const char *path, void *userdata);
+extern void
+oxr_mcp_tools_set_capture_handler(oxr_mcp_capture_fn fn, void *userdata);
+
+#define CAPTURE_TIMEOUT_MS 500 //!< Give the compositor ~30 frames at 60 Hz.
+
+void
+u_mcp_capture_init(struct u_mcp_capture_request *req)
+{
+	memset(req, 0, sizeof(*req));
+	pthread_mutex_init(&req->lock, NULL);
+	pthread_cond_init(&req->cond, NULL);
+}
+
+void
+u_mcp_capture_fini(struct u_mcp_capture_request *req)
+{
+	pthread_cond_destroy(&req->cond);
+	pthread_mutex_destroy(&req->lock);
+}
+
+// Invoked on the MCP server thread. Hands off to the compositor thread
+// and blocks until done or timeout.
+static bool
+handler_adapter(const char *path_prefix, void *userdata)
+{
+	struct u_mcp_capture_request *req = userdata;
+	if (req == NULL || path_prefix == NULL) {
+		return false;
+	}
+
+	pthread_mutex_lock(&req->lock);
+	// Truncate safely — path_prefix is caller-bounded but be defensive.
+	size_t n = strlen(path_prefix);
+	if (n >= sizeof(req->path_prefix)) {
+		n = sizeof(req->path_prefix) - 1;
+	}
+	memcpy(req->path_prefix, path_prefix, n);
+	req->path_prefix[n] = '\0';
+	// Default to full atlas + L/R until the tool surfaces a view arg;
+	// once oxr_mcp_tools threads a view through userdata we'll honor it.
+	req->views = U_MCP_CAPTURE_ALL;
+	req->pending = true;
+	req->done = false;
+	req->views_written = 0;
+
+	struct timespec deadline;
+	clock_gettime(CLOCK_REALTIME, &deadline);
+	deadline.tv_sec += CAPTURE_TIMEOUT_MS / 1000;
+	deadline.tv_nsec += (CAPTURE_TIMEOUT_MS % 1000) * 1000000L;
+	if (deadline.tv_nsec >= 1000000000L) {
+		deadline.tv_sec += 1;
+		deadline.tv_nsec -= 1000000000L;
+	}
+
+	while (!req->done) {
+		int rc = pthread_cond_timedwait(&req->cond, &req->lock, &deadline);
+		if (rc != 0) {
+			// Timed out — abandon; any late completion from the
+			// compositor will find !pending and no-op. We leak
+			// nothing because the buffer is on the struct.
+			req->pending = false;
+			pthread_mutex_unlock(&req->lock);
+			return false;
+		}
+	}
+
+	bool ok = req->views_written != 0;
+	req->pending = false;
+	pthread_mutex_unlock(&req->lock);
+	return ok;
+}
+
+void
+u_mcp_capture_install(struct u_mcp_capture_request *req)
+{
+	oxr_mcp_tools_set_capture_handler(handler_adapter, req);
+}
+
+void
+u_mcp_capture_uninstall(void)
+{
+	oxr_mcp_tools_set_capture_handler(NULL, NULL);
+}
+
+bool
+u_mcp_capture_poll(struct u_mcp_capture_request *req, char *out_path_prefix, uint32_t *out_views)
+{
+	pthread_mutex_lock(&req->lock);
+	bool pending = req->pending && !req->done;
+	if (pending) {
+		memcpy(out_path_prefix, req->path_prefix, sizeof(req->path_prefix));
+		*out_views = req->views;
+	}
+	pthread_mutex_unlock(&req->lock);
+	return pending;
+}
+
+void
+u_mcp_capture_complete(struct u_mcp_capture_request *req, uint32_t views_written)
+{
+	pthread_mutex_lock(&req->lock);
+	req->views_written = views_written;
+	req->done = true;
+	pthread_cond_signal(&req->cond);
+	pthread_mutex_unlock(&req->lock);
+}

--- a/src/xrt/auxiliary/util/u_mcp_capture.h
+++ b/src/xrt/auxiliary/util/u_mcp_capture.h
@@ -6,8 +6,13 @@
  *
  * The MCP server thread fills a request with a target PNG path and
  * blocks on a condvar. The compositor thread polls at end-of-frame,
- * does the GPU→CPU readback + PNG encode, and signals done. Keeps
+ * does the GPU→CPU readback, encodes PNG, and signals done. Keeps
  * GPU calls on the thread that owns the resource.
+ *
+ * Each capture produces a single PNG of the content region that the
+ * compositor hands to the display processor (tile_columns × view_width
+ * by tile_rows × view_height) — i.e. what the app actually wrote into
+ * its swapchain, not the worst-case atlas allocation.
  *
  * @ingroup aux_util
  */
@@ -16,7 +21,6 @@
 
 #include <pthread.h>
 #include <stdbool.h>
-#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -24,42 +28,16 @@ extern "C" {
 
 #define U_MCP_CAPTURE_PATH_MAX 256
 
-/*!
- * Which tiles the caller wants written. The compositor resolves
- * LEFT/RIGHT against its active tile layout; if the current mode has
- * no stereo split (1-view mono), LEFT/RIGHT fall back to ATLAS.
- *
- * Semantics mirror the shell-phase8 IPC capture flags so the two
- * capture surfaces (agent-facing MCP, user-facing hotkey) produce
- * comparable file sets.
- */
-enum u_mcp_capture_view
-{
-	U_MCP_CAPTURE_ATLAS = 1u << 0, //!< Full atlas (whatever the compositor composed)
-	U_MCP_CAPTURE_LEFT = 1u << 1,  //!< Left eye tile as a standalone PNG
-	U_MCP_CAPTURE_RIGHT = 1u << 2, //!< Right eye tile as a standalone PNG
-};
-
-#define U_MCP_CAPTURE_ALL (U_MCP_CAPTURE_ATLAS | U_MCP_CAPTURE_LEFT | U_MCP_CAPTURE_RIGHT)
-
 struct u_mcp_capture_request
 {
 	pthread_mutex_t lock;
 	pthread_cond_t cond;
-	/*! Path *prefix* without extension — the compositor appends
-	 *  `_atlas.png`, `_L.png`, `_R.png` per requested view. */
-	char path_prefix[U_MCP_CAPTURE_PATH_MAX];
-	uint32_t views; //!< Bitmask of @ref u_mcp_capture_view
+	char path[U_MCP_CAPTURE_PATH_MAX];
 	bool pending;
 	bool done;
 	bool success;
-	uint32_t views_written; //!< Bitmask of what succeeded (subset of @c views)
 };
 
-/*!
- * Initialise a request (mutex + condvar). Call once in the compositor
- * creator. @ref u_mcp_capture_fini frees.
- */
 void
 u_mcp_capture_init(struct u_mcp_capture_request *req);
 
@@ -67,36 +45,32 @@ void
 u_mcp_capture_fini(struct u_mcp_capture_request *req);
 
 /*!
- * Register @p req as the MCP @c capture_frame handler. The MCP server
- * thread will fill the request and wait. Safe to call even when the
- * MCP server is not running — `oxr_mcp_tools_set_capture_handler` is
- * a no-op in that case.
+ * Register @p req as the MCP @c capture_frame handler. Safe to call
+ * even when the MCP server is not running.
  */
 void
 u_mcp_capture_install(struct u_mcp_capture_request *req);
 
 /*!
- * Unregister. Call from the compositor destroy path before freeing @p req.
+ * Unregister. Call from compositor destroy before freeing @p req.
  */
 void
 u_mcp_capture_uninstall(void);
 
 /*!
- * Check for a pending request. Returns true if one is in flight, in which
- * case @p out_path_prefix (must be at least @c U_MCP_CAPTURE_PATH_MAX
- * bytes) is filled and @p out_views holds the requested bitmask. The
- * caller must follow up with @ref u_mcp_capture_complete once the PNGs
- * are written (or failed).
+ * Check for a pending request. Returns true if one is in flight and
+ * fills @p out_path (must be at least @c U_MCP_CAPTURE_PATH_MAX bytes).
+ * Caller must follow up with @ref u_mcp_capture_complete after the PNG
+ * is written (or failed).
  */
 bool
-u_mcp_capture_poll(struct u_mcp_capture_request *req, char *out_path_prefix, uint32_t *out_views);
+u_mcp_capture_poll(struct u_mcp_capture_request *req, char *out_path);
 
 /*!
- * Signal the waiting MCP thread. @p views_written records which
- * views actually produced PNGs; empty means total failure.
+ * Signal the waiting MCP thread.
  */
 void
-u_mcp_capture_complete(struct u_mcp_capture_request *req, uint32_t views_written);
+u_mcp_capture_complete(struct u_mcp_capture_request *req, bool success);
 
 #ifdef __cplusplus
 }

--- a/src/xrt/auxiliary/util/u_mcp_capture.h
+++ b/src/xrt/auxiliary/util/u_mcp_capture.h
@@ -1,0 +1,103 @@
+// Copyright 2026, DisplayXR / Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  Cross-thread hand-off for MCP capture_frame requests.
+ *
+ * The MCP server thread fills a request with a target PNG path and
+ * blocks on a condvar. The compositor thread polls at end-of-frame,
+ * does the GPU→CPU readback + PNG encode, and signals done. Keeps
+ * GPU calls on the thread that owns the resource.
+ *
+ * @ingroup aux_util
+ */
+
+#pragma once
+
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define U_MCP_CAPTURE_PATH_MAX 256
+
+/*!
+ * Which tiles the caller wants written. The compositor resolves
+ * LEFT/RIGHT against its active tile layout; if the current mode has
+ * no stereo split (1-view mono), LEFT/RIGHT fall back to ATLAS.
+ *
+ * Semantics mirror the shell-phase8 IPC capture flags so the two
+ * capture surfaces (agent-facing MCP, user-facing hotkey) produce
+ * comparable file sets.
+ */
+enum u_mcp_capture_view
+{
+	U_MCP_CAPTURE_ATLAS = 1u << 0, //!< Full atlas (whatever the compositor composed)
+	U_MCP_CAPTURE_LEFT = 1u << 1,  //!< Left eye tile as a standalone PNG
+	U_MCP_CAPTURE_RIGHT = 1u << 2, //!< Right eye tile as a standalone PNG
+};
+
+#define U_MCP_CAPTURE_ALL (U_MCP_CAPTURE_ATLAS | U_MCP_CAPTURE_LEFT | U_MCP_CAPTURE_RIGHT)
+
+struct u_mcp_capture_request
+{
+	pthread_mutex_t lock;
+	pthread_cond_t cond;
+	/*! Path *prefix* without extension — the compositor appends
+	 *  `_atlas.png`, `_L.png`, `_R.png` per requested view. */
+	char path_prefix[U_MCP_CAPTURE_PATH_MAX];
+	uint32_t views; //!< Bitmask of @ref u_mcp_capture_view
+	bool pending;
+	bool done;
+	bool success;
+	uint32_t views_written; //!< Bitmask of what succeeded (subset of @c views)
+};
+
+/*!
+ * Initialise a request (mutex + condvar). Call once in the compositor
+ * creator. @ref u_mcp_capture_fini frees.
+ */
+void
+u_mcp_capture_init(struct u_mcp_capture_request *req);
+
+void
+u_mcp_capture_fini(struct u_mcp_capture_request *req);
+
+/*!
+ * Register @p req as the MCP @c capture_frame handler. The MCP server
+ * thread will fill the request and wait. Safe to call even when the
+ * MCP server is not running — `oxr_mcp_tools_set_capture_handler` is
+ * a no-op in that case.
+ */
+void
+u_mcp_capture_install(struct u_mcp_capture_request *req);
+
+/*!
+ * Unregister. Call from the compositor destroy path before freeing @p req.
+ */
+void
+u_mcp_capture_uninstall(void);
+
+/*!
+ * Check for a pending request. Returns true if one is in flight, in which
+ * case @p out_path_prefix (must be at least @c U_MCP_CAPTURE_PATH_MAX
+ * bytes) is filled and @p out_views holds the requested bitmask. The
+ * caller must follow up with @ref u_mcp_capture_complete once the PNGs
+ * are written (or failed).
+ */
+bool
+u_mcp_capture_poll(struct u_mcp_capture_request *req, char *out_path_prefix, uint32_t *out_views);
+
+/*!
+ * Signal the waiting MCP thread. @p views_written records which
+ * views actually produced PNGs; empty means total failure.
+ */
+void
+u_mcp_capture_complete(struct u_mcp_capture_request *req, uint32_t views_written);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/xrt/auxiliary/util/u_mcp_log_ring.c
+++ b/src/xrt/auxiliary/util/u_mcp_log_ring.c
@@ -1,0 +1,115 @@
+// Copyright 2026, DisplayXR / Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  MCP log ring buffer implementation.
+ * @ingroup aux_util
+ */
+
+#include "u_mcp_log_ring.h"
+
+#include "util/u_logging.h"
+
+#include <pthread.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+
+#define RING_SIZE 512 /* must be power of two */
+#if (RING_SIZE & (RING_SIZE - 1)) != 0
+#error "RING_SIZE must be a power of two"
+#endif
+
+static pthread_mutex_t g_lock = PTHREAD_MUTEX_INITIALIZER;
+static struct u_mcp_log_entry g_ring[RING_SIZE];
+static uint64_t g_next_seq = 1;
+static bool g_installed = false;
+
+static int64_t
+mono_ns(void)
+{
+	struct timespec ts;
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	return (int64_t)ts.tv_sec * 1000000000LL + ts.tv_nsec;
+}
+
+static void
+sink_cb(const char *file, int line, const char *func, enum u_logging_level level, const char *format, va_list args,
+        void *data)
+{
+	(void)data;
+	char text[U_MCP_LOG_MAX_TEXT];
+	int n = vsnprintf(text, sizeof(text), format, args);
+	if (n < 0) {
+		return;
+	}
+	pthread_mutex_lock(&g_lock);
+	uint64_t seq = g_next_seq++;
+	struct u_mcp_log_entry *e = &g_ring[seq & (RING_SIZE - 1)];
+	e->seq = seq;
+	e->timestamp_ns = mono_ns();
+	e->level = level;
+	// Truncate safely — text is already bounded by vsnprintf.
+	size_t copy = (size_t)n < sizeof(e->text) ? (size_t)n : sizeof(e->text) - 1;
+	memcpy(e->text, text, copy);
+	e->text[copy] = '\0';
+	(void)file;
+	(void)line;
+	(void)func;
+	pthread_mutex_unlock(&g_lock);
+}
+
+void
+u_mcp_log_ring_start(void)
+{
+	pthread_mutex_lock(&g_lock);
+	bool already = g_installed;
+	if (!g_installed) {
+		g_installed = true;
+	}
+	pthread_mutex_unlock(&g_lock);
+	if (!already) {
+		u_log_set_sink(sink_cb, NULL);
+	}
+}
+
+void
+u_mcp_log_ring_stop(void)
+{
+	pthread_mutex_lock(&g_lock);
+	bool was = g_installed;
+	g_installed = false;
+	pthread_mutex_unlock(&g_lock);
+	if (was) {
+		u_log_set_sink(NULL, NULL);
+	}
+}
+
+void
+u_mcp_log_ring_read(uint64_t since,
+                    struct u_mcp_log_entry *out_entries,
+                    size_t max_entries,
+                    size_t *out_count,
+                    uint64_t *out_next_cursor,
+                    uint64_t *out_dropped)
+{
+	pthread_mutex_lock(&g_lock);
+	uint64_t next = g_next_seq;
+	uint64_t oldest_in_ring = (next > RING_SIZE) ? (next - RING_SIZE) : 1;
+	uint64_t start = since + 1;
+	uint64_t dropped = 0;
+	if (start < oldest_in_ring) {
+		dropped = oldest_in_ring - start;
+		start = oldest_in_ring;
+	}
+	size_t count = 0;
+	while (start < next && count < max_entries) {
+		out_entries[count++] = g_ring[start & (RING_SIZE - 1)];
+		start++;
+	}
+	pthread_mutex_unlock(&g_lock);
+	*out_count = count;
+	*out_next_cursor = start > 0 ? start - 1 : 0;
+	*out_dropped = dropped;
+}

--- a/src/xrt/auxiliary/util/u_mcp_log_ring.c
+++ b/src/xrt/auxiliary/util/u_mcp_log_ring.c
@@ -8,13 +8,13 @@
 
 #include "u_mcp_log_ring.h"
 
+#include "os/os_time.h"
 #include "util/u_logging.h"
 
 #include <pthread.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
-#include <time.h>
 
 #define RING_SIZE 512 /* must be power of two */
 #if (RING_SIZE & (RING_SIZE - 1)) != 0
@@ -26,13 +26,9 @@ static struct u_mcp_log_entry g_ring[RING_SIZE];
 static uint64_t g_next_seq = 1;
 static bool g_installed = false;
 
-static int64_t
-mono_ns(void)
-{
-	struct timespec ts;
-	clock_gettime(CLOCK_MONOTONIC, &ts);
-	return (int64_t)ts.tv_sec * 1000000000LL + ts.tv_nsec;
-}
+// Use the codebase's monotonic-time helper — it wraps clock_gettime on
+// POSIX and QueryPerformanceCounter on Windows (MSVC has no CLOCK_MONOTONIC).
+#define mono_ns() ((int64_t)os_monotonic_get_ns())
 
 static void
 sink_cb(const char *file, int line, const char *func, enum u_logging_level level, const char *format, va_list args,

--- a/src/xrt/auxiliary/util/u_mcp_log_ring.h
+++ b/src/xrt/auxiliary/util/u_mcp_log_ring.h
@@ -1,0 +1,64 @@
+// Copyright 2026, DisplayXR / Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  Opt-in MPSC log ring used by the MCP @c tail_log tool.
+ *
+ * Installs a @ref u_log_set_sink callback that formats each log line
+ * into a fixed-size entry in a ring buffer. Readers pull by sequence
+ * cursor — entries older than the reader's last-seen cursor by more
+ * than the ring size are reported as dropped.
+ *
+ * @ingroup aux_util
+ */
+
+#pragma once
+
+#include "util/u_logging.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define U_MCP_LOG_MAX_TEXT 512
+
+struct u_mcp_log_entry
+{
+	uint64_t seq;
+	int64_t timestamp_ns;
+	enum u_logging_level level;
+	char text[U_MCP_LOG_MAX_TEXT];
+};
+
+/*!
+ * Install the global log sink and start buffering. Idempotent.
+ * Safe to call before any logging has happened.
+ */
+void
+u_mcp_log_ring_start(void);
+
+/*!
+ * Uninstall the sink, free the ring. Idempotent.
+ */
+void
+u_mcp_log_ring_stop(void);
+
+/*!
+ * Read up to @p max_entries entries published with @c seq > @p since.
+ * Fills @p out_entries, writes the new cursor to @p out_next_cursor,
+ * and reports how many entries were lost (overwrite > @p since cursor).
+ */
+void
+u_mcp_log_ring_read(uint64_t since,
+                    struct u_mcp_log_entry *out_entries,
+                    size_t max_entries,
+                    size_t *out_count,
+                    uint64_t *out_next_cursor,
+                    uint64_t *out_dropped);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/xrt/auxiliary/util/u_mcp_server.c
+++ b/src/xrt/auxiliary/util/u_mcp_server.c
@@ -19,7 +19,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 
 #define LOG_PFX "[mcp] "
 #define MAX_TOOLS 32
@@ -435,7 +434,7 @@ u_mcp_server_maybe_start(void)
 	u_mcp_server_register_tool(&ECHO_TOOL);
 	u_mcp_server_register_tool(&TAIL_LOG_TOOL);
 
-	g_server.listener = u_mcp_listener_open(getpid());
+	g_server.listener = u_mcp_listener_open(u_mcp_self_pid());
 	if (g_server.listener == NULL) {
 		U_LOG_W(LOG_PFX "failed to open listener; MCP disabled");
 		return;
@@ -448,7 +447,7 @@ u_mcp_server_maybe_start(void)
 		return;
 	}
 	g_server.thread_started = true;
-	U_LOG_I(LOG_PFX "server started (pid=%ld)", (long)getpid());
+	U_LOG_I(LOG_PFX "server started (pid=%ld)", (long)u_mcp_self_pid());
 }
 
 void

--- a/src/xrt/auxiliary/util/u_mcp_server.c
+++ b/src/xrt/auxiliary/util/u_mcp_server.c
@@ -1,0 +1,396 @@
+// Copyright 2026, DisplayXR / Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  MCP server thread, JSON-RPC dispatch, tool registry.
+ * @ingroup aux_util
+ */
+
+#include "u_mcp_server.h"
+#include "u_mcp_transport.h"
+
+#include "util/u_logging.h"
+
+#include <cjson/cJSON.h>
+
+#include <errno.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#define LOG_PFX "[mcp] "
+#define MAX_TOOLS 32
+#define MAX_FRAME_BYTES (4 * 1024 * 1024)
+
+struct u_mcp_server
+{
+	pthread_t thread;
+	bool thread_started;
+	struct u_mcp_listener *listener;
+
+	pthread_mutex_t tools_mutex;
+	const struct u_mcp_tool *tools[MAX_TOOLS];
+	size_t tool_count;
+};
+
+static struct u_mcp_server g_server = {
+    .tools_mutex = PTHREAD_MUTEX_INITIALIZER,
+};
+
+// ---------- Frame I/O (Content-Length framing, LSP/MCP style) ----------
+
+static bool
+read_line(struct u_mcp_conn *conn, char *buf, size_t cap)
+{
+	size_t n = 0;
+	while (n + 1 < cap) {
+		char c;
+		if (!u_mcp_conn_read(conn, &c, 1)) {
+			return false;
+		}
+		buf[n++] = c;
+		if (c == '\n') {
+			buf[n] = '\0';
+			return true;
+		}
+	}
+	return false;
+}
+
+static char *
+read_frame(struct u_mcp_conn *conn, size_t *out_len)
+{
+	char line[256];
+	size_t content_length = 0;
+	bool have_length = false;
+
+	while (read_line(conn, line, sizeof(line))) {
+		// Header end: blank line (CRLF or LF).
+		if (line[0] == '\r' || line[0] == '\n') {
+			break;
+		}
+		size_t key_len = strlen("Content-Length:");
+		if (strncasecmp(line, "Content-Length:", key_len) == 0) {
+			content_length = (size_t)strtoul(line + key_len, NULL, 10);
+			have_length = true;
+		}
+		// Ignore other headers (e.g. Content-Type).
+	}
+
+	if (!have_length || content_length == 0 || content_length > MAX_FRAME_BYTES) {
+		return NULL;
+	}
+
+	char *body = malloc(content_length + 1);
+	if (body == NULL) {
+		return NULL;
+	}
+	if (!u_mcp_conn_read(conn, body, content_length)) {
+		free(body);
+		return NULL;
+	}
+	body[content_length] = '\0';
+	*out_len = content_length;
+	return body;
+}
+
+static bool
+write_frame(struct u_mcp_conn *conn, const char *body)
+{
+	if (body == NULL) {
+		return false;
+	}
+	size_t len = strlen(body);
+	char header[64];
+	int hlen = snprintf(header, sizeof(header), "Content-Length: %zu\r\n\r\n", len);
+	if (hlen < 0) {
+		return false;
+	}
+	if (!u_mcp_conn_write(conn, header, (size_t)hlen)) {
+		return false;
+	}
+	return u_mcp_conn_write(conn, body, len);
+}
+
+// ---------- JSON-RPC helpers ----------
+
+static cJSON *
+jsonrpc_envelope(const cJSON *id)
+{
+	cJSON *env = cJSON_CreateObject();
+	cJSON_AddStringToObject(env, "jsonrpc", "2.0");
+	if (id != NULL) {
+		cJSON_AddItemToObject(env, "id", cJSON_Duplicate(id, 1));
+	}
+	return env;
+}
+
+static char *
+jsonrpc_result(const cJSON *id, cJSON *result)
+{
+	cJSON *env = jsonrpc_envelope(id);
+	cJSON_AddItemToObject(env, "result", result != NULL ? result : cJSON_CreateObject());
+	char *out = cJSON_PrintUnformatted(env);
+	cJSON_Delete(env);
+	return out;
+}
+
+static char *
+jsonrpc_error(const cJSON *id, int code, const char *message)
+{
+	cJSON *env = jsonrpc_envelope(id);
+	cJSON *err = cJSON_CreateObject();
+	cJSON_AddNumberToObject(err, "code", code);
+	cJSON_AddStringToObject(err, "message", message ? message : "unknown error");
+	cJSON_AddItemToObject(env, "error", err);
+	char *out = cJSON_PrintUnformatted(env);
+	cJSON_Delete(env);
+	return out;
+}
+
+// ---------- Tool registry ----------
+
+static const struct u_mcp_tool *
+find_tool(const char *name)
+{
+	pthread_mutex_lock(&g_server.tools_mutex);
+	const struct u_mcp_tool *found = NULL;
+	for (size_t i = 0; i < g_server.tool_count; i++) {
+		if (strcmp(g_server.tools[i]->name, name) == 0) {
+			found = g_server.tools[i];
+			break;
+		}
+	}
+	pthread_mutex_unlock(&g_server.tools_mutex);
+	return found;
+}
+
+void
+u_mcp_server_register_tool(const struct u_mcp_tool *tool)
+{
+	if (tool == NULL || tool->name == NULL || tool->fn == NULL) {
+		return;
+	}
+	pthread_mutex_lock(&g_server.tools_mutex);
+	if (g_server.tool_count < MAX_TOOLS) {
+		g_server.tools[g_server.tool_count++] = tool;
+	} else {
+		U_LOG_W(LOG_PFX "tool registry full; dropping '%s'", tool->name);
+	}
+	pthread_mutex_unlock(&g_server.tools_mutex);
+}
+
+// ---------- Built-in echo tool (slice 1 handshake check) ----------
+
+static cJSON *
+tool_echo(const cJSON *params, void *userdata)
+{
+	(void)userdata;
+	cJSON *result = cJSON_CreateObject();
+	cJSON_AddItemToObject(result, "echo", params != NULL ? cJSON_Duplicate(params, 1) : cJSON_CreateNull());
+	return result;
+}
+
+static const struct u_mcp_tool ECHO_TOOL = {
+    .name = "echo",
+    .description = "Echoes the params back in {\"echo\": <params>}. Used for handshake testing.",
+    .input_schema_json = "{\"type\":\"object\"}",
+    .fn = tool_echo,
+    .userdata = NULL,
+};
+
+// ---------- MCP protocol methods ----------
+
+static cJSON *
+build_tools_list(void)
+{
+	cJSON *arr = cJSON_CreateArray();
+	pthread_mutex_lock(&g_server.tools_mutex);
+	for (size_t i = 0; i < g_server.tool_count; i++) {
+		const struct u_mcp_tool *t = g_server.tools[i];
+		cJSON *e = cJSON_CreateObject();
+		cJSON_AddStringToObject(e, "name", t->name);
+		if (t->description != NULL) {
+			cJSON_AddStringToObject(e, "description", t->description);
+		}
+		if (t->input_schema_json != NULL) {
+			cJSON *schema = cJSON_Parse(t->input_schema_json);
+			if (schema != NULL) {
+				cJSON_AddItemToObject(e, "inputSchema", schema);
+			}
+		}
+		cJSON_AddItemToArray(arr, e);
+	}
+	pthread_mutex_unlock(&g_server.tools_mutex);
+	return arr;
+}
+
+static char *
+handle_request(const cJSON *req)
+{
+	const cJSON *method_node = cJSON_GetObjectItemCaseSensitive(req, "method");
+	const cJSON *id = cJSON_GetObjectItemCaseSensitive(req, "id");
+	const cJSON *params = cJSON_GetObjectItemCaseSensitive(req, "params");
+	bool is_notification = (id == NULL);
+	const char *method = cJSON_IsString(method_node) ? method_node->valuestring : NULL;
+
+	if (method == NULL) {
+		return is_notification ? NULL : jsonrpc_error(id, -32600, "invalid request: missing method");
+	}
+
+	// Notifications are fire-and-forget; MCP sends notifications/initialized.
+	if (is_notification) {
+		return NULL;
+	}
+
+	if (strcmp(method, "initialize") == 0) {
+		cJSON *result = cJSON_CreateObject();
+		cJSON_AddStringToObject(result, "protocolVersion", "2024-11-05");
+		cJSON *caps = cJSON_CreateObject();
+		cJSON *tools_cap = cJSON_CreateObject();
+		cJSON_AddBoolToObject(tools_cap, "listChanged", false);
+		cJSON_AddItemToObject(caps, "tools", tools_cap);
+		cJSON_AddItemToObject(result, "capabilities", caps);
+		cJSON *info = cJSON_CreateObject();
+		cJSON_AddStringToObject(info, "name", "displayxr-mcp");
+		cJSON_AddStringToObject(info, "version", "0.2.0-phase-a");
+		cJSON_AddItemToObject(result, "serverInfo", info);
+		return jsonrpc_result(id, result);
+	}
+
+	if (strcmp(method, "ping") == 0) {
+		return jsonrpc_result(id, cJSON_CreateObject());
+	}
+
+	if (strcmp(method, "tools/list") == 0) {
+		cJSON *result = cJSON_CreateObject();
+		cJSON_AddItemToObject(result, "tools", build_tools_list());
+		return jsonrpc_result(id, result);
+	}
+
+	if (strcmp(method, "tools/call") == 0) {
+		const cJSON *tool_name = cJSON_GetObjectItemCaseSensitive(params, "name");
+		const cJSON *tool_args = cJSON_GetObjectItemCaseSensitive(params, "arguments");
+		if (!cJSON_IsString(tool_name)) {
+			return jsonrpc_error(id, -32602, "tools/call: missing string 'name'");
+		}
+		const struct u_mcp_tool *tool = find_tool(tool_name->valuestring);
+		if (tool == NULL) {
+			return jsonrpc_error(id, -32601, "tool not found");
+		}
+		cJSON *inner = tool->fn(tool_args, tool->userdata);
+		if (inner == NULL) {
+			return jsonrpc_error(id, -32000, "tool handler failed");
+		}
+		// MCP wraps tool results in { content: [{type:'text', text: <json>}] }
+		// so clients without per-tool schema rendering still see the payload.
+		cJSON *result = cJSON_CreateObject();
+		cJSON *content = cJSON_CreateArray();
+		cJSON *item = cJSON_CreateObject();
+		cJSON_AddStringToObject(item, "type", "text");
+		char *inner_str = cJSON_PrintUnformatted(inner);
+		cJSON_AddStringToObject(item, "text", inner_str != NULL ? inner_str : "");
+		free(inner_str);
+		cJSON_AddItemToArray(content, item);
+		cJSON_AddItemToObject(result, "content", content);
+		// Also expose the structured result for programmatic consumers.
+		cJSON_AddItemToObject(result, "structured", inner);
+		return jsonrpc_result(id, result);
+	}
+
+	return jsonrpc_error(id, -32601, "method not found");
+}
+
+// ---------- Per-connection serve loop ----------
+
+static void
+serve(struct u_mcp_conn *conn)
+{
+	for (;;) {
+		size_t len = 0;
+		char *body = read_frame(conn, &len);
+		if (body == NULL) {
+			return; // EOF or framing error.
+		}
+		cJSON *req = cJSON_ParseWithLength(body, len);
+		free(body);
+
+		char *reply = NULL;
+		if (req == NULL) {
+			reply = jsonrpc_error(NULL, -32700, "parse error");
+		} else {
+			reply = handle_request(req);
+			cJSON_Delete(req);
+		}
+		if (reply != NULL) {
+			if (!write_frame(conn, reply)) {
+				free(reply);
+				return;
+			}
+			free(reply);
+		}
+	}
+}
+
+// ---------- Thread entry ----------
+
+static void *
+server_thread(void *arg)
+{
+	(void)arg;
+	for (;;) {
+		struct u_mcp_conn *c = u_mcp_listener_accept(g_server.listener);
+		if (c == NULL) {
+			return NULL; // listener closed.
+		}
+		serve(c);
+		u_mcp_conn_close(c);
+	}
+}
+
+// ---------- Public start/stop ----------
+
+void
+u_mcp_server_maybe_start(void)
+{
+	if (g_server.thread_started) {
+		return;
+	}
+	const char *flag = getenv("DISPLAYXR_MCP");
+	if (flag == NULL || flag[0] == '\0' || flag[0] == '0') {
+		return;
+	}
+
+	// Register built-in tools (idempotent).
+	u_mcp_server_register_tool(&ECHO_TOOL);
+
+	g_server.listener = u_mcp_listener_open(getpid());
+	if (g_server.listener == NULL) {
+		U_LOG_W(LOG_PFX "failed to open listener; MCP disabled");
+		return;
+	}
+	int rc = pthread_create(&g_server.thread, NULL, server_thread, NULL);
+	if (rc != 0) {
+		U_LOG_W(LOG_PFX "pthread_create failed: %s", strerror(rc));
+		u_mcp_listener_close(g_server.listener);
+		g_server.listener = NULL;
+		return;
+	}
+	g_server.thread_started = true;
+	U_LOG_I(LOG_PFX "server started (pid=%ld)", (long)getpid());
+}
+
+void
+u_mcp_server_stop(void)
+{
+	if (!g_server.thread_started) {
+		return;
+	}
+	u_mcp_listener_close(g_server.listener);
+	g_server.listener = NULL;
+	pthread_join(g_server.thread, NULL);
+	g_server.thread_started = false;
+	U_LOG_I(LOG_PFX "server stopped");
+}

--- a/src/xrt/auxiliary/util/u_mcp_server.c
+++ b/src/xrt/auxiliary/util/u_mcp_server.c
@@ -20,6 +20,12 @@
 #include <stdlib.h>
 #include <string.h>
 
+// MSVC has no strncasecmp; the POSIX-named wrapper for _strnicmp is
+// the simplest cross-platform alias.
+#ifdef _WIN32
+#define strncasecmp _strnicmp
+#endif
+
 #define LOG_PFX "[mcp] "
 #define MAX_TOOLS 32
 #define MAX_FRAME_BYTES (4 * 1024 * 1024)

--- a/src/xrt/auxiliary/util/u_mcp_server.c
+++ b/src/xrt/auxiliary/util/u_mcp_server.c
@@ -8,6 +8,7 @@
 
 #include "u_mcp_server.h"
 #include "u_mcp_transport.h"
+#include "u_mcp_log_ring.h"
 
 #include "util/u_logging.h"
 
@@ -183,6 +184,71 @@ u_mcp_server_register_tool(const struct u_mcp_tool *tool)
 }
 
 // ---------- Built-in echo tool (slice 1 handshake check) ----------
+
+// ---------- Built-in tail_log tool ----------
+
+static cJSON *
+tool_tail_log(const cJSON *params, void *userdata)
+{
+	(void)userdata;
+	uint64_t since = 0;
+	size_t max_entries = 128;
+	if (params != NULL) {
+		const cJSON *s = cJSON_GetObjectItemCaseSensitive(params, "since");
+		if (cJSON_IsNumber(s)) {
+			since = (uint64_t)s->valuedouble;
+		}
+		const cJSON *m = cJSON_GetObjectItemCaseSensitive(params, "max");
+		if (cJSON_IsNumber(m)) {
+			double mv = m->valuedouble;
+			if (mv > 0 && mv <= 1024) {
+				max_entries = (size_t)mv;
+			}
+		}
+	}
+
+	struct u_mcp_log_entry *buf = calloc(max_entries, sizeof(*buf));
+	if (buf == NULL) {
+		return NULL;
+	}
+	size_t count = 0;
+	uint64_t next_cursor = since, dropped = 0;
+	u_mcp_log_ring_read(since, buf, max_entries, &count, &next_cursor, &dropped);
+
+	cJSON *r = cJSON_CreateObject();
+	cJSON_AddNumberToObject(r, "cursor", (double)next_cursor);
+	cJSON_AddNumberToObject(r, "dropped", (double)dropped);
+	cJSON *arr = cJSON_CreateArray();
+	static const char *level_names[] = {"trace", "debug", "info", "warn", "error", "raw"};
+	for (size_t i = 0; i < count; i++) {
+		cJSON *e = cJSON_CreateObject();
+		cJSON_AddNumberToObject(e, "seq", (double)buf[i].seq);
+		cJSON_AddNumberToObject(e, "ts_ns", (double)buf[i].timestamp_ns);
+		int lv = (int)buf[i].level;
+		cJSON_AddStringToObject(e, "level",
+		                        (lv >= 0 && lv < (int)(sizeof(level_names) / sizeof(level_names[0])))
+		                            ? level_names[lv]
+		                            : "unknown");
+		cJSON_AddStringToObject(e, "text", buf[i].text);
+		cJSON_AddItemToArray(arr, e);
+	}
+	cJSON_AddItemToObject(r, "entries", arr);
+	free(buf);
+	return r;
+}
+
+static const struct u_mcp_tool TAIL_LOG_TOOL = {
+    .name = "tail_log",
+    .description =
+        "Return buffered U_LOG lines with seq > `since`. Pass the returned `cursor` as `since` "
+        "on the next call to stream. `dropped` indicates how many entries were evicted before "
+        "the caller read them (ring size is fixed).",
+    .input_schema_json =
+        "{\"type\":\"object\",\"properties\":{\"since\":{\"type\":\"integer\",\"default\":0},"
+        "\"max\":{\"type\":\"integer\",\"default\":128,\"maximum\":1024}}}",
+    .fn = tool_tail_log,
+    .userdata = NULL,
+};
 
 static cJSON *
 tool_echo(const cJSON *params, void *userdata)
@@ -363,8 +429,11 @@ u_mcp_server_maybe_start(void)
 		return;
 	}
 
-	// Register built-in tools (idempotent).
+	// Start the log ring first so sink_cb captures bring-up messages,
+	// then register built-in tools.
+	u_mcp_log_ring_start();
 	u_mcp_server_register_tool(&ECHO_TOOL);
+	u_mcp_server_register_tool(&TAIL_LOG_TOOL);
 
 	g_server.listener = u_mcp_listener_open(getpid());
 	if (g_server.listener == NULL) {
@@ -392,5 +461,6 @@ u_mcp_server_stop(void)
 	g_server.listener = NULL;
 	pthread_join(g_server.thread, NULL);
 	g_server.thread_started = false;
+	u_mcp_log_ring_stop();
 	U_LOG_I(LOG_PFX "server stopped");
 }

--- a/src/xrt/auxiliary/util/u_mcp_server.h
+++ b/src/xrt/auxiliary/util/u_mcp_server.h
@@ -1,0 +1,72 @@
+// Copyright 2026, DisplayXR / Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  Opt-in in-process MCP server for DisplayXR (Phase A).
+ * @ingroup aux_util
+ *
+ * Enabled when the @c DISPLAYXR_MCP environment variable is set at
+ * xrInstanceCreate time. Spawns a detached thread that binds a per-PID
+ * unix socket and speaks MCP-style JSON-RPC 2.0 framed by Content-Length
+ * headers.
+ *
+ * @see docs/roadmap/mcp-spec-v0.2.md
+ * @see docs/roadmap/mcp-phase-a-plan.md
+ */
+
+#pragma once
+
+#include <cjson/cJSON.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*!
+ * Tool handler callback. @p params is the JSON-RPC `params` object (may be
+ * NULL). The handler returns a cJSON node that becomes the `result` field,
+ * or NULL to signal an error — in which case the server replies with a
+ * JSON-RPC internal-error response.
+ */
+typedef cJSON *(*u_mcp_tool_fn)(const cJSON *params, void *userdata);
+
+/*!
+ * Tool descriptor shown by `tools/list` and dispatched by `tools/call`.
+ * All fields except @p fn are optional; the MCP protocol requires a
+ * name + description and accepts a JSON Schema for parameters.
+ */
+struct u_mcp_tool
+{
+	const char *name;
+	const char *description;
+	const char *input_schema_json; //!< Optional static JSON Schema string.
+	u_mcp_tool_fn fn;
+	void *userdata;
+};
+
+/*!
+ * Start the server if @c DISPLAYXR_MCP is set. Idempotent no-op if
+ * already running or env var unset. Best-effort: failure logs U_LOG_W
+ * and returns without aborting instance creation.
+ */
+void
+u_mcp_server_maybe_start(void);
+
+/*!
+ * Stop the server (joins the thread, unlinks the socket). Safe to call
+ * when the server was never started.
+ */
+void
+u_mcp_server_stop(void);
+
+/*!
+ * Register a tool. Safe to call before or after the server starts.
+ * The descriptor pointer must outlive the server (use static storage).
+ */
+void
+u_mcp_server_register_tool(const struct u_mcp_tool *tool);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/xrt/auxiliary/util/u_mcp_transport.c
+++ b/src/xrt/auxiliary/util/u_mcp_transport.c
@@ -43,13 +43,13 @@ struct u_mcp_conn
 };
 
 static void
-build_sock_path(char *out, size_t cap, pid_t pid)
+build_sock_path(char *out, size_t cap, long pid)
 {
 	snprintf(out, cap, "%s%ld%s", SOCK_PREFIX, (long)pid, SOCK_SUFFIX);
 }
 
 struct u_mcp_listener *
-u_mcp_listener_open(pid_t pid)
+u_mcp_listener_open(long pid)
 {
 	struct u_mcp_listener *l = U_TYPED_CALLOC(struct u_mcp_listener);
 	l->fd = -1;
@@ -183,7 +183,7 @@ u_mcp_conn_fd(struct u_mcp_conn *conn)
 }
 
 struct u_mcp_conn *
-u_mcp_conn_connect(pid_t pid)
+u_mcp_conn_connect(long pid)
 {
 	int fd = socket(AF_UNIX, SOCK_STREAM, 0);
 	if (fd < 0) {
@@ -202,7 +202,7 @@ u_mcp_conn_connect(pid_t pid)
 }
 
 size_t
-u_mcp_enumerate_sessions(pid_t *out_pids, size_t cap)
+u_mcp_enumerate_sessions(long *out_pids, size_t cap)
 {
 	size_t n = 0;
 	DIR *d = opendir("/tmp");
@@ -230,7 +230,7 @@ u_mcp_enumerate_sessions(pid_t *out_pids, size_t cap)
 		if (pid <= 0) {
 			continue;
 		}
-		out_pids[n++] = (pid_t)pid;
+		out_pids[n++] = (long)pid;
 	}
 	closedir(d);
 	return n;
@@ -263,13 +263,13 @@ struct u_mcp_conn
 };
 
 static void
-build_pipe_name(char *out, size_t cap, pid_t pid)
+build_pipe_name(char *out, size_t cap, long pid)
 {
 	snprintf(out, cap, PIPE_PREFIX "%ld", (long)pid);
 }
 
 struct u_mcp_listener *
-u_mcp_listener_open(pid_t pid)
+u_mcp_listener_open(long pid)
 {
 	struct u_mcp_listener *l = U_TYPED_CALLOC(struct u_mcp_listener);
 	build_pipe_name(l->name, sizeof(l->name), pid);
@@ -381,7 +381,7 @@ u_mcp_conn_fd(struct u_mcp_conn *conn)
 }
 
 struct u_mcp_conn *
-u_mcp_conn_connect(pid_t pid)
+u_mcp_conn_connect(long pid)
 {
 	char name[128];
 	build_pipe_name(name, sizeof(name), pid);
@@ -398,7 +398,7 @@ u_mcp_conn_connect(pid_t pid)
 }
 
 size_t
-u_mcp_enumerate_sessions(pid_t *out_pids, size_t cap)
+u_mcp_enumerate_sessions(long *out_pids, size_t cap)
 {
 	size_t n = 0;
 	WIN32_FIND_DATAA fd;
@@ -414,7 +414,7 @@ u_mcp_enumerate_sessions(pid_t *out_pids, size_t cap)
 		}
 		long pid = strtol(p + strlen(prefix), NULL, 10);
 		if (pid > 0 && n < cap) {
-			out_pids[n++] = (pid_t)pid;
+			out_pids[n++] = (long)pid;
 		}
 	} while (FindNextFileA(h, &fd));
 	FindClose(h);

--- a/src/xrt/auxiliary/util/u_mcp_transport.c
+++ b/src/xrt/auxiliary/util/u_mcp_transport.c
@@ -234,59 +234,189 @@ u_mcp_enumerate_sessions(pid_t *out_pids, size_t cap)
 	return n;
 }
 
-#else // XRT_OS_WINDOWS — implemented in slice 7
+#else // XRT_OS_WINDOWS — named pipe transport
+//
+// Uses \\.\pipe\displayxr-mcp-<pid> with PIPE_TYPE_BYTE; framing (Content-
+// Length) is handled at a higher layer just like on POSIX. Enumeration
+// uses FindFirstFile over \\.\pipe\* (Named Pipe filesystem).
+
+#include <windows.h>
+#include <process.h>
+#include <stdio.h>
+#include <string.h>
+
+#define PIPE_PREFIX "\\\\.\\pipe\\displayxr-mcp-"
+
+struct u_mcp_listener
+{
+	HANDLE pipe;
+	char name[128];
+	volatile LONG closed;
+};
+
+struct u_mcp_conn
+{
+	HANDLE pipe;
+	bool owns_handle;
+};
+
+static void
+build_pipe_name(char *out, size_t cap, pid_t pid)
+{
+	snprintf(out, cap, PIPE_PREFIX "%ld", (long)pid);
+}
 
 struct u_mcp_listener *
 u_mcp_listener_open(pid_t pid)
 {
-	(void)pid;
-	U_LOG_W(LOG_PFX "Windows transport not implemented (slice 7)");
-	return NULL;
+	struct u_mcp_listener *l = U_TYPED_CALLOC(struct u_mcp_listener);
+	build_pipe_name(l->name, sizeof(l->name), pid);
+	l->pipe = CreateNamedPipeA(
+	    l->name,
+	    PIPE_ACCESS_DUPLEX,
+	    PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT,
+	    1,     // Max instances (single client).
+	    65536, // Out buffer.
+	    65536, // In buffer.
+	    0,
+	    NULL);
+	if (l->pipe == INVALID_HANDLE_VALUE) {
+		U_LOG_W(LOG_PFX "CreateNamedPipe(%s) failed: %lu", l->name, GetLastError());
+		free(l);
+		return NULL;
+	}
+	U_LOG_I(LOG_PFX "listening on %s", l->name);
+	return l;
 }
+
 struct u_mcp_conn *
-u_mcp_listener_accept(struct u_mcp_listener *l)
+u_mcp_listener_accept(struct u_mcp_listener *listener)
 {
-	(void)l;
-	return NULL;
+	if (listener == NULL) {
+		return NULL;
+	}
+	BOOL ok = ConnectNamedPipe(listener->pipe, NULL);
+	if (!ok && GetLastError() != ERROR_PIPE_CONNECTED) {
+		return NULL;
+	}
+	if (InterlockedCompareExchange(&listener->closed, 0, 0)) {
+		return NULL;
+	}
+	struct u_mcp_conn *c = U_TYPED_CALLOC(struct u_mcp_conn);
+	c->pipe = listener->pipe;
+	c->owns_handle = false; // listener retains ownership
+	return c;
 }
+
 void
-u_mcp_listener_close(struct u_mcp_listener *l)
+u_mcp_listener_close(struct u_mcp_listener *listener)
 {
-	(void)l;
+	if (listener == NULL) {
+		return;
+	}
+	InterlockedExchange(&listener->closed, 1);
+	if (listener->pipe != INVALID_HANDLE_VALUE) {
+		// Unblock any thread waiting in ConnectNamedPipe / ReadFile.
+		DisconnectNamedPipe(listener->pipe);
+		CloseHandle(listener->pipe);
+	}
+	free(listener);
 }
+
 bool
-u_mcp_conn_read(struct u_mcp_conn *c, void *buf, size_t len)
+u_mcp_conn_read(struct u_mcp_conn *conn, void *buf, size_t len)
 {
-	(void)c;
-	(void)buf;
-	(void)len;
-	return false;
+	if (conn == NULL) {
+		return false;
+	}
+	char *p = buf;
+	while (len > 0) {
+		DWORD got = 0;
+		if (!ReadFile(conn->pipe, p, (DWORD)len, &got, NULL) || got == 0) {
+			return false;
+		}
+		p += got;
+		len -= got;
+	}
+	return true;
 }
+
 bool
-u_mcp_conn_write(struct u_mcp_conn *c, const void *buf, size_t len)
+u_mcp_conn_write(struct u_mcp_conn *conn, const void *buf, size_t len)
 {
-	(void)c;
-	(void)buf;
-	(void)len;
-	return false;
+	if (conn == NULL) {
+		return false;
+	}
+	const char *p = buf;
+	while (len > 0) {
+		DWORD wrote = 0;
+		if (!WriteFile(conn->pipe, p, (DWORD)len, &wrote, NULL) || wrote == 0) {
+			return false;
+		}
+		p += wrote;
+		len -= wrote;
+	}
+	return true;
 }
+
 void
-u_mcp_conn_close(struct u_mcp_conn *c)
+u_mcp_conn_close(struct u_mcp_conn *conn)
 {
-	(void)c;
+	if (conn == NULL) {
+		return;
+	}
+	if (conn->owns_handle && conn->pipe != INVALID_HANDLE_VALUE) {
+		CloseHandle(conn->pipe);
+	}
+	free(conn);
 }
+
+int
+u_mcp_conn_fd(struct u_mcp_conn *conn)
+{
+	(void)conn;
+	return -1; // Windows clients cannot poll() a pipe HANDLE; adapter uses threads.
+}
+
 struct u_mcp_conn *
 u_mcp_conn_connect(pid_t pid)
 {
-	(void)pid;
-	return NULL;
+	char name[128];
+	build_pipe_name(name, sizeof(name), pid);
+	HANDLE h = CreateFileA(name, GENERIC_READ | GENERIC_WRITE, 0, NULL, OPEN_EXISTING, 0, NULL);
+	if (h == INVALID_HANDLE_VALUE) {
+		return NULL;
+	}
+	DWORD mode = PIPE_READMODE_BYTE;
+	(void)SetNamedPipeHandleState(h, &mode, NULL, NULL);
+	struct u_mcp_conn *c = U_TYPED_CALLOC(struct u_mcp_conn);
+	c->pipe = h;
+	c->owns_handle = true;
+	return c;
 }
+
 size_t
 u_mcp_enumerate_sessions(pid_t *out_pids, size_t cap)
 {
-	(void)out_pids;
-	(void)cap;
-	return 0;
+	size_t n = 0;
+	WIN32_FIND_DATAA fd;
+	HANDLE h = FindFirstFileA("\\\\.\\pipe\\displayxr-mcp-*", &fd);
+	if (h == INVALID_HANDLE_VALUE) {
+		return 0;
+	}
+	do {
+		const char *prefix = "displayxr-mcp-";
+		const char *p = strstr(fd.cFileName, prefix);
+		if (p == NULL) {
+			continue;
+		}
+		long pid = strtol(p + strlen(prefix), NULL, 10);
+		if (pid > 0 && n < cap) {
+			out_pids[n++] = (pid_t)pid;
+		}
+	} while (FindNextFileA(h, &fd));
+	FindClose(h);
+	return n;
 }
 
 #endif

--- a/src/xrt/auxiliary/util/u_mcp_transport.c
+++ b/src/xrt/auxiliary/util/u_mcp_transport.c
@@ -1,0 +1,292 @@
+// Copyright 2026, DisplayXR / Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  POSIX unix-socket transport for the MCP server.
+ * @ingroup aux_util
+ */
+
+#include "u_mcp_transport.h"
+#include "util/u_logging.h"
+#include "util/u_misc.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#ifndef XRT_OS_WINDOWS
+#include <dirent.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/un.h>
+#endif
+
+#define LOG_PFX "[mcp-transport] "
+#define SOCK_PREFIX "/tmp/displayxr-mcp-"
+#define SOCK_SUFFIX ".sock"
+
+struct u_mcp_listener
+{
+	int fd;
+	char path[128];
+};
+
+struct u_mcp_conn
+{
+	int fd;
+};
+
+static void
+build_sock_path(char *out, size_t cap, pid_t pid)
+{
+	snprintf(out, cap, "%s%ld%s", SOCK_PREFIX, (long)pid, SOCK_SUFFIX);
+}
+
+#ifndef XRT_OS_WINDOWS
+
+struct u_mcp_listener *
+u_mcp_listener_open(pid_t pid)
+{
+	struct u_mcp_listener *l = U_TYPED_CALLOC(struct u_mcp_listener);
+	l->fd = -1;
+	build_sock_path(l->path, sizeof(l->path), pid);
+
+	// Always unlink any stale socket; we own /tmp/displayxr-mcp-<pid>.sock.
+	(void)unlink(l->path);
+
+	int fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	if (fd < 0) {
+		U_LOG_W(LOG_PFX "socket() failed: %s", strerror(errno));
+		free(l);
+		return NULL;
+	}
+
+	struct sockaddr_un addr = {0};
+	addr.sun_family = AF_UNIX;
+	snprintf(addr.sun_path, sizeof(addr.sun_path), "%s", l->path);
+
+	if (bind(fd, (struct sockaddr *)&addr, sizeof(addr)) != 0) {
+		U_LOG_W(LOG_PFX "bind(%s) failed: %s", l->path, strerror(errno));
+		close(fd);
+		free(l);
+		return NULL;
+	}
+
+	// Owner-only access.
+	(void)chmod(l->path, 0600);
+
+	if (listen(fd, 4) != 0) {
+		U_LOG_W(LOG_PFX "listen() failed: %s", strerror(errno));
+		close(fd);
+		(void)unlink(l->path);
+		free(l);
+		return NULL;
+	}
+
+	l->fd = fd;
+	U_LOG_I(LOG_PFX "listening on %s", l->path);
+	return l;
+}
+
+struct u_mcp_conn *
+u_mcp_listener_accept(struct u_mcp_listener *listener)
+{
+	if (listener == NULL || listener->fd < 0) {
+		return NULL;
+	}
+	int cfd = accept(listener->fd, NULL, NULL);
+	if (cfd < 0) {
+		return NULL;
+	}
+	struct u_mcp_conn *c = U_TYPED_CALLOC(struct u_mcp_conn);
+	c->fd = cfd;
+	return c;
+}
+
+void
+u_mcp_listener_close(struct u_mcp_listener *listener)
+{
+	if (listener == NULL) {
+		return;
+	}
+	if (listener->fd >= 0) {
+		// shutdown() wakes a blocking accept() in the server thread.
+		(void)shutdown(listener->fd, SHUT_RDWR);
+		close(listener->fd);
+	}
+	(void)unlink(listener->path);
+	free(listener);
+}
+
+bool
+u_mcp_conn_read(struct u_mcp_conn *conn, void *buf, size_t len)
+{
+	if (conn == NULL) {
+		return false;
+	}
+	uint8_t *p = buf;
+	while (len > 0) {
+		ssize_t n = read(conn->fd, p, len);
+		if (n <= 0) {
+			if (n < 0 && errno == EINTR) {
+				continue;
+			}
+			return false;
+		}
+		p += n;
+		len -= (size_t)n;
+	}
+	return true;
+}
+
+bool
+u_mcp_conn_write(struct u_mcp_conn *conn, const void *buf, size_t len)
+{
+	if (conn == NULL) {
+		return false;
+	}
+	const uint8_t *p = buf;
+	while (len > 0) {
+		ssize_t n = write(conn->fd, p, len);
+		if (n <= 0) {
+			if (n < 0 && errno == EINTR) {
+				continue;
+			}
+			return false;
+		}
+		p += n;
+		len -= (size_t)n;
+	}
+	return true;
+}
+
+void
+u_mcp_conn_close(struct u_mcp_conn *conn)
+{
+	if (conn == NULL) {
+		return;
+	}
+	if (conn->fd >= 0) {
+		close(conn->fd);
+	}
+	free(conn);
+}
+
+int
+u_mcp_conn_fd(struct u_mcp_conn *conn)
+{
+	return conn != NULL ? conn->fd : -1;
+}
+
+struct u_mcp_conn *
+u_mcp_conn_connect(pid_t pid)
+{
+	int fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	if (fd < 0) {
+		return NULL;
+	}
+	struct sockaddr_un addr = {0};
+	addr.sun_family = AF_UNIX;
+	build_sock_path(addr.sun_path, sizeof(addr.sun_path), pid);
+	if (connect(fd, (struct sockaddr *)&addr, sizeof(addr)) != 0) {
+		close(fd);
+		return NULL;
+	}
+	struct u_mcp_conn *c = U_TYPED_CALLOC(struct u_mcp_conn);
+	c->fd = fd;
+	return c;
+}
+
+size_t
+u_mcp_enumerate_sessions(pid_t *out_pids, size_t cap)
+{
+	size_t n = 0;
+	DIR *d = opendir("/tmp");
+	if (d == NULL) {
+		return 0;
+	}
+	const char *prefix = "displayxr-mcp-";
+	const char *suffix = ".sock";
+	size_t plen = strlen(prefix);
+	size_t slen = strlen(suffix);
+	struct dirent *de;
+	while ((de = readdir(d)) != NULL && n < cap) {
+		const char *name = de->d_name;
+		size_t nlen = strlen(name);
+		if (nlen <= plen + slen) {
+			continue;
+		}
+		if (strncmp(name, prefix, plen) != 0) {
+			continue;
+		}
+		if (strcmp(name + nlen - slen, suffix) != 0) {
+			continue;
+		}
+		long pid = strtol(name + plen, NULL, 10);
+		if (pid <= 0) {
+			continue;
+		}
+		out_pids[n++] = (pid_t)pid;
+	}
+	closedir(d);
+	return n;
+}
+
+#else // XRT_OS_WINDOWS — implemented in slice 7
+
+struct u_mcp_listener *
+u_mcp_listener_open(pid_t pid)
+{
+	(void)pid;
+	U_LOG_W(LOG_PFX "Windows transport not implemented (slice 7)");
+	return NULL;
+}
+struct u_mcp_conn *
+u_mcp_listener_accept(struct u_mcp_listener *l)
+{
+	(void)l;
+	return NULL;
+}
+void
+u_mcp_listener_close(struct u_mcp_listener *l)
+{
+	(void)l;
+}
+bool
+u_mcp_conn_read(struct u_mcp_conn *c, void *buf, size_t len)
+{
+	(void)c;
+	(void)buf;
+	(void)len;
+	return false;
+}
+bool
+u_mcp_conn_write(struct u_mcp_conn *c, const void *buf, size_t len)
+{
+	(void)c;
+	(void)buf;
+	(void)len;
+	return false;
+}
+void
+u_mcp_conn_close(struct u_mcp_conn *c)
+{
+	(void)c;
+}
+struct u_mcp_conn *
+u_mcp_conn_connect(pid_t pid)
+{
+	(void)pid;
+	return NULL;
+}
+size_t
+u_mcp_enumerate_sessions(pid_t *out_pids, size_t cap)
+{
+	(void)out_pids;
+	(void)cap;
+	return 0;
+}
+
+#endif

--- a/src/xrt/auxiliary/util/u_mcp_transport.c
+++ b/src/xrt/auxiliary/util/u_mcp_transport.c
@@ -6,6 +6,8 @@
  * @ingroup aux_util
  */
 
+#include "xrt/xrt_config_os.h"
+
 #include "u_mcp_transport.h"
 #include "util/u_logging.h"
 #include "util/u_misc.h"
@@ -14,18 +16,20 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 
 #ifndef XRT_OS_WINDOWS
 #include <dirent.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/un.h>
+#include <unistd.h>
 #endif
 
 #define LOG_PFX "[mcp-transport] "
 #define SOCK_PREFIX "/tmp/displayxr-mcp-"
 #define SOCK_SUFFIX ".sock"
+
+#ifndef XRT_OS_WINDOWS
 
 struct u_mcp_listener
 {
@@ -43,8 +47,6 @@ build_sock_path(char *out, size_t cap, pid_t pid)
 {
 	snprintf(out, cap, "%s%ld%s", SOCK_PREFIX, (long)pid, SOCK_SUFFIX);
 }
-
-#ifndef XRT_OS_WINDOWS
 
 struct u_mcp_listener *
 u_mcp_listener_open(pid_t pid)

--- a/src/xrt/auxiliary/util/u_mcp_transport.c
+++ b/src/xrt/auxiliary/util/u_mcp_transport.c
@@ -31,6 +31,12 @@
 
 #ifndef XRT_OS_WINDOWS
 
+long
+u_mcp_self_pid(void)
+{
+	return (long)getpid();
+}
+
 struct u_mcp_listener
 {
 	int fd;
@@ -246,6 +252,12 @@ u_mcp_enumerate_sessions(long *out_pids, size_t cap)
 #include <process.h>
 #include <stdio.h>
 #include <string.h>
+
+long
+u_mcp_self_pid(void)
+{
+	return (long)GetCurrentProcessId();
+}
 
 #define PIPE_PREFIX "\\\\.\\pipe\\displayxr-mcp-"
 

--- a/src/xrt/auxiliary/util/u_mcp_transport.h
+++ b/src/xrt/auxiliary/util/u_mcp_transport.h
@@ -11,7 +11,6 @@
 
 #include <stdbool.h>
 #include <stddef.h>
-#include <sys/types.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -27,7 +26,7 @@ struct u_mcp_conn;
  * The caller unlinks via u_mcp_listener_close().
  */
 struct u_mcp_listener *
-u_mcp_listener_open(pid_t pid);
+u_mcp_listener_open(long pid);
 
 /*!
  * Accept one connection. Blocks. Returns NULL when the listener is closed
@@ -64,7 +63,7 @@ u_mcp_conn_close(struct u_mcp_conn *conn);
  * Connect to a per-PID listener as a client (used by the displayxr-mcp adapter).
  */
 struct u_mcp_conn *
-u_mcp_conn_connect(pid_t pid);
+u_mcp_conn_connect(long pid);
 
 /*!
  * Raw fd / handle for poll()-style multiplexing by the adapter.
@@ -78,7 +77,7 @@ u_mcp_conn_fd(struct u_mcp_conn *conn);
  * Fills @p out_pids (up to @p cap entries), returns count found.
  */
 size_t
-u_mcp_enumerate_sessions(pid_t *out_pids, size_t cap);
+u_mcp_enumerate_sessions(long *out_pids, size_t cap);
 
 #ifdef __cplusplus
 }

--- a/src/xrt/auxiliary/util/u_mcp_transport.h
+++ b/src/xrt/auxiliary/util/u_mcp_transport.h
@@ -20,6 +20,14 @@ struct u_mcp_listener;
 struct u_mcp_conn;
 
 /*!
+ * Return the current process id as a long. Hides the
+ * getpid() / GetCurrentProcessId() platform split so callers don't
+ * need <unistd.h> (MSVC has neither).
+ */
+long
+u_mcp_self_pid(void);
+
+/*!
  * Bind a per-PID listener. Returns NULL on failure.
  *
  * On POSIX this creates `/tmp/displayxr-mcp-<pid>.sock` with 0600 perms.

--- a/src/xrt/auxiliary/util/u_mcp_transport.h
+++ b/src/xrt/auxiliary/util/u_mcp_transport.h
@@ -1,0 +1,85 @@
+// Copyright 2026, DisplayXR / Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  Transport abstraction for the MCP server — unix socket on POSIX,
+ *         named pipe on Windows (Phase A slice 7).
+ * @ingroup aux_util
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <sys/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct u_mcp_listener;
+struct u_mcp_conn;
+
+/*!
+ * Bind a per-PID listener. Returns NULL on failure.
+ *
+ * On POSIX this creates `/tmp/displayxr-mcp-<pid>.sock` with 0600 perms.
+ * The caller unlinks via u_mcp_listener_close().
+ */
+struct u_mcp_listener *
+u_mcp_listener_open(pid_t pid);
+
+/*!
+ * Accept one connection. Blocks. Returns NULL when the listener is closed
+ * (u_mcp_listener_close from another thread wakes us via shutdown()).
+ */
+struct u_mcp_conn *
+u_mcp_listener_accept(struct u_mcp_listener *listener);
+
+/*!
+ * Close the listener. Safe to call from another thread to unblock accept().
+ */
+void
+u_mcp_listener_close(struct u_mcp_listener *listener);
+
+/*!
+ * Blocking read of exactly @p len bytes. Returns false on EOF / error.
+ */
+bool
+u_mcp_conn_read(struct u_mcp_conn *conn, void *buf, size_t len);
+
+/*!
+ * Blocking write of exactly @p len bytes. Returns false on error.
+ */
+bool
+u_mcp_conn_write(struct u_mcp_conn *conn, const void *buf, size_t len);
+
+/*!
+ * Close and free the connection.
+ */
+void
+u_mcp_conn_close(struct u_mcp_conn *conn);
+
+/*!
+ * Connect to a per-PID listener as a client (used by the displayxr-mcp adapter).
+ */
+struct u_mcp_conn *
+u_mcp_conn_connect(pid_t pid);
+
+/*!
+ * Raw fd / handle for poll()-style multiplexing by the adapter.
+ * Returns -1 when unavailable (e.g. Windows named-pipe slice).
+ */
+int
+u_mcp_conn_fd(struct u_mcp_conn *conn);
+
+/*!
+ * Enumerate running MCP sessions by scanning for socket files.
+ * Fills @p out_pids (up to @p cap entries), returns count found.
+ */
+size_t
+u_mcp_enumerate_sessions(pid_t *out_pids, size_t cap);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/xrt/compositor/d3d11/CMakeLists.txt
+++ b/src/xrt/compositor/d3d11/CMakeLists.txt
@@ -27,6 +27,7 @@ if(WIN32 AND XRT_HAVE_D3D11)
 			aux_util
 			aux_os
 			aux_math
+			xrt-external-stb
 			d3d11
 			dxgi
 			d3dcompiler

--- a/src/xrt/compositor/d3d11/comp_d3d11_compositor.cpp
+++ b/src/xrt/compositor/d3d11/comp_d3d11_compositor.cpp
@@ -35,6 +35,14 @@
 #include "xrt/xrt_display_processor_d3d11.h"
 
 #include "util/u_hud.h"
+#include "util/u_mcp_capture.h"
+
+// STB_IMAGE_WRITE_STATIC scopes stbi_write_* symbols to this TU so
+// we don't clash with comp_d3d11_service.cpp's implementation (both
+// link into ipc_server on Windows).
+#define STB_IMAGE_WRITE_STATIC
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+#include "stb_image_write.h"
 
 #include "math/m_api.h"
 #include "util/u_tiling.h"
@@ -209,6 +217,9 @@ struct comp_d3d11_compositor
 
 	//! Thread safety.
 	std::mutex mutex;
+
+	//! MCP capture_frame request box (serviced at end of layer_commit).
+	struct u_mcp_capture_request mcp_capture;
 };
 
 /*
@@ -861,6 +872,148 @@ d3d11_crop_atlas_for_dp(struct comp_d3d11_compositor *c,
 	return c->dp_input_srv;
 }
 
+// Stride-copy a sub-rect of BGRA source bytes into a tight RGBA buffer
+// and write it out as a PNG.
+static bool
+d3d11_write_png_subrect(const uint8_t *src_bgra,
+                        uint32_t row_pitch,
+                        uint32_t src_x,
+                        uint32_t src_y,
+                        uint32_t w,
+                        uint32_t h,
+                        const char *path)
+{
+	size_t bytes = (size_t)w * h * 4;
+	uint8_t *tight = (uint8_t *)malloc(bytes);
+	if (tight == NULL) {
+		return false;
+	}
+	for (uint32_t y = 0; y < h; y++) {
+		const uint8_t *s = src_bgra + (size_t)(src_y + y) * row_pitch + (size_t)src_x * 4;
+		uint8_t *d = tight + (size_t)y * w * 4;
+		for (uint32_t x = 0; x < w; x++) {
+			d[x * 4 + 0] = s[x * 4 + 2]; // R <- B
+			d[x * 4 + 1] = s[x * 4 + 1]; // G
+			d[x * 4 + 2] = s[x * 4 + 0]; // B <- R
+			d[x * 4 + 3] = s[x * 4 + 3]; // A
+		}
+	}
+	int rc = stbi_write_png(path, (int)w, (int)h, 4, tight, (int)(w * 4));
+	free(tight);
+	return rc != 0;
+}
+
+// Service a pending MCP capture_frame request by staging-copying the
+// renderer's atlas texture to CPU, then emitting _atlas / _L / _R PNGs.
+static void
+d3d11_compositor_service_mcp_capture(struct comp_d3d11_compositor *c)
+{
+	char prefix[U_MCP_CAPTURE_PATH_MAX];
+	uint32_t views = 0;
+	if (!u_mcp_capture_poll(&c->mcp_capture, prefix, &views)) {
+		return;
+	}
+
+	ID3D11Texture2D *atlas_tex = static_cast<ID3D11Texture2D *>(
+	    comp_d3d11_renderer_get_atlas_texture(c->renderer));
+	if (atlas_tex == nullptr) {
+		u_mcp_capture_complete(&c->mcp_capture, 0);
+		return;
+	}
+
+	D3D11_TEXTURE2D_DESC desc;
+	atlas_tex->GetDesc(&desc);
+	D3D11_TEXTURE2D_DESC sd = desc;
+	sd.Usage = D3D11_USAGE_STAGING;
+	sd.BindFlags = 0;
+	sd.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
+	sd.MiscFlags = 0;
+
+	ID3D11Texture2D *staging = nullptr;
+	if (FAILED(c->device->CreateTexture2D(&sd, nullptr, &staging)) || staging == nullptr) {
+		u_mcp_capture_complete(&c->mcp_capture, 0);
+		return;
+	}
+
+	c->context->CopyResource(staging, atlas_tex);
+
+	D3D11_MAPPED_SUBRESOURCE m = {};
+	if (FAILED(c->context->Map(staging, 0, D3D11_MAP_READ, 0, &m))) {
+		staging->Release();
+		u_mcp_capture_complete(&c->mcp_capture, 0);
+		return;
+	}
+
+	uint32_t atlas_w = desc.Width;
+	uint32_t atlas_h = desc.Height;
+	uint32_t written = 0;
+	char path[U_MCP_CAPTURE_PATH_MAX + 32];
+
+	// Atlas PNG — whether the native atlas is RGBA or BGRA, stbi_write_png
+	// treats the 4 channels as R,G,B,A and writes them in that order.
+	// The D3D11 compositor renders to DXGI_FORMAT_R8G8B8A8_UNORM (see
+	// comp_d3d11_renderer), so a direct pointer is correct for _atlas.png.
+	if (views & U_MCP_CAPTURE_ATLAS) {
+		snprintf(path, sizeof(path), "%s_atlas.png", prefix);
+		if (stbi_write_png(path, (int)atlas_w, (int)atlas_h, 4, m.pData, (int)m.RowPitch)) {
+			written |= U_MCP_CAPTURE_ATLAS;
+		}
+	}
+
+	uint32_t tile_columns = 1, tile_rows = 1;
+	comp_d3d11_renderer_get_tile_layout(c->renderer, &tile_columns, &tile_rows);
+	if (tile_columns > 0 && tile_rows > 0 && (tile_columns * tile_rows) >= 2) {
+		uint32_t eye_w = atlas_w / tile_columns;
+		uint32_t eye_h = atlas_h / tile_rows;
+		// Atlas is RGBA here (see note above); pass-through copy, not
+		// the BGRA swap that Metal needs. d3d11_write_png_subrect
+		// swaps channels, so we emulate an identity by
+		// double-swapping: use a tight-copy path.
+		uint8_t *src_rgba = (uint8_t *)m.pData;
+		if (views & U_MCP_CAPTURE_LEFT) {
+			snprintf(path, sizeof(path), "%s_L.png", prefix);
+			// stride-copy rows 0..eye_h, cols 0..eye_w
+			size_t tight_pitch = (size_t)eye_w * 4;
+			uint8_t *tight = (uint8_t *)malloc(tight_pitch * eye_h);
+			if (tight != NULL) {
+				for (uint32_t y = 0; y < eye_h; y++) {
+					memcpy(tight + (size_t)y * tight_pitch,
+					       src_rgba + (size_t)y * m.RowPitch,
+					       tight_pitch);
+				}
+				if (stbi_write_png(path, (int)eye_w, (int)eye_h, 4, tight, (int)tight_pitch)) {
+					written |= U_MCP_CAPTURE_LEFT;
+				}
+				free(tight);
+			}
+		}
+		if (views & U_MCP_CAPTURE_RIGHT) {
+			uint32_t rx = (tile_columns >= 2) ? eye_w : 0;
+			uint32_t ry = (tile_columns >= 2) ? 0 : eye_h;
+			snprintf(path, sizeof(path), "%s_R.png", prefix);
+			size_t tight_pitch = (size_t)eye_w * 4;
+			uint8_t *tight = (uint8_t *)malloc(tight_pitch * eye_h);
+			if (tight != NULL) {
+				for (uint32_t y = 0; y < eye_h; y++) {
+					memcpy(tight + (size_t)y * tight_pitch,
+					       src_rgba + (size_t)(ry + y) * m.RowPitch + (size_t)rx * 4,
+					       tight_pitch);
+				}
+				if (stbi_write_png(path, (int)eye_w, (int)eye_h, 4, tight, (int)tight_pitch)) {
+					written |= U_MCP_CAPTURE_RIGHT;
+				}
+			}
+			free(tight);
+		}
+	}
+	(void)d3d11_write_png_subrect; // unused on this path; retained for symmetry with other compositors
+
+	c->context->Unmap(staging, 0);
+	staging->Release();
+
+	u_mcp_capture_complete(&c->mcp_capture, written);
+}
+
 static xrt_result_t
 d3d11_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sync_handle)
 {
@@ -1382,6 +1535,10 @@ d3d11_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 		return xret;
 	}
 
+	// Service pending MCP capture_frame after Present so the atlas
+	// we stage-copy reflects exactly what the user just saw.
+	d3d11_compositor_service_mcp_capture(c);
+
 	return XRT_SUCCESS;
 }
 
@@ -1400,6 +1557,9 @@ d3d11_compositor_destroy(struct xrt_compositor *xc)
 	struct comp_d3d11_compositor *c = d3d11_comp(xc);
 
 	U_LOG_I("Destroying D3D11 compositor");
+
+	u_mcp_capture_uninstall();
+	u_mcp_capture_fini(&c->mcp_capture);
 
 #ifdef XRT_FEATURE_DEBUG_GUI
 	// Stop debug GUI first (before destroying resources it may reference)
@@ -1507,6 +1667,9 @@ comp_d3d11_compositor_create(struct xrt_device *xdev,
 	memset(&c->base, 0, sizeof(c->base));
 
 	c->xdev = xdev;
+
+	u_mcp_capture_init(&c->mcp_capture);
+	u_mcp_capture_install(&c->mcp_capture);
 	c->own_window = nullptr;
 	c->owns_window = false;
 	c->app_hwnd = nullptr;

--- a/src/xrt/compositor/d3d11/comp_d3d11_compositor.cpp
+++ b/src/xrt/compositor/d3d11/comp_d3d11_compositor.cpp
@@ -872,58 +872,47 @@ d3d11_crop_atlas_for_dp(struct comp_d3d11_compositor *c,
 	return c->dp_input_srv;
 }
 
-// Stride-copy a sub-rect of BGRA source bytes into a tight RGBA buffer
-// and write it out as a PNG.
-static bool
-d3d11_write_png_subrect(const uint8_t *src_bgra,
-                        uint32_t row_pitch,
-                        uint32_t src_x,
-                        uint32_t src_y,
-                        uint32_t w,
-                        uint32_t h,
-                        const char *path)
-{
-	size_t bytes = (size_t)w * h * 4;
-	uint8_t *tight = (uint8_t *)malloc(bytes);
-	if (tight == NULL) {
-		return false;
-	}
-	for (uint32_t y = 0; y < h; y++) {
-		const uint8_t *s = src_bgra + (size_t)(src_y + y) * row_pitch + (size_t)src_x * 4;
-		uint8_t *d = tight + (size_t)y * w * 4;
-		for (uint32_t x = 0; x < w; x++) {
-			d[x * 4 + 0] = s[x * 4 + 2]; // R <- B
-			d[x * 4 + 1] = s[x * 4 + 1]; // G
-			d[x * 4 + 2] = s[x * 4 + 0]; // B <- R
-			d[x * 4 + 3] = s[x * 4 + 3]; // A
-		}
-	}
-	int rc = stbi_write_png(path, (int)w, (int)h, 4, tight, (int)(w * 4));
-	free(tight);
-	return rc != 0;
-}
-
-// Service a pending MCP capture_frame request by staging-copying the
-// renderer's atlas texture to CPU, then emitting _atlas / _L / _R PNGs.
+// Service a pending MCP capture_frame request. Copies the content
+// region of the renderer's atlas (tile_columns × view_width by
+// tile_rows × view_height — what the app actually wrote, same region
+// the compositor crops and sends to the DP) into a staging texture,
+// then writes a single PNG. D3D11 renderer uses
+// DXGI_FORMAT_R8G8B8A8_UNORM so no channel swap is needed.
 static void
 d3d11_compositor_service_mcp_capture(struct comp_d3d11_compositor *c)
 {
-	char prefix[U_MCP_CAPTURE_PATH_MAX];
-	uint32_t views = 0;
-	if (!u_mcp_capture_poll(&c->mcp_capture, prefix, &views)) {
+	char path[U_MCP_CAPTURE_PATH_MAX];
+	if (!u_mcp_capture_poll(&c->mcp_capture, path)) {
 		return;
 	}
 
 	ID3D11Texture2D *atlas_tex = static_cast<ID3D11Texture2D *>(
 	    comp_d3d11_renderer_get_atlas_texture(c->renderer));
-	if (atlas_tex == nullptr) {
-		u_mcp_capture_complete(&c->mcp_capture, 0);
+	if (atlas_tex == nullptr || c->renderer == nullptr) {
+		u_mcp_capture_complete(&c->mcp_capture, false);
 		return;
 	}
 
-	D3D11_TEXTURE2D_DESC desc;
-	atlas_tex->GetDesc(&desc);
-	D3D11_TEXTURE2D_DESC sd = desc;
+	uint32_t tile_columns = 1, tile_rows = 1;
+	comp_d3d11_renderer_get_tile_layout(c->renderer, &tile_columns, &tile_rows);
+	uint32_t view_w = 0, view_h = 0;
+	comp_d3d11_renderer_get_view_dimensions(c->renderer, &view_w, &view_h);
+	if (tile_columns == 0 || tile_rows == 0 || view_w == 0 || view_h == 0) {
+		u_mcp_capture_complete(&c->mcp_capture, false);
+		return;
+	}
+
+	uint32_t content_w = tile_columns * view_w;
+	uint32_t content_h = tile_rows * view_h;
+
+	D3D11_TEXTURE2D_DESC adesc;
+	atlas_tex->GetDesc(&adesc);
+	if (content_w > adesc.Width)  content_w = adesc.Width;
+	if (content_h > adesc.Height) content_h = adesc.Height;
+
+	D3D11_TEXTURE2D_DESC sd = adesc;
+	sd.Width = content_w;
+	sd.Height = content_h;
 	sd.Usage = D3D11_USAGE_STAGING;
 	sd.BindFlags = 0;
 	sd.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
@@ -931,87 +920,27 @@ d3d11_compositor_service_mcp_capture(struct comp_d3d11_compositor *c)
 
 	ID3D11Texture2D *staging = nullptr;
 	if (FAILED(c->device->CreateTexture2D(&sd, nullptr, &staging)) || staging == nullptr) {
-		u_mcp_capture_complete(&c->mcp_capture, 0);
+		u_mcp_capture_complete(&c->mcp_capture, false);
 		return;
 	}
 
-	c->context->CopyResource(staging, atlas_tex);
+	D3D11_BOX src_box = {0, 0, 0, content_w, content_h, 1};
+	c->context->CopySubresourceRegion(staging, 0, 0, 0, 0, atlas_tex, 0, &src_box);
 
 	D3D11_MAPPED_SUBRESOURCE m = {};
 	if (FAILED(c->context->Map(staging, 0, D3D11_MAP_READ, 0, &m))) {
 		staging->Release();
-		u_mcp_capture_complete(&c->mcp_capture, 0);
+		u_mcp_capture_complete(&c->mcp_capture, false);
 		return;
 	}
 
-	uint32_t atlas_w = desc.Width;
-	uint32_t atlas_h = desc.Height;
-	uint32_t written = 0;
-	char path[U_MCP_CAPTURE_PATH_MAX + 32];
-
-	// Atlas PNG — whether the native atlas is RGBA or BGRA, stbi_write_png
-	// treats the 4 channels as R,G,B,A and writes them in that order.
-	// The D3D11 compositor renders to DXGI_FORMAT_R8G8B8A8_UNORM (see
-	// comp_d3d11_renderer), so a direct pointer is correct for _atlas.png.
-	if (views & U_MCP_CAPTURE_ATLAS) {
-		snprintf(path, sizeof(path), "%s_atlas.png", prefix);
-		if (stbi_write_png(path, (int)atlas_w, (int)atlas_h, 4, m.pData, (int)m.RowPitch)) {
-			written |= U_MCP_CAPTURE_ATLAS;
-		}
-	}
-
-	uint32_t tile_columns = 1, tile_rows = 1;
-	comp_d3d11_renderer_get_tile_layout(c->renderer, &tile_columns, &tile_rows);
-	if (tile_columns > 0 && tile_rows > 0 && (tile_columns * tile_rows) >= 2) {
-		uint32_t eye_w = atlas_w / tile_columns;
-		uint32_t eye_h = atlas_h / tile_rows;
-		// Atlas is RGBA here (see note above); pass-through copy, not
-		// the BGRA swap that Metal needs. d3d11_write_png_subrect
-		// swaps channels, so we emulate an identity by
-		// double-swapping: use a tight-copy path.
-		uint8_t *src_rgba = (uint8_t *)m.pData;
-		if (views & U_MCP_CAPTURE_LEFT) {
-			snprintf(path, sizeof(path), "%s_L.png", prefix);
-			// stride-copy rows 0..eye_h, cols 0..eye_w
-			size_t tight_pitch = (size_t)eye_w * 4;
-			uint8_t *tight = (uint8_t *)malloc(tight_pitch * eye_h);
-			if (tight != NULL) {
-				for (uint32_t y = 0; y < eye_h; y++) {
-					memcpy(tight + (size_t)y * tight_pitch,
-					       src_rgba + (size_t)y * m.RowPitch,
-					       tight_pitch);
-				}
-				if (stbi_write_png(path, (int)eye_w, (int)eye_h, 4, tight, (int)tight_pitch)) {
-					written |= U_MCP_CAPTURE_LEFT;
-				}
-				free(tight);
-			}
-		}
-		if (views & U_MCP_CAPTURE_RIGHT) {
-			uint32_t rx = (tile_columns >= 2) ? eye_w : 0;
-			uint32_t ry = (tile_columns >= 2) ? 0 : eye_h;
-			snprintf(path, sizeof(path), "%s_R.png", prefix);
-			size_t tight_pitch = (size_t)eye_w * 4;
-			uint8_t *tight = (uint8_t *)malloc(tight_pitch * eye_h);
-			if (tight != NULL) {
-				for (uint32_t y = 0; y < eye_h; y++) {
-					memcpy(tight + (size_t)y * tight_pitch,
-					       src_rgba + (size_t)(ry + y) * m.RowPitch + (size_t)rx * 4,
-					       tight_pitch);
-				}
-				if (stbi_write_png(path, (int)eye_w, (int)eye_h, 4, tight, (int)tight_pitch)) {
-					written |= U_MCP_CAPTURE_RIGHT;
-				}
-			}
-			free(tight);
-		}
-	}
-	(void)d3d11_write_png_subrect; // unused on this path; retained for symmetry with other compositors
+	bool ok = stbi_write_png(path, (int)content_w, (int)content_h, 4,
+	                         m.pData, (int)m.RowPitch) != 0;
 
 	c->context->Unmap(staging, 0);
 	staging->Release();
 
-	u_mcp_capture_complete(&c->mcp_capture, written);
+	u_mcp_capture_complete(&c->mcp_capture, ok);
 }
 
 static xrt_result_t

--- a/src/xrt/compositor/gl/CMakeLists.txt
+++ b/src/xrt/compositor/gl/CMakeLists.txt
@@ -22,6 +22,7 @@ target_link_libraries(
 		aux_os
 		aux_math
 		aux_ogl
+		xrt-external-stb
 	)
 
 target_include_directories(comp_gl PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)

--- a/src/xrt/compositor/gl/comp_gl_compositor.c
+++ b/src/xrt/compositor/gl/comp_gl_compositor.c
@@ -33,6 +33,14 @@
 #include "util/u_canvas.h"
 #include "util/u_time.h"
 #include "util/u_hud.h"
+#include "util/u_mcp_capture.h"
+
+// STB_IMAGE_WRITE_STATIC scopes the stbi_write_* symbols to this TU so
+// we can safely implement stb in multiple compositors that link into
+// the same binary (metal, gl, d3d11, d3d11_service).
+#define STB_IMAGE_WRITE_STATIC
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+#include "stb_image_write.h"
 #include "os/os_time.h"
 #include "os/os_threading.h"
 #include "math/m_api.h"
@@ -281,6 +289,9 @@ struct comp_gl_compositor
 
 	//! Canvas output rect for shared-texture apps.
 	struct u_canvas_rect canvas;
+
+	//! MCP capture_frame request box (serviced at end of layer_commit).
+	struct u_mcp_capture_request mcp_capture;
 };
 
 static inline struct comp_gl_compositor *
@@ -946,6 +957,123 @@ gl_crop_and_process_dp(struct comp_gl_compositor *c,
 
 /*
  *
+ * MCP capture helpers
+ *
+ */
+
+static bool
+gl_write_png_subrect(const uint8_t *rgba,
+                     uint32_t row_pitch,
+                     uint32_t src_x,
+                     uint32_t src_y,
+                     uint32_t w,
+                     uint32_t h,
+                     const char *path)
+{
+	size_t bytes = (size_t)w * h * 4;
+	uint8_t *tight = malloc(bytes);
+	if (tight == NULL) {
+		return false;
+	}
+	// glReadPixels returns bottom-up; flip Y while copying the sub-rect.
+	uint32_t atlas_h_full = 0;
+	(void)atlas_h_full; // unused; caller handles flip via src_y + region math
+	for (uint32_t y = 0; y < h; y++) {
+		memcpy(tight + (size_t)y * w * 4,
+		       rgba + (size_t)(src_y + y) * row_pitch + (size_t)src_x * 4,
+		       (size_t)w * 4);
+	}
+	int rc = stbi_write_png(path, (int)w, (int)h, 4, tight, (int)(w * 4));
+	free(tight);
+	return rc != 0;
+}
+
+// Service a pending MCP capture_frame request at end of layer_commit.
+// Reads atlas_texture back via glReadPixels into a CPU buffer, flips Y
+// (GL origin is bottom-left), and writes atlas / L / R PNGs.
+static void
+gl_compositor_service_mcp_capture(struct comp_gl_compositor *c)
+{
+	char prefix[U_MCP_CAPTURE_PATH_MAX];
+	uint32_t views = 0;
+	if (!u_mcp_capture_poll(&c->mcp_capture, prefix, &views)) {
+		return;
+	}
+	if (c->atlas_texture == 0) {
+		u_mcp_capture_complete(&c->mcp_capture, 0);
+		return;
+	}
+
+	uint32_t atlas_w = c->atlas_tex_width;
+	uint32_t atlas_h = c->atlas_tex_height;
+	size_t row_pitch = (size_t)atlas_w * 4;
+	size_t bytes = row_pitch * atlas_h;
+	uint8_t *bottom_up = malloc(bytes);
+	uint8_t *top_down = malloc(bytes);
+	if (bottom_up == NULL || top_down == NULL) {
+		free(bottom_up);
+		free(top_down);
+		u_mcp_capture_complete(&c->mcp_capture, 0);
+		return;
+	}
+
+	// Pull pixels off the atlas. Bind a temporary FBO so we don't
+	// clobber whatever the caller has bound.
+	GLuint prev_read_fbo = 0;
+	glGetIntegerv(GL_READ_FRAMEBUFFER_BINDING, (GLint *)&prev_read_fbo);
+	GLuint fbo = 0;
+	glGenFramebuffers(1, &fbo);
+	glBindFramebuffer(GL_READ_FRAMEBUFFER, fbo);
+	glFramebufferTexture2D(GL_READ_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, c->atlas_texture, 0);
+	glReadPixels(0, 0, (GLsizei)atlas_w, (GLsizei)atlas_h, GL_RGBA, GL_UNSIGNED_BYTE, bottom_up);
+	glFinish();
+	glBindFramebuffer(GL_READ_FRAMEBUFFER, prev_read_fbo);
+	glDeleteFramebuffers(1, &fbo);
+
+	// Flip vertically: glReadPixels returns origin-lower-left.
+	for (uint32_t y = 0; y < atlas_h; y++) {
+		memcpy(top_down + (size_t)y * row_pitch,
+		       bottom_up + (size_t)(atlas_h - 1 - y) * row_pitch,
+		       row_pitch);
+	}
+	free(bottom_up);
+
+	uint32_t written = 0;
+	char path[U_MCP_CAPTURE_PATH_MAX + 32];
+
+	if (views & U_MCP_CAPTURE_ATLAS) {
+		snprintf(path, sizeof(path), "%s_atlas.png", prefix);
+		if (stbi_write_png(path, (int)atlas_w, (int)atlas_h, 4, top_down, (int)row_pitch)) {
+			written |= U_MCP_CAPTURE_ATLAS;
+		}
+	}
+	if (c->tile_columns > 0 && c->tile_rows > 0 &&
+	    (c->tile_columns * c->tile_rows) >= 2) {
+		uint32_t eye_w = atlas_w / c->tile_columns;
+		uint32_t eye_h = atlas_h / c->tile_rows;
+		if (views & U_MCP_CAPTURE_LEFT) {
+			snprintf(path, sizeof(path), "%s_L.png", prefix);
+			if (gl_write_png_subrect(top_down, (uint32_t)row_pitch, 0, 0, eye_w, eye_h, path)) {
+				written |= U_MCP_CAPTURE_LEFT;
+			}
+		}
+		if (views & U_MCP_CAPTURE_RIGHT) {
+			uint32_t rx = (c->tile_columns >= 2) ? eye_w : 0;
+			uint32_t ry = (c->tile_columns >= 2) ? 0 : eye_h;
+			snprintf(path, sizeof(path), "%s_R.png", prefix);
+			if (gl_write_png_subrect(top_down, (uint32_t)row_pitch, rx, ry, eye_w, eye_h, path)) {
+				written |= U_MCP_CAPTURE_RIGHT;
+			}
+		}
+	}
+
+	free(top_down);
+	u_mcp_capture_complete(&c->mcp_capture, written);
+}
+
+
+/*
+ *
  * Layer commit — render atlas and present
  *
  */
@@ -1462,6 +1590,11 @@ gl_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t
 	if (prev_cull_face) glEnable(GL_CULL_FACE);
 	if (prev_scissor_test) glEnable(GL_SCISSOR_TEST);
 
+	// MCP capture_frame — runs while our GL context is still current so
+	// glReadPixels from atlas_texture is valid. Early-returns when no
+	// request is pending.
+	gl_compositor_service_mcp_capture(c);
+
 	// Restore previous GL context (critical for shared texture mode where
 	// app has its own context and needs it back after compositor work)
 #ifdef XRT_OS_WINDOWS
@@ -1490,6 +1623,9 @@ static void
 gl_compositor_destroy(struct xrt_compositor *xc)
 {
 	struct comp_gl_compositor *c = gl_comp(xc);
+
+	u_mcp_capture_uninstall();
+	u_mcp_capture_fini(&c->mcp_capture);
 
 #ifdef XRT_OS_WINDOWS
 	// Make compositor context current for GL resource cleanup
@@ -1985,6 +2121,9 @@ comp_gl_compositor_create(struct xrt_device *xdev,
 {
 	struct comp_gl_compositor *c = U_TYPED_CALLOC(struct comp_gl_compositor);
 	c->xdev = xdev;
+
+	u_mcp_capture_init(&c->mcp_capture);
+	u_mcp_capture_install(&c->mcp_capture);
 
 	// Get window dimensions
 	uint32_t width = GL_DEFAULT_WIDTH;

--- a/src/xrt/compositor/gl/comp_gl_compositor.c
+++ b/src/xrt/compositor/gl/comp_gl_compositor.c
@@ -961,114 +961,66 @@ gl_crop_and_process_dp(struct comp_gl_compositor *c,
  *
  */
 
-static bool
-gl_write_png_subrect(const uint8_t *rgba,
-                     uint32_t row_pitch,
-                     uint32_t src_x,
-                     uint32_t src_y,
-                     uint32_t w,
-                     uint32_t h,
-                     const char *path)
-{
-	size_t bytes = (size_t)w * h * 4;
-	uint8_t *tight = malloc(bytes);
-	if (tight == NULL) {
-		return false;
-	}
-	// glReadPixels returns bottom-up; flip Y while copying the sub-rect.
-	uint32_t atlas_h_full = 0;
-	(void)atlas_h_full; // unused; caller handles flip via src_y + region math
-	for (uint32_t y = 0; y < h; y++) {
-		memcpy(tight + (size_t)y * w * 4,
-		       rgba + (size_t)(src_y + y) * row_pitch + (size_t)src_x * 4,
-		       (size_t)w * 4);
-	}
-	int rc = stbi_write_png(path, (int)w, (int)h, 4, tight, (int)(w * 4));
-	free(tight);
-	return rc != 0;
-}
-
-// Service a pending MCP capture_frame request at end of layer_commit.
-// Reads atlas_texture back via glReadPixels into a CPU buffer, flips Y
-// (GL origin is bottom-left), and writes atlas / L / R PNGs.
+// Service a pending MCP capture_frame request. Reads the content
+// region of atlas_texture (tile_columns × view_width by tile_rows ×
+// view_height — what actually got composited, matching what the
+// compositor crops and sends to the DP), flips Y, and writes one PNG.
 static void
 gl_compositor_service_mcp_capture(struct comp_gl_compositor *c)
 {
-	char prefix[U_MCP_CAPTURE_PATH_MAX];
-	uint32_t views = 0;
-	if (!u_mcp_capture_poll(&c->mcp_capture, prefix, &views)) {
+	char path[U_MCP_CAPTURE_PATH_MAX];
+	if (!u_mcp_capture_poll(&c->mcp_capture, path)) {
 		return;
 	}
-	if (c->atlas_texture == 0) {
-		u_mcp_capture_complete(&c->mcp_capture, 0);
+	if (c->atlas_texture == 0 || c->tile_columns == 0 || c->tile_rows == 0 ||
+	    c->view_width == 0 || c->view_height == 0) {
+		u_mcp_capture_complete(&c->mcp_capture, false);
 		return;
 	}
 
-	uint32_t atlas_w = c->atlas_tex_width;
-	uint32_t atlas_h = c->atlas_tex_height;
-	size_t row_pitch = (size_t)atlas_w * 4;
-	size_t bytes = row_pitch * atlas_h;
+	uint32_t content_w = c->tile_columns * c->view_width;
+	uint32_t content_h = c->tile_rows * c->view_height;
+	if (content_w > c->atlas_tex_width)  content_w = c->atlas_tex_width;
+	if (content_h > c->atlas_tex_height) content_h = c->atlas_tex_height;
+
+	size_t row_pitch = (size_t)content_w * 4;
+	size_t bytes = row_pitch * content_h;
 	uint8_t *bottom_up = malloc(bytes);
 	uint8_t *top_down = malloc(bytes);
 	if (bottom_up == NULL || top_down == NULL) {
 		free(bottom_up);
 		free(top_down);
-		u_mcp_capture_complete(&c->mcp_capture, 0);
+		u_mcp_capture_complete(&c->mcp_capture, false);
 		return;
 	}
 
-	// Pull pixels off the atlas. Bind a temporary FBO so we don't
-	// clobber whatever the caller has bound.
+	// Attach atlas to a temporary read FBO; glReadPixels returns origin-
+	// lower-left so we flip Y into top_down.
 	GLuint prev_read_fbo = 0;
 	glGetIntegerv(GL_READ_FRAMEBUFFER_BINDING, (GLint *)&prev_read_fbo);
 	GLuint fbo = 0;
 	glGenFramebuffers(1, &fbo);
 	glBindFramebuffer(GL_READ_FRAMEBUFFER, fbo);
 	glFramebufferTexture2D(GL_READ_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, c->atlas_texture, 0);
-	glReadPixels(0, 0, (GLsizei)atlas_w, (GLsizei)atlas_h, GL_RGBA, GL_UNSIGNED_BYTE, bottom_up);
+	// Atlas's lower-left origin means our content region sits in the
+	// upper-left of the texture, at (0, atlas_h - content_h).
+	GLint src_y = (GLint)c->atlas_tex_height - (GLint)content_h;
+	if (src_y < 0) src_y = 0;
+	glReadPixels(0, src_y, (GLsizei)content_w, (GLsizei)content_h, GL_RGBA, GL_UNSIGNED_BYTE, bottom_up);
 	glFinish();
 	glBindFramebuffer(GL_READ_FRAMEBUFFER, prev_read_fbo);
 	glDeleteFramebuffers(1, &fbo);
 
-	// Flip vertically: glReadPixels returns origin-lower-left.
-	for (uint32_t y = 0; y < atlas_h; y++) {
+	for (uint32_t y = 0; y < content_h; y++) {
 		memcpy(top_down + (size_t)y * row_pitch,
-		       bottom_up + (size_t)(atlas_h - 1 - y) * row_pitch,
+		       bottom_up + (size_t)(content_h - 1 - y) * row_pitch,
 		       row_pitch);
 	}
 	free(bottom_up);
 
-	uint32_t written = 0;
-	char path[U_MCP_CAPTURE_PATH_MAX + 32];
-
-	if (views & U_MCP_CAPTURE_ATLAS) {
-		snprintf(path, sizeof(path), "%s_atlas.png", prefix);
-		if (stbi_write_png(path, (int)atlas_w, (int)atlas_h, 4, top_down, (int)row_pitch)) {
-			written |= U_MCP_CAPTURE_ATLAS;
-		}
-	}
-	if (c->tile_columns > 0 && c->tile_rows > 0 &&
-	    (c->tile_columns * c->tile_rows) >= 2) {
-		uint32_t eye_w = atlas_w / c->tile_columns;
-		uint32_t eye_h = atlas_h / c->tile_rows;
-		if (views & U_MCP_CAPTURE_LEFT) {
-			snprintf(path, sizeof(path), "%s_L.png", prefix);
-			if (gl_write_png_subrect(top_down, (uint32_t)row_pitch, 0, 0, eye_w, eye_h, path)) {
-				written |= U_MCP_CAPTURE_LEFT;
-			}
-		}
-		if (views & U_MCP_CAPTURE_RIGHT) {
-			uint32_t rx = (c->tile_columns >= 2) ? eye_w : 0;
-			uint32_t ry = (c->tile_columns >= 2) ? 0 : eye_h;
-			snprintf(path, sizeof(path), "%s_R.png", prefix);
-			if (gl_write_png_subrect(top_down, (uint32_t)row_pitch, rx, ry, eye_w, eye_h, path)) {
-				written |= U_MCP_CAPTURE_RIGHT;
-			}
-		}
-	}
-
+	bool ok = stbi_write_png(path, (int)content_w, (int)content_h, 4, top_down, (int)row_pitch) != 0;
 	free(top_down);
-	u_mcp_capture_complete(&c->mcp_capture, written);
+	u_mcp_capture_complete(&c->mcp_capture, ok);
 }
 
 

--- a/src/xrt/compositor/metal/CMakeLists.txt
+++ b/src/xrt/compositor/metal/CMakeLists.txt
@@ -20,6 +20,7 @@ if(APPLE AND XRT_HAVE_METAL)
 			aux_util
 			aux_os
 			aux_math
+			xrt-external-stb
 			"-framework Metal"
 			"-framework Cocoa"
 			"-framework QuartzCore"

--- a/src/xrt/compositor/metal/comp_metal_compositor.m
+++ b/src/xrt/compositor/metal/comp_metal_compositor.m
@@ -1258,61 +1258,47 @@ metal_compositor_render_hud(struct comp_metal_compositor *c, float dt,
 	[encoder endEncoding];
 }
 
-// Blit a tightly-packed rect out of the BGRA-swapped RGBA buffer and
-// encode a PNG. Returns true on success.
-static bool
-metal_write_png_subrect(const uint8_t *rgba,
-                        uint32_t row_pitch,
-                        uint32_t src_x,
-                        uint32_t src_y,
-                        uint32_t w,
-                        uint32_t h,
-                        const char *path)
-{
-	size_t bytes = (size_t)w * h * 4;
-	uint8_t *tight = malloc(bytes);
-	if (tight == NULL) {
-		return false;
-	}
-	for (uint32_t y = 0; y < h; y++) {
-		memcpy(tight + (size_t)y * w * 4, rgba + (size_t)(src_y + y) * row_pitch + (size_t)src_x * 4, (size_t)w * 4);
-	}
-	int rc = stbi_write_png(path, (int)w, (int)h, 4, tight, (int)(w * 4));
-	free(tight);
-	return rc != 0;
-}
-
-// Called at end of layer_commit. Reads atlas_texture back via a blit
-// to a shared MTLBuffer (atlas is StorageModePrivate), swaps BGRA→RGBA,
-// and writes PNGs for each requested view.
+// Service a pending MCP capture_frame request. Blits the content
+// region of c->atlas_texture (tile_columns × view_width by tile_rows
+// × view_height — what the app actually wrote, matching what the
+// compositor crops and hands to the DP) into a shared MTLBuffer,
+// swaps BGRA→RGBA, and writes a single PNG.
 static void
 metal_compositor_service_mcp_capture(struct comp_metal_compositor *c, id<MTLCommandBuffer> render_cmd_buf)
 {
-	char prefix[U_MCP_CAPTURE_PATH_MAX];
-	uint32_t views = 0;
-	if (!u_mcp_capture_poll(&c->mcp_capture, prefix, &views)) {
+	char path[U_MCP_CAPTURE_PATH_MAX];
+	if (!u_mcp_capture_poll(&c->mcp_capture, path)) {
 		return;
 	}
-
-	if (c->atlas_texture == nil) {
-		u_mcp_capture_complete(&c->mcp_capture, 0);
+	if (c->atlas_texture == nil || c->tile_columns == 0 || c->tile_rows == 0 ||
+	    c->view_width == 0 || c->view_height == 0) {
+		u_mcp_capture_complete(&c->mcp_capture, false);
 		return;
 	}
 
 	@autoreleasepool {
-		NSUInteger atlas_w = c->atlas_texture.width;
-		NSUInteger atlas_h = c->atlas_texture.height;
-		size_t row_pitch = atlas_w * 4;
-		size_t buf_bytes = row_pitch * atlas_h;
+		uint32_t content_w = c->tile_columns * c->view_width;
+		uint32_t content_h = c->tile_rows * c->view_height;
+		// Clamp to the allocated atlas in case a mode switch produces
+		// a content region larger than the worst-case pre-allocation.
+		if (content_w > (uint32_t)c->atlas_texture.width) {
+			content_w = (uint32_t)c->atlas_texture.width;
+		}
+		if (content_h > (uint32_t)c->atlas_texture.height) {
+			content_h = (uint32_t)c->atlas_texture.height;
+		}
+
+		size_t row_pitch = (size_t)content_w * 4;
+		size_t buf_bytes = row_pitch * content_h;
 		id<MTLBuffer> staging = [c->device newBufferWithLength:buf_bytes
 		                                               options:MTLResourceStorageModeShared];
 		if (staging == nil) {
-			u_mcp_capture_complete(&c->mcp_capture, 0);
+			u_mcp_capture_complete(&c->mcp_capture, false);
 			return;
 		}
 
-		// The render cmd_buf has already been committed; wait for it
-		// to finish so atlas writes are visible before we blit.
+		// Render cmd_buf was already committed; wait for it so the
+		// atlas contents are visible before we blit them out.
 		[render_cmd_buf waitUntilCompleted];
 
 		id<MTLCommandBuffer> blit_cb = [c->command_queue commandBuffer];
@@ -1321,7 +1307,7 @@ metal_compositor_service_mcp_capture(struct comp_metal_compositor *c, id<MTLComm
 		          sourceSlice:0
 		          sourceLevel:0
 		         sourceOrigin:MTLOriginMake(0, 0, 0)
-		           sourceSize:MTLSizeMake(atlas_w, atlas_h, 1)
+		           sourceSize:MTLSizeMake(content_w, content_h, 1)
 		             toBuffer:staging
 		    destinationOffset:0
 		destinationBytesPerRow:row_pitch
@@ -1330,11 +1316,11 @@ metal_compositor_service_mcp_capture(struct comp_metal_compositor *c, id<MTLComm
 		[blit_cb commit];
 		[blit_cb waitUntilCompleted];
 
-		// Atlas format is BGRA8Unorm; swap into an RGBA buffer for PNG.
+		// Atlas format is BGRA8Unorm — swap into RGBA for stbi_write_png.
 		uint8_t *bgra = (uint8_t *)staging.contents;
 		uint8_t *rgba = malloc(buf_bytes);
 		if (rgba == NULL) {
-			u_mcp_capture_complete(&c->mcp_capture, 0);
+			u_mcp_capture_complete(&c->mcp_capture, false);
 			return;
 		}
 		for (size_t i = 0; i < buf_bytes; i += 4) {
@@ -1343,39 +1329,9 @@ metal_compositor_service_mcp_capture(struct comp_metal_compositor *c, id<MTLComm
 			rgba[i + 2] = bgra[i + 0];
 			rgba[i + 3] = bgra[i + 3];
 		}
-
-		uint32_t written = 0;
-		char path[U_MCP_CAPTURE_PATH_MAX + 32];
-
-		if (views & U_MCP_CAPTURE_ATLAS) {
-			snprintf(path, sizeof(path), "%s_atlas.png", prefix);
-			if (stbi_write_png(path, (int)atlas_w, (int)atlas_h, 4, rgba, (int)row_pitch)) {
-				written |= U_MCP_CAPTURE_ATLAS;
-			}
-		}
-		// Stereo split only if the active mode actually has tiles.
-		if (c->tile_columns > 0 && c->tile_rows > 0 &&
-		    (c->tile_columns * c->tile_rows) >= 2) {
-			uint32_t eye_w = (uint32_t)atlas_w / c->tile_columns;
-			uint32_t eye_h = (uint32_t)atlas_h / c->tile_rows;
-			if (views & U_MCP_CAPTURE_LEFT) {
-				snprintf(path, sizeof(path), "%s_L.png", prefix);
-				if (metal_write_png_subrect(rgba, (uint32_t)row_pitch, 0, 0, eye_w, eye_h, path)) {
-					written |= U_MCP_CAPTURE_LEFT;
-				}
-			}
-			if (views & U_MCP_CAPTURE_RIGHT) {
-				uint32_t rx = (c->tile_columns >= 2) ? eye_w : 0;
-				uint32_t ry = (c->tile_columns >= 2) ? 0 : eye_h;
-				snprintf(path, sizeof(path), "%s_R.png", prefix);
-				if (metal_write_png_subrect(rgba, (uint32_t)row_pitch, rx, ry, eye_w, eye_h, path)) {
-					written |= U_MCP_CAPTURE_RIGHT;
-				}
-			}
-		}
-
+		bool ok = stbi_write_png(path, (int)content_w, (int)content_h, 4, rgba, (int)row_pitch) != 0;
 		free(rgba);
-		u_mcp_capture_complete(&c->mcp_capture, written);
+		u_mcp_capture_complete(&c->mcp_capture, ok);
 	}
 }
 

--- a/src/xrt/compositor/metal/comp_metal_compositor.m
+++ b/src/xrt/compositor/metal/comp_metal_compositor.m
@@ -42,7 +42,11 @@
 #include "util/u_canvas.h"
 #include "util/u_mcp_capture.h"
 
-// Single-TU inclusion of the stb implementation for this compositor.
+// STB_IMAGE_WRITE_STATIC scopes all stbi_write_* to this TU so linking
+// alongside other compositors that also implement stb doesn't produce
+// duplicate symbols. STB_IMAGE_WRITE_IMPLEMENTATION still forces the
+// single-header definitions to emit here.
+#define STB_IMAGE_WRITE_STATIC
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include "stb_image_write.h"
 

--- a/src/xrt/compositor/metal/comp_metal_compositor.m
+++ b/src/xrt/compositor/metal/comp_metal_compositor.m
@@ -40,6 +40,11 @@
 #include "util/u_hud.h"
 #include "util/u_tiling.h"
 #include "util/u_canvas.h"
+#include "util/u_mcp_capture.h"
+
+// Single-TU inclusion of the stb implementation for this compositor.
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+#include "stb_image_write.h"
 
 #ifdef XRT_BUILD_DRIVER_QWERTY
 #include "qwerty_interface.h"
@@ -212,6 +217,9 @@ struct comp_metal_compositor
 
 	//! Thread safety.
 	struct os_mutex mutex;
+
+	//! MCP capture request box (polled at end of layer_commit).
+	struct u_mcp_capture_request mcp_capture;
 };
 
 /*
@@ -1246,6 +1254,127 @@ metal_compositor_render_hud(struct comp_metal_compositor *c, float dt,
 	[encoder endEncoding];
 }
 
+// Blit a tightly-packed rect out of the BGRA-swapped RGBA buffer and
+// encode a PNG. Returns true on success.
+static bool
+metal_write_png_subrect(const uint8_t *rgba,
+                        uint32_t row_pitch,
+                        uint32_t src_x,
+                        uint32_t src_y,
+                        uint32_t w,
+                        uint32_t h,
+                        const char *path)
+{
+	size_t bytes = (size_t)w * h * 4;
+	uint8_t *tight = malloc(bytes);
+	if (tight == NULL) {
+		return false;
+	}
+	for (uint32_t y = 0; y < h; y++) {
+		memcpy(tight + (size_t)y * w * 4, rgba + (size_t)(src_y + y) * row_pitch + (size_t)src_x * 4, (size_t)w * 4);
+	}
+	int rc = stbi_write_png(path, (int)w, (int)h, 4, tight, (int)(w * 4));
+	free(tight);
+	return rc != 0;
+}
+
+// Called at end of layer_commit. Reads atlas_texture back via a blit
+// to a shared MTLBuffer (atlas is StorageModePrivate), swaps BGRA→RGBA,
+// and writes PNGs for each requested view.
+static void
+metal_compositor_service_mcp_capture(struct comp_metal_compositor *c, id<MTLCommandBuffer> render_cmd_buf)
+{
+	char prefix[U_MCP_CAPTURE_PATH_MAX];
+	uint32_t views = 0;
+	if (!u_mcp_capture_poll(&c->mcp_capture, prefix, &views)) {
+		return;
+	}
+
+	if (c->atlas_texture == nil) {
+		u_mcp_capture_complete(&c->mcp_capture, 0);
+		return;
+	}
+
+	@autoreleasepool {
+		NSUInteger atlas_w = c->atlas_texture.width;
+		NSUInteger atlas_h = c->atlas_texture.height;
+		size_t row_pitch = atlas_w * 4;
+		size_t buf_bytes = row_pitch * atlas_h;
+		id<MTLBuffer> staging = [c->device newBufferWithLength:buf_bytes
+		                                               options:MTLResourceStorageModeShared];
+		if (staging == nil) {
+			u_mcp_capture_complete(&c->mcp_capture, 0);
+			return;
+		}
+
+		// The render cmd_buf has already been committed; wait for it
+		// to finish so atlas writes are visible before we blit.
+		[render_cmd_buf waitUntilCompleted];
+
+		id<MTLCommandBuffer> blit_cb = [c->command_queue commandBuffer];
+		id<MTLBlitCommandEncoder> blit = [blit_cb blitCommandEncoder];
+		[blit copyFromTexture:c->atlas_texture
+		          sourceSlice:0
+		          sourceLevel:0
+		         sourceOrigin:MTLOriginMake(0, 0, 0)
+		           sourceSize:MTLSizeMake(atlas_w, atlas_h, 1)
+		             toBuffer:staging
+		    destinationOffset:0
+		destinationBytesPerRow:row_pitch
+		destinationBytesPerImage:buf_bytes];
+		[blit endEncoding];
+		[blit_cb commit];
+		[blit_cb waitUntilCompleted];
+
+		// Atlas format is BGRA8Unorm; swap into an RGBA buffer for PNG.
+		uint8_t *bgra = (uint8_t *)staging.contents;
+		uint8_t *rgba = malloc(buf_bytes);
+		if (rgba == NULL) {
+			u_mcp_capture_complete(&c->mcp_capture, 0);
+			return;
+		}
+		for (size_t i = 0; i < buf_bytes; i += 4) {
+			rgba[i + 0] = bgra[i + 2];
+			rgba[i + 1] = bgra[i + 1];
+			rgba[i + 2] = bgra[i + 0];
+			rgba[i + 3] = bgra[i + 3];
+		}
+
+		uint32_t written = 0;
+		char path[U_MCP_CAPTURE_PATH_MAX + 32];
+
+		if (views & U_MCP_CAPTURE_ATLAS) {
+			snprintf(path, sizeof(path), "%s_atlas.png", prefix);
+			if (stbi_write_png(path, (int)atlas_w, (int)atlas_h, 4, rgba, (int)row_pitch)) {
+				written |= U_MCP_CAPTURE_ATLAS;
+			}
+		}
+		// Stereo split only if the active mode actually has tiles.
+		if (c->tile_columns > 0 && c->tile_rows > 0 &&
+		    (c->tile_columns * c->tile_rows) >= 2) {
+			uint32_t eye_w = (uint32_t)atlas_w / c->tile_columns;
+			uint32_t eye_h = (uint32_t)atlas_h / c->tile_rows;
+			if (views & U_MCP_CAPTURE_LEFT) {
+				snprintf(path, sizeof(path), "%s_L.png", prefix);
+				if (metal_write_png_subrect(rgba, (uint32_t)row_pitch, 0, 0, eye_w, eye_h, path)) {
+					written |= U_MCP_CAPTURE_LEFT;
+				}
+			}
+			if (views & U_MCP_CAPTURE_RIGHT) {
+				uint32_t rx = (c->tile_columns >= 2) ? eye_w : 0;
+				uint32_t ry = (c->tile_columns >= 2) ? 0 : eye_h;
+				snprintf(path, sizeof(path), "%s_R.png", prefix);
+				if (metal_write_png_subrect(rgba, (uint32_t)row_pitch, rx, ry, eye_w, eye_h, path)) {
+					written |= U_MCP_CAPTURE_RIGHT;
+				}
+			}
+		}
+
+		free(rgba);
+		u_mcp_capture_complete(&c->mcp_capture, written);
+	}
+}
+
 static xrt_result_t
 metal_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sync_handle)
 {
@@ -1680,6 +1809,11 @@ metal_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 		[cmd_buf waitUntilCompleted];
 	}
 
+	// MCP capture_frame: if the server thread has posted a request,
+	// blit the atlas into a CPU-visible buffer, encode PNG(s), and
+	// unblock the waiter. Pays for itself only when actively capturing.
+	metal_compositor_service_mcp_capture(c, cmd_buf);
+
 	// Reset layer accumulator
 	c->layer_accum.layer_count = 0;
 
@@ -1692,6 +1826,12 @@ metal_compositor_destroy(struct xrt_compositor *xc)
 	struct comp_metal_compositor *c = metal_comp(xc);
 
 	U_LOG_I("Destroying Metal compositor");
+
+	// Uninstall the MCP capture hook before we drop any GPU resources —
+	// the MCP thread can no longer request a readback against us after
+	// this returns.
+	u_mcp_capture_uninstall();
+	u_mcp_capture_fini(&c->mcp_capture);
 
 	// Wrap teardown in @autoreleasepool so autoreleased Metal objects
 	// (drawables, command buffers, textures) are drained immediately
@@ -1839,6 +1979,9 @@ comp_metal_compositor_create(struct xrt_device *xdev,
 	if (c == NULL) {
 		return XRT_ERROR_ALLOCATION;
 	}
+
+	u_mcp_capture_init(&c->mcp_capture);
+	u_mcp_capture_install(&c->mcp_capture);
 
 	int ret = os_mutex_init(&c->mutex);
 	if (ret != 0) {

--- a/src/xrt/ipc/server/ipc_server_handler.c
+++ b/src/xrt/ipc/server/ipc_server_handler.c
@@ -1956,7 +1956,9 @@ ipc_handle_shell_activate(volatile struct ipc_client_state *_ics)
 		// If the previous session was dismissed (ESC), ensure_shell_window
 		// tears down the stale resources and creates a fresh window.
 		if (s->xsysc != NULL) {
+#ifdef XRT_OS_WINDOWS
 			comp_d3d11_service_ensure_shell_window(s->xsysc);
+#endif
 		}
 		return XRT_SUCCESS;
 	}
@@ -1967,8 +1969,10 @@ ipc_handle_shell_activate(volatile struct ipc_client_state *_ics)
 	if (s->xsysc != NULL) {
 		s->xsysc->info.shell_mode = true;
 
+#ifdef XRT_OS_WINDOWS
 		// Eagerly create the shell window so Ctrl+O works even with no apps.
 		comp_d3d11_service_ensure_shell_window(s->xsysc);
+#endif
 	}
 
 	return XRT_SUCCESS;

--- a/src/xrt/state_trackers/oxr/CMakeLists.txt
+++ b/src/xrt/state_trackers/oxr/CMakeLists.txt
@@ -33,6 +33,8 @@ add_library(
 	oxr_instance.c
 	oxr_logger.c
 	oxr_logger.h
+	oxr_mcp_tools.c
+	oxr_mcp_tools.h
 	oxr_objects.h
 	oxr_path.c
 	oxr_pretty_print.c

--- a/src/xrt/state_trackers/oxr/oxr_api_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_api_session.c
@@ -27,6 +27,7 @@
 #include "oxr_api_verify.h"
 #include "oxr_handle.h"
 #include "oxr_chain.h"
+#include "oxr_mcp_tools.h"
 
 #ifdef XRT_HAVE_D3D11_NATIVE_COMPOSITOR
 #include "d3d11/comp_d3d11_compositor.h"
@@ -315,6 +316,17 @@ oxr_xrLocateViews(XrSession session,
 	    viewCapacityInput,                   //
 	    viewCountOutput,                     //
 	    views);                              //
+
+	// Cache recommended-view signal for MCP introspection.
+	if (res == XR_SUCCESS && viewCapacityInput > 0 && views != NULL) {
+		uint32_t n = viewCountOutput != NULL ? *viewCountOutput : viewCapacityInput;
+		if (n > viewCapacityInput) {
+			n = viewCapacityInput;
+		}
+		uint64_t t_ns = time_state_ts_to_monotonic_ns(sess->sys->inst->timekeeping,
+		                                              viewLocateInfo->displayTime);
+		oxr_mcp_tools_record_recommended(sess, n, views, t_ns);
+	}
 
 	return res;
 }

--- a/src/xrt/state_trackers/oxr/oxr_instance.c
+++ b/src/xrt/state_trackers/oxr/oxr_instance.c
@@ -21,6 +21,7 @@
 #include "util/u_debug.h"
 #include "util/u_git_tag.h"
 #include "util/u_builders.h"
+#include "util/u_mcp_server.h"
 
 #ifdef XRT_FEATURE_CLIENT_DEBUG_GUI
 #include "util/u_debug_gui.h"
@@ -116,6 +117,10 @@ static XrResult
 oxr_instance_destroy(struct oxr_logger *log, struct oxr_handle_base *hb)
 {
 	struct oxr_instance *inst = (struct oxr_instance *)hb;
+
+	// Stop the MCP server before tearing down the runtime so that no
+	// in-flight tool handler can read freed state.
+	u_mcp_server_stop();
 
 	// Does a null-ptr check.
 	xrt_syscomp_destroy(&inst->system.xsysc);
@@ -579,6 +584,10 @@ oxr_instance_create(struct oxr_logger *log,
 #endif
 
 	*out_instance = inst;
+
+	// Opt-in AI introspection surface — Phase A.  No-op when the
+	// DISPLAYXR_MCP env var is unset, so normal runtime cost is zero.
+	u_mcp_server_maybe_start();
 
 	return XR_SUCCESS;
 }

--- a/src/xrt/state_trackers/oxr/oxr_instance.c
+++ b/src/xrt/state_trackers/oxr/oxr_instance.c
@@ -22,6 +22,7 @@
 #include "util/u_git_tag.h"
 #include "util/u_builders.h"
 #include "util/u_mcp_server.h"
+#include "oxr_mcp_tools.h"
 
 #ifdef XRT_FEATURE_CLIENT_DEBUG_GUI
 #include "util/u_debug_gui.h"
@@ -587,6 +588,7 @@ oxr_instance_create(struct oxr_logger *log,
 
 	// Opt-in AI introspection surface — Phase A.  No-op when the
 	// DISPLAYXR_MCP env var is unset, so normal runtime cost is zero.
+	oxr_mcp_tools_register_all();
 	u_mcp_server_maybe_start();
 
 	return XR_SUCCESS;

--- a/src/xrt/state_trackers/oxr/oxr_mcp_tools.c
+++ b/src/xrt/state_trackers/oxr/oxr_mcp_tools.c
@@ -653,18 +653,24 @@ oxr_mcp_tools_set_capture_handler(oxr_mcp_capture_fn fn, void *userdata)
 }
 
 // Stat the suffixed files the compositor may have written and add each
-// one that exists to the result with its byte size.
+// one that exists to the result with its byte size. Retries for up to
+// 200 ms to absorb any filesystem lag between fclose() and stat() —
+// observed intermittently on macOS for the third sequential write.
 static void
 add_written_path(cJSON *out_paths, const char *prefix, const char *suffix)
 {
 	char path[320];
 	snprintf(path, sizeof(path), "%s%s", prefix, suffix);
 	struct stat st;
-	if (stat(path, &st) == 0 && st.st_size > 0) {
-		cJSON *e = cJSON_CreateObject();
-		cJSON_AddStringToObject(e, "path", path);
-		cJSON_AddNumberToObject(e, "size_bytes", (double)st.st_size);
-		cJSON_AddItemToArray(out_paths, e);
+	for (int attempt = 0; attempt < 20; attempt++) {
+		if (stat(path, &st) == 0 && st.st_size > 0) {
+			cJSON *e = cJSON_CreateObject();
+			cJSON_AddStringToObject(e, "path", path);
+			cJSON_AddNumberToObject(e, "size_bytes", (double)st.st_size);
+			cJSON_AddItemToArray(out_paths, e);
+			return;
+		}
+		usleep(10000); // 10 ms
 	}
 }
 
@@ -691,7 +697,10 @@ tool_capture_frame(const cJSON *params, void *userdata)
 	char prefix[256];
 	long pid = (long)getpid();
 	struct oxr_session *sess = lock_session();
-	uint64_t seq = sess ? (uint64_t)sess->frame_id.begun : 0;
+	// frame_id.begun is -1 until xrBeginFrame runs; clamp to 0 so the
+	// filename doesn't render as UINT64_MAX.
+	int64_t begun = sess ? sess->frame_id.begun : 0;
+	uint64_t seq = begun >= 0 ? (uint64_t)begun : 0;
 	unlock_session();
 	// No extension — compositor appends _atlas.png / _L.png / _R.png.
 	snprintf(prefix, sizeof(prefix), "/tmp/displayxr-mcp-capture-%ld-%llu", pid, (unsigned long long)seq);

--- a/src/xrt/state_trackers/oxr/oxr_mcp_tools.c
+++ b/src/xrt/state_trackers/oxr/oxr_mcp_tools.c
@@ -67,7 +67,15 @@ struct mcp_frame_snapshot
 	uint64_t seq;
 	int64_t predicted_display_time_ns; //!< xrLocateViews::displayTime, monotonic ns.
 	uint64_t frame_id;                 //!< sess->frame_id.begun.
-	uint32_t view_count;
+
+	// xrLocateViews reports the system max view_count across all modes
+	// (e.g. 4 on a 3D display that supports Quad), while submit reports
+	// the active mode's actual view count (e.g. 2 for Anaglyph). Keep
+	// both so get_kooima_params / get_submitted_projection report the
+	// correct per-signal count, and diff_projection pairs declared[i]
+	// with recommended[i] for i in 0..min(rec,dec).
+	uint32_t recommended_view_count;
+	uint32_t declared_view_count;
 
 	// Recommended (runtime) — written by record_recommended.
 	struct mcp_view_data recommended[XRT_MAX_VIEWS];
@@ -347,7 +355,7 @@ tool_get_kooima_params(const cJSON *params, void *userdata)
 	cJSON_AddNumberToObject(r, "seq", (double)snap.seq);
 	cJSON_AddNumberToObject(r, "predicted_display_time_ns", (double)snap.predicted_display_time_ns);
 	cJSON_AddNumberToObject(r, "frame_id", (double)snap.frame_id);
-	cJSON_AddNumberToObject(r, "view_count", snap.view_count);
+	cJSON_AddNumberToObject(r, "view_count", snap.recommended_view_count);
 
 	cJSON *disp = cJSON_CreateObject();
 	cJSON_AddNumberToObject(disp, "width_m", snap.display_width_m);
@@ -364,7 +372,7 @@ tool_get_kooima_params(const cJSON *params, void *userdata)
 	cJSON_AddItemToObject(r, "display", disp);
 
 	cJSON *views = cJSON_CreateArray();
-	for (uint32_t i = 0; i < snap.view_count && i < XRT_MAX_VIEWS; i++) {
+	for (uint32_t i = 0; i < snap.recommended_view_count && i < XRT_MAX_VIEWS; i++) {
 		cJSON *v = cJSON_CreateObject();
 		cJSON_AddItemToObject(v, "recommended_pose", pose_to_json(&snap.recommended[i].pose));
 		cJSON_AddItemToObject(v, "recommended_fov", fov_to_json(&snap.recommended[i].fov));
@@ -403,10 +411,10 @@ tool_get_submitted_projection(const cJSON *params, void *userdata)
 	cJSON_AddNumberToObject(r, "seq", (double)snap.seq);
 	cJSON_AddNumberToObject(r, "predicted_display_time_ns", (double)snap.predicted_display_time_ns);
 	cJSON_AddNumberToObject(r, "frame_id", (double)snap.frame_id);
-	cJSON_AddNumberToObject(r, "view_count", snap.view_count);
+	cJSON_AddNumberToObject(r, "view_count", snap.declared_view_count);
 
 	cJSON *views = cJSON_CreateArray();
-	for (uint32_t i = 0; i < snap.view_count && i < XRT_MAX_VIEWS; i++) {
+	for (uint32_t i = 0; i < snap.declared_view_count && i < XRT_MAX_VIEWS; i++) {
 		cJSON *v = cJSON_CreateObject();
 		cJSON_AddItemToObject(v, "declared_pose", pose_to_json(&snap.declared[i].pose));
 		cJSON_AddItemToObject(v, "declared_fov", fov_to_json(&snap.declared[i].fov));
@@ -488,9 +496,18 @@ tool_diff_projection(const cJSON *params, void *userdata)
 		return error_object("snapshot missing recommended or declared — call xrLocateViews + xrEndFrame first");
 	}
 
+	// Pair declared[i] with recommended[i] for i in 0..min(counts). The
+	// active 3D mode (e.g. Anaglyph=2) often submits fewer views than
+	// xrLocateViews reports (system max, e.g. 4).
+	uint32_t diff_count = snap.declared_view_count < snap.recommended_view_count
+	                          ? snap.declared_view_count
+	                          : snap.recommended_view_count;
+
 	cJSON *r = cJSON_CreateObject();
 	cJSON_AddNumberToObject(r, "seq", (double)snap.seq);
-	cJSON_AddNumberToObject(r, "view_count", snap.view_count);
+	cJSON_AddNumberToObject(r, "recommended_view_count", snap.recommended_view_count);
+	cJSON_AddNumberToObject(r, "declared_view_count", snap.declared_view_count);
+	cJSON_AddNumberToObject(r, "view_count", diff_count);
 
 	float display_aspect =
 	    (snap.display_height_m > 0.f) ? (snap.display_width_m / snap.display_height_m) : 0.f;
@@ -499,7 +516,7 @@ tool_diff_projection(const cJSON *params, void *userdata)
 	cJSON *flags_set = cJSON_CreateArray();
 	bool have_any_flag = false;
 
-	for (uint32_t i = 0; i < snap.view_count && i < XRT_MAX_VIEWS; i++) {
+	for (uint32_t i = 0; i < diff_count && i < XRT_MAX_VIEWS; i++) {
 		const struct mcp_view_data *rec = &snap.recommended[i];
 		const struct mcp_view_data *dec = &snap.declared[i];
 		cJSON *v = cJSON_CreateObject();
@@ -526,7 +543,7 @@ tool_diff_projection(const cJSON *params, void *userdata)
 		if (sub_aspect > 0.f && !sub_aspect_ok) {
 			cJSON_AddItemToArray(vflags, cJSON_CreateString("fov_aspect_mismatch_subimage"));
 		}
-		if (display_aspect > 0.f && !disp_aspect_ok && snap.view_count == 1) {
+		if (display_aspect > 0.f && !disp_aspect_ok && diff_count == 1) {
 			// Only flag display-aspect mismatch for mono; stereo halves the fov aspect.
 			cJSON_AddItemToArray(vflags, cJSON_CreateString("fov_aspect_mismatch_display"));
 		}
@@ -560,7 +577,7 @@ tool_diff_projection(const cJSON *params, void *userdata)
 		cJSON_AddItemToArray(views, v);
 
 		if (fov_differs || pose_stale || (sub_aspect > 0.f && !sub_aspect_ok) ||
-		    (display_aspect > 0.f && !disp_aspect_ok && snap.view_count == 1)) {
+		    (display_aspect > 0.f && !disp_aspect_ok && diff_count == 1)) {
 			have_any_flag = true;
 		}
 	}
@@ -698,7 +715,7 @@ oxr_mcp_tools_record_recommended(struct oxr_session *sess,
 	if (sess == NULL || views == NULL || view_count == 0 || view_count > XRT_MAX_VIEWS) {
 		return;
 	}
-	g_scratch.view_count = view_count;
+	g_scratch.recommended_view_count = view_count;
 	g_scratch.predicted_display_time_ns = (int64_t)display_time_ns;
 	for (uint32_t i = 0; i < view_count; i++) {
 		// XrPosef layout matches xrt_pose; same for XrFovf and xrt_fov.
@@ -728,7 +745,7 @@ oxr_mcp_tools_record_submitted(struct oxr_session *sess, const struct xrt_layer_
 	if (data->type != XRT_LAYER_PROJECTION && data->type != XRT_LAYER_PROJECTION_DEPTH) {
 		return;
 	}
-	g_scratch.view_count = data->view_count;
+	g_scratch.declared_view_count = data->view_count;
 	for (uint32_t i = 0; i < data->view_count; i++) {
 		const struct xrt_layer_projection_view_data *v = &data->proj.v[i];
 		g_scratch.declared[i].pose = v->pose;

--- a/src/xrt/state_trackers/oxr/oxr_mcp_tools.c
+++ b/src/xrt/state_trackers/oxr/oxr_mcp_tools.c
@@ -522,10 +522,13 @@ tool_diff_projection(const cJSON *params, void *userdata)
 		cJSON *v = cJSON_CreateObject();
 		cJSON *vflags = cJSON_CreateArray();
 
-		// (1) app_ignores_recommended: declared fov != recommended fov.
+		// (1) declared fov != recommended fov — neutral observation, not
+		// a bug (some apps deliberately compute their own Kooima with
+		// different tunables). Use fov_aspect_mismatch_* to detect real
+		// pipeline breaks.
 		bool fov_differs = !fov_equal(&rec->fov, &dec->fov);
 		if (fov_differs) {
-			cJSON_AddItemToArray(vflags, cJSON_CreateString("app_ignores_recommended"));
+			cJSON_AddItemToArray(vflags, cJSON_CreateString("app_not_forwarding_locate_views_fov"));
 		}
 
 		// (2) fov_aspect_mismatch: declared fov aspect vs. subImage aspect,
@@ -548,13 +551,17 @@ tool_diff_projection(const cJSON *params, void *userdata)
 			cJSON_AddItemToArray(vflags, cJSON_CreateString("fov_aspect_mismatch_display"));
 		}
 
-		// (3) stale_head_pose: declared vs. recommended pose delta.
+		// (3) declared vs. recommended pose delta — same caveat as (1):
+		// apps doing client-side Kooima will also submit a different
+		// pose. Not inherently a bug. Phase B may add a cross-frame
+		// staleness check (true "pose froze for N frames") which is a
+		// real bug class.
 		float dp = pos_delta(&dec->pose.position, &rec->pose.position);
 		float qdot = quat_dot(&dec->pose.orientation, &rec->pose.orientation);
 		if (qdot < 0.f) qdot = -qdot; // double-cover
 		bool pose_stale = (dp > EPS_POSITION_M) || (qdot < EPS_QUAT_DOT);
 		if (pose_stale) {
-			cJSON_AddItemToArray(vflags, cJSON_CreateString("stale_head_pose"));
+			cJSON_AddItemToArray(vflags, cJSON_CreateString("app_not_forwarding_locate_views_pose"));
 		}
 
 		// (4) wrong_disparity: reserved for slice 6 when capture_frame lands.
@@ -576,13 +583,19 @@ tool_diff_projection(const cJSON *params, void *userdata)
 
 		cJSON_AddItemToArray(views, v);
 
-		if (fov_differs || pose_stale || (sub_aspect > 0.f && !sub_aspect_ok) ||
+		// Only aspect-class mismatches are considered pipeline bugs.
+		// app_not_forwarding_locate_views_{fov,pose} are neutral
+		// observations — many apps deliberately compute their own
+		// Kooima with custom tunables.
+		if ((sub_aspect > 0.f && !sub_aspect_ok) ||
 		    (display_aspect > 0.f && !disp_aspect_ok && diff_count == 1)) {
 			have_any_flag = true;
 		}
+		(void)fov_differs;
+		(void)pose_stale;
 	}
 
-	if (have_any_flag) {
+	if (have_any_flag || cJSON_GetArraySize(views) > 0) {
 		// Unioned flag set across all views, for quick triage.
 		for (int i = 0; i < cJSON_GetArraySize(views); i++) {
 			cJSON *v = cJSON_GetArrayItem(views, i);
@@ -605,7 +618,12 @@ tool_diff_projection(const cJSON *params, void *userdata)
 
 	cJSON_AddItemToObject(r, "flags", flags_set);
 	cJSON_AddItemToObject(r, "views", views);
-	cJSON_AddBoolToObject(r, "ok", !have_any_flag);
+	// Renamed from "ok" to make the semantics explicit: this asks
+	// whether the declared projection is internally consistent
+	// (subImage / display aspect), not whether it matches the runtime's
+	// recommendation. Many apps deliberately diverge from the
+	// recommendation with their own Kooima — that's expected, not a bug.
+	cJSON_AddBoolToObject(r, "pipeline_consistent", !have_any_flag);
 	return r;
 }
 

--- a/src/xrt/state_trackers/oxr/oxr_mcp_tools.c
+++ b/src/xrt/state_trackers/oxr/oxr_mcp_tools.c
@@ -22,6 +22,9 @@
 #include "oxr_objects.h"
 
 #include "util/u_mcp_server.h"
+#include "util/u_mcp_transport.h"
+
+#include "os/os_time.h"
 
 #include "xrt/xrt_compositor.h"
 #include "xrt/xrt_limits.h"
@@ -33,7 +36,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
-#include <unistd.h>
 
 static pthread_mutex_t g_sess_lock = PTHREAD_MUTEX_INITIALIZER;
 static struct oxr_session *g_sess = NULL;
@@ -147,7 +149,7 @@ tool_list_sessions(const cJSON *params, void *userdata)
 	struct oxr_session *sess = lock_session();
 	if (sess != NULL) {
 		cJSON *e = cJSON_CreateObject();
-		cJSON_AddNumberToObject(e, "pid", (double)getpid());
+		cJSON_AddNumberToObject(e, "pid", (double)u_mcp_self_pid());
 		// Phase A is single-session; display_id is 0.
 		cJSON_AddNumberToObject(e, "display_id", 0);
 		cJSON_AddStringToObject(e, "api", gfx_api_name(sess));
@@ -672,7 +674,7 @@ tool_capture_frame(const cJSON *params, void *userdata)
 	}
 
 	char path[256];
-	long pid = (long)getpid();
+	long pid = (long)u_mcp_self_pid();
 	struct oxr_session *sess = lock_session();
 	int64_t begun = sess ? sess->frame_id.begun : 0;
 	uint64_t seq = begun >= 0 ? (uint64_t)begun : 0;
@@ -690,7 +692,7 @@ tool_capture_frame(const cJSON *params, void *userdata)
 		if (stat(path, &st) == 0 && st.st_size > 0) {
 			break;
 		}
-		usleep(10000);
+		os_nanosleep(10 * 1000 * 1000); // 10 ms
 	}
 	cJSON_AddNumberToObject(r, "size_bytes", (double)st.st_size);
 	if (!ok || st.st_size == 0) {

--- a/src/xrt/state_trackers/oxr/oxr_mcp_tools.c
+++ b/src/xrt/state_trackers/oxr/oxr_mcp_tools.c
@@ -29,11 +29,64 @@
 #include <cjson/cJSON.h>
 
 #include <pthread.h>
+#include <stdatomic.h>
+#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 
 static pthread_mutex_t g_sess_lock = PTHREAD_MUTEX_INITIALIZER;
 static struct oxr_session *g_sess = NULL;
+
+// ---------- Per-view snapshot ----------
+//
+// Three signals per spec §4.C, captured per view (1..XRT_MAX_VIEWS) so the
+// same machinery handles mono / stereo / quilted displays:
+//   recommended  = runtime's xrLocateViews output (Kooima from display geometry)
+//   declared     = app's XrCompositionLayerProjectionView at frame submit
+//   actual       = pixels (slice 6, not here)
+//
+// Published via atomic pointer swap: writer fills the off-buffer, swaps in.
+// Reader does an atomic load + memcpy, so the whole snapshot is self-consistent.
+
+struct mcp_view_data
+{
+	struct xrt_pose pose;
+	struct xrt_fov fov;
+	// subImage fields are only meaningful on declared views.
+	struct
+	{
+		uint32_t width_pixels, height_pixels;
+		int32_t x_pixels, y_pixels;
+		uint32_t array_index;
+		uint32_t image_index;
+	} subimage;
+};
+
+struct mcp_frame_snapshot
+{
+	uint64_t seq;
+	int64_t predicted_display_time_ns; //!< xrLocateViews::displayTime, monotonic ns.
+	uint64_t frame_id;                 //!< sess->frame_id.begun.
+	uint32_t view_count;
+
+	// Recommended (runtime) — written by record_recommended.
+	struct mcp_view_data recommended[XRT_MAX_VIEWS];
+	bool have_recommended;
+
+	// Declared (app) — written by record_submitted.
+	struct mcp_view_data declared[XRT_MAX_VIEWS];
+	bool have_declared;
+
+	// Display context — copied in at publish so the snapshot is self-contained.
+	float display_width_m, display_height_m;
+	uint32_t atlas_width_pixels, atlas_height_pixels;
+	uint32_t panel_width_pixels, panel_height_pixels;
+	float nominal_viewer_x_m, nominal_viewer_y_m, nominal_viewer_z_m;
+};
+
+static _Atomic(struct mcp_frame_snapshot *) g_published = NULL;
+static struct mcp_frame_snapshot g_scratch;
+static uint64_t g_next_seq = 1;
 
 static struct oxr_session *
 lock_session(void)
@@ -212,6 +265,174 @@ static const struct u_mcp_tool TOOL_GET_RUNTIME_METRICS = {
     .fn = tool_get_runtime_metrics,
 };
 
+// ---------- Snapshot helpers ----------
+
+static void
+copy_display_context(struct mcp_frame_snapshot *dst, const struct oxr_session *sess)
+{
+	if (sess->sys == NULL || sess->sys->xsysc == NULL) {
+		return;
+	}
+	const struct xrt_system_compositor_info *info = &sess->sys->xsysc->info;
+	dst->display_width_m = info->display_width_m;
+	dst->display_height_m = info->display_height_m;
+	dst->atlas_width_pixels = info->atlas_width_pixels;
+	dst->atlas_height_pixels = info->atlas_height_pixels;
+	dst->panel_width_pixels = info->display_pixel_width;
+	dst->panel_height_pixels = info->display_pixel_height;
+	dst->nominal_viewer_x_m = info->nominal_viewer_x_m;
+	dst->nominal_viewer_y_m = info->nominal_viewer_y_m;
+	dst->nominal_viewer_z_m = info->nominal_viewer_z_m;
+}
+
+static cJSON *
+pose_to_json(const struct xrt_pose *p)
+{
+	cJSON *o = cJSON_CreateObject();
+	cJSON *pos = cJSON_CreateObject();
+	cJSON_AddNumberToObject(pos, "x", p->position.x);
+	cJSON_AddNumberToObject(pos, "y", p->position.y);
+	cJSON_AddNumberToObject(pos, "z", p->position.z);
+	cJSON_AddItemToObject(o, "position", pos);
+	cJSON *q = cJSON_CreateObject();
+	cJSON_AddNumberToObject(q, "x", p->orientation.x);
+	cJSON_AddNumberToObject(q, "y", p->orientation.y);
+	cJSON_AddNumberToObject(q, "z", p->orientation.z);
+	cJSON_AddNumberToObject(q, "w", p->orientation.w);
+	cJSON_AddItemToObject(o, "orientation", q);
+	return o;
+}
+
+static cJSON *
+fov_to_json(const struct xrt_fov *f)
+{
+	cJSON *o = cJSON_CreateObject();
+	cJSON_AddNumberToObject(o, "angle_left", f->angle_left);
+	cJSON_AddNumberToObject(o, "angle_right", f->angle_right);
+	cJSON_AddNumberToObject(o, "angle_up", f->angle_up);
+	cJSON_AddNumberToObject(o, "angle_down", f->angle_down);
+	return o;
+}
+
+// Atomically load the published snapshot into @p out. Returns false if
+// no snapshot has been published yet.
+static bool
+load_snapshot(struct mcp_frame_snapshot *out)
+{
+	struct mcp_frame_snapshot *p = atomic_load_explicit(&g_published, memory_order_acquire);
+	if (p == NULL) {
+		return false;
+	}
+	*out = *p;
+	return true;
+}
+
+// ---------- get_kooima_params ----------
+//
+// Returns the runtime's recommended per-view projection + the display
+// geometry that Kooima used to derive it. Per-view arrays size to
+// view_count so mono/stereo/quilted displays all report correctly.
+
+static cJSON *
+tool_get_kooima_params(const cJSON *params, void *userdata)
+{
+	(void)params;
+	(void)userdata;
+	struct mcp_frame_snapshot snap;
+	if (!load_snapshot(&snap) || !snap.have_recommended) {
+		return error_object("no recommended views yet — ensure xrLocateViews has been called");
+	}
+
+	cJSON *r = cJSON_CreateObject();
+	cJSON_AddNumberToObject(r, "seq", (double)snap.seq);
+	cJSON_AddNumberToObject(r, "predicted_display_time_ns", (double)snap.predicted_display_time_ns);
+	cJSON_AddNumberToObject(r, "frame_id", (double)snap.frame_id);
+	cJSON_AddNumberToObject(r, "view_count", snap.view_count);
+
+	cJSON *disp = cJSON_CreateObject();
+	cJSON_AddNumberToObject(disp, "width_m", snap.display_width_m);
+	cJSON_AddNumberToObject(disp, "height_m", snap.display_height_m);
+	cJSON_AddNumberToObject(disp, "panel_width_pixels", snap.panel_width_pixels);
+	cJSON_AddNumberToObject(disp, "panel_height_pixels", snap.panel_height_pixels);
+	cJSON_AddNumberToObject(disp, "atlas_width_pixels", snap.atlas_width_pixels);
+	cJSON_AddNumberToObject(disp, "atlas_height_pixels", snap.atlas_height_pixels);
+	cJSON *nom = cJSON_CreateObject();
+	cJSON_AddNumberToObject(nom, "x_m", snap.nominal_viewer_x_m);
+	cJSON_AddNumberToObject(nom, "y_m", snap.nominal_viewer_y_m);
+	cJSON_AddNumberToObject(nom, "z_m", snap.nominal_viewer_z_m);
+	cJSON_AddItemToObject(disp, "nominal_viewer", nom);
+	cJSON_AddItemToObject(r, "display", disp);
+
+	cJSON *views = cJSON_CreateArray();
+	for (uint32_t i = 0; i < snap.view_count && i < XRT_MAX_VIEWS; i++) {
+		cJSON *v = cJSON_CreateObject();
+		cJSON_AddItemToObject(v, "recommended_pose", pose_to_json(&snap.recommended[i].pose));
+		cJSON_AddItemToObject(v, "recommended_fov", fov_to_json(&snap.recommended[i].fov));
+		cJSON_AddItemToArray(views, v);
+	}
+	cJSON_AddItemToObject(r, "views", views);
+	return r;
+}
+
+static const struct u_mcp_tool TOOL_GET_KOOIMA_PARAMS = {
+    .name = "get_kooima_params",
+    .description =
+        "Return the runtime's per-view recommended projection (pose + FoV) as computed from "
+        "display geometry and viewer pose, plus the display context used. Array sized to "
+        "view_count (1=mono, 2=stereo, 4/8=quilted).",
+    .input_schema_json = "{\"type\":\"object\",\"properties\":{}}",
+    .fn = tool_get_kooima_params,
+};
+
+// ---------- get_submitted_projection ----------
+//
+// Returns the per-view projection the app actually submitted via
+// XrCompositionLayerProjectionView at the most recent xrEndFrame.
+
+static cJSON *
+tool_get_submitted_projection(const cJSON *params, void *userdata)
+{
+	(void)params;
+	(void)userdata;
+	struct mcp_frame_snapshot snap;
+	if (!load_snapshot(&snap) || !snap.have_declared) {
+		return error_object("no submitted projection yet — waiting for xrEndFrame");
+	}
+
+	cJSON *r = cJSON_CreateObject();
+	cJSON_AddNumberToObject(r, "seq", (double)snap.seq);
+	cJSON_AddNumberToObject(r, "predicted_display_time_ns", (double)snap.predicted_display_time_ns);
+	cJSON_AddNumberToObject(r, "frame_id", (double)snap.frame_id);
+	cJSON_AddNumberToObject(r, "view_count", snap.view_count);
+
+	cJSON *views = cJSON_CreateArray();
+	for (uint32_t i = 0; i < snap.view_count && i < XRT_MAX_VIEWS; i++) {
+		cJSON *v = cJSON_CreateObject();
+		cJSON_AddItemToObject(v, "declared_pose", pose_to_json(&snap.declared[i].pose));
+		cJSON_AddItemToObject(v, "declared_fov", fov_to_json(&snap.declared[i].fov));
+		cJSON *sub = cJSON_CreateObject();
+		cJSON_AddNumberToObject(sub, "x_pixels", snap.declared[i].subimage.x_pixels);
+		cJSON_AddNumberToObject(sub, "y_pixels", snap.declared[i].subimage.y_pixels);
+		cJSON_AddNumberToObject(sub, "width_pixels", snap.declared[i].subimage.width_pixels);
+		cJSON_AddNumberToObject(sub, "height_pixels", snap.declared[i].subimage.height_pixels);
+		cJSON_AddNumberToObject(sub, "array_index", snap.declared[i].subimage.array_index);
+		cJSON_AddNumberToObject(sub, "image_index", snap.declared[i].subimage.image_index);
+		cJSON_AddItemToObject(v, "subimage", sub);
+		cJSON_AddItemToArray(views, v);
+	}
+	cJSON_AddItemToObject(r, "views", views);
+	return r;
+}
+
+static const struct u_mcp_tool TOOL_GET_SUBMITTED_PROJECTION = {
+    .name = "get_submitted_projection",
+    .description =
+        "Return the per-view projection the app submitted via XrCompositionLayerProjectionView "
+        "at the most recent xrEndFrame, plus the swapchain sub-image rect for each view.",
+    .input_schema_json = "{\"type\":\"object\",\"properties\":{}}",
+    .fn = tool_get_submitted_projection,
+};
+
 // ---------- Public API ----------
 
 void
@@ -220,6 +441,72 @@ oxr_mcp_tools_register_all(void)
 	u_mcp_server_register_tool(&TOOL_LIST_SESSIONS);
 	u_mcp_server_register_tool(&TOOL_GET_DISPLAY_INFO);
 	u_mcp_server_register_tool(&TOOL_GET_RUNTIME_METRICS);
+	u_mcp_server_register_tool(&TOOL_GET_KOOIMA_PARAMS);
+	u_mcp_server_register_tool(&TOOL_GET_SUBMITTED_PROJECTION);
+}
+
+void
+oxr_mcp_tools_record_recommended(struct oxr_session *sess,
+                                 uint32_t view_count,
+                                 const XrView *views,
+                                 uint64_t display_time_ns)
+{
+	if (sess == NULL || views == NULL || view_count == 0 || view_count > XRT_MAX_VIEWS) {
+		return;
+	}
+	g_scratch.view_count = view_count;
+	g_scratch.predicted_display_time_ns = (int64_t)display_time_ns;
+	for (uint32_t i = 0; i < view_count; i++) {
+		// XrPosef layout matches xrt_pose; same for XrFovf and xrt_fov.
+		memcpy(&g_scratch.recommended[i].pose, &views[i].pose, sizeof(struct xrt_pose));
+		memcpy(&g_scratch.recommended[i].fov, &views[i].fov, sizeof(struct xrt_fov));
+	}
+	g_scratch.have_recommended = true;
+	copy_display_context(&g_scratch, sess);
+	// Not publishing here — declared data comes from frame_end; publish there.
+	// Make recommended visible on its own so a diff can proceed even if no
+	// projection layer has been submitted yet.
+	g_scratch.seq = g_next_seq++;
+	g_scratch.frame_id = (uint64_t)sess->frame_id.begun;
+	static struct mcp_frame_snapshot a, b;
+	struct mcp_frame_snapshot *cur = atomic_load_explicit(&g_published, memory_order_relaxed);
+	struct mcp_frame_snapshot *next = (cur == &a) ? &b : &a;
+	*next = g_scratch;
+	atomic_store_explicit(&g_published, next, memory_order_release);
+}
+
+void
+oxr_mcp_tools_record_submitted(struct oxr_session *sess, const struct xrt_layer_data *data)
+{
+	if (sess == NULL || data == NULL || data->view_count == 0 || data->view_count > XRT_MAX_VIEWS) {
+		return;
+	}
+	if (data->type != XRT_LAYER_PROJECTION && data->type != XRT_LAYER_PROJECTION_DEPTH) {
+		return;
+	}
+	g_scratch.view_count = data->view_count;
+	for (uint32_t i = 0; i < data->view_count; i++) {
+		const struct xrt_layer_projection_view_data *v = &data->proj.v[i];
+		g_scratch.declared[i].pose = v->pose;
+		g_scratch.declared[i].fov = v->fov;
+		g_scratch.declared[i].subimage.x_pixels = v->sub.rect.offset.w;
+		g_scratch.declared[i].subimage.y_pixels = v->sub.rect.offset.h;
+		g_scratch.declared[i].subimage.width_pixels = v->sub.rect.extent.w;
+		g_scratch.declared[i].subimage.height_pixels = v->sub.rect.extent.h;
+		g_scratch.declared[i].subimage.array_index = v->sub.array_index;
+		g_scratch.declared[i].subimage.image_index = v->sub.image_index;
+	}
+	g_scratch.have_declared = true;
+	copy_display_context(&g_scratch, sess);
+	g_scratch.seq = g_next_seq++;
+	g_scratch.frame_id = (uint64_t)sess->frame_id.begun;
+
+	// Double-buffer publish. Two static slots alternate; we never free.
+	static struct mcp_frame_snapshot a, b;
+	struct mcp_frame_snapshot *cur = atomic_load_explicit(&g_published, memory_order_relaxed);
+	struct mcp_frame_snapshot *next = (cur == &a) ? &b : &a;
+	*next = g_scratch;
+	atomic_store_explicit(&g_published, next, memory_order_release);
 }
 
 void

--- a/src/xrt/state_trackers/oxr/oxr_mcp_tools.c
+++ b/src/xrt/state_trackers/oxr/oxr_mcp_tools.c
@@ -592,6 +592,78 @@ tool_diff_projection(const cJSON *params, void *userdata)
 	return r;
 }
 
+// ---------- capture_frame ----------
+//
+// Per-API readback of the compositor's most recent submitted frame or
+// atlas, returned as a PNG (base64) or a file path in /tmp. The actual
+// GPU→CPU copy lives in the compositor that owns the swapchain; this
+// tool registers a stub path until per-compositor hooks land.
+//
+// Hook registration pattern: each compositor calls oxr_mcp_tools_set
+// _capture_handler() at creation time; the tool then dispatches to
+// whichever compositor the current session uses.
+
+static pthread_mutex_t g_capture_lock = PTHREAD_MUTEX_INITIALIZER;
+static oxr_mcp_capture_fn g_capture_fn = NULL;
+static void *g_capture_userdata = NULL;
+
+void
+oxr_mcp_tools_set_capture_handler(oxr_mcp_capture_fn fn, void *userdata)
+{
+	pthread_mutex_lock(&g_capture_lock);
+	g_capture_fn = fn;
+	g_capture_userdata = userdata;
+	pthread_mutex_unlock(&g_capture_lock);
+}
+
+static cJSON *
+tool_capture_frame(const cJSON *params, void *userdata)
+{
+	(void)userdata;
+	pthread_mutex_lock(&g_capture_lock);
+	oxr_mcp_capture_fn fn = g_capture_fn;
+	void *ud = g_capture_userdata;
+	pthread_mutex_unlock(&g_capture_lock);
+
+	if (fn == NULL) {
+		cJSON *o = cJSON_CreateObject();
+		cJSON_AddStringToObject(
+		    o, "error",
+		    "capture_frame not wired: compositor has not registered a handler. "
+		    "Metal/GL slice-6 hook and D3D11 slice-7 hook are pending.");
+		cJSON_AddStringToObject(o, "hint", "run diff_projection and tail_log in the meantime");
+		return o;
+	}
+
+	char path[256];
+	long pid = (long)getpid();
+	struct oxr_session *sess = lock_session();
+	uint64_t seq = sess ? (uint64_t)sess->frame_id.begun : 0;
+	unlock_session();
+	snprintf(path, sizeof(path), "/tmp/displayxr-mcp-capture-%ld-%llu.png", pid, (unsigned long long)seq);
+
+	if (!fn(path, ud)) {
+		cJSON *o = cJSON_CreateObject();
+		cJSON_AddStringToObject(o, "error", "compositor capture handler failed");
+		return o;
+	}
+
+	cJSON *r = cJSON_CreateObject();
+	cJSON_AddStringToObject(r, "path", path);
+	cJSON_AddNumberToObject(r, "frame_id", (double)seq);
+	return r;
+}
+
+static const struct u_mcp_tool TOOL_CAPTURE_FRAME = {
+    .name = "capture_frame",
+    .description =
+        "Capture the compositor's most recent atlas to a PNG and return its path. "
+        "Requires a per-API compositor hook (Metal/GL: slice 6; D3D11: slice 7). "
+        "Returns an error with diagnostics if no hook is registered.",
+    .input_schema_json = "{\"type\":\"object\",\"properties\":{}}",
+    .fn = tool_capture_frame,
+};
+
 static const struct u_mcp_tool TOOL_DIFF_PROJECTION = {
     .name = "diff_projection",
     .description =
@@ -614,6 +686,7 @@ oxr_mcp_tools_register_all(void)
 	u_mcp_server_register_tool(&TOOL_GET_KOOIMA_PARAMS);
 	u_mcp_server_register_tool(&TOOL_GET_SUBMITTED_PROJECTION);
 	u_mcp_server_register_tool(&TOOL_DIFF_PROJECTION);
+	u_mcp_server_register_tool(&TOOL_CAPTURE_FRAME);
 }
 
 void

--- a/src/xrt/state_trackers/oxr/oxr_mcp_tools.c
+++ b/src/xrt/state_trackers/oxr/oxr_mcp_tools.c
@@ -32,7 +32,6 @@
 #include <cjson/cJSON.h>
 
 #include <pthread.h>
-#include <stdatomic.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
@@ -95,7 +94,12 @@ struct mcp_frame_snapshot
 	float nominal_viewer_x_m, nominal_viewer_y_m, nominal_viewer_z_m;
 };
 
-static _Atomic(struct mcp_frame_snapshot *) g_published = NULL;
+// Originally an _Atomic pointer swap, but MSVC's <stdatomic.h> requires
+// /experimental:c11atomics and even then doesn't accept _Atomic(T*).
+// A tiny mutex is correct everywhere and uncontended in our case
+// (single writer per frame, occasional reader on the MCP thread).
+static pthread_mutex_t g_published_lock = PTHREAD_MUTEX_INITIALIZER;
+static struct mcp_frame_snapshot *g_published = NULL;
 static struct mcp_frame_snapshot g_scratch;
 static uint64_t g_next_seq = 1;
 
@@ -325,17 +329,20 @@ fov_to_json(const struct xrt_fov *f)
 	return o;
 }
 
-// Atomically load the published snapshot into @p out. Returns false if
-// no snapshot has been published yet.
+// Load the published snapshot into @p out. Returns false if no snapshot
+// has been published yet. Mutex-guarded; uncontended in practice (one
+// frame writer + one MCP-thread reader).
 static bool
 load_snapshot(struct mcp_frame_snapshot *out)
 {
-	struct mcp_frame_snapshot *p = atomic_load_explicit(&g_published, memory_order_acquire);
-	if (p == NULL) {
-		return false;
+	bool ok = false;
+	pthread_mutex_lock(&g_published_lock);
+	if (g_published != NULL) {
+		*out = *g_published;
+		ok = true;
 	}
-	*out = *p;
-	return true;
+	pthread_mutex_unlock(&g_published_lock);
+	return ok;
 }
 
 // ---------- get_kooima_params ----------
@@ -760,10 +767,11 @@ oxr_mcp_tools_record_recommended(struct oxr_session *sess,
 	g_scratch.seq = g_next_seq++;
 	g_scratch.frame_id = (uint64_t)sess->frame_id.begun;
 	static struct mcp_frame_snapshot a, b;
-	struct mcp_frame_snapshot *cur = atomic_load_explicit(&g_published, memory_order_relaxed);
-	struct mcp_frame_snapshot *next = (cur == &a) ? &b : &a;
+	pthread_mutex_lock(&g_published_lock);
+	struct mcp_frame_snapshot *next = (g_published == &a) ? &b : &a;
 	*next = g_scratch;
-	atomic_store_explicit(&g_published, next, memory_order_release);
+	g_published = next;
+	pthread_mutex_unlock(&g_published_lock);
 }
 
 void
@@ -794,10 +802,11 @@ oxr_mcp_tools_record_submitted(struct oxr_session *sess, const struct xrt_layer_
 
 	// Double-buffer publish. Two static slots alternate; we never free.
 	static struct mcp_frame_snapshot a, b;
-	struct mcp_frame_snapshot *cur = atomic_load_explicit(&g_published, memory_order_relaxed);
-	struct mcp_frame_snapshot *next = (cur == &a) ? &b : &a;
+	pthread_mutex_lock(&g_published_lock);
+	struct mcp_frame_snapshot *next = (g_published == &a) ? &b : &a;
 	*next = g_scratch;
-	atomic_store_explicit(&g_published, next, memory_order_release);
+	g_published = next;
+	pthread_mutex_unlock(&g_published_lock);
 }
 
 void

--- a/src/xrt/state_trackers/oxr/oxr_mcp_tools.c
+++ b/src/xrt/state_trackers/oxr/oxr_mcp_tools.c
@@ -652,28 +652,6 @@ oxr_mcp_tools_set_capture_handler(oxr_mcp_capture_fn fn, void *userdata)
 	pthread_mutex_unlock(&g_capture_lock);
 }
 
-// Stat the suffixed files the compositor may have written and add each
-// one that exists to the result with its byte size. Retries for up to
-// 200 ms to absorb any filesystem lag between fclose() and stat() —
-// observed intermittently on macOS for the third sequential write.
-static void
-add_written_path(cJSON *out_paths, const char *prefix, const char *suffix)
-{
-	char path[320];
-	snprintf(path, sizeof(path), "%s%s", prefix, suffix);
-	struct stat st;
-	for (int attempt = 0; attempt < 20; attempt++) {
-		if (stat(path, &st) == 0 && st.st_size > 0) {
-			cJSON *e = cJSON_CreateObject();
-			cJSON_AddStringToObject(e, "path", path);
-			cJSON_AddNumberToObject(e, "size_bytes", (double)st.st_size);
-			cJSON_AddItemToArray(out_paths, e);
-			return;
-		}
-		usleep(10000); // 10 ms
-	}
-}
-
 static cJSON *
 tool_capture_frame(const cJSON *params, void *userdata)
 {
@@ -690,33 +668,32 @@ tool_capture_frame(const cJSON *params, void *userdata)
 		    o, "error",
 		    "capture_frame not wired: compositor has not registered a handler. "
 		    "Rebuild with the MCP capture hooks enabled for this graphics API.");
-		cJSON_AddStringToObject(o, "hint", "run diff_projection and tail_log in the meantime");
 		return o;
 	}
 
-	char prefix[256];
+	char path[256];
 	long pid = (long)getpid();
 	struct oxr_session *sess = lock_session();
-	// frame_id.begun is -1 until xrBeginFrame runs; clamp to 0 so the
-	// filename doesn't render as UINT64_MAX.
 	int64_t begun = sess ? sess->frame_id.begun : 0;
 	uint64_t seq = begun >= 0 ? (uint64_t)begun : 0;
 	unlock_session();
-	// No extension — compositor appends _atlas.png / _L.png / _R.png.
-	snprintf(prefix, sizeof(prefix), "/tmp/displayxr-mcp-capture-%ld-%llu", pid, (unsigned long long)seq);
+	snprintf(path, sizeof(path), "/tmp/displayxr-mcp-capture-%ld-%llu.png", pid, (unsigned long long)seq);
 
-	bool handler_ok = fn(prefix, ud);
+	bool ok = fn(path, ud);
 
 	cJSON *r = cJSON_CreateObject();
 	cJSON_AddNumberToObject(r, "frame_id", (double)seq);
-	cJSON_AddStringToObject(r, "path_prefix", prefix);
-	cJSON *paths = cJSON_CreateArray();
-	add_written_path(paths, prefix, "_atlas.png");
-	add_written_path(paths, prefix, "_L.png");
-	add_written_path(paths, prefix, "_R.png");
-	cJSON_AddItemToObject(r, "files", paths);
-
-	if (!handler_ok && cJSON_GetArraySize(paths) == 0) {
+	cJSON_AddStringToObject(r, "path", path);
+	// Absorb any brief fclose→stat lag before reporting size.
+	struct stat st = {0};
+	for (int attempt = 0; attempt < 20; attempt++) {
+		if (stat(path, &st) == 0 && st.st_size > 0) {
+			break;
+		}
+		usleep(10000);
+	}
+	cJSON_AddNumberToObject(r, "size_bytes", (double)st.st_size);
+	if (!ok || st.st_size == 0) {
 		cJSON_AddStringToObject(r, "error", "compositor capture handler reported failure");
 	}
 	return r;
@@ -725,10 +702,9 @@ tool_capture_frame(const cJSON *params, void *userdata)
 static const struct u_mcp_tool TOOL_CAPTURE_FRAME = {
     .name = "capture_frame",
     .description =
-        "Capture the compositor's most recent composited frame. Returns an array of PNG "
-        "file paths (_atlas.png, and when the active mode has a stereo split, _L.png and "
-        "_R.png) plus byte sizes. Requires a per-API compositor hook; returns a structured "
-        "error if none is registered.",
+        "Capture the compositor's most recent composited frame — the content region of the "
+        "atlas that the compositor crops and hands to the display processor (i.e. what the "
+        "app actually wrote to its swapchain). Returns the PNG path and byte size.",
     .input_schema_json = "{\"type\":\"object\",\"properties\":{}}",
     .fn = tool_capture_frame,
 };

--- a/src/xrt/state_trackers/oxr/oxr_mcp_tools.c
+++ b/src/xrt/state_trackers/oxr/oxr_mcp_tools.c
@@ -32,6 +32,7 @@
 #include <stdatomic.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 static pthread_mutex_t g_sess_lock = PTHREAD_MUTEX_INITIALIZER;
@@ -651,9 +652,26 @@ oxr_mcp_tools_set_capture_handler(oxr_mcp_capture_fn fn, void *userdata)
 	pthread_mutex_unlock(&g_capture_lock);
 }
 
+// Stat the suffixed files the compositor may have written and add each
+// one that exists to the result with its byte size.
+static void
+add_written_path(cJSON *out_paths, const char *prefix, const char *suffix)
+{
+	char path[320];
+	snprintf(path, sizeof(path), "%s%s", prefix, suffix);
+	struct stat st;
+	if (stat(path, &st) == 0 && st.st_size > 0) {
+		cJSON *e = cJSON_CreateObject();
+		cJSON_AddStringToObject(e, "path", path);
+		cJSON_AddNumberToObject(e, "size_bytes", (double)st.st_size);
+		cJSON_AddItemToArray(out_paths, e);
+	}
+}
+
 static cJSON *
 tool_capture_frame(const cJSON *params, void *userdata)
 {
+	(void)params;
 	(void)userdata;
 	pthread_mutex_lock(&g_capture_lock);
 	oxr_mcp_capture_fn fn = g_capture_fn;
@@ -665,36 +683,43 @@ tool_capture_frame(const cJSON *params, void *userdata)
 		cJSON_AddStringToObject(
 		    o, "error",
 		    "capture_frame not wired: compositor has not registered a handler. "
-		    "Metal/GL slice-6 hook and D3D11 slice-7 hook are pending.");
+		    "Rebuild with the MCP capture hooks enabled for this graphics API.");
 		cJSON_AddStringToObject(o, "hint", "run diff_projection and tail_log in the meantime");
 		return o;
 	}
 
-	char path[256];
+	char prefix[256];
 	long pid = (long)getpid();
 	struct oxr_session *sess = lock_session();
 	uint64_t seq = sess ? (uint64_t)sess->frame_id.begun : 0;
 	unlock_session();
-	snprintf(path, sizeof(path), "/tmp/displayxr-mcp-capture-%ld-%llu.png", pid, (unsigned long long)seq);
+	// No extension — compositor appends _atlas.png / _L.png / _R.png.
+	snprintf(prefix, sizeof(prefix), "/tmp/displayxr-mcp-capture-%ld-%llu", pid, (unsigned long long)seq);
 
-	if (!fn(path, ud)) {
-		cJSON *o = cJSON_CreateObject();
-		cJSON_AddStringToObject(o, "error", "compositor capture handler failed");
-		return o;
-	}
+	bool handler_ok = fn(prefix, ud);
 
 	cJSON *r = cJSON_CreateObject();
-	cJSON_AddStringToObject(r, "path", path);
 	cJSON_AddNumberToObject(r, "frame_id", (double)seq);
+	cJSON_AddStringToObject(r, "path_prefix", prefix);
+	cJSON *paths = cJSON_CreateArray();
+	add_written_path(paths, prefix, "_atlas.png");
+	add_written_path(paths, prefix, "_L.png");
+	add_written_path(paths, prefix, "_R.png");
+	cJSON_AddItemToObject(r, "files", paths);
+
+	if (!handler_ok && cJSON_GetArraySize(paths) == 0) {
+		cJSON_AddStringToObject(r, "error", "compositor capture handler reported failure");
+	}
 	return r;
 }
 
 static const struct u_mcp_tool TOOL_CAPTURE_FRAME = {
     .name = "capture_frame",
     .description =
-        "Capture the compositor's most recent atlas to a PNG and return its path. "
-        "Requires a per-API compositor hook (Metal/GL: slice 6; D3D11: slice 7). "
-        "Returns an error with diagnostics if no hook is registered.",
+        "Capture the compositor's most recent composited frame. Returns an array of PNG "
+        "file paths (_atlas.png, and when the active mode has a stereo split, _L.png and "
+        "_R.png) plus byte sizes. Requires a per-API compositor hook; returns a structured "
+        "error if none is registered.",
     .input_schema_json = "{\"type\":\"object\",\"properties\":{}}",
     .fn = tool_capture_frame,
 };

--- a/src/xrt/state_trackers/oxr/oxr_mcp_tools.c
+++ b/src/xrt/state_trackers/oxr/oxr_mcp_tools.c
@@ -1,0 +1,241 @@
+// Copyright 2026, DisplayXR / Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  MCP tool implementations for the OpenXR state tracker.
+ *
+ * In Phase A the DisplayXR runtime supports exactly one handle-app session
+ * at a time, so a single attached @c oxr_session pointer is sufficient.
+ * Access is synchronized with a mutex — tool handlers run on the MCP
+ * server thread, the session pointer is written from the app thread.
+ *
+ * Tools are registered in two phases:
+ *   @ref oxr_mcp_tools_register_all — called from xrCreateInstance.
+ *   @ref oxr_mcp_tools_attach_session — called from xrCreateSession.
+ * Handlers read-check the session pointer and return an error result when
+ * no session is attached yet.
+ *
+ * @ingroup oxr_main
+ */
+
+#include "oxr_mcp_tools.h"
+#include "oxr_objects.h"
+
+#include "util/u_mcp_server.h"
+
+#include "xrt/xrt_compositor.h"
+#include "xrt/xrt_limits.h"
+
+#include <cjson/cJSON.h>
+
+#include <pthread.h>
+#include <string.h>
+#include <unistd.h>
+
+static pthread_mutex_t g_sess_lock = PTHREAD_MUTEX_INITIALIZER;
+static struct oxr_session *g_sess = NULL;
+
+static struct oxr_session *
+lock_session(void)
+{
+	pthread_mutex_lock(&g_sess_lock);
+	return g_sess;
+}
+
+static void
+unlock_session(void)
+{
+	pthread_mutex_unlock(&g_sess_lock);
+}
+
+static cJSON *
+error_object(const char *message)
+{
+	cJSON *o = cJSON_CreateObject();
+	cJSON_AddStringToObject(o, "error", message);
+	return o;
+}
+
+static const char *
+gfx_api_name(const struct oxr_session *sess)
+{
+	if (sess->is_d3d11_native_compositor)
+		return "d3d11";
+	if (sess->is_d3d12_native_compositor)
+		return "d3d12";
+	if (sess->is_metal_native_compositor)
+		return "metal";
+	if (sess->is_gl_native_compositor)
+		return "opengl";
+	if (sess->is_vk_native_compositor)
+		return "vulkan";
+	return "unknown";
+}
+
+// ---------- list_sessions ----------
+
+static cJSON *
+tool_list_sessions(const cJSON *params, void *userdata)
+{
+	(void)params;
+	(void)userdata;
+	cJSON *result = cJSON_CreateObject();
+	cJSON *arr = cJSON_CreateArray();
+
+	struct oxr_session *sess = lock_session();
+	if (sess != NULL) {
+		cJSON *e = cJSON_CreateObject();
+		cJSON_AddNumberToObject(e, "pid", (double)getpid());
+		// Phase A is single-session; display_id is 0.
+		cJSON_AddNumberToObject(e, "display_id", 0);
+		cJSON_AddStringToObject(e, "api", gfx_api_name(sess));
+		cJSON_AddNumberToObject(e, "session_state", sess->state);
+		cJSON_AddNumberToObject(e, "view_count", sess->sys != NULL ? sess->sys->view_count : 0);
+		cJSON_AddItemToArray(arr, e);
+	}
+	unlock_session();
+
+	cJSON_AddItemToObject(result, "sessions", arr);
+	return result;
+}
+
+static const struct u_mcp_tool TOOL_LIST_SESSIONS = {
+    .name = "list_sessions",
+    .description = "List MCP-introspectable DisplayXR sessions visible from this process.",
+    .input_schema_json = "{\"type\":\"object\",\"properties\":{}}",
+    .fn = tool_list_sessions,
+};
+
+// ---------- get_display_info ----------
+
+static cJSON *
+tool_get_display_info(const cJSON *params, void *userdata)
+{
+	(void)params;
+	(void)userdata;
+	struct oxr_session *sess = lock_session();
+	if (sess == NULL || sess->sys == NULL || sess->sys->xsysc == NULL) {
+		unlock_session();
+		return error_object("no active session");
+	}
+	const struct xrt_system_compositor_info *info = &sess->sys->xsysc->info;
+	uint32_t view_count = sess->sys->view_count;
+
+	cJSON *r = cJSON_CreateObject();
+
+	cJSON *phys = cJSON_CreateObject();
+	cJSON_AddNumberToObject(phys, "width_m", info->display_width_m);
+	cJSON_AddNumberToObject(phys, "height_m", info->display_height_m);
+	cJSON_AddItemToObject(r, "physical_size", phys);
+
+	cJSON *panel = cJSON_CreateObject();
+	cJSON_AddNumberToObject(panel, "width_pixels", info->display_pixel_width);
+	cJSON_AddNumberToObject(panel, "height_pixels", info->display_pixel_height);
+	cJSON_AddItemToObject(r, "panel", panel);
+
+	cJSON *atlas = cJSON_CreateObject();
+	cJSON_AddNumberToObject(atlas, "width_pixels", info->atlas_width_pixels);
+	cJSON_AddNumberToObject(atlas, "height_pixels", info->atlas_height_pixels);
+	cJSON_AddItemToObject(r, "atlas", atlas);
+
+	cJSON *nom = cJSON_CreateObject();
+	cJSON_AddNumberToObject(nom, "x_m", info->nominal_viewer_x_m);
+	cJSON_AddNumberToObject(nom, "y_m", info->nominal_viewer_y_m);
+	cJSON_AddNumberToObject(nom, "z_m", info->nominal_viewer_z_m);
+	cJSON_AddItemToObject(r, "nominal_viewer", nom);
+
+	cJSON *scale = cJSON_CreateObject();
+	cJSON_AddNumberToObject(scale, "x", info->recommended_view_scale_x);
+	cJSON_AddNumberToObject(scale, "y", info->recommended_view_scale_y);
+	cJSON_AddItemToObject(r, "recommended_view_scale", scale);
+
+	cJSON_AddNumberToObject(r, "view_count", view_count);
+	cJSON_AddBoolToObject(r, "hardware_display_3d", sess->hardware_display_3d);
+
+	cJSON *views = cJSON_CreateArray();
+	for (uint32_t i = 0; i < view_count && i < XRT_MAX_VIEWS; i++) {
+		const XrViewConfigurationView *v = &sess->sys->views[i];
+		cJSON *vo = cJSON_CreateObject();
+		cJSON_AddNumberToObject(vo, "recommended_width", v->recommendedImageRectWidth);
+		cJSON_AddNumberToObject(vo, "recommended_height", v->recommendedImageRectHeight);
+		cJSON_AddNumberToObject(vo, "max_width", v->maxImageRectWidth);
+		cJSON_AddNumberToObject(vo, "max_height", v->maxImageRectHeight);
+		cJSON_AddItemToArray(views, vo);
+	}
+	cJSON_AddItemToObject(r, "views", views);
+
+	unlock_session();
+	return r;
+}
+
+static const struct u_mcp_tool TOOL_GET_DISPLAY_INFO = {
+    .name = "get_display_info",
+    .description =
+        "Return the DisplayXR display dimensions, panel size, atlas size, nominal viewer position, "
+        "and per-view recommended/max image rects. Wraps XR_EXT_display_info.",
+    .input_schema_json = "{\"type\":\"object\",\"properties\":{}}",
+    .fn = tool_get_display_info,
+};
+
+// ---------- get_runtime_metrics ----------
+
+static cJSON *
+tool_get_runtime_metrics(const cJSON *params, void *userdata)
+{
+	(void)params;
+	(void)userdata;
+	struct oxr_session *sess = lock_session();
+	if (sess == NULL) {
+		unlock_session();
+		return error_object("no active session");
+	}
+	cJSON *r = cJSON_CreateObject();
+	cJSON_AddStringToObject(r, "gfx_api", gfx_api_name(sess));
+	cJSON_AddNumberToObject(r, "session_state", sess->state);
+	cJSON_AddNumberToObject(r, "frames_begun", (double)sess->frame_id.begun);
+	cJSON_AddNumberToObject(r, "frames_waited", (double)sess->frame_id.waited);
+	cJSON_AddNumberToObject(r, "active_wait_frames", sess->active_wait_frames);
+	cJSON_AddBoolToObject(r, "compositor_visible", sess->compositor_visible);
+	cJSON_AddBoolToObject(r, "compositor_focused", sess->compositor_focused);
+	cJSON_AddBoolToObject(r, "has_external_window", sess->has_external_window);
+	cJSON_AddNumberToObject(r, "ipd_meters", sess->ipd_meters);
+	unlock_session();
+	return r;
+}
+
+static const struct u_mcp_tool TOOL_GET_RUNTIME_METRICS = {
+    .name = "get_runtime_metrics",
+    .description =
+        "Return cheap runtime counters: frames begun/waited, compositor visibility/focus, "
+        "graphics API, current session state.",
+    .input_schema_json = "{\"type\":\"object\",\"properties\":{}}",
+    .fn = tool_get_runtime_metrics,
+};
+
+// ---------- Public API ----------
+
+void
+oxr_mcp_tools_register_all(void)
+{
+	u_mcp_server_register_tool(&TOOL_LIST_SESSIONS);
+	u_mcp_server_register_tool(&TOOL_GET_DISPLAY_INFO);
+	u_mcp_server_register_tool(&TOOL_GET_RUNTIME_METRICS);
+}
+
+void
+oxr_mcp_tools_attach_session(struct oxr_session *sess)
+{
+	pthread_mutex_lock(&g_sess_lock);
+	g_sess = sess;
+	pthread_mutex_unlock(&g_sess_lock);
+}
+
+void
+oxr_mcp_tools_detach_session(struct oxr_session *sess)
+{
+	pthread_mutex_lock(&g_sess_lock);
+	if (g_sess == sess) {
+		g_sess = NULL;
+	}
+	pthread_mutex_unlock(&g_sess_lock);
+}

--- a/src/xrt/state_trackers/oxr/oxr_mcp_tools.c
+++ b/src/xrt/state_trackers/oxr/oxr_mcp_tools.c
@@ -433,6 +433,176 @@ static const struct u_mcp_tool TOOL_GET_SUBMITTED_PROJECTION = {
     .fn = tool_get_submitted_projection,
 };
 
+// ---------- diff_projection ----------
+//
+// Classifies the delta between recommended and declared per view. See
+// docs/roadmap/mcp-spec-v0.2.md §4.C for the bug-class taxonomy.
+
+#include <math.h>
+
+#define EPS_FOV_RAD 0.0005f     // ~0.03°
+#define EPS_ASPECT 0.01f        // ~1% aspect mismatch tolerance
+#define EPS_POSITION_M 0.001f   // 1 mm
+#define EPS_QUAT_DOT 0.9999f    // ≈0.8° rotation tolerance
+
+static float
+fov_aspect_wh(const struct xrt_fov *f)
+{
+	float w = tanf(f->angle_right) + tanf(-f->angle_left);
+	float h = tanf(f->angle_up) + tanf(-f->angle_down);
+	return h > 1e-6f ? (w / h) : 0.0f;
+}
+
+static bool
+fov_equal(const struct xrt_fov *a, const struct xrt_fov *b)
+{
+	return fabsf(a->angle_left - b->angle_left) < EPS_FOV_RAD &&
+	       fabsf(a->angle_right - b->angle_right) < EPS_FOV_RAD &&
+	       fabsf(a->angle_up - b->angle_up) < EPS_FOV_RAD &&
+	       fabsf(a->angle_down - b->angle_down) < EPS_FOV_RAD;
+}
+
+static float
+quat_dot(const struct xrt_quat *a, const struct xrt_quat *b)
+{
+	return a->x * b->x + a->y * b->y + a->z * b->z + a->w * b->w;
+}
+
+static float
+pos_delta(const struct xrt_vec3 *a, const struct xrt_vec3 *b)
+{
+	float dx = a->x - b->x, dy = a->y - b->y, dz = a->z - b->z;
+	return sqrtf(dx * dx + dy * dy + dz * dz);
+}
+
+static cJSON *
+tool_diff_projection(const cJSON *params, void *userdata)
+{
+	(void)params;
+	(void)userdata;
+	struct mcp_frame_snapshot snap;
+	if (!load_snapshot(&snap)) {
+		return error_object("no snapshot yet");
+	}
+	if (!snap.have_recommended || !snap.have_declared) {
+		return error_object("snapshot missing recommended or declared — call xrLocateViews + xrEndFrame first");
+	}
+
+	cJSON *r = cJSON_CreateObject();
+	cJSON_AddNumberToObject(r, "seq", (double)snap.seq);
+	cJSON_AddNumberToObject(r, "view_count", snap.view_count);
+
+	float display_aspect =
+	    (snap.display_height_m > 0.f) ? (snap.display_width_m / snap.display_height_m) : 0.f;
+
+	cJSON *views = cJSON_CreateArray();
+	cJSON *flags_set = cJSON_CreateArray();
+	bool have_any_flag = false;
+
+	for (uint32_t i = 0; i < snap.view_count && i < XRT_MAX_VIEWS; i++) {
+		const struct mcp_view_data *rec = &snap.recommended[i];
+		const struct mcp_view_data *dec = &snap.declared[i];
+		cJSON *v = cJSON_CreateObject();
+		cJSON *vflags = cJSON_CreateArray();
+
+		// (1) app_ignores_recommended: declared fov != recommended fov.
+		bool fov_differs = !fov_equal(&rec->fov, &dec->fov);
+		if (fov_differs) {
+			cJSON_AddItemToArray(vflags, cJSON_CreateString("app_ignores_recommended"));
+		}
+
+		// (2) fov_aspect_mismatch: declared fov aspect vs. subImage aspect,
+		// and vs. display aspect when available.
+		float dec_fov_aspect = fov_aspect_wh(&dec->fov);
+		float sub_aspect = 0.0f;
+		if (dec->subimage.height_pixels > 0) {
+			sub_aspect = (float)dec->subimage.width_pixels / (float)dec->subimage.height_pixels;
+		}
+		bool sub_aspect_ok =
+		    (sub_aspect > 0.f && fabsf(dec_fov_aspect - sub_aspect) < EPS_ASPECT * dec_fov_aspect);
+		bool disp_aspect_ok =
+		    (display_aspect > 0.f &&
+		     fabsf(dec_fov_aspect - display_aspect) < EPS_ASPECT * dec_fov_aspect);
+		if (sub_aspect > 0.f && !sub_aspect_ok) {
+			cJSON_AddItemToArray(vflags, cJSON_CreateString("fov_aspect_mismatch_subimage"));
+		}
+		if (display_aspect > 0.f && !disp_aspect_ok && snap.view_count == 1) {
+			// Only flag display-aspect mismatch for mono; stereo halves the fov aspect.
+			cJSON_AddItemToArray(vflags, cJSON_CreateString("fov_aspect_mismatch_display"));
+		}
+
+		// (3) stale_head_pose: declared vs. recommended pose delta.
+		float dp = pos_delta(&dec->pose.position, &rec->pose.position);
+		float qdot = quat_dot(&dec->pose.orientation, &rec->pose.orientation);
+		if (qdot < 0.f) qdot = -qdot; // double-cover
+		bool pose_stale = (dp > EPS_POSITION_M) || (qdot < EPS_QUAT_DOT);
+		if (pose_stale) {
+			cJSON_AddItemToArray(vflags, cJSON_CreateString("stale_head_pose"));
+		}
+
+		// (4) wrong_disparity: reserved for slice 6 when capture_frame lands.
+
+		cJSON_AddNumberToObject(v, "view_index", i);
+		cJSON_AddItemToObject(v, "flags", vflags);
+
+		cJSON *metrics = cJSON_CreateObject();
+		cJSON_AddNumberToObject(metrics, "declared_fov_aspect_wh", dec_fov_aspect);
+		cJSON_AddNumberToObject(metrics, "subimage_aspect_wh", sub_aspect);
+		cJSON_AddNumberToObject(metrics, "position_delta_m", dp);
+		cJSON_AddNumberToObject(metrics, "orientation_dot", qdot);
+		cJSON_AddItemToObject(v, "metrics", metrics);
+
+		cJSON *expected = cJSON_CreateObject();
+		cJSON_AddItemToObject(expected, "recommended_fov", fov_to_json(&rec->fov));
+		cJSON_AddItemToObject(expected, "declared_fov", fov_to_json(&dec->fov));
+		cJSON_AddItemToObject(v, "fovs", expected);
+
+		cJSON_AddItemToArray(views, v);
+
+		if (fov_differs || pose_stale || (sub_aspect > 0.f && !sub_aspect_ok) ||
+		    (display_aspect > 0.f && !disp_aspect_ok && snap.view_count == 1)) {
+			have_any_flag = true;
+		}
+	}
+
+	if (have_any_flag) {
+		// Unioned flag set across all views, for quick triage.
+		for (int i = 0; i < cJSON_GetArraySize(views); i++) {
+			cJSON *v = cJSON_GetArrayItem(views, i);
+			cJSON *vflags = cJSON_GetObjectItemCaseSensitive(v, "flags");
+			for (int j = 0; j < cJSON_GetArraySize(vflags); j++) {
+				const char *s = cJSON_GetArrayItem(vflags, j)->valuestring;
+				bool seen = false;
+				for (int k = 0; k < cJSON_GetArraySize(flags_set); k++) {
+					if (strcmp(cJSON_GetArrayItem(flags_set, k)->valuestring, s) == 0) {
+						seen = true;
+						break;
+					}
+				}
+				if (!seen) {
+					cJSON_AddItemToArray(flags_set, cJSON_CreateString(s));
+				}
+			}
+		}
+	}
+
+	cJSON_AddItemToObject(r, "flags", flags_set);
+	cJSON_AddItemToObject(r, "views", views);
+	cJSON_AddBoolToObject(r, "ok", !have_any_flag);
+	return r;
+}
+
+static const struct u_mcp_tool TOOL_DIFF_PROJECTION = {
+    .name = "diff_projection",
+    .description =
+        "Compare the runtime's recommended per-view projection against the app's declared "
+        "projection and flag mismatches per spec §4.C: app_ignores_recommended, "
+        "fov_aspect_mismatch_{subimage,display}, stale_head_pose. "
+        "wrong_disparity is reserved for slice 6 (capture_frame).",
+    .input_schema_json = "{\"type\":\"object\",\"properties\":{}}",
+    .fn = tool_diff_projection,
+};
+
 // ---------- Public API ----------
 
 void
@@ -443,6 +613,7 @@ oxr_mcp_tools_register_all(void)
 	u_mcp_server_register_tool(&TOOL_GET_RUNTIME_METRICS);
 	u_mcp_server_register_tool(&TOOL_GET_KOOIMA_PARAMS);
 	u_mcp_server_register_tool(&TOOL_GET_SUBMITTED_PROJECTION);
+	u_mcp_server_register_tool(&TOOL_DIFF_PROJECTION);
 }
 
 void

--- a/src/xrt/state_trackers/oxr/oxr_mcp_tools.h
+++ b/src/xrt/state_trackers/oxr/oxr_mcp_tools.h
@@ -14,7 +14,12 @@
 extern "C" {
 #endif
 
+#include <openxr/openxr.h>
+
+#include <stdint.h>
+
 struct oxr_session;
+struct xrt_layer_data;
 
 /*!
  * Register the tool table with the MCP server. Idempotent; safe when the
@@ -36,6 +41,24 @@ oxr_mcp_tools_attach_session(struct oxr_session *sess);
  */
 void
 oxr_mcp_tools_detach_session(struct oxr_session *sess);
+
+/*!
+ * Record the recommended per-view pose + fov as returned by
+ * xrLocateViews. Called once per locate on the app thread.
+ */
+void
+oxr_mcp_tools_record_recommended(struct oxr_session *sess,
+                                 uint32_t view_count,
+                                 const XrView *views,
+                                 uint64_t display_time_ns);
+
+/*!
+ * Record the app-submitted projection layer data at frame submit
+ * and atomically publish the completed snapshot. Called once per
+ * successfully submitted projection layer from @ref oxr_session_frame_end.
+ */
+void
+oxr_mcp_tools_record_submitted(struct oxr_session *sess, const struct xrt_layer_data *data);
 
 #ifdef __cplusplus
 }

--- a/src/xrt/state_trackers/oxr/oxr_mcp_tools.h
+++ b/src/xrt/state_trackers/oxr/oxr_mcp_tools.h
@@ -16,6 +16,7 @@ extern "C" {
 
 #include <openxr/openxr.h>
 
+#include <stdbool.h>
 #include <stdint.h>
 
 struct oxr_session;
@@ -59,6 +60,20 @@ oxr_mcp_tools_record_recommended(struct oxr_session *sess,
  */
 void
 oxr_mcp_tools_record_submitted(struct oxr_session *sess, const struct xrt_layer_data *data);
+
+/*!
+ * Register a per-compositor capture handler. The handler is invoked on
+ * the MCP server thread with a target path; it must write a PNG to
+ * that path (synchronously or with its own synchronization) and return
+ * true on success. The state tracker passes a stable path of the form
+ * `/tmp/displayxr-mcp-capture-<pid>-<frame>.png`.
+ *
+ * Pass NULL to unregister.
+ */
+typedef bool (*oxr_mcp_capture_fn)(const char *path, void *userdata);
+
+void
+oxr_mcp_tools_set_capture_handler(oxr_mcp_capture_fn fn, void *userdata);
 
 #ifdef __cplusplus
 }

--- a/src/xrt/state_trackers/oxr/oxr_mcp_tools.h
+++ b/src/xrt/state_trackers/oxr/oxr_mcp_tools.h
@@ -1,0 +1,42 @@
+// Copyright 2026, DisplayXR / Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  MCP tool implementations that read OpenXR state tracker state.
+ *         Registered from @ref oxr_instance_create alongside
+ *         @ref u_mcp_server_maybe_start.
+ * @ingroup oxr_main
+ */
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct oxr_session;
+
+/*!
+ * Register the tool table with the MCP server. Idempotent; safe when the
+ * MCP server is disabled (registrations are harmless).
+ */
+void
+oxr_mcp_tools_register_all(void);
+
+/*!
+ * Publish the current session so tool handlers can read its state.
+ * Called from @ref oxr_session_create on success.
+ */
+void
+oxr_mcp_tools_attach_session(struct oxr_session *sess);
+
+/*!
+ * Clear the session pointer. Called from @ref oxr_session_destroy before
+ * the session backing memory is freed.
+ */
+void
+oxr_mcp_tools_detach_session(struct oxr_session *sess);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/xrt/state_trackers/oxr/oxr_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_session.c
@@ -42,6 +42,7 @@
 #include "math/m_camera3d_view.h"
 
 #include "oxr_objects.h"
+#include "oxr_mcp_tools.h"
 #include "oxr_logger.h"
 #include "oxr_two_call.h"
 #include "oxr_handle.h"
@@ -1915,6 +1916,10 @@ oxr_session_destroy(struct oxr_logger *log, struct oxr_handle_base *hb)
 {
 	struct oxr_session *sess = (struct oxr_session *)hb;
 
+	// Detach before we start tearing down the session so any in-flight
+	// MCP tool handler stops reading.
+	oxr_mcp_tools_detach_session(sess);
+
 	XrResult ret = oxr_event_remove_session_events(log, sess);
 
 	oxr_session_binding_destroy_all(log, sess);
@@ -2644,6 +2649,9 @@ oxr_session_create(struct oxr_logger *log,
 	// Everything is in order, start the state changes.
 	oxr_session_change_state(log, sess, XR_SESSION_STATE_IDLE, 0);
 	oxr_session_change_state(log, sess, XR_SESSION_STATE_READY, 0);
+
+	// Publish the session to the MCP server (no-op when MCP is disabled).
+	oxr_mcp_tools_attach_session(sess);
 
 	*out_session = sess;
 

--- a/src/xrt/state_trackers/oxr/oxr_session_frame_end.c
+++ b/src/xrt/state_trackers/oxr/oxr_session_frame_end.c
@@ -25,6 +25,7 @@
 #include "math/m_space.h"
 
 #include "oxr_objects.h"
+#include "oxr_mcp_tools.h"
 #include "oxr_logger.h"
 #include "oxr_two_call.h"
 #include "oxr_handle.h"
@@ -1472,6 +1473,9 @@ submit_projection_layer(struct oxr_session *sess,
 		    &data);                                    // data
 		OXR_CHECK_XRET(log, sess, xret, xrt_comp_layer_projection);
 	}
+
+	// Publish the per-view declared projection for MCP introspection.
+	oxr_mcp_tools_record_submitted(sess, &data);
 
 	return XR_SUCCESS;
 }

--- a/src/xrt/targets/CMakeLists.txt
+++ b/src/xrt/targets/CMakeLists.txt
@@ -20,11 +20,8 @@ if(XRT_MODULE_MONADO_CLI)
 	add_subdirectory(cli)
 endif()
 
-# MCP adapter (Phase A): stdio ↔ per-PID-socket bridge.
-# POSIX only for now; Windows named-pipe variant lands in Phase A slice 7.
-if(NOT WIN32)
-	add_subdirectory(mcp_adapter)
-endif()
+# MCP adapter (Phase A): stdio ↔ per-PID-socket/pipe bridge.
+add_subdirectory(mcp_adapter)
 
 if(XRT_MODULE_MONADO_GUI)
 	add_subdirectory(gui)

--- a/src/xrt/targets/CMakeLists.txt
+++ b/src/xrt/targets/CMakeLists.txt
@@ -20,6 +20,12 @@ if(XRT_MODULE_MONADO_CLI)
 	add_subdirectory(cli)
 endif()
 
+# MCP adapter (Phase A): stdio ↔ per-PID-socket bridge.
+# POSIX only for now; Windows named-pipe variant lands in Phase A slice 7.
+if(NOT WIN32)
+	add_subdirectory(mcp_adapter)
+endif()
+
 if(XRT_MODULE_MONADO_GUI)
 	add_subdirectory(gui)
 endif()

--- a/src/xrt/targets/mcp_adapter/CMakeLists.txt
+++ b/src/xrt/targets/mcp_adapter/CMakeLists.txt
@@ -1,0 +1,21 @@
+# Copyright 2026, DisplayXR / Leia Inc.
+# SPDX-License-Identifier: BSL-1.0
+
+######
+# displayxr-mcp — stdio ↔ per-PID-socket bridge for the MCP server.
+# POSIX-only in Phase A slice 1–6; Windows named-pipe path lands in slice 7.
+
+if(WIN32)
+	return()
+endif()
+
+add_executable(mcp_adapter displayxr_mcp.c)
+add_sanitizers(mcp_adapter)
+
+set_target_properties(
+	mcp_adapter PROPERTIES OUTPUT_NAME displayxr-mcp PREFIX ""
+	)
+
+target_link_libraries(mcp_adapter PRIVATE aux_util)
+
+install(TARGETS mcp_adapter RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/xrt/targets/mcp_adapter/CMakeLists.txt
+++ b/src/xrt/targets/mcp_adapter/CMakeLists.txt
@@ -2,12 +2,7 @@
 # SPDX-License-Identifier: BSL-1.0
 
 ######
-# displayxr-mcp — stdio ↔ per-PID-socket bridge for the MCP server.
-# POSIX-only in Phase A slice 1–6; Windows named-pipe path lands in slice 7.
-
-if(WIN32)
-	return()
-endif()
+# displayxr-mcp — stdio ↔ per-PID-socket/pipe bridge for the MCP server.
 
 add_executable(mcp_adapter displayxr_mcp.c)
 add_sanitizers(mcp_adapter)
@@ -17,5 +12,10 @@ set_target_properties(
 	)
 
 target_link_libraries(mcp_adapter PRIVATE aux_util)
+
+if(WIN32)
+	# pthreads via the vendored pthreads4w (same as xrt-pthreads).
+	target_link_libraries(mcp_adapter PRIVATE xrt-pthreads)
+endif()
 
 install(TARGETS mcp_adapter RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/xrt/targets/mcp_adapter/displayxr_mcp.c
+++ b/src/xrt/targets/mcp_adapter/displayxr_mcp.c
@@ -2,24 +2,58 @@
 // SPDX-License-Identifier: BSL-1.0
 /*!
  * @file
- * @brief  Stdio ↔ per-PID-socket bridge for the DisplayXR MCP server.
+ * @brief  Stdio ↔ per-PID-socket/pipe bridge for the DisplayXR MCP server.
  *
- * Claude Code / Cursor launches this binary with `--pid <N|auto>`.
- * We pump byte streams between stdio (MCP over Content-Length frames)
- * and the runtime's unix socket. No parsing — the adapter is a dumb pipe.
+ * Two blocking threads pump bytes in opposite directions. No parsing.
+ * Works on POSIX (unix domain socket) and Windows (named pipe).
  */
 
 #include "util/u_mcp_transport.h"
 
 #include <errno.h>
-#include <fcntl.h>
-#include <poll.h>
+#include <pthread.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/types.h>
+
+#ifdef _WIN32
+#include <fcntl.h>
+#include <io.h>
+#include <windows.h>
+#else
 #include <unistd.h>
+#endif
+
+#ifdef _WIN32
+typedef SSIZE_T ssize_t;
+static ssize_t
+read_fd(int fd, void *buf, size_t n)
+{
+	return _read(fd, buf, (unsigned)n);
+}
+static ssize_t
+write_fd(int fd, const void *buf, size_t n)
+{
+	return _write(fd, buf, (unsigned)n);
+}
+#define STDIN_FD _fileno(stdin)
+#define STDOUT_FD _fileno(stdout)
+#else
+static ssize_t
+read_fd(int fd, void *buf, size_t n)
+{
+	return read(fd, buf, n);
+}
+static ssize_t
+write_fd(int fd, const void *buf, size_t n)
+{
+	return write(fd, buf, n);
+}
+#define STDIN_FD STDIN_FILENO
+#define STDOUT_FD STDOUT_FILENO
+#endif
 
 static void
 usage(const char *argv0)
@@ -32,53 +66,55 @@ usage(const char *argv0)
 	        argv0);
 }
 
-static bool
-set_nonblock(int fd)
+// Thread args: pump stdin→conn or conn→stdout.
+struct pump_args
 {
-	int flags = fcntl(fd, F_GETFL, 0);
-	if (flags < 0) {
-		return false;
-	}
-	return fcntl(fd, F_SETFL, flags | O_NONBLOCK) == 0;
-}
+	struct u_mcp_conn *conn;
+	bool stdin_to_conn;
+};
 
-static int
-pump(int from, int to)
+static void *
+pump_thread(void *arg)
 {
+	struct pump_args *a = arg;
 	char buf[4096];
-	for (;;) {
-		ssize_t r = read(from, buf, sizeof(buf));
-		if (r == 0) {
-			return 0; // EOF on this side
+	if (a->stdin_to_conn) {
+		for (;;) {
+			ssize_t r = read_fd(STDIN_FD, buf, sizeof(buf));
+			if (r <= 0) {
+				break;
+			}
+			if (!u_mcp_conn_write(a->conn, buf, (size_t)r)) {
+				break;
+			}
 		}
-		if (r < 0) {
-			if (errno == EAGAIN || errno == EWOULDBLOCK) {
-				return 1; // drained, keep polling
+	} else {
+		for (;;) {
+			// The transport's read is blocking and fetches as many
+			// bytes as the caller asks for — pull in chunks instead.
+			char c;
+			if (!u_mcp_conn_read(a->conn, &c, 1)) {
+				break;
 			}
-			if (errno == EINTR) {
-				continue;
+			// Drain any more bytes already queued — simple one-at-a-time
+			// keeps the adapter simple and low-latency.
+			if (write_fd(STDOUT_FD, &c, 1) <= 0) {
+				break;
 			}
-			return -1;
-		}
-		char *p = buf;
-		size_t left = (size_t)r;
-		while (left > 0) {
-			ssize_t w = write(to, p, left);
-			if (w <= 0) {
-				if (w < 0 && errno == EINTR) {
-					continue;
-				}
-				return -1;
-			}
-			p += w;
-			left -= (size_t)w;
 		}
 	}
+	return NULL;
 }
 
 int
 main(int argc, char **argv)
 {
+#ifdef _WIN32
+	// MCP peers speak raw binary framing; disable CRLF translation.
+	_setmode(_fileno(stdin), _O_BINARY);
+	_setmode(_fileno(stdout), _O_BINARY);
+#endif
+
 	const char *pid_arg = NULL;
 	bool list_mode = false;
 	for (int i = 1; i < argc; i++) {
@@ -132,49 +168,18 @@ main(int argc, char **argv)
 		fprintf(stderr, "displayxr-mcp: cannot connect to pid %ld\n", (long)pid);
 		return 1;
 	}
-	int sock_fd = u_mcp_conn_fd(conn);
 
-	if (!set_nonblock(STDIN_FILENO) || !set_nonblock(sock_fd)) {
-		fprintf(stderr, "displayxr-mcp: fcntl failed: %s\n", strerror(errno));
-		u_mcp_conn_close(conn);
-		return 1;
-	}
+	struct pump_args up = {.conn = conn, .stdin_to_conn = true};
+	struct pump_args down = {.conn = conn, .stdin_to_conn = false};
 
-	struct pollfd pfds[2] = {
-	    {.fd = STDIN_FILENO, .events = POLLIN},
-	    {.fd = sock_fd, .events = POLLIN},
-	};
+	pthread_t t_up, t_down;
+	pthread_create(&t_up, NULL, pump_thread, &up);
+	pthread_create(&t_down, NULL, pump_thread, &down);
 
-	bool stdin_open = true;
-	bool sock_open = true;
-	while (stdin_open && sock_open) {
-		pfds[0].fd = stdin_open ? STDIN_FILENO : -1;
-		pfds[1].fd = sock_open ? sock_fd : -1;
-		int n = poll(pfds, 2, -1);
-		if (n < 0) {
-			if (errno == EINTR) {
-				continue;
-			}
-			break;
-		}
-		if (pfds[0].revents & (POLLIN | POLLHUP)) {
-			int r = pump(STDIN_FILENO, sock_fd);
-			if (r == 0) {
-				stdin_open = false;
-			} else if (r < 0) {
-				break;
-			}
-		}
-		if (pfds[1].revents & (POLLIN | POLLHUP)) {
-			int r = pump(sock_fd, STDOUT_FILENO);
-			if (r == 0) {
-				sock_open = false;
-			} else if (r < 0) {
-				break;
-			}
-		}
-	}
-
+	// When the stdin-side thread exits (client closed stdin), tear the
+	// connection so the conn-side thread can unblock its read.
+	pthread_join(t_up, NULL);
 	u_mcp_conn_close(conn);
+	pthread_join(t_down, NULL);
 	return 0;
 }

--- a/src/xrt/targets/mcp_adapter/displayxr_mcp.c
+++ b/src/xrt/targets/mcp_adapter/displayxr_mcp.c
@@ -129,7 +129,7 @@ main(int argc, char **argv)
 	}
 
 	if (list_mode) {
-		pid_t pids[64];
+		long pids[64];
 		size_t n = u_mcp_enumerate_sessions(pids, 64);
 		for (size_t i = 0; i < n; i++) {
 			printf("%ld\n", (long)pids[i]);
@@ -142,9 +142,9 @@ main(int argc, char **argv)
 		return 2;
 	}
 
-	pid_t pid = 0;
+	long pid = 0;
 	if (strcmp(pid_arg, "auto") == 0) {
-		pid_t pids[64];
+		long pids[64];
 		size_t n = u_mcp_enumerate_sessions(pids, 64);
 		if (n == 0) {
 			fprintf(stderr, "displayxr-mcp: no running MCP sessions found\n");
@@ -156,7 +156,7 @@ main(int argc, char **argv)
 		}
 		pid = pids[0];
 	} else {
-		pid = (pid_t)strtol(pid_arg, NULL, 10);
+		pid = (long)strtol(pid_arg, NULL, 10);
 		if (pid <= 0) {
 			usage(argv[0]);
 			return 2;

--- a/src/xrt/targets/mcp_adapter/displayxr_mcp.c
+++ b/src/xrt/targets/mcp_adapter/displayxr_mcp.c
@@ -1,0 +1,180 @@
+// Copyright 2026, DisplayXR / Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  Stdio ↔ per-PID-socket bridge for the DisplayXR MCP server.
+ *
+ * Claude Code / Cursor launches this binary with `--pid <N|auto>`.
+ * We pump byte streams between stdio (MCP over Content-Length frames)
+ * and the runtime's unix socket. No parsing — the adapter is a dumb pipe.
+ */
+
+#include "util/u_mcp_transport.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+static void
+usage(const char *argv0)
+{
+	fprintf(stderr,
+	        "usage: %s --pid <N|auto> | --list\n"
+	        "  --pid N     attach to a specific runtime process\n"
+	        "  --pid auto  attach iff exactly one MCP session exists\n"
+	        "  --list      print discovered sessions and exit\n",
+	        argv0);
+}
+
+static bool
+set_nonblock(int fd)
+{
+	int flags = fcntl(fd, F_GETFL, 0);
+	if (flags < 0) {
+		return false;
+	}
+	return fcntl(fd, F_SETFL, flags | O_NONBLOCK) == 0;
+}
+
+static int
+pump(int from, int to)
+{
+	char buf[4096];
+	for (;;) {
+		ssize_t r = read(from, buf, sizeof(buf));
+		if (r == 0) {
+			return 0; // EOF on this side
+		}
+		if (r < 0) {
+			if (errno == EAGAIN || errno == EWOULDBLOCK) {
+				return 1; // drained, keep polling
+			}
+			if (errno == EINTR) {
+				continue;
+			}
+			return -1;
+		}
+		char *p = buf;
+		size_t left = (size_t)r;
+		while (left > 0) {
+			ssize_t w = write(to, p, left);
+			if (w <= 0) {
+				if (w < 0 && errno == EINTR) {
+					continue;
+				}
+				return -1;
+			}
+			p += w;
+			left -= (size_t)w;
+		}
+	}
+}
+
+int
+main(int argc, char **argv)
+{
+	const char *pid_arg = NULL;
+	bool list_mode = false;
+	for (int i = 1; i < argc; i++) {
+		if (strcmp(argv[i], "--pid") == 0 && i + 1 < argc) {
+			pid_arg = argv[++i];
+		} else if (strcmp(argv[i], "--list") == 0) {
+			list_mode = true;
+		} else {
+			usage(argv[0]);
+			return 2;
+		}
+	}
+
+	if (list_mode) {
+		pid_t pids[64];
+		size_t n = u_mcp_enumerate_sessions(pids, 64);
+		for (size_t i = 0; i < n; i++) {
+			printf("%ld\n", (long)pids[i]);
+		}
+		return 0;
+	}
+
+	if (pid_arg == NULL) {
+		usage(argv[0]);
+		return 2;
+	}
+
+	pid_t pid = 0;
+	if (strcmp(pid_arg, "auto") == 0) {
+		pid_t pids[64];
+		size_t n = u_mcp_enumerate_sessions(pids, 64);
+		if (n == 0) {
+			fprintf(stderr, "displayxr-mcp: no running MCP sessions found\n");
+			return 1;
+		}
+		if (n > 1) {
+			fprintf(stderr, "displayxr-mcp: %zu sessions found, pass --pid <N> explicitly\n", n);
+			return 1;
+		}
+		pid = pids[0];
+	} else {
+		pid = (pid_t)strtol(pid_arg, NULL, 10);
+		if (pid <= 0) {
+			usage(argv[0]);
+			return 2;
+		}
+	}
+
+	struct u_mcp_conn *conn = u_mcp_conn_connect(pid);
+	if (conn == NULL) {
+		fprintf(stderr, "displayxr-mcp: cannot connect to pid %ld\n", (long)pid);
+		return 1;
+	}
+	int sock_fd = u_mcp_conn_fd(conn);
+
+	if (!set_nonblock(STDIN_FILENO) || !set_nonblock(sock_fd)) {
+		fprintf(stderr, "displayxr-mcp: fcntl failed: %s\n", strerror(errno));
+		u_mcp_conn_close(conn);
+		return 1;
+	}
+
+	struct pollfd pfds[2] = {
+	    {.fd = STDIN_FILENO, .events = POLLIN},
+	    {.fd = sock_fd, .events = POLLIN},
+	};
+
+	bool stdin_open = true;
+	bool sock_open = true;
+	while (stdin_open && sock_open) {
+		pfds[0].fd = stdin_open ? STDIN_FILENO : -1;
+		pfds[1].fd = sock_open ? sock_fd : -1;
+		int n = poll(pfds, 2, -1);
+		if (n < 0) {
+			if (errno == EINTR) {
+				continue;
+			}
+			break;
+		}
+		if (pfds[0].revents & (POLLIN | POLLHUP)) {
+			int r = pump(STDIN_FILENO, sock_fd);
+			if (r == 0) {
+				stdin_open = false;
+			} else if (r < 0) {
+				break;
+			}
+		}
+		if (pfds[1].revents & (POLLIN | POLLHUP)) {
+			int r = pump(sock_fd, STDOUT_FILENO);
+			if (r == 0) {
+				sock_open = false;
+			} else if (r < 0) {
+				break;
+			}
+		}
+	}
+
+	u_mcp_conn_close(conn);
+	return 0;
+}

--- a/tests/mcp/demo_maya.sh
+++ b/tests/mcp/demo_maya.sh
@@ -82,9 +82,12 @@ try:
           f"declared={sub['view_count']} recommended={k['view_count']}")
 
     d = structured(call(5,"tools/call",{"name":"diff_projection","arguments":{}}))
-    known = {"app_ignores_recommended","fov_aspect_mismatch_subimage","fov_aspect_mismatch_display","stale_head_pose"}
+    known = {"app_not_forwarding_locate_views_fov","app_not_forwarding_locate_views_pose",
+            "fov_aspect_mismatch_subimage","fov_aspect_mismatch_display"}
+    forwards = not any(f.startswith("app_not_forwarding_locate_views") for f in d["flags"])
+    fwd_note = "forwards xrLocateViews" if forwards else "uses own projection math (not forwarding xrLocateViews)"
     check("diff_projection", set(d["flags"]).issubset(known),
-          f"flags={d['flags']} ok={d['ok']}")
+          f"pipeline_consistent={d['pipeline_consistent']}, {fwd_note}")
 
     cap = structured(call(6,"tools/call",{"name":"capture_frame","arguments":{}}))
     check("capture_frame (stub ok until #153)", "error" in cap and "capture_frame" in cap["error"])

--- a/tests/mcp/demo_maya.sh
+++ b/tests/mcp/demo_maya.sh
@@ -90,7 +90,11 @@ try:
           f"pipeline_consistent={d['pipeline_consistent']}, {fwd_note}")
 
     cap = structured(call(6,"tools/call",{"name":"capture_frame","arguments":{}}))
-    check("capture_frame (stub ok until #153)", "error" in cap and "capture_frame" in cap["error"])
+    import os
+    files = cap.get("files", [])
+    all_exist = files and all(os.path.isfile(f["path"]) and f["size_bytes"] > 1024 for f in files)
+    names = sorted(os.path.basename(f["path"]).split("_",1)[-1] for f in files)
+    check("capture_frame", all_exist, f"wrote {names}")
 
     tl = structured(call(7,"tools/call",{"name":"tail_log","arguments":{"since":0,"max":8}}))
     check("tail_log", len(tl["entries"]) > 0, f"got {len(tl['entries'])} entries")

--- a/tests/mcp/demo_maya.sh
+++ b/tests/mcp/demo_maya.sh
@@ -91,10 +91,9 @@ try:
 
     cap = structured(call(6,"tools/call",{"name":"capture_frame","arguments":{}}))
     import os
-    files = cap.get("files", [])
-    all_exist = files and all(os.path.isfile(f["path"]) and f["size_bytes"] > 1024 for f in files)
-    names = sorted(os.path.basename(f["path"]).split("_",1)[-1] for f in files)
-    check("capture_frame", all_exist, f"wrote {names}")
+    path = cap.get("path", "")
+    ok = path and os.path.isfile(path) and cap.get("size_bytes", 0) > 1024
+    check("capture_frame", ok, f"{os.path.basename(path)} ({cap.get('size_bytes', 0)} bytes)")
 
     tl = structured(call(7,"tools/call",{"name":"tail_log","arguments":{"since":0,"max":8}}))
     check("tail_log", len(tl["entries"]) > 0, f"got {len(tl['entries'])} entries")

--- a/tests/mcp/demo_maya.sh
+++ b/tests/mcp/demo_maya.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Copyright 2026, DisplayXR / Leia Inc.
+# SPDX-License-Identifier: BSL-1.0
+#
+# MCP Phase A end-to-end "Maya stereo-debug" demo.
+#
+# Drives the tool sequence from docs/roadmap/mcp-phase-a-agent-prompt.md
+# against a running cube_handle_metal_macos via displayxr-mcp, and prints
+# a pass/fail summary. This is the slice-6-complete checkpoint the plan
+# calls out.
+
+set -u
+set -o pipefail
+
+cd "$(dirname "$0")/../.."
+ROOT="$(pwd)"
+
+if [[ "$(uname)" != "Darwin" ]]; then
+	echo "demo_maya.sh: skip — mac-only demo (Windows adapter runs the same tools over named pipes)"
+	exit 0
+fi
+
+ADAPTER="$ROOT/build/src/xrt/targets/mcp_adapter/displayxr-mcp"
+APP="$ROOT/test_apps/cube_handle_metal_macos/build/cube_handle_metal_macos"
+RUNTIME_JSON="$ROOT/build/openxr_displayxr-dev.json"
+for f in "$ADAPTER" "$APP" "$RUNTIME_JSON"; do
+	[[ -e "$f" ]] || { echo "FAIL: missing $f — run ./scripts/build_macos.sh first"; exit 1; }
+done
+
+export DISPLAYXR_MCP=1 XR_RUNTIME_JSON="$RUNTIME_JSON"
+"$APP" >/tmp/mcp_demo_app.log 2>&1 &
+APP_PID=$!
+trap 'kill $APP_PID 2>/dev/null; wait $APP_PID 2>/dev/null' EXIT
+SOCK="/tmp/displayxr-mcp-${APP_PID}.sock"
+for _ in $(seq 1 50); do [[ -S "$SOCK" ]] && break; sleep 0.1; done
+[[ -S "$SOCK" ]] || { echo "FAIL: no socket"; cat /tmp/mcp_demo_app.log; exit 1; }
+sleep 2
+
+python3 - "$ADAPTER" "$APP_PID" <<'PY'
+import json, subprocess, sys, time
+ad, pid = sys.argv[1], sys.argv[2]
+def fr(o):
+    b = json.dumps(o).encode()
+    return b"Content-Length: %d\r\n\r\n" % len(b) + b
+p = subprocess.Popen([ad,"--pid",pid], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+def rd():
+    h=b""
+    while b"\r\n\r\n" not in h and b"\n\n" not in h:
+        c=p.stdout.read(1)
+        if not c: raise RuntimeError(p.stderr.read().decode("utf-8","replace"))
+        h+=c
+    n=next(int(l.split(b":",1)[1]) for l in h.splitlines() if l.lower().startswith(b"content-length:"))
+    return json.loads(p.stdout.read(n))
+def call(i,m,a=None):
+    msg={"jsonrpc":"2.0","id":i,"method":m}
+    if a is not None: msg["params"]=a
+    p.stdin.write(fr(msg)); p.stdin.flush()
+    return rd()
+def structured(r):
+    return r["result"]["structured"]
+passed = []
+failed = []
+def check(name, cond, note=""):
+    (passed if cond else failed).append(f"{name}" + (f" — {note}" if note else ""))
+try:
+    r = call(1,"initialize",{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"demo_maya","version":"0"}})
+    check("initialize", r["result"]["serverInfo"]["name"] == "displayxr-mcp")
+
+    s = structured(call(2,"tools/call",{"name":"list_sessions","arguments":{}}))
+    check("list_sessions", len(s["sessions"]) == 1 and s["sessions"][0]["api"] == "metal",
+          f"api={s['sessions'][0]['api']}")
+
+    k = structured(call(3,"tools/call",{"name":"get_kooima_params","arguments":{}}))
+    check("get_kooima_params", k["view_count"] >= 1 and len(k["views"]) == k["view_count"],
+          f"view_count={k['view_count']}")
+
+    sub = structured(call(4,"tools/call",{"name":"get_submitted_projection","arguments":{}}))
+    # declared view_count may be less than kooima's (system max vs. active
+    # mode count) — e.g. 2 in Anaglyph mode, 4 from xrLocateViews.
+    check("get_submitted_projection",
+          sub["view_count"] >= 1 and sub["view_count"] <= k["view_count"],
+          f"declared={sub['view_count']} recommended={k['view_count']}")
+
+    d = structured(call(5,"tools/call",{"name":"diff_projection","arguments":{}}))
+    known = {"app_ignores_recommended","fov_aspect_mismatch_subimage","fov_aspect_mismatch_display","stale_head_pose"}
+    check("diff_projection", set(d["flags"]).issubset(known),
+          f"flags={d['flags']} ok={d['ok']}")
+
+    cap = structured(call(6,"tools/call",{"name":"capture_frame","arguments":{}}))
+    check("capture_frame (stub ok until #153)", "error" in cap and "capture_frame" in cap["error"])
+
+    tl = structured(call(7,"tools/call",{"name":"tail_log","arguments":{"since":0,"max":8}}))
+    check("tail_log", len(tl["entries"]) > 0, f"got {len(tl['entries'])} entries")
+finally:
+    try: p.stdin.close()
+    except: pass
+    p.wait(timeout=5)
+
+print()
+print("=== Maya stereo-debug demo ===")
+for n in passed:
+    print(f"  PASS  {n}")
+for n in failed:
+    print(f"  FAIL  {n}")
+sys.exit(1 if failed else 0)
+PY
+RC=$?
+exit $RC

--- a/tests/mcp/test_capture_frame.sh
+++ b/tests/mcp/test_capture_frame.sh
@@ -56,17 +56,12 @@ try:
     r = call(3,"tools/call",{"name":"capture_frame","arguments":{}})
     d = r["result"]["structured"]
     assert "error" not in d, d
-    files = d["files"]
-    assert len(files) >= 1, d
-    # Every returned path should exist and have a non-trivial byte size.
-    for f in files:
-        assert os.path.isfile(f["path"]), f
-        assert f["size_bytes"] > 1024, f
-        with open(f["path"], "rb") as fh:
-            sig = fh.read(8)
-        assert sig[:8] == b"\x89PNG\r\n\x1a\n", f["path"]
-    names = sorted(os.path.basename(f["path"]) for f in files)
-    print(f"PASS (files={names})")
+    assert os.path.isfile(d["path"]), d
+    assert d["size_bytes"] > 1024, d
+    with open(d["path"], "rb") as fh:
+        sig = fh.read(8)
+    assert sig == b"\x89PNG\r\n\x1a\n", d
+    print(f"PASS ({os.path.basename(d['path'])}, {d['size_bytes']} bytes)")
 finally:
     try: p.stdin.close()
     except: pass

--- a/tests/mcp/test_capture_frame.sh
+++ b/tests/mcp/test_capture_frame.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Copyright 2026, DisplayXR / Leia Inc.
+# SPDX-License-Identifier: BSL-1.0
+#
+# MCP Phase A slice 6 test: capture_frame is registered and returns a
+# structured diagnostic when no compositor handler is installed. The
+# actual PNG-producing hook (Metal/GL on mac, D3D11 on Windows) is a
+# follow-up task — tracked in issue #153.
+
+set -u
+set -o pipefail
+
+if [[ "$(uname)" != "Darwin" ]]; then exit 0; fi
+
+cd "$(dirname "$0")/../.."
+ROOT="$(pwd)"
+ADAPTER="$ROOT/build/src/xrt/targets/mcp_adapter/displayxr-mcp"
+APP="$ROOT/test_apps/cube_handle_metal_macos/build/cube_handle_metal_macos"
+RUNTIME_JSON="$ROOT/build/openxr_displayxr-dev.json"
+for f in "$ADAPTER" "$APP" "$RUNTIME_JSON"; do
+	[[ -e "$f" ]] || { echo "FAIL: missing $f"; exit 1; }
+done
+export DISPLAYXR_MCP=1 XR_RUNTIME_JSON="$RUNTIME_JSON"
+"$APP" >/tmp/mcp_cap_app.log 2>&1 &
+APP_PID=$!
+trap 'kill $APP_PID 2>/dev/null; wait $APP_PID 2>/dev/null' EXIT
+SOCK="/tmp/displayxr-mcp-${APP_PID}.sock"
+for _ in $(seq 1 50); do [[ -S "$SOCK" ]] && break; sleep 0.1; done
+[[ -S "$SOCK" ]] || { echo "FAIL: no socket"; cat /tmp/mcp_cap_app.log; exit 1; }
+sleep 1
+
+python3 - "$ADAPTER" "$APP_PID" <<'PY'
+import json, subprocess, sys
+ad, pid = sys.argv[1], sys.argv[2]
+def fr(o):
+    b = json.dumps(o).encode()
+    return b"Content-Length: %d\r\n\r\n" % len(b) + b
+p = subprocess.Popen([ad,"--pid",pid], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+def rd():
+    h=b""
+    while b"\r\n\r\n" not in h and b"\n\n" not in h:
+        c=p.stdout.read(1)
+        if not c: raise RuntimeError(p.stderr.read().decode("utf-8","replace"))
+        h+=c
+    n=next(int(l.split(b":",1)[1]) for l in h.splitlines() if l.lower().startswith(b"content-length:"))
+    return json.loads(p.stdout.read(n))
+def call(i,m,a=None):
+    msg={"jsonrpc":"2.0","id":i,"method":m}
+    if a is not None: msg["params"]=a
+    p.stdin.write(fr(msg)); p.stdin.flush()
+    return rd()
+try:
+    call(1,"initialize",{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"t","version":"0"}})
+    r = call(2,"tools/list")
+    tools = {t["name"] for t in r["result"]["tools"]}
+    assert "capture_frame" in tools, tools
+    r = call(3,"tools/call",{"name":"capture_frame","arguments":{}})
+    d = r["result"]["structured"]
+    # Until the compositor hook lands, the tool returns a structured
+    # "not wired" diagnostic, not a JSON-RPC error.
+    assert "error" in d, d
+    assert "capture_frame" in d["error"], d
+    print("PASS")
+finally:
+    try: p.stdin.close()
+    except: pass
+    p.wait(timeout=3)
+PY
+RC=$?
+[[ $RC -eq 0 ]] && echo "test_capture_frame.sh: OK" || { echo "test_capture_frame.sh: FAIL"; cat /tmp/mcp_cap_app.log; }
+exit $RC

--- a/tests/mcp/test_capture_frame.sh
+++ b/tests/mcp/test_capture_frame.sh
@@ -2,10 +2,9 @@
 # Copyright 2026, DisplayXR / Leia Inc.
 # SPDX-License-Identifier: BSL-1.0
 #
-# MCP Phase A slice 6 test: capture_frame is registered and returns a
-# structured diagnostic when no compositor handler is installed. The
-# actual PNG-producing hook (Metal/GL on mac, D3D11 on Windows) is a
-# follow-up task — tracked in issue #153.
+# MCP capture_frame end-to-end test: drives a capture against a running
+# cube_handle_metal_macos and asserts the returned PNG paths exist and
+# are non-trivial.
 
 set -u
 set -o pipefail
@@ -27,10 +26,10 @@ trap 'kill $APP_PID 2>/dev/null; wait $APP_PID 2>/dev/null' EXIT
 SOCK="/tmp/displayxr-mcp-${APP_PID}.sock"
 for _ in $(seq 1 50); do [[ -S "$SOCK" ]] && break; sleep 0.1; done
 [[ -S "$SOCK" ]] || { echo "FAIL: no socket"; cat /tmp/mcp_cap_app.log; exit 1; }
-sleep 1
+sleep 2
 
 python3 - "$ADAPTER" "$APP_PID" <<'PY'
-import json, subprocess, sys
+import json, os, subprocess, sys
 ad, pid = sys.argv[1], sys.argv[2]
 def fr(o):
     b = json.dumps(o).encode()
@@ -56,11 +55,18 @@ try:
     assert "capture_frame" in tools, tools
     r = call(3,"tools/call",{"name":"capture_frame","arguments":{}})
     d = r["result"]["structured"]
-    # Until the compositor hook lands, the tool returns a structured
-    # "not wired" diagnostic, not a JSON-RPC error.
-    assert "error" in d, d
-    assert "capture_frame" in d["error"], d
-    print("PASS")
+    assert "error" not in d, d
+    files = d["files"]
+    assert len(files) >= 1, d
+    # Every returned path should exist and have a non-trivial byte size.
+    for f in files:
+        assert os.path.isfile(f["path"]), f
+        assert f["size_bytes"] > 1024, f
+        with open(f["path"], "rb") as fh:
+            sig = fh.read(8)
+        assert sig[:8] == b"\x89PNG\r\n\x1a\n", f["path"]
+    names = sorted(os.path.basename(f["path"]) for f in files)
+    print(f"PASS (files={names})")
 finally:
     try: p.stdin.close()
     except: pass

--- a/tests/mcp/test_capture_frame_gl.sh
+++ b/tests/mcp/test_capture_frame_gl.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Copyright 2026, DisplayXR / Leia Inc.
+# SPDX-License-Identifier: BSL-1.0
+#
+# MCP capture_frame end-to-end test on the OpenGL native compositor.
+
+set -u
+set -o pipefail
+
+if [[ "$(uname)" != "Darwin" ]]; then exit 0; fi
+
+cd "$(dirname "$0")/../.."
+ROOT="$(pwd)"
+ADAPTER="$ROOT/build/src/xrt/targets/mcp_adapter/displayxr-mcp"
+APP="$ROOT/test_apps/cube_handle_gl_macos/build/cube_handle_gl_macos"
+RUNTIME_JSON="$ROOT/build/openxr_displayxr-dev.json"
+for f in "$ADAPTER" "$APP" "$RUNTIME_JSON"; do
+	[[ -e "$f" ]] || { echo "FAIL: missing $f"; exit 1; }
+done
+export DISPLAYXR_MCP=1 XR_RUNTIME_JSON="$RUNTIME_JSON"
+"$APP" >/tmp/mcp_cap_gl_app.log 2>&1 &
+APP_PID=$!
+trap 'kill $APP_PID 2>/dev/null; wait $APP_PID 2>/dev/null' EXIT
+SOCK="/tmp/displayxr-mcp-${APP_PID}.sock"
+for _ in $(seq 1 50); do [[ -S "$SOCK" ]] && break; sleep 0.1; done
+[[ -S "$SOCK" ]] || { echo "FAIL: no socket"; cat /tmp/mcp_cap_gl_app.log; exit 1; }
+sleep 2
+
+python3 - "$ADAPTER" "$APP_PID" <<'PY'
+import json, os, subprocess, sys
+ad, pid = sys.argv[1], sys.argv[2]
+def fr(o):
+    b = json.dumps(o).encode()
+    return b"Content-Length: %d\r\n\r\n" % len(b) + b
+p = subprocess.Popen([ad,"--pid",pid], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+def rd():
+    h=b""
+    while b"\r\n\r\n" not in h and b"\n\n" not in h:
+        c=p.stdout.read(1)
+        if not c: raise RuntimeError(p.stderr.read().decode("utf-8","replace"))
+        h+=c
+    n=next(int(l.split(b":",1)[1]) for l in h.splitlines() if l.lower().startswith(b"content-length:"))
+    return json.loads(p.stdout.read(n))
+def call(i,m,a=None):
+    msg={"jsonrpc":"2.0","id":i,"method":m}
+    if a is not None: msg["params"]=a
+    p.stdin.write(fr(msg)); p.stdin.flush()
+    return rd()
+try:
+    call(1,"initialize",{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"t","version":"0"}})
+    # Confirm we really are talking to the GL compositor.
+    s = call(2,"tools/call",{"name":"list_sessions","arguments":{}})["result"]["structured"]
+    assert s["sessions"][0]["api"] == "opengl", s
+    r = call(3,"tools/call",{"name":"capture_frame","arguments":{}})
+    d = r["result"]["structured"]
+    files = d.get("files", [])
+    assert len(files) >= 1, d
+    for f in files:
+        assert os.path.isfile(f["path"]), f
+        assert f["size_bytes"] > 1024, f
+        with open(f["path"], "rb") as fh:
+            assert fh.read(8) == b"\x89PNG\r\n\x1a\n", f["path"]
+    print(f"PASS (files={sorted(os.path.basename(f['path']).split('_',1)[-1] for f in files)})")
+finally:
+    try: p.stdin.close()
+    except: pass
+    p.wait(timeout=3)
+PY
+RC=$?
+[[ $RC -eq 0 ]] && echo "test_capture_frame_gl.sh: OK" || { echo "test_capture_frame_gl.sh: FAIL"; cat /tmp/mcp_cap_gl_app.log; }
+exit $RC

--- a/tests/mcp/test_capture_frame_gl.sh
+++ b/tests/mcp/test_capture_frame_gl.sh
@@ -53,14 +53,12 @@ try:
     assert s["sessions"][0]["api"] == "opengl", s
     r = call(3,"tools/call",{"name":"capture_frame","arguments":{}})
     d = r["result"]["structured"]
-    files = d.get("files", [])
-    assert len(files) >= 1, d
-    for f in files:
-        assert os.path.isfile(f["path"]), f
-        assert f["size_bytes"] > 1024, f
-        with open(f["path"], "rb") as fh:
-            assert fh.read(8) == b"\x89PNG\r\n\x1a\n", f["path"]
-    print(f"PASS (files={sorted(os.path.basename(f['path']).split('_',1)[-1] for f in files)})")
+    assert "error" not in d, d
+    assert os.path.isfile(d["path"]), d
+    assert d["size_bytes"] > 1024, d
+    with open(d["path"], "rb") as fh:
+        assert fh.read(8) == b"\x89PNG\r\n\x1a\n", d
+    print(f"PASS ({os.path.basename(d['path'])}, {d['size_bytes']} bytes)")
 finally:
     try: p.stdin.close()
     except: pass

--- a/tests/mcp/test_core_tools.sh
+++ b/tests/mcp/test_core_tools.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Copyright 2026, DisplayXR / Leia Inc.
+# SPDX-License-Identifier: BSL-1.0
+#
+# MCP Phase A slice 2 test: list_sessions / get_display_info /
+# get_runtime_metrics round-trip via the stdio adapter.
+
+set -u
+set -o pipefail
+
+if [[ "$(uname)" != "Darwin" ]]; then
+	echo "skip: mac-only test" >&2
+	exit 0
+fi
+
+cd "$(dirname "$0")/../.."
+ROOT="$(pwd)"
+
+ADAPTER="$ROOT/build/src/xrt/targets/mcp_adapter/displayxr-mcp"
+APP="$ROOT/test_apps/cube_handle_metal_macos/build/cube_handle_metal_macos"
+RUNTIME_JSON="$ROOT/build/openxr_displayxr-dev.json"
+
+for f in "$ADAPTER" "$APP" "$RUNTIME_JSON"; do
+	if [[ ! -e "$f" ]]; then
+		echo "FAIL: missing $f — run ./scripts/build_macos.sh first" >&2
+		exit 1
+	fi
+done
+
+export DISPLAYXR_MCP=1
+export XR_RUNTIME_JSON="$RUNTIME_JSON"
+
+"$APP" >/tmp/mcp_core_app.log 2>&1 &
+APP_PID=$!
+trap 'kill $APP_PID 2>/dev/null; wait $APP_PID 2>/dev/null' EXIT
+
+SOCK="/tmp/displayxr-mcp-${APP_PID}.sock"
+for _ in $(seq 1 50); do
+	[[ -S "$SOCK" ]] && break
+	sleep 0.1
+done
+[[ -S "$SOCK" ]] || { echo "FAIL: socket never appeared"; cat /tmp/mcp_core_app.log; exit 1; }
+
+# Give the app a moment to create its XrSession so the tool handlers
+# see an attached session — list_sessions returns empty pre-session.
+sleep 1
+
+python3 - "$ADAPTER" "$APP_PID" <<'PY'
+import json, subprocess, sys
+
+adapter, pid = sys.argv[1], sys.argv[2]
+
+def frame(obj):
+    body = json.dumps(obj).encode()
+    return b"Content-Length: %d\r\n\r\n" % len(body) + body
+
+proc = subprocess.Popen(
+    [adapter, "--pid", pid],
+    stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+)
+
+def read_frame(p):
+    hdr = b""
+    while b"\r\n\r\n" not in hdr and b"\n\n" not in hdr:
+        c = p.stdout.read(1)
+        if not c:
+            raise RuntimeError("EOF: " + p.stderr.read().decode("utf-8", "replace"))
+        hdr += c
+    clen = next(int(l.split(b":",1)[1]) for l in hdr.splitlines() if l.lower().startswith(b"content-length:"))
+    return json.loads(p.stdout.read(clen))
+
+def call(i, method, params=None):
+    msg = {"jsonrpc":"2.0","id":i,"method":method}
+    if params is not None: msg["params"] = params
+    proc.stdin.write(frame(msg)); proc.stdin.flush()
+    return read_frame(proc)
+
+try:
+    r = call(1, "initialize", {"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"0"}})
+    assert r["result"]["serverInfo"]["name"] == "displayxr-mcp", r
+
+    r = call(2, "tools/list")
+    tools = {t["name"] for t in r["result"]["tools"]}
+    for needed in ("echo","list_sessions","get_display_info","get_runtime_metrics"):
+        assert needed in tools, f"missing tool {needed} in {tools}"
+
+    r = call(3, "tools/call", {"name":"list_sessions","arguments":{}})
+    sessions = r["result"]["structured"]["sessions"]
+    assert len(sessions) == 1, f"expected 1 session, got {sessions}"
+    assert sessions[0]["api"] == "metal", sessions
+    assert sessions[0]["view_count"] >= 1, sessions
+
+    r = call(4, "tools/call", {"name":"get_display_info","arguments":{}})
+    di = r["result"]["structured"]
+    assert "physical_size" in di, di
+    assert "panel" in di, di
+    assert "views" in di and len(di["views"]) >= 1, di
+    assert di["view_count"] == len(di["views"]), di
+
+    r = call(5, "tools/call", {"name":"get_runtime_metrics","arguments":{}})
+    m = r["result"]["structured"]
+    assert m["gfx_api"] == "metal", m
+    assert "frames_begun" in m, m
+
+    print("PASS")
+finally:
+    try: proc.stdin.close()
+    except: pass
+    proc.wait(timeout=3)
+PY
+RC=$?
+[[ $RC -eq 0 ]] && echo "test_core_tools.sh: OK" || { echo "test_core_tools.sh: FAIL"; cat /tmp/mcp_core_app.log; }
+exit $RC

--- a/tests/mcp/test_diff_projection.sh
+++ b/tests/mcp/test_diff_projection.sh
@@ -59,18 +59,18 @@ try:
     assert len(d["views"]) == d["view_count"], d
     v0 = d["views"][0]
     assert "metrics" in v0 and "declared_fov_aspect_wh" in v0["metrics"], v0
-    # cube_handle_metal_macos recomputes Kooima client-side instead of
-    # forwarding the runtime's recommendation, so the tool may flag
-    # app_ignores_recommended / stale_head_pose — that's a working tool,
-    # not a failure. We only assert that every flag is a known class.
+    # cube_handle_metal_macos recomputes Kooima client-side — the tool
+    # surfaces that as an "app_not_forwarding_locate_views_*" observation
+    # (neutral, not a bug). Only aspect-class mismatches flip
+    # pipeline_consistent to false.
     known = {
-        "app_ignores_recommended",
+        "app_not_forwarding_locate_views_fov",
+        "app_not_forwarding_locate_views_pose",
         "fov_aspect_mismatch_subimage",
         "fov_aspect_mismatch_display",
-        "stale_head_pose",
     }
     assert set(d["flags"]).issubset(known), f"unexpected flag in {d['flags']}"
-    print(f"PASS (flags={d['flags']}, ok={d['ok']})")
+    print(f"PASS (flags={d['flags']}, pipeline_consistent={d['pipeline_consistent']})")
 finally:
     try: p.stdin.close()
     except: pass

--- a/tests/mcp/test_diff_projection.sh
+++ b/tests/mcp/test_diff_projection.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Copyright 2026, DisplayXR / Leia Inc.
+# SPDX-License-Identifier: BSL-1.0
+#
+# MCP Phase A slice 4 test: diff_projection on a well-behaved handle app
+# (cube_handle_metal_macos) should return ok=true with an empty flags
+# array. Exercising the bug-class triggers requires a deliberately-
+# broken app and is deferred to an end-to-end demo (demo_maya.sh).
+
+set -u
+set -o pipefail
+
+if [[ "$(uname)" != "Darwin" ]]; then exit 0; fi
+
+cd "$(dirname "$0")/../.."
+ROOT="$(pwd)"
+ADAPTER="$ROOT/build/src/xrt/targets/mcp_adapter/displayxr-mcp"
+APP="$ROOT/test_apps/cube_handle_metal_macos/build/cube_handle_metal_macos"
+RUNTIME_JSON="$ROOT/build/openxr_displayxr-dev.json"
+for f in "$ADAPTER" "$APP" "$RUNTIME_JSON"; do
+	[[ -e "$f" ]] || { echo "FAIL: missing $f"; exit 1; }
+done
+export DISPLAYXR_MCP=1 XR_RUNTIME_JSON="$RUNTIME_JSON"
+"$APP" >/tmp/mcp_diff_app.log 2>&1 &
+APP_PID=$!
+trap 'kill $APP_PID 2>/dev/null; wait $APP_PID 2>/dev/null' EXIT
+SOCK="/tmp/displayxr-mcp-${APP_PID}.sock"
+for _ in $(seq 1 50); do [[ -S "$SOCK" ]] && break; sleep 0.1; done
+[[ -S "$SOCK" ]] || { echo "FAIL: no socket"; cat /tmp/mcp_diff_app.log; exit 1; }
+sleep 2
+
+python3 - "$ADAPTER" "$APP_PID" <<'PY'
+import json, subprocess, sys
+ad, pid = sys.argv[1], sys.argv[2]
+def fr(o):
+    b = json.dumps(o).encode()
+    return b"Content-Length: %d\r\n\r\n" % len(b) + b
+p = subprocess.Popen([ad,"--pid",pid], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+def rd():
+    h=b""
+    while b"\r\n\r\n" not in h and b"\n\n" not in h:
+        c=p.stdout.read(1)
+        if not c: raise RuntimeError(p.stderr.read().decode("utf-8","replace"))
+        h+=c
+    n=next(int(l.split(b":",1)[1]) for l in h.splitlines() if l.lower().startswith(b"content-length:"))
+    return json.loads(p.stdout.read(n))
+def call(i,m,ar=None):
+    msg={"jsonrpc":"2.0","id":i,"method":m}
+    if ar is not None: msg["params"]=ar
+    p.stdin.write(fr(msg)); p.stdin.flush()
+    return rd()
+try:
+    call(1,"initialize",{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"t","version":"0"}})
+    r = call(2,"tools/call",{"name":"diff_projection","arguments":{}})
+    d = r["result"]["structured"]
+    assert "error" not in d, d
+    assert "flags" in d and isinstance(d["flags"], list), d
+    assert d["view_count"] >= 1, d
+    assert len(d["views"]) == d["view_count"], d
+    v0 = d["views"][0]
+    assert "metrics" in v0 and "declared_fov_aspect_wh" in v0["metrics"], v0
+    # cube_handle_metal_macos recomputes Kooima client-side instead of
+    # forwarding the runtime's recommendation, so the tool may flag
+    # app_ignores_recommended / stale_head_pose — that's a working tool,
+    # not a failure. We only assert that every flag is a known class.
+    known = {
+        "app_ignores_recommended",
+        "fov_aspect_mismatch_subimage",
+        "fov_aspect_mismatch_display",
+        "stale_head_pose",
+    }
+    assert set(d["flags"]).issubset(known), f"unexpected flag in {d['flags']}"
+    print(f"PASS (flags={d['flags']}, ok={d['ok']})")
+finally:
+    try: p.stdin.close()
+    except: pass
+    p.wait(timeout=3)
+PY
+RC=$?
+[[ $RC -eq 0 ]] && echo "test_diff_projection.sh: OK" || { echo "test_diff_projection.sh: FAIL"; cat /tmp/mcp_diff_app.log; }
+exit $RC

--- a/tests/mcp/test_handshake.sh
+++ b/tests/mcp/test_handshake.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Copyright 2026, DisplayXR / Leia Inc.
+# SPDX-License-Identifier: BSL-1.0
+#
+# MCP Phase A slice 1 handshake test.
+#
+# Launches cube_handle_metal_macos with DISPLAYXR_MCP=1 and verifies that
+# the runtime's MCP server accepts an `initialize` + `echo` round-trip via
+# the displayxr-mcp stdio adapter.
+#
+# Exit 0 = pass, nonzero = fail.
+
+set -u
+set -o pipefail
+
+if [[ "$(uname)" != "Darwin" ]]; then
+	echo "skip: mac-only test" >&2
+	exit 0
+fi
+
+cd "$(dirname "$0")/../.."
+ROOT="$(pwd)"
+
+ADAPTER="$ROOT/build/src/xrt/targets/mcp_adapter/displayxr-mcp"
+APP="$ROOT/test_apps/cube_handle_metal_macos/build/cube_handle_metal_macos"
+RUNTIME_JSON="$ROOT/build/openxr_displayxr-dev.json"
+
+for f in "$ADAPTER" "$APP" "$RUNTIME_JSON"; do
+	if [[ ! -e "$f" ]]; then
+		echo "FAIL: missing $f — run ./scripts/build_macos.sh first" >&2
+		exit 1
+	fi
+done
+
+export DISPLAYXR_MCP=1
+export XR_RUNTIME_JSON="$RUNTIME_JSON"
+
+# Launch the handle app detached.
+"$APP" >/tmp/mcp_handshake_app.log 2>&1 &
+APP_PID=$!
+
+cleanup() {
+	kill "$APP_PID" 2>/dev/null || true
+	wait "$APP_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# Wait for the MCP socket to appear.
+SOCK="/tmp/displayxr-mcp-${APP_PID}.sock"
+for _ in $(seq 1 50); do
+	[[ -S "$SOCK" ]] && break
+	sleep 0.1
+done
+if [[ ! -S "$SOCK" ]]; then
+	echo "FAIL: socket $SOCK never appeared (app log:)" >&2
+	cat /tmp/mcp_handshake_app.log >&2 || true
+	exit 1
+fi
+
+# Drive an initialize + tools/call echo round-trip through the adapter.
+python3 - "$ADAPTER" "$APP_PID" <<'PY'
+import json, os, subprocess, sys
+
+adapter, pid = sys.argv[1], sys.argv[2]
+
+def frame(obj):
+    body = json.dumps(obj).encode()
+    return b"Content-Length: %d\r\n\r\n" % len(body) + body
+
+proc = subprocess.Popen(
+    [adapter, "--pid", pid],
+    stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+)
+
+def read_frame(p):
+    hdr = b""
+    while b"\r\n\r\n" not in hdr and b"\n\n" not in hdr:
+        c = p.stdout.read(1)
+        if not c:
+            raise RuntimeError("EOF reading header; stderr=%s" % p.stderr.read().decode("utf-8", "replace"))
+        hdr += c
+    clen = None
+    for line in hdr.splitlines():
+        if line.lower().startswith(b"content-length:"):
+            clen = int(line.split(b":", 1)[1].strip())
+    if clen is None:
+        raise RuntimeError("no Content-Length in %r" % hdr)
+    return json.loads(p.stdout.read(clen))
+
+try:
+    proc.stdin.write(frame({
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+        "params": {"protocolVersion": "2024-11-05", "capabilities": {}, "clientInfo": {"name": "test", "version": "0"}},
+    }))
+    proc.stdin.flush()
+    r = read_frame(proc)
+    assert r.get("id") == 1, r
+    assert r.get("result", {}).get("serverInfo", {}).get("name") == "displayxr-mcp", r
+
+    proc.stdin.write(frame({
+        "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+        "params": {"name": "echo", "arguments": {"hello": "mcp"}},
+    }))
+    proc.stdin.flush()
+    r = read_frame(proc)
+    assert r.get("id") == 2, r
+    structured = r["result"]["structured"]
+    assert structured["echo"] == {"hello": "mcp"}, r
+    print("PASS")
+finally:
+    try:
+        proc.stdin.close()
+    except Exception:
+        pass
+    proc.wait(timeout=3)
+PY
+RC=$?
+
+if [[ $RC -eq 0 ]]; then
+	echo "test_handshake.sh: OK"
+else
+	echo "test_handshake.sh: FAIL (rc=$RC)" >&2
+	echo "--- app log ---" >&2
+	cat /tmp/mcp_handshake_app.log >&2 || true
+fi
+exit $RC

--- a/tests/mcp/test_snapshot.sh
+++ b/tests/mcp/test_snapshot.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Copyright 2026, DisplayXR / Leia Inc.
+# SPDX-License-Identifier: BSL-1.0
+#
+# MCP Phase A slice 3 test: get_kooima_params / get_submitted_projection
+# return matching-shape per-view data from a running handle app.
+
+set -u
+set -o pipefail
+
+if [[ "$(uname)" != "Darwin" ]]; then exit 0; fi
+
+cd "$(dirname "$0")/../.."
+ROOT="$(pwd)"
+
+ADAPTER="$ROOT/build/src/xrt/targets/mcp_adapter/displayxr-mcp"
+APP="$ROOT/test_apps/cube_handle_metal_macos/build/cube_handle_metal_macos"
+RUNTIME_JSON="$ROOT/build/openxr_displayxr-dev.json"
+
+for f in "$ADAPTER" "$APP" "$RUNTIME_JSON"; do
+	[[ -e "$f" ]] || { echo "FAIL: missing $f"; exit 1; }
+done
+
+export DISPLAYXR_MCP=1 XR_RUNTIME_JSON="$RUNTIME_JSON"
+"$APP" >/tmp/mcp_snap_app.log 2>&1 &
+APP_PID=$!
+trap 'kill $APP_PID 2>/dev/null; wait $APP_PID 2>/dev/null' EXIT
+
+SOCK="/tmp/displayxr-mcp-${APP_PID}.sock"
+for _ in $(seq 1 50); do [[ -S "$SOCK" ]] && break; sleep 0.1; done
+[[ -S "$SOCK" ]] || { echo "FAIL: no socket"; cat /tmp/mcp_snap_app.log; exit 1; }
+
+# Give the app time to run xrLocateViews + xrEndFrame at least once.
+sleep 2
+
+python3 - "$ADAPTER" "$APP_PID" <<'PY'
+import json, subprocess, sys
+adapter, pid = sys.argv[1], sys.argv[2]
+def frame(o):
+    b = json.dumps(o).encode()
+    return b"Content-Length: %d\r\n\r\n" % len(b) + b
+p = subprocess.Popen([adapter,"--pid",pid], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+def read():
+    h = b""
+    while b"\r\n\r\n" not in h and b"\n\n" not in h:
+        c = p.stdout.read(1)
+        if not c: raise RuntimeError("EOF: "+p.stderr.read().decode("utf-8","replace"))
+        h += c
+    n = next(int(l.split(b":",1)[1]) for l in h.splitlines() if l.lower().startswith(b"content-length:"))
+    return json.loads(p.stdout.read(n))
+def call(i,m,par=None):
+    msg={"jsonrpc":"2.0","id":i,"method":m}
+    if par is not None: msg["params"]=par
+    p.stdin.write(frame(msg)); p.stdin.flush()
+    return read()
+try:
+    call(1,"initialize",{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"t","version":"0"}})
+
+    r = call(2,"tools/call",{"name":"get_kooima_params","arguments":{}})
+    k = r["result"]["structured"]
+    assert "error" not in k, k
+    assert k["view_count"] >= 1, k
+    assert len(k["views"]) == k["view_count"], k
+    assert "recommended_pose" in k["views"][0] and "recommended_fov" in k["views"][0], k
+    assert "display" in k, k
+
+    r = call(3,"tools/call",{"name":"get_submitted_projection","arguments":{}})
+    s = r["result"]["structured"]
+    assert "error" not in s, s
+    assert s["view_count"] == k["view_count"], (s, k)
+    assert "declared_pose" in s["views"][0] and "declared_fov" in s["views"][0] and "subimage" in s["views"][0], s
+    print("PASS")
+finally:
+    try: p.stdin.close()
+    except: pass
+    p.wait(timeout=3)
+PY
+RC=$?
+[[ $RC -eq 0 ]] && echo "test_snapshot.sh: OK" || { echo "test_snapshot.sh: FAIL"; cat /tmp/mcp_snap_app.log; }
+exit $RC

--- a/tests/mcp/test_snapshot.sh
+++ b/tests/mcp/test_snapshot.sh
@@ -67,7 +67,8 @@ try:
     r = call(3,"tools/call",{"name":"get_submitted_projection","arguments":{}})
     s = r["result"]["structured"]
     assert "error" not in s, s
-    assert s["view_count"] == k["view_count"], (s, k)
+    # declared view_count can be < recommended (active mode vs. system max).
+    assert 1 <= s["view_count"] <= k["view_count"], (s, k)
     assert "declared_pose" in s["views"][0] and "declared_fov" in s["views"][0] and "subimage" in s["views"][0], s
     print("PASS")
 finally:

--- a/tests/mcp/test_tail_log.sh
+++ b/tests/mcp/test_tail_log.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Copyright 2026, DisplayXR / Leia Inc.
+# SPDX-License-Identifier: BSL-1.0
+#
+# MCP Phase A slice 5 test: tail_log returns buffered U_LOG lines with
+# monotonic seq, and cursor advances across calls.
+
+set -u
+set -o pipefail
+
+if [[ "$(uname)" != "Darwin" ]]; then exit 0; fi
+
+cd "$(dirname "$0")/../.."
+ROOT="$(pwd)"
+ADAPTER="$ROOT/build/src/xrt/targets/mcp_adapter/displayxr-mcp"
+APP="$ROOT/test_apps/cube_handle_metal_macos/build/cube_handle_metal_macos"
+RUNTIME_JSON="$ROOT/build/openxr_displayxr-dev.json"
+for f in "$ADAPTER" "$APP" "$RUNTIME_JSON"; do
+	[[ -e "$f" ]] || { echo "FAIL: missing $f"; exit 1; }
+done
+export DISPLAYXR_MCP=1 XR_RUNTIME_JSON="$RUNTIME_JSON" XRT_LOG=info
+"$APP" >/tmp/mcp_log_app.log 2>&1 &
+APP_PID=$!
+trap 'kill $APP_PID 2>/dev/null; wait $APP_PID 2>/dev/null' EXIT
+SOCK="/tmp/displayxr-mcp-${APP_PID}.sock"
+for _ in $(seq 1 50); do [[ -S "$SOCK" ]] && break; sleep 0.1; done
+[[ -S "$SOCK" ]] || { echo "FAIL: no socket"; cat /tmp/mcp_log_app.log; exit 1; }
+sleep 1
+
+python3 - "$ADAPTER" "$APP_PID" <<'PY'
+import json, subprocess, sys, time
+ad, pid = sys.argv[1], sys.argv[2]
+def fr(o):
+    b = json.dumps(o).encode()
+    return b"Content-Length: %d\r\n\r\n" % len(b) + b
+p = subprocess.Popen([ad,"--pid",pid], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+def rd():
+    h=b""
+    while b"\r\n\r\n" not in h and b"\n\n" not in h:
+        c=p.stdout.read(1)
+        if not c: raise RuntimeError(p.stderr.read().decode("utf-8","replace"))
+        h+=c
+    n=next(int(l.split(b":",1)[1]) for l in h.splitlines() if l.lower().startswith(b"content-length:"))
+    return json.loads(p.stdout.read(n))
+def call(i,m,a=None):
+    msg={"jsonrpc":"2.0","id":i,"method":m}
+    if a is not None: msg["params"]=a
+    p.stdin.write(fr(msg)); p.stdin.flush()
+    return rd()
+try:
+    call(1,"initialize",{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"t","version":"0"}})
+    r = call(2,"tools/call",{"name":"tail_log","arguments":{"since":0,"max":16}})
+    d = r["result"]["structured"]
+    assert "entries" in d and "cursor" in d, d
+    assert isinstance(d["entries"], list), d
+    # We should have buffered at least a few INFO/WARN lines from startup.
+    assert len(d["entries"]) > 0, d
+    for e in d["entries"]:
+        assert "seq" in e and "text" in e and "level" in e, e
+    first_cursor = d["cursor"]
+
+    # Second call advances cursor to the latest.
+    time.sleep(0.5)
+    r2 = call(3,"tools/call",{"name":"tail_log","arguments":{"since":first_cursor,"max":16}})
+    d2 = r2["result"]["structured"]
+    assert d2["cursor"] >= first_cursor, (first_cursor, d2)
+    # Every returned entry must have seq > first_cursor.
+    for e in d2["entries"]:
+        assert e["seq"] > first_cursor, (first_cursor, e)
+    print(f"PASS (first={len(d['entries'])} second={len(d2['entries'])} cursor {first_cursor}->{d2['cursor']})")
+finally:
+    try: p.stdin.close()
+    except: pass
+    p.wait(timeout=3)
+PY
+RC=$?
+[[ $RC -eq 0 ]] && echo "test_tail_log.sh: OK" || { echo "test_tail_log.sh: FAIL"; cat /tmp/mcp_log_app.log; }
+exit $RC


### PR DESCRIPTION
Replaces #154 (which auto-closed when the source branch was renamed from \`feature/mcp-phase-a-ci\` to \`feature/mcp-phase-a\` to stop CI from firing on every push).

## Summary

Opt-in in-process MCP server inside \`libopenxr_displayxr\` + \`displayxr-mcp\` stdio adapter. Exposes 8 tools over a per-PID unix socket (mac) / named pipe (Windows) so Claude Code / Cursor can introspect a running handle-app session. Zero runtime cost when \`DISPLAYXR_MCP\` is unset.

- **Spec:** \`docs/roadmap/mcp-spec-v0.2.md\` §3.1, §4.A, §4.C
- **Plan:** \`docs/roadmap/mcp-phase-a-plan.md\`
- **Status:** \`docs/roadmap/mcp-phase-a-status.md\`
- **Tracking issue:** #150
- **Sub-issue:** #153 (capture_frame per-compositor hooks — closed, all three landed)

## Tools

\`list_sessions\`, \`get_display_info\`, \`get_runtime_metrics\`, \`get_kooima_params\`, \`get_submitted_projection\`, \`diff_projection\`, \`capture_frame\`, \`tail_log\`.

\`capture_frame\` writes a single PNG of the **content region** the compositor crops and hands to the display processor — i.e. exactly what the app wrote into its swapchain (3024×823 in the mac sim_display test).

## Test plan

- [x] \`./scripts/build_macos.sh\` succeeds
- [x] All scripted tests green (\`tests/mcp/test_*.sh\`)
- [x] \`tests/mcp/demo_maya.sh\` green end-to-end (Metal + capture)
- [x] Runtime with \`DISPLAYXR_MCP\` unset: no socket, no log-ring sink
- [ ] Local Windows build (will validate before merge — branch dropped \`-ci\` suffix to avoid burning remote CI on iteration)
- [ ] Validation on a Leia SR display (named-pipe transport + D3D11 capture)

🤖 Generated with [Claude Code](https://claude.com/claude-code)