### PR TITLE
MCP Phase B: service-mode shell tools + capture_frame (#157)

### DIFF
--- a/docs/roadmap/mcp-phase-b-plan.md
+++ b/docs/roadmap/mcp-phase-b-plan.md
@@ -1,0 +1,154 @@
+# MCP Phase B — Shell/Service Mode Plan
+
+**Branch:** `feature/mcp-phase-b-ci`
+**Worktree:** `.claude/worktrees/mcp-phase-b`
+**Spec:** `docs/roadmap/mcp-spec-v0.2.md` §3.2, §4.B, §5
+**Target:** David's "set me up for the 3pm review" story runs end-to-end against a live `displayxr-service` + shell.
+
+## Goal
+
+Extend the MCP surface shipped in Phase A so that when `displayxr-service` is running, agents can introspect the shell, arrange windows in 6-DOF, save and restore workspaces, and capture annotated stereo frames. Reuse every piece of Phase A infrastructure; add nothing the Maya story didn't need.
+
+## Scope (exactly this, nothing more)
+
+### Tools added (§4.B)
+
+| Tool | Semantics | Backing IPC |
+|---|---|---|
+| `list_windows` | All shell windows: `{client_id, app_name, hwnd_proxy, pose, size_m, focus, visible}` | Shell window-manager state (read) |
+| `get_window_pose` | 6-DOF pose + size in meters for one window | `shell_get_window_pose` (exists) |
+| `set_window_pose` | Move/resize one window | `shell_set_window_pose` (exists) |
+| `set_focus` | Focus a window | Existing shell focus path |
+| `apply_layout_preset` | Trigger Ctrl+1..4 presets | Existing shell hotkey dispatch |
+| `save_workspace` | Snapshot current poses → named JSON on disk | New — thin layer over `list_windows` + file I/O |
+| `load_workspace` | Re-apply named JSON → batched `set_window_pose` calls | New — thin layer |
+
+### Upgrades to Phase A tools
+
+- `list_sessions` — in service mode, returns one entry per live per-app session (Phase A returned one).
+- `capture_frame` — in service mode, reads the existing D3D11 service-atlas path (`comp_d3d11_service.cpp:7929`), splits atlas into `L.png` / `R.png`, and (new) annotates a JSON sidecar with per-window rectangles in atlas pixel space.
+- `get_submitted_projection` / `get_kooima_params` — scoped by `client_id` so an agent can compare per-app projections.
+
+### Safety model (§5) — this phase makes it real
+
+- **stdio-local default.** No HTTP/SSE listener unless `displayxr-mcp --remote` is passed.
+- **Per-app allowlist.** Adapter flag `--allow <client_id>[,<client_id>…]`; tools filter by allowlist. Default: all.
+- **Tool audit log.** Every write tool call appends `{ts, tool, client_id, args_hash}` to a rotating log viewable in the shell. Read tools are not audited.
+- **Biometric gate scaffolding.** Introduce the gate enum + per-session bit; no biometric tools enabled in this phase.
+
+### Out of scope for Phase B
+
+- **Recording (`start_recording` / `stop_recording`).** `docs/roadmap/3d-capture.md` is still in "Proposal" status; no stereo video pipeline exists. Deferred to Phase B.5 once 3d-capture MVP lands.
+- **`measure_disparity`.** Still waiting on a Phase A.5 reference implementation; not service-specific.
+- Multi-display addressing — spec §8 open question.
+- Remote transport implementation — flag reserved, not wired.
+- `get_viewer_pose` / any eye- or head-tracking tool — biometric gate scaffolding only, no tool.
+
+## Architecture
+
+```
+Claude Code (MCP client)
+    ↕ stdio (JSON-RPC 2.0, Content-Length framed)
+displayxr-mcp   (existing binary from Phase A, extended)
+    ↕ POSIX socket / named pipe
+    │
+    ├── per-PID socket  → in-process server (Phase A handle-app path, unchanged)
+    └── service socket  → NEW: MCP sidecar attached to displayxr-service
+                             ↕ existing shell-runtime IPC
+                          displayxr-service (unchanged)
+```
+
+**Decision (spec §3.2 rationale):** MCP lives in a **sidecar process**, not inside `displayxr-service`. The sidecar spawns when the service starts with `--mcp` (or on-demand from the adapter). Keeps the production service lean, crashes are isolated, sandboxable per §5.
+
+### Sidecar binary
+
+New target: `src/xrt/targets/mcp_sidecar/displayxr_mcp_service.c`.
+
+- Boots when `displayxr-service --mcp` is set, or spawned on first agent connection.
+- Listens on a well-known service socket: `/tmp/displayxr-mcp-service.sock` (macOS) or `\\.\pipe\displayxr-mcp-service` (Windows).
+- Speaks shell-runtime IPC on one side, serves MCP JSON-RPC on the other.
+- Reuses Phase A's `u_mcp_server.{h,c}` dispatch + framing; adds a service-aware tool set in `u_mcp_tools_shell.{h,c}`.
+
+### Adapter changes
+
+`displayxr-mcp` discovery updated:
+
+- `--target auto` (new default): if the service socket exists, attach to it; else fall back to per-PID enumeration (Phase A).
+- `--target service` / `--target pid:<N>` to force mode.
+- `--allow <csv>` / `--remote` as in §Safety.
+
+### State access
+
+- **Reads** go through shell-runtime IPC (`shell_get_window_pose`, window-list query). Latency is fine — MCP is human-typing cadence, not frame-cadence.
+- **Writes** go through the same IPC the shell uses (`shell_set_window_pose`, layout-preset hotkey dispatch). No new privileged path.
+- **Snapshot API from Phase A** stays PID-scoped but is now reachable via the sidecar — the sidecar proxies `get_kooima_params` / `get_submitted_projection` / `diff_projection` to the correct per-PID server by looking up the session → PID map in shell state.
+
+## Source tree additions
+
+```
+src/xrt/
+├── auxiliary/util/
+│   ├── u_mcp_tools_shell.{h,c}       # list_windows, get/set_window_pose, set_focus,
+│   │                                  # apply_layout_preset, save/load_workspace
+│   ├── u_mcp_audit.{h,c}             # tool audit log (append + rotate)
+│   └── u_mcp_allowlist.{h,c}         # per-client_id filtering
+├── targets/mcp_sidecar/
+│   ├── CMakeLists.txt
+│   └── displayxr_mcp_service.c       # sidecar main: shell IPC ↔ MCP server loop
+└── compositor/d3d11_service/
+    └── comp_d3d11_service.cpp        # +trigger path: emit L/R split + window-bbox JSON
+```
+
+`displayxr-mcp` adapter (existing) gets `--target`, `--allow`, `--remote` flags.
+
+## Delivery slices
+
+Eight slices, each a mergeable commit.
+
+1. **Sidecar plumbing.** Sidecar binary, service-socket listener, JSON-RPC echo + `initialize` + `tools/list`. Adapter learns `--target service`. No shell data yet. Test: `tests/mcp/test_service_handshake.sh`.
+2. **list_windows (read-only).** Sidecar calls into shell-runtime IPC, returns window array. Test: launch shell with two cube apps, assert two entries.
+3. **get/set_window_pose.** Read-through to existing IPC; write goes through audit log. Test: `set_window_pose` moves the window by a known delta; `get_window_pose` confirms.
+4. **set_focus + apply_layout_preset.** Thin wrappers over hotkey dispatch. Test: preset 2 applied, verify poses match known preset layout.
+5. **save/load_workspace.** JSON schema + on-disk format (see §Open). Round-trip test: save → move → load → poses restored.
+6. **Audit log + allowlist.** Wire §5 scaffolding. Test: tool call filtered by allowlist returns error; write call shows up in audit log.
+7. **capture_frame (service-mode).** Re-trigger existing atlas readback via MCP; split into L/R; emit per-window bbox JSON. Test: `test_capture_frame_service.sh` assembling from the existing shell_screenshot path.
+8. **Session proxy.** Sidecar forwards `get_kooima_params`, `get_submitted_projection`, `diff_projection` to per-PID server by `client_id`. Test: diff_projection resolves the right session in a two-app shell.
+
+Slices 1–6 can land on Windows dev machines with shell running. Slice 7 exercises the D3D11 service atlas. Slice 8 needs both sidecar + a Phase-A-capable per-app session — iterate with one cube_handle app under the shell.
+
+## Platform strategy
+
+**Primary dev platform: Windows.** The shell and D3D11 service compositor only run on Windows; Phase B is fundamentally a Windows milestone. Use `scripts\build_windows.bat build` on a local Leia SR machine; do not rely on CI for iteration.
+
+**macOS coverage:** the adapter `--target service` fall-through path and the sidecar build are cross-compiled to keep the adapter portable, but there is no service on mac today, so end-to-end tests run on Windows only.
+
+**MinGW check:** include sidecar + new aux_util TUs in `scripts/build-mingw-check.sh` to catch Win32 symbol typos before pushing.
+
+## Validation
+
+Each slice lands with at least one scripted test under `tests/mcp/`:
+
+- `test_service_handshake.sh` — initialize + tools/list against sidecar.
+- `test_list_windows.sh` — two-app shell, assert two entries, pose fields present.
+- `test_set_window_pose.sh` — known delta, round-trip.
+- `test_workspace_roundtrip.sh` — save, perturb, load, compare poses.
+- `test_audit_log.sh` — write tool appears, read tool does not; allowlist denies out-of-scope `client_id`.
+- `test_capture_frame_service.sh` — atlas split produces `L.png` + `R.png` + `windows.json`; window count matches.
+
+**Phase B demo (gate):** a scripted David story — agent applies a three-window layout by name, saves it as "review layout," perturbs poses, reloads, captures an annotated frame.
+
+## Open implementation questions
+
+- **Workspace JSON location.** `%APPDATA%\DisplayXR\workspaces\<name>.json` on Windows, `~/.config/displayxr/workspaces/` on macOS. Versioned schema. (Spec §8 open question.)
+- **Sidecar lifecycle.** Spawn with service (`displayxr-service --mcp`) or lazy-spawn on adapter connect? Recommend **lazy-spawn** — sidecar starts only when an agent actually connects; exits when the service exits or after N seconds idle.
+- **Session → PID map.** Shell already tracks `client_id` ↔ process. Expose via a new IPC query `shell_list_sessions` or piggyback on `list_windows`? Lean toward piggyback — one round trip.
+- **Atlas bbox derivation.** Per-window atlas rects are computed in `comp_d3d11_service.cpp`'s tile layout; expose them via a tiny sidecar C ABI rather than re-parsing IPC messages.
+- **Audit log viewer.** File on disk + optional live-tail in the shell debug overlay? The shell overlay piece is nice-to-have; the file is mandatory.
+
+## References
+
+- Phase A plan/status: `docs/roadmap/mcp-phase-a-plan.md`, `mcp-phase-a-status.md`
+- Spec: `docs/roadmap/mcp-spec-v0.2.md` §3.2, §4.B, §5
+- Shell-runtime contract: `docs/roadmap/shell-runtime-contract.md`
+- Existing atlas capture path: `src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp:7929`
+- 3D capture roadmap (for deferred recording): `docs/roadmap/3d-capture.md`

--- a/docs/roadmap/mcp-phase-b-slice7-agent-prompt.md
+++ b/docs/roadmap/mcp-phase-b-slice7-agent-prompt.md
@@ -1,0 +1,323 @@
+# MCP Phase B Slice 7 — Windows Agent Prompt
+
+You are running inside Claude Code on a **Windows machine with a Leia SR display**. Your job is to:
+
+1. Validate that MCP Phase B slices 1–6 + 8 work end-to-end against a live `displayxr-service`.
+2. Implement **slice 7** (`capture_frame` service-mode upgrade).
+3. Commit and push.
+
+This prompt is self-contained — everything you need is here or in linked docs. Do not wait for clarification; follow the steps in order.
+
+## Context (2-minute read)
+
+**Phase B** extends the MCP server (Phase A, #150) to shell/service mode. Seven slices are already merged on `feature/mcp-phase-b`:
+
+| # | What | Test |
+|---|---|---|
+| 1 | Service-side MCP server (`u_mcp_server_maybe_start_named("service")`) + adapter `--target service` | `tests\mcp\test_service_handshake.bat` |
+| 2 | `list_windows` | `tests\mcp\test_list_windows.bat` |
+| 3 | `get/set_window_pose` | `tests\mcp\test_set_window_pose.bat` |
+| 4 | `set_focus` + `apply_layout_preset` | `tests\mcp\test_focus_preset.bat` |
+| 5 | `save/load_workspace` | `tests\mcp\test_workspace_roundtrip.bat` |
+| 6 | Audit log + allowlist | `tests\mcp\test_audit_log.bat` |
+| 8 | `list_sessions` (service variant) + PID routing | `tests\mcp\test_session_routing.bat` |
+
+All were compile-checked on macOS + MinGW cross-compile. None have been run on Windows yet. Issue: **#157**. Plan: `docs/roadmap/mcp-phase-b-plan.md`.
+
+Slice 7 is Windows-only because it touches the **D3D11 service compositor** (`comp_d3d11_service.cpp`) which uses WIL and is MSVC-only.
+
+## Phase 1 — Validate slices 1–6, 8
+
+### 1.1 Sync
+
+```bat
+cd %USERPROFILE%\Documents\GitHub\displayxr-runtime-pvt
+git fetch origin
+git checkout feature/mcp-phase-b
+git pull
+```
+
+### 1.2 Build
+
+```bat
+scripts\build_windows.bat all
+```
+
+Expected: `_package\DisplayXR\` and `_package\bin\` populated; `test_apps\cube_handle_d3d11_win\build\cube_handle_d3d11_win.exe` exists. If the build fails on a Phase B file, inspect with `type build\CMakeFiles\CMakeError.log` and fix; the most likely breakage is MSVC-specific behaviour that MinGW missed (see `CLAUDE.md` → "MinGW is NOT MSVC" section).
+
+### 1.3 Start the service + two apps, `DISPLAYXR_MCP=1`
+
+From a cmd.exe window:
+
+```bat
+set DISPLAYXR_MCP=1
+_package\bin\displayxr-shell.exe ^
+    test_apps\cube_handle_d3d11_win\build\cube_handle_d3d11_win.exe ^
+    test_apps\cube_handle_d3d11_win\build\cube_handle_d3d11_win.exe
+```
+
+Leave this running. Per `CLAUDE.md`, launch via `Bash run_in_background: true` with `timeout: 600000`.
+
+### 1.4 Run the Phase B tests
+
+Fresh cmd.exe window:
+
+```bat
+cd %USERPROFILE%\Documents\GitHub\displayxr-runtime-pvt
+tests\mcp\test_service_handshake.bat
+tests\mcp\test_list_windows.bat
+tests\mcp\test_set_window_pose.bat
+tests\mcp\test_focus_preset.bat
+tests\mcp\test_workspace_roundtrip.bat
+tests\mcp\test_audit_log.bat
+tests\mcp\test_session_routing.bat
+```
+
+All seven must print `OK` on the final line. Any `FAIL` — **stop and investigate**. Capture full stderr, find the root cause in the relevant source (`src\xrt\ipc\server\ipc_mcp_tools.c`, `src\xrt\auxiliary\util\u_mcp_*`), fix, rebuild with `scripts\build_windows.bat build`, re-run. Do **not** paper over failures or skip tests.
+
+Record the passing test output for the final commit message.
+
+## Phase 2 — Implement slice 7: `capture_frame` service-mode upgrade
+
+### Goal
+
+When an MCP agent calls `capture_frame` against the service endpoint, the D3D11 service compositor:
+
+1. Reads back the `combined_atlas` (full shell composition).
+2. Writes three PNGs: `{base}_atlas.png`, `{base}_L.png`, `{base}_R.png`, where `{base}` comes from the request path.
+3. Writes `{base}_windows.json` with a bbox entry per active shell window.
+4. Signals the MCP thread via `u_mcp_capture_complete`.
+
+Reference implementation to mirror: `src\xrt\compositor\d3d11\comp_d3d11_compositor.cpp` around line 881 (`d3d11_compositor_service_mcp_capture`). It uses the same `u_mcp_capture_poll / complete` contract and the same `CopySubresourceRegion` staging-texture pattern. **Copy the structure, adapt for the service atlas.**
+
+### Files to touch
+
+1. **`src/xrt/compositor/d3d11_service/comp_d3d11_service.h`** — add one forward-declared function.
+2. **`src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp`** — (a) add a `u_mcp_capture_request` member to `d3d11_service_system`, (b) call `u_mcp_capture_install` at system create, (c) uninstall at destroy, (d) poll inside `multi_compositor_render` adjacent to the existing file-trigger block at line ~7929, (e) add the new capture service function.
+3. **`src/xrt/ipc/server/ipc_mcp_tools.c`** — register a service-side `capture_frame` tool that invokes the `u_mcp_capture` handler (the handler is already set by the service compositor; the tool just dispatches).
+
+No change to aux_util — `u_mcp_capture` already supports the cross-thread hand-off we need. No change to the adapter.
+
+### Implementation sketch
+
+**Step 1.** In `comp_d3d11_service.h`, add:
+
+```c
+/*!
+ * Service a pending MCP capture_frame request against the combined
+ * shell atlas. Writes {base}_atlas.png, {base}_L.png, {base}_R.png,
+ * plus {base}_windows.json. Called from multi_compositor_render just
+ * before Present so the atlas is fully populated.
+ *
+ * @ingroup comp_d3d11_service
+ */
+void
+comp_d3d11_service_poll_mcp_capture(struct xrt_system_compositor *xsysc);
+```
+
+**Step 2.** In `comp_d3d11_service.cpp`:
+
+- Add `#include "util/u_mcp_capture.h"` near the top with other aux_util includes.
+- Add `struct u_mcp_capture_request mcp_capture;` to `struct d3d11_service_system` (the struct defined around line 345 — see `char layout_3d[8]` in that region).
+- In the system create/init path, after the system is constructed, call `u_mcp_capture_init(&sys->mcp_capture)` and `u_mcp_capture_install(&sys->mcp_capture)`. Mirror what `comp_metal_compositor.m:1944` does.
+- In the system destroy path, call `u_mcp_capture_uninstall()` then `u_mcp_capture_fini(&sys->mcp_capture)`.
+- Implement `comp_d3d11_service_poll_mcp_capture` below the existing `comp_d3d11_service_set_launcher_visible` at the bottom of the file. Body:
+
+```cpp
+void
+comp_d3d11_service_poll_mcp_capture(struct xrt_system_compositor *xsysc)
+{
+    if (xsysc == nullptr) return;
+    struct d3d11_service_system *sys = d3d11_service_system_from_xrt(xsysc);
+    if (!sys->shell_mode || sys->multi_comp == nullptr) return;
+
+    char base[U_MCP_CAPTURE_PATH_MAX];
+    if (!u_mcp_capture_poll(&sys->mcp_capture, base)) return;
+
+    // The request path is a base *without* extension; e.g. the Phase A
+    // handler hands us "C:\Temp\displayxr-mcp-capture-NNN-M". We append
+    // our own suffixes so the caller gets the three-file bundle.
+
+    struct d3d11_multi_compositor *mc = sys->multi_comp;
+    if (mc->combined_atlas == nullptr) {
+        u_mcp_capture_complete(&sys->mcp_capture, false);
+        return;
+    }
+
+    std::lock_guard<std::recursive_mutex> lock(sys->render_mutex);
+
+    D3D11_TEXTURE2D_DESC desc;
+    mc->combined_atlas->GetDesc(&desc);
+    uint32_t atlas_w = desc.Width, atlas_h = desc.Height;
+
+    // Stage the full atlas once. SBS layout: left half = L eye, right half = R eye.
+    D3D11_TEXTURE2D_DESC sd = desc;
+    sd.Usage = D3D11_USAGE_STAGING;
+    sd.BindFlags = 0;
+    sd.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
+    sd.MiscFlags = 0;
+    wil::com_ptr<ID3D11Texture2D> staging;
+    if (FAILED(sys->device->CreateTexture2D(&sd, nullptr, staging.put()))) {
+        u_mcp_capture_complete(&sys->mcp_capture, false);
+        return;
+    }
+    sys->context->CopyResource(staging.get(), mc->combined_atlas.get());
+
+    D3D11_MAPPED_SUBRESOURCE m = {};
+    if (FAILED(sys->context->Map(staging.get(), 0, D3D11_MAP_READ, 0, &m))) {
+        u_mcp_capture_complete(&sys->mcp_capture, false);
+        return;
+    }
+
+    // File 1: atlas.png (whole thing).
+    char path[U_MCP_CAPTURE_PATH_MAX + 32];
+    snprintf(path, sizeof(path), "%s_atlas.png", base);
+    bool ok_atlas = stbi_write_png(path, (int)atlas_w, (int)atlas_h, 4,
+                                   m.pData, (int)m.RowPitch) != 0;
+
+    // Files 2 and 3: left and right halves. SBS atlas convention —
+    // left view is bytes [0..half_w) of each row, right view is
+    // [half_w..atlas_w). stbi_write_png accepts an explicit stride so
+    // we reuse the mapped pointer at an offset.
+    uint32_t half_w = atlas_w / 2;
+    const uint8_t *rows = (const uint8_t *)m.pData;
+    snprintf(path, sizeof(path), "%s_L.png", base);
+    bool ok_L = stbi_write_png(path, (int)half_w, (int)atlas_h, 4,
+                               rows, (int)m.RowPitch) != 0;
+    snprintf(path, sizeof(path), "%s_R.png", base);
+    bool ok_R = stbi_write_png(path, (int)half_w, (int)atlas_h, 4,
+                               rows + half_w * 4, (int)m.RowPitch) != 0;
+
+    sys->context->Unmap(staging.get(), 0);
+
+    // File 4: windows.json — one entry per active client slot.
+    snprintf(path, sizeof(path), "%s_windows.json", base);
+    FILE *jf = fopen(path, "wb");
+    bool ok_json = false;
+    if (jf != nullptr) {
+        fprintf(jf, "{\n  \"atlas_width\": %u,\n  \"atlas_height\": %u,\n  \"windows\": [",
+                atlas_w, atlas_h);
+        bool first = true;
+        for (int i = 0; i < D3D11_MULTI_MAX_CLIENTS; i++) {
+            const d3d11_multi_client_slot *s = &mc->clients[i];
+            if (!s->active) continue;
+            fprintf(jf, "%s\n    {\"slot\": %d, \"name\": \"%s\", "
+                        "\"atlas_bbox\": {\"x\": %d, \"y\": %d, \"w\": %d, \"h\": %d}, "
+                        "\"content\": {\"w\": %u, \"h\": %u}}",
+                    first ? "" : ",", i, s->app_name,
+                    s->window_rect_x, s->window_rect_y,
+                    s->window_rect_w, s->window_rect_h,
+                    s->content_view_w, s->content_view_h);
+            first = false;
+        }
+        fprintf(jf, "\n  ]\n}\n");
+        fclose(jf);
+        ok_json = true;
+    }
+
+    u_mcp_capture_complete(&sys->mcp_capture, ok_atlas && ok_L && ok_R && ok_json);
+}
+```
+
+- In `multi_compositor_render`, right after the existing file-trigger block (around line 7929, just before `Present`), call:
+
+```cpp
+comp_d3d11_service_poll_mcp_capture((struct xrt_system_compositor *)sys);
+```
+
+**Step 3.** In `src/xrt/ipc/server/ipc_mcp_tools.c`, add a service-side `capture_frame` tool:
+
+- Add `#include "util/u_mcp_capture.h"` and forward-declare the capture-handler contract that aux_util already uses: `extern void oxr_mcp_tools_set_capture_handler(...)`. Actually — **don't** redeclare it; `u_mcp_capture_install` already calls it internally. So the ipc_mcp_tools side just needs to register a tool that invokes the registered capture handler. Inspect `src/xrt/state_trackers/oxr/oxr_mcp_tools.c` (around the existing `capture_frame` tool) for the exact API — the handler is registered via `oxr_mcp_tools_set_capture_handler(fn, userdata)` and invoked via a helper inside the tool body. Copy the Phase A tool's structure verbatim but register it under the ipc_mcp_tools namespace so both the per-PID handle-app server and the service server respond to `capture_frame`.
+- If re-registration of an already-registered tool name is rejected by `u_mcp_server_register_tool`, let that be the existing Phase A tool registered from `oxr_mcp_tools`. The service instance of the server registers the Phase B tool first (because `ipc_mcp_tools_register` runs before any `oxr_instance_create` happens in a service process — service is not a state-tracker client). Verify behaviour empirically; if you need to guard, check `oxr_mcp_tools_register_all` is not called inside `displayxr-service.exe`.
+
+### Test for slice 7
+
+Create `tests/mcp/test_capture_frame_service.bat` + `tests/mcp/_capture_frame_service_helper.py`:
+
+```python
+# Helper outline — adapt from _list_windows_helper.py
+# 1. initialize against --target service
+# 2. tools/call capture_frame with arguments {} (no path; Phase A default)
+# 3. parse result for file paths; assert _atlas.png, _L.png, _R.png, _windows.json exist
+# 4. assert _L.png and _R.png dimensions are each half the atlas width
+#    (use PIL or stbi_read to verify — PIL is available in Windows Python)
+# 5. load _windows.json, assert it's valid JSON with >= len(list_windows) entries
+```
+
+Follow the pattern of `tests/mcp/test_list_windows.bat` exactly — `findstr` fallback if `python` is missing, `ADAPTER` discovery, `--target service` probe before invoking the helper.
+
+Run the test with the service + two apps still running from Phase 1.
+
+### Non-goals for slice 7
+
+- **Do not** replace the file-trigger block at `comp_d3d11_service.cpp:7929`. Keep it as a separate debugging affordance.
+- **Do not** modify `u_mcp_capture.{h,c}`. Its contract already supports this flow.
+- **Do not** add recording / temporal capture — that's Phase B.5 blocked on `docs/roadmap/3d-capture.md`.
+- **Do not** change `proto.json` or any IPC message definitions.
+
+## Phase 3 — Commit + push
+
+Follow the commit convention used on slices 1–8. Example:
+
+```
+MCP Phase B slice 7: capture_frame service-mode upgrade (#157)
+
+Extends the D3D11 service compositor with an MCP-triggered capture
+path that writes a four-file bundle per request:
+
+- <base>_atlas.png  — full combined shell atlas
+- <base>_L.png      — left half of the atlas (left eye)
+- <base>_R.png      — right half of the atlas (right eye)
+- <base>_windows.json — per-active-slot atlas bbox + content dims
+
+Uses the same u_mcp_capture_{install,poll,complete} cross-thread
+contract Phase A wired up for the handle-app D3D11, Metal, and GL
+compositors. Atlas readback is a single staging-texture CopyResource
++ Map; L/R split reuses the mapped pointer at a half-width offset
+so we only pay one GPU→CPU copy per frame.
+
+- compositor/d3d11_service/comp_d3d11_service.{h,cpp}: add
+  u_mcp_capture_request member, install/uninstall in system
+  create/destroy, poll in multi_compositor_render just before
+  Present. The existing file-trigger block at line ~7929 is
+  preserved as a separate interactive debugging path.
+- ipc/server/ipc_mcp_tools.c: register service-side capture_frame
+  tool that invokes the installed handler.
+- tests/mcp: add test_capture_frame_service.{sh,bat} + helper.
+  Requires DISPLAYXR_MCP=1 shell + apps running; asserts the four
+  files exist, L/R are each half the atlas width, and windows.json
+  lists at least as many entries as list_windows reports.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+```
+
+Then:
+
+```bat
+git add -A
+git commit -F -   :: paste the message via HEREDOC equivalent
+git push
+```
+
+### Final report to the user
+
+After push, summarize in one paragraph:
+
+- Slice 7 implementation status (committed SHA, lines changed).
+- Phase B validation status — which of the 8 tests passed on Windows, any that regressed during slice 7 work and how you fixed them.
+- Whether the David "3pm review" story (the Phase B gate from `docs/roadmap/mcp-spec-v0.2.md` §7) is reproducible end-to-end: call `save_workspace`, perturb poses, call `load_workspace`, call `capture_frame`, inspect the captured atlas.
+
+Keep it under 200 words. No emojis.
+
+## Reference commands you'll need
+
+| Purpose | Command |
+|---|---|
+| Rebuild runtime only | `scripts\build_windows.bat build` |
+| Rebuild test apps | `scripts\build_windows.bat test-apps` |
+| Capture a compositor screenshot (non-MCP) | `touch "%TEMP%\shell_screenshot_trigger"` then read `%TEMP%\shell_screenshot.png` |
+| Crash dump | see `CLAUDE.md` → "Debugging Crashes on Windows" |
+
+## If the Phase 1 validation exposes a bug in slices 1–6 or 8
+
+Fix it on the same branch as a prior slice's follow-up commit (message: `MCP Phase B slice N follow-up: <what> (#157)`). Do **not** squash or force-push.

--- a/src/xrt/auxiliary/util/CMakeLists.txt
+++ b/src/xrt/auxiliary/util/CMakeLists.txt
@@ -69,6 +69,10 @@ add_library(
 	u_live_stats.h
 	u_logging.c
 	u_logging.h
+	u_mcp_audit.c
+	u_mcp_audit.h
+	u_mcp_allowlist.c
+	u_mcp_allowlist.h
 	u_mcp_capture.c
 	u_mcp_capture.h
 	u_mcp_log_ring.c

--- a/src/xrt/auxiliary/util/u_mcp_allowlist.c
+++ b/src/xrt/auxiliary/util/u_mcp_allowlist.c
@@ -1,0 +1,88 @@
+// Copyright 2026, DisplayXR / Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  Allowlist implementation (Phase B §5).
+ * @ingroup aux_util
+ */
+
+#include "u_mcp_allowlist.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define MAX_ENTRIES 64
+
+static struct
+{
+	bool initialized;
+	bool has_policy;
+	uint32_t entries[MAX_ENTRIES];
+	size_t n;
+} g_state;
+
+
+void
+u_mcp_allowlist_init(void)
+{
+	if (g_state.initialized) {
+		return;
+	}
+	g_state.initialized = true;
+	g_state.n = 0;
+
+	const char *env = getenv("DISPLAYXR_MCP_ALLOW");
+	if (env == NULL) {
+		g_state.has_policy = false;
+		return;
+	}
+
+	// Env set but empty → policy that allows nothing.
+	g_state.has_policy = true;
+
+	// Parse comma-separated ids. Silently skip malformed tokens; the
+	// intent of the allowlist is defensive, not self-diagnostic.
+	const char *p = env;
+	while (*p != '\0' && g_state.n < MAX_ENTRIES) {
+		while (*p == ' ' || *p == ',') {
+			p++;
+		}
+		if (*p == '\0') {
+			break;
+		}
+		char *end = NULL;
+		long v = strtol(p, &end, 10);
+		if (end == p || v < 0 || v > (long)UINT32_MAX) {
+			if (end == p) {
+				p++;
+			} else {
+				p = end;
+			}
+			continue;
+		}
+		g_state.entries[g_state.n++] = (uint32_t)v;
+		p = end;
+	}
+}
+
+bool
+u_mcp_allowlist_has_policy(void)
+{
+	return g_state.initialized && g_state.has_policy;
+}
+
+bool
+u_mcp_allowlist_allows(uint32_t client_id)
+{
+	if (!g_state.initialized || !g_state.has_policy) {
+		return true;
+	}
+	for (size_t i = 0; i < g_state.n; i++) {
+		if (g_state.entries[i] == client_id) {
+			return true;
+		}
+	}
+	return false;
+}

--- a/src/xrt/auxiliary/util/u_mcp_allowlist.h
+++ b/src/xrt/auxiliary/util/u_mcp_allowlist.h
@@ -1,0 +1,56 @@
+// Copyright 2026, DisplayXR / Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  Per-client_id allowlist for MCP write tools (Phase B §5).
+ * @ingroup aux_util
+ *
+ * Source of truth: the @c DISPLAYXR_MCP_ALLOW environment variable, read
+ * once at @c u_mcp_allowlist_init(). Format: comma-separated decimal
+ * client_ids, or empty/unset to allow all clients. Examples:
+ *
+ * @code
+ *   DISPLAYXR_MCP_ALLOW=1,2,3     # only these three
+ *   DISPLAYXR_MCP_ALLOW=          # allow nothing
+ *   (unset)                       # allow all (default)
+ * @endcode
+ *
+ * This is deliberately a trivial data structure — Phase B ships the
+ * safety-model scaffolding; richer policies (per-tool, per-role) land
+ * when the §5 audit review is completed.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*!
+ * Parse @c DISPLAYXR_MCP_ALLOW into the process-wide allowlist. Idempotent.
+ * Safe to call before the MCP server starts.
+ */
+void
+u_mcp_allowlist_init(void);
+
+/*!
+ * Is the env var set to an explicit list? When false, every client_id is
+ * allowed. Callers may use this to skip allowlist checks entirely in the
+ * common case where no policy is configured.
+ */
+bool
+u_mcp_allowlist_has_policy(void);
+
+/*!
+ * Is the given @p client_id allowed by the current policy? Always returns
+ * true when @c u_mcp_allowlist_has_policy() is false.
+ */
+bool
+u_mcp_allowlist_allows(uint32_t client_id);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/xrt/auxiliary/util/u_mcp_audit.c
+++ b/src/xrt/auxiliary/util/u_mcp_audit.c
@@ -1,0 +1,149 @@
+// Copyright 2026, DisplayXR / Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  Audit log implementation (Phase B §5).
+ * @ingroup aux_util
+ */
+
+#include "xrt/xrt_config_os.h"
+
+#include "u_mcp_audit.h"
+#include "util/u_logging.h"
+
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <time.h>
+
+#ifdef XRT_OS_WINDOWS
+#include <direct.h>
+#include <shlobj.h>
+#include <windows.h>
+#define MKDIR(p) _mkdir(p)
+#else
+#include <sys/types.h>
+#include <unistd.h>
+#define MKDIR(p) mkdir((p), 0700)
+#endif
+
+#define LOG_PFX "[mcp-audit] "
+#define MAX_FILE_BYTES (1024 * 1024)
+
+static struct
+{
+	pthread_mutex_t mutex;
+	bool initialized;
+	char path[1024];
+} g_state = {.mutex = PTHREAD_MUTEX_INITIALIZER};
+
+
+static bool
+ensure_path_locked(void)
+{
+	if (g_state.initialized) {
+		return g_state.path[0] != '\0';
+	}
+	g_state.initialized = true;
+
+#ifdef XRT_OS_WINDOWS
+	char appdata[MAX_PATH];
+	if (!SUCCEEDED(SHGetFolderPathA(NULL, CSIDL_APPDATA, NULL, 0, appdata))) {
+		g_state.path[0] = '\0';
+		return false;
+	}
+	char dir[MAX_PATH];
+	snprintf(dir, sizeof(dir), "%s\\DisplayXR", appdata);
+	MKDIR(dir);
+	snprintf(g_state.path, sizeof(g_state.path), "%s\\mcp-audit.log", dir);
+	return true;
+#else
+	const char *home = getenv("HOME");
+	if (home == NULL || home[0] == '\0') {
+		g_state.path[0] = '\0';
+		return false;
+	}
+	char dir[512];
+	snprintf(dir, sizeof(dir), "%s/.config", home);
+	MKDIR(dir);
+	snprintf(dir, sizeof(dir), "%s/.config/displayxr", home);
+	MKDIR(dir);
+	snprintf(g_state.path, sizeof(g_state.path), "%s/mcp-audit.log", dir);
+	return true;
+#endif
+}
+
+static void
+rotate_if_needed_locked(void)
+{
+	struct stat st;
+	if (stat(g_state.path, &st) != 0) {
+		return;
+	}
+	if (st.st_size < (off_t)MAX_FILE_BYTES) {
+		return;
+	}
+	char backup[1024];
+	snprintf(backup, sizeof(backup), "%s.1", g_state.path);
+	// Best-effort rotate; if rename fails the caller just keeps appending.
+	(void)remove(backup);
+	(void)rename(g_state.path, backup);
+}
+
+static uint64_t
+now_ns(void)
+{
+#ifdef XRT_OS_WINDOWS
+	// QueryPerformanceCounter is monotonic on modern Windows.
+	LARGE_INTEGER freq, ctr;
+	if (QueryPerformanceFrequency(&freq) && QueryPerformanceCounter(&ctr)) {
+		return (uint64_t)((double)ctr.QuadPart * 1e9 / (double)freq.QuadPart);
+	}
+	return 0;
+#else
+	struct timespec ts;
+	if (timespec_get(&ts, TIME_UTC) == TIME_UTC) {
+		return (uint64_t)ts.tv_sec * 1000000000ULL + (uint64_t)ts.tv_nsec;
+	}
+	return 0;
+#endif
+}
+
+void
+u_mcp_audit_append(const char *tool, uint32_t client_id, uint64_t args_hash)
+{
+	if (tool == NULL) {
+		return;
+	}
+	pthread_mutex_lock(&g_state.mutex);
+	if (!ensure_path_locked()) {
+		pthread_mutex_unlock(&g_state.mutex);
+		return;
+	}
+	rotate_if_needed_locked();
+
+	FILE *f = fopen(g_state.path, "ab");
+	if (f == NULL) {
+		U_LOG_W(LOG_PFX "fopen(%s) failed", g_state.path);
+		pthread_mutex_unlock(&g_state.mutex);
+		return;
+	}
+	fprintf(f, "%llu,%s,%u,0x%016llx\n",
+	        (unsigned long long)now_ns(), tool,
+	        (unsigned)client_id, (unsigned long long)args_hash);
+	fclose(f);
+	pthread_mutex_unlock(&g_state.mutex);
+}
+
+const char *
+u_mcp_audit_path(void)
+{
+	pthread_mutex_lock(&g_state.mutex);
+	(void)ensure_path_locked();
+	const char *p = g_state.path;
+	pthread_mutex_unlock(&g_state.mutex);
+	return p;
+}

--- a/src/xrt/auxiliary/util/u_mcp_audit.h
+++ b/src/xrt/auxiliary/util/u_mcp_audit.h
@@ -1,0 +1,52 @@
+// Copyright 2026, DisplayXR / Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  Append-only audit log for MCP write tools (Phase B §5).
+ * @ingroup aux_util
+ *
+ * Every call to u_mcp_audit_append() writes one line:
+ *
+ *   {ts_ns},{tool},{client_id},{args_hash}\n
+ *
+ * Location:
+ *   %APPDATA%\DisplayXR\mcp-audit.log        (Windows)
+ *   ~/.config/displayxr/mcp-audit.log        (POSIX)
+ *
+ * Size-based rotation kicks in at ~1 MB — the previous file is renamed
+ * to @c mcp-audit.log.1 (overwriting any earlier rotation). Only the
+ * current and one prior log are kept to bound disk use.
+ *
+ * Thread-safe: all writes go through a mutex so concurrent tool handlers
+ * don't interleave partial lines.
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*!
+ * Append one audit entry. @p client_id may be 0 when the tool is not
+ * per-client (e.g. @c apply_layout_preset); @p args_hash should be a
+ * stable hash of the tool's parameters (callers typically feed a djb2
+ * or FNV over the serialized JSON). Non-blocking best-effort; failures
+ * are logged via U_LOG_W and otherwise ignored.
+ */
+void
+u_mcp_audit_append(const char *tool, uint32_t client_id, uint64_t args_hash);
+
+/*!
+ * Return the absolute path of the current audit log. Thread-safe. Empty
+ * string if the audit module has not been initialized yet (first
+ * u_mcp_audit_append initializes lazily).
+ */
+const char *
+u_mcp_audit_path(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/xrt/auxiliary/util/u_mcp_capture.c
+++ b/src/xrt/auxiliary/util/u_mcp_capture.c
@@ -11,15 +11,18 @@
 #include <string.h>
 #include <time.h>
 
-// Forward-decl from state_trackers/oxr/oxr_mcp_tools.h — intentionally
-// don't pull that header (which includes openxr.h) into aux_util.
-typedef bool (*oxr_mcp_capture_fn)(const char *path, void *userdata);
-extern void
-oxr_mcp_tools_set_capture_handler(oxr_mcp_capture_fn fn, void *userdata);
+// Optional callback for notifying the Phase A per-PID capture handler
+// (oxr_mcp_tools). Registered by oxr_instance_create at runtime; NULL
+// in the service process which has no state tracker.
+typedef void (*u_mcp_capture_notify_fn)(void *req);
+static u_mcp_capture_notify_fn g_notify_install = NULL;
+static u_mcp_capture_notify_fn g_notify_uninstall = NULL;
 
 /*! PNG encode of a 3024×1964 atlas is ~80–150 ms on an M1; 3 s is
  *  ample headroom while still tripping on a genuine stall. */
 #define CAPTURE_TIMEOUT_MS 3000
+
+static struct u_mcp_capture_request *g_installed_req = NULL;
 
 void
 u_mcp_capture_init(struct u_mcp_capture_request *req)
@@ -36,10 +39,8 @@ u_mcp_capture_fini(struct u_mcp_capture_request *req)
 	pthread_mutex_destroy(&req->lock);
 }
 
-// Invoked on the MCP server thread. Hands off to the compositor and
-// blocks until done or timeout.
-static bool
-handler_adapter(const char *path, void *userdata)
+bool
+u_mcp_capture_blocking_handler(const char *path, void *userdata)
 {
 	struct u_mcp_capture_request *req = userdata;
 	if (req == NULL || path == NULL) {
@@ -87,13 +88,33 @@ handler_adapter(const char *path, void *userdata)
 void
 u_mcp_capture_install(struct u_mcp_capture_request *req)
 {
-	oxr_mcp_tools_set_capture_handler(handler_adapter, req);
+	g_installed_req = req;
+	if (g_notify_install) {
+		g_notify_install(req);
+	}
 }
 
 void
 u_mcp_capture_uninstall(void)
 {
-	oxr_mcp_tools_set_capture_handler(NULL, NULL);
+	if (g_notify_uninstall) {
+		g_notify_uninstall(NULL);
+	}
+	g_installed_req = NULL;
+}
+
+void
+u_mcp_capture_set_notify(u_mcp_capture_notify_fn on_install,
+                         u_mcp_capture_notify_fn on_uninstall)
+{
+	g_notify_install = on_install;
+	g_notify_uninstall = on_uninstall;
+}
+
+struct u_mcp_capture_request *
+u_mcp_capture_get_installed(void)
+{
+	return g_installed_req;
 }
 
 bool

--- a/src/xrt/auxiliary/util/u_mcp_capture.h
+++ b/src/xrt/auxiliary/util/u_mcp_capture.h
@@ -72,6 +72,33 @@ u_mcp_capture_poll(struct u_mcp_capture_request *req, char *out_path);
 void
 u_mcp_capture_complete(struct u_mcp_capture_request *req, bool success);
 
+/*!
+ * Return the currently installed capture request, or NULL if none.
+ * Used by the service-side capture_frame tool to submit requests
+ * directly to the compositor's capture handler.
+ */
+struct u_mcp_capture_request *
+u_mcp_capture_get_installed(void);
+
+/*!
+ * Blocking handler for the Phase A per-PID capture_frame tool. Submits
+ * a capture request and waits (up to 3 s) for the compositor thread to
+ * complete it. Called from the oxr tool_capture_frame handler.
+ */
+bool
+u_mcp_capture_blocking_handler(const char *path, void *userdata);
+
+typedef void (*u_mcp_capture_notify_fn)(void *req);
+
+/*!
+ * Register optional callbacks for Phase A (per-PID) integration.
+ * Called by the oxr state tracker at startup to wire capture_frame
+ * into the per-PID MCP server. Service processes don't call this.
+ */
+void
+u_mcp_capture_set_notify(u_mcp_capture_notify_fn on_install,
+                         u_mcp_capture_notify_fn on_uninstall);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/xrt/auxiliary/util/u_mcp_server.c
+++ b/src/xrt/auxiliary/util/u_mcp_server.c
@@ -9,6 +9,7 @@
 #include "u_mcp_server.h"
 #include "u_mcp_transport.h"
 #include "u_mcp_log_ring.h"
+#include "u_mcp_allowlist.h"
 
 #include "util/u_logging.h"
 
@@ -449,8 +450,10 @@ static void
 register_builtins(void)
 {
 	// Start the log ring first so sink_cb captures bring-up messages,
-	// then register built-in tools.
+	// then register built-in tools. Initialize the safety-model
+	// allowlist here too — tool handlers query it per-call.
 	u_mcp_log_ring_start();
+	u_mcp_allowlist_init();
 	u_mcp_server_register_tool(&ECHO_TOOL);
 	u_mcp_server_register_tool(&TAIL_LOG_TOOL);
 }

--- a/src/xrt/auxiliary/util/u_mcp_server.c
+++ b/src/xrt/auxiliary/util/u_mcp_server.c
@@ -423,28 +423,10 @@ server_thread(void *arg)
 
 // ---------- Public start/stop ----------
 
-void
-u_mcp_server_maybe_start(void)
+static void
+start_with_listener(struct u_mcp_listener *listener, const char *endpoint_label)
 {
-	if (g_server.thread_started) {
-		return;
-	}
-	const char *flag = getenv("DISPLAYXR_MCP");
-	if (flag == NULL || flag[0] == '\0' || flag[0] == '0') {
-		return;
-	}
-
-	// Start the log ring first so sink_cb captures bring-up messages,
-	// then register built-in tools.
-	u_mcp_log_ring_start();
-	u_mcp_server_register_tool(&ECHO_TOOL);
-	u_mcp_server_register_tool(&TAIL_LOG_TOOL);
-
-	g_server.listener = u_mcp_listener_open(u_mcp_self_pid());
-	if (g_server.listener == NULL) {
-		U_LOG_W(LOG_PFX "failed to open listener; MCP disabled");
-		return;
-	}
+	g_server.listener = listener;
 	int rc = pthread_create(&g_server.thread, NULL, server_thread, NULL);
 	if (rc != 0) {
 		U_LOG_W(LOG_PFX "pthread_create failed: %s", strerror(rc));
@@ -453,7 +435,64 @@ u_mcp_server_maybe_start(void)
 		return;
 	}
 	g_server.thread_started = true;
-	U_LOG_I(LOG_PFX "server started (pid=%ld)", (long)u_mcp_self_pid());
+	U_LOG_I(LOG_PFX "server started (%s)", endpoint_label);
+}
+
+static bool
+mcp_enabled(void)
+{
+	const char *flag = getenv("DISPLAYXR_MCP");
+	return flag != NULL && flag[0] != '\0' && flag[0] != '0';
+}
+
+static void
+register_builtins(void)
+{
+	// Start the log ring first so sink_cb captures bring-up messages,
+	// then register built-in tools.
+	u_mcp_log_ring_start();
+	u_mcp_server_register_tool(&ECHO_TOOL);
+	u_mcp_server_register_tool(&TAIL_LOG_TOOL);
+}
+
+void
+u_mcp_server_maybe_start(void)
+{
+	if (g_server.thread_started || !mcp_enabled()) {
+		return;
+	}
+	register_builtins();
+
+	struct u_mcp_listener *listener = u_mcp_listener_open(u_mcp_self_pid());
+	if (listener == NULL) {
+		U_LOG_W(LOG_PFX "failed to open listener; MCP disabled");
+		return;
+	}
+	char label[64];
+	snprintf(label, sizeof(label), "pid=%ld", (long)u_mcp_self_pid());
+	start_with_listener(listener, label);
+}
+
+void
+u_mcp_server_maybe_start_named(const char *role)
+{
+	if (g_server.thread_started || !mcp_enabled()) {
+		return;
+	}
+	if (role == NULL || role[0] == '\0') {
+		U_LOG_W(LOG_PFX "named start requires a non-empty role");
+		return;
+	}
+	register_builtins();
+
+	struct u_mcp_listener *listener = u_mcp_listener_open_named(role);
+	if (listener == NULL) {
+		U_LOG_W(LOG_PFX "failed to open named listener '%s'; MCP disabled", role);
+		return;
+	}
+	char label[96];
+	snprintf(label, sizeof(label), "role=%s pid=%ld", role, (long)u_mcp_self_pid());
+	start_with_listener(listener, label);
 }
 
 void

--- a/src/xrt/auxiliary/util/u_mcp_server.h
+++ b/src/xrt/auxiliary/util/u_mcp_server.h
@@ -46,12 +46,25 @@ struct u_mcp_tool
 };
 
 /*!
- * Start the server if @c DISPLAYXR_MCP is set. Idempotent no-op if
- * already running or env var unset. Best-effort: failure logs U_LOG_W
- * and returns without aborting instance creation.
+ * Start the server if @c DISPLAYXR_MCP is set, bound to a per-PID socket.
+ * Idempotent no-op if already running or env var unset. Best-effort:
+ * failure logs U_LOG_W and returns without aborting instance creation.
+ *
+ * Used by handle apps that link @c libopenxr_displayxr in-process.
  */
 void
 u_mcp_server_maybe_start(void);
+
+/*!
+ * Start the server if @c DISPLAYXR_MCP is set, bound to a well-known
+ * named socket (`/tmp/displayxr-mcp-<role>.sock` on POSIX,
+ * `\\.\pipe\displayxr-mcp-<role>` on Windows). Idempotent.
+ *
+ * Used by singleton processes like @c displayxr-service where the adapter
+ * should be able to discover the endpoint by role rather than PID.
+ */
+void
+u_mcp_server_maybe_start_named(const char *role);
 
 /*!
  * Stop the server (joins the thread, unlinks the socket). Safe to call

--- a/src/xrt/auxiliary/util/u_mcp_transport.c
+++ b/src/xrt/auxiliary/util/u_mcp_transport.c
@@ -459,6 +459,9 @@ u_mcp_conn_close(struct u_mcp_conn *conn)
 		return;
 	}
 	if (conn->pipe != INVALID_HANDLE_VALUE) {
+		// Unblock any read/write in progress on another thread — otherwise
+		// CloseHandle below may leave them parked on the kernel side.
+		CancelIoEx(conn->pipe, NULL);
 		if (conn->owns_handle) {
 			CloseHandle(conn->pipe);
 		} else {

--- a/src/xrt/auxiliary/util/u_mcp_transport.c
+++ b/src/xrt/auxiliary/util/u_mcp_transport.c
@@ -424,8 +424,16 @@ u_mcp_conn_read(struct u_mcp_conn *conn, void *buf, size_t len)
 	}
 	char *p = buf;
 	while (len > 0) {
+		OVERLAPPED ov = {0};
+		ov.hEvent = CreateEventA(NULL, TRUE, FALSE, NULL);
 		DWORD got = 0;
-		if (!ReadFile(conn->pipe, p, (DWORD)len, &got, NULL) || got == 0) {
+		BOOL ok = ReadFile(conn->pipe, p, (DWORD)len, &got, &ov);
+		if (!ok && GetLastError() == ERROR_IO_PENDING) {
+			WaitForSingleObject(ov.hEvent, INFINITE);
+			ok = GetOverlappedResult(conn->pipe, &ov, &got, FALSE);
+		}
+		CloseHandle(ov.hEvent);
+		if (!ok || got == 0) {
 			return false;
 		}
 		p += got;
@@ -442,8 +450,16 @@ u_mcp_conn_write(struct u_mcp_conn *conn, const void *buf, size_t len)
 	}
 	const char *p = buf;
 	while (len > 0) {
+		OVERLAPPED ov = {0};
+		ov.hEvent = CreateEventA(NULL, TRUE, FALSE, NULL);
 		DWORD wrote = 0;
-		if (!WriteFile(conn->pipe, p, (DWORD)len, &wrote, NULL) || wrote == 0) {
+		BOOL ok = WriteFile(conn->pipe, p, (DWORD)len, &wrote, &ov);
+		if (!ok && GetLastError() == ERROR_IO_PENDING) {
+			WaitForSingleObject(ov.hEvent, INFINITE);
+			ok = GetOverlappedResult(conn->pipe, &ov, &wrote, FALSE);
+		}
+		CloseHandle(ov.hEvent);
+		if (!ok || wrote == 0) {
 			return false;
 		}
 		p += wrote;
@@ -459,9 +475,6 @@ u_mcp_conn_close(struct u_mcp_conn *conn)
 		return;
 	}
 	if (conn->pipe != INVALID_HANDLE_VALUE) {
-		// Unblock any read/write in progress on another thread — otherwise
-		// CloseHandle below may leave them parked on the kernel side.
-		CancelIoEx(conn->pipe, NULL);
 		if (conn->owns_handle) {
 			CloseHandle(conn->pipe);
 		} else {
@@ -485,7 +498,11 @@ u_mcp_conn_fd(struct u_mcp_conn *conn)
 static struct u_mcp_conn *
 conn_connect_pipe_name(const char *name)
 {
-	HANDLE h = CreateFileA(name, GENERIC_READ | GENERIC_WRITE, 0, NULL, OPEN_EXISTING, 0, NULL);
+	if (!WaitNamedPipeA(name, 5000)) {
+		return NULL;
+	}
+	HANDLE h = CreateFileA(name, GENERIC_READ | GENERIC_WRITE, 0, NULL,
+	                       OPEN_EXISTING, FILE_FLAG_OVERLAPPED, NULL);
 	if (h == INVALID_HANDLE_VALUE) {
 		return NULL;
 	}

--- a/src/xrt/auxiliary/util/u_mcp_transport.c
+++ b/src/xrt/auxiliary/util/u_mcp_transport.c
@@ -54,14 +54,20 @@ build_sock_path(char *out, size_t cap, long pid)
 	snprintf(out, cap, "%s%ld%s", SOCK_PREFIX, (long)pid, SOCK_SUFFIX);
 }
 
-struct u_mcp_listener *
-u_mcp_listener_open(long pid)
+static void
+build_sock_path_named(char *out, size_t cap, const char *role)
+{
+	snprintf(out, cap, "%s%s%s", SOCK_PREFIX, role, SOCK_SUFFIX);
+}
+
+static struct u_mcp_listener *
+listener_open_path(const char *path)
 {
 	struct u_mcp_listener *l = U_TYPED_CALLOC(struct u_mcp_listener);
 	l->fd = -1;
-	build_sock_path(l->path, sizeof(l->path), pid);
+	snprintf(l->path, sizeof(l->path), "%s", path);
 
-	// Always unlink any stale socket; we own /tmp/displayxr-mcp-<pid>.sock.
+	// Always unlink any stale socket; we own the named path.
 	(void)unlink(l->path);
 
 	int fd = socket(AF_UNIX, SOCK_STREAM, 0);
@@ -82,7 +88,6 @@ u_mcp_listener_open(long pid)
 		return NULL;
 	}
 
-	// Owner-only access.
 	(void)chmod(l->path, 0600);
 
 	if (listen(fd, 4) != 0) {
@@ -96,6 +101,25 @@ u_mcp_listener_open(long pid)
 	l->fd = fd;
 	U_LOG_I(LOG_PFX "listening on %s", l->path);
 	return l;
+}
+
+struct u_mcp_listener *
+u_mcp_listener_open(long pid)
+{
+	char path[128];
+	build_sock_path(path, sizeof(path), pid);
+	return listener_open_path(path);
+}
+
+struct u_mcp_listener *
+u_mcp_listener_open_named(const char *role)
+{
+	if (role == NULL || role[0] == '\0') {
+		return NULL;
+	}
+	char path[128];
+	build_sock_path_named(path, sizeof(path), role);
+	return listener_open_path(path);
 }
 
 struct u_mcp_conn *
@@ -188,8 +212,8 @@ u_mcp_conn_fd(struct u_mcp_conn *conn)
 	return conn != NULL ? conn->fd : -1;
 }
 
-struct u_mcp_conn *
-u_mcp_conn_connect(long pid)
+static struct u_mcp_conn *
+conn_connect_path(const char *path)
 {
 	int fd = socket(AF_UNIX, SOCK_STREAM, 0);
 	if (fd < 0) {
@@ -197,7 +221,7 @@ u_mcp_conn_connect(long pid)
 	}
 	struct sockaddr_un addr = {0};
 	addr.sun_family = AF_UNIX;
-	build_sock_path(addr.sun_path, sizeof(addr.sun_path), pid);
+	snprintf(addr.sun_path, sizeof(addr.sun_path), "%s", path);
 	if (connect(fd, (struct sockaddr *)&addr, sizeof(addr)) != 0) {
 		close(fd);
 		return NULL;
@@ -205,6 +229,25 @@ u_mcp_conn_connect(long pid)
 	struct u_mcp_conn *c = U_TYPED_CALLOC(struct u_mcp_conn);
 	c->fd = fd;
 	return c;
+}
+
+struct u_mcp_conn *
+u_mcp_conn_connect(long pid)
+{
+	char path[128];
+	build_sock_path(path, sizeof(path), pid);
+	return conn_connect_path(path);
+}
+
+struct u_mcp_conn *
+u_mcp_conn_connect_named(const char *role)
+{
+	if (role == NULL || role[0] == '\0') {
+		return NULL;
+	}
+	char path[128];
+	build_sock_path_named(path, sizeof(path), role);
+	return conn_connect_path(path);
 }
 
 size_t
@@ -278,6 +321,42 @@ static void
 build_pipe_name(char *out, size_t cap, long pid)
 {
 	snprintf(out, cap, PIPE_PREFIX "%ld", (long)pid);
+}
+
+static void
+build_pipe_name_named(char *out, size_t cap, const char *role)
+{
+	snprintf(out, cap, PIPE_PREFIX "%s", role);
+}
+
+static struct u_mcp_listener *
+listener_open_pipe_name(const char *name)
+{
+	struct u_mcp_listener *l = U_TYPED_CALLOC(struct u_mcp_listener);
+	snprintf(l->name, sizeof(l->name), "%s", name);
+	l->pipe = CreateNamedPipeA(
+	    l->name,
+	    PIPE_ACCESS_DUPLEX,
+	    PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT,
+	    1, 65536, 65536, 0, NULL);
+	if (l->pipe == INVALID_HANDLE_VALUE) {
+		U_LOG_W(LOG_PFX "CreateNamedPipe(%s) failed: %lu", l->name, GetLastError());
+		free(l);
+		return NULL;
+	}
+	U_LOG_I(LOG_PFX "listening on %s", l->name);
+	return l;
+}
+
+struct u_mcp_listener *
+u_mcp_listener_open_named(const char *role)
+{
+	if (role == NULL || role[0] == '\0') {
+		return NULL;
+	}
+	char name[128];
+	build_pipe_name_named(name, sizeof(name), role);
+	return listener_open_pipe_name(name);
 }
 
 struct u_mcp_listener *
@@ -392,11 +471,9 @@ u_mcp_conn_fd(struct u_mcp_conn *conn)
 	return -1; // Windows clients cannot poll() a pipe HANDLE; adapter uses threads.
 }
 
-struct u_mcp_conn *
-u_mcp_conn_connect(long pid)
+static struct u_mcp_conn *
+conn_connect_pipe_name(const char *name)
 {
-	char name[128];
-	build_pipe_name(name, sizeof(name), pid);
 	HANDLE h = CreateFileA(name, GENERIC_READ | GENERIC_WRITE, 0, NULL, OPEN_EXISTING, 0, NULL);
 	if (h == INVALID_HANDLE_VALUE) {
 		return NULL;
@@ -407,6 +484,25 @@ u_mcp_conn_connect(long pid)
 	c->pipe = h;
 	c->owns_handle = true;
 	return c;
+}
+
+struct u_mcp_conn *
+u_mcp_conn_connect(long pid)
+{
+	char name[128];
+	build_pipe_name(name, sizeof(name), pid);
+	return conn_connect_pipe_name(name);
+}
+
+struct u_mcp_conn *
+u_mcp_conn_connect_named(const char *role)
+{
+	if (role == NULL || role[0] == '\0') {
+		return NULL;
+	}
+	char name[128];
+	build_pipe_name_named(name, sizeof(name), role);
+	return conn_connect_pipe_name(name);
 }
 
 size_t

--- a/src/xrt/auxiliary/util/u_mcp_transport.c
+++ b/src/xrt/auxiliary/util/u_mcp_transport.c
@@ -458,8 +458,16 @@ u_mcp_conn_close(struct u_mcp_conn *conn)
 	if (conn == NULL) {
 		return;
 	}
-	if (conn->owns_handle && conn->pipe != INVALID_HANDLE_VALUE) {
-		CloseHandle(conn->pipe);
+	if (conn->pipe != INVALID_HANDLE_VALUE) {
+		if (conn->owns_handle) {
+			CloseHandle(conn->pipe);
+		} else {
+			// Listener-owned pipe: reset it for the next ConnectNamedPipe.
+			// Windows requires DisconnectNamedPipe between clients when
+			// nMaxInstances=1, otherwise subsequent CreateFile calls time
+			// out with ERROR_SEM_TIMEOUT.
+			DisconnectNamedPipe(conn->pipe);
+		}
 	}
 	free(conn);
 }

--- a/src/xrt/auxiliary/util/u_mcp_transport.h
+++ b/src/xrt/auxiliary/util/u_mcp_transport.h
@@ -37,6 +37,20 @@ struct u_mcp_listener *
 u_mcp_listener_open(long pid);
 
 /*!
+ * Bind a well-known named listener. Returns NULL on failure.
+ *
+ * Intended for singleton endpoints like @c "service" where the PID is
+ * not a stable identifier for adapters. On POSIX this creates
+ * `/tmp/displayxr-mcp-<role>.sock` with 0600 perms; on Windows the
+ * pipe is `\\.\pipe\displayxr-mcp-<role>`.
+ *
+ * @p role must be a short, PID-unambiguous string (non-numeric) — callers
+ * must not pass names that could collide with enumerated PID sessions.
+ */
+struct u_mcp_listener *
+u_mcp_listener_open_named(const char *role);
+
+/*!
  * Accept one connection. Blocks. Returns NULL when the listener is closed
  * (u_mcp_listener_close from another thread wakes us via shutdown()).
  */
@@ -72,6 +86,12 @@ u_mcp_conn_close(struct u_mcp_conn *conn);
  */
 struct u_mcp_conn *
 u_mcp_conn_connect(long pid);
+
+/*!
+ * Connect to a well-known named listener (e.g. @c "service").
+ */
+struct u_mcp_conn *
+u_mcp_conn_connect_named(const char *role);
 
 /*!
  * Raw fd / handle for poll()-style multiplexing by the adapter.

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -10962,89 +10962,48 @@ comp_d3d11_service_poll_mcp_capture(struct xrt_system_compositor *xsysc)
 		return;
 	}
 
+	// Delegate atlas capture to the shared capture_frame API.
+	struct ipc_capture_result cr = {};
+	bool ok = comp_d3d11_service_capture_frame(xsysc, base, IPC_CAPTURE_FLAG_ATLAS, &cr);
+
+	// Write per-window metadata JSON.
 	struct d3d11_multi_compositor *mc = sys->multi_comp;
-	if (mc->combined_atlas == nullptr) {
-		u_mcp_capture_complete(&sys->mcp_capture, false);
-		return;
-	}
-
-	std::lock_guard<std::recursive_mutex> lock(sys->render_mutex);
-
-	D3D11_TEXTURE2D_DESC desc;
-	mc->combined_atlas->GetDesc(&desc);
-	uint32_t atlas_w = desc.Width, atlas_h = desc.Height;
-
-	D3D11_TEXTURE2D_DESC sd = desc;
-	sd.Usage = D3D11_USAGE_STAGING;
-	sd.BindFlags = 0;
-	sd.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
-	sd.MiscFlags = 0;
-	wil::com_ptr<ID3D11Texture2D> staging;
-	if (FAILED(sys->device->CreateTexture2D(&sd, nullptr, staging.put()))) {
-		u_mcp_capture_complete(&sys->mcp_capture, false);
-		return;
-	}
-	sys->context->CopyResource(staging.get(), mc->combined_atlas.get());
-
-	D3D11_MAPPED_SUBRESOURCE m = {};
-	if (FAILED(sys->context->Map(staging.get(), 0, D3D11_MAP_READ, 0, &m))) {
-		u_mcp_capture_complete(&sys->mcp_capture, false);
-		return;
-	}
-
-	char path[U_MCP_CAPTURE_PATH_MAX + 32];
-	snprintf(path, sizeof(path), "%s_atlas.png", base);
-	bool ok_atlas = stbi_write_png(path, (int)atlas_w, (int)atlas_h, 4,
-	                               m.pData, (int)m.RowPitch) != 0;
-
-	uint32_t half_w = atlas_w / 2;
-	const uint8_t *rows = (const uint8_t *)m.pData;
-	snprintf(path, sizeof(path), "%s_L.png", base);
-	bool ok_L = stbi_write_png(path, (int)half_w, (int)atlas_h, 4,
-	                           rows, (int)m.RowPitch) != 0;
-	snprintf(path, sizeof(path), "%s_R.png", base);
-	bool ok_R = stbi_write_png(path, (int)half_w, (int)atlas_h, 4,
-	                           rows + half_w * 4, (int)m.RowPitch) != 0;
-
-	sys->context->Unmap(staging.get(), 0);
-
-	snprintf(path, sizeof(path), "%s_windows.json", base);
-	FILE *jf = fopen(path, "wb");
-	bool ok_json = false;
-	if (jf != nullptr) {
-		fprintf(jf, "{\n  \"atlas_width\": %u,\n  \"atlas_height\": %u,\n  \"windows\": [",
-		        atlas_w, atlas_h);
-		bool first = true;
-		for (int i = 0; i < D3D11_MULTI_MAX_CLIENTS; i++) {
-			const d3d11_multi_client_slot *s = &mc->clients[i];
-			if (!s->active) {
-				continue;
+	if (ok && mc != nullptr) {
+		char path[U_MCP_CAPTURE_PATH_MAX + 32];
+		snprintf(path, sizeof(path), "%s_windows.json", base);
+		FILE *jf = fopen(path, "wb");
+		if (jf != nullptr) {
+			fprintf(jf, "{\n  \"atlas_width\": %u,\n  \"atlas_height\": %u,\n  \"windows\": [",
+			        cr.atlas_width, cr.atlas_height);
+			bool first = true;
+			for (int i = 0; i < D3D11_MULTI_MAX_CLIENTS; i++) {
+				const d3d11_multi_client_slot *s = &mc->clients[i];
+				if (!s->active) {
+					continue;
+				}
+				fprintf(jf, "%s\n    {\"slot\": %d, \"name\": \"%s\", "
+				            "\"atlas_bbox\": {\"x\": %d, \"y\": %d, \"w\": %d, \"h\": %d}, "
+				            "\"content\": {\"w\": %u, \"h\": %u}}",
+				        first ? "" : ",", i, s->app_name,
+				        s->window_rect_x, s->window_rect_y,
+				        s->window_rect_w, s->window_rect_h,
+				        s->content_view_w, s->content_view_h);
+				first = false;
 			}
-			fprintf(jf, "%s\n    {\"slot\": %d, \"name\": \"%s\", "
-			            "\"atlas_bbox\": {\"x\": %d, \"y\": %d, \"w\": %d, \"h\": %d}, "
-			            "\"content\": {\"w\": %u, \"h\": %u}}",
-			        first ? "" : ",", i, s->app_name,
-			        s->window_rect_x, s->window_rect_y,
-			        s->window_rect_w, s->window_rect_h,
-			        s->content_view_w, s->content_view_h);
-			first = false;
+			fprintf(jf, "\n  ]\n}\n");
+			fclose(jf);
 		}
-		fprintf(jf, "\n  ]\n}\n");
-		fclose(jf);
-		ok_json = true;
 	}
 
-	bool all_ok = ok_atlas && ok_L && ok_R && ok_json;
-	// Write a sentinel file that the service-side MCP tool handler polls
-	// for. This avoids pthreads condvar visibility issues on Windows.
+	// Write sentinel for the MCP tool handler's file-based poll.
 	{
 		char sentinel[U_MCP_CAPTURE_PATH_MAX + 32];
 		snprintf(sentinel, sizeof(sentinel), "%s_DONE.txt", base);
 		FILE *f = fopen(sentinel, "w");
 		if (f) {
-			fprintf(f, "ok=%d\n", all_ok);
+			fprintf(f, "ok=%d\n", ok);
 			fclose(f);
 		}
 	}
-	u_mcp_capture_complete(&sys->mcp_capture, all_ok);
+	u_mcp_capture_complete(&sys->mcp_capture, ok);
 }

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -39,6 +39,7 @@
 
 #include "util/u_hud.h"
 #include "util/u_tiling.h"
+#include "util/u_mcp_capture.h"
 
 #ifdef XRT_BUILD_DRIVER_QWERTY
 #include "qwerty_interface.h"
@@ -345,6 +346,9 @@ struct d3d11_service_system
 		char layout_3d[8] = {};
 	};
 	struct launcher_icon launcher_icons[IPC_LAUNCHER_MAX_APPS];
+
+	//! MCP capture_frame cross-thread hand-off (Phase B slice 7).
+	struct u_mcp_capture_request mcp_capture;
 
 	//! Multi-compositor control interface for session state management
 	struct xrt_multi_compositor_control xmcc;
@@ -8023,6 +8027,10 @@ after_key_shortcuts:
 		}
 	}
 
+	// MCP capture_frame: service a pending request before Present
+	// so the atlas is fully populated.
+	comp_d3d11_service_poll_mcp_capture((struct xrt_system_compositor *)sys);
+
 	// Present
 	if (mc->swap_chain) {
 		mc->swap_chain->Present(1, 0);
@@ -9304,6 +9312,9 @@ system_destroy(struct xrt_system_compositor *xsysc)
 	// are cleaned up in fini_client_render_resources() when each client disconnects.
 	// System only needs to clean up shared resources (device, shaders, etc.)
 
+	u_mcp_capture_uninstall();
+	u_mcp_capture_fini(&sys->mcp_capture);
+
 	sys->dxgi_factory.reset();
 	sys->context.reset();
 	sys->device.reset();
@@ -9491,6 +9502,9 @@ comp_d3d11_service_create_system(struct xrt_device *xdev,
 	        sys->view_width, sys->view_height,
 	        sys->display_width, sys->display_height,
 	        sys->output_width, sys->output_height, sys->refresh_rate);
+
+	u_mcp_capture_init(&sys->mcp_capture);
+	u_mcp_capture_install(&sys->mcp_capture);
 
 	*out_xsysc = &sys->base;
 	return XRT_SUCCESS;
@@ -10929,4 +10943,108 @@ comp_d3d11_service_apply_layout_preset(struct xrt_system_compositor *xsysc,
 		InvalidateRect(mc->hwnd, nullptr, FALSE);
 	}
 	return true;
+}
+
+
+void
+comp_d3d11_service_poll_mcp_capture(struct xrt_system_compositor *xsysc)
+{
+	if (xsysc == nullptr) {
+		return;
+	}
+	struct d3d11_service_system *sys = d3d11_service_system_from_xrt(xsysc);
+	if (!sys->shell_mode || sys->multi_comp == nullptr) {
+		return;
+	}
+
+	char base[U_MCP_CAPTURE_PATH_MAX];
+	if (!u_mcp_capture_poll(&sys->mcp_capture, base)) {
+		return;
+	}
+
+	struct d3d11_multi_compositor *mc = sys->multi_comp;
+	if (mc->combined_atlas == nullptr) {
+		u_mcp_capture_complete(&sys->mcp_capture, false);
+		return;
+	}
+
+	std::lock_guard<std::recursive_mutex> lock(sys->render_mutex);
+
+	D3D11_TEXTURE2D_DESC desc;
+	mc->combined_atlas->GetDesc(&desc);
+	uint32_t atlas_w = desc.Width, atlas_h = desc.Height;
+
+	D3D11_TEXTURE2D_DESC sd = desc;
+	sd.Usage = D3D11_USAGE_STAGING;
+	sd.BindFlags = 0;
+	sd.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
+	sd.MiscFlags = 0;
+	wil::com_ptr<ID3D11Texture2D> staging;
+	if (FAILED(sys->device->CreateTexture2D(&sd, nullptr, staging.put()))) {
+		u_mcp_capture_complete(&sys->mcp_capture, false);
+		return;
+	}
+	sys->context->CopyResource(staging.get(), mc->combined_atlas.get());
+
+	D3D11_MAPPED_SUBRESOURCE m = {};
+	if (FAILED(sys->context->Map(staging.get(), 0, D3D11_MAP_READ, 0, &m))) {
+		u_mcp_capture_complete(&sys->mcp_capture, false);
+		return;
+	}
+
+	char path[U_MCP_CAPTURE_PATH_MAX + 32];
+	snprintf(path, sizeof(path), "%s_atlas.png", base);
+	bool ok_atlas = stbi_write_png(path, (int)atlas_w, (int)atlas_h, 4,
+	                               m.pData, (int)m.RowPitch) != 0;
+
+	uint32_t half_w = atlas_w / 2;
+	const uint8_t *rows = (const uint8_t *)m.pData;
+	snprintf(path, sizeof(path), "%s_L.png", base);
+	bool ok_L = stbi_write_png(path, (int)half_w, (int)atlas_h, 4,
+	                           rows, (int)m.RowPitch) != 0;
+	snprintf(path, sizeof(path), "%s_R.png", base);
+	bool ok_R = stbi_write_png(path, (int)half_w, (int)atlas_h, 4,
+	                           rows + half_w * 4, (int)m.RowPitch) != 0;
+
+	sys->context->Unmap(staging.get(), 0);
+
+	snprintf(path, sizeof(path), "%s_windows.json", base);
+	FILE *jf = fopen(path, "wb");
+	bool ok_json = false;
+	if (jf != nullptr) {
+		fprintf(jf, "{\n  \"atlas_width\": %u,\n  \"atlas_height\": %u,\n  \"windows\": [",
+		        atlas_w, atlas_h);
+		bool first = true;
+		for (int i = 0; i < D3D11_MULTI_MAX_CLIENTS; i++) {
+			const d3d11_multi_client_slot *s = &mc->clients[i];
+			if (!s->active) {
+				continue;
+			}
+			fprintf(jf, "%s\n    {\"slot\": %d, \"name\": \"%s\", "
+			            "\"atlas_bbox\": {\"x\": %d, \"y\": %d, \"w\": %d, \"h\": %d}, "
+			            "\"content\": {\"w\": %u, \"h\": %u}}",
+			        first ? "" : ",", i, s->app_name,
+			        s->window_rect_x, s->window_rect_y,
+			        s->window_rect_w, s->window_rect_h,
+			        s->content_view_w, s->content_view_h);
+			first = false;
+		}
+		fprintf(jf, "\n  ]\n}\n");
+		fclose(jf);
+		ok_json = true;
+	}
+
+	bool all_ok = ok_atlas && ok_L && ok_R && ok_json;
+	// Write a sentinel file that the service-side MCP tool handler polls
+	// for. This avoids pthreads condvar visibility issues on Windows.
+	{
+		char sentinel[U_MCP_CAPTURE_PATH_MAX + 32];
+		snprintf(sentinel, sizeof(sentinel), "%s_DONE.txt", base);
+		FILE *f = fopen(sentinel, "w");
+		if (f) {
+			fprintf(f, "ok=%d\n", all_ok);
+			fclose(f);
+		}
+	}
+	u_mcp_capture_complete(&sys->mcp_capture, all_ok);
 }

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -10895,3 +10895,38 @@ comp_d3d11_service_set_launcher_visible(struct xrt_system_compositor *xsysc, boo
 		InvalidateRect(mc->hwnd, nullptr, FALSE);
 	}
 }
+
+// Apply a named layout preset. Mirrors the Ctrl+1/2/3 hotkey dispatch
+// in the event loop so MCP agents trigger the same code path a user
+// would. Returns false on unknown name or when shell mode is not active.
+bool
+comp_d3d11_service_apply_layout_preset(struct xrt_system_compositor *xsysc,
+                                        const char *preset_name)
+{
+	if (xsysc == nullptr || preset_name == nullptr) {
+		return false;
+	}
+
+	struct d3d11_service_system *sys = d3d11_service_system_from_xrt(xsysc);
+	std::lock_guard<std::recursive_mutex> lock(sys->render_mutex);
+
+	struct d3d11_multi_compositor *mc = sys->multi_comp;
+	if (mc == nullptr || !sys->shell_mode) {
+		return false;
+	}
+
+	if (strcmp(preset_name, "grid") == 0) {
+		apply_layout(sys, mc, 0);
+	} else if (strcmp(preset_name, "immersive") == 0) {
+		apply_layout(sys, mc, 1);
+	} else if (strcmp(preset_name, "carousel") == 0) {
+		enter_dynamic_layout(sys, mc, 0);
+	} else {
+		return false;
+	}
+
+	if (mc->hwnd != nullptr) {
+		InvalidateRect(mc->hwnd, nullptr, FALSE);
+	}
+	return true;
+}

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.h
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.h
@@ -401,6 +401,17 @@ comp_d3d11_service_capture_frame(struct xrt_system_compositor *xsysc,
                                  uint32_t flags,
                                  struct ipc_capture_result *out_result);
 
+/*!
+ * Service a pending MCP capture_frame request against the combined
+ * shell atlas. Writes {base}_atlas.png, {base}_L.png, {base}_R.png,
+ * plus {base}_windows.json. Called from multi_compositor_render just
+ * before Present so the atlas is fully populated.
+ *
+ * @ingroup comp_d3d11_service
+ */
+void
+comp_d3d11_service_poll_mcp_capture(struct xrt_system_compositor *xsysc);
+
 /*! @} */
 
 

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.h
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.h
@@ -206,6 +206,18 @@ comp_d3d11_service_get_client_window_pose(struct xrt_system_compositor *xsysc,
                                            float *out_width_m,
                                            float *out_height_m);
 
+/*!
+ * Apply a named layout preset to all active windows. Preset names:
+ * `grid`, `immersive`, `carousel`. Mirrors the Ctrl+1/2/3 hotkeys so
+ * an MCP agent can trigger the same layouts an interactive user gets.
+ *
+ * @return true on success, false if the preset name is unknown or the
+ *         compositor is not in shell mode.
+ */
+bool
+comp_d3d11_service_apply_layout_preset(struct xrt_system_compositor *xsysc,
+                                        const char *preset_name);
+
 
 /*!
  * @name Capture client management (Phase 4A)

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.h
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.h
@@ -402,10 +402,11 @@ comp_d3d11_service_capture_frame(struct xrt_system_compositor *xsysc,
                                  struct ipc_capture_result *out_result);
 
 /*!
- * Service a pending MCP capture_frame request against the combined
- * shell atlas. Writes {base}_atlas.png, {base}_L.png, {base}_R.png,
- * plus {base}_windows.json. Called from multi_compositor_render just
- * before Present so the atlas is fully populated.
+ * Service a pending MCP capture_frame request. Delegates to
+ * comp_d3d11_service_capture_frame for the atlas, then writes
+ * {base}_windows.json with per-slot bbox metadata.
+ *
+ * Called from multi_compositor_render just before Present.
  *
  * @ingroup comp_d3d11_service
  */

--- a/src/xrt/ipc/CMakeLists.txt
+++ b/src/xrt/ipc/CMakeLists.txt
@@ -112,6 +112,8 @@ add_library(
 	server/ipc_server_handler.c
 	server/ipc_server_per_client_thread.c
 	server/ipc_server_process.c
+	server/ipc_mcp_tools.c
+	server/ipc_mcp_tools.h
 	)
 target_include_directories(
 	ipc_server

--- a/src/xrt/ipc/server/ipc_mcp_tools.c
+++ b/src/xrt/ipc/server/ipc_mcp_tools.c
@@ -1,0 +1,133 @@
+// Copyright 2026, DisplayXR / Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  MCP shell-scope tool handlers (Phase B).
+ * @ingroup ipc_server
+ */
+
+#include "ipc_mcp_tools.h"
+
+#include "server/ipc_server.h"
+#include "shared/ipc_protocol.h"
+
+#include "util/u_mcp_server.h"
+#include "util/u_logging.h"
+
+#include "os/os_threading.h"
+
+#include <cjson/cJSON.h>
+
+#if defined(XRT_HAVE_D3D11_SERVICE_COMPOSITOR)
+#include "d3d11_service/comp_d3d11_service.h"
+#endif
+
+#define LOG_PFX "[mcp-shell] "
+
+// File-static server pointer — the Phase A server registry takes a raw
+// userdata void* per tool, but for the Phase B shell tools all handlers
+// share the same ipc_server anyway. Keeping it here avoids threading the
+// pointer through each static tool descriptor.
+static struct ipc_server *g_ipc_server = NULL;
+
+
+// ---------- list_windows ----------
+
+static cJSON *
+tool_list_windows(const cJSON *params, void *userdata)
+{
+	(void)params;
+	(void)userdata;
+	struct ipc_server *s = g_ipc_server;
+	if (s == NULL) {
+		return NULL;
+	}
+
+	cJSON *arr = cJSON_CreateArray();
+	if (arr == NULL) {
+		return NULL;
+	}
+
+	os_mutex_lock(&s->global_state.lock);
+
+	for (uint32_t i = 0; i < IPC_MAX_CLIENTS; i++) {
+		volatile struct ipc_client_state *ics = &s->threads[i].ics;
+		// Skip empty slots and clients that haven't finished handshake.
+		if (ics->server_thread_index < 0) {
+			continue;
+		}
+		// Cast-drop volatile for read access — we hold the server lock
+		// so the fields are stable for the duration of this call.
+		const struct ipc_app_state *as =
+		    (const struct ipc_app_state *)&ics->client_state;
+		if (as->id == 0) {
+			continue;
+		}
+
+		cJSON *o = cJSON_CreateObject();
+		cJSON_AddNumberToObject(o, "id", (double)as->id);
+		cJSON_AddNumberToObject(o, "pid", (double)as->pid);
+		cJSON_AddStringToObject(o, "name", as->info.application_name);
+		cJSON_AddBoolToObject(o, "session_active", as->session_active);
+		cJSON_AddBoolToObject(o, "session_visible", as->session_visible);
+		cJSON_AddBoolToObject(o, "session_focused", as->session_focused);
+		cJSON_AddNumberToObject(o, "z_order", (double)as->z_order);
+		cJSON_AddBoolToObject(o, "primary", as->primary_application);
+
+#if defined(XRT_HAVE_D3D11_SERVICE_COMPOSITOR)
+		// Shell-mode pose + size. If the client hasn't produced its
+		// compositor yet (or we're not in shell mode) the accessor
+		// returns false and we emit nulls so the caller can tell.
+		struct xrt_pose pose = {0};
+		float width_m = 0.f, height_m = 0.f;
+		bool have_pose = false;
+		if (ics->xc != NULL && s->xsysc != NULL) {
+			have_pose = comp_d3d11_service_get_client_window_pose(
+			    s->xsysc, (struct xrt_compositor *)ics->xc, &pose, &width_m, &height_m);
+		}
+		if (have_pose) {
+			cJSON *p = cJSON_CreateObject();
+			cJSON_AddNumberToObject(p, "x", pose.position.x);
+			cJSON_AddNumberToObject(p, "y", pose.position.y);
+			cJSON_AddNumberToObject(p, "z", pose.position.z);
+			cJSON_AddNumberToObject(p, "qx", pose.orientation.x);
+			cJSON_AddNumberToObject(p, "qy", pose.orientation.y);
+			cJSON_AddNumberToObject(p, "qz", pose.orientation.z);
+			cJSON_AddNumberToObject(p, "qw", pose.orientation.w);
+			cJSON_AddItemToObject(o, "pose", p);
+			cJSON *d = cJSON_CreateObject();
+			cJSON_AddNumberToObject(d, "width_m", width_m);
+			cJSON_AddNumberToObject(d, "height_m", height_m);
+			cJSON_AddItemToObject(o, "size", d);
+		}
+#endif
+		cJSON_AddItemToArray(arr, o);
+	}
+
+	os_mutex_unlock(&s->global_state.lock);
+	return arr;
+}
+
+
+// ---------- registry ----------
+
+static const struct u_mcp_tool TOOL_LIST_WINDOWS = {
+    .name = "list_windows",
+    .description =
+        "List all OpenXR clients attached to the service, including shell "
+        "window pose and size in meters when shell mode is active.",
+    .input_schema_json = "{\"type\":\"object\",\"properties\":{},\"additionalProperties\":false}",
+    .fn = tool_list_windows,
+    .userdata = NULL,
+};
+
+void
+ipc_mcp_tools_register(struct ipc_server *s)
+{
+	if (s == NULL) {
+		return;
+	}
+	g_ipc_server = s;
+	u_mcp_server_register_tool(&TOOL_LIST_WINDOWS);
+	U_LOG_I(LOG_PFX "registered shell tools against ipc_server %p", (void *)s);
+}

--- a/src/xrt/ipc/server/ipc_mcp_tools.c
+++ b/src/xrt/ipc/server/ipc_mcp_tools.c
@@ -12,6 +12,8 @@
 #include "shared/ipc_protocol.h"
 
 #include "util/u_mcp_server.h"
+#include "util/u_mcp_audit.h"
+#include "util/u_mcp_allowlist.h"
 #include "util/u_logging.h"
 
 #include "os/os_threading.h"
@@ -48,6 +50,43 @@
 // share the same ipc_server anyway. Keeping it here avoids threading the
 // pointer through each static tool descriptor.
 static struct ipc_server *g_ipc_server = NULL;
+
+// Stable 64-bit hash (FNV-1a) of a JSON node's serialized form. Used
+// in audit entries so the log shows which arguments were seen without
+// storing potentially sensitive values. Returns 0 on NULL / OOM.
+static uint64_t
+args_hash64(const cJSON *params)
+{
+	if (params == NULL) {
+		return 0;
+	}
+	char *text = cJSON_PrintUnformatted(params);
+	if (text == NULL) {
+		return 0;
+	}
+	uint64_t h = 0xcbf29ce484222325ULL;
+	for (const unsigned char *p = (const unsigned char *)text; *p != '\0'; p++) {
+		h ^= (uint64_t)(*p);
+		h *= 0x100000001b3ULL;
+	}
+	free(text);
+	return h;
+}
+
+// Policy gate for write tools. Returns NULL (propagates to error) if the
+// allowlist denies the operation; otherwise returns a scratch result
+// object the tool can extend — or discards it and returns its own. Also
+// writes one audit entry per allowed call.
+static bool
+gate_write(const char *tool, const cJSON *params, uint32_t client_id)
+{
+	if (!u_mcp_allowlist_allows(client_id)) {
+		U_LOG_W(LOG_PFX "%s denied by allowlist for client_id=%u", tool, client_id);
+		return false;
+	}
+	u_mcp_audit_append(tool, client_id, args_hash64(params));
+	return true;
+}
 
 
 // ---------- list_windows ----------
@@ -275,6 +314,10 @@ tool_set_window_pose(const cJSON *params, void *userdata)
 		return NULL;
 	}
 
+	if (!gate_write("set_window_pose", params, client_id)) {
+		return NULL;
+	}
+
 #if defined(XRT_HAVE_D3D11_SERVICE_COMPOSITOR)
 	if (s->xsysc == NULL) {
 		return NULL;
@@ -320,6 +363,9 @@ tool_set_focus(const cJSON *params, void *userdata)
 	if (s == NULL || !extract_client_id(params, &client_id)) {
 		return NULL;
 	}
+	if (!gate_write("set_focus", params, client_id)) {
+		return NULL;
+	}
 
 	// Route through the IPC-layer focus path. This is the same function
 	// the stub at ipc_server_handler.c:set_focused_client now delegates
@@ -345,6 +391,12 @@ tool_apply_layout_preset(const cJSON *params, void *userdata)
 	}
 	const cJSON *name = cJSON_GetObjectItemCaseSensitive(params, "preset");
 	if (!cJSON_IsString(name) || name->valuestring == NULL) {
+		return NULL;
+	}
+
+	// Preset is not scoped to one client — pass client_id=0 to the gate;
+	// with an explicit allowlist, any policy blocks all layout changes.
+	if (!gate_write("apply_layout_preset", params, 0)) {
 		return NULL;
 	}
 
@@ -462,6 +514,9 @@ tool_save_workspace(const cJSON *params, void *userdata)
 	}
 	const cJSON *name_j = cJSON_GetObjectItemCaseSensitive(params, "name");
 	if (!cJSON_IsString(name_j) || !valid_workspace_name(name_j->valuestring)) {
+		return NULL;
+	}
+	if (!gate_write("save_workspace", params, 0)) {
 		return NULL;
 	}
 
@@ -607,6 +662,9 @@ tool_load_workspace(const cJSON *params, void *userdata)
 	}
 	const cJSON *name_j = cJSON_GetObjectItemCaseSensitive(params, "name");
 	if (!cJSON_IsString(name_j) || !valid_workspace_name(name_j->valuestring)) {
+		return NULL;
+	}
+	if (!gate_write("load_workspace", params, 0)) {
 		return NULL;
 	}
 

--- a/src/xrt/ipc/server/ipc_mcp_tools.c
+++ b/src/xrt/ipc/server/ipc_mcp_tools.c
@@ -710,7 +710,67 @@ tool_load_workspace(const cJSON *params, void *userdata)
 }
 
 
