### PR TITLE
Shell: focus cycling, maximize button, ESC restore, immersive default layout

### DIFF
--- a/src/xrt/compositor/d3d11/comp_d3d11_window.cpp
+++ b/src/xrt/compositor/d3d11/comp_d3d11_window.cpp
@@ -163,6 +163,9 @@ struct comp_d3d11_window
 	//! PostMessage(WM_CLOSE) and take the service down with it.
 	volatile LONG shell_mode_active;
 
+	//! True while any shell window is maximized (fullscreen). Gates ESC suppression
+	//! so ESC only restores fullscreen and doesn't reach apps when not maximized.
+	volatile LONG any_window_maximized;
 
 	//! Focused window rect in shell-window client pixels (for mouse coord remapping).
 	//! When forwarding mouse events, shell coords are remapped to app-local coords.
@@ -262,7 +265,6 @@ is_shell_reserved_key(WPARAM vk)
 	// tries to change rendering mode via xrRequestDisplayRenderingModeEXT,
 	// that call is blocked in shell/IPC mode.
 	switch (vk) {
-	case VK_ESCAPE: // Restore fullscreen / shell dismiss
 	case VK_TAB:    // Cycle focus
 	case VK_DELETE: // Close focused app
 		return true;
@@ -545,7 +547,13 @@ wnd_proc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 			}
 #endif
 			if (is_shell_reserved_key(wParam)) {
-				// Shell-only keys (ESC, TAB, DELETE) → don't forward to app
+				// Shell-only keys (TAB, DELETE) → don't forward to app
+				return 0;
+			}
+			// ESC: only suppress when a window is maximized (fullscreen restore).
+			// When not maximized, let ESC through so the app can handle it.
+			if (wParam == VK_ESCAPE &&
+			    InterlockedCompareExchange(&w->any_window_maximized, 0, 0)) {
 				return 0;
 			}
 			// Ctrl+1-4: layout presets (handled server-side) → don't forward
@@ -1219,6 +1227,15 @@ comp_d3d11_window_set_shell_mode_active(struct comp_d3d11_window *window, bool a
 		return;
 	}
 	InterlockedExchange(&window->shell_mode_active, active ? 1 : 0);
+}
+
+void
+comp_d3d11_window_set_any_maximized(struct comp_d3d11_window *window, bool maximized)
+{
+	if (window == NULL) {
+		return;
+	}
+	InterlockedExchange(&window->any_window_maximized, maximized ? 1 : 0);
 }
 
 // Returns true if input forwarding should currently be suppressed, considering

