### PR TITLE
Shell: Ctrl+L auto-activates the shell instead of silently bailing

### DIFF
--- a/src/xrt/targets/shell/main.c
+++ b/src/xrt/targets/shell/main.c
@@ -1961,27 +1961,41 @@ main(int argc, char *argv[])
 					// multi-compositor renders the panel in its own window when
 					// launcher_visible is true. Tile grid + launch dispatch
 					// come in later Phase 5 tasks.
-					if (g_shell_active) {
-						g_launcher_visible = !g_launcher_visible;
 
-						// Phase 5.12: when opening, hand the service process
-						// foreground-activation permission so it can pull its
-						// compositor window into focus. Otherwise keys like
-						// Esc stay routed to whichever app previously had
-						// focus and never reach the compositor WndProc that
-						// the launcher keyboard handler depends on.
-						if (g_launcher_visible && service_pid != 0) {
-							AllowSetForegroundWindow(service_pid);
+					// Auto-activate the shell if it's currently in tray. The
+					// empty-state hint promises "Press Ctrl+L to open launcher",
+					// and after closing every app the user expects one keypress
+					// to bring the launcher back without first hitting Ctrl+Space.
+					if (!g_shell_active) {
+						xrt_result_t aret = ipc_call_shell_activate(&ipc_c);
+						if (aret != XRT_SUCCESS) {
+							PE("Ctrl+L: shell_activate failed (%d)\n", aret);
+							continue;
 						}
+						g_shell_active = true;
+						tray_update_tooltip(true);
+						P("Shell activated by Ctrl+L.\n");
+					}
 
-						xrt_result_t lret = ipc_call_shell_set_launcher_visible(
-						    &ipc_c, g_launcher_visible);
-						if (lret != XRT_SUCCESS) {
-							PE("ipc_call_shell_set_launcher_visible failed: %d\n", lret);
-							g_launcher_visible = !g_launcher_visible; // roll back
-						} else {
-							P("Launcher %s\n", g_launcher_visible ? "shown" : "hidden");
-						}
+					g_launcher_visible = !g_launcher_visible;
+
+					// Phase 5.12: when opening, hand the service process
+					// foreground-activation permission so it can pull its
+					// compositor window into focus. Otherwise keys like
+					// Esc stay routed to whichever app previously had
+					// focus and never reach the compositor WndProc that
+					// the launcher keyboard handler depends on.
+					if (g_launcher_visible && service_pid != 0) {
+						AllowSetForegroundWindow(service_pid);
+					}
+
+					xrt_result_t lret = ipc_call_shell_set_launcher_visible(
+					    &ipc_c, g_launcher_visible);
+					if (lret != XRT_SUCCESS) {
+						PE("ipc_call_shell_set_launcher_visible failed: %d\n", lret);
+						g_launcher_visible = !g_launcher_visible; // roll back
+					} else {
+						P("Launcher %s\n", g_launcher_visible ? "shown" : "hidden");
 					}
 				} else if (msg.message == WM_HOTKEY && msg.wParam == HOTKEY_CAPTURE) {
 					// --- Ctrl+Shift+C: capture pre-weave SBS frame (Phase 8) ---


### PR DESCRIPTION
## Summary

The `HOTKEY_LAUNCH` (`Ctrl+L`) handler was gated on `g_shell_active`, so pressing `Ctrl+L` while the shell sat in the tray did nothing — including the case the user just hit, where they opened two apps, closed both, and tried to bring the launcher back. The empty-state screen even displays *"Press Ctrl+L to open launcher"*, but the keypress was a silent no-op until the user first pressed `Ctrl+Space` to re-activate the shell.

This PR drops the gate. If `g_shell_active` is `false`, the handler calls `ipc_call_shell_activate` first (same path Ctrl+Space takes), updates the tray tooltip, then toggles the launcher panel. A single `Ctrl+L` press now reliably produces the launcher regardless of whether the shell was foreground, in tray, or freshly emptied of apps.

`src/xrt/targets/shell/main.c:1965-1978`

## Test plan
- [ ] Launch shell with two apps, close both, press `Ctrl+L` → launcher panel appears (was: nothing).
- [ ] Launch `displayxr-shell.exe` standalone (tray mode), press `Ctrl+L` → shell activates and launcher appears (was: nothing).
- [ ] Launch shell with apps, press `Ctrl+L` while active → toggles launcher as before (no regression).
- [ ] Press `Ctrl+L` a second time while launcher is shown → hides it (no regression).
- [ ] If service is dead, `ipc_call_shell_activate` returns failure → log line printed, no state corruption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)