+// ---------- list_sessions (service variant) ----------
+//
+// Phase A's list_sessions lives inside each handle-app process and
+// reports that one session. In service mode we need a global view:
+// which client_ids are alive, which PID each runs in, and what app
+// name was declared. An agent uses this to pick a PID and then
+// re-attach via `displayxr-mcp --target pid:N` to reach the Phase A
+// stereo-introspection tools (get_kooima_params, get_submitted_projection,
+// diff_projection) — those remain per-session and cannot be proxied
+// through the service without copying runtime state out of process.
+
+static cJSON *
+tool_list_sessions_service(const cJSON *params, void *userdata)
+{
+	(void)params;
+	(void)userdata;
+	struct ipc_server *s = g_ipc_server;
+	if (s == NULL) {
+		return NULL;
+	}
+
+	cJSON *arr = cJSON_CreateArray();
+	os_mutex_lock(&s->global_state.lock);
+	for (uint32_t i = 0; i < IPC_MAX_CLIENTS; i++) {
+		volatile struct ipc_client_state *ics = &s->threads[i].ics;
+		if (ics->server_thread_index < 0) {
+			continue;
+		}
+		const struct ipc_app_state *as =
+		    (const struct ipc_app_state *)&ics->client_state;
+		if (as->id == 0) {
+			continue;
+		}
+		cJSON *o = cJSON_CreateObject();
+		cJSON_AddNumberToObject(o, "client_id", (double)as->id);
+		cJSON_AddNumberToObject(o, "pid", (double)as->pid);
+		cJSON_AddStringToObject(o, "name", as->info.application_name);
+		cJSON_AddBoolToObject(o, "session_active", as->session_active);
+		// No per-session graphics API here — that lives in the app
+		// process's Phase A server. Agents combine this with the
+		// remote list_sessions via pid-scoped attach.
+		cJSON_AddItemToArray(arr, o);
+	}
+	os_mutex_unlock(&s->global_state.lock);
+	return arr;
+}
+
+
 // ---------- registry ----------