--- a/src/xrt/compositor/d3d11/comp_d3d11_window.cpp
+++ b/src/xrt/compositor/d3d11/comp_d3d11_window.cpp
@@ -262,6 +262,7 @@ is_shell_reserved_key(WPARAM vk)
 	// tries to change rendering mode via xrRequestDisplayRenderingModeEXT,
 	// that call is blocked in shell/IPC mode.
 	switch (vk) {
+	case VK_ESCAPE: // Restore fullscreen / shell dismiss
 	case VK_TAB:    // Cycle focus
 	case VK_DELETE: // Close focused app
 		return true;

--- a/src/xrt/compositor/d3d11/comp_d3d11_window.h
+++ b/src/xrt/compositor/d3d11/comp_d3d11_window.h
@@ -219,6 +219,14 @@ void
 comp_d3d11_window_set_shell_mode_active(struct comp_d3d11_window *window, bool active);
 
 /*!
+ * Tell the window layer whether any client is currently maximized/fullscreen.
+ * When true, ESC is consumed by the shell for fullscreen restore and not
+ * forwarded to the focused app.
+ */
+void
+comp_d3d11_window_set_any_maximized(struct comp_d3d11_window *window, bool maximized);
+
+/*!
  * Suppress or resume input forwarding (for shell drag/resize operations).
  * When suppressed, the WndProc does not forward mouse or keyboard events to
  * the app.

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -800,12 +800,6 @@ struct d3d11_multi_compositor
 	char toast_text[256];
 	uint64_t toast_until_ns;
 
-	//! Empty-state "Apps" button bounds in display-space meters (for click detection).
-	//! Updated every render frame when the empty state is drawn.
-	float empty_apps_btn_cy_m;
-	float empty_apps_btn_half_w_m;
-	float empty_apps_btn_half_h_m;
-
 	//! Previous frame LMB/RMB state (for rising-edge detection).
 	bool prev_lmb_held;
 	bool prev_rmb_held;
@@ -6138,14 +6132,6 @@ after_key_shortcuts:
 					                   disp_h_tb / (float)sys->base.info.display_pixel_height;
 					float cursor_x_m = ((float)pt.x - (float)sys->base.info.display_pixel_width / 2.0f) *
 					                   disp_w_tb / (float)sys->base.info.display_pixel_width;
-					// Empty-state "Apps (Ctrl+L)" button
-					if (mc->client_count == 0 && !mc->launcher_visible &&
-					    fabsf(cursor_x_m) <= mc->empty_apps_btn_half_w_m &&
-					    fabsf(cursor_y_m - mc->empty_apps_btn_cy_m) <= mc->empty_apps_btn_half_h_m) {
-						launcher_set_visible(sys, mc, true);
-						U_LOG_W("Multi-comp: Apps button clicked → show launcher");
-					}
-
 					// Taskbar at bottom: y from -disp_h/2 to -disp_h/2 + taskbar_h
 					float tb_bottom_m = -disp_h_tb / 2.0f;
 					float tb_top_m = tb_bottom_m + UI_TASKBAR_H_M;
@@ -6710,7 +6696,7 @@ after_key_shortcuts:
 		sys->context->ClearRenderTargetView(mc->combined_atlas_rtv.get(), bg_color);
 	}
 
-	// Empty state: DisplayXR logo + "Apps (Ctrl+L)" button.
+	// Draw a hint when there are no visible clients and the launcher isn't open.
 	if (mc->client_count == 0 && !mc->launcher_visible && mc->font_atlas_srv) {
 		uint32_t ca_w = sys->base.info.display_pixel_width;
 		uint32_t ca_h = sys->base.info.display_pixel_height;
@@ -6719,44 +6705,20 @@ after_key_shortcuts:
 		uint32_t num_views = sys->tile_columns * sys->tile_rows;
 		uint32_t half_w, half_h;
 		resolve_active_view_dims(sys, ca_w, ca_h, &half_w, &half_h);
+		float scale = 3.0f;
+		float gh = (float)mc->font_glyph_h * scale;
+		const char *hint = "Press Ctrl+L to open launcher";
 
-		float disp_w_m = sys->base.info.display_width_m;
-		float disp_h_m = sys->base.info.display_height_m;
-		if (disp_w_m <= 0) disp_w_m = 0.700f;
-		if (disp_h_m <= 0) disp_h_m = 0.394f;
-
-		// Logo: "DisplayXR" large text
-		const float logo_scale = 5.0f;
-		const float logo_gh = (float)mc->font_glyph_h * logo_scale;
-		const char *logo_str = "DisplayXR";
-		float logo_w = 0;
-		for (const char *p = logo_str; *p; p++) {
-			unsigned char ch = (unsigned char)*p; if (ch < 0x20 || ch > 0x7E) ch = '?';
-			logo_w += mc->glyph_advances[ch - 0x20] * logo_scale;
-		}
-
-		// Button: "Apps (Ctrl+L)"
-		const float btn_scale = 2.0f;
-		const float btn_gh = (float)mc->font_glyph_h * btn_scale;
-		const char *btn_str = "Apps (Ctrl+L)";
-		float btn_text_w = 0;
-		for (const char *p = btn_str; *p; p++) {
-			unsigned char ch = (unsigned char)*p; if (ch < 0x20 || ch > 0x7E) ch = '?';
-			btn_text_w += mc->glyph_advances[ch - 0x20] * btn_scale;
-		}
-		const float btn_pad_x = btn_gh * 0.9f;
-		const float btn_pad_y = btn_gh * 0.35f;
-		const float btn_w = btn_text_w + 2.0f * btn_pad_x;
-		const float btn_h = btn_gh + 2.0f * btn_pad_y;
-		const float gap = logo_gh * 0.6f; // gap between logo and button
-
-		// Pipeline setup
 		sys->context->VSSetShader(sys->blit_vs.get(), nullptr, 0);
 		sys->context->PSSetShader(sys->blit_ps.get(), nullptr, 0);
 		sys->context->VSSetConstantBuffers(0, 1, sys->blit_constant_buffer.addressof());
 		sys->context->PSSetConstantBuffers(0, 1, sys->blit_constant_buffer.addressof());
+		ID3D11ShaderResourceView *font_srv = mc->font_atlas_srv.get();
+		sys->context->PSSetShaderResources(0, 1, &font_srv);
+		sys->context->PSSetSamplers(0, 1, sys->sampler_linear.addressof());
 		ID3D11RenderTargetView *rtvs[] = {mc->combined_atlas_rtv.get()};
 		sys->context->OMSetRenderTargets(1, rtvs, nullptr);
+		sys->context->OMSetBlendState(sys->blend_alpha.get(), nullptr, 0xFFFFFFFF);
 		sys->context->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
 		sys->context->IASetInputLayout(nullptr);
 		sys->context->RSSetState(sys->rasterizer_state.get());
@@ -6770,111 +6732,47 @@ after_key_shortcuts:
 			uint32_t row = v / sys->tile_columns;
 			float cx = (float)(col * half_w) + (float)half_w * 0.5f;
 			float cy = (float)(row * half_h) + (float)half_h * 0.5f;
-
-			float total_h = logo_gh + gap + btn_h;
-			float logo_y = cy - total_h * 0.5f;
-			float btn_y  = logo_y + logo_gh + gap;
-
-			// --- Logo text "DisplayXR" (white) ---
-			sys->context->OMSetBlendState(sys->blend_alpha.get(), nullptr, 0xFFFFFFFF);
-			ID3D11ShaderResourceView *font_srv = mc->font_atlas_srv.get();
-			sys->context->PSSetShaderResources(0, 1, &font_srv);
-			sys->context->PSSetSamplers(0, 1, sys->sampler_linear.addressof());
-			{
-				float tx = cx - logo_w * 0.5f;
-				float cursor = 0;
-				for (const char *p = logo_str; *p; p++) {
-					unsigned char ch = (unsigned char)*p; if (ch < 0x20 || ch > 0x7E) ch = '?';
-					int gi = ch - 0x20;
-					float src_x = 0; for (int i = 0; i < gi; i++) src_x += mc->glyph_advances[i];
-					float src_gw = mc->glyph_advances[gi];
-					float dst_gw = src_gw * logo_scale;
-					D3D11_MAPPED_SUBRESOURCE m;
-					if (SUCCEEDED(sys->context->Map(sys->blit_constant_buffer.get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &m))) {
-						BlitConstants *cb = static_cast<BlitConstants *>(m.pData);
-						cb->src_rect[0] = src_x; cb->src_rect[1] = 0;
-						cb->src_rect[2] = src_gw; cb->src_rect[3] = (float)mc->font_glyph_h;
-						cb->src_size[0] = (float)mc->font_atlas_w; cb->src_size[1] = (float)mc->font_atlas_h;
-						cb->dst_size[0] = (float)ca_w; cb->dst_size[1] = (float)ca_h;
-						cb->convert_srgb = 0.0f; cb->corner_radius = 0; cb->corner_aspect = 0;
-						cb->edge_feather = 0; cb->glow_intensity = 0; cb->quad_mode = 0;
-						cb->dst_offset[0] = tx + cursor; cb->dst_offset[1] = logo_y;
-						cb->dst_rect_wh[0] = dst_gw; cb->dst_rect_wh[1] = logo_gh;
-						memset(cb->quad_corners_01, 0, sizeof(cb->quad_corners_01));
-						memset(cb->quad_corners_23, 0, sizeof(cb->quad_corners_23));
-						sys->context->Unmap(sys->blit_constant_buffer.get(), 0);
-						sys->context->Draw(4, 0);
-					}
-					cursor += dst_gw;
+			// Measure text width
+			float tw = 0;
+			for (const char *p = hint; *p; p++) {
+				unsigned char ch = (unsigned char)*p;
+				if (ch < 0x20 || ch > 0x7E) ch = '?';
+				tw += mc->glyph_advances[ch - 0x20] * scale;
+			}
+			float tx = cx - tw * 0.5f;
+			float ty = cy - gh * 0.5f;
+			float cursor = 0;
+			for (const char *p = hint; *p; p++) {
+				unsigned char ch = (unsigned char)*p;
+				if (ch < 0x20 || ch > 0x7E) ch = '?';
+				int gi = ch - 0x20;
+				float src_gw = mc->glyph_advances[gi];
+				float src_x = 0;
+				for (int i = 0; i < gi; i++) src_x += mc->glyph_advances[i];
+				float dst_gw = src_gw * scale;
+				D3D11_MAPPED_SUBRESOURCE m;
+				if (SUCCEEDED(sys->context->Map(sys->blit_constant_buffer.get(), 0,
+				              D3D11_MAP_WRITE_DISCARD, 0, &m))) {
+					BlitConstants *cb = static_cast<BlitConstants *>(m.pData);
+					cb->src_rect[0] = src_x; cb->src_rect[1] = 0;
+					cb->src_rect[2] = src_gw; cb->src_rect[3] = (float)mc->font_glyph_h;
+					cb->src_size[0] = (float)mc->font_atlas_w;
+					cb->src_size[1] = (float)mc->font_atlas_h;
+					cb->dst_size[0] = (float)ca_w; cb->dst_size[1] = (float)ca_h;
+					cb->convert_srgb = 0.0f;
+					cb->corner_radius = 0; cb->corner_aspect = 0;
+					cb->edge_feather = 0; cb->glow_intensity = 0;
+					cb->quad_mode = 0;
+					cb->dst_offset[0] = tx + cursor; cb->dst_offset[1] = ty;
+					cb->dst_rect_wh[0] = dst_gw; cb->dst_rect_wh[1] = gh;
+					memset(cb->quad_corners_01, 0, sizeof(cb->quad_corners_01));
+					memset(cb->quad_corners_23, 0, sizeof(cb->quad_corners_23));
+					sys->context->Unmap(sys->blit_constant_buffer.get(), 0);
+					sys->context->Draw(4, 0);
 				}
-			}
-
-			// --- "Apps (Ctrl+L)" button background (pill) ---
-			float btn_x = cx - btn_w * 0.5f;
-			sys->context->OMSetBlendState(sys->blend_alpha.get(), nullptr, 0xFFFFFFFF);
-			{
-				ID3D11ShaderResourceView *null_srv = nullptr;
-				sys->context->PSSetShaderResources(0, 1, &null_srv);
-			}
-			D3D11_MAPPED_SUBRESOURCE m;
-			if (SUCCEEDED(sys->context->Map(sys->blit_constant_buffer.get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &m))) {
-				BlitConstants *cb = static_cast<BlitConstants *>(m.pData);
-				cb->src_rect[0] = 0.22f; cb->src_rect[1] = 0.22f;
-				cb->src_rect[2] = 0.28f; cb->src_rect[3] = 1.0f;
-				cb->src_size[0] = 1; cb->src_size[1] = 1;
-				cb->dst_size[0] = (float)ca_w; cb->dst_size[1] = (float)ca_h;
-				cb->convert_srgb = 2.0f; cb->quad_mode = 0;
-				cb->dst_offset[0] = btn_x; cb->dst_offset[1] = btn_y;
-				cb->dst_rect_wh[0] = btn_w; cb->dst_rect_wh[1] = btn_h;
-				cb->corner_radius = 0.5f; cb->corner_aspect = btn_w / btn_h;
-				cb->edge_feather = 0; cb->glow_intensity = 0;
-				memset(cb->quad_corners_01, 0, sizeof(cb->quad_corners_01));
-				memset(cb->quad_corners_23, 0, sizeof(cb->quad_corners_23));
-				sys->context->Unmap(sys->blit_constant_buffer.get(), 0);
-				sys->context->Draw(4, 0);
-			}
-
-			// --- Button text ---
-			sys->context->PSSetShaderResources(0, 1, &font_srv);
-			{
-				float tx = btn_x + btn_pad_x;
-				float ty = btn_y + btn_pad_y;
-				float cursor = 0;
-				for (const char *p = btn_str; *p; p++) {
-					unsigned char ch = (unsigned char)*p; if (ch < 0x20 || ch > 0x7E) ch = '?';
-					int gi = ch - 0x20;
-					float src_x = 0; for (int i = 0; i < gi; i++) src_x += mc->glyph_advances[i];
-					float src_gw = mc->glyph_advances[gi];
-					float dst_gw = src_gw * btn_scale;
-					if (SUCCEEDED(sys->context->Map(sys->blit_constant_buffer.get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &m))) {
-						BlitConstants *cb = static_cast<BlitConstants *>(m.pData);
-						cb->src_rect[0] = src_x; cb->src_rect[1] = 0;
-						cb->src_rect[2] = src_gw; cb->src_rect[3] = (float)mc->font_glyph_h;
-						cb->src_size[0] = (float)mc->font_atlas_w; cb->src_size[1] = (float)mc->font_atlas_h;
-						cb->dst_size[0] = (float)ca_w; cb->dst_size[1] = (float)ca_h;
-						cb->convert_srgb = 0.0f; cb->corner_radius = 0; cb->corner_aspect = 0;
-						cb->edge_feather = 0; cb->glow_intensity = 0; cb->quad_mode = 0;
-						cb->dst_offset[0] = tx + cursor; cb->dst_offset[1] = ty;
-						cb->dst_rect_wh[0] = dst_gw; cb->dst_rect_wh[1] = btn_gh;
-						memset(cb->quad_corners_01, 0, sizeof(cb->quad_corners_01));
-						memset(cb->quad_corners_23, 0, sizeof(cb->quad_corners_23));
-						sys->context->Unmap(sys->blit_constant_buffer.get(), 0);
-						sys->context->Draw(4, 0);
-					}
-					cursor += dst_gw;
-				}
-			}
-
-			// Store button bounds in display-space meters for click detection (first view only)
-			if (v == 0) {
-				float btn_center_px_y = btn_y + btn_h * 0.5f;
-				mc->empty_apps_btn_cy_m     = ((float)half_h * 0.5f - btn_center_px_y) * disp_h_m / (float)half_h;
-				mc->empty_apps_btn_half_w_m = btn_w * 0.5f * disp_w_m / (float)half_w;
-				mc->empty_apps_btn_half_h_m = btn_h * 0.5f * disp_h_m / (float)half_h;
+				cursor += dst_gw;
 			}
 		}
-		sys->context->OMSetBlendState(sys->blend_opaque.get(), nullptr, 0xFFFFFFFF);
-		sys->context->PSSetSamplers(0, 1, sys->sampler_linear.addressof());
 	}
 
 	// Copy client atlas → combined atlas, crop to content dims, send to DP.

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -5120,6 +5120,13 @@ toggle_fullscreen(struct d3d11_service_system *sys,
 
 	mc->focused_slot = slot;
 	multi_compositor_update_input_forward(mc);
+
+	// Update window layer's ESC-suppression flag
+	bool any_max = false;
+	for (int j = 0; j < D3D11_MULTI_MAX_CLIENTS; j++) {
+		if (mc->clients[j].active && mc->clients[j].maximized) { any_max = true; break; }
+	}
+	comp_d3d11_window_set_any_maximized(mc->window, any_max);
 }
 
 /*!
@@ -7362,30 +7369,67 @@ after_key_shortcuts:
 								sys->context->Draw(4, 0);
 							}
 						}
-						// ^ or v glyph on maximize button (^ = expand, v = restore)
+						// Hollow rounded-square icon on maximize button
 						{
-							int mg = (mc->clients[s].maximized ? 'v' : '^') - 0x20;
-							float src_gw = mc->glyph_advances[mg];
-							float dst_gw = src_gw * btn_scale;
-							float bx = tox + tow - 3.0f * (float)CLOSE_BTN_WIDTH_PX +
-							           ((float)CLOSE_BTN_WIDTH_PX - dst_gw) / 2.0f;
-							float xg_left = win_hw - 3*btn_w_m_val + (btn_w_m_val - glyph_w_m) / 2.0f;
-							float xg_top = win_hh + tb_h_m - glyph_vpad_m;
+							bool max_hover_ic = (mc->hover_btn == 3 && mc->hover_btn_slot == s);
+							float max_x_ic = tox + tow - 3.0f * (float)CLOSE_BTN_WIDTH_PX;
+							float pad_x = btn_w_m_val * 0.22f;
+							float pad_y = tb_h_m    * 0.22f;
+							float icon_l = win_hw - 3*btn_w_m_val + pad_x;
+							float icon_r = win_hw - 2*btn_w_m_val - pad_x;
+							float icon_t = win_hh + tb_h_m        - pad_y;
+							float icon_b = win_hh                 + pad_y;
+							float icon_w = icon_r - icon_l;
+							float icon_h = icon_t - icon_b;
+							float stroke_x = icon_w * 0.18f;
+							float stroke_y = icon_h * 0.18f;
+
+							float pad_x_px = (float)CLOSE_BTN_WIDTH_PX * 0.22f;
+							float pad_y_px = toh * 0.22f;
+							float ipx_l = max_x_ic + pad_x_px;
+							float ipx_t = toy   + pad_y_px;
+							float ipx_w = (float)CLOSE_BTN_WIDTH_PX - 2*pad_x_px;
+							float ipx_h = toh - 2*pad_y_px;
+							float st_px = ipx_w * 0.18f;
+							float st_py = ipx_h * 0.18f;
+
+							// Outer: white rounded rect
 							D3D11_MAPPED_SUBRESOURCE mapped;
 							if (SUCCEEDED(sys->context->Map(sys->blit_constant_buffer.get(), 0,
 							              D3D11_MAP_WRITE_DISCARD, 0, &mapped))) {
 								BlitConstants *cb = static_cast<BlitConstants *>(mapped.pData);
-								cb->src_rect[0] = atlas_x_for(mg); cb->src_rect[1] = 0;
-								cb->src_rect[2] = src_gw; cb->src_rect[3] = (float)mc->font_glyph_h;
-								cb->src_size[0] = (float)mc->font_atlas_w;
-								cb->src_size[1] = (float)mc->font_atlas_h;
+								cb->src_rect[0] = 0.90f; cb->src_rect[1] = 0.90f;
+								cb->src_rect[2] = 0.90f; cb->src_rect[3] = 1.0f;
+								cb->src_size[0] = 1; cb->src_size[1] = 1;
 								cb->dst_size[0] = (float)ca_w; cb->dst_size[1] = (float)ca_h;
-								cb->convert_srgb = 0.0f;
-								cb->corner_radius = 0; cb->corner_aspect = 0;
+								cb->convert_srgb = 2.0f;
+								cb->corner_radius = 0.28f;
+								cb->corner_aspect = icon_w / icon_h;
+								cb->edge_feather = 0.0f; cb->glow_intensity = 0.0f;
+								CHROME_BLIT_POS(cb, icon_l, icon_t, icon_r, icon_b,
+								    ipx_l, ipx_t, ipx_w, ipx_h);
+								sys->context->Unmap(sys->blit_constant_buffer.get(), 0);
+								sys->context->Draw(4, 0);
+							}
+							// Inner: button bg color — punches out the center to make it hollow
+							if (SUCCEEDED(sys->context->Map(sys->blit_constant_buffer.get(), 0,
+							              D3D11_MAP_WRITE_DISCARD, 0, &mapped))) {
+								BlitConstants *cb = static_cast<BlitConstants *>(mapped.pData);
+								cb->src_rect[0] = max_hover_ic ? 0.30f : 0.20f;
+								cb->src_rect[1] = max_hover_ic ? 0.50f : 0.35f;
+								cb->src_rect[2] = max_hover_ic ? 0.85f : 0.70f;
+								cb->src_rect[3] = 1.0f;
+								cb->src_size[0] = 1; cb->src_size[1] = 1;
+								cb->dst_size[0] = (float)ca_w; cb->dst_size[1] = (float)ca_h;
+								cb->convert_srgb = 2.0f;
+								cb->corner_radius = 0.20f;
+								float iw2 = icon_w - 2*stroke_x;
+								float ih2 = icon_h - 2*stroke_y;
+								cb->corner_aspect = (ih2 > 0) ? iw2/ih2 : 1.0f;
 								cb->edge_feather = 0.0f; cb->glow_intensity = 0.0f;
 								CHROME_BLIT_POS(cb,
-								    xg_left, xg_top, xg_left + glyph_w_m, xg_top - glyph_h_m,
-								    bx, toy + gpad, dst_gw, gh);
+								    icon_l+stroke_x, icon_t-stroke_y, icon_r-stroke_x, icon_b+stroke_y,
+								    ipx_l+st_px, ipx_t+st_py, ipx_w-2*st_px, ipx_h-2*st_py);
 								sys->context->Unmap(sys->blit_constant_buffer.get(), 0);
 								sys->context->Draw(4, 0);
 							}

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -792,9 +792,13 @@ struct d3d11_multi_compositor
 		float target_angle;      //!< Target angle to animate toward (for TAB snap-to-front)
 	} dynamic_layout;
 
-	//! Hovered button: 0=none, 1=close, 2=minimize, for the hovered slot.
+	//! Hovered button: 0=none, 1=close, 2=minimize, 3=maximize, for the hovered slot.
 	int hover_btn;
 	int hover_btn_slot;
+
+	//! Momentary toast notification (e.g. "how to restore after fullscreen").
+	char toast_text[256];
+	uint64_t toast_until_ns;
 
 	//! Previous frame LMB/RMB state (for rising-edge detection).
 	bool prev_lmb_held;
@@ -4529,8 +4533,9 @@ struct shell_hit_result
 {
 	int slot;            //!< Hit window slot (-1 = no hit)
 	bool in_title_bar;   //!< Hit is in the title bar region
-	bool in_close_btn;   //!< Hit is on the close button
+	bool in_close_btn;    //!< Hit is on the close button
 	bool in_minimize_btn; //!< Hit is on the minimize button
+	bool in_maximize_btn; //!< Hit is on the maximize/fullscreen button
 	bool in_content;     //!< Hit is in the content area
 	float local_x_m;    //!< Hit point in window-local meters (0 = left edge)
 	float local_y_m;    //!< Hit point in window-local meters (0 = top of title bar, positive down)
@@ -4908,6 +4913,8 @@ shell_raycast_hit_test(struct d3d11_service_system *sys,
 				result.in_close_btn = (local_x >= win_w - btn_w_m);
 				result.in_minimize_btn = !result.in_close_btn &&
 				                         (local_x >= win_w - 2.0f * btn_w_m);
+				result.in_maximize_btn = !result.in_close_btn && !result.in_minimize_btn &&
+				                         (local_x >= win_w - 3.0f * btn_w_m);
 			}
 
 			// Edge detection (resize zones)
@@ -5071,6 +5078,7 @@ toggle_fullscreen(struct d3d11_service_system *sys,
 		                mc->clients[slot].pre_max_height_m,
 		                now_ns, ANIM_DURATION_NS);
 		mc->clients[slot].maximized = false;
+		mc->toast_until_ns = 0; // dismiss restore hint
 		// Un-hide windows that were hidden by fullscreen
 		for (int j = 0; j < D3D11_MULTI_MAX_CLIENTS; j++) {
 			if (mc->clients[j].fullscreen_minimized) {
@@ -5096,6 +5104,10 @@ toggle_fullscreen(struct d3d11_service_system *sys,
 		                disp_h_m,
 		                now_ns, ANIM_DURATION_NS);
 		mc->clients[slot].maximized = true;
+		// Show restore hint toast for 3 seconds
+		snprintf(mc->toast_text, sizeof(mc->toast_text),
+		         "Click [^] button or double-click title bar to restore");
+		mc->toast_until_ns = os_monotonic_get_ns() + 3000000000ULL;
 		// Hide all other windows
 		for (int j = 0; j < D3D11_MULTI_MAX_CLIENTS; j++) {
 			if (j != slot && mc->clients[j].active && !mc->clients[j].minimized) {
@@ -5848,9 +5860,10 @@ after_key_shortcuts:
 			mc->hover_btn_slot = -1;
 			if (hover.in_close_btn) { mc->hover_btn = 1; mc->hover_btn_slot = hover.slot; }
 			else if (hover.in_minimize_btn) { mc->hover_btn = 2; mc->hover_btn_slot = hover.slot; }
+			else if (hover.in_maximize_btn) { mc->hover_btn = 3; mc->hover_btn_slot = hover.slot; }
 
 			// Buttons get arrow cursor (no resize/drag cursor on buttons)
-			if (hover.in_close_btn || hover.in_minimize_btn) {
+			if (hover.in_close_btn || hover.in_minimize_btn || hover.in_maximize_btn) {
 				cursor_id = 0; // arrow
 			} else {
 				int ef = hover.edge_flags;
@@ -5885,7 +5898,7 @@ after_key_shortcuts:
 				ScreenToClient(mc->hwnd, &pt);
 				struct shell_hit_result hit = shell_raycast_hit_test(sys, mc, pt);
 				// Close/minimize/background/taskbar → normal handler
-				if (hit.slot < 0 || hit.in_close_btn || hit.in_minimize_btn) {
+				if (hit.slot < 0 || hit.in_close_btn || hit.in_minimize_btn || hit.in_maximize_btn) {
 					goto normal_lmb_handling;
 				}
 				// Content click → pause rotation, focus window.
@@ -5995,7 +6008,7 @@ after_key_shortcuts:
 
 			// Edge/corner resize takes priority (unless clicking a title bar button)
 			if (hit.slot >= 0 && hit.edge_flags != RESIZE_NONE &&
-			    !hit.in_close_btn && !hit.in_minimize_btn) {
+			    !hit.in_close_btn && !hit.in_minimize_btn && !hit.in_maximize_btn) {
 				mc->resize.active = true;
 				mc->resize.slot = hit.slot;
 				mc->resize.edges = hit.edge_flags;
@@ -6019,6 +6032,7 @@ after_key_shortcuts:
 			bool in_title_bar = hit.in_title_bar;
 			bool in_close_btn = hit.in_close_btn;
 			bool in_minimize_btn = hit.in_minimize_btn;
+			bool in_maximize_btn = hit.in_maximize_btn;
 
 			// Debug: log click coordinates and hit results
 			if (hit_slot >= 0 && in_title_bar) {
@@ -6046,6 +6060,8 @@ after_key_shortcuts:
 						U_LOG_W("Multi-comp: close button → exit request for slot %d", hit_slot);
 					}
 				}
+			} else if (in_maximize_btn && hit_slot >= 0) {
+				toggle_fullscreen(sys, mc, hit_slot);
 			} else if (in_minimize_btn && hit_slot >= 0) {
 				// Minimize button: hide window
 				mc->clients[hit_slot].minimized = true;
@@ -7187,6 +7203,30 @@ after_key_shortcuts:
 							sys->context->Draw(4, 0);
 						}
 					}
+					// Maximize/fullscreen button (blue)
+					{
+						D3D11_MAPPED_SUBRESOURCE mapped;
+						if (SUCCEEDED(sys->context->Map(sys->blit_constant_buffer.get(), 0,
+						              D3D11_MAP_WRITE_DISCARD, 0, &mapped))) {
+							BlitConstants *cb = static_cast<BlitConstants *>(mapped.pData);
+							bool max_hover = (mc->hover_btn == 3 && mc->hover_btn_slot == s);
+							cb->src_rect[0] = max_hover ? 0.30f : 0.20f;
+							cb->src_rect[1] = max_hover ? 0.50f : 0.35f;
+							cb->src_rect[2] = max_hover ? 0.85f : 0.70f;
+							cb->src_rect[3] = 1.0f;
+							cb->src_size[0] = 1; cb->src_size[1] = 1;
+							cb->dst_size[0] = (float)ca_w; cb->dst_size[1] = (float)ca_h;
+							cb->convert_srgb = 2.0f;
+							cb->corner_radius = 0; cb->corner_aspect = 0;
+							cb->edge_feather = 0.0f; cb->glow_intensity = 0.0f;
+							float max_x = tox + tow - 3.0f * (float)CLOSE_BTN_WIDTH_PX;
+							CHROME_BLIT_POS(cb,
+							    win_hw - 3*btn_w_m_val, win_hh + tb_h_m, win_hw - 2*btn_w_m_val, win_hh,
+							    max_x, toy, (float)CLOSE_BTN_WIDTH_PX, toh);
+							sys->context->Unmap(sys->blit_constant_buffer.get(), 0);
+							sys->context->Draw(4, 0);
+						}
+					}
 					// Text + glyphs
 					if (mc->font_atlas_srv && mc->clients[s].app_name[0] != '\0') {
 						sys->context->OMSetBlendState(sys->blend_alpha.get(), nullptr, 0xFFFFFFFF);
@@ -7208,7 +7248,7 @@ after_key_shortcuts:
 
 						// Compute atlas x-offset for each glyph (cumulative advances)
 						float px_cursor = 0; // pixel cursor in dest
-						float avail_w = tow - (float)GLYPH_W - 2.0f * (float)CLOSE_BTN_WIDTH_PX;
+						float avail_w = tow - (float)GLYPH_W - 3.0f * (float)CLOSE_BTN_WIDTH_PX;
 						float scale = 1.0f; // 1:1 rendering from atlas
 						for (int ci = 0; ci < 30 && name[ci] != '\0'; ci++) {
 							unsigned char ch = (unsigned char)name[ci];
@@ -7308,6 +7348,34 @@ after_key_shortcuts:
 								CHROME_BLIT_POS(cb,
 								    mg_left, mg_top, mg_left + glyph_w_m, mg_top - glyph_h_m,
 								    mx, toy + gpad, dst_gw, gh);
+								sys->context->Unmap(sys->blit_constant_buffer.get(), 0);
+								sys->context->Draw(4, 0);
+							}
+						}
+						// ^ or v glyph on maximize button (^ = expand, v = restore)
+						{
+							int mg = (mc->clients[s].maximized ? 'v' : '^') - 0x20;
+							float src_gw = mc->glyph_advances[mg];
+							float dst_gw = src_gw * btn_scale;
+							float bx = tox + tow - 3.0f * (float)CLOSE_BTN_WIDTH_PX +
+							           ((float)CLOSE_BTN_WIDTH_PX - dst_gw) / 2.0f;
+							float xg_left = win_hw - 3*btn_w_m_val + (btn_w_m_val - glyph_w_m) / 2.0f;
+							float xg_top = win_hh + tb_h_m - glyph_vpad_m;
+							D3D11_MAPPED_SUBRESOURCE mapped;
+							if (SUCCEEDED(sys->context->Map(sys->blit_constant_buffer.get(), 0,
+							              D3D11_MAP_WRITE_DISCARD, 0, &mapped))) {
+								BlitConstants *cb = static_cast<BlitConstants *>(mapped.pData);
+								cb->src_rect[0] = atlas_x_for(mg); cb->src_rect[1] = 0;
+								cb->src_rect[2] = src_gw; cb->src_rect[3] = (float)mc->font_glyph_h;
+								cb->src_size[0] = (float)mc->font_atlas_w;
+								cb->src_size[1] = (float)mc->font_atlas_h;
+								cb->dst_size[0] = (float)ca_w; cb->dst_size[1] = (float)ca_h;
+								cb->convert_srgb = 0.0f;
+								cb->corner_radius = 0; cb->corner_aspect = 0;
+								cb->edge_feather = 0.0f; cb->glow_intensity = 0.0f;
+								CHROME_BLIT_POS(cb,
+								    xg_left, xg_top, xg_left + glyph_w_m, xg_top - glyph_h_m,
+								    bx, toy + gpad, dst_gw, gh);
 								sys->context->Unmap(sys->blit_constant_buffer.get(), 0);
 								sys->context->Draw(4, 0);
 							}
@@ -7493,6 +7561,120 @@ after_key_shortcuts:
 					sys->context->PSSetSamplers(0, 1, sys->sampler_linear.addressof());
 				}
 			}
+		}
+	}
+
+	// Toast notification overlay (momentary centered message).
+	if (mc->toast_until_ns > 0 && mc->font_atlas_srv && sys->blit_vs && sys->blit_ps) {
+		uint64_t now_ns = os_monotonic_get_ns();
+		if (now_ns < mc->toast_until_ns) {
+			uint32_t ca_w = sys->base.info.display_pixel_width;
+			uint32_t ca_h = sys->base.info.display_pixel_height;
+			if (ca_w == 0) ca_w = 3840;
+			if (ca_h == 0) ca_h = 2160;
+			uint32_t half_w, half_h;
+			resolve_active_view_dims(sys, ca_w, ca_h, &half_w, &half_h);
+			uint32_t num_views = sys->tile_columns * sys->tile_rows;
+
+			const float scale = 2.0f; // 2x glyph size for toast
+			float gh = (float)mc->font_glyph_h * scale;
+			float pad_px = 12.0f;
+			float toast_h = gh + pad_px * 2.0f;
+
+			// Measure total text width
+			const char *txt = mc->toast_text;
+			float total_w = 0;
+			for (int ci = 0; txt[ci] != '\0' && ci < 80; ci++) {
+				unsigned char ch = (unsigned char)txt[ci];
+				if (ch < 0x20 || ch > 0x7E) ch = '?';
+				total_w += mc->glyph_advances[ch - 0x20] * scale;
+			}
+			float toast_w = total_w + pad_px * 2.0f;
+
+			// Pipeline setup
+			sys->context->VSSetShader(sys->blit_vs.get(), nullptr, 0);
+			sys->context->PSSetShader(sys->blit_ps.get(), nullptr, 0);
+			sys->context->VSSetConstantBuffers(0, 1, sys->blit_constant_buffer.addressof());
+			sys->context->PSSetConstantBuffers(0, 1, sys->blit_constant_buffer.addressof());
+			ID3D11RenderTargetView *t_rtvs[] = {mc->combined_atlas_rtv.get()};
+			sys->context->OMSetRenderTargets(1, t_rtvs, nullptr);
+			sys->context->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
+			sys->context->IASetInputLayout(nullptr);
+			sys->context->RSSetState(sys->rasterizer_state.get());
+			sys->context->OMSetDepthStencilState(sys->depth_disabled.get(), 0);
+			D3D11_VIEWPORT t_vp = {};
+			t_vp.Width = (float)ca_w; t_vp.Height = (float)ca_h; t_vp.MaxDepth = 1.0f;
+			sys->context->RSSetViewports(1, &t_vp);
+
+			for (uint32_t v = 0; v < num_views && v < XRT_MAX_VIEWS; v++) {
+				uint32_t col = v % sys->tile_columns;
+				uint32_t row = v / sys->tile_columns;
+				float vx = (float)(col * half_w);
+				float vy = (float)(row * half_h);
+
+				float bg_x = vx + ((float)half_w - toast_w) * 0.5f;
+				float bg_y = vy + ((float)half_h - toast_h) * 0.5f;
+
+				// Semi-transparent dark background
+				sys->context->OMSetBlendState(sys->blend_alpha.get(), nullptr, 0xFFFFFFFF);
+				D3D11_MAPPED_SUBRESOURCE mapped;
+				if (SUCCEEDED(sys->context->Map(sys->blit_constant_buffer.get(), 0,
+				              D3D11_MAP_WRITE_DISCARD, 0, &mapped))) {
+					BlitConstants *cb = static_cast<BlitConstants *>(mapped.pData);
+					cb->src_rect[0] = 0.08f; cb->src_rect[1] = 0.08f;
+					cb->src_rect[2] = 0.10f; cb->src_rect[3] = 0.82f;
+					cb->src_size[0] = 1; cb->src_size[1] = 1;
+					cb->dst_size[0] = (float)ca_w; cb->dst_size[1] = (float)ca_h;
+					cb->convert_srgb = 2.0f;
+					cb->quad_mode = 0;
+					cb->dst_offset[0] = bg_x; cb->dst_offset[1] = bg_y;
+					cb->dst_rect_wh[0] = toast_w; cb->dst_rect_wh[1] = toast_h;
+					cb->corner_radius = 0.3f;
+					cb->corner_aspect = toast_w / toast_h;
+					cb->edge_feather = 0.0f; cb->glow_intensity = 0.0f;
+					sys->context->Unmap(sys->blit_constant_buffer.get(), 0);
+					sys->context->Draw(4, 0);
+				}
+
+				// Text glyphs
+				ID3D11ShaderResourceView *font_srv = mc->font_atlas_srv.get();
+				sys->context->PSSetShaderResources(0, 1, &font_srv);
+				sys->context->PSSetSamplers(0, 1, sys->sampler_linear.addressof());
+
+				float cursor_x = bg_x + pad_px;
+				float text_y = bg_y + pad_px;
+				for (int ci = 0; txt[ci] != '\0' && ci < 80; ci++) {
+					unsigned char ch = (unsigned char)txt[ci];
+					if (ch < 0x20 || ch > 0x7E) ch = '?';
+					int gi = ch - 0x20;
+					float src_x = 0;
+					for (int p = 0; p < gi; p++) src_x += mc->glyph_advances[p];
+					float src_gw = mc->glyph_advances[gi];
+					float dst_gw = src_gw * scale;
+					if (SUCCEEDED(sys->context->Map(sys->blit_constant_buffer.get(), 0,
+					              D3D11_MAP_WRITE_DISCARD, 0, &mapped))) {
+						BlitConstants *cb = static_cast<BlitConstants *>(mapped.pData);
+						cb->src_rect[0] = src_x; cb->src_rect[1] = 0;
+						cb->src_rect[2] = src_gw; cb->src_rect[3] = (float)mc->font_glyph_h;
+						cb->src_size[0] = (float)mc->font_atlas_w;
+						cb->src_size[1] = (float)mc->font_atlas_h;
+						cb->dst_size[0] = (float)ca_w; cb->dst_size[1] = (float)ca_h;
+						cb->convert_srgb = 0.0f;
+						cb->quad_mode = 0;
+						cb->dst_offset[0] = cursor_x; cb->dst_offset[1] = text_y;
+						cb->dst_rect_wh[0] = dst_gw; cb->dst_rect_wh[1] = gh;
+						cb->corner_radius = 0; cb->corner_aspect = 0;
+						cb->edge_feather = 0.0f; cb->glow_intensity = 0.0f;
+						sys->context->Unmap(sys->blit_constant_buffer.get(), 0);
+						sys->context->Draw(4, 0);
+					}
+					cursor_x += dst_gw;
+				}
+			}
+			sys->context->OMSetBlendState(sys->blend_opaque.get(), nullptr, 0xFFFFFFFF);
+			sys->context->PSSetSamplers(0, 1, sys->sampler_linear.addressof());
+		} else {
+			mc->toast_until_ns = 0; // expired — clear
 		}
 	}
 

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -800,6 +800,12 @@ struct d3d11_multi_compositor
 	char toast_text[256];
 	uint64_t toast_until_ns;
 
+	//! Empty-state "Apps" button bounds in display-space meters (for click detection).
+	//! Updated every render frame when the empty state is drawn.
+	float empty_apps_btn_cy_m;
+	float empty_apps_btn_half_w_m;
+	float empty_apps_btn_half_h_m;
+
 	//! Previous frame LMB/RMB state (for rising-edge detection).
 	bool prev_lmb_held;
 	bool prev_rmb_held;
@@ -6132,6 +6138,14 @@ after_key_shortcuts:
 					                   disp_h_tb / (float)sys->base.info.display_pixel_height;
 					float cursor_x_m = ((float)pt.x - (float)sys->base.info.display_pixel_width / 2.0f) *
 					                   disp_w_tb / (float)sys->base.info.display_pixel_width;
+					// Empty-state "Apps (Ctrl+L)" button
+					if (mc->client_count == 0 && !mc->launcher_visible &&
+					    fabsf(cursor_x_m) <= mc->empty_apps_btn_half_w_m &&
+					    fabsf(cursor_y_m - mc->empty_apps_btn_cy_m) <= mc->empty_apps_btn_half_h_m) {
+						launcher_set_visible(sys, mc, true);
+						U_LOG_W("Multi-comp: Apps button clicked → show launcher");
+					}
+
 					// Taskbar at bottom: y from -disp_h/2 to -disp_h/2 + taskbar_h
 					float tb_bottom_m = -disp_h_tb / 2.0f;
 					float tb_top_m = tb_bottom_m + UI_TASKBAR_H_M;
@@ -6696,7 +6710,7 @@ after_key_shortcuts:
 		sys->context->ClearRenderTargetView(mc->combined_atlas_rtv.get(), bg_color);
 	}
 
-	// Draw a hint when there are no visible clients and the launcher isn't open.
+	// Empty state: DisplayXR logo + "Apps (Ctrl+L)" button.
 	if (mc->client_count == 0 && !mc->launcher_visible && mc->font_atlas_srv) {
 		uint32_t ca_w = sys->base.info.display_pixel_width;
 		uint32_t ca_h = sys->base.info.display_pixel_height;
@@ -6705,20 +6719,44 @@ after_key_shortcuts:
 		uint32_t num_views = sys->tile_columns * sys->tile_rows;
 		uint32_t half_w, half_h;
 		resolve_active_view_dims(sys, ca_w, ca_h, &half_w, &half_h);
-		float scale = 3.0f;
-		float gh = (float)mc->font_glyph_h * scale;
-		const char *hint = "Press Ctrl+L to open launcher";
 
+		float disp_w_m = sys->base.info.display_width_m;
+		float disp_h_m = sys->base.info.display_height_m;
+		if (disp_w_m <= 0) disp_w_m = 0.700f;
+		if (disp_h_m <= 0) disp_h_m = 0.394f;
+
+		// Logo: "DisplayXR" large text
+		const float logo_scale = 5.0f;
+		const float logo_gh = (float)mc->font_glyph_h * logo_scale;
+		const char *logo_str = "DisplayXR";
+		float logo_w = 0;
+		for (const char *p = logo_str; *p; p++) {
+			unsigned char ch = (unsigned char)*p; if (ch < 0x20 || ch > 0x7E) ch = '?';
+			logo_w += mc->glyph_advances[ch - 0x20] * logo_scale;
+		}
+
+		// Button: "Apps (Ctrl+L)"
+		const float btn_scale = 2.0f;
+		const float btn_gh = (float)mc->font_glyph_h * btn_scale;
+		const char *btn_str = "Apps (Ctrl+L)";
+		float btn_text_w = 0;
+		for (const char *p = btn_str; *p; p++) {
+			unsigned char ch = (unsigned char)*p; if (ch < 0x20 || ch > 0x7E) ch = '?';
+			btn_text_w += mc->glyph_advances[ch - 0x20] * btn_scale;
+		}
+		const float btn_pad_x = btn_gh * 0.9f;
+		const float btn_pad_y = btn_gh * 0.35f;
+		const float btn_w = btn_text_w + 2.0f * btn_pad_x;
+		const float btn_h = btn_gh + 2.0f * btn_pad_y;
+		const float gap = logo_gh * 0.6f; // gap between logo and button
+
+		// Pipeline setup
 		sys->context->VSSetShader(sys->blit_vs.get(), nullptr, 0);
 		sys->context->PSSetShader(sys->blit_ps.get(), nullptr, 0);
 		sys->context->VSSetConstantBuffers(0, 1, sys->blit_constant_buffer.addressof());
 		sys->context->PSSetConstantBuffers(0, 1, sys->blit_constant_buffer.addressof());
-		ID3D11ShaderResourceView *font_srv = mc->font_atlas_srv.get();
-		sys->context->PSSetShaderResources(0, 1, &font_srv);
-		sys->context->PSSetSamplers(0, 1, sys->sampler_linear.addressof());
 		ID3D11RenderTargetView *rtvs[] = {mc->combined_atlas_rtv.get()};
 		sys->context->OMSetRenderTargets(1, rtvs, nullptr);
-		sys->context->OMSetBlendState(sys->blend_alpha.get(), nullptr, 0xFFFFFFFF);
 		sys->context->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
 		sys->context->IASetInputLayout(nullptr);
 		sys->context->RSSetState(sys->rasterizer_state.get());
@@ -6732,47 +6770,111 @@ after_key_shortcuts:
 			uint32_t row = v / sys->tile_columns;
 			float cx = (float)(col * half_w) + (float)half_w * 0.5f;
 			float cy = (float)(row * half_h) + (float)half_h * 0.5f;
-			// Measure text width
-			float tw = 0;
-			for (const char *p = hint; *p; p++) {
-				unsigned char ch = (unsigned char)*p;
-				if (ch < 0x20 || ch > 0x7E) ch = '?';
-				tw += mc->glyph_advances[ch - 0x20] * scale;
-			}
-			float tx = cx - tw * 0.5f;
-			float ty = cy - gh * 0.5f;
-			float cursor = 0;
-			for (const char *p = hint; *p; p++) {
-				unsigned char ch = (unsigned char)*p;
-				if (ch < 0x20 || ch > 0x7E) ch = '?';
-				int gi = ch - 0x20;
-				float src_gw = mc->glyph_advances[gi];
-				float src_x = 0;
-				for (int i = 0; i < gi; i++) src_x += mc->glyph_advances[i];
-				float dst_gw = src_gw * scale;
-				D3D11_MAPPED_SUBRESOURCE m;
-				if (SUCCEEDED(sys->context->Map(sys->blit_constant_buffer.get(), 0,
-				              D3D11_MAP_WRITE_DISCARD, 0, &m))) {
-					BlitConstants *cb = static_cast<BlitConstants *>(m.pData);
-					cb->src_rect[0] = src_x; cb->src_rect[1] = 0;
-					cb->src_rect[2] = src_gw; cb->src_rect[3] = (float)mc->font_glyph_h;
-					cb->src_size[0] = (float)mc->font_atlas_w;
-					cb->src_size[1] = (float)mc->font_atlas_h;
-					cb->dst_size[0] = (float)ca_w; cb->dst_size[1] = (float)ca_h;
-					cb->convert_srgb = 0.0f;
-					cb->corner_radius = 0; cb->corner_aspect = 0;
-					cb->edge_feather = 0; cb->glow_intensity = 0;
-					cb->quad_mode = 0;
-					cb->dst_offset[0] = tx + cursor; cb->dst_offset[1] = ty;
-					cb->dst_rect_wh[0] = dst_gw; cb->dst_rect_wh[1] = gh;
-					memset(cb->quad_corners_01, 0, sizeof(cb->quad_corners_01));
-					memset(cb->quad_corners_23, 0, sizeof(cb->quad_corners_23));
-					sys->context->Unmap(sys->blit_constant_buffer.get(), 0);
-					sys->context->Draw(4, 0);
+
+			float total_h = logo_gh + gap + btn_h;
+			float logo_y = cy - total_h * 0.5f;
+			float btn_y  = logo_y + logo_gh + gap;
+
+			// --- Logo text "DisplayXR" (white) ---
+			sys->context->OMSetBlendState(sys->blend_alpha.get(), nullptr, 0xFFFFFFFF);
+			ID3D11ShaderResourceView *font_srv = mc->font_atlas_srv.get();
+			sys->context->PSSetShaderResources(0, 1, &font_srv);
+			sys->context->PSSetSamplers(0, 1, sys->sampler_linear.addressof());
+			{
+				float tx = cx - logo_w * 0.5f;
+				float cursor = 0;
+				for (const char *p = logo_str; *p; p++) {
+					unsigned char ch = (unsigned char)*p; if (ch < 0x20 || ch > 0x7E) ch = '?';
+					int gi = ch - 0x20;
+					float src_x = 0; for (int i = 0; i < gi; i++) src_x += mc->glyph_advances[i];
+					float src_gw = mc->glyph_advances[gi];
+					float dst_gw = src_gw * logo_scale;
+					D3D11_MAPPED_SUBRESOURCE m;
+					if (SUCCEEDED(sys->context->Map(sys->blit_constant_buffer.get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &m))) {
+						BlitConstants *cb = static_cast<BlitConstants *>(m.pData);
+						cb->src_rect[0] = src_x; cb->src_rect[1] = 0;
+						cb->src_rect[2] = src_gw; cb->src_rect[3] = (float)mc->font_glyph_h;
+						cb->src_size[0] = (float)mc->font_atlas_w; cb->src_size[1] = (float)mc->font_atlas_h;
+						cb->dst_size[0] = (float)ca_w; cb->dst_size[1] = (float)ca_h;
+						cb->convert_srgb = 0.0f; cb->corner_radius = 0; cb->corner_aspect = 0;
+						cb->edge_feather = 0; cb->glow_intensity = 0; cb->quad_mode = 0;
+						cb->dst_offset[0] = tx + cursor; cb->dst_offset[1] = logo_y;
+						cb->dst_rect_wh[0] = dst_gw; cb->dst_rect_wh[1] = logo_gh;
+						memset(cb->quad_corners_01, 0, sizeof(cb->quad_corners_01));
+						memset(cb->quad_corners_23, 0, sizeof(cb->quad_corners_23));
+						sys->context->Unmap(sys->blit_constant_buffer.get(), 0);
+						sys->context->Draw(4, 0);
+					}
+					cursor += dst_gw;
 				}
-				cursor += dst_gw;
+			}
+
+			// --- "Apps (Ctrl+L)" button background (pill) ---
+			float btn_x = cx - btn_w * 0.5f;
+			sys->context->OMSetBlendState(sys->blend_alpha.get(), nullptr, 0xFFFFFFFF);
+			{
+				ID3D11ShaderResourceView *null_srv = nullptr;
+				sys->context->PSSetShaderResources(0, 1, &null_srv);
+			}
+			D3D11_MAPPED_SUBRESOURCE m;
+			if (SUCCEEDED(sys->context->Map(sys->blit_constant_buffer.get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &m))) {
+				BlitConstants *cb = static_cast<BlitConstants *>(m.pData);
+				cb->src_rect[0] = 0.22f; cb->src_rect[1] = 0.22f;
+				cb->src_rect[2] = 0.28f; cb->src_rect[3] = 1.0f;
+				cb->src_size[0] = 1; cb->src_size[1] = 1;
+				cb->dst_size[0] = (float)ca_w; cb->dst_size[1] = (float)ca_h;
+				cb->convert_srgb = 2.0f; cb->quad_mode = 0;
+				cb->dst_offset[0] = btn_x; cb->dst_offset[1] = btn_y;
+				cb->dst_rect_wh[0] = btn_w; cb->dst_rect_wh[1] = btn_h;
+				cb->corner_radius = 0.5f; cb->corner_aspect = btn_w / btn_h;
+				cb->edge_feather = 0; cb->glow_intensity = 0;
+				memset(cb->quad_corners_01, 0, sizeof(cb->quad_corners_01));
+				memset(cb->quad_corners_23, 0, sizeof(cb->quad_corners_23));
+				sys->context->Unmap(sys->blit_constant_buffer.get(), 0);
+				sys->context->Draw(4, 0);
+			}
+
+			// --- Button text ---
+			sys->context->PSSetShaderResources(0, 1, &font_srv);
+			{
+				float tx = btn_x + btn_pad_x;
+				float ty = btn_y + btn_pad_y;
+				float cursor = 0;
+				for (const char *p = btn_str; *p; p++) {
+					unsigned char ch = (unsigned char)*p; if (ch < 0x20 || ch > 0x7E) ch = '?';
+					int gi = ch - 0x20;
+					float src_x = 0; for (int i = 0; i < gi; i++) src_x += mc->glyph_advances[i];
+					float src_gw = mc->glyph_advances[gi];
+					float dst_gw = src_gw * btn_scale;
+					if (SUCCEEDED(sys->context->Map(sys->blit_constant_buffer.get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &m))) {
+						BlitConstants *cb = static_cast<BlitConstants *>(m.pData);
+						cb->src_rect[0] = src_x; cb->src_rect[1] = 0;
+						cb->src_rect[2] = src_gw; cb->src_rect[3] = (float)mc->font_glyph_h;
+						cb->src_size[0] = (float)mc->font_atlas_w; cb->src_size[1] = (float)mc->font_atlas_h;
+						cb->dst_size[0] = (float)ca_w; cb->dst_size[1] = (float)ca_h;
+						cb->convert_srgb = 0.0f; cb->corner_radius = 0; cb->corner_aspect = 0;
+						cb->edge_feather = 0; cb->glow_intensity = 0; cb->quad_mode = 0;
+						cb->dst_offset[0] = tx + cursor; cb->dst_offset[1] = ty;
+						cb->dst_rect_wh[0] = dst_gw; cb->dst_rect_wh[1] = btn_gh;
+						memset(cb->quad_corners_01, 0, sizeof(cb->quad_corners_01));
+						memset(cb->quad_corners_23, 0, sizeof(cb->quad_corners_23));
+						sys->context->Unmap(sys->blit_constant_buffer.get(), 0);
+						sys->context->Draw(4, 0);
+					}
+					cursor += dst_gw;
+				}
+			}
+
+			// Store button bounds in display-space meters for click detection (first view only)
+			if (v == 0) {
+				float btn_center_px_y = btn_y + btn_h * 0.5f;
+				mc->empty_apps_btn_cy_m     = ((float)half_h * 0.5f - btn_center_px_y) * disp_h_m / (float)half_h;
+				mc->empty_apps_btn_half_w_m = btn_w * 0.5f * disp_w_m / (float)half_w;
+				mc->empty_apps_btn_half_h_m = btn_h * 0.5f * disp_h_m / (float)half_h;
 			}
 		}
+		sys->context->OMSetBlendState(sys->blend_opaque.get(), nullptr, 0xFFFFFFFF);
+		sys->context->PSSetSamplers(0, 1, sys->sampler_linear.addressof());
 	}
 
 	// Copy client atlas → combined atlas, crop to content dims, send to DP.

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -5106,7 +5106,7 @@ toggle_fullscreen(struct d3d11_service_system *sys,
 		mc->clients[slot].maximized = true;
 		// Show restore hint toast for 3 seconds
 		snprintf(mc->toast_text, sizeof(mc->toast_text),
-		         "Click [^] button or double-click title bar to restore");
+		         "Press F11 to restore");
 		mc->toast_until_ns = os_monotonic_get_ns() + 3000000000ULL;
 		// Hide all other windows
 		for (int j = 0; j < D3D11_MULTI_MAX_CLIENTS; j++) {

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -3745,6 +3745,12 @@ multi_compositor_unregister_client(struct d3d11_service_system *sys, struct d3d1
 			mc->client_count--;
 			if (mc->focused_slot == i) {
 				mc->focused_slot = -1;
+				for (int j = 0; j < D3D11_MULTI_MAX_CLIENTS; j++) {
+					if (mc->clients[j].active && !mc->clients[j].minimized) {
+						mc->focused_slot = j;
+						break;
+					}
+				}
 				multi_compositor_update_input_forward(mc);
 			}
 			// Cancel any active drag on this slot
@@ -4047,6 +4053,12 @@ multi_compositor_remove_capture_client(struct d3d11_service_system *sys, int slo
 
 	if (mc->focused_slot == slot_index) {
 		mc->focused_slot = -1;
+		for (int j = 0; j < D3D11_MULTI_MAX_CLIENTS; j++) {
+			if (mc->clients[j].active && !mc->clients[j].minimized) {
+				mc->focused_slot = j;
+				break;
+			}
+		}
 		multi_compositor_update_input_forward(mc);
 	}
 	if (mc->drag.active && mc->drag.slot == slot_index) {
@@ -5710,32 +5722,24 @@ multi_compositor_render(struct d3d11_service_system *sys)
 		goto after_key_shortcuts;
 	}
 
-	// TAB: cycle focus — includes unfocused state (-1)
-	// Cycle: slot 0 → slot 1 → ... → -1 (unfocused) → slot 0
+	// TAB / Shift+TAB: cycle focus forward/backward. Never unfocuses when windows exist.
 	// Ignore ALT+TAB (system task switcher) — only process bare TAB.
 	if ((GetAsyncKeyState(VK_TAB) & 1) && !(GetAsyncKeyState(VK_MENU) & 0x8000)) {
 		if (mc->client_count > 0) {
-			// Start from current and advance
-			int next = mc->focused_slot + 1;
-			bool found = false;
-			// Search active slots starting from next
-			for (int i = 0; i < D3D11_MULTI_MAX_CLIENTS; i++) {
-				int idx = (next + i) % D3D11_MULTI_MAX_CLIENTS;
-				if (idx <= mc->focused_slot && mc->focused_slot >= 0) {
-					// Wrapped around — go to unfocused
-					break;
-				}
+			bool reverse = (GetAsyncKeyState(VK_SHIFT) & 0x8000) != 0;
+			int n = D3D11_MULTI_MAX_CLIENTS;
+			// base: for -1, forward searches from slot 0, reverse from last slot
+			int base = (mc->focused_slot >= 0) ? mc->focused_slot : (reverse ? n : -1);
+			for (int i = 1; i <= n; i++) {
+				int idx = reverse
+				        ? ((base - i) % n + n) % n
+				        : (base + i) % n;
 				if (mc->clients[idx].active && !mc->clients[idx].minimized) {
 					mc->focused_slot = idx;
-					found = true;
 					break;
 				}
 			}
-			if (!found) {
-				mc->focused_slot = -1; // unfocused
-			}
-			U_LOG_W("Multi-comp: TAB → focused slot %d%s", mc->focused_slot,
-			        mc->focused_slot < 0 ? " (unfocused)" : "");
+			U_LOG_W("Multi-comp: %sTAB → focused slot %d", reverse ? "Shift+" : "", mc->focused_slot);
 			multi_compositor_update_input_forward(mc);
 
 

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -5106,7 +5106,7 @@ toggle_fullscreen(struct d3d11_service_system *sys,
 		mc->clients[slot].maximized = true;
 		// Show restore hint toast for 3 seconds
 		snprintf(mc->toast_text, sizeof(mc->toast_text),
-		         "Press F11 to restore");
+		         "Press F11 or Esc to restore");
 		mc->toast_until_ns = os_monotonic_get_ns() + 3000000000ULL;
 		// Hide all other windows
 		for (int j = 0; j < D3D11_MULTI_MAX_CLIENTS; j++) {
@@ -5809,6 +5809,16 @@ multi_compositor_render(struct d3d11_service_system *sys)
 	if (GetAsyncKeyState(VK_F11) & 1) {
 		if (mc->focused_slot >= 0) {
 			toggle_fullscreen(sys, mc, mc->focused_slot);
+		}
+	}
+
+	// ESC: restore maximized window (if any) before doing anything else
+	if (GetAsyncKeyState(VK_ESCAPE) & 1) {
+		for (int i = 0; i < D3D11_MULTI_MAX_CLIENTS; i++) {
+			if (mc->clients[i].active && mc->clients[i].maximized) {
+				toggle_fullscreen(sys, mc, i);
+				break;
+			}
 		}
 	}
 

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -767,7 +767,7 @@ struct d3d11_multi_compositor
 	} title_rmb_drag;
 
 	//! Current layout preset (-1=none, 0-4=preset index). Used for TAB Z-reorder in Stack.
-	int32_t current_layout;
+	int32_t current_layout = 1; // default: immersive (Ctrl+2)
 
 	//! Dynamic layout state (carousel, orbital, helix, expose).
 	//! When mode >= 0, the layout continuously drives window poses each frame.
@@ -6559,7 +6559,7 @@ after_key_shortcuts:
 	if (mc->regrid_pending_ns > 0 && os_monotonic_get_ns() >= mc->regrid_pending_ns &&
 	    mc->dynamic_layout.mode < 0) {
 		mc->regrid_pending_ns = 0;
-		apply_layout(sys, mc, mc->current_layout >= 0 ? mc->current_layout : 0);
+		apply_layout(sys, mc, mc->current_layout >= 0 ? mc->current_layout : 1);
 		U_LOG_W("Multi-comp: debounced re-grid applied (%u clients)", mc->client_count);
 	}
 


### PR DESCRIPTION
## Summary

### Focus cycling improvements
- **Auto-focus on close**: when a window is closed or removed, focus automatically moves to the next available window instead of leaving nothing focused
- **Shift+Tab reverse cycling**: `Shift+Tab` now cycles focus backwards through windows
- **No unfocus on wrap**: TAB never drops focus to "nothing" — it wraps continuously so there is always a focused window as long as one exists

### Maximize button
- Added a **hollow rounded-square maximize button** (3rd button in the title bar, left of close/minimize) that toggles fullscreen for a window
- On maximize: a momentary toast appears saying **"Press F11 or Esc to restore"**
- `F11` toggles fullscreen (existing)
- `ESC` now restores a maximized window — but only suppresses ESC from reaching the app when a window is maximized; non-maximized windows receive ESC normally so apps that use it to quit still work

### Default layout
- Shell now defaults to **immersive layout (Ctrl+2)** on first window connection instead of grid (Ctrl+1)
- Subsequent window additions re-apply the last layout the user chose

## Files changed
- `comp_d3d11_service.cpp` — focus cycling, maximize button rendering + hit-test, ESC restore logic, toast, default layout
- `comp_d3d11_window.cpp` / `.h` — `any_window_maximized` flag + setter; ESC conditional suppression in input forwarding path

🤖 Generated with [Claude Code](https://claude.com/claude-code)