### PR TITLE
Shell: draw embedded DisplayXR logo on empty-state screen

### DIFF
--- a/src/xrt/compositor/d3d11_service/CMakeLists.txt
+++ b/src/xrt/compositor/d3d11_service/CMakeLists.txt
@@ -9,6 +9,22 @@
 # DXGI shared handles and uses KeyedMutex for synchronization.
 #
 
+# Embed doc/displayxr_white.png as a byte array so the compositor can draw the
+# logo on the empty-state screen without shipping the PNG alongside the binary.
+set(DISPLAYXR_LOGO_SRC "${CMAKE_SOURCE_DIR}/doc/displayxr_white.png")
+set(DISPLAYXR_LOGO_GENERATED "${CMAKE_CURRENT_BINARY_DIR}/displayxr_logo_data.c")
+add_custom_command(
+	OUTPUT "${DISPLAYXR_LOGO_GENERATED}"
+	COMMAND ${CMAKE_COMMAND}
+		-DINPUT_FILE=${DISPLAYXR_LOGO_SRC}
+		-DOUTPUT_FILE=${DISPLAYXR_LOGO_GENERATED}
+		-DSYMBOL=displayxr_white_png
+		-P "${CMAKE_CURRENT_SOURCE_DIR}/embed_binary.cmake"
+	DEPENDS "${DISPLAYXR_LOGO_SRC}" "${CMAKE_CURRENT_SOURCE_DIR}/embed_binary.cmake"
+	VERBATIM
+	COMMENT "Embedding ${DISPLAYXR_LOGO_SRC}"
+)
+
 add_library(
 	comp_d3d11_service STATIC
 	comp_d3d11_service.cpp
@@ -18,6 +34,8 @@ add_library(
 	d3d11_capture.h
 	d3d11_icon_loader.cpp
 	d3d11_icon_loader.h
+	displayxr_logo_data.h
+	"${DISPLAYXR_LOGO_GENERATED}"
 	# Include layer accumulator directly (it has no Vulkan dependencies)
 	../util/comp_layer_accum.c
 	../util/comp_layer_accum.h

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -12,6 +12,7 @@
 #include "d3d11_bitmap_font.h"
 #include "d3d11_capture.h"
 #include "d3d11_icon_loader.h"
+#include "displayxr_logo_data.h"
 
 #include "shared/ipc_protocol.h" // struct ipc_launcher_app_list
 
@@ -816,6 +817,14 @@ struct d3d11_multi_compositor
 	uint32_t font_glyph_h;     //!< Glyph cell height in atlas pixels
 	uint32_t font_atlas_w;     //!< Total atlas width in pixels
 	uint32_t font_atlas_h;     //!< Total atlas height in pixels
+
+	//! Embedded DisplayXR logo PNG decoded to an SRV on first use. Rendered in
+	//! the empty state (no clients, no launcher). Source bytes come from
+	//! displayxr_white_png[] which is generated from doc/displayxr_white.png.
+	wil::com_ptr<ID3D11ShaderResourceView> logo_srv;
+	uint32_t logo_w;
+	uint32_t logo_h;
+	bool logo_load_tried;
 
 	//! @name Capture client render timer
 	//! @{
@@ -4125,6 +4134,7 @@ multi_compositor_destroy(struct d3d11_multi_compositor *mc)
 	mc->combined_atlas.reset();
 	mc->font_atlas_srv.reset();
 	mc->font_atlas.reset();
+	mc->logo_srv.reset();
 	mc->swap_chain.reset();
 
 	if (mc->window != nullptr) {
@@ -6696,8 +6706,23 @@ after_key_shortcuts:
 		sys->context->ClearRenderTargetView(mc->combined_atlas_rtv.get(), bg_color);
 	}
 
-	// Draw a hint when there are no visible clients and the launcher isn't open.
+	// Empty state: DisplayXR logo + "Press Ctrl+L" hint when no clients are visible
+	// and the launcher isn't open.
 	if (mc->client_count == 0 && !mc->launcher_visible && mc->font_atlas_srv) {
+		// Lazy-load the embedded logo PNG on first entry.
+		if (!mc->logo_load_tried) {
+			mc->logo_load_tried = true;
+			ID3D11ShaderResourceView *srv = nullptr;
+			uint32_t lw = 0, lh = 0;
+			if (d3d11_icon_load_from_memory(sys->device.get(), displayxr_white_png,
+			                                 displayxr_white_png_size,
+			                                 "doc/displayxr_white.png", &srv, &lw, &lh)) {
+				mc->logo_srv.attach(srv);
+				mc->logo_w = lw;
+				mc->logo_h = lh;
+			}
+		}
+
 		uint32_t ca_w = sys->base.info.display_pixel_width;
 		uint32_t ca_h = sys->base.info.display_pixel_height;
 		if (ca_w == 0) ca_w = 3840;
@@ -6705,16 +6730,22 @@ after_key_shortcuts:
 		uint32_t num_views = sys->tile_columns * sys->tile_rows;
 		uint32_t half_w, half_h;
 		resolve_active_view_dims(sys, ca_w, ca_h, &half_w, &half_h);
-		float scale = 3.0f;
-		float gh = (float)mc->font_glyph_h * scale;
+		const float scale = 3.0f;
+		const float gh = (float)mc->font_glyph_h * scale;
 		const char *hint = "Press Ctrl+L to open launcher";
+
+		// Logo target height: 35% of view height, preserving aspect ratio.
+		float logo_dst_h = (float)half_h * 0.35f;
+		float logo_dst_w = 0.0f;
+		if (mc->logo_srv && mc->logo_h > 0) {
+			logo_dst_w = logo_dst_h * (float)mc->logo_w / (float)mc->logo_h;
+		}
+		const float gap = gh * 0.8f; // gap between logo and hint text
 
 		sys->context->VSSetShader(sys->blit_vs.get(), nullptr, 0);
 		sys->context->PSSetShader(sys->blit_ps.get(), nullptr, 0);
 		sys->context->VSSetConstantBuffers(0, 1, sys->blit_constant_buffer.addressof());
 		sys->context->PSSetConstantBuffers(0, 1, sys->blit_constant_buffer.addressof());
-		ID3D11ShaderResourceView *font_srv = mc->font_atlas_srv.get();
-		sys->context->PSSetShaderResources(0, 1, &font_srv);
 		sys->context->PSSetSamplers(0, 1, sys->sampler_linear.addressof());
 		ID3D11RenderTargetView *rtvs[] = {mc->combined_atlas_rtv.get()};
 		sys->context->OMSetRenderTargets(1, rtvs, nullptr);
@@ -6732,6 +6763,42 @@ after_key_shortcuts:
 			uint32_t row = v / sys->tile_columns;
 			float cx = (float)(col * half_w) + (float)half_w * 0.5f;
 			float cy = (float)(row * half_h) + (float)half_h * 0.5f;
+
+			// Stack: [logo] [gap] [hint]. Center the whole stack vertically.
+			float block_h = (mc->logo_srv ? logo_dst_h + gap : 0.0f) + gh;
+			float logo_y = cy - block_h * 0.5f;
+			float hint_y = logo_y + (mc->logo_srv ? logo_dst_h + gap : 0.0f);
+
+			// --- Logo quad ---
+			if (mc->logo_srv) {
+				ID3D11ShaderResourceView *logo_srv = mc->logo_srv.get();
+				sys->context->PSSetShaderResources(0, 1, &logo_srv);
+				D3D11_MAPPED_SUBRESOURCE m;
+				if (SUCCEEDED(sys->context->Map(sys->blit_constant_buffer.get(), 0,
+				              D3D11_MAP_WRITE_DISCARD, 0, &m))) {
+					BlitConstants *cb = static_cast<BlitConstants *>(m.pData);
+					cb->src_rect[0] = 0; cb->src_rect[1] = 0;
+					cb->src_rect[2] = (float)mc->logo_w; cb->src_rect[3] = (float)mc->logo_h;
+					cb->src_size[0] = (float)mc->logo_w; cb->src_size[1] = (float)mc->logo_h;
+					cb->dst_size[0] = (float)ca_w; cb->dst_size[1] = (float)ca_h;
+					cb->convert_srgb = 0.0f;
+					cb->corner_radius = 0; cb->corner_aspect = 0;
+					cb->edge_feather = 0; cb->glow_intensity = 0;
+					cb->quad_mode = 0;
+					cb->dst_offset[0] = cx - logo_dst_w * 0.5f;
+					cb->dst_offset[1] = logo_y;
+					cb->dst_rect_wh[0] = logo_dst_w;
+					cb->dst_rect_wh[1] = logo_dst_h;
+					memset(cb->quad_corners_01, 0, sizeof(cb->quad_corners_01));
+					memset(cb->quad_corners_23, 0, sizeof(cb->quad_corners_23));
+					sys->context->Unmap(sys->blit_constant_buffer.get(), 0);
+					sys->context->Draw(4, 0);
+				}
+			}
+
+			// --- Hint text ---
+			ID3D11ShaderResourceView *font_srv = mc->font_atlas_srv.get();
+			sys->context->PSSetShaderResources(0, 1, &font_srv);
 			// Measure text width
 			float tw = 0;
 			for (const char *p = hint; *p; p++) {
@@ -6740,7 +6807,6 @@ after_key_shortcuts:
 				tw += mc->glyph_advances[ch - 0x20] * scale;
 			}
 			float tx = cx - tw * 0.5f;
-			float ty = cy - gh * 0.5f;
 			float cursor = 0;
 			for (const char *p = hint; *p; p++) {
 				unsigned char ch = (unsigned char)*p;
@@ -6763,7 +6829,7 @@ after_key_shortcuts:
 					cb->corner_radius = 0; cb->corner_aspect = 0;
 					cb->edge_feather = 0; cb->glow_intensity = 0;
 					cb->quad_mode = 0;
-					cb->dst_offset[0] = tx + cursor; cb->dst_offset[1] = ty;
+					cb->dst_offset[0] = tx + cursor; cb->dst_offset[1] = hint_y;
 					cb->dst_rect_wh[0] = dst_gw; cb->dst_rect_wh[1] = gh;
 					memset(cb->quad_corners_01, 0, sizeof(cb->quad_corners_01));
 					memset(cb->quad_corners_23, 0, sizeof(cb->quad_corners_23));

--- a/src/xrt/compositor/d3d11_service/d3d11_icon_loader.cpp
+++ b/src/xrt/compositor/d3d11_service/d3d11_icon_loader.cpp
@@ -22,6 +22,55 @@
 #define STBI_NO_LINEAR
 #include "stb_image.h"
 
+static bool
+create_srgb_srv_from_rgba8(ID3D11Device *device,
+                           const stbi_uc *pixels,
+                           int w,
+                           int h,
+                           const char *tag,
+                           ID3D11ShaderResourceView **out_srv)
+{
+	D3D11_TEXTURE2D_DESC desc = {};
+	desc.Width = static_cast<UINT>(w);
+	desc.Height = static_cast<UINT>(h);
+	desc.MipLevels = 1;
+	desc.ArraySize = 1;
+	desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM_SRGB;
+	desc.SampleDesc.Count = 1;
+	desc.Usage = D3D11_USAGE_IMMUTABLE;
+	desc.BindFlags = D3D11_BIND_SHADER_RESOURCE;
+
+	D3D11_SUBRESOURCE_DATA init = {};
+	init.pSysMem = pixels;
+	init.SysMemPitch = static_cast<UINT>(w) * 4u;
+
+	ID3D11Texture2D *tex = nullptr;
+	HRESULT hr = device->CreateTexture2D(&desc, &init, &tex);
+	if (FAILED(hr) || tex == nullptr) {
+		U_LOG_W("d3d11_icon_loader: CreateTexture2D failed 0x%08lX for '%s'",
+		        static_cast<unsigned long>(hr), tag);
+		return false;
+	}
+
+	D3D11_SHADER_RESOURCE_VIEW_DESC srv_desc = {};
+	srv_desc.Format = desc.Format;
+	srv_desc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
+	srv_desc.Texture2D.MipLevels = 1;
+
+	ID3D11ShaderResourceView *srv = nullptr;
+	hr = device->CreateShaderResourceView(tex, &srv_desc, &srv);
+	tex->Release();
+
+	if (FAILED(hr) || srv == nullptr) {
+		U_LOG_W("d3d11_icon_loader: CreateShaderResourceView failed 0x%08lX for '%s'",
+		        static_cast<unsigned long>(hr), tag);
+		return false;
+	}
+
+	*out_srv = srv;
+	return true;
+}
+
 bool
 d3d11_icon_load_from_file(ID3D11Device *device,
                           const char *path,
@@ -59,55 +108,71 @@ d3d11_icon_load_from_file(ID3D11Device *device,
 		return false;
 	}
 
-	D3D11_TEXTURE2D_DESC desc = {};
-	desc.Width = static_cast<UINT>(w);
-	desc.Height = static_cast<UINT>(h);
-	desc.MipLevels = 1;
-	desc.ArraySize = 1;
-	desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM_SRGB;
-	desc.SampleDesc.Count = 1;
-	desc.Usage = D3D11_USAGE_IMMUTABLE;
-	desc.BindFlags = D3D11_BIND_SHADER_RESOURCE;
-	desc.CPUAccessFlags = 0;
-	desc.MiscFlags = 0;
-
-	D3D11_SUBRESOURCE_DATA init = {};
-	init.pSysMem = pixels;
-	init.SysMemPitch = static_cast<UINT>(w) * 4u;
-	init.SysMemSlicePitch = 0;
-
-	ID3D11Texture2D *tex = nullptr;
-	HRESULT hr = device->CreateTexture2D(&desc, &init, &tex);
+	bool ok = create_srgb_srv_from_rgba8(device, pixels, w, h, path, out_srv);
 	stbi_image_free(pixels);
 
-	if (FAILED(hr) || tex == nullptr) {
-		U_LOG_W("d3d11_icon_load_from_file: CreateTexture2D failed 0x%08lX for '%s'",
-		        static_cast<unsigned long>(hr), path);
-		return false;
+	if (ok) {
+		if (out_width != nullptr) {
+			*out_width = static_cast<uint32_t>(w);
+		}
+		if (out_height != nullptr) {
+			*out_height = static_cast<uint32_t>(h);
+		}
 	}
+	return ok;
+}
 
-	D3D11_SHADER_RESOURCE_VIEW_DESC srv_desc = {};
-	srv_desc.Format = desc.Format;
-	srv_desc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
-	srv_desc.Texture2D.MostDetailedMip = 0;
-	srv_desc.Texture2D.MipLevels = 1;
-
-	ID3D11ShaderResourceView *srv = nullptr;
-	hr = device->CreateShaderResourceView(tex, &srv_desc, &srv);
-	tex->Release();
-
-	if (FAILED(hr) || srv == nullptr) {
-		U_LOG_W("d3d11_icon_load_from_file: CreateShaderResourceView failed 0x%08lX for '%s'",
-		        static_cast<unsigned long>(hr), path);
-		return false;
+bool
+d3d11_icon_load_from_memory(ID3D11Device *device,
+                            const uint8_t *data,
+                            size_t size,
+                            const char *tag,
+                            ID3D11ShaderResourceView **out_srv,
+                            uint32_t *out_width,
+                            uint32_t *out_height)
+{
+	if (out_srv != nullptr) {
+		*out_srv = nullptr;
 	}
-
-	*out_srv = srv;
 	if (out_width != nullptr) {
-		*out_width = static_cast<uint32_t>(w);
+		*out_width = 0;
 	}
 	if (out_height != nullptr) {
-		*out_height = static_cast<uint32_t>(h);
+		*out_height = 0;
 	}
-	return true;
+
+	if (device == nullptr || data == nullptr || size == 0 || out_srv == nullptr) {
+		return false;
+	}
+
+	const char *log_tag = tag != nullptr ? tag : "<memory>";
+
+	int w = 0;
+	int h = 0;
+	int channels_in_file = 0;
+	stbi_uc *pixels = stbi_load_from_memory(data, static_cast<int>(size), &w, &h,
+	                                         &channels_in_file, 4);
+	if (pixels == nullptr) {
+		U_LOG_W("d3d11_icon_load_from_memory: stbi_load_from_memory failed for '%s': %s",
+		        log_tag, stbi_failure_reason());
+		return false;
+	}
+	if (w <= 0 || h <= 0) {
+		stbi_image_free(pixels);
+		U_LOG_W("d3d11_icon_load_from_memory: invalid dims for '%s'", log_tag);
+		return false;
+	}
+
+	bool ok = create_srgb_srv_from_rgba8(device, pixels, w, h, log_tag, out_srv);
+	stbi_image_free(pixels);
+
+	if (ok) {
+		if (out_width != nullptr) {
+			*out_width = static_cast<uint32_t>(w);
+		}
+		if (out_height != nullptr) {
+			*out_height = static_cast<uint32_t>(h);
+		}
+	}
+	return ok;
 }

--- a/src/xrt/compositor/d3d11_service/d3d11_icon_loader.h
+++ b/src/xrt/compositor/d3d11_service/d3d11_icon_loader.h
@@ -43,3 +43,17 @@ d3d11_icon_load_from_file(ID3D11Device *device,
                           ID3D11ShaderResourceView **out_srv,
                           uint32_t *out_width,
                           uint32_t *out_height);
+
+/*!
+ * Like d3d11_icon_load_from_file() but decodes from an in-memory buffer
+ * (e.g. a PNG byte array embedded via embed_binary.cmake). @p tag is used
+ * only in log messages to identify the source.
+ */
+bool
+d3d11_icon_load_from_memory(ID3D11Device *device,
+                            const uint8_t *data,
+                            size_t size,
+                            const char *tag,
+                            ID3D11ShaderResourceView **out_srv,
+                            uint32_t *out_width,
+                            uint32_t *out_height);

--- a/src/xrt/compositor/d3d11_service/displayxr_logo_data.h
+++ b/src/xrt/compositor/d3d11_service/displayxr_logo_data.h
@@ -1,0 +1,23 @@
+// Copyright 2026, Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  Embedded DisplayXR white logo PNG (doc/displayxr_white.png).
+ *
+ * The byte array is generated at build time from the source PNG via
+ * embed_binary.cmake, so the binary artifact does not need to ship the image
+ * file alongside it. Decoded at runtime by stb_image through
+ * d3d11_icon_load_from_memory().
+ *
+ * @ingroup comp_d3d11_service
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+extern "C" {
+extern const uint8_t displayxr_white_png[];
+extern const size_t displayxr_white_png_size;
+}

--- a/src/xrt/compositor/d3d11_service/embed_binary.cmake
+++ b/src/xrt/compositor/d3d11_service/embed_binary.cmake
@@ -1,0 +1,30 @@
+# Copyright 2026, Leia Inc.
+# SPDX-License-Identifier: BSL-1.0
+#
+# Emit a C source file containing the bytes of INPUT_FILE as a named array.
+# Invoked at build time via:
+#   cmake -DINPUT_FILE=<path> -DOUTPUT_FILE=<path> -DSYMBOL=<name> -P embed_binary.cmake
+
+if(NOT DEFINED INPUT_FILE OR NOT DEFINED OUTPUT_FILE OR NOT DEFINED SYMBOL)
+    message(FATAL_ERROR "embed_binary.cmake requires INPUT_FILE, OUTPUT_FILE, SYMBOL")
+endif()
+
+file(READ "${INPUT_FILE}" HEX_CONTENTS HEX)
+string(LENGTH "${HEX_CONTENTS}" HEX_LEN)
+math(EXPR BYTE_LEN "${HEX_LEN} / 2")
+
+# "aabbcc..." -> "0xaa,0xbb,0xcc,..."
+string(REGEX REPLACE "([0-9a-f][0-9a-f])" "0x\\1," BYTE_ARRAY "${HEX_CONTENTS}")
+# Insert a newline every 16 bytes (96 chars of "0xNN," each) to keep line lengths sane.
+string(REGEX REPLACE "((0x[0-9a-f][0-9a-f],){16})" "\\1\n    " BYTE_ARRAY "${BYTE_ARRAY}")
+string(REGEX REPLACE ",$" "" BYTE_ARRAY "${BYTE_ARRAY}")
+
+file(WRITE "${OUTPUT_FILE}" "/* Auto-generated from ${INPUT_FILE} by embed_binary.cmake — do not edit. */
+#include <stdint.h>
+#include <stddef.h>
+
+const uint8_t ${SYMBOL}[${BYTE_LEN}] = {
+    ${BYTE_ARRAY}
+};
+const size_t ${SYMBOL}_size = ${BYTE_LEN};
+")


### PR DESCRIPTION
## Summary

When the D3D11 service compositor has no client windows visible and the launcher is closed, it used to show only the text "Press Ctrl+L to open launcher". This PR adds the DisplayXR white logo, centered above that hint, so the empty state looks branded instead of blank.

The source PNG (`doc/displayxr_white.png`, 771x739, 288 KB) is **embedded into the compositor static library at build time** — the binary does not need the image file shipped alongside it at runtime.

## How the PNG gets embedded

- `src/xrt/compositor/d3d11_service/embed_binary.cmake` — reusable CMake script that reads any binary file via `file(READ ... HEX)` and emits a C source file with a named `const uint8_t ...[]` byte array plus a `size_t ..._size`. Newlines every 16 bytes to keep the generated source readable.
- `src/xrt/compositor/d3d11_service/CMakeLists.txt` — `add_custom_command` invokes the embed script to produce `${CMAKE_CURRENT_BINARY_DIR}/displayxr_logo_data.c` from `${CMAKE_SOURCE_DIR}/doc/displayxr_white.png`. Declared `DEPENDS` ensure it re-runs only when the PNG or the embed script changes. The generated `.c` is added to `comp_d3d11_service` sources.
- `src/xrt/compositor/d3d11_service/displayxr_logo_data.h` — declares the symbols via `extern "C"` so the C++ compositor TU can reference them.

Verified in the build log: step `[16/54] Embedding C:/openxr-3d-display/doc/displayxr_white.png` runs, generated `.c` is 1.4 MB, begins with the correct PNG header (`89 50 4e 47`) and ends with IEND, total 288,107 bytes matching the source.

## Icon loader: from-memory variant

- `d3d11_icon_loader.{h,cpp}` — new `d3d11_icon_load_from_memory(device, data, size, tag, out_srv, out_w, out_h)` that decodes via `stbi_load_from_memory` and shares a new `create_srgb_srv_from_rgba8()` helper with the existing `d3d11_icon_load_from_file` path. The texture is created as `DXGI_FORMAT_R8G8B8A8_UNORM_SRGB` and bound with alpha blending, matching how the launcher renders its icons.

## Render path

- `struct d3d11_multi_compositor` gains `logo_srv`, `logo_w`, `logo_h`, `logo_load_tried`. The existing zero-init via `memset` leaves them all null/false; teardown resets `logo_srv` next to `font_atlas_srv`.
- The empty-state block (previously just text) now:
  1. Lazy-decodes the embedded PNG on first entry, stores the SRV, and flags that we tried (so a one-time decode failure doesn't retry every frame).
  2. Draws each view tile with a stacked `[logo] [gap] [hint]` layout — the logo at 35% of the per-view height preserving aspect ratio, then the existing "Press Ctrl+L to open launcher" text below. Vertical centering covers the whole stack, not just the text.
  3. Binds the logo SRV, draws the quad via the existing `blit_vs`/`blit_ps` pipeline with alpha blending (so the transparent areas of the PNG don't occlude the background), then swaps to the font atlas SRV and draws the hint.

The empty state only renders once the compositor window has been created (which happens on the first client connect). With zero clients ever connected, the compositor never spins up — the screen shows whatever the desktop wallpaper is. Once a client connects and disconnects, the logo + hint shows.

## Test plan

- [x] Local Windows build (`scripts\build_windows.bat build`) succeeds — embed step runs, all three touched TUs compile, `displayxr-service.exe` links.
- [x] Generated byte array matches the source PNG byte-for-byte (288,107 bytes; header/footer intact).
- [ ] Visual verification on a Leia SR display: launch shell with a test app, close the app, confirm logo + hint render in the compositor atlas.
- [ ] CI build (`build-windows.yml`) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)