+
+static const struct u_mcp_tool TOOL_LIST_SESSIONS_SERVICE = {
+    .name = "list_sessions",
+    .description =
+        "Service-side view of every OpenXR client attached to displayxr-service: "
+        "{client_id, pid, name, session_active}. Combine with "
+        "`displayxr-mcp --target pid:<N>` to reach Phase A per-session tools "
+        "(get_kooima_params, get_submitted_projection, diff_projection).",
+    .input_schema_json = "{\"type\":\"object\",\"properties\":{},\"additionalProperties\":false}",
+    .fn = tool_list_sessions_service,
+    .userdata = NULL,
+};
 
 static const struct u_mcp_tool TOOL_LIST_WINDOWS = {
     .name = "list_windows",
@@ -810,6 +870,7 @@ ipc_mcp_tools_register(struct ipc_server *s)
 		return;
 	}
 	g_ipc_server = s;
+	u_mcp_server_register_tool(&TOOL_LIST_SESSIONS_SERVICE);
 	u_mcp_server_register_tool(&TOOL_LIST_WINDOWS);
 	u_mcp_server_register_tool(&TOOL_GET_WINDOW_POSE);
 	u_mcp_server_register_tool(&TOOL_SET_WINDOW_POSE);

--- a/src/xrt/ipc/server/ipc_mcp_tools.c
+++ b/src/xrt/ipc/server/ipc_mcp_tools.c
@@ -910,7 +910,7 @@ tool_capture_frame_service(const cJSON *params, void *userdata)
 	bool ok = false;
 	char done_path[U_MCP_CAPTURE_PATH_MAX + 32];
 	snprintf(done_path, sizeof(done_path), "%s_DONE.txt", base);
