### PR TITLE
Fix HWND-bound present so DWM doesn't bleed through (#163)

### DIFF
--- a/src/xrt/compositor/d3d11/comp_d3d11_target.cpp
+++ b/src/xrt/compositor/d3d11/comp_d3d11_target.cpp
@@ -122,6 +122,8 @@ comp_d3d11_target_create(struct comp_d3d11_compositor *c,
 	desc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
 	desc.BufferCount = 2;
 	desc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+	// IGNORE so DWM doesn't composite the desktop through the bound HWND (#163).
+	desc.AlphaMode = DXGI_ALPHA_MODE_IGNORE;
 	desc.Flags = 0;
 
 	DXGI_SWAP_CHAIN_FULLSCREEN_DESC fsDesc = {};

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -1975,6 +1975,8 @@ init_client_render_resources(struct d3d11_service_system *sys,
 	sc_desc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
 	sc_desc.BufferCount = 2;
 	sc_desc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+	// IGNORE so DWM doesn't composite the desktop through the bound HWND (#163).
+	sc_desc.AlphaMode = DXGI_ALPHA_MODE_IGNORE;
 
 	hr = sys->dxgi_factory->CreateSwapChainForHwnd(
 	    sys->device.get(),
@@ -4146,6 +4148,8 @@ multi_compositor_ensure_output(struct d3d11_service_system *sys)
 	sc_desc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
 	sc_desc.BufferCount = 2;
 	sc_desc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+	// IGNORE so DWM doesn't composite the desktop through the bound HWND (#163).
+	sc_desc.AlphaMode = DXGI_ALPHA_MODE_IGNORE;
 
 	HRESULT hr = sys->dxgi_factory->CreateSwapChainForHwnd(
 	    sys->device.get(), mc->hwnd, &sc_desc, nullptr, nullptr,

--- a/src/xrt/compositor/d3d12/comp_d3d12_target.cpp
+++ b/src/xrt/compositor/d3d12/comp_d3d12_target.cpp
@@ -320,6 +320,8 @@ comp_d3d12_target_create(struct comp_d3d12_compositor *c,
 	desc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
 	desc.BufferCount = BACK_BUFFER_COUNT;
 	desc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+	// IGNORE so DWM doesn't composite the desktop through the bound HWND (#163).
+	desc.AlphaMode = DXGI_ALPHA_MODE_IGNORE;
 	desc.Flags = 0;
 
 	DXGI_SWAP_CHAIN_FULLSCREEN_DESC fs_desc = {};


### PR DESCRIPTION
## Summary

Fixes #163. The DXGI swap chains the runtime creates on the app's (or shell's) HWND were leaving `AlphaMode` at the default `DXGI_ALPHA_MODE_UNSPECIFIED`, so DWM treated them as alpha-bearing and composited whatever was behind the window through the presented rect. For `XR_EXT_win32_window_binding` consumers — most visibly UE's editor-PIE 3D mirror — the editor / desktop bled through the runtime's atlas presentation.

Set `AlphaMode = DXGI_ALPHA_MODE_IGNORE` on every `CreateSwapChainForHwnd` site:

- `compositor/d3d11/comp_d3d11_target.cpp` — in-process D3D11 native compositor
- `compositor/d3d12/comp_d3d12_target.cpp` — in-process D3D12 native compositor
- `compositor/d3d11_service/comp_d3d11_service.cpp` ×2 — service-mode swap chains (per-client + multi-comp)

The runtime's internal layer compositing uses shader-side blending and is unaffected by swap-chain alpha mode, so this is purely a final-present fix. No public API or extension semantics change. Vulkan native goes through `VkSurfaceKHR` and is a separate alpha story (not touched).

## Why this was never noticed before

Stock test apps create normal opaque `WS_OVERLAPPEDWINDOW` HWNDs, so DWM had nothing visible to bleed through. The bug only surfaces when an app deliberately creates a transparent / layered HWND (UE's `editor-preview-xr-native` raw-Win32 mirror) or when another window is dragged behind a normal app window on the same monitor.

## Test plan

- [x] Local Windows build (`scripts\build_windows.bat build`) clean
- [x] `cube_handle_d3d11_win` — atlas presents stably, 3D weave correct, V toggle works, no regression
- [x] `cube_handle_d3d12_win` — same
- [ ] CI Windows + macOS build green
- [ ] UE `editor-preview-xr-native@b84bee4` PIE mirror — editor no longer bleeds through the weaved atlas (final acceptance from #163)

🤖 Generated with [Claude Code](https://claude.com/claude-code)