### PR TITLE
Shell Phase 8 + D3D11 stereo view scale fix (#43, #158, #151)

### DIFF
--- a/docs/internal/issue-158-agent-prompt.md
+++ b/docs/internal/issue-158-agent-prompt.md
@@ -1,0 +1,89 @@
+# Issue #158 Handoff: D3D11 service — stereo view_height ignores rendering_mode view_scale_y
+
+Use this prompt to start a fresh Claude Code session for fixing the compositor per-view stretch bug that Phase 8 capture made visible.
+
+---
+
+## Prompt
+
+```
+I'm working on the DisplayXR runtime. Issue #158 is a D3D11 service-compositor bug: in stereo SBS (2×1) render mode the per-view tile is allocated/used at 2× the correct vertical resolution, so each eye's content is rendered stretched 2× vertically. Please implement the fix.
+
+## Context (read in order)
+
+1. `CLAUDE.md` — project overview, build commands, architecture
+2. Issue text on GitHub: https://github.com/DisplayXR/displayxr-runtime-pvt/issues/158
+3. Phase 8 status doc `docs/roadmap/shell-phase8-status.md` — Phase 8 surfaced the bug; the capture code intentionally dumps the full atlas uncropped for now, and re-adding the crop depends on this fix.
+4. `src/xrt/include/xrt/xrt_device.h` lines 234–251 — the `xrt_rendering_mode` struct. Note the vendor-set `view_scale_x/y` and the runtime-computed `view_width_pixels / view_height_pixels / atlas_width_pixels / atlas_height_pixels`.
+
+## Current state on `main`
+
+- Phase 8 MVP shipped on `feature/shell-phase8` (not yet merged). The capture code dumps the full atlas so this bug is visible in captures as vertically-stretched per-eye content.
+- `docs/roadmap/shell-phase8-plan.md` and status doc describe what Phase 8 does and why capture is currently uncropped.
+
+## Bug
+
+`src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp:859-860`:
+
+    sys->view_width  = sys->display_width  / sys->tile_columns;
+    sys->view_height = sys->display_height / sys->tile_rows;
+
+For stereo on a 4K display (`tile_columns=2, tile_rows=1`): view = 3840/2 × 2160/1 = 1920×2160 — effective scale 0.5 × 1.0. For 2×2 quad view this formula happens to produce the right answer (1920×1080) because `tile_rows=2`, which is why nobody noticed.
+
+Similar divide-by-tile computations exist at lines ~1929-1930 and ~5466-5467. Check whether they need the same treatment or whether they're correct as-is.
+
+## Proposed fix
+
+Use the precomputed values on `xrt_rendering_mode`:
+
+    sys->view_width  = sys->xdev->rendering_modes[idx].view_width_pixels;
+    sys->view_height = sys->xdev->rendering_modes[idx].view_height_pixels;
+
+Atlas allocation stays at `display_pixel_width × display_pixel_height` (worst-case swapchain sizing — that part is correct). The compositor should render each client into its top-left per-tile rect at `view_w × view_h`, leaving the remainder of the tile (and anything outside `(view_w × tile_cols) × (view_h × tile_rows)`) black. The display processor crop-blits the active region to the weaver.
+
+Driver side: confirm the Leia SR driver populates `view_scale_x/y` and that `u_tiling_compute_mode` (or equivalent) computes `view_width_pixels / view_height_pixels` correctly. Grep the codebase for `view_scale_x`, `view_scale_y`, `view_width_pixels`, `u_tiling_compute_mode`.
+
+## Tasks (suggested split)
+
+1. **Trace**: grep every site in the D3D11 service compositor that computes per-view dims by dividing display dims. Decide which are correct (2×2 quad math) vs bugs (stereo 2×1). Likely candidates already known: lines ~859-860, ~1929-1930, ~5466-5467.
+2. **Driver audit**: verify the Leia SR driver (`src/xrt/drivers/leia/`) sets `view_scale_x/y` and that modes are populated so `rendering_modes[idx].view_width_pixels/view_height_pixels` are meaningful at the call sites.
+3. **Fix**: replace the divide-by-tile code with reads from `rendering_modes[idx]`. Handle the case where the mode's `view_width_pixels` is 0 (fall back to the old formula, log a warning).
+4. **Verify compositor render path respects the smaller tile**: the per-client draw into the atlas must use `view_w × view_h` as the dst rect, not `atlas_w/tile_columns × atlas_h/tile_rows`. Grep for where client swapchains are blit into `combined_atlas` (search for `combined_atlas_rtv`, `ca_rtvs`, `dst_rect`).
+5. **Re-enable capture crop** (optional, tied to Phase 8): once the atlas has natural black padding outside the active region, restore the `(view_w × tile_cols) × (view_h × tile_rows)` crop in `comp_d3d11_service_capture_frame` so Phase 8 captures drop the black padding. The previous crop code is in the Phase 8 commits on `feature/shell-phase8`; the revert commit is `0773e5388`.
+
+## Verification
+
+1. Build locally:
+   ```
+   scripts\build_windows.bat build
+   ```
+2. Stop any running service/shell and redeploy to `C:\Program Files\DisplayXR\Runtime\` (both `displayxr-service.exe` AND `DisplayXRClient.dll` per `feedback_dll_version_mismatch.md`).
+3. Launch the shell with the D3D11 cube app and press **Ctrl+Shift+C** to capture:
+   ```
+   _package\bin\displayxr-shell.exe test_apps\cube_handle_d3d11_win\build\cube_handle_d3d11_win.exe
+   ```
+4. Inspect `%USERPROFILE%\Pictures\DisplayXR\capture_*_sbs.png`:
+   - Atlas should still be 3840×2160 (full swapchain)
+   - Each eye tile should show correct 16:9 content at `1920×1080` in the top-left of its tile (top 3840×1080 of the atlas)
+   - The lower 3840×1080 strip of the atlas should be black
+   - Cubes should have natural aspect, not tall/narrow
+5. Check non-captured live display: per-eye content should no longer look horizontally-squashed on the weaver output.
+6. Regression-check quad-view (if you have a 4-view mode available) — tile dims should stay 1920×1080 there.
+
+## When to ask the user
+
+- If the driver doesn't populate `view_scale_x/y` for stereo, confirm whether to add the driver change or scope the fix to the compositor only (with a fallback).
+- Before modifying the compositor's per-client blit path — that can cascade.
+- Before the Phase 8 capture crop re-enable if you're not sure the atlas black-padding convention holds in every mode (2D / stereo / quad-view).
+
+## Branch
+
+Create `feature/issue-158-stereo-view-scale` off `main`. Commits reference `#158`.
+
+## Memory files to rely on
+
+- `feedback_dll_version_mismatch.md` — copy both binaries after IPC or struct changes
+- `feedback_test_before_ci.md` — wait for user live-test before pushing
+- `feedback_local_vs_ci_builds.md` — prefer local builds
+- `reference_runtime_screenshot.md` — file-trigger screenshot (%TEMP%\shell_screenshot_trigger → shell_screenshot_sbs.png) for autonomous self-inspection
+```

--- a/docs/roadmap/shell-phase8-agent-prompt.md
+++ b/docs/roadmap/shell-phase8-agent-prompt.md
@@ -1,0 +1,187 @@
+# Shell Phase 8: Agent Prompt — 3D Capture MVP
+
+Use this prompt to start a new Claude Code session for implementing Phase 8 on branch `feature/shell-phase8`.
+
+---
+
+## Prompt
+
+```
+I'm working on the DisplayXR spatial shell — a spatial window manager for 3D lenticular displays. Phase 8 delivers the MVP of 3D capture: a user-triggered spatial screenshot that saves pre-weave L/R stereo images plus a metadata sidecar.
+
+## Context
+
+Read these docs first (in order):
+1. `CLAUDE.md` — project overview, build commands, architecture (Windows)
+2. `docs/roadmap/shell-phase8-plan.md` — **the plan you're implementing**
+3. `docs/roadmap/shell-phase8-status.md` — task checklist (update as you complete tasks)
+4. `docs/roadmap/3d-capture.md` — full 3D capture design (MVP is just frame capture for now)
+5. `docs/roadmap/shell-phase7-status.md` — what Phase 7 delivered (file-trigger screenshot you're building on)
+
+## Branch
+
+You are on `feature/shell-phase8`, branched from `main` after Phase 7 was merged. All work goes here. Commits reference #43 (Spatial OS tracking issue).
+
+## Memory files you should rely on
+
+- `reference_runtime_screenshot.md` — how to capture screenshots of the compositor for self-feedback loops (file trigger + PostMessage for launcher toggle)
+- `feedback_dll_version_mismatch.md` — after IPC protocol changes, copy both `displayxr-service.exe` AND `DisplayXRClient.dll` to `C:\Program Files\DisplayXR\Runtime\` or apps fail OpenXR init
+- `feedback_test_before_ci.md` — wait for user to test locally before pushing
+- `feedback_shell_screenshot_reliability.md` — shell screenshots via PrintWindow miss UI during eye-tracking warmup; use the F12 / file-trigger atlas screenshot instead
+
+## What already exists
+
+The Phase 7 screenshot mechanism is 80% of the work:
+
+- **File-trigger screenshot**: compositor checks for `%TEMP%\shell_screenshot_trigger` each frame, reads `combined_atlas` texture, writes full SBS PNG to `%TEMP%\shell_screenshot.png`
+- **Capture point**: `multi_compositor_render()` in `src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp`, just before `swap_chain->Present()`
+- **PNG encoder**: `stb_image_write.h` with `STB_IMAGE_WRITE_IMPLEMENTATION` defined in `comp_d3d11_service.cpp`
+
+What Phase 8 adds:
+- IPC call `shell_capture_frame(path_prefix, flags)` so the shell drives capture
+- L/R sub-image extraction from the SBS atlas (split into two PNGs)
+- Metadata returned via IPC, written by the shell as a JSON sidecar
+- Shell hotkey `Ctrl+Shift+3` (in addition to keeping the file-trigger for dev workflows)
+
+## Tasks
+
+### 8.1 — IPC protocol
+
+Add to `src/xrt/ipc/shared/ipc_protocol.h`:
+- `IPC_CAPTURE_FLAG_LEFT|RIGHT|SBS|ALL` bitmask defines
+- `struct ipc_capture_result` with timestamp, atlas/eye dims, tile columns/rows, display dims (meters), eye poses, views_written bitmask
+
+Add to `src/xrt/ipc/shared/proto.json`:
+- `shell_capture_frame(char[256] path_prefix, uint32_t flags) -> struct ipc_capture_result`
+
+Regenerate IPC bindings via the CMake build.
+
+### 8.2 — Service: refactor into `capture_frame_impl`
+
+In `src/xrt/compositor/d3d11_service/comp_d3d11_service.{cpp,h}`, add:
+
+```cpp
+bool
+comp_d3d11_service_capture_frame(struct xrt_system_compositor *xsysc,
+                                 const char *path_prefix,
+                                 uint32_t flags,
+                                 struct ipc_capture_result *out_result);
+```
+
+Implementation:
+1. Acquire `sys->render_mutex`
+2. Validate `combined_atlas` + device + context
+3. Create staging texture (USAGE_STAGING, CPU_ACCESS_READ)
+4. `CopyResource(staging, combined_atlas)`, `Map()` staging
+5. If `flags & SBS`: `stbi_write_png("{prefix}_sbs.png", atlas_w, atlas_h, 4, mapped.pData, mapped.RowPitch)`
+6. If `flags & LEFT`: extract left half → tightly-packed buffer → `{prefix}_L.png`
+7. If `flags & RIGHT`: extract right half → tightly-packed buffer → `{prefix}_R.png`
+8. Populate `out_result` with timestamp_ns, dims, eye poses (from the most recent tracker state — look at how the hit-test code accesses eye positions; same data), display_width_m/height_m
+9. `Unmap()`, release staging
+
+Implement the IPC handler (`ipc_server_handler.c`) that calls this function.
+
+### 8.3 — L/R sub-image extraction
+
+In the capture function, for each requested eye:
+
+```cpp
+uint32_t eye_w = atlas_w / sys->tile_columns;
+uint32_t eye_h = atlas_h / sys->tile_rows;
+uint32_t eye_x = eye_index * eye_w;  // 0 for left, eye_w for right
+std::vector<uint8_t> buf(eye_w * eye_h * 4);
+const uint8_t *src = (const uint8_t *)mapped.pData;
+for (uint32_t y = 0; y < eye_h; y++) {
+    const uint8_t *src_row = src + y * mapped.RowPitch + eye_x * 4;
+    memcpy(buf.data() + y * eye_w * 4, src_row, eye_w * 4);
+}
+stbi_write_png(path, eye_w, eye_h, 4, buf.data(), eye_w * 4);
+```
+
+Make sure to handle the case `tile_columns == 1` (mono) — then LEFT == RIGHT == SBS (all the same image).
+
+### 8.4 — Shell: hotkey + IPC + sidecar JSON
+
+In `src/xrt/targets/shell/main.c`:
+
+1. Define `HOTKEY_CAPTURE 3` next to `HOTKEY_TOGGLE`, `HOTKEY_LAUNCH`
+2. `RegisterHotKey(g_msg_hwnd, HOTKEY_CAPTURE, MOD_CONTROL | MOD_SHIFT, '3')` alongside the others
+3. Handle the message:
+   ```c
+   } else if (msg.message == WM_HOTKEY && msg.wParam == HOTKEY_CAPTURE) {
+       capture_frame(ipc_c);
+   }
+   ```
+4. Build the output path: `%USERPROFILE%\Pictures\DisplayXR\capture_YYYY-MM-DD_HH-MM-SS` (create dir if missing, use `GetLocalTime`)
+5. Call `ipc_call_shell_capture_frame(ipc_c, prefix, IPC_CAPTURE_FLAG_ALL, &result)`
+6. Write the sidecar JSON file at `{prefix}.json` with timestamp, dims, eye poses, views_written. Use cJSON (already linked into the shell target).
+
+### 8.5 — Capture flash indicator (optional)
+
+Set `sys->capture_flash_until_ns = now + 300ms` when capture runs. In the render path before Present, if `now < flash_until_ns`, draw a bright cyan border around the atlas edge using the glow shader. Skip if this slows down MVP; add as a follow-up.
+
+### 8.6 — Route file-trigger through same code path
+
+The Phase 7 file-trigger block should be refactored to call `comp_d3d11_service_capture_frame(xsysc, "%TEMP%\shell_screenshot", IPC_CAPTURE_FLAG_SBS, &dummy)` so there's one code path. Keep the trigger mechanism for dev workflows (useful when you need a quick atlas dump without shell IPC).
+
+## Key code locations
+
+- `src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp` — Phase 7 screenshot block is before the `swap_chain->Present()` call inside `multi_compositor_render()`
+- `src/xrt/compositor/d3d11_service/comp_d3d11_service.h` — public API for the service
+- `src/xrt/ipc/shared/ipc_protocol.h` — IPC struct definitions
+- `src/xrt/ipc/shared/proto.json` — IPC call definitions (re-run build to regenerate bindings)
+- `src/xrt/ipc/server/ipc_server_handler.c` — where to add the `shell_capture_frame` handler
+- `src/xrt/targets/shell/main.c` — shell message loop, hotkey registration, IPC calls
+
+## Commit style
+
+- Commit per task (or small group)
+- Reference #43 in every commit
+- Use `Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>`
+
+## Testing
+
+Build locally:
+```
+scripts\build_windows.bat build
+```
+
+Important: after any IPC protocol change, copy BOTH binaries to the installed location or apps will fail OpenXR init:
+```
+powershell -Command "Copy-Item _package\bin\displayxr-service.exe 'C:\Program Files\DisplayXR\Runtime\displayxr-service.exe' -Force; Copy-Item _package\bin\DisplayXRClient.dll 'C:\Program Files\DisplayXR\Runtime\DisplayXRClient.dll' -Force"
+```
+
+If the DLL is locked, find the holder and kill it:
+```
+powershell -Command "Get-Process | Where-Object { $_.Modules.FileName -match 'DisplayXRClient' } | Select-Object Id, ProcessName"
+```
+
+Launch the shell:
+```
+_package\bin\displayxr-shell.exe test_apps\cube_handle_d3d11_win\build\cube_handle_d3d11_win.exe
+```
+
+Press **Ctrl+Shift+3** → check `%USERPROFILE%\Pictures\DisplayXR\`:
+- `capture_<ts>_L.png` — 1920×2160
+- `capture_<ts>_R.png` — 1920×2160
+- `capture_<ts>_sbs.png` — 3840×2160
+- `capture_<ts>.json` — metadata
+
+Verify parallax between L and R (the cube should appear horizontally shifted).
+
+### Autonomous screenshot iteration
+
+You can use the Phase 7 file-trigger mechanism to self-inspect the shell during development:
+```bash
+touch "/c/Users/SPARKS~1/AppData/Local/Temp/shell_screenshot_trigger"
+sleep 3
+# Read %TEMP%\shell_screenshot.png via the Read tool
+```
+
+## When to ask the user
+
+- After completing each task — wait for live verification before committing
+- Before adding the capture flash (design call: cyan border? full-screen flash? flicker?)
+- If the IPC binding regeneration fails or produces unexpected output
+- When you hit any GPU texture access issue (format mismatches are common with staging textures)
+```

--- a/docs/roadmap/shell-phase8-plan.md
+++ b/docs/roadmap/shell-phase8-plan.md
@@ -1,0 +1,269 @@
+# Shell Phase 8 Plan: 3D Capture MVP
+
+**Branch:** `feature/shell-phase8`
+**Issue:** #43, #44 (tracking), new capture issue TBD
+**Date:** 2026-04-13
+
+## Goal
+
+Deliver the MVP of the 3D capture pipeline: a user-triggered spatial screenshot that saves pre-weave L/R stereo images plus a metadata sidecar. Builds on the Phase 7 file-trigger screenshot by promoting it to an IPC-driven, shell-owned feature with proper L/R separation and metadata.
+
+**User experience:** Press `Ctrl+Shift+3` in the spatial shell → a cyan flash on screen → a new `capture_<timestamp>.png` pair appears in `%USERPROFILE%\Pictures\DisplayXR\`.
+
+**Full spec:** [3d-capture.md](3d-capture.md) — this phase delivers MVP (frame capture only; recording and dataset modes deferred).
+
+## Architecture
+
+Ownership split matches `3d-capture.md`:
+
+| Runtime (service compositor) owns | Shell owns |
+|-----------------------------------|------------|
+| GPU texture read-back | Hotkey binding (`Ctrl+Shift+3`) |
+| Capture point (post-composite, pre-weave) | Output path construction (timestamp, directory policy) |
+| PNG encoding (stb_image_write) | Sidecar JSON metadata file |
+| Metadata collection (eye pose, timestamps) | Toast / notification UX (optional) |
+| L/R split from combined atlas | Privacy policy / opt-out (future) |
+
+**IPC flow:**
+```
+Shell (Ctrl+Shift+3)
+  └─ build path: %USERPROFILE%\Pictures\DisplayXR\capture_2026-04-13_14-52-10
+  └─ ipc_call_shell_capture_frame(path_prefix, flags=SBS|L|R|ALL)
+     └─ Service: copy combined_atlas → staging → map → stbi_write_png for each requested view
+     └─ Return: struct ipc_capture_result { timestamp_ns, width, height, views_written }
+  └─ Shell: write path_prefix.json with metadata
+  └─ Shell: optional flash indicator
+```
+
+## Capture Point (unchanged from Phase 7)
+
+The existing screenshot code in `comp_d3d11_service.cpp`, `multi_compositor_render()` just before `swap_chain->Present()`, is already the correct capture point:
+- Post-composite (all windows composed)
+- Pre-weave (L/R still separable; not display-specific)
+- GPU-resident (`combined_atlas` texture)
+
+Phase 8 refactors this to be IPC-triggered with L/R output instead of a monolithic file-trigger SBS dump.
+
+## Tasks
+
+### 8.1 — IPC protocol
+
+**Files:**
+- `src/xrt/ipc/shared/ipc_protocol.h` — add flags + result struct
+- `src/xrt/ipc/shared/proto.json` — new call
+- `src/xrt/ipc/server/ipc_server_handler.c` — handler stub
+
+**Changes:**
+
+Add to `ipc_protocol.h`:
+```c
+// Phase 8: 3D capture flags
+#define IPC_CAPTURE_FLAG_LEFT   (1u << 0)
+#define IPC_CAPTURE_FLAG_RIGHT  (1u << 1)
+#define IPC_CAPTURE_FLAG_SBS    (1u << 2)
+#define IPC_CAPTURE_FLAG_ALL    (IPC_CAPTURE_FLAG_LEFT | IPC_CAPTURE_FLAG_RIGHT | IPC_CAPTURE_FLAG_SBS)
+
+struct ipc_capture_result
+{
+    uint64_t timestamp_ns;      // CLOCK_MONOTONIC-equivalent at capture
+    uint32_t atlas_width;       // full atlas (SBS) dims
+    uint32_t atlas_height;
+    uint32_t eye_width;         // per-eye dims (atlas_width / tile_columns)
+    uint32_t eye_height;
+    uint32_t views_written;     // bitmask of which flags succeeded
+    uint32_t tile_columns;      // stereo mode at capture (1 or 2)
+    uint32_t tile_rows;
+    float display_width_m;
+    float display_height_m;
+    float eye_left_m[3];        // left eye pose in meters
+    float eye_right_m[3];
+    char _pad[16];
+};
+```
+
+Add to `proto.json`:
+```json
+{
+    "name": "shell_capture_frame",
+    "in": [
+        {"name": "path_prefix", "type": "char[256]"},
+        {"name": "flags", "type": "uint32_t"}
+    ],
+    "out": [
+        {"name": "result", "type": "struct ipc_capture_result"}
+    ]
+}
+```
+
+The `path_prefix` is the full base path *without* extension — e.g. `C:\Users\...\Pictures\DisplayXR\capture_2026-04-13_14-52-10`. The runtime appends `_L.png`, `_R.png`, `_sbs.png` depending on flags. This keeps filename policy in the shell.
+
+### 8.2 — Service: refactor screenshot into capture_frame_impl
+
+**Files:**
+- `src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp`
+- `src/xrt/compositor/d3d11_service/comp_d3d11_service.h`
+
+**Changes:**
+
+Extract the Phase 7 screenshot block into a reusable function:
+
+```cpp
+bool
+comp_d3d11_service_capture_frame(struct xrt_system_compositor *xsysc,
+                                 const char *path_prefix,
+                                 uint32_t flags,
+                                 struct ipc_capture_result *out_result);
+```
+
+Implementation steps:
+1. Lock `render_mutex`
+2. Validate `combined_atlas` exists
+3. Create staging texture matching atlas format + dims, `USAGE_STAGING`, `CPU_ACCESS_READ`
+4. `CopyResource(staging, combined_atlas)`
+5. `Map()` staging, read RGBA pixels
+6. If `flags & SBS`: write full atlas to `{prefix}_sbs.png`
+7. If `flags & LEFT`: extract left tile `(0, 0, eye_w, eye_h)` into a new buffer (stride handling!), write to `{prefix}_L.png`
+8. If `flags & RIGHT`: extract right tile `(eye_w, 0, eye_w, eye_h)`, write to `{prefix}_R.png`
+9. Collect metadata:
+   - `timestamp_ns` from `os_monotonic_get_ns()`
+   - atlas dims from `combined_atlas->GetDesc()`
+   - eye dims = atlas_w / `sys->tile_columns`, atlas_h / `sys->tile_rows`
+   - eye poses from the most recent `eye_pos` state on the active compositor (see Phase 6 code that populates `data.eyes[]`)
+   - display dims from `sys->base.info.display_*_m`
+10. `Unmap()`, return
+
+Keep the Phase 7 file-trigger path as a backward-compat fallback (small cost, useful for dev workflows without IPC): if `shell_screenshot_trigger` exists, call `capture_frame(SBS, default_path)`.
+
+### 8.3 — Left/right sub-image extraction
+
+**File:** `comp_d3d11_service.cpp` in the capture function
+
+For L/R split, the mapped staging texture gives us the full SBS atlas with a row stride (`mapped.RowPitch`). Each eye half is `eye_w = atlas_w / tile_columns` pixels wide starting at `x = eye_index * eye_w`.
+
+Approach: allocate a tightly-packed RGBA8 buffer for each eye (`eye_w * eye_h * 4` bytes), copy rows from the mapped staging memory:
+
+```cpp
+std::vector<uint8_t> buf(eye_w * eye_h * 4);
+const uint8_t *src = (const uint8_t *)mapped.pData;
+for (uint32_t y = 0; y < eye_h; y++) {
+    const uint8_t *src_row = src + y * mapped.RowPitch + eye_x_offset * 4;
+    uint8_t *dst_row = buf.data() + y * eye_w * 4;
+    memcpy(dst_row, src_row, eye_w * 4);
+}
+stbi_write_png(path, eye_w, eye_h, 4, buf.data(), eye_w * 4);
+```
+
+For SBS write, `stbi_write_png` handles row stride via the last arg, so no copy needed.
+
+### 8.4 — Shell: hotkey + IPC call + filename policy
+
+**File:** `src/xrt/targets/shell/main.c`
+
+**Changes:**
+
+1. Register a new hotkey:
+```c
+#define HOTKEY_CAPTURE 3
+RegisterHotKey(g_msg_hwnd, HOTKEY_CAPTURE, MOD_CONTROL | MOD_SHIFT, '3');
+```
+
+2. In the message loop, handle it:
+```c
+} else if (msg.message == WM_HOTKEY && msg.wParam == HOTKEY_CAPTURE) {
+    capture_frame(ipc_c);
+}
+```
+
+3. New `capture_frame()` function:
+```c
+static void capture_frame(struct ipc_connection *ipc_c) {
+    // Build path: %USERPROFILE%\Pictures\DisplayXR\capture_YYYY-MM-DD_HH-MM-SS
+    char dir[MAX_PATH], prefix[MAX_PATH];
+    const char *home = getenv("USERPROFILE");
+    snprintf(dir, sizeof(dir), "%s\\Pictures\\DisplayXR", home ? home : ".");
+    CreateDirectoryA(dir, NULL); // ignore error if exists
+
+    SYSTEMTIME st;
+    GetLocalTime(&st);
+    snprintf(prefix, sizeof(prefix),
+             "%s\\capture_%04d-%02d-%02d_%02d-%02d-%02d",
+             dir, st.wYear, st.wMonth, st.wDay, st.wHour, st.wMinute, st.wSecond);
+
+    struct ipc_capture_result result = {};
+    xrt_result_t r = ipc_call_shell_capture_frame(ipc_c, prefix,
+                                                  IPC_CAPTURE_FLAG_ALL, &result);
+    if (r != XRT_SUCCESS) {
+        PE("capture_frame: IPC call failed: %d\n", r);
+        return;
+    }
+
+    // Write sidecar JSON
+    char json_path[MAX_PATH];
+    snprintf(json_path, sizeof(json_path), "%s.json", prefix);
+    write_capture_sidecar(json_path, &result);
+
+    P("Capture saved: %s\n", prefix);
+}
+```
+
+4. `write_capture_sidecar()` writes minimal JSON using cJSON (already linked):
+```json
+{
+    "schema_version": 1,
+    "timestamp_ns": 12345678901234,
+    "atlas": {"width": 3840, "height": 2160},
+    "eye": {"width": 1920, "height": 2160},
+    "stereo": {"tile_columns": 2, "tile_rows": 1},
+    "display_m": {"width": 0.700, "height": 0.394},
+    "eye_left_m": [-0.032, 0.0, 0.6],
+    "eye_right_m": [0.032, 0.0, 0.6],
+    "views_written": ["sbs", "L", "R"]
+}
+```
+
+### 8.5 — Capture indicator (optional but nice)
+
+**File:** `comp_d3d11_service.cpp`
+
+A brief cyan flash on the atlas edges provides visual feedback. Approach: when `capture_frame_impl` runs, set a timestamp `sys->capture_flash_until_ns = now + 300ms`. In the render path, if current time < flash_until, draw a bright cyan border using the glow shader around the atlas.
+
+Can defer to 8.6 or a follow-up; MVP works without it.
+
+### 8.6 — Deprecate file-trigger screenshot
+
+**File:** `comp_d3d11_service.cpp`
+
+Replace the Phase 7 `shell_screenshot_trigger` file check with a call to `capture_frame_impl(sys, temp_path, IPC_CAPTURE_FLAG_SBS, &dummy)`. Keeps the dev workflow working (touch a file → get a PNG) but routes through the same code path as the IPC call.
+
+## Verification
+
+1. Build: `scripts\build_windows.bat build`
+2. Deploy: copy binaries to `C:\Program Files\DisplayXR\Runtime\`
+3. Launch: `_package\bin\displayxr-shell.exe test_apps\cube_handle_d3d11_win\build\cube_handle_d3d11_win.exe`
+4. Activate shell (Ctrl+Space if needed), press **Ctrl+Shift+3**
+5. Check `%USERPROFILE%\Pictures\DisplayXR\` for new files:
+   - `capture_<ts>_L.png` — 1920×2160 left-eye view
+   - `capture_<ts>_R.png` — 1920×2160 right-eye view
+   - `capture_<ts>_sbs.png` — 3840×2160 SBS
+   - `capture_<ts>.json` — metadata sidecar
+6. Open L + R in an image diff tool — verify visible parallax on the cube (depth cue)
+7. Verify file-trigger fallback still works: `touch %TEMP%\shell_screenshot_trigger` → `%TEMP%\shell_screenshot.png` appears
+
+## Commit plan
+
+- **Commit 1** — Task 8.1 (IPC protocol) — references #43
+- **Commit 2** — Task 8.2 + 8.3 (service capture impl + L/R split) — references #43
+- **Commit 3** — Task 8.4 (shell hotkey + IPC call + sidecar) — references #43
+- **Commit 4** — Task 8.5 (capture flash) — optional, references #43
+- **Commit 5** — Task 8.6 (refactor file-trigger to use same code path) — references #43
+
+Wait for user live verification after each commit before proceeding.
+
+## Scope notes / non-goals
+
+- **No recording** — still-frame only. Video capture is Phase 2 of 3d-capture.md.
+- **No session capture** — Phase 3.
+- **No dataset mode** — Phase 4.
+- **No depth capture** — requires DP vtable changes.
+- **No privacy / consent UI** — future work; capture fires silently for the MVP.
+- **No cross-platform** — Windows D3D11 only. Metal/macOS capture follows in a later phase.

--- a/docs/roadmap/shell-phase8-status.md
+++ b/docs/roadmap/shell-phase8-status.md
@@ -1,8 +1,8 @@
 # Shell Phase 8 Status: 3D Capture MVP
 
 **Branch:** `feature/shell-phase8`
-**Status:** In progress — 8.1, 8.2, 8.3, 8.4, 8.6 implemented; awaiting live verification. 8.5 deferred.
-**Date:** 2026-04-13
+**Status:** MVP complete — live-verified 2026-04-15. Hotkey is Ctrl+Shift+C; SBS-only output. 8.5 deferred. Compositor stretch bug (#158) blocks adding the active-region crop back.
+**Date:** 2026-04-13, updated 2026-04-15
 
 ## Scope
 
@@ -18,21 +18,30 @@ Deliver the MVP of the 3D capture pipeline: `Ctrl+Shift+3` in the shell captures
 | [x] | 8.1 | IPC protocol: capture flags, `ipc_capture_request`/`ipc_capture_result` structs, `shell_capture_frame` call |
 | [x] | 8.2 | Service: `comp_d3d11_service_capture_frame` with L/R/SBS outputs (new function, not a refactor) |
 | [x] | 8.3 | L/R sub-image extraction from combined atlas staging texture |
-| [x] | 8.4 | Shell: `Ctrl+Shift+3` hotkey, filename policy, IPC call, cJSON sidecar |
+| [x] | 8.4 | Shell: `Ctrl+Shift+C` hotkey, filename policy, IPC call, cJSON sidecar |
 | [ ] | 8.5 | Capture flash indicator — DEFERRED (per agent prompt: skip if it slows down MVP) |
 | [x] | 8.6 | Phase 7 file-trigger now routes through `capture_frame` (output renamed to `shell_screenshot_sbs.png`) |
 
 ## Commits
 
-_(none yet — pending live verification)_
+- `6f3eed00b` Shell 8.1: IPC protocol for shell_capture_frame
+- `62158f3ad` Shell 8.2/8.3/8.6: capture_frame impl + L/R split + file-trigger refactor
+- `fa65a2021` Shell 8.4: Ctrl+Shift+3 capture hotkey + JSON sidecar (later renamed to Ctrl+Shift+C)
+- `be9e6c409` Docs: initial Phase 8 status update
+- `0773e5388` Shell 8: SBS-only capture, Ctrl+Shift+C hotkey, uncropped atlas dump
 
 ## Design Decisions
 
-- **`char[256]` not supported by IPC schema.** The original plan called for `path_prefix` as a raw `char[256]` parameter to `shell_capture_frame`, but the proto schema only accepts scalar/struct/enum/handle types. Wrapped the path + flags in a new `struct ipc_capture_request` instead.
-- **File-trigger output renamed.** Previously `%TEMP%\shell_screenshot.png`; now `%TEMP%\shell_screenshot_sbs.png` to keep a single code path. Memory file `reference_runtime_screenshot.md` will need a one-line update once verified.
-- **Mono fallback.** When `tile_columns == 1`, requesting `LEFT` and `RIGHT` both write the full-frame (eye_x = 0). SBS is identical to L/R in this case.
+- **`char[256]` not supported by IPC schema.** The proto schema only accepts scalar / struct / enum / handle types, so the path prefix is wrapped in `struct ipc_capture_request` (prefix + flags) rather than passed as a raw `char[N]` parameter.
+- **Output param `result` → `capture_result`.** The generated reply struct already has `xrt_result_t result`; the Phase 8 output struct must use a different name to avoid a C struct-member collision.
+- **Hotkey is Ctrl+Shift+C, not Ctrl+Shift+3.** Ctrl+Shift+3 passed through to the compositor's layout-preset handler (which only checks Ctrl+digit and ignores Shift), so both fired.
+- **SBS-only, no L/R PNGs.** Per-eye PNGs were redundant with SBS — removed. The IPC flag plumbing remains (LEFT/RIGHT/SBS) for future use.
+- **Uncropped atlas dump.** The capture dumps the full atlas (`atlas_w × atlas_h`) without cropping to an "active region". The previous crop assumed the compositor rendered each tile at `view_w × view_h`; in practice the compositor is stretching each view to fill `atlas_w/tile_columns × atlas_h/tile_rows`. Honest uncropped output surfaces that bug. Re-add the crop once #158 lands.
+- **File-trigger output renamed** `%TEMP%\shell_screenshot.png` → `%TEMP%\shell_screenshot_sbs.png` so there is a single capture code path.
 
 ## Known Issues
 
-- **Color format unverified.** Atlas may be BGRA8 rather than RGBA8 — Phase 7 didn't normalize, and Phase 8 follows the same convention. If captured PNGs show R/B-swapped colors, add a swizzle pass during the L/R copy loop.
-- **`shell_capture_frame` while shell is *inactive*.** The service handler returns `XRT_ERROR_IPC_FAILURE` if `combined_atlas` doesn't exist (i.e., shell not active). The shell-side wrapper guards on `g_shell_active` before issuing the call.
+- **#158 — Compositor stretches each view vertically in stereo mode.** `view_height = display_height / tile_rows` (= display_height for 2×1 stereo) instead of using `rendering_mode.view_height_pixels`. Visible as tall/narrow content in each eye tile of the capture. Blocks re-adding the crop in capture; doesn't block the Phase 8 MVP itself.
+- **8.5 capture flash indicator — deferred.** Not required for MVP per the agent prompt; can be added as a follow-up if desired.
+- **Color format unverified.** Atlas may be BGRA8 rather than RGBA8 — Phase 7 didn't normalize, and Phase 8 follows the same convention. Live captures look correct so far.
+- **`shell_capture_frame` while shell is inactive.** The service handler returns `XRT_ERROR_IPC_FAILURE` if `combined_atlas` doesn't exist; the shell guards on `g_shell_active` before issuing the call.

--- a/docs/roadmap/shell-phase8-status.md
+++ b/docs/roadmap/shell-phase8-status.md
@@ -1,7 +1,7 @@
 # Shell Phase 8 Status: 3D Capture MVP
 
 **Branch:** `feature/shell-phase8`
-**Status:** Not started
+**Status:** In progress — 8.1, 8.2, 8.3, 8.4, 8.6 implemented; awaiting live verification. 8.5 deferred.
 **Date:** 2026-04-13
 
 ## Scope
@@ -15,21 +15,24 @@ Deliver the MVP of the 3D capture pipeline: `Ctrl+Shift+3` in the shell captures
 
 | Status | Task | Description |
 |--------|------|-------------|
-| [ ] | 8.1 | IPC protocol: add capture flags, `ipc_capture_result` struct, `shell_capture_frame` call |
-| [ ] | 8.2 | Service: refactor screenshot into `capture_frame_impl` with L/R/SBS outputs |
-| [ ] | 8.3 | L/R sub-image extraction from combined atlas staging texture |
-| [ ] | 8.4 | Shell: `Ctrl+Shift+3` hotkey, filename policy, IPC call, JSON sidecar |
-| [ ] | 8.5 | Capture flash indicator (optional) |
-| [ ] | 8.6 | Replace Phase 7 file-trigger screenshot with call through same code path |
+| [x] | 8.1 | IPC protocol: capture flags, `ipc_capture_request`/`ipc_capture_result` structs, `shell_capture_frame` call |
+| [x] | 8.2 | Service: `comp_d3d11_service_capture_frame` with L/R/SBS outputs (new function, not a refactor) |
+| [x] | 8.3 | L/R sub-image extraction from combined atlas staging texture |
+| [x] | 8.4 | Shell: `Ctrl+Shift+3` hotkey, filename policy, IPC call, cJSON sidecar |
+| [ ] | 8.5 | Capture flash indicator — DEFERRED (per agent prompt: skip if it slows down MVP) |
+| [x] | 8.6 | Phase 7 file-trigger now routes through `capture_frame` (output renamed to `shell_screenshot_sbs.png`) |
 
 ## Commits
 
-_(none yet)_
+_(none yet — pending live verification)_
 
 ## Design Decisions
 
-_(to be filled in during implementation)_
+- **`char[256]` not supported by IPC schema.** The original plan called for `path_prefix` as a raw `char[256]` parameter to `shell_capture_frame`, but the proto schema only accepts scalar/struct/enum/handle types. Wrapped the path + flags in a new `struct ipc_capture_request` instead.
+- **File-trigger output renamed.** Previously `%TEMP%\shell_screenshot.png`; now `%TEMP%\shell_screenshot_sbs.png` to keep a single code path. Memory file `reference_runtime_screenshot.md` will need a one-line update once verified.
+- **Mono fallback.** When `tile_columns == 1`, requesting `LEFT` and `RIGHT` both write the full-frame (eye_x = 0). SBS is identical to L/R in this case.
 
 ## Known Issues
 
-_(to be filled in during implementation)_
+- **Color format unverified.** Atlas may be BGRA8 rather than RGBA8 — Phase 7 didn't normalize, and Phase 8 follows the same convention. If captured PNGs show R/B-swapped colors, add a swizzle pass during the L/R copy loop.
+- **`shell_capture_frame` while shell is *inactive*.** The service handler returns `XRT_ERROR_IPC_FAILURE` if `combined_atlas` doesn't exist (i.e., shell not active). The shell-side wrapper guards on `g_shell_active` before issuing the call.

--- a/docs/roadmap/shell-phase8-status.md
+++ b/docs/roadmap/shell-phase8-status.md
@@ -1,0 +1,35 @@
+# Shell Phase 8 Status: 3D Capture MVP
+
+**Branch:** `feature/shell-phase8`
+**Status:** Not started
+**Date:** 2026-04-13
+
+## Scope
+
+Deliver the MVP of the 3D capture pipeline: `Ctrl+Shift+3` in the shell captures the pre-weave L/R stereo pair to disk with a metadata sidecar. Promotes the Phase 7 file-trigger screenshot to a shell-owned, IPC-driven feature with L/R separation and metadata.
+
+**Full plan:** [shell-phase8-plan.md](shell-phase8-plan.md)
+**Full spec:** [3d-capture.md](3d-capture.md)
+
+## Tasks
+
+| Status | Task | Description |
+|--------|------|-------------|
+| [ ] | 8.1 | IPC protocol: add capture flags, `ipc_capture_result` struct, `shell_capture_frame` call |
+| [ ] | 8.2 | Service: refactor screenshot into `capture_frame_impl` with L/R/SBS outputs |
+| [ ] | 8.3 | L/R sub-image extraction from combined atlas staging texture |
+| [ ] | 8.4 | Shell: `Ctrl+Shift+3` hotkey, filename policy, IPC call, JSON sidecar |
+| [ ] | 8.5 | Capture flash indicator (optional) |
+| [ ] | 8.6 | Replace Phase 7 file-trigger screenshot with call through same code path |
+
+## Commits
+
+_(none yet)_
+
+## Design Decisions
+
+_(to be filled in during implementation)_
+
+## Known Issues
+
+_(to be filled in during implementation)_

--- a/src/xrt/compositor/client/comp_d3d12_client.cpp
+++ b/src/xrt/compositor/client/comp_d3d12_client.cpp
@@ -373,6 +373,12 @@ client_d3d12_swapchain_acquire_image(struct xrt_swapchain *xsc, uint32_t *out_in
 	if (xret == XRT_SUCCESS) {
 		// Set output variable
 		*out_index = index;
+		U_LOG_W("[#151] d3d12 client acquire_image: OK index=%u (image_count=%u)",
+		        index, sc->base.base.image_count);
+	} else {
+		U_LOG_W("[#151] d3d12 client acquire_image FAILED: xret=%d (XRT_ERROR) -> "
+		        "xrAcquireSwapchainImage will return XR_ERROR_RUNTIME_FAILURE",
+		        (int)xret);
 	}
 	return xret;
 }
@@ -460,6 +466,16 @@ client_d3d12_create_swapchain(struct xrt_compositor *xc,
                               struct xrt_swapchain **out_xsc)
 try {
 	struct client_d3d12_compositor *c = as_client_d3d12_compositor(xc);
+	U_LOG_W("[#151] d3d12 client create_swapchain: format=%lld (DXGI=%d) w=%u h=%u "
+	        "arraySize=%u mipCount=%u sampleCount=%u faceCount=%u bits=0x%x create=0x%x "
+	        "MUTABLE_FORMAT=%s SAMPLED=%s",
+	        (long long)info->format, (int)info->format, info->width, info->height,
+	        info->array_size, info->mip_count, info->sample_count, info->face_count,
+	        (unsigned)info->bits, (unsigned)info->create,
+	        (info->bits & XRT_SWAPCHAIN_USAGE_MUTABLE_FORMAT) ? "YES" : "no",
+	        (info->bits & XRT_SWAPCHAIN_USAGE_SAMPLED) ? "YES" : "no");
+	U_LOG_W("[#151] d3d12 client device=%p app_queue=%p",
+	        (void *)c->device.get(), (void *)c->app_queue.get());
 	xrt_result_t xret = XRT_SUCCESS;
 	xrt_swapchain_create_properties xsccp{};
 	xret = xrt_comp_get_swapchain_create_properties(xc, info, &xsccp);
@@ -499,12 +515,16 @@ try {
 	// Ask the service to create the swapchain (server-creates-swapchain model).
 	// The D3D11 service creates shared textures with NT handles that D3D12 can import.
 	D3D_INFO(c, "Requesting server to create swapchain (server-creates-swapchain model)");
+	U_LOG_W("[#151] d3d12 client -> service create_swapchain: vk_format=%lld bits=0x%x",
+	        (long long)vkinfo.format, (unsigned)vkinfo.bits);
 	xrt_swapchain *xsc_raw = nullptr;
 	xret = xrt_comp_create_swapchain(&c->xcn->base, &vkinfo, &xsc_raw);
 	if (xret != XRT_SUCCESS) {
 		D3D_ERROR(c, "Service failed to create swapchain: %d", xret);
+		U_LOG_W("[#151] d3d12 service create_swapchain FAILED: xret=%d", (int)xret);
 		return xret;
 	}
+	U_LOG_W("[#151] d3d12 service create_swapchain OK");
 	sc->xsc.reset(xsc_raw);
 
 	// Get handles from service-created swapchain
@@ -530,8 +550,12 @@ try {
 			image = xrt::auxiliary::d3d::d3d12::importImage(*(c->device), handle);
 		} catch (wil::ResultException const &e) {
 			D3D_ERROR(c, "Failed to import D3D11 texture [%u] into D3D12: %s", i, e.what());
+			U_LOG_W("[#151] d3d12 importImage FAILED [%u]: handle=%p hr=0x%08lx msg=%s",
+			        i, handle, (unsigned long)e.GetErrorCode(), e.what());
 			return XRT_ERROR_SWAPCHAIN_FLAG_VALID_BUT_UNSUPPORTED;
 		}
+		U_LOG_W("[#151] d3d12 importImage OK [%u]: handle=%p -> resource=%p",
+		        i, handle, (void *)image.get());
 
 		// Put the image where the OpenXR state tracker can get it
 		sc->base.images[i] = image.get();
@@ -570,6 +594,8 @@ try {
 				char buf[kErrorBufSize];
 				formatMessage(hr, buf);
 				D3D_ERROR(c, "Error creating command list: %s", buf);
+				U_LOG_W("[#151] d3d12 createCommandLists FAILED [%u]: hr=0x%08lx msg=%s",
+				        i, (unsigned long)hr, buf);
 				return XRT_ERROR_D3D12;
 			}
 
@@ -618,16 +644,21 @@ try {
 	xrt_swapchain_reference(out_xsc, &sc->base.base);
 	(void)sc.release();
 
+	U_LOG_W("[#151] d3d12 client create_swapchain COMPLETE: %u images imported", image_count);
 	return XRT_SUCCESS;
 
 } catch (wil::ResultException const &e) {
 	U_LOG_E("Error creating D3D12 swapchain: %s", e.what());
+	U_LOG_W("[#151] d3d12 client create_swapchain EXCEPTION (wil): hr=0x%08lx msg=%s",
+	        (unsigned long)e.GetErrorCode(), e.what());
 	return XRT_ERROR_ALLOCATION;
 } catch (std::exception const &e) {
 	U_LOG_E("Error creating D3D12 swapchain: %s", e.what());
+	U_LOG_W("[#151] d3d12 client create_swapchain EXCEPTION (std): %s", e.what());
 	return XRT_ERROR_ALLOCATION;
 } catch (...) {
 	U_LOG_E("Error creating D3D12 swapchain");
+	U_LOG_W("[#151] d3d12 client create_swapchain EXCEPTION (unknown)");
 	return XRT_ERROR_ALLOCATION;
 }
 

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -862,6 +862,39 @@ sync_tile_layout(struct d3d11_service_system *sys)
 }
 
 /*!
+ * Resolve per-view tile dimensions for layout / DP handoff / capture.
+ *
+ * Non-legacy sessions (shell + display-info-aware apps) use the true vendor
+ * scale from the active rendering mode — for stereo on 4K this is 1920×1080
+ * per view. Legacy sessions fall back to the system's compromise dims
+ * (display / tile count), preserving existing behavior for apps that aren't
+ * XR_EXT_display_info aware. Issue #158.
+ */
+static inline void
+resolve_active_view_dims(const struct d3d11_service_system *sys,
+                         uint32_t fallback_w, uint32_t fallback_h,
+                         uint32_t *out_vw, uint32_t *out_vh)
+{
+	uint32_t vw = 0, vh = 0;
+	if (!sys->base.info.legacy_app_tile_scaling &&
+	    sys->xdev != NULL && sys->xdev->hmd != NULL) {
+		uint32_t idx = sys->xdev->hmd->active_rendering_mode_index;
+		if (idx < sys->xdev->rendering_mode_count) {
+			vw = sys->xdev->rendering_modes[idx].view_width_pixels;
+			vh = sys->xdev->rendering_modes[idx].view_height_pixels;
+		}
+	}
+	if (vw == 0 || vh == 0) {
+		uint32_t tc = sys->tile_columns > 0 ? sys->tile_columns : 1;
+		uint32_t tr = sys->tile_rows > 0 ? sys->tile_rows : 1;
+		vw = fallback_w / tc;
+		vh = fallback_h / tr;
+	}
+	*out_vw = vw;
+	*out_vh = vh;
+}
+
+/*!
  * Check if a DXGI format is an SRGB format.
  */
 static inline bool
@@ -6442,8 +6475,8 @@ after_key_shortcuts:
 		if (ca_w == 0) ca_w = 3840;
 		if (ca_h == 0) ca_h = 2160;
 		uint32_t num_views = sys->tile_columns * sys->tile_rows;
-		uint32_t half_w = ca_w / sys->tile_columns;
-		uint32_t half_h = ca_h / sys->tile_rows;
+		uint32_t half_w, half_h;
+		resolve_active_view_dims(sys, ca_w, ca_h, &half_w, &half_h);
 		float scale = 3.0f;
 		float gh = (float)mc->font_glyph_h * scale;
 		const char *hint = "Press Ctrl+L to open launcher";
@@ -6585,8 +6618,11 @@ after_key_shortcuts:
 		uint32_t ca_h = sys->base.info.display_pixel_height;
 		if (ca_w == 0) ca_w = 3840;
 		if (ca_h == 0) ca_h = 2160;
-		uint32_t half_w = ca_w / sys->tile_columns;
-		uint32_t half_h = ca_h / sys->tile_rows;
+		// Tile layout dims: non-legacy sessions use the true per-view dims
+		// (e.g. 1920×1080 stereo), legacy uses the atlas-divided compromise.
+		// Issue #158.
+		uint32_t half_w, half_h;
+		resolve_active_view_dims(sys, ca_w, ca_h, &half_w, &half_h);
 
 		// Per-eye projected pixel rects (parallax shift for windows at Z != 0).
 		int32_t eye_rect_x[2], eye_rect_y[2], eye_rect_w[2], eye_rect_h[2];
@@ -7109,8 +7145,8 @@ after_key_shortcuts:
 			uint32_t ca_h = sys->base.info.display_pixel_height;
 			if (ca_w == 0) ca_w = 3840;
 			if (ca_h == 0) ca_h = 2160;
-			uint32_t half_w = ca_w / sys->tile_columns;
-			uint32_t half_h = ca_h / sys->tile_rows;
+			uint32_t half_w, half_h;
+			resolve_active_view_dims(sys, ca_w, ca_h, &half_w, &half_h);
 
 			float tb_y = (float)(ca_h - TASKBAR_HEIGHT_PX);
 
@@ -7269,8 +7305,8 @@ after_key_shortcuts:
 		uint32_t ca_h = sys->base.info.display_pixel_height;
 		if (ca_w == 0) ca_w = 3840;
 		if (ca_h == 0) ca_h = 2160;
-		uint32_t half_w = ca_w / sys->tile_columns;
-		uint32_t half_h = ca_h / sys->tile_rows;
+		uint32_t half_w, half_h;
+		resolve_active_view_dims(sys, ca_w, ca_h, &half_w, &half_h);
 		uint32_t num_views = sys->tile_columns * sys->tile_rows;
 
 		// Panel size as a fraction of the physical display — resolution-
@@ -7302,8 +7338,11 @@ after_key_shortcuts:
 		// Physically square tiles: X pixels are wider than Y pixels in
 		// SBS mode (1920 pixels span 0.700m but 2160 span 0.394m).
 		// Scale tile_h so each tile is the same physical width and height.
-		uint32_t tpw = sys->base.info.display_pixel_width / sys->tile_columns;
-		uint32_t tph = sys->base.info.display_pixel_height / sys->tile_rows;
+		uint32_t tpw, tph;
+		resolve_active_view_dims(sys,
+		                         sys->base.info.display_pixel_width,
+		                         sys->base.info.display_pixel_height,
+		                         &tpw, &tph);
 		float pix_ratio = (tpw > 0 && tph > 0 && disp_w_m > 0 && disp_h_m > 0)
 		    ? ((disp_w_m / (float)tpw) / (disp_h_m / (float)tph))
 		    : 1.0f;
@@ -7842,15 +7881,17 @@ after_key_shortcuts:
 
 	// Send full combined atlas to DP — content is placed at sub-rect positions,
 	// background is dark gray. The DP interlaces the entire image.
-	// View width/height = full atlas divided by tile layout (not sub-rect).
+	// Non-legacy sessions use true per-view dims from the active rendering mode
+	// (e.g. 1920×1080 per view in stereo SBS, not 1920×2160). Legacy sessions
+	// keep the atlas-divided size so compromise-scaled submissions aren't cropped.
+	// Issue #158.
 	ID3D11ShaderResourceView *dp_input_srv = mc->combined_atlas_srv.get();
 	{
 		uint32_t aw = sys->base.info.display_pixel_width;
 		uint32_t ah = sys->base.info.display_pixel_height;
 		if (aw == 0) aw = sys->display_width;
 		if (ah == 0) ah = sys->display_height;
-		dp_view_w = aw / sys->tile_columns;
-		dp_view_h = ah / sys->tile_rows;
+		resolve_active_view_dims(sys, aw, ah, &dp_view_w, &dp_view_h);
 	}
 	uint32_t content_w = sys->tile_columns * dp_view_w;
 	uint32_t content_h = sys->tile_rows * dp_view_h;
@@ -9551,16 +9592,16 @@ comp_d3d11_service_capture_frame(struct xrt_system_compositor *xsysc,
 	const uint32_t atlas_h = desc.Height;
 	const uint32_t tile_columns = sys->tile_columns > 0 ? sys->tile_columns : 1;
 	const uint32_t tile_rows = sys->tile_rows > 0 ? sys->tile_rows : 1;
-	// Dump the atlas as-is. The compositor is supposed to render each tile
-	// into (atlas_w / tile_columns) × (atlas_h / tile_rows) and leave the
-	// rest black. If it's stretching content to fill the whole atlas instead
-	// of respecting the scale hint, that bug surfaces here as a vertically
-	// distorted capture — which is the honest representation of what the
-	// display processor receives.
-	const uint32_t used_w = atlas_w;
-	const uint32_t used_h = atlas_h;
-	const uint32_t eye_w = atlas_w / tile_columns;
-	const uint32_t eye_h = atlas_h / tile_rows;
+	// Crop to the active region: in non-legacy sessions each view occupies
+	// view_width_pixels × view_height_pixels in the top-left of its tile
+	// (e.g. 1920×1080 per eye in stereo SBS on 4K, leaving the rest black).
+	// Legacy sessions use the full tile. Issue #158.
+	uint32_t eye_w_res, eye_h_res;
+	resolve_active_view_dims(sys, atlas_w, atlas_h, &eye_w_res, &eye_h_res);
+	const uint32_t eye_w = eye_w_res;
+	const uint32_t eye_h = eye_h_res;
+	const uint32_t used_w = eye_w * tile_columns;
+	const uint32_t used_h = eye_h * tile_rows;
 
 	// Create CPU-readable staging texture and copy atlas into it.
 	D3D11_TEXTURE2D_DESC sd = desc;

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -2035,6 +2035,11 @@ swapchain_acquire_image(struct xrt_swapchain *xsc, uint32_t *out_index)
 	*out_index = next_index % sc->image_count;
 	next_index++;
 
+	U_LOG_W("[#151] d3d11_service swapchain_acquire_image: index=%u image_count=%u "
+	        "(w=%u h=%u format=%lld bits=0x%x service_created=%d)",
+	        *out_index, sc->image_count, sc->info.width, sc->info.height,
+	        (long long)sc->info.format, (unsigned)sc->info.bits, (int)sc->service_created);
+
 	return XRT_SUCCESS;
 }
 
@@ -2250,6 +2255,14 @@ compositor_create_swapchain(struct xrt_compositor *xc,
 
 	U_LOG_W("Creating swapchain: %u images, %ux%u, format=%u, usage=0x%x",
 	        image_count, info->width, info->height, info->format, info->bits);
+	U_LOG_W("[#151] d3d11_service create_swapchain: arraySize=%u mipCount=%u sampleCount=%u "
+	        "faceCount=%u create=0x%x MUTABLE_FORMAT=%s SAMPLED=%s COLOR=%s DEPTH_STENCIL=%s",
+	        info->array_size, info->mip_count, info->sample_count, info->face_count,
+	        (unsigned)info->create,
+	        (info->bits & XRT_SWAPCHAIN_USAGE_MUTABLE_FORMAT) ? "YES" : "no",
+	        (info->bits & XRT_SWAPCHAIN_USAGE_SAMPLED) ? "YES" : "no",
+	        (info->bits & XRT_SWAPCHAIN_USAGE_COLOR) ? "YES" : "no",
+	        (info->bits & XRT_SWAPCHAIN_USAGE_DEPTH_STENCIL) ? "YES" : "no");
 
 	// Allocate swapchain
 	struct d3d11_service_swapchain *sc = new d3d11_service_swapchain();
@@ -7926,38 +7939,24 @@ after_key_shortcuts:
 		sys->context->CopyResource(back_buffer.get(), mc->combined_atlas.get());
 	}
 
-	// Screenshot: file-trigger check. Runs every frame after atlas is finalized.
-	// Create %TEMP%\shell_screenshot_trigger to capture next frame.
+	// Phase 8: screenshot file-trigger now routes through the same capture path
+	// as the shell-driven Ctrl+Shift+3 IPC call. Create %TEMP%\shell_screenshot_trigger
+	// to drop %TEMP%\shell_screenshot_sbs.png on the next frame.
 	{
 		static char ss_trigger[MAX_PATH] = {};
-		static char ss_output[MAX_PATH] = {};
+		static char ss_prefix[MAX_PATH] = {};
 		if (!ss_trigger[0]) {
 			const char *tmp = getenv("TEMP");
 			if (!tmp) tmp = "C:\\Temp";
 			snprintf(ss_trigger, sizeof(ss_trigger), "%s\\shell_screenshot_trigger", tmp);
-			snprintf(ss_output, sizeof(ss_output), "%s\\shell_screenshot.png", tmp);
+			snprintf(ss_prefix, sizeof(ss_prefix), "%s\\shell_screenshot", tmp);
 		}
 		if (mc->combined_atlas &&
 		    GetFileAttributesA(ss_trigger) != INVALID_FILE_ATTRIBUTES) {
 			DeleteFileA(ss_trigger);
-			D3D11_TEXTURE2D_DESC desc;
-			mc->combined_atlas->GetDesc(&desc);
-			D3D11_TEXTURE2D_DESC sd = desc;
-			sd.Usage = D3D11_USAGE_STAGING;
-			sd.BindFlags = 0;
-			sd.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
-			sd.MiscFlags = 0;
-			wil::com_ptr<ID3D11Texture2D> staging;
-			if (SUCCEEDED(sys->device->CreateTexture2D(&sd, nullptr, staging.put()))) {
-				sys->context->CopyResource(staging.get(), mc->combined_atlas.get());
-				D3D11_MAPPED_SUBRESOURCE m;
-				if (SUCCEEDED(sys->context->Map(staging.get(), 0, D3D11_MAP_READ, 0, &m))) {
-					stbi_write_png(ss_output,
-					               (int)desc.Width, (int)desc.Height, 4,
-					               m.pData, (int)m.RowPitch);
-					sys->context->Unmap(staging.get(), 0);
-				}
-			}
+			struct ipc_capture_result dummy = {};
+			comp_d3d11_service_capture_frame(&sys->base, ss_prefix,
+			                                 IPC_CAPTURE_FLAG_SBS, &dummy);
 		}
 	}
 
@@ -9518,6 +9517,129 @@ comp_d3d11_service_get_predicted_eye_positions(struct xrt_system_compositor *xsy
 	}
 
 	return false;
+}
+
+bool
+comp_d3d11_service_capture_frame(struct xrt_system_compositor *xsysc,
+                                 const char *path_prefix,
+                                 uint32_t flags,
+                                 struct ipc_capture_result *out_result)
+{
+	if (xsysc == nullptr || path_prefix == nullptr || out_result == nullptr || flags == 0) {
+		return false;
+	}
+
+	memset(out_result, 0, sizeof(*out_result));
+
+	struct d3d11_service_system *sys = d3d11_service_system_from_xrt(xsysc);
+	struct d3d11_multi_compositor *mc = sys ? sys->multi_comp : nullptr;
+	if (mc == nullptr || !mc->combined_atlas || sys->device == nullptr || sys->context == nullptr) {
+		U_LOG_W("capture_frame: no combined atlas / device / context available");
+		return false;
+	}
+
+	std::lock_guard<std::recursive_mutex> lock(sys->render_mutex);
+
+	// Re-check under lock.
+	if (!mc->combined_atlas) {
+		return false;
+	}
+
+	D3D11_TEXTURE2D_DESC desc;
+	mc->combined_atlas->GetDesc(&desc);
+	const uint32_t atlas_w = desc.Width;
+	const uint32_t atlas_h = desc.Height;
+	const uint32_t tile_columns = sys->tile_columns > 0 ? sys->tile_columns : 1;
+	const uint32_t tile_rows = sys->tile_rows > 0 ? sys->tile_rows : 1;
+	const uint32_t eye_w = atlas_w / tile_columns;
+	const uint32_t eye_h = atlas_h / tile_rows;
+
+	// Create CPU-readable staging texture and copy atlas into it.
+	D3D11_TEXTURE2D_DESC sd = desc;
+	sd.Usage = D3D11_USAGE_STAGING;
+	sd.BindFlags = 0;
+	sd.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
+	sd.MiscFlags = 0;
+	wil::com_ptr<ID3D11Texture2D> staging;
+	HRESULT hr = sys->device->CreateTexture2D(&sd, nullptr, staging.put());
+	if (FAILED(hr)) {
+		U_LOG_W("capture_frame: CreateTexture2D(staging) failed 0x%08lx", hr);
+		return false;
+	}
+	sys->context->CopyResource(staging.get(), mc->combined_atlas.get());
+
+	D3D11_MAPPED_SUBRESOURCE m;
+	hr = sys->context->Map(staging.get(), 0, D3D11_MAP_READ, 0, &m);
+	if (FAILED(hr)) {
+		U_LOG_W("capture_frame: Map(staging) failed 0x%08lx", hr);
+		return false;
+	}
+
+	uint32_t views_written = 0;
+
+	if (flags & IPC_CAPTURE_FLAG_SBS) {
+		char path[MAX_PATH];
+		snprintf(path, sizeof(path), "%s_sbs.png", path_prefix);
+		if (stbi_write_png(path, (int)atlas_w, (int)atlas_h, 4,
+		                   m.pData, (int)m.RowPitch) != 0) {
+			views_written |= IPC_CAPTURE_FLAG_SBS;
+		} else {
+			U_LOG_W("capture_frame: stbi_write_png failed for %s", path);
+		}
+	}
+
+	for (int eye = 0; eye < 2; eye++) {
+		uint32_t flag = (eye == 0) ? IPC_CAPTURE_FLAG_LEFT : IPC_CAPTURE_FLAG_RIGHT;
+		if (!(flags & flag)) {
+			continue;
+		}
+		// In mono (tile_columns == 1) both L and R map to the same full-frame.
+		const uint32_t eye_x = (tile_columns > 1 ? (uint32_t)eye : 0u) * eye_w;
+		std::vector<uint8_t> buf((size_t)eye_w * eye_h * 4u);
+		const uint8_t *src = static_cast<const uint8_t *>(m.pData);
+		for (uint32_t y = 0; y < eye_h; y++) {
+			memcpy(buf.data() + (size_t)y * eye_w * 4u,
+			       src + (size_t)y * m.RowPitch + (size_t)eye_x * 4u,
+			       (size_t)eye_w * 4u);
+		}
+		char path[MAX_PATH];
+		snprintf(path, sizeof(path), "%s_%c.png", path_prefix, eye == 0 ? 'L' : 'R');
+		if (stbi_write_png(path, (int)eye_w, (int)eye_h, 4,
+		                   buf.data(), (int)(eye_w * 4u)) != 0) {
+			views_written |= flag;
+		} else {
+			U_LOG_W("capture_frame: stbi_write_png failed for %s", path);
+		}
+	}
+
+	sys->context->Unmap(staging.get(), 0);
+
+	// Populate metadata.
+	out_result->timestamp_ns = os_monotonic_get_ns();
+	out_result->atlas_width = atlas_w;
+	out_result->atlas_height = atlas_h;
+	out_result->eye_width = eye_w;
+	out_result->eye_height = eye_h;
+	out_result->views_written = views_written;
+	out_result->tile_columns = tile_columns;
+	out_result->tile_rows = tile_rows;
+	out_result->display_width_m = sys->base.info.display_width_m;
+	out_result->display_height_m = sys->base.info.display_height_m;
+
+	struct xrt_vec3 le = {0, 0, 0}, re = {0, 0, 0};
+	if (comp_d3d11_service_get_predicted_eye_positions(xsysc, &le, &re)) {
+		out_result->eye_left_m[0] = le.x;
+		out_result->eye_left_m[1] = le.y;
+		out_result->eye_left_m[2] = le.z;
+		out_result->eye_right_m[0] = re.x;
+		out_result->eye_right_m[1] = re.y;
+		out_result->eye_right_m[2] = re.z;
+	}
+
+	U_LOG_W("capture_frame: prefix=%s flags=0x%x written=0x%x atlas=%ux%u eye=%ux%u",
+	        path_prefix, flags, views_written, atlas_w, atlas_h, eye_w, eye_h);
+
+	return views_written != 0;
 }
 
 bool

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -9551,6 +9551,14 @@ comp_d3d11_service_capture_frame(struct xrt_system_compositor *xsysc,
 	const uint32_t atlas_h = desc.Height;
 	const uint32_t tile_columns = sys->tile_columns > 0 ? sys->tile_columns : 1;
 	const uint32_t tile_rows = sys->tile_rows > 0 ? sys->tile_rows : 1;
+	// Dump the atlas as-is. The compositor is supposed to render each tile
+	// into (atlas_w / tile_columns) × (atlas_h / tile_rows) and leave the
+	// rest black. If it's stretching content to fill the whole atlas instead
+	// of respecting the scale hint, that bug surfaces here as a vertically
+	// distorted capture — which is the honest representation of what the
+	// display processor receives.
+	const uint32_t used_w = atlas_w;
+	const uint32_t used_h = atlas_h;
 	const uint32_t eye_w = atlas_w / tile_columns;
 	const uint32_t eye_h = atlas_h / tile_rows;
 
@@ -9578,35 +9586,21 @@ comp_d3d11_service_capture_frame(struct xrt_system_compositor *xsysc,
 	uint32_t views_written = 0;
 
 	if (flags & IPC_CAPTURE_FLAG_SBS) {
+		// Tightly-pack the active top-left region (used_w × used_h) into a
+		// contiguous RGBA8 buffer. Drops the black padding outside the tile
+		// grid and also handles staging RowPitch > used_w*4.
+		std::vector<uint8_t> buf((size_t)used_w * used_h * 4u);
+		const uint8_t *src = static_cast<const uint8_t *>(m.pData);
+		for (uint32_t y = 0; y < used_h; y++) {
+			memcpy(buf.data() + (size_t)y * used_w * 4u,
+			       src + (size_t)y * m.RowPitch,
+			       (size_t)used_w * 4u);
+		}
 		char path[MAX_PATH];
 		snprintf(path, sizeof(path), "%s_sbs.png", path_prefix);
-		if (stbi_write_png(path, (int)atlas_w, (int)atlas_h, 4,
-		                   m.pData, (int)m.RowPitch) != 0) {
+		if (stbi_write_png(path, (int)used_w, (int)used_h, 4,
+		                   buf.data(), (int)(used_w * 4u)) != 0) {
 			views_written |= IPC_CAPTURE_FLAG_SBS;
-		} else {
-			U_LOG_W("capture_frame: stbi_write_png failed for %s", path);
-		}
-	}
-
-	for (int eye = 0; eye < 2; eye++) {
-		uint32_t flag = (eye == 0) ? IPC_CAPTURE_FLAG_LEFT : IPC_CAPTURE_FLAG_RIGHT;
-		if (!(flags & flag)) {
-			continue;
-		}
-		// In mono (tile_columns == 1) both L and R map to the same full-frame.
-		const uint32_t eye_x = (tile_columns > 1 ? (uint32_t)eye : 0u) * eye_w;
-		std::vector<uint8_t> buf((size_t)eye_w * eye_h * 4u);
-		const uint8_t *src = static_cast<const uint8_t *>(m.pData);
-		for (uint32_t y = 0; y < eye_h; y++) {
-			memcpy(buf.data() + (size_t)y * eye_w * 4u,
-			       src + (size_t)y * m.RowPitch + (size_t)eye_x * 4u,
-			       (size_t)eye_w * 4u);
-		}
-		char path[MAX_PATH];
-		snprintf(path, sizeof(path), "%s_%c.png", path_prefix, eye == 0 ? 'L' : 'R');
-		if (stbi_write_png(path, (int)eye_w, (int)eye_h, 4,
-		                   buf.data(), (int)(eye_w * 4u)) != 0) {
-			views_written |= flag;
 		} else {
 			U_LOG_W("capture_frame: stbi_write_png failed for %s", path);
 		}
@@ -9614,10 +9608,11 @@ comp_d3d11_service_capture_frame(struct xrt_system_compositor *xsysc,
 
 	sys->context->Unmap(staging.get(), 0);
 
-	// Populate metadata.
+	// Populate metadata. atlas_width/height report the cropped active region
+	// (what was actually written to disk), not the full-display staging size.
 	out_result->timestamp_ns = os_monotonic_get_ns();
-	out_result->atlas_width = atlas_w;
-	out_result->atlas_height = atlas_h;
+	out_result->atlas_width = used_w;
+	out_result->atlas_height = used_h;
 	out_result->eye_width = eye_w;
 	out_result->eye_height = eye_h;
 	out_result->views_written = views_written;
@@ -9636,8 +9631,8 @@ comp_d3d11_service_capture_frame(struct xrt_system_compositor *xsysc,
 		out_result->eye_right_m[2] = re.z;
 	}
 
-	U_LOG_W("capture_frame: prefix=%s flags=0x%x written=0x%x atlas=%ux%u eye=%ux%u",
-	        path_prefix, flags, views_written, atlas_w, atlas_h, eye_w, eye_h);
+	U_LOG_W("capture_frame: prefix=%s flags=0x%x written=0x%x used=%ux%u (atlas=%ux%u) eye=%ux%u",
+	        path_prefix, flags, views_written, used_w, used_h, atlas_w, atlas_h, eye_w, eye_h);
 
 	return views_written != 0;
 }

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -493,15 +493,33 @@ struct d3d11_service_system
 #define RESIZE_TOP    4
 #define RESIZE_BOTTOM 8
 
+// Forward decl — defined after sync_tile_layout (see resolve_active_view_dims
+// below). Needed here because the UI meter→pixel helpers use it to get the
+// active-region tile dims (post-#158) instead of the atlas-divided dims.
+static inline void
+resolve_active_view_dims(const struct d3d11_service_system *sys,
+                         uint32_t fallback_w, uint32_t fallback_h,
+                         uint32_t *out_vw, uint32_t *out_vh);
+
 /*!
- * Convert meters to pixels in the SBS tile (not full display).
- * Each tile represents the full physical display, so m_per_px = display_m / tile_px.
+ * Convert meters to pixels inside one per-view tile.
+ *
+ * One tile represents the full physical display area, so the conversion
+ * is m_per_px = display_m / tile_px. For the tile_px denominator use the
+ * *active* per-view dims (rendering_modes[idx].view_{width,height}_pixels)
+ * when running a non-legacy session — that way shell UI laid out in meters
+ * lands inside the active 1920×1080 region in stereo SBS instead of getting
+ * sized for the 2160-tall atlas tile and overflowing the top (#158).
  */
 static inline float
 ui_m_to_tile_px_x(float meters, const struct d3d11_service_system *sys)
 {
 	float disp_w_m = sys->base.info.display_width_m;
-	uint32_t tile_px_w = sys->base.info.display_pixel_width / sys->tile_columns;
+	uint32_t tile_px_w, tile_px_h;
+	resolve_active_view_dims(sys,
+	                         sys->base.info.display_pixel_width,
+	                         sys->base.info.display_pixel_height,
+	                         &tile_px_w, &tile_px_h);
 	if (disp_w_m <= 0.0f) disp_w_m = 0.700f;
 	if (tile_px_w == 0) tile_px_w = 1920;
 	return meters / disp_w_m * (float)tile_px_w;
@@ -511,7 +529,11 @@ static inline float
 ui_m_to_tile_px_y(float meters, const struct d3d11_service_system *sys)
 {
 	float disp_h_m = sys->base.info.display_height_m;
-	uint32_t tile_px_h = sys->base.info.display_pixel_height / sys->tile_rows;
+	uint32_t tile_px_w, tile_px_h;
+	resolve_active_view_dims(sys,
+	                         sys->base.info.display_pixel_width,
+	                         sys->base.info.display_pixel_height,
+	                         &tile_px_w, &tile_px_h);
 	if (disp_h_m <= 0.0f) disp_h_m = 0.394f;
 	if (tile_px_h == 0) tile_px_h = 1080;
 	return meters / disp_h_m * (float)tile_px_h;
@@ -7997,7 +8019,7 @@ after_key_shortcuts:
 			DeleteFileA(ss_trigger);
 			struct ipc_capture_result dummy = {};
 			comp_d3d11_service_capture_frame(&sys->base, ss_prefix,
-			                                 IPC_CAPTURE_FLAG_SBS, &dummy);
+			                                 IPC_CAPTURE_FLAG_ATLAS, &dummy);
 		}
 	}
 
@@ -9626,7 +9648,7 @@ comp_d3d11_service_capture_frame(struct xrt_system_compositor *xsysc,
 
 	uint32_t views_written = 0;
 
-	if (flags & IPC_CAPTURE_FLAG_SBS) {
+	if (flags & IPC_CAPTURE_FLAG_ATLAS) {
 		// Tightly-pack the active top-left region (used_w × used_h) into a
 		// contiguous RGBA8 buffer. Drops the black padding outside the tile
 		// grid and also handles staging RowPitch > used_w*4.
@@ -9638,10 +9660,10 @@ comp_d3d11_service_capture_frame(struct xrt_system_compositor *xsysc,
 			       (size_t)used_w * 4u);
 		}
 		char path[MAX_PATH];
-		snprintf(path, sizeof(path), "%s_sbs.png", path_prefix);
+		snprintf(path, sizeof(path), "%s_atlas.png", path_prefix);
 		if (stbi_write_png(path, (int)used_w, (int)used_h, 4,
 		                   buf.data(), (int)(used_w * 4u)) != 0) {
-			views_written |= IPC_CAPTURE_FLAG_SBS;
+			views_written |= IPC_CAPTURE_FLAG_ATLAS;
 		} else {
 			U_LOG_W("capture_frame: stbi_write_png failed for %s", path);
 		}

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.h
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.h
@@ -363,14 +363,13 @@ void
 comp_d3d11_service_set_running_tile_mask(struct xrt_system_compositor *xsysc, uint64_t mask);
 
 /*!
- * Phase 8: capture the current pre-weave combined atlas to disk. Writes one
- * or more PNGs (full SBS, left-eye crop, right-eye crop) depending on
- * @p flags, and fills @p out_result with metadata for the shell's sidecar
- * JSON file.
+ * Phase 8: capture the current pre-weave combined atlas to disk. Writes a
+ * PNG of the full multi-view atlas (cropped to the active region in non-
+ * legacy sessions) and fills @p out_result with metadata for the shell's
+ * sidecar JSON file.
  *
- * The runtime appends @c "_sbs.png", @c "_L.png", @c "_R.png" to
- * @p path_prefix as needed. Caller owns the prefix string and the result
- * struct.
+ * The runtime appends @c "_atlas.png" to @p path_prefix. Caller owns the
+ * prefix string and the result struct.
  *
  * Must be called while the multi-compositor render mutex is held by this
  * thread, OR from a thread that does not hold the lock (this function takes

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.h
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.h
@@ -27,6 +27,7 @@ extern "C" {
 
 // Forward decl from ipc_protocol.h — full definition is included by callers.
 struct ipc_launcher_app;
+struct ipc_capture_result;
 
 
 /*!
@@ -360,6 +361,34 @@ comp_d3d11_service_poll_launcher_click(struct xrt_system_compositor *xsysc);
  */
 void
 comp_d3d11_service_set_running_tile_mask(struct xrt_system_compositor *xsysc, uint64_t mask);
+
+/*!
+ * Phase 8: capture the current pre-weave combined atlas to disk. Writes one
+ * or more PNGs (full SBS, left-eye crop, right-eye crop) depending on
+ * @p flags, and fills @p out_result with metadata for the shell's sidecar
+ * JSON file.
+ *
+ * The runtime appends @c "_sbs.png", @c "_L.png", @c "_R.png" to
+ * @p path_prefix as needed. Caller owns the prefix string and the result
+ * struct.
+ *
+ * Must be called while the multi-compositor render mutex is held by this
+ * thread, OR from a thread that does not hold the lock (this function takes
+ * the lock itself).
+ *
+ * @param xsysc       The system compositor (must be D3D11 service).
+ * @param path_prefix Filename prefix without extension.
+ * @param flags       Bitmask of IPC_CAPTURE_FLAG_* views to write.
+ * @param out_result  Filled with capture metadata. May not be NULL.
+ * @return true if at least one view was successfully written.
+ *
+ * @ingroup comp_d3d11_service
+ */
+bool
+comp_d3d11_service_capture_frame(struct xrt_system_compositor *xsysc,
+                                 const char *path_prefix,
+                                 uint32_t flags,
+                                 struct ipc_capture_result *out_result);
 
 /*! @} */
 

--- a/src/xrt/compositor/d3d12/comp_d3d12_swapchain.cpp
+++ b/src/xrt/compositor/d3d12/comp_d3d12_swapchain.cpp
@@ -47,15 +47,17 @@ struct comp_d3d12_swapchain
 	//! Creation info.
 	struct xrt_swapchain_create_info info;
 
-	//! Currently acquired image index (-1 if none).
-	int32_t acquired_index;
+	//! Per-image state for multi-acquire tracking (#151).
+	//! 0 = FREE, 1 = ACQUIRED, 2 = WAITED.
+	uint8_t img_state[MAX_SWAPCHAIN_IMAGES];
 
-	//! Currently waited image index (-1 if none).
-	int32_t waited_index;
-
-	//! Last released image index (for round-robin).
-	uint32_t last_released_index;
+	//! Round-robin hint for next acquire.
+	uint32_t next_hint;
 };
+
+static constexpr uint8_t IMG_FREE = 0;
+static constexpr uint8_t IMG_ACQUIRED = 1;
+static constexpr uint8_t IMG_WAITED = 2;
 
 // Access compositor internals
 extern "C" {
@@ -128,17 +130,19 @@ d3d12_swapchain_acquire_image(struct xrt_swapchain *xsc, uint32_t *out_index)
 {
 	struct comp_d3d12_swapchain *sc = d3d12_sc(xsc);
 
-	if (sc->acquired_index >= 0) {
-		U_LOG_E("Image already acquired");
-		return XRT_ERROR_IPC_FAILURE;
+	// Find a FREE image starting from next_hint (#151: support multiple outstanding acquires).
+	for (uint32_t offset = 0; offset < sc->image_count; offset++) {
+		uint32_t idx = (sc->next_hint + offset) % sc->image_count;
+		if (sc->img_state[idx] == IMG_FREE) {
+			sc->img_state[idx] = IMG_ACQUIRED;
+			sc->next_hint = (idx + 1) % sc->image_count;
+			*out_index = idx;
+			return XRT_SUCCESS;
+		}
 	}
 
-	uint32_t index = (sc->last_released_index + 1) % sc->image_count;
-
-	sc->acquired_index = static_cast<int32_t>(index);
-	*out_index = index;
-
-	return XRT_SUCCESS;
+	U_LOG_E("No FREE swapchain image available (all %u acquired/waited)", sc->image_count);
+	return XRT_ERROR_IPC_FAILURE;
 }
 
 static xrt_result_t
@@ -147,19 +151,13 @@ d3d12_swapchain_wait_image(struct xrt_swapchain *xsc, int64_t timeout_ns, uint32
 	struct comp_d3d12_swapchain *sc = d3d12_sc(xsc);
 	(void)timeout_ns;
 
-	if (sc->acquired_index < 0) {
-		U_LOG_E("No image acquired");
+	if (index >= sc->image_count || sc->img_state[index] != IMG_ACQUIRED) {
+		U_LOG_E("Wait on non-acquired image index %u (state=%u)", index,
+		        index < sc->image_count ? sc->img_state[index] : 0xff);
 		return XRT_ERROR_IPC_FAILURE;
 	}
 
-	if (static_cast<uint32_t>(sc->acquired_index) != index) {
-		U_LOG_E("Wait index %u doesn't match acquired index %d", index, sc->acquired_index);
-		return XRT_ERROR_IPC_FAILURE;
-	}
-
-	sc->waited_index = sc->acquired_index;
-	sc->acquired_index = -1;
-
+	sc->img_state[index] = IMG_WAITED;
 	return XRT_SUCCESS;
 }
 
@@ -179,19 +177,13 @@ d3d12_swapchain_release_image(struct xrt_swapchain *xsc, uint32_t index)
 {
 	struct comp_d3d12_swapchain *sc = d3d12_sc(xsc);
 
-	if (sc->waited_index < 0) {
-		U_LOG_E("No image to release");
+	if (index >= sc->image_count || sc->img_state[index] != IMG_WAITED) {
+		U_LOG_E("Release on non-waited image index %u (state=%u)", index,
+		        index < sc->image_count ? sc->img_state[index] : 0xff);
 		return XRT_ERROR_IPC_FAILURE;
 	}
 
-	if (static_cast<uint32_t>(sc->waited_index) != index) {
-		U_LOG_E("Release index %u doesn't match waited index %d", index, sc->waited_index);
-		return XRT_ERROR_IPC_FAILURE;
-	}
-
-	sc->last_released_index = index;
-	sc->waited_index = -1;
-
+	sc->img_state[index] = IMG_FREE;
 	return XRT_SUCCESS;
 }
 
@@ -233,9 +225,11 @@ comp_d3d12_swapchain_create(struct comp_d3d12_compositor *c,
 	sc->c = c;
 	sc->info = *info;
 	sc->image_count = image_count;
-	sc->acquired_index = -1;
-	sc->waited_index = -1;
-	sc->last_released_index = image_count - 1;
+	// All images start FREE (memset already zeroed, but explicit for clarity).
+	for (uint32_t i = 0; i < image_count; i++) {
+		sc->img_state[i] = IMG_FREE;
+	}
+	sc->next_hint = 0;
 
 	DXGI_FORMAT dxgi_format = xrt_format_to_dxgi(info->format);
 

--- a/src/xrt/ipc/server/ipc_server_handler.c
+++ b/src/xrt/ipc/server/ipc_server_handler.c
@@ -2323,6 +2323,42 @@ ipc_handle_shell_remove_capture_client(volatile struct ipc_client_state *_ics,
 }
 
 xrt_result_t
+ipc_handle_shell_capture_frame(volatile struct ipc_client_state *_ics,
+                                const struct ipc_capture_request *request,
+                                struct ipc_capture_result *out_capture_result)
+{
+	struct ipc_server *s = _ics->server;
+
+	if (out_capture_result == NULL) {
+		return XRT_ERROR_IPC_FAILURE;
+	}
+	memset((void *)out_capture_result, 0, sizeof(*out_capture_result));
+
+#if defined(XRT_HAVE_D3D11_SERVICE_COMPOSITOR)
+	if (s->xsysc == NULL || request == NULL) {
+		return XRT_ERROR_IPC_FAILURE;
+	}
+
+	IPC_INFO(s, "Shell: capture_frame prefix=%s flags=0x%x",
+	         request->path_prefix, request->flags);
+
+	// Ensure NUL terminator (defense in depth — IPC marshalling should already
+	// preserve the trailing NUL, but the buffer is fixed-size).
+	char prefix[IPC_CAPTURE_PATH_MAX];
+	memcpy(prefix, request->path_prefix, sizeof(prefix));
+	prefix[sizeof(prefix) - 1] = '\0';
+
+	bool ok = comp_d3d11_service_capture_frame(s->xsysc, prefix, request->flags,
+	                                           out_capture_result);
+	return ok ? XRT_SUCCESS : XRT_ERROR_IPC_FAILURE;
+#else
+	(void)s;
+	(void)request;
+	return XRT_ERROR_IPC_FAILURE;
+#endif
+}
+
+xrt_result_t
 ipc_handle_swapchain_get_properties(volatile struct ipc_client_state *ics,
                                     const struct xrt_swapchain_create_info *info,
                                     struct xrt_swapchain_create_properties *xsccp)
@@ -2472,6 +2508,7 @@ xrt_result_t
 ipc_handle_swapchain_acquire_image(volatile struct ipc_client_state *ics, uint32_t id, uint32_t *out_index)
 {
 	if (ics->xc == NULL) {
+		U_LOG_W("[#151] ipc server acquire_image: session not created -> IPC_SESSION_NOT_CREATED");
 		return XRT_ERROR_IPC_SESSION_NOT_CREATED;
 	}
 
@@ -2479,7 +2516,14 @@ ipc_handle_swapchain_acquire_image(volatile struct ipc_client_state *ics, uint32
 	uint32_t sc_index = id;
 	struct xrt_swapchain *xsc = ics->xscs[sc_index];
 
-	xrt_swapchain_acquire_image(xsc, out_index);
+	if (xsc == NULL) {
+		U_LOG_W("[#151] ipc server acquire_image: xsc[%u]=NULL -> IPC_FAILURE", sc_index);
+		return XRT_ERROR_IPC_FAILURE;
+	}
+
+	xrt_result_t xret = xrt_swapchain_acquire_image(xsc, out_index);
+	U_LOG_W("[#151] ipc server acquire_image: sc_id=%u xret=%d out_index=%u",
+	        sc_index, (int)xret, *out_index);
 
 	return XRT_SUCCESS;
 }

--- a/src/xrt/ipc/shared/ipc_protocol.h
+++ b/src/xrt/ipc/shared/ipc_protocol.h
@@ -342,6 +342,56 @@ struct ipc_launcher_app
 };
 
 /*!
+ * Phase 8: 3D capture MVP. Bitmask of which views (sub-images) the shell
+ * is requesting from the service compositor's combined atlas.
+ *
+ * @ingroup ipc
+ */
+#define IPC_CAPTURE_FLAG_LEFT (1u << 0)
+#define IPC_CAPTURE_FLAG_RIGHT (1u << 1)
+#define IPC_CAPTURE_FLAG_SBS (1u << 2)
+#define IPC_CAPTURE_FLAG_ALL (IPC_CAPTURE_FLAG_LEFT | IPC_CAPTURE_FLAG_RIGHT | IPC_CAPTURE_FLAG_SBS)
+
+#define IPC_CAPTURE_PATH_MAX 256
+
+/*!
+ * Phase 8: request struct for shell_capture_frame. Wraps the path prefix
+ * (without extension — runtime appends "_sbs.png" / "_L.png" / "_R.png")
+ * because the IPC schema only supports struct/scalar parameter types.
+ *
+ * @ingroup ipc
+ */
+struct ipc_capture_request
+{
+	char path_prefix[IPC_CAPTURE_PATH_MAX];
+	uint32_t flags; // IPC_CAPTURE_FLAG_* bitmask
+};
+
+/*!
+ * Phase 8: result returned by shell_capture_frame. The runtime fills this
+ * with the metadata needed for a sidecar JSON file (timestamp, atlas/eye
+ * dimensions, stereo layout, display physical size, eye poses at capture).
+ *
+ * @ingroup ipc
+ */
+struct ipc_capture_result
+{
+	uint64_t timestamp_ns;
+	uint32_t atlas_width;
+	uint32_t atlas_height;
+	uint32_t eye_width;
+	uint32_t eye_height;
+	uint32_t views_written; // bitmask of IPC_CAPTURE_FLAG_* actually written
+	uint32_t tile_columns;
+	uint32_t tile_rows;
+	float display_width_m;
+	float display_height_m;
+	float eye_left_m[3];
+	float eye_right_m[3];
+	char _pad[16];
+};
+
+/*!
  * State for a connected application.
  *
  * @ingroup ipc

--- a/src/xrt/ipc/shared/ipc_protocol.h
+++ b/src/xrt/ipc/shared/ipc_protocol.h
@@ -347,17 +347,15 @@ struct ipc_launcher_app
  *
  * @ingroup ipc
  */
-#define IPC_CAPTURE_FLAG_LEFT (1u << 0)
-#define IPC_CAPTURE_FLAG_RIGHT (1u << 1)
-#define IPC_CAPTURE_FLAG_SBS (1u << 2)
-#define IPC_CAPTURE_FLAG_ALL (IPC_CAPTURE_FLAG_LEFT | IPC_CAPTURE_FLAG_RIGHT | IPC_CAPTURE_FLAG_SBS)
+#define IPC_CAPTURE_FLAG_ATLAS (1u << 0)
+#define IPC_CAPTURE_FLAG_ALL (IPC_CAPTURE_FLAG_ATLAS)
 
 #define IPC_CAPTURE_PATH_MAX 256
 
 /*!
  * Phase 8: request struct for shell_capture_frame. Wraps the path prefix
- * (without extension — runtime appends "_sbs.png" / "_L.png" / "_R.png")
- * because the IPC schema only supports struct/scalar parameter types.
+ * (without extension — runtime appends "_atlas.png") because the IPC
+ * schema only supports struct/scalar parameter types.
  *
  * @ingroup ipc
  */

--- a/src/xrt/ipc/shared/proto.json
+++ b/src/xrt/ipc/shared/proto.json
@@ -134,6 +134,15 @@
 		]
 	},
 
+	"shell_capture_frame": {
+		"in": [
+			{"name": "request", "type": "struct ipc_capture_request"}
+		],
+		"out": [
+			{"name": "capture_result", "type": "struct ipc_capture_result"}
+		]
+	},
+
 	"system_devices_get_roles": {
 		"out": [
 			{"name": "system_roles", "type": "struct xrt_system_roles"}

--- a/src/xrt/state_trackers/oxr/oxr_swapchain.c
+++ b/src/xrt/state_trackers/oxr/oxr_swapchain.c
@@ -8,6 +8,7 @@
  */
 
 #include "util/u_debug.h"
+#include "util/u_logging.h"
 #include "util/u_misc.h"
 
 #include "oxr_chain.h"
@@ -184,23 +185,37 @@ oxr_swapchain_common_acquire(struct oxr_logger *log, struct oxr_swapchain *sc, u
 {
 	uint32_t index;
 
+	U_LOG_W("[#151] oxr acquire: sc=%p image_count=%u acquired.num=%u is_static=%d released.yes=%d",
+	        (void *)sc, sc->swapchain ? sc->swapchain->image_count : 0,
+	        sc->acquired.num, (int)sc->is_static, (int)sc->released.yes);
+
 	if (sc->acquired.num >= sc->swapchain->image_count) {
+		U_LOG_W("[#151] oxr acquire FAIL: all images acquired (num=%u count=%u) -> CALL_ORDER_INVALID",
+		        sc->acquired.num, sc->swapchain->image_count);
 		return oxr_error(log, XR_ERROR_CALL_ORDER_INVALID, "All images have been acquired");
 	}
 
 	if (sc->is_static && (sc->released.yes || sc->images[0].state != OXR_IMAGE_STATE_READY)) {
+		U_LOG_W("[#151] oxr acquire FAIL: static sc, released=%d state0=%d -> CALL_ORDER_INVALID",
+		        (int)sc->released.yes, (int)sc->images[0].state);
 		return oxr_error(log, XR_ERROR_CALL_ORDER_INVALID, "Can only acquire once on a static swapchain");
 	}
 
 	struct xrt_swapchain *xsc = (struct xrt_swapchain *)sc->swapchain;
 
 	xrt_result_t xret = xrt_swapchain_acquire_image(xsc, &index);
+	if (xret != XRT_SUCCESS) {
+		U_LOG_W("[#151] oxr acquire FAIL: xrt_swapchain_acquire_image xret=%d", (int)xret);
+	}
 	OXR_CHECK_XRET(log, sc->sess, xret, xrt_swapchain_acquire_image);
 
 	if (sc->images[index].state != OXR_IMAGE_STATE_READY) {
+		U_LOG_W("[#151] oxr acquire FAIL: image[%u].state=%d != READY(%d) -> RUNTIME_FAILURE",
+		        index, (int)sc->images[index].state, (int)OXR_IMAGE_STATE_READY);
 		return oxr_error(log, XR_ERROR_RUNTIME_FAILURE,
 		                 "Internal xrt_swapchain_acquire_image call returned non-ready image.");
 	}
+	U_LOG_W("[#151] oxr acquire OK: index=%u", index);
 
 	sc->acquired.num++;
 	u_index_fifo_push(&sc->acquired.fifo, index);

--- a/src/xrt/targets/shell/main.c
+++ b/src/xrt/targets/shell/main.c
@@ -1608,14 +1608,8 @@ capture_write_sidecar(const char *json_path, const struct ipc_capture_result *r)
 	cJSON_AddItemToArray(re, cJSON_CreateNumber(r->eye_right_m[2]));
 
 	cJSON *views = cJSON_AddArrayToObject(root, "views_written");
-	if (r->views_written & IPC_CAPTURE_FLAG_SBS) {
-		cJSON_AddItemToArray(views, cJSON_CreateString("sbs"));
-	}
-	if (r->views_written & IPC_CAPTURE_FLAG_LEFT) {
-		cJSON_AddItemToArray(views, cJSON_CreateString("L"));
-	}
-	if (r->views_written & IPC_CAPTURE_FLAG_RIGHT) {
-		cJSON_AddItemToArray(views, cJSON_CreateString("R"));
+	if (r->views_written & IPC_CAPTURE_FLAG_ATLAS) {
+		cJSON_AddItemToArray(views, cJSON_CreateString("atlas"));
 	}
 
 	char *text = cJSON_Print(root);
@@ -1659,7 +1653,7 @@ capture_frame(struct ipc_connection *ipc_c)
 	snprintf(req.path_prefix, sizeof(req.path_prefix),
 	         "%s\\capture_%04d-%02d-%02d_%02d-%02d-%02d",
 	         dir, st.wYear, st.wMonth, st.wDay, st.wHour, st.wMinute, st.wSecond);
-	req.flags = IPC_CAPTURE_FLAG_SBS;
+	req.flags = IPC_CAPTURE_FLAG_ATLAS;
 
 	struct ipc_capture_result result = {0};
 	xrt_result_t r = ipc_call_shell_capture_frame(ipc_c, &req, &result);

--- a/src/xrt/targets/shell/main.c
+++ b/src/xrt/targets/shell/main.c
@@ -1659,7 +1659,7 @@ capture_frame(struct ipc_connection *ipc_c)
 	snprintf(req.path_prefix, sizeof(req.path_prefix),
 	         "%s\\capture_%04d-%02d-%02d_%02d-%02d-%02d",
 	         dir, st.wYear, st.wMonth, st.wDay, st.wHour, st.wMinute, st.wSecond);
-	req.flags = IPC_CAPTURE_FLAG_ALL;
+	req.flags = IPC_CAPTURE_FLAG_SBS;
 
 	struct ipc_capture_result result = {0};
 	xrt_result_t r = ipc_call_shell_capture_frame(ipc_c, &req, &result);
@@ -1780,8 +1780,8 @@ main(int argc, char *argv[])
 		if (!RegisterHotKey(g_msg_hwnd, HOTKEY_LAUNCH, MOD_CONTROL, 'L')) {
 			PE("Warning: RegisterHotKey(Ctrl+L) failed — launcher hotkey unavailable\n");
 		}
-		if (!RegisterHotKey(g_msg_hwnd, HOTKEY_CAPTURE, MOD_CONTROL | MOD_SHIFT, '3')) {
-			PE("Warning: RegisterHotKey(Ctrl+Shift+3) failed — capture hotkey unavailable\n");
+		if (!RegisterHotKey(g_msg_hwnd, HOTKEY_CAPTURE, MOD_CONTROL | MOD_SHIFT, 'C')) {
+			PE("Warning: RegisterHotKey(Ctrl+Shift+C) failed — capture hotkey unavailable\n");
 		}
 	}
 
@@ -1965,7 +1965,7 @@ main(int argc, char *argv[])
 						}
 					}
 				} else if (msg.message == WM_HOTKEY && msg.wParam == HOTKEY_CAPTURE) {
-					// --- Ctrl+Shift+3: capture pre-weave L/R/SBS frames (Phase 8) ---
+					// --- Ctrl+Shift+C: capture pre-weave SBS frame (Phase 8) ---
 					if (g_shell_active) {
 						capture_frame(&ipc_c);
 					} else {

--- a/src/xrt/targets/shell/main.c
+++ b/src/xrt/targets/shell/main.c
@@ -50,6 +50,7 @@
 #ifdef _WIN32
 #define HOTKEY_TOGGLE 1
 #define HOTKEY_LAUNCH 2
+#define HOTKEY_CAPTURE 3
 #define WM_TRAYICON (WM_USER + 1)
 #define TRAY_CMD_ACTIVATE 2001
 #define TRAY_CMD_EXIT 2002
@@ -1562,6 +1563,126 @@ tray_show_context_menu(HWND hwnd, bool shell_active)
 #endif // _WIN32
 
 #ifdef _WIN32
+/*
+ * Phase 8: 3D capture MVP.
+ *
+ * Builds an output prefix under %USERPROFILE%\Pictures\DisplayXR, asks the
+ * runtime to write SBS / L / R PNGs of the current pre-weave atlas, then
+ * writes a JSON sidecar with the metadata returned by the runtime.
+ */
+static void
+capture_write_sidecar(const char *json_path, const struct ipc_capture_result *r)
+{
+	cJSON *root = cJSON_CreateObject();
+	if (root == NULL) {
+		return;
+	}
+
+	cJSON_AddNumberToObject(root, "schema_version", 1);
+	cJSON_AddNumberToObject(root, "timestamp_ns", (double)r->timestamp_ns);
+
+	cJSON *atlas = cJSON_AddObjectToObject(root, "atlas");
+	cJSON_AddNumberToObject(atlas, "width", r->atlas_width);
+	cJSON_AddNumberToObject(atlas, "height", r->atlas_height);
+
+	cJSON *eye = cJSON_AddObjectToObject(root, "eye");
+	cJSON_AddNumberToObject(eye, "width", r->eye_width);
+	cJSON_AddNumberToObject(eye, "height", r->eye_height);
+
+	cJSON *stereo = cJSON_AddObjectToObject(root, "stereo");
+	cJSON_AddNumberToObject(stereo, "tile_columns", r->tile_columns);
+	cJSON_AddNumberToObject(stereo, "tile_rows", r->tile_rows);
+
+	cJSON *disp = cJSON_AddObjectToObject(root, "display_m");
+	cJSON_AddNumberToObject(disp, "width", r->display_width_m);
+	cJSON_AddNumberToObject(disp, "height", r->display_height_m);
+
+	cJSON *le = cJSON_AddArrayToObject(root, "eye_left_m");
+	cJSON_AddItemToArray(le, cJSON_CreateNumber(r->eye_left_m[0]));
+	cJSON_AddItemToArray(le, cJSON_CreateNumber(r->eye_left_m[1]));
+	cJSON_AddItemToArray(le, cJSON_CreateNumber(r->eye_left_m[2]));
+
+	cJSON *re = cJSON_AddArrayToObject(root, "eye_right_m");
+	cJSON_AddItemToArray(re, cJSON_CreateNumber(r->eye_right_m[0]));
+	cJSON_AddItemToArray(re, cJSON_CreateNumber(r->eye_right_m[1]));
+	cJSON_AddItemToArray(re, cJSON_CreateNumber(r->eye_right_m[2]));
+
+	cJSON *views = cJSON_AddArrayToObject(root, "views_written");
+	if (r->views_written & IPC_CAPTURE_FLAG_SBS) {
+		cJSON_AddItemToArray(views, cJSON_CreateString("sbs"));
+	}
+	if (r->views_written & IPC_CAPTURE_FLAG_LEFT) {
+		cJSON_AddItemToArray(views, cJSON_CreateString("L"));
+	}
+	if (r->views_written & IPC_CAPTURE_FLAG_RIGHT) {
+		cJSON_AddItemToArray(views, cJSON_CreateString("R"));
+	}
+
+	char *text = cJSON_Print(root);
+	if (text != NULL) {
+		FILE *f = fopen(json_path, "wb");
+		if (f != NULL) {
+			fwrite(text, 1, strlen(text), f);
+			fclose(f);
+		} else {
+			PE("capture: failed to open sidecar %s\n", json_path);
+		}
+		free(text);
+	}
+	cJSON_Delete(root);
+}
+
+static void
+capture_frame(struct ipc_connection *ipc_c)
+{
+	const char *home = getenv("USERPROFILE");
+	if (home == NULL || home[0] == '\0') {
+		home = ".";
+	}
+
+	char dir[MAX_PATH];
+	snprintf(dir, sizeof(dir), "%s\\Pictures\\DisplayXR", home);
+
+	// Best-effort: Pictures should already exist; create the DisplayXR subdir.
+	char pictures[MAX_PATH];
+	snprintf(pictures, sizeof(pictures), "%s\\Pictures", home);
+	CreateDirectoryA(pictures, NULL);
+	if (!CreateDirectoryA(dir, NULL) && GetLastError() != ERROR_ALREADY_EXISTS) {
+		PE("capture: CreateDirectory(%s) failed: %lu\n", dir, GetLastError());
+		return;
+	}
+
+	SYSTEMTIME st;
+	GetLocalTime(&st);
+
+	struct ipc_capture_request req = {0};
+	snprintf(req.path_prefix, sizeof(req.path_prefix),
+	         "%s\\capture_%04d-%02d-%02d_%02d-%02d-%02d",
+	         dir, st.wYear, st.wMonth, st.wDay, st.wHour, st.wMinute, st.wSecond);
+	req.flags = IPC_CAPTURE_FLAG_ALL;
+
+	struct ipc_capture_result result = {0};
+	xrt_result_t r = ipc_call_shell_capture_frame(ipc_c, &req, &result);
+	if (r != XRT_SUCCESS) {
+		PE("capture: shell_capture_frame failed: %d\n", r);
+		return;
+	}
+
+	if (result.views_written == 0) {
+		PE("capture: runtime returned 0 views written\n");
+		return;
+	}
+
+	char json_path[MAX_PATH];
+	snprintf(json_path, sizeof(json_path), "%s.json", req.path_prefix);
+	capture_write_sidecar(json_path, &result);
+
+	P("Capture saved: %s (views=0x%x atlas=%ux%u eye=%ux%u)\n",
+	  req.path_prefix, result.views_written,
+	  result.atlas_width, result.atlas_height,
+	  result.eye_width, result.eye_height);
+}
+
 // WIN32 subsystem entry point — no console window.
 // Delegates to main() with the command line split into argc/argv.
 int WINAPI
@@ -1658,6 +1779,9 @@ main(int argc, char *argv[])
 		}
 		if (!RegisterHotKey(g_msg_hwnd, HOTKEY_LAUNCH, MOD_CONTROL, 'L')) {
 			PE("Warning: RegisterHotKey(Ctrl+L) failed — launcher hotkey unavailable\n");
+		}
+		if (!RegisterHotKey(g_msg_hwnd, HOTKEY_CAPTURE, MOD_CONTROL | MOD_SHIFT, '3')) {
+			PE("Warning: RegisterHotKey(Ctrl+Shift+3) failed — capture hotkey unavailable\n");
 		}
 	}
 
@@ -1839,6 +1963,13 @@ main(int argc, char *argv[])
 						} else {
 							P("Launcher %s\n", g_launcher_visible ? "shown" : "hidden");
 						}
+					}
+				} else if (msg.message == WM_HOTKEY && msg.wParam == HOTKEY_CAPTURE) {
+					// --- Ctrl+Shift+3: capture pre-weave L/R/SBS frames (Phase 8) ---
+					if (g_shell_active) {
+						capture_frame(&ipc_c);
+					} else {
+						P("Capture ignored: shell not active\n");
 					}
 				} else if (msg.message == WM_TRAYICON) {
 					if (LOWORD(msg.lParam) == WM_LBUTTONUP) {


### PR DESCRIPTION
## Summary

- **Phase 8 Spatial Shell capture MVP (#43):** Ctrl+Shift+C hotkey, IPC shell_capture_frame, SBS PNG + JSON sidecar, file-trigger refactor, physically square launcher tiles, icon textures, selection glow.
- **D3D11 service: stereo view_height fix (#158):** per-view tile dims now come from `rendering_modes[idx].view_{width,height}_pixels` for non-legacy sessions instead of `display / tile_count`, which ignored vendor `view_scale_y=0.5`. Each eye in SBS now renders at native 1920×1080 (not stretched to 1920×2160). Capture atlas is 3840×1080 with natural-aspect content. Legacy apps without `XR_EXT_display_info` keep the existing compromise-scale path.
- **D3D12 multi-acquire swapchain (#151):** Unreal Engine support.

## Test plan

- [x] Local build on Windows (`scripts\build_windows.bat build`)
- [x] Shell + `cube_handle_d3d11_win` — Ctrl+Shift+C produces 3840×1080 capture, eye 1920×1080, natural-aspect cubes (verified live on 4K Leia SR)
- [x] Live weaver output — no vertical squash per eye
- [ ] CI: Windows + macOS builds pass
- [ ] Regression: quad-view mode tile dims (1920×1080)
- [ ] Regression: legacy app (no XR_EXT_display_info) still renders correctly with compromise scale

🤖 Generated with [Claude Code](https://claude.com/claude-code)