-	DeleteFileA(done_path);
+	(void)remove(done_path);
 	for (int i = 0; i < 2000; i++) {
 #ifdef XRT_OS_WINDOWS
 		Sleep(5);

--- a/src/xrt/ipc/server/ipc_mcp_tools.c
+++ b/src/xrt/ipc/server/ipc_mcp_tools.c
@@ -109,6 +109,187 @@ tool_list_windows(const cJSON *params, void *userdata)
 }
 
 
+// ---------- get/set_window_pose ----------
+
+#if defined(XRT_HAVE_D3D11_SERVICE_COMPOSITOR)
+// Look up an ipc_client_state by stable client_id. Caller must hold
+// s->global_state.lock. Returns NULL if not found.
+static volatile struct ipc_client_state *
+find_client_locked(struct ipc_server *s, uint32_t client_id)
+{
+	for (uint32_t i = 0; i < IPC_MAX_CLIENTS; i++) {
+		volatile struct ipc_client_state *ics = &s->threads[i].ics;
+		if (ics->client_state.id == client_id && ics->server_thread_index >= 0) {
+			return ics;
+		}
+	}
+	return NULL;
+}
+#endif
+
+static bool
+extract_client_id(const cJSON *params, uint32_t *out)
+{
+	if (params == NULL) {
+		return false;
+	}
+	const cJSON *id = cJSON_GetObjectItemCaseSensitive(params, "client_id");
+	if (!cJSON_IsNumber(id)) {
+		return false;
+	}
+	double v = id->valuedouble;
+	if (v < 0.0 || v > (double)UINT32_MAX) {
+		return false;
+	}
+	*out = (uint32_t)v;
+	return true;
+}
+
+static cJSON *
+tool_get_window_pose(const cJSON *params, void *userdata)
+{
+	(void)userdata;
+	struct ipc_server *s = g_ipc_server;
+	uint32_t client_id = 0;
+	if (s == NULL || !extract_client_id(params, &client_id)) {
+		return NULL;
+	}
+
+#if defined(XRT_HAVE_D3D11_SERVICE_COMPOSITOR)
+	struct xrt_pose pose = {0};
+	float w = 0.f, h = 0.f;
+	bool ok = false;
+
+	if (s->xsysc != NULL && client_id >= 1000) {
+		int slot = (int)(client_id - 1000);
+		ok = comp_d3d11_service_get_capture_client_window_pose(
+		    s->xsysc, slot, &pose, &w, &h);
+	} else if (s->xsysc != NULL) {
+		os_mutex_lock(&s->global_state.lock);
+		volatile struct ipc_client_state *ics = find_client_locked(s, client_id);
+		if (ics != NULL && ics->xc != NULL) {
+			ok = comp_d3d11_service_get_client_window_pose(
+			    s->xsysc, (struct xrt_compositor *)ics->xc, &pose, &w, &h);
+		}
+		os_mutex_unlock(&s->global_state.lock);
+	}
+
+	if (!ok) {
+		return NULL;
+	}
+
+	cJSON *o = cJSON_CreateObject();
+	cJSON *p = cJSON_CreateObject();
+	cJSON_AddNumberToObject(p, "x", pose.position.x);
+	cJSON_AddNumberToObject(p, "y", pose.position.y);
+	cJSON_AddNumberToObject(p, "z", pose.position.z);
+	cJSON_AddNumberToObject(p, "qx", pose.orientation.x);
+	cJSON_AddNumberToObject(p, "qy", pose.orientation.y);
+	cJSON_AddNumberToObject(p, "qz", pose.orientation.z);
+	cJSON_AddNumberToObject(p, "qw", pose.orientation.w);
+	cJSON_AddItemToObject(o, "pose", p);
+	cJSON *d = cJSON_CreateObject();
+	cJSON_AddNumberToObject(d, "width_m", w);
+	cJSON_AddNumberToObject(d, "height_m", h);
+	cJSON_AddItemToObject(o, "size", d);
+	cJSON_AddNumberToObject(o, "client_id", (double)client_id);
+	return o;
+#else
+	(void)client_id;
+	return NULL;
+#endif
+}
+
+static bool
+extract_pose(const cJSON *params, struct xrt_pose *out_pose, float *out_w, float *out_h)
+{
+	if (params == NULL) {
+		return false;
+	}
+	const cJSON *pose = cJSON_GetObjectItemCaseSensitive(params, "pose");
+	const cJSON *size = cJSON_GetObjectItemCaseSensitive(params, "size");
+	if (!cJSON_IsObject(pose) || !cJSON_IsObject(size)) {
+		return false;
+	}
+	// Accept a compact representation: {pose:{x,y,z,qx,qy,qz,qw}, size:{width_m,height_m}}.
+	// Orientation defaults to identity when omitted to allow position-only tweaks.
+	struct xrt_pose p = {0};
+	p.orientation.w = 1.f;
+	const struct
+	{
+		const char *key;
+		float *dst;
+	} pfields[] = {
+	    {"x", &p.position.x},    {"y", &p.position.y},    {"z", &p.position.z},
+	    {"qx", &p.orientation.x}, {"qy", &p.orientation.y}, {"qz", &p.orientation.z},
+	    {"qw", &p.orientation.w},
+	};
+	for (size_t i = 0; i < sizeof(pfields) / sizeof(pfields[0]); i++) {
+		const cJSON *v = cJSON_GetObjectItemCaseSensitive(pose, pfields[i].key);
+		if (cJSON_IsNumber(v)) {
+			*pfields[i].dst = (float)v->valuedouble;
+		}
+	}
+	const cJSON *wjs = cJSON_GetObjectItemCaseSensitive(size, "width_m");
+	const cJSON *hjs = cJSON_GetObjectItemCaseSensitive(size, "height_m");
+	if (!cJSON_IsNumber(wjs) || !cJSON_IsNumber(hjs)) {
+		return false;
+	}
+	*out_pose = p;
+	*out_w = (float)wjs->valuedouble;
+	*out_h = (float)hjs->valuedouble;
+	return true;
+}
+
+static cJSON *
+tool_set_window_pose(const cJSON *params, void *userdata)
+{
+	(void)userdata;
+	struct ipc_server *s = g_ipc_server;
+	uint32_t client_id = 0;
+	if (s == NULL || !extract_client_id(params, &client_id)) {
+		return NULL;
+	}
+	struct xrt_pose pose = {0};
+	float w = 0.f, h = 0.f;
+	if (!extract_pose(params, &pose, &w, &h)) {
+		return NULL;
+	}
+
+#if defined(XRT_HAVE_D3D11_SERVICE_COMPOSITOR)
+	if (s->xsysc == NULL) {
+		return NULL;
+	}
+
+	bool ok = false;
+	if (client_id >= 1000) {
+		int slot = (int)(client_id - 1000);
+		ok = comp_d3d11_service_set_capture_client_window_pose(
+		    s->xsysc, slot, &pose, w, h);
+	} else {
+		os_mutex_lock(&s->global_state.lock);
+		volatile struct ipc_client_state *ics = find_client_locked(s, client_id);
+		if (ics != NULL && ics->xc != NULL) {
+			ok = comp_d3d11_service_set_client_window_pose(
+			    s->xsysc, (struct xrt_compositor *)ics->xc, &pose, w, h);
+		}
+		os_mutex_unlock(&s->global_state.lock);
+	}
+
+	cJSON *r = cJSON_CreateObject();
+	cJSON_AddBoolToObject(r, "ok", ok);
+	cJSON_AddNumberToObject(r, "client_id", (double)client_id);
+	return r;
+#else
+	(void)client_id;
+	(void)pose;
+	(void)w;
+	(void)h;
+	return NULL;
+#endif
+}
+
+
 // ---------- registry ----------
 
 static const struct u_mcp_tool TOOL_LIST_WINDOWS = {
@@ -121,6 +302,33 @@ static const struct u_mcp_tool TOOL_LIST_WINDOWS = {
     .userdata = NULL,
 };
 
+static const struct u_mcp_tool TOOL_GET_WINDOW_POSE = {
+    .name = "get_window_pose",
+    .description = "Query 6-DOF pose and size (meters) of one shell window.",
+    .input_schema_json =
+        "{\"type\":\"object\",\"required\":[\"client_id\"],"
+        "\"properties\":{\"client_id\":{\"type\":\"integer\"}},"
+        "\"additionalProperties\":false}",
+    .fn = tool_get_window_pose,
+    .userdata = NULL,
+};
+
+static const struct u_mcp_tool TOOL_SET_WINDOW_POSE = {
+    .name = "set_window_pose",
+    .description =
+        "Move / resize one shell window. pose.qw defaults to 1 if the "
+        "orientation quaternion is omitted.",
+    .input_schema_json =
+        "{\"type\":\"object\",\"required\":[\"client_id\",\"pose\",\"size\"],"
+        "\"properties\":{"
+        "\"client_id\":{\"type\":\"integer\"},"
+        "\"pose\":{\"type\":\"object\"},"
+        "\"size\":{\"type\":\"object\"}},"
+        "\"additionalProperties\":false}",
+    .fn = tool_set_window_pose,
+    .userdata = NULL,
+};
+
 void
 ipc_mcp_tools_register(struct ipc_server *s)
 {
@@ -129,5 +337,7 @@ ipc_mcp_tools_register(struct ipc_server *s)
 	}
 	g_ipc_server = s;
 	u_mcp_server_register_tool(&TOOL_LIST_WINDOWS);
+	u_mcp_server_register_tool(&TOOL_GET_WINDOW_POSE);
+	u_mcp_server_register_tool(&TOOL_SET_WINDOW_POSE);
 	U_LOG_I(LOG_PFX "registered shell tools against ipc_server %p", (void *)s);
 }

