### PR TITLE
Shell: forward plain scroll to focused app; modifier/off-content → shell

### DIFF
--- a/src/xrt/compositor/d3d11/comp_d3d11_window.cpp
+++ b/src/xrt/compositor/d3d11/comp_d3d11_window.cpp
@@ -621,10 +621,38 @@ wnd_proc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 		HWND fwd = (HWND)InterlockedCompareExchangePointer((volatile PVOID *)&w->input_forward_hwnd, NULL, NULL);
 		LONG is_capture = InterlockedCompareExchange(&w->input_forward_is_capture, 0, 0);
 		if (fwd != NULL) {
-			// Shell mode: scroll is reserved for window resize.
+			// Shell mode wheel routing:
+			//   cursor over app content + no modifier → forward to app (e.g. 3DGS zoom)
+			//   cursor outside app content            → shell resize (no modifier needed)
+			//   Ctrl + scroll                         → shell resize (force, even over app)
+			//   Shift + scroll                        → window Z-depth
+			// Capture clients don't take wheel input, so always consume their delta.
 			if (message == WM_MOUSEWHEEL) {
-				short delta = GET_WHEEL_DELTA_WPARAM(wParam);
-				InterlockedExchangeAdd(&w->scroll_accum, (LONG)delta);
+				bool ctrl  = (GetAsyncKeyState(VK_CONTROL) & 0x8000) != 0;
+				bool shift = (GetAsyncKeyState(VK_SHIFT) & 0x8000) != 0;
+
+				// WM_MOUSEWHEEL puts SCREEN coords in lParam (unlike other
+				// mouse messages). Convert to shell-client coords for the
+				// in-rect test.
+				POINT pt;
+				pt.x = GET_X_LPARAM(lParam);
+				pt.y = GET_Y_LPARAM(lParam);
+				ScreenToClient(hWnd, &pt);
+
+				LONG rx = InterlockedCompareExchange(&w->input_forward_rect_x, 0, 0);
+				LONG ry = InterlockedCompareExchange(&w->input_forward_rect_y, 0, 0);
+				LONG rw = InterlockedCompareExchange(&w->input_forward_rect_w, 0, 0);
+				LONG rh = InterlockedCompareExchange(&w->input_forward_rect_h, 0, 0);
+				bool in_rect = (rw > 0 && rh > 0 &&
+				                pt.x >= rx && pt.x < rx + rw &&
+				                pt.y >= ry && pt.y < ry + rh);
+
+				if (in_rect && !is_capture && !ctrl && !shift) {
+					PostMessage(fwd, message, wParam, lParam);
+				} else {
+					short delta = GET_WHEEL_DELTA_WPARAM(wParam);
+					InterlockedExchangeAdd(&w->scroll_accum, (LONG)delta);
+				}
 				return 0;
 			}
 

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -6550,7 +6550,10 @@ after_key_shortcuts:
 		(void)0; // label target for the launcher-visible fast-path above.
 	}
 
-	// Scroll wheel: Shift+Scroll = Z-depth, plain scroll = resize.
+	// Scroll wheel (shell consumes only when modifier held; plain scroll is
+	// forwarded to the focused app by the WndProc):
+	//   Shift+Scroll → Z-depth
+	//   Ctrl+Scroll  → resize
 	if (mc->window != nullptr && mc->focused_slot >= 0) {
 		int32_t scroll = comp_d3d11_window_consume_scroll(mc->window);
 		if (scroll != 0) {


### PR DESCRIPTION
## Summary
- Plain mouse-wheel over a focused app's content forwards to the app via `PostMessage(WM_MOUSEWHEEL)` so apps that bind scroll (e.g. Gaussian Splat zoom) work as users expect.
- Scrolling outside the focused app's content rect still resizes the window — the prior behavior remains accessible by moving off content or holding **Ctrl**.
- **Shift+scroll** still moves the window in Z. Capture clients continue to consume locally (preview-only, no wheel input).

### Routing matrix (shell mode)
| Cursor location | Modifier | Result |
|---|---|---|
| over app content | none | forwarded to app |
| outside app content | none | shell resize |
| anywhere | Ctrl | shell resize (force) |
| anywhere | Shift | window Z-depth |

`WM_MOUSEWHEEL`'s screen-coord `lParam` is converted with `ScreenToClient` and tested against the focused slot's `input_forward_rect_*` in the WndProc.

## Test plan
- [ ] Build runtime + cube_handle_d3d11_win locally; launch via `displayxr-shell.exe <cube>`.
- [ ] Cursor over cube content + scroll → cube ignores it (cube doesn't bind wheel); window does NOT resize.
- [ ] Cursor on shell background + scroll → focused cube window resizes.
- [ ] Ctrl+scroll over cube content → window resizes (force path).
- [ ] Shift+scroll → cube moves in Z.
- [ ] Once VK-in-shell crash is fixed (separate issue): plain scroll over 3DGS demo zooms the splat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)