### PR TITLE
Shell: pin service + test apps to discrete GPU on hybrid laptops

### DIFF
--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -10512,9 +10512,33 @@ comp_d3d11_service_create_system(struct xrt_device *xdev,
 	wil::com_ptr<ID3D11Device> device_base;
 	wil::com_ptr<ID3D11DeviceContext> context_base;
 
+	// Pin the service to the high-performance (discrete) GPU on hybrid laptops.
+	// IPC shared textures cannot bridge two physical adapters, so picking dGPU
+	// here keeps both the compositor and any well-behaved client (which honours
+	// the LUID we publish below) on the same GPU.
+	wil::com_ptr<IDXGIAdapter> preferred_adapter;
+	{
+		wil::com_ptr<IDXGIFactory6> factory6;
+		if (SUCCEEDED(CreateDXGIFactory1(IID_PPV_ARGS(factory6.put()))) && factory6) {
+			wil::com_ptr<IDXGIAdapter1> high_perf;
+			if (SUCCEEDED(factory6->EnumAdapterByGpuPreference(
+			        0, DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE,
+			        IID_PPV_ARGS(high_perf.put())))) {
+				DXGI_ADAPTER_DESC1 desc1{};
+				if (SUCCEEDED(high_perf->GetDesc1(&desc1)) &&
+				    (desc1.Flags & DXGI_ADAPTER_FLAG_SOFTWARE) == 0) {
+					preferred_adapter = high_perf;
+					U_LOG_W("D3D11 service: preferring high-performance adapter '%ls'",
+					        desc1.Description);
+				}
+			}
+		}
+	}
+
+	// D3D11CreateDevice requires DRIVER_TYPE_UNKNOWN when an explicit adapter is supplied.
 	HRESULT hr = D3D11CreateDevice(
-	    nullptr,                     // Default adapter
-	    D3D_DRIVER_TYPE_HARDWARE,
+	    preferred_adapter.get(),
+	    preferred_adapter ? D3D_DRIVER_TYPE_UNKNOWN : D3D_DRIVER_TYPE_HARDWARE,
 	    nullptr,
 	    flags,
 	    feature_levels, ARRAYSIZE(feature_levels),

--- a/src/xrt/targets/service/main.c
+++ b/src/xrt/targets/service/main.c
@@ -37,6 +37,13 @@ U_TRACE_TARGET_SETUP(U_TRACE_WHICH_SERVICE)
 
 #ifdef XRT_OS_WINDOWS
 
+// Optimus / PowerXpress hints: tell hybrid-GPU drivers to put this process on
+// the discrete GPU. NVIDIA and AMD drivers look these up by name from the main
+// executable. The service compositor also explicitly picks the high-performance
+// DXGI adapter — these exports cover the rest of the driver-side selection.
+__declspec(dllexport) DWORD NvOptimusEnablement = 1;
+__declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
+
 // Shutdown flag defined in ipc_server_mainloop_windows.cpp.
 // Set by the tray icon's "Exit" menu item, checked by ipc_server_mainloop_poll().
 extern volatile bool g_service_shutdown_requested;

--- a/test_apps/common/CMakeLists.txt
+++ b/test_apps/common/CMakeLists.txt
@@ -35,12 +35,27 @@ add_library(sr_common_base STATIC
     # API dependencies.
     atlas_capture.h
     atlas_capture.cpp
+    # Hybrid-GPU dGPU hint (Windows): NvOptimusEnablement / AmdPowerXpressRequestHighPerformance.
+    # Forced into the EXE via the /INCLUDE linker option below so the driver-side
+    # GPU selection lines up with the service compositor's dGPU pin.
+    optimus_dgpu_hint.c
 )
 
 target_include_directories(sr_common_base PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../src/external/openxr_includes
 )
+
+# Force the linker to pull optimus_dgpu_hint.c into every EXE that links
+# sr_common_base, even though nothing references its symbols. /INCLUDE on
+# MSVC, --undefined on GNU-style linkers (e.g. clang on Windows).
+if(WIN32)
+    if(MSVC)
+        target_link_options(sr_common_base INTERFACE "/INCLUDE:NvOptimusEnablement")
+    else()
+        target_link_options(sr_common_base INTERFACE "-Wl,--undefined=NvOptimusEnablement")
+    endif()
+endif()
 
 # D3D11-specific library: extends base with D3D11 renderer + text overlay + HUD
 add_library(sr_common STATIC

--- a/test_apps/common/optimus_dgpu_hint.c
+++ b/test_apps/common/optimus_dgpu_hint.c
@@ -1,0 +1,19 @@
+// Copyright 2026, Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+//
+// Optimus / PowerXpress hints for NVIDIA / AMD hybrid-GPU laptops.
+// Exporting these symbols from the executable tells the driver to put
+// the process on the discrete GPU. The DisplayXR service compositor is
+// pinned to the same dGPU via DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE; if
+// an app lands on the iGPU instead, IPC shared textures fail.
+//
+// Lives in sr_common_base. The CMake target uses /INCLUDE:NvOptimusEnablement
+// (INTERFACE linker option) to force inclusion of this TU even though no
+// other code references the symbols.
+
+#ifdef _WIN32
+#include <windows.h>
+
+__declspec(dllexport) DWORD NvOptimusEnablement = 1;
+__declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
+#endif


### PR DESCRIPTION
## Summary

IPC shared textures cannot bridge two physical adapters, so on hybrid Optimus / PowerXpress laptops the service compositor would land on the dGPU while a Vulkan handle app could land on the iGPU. The mismatch crashed apps on session create with `vk::SystemError` → `ACCESS_VIOLATION` (e.g. `gaussian_splatting_handle_vk_win` died within ~3s in shell session mode).

This PR keeps every DisplayXR-shipped binary on the same dGPU.

### Three-pronged fix

1. **Service compositor** picks the high-perf adapter explicitly via `IDXGIFactory6::EnumAdapterByGpuPreference(DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE)` before `D3D11CreateDevice`. The adapter LUID we already publish to clients via `client_d3d_deviceLUID` is now the dGPU's, so well-behaved apps (those that honour `xrGetD3D11GraphicsRequirementsKHR` / `xrGetVulkanGraphicsDeviceKHR`) follow automatically.
2. **Service exe** exports `NvOptimusEnablement = 1` and `AmdPowerXpressRequestHighPerformance = 1` so the NVIDIA / AMD driver-side per-process selection also pins us to the dGPU.
3. **Test apps + 3DGS demo** get the same Optimus exports via a tiny TU in `sr_common_base`. Because static-lib symbols aren't pulled into the EXE just by being defined, an `INTERFACE` linker option (`/INCLUDE:NvOptimusEnablement` on MSVC, `--undefined=...` on GNU-style linkers) on `sr_common_base` forces inclusion. No per-app CMakeLists edit needed.

### Verification

- Service log: `D3D11 service: preferring high-performance adapter 'NVIDIA GeForce RTX 4070 Laptop GPU'`.
- `dumpbin /EXPORTS` confirms `NvOptimusEnablement` + `AmdPowerXpressRequestHighPerformance` are present in: `displayxr-service.exe`, `gaussian_splatting_handle_vk_win.exe`, and all 7 cube test app variants (d3d11/d3d12/gl/vk × handle, hosted, texture).
- The 3DGS demo now reaches its render loop in shell session mode where it previously crashed during `oxr_session_create`.

## Test plan
- [ ] Build runtime + test apps locally on a hybrid-GPU machine.
- [ ] `displayxr-shell.exe gaussian_splatting_handle_vk_win.exe` — demo connects and renders frames (was: VK exception → AV).
- [ ] Service log shows `preferring high-performance adapter 'NVIDIA …'` (or AMD on Radeon).
- [ ] `dumpbin /EXPORTS displayxr-service.exe` and any test app shows both Optimus symbols.
- [ ] Sanity-check on a single-GPU machine: service still creates a device (the high-perf path falls back to default if no factory6 / no eligible adapter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)