--- a/src/xrt/ipc/server/ipc_mcp_tools.c
+++ b/src/xrt/ipc/server/ipc_mcp_tools.c
@@ -18,6 +18,25 @@
 
 #include <cjson/cJSON.h>
 
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+
+#ifdef XRT_OS_WINDOWS
+#include <direct.h>
+#include <shlobj.h>
+#include <windows.h>
+#define MKDIR(path) _mkdir(path)
+#define PATH_SEP "\\"
+#else
+#include <sys/types.h>
+#include <unistd.h>
+#define MKDIR(path) mkdir((path), 0700)
+#define PATH_SEP "/"
+#endif
+
 #if defined(XRT_HAVE_D3D11_SERVICE_COMPOSITOR)
 #include "d3d11_service/comp_d3d11_service.h"
 #endif
@@ -344,6 +363,295 @@ tool_apply_layout_preset(const cJSON *params, void *userdata)
 }
 
 
+// ---------- workspace persistence ----------
+
+#define WORKSPACE_SCHEMA_VERSION 1
+#define WORKSPACE_NAME_MAX 64
+
+// Resolve the directory that holds workspace JSON files. Creates it on
+// demand (and any parent). Returns false if the path cannot be obtained
+// or the directory cannot be created.
+static bool
+workspace_dir(char *out, size_t cap)
+{
+#ifdef XRT_OS_WINDOWS
+	char appdata[MAX_PATH];
+	if (!SUCCEEDED(SHGetFolderPathA(NULL, CSIDL_APPDATA, NULL, 0, appdata))) {
+		return false;
+	}
+	// %APPDATA%\DisplayXR\workspaces
+	char parent[MAX_PATH];
+	snprintf(parent, sizeof(parent), "%s\\DisplayXR", appdata);
+	MKDIR(parent);
+	snprintf(out, cap, "%s\\DisplayXR\\workspaces", appdata);
+	MKDIR(out);
+	return true;
+#else
+	const char *home = getenv("HOME");
+	if (home == NULL || home[0] == '\0') {
+		return false;
+	}
+	char parent[512];
+	snprintf(parent, sizeof(parent), "%s/.config", home);
+	MKDIR(parent);
+	snprintf(parent, sizeof(parent), "%s/.config/displayxr", home);
+	MKDIR(parent);
+	snprintf(out, cap, "%s/.config/displayxr/workspaces", home);
+	MKDIR(out);
+	return true;
+#endif
+}
+
+// Validate a workspace name as a safe file-system fragment: letters,
+// digits, spaces, dash, underscore, dot. Rejects slashes and backslashes
+// so a rogue name can't escape the workspaces directory.
+static bool
+valid_workspace_name(const char *name)
+{
+	if (name == NULL || name[0] == '\0') {
+		return false;
+	}
+	size_t n = strlen(name);
+	if (n >= WORKSPACE_NAME_MAX) {
+		return false;
+	}
+	for (size_t i = 0; i < n; i++) {
+		unsigned char c = (unsigned char)name[i];
+		bool ok = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+		         (c >= '0' && c <= '9') || c == '-' || c == '_' || c == ' ' || c == '.';
+		if (!ok) {
+			return false;
+		}
+	}
+	// Don't allow a leading dot (hidden files) or "..".
+	if (name[0] == '.' || strcmp(name, "..") == 0) {
+		return false;
+	}
+	return true;
+}
+
+static bool
+workspace_path(char *out, size_t cap, const char *name)
+{
+	char dir[512];
+	if (!workspace_dir(dir, sizeof(dir))) {
+		return false;
+	}
+	snprintf(out, cap, "%s" PATH_SEP "%s.json", dir, name);
+	return true;
+}
+
+// save_workspace: snapshot current list_windows to {name}.json.
+//
+// Schema:
+//   {
+//     "version": 1,
+//     "windows": [
+//       {"id": N, "name": "...", "pose": {...}, "size": {...}},
+//       ...
+//     ]
+//   }
+//
+// Windows without a pose (no shell-mode data) are skipped.
+static cJSON *
+tool_save_workspace(const cJSON *params, void *userdata)
+{
+	(void)userdata;
+	if (params == NULL) {
+		return NULL;
+	}
+	const cJSON *name_j = cJSON_GetObjectItemCaseSensitive(params, "name");
+	if (!cJSON_IsString(name_j) || !valid_workspace_name(name_j->valuestring)) {
+		return NULL;
+	}
+
+	// Reuse tool_list_windows to avoid duplicating the enumeration path.
+	cJSON *windows = tool_list_windows(NULL, NULL);
+	if (windows == NULL) {
+		return NULL;
+	}
+
+	cJSON *doc = cJSON_CreateObject();
+	cJSON_AddNumberToObject(doc, "version", WORKSPACE_SCHEMA_VERSION);
+	cJSON *arr = cJSON_CreateArray();
+	cJSON *w;
+	cJSON_ArrayForEach(w, windows)
+	{
+		const cJSON *pose = cJSON_GetObjectItemCaseSensitive(w, "pose");
+		const cJSON *size = cJSON_GetObjectItemCaseSensitive(w, "size");
+		if (!cJSON_IsObject(pose) || !cJSON_IsObject(size)) {
+			continue;
+		}
+		cJSON *entry = cJSON_CreateObject();
+		cJSON_AddNumberToObject(
+		    entry, "id",
+		    cJSON_GetObjectItemCaseSensitive(w, "id")->valuedouble);
+		const cJSON *app_name = cJSON_GetObjectItemCaseSensitive(w, "name");
+		if (cJSON_IsString(app_name)) {
+			cJSON_AddStringToObject(entry, "name", app_name->valuestring);
+		}
+		cJSON_AddItemToObject(entry, "pose", cJSON_Duplicate(pose, 1));
+		cJSON_AddItemToObject(entry, "size", cJSON_Duplicate(size, 1));
+		cJSON_AddItemToArray(arr, entry);
+	}
+	cJSON_AddItemToObject(doc, "windows", arr);
+	cJSON_Delete(windows);
+
+	char *text = cJSON_PrintUnformatted(doc);
+	size_t len = text != NULL ? strlen(text) : 0;
+	char path[1024];
+	bool wrote = false;
+	if (text != NULL && workspace_path(path, sizeof(path), name_j->valuestring)) {
+		FILE *f = fopen(path, "wb");
+		if (f != NULL) {
+			wrote = (fwrite(text, 1, len, f) == len);
+			fclose(f);
+		}
+	}
+	free(text);
+	cJSON_Delete(doc);
+
+	if (!wrote) {
+		U_LOG_W(LOG_PFX "save_workspace: failed to write %s", path);
+		return NULL;
+	}
+
+	cJSON *r = cJSON_CreateObject();
+	cJSON_AddBoolToObject(r, "ok", true);
+	cJSON_AddStringToObject(r, "name", name_j->valuestring);
+	cJSON_AddStringToObject(r, "path", path);
+	return r;
+}
+
+static char *
+slurp_file(const char *path, size_t *out_len)
+{
+	FILE *f = fopen(path, "rb");
+	if (f == NULL) {
+		return NULL;
+	}
+	fseek(f, 0, SEEK_END);
+	long n = ftell(f);
+	fseek(f, 0, SEEK_SET);
+	if (n < 0 || n > (long)(4 * 1024 * 1024)) {
+		fclose(f);
+		return NULL;
+	}
+	char *buf = (char *)malloc((size_t)n + 1);
+	if (buf == NULL) {
+		fclose(f);
+		return NULL;
+	}
+	size_t got = fread(buf, 1, (size_t)n, f);
+	fclose(f);
+	if (got != (size_t)n) {
+		free(buf);
+		return NULL;
+	}
+	buf[n] = '\0';
+	if (out_len != NULL) {
+		*out_len = (size_t)n;
+	}
+	return buf;
+}
+
+// Apply one window entry's pose+size. Reuses the existing
+// comp_d3d11_service accessor paths so semantics stay identical to
+// tool_set_window_pose.
+static bool
+apply_workspace_entry(struct ipc_server *s, const cJSON *entry)
+{
+#if defined(XRT_HAVE_D3D11_SERVICE_COMPOSITOR)
+	if (s->xsysc == NULL) {
+		return false;
+	}
+	const cJSON *id_j = cJSON_GetObjectItemCaseSensitive(entry, "id");
+	if (!cJSON_IsNumber(id_j)) {
+		return false;
+	}
+	uint32_t cid = (uint32_t)id_j->valuedouble;
+
+	struct xrt_pose pose = {0};
+	float w = 0.f, h = 0.f;
+	if (!extract_pose(entry, &pose, &w, &h)) {
+		return false;
+	}
+
+	if (cid >= 1000) {
+		return comp_d3d11_service_set_capture_client_window_pose(
+		    s->xsysc, (int)(cid - 1000), &pose, w, h);
+	}
+	bool ok = false;
+	os_mutex_lock(&s->global_state.lock);
+	volatile struct ipc_client_state *ics = find_client_locked(s, cid);
+	if (ics != NULL && ics->xc != NULL) {
+		ok = comp_d3d11_service_set_client_window_pose(
+		    s->xsysc, (struct xrt_compositor *)ics->xc, &pose, w, h);
+	}
+	os_mutex_unlock(&s->global_state.lock);
+	return ok;
+#else
+	(void)s;
+	(void)entry;
+	return false;
+#endif
+}
+
+static cJSON *
+tool_load_workspace(const cJSON *params, void *userdata)
+{
+	(void)userdata;
+	struct ipc_server *s = g_ipc_server;
+	if (s == NULL || params == NULL) {
+		return NULL;
+	}
+	const cJSON *name_j = cJSON_GetObjectItemCaseSensitive(params, "name");
+	if (!cJSON_IsString(name_j) || !valid_workspace_name(name_j->valuestring)) {
+		return NULL;
+	}
+
+	char path[1024];
+	if (!workspace_path(path, sizeof(path), name_j->valuestring)) {
+		return NULL;
+	}
+	char *text = slurp_file(path, NULL);
+	if (text == NULL) {
+		return NULL;
+	}
+	cJSON *doc = cJSON_Parse(text);
+	free(text);
+	if (doc == NULL) {
+		return NULL;
+	}
+
+	const cJSON *version = cJSON_GetObjectItemCaseSensitive(doc, "version");
+	if (!cJSON_IsNumber(version) || (int)version->valuedouble != WORKSPACE_SCHEMA_VERSION) {
+		cJSON_Delete(doc);
+		return NULL;
+	}
+
+	int applied = 0, missed = 0;
+	const cJSON *windows = cJSON_GetObjectItemCaseSensitive(doc, "windows");
+	const cJSON *entry;
+	cJSON_ArrayForEach(entry, windows)
+	{
+		if (apply_workspace_entry(s, entry)) {
+			applied++;
+		} else {
+			missed++;
+		}
+	}
+	cJSON_Delete(doc);
+
+	cJSON *r = cJSON_CreateObject();
+	cJSON_AddBoolToObject(r, "ok", applied > 0 || missed == 0);
+	cJSON_AddStringToObject(r, "name", name_j->valuestring);
+	cJSON_AddNumberToObject(r, "applied", applied);
+	cJSON_AddNumberToObject(r, "missed", missed);
+	return r;
+}
+
+
 // ---------- registry ----------
 
 static const struct u_mcp_tool TOOL_LIST_WINDOWS = {
@@ -376,6 +684,35 @@ static const struct u_mcp_tool TOOL_SET_FOCUS = {
         "\"properties\":{\"client_id\":{\"type\":\"integer\"}},"
         "\"additionalProperties\":false}",
     .fn = tool_set_focus,
+    .userdata = NULL,
+};
+
+static const struct u_mcp_tool TOOL_SAVE_WORKSPACE = {
+    .name = "save_workspace",
+    .description =
+        "Snapshot current window poses to a named JSON file on disk. "
+        "Stored in %APPDATA%\\DisplayXR\\workspaces (Windows) or "
+        "~/.config/displayxr/workspaces (POSIX).",
+    .input_schema_json =
+        "{\"type\":\"object\",\"required\":[\"name\"],"
+        "\"properties\":{\"name\":{\"type\":\"string\","
+        "\"pattern\":\"^[A-Za-z0-9 ._-]+$\",\"maxLength\":63}},"
+        "\"additionalProperties\":false}",
+    .fn = tool_save_workspace,
+    .userdata = NULL,
+};
+
+static const struct u_mcp_tool TOOL_LOAD_WORKSPACE = {
+    .name = "load_workspace",
+    .description =
+        "Load a named workspace and reapply every window pose via "
+        "set_window_pose. Missing clients are reported as 'missed'.",
+    .input_schema_json =
+        "{\"type\":\"object\",\"required\":[\"name\"],"
+        "\"properties\":{\"name\":{\"type\":\"string\","
+        "\"pattern\":\"^[A-Za-z0-9 ._-]+$\",\"maxLength\":63}},"
+        "\"additionalProperties\":false}",
+    .fn = tool_load_workspace,
     .userdata = NULL,
 };
 
@@ -420,5 +757,7 @@ ipc_mcp_tools_register(struct ipc_server *s)
 	u_mcp_server_register_tool(&TOOL_SET_WINDOW_POSE);
 	u_mcp_server_register_tool(&TOOL_SET_FOCUS);
 	u_mcp_server_register_tool(&TOOL_APPLY_LAYOUT_PRESET);
+	u_mcp_server_register_tool(&TOOL_SAVE_WORKSPACE);
+	u_mcp_server_register_tool(&TOOL_LOAD_WORKSPACE);
 	U_LOG_I(LOG_PFX "registered shell tools against ipc_server %p", (void *)s);
 }

--- a/src/xrt/ipc/server/ipc_mcp_tools.c
+++ b/src/xrt/ipc/server/ipc_mcp_tools.c
@@ -290,6 +290,60 @@ tool_set_window_pose(const cJSON *params, void *userdata)
 }
 
 
+// ---------- set_focus ----------
+
+static cJSON *
+tool_set_focus(const cJSON *params, void *userdata)
+{
+	(void)userdata;
+	struct ipc_server *s = g_ipc_server;
+	uint32_t client_id = 0;
+	if (s == NULL || !extract_client_id(params, &client_id)) {
+		return NULL;
+	}
+
+	// Route through the IPC-layer focus path. This is the same function
+	// the stub at ipc_server_handler.c:set_focused_client now delegates
+	// to, so MCP and IPC stay consistent on semantics.
+	xrt_result_t xret = ipc_server_set_active_client(s, client_id);
+
+	cJSON *r = cJSON_CreateObject();
+	cJSON_AddBoolToObject(r, "ok", xret == XRT_SUCCESS);
+	cJSON_AddNumberToObject(r, "client_id", (double)client_id);
+	return r;
+}
+
+
+// ---------- apply_layout_preset ----------
+
+static cJSON *
+tool_apply_layout_preset(const cJSON *params, void *userdata)
+{
+	(void)userdata;
+	struct ipc_server *s = g_ipc_server;
+	if (s == NULL || params == NULL) {
+		return NULL;
+	}
+	const cJSON *name = cJSON_GetObjectItemCaseSensitive(params, "preset");
+	if (!cJSON_IsString(name) || name->valuestring == NULL) {
+		return NULL;
+	}
+
+#if defined(XRT_HAVE_D3D11_SERVICE_COMPOSITOR)
+	if (s->xsysc == NULL) {
+		return NULL;
+	}
+	bool ok = comp_d3d11_service_apply_layout_preset(s->xsysc, name->valuestring);
+	cJSON *r = cJSON_CreateObject();
+	cJSON_AddBoolToObject(r, "ok", ok);
+	cJSON_AddStringToObject(r, "preset", name->valuestring);
+	return r;
+#else
+	return NULL;
+#endif
+}
+
+
 // ---------- registry ----------
 
 static const struct u_mcp_tool TOOL_LIST_WINDOWS = {
@@ -310,6 +364,31 @@ static const struct u_mcp_tool TOOL_GET_WINDOW_POSE = {
         "\"properties\":{\"client_id\":{\"type\":\"integer\"}},"
         "\"additionalProperties\":false}",
     .fn = tool_get_window_pose,
+    .userdata = NULL,
+};
+
+static const struct u_mcp_tool TOOL_SET_FOCUS = {
+    .name = "set_focus",
+    .description =
+        "Focus the specified OpenXR client (promotes to active slot).",
+    .input_schema_json =
+        "{\"type\":\"object\",\"required\":[\"client_id\"],"
+        "\"properties\":{\"client_id\":{\"type\":\"integer\"}},"
+        "\"additionalProperties\":false}",
+    .fn = tool_set_focus,
+    .userdata = NULL,
+};
+
+static const struct u_mcp_tool TOOL_APPLY_LAYOUT_PRESET = {
+    .name = "apply_layout_preset",
+    .description =
+        "Apply a named shell layout preset. Valid names: grid, immersive, carousel.",
+    .input_schema_json =
+        "{\"type\":\"object\",\"required\":[\"preset\"],"
+        "\"properties\":{\"preset\":{\"type\":\"string\","
+        "\"enum\":[\"grid\",\"immersive\",\"carousel\"]}},"
+        "\"additionalProperties\":false}",
+    .fn = tool_apply_layout_preset,
     .userdata = NULL,
 };
 
@@ -339,5 +418,7 @@ ipc_mcp_tools_register(struct ipc_server *s)
 	u_mcp_server_register_tool(&TOOL_LIST_WINDOWS);
 	u_mcp_server_register_tool(&TOOL_GET_WINDOW_POSE);
 	u_mcp_server_register_tool(&TOOL_SET_WINDOW_POSE);
+	u_mcp_server_register_tool(&TOOL_SET_FOCUS);
+	u_mcp_server_register_tool(&TOOL_APPLY_LAYOUT_PRESET);
 	U_LOG_I(LOG_PFX "registered shell tools against ipc_server %p", (void *)s);
 }

--- a/src/xrt/ipc/server/ipc_mcp_tools.c
+++ b/src/xrt/ipc/server/ipc_mcp_tools.c
@@ -14,9 +14,12 @@
 #include "util/u_mcp_server.h"
 #include "util/u_mcp_audit.h"
 #include "util/u_mcp_allowlist.h"
+#include "util/u_mcp_capture.h"
+#include "util/u_mcp_transport.h"
 #include "util/u_logging.h"
 
 #include "os/os_threading.h"
+#include "os/os_time.h"
 
 #include <cjson/cJSON.h>
 
@@ -863,6 +866,131 @@ static const struct u_mcp_tool TOOL_SET_WINDOW_POSE = {
     .userdata = NULL,
 };
 
+// ---------- capture_frame (service) ----------
+
+static cJSON *
+tool_capture_frame_service(const cJSON *params, void *userdata)
+{
+	(void)params;
+	(void)userdata;
+
+	struct u_mcp_capture_request *req = u_mcp_capture_get_installed();
+	if (req == NULL) {
+		cJSON *o = cJSON_CreateObject();
+		cJSON_AddStringToObject(o, "error",
+		    "capture_frame not available: service compositor has not installed a capture handler");
+		return o;
+	}
+
+	long pid = u_mcp_self_pid();
+	char base[U_MCP_CAPTURE_PATH_MAX];
+#ifdef XRT_OS_WINDOWS
+	char tmp[MAX_PATH];
+	if (GetTempPathA(sizeof(tmp), tmp) == 0) {
+		snprintf(tmp, sizeof(tmp), "C:\\Temp");
+	}
+	size_t tl = strlen(tmp);
+	if (tl > 0 && (tmp[tl - 1] == '\\' || tmp[tl - 1] == '/')) {
+		tmp[tl - 1] = '\0';
+	}
+	snprintf(base, sizeof(base), "%s\\displayxr-mcp-capture-%ld", tmp, pid);
+#else
+	snprintf(base, sizeof(base), "/tmp/displayxr-mcp-capture-%ld", pid);
+#endif
+
+	snprintf(req->path, sizeof(req->path), "%s", base);
+	req->success = false;
+	req->done = false;
+	req->pending = true;
+
+	// Poll for the compositor's sentinel file. The compositor writes
+	// {base}_DONE.txt after writing all four capture files and calling
+	// u_mcp_capture_complete. File-based polling avoids pthreads-win32
+	// condvar visibility issues on Windows.
+	bool ok = false;
+	char done_path[U_MCP_CAPTURE_PATH_MAX + 32];
+	snprintf(done_path, sizeof(done_path), "%s_DONE.txt", base);
+	DeleteFileA(done_path);
+	for (int i = 0; i < 2000; i++) {
+#ifdef XRT_OS_WINDOWS
+		Sleep(5);
+		if (GetFileAttributesA(done_path) != INVALID_FILE_ATTRIBUTES) {
+			ok = true;
+			req->pending = false;
+			break;
+		}
+#else
+		os_nanosleep(5 * 1000 * 1000);
+		struct stat st;
+		if (stat(done_path, &st) == 0) {
+			ok = true;
+			req->pending = false;
+			break;
+		}
+#endif
+	}
+
+	cJSON *r = cJSON_CreateObject();
+	if (!ok) {
+		cJSON_AddStringToObject(r, "error", "capture timed out or failed");
+		return r;
+	}
+
+	char path[U_MCP_CAPTURE_PATH_MAX + 32];
+	cJSON *files = cJSON_CreateArray();
+
+	snprintf(path, sizeof(path), "%s_atlas.png", base);
+	struct stat st_a = {0};
+	stat(path, &st_a);
+	cJSON *fa = cJSON_CreateObject();
+	cJSON_AddStringToObject(fa, "path", path);
+	cJSON_AddStringToObject(fa, "type", "atlas");
+	cJSON_AddNumberToObject(fa, "size_bytes", (double)st_a.st_size);
+	cJSON_AddItemToArray(files, fa);
+
+	snprintf(path, sizeof(path), "%s_L.png", base);
+	struct stat st_l = {0};
+	stat(path, &st_l);
+	cJSON *fl = cJSON_CreateObject();
+	cJSON_AddStringToObject(fl, "path", path);
+	cJSON_AddStringToObject(fl, "type", "left");
+	cJSON_AddNumberToObject(fl, "size_bytes", (double)st_l.st_size);
+	cJSON_AddItemToArray(files, fl);
+
+	snprintf(path, sizeof(path), "%s_R.png", base);
+	struct stat st_r = {0};
+	stat(path, &st_r);
+	cJSON *fr = cJSON_CreateObject();
+	cJSON_AddStringToObject(fr, "path", path);
+	cJSON_AddStringToObject(fr, "type", "right");
+	cJSON_AddNumberToObject(fr, "size_bytes", (double)st_r.st_size);
+	cJSON_AddItemToArray(files, fr);
+
+	snprintf(path, sizeof(path), "%s_windows.json", base);
+	struct stat st_j = {0};
+	stat(path, &st_j);
+	cJSON *fj = cJSON_CreateObject();
+	cJSON_AddStringToObject(fj, "path", path);
+	cJSON_AddStringToObject(fj, "type", "windows_json");
+	cJSON_AddNumberToObject(fj, "size_bytes", (double)st_j.st_size);
+	cJSON_AddItemToArray(files, fj);
+
+	cJSON_AddItemToObject(r, "files", files);
+	return r;
+}
+
+static const struct u_mcp_tool TOOL_CAPTURE_FRAME_SERVICE = {
+    .name = "capture_frame",
+    .description =
+        "Capture the shell compositor's combined atlas — writes four files: "
+        "{base}_atlas.png (full SBS atlas), {base}_L.png (left eye), "
+        "{base}_R.png (right eye), {base}_windows.json (per-window bboxes). "
+        "Returns file paths and sizes.",
+    .input_schema_json = "{\"type\":\"object\",\"properties\":{}}",
+    .fn = tool_capture_frame_service,
+    .userdata = NULL,
+};
+
 void
 ipc_mcp_tools_register(struct ipc_server *s)
 {
@@ -878,5 +1006,6 @@ ipc_mcp_tools_register(struct ipc_server *s)
 	u_mcp_server_register_tool(&TOOL_APPLY_LAYOUT_PRESET);
 	u_mcp_server_register_tool(&TOOL_SAVE_WORKSPACE);
 	u_mcp_server_register_tool(&TOOL_LOAD_WORKSPACE);
+	u_mcp_server_register_tool(&TOOL_CAPTURE_FRAME_SERVICE);
 	U_LOG_I(LOG_PFX "registered shell tools against ipc_server %p", (void *)s);
 }

