### PR TITLE
Shell: place compositor window on 3D display via fresh EDID probe (#135)

### DIFF
--- a/src/xrt/compositor/d3d11/comp_d3d11_window.cpp
+++ b/src/xrt/compositor/d3d11/comp_d3d11_window.cpp
@@ -83,11 +83,6 @@ bridge_page_attached(HWND hwnd)
 static WCHAR szWindowClass[] = L"DisplayXRD3D11";
 static WCHAR szWindowData[] = L"DisplayXRD3D11Window";
 
-// Monitor enumeration data
-static bool g_use_secondary_monitor = true;
-static int g_monitor_info_count = 0;
-static MONITORINFOEX g_monitor_info[16] = {};
-
 /*!
  * D3D11 compositor self-owned window structure.
  *
@@ -274,55 +269,29 @@ is_shell_reserved_key(WPARAM vk)
 }
 
 /*!
- * Monitor enumeration callback.
- */
-static BOOL CALLBACK
-monitor_enum_proc(HMONITOR hMonitor, HDC hdcMonitor, LPRECT lprcMonitor, LPARAM dwData)
-{
-	MONITORINFOEX info;
-	ZeroMemory(&info, sizeof(info));
-	info.cbSize = sizeof(info);
-	GetMonitorInfo(hMonitor, (LPMONITORINFO)&info);
-	if (g_monitor_info_count < 16) {
-		g_monitor_info[g_monitor_info_count++] = info;
-	}
-	return TRUE;
-}
-
-/*!
- * Get the top-left coordinate of a known 3D display, or secondary monitor.
+ * Resolve the top-left pixel coordinate of the 3D display on this machine.
  *
- * Uses EDID-based identification via the Leia driver's cached probe result
- * (if available), falling back to secondary monitor detection.
+ * Does a fresh EDID probe every call (no stale cache) so monitor rearrangements
+ * take effect without restarting the service. Falls back to primary (0, 0) when
+ * no 3D display is identified — we do NOT guess "first non-primary monitor",
+ * because on a setup where the 3D display IS primary, that guess would land
+ * the compositor on a 2D monitor.
  */
 static bool
 get_3d_display_top_left(int *x, int *y)
 {
-	// Try cached EDID probe result from Leia driver (set during builder estimation)
 #ifdef XRT_HAVE_LEIA_SR
-	struct leia_display_probe_result edid;
-	if (leia_edid_get_cached_result(&edid) && edid.hw_found) {
-		*x = edid.screen_left;
-		*y = edid.screen_top;
+	int32_t left = 0;
+	int32_t top = 0;
+	if (leia_edid_find_3d_display_rect(&left, &top, NULL, NULL)) {
+		*x = (int)left;
+		*y = (int)top;
+		U_LOG_W("3D display resolved via EDID to (%d, %d)", *x, *y);
 		return true;
 	}
+	U_LOG_W("3D display EDID probe found no known panel — defaulting to primary monitor");
 #endif
 
-	// Fall back to monitor enumeration + secondary monitor
-	g_monitor_info_count = 0;
-	EnumDisplayMonitors(NULL, NULL, monitor_enum_proc, 0);
-
-	if (g_use_secondary_monitor) {
-		for (int i = 0; i < g_monitor_info_count; i++) {
-			if (0 == (g_monitor_info[i].dwFlags & MONITORINFOF_PRIMARY)) {
-				*x = g_monitor_info[i].rcMonitor.left;
-				*y = g_monitor_info[i].rcMonitor.top;
-				return true;
-			}
-		}
-	}
-
-	// Only one display - use primary
 	*x = 0;
 	*y = 0;
 	return false;
@@ -918,6 +887,20 @@ window_thread_func(LPVOID param)
 	// Associate window data before showing
 	SetPropW(hwnd, szWindowData, w);
 	SetWindowLongPtr(hwnd, GWLP_USERDATA, (LONG_PTR)w);
+
+	// Verify the window actually landed where we asked. Win32 occasionally
+	// nudges overlapped windows at negative coordinates to the primary monitor.
+	// If that happened, force-move it back onto the 3D display.
+	{
+		RECT actual = {0};
+		if (GetWindowRect(hwnd, &actual) && (actual.left != rc.left || actual.top != rc.top)) {
+			U_LOG_W("D3D11 window: CreateWindow landed at (%d, %d), expected (%d, %d) — correcting",
+			        (int)actual.left, (int)actual.top, (int)rc.left, (int)rc.top);
+			SetWindowPos(hwnd, NULL, rc.left, rc.top,
+			             rc.right - rc.left, rc.bottom - rc.top,
+			             SWP_NOZORDER | SWP_NOACTIVATE);
+		}
+	}
 
 	if (!w->hidden) {
 		// Check if we should start fullscreen

--- a/src/xrt/drivers/leia/leia_edid_probe.c
+++ b/src/xrt/drivers/leia/leia_edid_probe.c
@@ -307,3 +307,35 @@ leia_edid_get_cached_result(struct leia_display_probe_result *out)
 	*out = g_leia_edid_result;
 	return g_leia_edid_result.hw_found;
 }
+
+bool
+leia_edid_find_3d_display_rect(int32_t *out_left,
+                               int32_t *out_top,
+                               int32_t *out_width,
+                               int32_t *out_height)
+{
+	struct os_display_edid_list list;
+	if (!os_display_edid_enumerate(&list)) {
+		return false;
+	}
+
+	const struct os_display_edid_monitor *match =
+	    os_display_edid_find_in_table(&list, leia_edid_table, LEIA_EDID_TABLE_LEN);
+	if (match == NULL) {
+		return false;
+	}
+
+	if (out_left != NULL) {
+		*out_left = match->screen_left;
+	}
+	if (out_top != NULL) {
+		*out_top = match->screen_top;
+	}
+	if (out_width != NULL) {
+		*out_width = (int32_t)match->pixel_width;
+	}
+	if (out_height != NULL) {
+		*out_height = (int32_t)match->pixel_height;
+	}
+	return true;
+}

--- a/src/xrt/drivers/leia/leia_interface.h
+++ b/src/xrt/drivers/leia/leia_interface.h
@@ -96,6 +96,29 @@ bool
 leia_edid_get_cached_result(struct leia_display_probe_result *out);
 
 /*!
+ * Perform a fresh EDID probe and return the current screen rectangle of the
+ * first Leia/Dimenco 3D display connected to the system.
+ *
+ * Unlike leia_edid_get_cached_result(), this re-enumerates monitors on every
+ * call, so it reflects the current monitor arrangement — useful for placing a
+ * compositor window after the user has changed their display layout without
+ * restarting the service.
+ *
+ * @param[out] out_left   Monitor left edge in virtual screen coords.
+ * @param[out] out_top    Monitor top edge in virtual screen coords.
+ * @param[out] out_width  Monitor width in pixels (optional, may be NULL).
+ * @param[out] out_height Monitor height in pixels (optional, may be NULL).
+ * @return true if a Leia 3D display was found; false otherwise.
+ *
+ * @ingroup drv_leia
+ */
+bool
+leia_edid_find_3d_display_rect(int32_t *out_left,
+                               int32_t *out_top,
+                               int32_t *out_width,
+                               int32_t *out_height);
+
+/*!
  * Probe for SR display hardware.
  *
  * Creates a temporary SR context and checks for an active SR display.


### PR DESCRIPTION
## Summary

Fixes #135 — on dual-monitor setups (2D primary + 3D secondary, or vice versa) the shell's compositor window was landing on the 2D monitor. Works on single-monitor 3D setups too (same end result as before).

## Root cause

`get_3d_display_top_left` in `comp_d3d11_window.cpp` did two things wrong:

1. It read `leia_edid_get_cached_result()` — a snapshot taken once during service-startup builder estimation. If the user rearranged monitors afterward, the cached `screen_left/screen_top` was stale.
2. If the cache had no match, it fell back to "first non-primary monitor". On setups where the 3D display is the **primary** monitor, this guess grabs an arbitrary 2D monitor and lands the compositor there.

## Fix

- `drv_leia`: new `leia_edid_find_3d_display_rect()` (`leia_interface.h` + `leia_edid_probe.c`) that re-enumerates monitors and matches the Leia/Dimenco EDID table on every call, returning the current screen rectangle. No caching.
- `comp_d3d11_window`: rewrite `get_3d_display_top_left()` to use the fresh probe. Removed the `g_use_secondary_monitor` guess entirely; if no 3D panel is identified we log and fall through to primary (0, 0).
- `comp_d3d11_window`: after `CreateWindowExW`, verify the actual window rect matches the requested position. Win32 occasionally nudges overlapped windows at negative coordinates onto the primary monitor — when that happens, force it back onto the 3D display with `SetWindowPos` before `set_fullscreen` / `ShowWindow` runs (otherwise fullscreen's `MonitorFromWindow` would latch onto the wrong monitor).

## Single-monitor 3D

Enumerate finds the one monitor, EDID matches, returns `(0, 0)`. Window creates at `(0, 0)` which is the only monitor. No regression.

## Test plan

- [x] Local Windows build succeeds (`scripts\build_windows.bat build` + `installer`).
- [x] On my 2-monitor setup (Leia at `-3840,0`, Acer primary at `0,0`): service log shows `3D display resolved via EDID to (-3840, 0)`, compositor window lands on the Leia monitor. Verified via `GetWindowRect` + `MonitorFromWindow`.
- [ ] Verify on a setup where the 3D display is the **primary** monitor (was the worst-case for the old fallback).
- [ ] Verify on a single-monitor 3D setup (no regression).
- [ ] CI (`build-windows.yml`) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)