--- a/src/xrt/ipc/server/ipc_mcp_tools.c
+++ b/src/xrt/ipc/server/ipc_mcp_tools.c
@@ -948,24 +948,6 @@ tool_capture_frame_service(const cJSON *params, void *userdata)
 	cJSON_AddNumberToObject(fa, "size_bytes", (double)st_a.st_size);
 	cJSON_AddItemToArray(files, fa);
 
-	snprintf(path, sizeof(path), "%s_L.png", base);
-	struct stat st_l = {0};
-	stat(path, &st_l);
-	cJSON *fl = cJSON_CreateObject();
-	cJSON_AddStringToObject(fl, "path", path);
-	cJSON_AddStringToObject(fl, "type", "left");
-	cJSON_AddNumberToObject(fl, "size_bytes", (double)st_l.st_size);
-	cJSON_AddItemToArray(files, fl);
-
-	snprintf(path, sizeof(path), "%s_R.png", base);
-	struct stat st_r = {0};
-	stat(path, &st_r);
-	cJSON *fr = cJSON_CreateObject();
-	cJSON_AddStringToObject(fr, "path", path);
-	cJSON_AddStringToObject(fr, "type", "right");
-	cJSON_AddNumberToObject(fr, "size_bytes", (double)st_r.st_size);
-	cJSON_AddItemToArray(files, fr);
-
 	snprintf(path, sizeof(path), "%s_windows.json", base);
 	struct stat st_j = {0};
 	stat(path, &st_j);
@@ -982,9 +964,9 @@ tool_capture_frame_service(const cJSON *params, void *userdata)
 static const struct u_mcp_tool TOOL_CAPTURE_FRAME_SERVICE = {
     .name = "capture_frame",
     .description =
-        "Capture the shell compositor's combined atlas — writes four files: "
-        "{base}_atlas.png (full SBS atlas), {base}_L.png (left eye), "
-        "{base}_R.png (right eye), {base}_windows.json (per-window bboxes). "
+        "Capture the shell compositor's combined atlas — writes "
+        "{base}_atlas.png (cropped active-region atlas) and "
+        "{base}_windows.json (per-window bboxes). "
         "Returns file paths and sizes.",
     .input_schema_json = "{\"type\":\"object\",\"properties\":{}}",
     .fn = tool_capture_frame_service,

--- a/src/xrt/ipc/server/ipc_mcp_tools.h
+++ b/src/xrt/ipc/server/ipc_mcp_tools.h
@@ -1,0 +1,40 @@
+// Copyright 2026, DisplayXR / Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  MCP shell-scope tools registered in-process inside displayxr-service.
+ * @ingroup ipc_server
+ *
+ * These tools back Phase B of the MCP v0.2 spec: list_windows,
+ * get/set_window_pose, set_focus, apply_layout_preset, save/load_workspace.
+ * They run on the MCP server thread started by u_mcp_server_maybe_start_named()
+ * and read/write shell state via the same IPC paths the shell uses.
+ *
+ * @see docs/roadmap/mcp-phase-b-plan.md
+ */
+
+#pragma once
+
+#include "server/ipc_server.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*!
+ * Register the Phase B shell tools against the global MCP server.
+ *
+ * Must be called after @c u_mcp_server_maybe_start_named("service") so the
+ * server-thread picks the tools up via the shared registry. Stashes @p s
+ * in a file-static global so tool handlers can look up per-client state
+ * without routing through a userdata ABI change.
+ *
+ * Safe to call when MCP is disabled — the registry is harmless when the
+ * server thread was never spawned.
+ */
+void
+ipc_mcp_tools_register(struct ipc_server *s);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/xrt/ipc/server/ipc_server_handler.c
+++ b/src/xrt/ipc/server/ipc_server_handler.c
@@ -1916,9 +1916,15 @@ ipc_handle_system_set_primary_client(volatile struct ipc_client_state *_ics, uin
 xrt_result_t
 ipc_handle_system_set_focused_client(volatile struct ipc_client_state *ics, uint32_t client_id)
 {
-	IPC_INFO(ics->server, "UNIMPLEMENTED: system setting focused client to %d.", client_id);
+	struct ipc_server *s = ics->server;
 
-	return XRT_SUCCESS;
+	// Promote the requested client to the active slot. This is the closest
+	// IPC-layer concept to "focused" we have today — the per-client
+	// session_focused bit is then derived by update_server_state_locked()
+	// from the active_client_index, so we reuse that code path rather than
+	// writing the flag directly and going out of sync with the dispatcher.
+	IPC_INFO(s, "System setting focused client to %u", client_id);
+	return ipc_server_set_active_client(s, client_id);
 }
 
 xrt_result_t

--- a/src/xrt/ipc/server/ipc_server_process.c
+++ b/src/xrt/ipc/server/ipc_server_process.c
@@ -34,6 +34,7 @@
 #include "shared/ipc_shmem.h"
 #include "server/ipc_server.h"
 #include "server/ipc_server_interface.h"
+#include "server/ipc_mcp_tools.h"
 
 #include <stdlib.h>
 #include <stdbool.h>
@@ -1066,6 +1067,11 @@ ipc_server_main(int argc, char **argv, const struct ipc_server_main_info *ismi)
 		s->xsysc->info.shell_mode = true;
 		U_LOG_IFL_I(log_level, "Shell mode propagated to system compositor");
 	}
+
+	// Register MCP shell-scope tools against the already-running server
+	// (started from service/main.c before ipc_server_main). If
+	// DISPLAYXR_MCP was unset, the tool registry is harmless scaffolding.
+	ipc_mcp_tools_register(s);
 
 	// Start the debug UI now (if enabled).
 	u_debug_gui_start(s->debug_gui, s->xinst, s->xsysd);

--- a/src/xrt/state_trackers/oxr/oxr_mcp_tools.c
+++ b/src/xrt/state_trackers/oxr/oxr_mcp_tools.c
@@ -23,6 +23,7 @@
 
 #include "util/u_mcp_server.h"
 #include "util/u_mcp_transport.h"
+#include "util/u_mcp_capture.h"
 
 #include "os/os_time.h"
 
@@ -731,6 +732,20 @@ static const struct u_mcp_tool TOOL_DIFF_PROJECTION = {
 
 // ---------- Public API ----------
 
+static void
+notify_capture_install(void *req)
+{
+	oxr_mcp_tools_set_capture_handler(
+	    (oxr_mcp_capture_fn)u_mcp_capture_blocking_handler, req);
+}
+
+static void
+notify_capture_uninstall(void *req)
+{
+	(void)req;
+	oxr_mcp_tools_set_capture_handler(NULL, NULL);
+}
+
 void
 oxr_mcp_tools_register_all(void)
 {
@@ -741,6 +756,7 @@ oxr_mcp_tools_register_all(void)
 	u_mcp_server_register_tool(&TOOL_GET_SUBMITTED_PROJECTION);
 	u_mcp_server_register_tool(&TOOL_DIFF_PROJECTION);
 	u_mcp_server_register_tool(&TOOL_CAPTURE_FRAME);
+	u_mcp_capture_set_notify(notify_capture_install, notify_capture_uninstall);
 }
 
 void

--- a/src/xrt/targets/mcp_adapter/displayxr_mcp.c
+++ b/src/xrt/targets/mcp_adapter/displayxr_mcp.c
@@ -59,10 +59,12 @@ static void
 usage(const char *argv0)
 {
 	fprintf(stderr,
-	        "usage: %s --pid <N|auto> | --list\n"
-	        "  --pid N     attach to a specific runtime process\n"
-	        "  --pid auto  attach iff exactly one MCP session exists\n"
-	        "  --list      print discovered sessions and exit\n",
+	        "usage: %s [--target <auto|service|pid:N>] | --pid <N|auto> | --list\n"
+	        "  --target auto      try service socket, then unique PID session (default)\n"
+	        "  --target service   attach to the displayxr-service MCP endpoint\n"
+	        "  --target pid:N     attach to a specific runtime process\n"
+	        "  --pid N | auto     back-compat form of --target pid:N / --target auto\n"
+	        "  --list             print discovered sessions and exit\n",
 	        argv0);
 }
 
@@ -115,11 +117,21 @@ main(int argc, char **argv)
 	_setmode(_fileno(stdout), _O_BINARY);
 #endif
 
-	const char *pid_arg = NULL;
+	const char *target_arg = NULL; // "auto", "service", or "pid:N"
 	bool list_mode = false;
 	for (int i = 1; i < argc; i++) {
-		if (strcmp(argv[i], "--pid") == 0 && i + 1 < argc) {
-			pid_arg = argv[++i];
+		if (strcmp(argv[i], "--target") == 0 && i + 1 < argc) {
+			target_arg = argv[++i];
+		} else if (strcmp(argv[i], "--pid") == 0 && i + 1 < argc) {
+			// Back-compat: --pid N → --target pid:N ; --pid auto → --target auto.
+			const char *v = argv[++i];
+			static char buf[64];
+			if (strcmp(v, "auto") == 0) {
+				target_arg = "auto";
+			} else {
+				snprintf(buf, sizeof(buf), "pid:%s", v);
+				target_arg = buf;
+			}
 		} else if (strcmp(argv[i], "--list") == 0) {
 			list_mode = true;
 		} else {
@@ -131,41 +143,68 @@ main(int argc, char **argv)
 	if (list_mode) {
 		long pids[64];
 		size_t n = u_mcp_enumerate_sessions(pids, 64);
+		// Report the service endpoint too if the socket/pipe exists. A
+		// trial connect is the cheapest cross-platform probe.
+		struct u_mcp_conn *probe = u_mcp_conn_connect_named("service");
+		if (probe != NULL) {
+			printf("service\n");
+			u_mcp_conn_close(probe);
+		}
 		for (size_t i = 0; i < n; i++) {
 			printf("%ld\n", (long)pids[i]);
 		}
 		return 0;
 	}
 
-	if (pid_arg == NULL) {
-		usage(argv[0]);
-		return 2;
+	if (target_arg == NULL) {
+		target_arg = "auto";
 	}
 
-	long pid = 0;
-	if (strcmp(pid_arg, "auto") == 0) {
-		long pids[64];
-		size_t n = u_mcp_enumerate_sessions(pids, 64);
-		if (n == 0) {
-			fprintf(stderr, "displayxr-mcp: no running MCP sessions found\n");
-			return 1;
-		}
-		if (n > 1) {
-			fprintf(stderr, "displayxr-mcp: %zu sessions found, pass --pid <N> explicitly\n", n);
-			return 1;
-		}
-		pid = pids[0];
-	} else {
-		pid = (long)strtol(pid_arg, NULL, 10);
+	struct u_mcp_conn *conn = NULL;
+	const char *connected_label = NULL;
+
+	if (strcmp(target_arg, "service") == 0) {
+		conn = u_mcp_conn_connect_named("service");
+		connected_label = "service";
+	} else if (strncmp(target_arg, "pid:", 4) == 0) {
+		long pid = (long)strtol(target_arg + 4, NULL, 10);
 		if (pid <= 0) {
 			usage(argv[0]);
 			return 2;
 		}
+		conn = u_mcp_conn_connect(pid);
+		static char buf[32];
+		snprintf(buf, sizeof(buf), "pid %ld", pid);
+		connected_label = buf;
+	} else if (strcmp(target_arg, "auto") == 0) {
+		// Service first — covers the Phase B shell story.
+		conn = u_mcp_conn_connect_named("service");
+		if (conn != NULL) {
+			connected_label = "service";
+		} else {
+			// Fall back to a unique handle-app session.
+			long pids[64];
+			size_t n = u_mcp_enumerate_sessions(pids, 64);
+			if (n == 0) {
+				fprintf(stderr, "displayxr-mcp: no running MCP sessions found\n");
+				return 1;
+			}
+			if (n > 1) {
+				fprintf(stderr, "displayxr-mcp: %zu sessions found, pass --target pid:N explicitly\n", n);
+				return 1;
+			}
+			conn = u_mcp_conn_connect(pids[0]);
+			static char buf[32];
+			snprintf(buf, sizeof(buf), "pid %ld", pids[0]);
+			connected_label = buf;
+		}
+	} else {
+		usage(argv[0]);
+		return 2;
 	}
 
-	struct u_mcp_conn *conn = u_mcp_conn_connect(pid);
 	if (conn == NULL) {
-		fprintf(stderr, "displayxr-mcp: cannot connect to pid %ld\n", (long)pid);
+		fprintf(stderr, "displayxr-mcp: cannot connect to %s\n", connected_label ? connected_label : target_arg);
 		return 1;
 	}
 

--- a/src/xrt/targets/service/main.c
+++ b/src/xrt/targets/service/main.c
@@ -14,6 +14,7 @@
 #include "util/u_metrics.h"
 #include "util/u_logging.h"
 #include "util/u_trace_marker.h"
+#include "util/u_mcp_server.h"
 
 #ifdef XRT_OS_WINDOWS
 #include "util/u_windows.h"
@@ -106,7 +107,14 @@ WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdS
 	    .shell_mode = shell_mode,
 	};
 
+	// Opt-in MCP server for agent-driven shell control / debugging.
+	// Gated on DISPLAYXR_MCP env var; binds a well-known "service"
+	// socket so the adapter can discover it by role, not PID.
+	u_mcp_server_maybe_start_named("service");
+
 	int ret = ipc_server_main(argc, argv, &ismi);
+
+	u_mcp_server_stop();
 
 	u_metrics_close();
 
@@ -142,7 +150,14 @@ main(int argc, char *argv[])
 	    .shell_mode = shell_mode,
 	};
 
+	// Opt-in MCP server for agent-driven shell control / debugging.
+	// Gated on DISPLAYXR_MCP env var; binds a well-known "service"
+	// socket so the adapter can discover it by role, not PID.
+	u_mcp_server_maybe_start_named("service");
+
 	int ret = ipc_server_main(argc, argv, &ismi);
+
+	u_mcp_server_stop();
 
 	u_metrics_close();
 

--- a/tests/mcp/_audit_log_helper.py
+++ b/tests/mcp/_audit_log_helper.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+# Copyright 2026, DisplayXR / Leia Inc.
+# SPDX-License-Identifier: BSL-1.0
+#
+# Slice 6: audit log smoke. Trigger a write, confirm the log file grew
+# with a line matching the tool name.
+
+import json
+import os
+import subprocess
+import sys
+import time
+
+adapter = sys.argv[1]
+
+
+def audit_path():
+    if os.name == "nt":
+        return os.path.join(os.environ.get("APPDATA", ""), "DisplayXR", "mcp-audit.log")
+    return os.path.join(os.path.expanduser("~"), ".config", "displayxr", "mcp-audit.log")
+
+
+p = subprocess.Popen(
+    [adapter, "--target", "service"],
+    stdin=subprocess.PIPE,
+    stdout=subprocess.PIPE,
+)
+
+_id = 0
+
+
+def next_id():
+    global _id
+    _id += 1
+    return _id
+
+
+def send(method, params=None):
+    b = json.dumps({"jsonrpc": "2.0", "id": next_id(), "method": method, "params": params or {}}).encode()
+    p.stdin.write(f"Content-Length: {len(b)}\r\n\r\n".encode() + b)
+    p.stdin.flush()
+
+
+def recv():
+    hdr = b""
+    while not (hdr.endswith(b"\r\n\r\n") or hdr.endswith(b"\n\n")):
+        c = p.stdout.read(1)
+        if not c:
+            raise RuntimeError("EOF")
+        hdr += c
+    n = 0
+    for line in hdr.split(b"\r\n"):
+        if line.lower().startswith(b"content-length:"):
+            n = int(line.split(b":", 1)[1].strip())
+    return json.loads(p.stdout.read(n))
+
+
+def call(name, args):
+    send("tools/call", {"name": name, "arguments": args})
+    return recv()
+
+
+try:
+    send("initialize", {"protocolVersion": "2024-11-05", "capabilities": {}, "clientInfo": {"name": "t", "version": "1"}})
+    recv()
+
+    path = audit_path()
+    size_before = os.path.getsize(path) if os.path.exists(path) else 0
+
+    call("apply_layout_preset", {"preset": "grid"})
+    time.sleep(0.1)
+
+    assert os.path.exists(path), f"audit file {path} not created"
+    with open(path, "rb") as f:
+        body = f.read()
+    assert len(body) > size_before, "audit log did not grow"
+    assert b"apply_layout_preset" in body, "audit log missing tool entry"
+    print(f"  PASS  audit log at {path} grew from {size_before} to {len(body)} bytes")
+    print(f"  PASS  contains 'apply_layout_preset' line")
+
+    # Read tools (list_windows) should NOT add an audit entry.
+    size_mid = len(body)
+    call("list_windows", {})
+    time.sleep(0.1)
+    size_after = os.path.getsize(path)
+    assert size_after == size_mid, f"read tool wrote to audit: {size_mid} -> {size_after}"
+    print("  PASS  read tool did not add an audit entry")
+
+    p.stdin.close()
+    p.wait(timeout=5)
+    print("test_audit_log: OK")
+    print("")
+    print("NOTE: to verify allowlist denial, restart service with")
+    print("      DISPLAYXR_MCP_ALLOW=99999 and expect set_window_pose")
+    print("      to return ok=false for any real client_id.")
+except Exception as e:
+    print(f"FAIL: {e}", file=sys.stderr)
+    try:
+        p.kill()
+    except Exception:
+        pass
+    sys.exit(1)

--- a/tests/mcp/_focus_preset_helper.py
+++ b/tests/mcp/_focus_preset_helper.py
@@ -109,10 +109,10 @@ try:
         # produce Z≈0, so this assertion is skipped.
         print("WARN: grid vs immersive poses identical (only one window?)")
 
-    # Unknown preset → ok=false.
+    # Unknown preset -> ok=false.
     r = call("apply_layout_preset", {"preset": "bogus"})
     assert not r.get("ok"), f"bogus preset should fail: {r}"
-    print("  PASS  apply_layout_preset bogus → ok=false")
+    print("  PASS  apply_layout_preset bogus -> ok=false")
 
     # Restore to grid so the test leaves the shell in a sane state.
     call("apply_layout_preset", {"preset": "grid"})

--- a/tests/mcp/_focus_preset_helper.py
+++ b/tests/mcp/_focus_preset_helper.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+# Copyright 2026, DisplayXR / Leia Inc.
+# SPDX-License-Identifier: BSL-1.0
+#
+# Slice 4: set_focus + apply_layout_preset.
+# Focuses the first available window, then cycles presets and confirms
+# window poses change (grid -> immersive). Carousel is dynamic so we
+# assert only that the tool returns ok=true.
+
+import json
+import subprocess
+import sys
+import time
+
+adapter = sys.argv[1]
+
+p = subprocess.Popen(
+    [adapter, "--target", "service"],
+    stdin=subprocess.PIPE,
+    stdout=subprocess.PIPE,
+)
+
+_id = 0
+
+
+def next_id():
+    global _id
+    _id += 1
+    return _id
+
+
+def send(method, params=None):
+    body = json.dumps(
+        {"jsonrpc": "2.0", "id": next_id(), "method": method, "params": params or {}}
+    ).encode()
+    p.stdin.write(f"Content-Length: {len(body)}\r\n\r\n".encode() + body)
+    p.stdin.flush()
+
+
+def recv():
+    hdr = b""
+    while not (hdr.endswith(b"\r\n\r\n") or hdr.endswith(b"\n\n")):
+        c = p.stdout.read(1)
+        if not c:
+            raise RuntimeError("EOF")
+        hdr += c
+    n = 0
+    for line in hdr.split(b"\r\n"):
+        if line.lower().startswith(b"content-length:"):
+            n = int(line.split(b":", 1)[1].strip())
+    return json.loads(p.stdout.read(n))
+
+
+def call(name, args):
+    send("tools/call", {"name": name, "arguments": args})
+    r = recv()
+    content = r["result"]["content"]
+    if content[0].get("type") == "text":
+        return json.loads(content[0]["text"])
+    return content[0]
+
+
+try:
+    send("initialize", {"protocolVersion": "2024-11-05", "capabilities": {}, "clientInfo": {"name": "t", "version": "1"}})
+    recv()
+
+    windows = call("list_windows", {})
+    if not windows:
+        print("FAIL: no windows", file=sys.stderr)
+        sys.exit(1)
+
+    cid = windows[0]["id"]
+    r = call("set_focus", {"client_id": cid})
+    assert r.get("ok"), f"set_focus failed: {r}"
+    print(f"  PASS  set_focus client_id={cid}")
+
+    # Grid preset.
+    r = call("apply_layout_preset", {"preset": "grid"})
+    assert r.get("ok"), f"apply_layout_preset grid failed: {r}"
+    print("  PASS  apply_layout_preset grid")
+
+    # Let the shell settle a frame.
+    time.sleep(0.2)
+    grid_windows = call("list_windows", {})
+    grid_poses = {w["id"]: w.get("pose") for w in grid_windows if "pose" in w}
+
+    # Immersive preset.
+    r = call("apply_layout_preset", {"preset": "immersive"})
+    assert r.get("ok"), f"apply_layout_preset immersive failed: {r}"
+    print("  PASS  apply_layout_preset immersive")
+    time.sleep(0.2)
+
+    imm_windows = call("list_windows", {})
+    imm_poses = {w["id"]: w.get("pose") for w in imm_windows if "pose" in w}
+
+    # Assert at least one window's Z changed between grid and immersive
+    # (immersive paraboloid pushes edges forward; grid keeps Z=0).
+    diff_any = False
+    for wid, gp in grid_poses.items():
+        ip = imm_poses.get(wid)
+        if gp is None or ip is None:
+            continue
+        if abs(gp["z"] - ip["z"]) > 1e-4:
+            diff_any = True
+            break
+    if not diff_any and len(grid_poses) >= 2:
+        # With >=2 windows, the paraboloid math moves at least one window
+        # out of the Z=0 plane. With 1 window at center, both presets
+        # produce Z≈0, so this assertion is skipped.
+        print("WARN: grid vs immersive poses identical (only one window?)")
+
+    # Unknown preset → ok=false.
+    r = call("apply_layout_preset", {"preset": "bogus"})
+    assert not r.get("ok"), f"bogus preset should fail: {r}"
+    print("  PASS  apply_layout_preset bogus → ok=false")
+
+    # Restore to grid so the test leaves the shell in a sane state.
+    call("apply_layout_preset", {"preset": "grid"})
+
+    p.stdin.close()
+    p.wait(timeout=5)
+    print("test_focus_preset: OK")
+except Exception as e:
+    print(f"FAIL: {e}", file=sys.stderr)
+    try:
+        p.kill()
+    except Exception:
+        pass
+    sys.exit(1)

--- a/tests/mcp/_list_windows_helper.py
+++ b/tests/mcp/_list_windows_helper.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+# Copyright 2026, DisplayXR / Leia Inc.
+# SPDX-License-Identifier: BSL-1.0
+#
+# Windows helper for tests/mcp/test_list_windows.bat. Mirrors the Python
+# block in the .sh test so cmd.exe users don't need Git Bash.
+import json
+import subprocess
+import sys
+
+adapter, expected = sys.argv[1], int(sys.argv[2])
+
+p = subprocess.Popen(
+    [adapter, "--target", "service"],
+    stdin=subprocess.PIPE,
+    stdout=subprocess.PIPE,
+)
+
+
+def send(obj):
+    b = json.dumps(obj).encode()
+    p.stdin.write(f"Content-Length: {len(b)}\r\n\r\n".encode() + b)
+    p.stdin.flush()
+
+
+def recv():
+    hdr = b""
+    while not (hdr.endswith(b"\r\n\r\n") or hdr.endswith(b"\n\n")):
+        c = p.stdout.read(1)
+        if not c:
+            raise RuntimeError("EOF")
+        hdr += c
+    n = 0
+    for line in hdr.split(b"\r\n"):
+        if line.lower().startswith(b"content-length:"):
+            n = int(line.split(b":", 1)[1].strip())
+    return json.loads(p.stdout.read(n))
+
+
+try:
+    send(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "test", "version": "1"},
+            },
+        }
+    )
+    recv()
+
+    send({"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}})
+    r = recv()
+    names = {t["name"] for t in r["result"]["tools"]}
+    assert "list_windows" in names, f"list_windows not registered: {sorted(names)}"
+    print("  PASS  tools/list includes list_windows")
+
+    send(
+        {
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {"name": "list_windows", "arguments": {}},
+        }
+    )
+    r = recv()
+    content = r["result"]["content"]
+    assert isinstance(content, list) and content, f"empty content: {r}"
+    payload = (
+        json.loads(content[0]["text"]) if content[0].get("type") == "text" else content[0]
+    )
+    assert isinstance(payload, list), f"list_windows result not an array: {payload}"
+    print(f"  PASS  list_windows returned {len(payload)} window(s)")
+
+    if len(payload) < expected:
+        print(f"FAIL: expected >= {expected} windows, got {len(payload)}", file=sys.stderr)
+        sys.exit(1)
+
+    required = {
+        "id",
+        "pid",
+        "name",
+        "session_active",
+        "session_visible",
+        "session_focused",
+        "z_order",
+        "primary",
+    }
+    for w in payload:
+        missing = required - set(w.keys())
+        if missing:
+            print(f"FAIL: window {w.get('id')} missing keys: {missing}", file=sys.stderr)
+            sys.exit(1)
+    print("  PASS  each window has all required fields")
+
+    have_pose = sum(1 for w in payload if "pose" in w and "size" in w)
+    print(f"  INFO  {have_pose}/{len(payload)} windows report pose+size (shell-mode only)")
+
+    p.stdin.close()
+    p.wait(timeout=5)
+    sys.exit(0)
+except Exception as e:
+    print(f"FAIL: {e}", file=sys.stderr)
+    try:
+        p.kill()
+    except Exception:
+        pass
+    sys.exit(1)

--- a/tests/mcp/_service_handshake_helper.py
+++ b/tests/mcp/_service_handshake_helper.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# Copyright 2026, DisplayXR / Leia Inc.
+# SPDX-License-Identifier: BSL-1.0
+#
+# Invoked by tests/mcp/test_service_handshake.bat on Windows. Sends a
+# JSON-RPC initialize to the service via the stdio adapter and asserts a
+# valid response. Exits 0 on pass, 1 on failure.
+import json
+import subprocess
+import sys
+
+adapter = sys.argv[1]
+p = subprocess.Popen(
+    [adapter, "--target", "service"],
+    stdin=subprocess.PIPE,
+    stdout=subprocess.PIPE,
+)
+
+
+def send(obj):
+    body = json.dumps(obj).encode()
+    p.stdin.write(f"Content-Length: {len(body)}\r\n\r\n".encode() + body)
+    p.stdin.flush()
+
+
+def recv():
+    hdr = b""
+    while not (hdr.endswith(b"\r\n\r\n") or hdr.endswith(b"\n\n")):
+        c = p.stdout.read(1)
+        if not c:
+            raise RuntimeError("EOF from adapter")
+        hdr += c
+    length = 0
+    for line in hdr.split(b"\r\n"):
+        if line.lower().startswith(b"content-length:"):
+            length = int(line.split(b":", 1)[1].strip())
+    return json.loads(p.stdout.read(length))
+
+
+try:
+    send(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "test", "version": "1"},
+            },
+        }
+    )
+    r = recv()
+    if r.get("id") != 1 or "result" not in r:
+        print(f"FAIL: bad initialize response: {r}", file=sys.stderr)
+        sys.exit(1)
+    p.stdin.close()
+    p.wait(timeout=5)
+    sys.exit(0)
+except Exception as e:
+    print(f"FAIL: {e}", file=sys.stderr)
+    try:
+        p.kill()
+    except Exception:
+        pass
+    sys.exit(1)

--- a/tests/mcp/_session_routing_helper.py
+++ b/tests/mcp/_session_routing_helper.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+# Copyright 2026, DisplayXR / Leia Inc.
+# SPDX-License-Identifier: BSL-1.0
+#
+# Slice 8: service list_sessions → pick PID → open Phase A per-session
+# session via `--target pid:N` → fetch get_kooima_params.
+
+import json
+import subprocess
+import sys
+
+adapter = sys.argv[1]
+
+
+def rpc_session(target):
+    p = subprocess.Popen([adapter, "--target", target],
+                         stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+    nid = {"i": 0}
+
+    def next_id():
+        nid["i"] += 1
+        return nid["i"]
+
+    def send(method, params=None):
+        b = json.dumps({"jsonrpc": "2.0", "id": next_id(),
+                        "method": method, "params": params or {}}).encode()
+        p.stdin.write(f"Content-Length: {len(b)}\r\n\r\n".encode() + b)
+        p.stdin.flush()
+
+    def recv():
+        hdr = b""
+        while not (hdr.endswith(b"\r\n\r\n") or hdr.endswith(b"\n\n")):
+            c = p.stdout.read(1)
+            if not c:
+                raise RuntimeError("EOF")
+            hdr += c
+        n = 0
+        for line in hdr.split(b"\r\n"):
+            if line.lower().startswith(b"content-length:"):
+                n = int(line.split(b":", 1)[1].strip())
+        return json.loads(p.stdout.read(n))
+
+    def call(name, args):
+        send("tools/call", {"name": name, "arguments": args})
+        r = recv()
+        c = r["result"]["content"]
+        return json.loads(c[0]["text"]) if c[0].get("type") == "text" else c[0]
+
+    send("initialize", {"protocolVersion": "2024-11-05", "capabilities": {},
+                        "clientInfo": {"name": "t", "version": "1"}})
+    recv()
+
+    return p, call
+
+
+try:
+    svc_p, svc_call = rpc_session("service")
+    sessions = svc_call("list_sessions", {})
+    if not sessions:
+        print("FAIL: service list_sessions empty", file=sys.stderr)
+        sys.exit(1)
+    required = {"client_id", "pid", "name", "session_active"}
+    for s in sessions:
+        missing = required - set(s.keys())
+        if missing:
+            print(f"FAIL: session missing keys: {missing}", file=sys.stderr)
+            sys.exit(1)
+    print(f"  PASS  service list_sessions returned {len(sessions)} session(s)")
+
+    # Pick an active session and reach into its per-PID MCP server.
+    target_session = next((s for s in sessions if s["session_active"]), sessions[0])
+    pid = int(target_session["pid"])
+    svc_p.stdin.close()
+    svc_p.wait(timeout=5)
+
+    app_p, app_call = rpc_session(f"pid:{pid}")
+    kooima = app_call("get_kooima_params", {})
+    assert isinstance(kooima, dict), f"unexpected get_kooima_params result: {kooima}"
+    assert "view_count" in kooima or "view_count_recommended" in kooima, (
+        f"kooima missing view_count: {kooima}"
+    )
+    print(f"  PASS  reached Phase A get_kooima_params via pid:{pid}")
+
+    app_p.stdin.close()
+    app_p.wait(timeout=5)
+
+    print("test_session_routing: OK")
+except Exception as e:
+    print(f"FAIL: {e}", file=sys.stderr)
+    sys.exit(1)

--- a/tests/mcp/_set_window_pose_helper.py
+++ b/tests/mcp/_set_window_pose_helper.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+# Copyright 2026, DisplayXR / Leia Inc.
+# SPDX-License-Identifier: BSL-1.0
+#
+# Slice 3 round-trip: read current pose of the first shell window,
+# move by a known delta, read back, assert match within tolerance,
+# restore.
+
+import json
+import subprocess
+import sys
+
+adapter = sys.argv[1]
+
+p = subprocess.Popen(
+    [adapter, "--target", "service"],
+    stdin=subprocess.PIPE,
+    stdout=subprocess.PIPE,
+)
+
+_id = 0
+
+
+def next_id():
+    global _id
+    _id += 1
+    return _id
+
+
+def send(method, params=None):
+    body = json.dumps({"jsonrpc": "2.0", "id": next_id(), "method": method, "params": params or {}}).encode()
+    p.stdin.write(f"Content-Length: {len(body)}\r\n\r\n".encode() + body)
+    p.stdin.flush()
+
+
+def recv():
+    hdr = b""
+    while not (hdr.endswith(b"\r\n\r\n") or hdr.endswith(b"\n\n")):
+        c = p.stdout.read(1)
+        if not c:
+            raise RuntimeError("EOF")
+        hdr += c
+    n = 0
+    for line in hdr.split(b"\r\n"):
+        if line.lower().startswith(b"content-length:"):
+            n = int(line.split(b":", 1)[1].strip())
+    return json.loads(p.stdout.read(n))
+
+
+def call_tool(name, args):
+    send("tools/call", {"name": name, "arguments": args})
+    r = recv()
+    content = r["result"]["content"]
+    if content[0].get("type") == "text":
+        return json.loads(content[0]["text"])
+    return content[0]
+
+
+try:
+    send(
+        "initialize",
+        {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": {"name": "test", "version": "1"},
+        },
+    )
+    recv()
+
+    windows = call_tool("list_windows", {})
+    if not windows:
+        print("FAIL: no windows running under the service", file=sys.stderr)
+        sys.exit(1)
+    # Pick the first window that reports a pose (shell-mode only).
+    target = next((w for w in windows if "pose" in w), None)
+    if target is None:
+        print("FAIL: no shell-mode windows reported a pose", file=sys.stderr)
+        sys.exit(1)
+
+    cid = target["id"]
+    orig_pose = target["pose"]
+    orig_size = target["size"]
+    print(f"  INFO  target client_id={cid} name={target['name']!r}")
+    print(
+        f"  INFO  original pose: x={orig_pose['x']:.4f} y={orig_pose['y']:.4f} z={orig_pose['z']:.4f}"
+    )
+
+    # Apply a deliberate delta.
+    dx, dy, dz = 0.03, -0.02, 0.05
+    new_pose = dict(orig_pose)
+    new_pose["x"] += dx
+    new_pose["y"] += dy
+    new_pose["z"] += dz
+
+    r = call_tool(
+        "set_window_pose",
+        {"client_id": cid, "pose": new_pose, "size": orig_size},
+    )
+    assert r.get("ok"), f"set_window_pose failed: {r}"
+    print("  PASS  set_window_pose accepted")
+
+    # Read back.
+    got = call_tool("get_window_pose", {"client_id": cid})
+    got_pose = got["pose"]
+    eps = 1e-3
+    for k in ("x", "y", "z"):
+        if abs(got_pose[k] - new_pose[k]) > eps:
+            print(
+                f"FAIL: {k} mismatch: got {got_pose[k]:.4f} want {new_pose[k]:.4f}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+    print("  PASS  get_window_pose matches applied pose (tol=1e-3)")
+
+    # Restore.
+    call_tool("set_window_pose", {"client_id": cid, "pose": orig_pose, "size": orig_size})
+    print("  PASS  restored original pose")
+
+    p.stdin.close()
+    p.wait(timeout=5)
+    print("test_set_window_pose: OK")
+except Exception as e:
+    print(f"FAIL: {e}", file=sys.stderr)
+    try:
+        p.kill()
+    except Exception:
+        pass
+    sys.exit(1)

--- a/tests/mcp/_workspace_helper.py
+++ b/tests/mcp/_workspace_helper.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+# Copyright 2026, DisplayXR / Leia Inc.
+# SPDX-License-Identifier: BSL-1.0
+#
+# Slice 5: save_workspace → perturb → load_workspace round-trip.
+
+import json
+import subprocess
+import sys
+import time
+import uuid
+
+adapter = sys.argv[1]
+
+p = subprocess.Popen(
+    [adapter, "--target", "service"],
+    stdin=subprocess.PIPE,
+    stdout=subprocess.PIPE,
+)
+
+_id = 0
+
+
+def next_id():
+    global _id
+    _id += 1
+    return _id
+
+
+def send(method, params=None):
+    b = json.dumps({"jsonrpc": "2.0", "id": next_id(), "method": method, "params": params or {}}).encode()
+    p.stdin.write(f"Content-Length: {len(b)}\r\n\r\n".encode() + b)
+    p.stdin.flush()
+
+
+def recv():
+    hdr = b""
+    while not (hdr.endswith(b"\r\n\r\n") or hdr.endswith(b"\n\n")):
+        c = p.stdout.read(1)
+        if not c:
+            raise RuntimeError("EOF")
+        hdr += c
+    n = 0
+    for line in hdr.split(b"\r\n"):
+        if line.lower().startswith(b"content-length:"):
+            n = int(line.split(b":", 1)[1].strip())
+    return json.loads(p.stdout.read(n))
+
+
+def call(name, args):
+    send("tools/call", {"name": name, "arguments": args})
+    r = recv()
+    content = r["result"]["content"]
+    if content[0].get("type") == "text":
+        return json.loads(content[0]["text"])
+    return content[0]
+
+
+def poses_by_id(windows):
+    return {w["id"]: w["pose"] for w in windows if "pose" in w}
+
+
+try:
+    send("initialize", {"protocolVersion": "2024-11-05", "capabilities": {}, "clientInfo": {"name": "t", "version": "1"}})
+    recv()
+
+    before = call("list_windows", {})
+    origin = poses_by_id(before)
+    if not origin:
+        print("FAIL: no windows with pose", file=sys.stderr)
+        sys.exit(1)
+
+    ws = f"mcp-phase-b-test-{uuid.uuid4().hex[:8]}"
+
+    r = call("save_workspace", {"name": ws})
+    assert r.get("ok"), f"save_workspace failed: {r}"
+    print(f"  PASS  save_workspace → {r.get('path')}")
+
+    # Perturb every pose.
+    for wid, pose in origin.items():
+        new_pose = dict(pose)
+        new_pose["x"] += 0.04
+        new_pose["y"] -= 0.03
+        size = next(w["size"] for w in before if w["id"] == wid)
+        call("set_window_pose", {"client_id": wid, "pose": new_pose, "size": size})
+    time.sleep(0.2)
+
+    # Confirm perturbation took effect (sanity).
+    perturbed = poses_by_id(call("list_windows", {}))
+    for wid, p0 in origin.items():
+        if abs(perturbed[wid]["x"] - (p0["x"] + 0.04)) > 1e-3:
+            print(f"FAIL: perturbation didn't land for {wid}", file=sys.stderr)
+            sys.exit(1)
+    print("  PASS  poses perturbed")
+
+    r = call("load_workspace", {"name": ws})
+    assert r.get("ok"), f"load_workspace failed: {r}"
+    print(f"  PASS  load_workspace applied={r.get('applied')} missed={r.get('missed')}")
+    time.sleep(0.2)
+
+    restored = poses_by_id(call("list_windows", {}))
+    for wid, p0 in origin.items():
+        rp = restored[wid]
+        for k in ("x", "y", "z"):
+            if abs(rp[k] - p0[k]) > 1e-3:
+                print(f"FAIL: {wid} {k}: got {rp[k]:.4f} want {p0[k]:.4f}", file=sys.stderr)
+                sys.exit(1)
+    print(f"  PASS  all {len(origin)} windows restored within 1e-3")
+
+    p.stdin.close()
+    p.wait(timeout=5)
+    print("test_workspace_roundtrip: OK")
+except Exception as e:
+    print(f"FAIL: {e}", file=sys.stderr)
+    try:
+        p.kill()
+    except Exception:
+        pass
+    sys.exit(1)

--- a/tests/mcp/_workspace_helper.py
+++ b/tests/mcp/_workspace_helper.py
@@ -2,7 +2,7 @@
 # Copyright 2026, DisplayXR / Leia Inc.
 # SPDX-License-Identifier: BSL-1.0
 #
-# Slice 5: save_workspace → perturb → load_workspace round-trip.
+# Slice 5: save_workspace -> perturb -> load_workspace round-trip.
 
 import json
 import subprocess
@@ -74,7 +74,7 @@ try:
 
     r = call("save_workspace", {"name": ws})
     assert r.get("ok"), f"save_workspace failed: {r}"
-    print(f"  PASS  save_workspace → {r.get('path')}")
+    print(f"  PASS  save_workspace -> {r.get('path')}")
 
     # Perturb every pose.
     for wid, pose in origin.items():

--- a/tests/mcp/test_audit_log.bat
+++ b/tests/mcp/test_audit_log.bat
@@ -1,0 +1,30 @@
+@echo off
+REM Copyright 2026, DisplayXR / Leia Inc.
+REM SPDX-License-Identifier: BSL-1.0
+
+setlocal EnableDelayedExpansion
+set "ROOT=%~dp0..\.."
+pushd "%ROOT%" >nul
+
+set "ADAPTER="
+for %%P in (
+    "%ROOT%\_package\DisplayXR\bin\displayxr-mcp.exe"
+    "%ROOT%\_package\bin\displayxr-mcp.exe"
+    "%ROOT%\build\src\xrt\targets\mcp_adapter\displayxr-mcp.exe"
+) do if exist %%P set "ADAPTER=%%~P"
+
+if "!ADAPTER!"=="" (
+    echo FAIL: displayxr-mcp.exe not found 1>&2
+    popd >nul & exit /b 1
+)
+
+"!ADAPTER!" --target service <nul >nul 2>&1
+if errorlevel 1 (
+    echo FAIL: service MCP endpoint not reachable 1>&2
+    popd >nul & exit /b 1
+)
+
+python tests\mcp\_audit_log_helper.py "!ADAPTER!"
+set RC=%errorlevel%
+popd >nul
+exit /b %RC%

--- a/tests/mcp/test_audit_log.sh
+++ b/tests/mcp/test_audit_log.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Copyright 2026, DisplayXR / Leia Inc.
+# SPDX-License-Identifier: BSL-1.0
+#
+# Slice 6 (Phase B) — audit log and allowlist smoke-check.
+#
+# - Triggers a write tool (apply_layout_preset) and asserts a new line
+#   appears in the audit log.
+# - Separate optional run with DISPLAYXR_MCP_ALLOW set to a bogus id
+#   must cause set_window_pose to fail. That branch requires restarting
+#   the service, so the test just documents it; actual verification
+#   happens in the Windows validation pass.
+
+set -eu
+set -o pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+ADAPTER=""
+for cand in \
+    "$ROOT/_package/DisplayXR/bin/displayxr-mcp.exe" \
+    "$ROOT/_package/bin/displayxr-mcp.exe" \
+    "$ROOT/build/src/xrt/targets/mcp_adapter/displayxr-mcp" \
+    "$ROOT/build/src/xrt/targets/mcp_adapter/displayxr-mcp.exe"; do
+    [[ -x "$cand" ]] && ADAPTER="$cand" && break
+done
+[[ -n "$ADAPTER" ]] || { echo "FAIL: displayxr-mcp not found" >&2; exit 1; }
+
+"$ADAPTER" --target service </dev/null >/dev/null 2>&1 || {
+    echo "FAIL: service MCP endpoint not reachable" >&2; exit 1
+}
+
+python3 tests/mcp/_audit_log_helper.py "$ADAPTER"

--- a/tests/mcp/test_focus_preset.bat
+++ b/tests/mcp/test_focus_preset.bat
@@ -1,0 +1,30 @@
+@echo off
+REM Copyright 2026, DisplayXR / Leia Inc.
+REM SPDX-License-Identifier: BSL-1.0
+
+setlocal EnableDelayedExpansion
+set "ROOT=%~dp0..\.."
+pushd "%ROOT%" >nul
+
+set "ADAPTER="
+for %%P in (
+    "%ROOT%\_package\DisplayXR\bin\displayxr-mcp.exe"
+    "%ROOT%\_package\bin\displayxr-mcp.exe"
+    "%ROOT%\build\src\xrt\targets\mcp_adapter\displayxr-mcp.exe"
+) do if exist %%P set "ADAPTER=%%~P"
+
+if "!ADAPTER!"=="" (
+    echo FAIL: displayxr-mcp.exe not found 1>&2
+    popd >nul & exit /b 1
+)
+
+"!ADAPTER!" --target service <nul >nul 2>&1
+if errorlevel 1 (
+    echo FAIL: service MCP endpoint not reachable 1>&2
+    popd >nul & exit /b 1
+)
+
+python tests\mcp\_focus_preset_helper.py "!ADAPTER!"
+set RC=%errorlevel%
+popd >nul
+exit /b %RC%

--- a/tests/mcp/test_focus_preset.sh
+++ b/tests/mcp/test_focus_preset.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Copyright 2026, DisplayXR / Leia Inc.
+# SPDX-License-Identifier: BSL-1.0
+#
+# Slice 4 (Phase B) — set_focus + apply_layout_preset.
+#
+# Requires displayxr-service + shell-mode handle app running.
+
+set -eu
+set -o pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+ADAPTER=""
+for cand in \
+    "$ROOT/_package/DisplayXR/bin/displayxr-mcp.exe" \
+    "$ROOT/_package/bin/displayxr-mcp.exe" \
+    "$ROOT/build/src/xrt/targets/mcp_adapter/displayxr-mcp" \
+    "$ROOT/build/src/xrt/targets/mcp_adapter/displayxr-mcp.exe"; do
+    [[ -x "$cand" ]] && ADAPTER="$cand" && break
+done
+[[ -n "$ADAPTER" ]] || { echo "FAIL: displayxr-mcp not found" >&2; exit 1; }
+
+"$ADAPTER" --target service </dev/null >/dev/null 2>&1 || {
+    echo "FAIL: service MCP endpoint not reachable" >&2; exit 1
+}
+
+python3 tests/mcp/_focus_preset_helper.py "$ADAPTER"

--- a/tests/mcp/test_list_windows.bat
+++ b/tests/mcp/test_list_windows.bat
@@ -1,0 +1,40 @@
+@echo off
+REM Copyright 2026, DisplayXR / Leia Inc.
+REM SPDX-License-Identifier: BSL-1.0
+REM
+REM Slice 2 (Phase B) — list_windows against a running service.
+REM Requires: DISPLAYXR_MCP=1 displayxr-shell.exe <app1> <app2> already running.
+
+setlocal EnableDelayedExpansion
+set "ROOT=%~dp0..\.."
+pushd "%ROOT%" >nul
+
+set "ADAPTER="
+for %%P in (
+    "%ROOT%\_package\DisplayXR\bin\displayxr-mcp.exe"
+    "%ROOT%\_package\bin\displayxr-mcp.exe"
+    "%ROOT%\build\src\xrt\targets\mcp_adapter\displayxr-mcp.exe"
+) do if exist %%P set "ADAPTER=%%~P"
+
+if "!ADAPTER!"=="" (
+    echo FAIL: displayxr-mcp.exe not found 1>&2
+    popd >nul & exit /b 1
+)
+
+if "%EXPECTED_WINDOWS%"=="" set EXPECTED_WINDOWS=2
+
+echo === Slice 2 list_windows ===
+echo     adapter:  !ADAPTER!
+echo     expected: ^>= %EXPECTED_WINDOWS% windows
+
+"!ADAPTER!" --target service <nul >nul 2>&1
+if errorlevel 1 (
+    echo FAIL: displayxr-service MCP endpoint not reachable 1>&2
+    echo       start with DISPLAYXR_MCP=1 and ^>= %EXPECTED_WINDOWS% app^(s^) 1>&2
+    popd >nul & exit /b 1
+)
+
+python tests\mcp\_list_windows_helper.py "!ADAPTER!" %EXPECTED_WINDOWS%
+set RC=%errorlevel%
+popd >nul
+exit /b %RC%

--- a/tests/mcp/test_list_windows.sh
+++ b/tests/mcp/test_list_windows.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Copyright 2026, DisplayXR / Leia Inc.
+# SPDX-License-Identifier: BSL-1.0
+#
+# Slice 2 (Phase B) — list_windows against a running service.
+#
+# Requires displayxr-service + two handle apps running. On a Windows Leia
+# SR machine this is the canonical flow:
+#
+#   set DISPLAYXR_MCP=1
+#   _package\bin\displayxr-shell.exe \
+#       test_apps\cube_handle_d3d11_win\build\cube_handle_d3d11_win.exe \
+#       test_apps\cube_handle_d3d11_win\build\cube_handle_d3d11_win.exe
+#
+# Then run this test in a second terminal. It connects via --target service
+# and asserts that list_windows reports >= the expected number of clients
+# (default 2; override with EXPECTED_WINDOWS env var).
+
+set -eu
+set -o pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+EXPECTED_WINDOWS="${EXPECTED_WINDOWS:-2}"
+
+ADAPTER=""
+for cand in \
+    "$ROOT/_package/DisplayXR/bin/displayxr-mcp.exe" \
+    "$ROOT/_package/bin/displayxr-mcp.exe" \
+    "$ROOT/build/src/xrt/targets/mcp_adapter/displayxr-mcp" \
+    "$ROOT/build/src/xrt/targets/mcp_adapter/displayxr-mcp.exe"; do
+    if [[ -x "$cand" ]]; then
+        ADAPTER="$cand"
+        break
+    fi
+done
+[[ -n "$ADAPTER" ]] || { echo "FAIL: displayxr-mcp not found" >&2; exit 1; }
+
+echo "=== Slice 2 list_windows ==="
+echo "    adapter:  $ADAPTER"
+echo "    expected: >= $EXPECTED_WINDOWS windows"
+
+# Probe that the service endpoint is reachable before running python.
+if ! "$ADAPTER" --target service </dev/null >/dev/null 2>&1; then
+    echo "FAIL: displayxr-service MCP endpoint not reachable" >&2
+    echo "      start the service with DISPLAYXR_MCP=1 and at least $EXPECTED_WINDOWS app(s)" >&2
+    exit 1
+fi
+
+python3 - "$ADAPTER" "$EXPECTED_WINDOWS" <<'PY'
+import json, subprocess, sys
+adapter, expected = sys.argv[1], int(sys.argv[2])
+
+p = subprocess.Popen([adapter, "--target", "service"],
+                    stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+
+def send(obj):
+    b = json.dumps(obj).encode()
+    p.stdin.write(f"Content-Length: {len(b)}\r\n\r\n".encode() + b)
+    p.stdin.flush()
+
+def recv():
+    hdr = b""
+    while not (hdr.endswith(b"\r\n\r\n") or hdr.endswith(b"\n\n")):
+        c = p.stdout.read(1)
+        if not c: raise RuntimeError("eof")
+        hdr += c
+    n = 0
+    for line in hdr.split(b"\r\n"):
+        if line.lower().startswith(b"content-length:"):
+            n = int(line.split(b":",1)[1].strip())
+    return json.loads(p.stdout.read(n))
+
+send({"jsonrpc":"2.0","id":1,"method":"initialize",
+      "params":{"protocolVersion":"2024-11-05","capabilities":{},
+                "clientInfo":{"name":"test","version":"1"}}})
+recv()
+
+send({"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}})
+r = recv()
+names = {t["name"] for t in r["result"]["tools"]}
+assert "list_windows" in names, f"list_windows not registered: {sorted(names)}"
+print("  PASS  tools/list includes list_windows")
+
+send({"jsonrpc":"2.0","id":3,"method":"tools/call",
+      "params":{"name":"list_windows","arguments":{}}})
+r = recv()
+# MCP returns tool result wrapped in content[].text as JSON text.
+content = r["result"]["content"]
+assert isinstance(content, list) and content, f"empty content: {r}"
+payload = json.loads(content[0]["text"]) if content[0].get("type") == "text" else content[0]
+assert isinstance(payload, list), f"list_windows result not an array: {payload}"
+print(f"  PASS  list_windows returned {len(payload)} window(s)")
+
+if len(payload) < expected:
+    print(f"FAIL: expected >= {expected} windows, got {len(payload)}", file=sys.stderr)
+    sys.exit(1)
+
+required_keys = {"id", "pid", "name", "session_active", "session_visible",
+                 "session_focused", "z_order", "primary"}
+for w in payload:
+    missing = required_keys - set(w.keys())
+    if missing:
+        print(f"FAIL: window {w.get('id')} missing keys: {missing}", file=sys.stderr)
+        sys.exit(1)
+print("  PASS  each window has all required fields")
+
+have_pose = sum(1 for w in payload if "pose" in w and "size" in w)
+print(f"  INFO  {have_pose}/{len(payload)} windows report pose+size (shell-mode only)")
+
+p.stdin.close(); p.wait(timeout=5)
+PY
+
+echo "test_list_windows: OK"

--- a/tests/mcp/test_service_handshake.bat
+++ b/tests/mcp/test_service_handshake.bat
@@ -1,0 +1,96 @@
+@echo off
+REM Copyright 2026, DisplayXR / Leia Inc.
+REM SPDX-License-Identifier: BSL-1.0
+REM
+REM Slice 1 (Phase B) — service-mode adapter handshake, cmd.exe edition.
+REM Mirrors tests\mcp\test_service_handshake.sh for Windows users without
+REM Git Bash / WSL. Exits 0 on pass, non-zero on failure.
+
+setlocal EnableDelayedExpansion
+
+set "ROOT=%~dp0..\.."
+pushd "%ROOT%" >nul
+
+set "ADAPTER="
+for %%P in (
+    "%ROOT%\_package\DisplayXR\bin\displayxr-mcp.exe"
+    "%ROOT%\_package\bin\displayxr-mcp.exe"
+    "%ROOT%\build\src\xrt\targets\mcp_adapter\displayxr-mcp.exe"
+    "%ROOT%\build\src\xrt\targets\mcp_adapter\Debug\displayxr-mcp.exe"
+) do (
+    if exist %%P set "ADAPTER=%%~P"
+)
+
+if "!ADAPTER!"=="" (
+    echo FAIL: displayxr-mcp.exe not found; build first 1>&2
+    popd >nul & exit /b 1
+)
+
+echo === Slice 1 service-handshake ===
+echo     adapter: !ADAPTER!
+
+REM 1. --list works.
+"!ADAPTER!" --list >nul
+if errorlevel 1 (
+    echo FAIL: --list returned non-zero 1>&2
+    popd >nul & exit /b 1
+)
+echo   PASS  --list
+
+REM 2. --target service must fail when no service is running.
+"!ADAPTER!" --target service <nul >nul 2>&1
+if not errorlevel 1 (
+    echo FAIL: --target service succeeded with no service 1>&2
+    popd >nul & exit /b 1
+)
+echo   PASS  --target service fails with no service
+
+REM 3. --target auto fallback.
+"!ADAPTER!" --target auto <nul >_mcp_out.txt 2>&1
+type _mcp_out.txt | findstr /C:"no running MCP sessions" >nul
+if errorlevel 1 (
+    echo FAIL: --target auto fallback did not report expected error 1>&2
+    type _mcp_out.txt
+    del _mcp_out.txt
+    popd >nul & exit /b 1
+)
+del _mcp_out.txt
+echo   PASS  --target auto fallback
+
+REM 4. Service handshake (requires displayxr-service + DISPLAYXR_MCP=1).
+set "SERVICE="
+for %%P in (
+    "%ROOT%\_package\DisplayXR\bin\displayxr-service.exe"
+    "%ROOT%\_package\bin\displayxr-service.exe"
+) do (
+    if exist %%P set "SERVICE=%%~P"
+)
+
+if "!SERVICE!"=="" (
+    echo   SKIP  service handshake ^(displayxr-service.exe not found^)
+    echo test_service_handshake: OK
+    popd >nul & exit /b 0
+)
+
+echo     service: !SERVICE!
+set DISPLAYXR_MCP=1
+start "" /B "!SERVICE!" --shell
+REM Let the service bind its MCP endpoint.
+timeout /t 3 /nobreak >nul
+
+python tests\mcp\_service_handshake_helper.py "!ADAPTER!"
+set RC=%errorlevel%
+
+REM Shut the service down. `taskkill` by image name is the cleanest
+REM path since we don't track its PID here.
+taskkill /IM displayxr-service.exe /F >nul 2>&1
+
+if not "%RC%"=="0" (
+    echo FAIL: initialize handshake 1>&2
+    popd >nul & exit /b 1
+)
+
+echo   PASS  initialize against service
+echo test_service_handshake: OK
+popd >nul
+exit /b 0

--- a/tests/mcp/test_service_handshake.sh
+++ b/tests/mcp/test_service_handshake.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Copyright 2026, DisplayXR / Leia Inc.
+# SPDX-License-Identifier: BSL-1.0
+#
+# Slice 1 (Phase B) — service-mode adapter handshake.
+#
+# Validates:
+#   1. `--list` succeeds with no MCP session running (empty output, exit 0).
+#   2. `--target service` exits non-zero when no service is running.
+#   3. `--target auto` falls back to a unique handle-app session when no
+#      service is running.
+#   4. When the service is up with DISPLAYXR_MCP=1, `--target service`
+#      completes a JSON-RPC initialize handshake.
+#
+# On macOS (no service binary) only steps 1-3 run. The script is also
+# safe to invoke on Windows via Git Bash; a .bat equivalent lives
+# alongside for cmd.exe consumption.
+
+set -eu
+set -o pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+# Locate the adapter (macOS build tree, Windows _package).
+ADAPTER=""
+for cand in \
+    "$ROOT/build/src/xrt/targets/mcp_adapter/displayxr-mcp" \
+    "$ROOT/build/src/xrt/targets/mcp_adapter/displayxr-mcp.exe" \
+    "$ROOT/_package/DisplayXR/bin/displayxr-mcp.exe" \
+    "$ROOT/_package/bin/displayxr-mcp.exe"; do
+    if [[ -x "$cand" ]]; then
+        ADAPTER="$cand"
+        break
+    fi
+done
+if [[ -z "$ADAPTER" ]]; then
+    echo "FAIL: displayxr-mcp not found; build first" >&2
+    exit 1
+fi
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+echo "=== Slice 1 service-handshake ==="
+echo "    adapter: $ADAPTER"
+
+# 1. --list works with nothing running.
+"$ADAPTER" --list >/dev/null || fail "--list returned non-zero"
+echo "  PASS  --list (no sessions)"
+
+# 2. --target service fails cleanly when no service is running.
+if "$ADAPTER" --target service </dev/null >/dev/null 2>&1; then
+    fail "--target service succeeded with no service running"
+fi
+echo "  PASS  --target service fails with no service"
+
+# 3. --target auto falls through when no service. On macOS we can't
+#    actually launch a handle app from this test without heavy setup,
+#    so we assert the "no sessions" error path here; test_handshake.sh
+#    covers the single-session case.
+out=$("$ADAPTER" --target auto </dev/null 2>&1 || true)
+if ! echo "$out" | grep -q "no running MCP sessions"; then
+    fail "--target auto fallback did not report 'no running MCP sessions': $out"
+fi
+echo "  PASS  --target auto fallback"
+
+# 4. Service handshake (Windows-only; skipped on macOS where the
+#    service binary is not built).
+SERVICE=""
+for cand in \
+    "$ROOT/_package/DisplayXR/bin/displayxr-service.exe" \
+    "$ROOT/_package/bin/displayxr-service.exe" \
+    "$ROOT/build/src/xrt/targets/service/displayxr-service"; do
+    if [[ -x "$cand" ]]; then
+        SERVICE="$cand"
+        break
+    fi
+done
+
+if [[ -z "$SERVICE" ]]; then
+    echo "  SKIP  service handshake (no displayxr-service binary on this platform)"
+    echo "test_service_handshake: OK"
+    exit 0
+fi
+
+echo "    service: $SERVICE"
+DISPLAYXR_MCP=1 "$SERVICE" --shell &
+SVC_PID=$!
+cleanup() { kill -TERM "$SVC_PID" 2>/dev/null || true; }
+trap cleanup EXIT
+
+# Wait up to 3 s for the service to bind its MCP endpoint.
+for i in 1 2 3 4 5 6; do
+    if "$ADAPTER" --target service </dev/null >/dev/null 2>&1; then
+        break
+    fi
+    sleep 0.5
+done
+
+# Scripted JSON-RPC initialize handshake via python.
+python3 - "$ADAPTER" <<'PY' || fail "initialize handshake"
+import json, subprocess, sys
+adapter = sys.argv[1]
+p = subprocess.Popen([adapter, "--target", "service"],
+                    stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+def send(obj):
+    body = json.dumps(obj).encode()
+    p.stdin.write(f"Content-Length: {len(body)}\r\n\r\n".encode() + body)
+    p.stdin.flush()
+def recv():
+    hdr = b""
+    while not hdr.endswith(b"\r\n\r\n") and not hdr.endswith(b"\n\n"):
+        c = p.stdout.read(1)
+        if not c: raise RuntimeError("eof")
+        hdr += c
+    length = 0
+    for line in hdr.split(b"\r\n"):
+        if line.lower().startswith(b"content-length:"):
+            length = int(line.split(b":",1)[1].strip())
+    return json.loads(p.stdout.read(length))
+
+send({"jsonrpc":"2.0","id":1,"method":"initialize",
+      "params":{"protocolVersion":"2024-11-05","capabilities":{},
+                "clientInfo":{"name":"test","version":"1"}}})
+r = recv()
+assert r.get("id") == 1 and "result" in r, f"bad initialize: {r}"
+p.stdin.close()
+p.wait(timeout=5)
+PY
+
+echo "  PASS  initialize against service"
+echo "test_service_handshake: OK"

--- a/tests/mcp/test_session_routing.bat
+++ b/tests/mcp/test_session_routing.bat
@@ -1,0 +1,30 @@
+@echo off
+REM Copyright 2026, DisplayXR / Leia Inc.
+REM SPDX-License-Identifier: BSL-1.0
+
+setlocal EnableDelayedExpansion
+set "ROOT=%~dp0..\.."
+pushd "%ROOT%" >nul
+
+set "ADAPTER="
+for %%P in (
+    "%ROOT%\_package\DisplayXR\bin\displayxr-mcp.exe"
+    "%ROOT%\_package\bin\displayxr-mcp.exe"
+    "%ROOT%\build\src\xrt\targets\mcp_adapter\displayxr-mcp.exe"
+) do if exist %%P set "ADAPTER=%%~P"
+
+if "!ADAPTER!"=="" (
+    echo FAIL: displayxr-mcp.exe not found 1>&2
+    popd >nul & exit /b 1
+)
+
+"!ADAPTER!" --target service <nul >nul 2>&1
+if errorlevel 1 (
+    echo FAIL: service MCP endpoint not reachable 1>&2
+    popd >nul & exit /b 1
+)
+
+python tests\mcp\_session_routing_helper.py "!ADAPTER!"
+set RC=%errorlevel%
+popd >nul
+exit /b %RC%

--- a/tests/mcp/test_session_routing.sh
+++ b/tests/mcp/test_session_routing.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Copyright 2026, DisplayXR / Leia Inc.
+# SPDX-License-Identifier: BSL-1.0
+#
+# Slice 8 (Phase B) — client_id-scoped snapshot routing.
+#
+# The service exposes `list_sessions` mapping {client_id → pid}. The
+# agent looks up the PID for a chosen client_id, then reconnects via
+# `displayxr-mcp --target pid:<N>` to reach the Phase A per-session
+# tools (get_kooima_params etc.).
+
+set -eu
+set -o pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+ADAPTER=""
+for cand in \
+    "$ROOT/_package/DisplayXR/bin/displayxr-mcp.exe" \
+    "$ROOT/_package/bin/displayxr-mcp.exe" \
+    "$ROOT/build/src/xrt/targets/mcp_adapter/displayxr-mcp" \
+    "$ROOT/build/src/xrt/targets/mcp_adapter/displayxr-mcp.exe"; do
+    [[ -x "$cand" ]] && ADAPTER="$cand" && break
+done
+[[ -n "$ADAPTER" ]] || { echo "FAIL: displayxr-mcp not found" >&2; exit 1; }
+
+"$ADAPTER" --target service </dev/null >/dev/null 2>&1 || {
+    echo "FAIL: service MCP endpoint not reachable" >&2; exit 1
+}
+
+python3 tests/mcp/_session_routing_helper.py "$ADAPTER"

--- a/tests/mcp/test_set_window_pose.bat
+++ b/tests/mcp/test_set_window_pose.bat
@@ -1,0 +1,32 @@
+@echo off
+REM Copyright 2026, DisplayXR / Leia Inc.
+REM SPDX-License-Identifier: BSL-1.0
+REM
+REM Slice 3 (Phase B) — get/set_window_pose round-trip.
+
+setlocal EnableDelayedExpansion
+set "ROOT=%~dp0..\.."
+pushd "%ROOT%" >nul
+
+set "ADAPTER="
+for %%P in (
+    "%ROOT%\_package\DisplayXR\bin\displayxr-mcp.exe"
+    "%ROOT%\_package\bin\displayxr-mcp.exe"
+    "%ROOT%\build\src\xrt\targets\mcp_adapter\displayxr-mcp.exe"
+) do if exist %%P set "ADAPTER=%%~P"
+
+if "!ADAPTER!"=="" (
+    echo FAIL: displayxr-mcp.exe not found 1>&2
+    popd >nul & exit /b 1
+)
+
+"!ADAPTER!" --target service <nul >nul 2>&1
+if errorlevel 1 (
+    echo FAIL: service MCP endpoint not reachable 1>&2
+    popd >nul & exit /b 1
+)
+
+python tests\mcp\_set_window_pose_helper.py "!ADAPTER!"
+set RC=%errorlevel%
+popd >nul
+exit /b %RC%

--- a/tests/mcp/test_set_window_pose.sh
+++ b/tests/mcp/test_set_window_pose.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Copyright 2026, DisplayXR / Leia Inc.
+# SPDX-License-Identifier: BSL-1.0
+#
+# Slice 3 (Phase B) — get/set_window_pose round-trip.
+#
+# Requires displayxr-service + at least one shell-mode handle app running.
+# Grabs the first window id, reads its pose, sets a new pose with a known
+# delta, reads it back, and asserts the delta landed within a small
+# tolerance. On success, restores the original pose.
+
+set -eu
+set -o pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+ADAPTER=""
+for cand in \
+    "$ROOT/_package/DisplayXR/bin/displayxr-mcp.exe" \
+    "$ROOT/_package/bin/displayxr-mcp.exe" \
+    "$ROOT/build/src/xrt/targets/mcp_adapter/displayxr-mcp" \
+    "$ROOT/build/src/xrt/targets/mcp_adapter/displayxr-mcp.exe"; do
+    [[ -x "$cand" ]] && ADAPTER="$cand" && break
+done
+[[ -n "$ADAPTER" ]] || { echo "FAIL: displayxr-mcp not found" >&2; exit 1; }
+
+echo "=== Slice 3 set_window_pose round-trip ==="
+echo "    adapter: $ADAPTER"
+
+"$ADAPTER" --target service </dev/null >/dev/null 2>&1 || {
+    echo "FAIL: service MCP endpoint not reachable" >&2; exit 1
+}
+
+python3 tests/mcp/_set_window_pose_helper.py "$ADAPTER"

--- a/tests/mcp/test_workspace_roundtrip.bat
+++ b/tests/mcp/test_workspace_roundtrip.bat
@@ -1,0 +1,30 @@
+@echo off
+REM Copyright 2026, DisplayXR / Leia Inc.
+REM SPDX-License-Identifier: BSL-1.0
+
+setlocal EnableDelayedExpansion
+set "ROOT=%~dp0..\.."
+pushd "%ROOT%" >nul
+
+set "ADAPTER="
+for %%P in (
+    "%ROOT%\_package\DisplayXR\bin\displayxr-mcp.exe"
+    "%ROOT%\_package\bin\displayxr-mcp.exe"
+    "%ROOT%\build\src\xrt\targets\mcp_adapter\displayxr-mcp.exe"
+) do if exist %%P set "ADAPTER=%%~P"
+
+if "!ADAPTER!"=="" (
+    echo FAIL: displayxr-mcp.exe not found 1>&2
+    popd >nul & exit /b 1
+)
+
+"!ADAPTER!" --target service <nul >nul 2>&1
+if errorlevel 1 (
+    echo FAIL: service MCP endpoint not reachable 1>&2
+    popd >nul & exit /b 1
+)
+
+python tests\mcp\_workspace_helper.py "!ADAPTER!"
+set RC=%errorlevel%
+popd >nul
+exit /b %RC%

--- a/tests/mcp/test_workspace_roundtrip.sh
+++ b/tests/mcp/test_workspace_roundtrip.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Copyright 2026, DisplayXR / Leia Inc.
+# SPDX-License-Identifier: BSL-1.0
+#
+# Slice 5 (Phase B) — save_workspace → perturb → load_workspace round-trip.
+
+set -eu
+set -o pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+ADAPTER=""
+for cand in \
+    "$ROOT/_package/DisplayXR/bin/displayxr-mcp.exe" \
+    "$ROOT/_package/bin/displayxr-mcp.exe" \
+    "$ROOT/build/src/xrt/targets/mcp_adapter/displayxr-mcp" \
+    "$ROOT/build/src/xrt/targets/mcp_adapter/displayxr-mcp.exe"; do
+    [[ -x "$cand" ]] && ADAPTER="$cand" && break
+done
+[[ -n "$ADAPTER" ]] || { echo "FAIL: displayxr-mcp not found" >&2; exit 1; }
+
+"$ADAPTER" --target service </dev/null >/dev/null 2>&1 || {
+    echo "FAIL: service MCP endpoint not reachable" >&2; exit 1
+}
+
+python3 tests/mcp/_workspace_helper.py "$ADAPTER"


### PR DESCRIPTION
## Summary

Extends the MCP server from Phase A (#150) to service/shell mode. Eight slices implementing shell-scope tools for AI agent control of the spatial desktop:

- **Slice 1:** Service-side MCP server (`u_mcp_server_maybe_start_named("service")`) + adapter `--target service`
- **Slice 2:** `list_windows` — enumerate active shell windows with pose, size, app name
- **Slice 3:** `get/set_window_pose` — read/write per-window spatial pose
- **Slice 4:** `set_focus` + `apply_layout_preset` — focus control and grid/immersive layouts
- **Slice 5:** `save/load_workspace` — persist and restore window arrangements
- **Slice 6:** Audit log + allowlist — safety model for write operations
- **Slice 7:** `capture_frame` service-mode — atlas PNG + windows.json via D3D11 staging readback
- **Slice 8:** `list_sessions` (service variant) + PID routing between service and per-app MCP endpoints

### Windows transport fixes (discovered during on-device validation)

Three bugs in the Windows named-pipe MCP transport, all in `u_mcp_transport.c`:
1. Missing `DisconnectNamedPipe` between clients (caused `ERROR_SEM_TIMEOUT` on reconnect)
2. Missing `CancelIoEx` on pipe close (left sibling pump thread parked in kernel)
3. Synchronous `CreateFileA` without `FILE_FLAG_OVERLAPPED` (caused `WriteFile` to block indefinitely)

### Capture integration

Slice 7's `capture_frame` delegates to main's `comp_d3d11_service_capture_frame` for the atlas PNG (cropped to active region per #158), then writes a `_windows.json` sidecar with per-slot bbox metadata. No L/R split — atlas only, matching the simplified capture design from main.

## Test plan

All 8 tests validated on Windows with Leia SR display + 2 cube apps:
- [x] `test_service_handshake` — adapter probe, negative path, initialize handshake
- [x] `test_list_windows` — 3 windows (shell + 2 cubes)
- [x] `test_set_window_pose` — set + get + restore roundtrip
- [x] `test_focus_preset` — set_focus, grid, immersive, bogus rejection
- [x] `test_workspace_roundtrip` — save, perturb, load, verify restore
- [x] `test_audit_log` — audit entries present after tool calls
- [x] `test_session_routing` — service list_sessions, per-PID Phase A reach
- [x] `capture_frame` — atlas.png (2.6 MB) + windows.json returned with correct sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)