### PR TITLE
Shell: drop-in manifest discovery + GPU pref + CWD fixes (#182)

### DIFF
--- a/docs/roadmap/shell-app-discovery-v2-plan.md
+++ b/docs/roadmap/shell-app-discovery-v2-plan.md
@@ -1,0 +1,155 @@
+# Shell App Discovery v2: Drop-in Manifest Registration
+
+**Branch:** `in-shell-apps-manifest`
+**Tracking issue:** TBD (this repo, label `shell`)
+**Depends on:** Phase 5 launcher (merged) and the v1.0 manifest spec
+
+## Why this work
+
+The v1 launcher only discovers apps in a closed set of paths — dev-tree
+`test_apps/*/build/`, `demos/*/build/`, `_package/bin/`, plus the single production
+path `%PROGRAMFILES%\DisplayXR\apps\` (`shell_app_scan.c::shell_scan_apps`). Real
+third-party apps (Unity / Unreal builds in `Documents\Unity\…`,
+`Documents\Unreal Projects\…`, etc.) never get discovered. The Browse-for-app
+fallback works but produces a default-iconed tile with `type:"3d"`, no description,
+no display-mode preference — and the entry is stored as raw fields in
+`registered_apps.json`, which mixes "what apps exist" state with "where windows
+were last placed" state.
+
+We want third-party app installers (and engine plugins) to be able to register an
+app by dropping a single `.displayxr.json` file into a known directory, without
+the app needing to be installed under `Program Files`. We also want the
+Browse-for-app path to flow through the same registration mechanism so user-added
+apps are first-class citizens with the same metadata pipeline as installer-added
+apps.
+
+## Design
+
+### Two manifest modes, one parser
+
+`.displayxr.json` v1.0 grows one optional field — `exe_path`. The field's
+presence is the dispatch:
+
+- **Sidecar mode** (existing): manifest sits next to the exe in a scanned
+  dev path; `exe_path` MUST be absent; the exe is the sibling file.
+- **Registered mode** (new): manifest sits in a discovery dir and `exe_path`
+  is required.
+
+Schema-wise this is additive — same `schema_version: 1`, older shells just
+fall back to sidecar resolution and skip registered manifests gracefully. See
+`docs/specs/displayxr-app-manifest.md` §2, §3.2.
+
+### Discovery dirs (registered mode)
+
+```
+%LOCALAPPDATA%\DisplayXR\apps\          ← per-user (no elevation)
+%ProgramData%\DisplayXR\apps\           ← system-wide (installer needs elevation)
+```
+
+Scanner walks these first, then the existing dev-tree sidecar paths, then
+`%PROGRAMFILES%\DisplayXR\apps\`. Dedup is by case-insensitive
+slash-normalized `exe_path` — discovery order defines precedence. Per-user
+wins over system-wide, which lets a user override a vendor registration
+without uninstalling.
+
+### Browse-for-app rewrite
+
+`shell_browse_and_add_app` (currently `main.c:1292`) stops appending raw
+fields to `g_registered_apps[]`. New behavior:
+
+1. `GetOpenFileNameA` → exe path.
+2. Sanitize basename (`[^A-Za-z0-9._-]` → `_`).
+3. Extract the embedded PE icon via `ExtractIconExA` → save as
+   `<sanitized>.png` in `%LOCALAPPDATA%\DisplayXR\apps\` (GDI+ encode). If
+   extraction fails, omit `icon`.
+4. Write `<sanitized>.displayxr.json` with `schema_version:1`, `name` from
+   the basename (or PE `FileDescription` if cheap to read), `type:"3d"`,
+   `category:"app"`, `exe_path` set, optional `icon`.
+5. Trigger a re-scan + push to service.
+
+`registered_apps.json` becomes a state cache only — saved poses, MRU,
+hide flags. The `source:"user"` vs `source:"scan"` distinction is removed:
+everything is registered via a manifest file.
+
+### Remove → manifest delete
+
+Launcher's remove action (currently `main.c:2152`) deletes the manifest file
+when it's under one of the registered dirs. ProgramData deletes may fail
+without elevation; on `ERROR_ACCESS_DENIED` we hide the tile via state
+cache instead. Sidecar manifests in dev paths are never deleted (they're
+developer-owned).
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `docs/specs/displayxr-app-manifest.md` | Spec bump — `exe_path` field, two modes, two new dirs, icon-as-Windows-app-icon section |
+| `docs/roadmap/shell-app-discovery-v2-plan.md` | This doc |
+| `src/xrt/targets/shell/shell_app_scan.h` | `shell_scanned_app` gains `manifest_path` so the launcher can delete it on remove |
+| `src/xrt/targets/shell/shell_app_scan.c` | New `scan_registered_dir` walks `*.displayxr.json`; manifest parser refactored to be exe-source-agnostic; dedup-by-`exe_path`; `shell_scan_apps` calls registered-dir scan first |
+| `src/xrt/targets/shell/main.c` | `shell_browse_and_add_app` writes manifest + extracts PE icon; `registered_apps_load` drops user/scan distinction; remove path deletes manifest file |
+
+## Existing utilities reused
+
+- `parse_sidecar` in `shell_app_scan.c:109` — already takes `exe_path` as a
+  parameter, so registered mode just supplies it from the JSON instead of
+  the sibling file.
+- `read_file_text` and `resolve_icon_path` in `shell_app_scan.c` — reused
+  unchanged for registered mode.
+- `exe_path_equal` in `main.c:298` — slash-normalized case-insensitive
+  comparison for dedup.
+- `ExtractIconExA` (Win32 `<shellapi.h>`) — extracts the PE app icon for
+  the Browse flow.
+- GDI+ `Bitmap::Save` — encodes the extracted icon to PNG.
+
+## Plugin-side follow-ups
+
+Plugin-repo issues track the engine-side work:
+
+- **`DisplayXR/displayxr-unity`** — `DisplayXRBuildProcessor.cs` already
+  writes a sidecar manifest next to the built exe. Add a "Register with
+  DisplayXR shell" toggle to `DisplayXRManifestSettings`; when on, ALSO
+  write a registered manifest to `%LOCALAPPDATA%\DisplayXR\apps\` with
+  `exe_path` set + copy icons there. Add an editor warning when Player
+  Settings → Icon and the manifest icon both exist but differ.
+
+- **`DisplayXR/displayxr-unreal`** — no manifest pipeline today. Add a
+  `UDisplayXRManifestSettings` (`UDeveloperSettings` subclass) for the
+  same fields as Unity. Editor module exports settings to a small JSON in
+  `Saved/Config/`; `Scripts/PackageApp.py` reads it post-cook and writes
+  the manifest next to the staged exe + optional registered manifest. Same
+  icon-mismatch warning vs. Project Settings → Game Icon.
+
+## Verification
+
+End-to-end on Windows:
+
+1. `scripts\build_windows.bat build` — rebuild runtime + shell.
+2. Copy a Unity build's exe to `Documents\test-app\`. Hand-author
+   `%LOCALAPPDATA%\DisplayXR\apps\test_unity.displayxr.json` with
+   `exe_path` pointing at it + an `icon.png` sibling. Launch shell —
+   tile appears with the right icon and is launchable.
+3. Move the exe so `exe_path` no longer resolves. Restart shell — tile is
+   skipped with a warning in the shell log.
+4. Use Browse-for-app on a fresh exe. Verify a `.displayxr.json` + `.png`
+   appear under `%LOCALAPPDATA%\DisplayXR\apps\`. Restart shell — same
+   tile re-appears (proves persistence is via manifest, not
+   `registered_apps.json`).
+5. Drop a manifest with the same `exe_path` into
+   `%ProgramData%\DisplayXR\apps\`. Verify the per-user one wins.
+6. Click remove on a Browse-added tile. Verify the manifest file is
+   gone from `%LOCALAPPDATA%\DisplayXR\apps\`.
+7. Capture compositor screenshot via `%TEMP%\shell_screenshot_trigger`
+   to confirm tile rendering.
+
+## Out of scope
+
+- Vendor-prefixed manifest filenames (`<vendor>.<app>.displayxr.json`) —
+  current dedup-by-`exe_path` handles collisions; revisit if real-world
+  collisions show up.
+- App update / version tracking — `version`, `min_runtime`, etc. are
+  reserved in the spec for a future schema bump.
+- Per-app launch args / working directory — `args`, `working_dir`
+  reserved for a future bump.
+- Cross-platform discovery (macOS, Linux). Registered mode is Windows-only
+  in this slice; the macOS shell port is deferred per CLAUDE.md.

--- a/docs/specs/displayxr-app-manifest.md
+++ b/docs/specs/displayxr-app-manifest.md
@@ -20,21 +20,45 @@ DisplayXR Unity and Unreal plugins are expected to generate a manifest automatic
 
 **The shell ships no built-in default apps.** When `registered_apps.json` does not exist (first run), the registry starts empty. The scanner immediately populates whatever it finds via sidecars; if it finds nothing, the launcher renders the empty-state hint instead of a tile grid. There is no pre-seeded "Notepad" or other system app — the launcher is exclusively a curated DisplayXR app surface, never a generic Windows app drawer.
 
-## 2. File location
+## 2. Manifest modes and file locations
 
-The manifest lives **next to the executable** it describes, with the filename stem matching the executable:
+A manifest can live in one of two places, dispatched by whether it carries an `exe_path` field (see §3.2). The parser is the same for both modes — only the exe-resolution rule differs.
+
+### 2.1 Sidecar mode (next to the exe)
+
+The manifest sits in the same directory as its executable, with the filename stem matching the exe:
 
 ```
 my_app/
 ├── my_app.exe
-├── my_app.displayxr.json     ← manifest
+├── my_app.displayxr.json     ← manifest (no exe_path)
 ├── icon.png                  ← referenced from manifest
 └── icon_sbs.png              ← optional 3D icon
 ```
 
-- The scanner looks for `<exe_basename>.displayxr.json` in the same directory as each discovered `.exe`.
-- All paths inside the manifest are resolved **relative to the manifest file**, not the CWD.
-- The scanner never writes to the manifest. It is developer-owned.
+- The scanner looks for `<exe_basename>.displayxr.json` next to each discovered `.exe` in the dev-tree paths (see §5).
+- `exe_path` MUST be absent in sidecar mode — the exe is the sibling file.
+- Sidecar mode is the natural fit for in-tree dev (`test_apps/`, `demos/`) and for app installs that bundle the manifest into their own install directory.
+
+### 2.2 Registered mode (drop-in directory)
+
+The manifest sits in a system-known discovery directory and points at any executable on disk via an absolute `exe_path`. This is how third-party apps install themselves into the launcher without having to live under `Program Files`.
+
+```
+%LOCALAPPDATA%\DisplayXR\apps\           ← per-user installs (no elevation)
+└── my_unity_app.displayxr.json          ← exe_path points to user's build dir
+%ProgramData%\DisplayXR\apps\            ← system-wide installs (installer-elevated)
+└── vendor_app.displayxr.json
+```
+
+- The manifest filename can be anything ending in `.displayxr.json`. Recommended convention: `<sanitized_exe_basename>.displayxr.json`.
+- `exe_path` MUST be present and resolve to an existing `.exe`. Manifests whose exe no longer exists are skipped with a warning.
+- Icon paths are still resolved **relative to the manifest file**, so installers should drop icon files alongside the manifest (not next to the exe).
+
+### 2.3 Common rules
+
+- All paths inside the manifest are resolved **relative to the manifest file**, not the CWD and not the exe directory.
+- The scanner never writes to the manifest. It is owned by whoever installed it (developer, installer, or the user via Browse-for-app).
 
 ## 3. Schema (v1.0)
 
@@ -64,6 +88,7 @@ my_app/
 
 | Field | Type | Default | Notes |
 |---|---|---|---|
+| `exe_path` | string | *none* | Absolute path to the executable. **Required in registered mode (§2.2), MUST be absent in sidecar mode (§2.1).** Forward or back slashes accepted; the scanner normalizes to backslashes. The referenced file must exist at scan time or the entry is skipped. |
 | `icon` | string | *none* | Relative path to a 2D icon image. PNG or JPEG. Recommended 512×512. When absent, the tile is rendered with the app name as a text label on a category-colored background. |
 | `icon_3d` | string | *none* | Relative path to a stereoscopic icon image. When present, the shell renders the tile stereoscopically. Resolution matches `icon` aspect but doubled along the layout axis (e.g. 1024×512 for `sbs-lr`). Requires `icon` to also be set (as the 2D fallback). |
 | `icon_3d_layout` | string | `"sbs-lr"` | How the stereo pair is packed in `icon_3d`. One of `"sbs-lr"` (left-right), `"sbs-rl"` (right-left), `"tb"` (top-bottom, left eye on top), `"bt"` (bottom-top). Ignored if `icon_3d` is absent. |
@@ -75,7 +100,7 @@ my_app/
 
 Names the shell may consume in later schema versions — do not use for custom data:
 
-`version`, `publisher`, `homepage`, `min_runtime`, `required_extensions`, `screenshots`, `trailer`, `pose`, `window_size`.
+`version`, `publisher`, `homepage`, `min_runtime`, `required_extensions`, `screenshots`, `trailer`, `pose`, `window_size`, `args`, `working_dir`.
 
 ## 4. 3D icons
 
@@ -93,8 +118,15 @@ The shell renders launcher tiles at ~40 cm in front of the viewer. Stereo icons 
 
 ## 5. Discovery behavior
 
-The shell scanner walks a fixed set of paths (see `shell-phase5-plan.md` Part 1):
+The shell scanner walks two kinds of paths in this order:
 
+**Registered-mode discovery dirs** (manifests own the exe via `exe_path`):
+```
+%LOCALAPPDATA%\DisplayXR\apps\          ← per-user, user/installer-writable
+%ProgramData%\DisplayXR\apps\           ← system-wide, installer-writable (elevated)
+```
+
+**Sidecar-mode dev paths** (manifests sit next to the exe):
 ```
 <shell-exe>/../test_apps/*/build/
 <shell-exe>/../demos/*/build/
@@ -102,12 +134,20 @@ The shell scanner walks a fixed set of paths (see `shell-phase5-plan.md` Part 1)
 %PROGRAMFILES%\DisplayXR\apps\
 ```
 
-For each `.exe` found:
+For each registered-mode dir, the scanner enumerates `*.displayxr.json` directly. For each manifest:
 
-1. Look for `<exe_basename>.displayxr.json` in the same directory.
+1. Parse + validate per §6.
+2. Read `exe_path`. If missing or the file does not exist → skip with warning.
+3. Add the entry to the registry; the manifest path is also recorded so the launcher's "remove" action can delete it.
+
+For each sidecar-mode dir, the scanner enumerates `*.exe`. For each exe:
+
+1. Look for `<exe_basename>.displayxr.json` next to it.
 2. If absent → **skip the exe entirely**.
-3. If present → parse, validate against this spec, resolve icon paths, add to the registry with `source: "scan"`.
+3. If present → parse + validate per §6, resolve icon paths.
 4. Sanity check: verify the exe imports `openxr_loader.dll` (PE import scan). If not, log a warning and still add the entry (the manifest is authoritative — a 2D `type` app wouldn't import OpenXR anyway).
+
+**Dedup**: across all dirs, entries are deduplicated by case-insensitive `exe_path`. Discovery order above defines precedence — `%LOCALAPPDATA%` wins over `%ProgramData%`, which wins over the dev/Program-Files sidecar paths. Later duplicates are dropped silently.
 
 Manifest parse errors are logged to the shell log and the entry is dropped. Malformed manifests do not crash the scanner.
 
@@ -118,6 +158,8 @@ The scanner rejects a manifest if any of the following are true:
 - `schema_version` is missing or not `1`.
 - `name` is missing, empty, or longer than 64 characters.
 - `type` is missing or not one of `"3d"` / `"2d"`.
+- `exe_path` is required (registered mode) but missing, empty, or refers to a file that does not exist.
+- `exe_path` is set but the manifest is in a sidecar location — `exe_path` is reserved for registered mode (warning only; the sibling exe still wins).
 - `icon` is specified but the referenced file does not exist or is not a readable PNG/JPEG.
 - `icon_3d` is specified but the file does not exist or is not a readable PNG/JPEG, or `icon` is not also set.
 - `icon_3d_layout` is specified but not one of the four allowed values.
@@ -152,12 +194,33 @@ This is enough for the launcher to show a named tile. Without `icon` the tile re
 }
 ```
 
-## 9. Versioning
+## 9. Reusing the 2D icon as the Windows app icon
 
-Breaking changes bump `schema_version`. The shell will refuse to parse manifests with a `schema_version` it does not understand, and log the unsupported version. Additive changes (new optional fields) keep `schema_version: 1`.
+The shell launcher renders `icon` as the tile face. The same image should also be the **embedded application icon** in the executable, so Windows uses it for the Start Menu, Desktop shortcut, and taskbar — i.e. the user sees the same icon whether they launch from the DisplayXR shell or from a regular Windows shortcut.
 
-## 10. Relationship to `registered_apps.json`
+There is no DisplayXR plumbing for this — engines already embed an icon resource into the PE during build. Authors should configure both sides from a single source asset:
 
-`registered_apps.json` at `%LOCALAPPDATA%\DisplayXR\registered_apps.json` is the shell's local registry — the cached result of scanning plus any user-added entries. Entries discovered from sidecars are written there with `source: "scan"`; entries added via **Browse for app…** get `source: "user"`. The registry is rebuilt from sidecars on each shell startup; `source: "user"` entries are preserved across rebuilds.
+- **Unity** — set the icon in *Project Settings → Player → Icon* (standalone platform). The DisplayXR Unity plugin's manifest settings asset has a separate `icon` field that should reference the **same source texture**. Mismatch produces an editor warning.
+- **Unreal** — set the icon in *Project Settings → Platforms → Windows → Game Icon*. The DisplayXR Unreal plugin's manifest settings has a separate `icon` field that should reference the **same source asset**. Mismatch produces an editor warning.
+- **Native apps** — embed an `.ico` resource in your `.rc`/manifest the way you normally would, and point `icon` in the manifest at the corresponding `.png` next to your manifest.
 
-Developers should never edit `registered_apps.json` directly — edit the sidecar next to your app and relaunch the shell.
+The shell does NOT extract icons from the PE for sidecar/registered manifests — it always reads the path in `icon`. The PE-icon-extraction path is only used by the **Browse for app…** flow when registering an arbitrary executable that does not already ship a manifest (see §11).
+
+## 10. Versioning
+
+Breaking changes bump `schema_version`. The shell will refuse to parse manifests with a `schema_version` it does not understand, and log the unsupported version. Additive changes (new optional fields) keep `schema_version: 1`. The `exe_path` field added in this revision is additive — older shells that read a registered manifest will fall back to sidecar resolution (look for sibling exe, fail, skip the entry); they will never crash. Registered-mode manifests therefore require shell ≥ the version that introduced this field.
+
+## 11. Browse-for-app and `registered_apps.json`
+
+`registered_apps.json` at `%LOCALAPPDATA%\DisplayXR\registered_apps.json` is the shell's **state cache** — saved window poses, MRU order, hide flags, and other per-tile UI state. It is **not** the source of truth for which apps exist; that role belongs entirely to manifests under §5's discovery dirs.
+
+The launcher's **Browse for app…** entry registers an arbitrary executable by **writing a manifest** into `%LOCALAPPDATA%\DisplayXR\apps\`:
+
+1. The user picks an `.exe`.
+2. The shell extracts the embedded PE icon to `<sanitized_basename>.png` next to the new manifest. If extraction fails the manifest omits `icon`.
+3. The shell writes `<sanitized_basename>.displayxr.json` with `schema_version:1`, `name` derived from the exe basename, `type:"3d"`, `category:"app"`, `exe_path` set to the picked path, and `icon` if extraction succeeded.
+4. The scanner re-runs and the new manifest is picked up like any other registered entry.
+
+The launcher's "remove" action on a tile **deletes the manifest file** when it lives under `%LOCALAPPDATA%\DisplayXR\apps\` (per-user, no elevation needed) or `%ProgramData%\DisplayXR\apps\` (system-wide, may fail without elevation — falls back to hiding the tile via state cache). Sidecar manifests in dev paths are never deleted by the launcher; they are developer-owned.
+
+Developers should never edit `registered_apps.json` directly — edit the manifest and relaunch the shell.

--- a/src/xrt/targets/service/service_orchestrator.c
+++ b/src/xrt/targets/service/service_orchestrator.c
@@ -45,9 +45,14 @@ DEBUG_GET_ONCE_LOG_OPTION(orchestrator_log, "DISPLAYXR_ORCHESTRATOR_LOG", U_LOGG
 // install/uninstall of the hook (which must happen on the tray thread since
 // WH_KEYBOARD_LL requires a message pump on the installing thread, and our
 // main thread blocks in ipc_server_main without one).
-#define WM_ORCHESTRATOR_SPAWN_SHELL    (WM_APP + 1)
-#define WM_ORCHESTRATOR_INSTALL_HOOK   (WM_APP + 2)
-#define WM_ORCHESTRATOR_UNINSTALL_HOOK (WM_APP + 3)
+//
+// Must NOT collide with WM_TRAYICON (WM_APP + 1) defined in service_tray_win.c
+// — every Shell_NotifyIcon notification (WM_RBUTTONUP, WM_MOUSEMOVE,
+// NIN_POPUPOPEN, …) is delivered as that message, and a clash makes this
+// orchestrator subclass eat them all before tray_wnd_proc ever sees them.
+#define WM_ORCHESTRATOR_SPAWN_SHELL    (WM_APP + 100)
+#define WM_ORCHESTRATOR_INSTALL_HOOK   (WM_APP + 101)
+#define WM_ORCHESTRATOR_UNINSTALL_HOOK (WM_APP + 102)
 
 
 /*

--- a/src/xrt/targets/shell/CMakeLists.txt
+++ b/src/xrt/targets/shell/CMakeLists.txt
@@ -10,7 +10,10 @@ add_executable(displayxr-shell WIN32
 )
 add_sanitizers(displayxr-shell)
 
-target_include_directories(displayxr-shell PRIVATE ipc)
+target_include_directories(displayxr-shell PRIVATE
+    ipc
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../external/stb  # stb_image_write.h (Browse-for-app icon extract)
+)
 
 target_link_libraries(displayxr-shell PRIVATE aux_util ipc_client)
 

--- a/src/xrt/targets/shell/main.c
+++ b/src/xrt/targets/shell/main.c
@@ -37,8 +37,16 @@
 #include <windows.h>
 #include <process.h>
 #include <tlhelp32.h> // For process enumeration (service PID lookup)
-#include <shellapi.h> // For Shell_NotifyIcon (system tray)
+#include <shellapi.h> // For Shell_NotifyIcon (system tray); PrivateExtractIconsA (Browse PE-icon extract)
 #include <commdlg.h>  // For GetOpenFileNameA (Phase 5.14 Browse tile)
+
+// PNG encoding for the Browse-for-app PE icon → tile-icon conversion. Defined
+// here (not in shell_app_scan.c) because main.c owns the Browse flow and this
+// keeps the dependency in one TU. STB_IMAGE_WRITE_IMPLEMENTATION must be
+// defined in exactly one source file per binary; the displayxr-service binary
+// has its own definition in comp_d3d11_service.cpp.
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+#include "stb_image_write.h"
 #else
 #include <unistd.h>
 #endif
@@ -258,13 +266,13 @@ struct registered_app
 {
 	char name[128];
 	char exe_path[MAX_PATH];
+	char manifest_path[MAX_PATH];  // .displayxr.json path (so launcher remove can delete it); "" for legacy entries
 	char type[8];          // "3d", "2d", or "" (unknown)
-	char source[8];        // "user" | "scan"  (5.5)
-	char category[32];     // sidecar "category", default "app"
-	char description[256]; // sidecar "description"
-	char display_mode[16]; // sidecar "display_mode", default "auto"
+	char category[32];     // manifest "category", default "app"
+	char description[256]; // manifest "description"
+	char display_mode[16]; // manifest "display_mode", default "auto"
 	char icon_path[MAX_PATH];     // resolved 2D icon (absolute) or ""
-	char icon_3d_path[MAX_PATH];  // resolved SBS icon (absolute) or ""
+	char icon_3d_path[MAX_PATH];  // resolved 3D icon (absolute) or ""
 	char icon_3d_layout[8];       // "sbs-lr"|"sbs-rl"|"tb"|"bt"|""
 };
 
@@ -328,32 +336,12 @@ registered_app_zero(struct registered_app *app)
 	memset(app, 0, sizeof(*app));
 }
 
-// Merge a single scanned app into the in-memory registry. If an existing
-// entry has a matching exe_path it is replaced; otherwise the entry is
-// appended.
+// Append a scanned app into the in-memory registry. The scanner already
+// dedups by exe_path, so we just append. Caller is responsible for clearing
+// g_registered_apps[] before the scan run.
 static void
-merge_scanned_app(const struct shell_scanned_app *s)
+append_scanned_app(const struct shell_scanned_app *s)
 {
-	// Replace any existing entry (user or scan) with the same exe_path.
-	for (int i = 0; i < g_registered_app_count; i++) {
-		if (exe_path_equal(g_registered_apps[i].exe_path, s->exe_path)) {
-			struct registered_app *app = &g_registered_apps[i];
-			registered_app_zero(app);
-			snprintf(app->name, sizeof(app->name), "%s", s->name);
-			snprintf(app->exe_path, sizeof(app->exe_path), "%s", s->exe_path);
-			snprintf(app->type, sizeof(app->type), "%s", s->type);
-			snprintf(app->source, sizeof(app->source), "scan");
-			snprintf(app->category, sizeof(app->category), "%s", s->category);
-			snprintf(app->description, sizeof(app->description), "%s", s->description);
-			snprintf(app->display_mode, sizeof(app->display_mode), "%s", s->display_mode);
-			snprintf(app->icon_path, sizeof(app->icon_path), "%s", s->icon_path);
-			snprintf(app->icon_3d_path, sizeof(app->icon_3d_path), "%s", s->icon_3d_path);
-			snprintf(app->icon_3d_layout, sizeof(app->icon_3d_layout), "%s", s->icon_3d_layout);
-			return;
-		}
-	}
-
-	// Append as a new entry.
 	if (g_registered_app_count >= MAX_REGISTERED_APPS) {
 		PE("registry full — dropping scanned app '%s'\n", s->name);
 		return;
@@ -362,31 +350,14 @@ merge_scanned_app(const struct shell_scanned_app *s)
 	registered_app_zero(app);
 	snprintf(app->name, sizeof(app->name), "%s", s->name);
 	snprintf(app->exe_path, sizeof(app->exe_path), "%s", s->exe_path);
+	snprintf(app->manifest_path, sizeof(app->manifest_path), "%s", s->manifest_path);
 	snprintf(app->type, sizeof(app->type), "%s", s->type);
-	snprintf(app->source, sizeof(app->source), "scan");
 	snprintf(app->category, sizeof(app->category), "%s", s->category);
 	snprintf(app->description, sizeof(app->description), "%s", s->description);
 	snprintf(app->display_mode, sizeof(app->display_mode), "%s", s->display_mode);
 	snprintf(app->icon_path, sizeof(app->icon_path), "%s", s->icon_path);
 	snprintf(app->icon_3d_path, sizeof(app->icon_3d_path), "%s", s->icon_3d_path);
 	snprintf(app->icon_3d_layout, sizeof(app->icon_3d_layout), "%s", s->icon_3d_layout);
-}
-
-// Remove every entry whose source == "scan". Called before re-running the
-// scanner so stale scan results from previous runs don't linger.
-static void
-drop_scan_entries(void)
-{
-	int dst = 0;
-	for (int i = 0; i < g_registered_app_count; i++) {
-		if (strcmp(g_registered_apps[i].source, "scan") != 0) {
-			if (dst != i) {
-				g_registered_apps[dst] = g_registered_apps[i];
-			}
-			dst++;
-		}
-	}
-	g_registered_app_count = dst;
 }
 
 // Forward declarations — these are called from registered_apps_load but
@@ -398,6 +369,10 @@ static void
 get_exe_dir(char *buf, size_t buf_size);
 #endif
 
+// Rebuild the in-memory registry from the manifest scanner. Manifests
+// (sidecar + registered) are now the sole source of truth — registered_apps.json
+// is just a debug snapshot of the last scan, not a separate input. See
+// docs/specs/displayxr-app-manifest.md §11.
 static void
 registered_apps_load(void)
 {
@@ -408,73 +383,14 @@ registered_apps_load(void)
 
 #ifdef _WIN32
 	{
-		// Make sure the parent directory exists before we try to write.
+		// Make sure the parent directory exists before we try to write the
+		// debug snapshot.
 		char dir[512];
 		snprintf(dir, sizeof(dir), "%s", path);
 		char *last = strrchr(dir, '\\');
 		if (last) { *last = '\0'; CreateDirectoryA(dir, NULL); }
 	}
-#endif
 
-	// -------- 1) Load existing JSON, if present. --------
-	FILE *f = fopen(path, "rb");
-	if (f != NULL) {
-		fseek(f, 0, SEEK_END);
-		long len = ftell(f);
-		fseek(f, 0, SEEK_SET);
-		if (len > 0 && len <= 256 * 1024) {
-			char *data = (char *)malloc((size_t)len + 1);
-			if (data != NULL) {
-				fread(data, 1, (size_t)len, f);
-				data[len] = '\0';
-
-				cJSON *root = cJSON_Parse(data);
-				free(data);
-				if (root && cJSON_IsArray(root)) {
-					cJSON *entry = NULL;
-					cJSON_ArrayForEach(entry, root)
-					{
-						if (g_registered_app_count >= MAX_REGISTERED_APPS) break;
-						struct registered_app *app =
-						    &g_registered_apps[g_registered_app_count];
-						registered_app_zero(app);
-
-						json_copy_str(app->name, sizeof(app->name), entry, "name");
-						json_copy_str(app->exe_path, sizeof(app->exe_path), entry, "exe_path");
-						json_copy_str(app->type, sizeof(app->type), entry, "type");
-						json_copy_str(app->source, sizeof(app->source), entry, "source");
-						json_copy_str(app->category, sizeof(app->category), entry, "category");
-						json_copy_str(app->description, sizeof(app->description), entry, "description");
-						json_copy_str(app->display_mode, sizeof(app->display_mode), entry, "display_mode");
-						json_copy_str(app->icon_path, sizeof(app->icon_path), entry, "icon_path");
-						json_copy_str(app->icon_3d_path, sizeof(app->icon_3d_path), entry, "icon_3d_path");
-						json_copy_str(app->icon_3d_layout, sizeof(app->icon_3d_layout), entry, "icon_3d_layout");
-
-						// Back-compat: a Phase 4C JSON has no `source` field.
-						// Treat pre-existing entries as user-added.
-						if (app->source[0] == '\0') {
-							snprintf(app->source, sizeof(app->source), "user");
-						}
-
-						g_registered_app_count++;
-					}
-				}
-				cJSON_Delete(root);
-			}
-		}
-		fclose(f);
-	} else {
-		P("No registered_apps.json found — starting with empty registry.\n");
-		// Per the spec, the launcher is manifest-gated: only apps with a
-		// .displayxr.json sidecar (or apps the user explicitly adds via
-		// Browse-for-app) appear. No built-in defaults. The scanner runs
-		// next and populates anything it finds.
-	}
-
-	// -------- 2) Drop stale scan entries, re-run scanner, merge. --------
-	drop_scan_entries();
-
-#ifdef _WIN32
 	{
 		char exe_dir[MAX_PATH] = {0};
 		get_exe_dir(exe_dir, sizeof(exe_dir));
@@ -486,18 +402,18 @@ registered_apps_load(void)
 		struct shell_scanned_app scanned[MAX_REGISTERED_APPS];
 		int n = shell_scan_apps(exe_dir, scanned, MAX_REGISTERED_APPS);
 		for (int i = 0; i < n; i++) {
-			merge_scanned_app(&scanned[i]);
+			append_scanned_app(&scanned[i]);
 		}
 	}
 #endif
 
-	P("Registry: %d app(s) after merge.\n", g_registered_app_count);
+	P("Registry: %d app(s) after scan.\n", g_registered_app_count);
 	for (int i = 0; i < g_registered_app_count; i++) {
-		P("  [%s] %s  (%s)\n", g_registered_apps[i].source, g_registered_apps[i].name,
-		  g_registered_apps[i].exe_path);
+		P("  %s  (%s)\n", g_registered_apps[i].name, g_registered_apps[i].exe_path);
 	}
 
-	// -------- 3) Persist merged registry so users can hand-edit later. --------
+	// Persist a snapshot of the current scan for debugging / inspection.
+	// Not a source of truth — the next load() rebuilds entirely from manifests.
 	registered_apps_save();
 }
 
@@ -514,7 +430,7 @@ registered_apps_save(void)
 		cJSON_AddStringToObject(obj, "name", app->name);
 		cJSON_AddStringToObject(obj, "exe_path", app->exe_path);
 		cJSON_AddStringToObject(obj, "type", app->type);
-		cJSON_AddStringToObject(obj, "source", app->source[0] ? app->source : "user");
+		if (app->manifest_path[0])  cJSON_AddStringToObject(obj, "manifest_path", app->manifest_path);
 		if (app->category[0])       cJSON_AddStringToObject(obj, "category", app->category);
 		if (app->description[0])    cJSON_AddStringToObject(obj, "description", app->description);
 		if (app->display_mode[0])   cJSON_AddStringToObject(obj, "display_mode", app->display_mode);
@@ -1277,32 +1193,149 @@ shell_push_registered_apps_to_service(struct ipc_connection *ipc_c)
 }
 
 #ifdef _WIN32
+
+// Get the per-user registered-mode discovery dir, e.g.
+// "C:\Users\foo\AppData\Local\DisplayXR\apps". Creates intermediate dirs.
+// Returns true on success.
+static bool
+get_registered_apps_dir(char *out, size_t out_size)
+{
+	const char *local_appdata = getenv("LOCALAPPDATA");
+	if (local_appdata == NULL || !*local_appdata) return false;
+
+	char base[MAX_PATH];
+	snprintf(base, sizeof(base), "%s\\DisplayXR", local_appdata);
+	CreateDirectoryA(base, NULL);
+
+	snprintf(out, out_size, "%s\\apps", base);
+	CreateDirectoryA(out, NULL);
+	return true;
+}
+
+// Replace path separators and any non-portable characters with '_'. Used to
+// derive a manifest filename from an exe basename.
+static void
+sanitize_basename(const char *src, char *dst, size_t dst_size)
+{
+	size_t i = 0;
+	for (; src[i] && i + 1 < dst_size; i++) {
+		char c = src[i];
+		bool ok = (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+		          (c >= '0' && c <= '9') || c == '.' || c == '_' || c == '-';
+		dst[i] = ok ? c : '_';
+	}
+	dst[i] = '\0';
+}
+
+// Extract the largest available app icon from @p exe and write it as PNG to
+// @p out_png. Uses PrivateExtractIconsA to request the largest standard size
+// (256x256), then DrawIconEx onto a 32-bit DIB so PNG-compressed Vista-era
+// icons render correctly. Returns true on success.
+static bool
+extract_pe_icon_to_png(const char *exe, const char *out_png)
+{
+	const int target = 256;
+	HICON hicon = NULL;
+	UINT extracted = PrivateExtractIconsA(exe, 0, target, target, &hicon, NULL, 1, 0);
+	if (extracted == 0 || extracted == (UINT)-1 || hicon == NULL) {
+		// Fall back to the system "large icon" size (32x32 on classic
+		// Windows). Better than nothing.
+		extracted = PrivateExtractIconsA(exe, 0, GetSystemMetrics(SM_CXICON),
+		                                 GetSystemMetrics(SM_CYICON), &hicon,
+		                                 NULL, 1, 0);
+		if (extracted == 0 || extracted == (UINT)-1 || hicon == NULL) {
+			return false;
+		}
+	}
+
+	// Determine icon dimensions from the actual HICON (PrivateExtractIcons
+	// may have given us the largest available size, not 256).
+	ICONINFO ii = {0};
+	if (!GetIconInfo(hicon, &ii)) {
+		DestroyIcon(hicon);
+		return false;
+	}
+	BITMAP bm = {0};
+	int w = target, h = target;
+	if (ii.hbmColor && GetObject(ii.hbmColor, sizeof(bm), &bm)) {
+		w = bm.bmWidth;
+		h = bm.bmHeight;
+	}
+	if (ii.hbmMask) DeleteObject(ii.hbmMask);
+	if (ii.hbmColor) DeleteObject(ii.hbmColor);
+
+	// Render the icon onto a 32bpp top-down DIB. DrawIconEx handles alpha
+	// for both Vista PNG icons and classic AND/XOR-mask icons.
+	BITMAPINFO bi = {0};
+	bi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
+	bi.bmiHeader.biWidth = w;
+	bi.bmiHeader.biHeight = -h;     // negative → top-down
+	bi.bmiHeader.biPlanes = 1;
+	bi.bmiHeader.biBitCount = 32;
+	bi.bmiHeader.biCompression = BI_RGB;
+
+	HDC screen_dc = GetDC(NULL);
+	HDC mem_dc = CreateCompatibleDC(screen_dc);
+	void *bits = NULL;
+	HBITMAP dib = CreateDIBSection(screen_dc, &bi, DIB_RGB_COLORS, &bits, NULL, 0);
+	ReleaseDC(NULL, screen_dc);
+
+	if (dib == NULL || bits == NULL) {
+		if (dib) DeleteObject(dib);
+		DeleteDC(mem_dc);
+		DestroyIcon(hicon);
+		return false;
+	}
+
+	HGDIOBJ prev = SelectObject(mem_dc, dib);
+	memset(bits, 0, (size_t)w * (size_t)h * 4);  // transparent background
+	BOOL drew = DrawIconEx(mem_dc, 0, 0, hicon, w, h, 0, NULL, DI_NORMAL);
+	SelectObject(mem_dc, prev);
+	DeleteDC(mem_dc);
+	DestroyIcon(hicon);
+
+	if (!drew) {
+		DeleteObject(dib);
+		return false;
+	}
+
+	// DIB layout is BGRA; stb expects RGBA, so swap channels in place.
+	uint8_t *px = (uint8_t *)bits;
+	for (int i = 0; i < w * h; i++) {
+		uint8_t b = px[i * 4 + 0];
+		px[i * 4 + 0] = px[i * 4 + 2];
+		px[i * 4 + 2] = b;
+	}
+
+	int ok = stbi_write_png(out_png, w, h, 4, bits, w * 4);
+	DeleteObject(dib);
+	return ok != 0;
+}
+
 /*!
- * Phase 5.14: prompt the user for an executable via GetOpenFileNameA,
- * append it to g_registered_apps as a user entry, persist to JSON, and
- * re-push the registry to the service. Mirrors the OPENFILENAMEA idiom
- * used by comp_d3d11_window.cpp's Ctrl+O launch flow.
+ * Browse-for-app: prompt for an executable, write a registered-mode manifest
+ * (`<sanitized>.displayxr.json` with `exe_path`) into
+ * `%LOCALAPPDATA%\DisplayXR\apps\`, extract the embedded PE icon as a sibling
+ * `<sanitized>.png`, and re-trigger discovery so the new tile shows up. See
+ * docs/specs/displayxr-app-manifest.md §11.
  *
  * Called from the launcher click-poll branch when the service signals a
- * Browse-tile hit (IPC_LAUNCHER_ACTION_BROWSE). The dialog is modal and
- * blocks the shell's message loop; on return the launcher is re-shown so
- * the user sees their new tile at the end of the grid.
+ * Browse-tile hit (IPC_LAUNCHER_ACTION_BROWSE). The file dialog is modal and
+ * blocks the shell's message loop; on return the launcher is re-shown so the
+ * user sees their new tile.
  */
 static void
 shell_browse_and_add_app(struct ipc_connection *ipc_c)
 {
-	// Phase 5.14: open the file dialog as a top-level window
-	// (hwndOwner=NULL). The service granted ASFW_ANY foreground permission
-	// when it processed the Browse click, so Windows lets the modal dialog
-	// activate normally. Using the hidden HWND_MESSAGE g_msg_hwnd as owner
-	// doesn't help — message-only windows can't be focused, so the dialog
-	// would still hide behind the compositor.
-	char path[MAX_PATH] = {0};
+	// Open the file dialog as a top-level window (hwndOwner=NULL). The
+	// service granted ASFW_ANY foreground permission when it processed the
+	// Browse click, so Windows lets the modal dialog activate normally.
+	char exe_path[MAX_PATH] = {0};
 	OPENFILENAMEA ofn = {0};
 	ofn.lStructSize = sizeof(ofn);
 	ofn.hwndOwner = NULL;
 	ofn.lpstrFilter = "Executables (*.exe)\0*.exe\0All Files (*.*)\0*.*\0";
-	ofn.lpstrFile = path;
+	ofn.lpstrFile = exe_path;
 	ofn.nMaxFile = MAX_PATH;
 	ofn.lpstrTitle = "Add app to DisplayXR launcher";
 	ofn.Flags = OFN_FILEMUSTEXIST | OFN_PATHMUSTEXIST | OFN_NOCHANGEDIR;
@@ -1312,16 +1345,10 @@ shell_browse_and_add_app(struct ipc_connection *ipc_c)
 		return;
 	}
 
-	if (g_registered_app_count >= MAX_REGISTERED_APPS) {
-		PE("Registry full (%d) — cannot add '%s'\n",
-		   g_registered_app_count, path);
-		return;
-	}
-
 	// Derive a display name from the exe basename (strip path and .exe).
-	const char *base = strrchr(path, '\\');
-	if (base == NULL) base = strrchr(path, '/');
-	base = base ? base + 1 : path;
+	const char *base = strrchr(exe_path, '\\');
+	if (base == NULL) base = strrchr(exe_path, '/');
+	base = base ? base + 1 : exe_path;
 	char name[128];
 	snprintf(name, sizeof(name), "%s", base);
 	size_t nlen = strlen(name);
@@ -1329,17 +1356,64 @@ shell_browse_and_add_app(struct ipc_connection *ipc_c)
 		name[nlen - 4] = '\0';
 	}
 
-	struct registered_app *app = &g_registered_apps[g_registered_app_count++];
-	registered_app_zero(app);
-	snprintf(app->name, sizeof(app->name), "%s", name);
-	snprintf(app->exe_path, sizeof(app->exe_path), "%s", path);
-	snprintf(app->type, sizeof(app->type), "3d");   // assume 3d; user can edit JSON
-	snprintf(app->source, sizeof(app->source), "user");
-	snprintf(app->category, sizeof(app->category), "app");
+	char sanitized[128];
+	sanitize_basename(name, sanitized, sizeof(sanitized));
 
-	registered_apps_save();
+	char dir[MAX_PATH];
+	if (!get_registered_apps_dir(dir, sizeof(dir))) {
+		PE("Browse: cannot resolve %%LOCALAPPDATA%%\\DisplayXR\\apps\n");
+		return;
+	}
+
+	char manifest_path[MAX_PATH];
+	snprintf(manifest_path, sizeof(manifest_path), "%s\\%s.displayxr.json", dir,
+	         sanitized);
+	char icon_path[MAX_PATH];
+	snprintf(icon_path, sizeof(icon_path), "%s\\%s.png", dir, sanitized);
+
+	bool have_icon = extract_pe_icon_to_png(exe_path, icon_path);
+	if (!have_icon) {
+		P("Browse: PE icon extraction failed for %s — manifest will be iconless\n",
+		  exe_path);
+	}
+
+	// Build the manifest JSON via cJSON for proper escaping of paths
+	// containing backslashes, spaces, etc.
+	cJSON *root = cJSON_CreateObject();
+	cJSON_AddNumberToObject(root, "schema_version", 1);
+	cJSON_AddStringToObject(root, "name", name);
+	cJSON_AddStringToObject(root, "type", "3d");
+	cJSON_AddStringToObject(root, "category", "app");
+	cJSON_AddStringToObject(root, "exe_path", exe_path);
+	if (have_icon) {
+		// Icon path is relative to the manifest, per §2.3.
+		char icon_rel[256];
+		snprintf(icon_rel, sizeof(icon_rel), "%s.png", sanitized);
+		cJSON_AddStringToObject(root, "icon", icon_rel);
+	}
+
+	char *json_str = cJSON_Print(root);
+	cJSON_Delete(root);
+	if (json_str == NULL) {
+		PE("Browse: cJSON_Print failed\n");
+		return;
+	}
+
+	FILE *f = fopen(manifest_path, "wb");
+	if (f == NULL) {
+		PE("Browse: cannot write manifest %s\n", manifest_path);
+		free(json_str);
+		return;
+	}
+	fwrite(json_str, 1, strlen(json_str), f);
+	fclose(f);
+	free(json_str);
+
+	P("Browse: wrote manifest %s\n", manifest_path);
+
+	// Re-scan + re-push so the new tile appears.
+	registered_apps_load();
 	shell_push_registered_apps_to_service(ipc_c);
-	P("Browse: added '%s' from %s\n", name, path);
 }
 #else
 static void
@@ -2148,8 +2222,52 @@ main(int argc, char *argv[])
 				} else if (tile_index <= -(int64_t)IPC_LAUNCHER_ACTION_REMOVE_BASE) {
 					int full_idx = (int)(-(tile_index) - IPC_LAUNCHER_ACTION_REMOVE_BASE);
 					if (full_idx >= 0 && full_idx < g_registered_app_count) {
-						P("Launcher: removing '%s' permanently\n",
-						  g_registered_apps[full_idx].name);
+						struct registered_app *rm = &g_registered_apps[full_idx];
+						P("Launcher: removing '%s' permanently\n", rm->name);
+
+#ifdef _WIN32
+						// Delete the manifest file (and sibling icon files)
+						// when it's a registered-mode manifest the user owns.
+						// Sidecar manifests in dev paths are developer-owned
+						// and never deleted here.
+						if (rm->manifest_path[0]) {
+							const char *local = getenv("LOCALAPPDATA");
+							const char *progdata = getenv("ProgramData");
+							bool in_user_dir = (local && _strnicmp(rm->manifest_path,
+							    local, strlen(local)) == 0);
+							bool in_system_dir = (progdata && _strnicmp(rm->manifest_path,
+							    progdata, strlen(progdata)) == 0);
+							if (in_user_dir || in_system_dir) {
+								if (DeleteFileA(rm->manifest_path)) {
+									P("  deleted manifest: %s\n", rm->manifest_path);
+								} else {
+									DWORD err = GetLastError();
+									PE("  could not delete manifest %s "
+									   "(err=%lu) — tile will reappear next scan\n",
+									   rm->manifest_path, err);
+								}
+								// Also delete the resolved icon files when
+								// they live alongside the manifest. We
+								// compare directories so we don't nuke a
+								// shared icon in another location.
+								char manifest_dir[MAX_PATH];
+								snprintf(manifest_dir, sizeof(manifest_dir), "%s",
+								         rm->manifest_path);
+								char *sep = strrchr(manifest_dir, '\\');
+								if (sep) *sep = '\0';
+								if (rm->icon_path[0] &&
+								    _strnicmp(rm->icon_path, manifest_dir,
+								              strlen(manifest_dir)) == 0) {
+									DeleteFileA(rm->icon_path);
+								}
+								if (rm->icon_3d_path[0] &&
+								    _strnicmp(rm->icon_3d_path, manifest_dir,
+								              strlen(manifest_dir)) == 0) {
+									DeleteFileA(rm->icon_3d_path);
+								}
+							}
+						}
+#endif
 						// Shift remaining entries down.
 						for (int j = full_idx; j < g_registered_app_count - 1; j++) {
 							g_registered_apps[j] = g_registered_apps[j + 1];

--- a/src/xrt/targets/shell/main.c
+++ b/src/xrt/targets/shell/main.c
@@ -512,6 +512,85 @@ get_runtime_json_path(char *buf, size_t buf_size)
 	return false;
 }
 
+// Write everything before the last path separator of @p path into @p out.
+// If there's no separator, @p out is set to "." (current dir). Used to derive
+// lpCurrentDirectory for CreateProcessA so launched apps land with their
+// install dir as CWD, matching Explorer-launched behavior.
+static void
+dirname_of(const char *path, char *out, size_t out_size)
+{
+	if (out_size == 0) return;
+	out[0] = '\0';
+	if (path == NULL || !*path) {
+		snprintf(out, out_size, ".");
+		return;
+	}
+
+	const char *last_bs = strrchr(path, '\\');
+	const char *last_fs = strrchr(path, '/');
+	const char *last = last_bs > last_fs ? last_bs : last_fs;
+	if (last == NULL) {
+		snprintf(out, out_size, ".");
+		return;
+	}
+
+	size_t len = (size_t)(last - path);
+	if (len >= out_size) len = out_size - 1;
+	memcpy(out, path, len);
+	out[len] = '\0';
+}
+
+// Ensure the Windows Per-App Graphics Settings registry has a "high
+// performance" preference for @p exe_path, matching what Settings → System →
+// Display → Graphics writes. DXGI honours this at process start, which puts
+// the launched app on the same adapter as the (dGPU-pinned) service. Without
+// it, third-party apps that don't carry NvOptimusEnablement land on the iGPU
+// on hybrid laptops, and the IPC shared swapchain texture renders black on
+// the service side because shared textures can't bridge two adapters.
+//
+// Idempotent. Only writes if the entry is missing or empty so a user-set
+// "Power saving" preference is respected.
+//
+// Reference: docs.microsoft.com/en-us/windows/win32/direct3ddxgi/dxgi-1-6-improvements
+static void
+ensure_app_gpu_pref_high(const char *exe_path)
+{
+	const char *kSubkey = "Software\\Microsoft\\DirectX\\UserGpuPreferences";
+	HKEY hkey = NULL;
+	DWORD disposition = 0;
+	LSTATUS rc = RegCreateKeyExA(HKEY_CURRENT_USER, kSubkey, 0, NULL,
+	                             REG_OPTION_NON_VOLATILE, KEY_READ | KEY_WRITE,
+	                             NULL, &hkey, &disposition);
+	if (rc != ERROR_SUCCESS || hkey == NULL) {
+		PE("ensure_app_gpu_pref_high: RegCreateKeyEx failed (%ld) for %s\n",
+		   (long)rc, exe_path);
+		return;
+	}
+
+	// Read existing value first — respect any pre-existing preference, even
+	// "power saving". Only write when missing/empty.
+	char existing[256] = {0};
+	DWORD existing_size = sizeof(existing);
+	DWORD existing_type = 0;
+	rc = RegQueryValueExA(hkey, exe_path, NULL, &existing_type,
+	                      (LPBYTE)existing, &existing_size);
+	bool already_set = (rc == ERROR_SUCCESS && existing_type == REG_SZ &&
+	                    existing_size > 1);
+	if (!already_set) {
+		const char *value = "GpuPreference=2;"; // 2 = high-performance / dGPU
+		rc = RegSetValueExA(hkey, exe_path, 0, REG_SZ, (const BYTE *)value,
+		                    (DWORD)strlen(value) + 1);
+		if (rc == ERROR_SUCCESS) {
+			P("Registered high-perf GPU preference for %s\n", exe_path);
+		} else {
+			PE("ensure_app_gpu_pref_high: RegSetValueEx failed (%ld) for %s\n",
+			   (long)rc, exe_path);
+		}
+	}
+
+	RegCloseKey(hkey);
+}
+
 /*!
  * Launch an app with DISPLAYXR_SHELL_SESSION=1 and XR_RUNTIME_JSON set.
  */
@@ -533,6 +612,17 @@ launch_app(struct app_entry *app, const char *runtime_json)
 		return false;
 	}
 
+	// Force the launched app onto the same adapter as the dGPU-pinned
+	// service so the IPC shared swapchain texture works on hybrid laptops.
+	// See ensure_app_gpu_pref_high for why this matters.
+	ensure_app_gpu_pref_high(abs_path);
+
+	// CWD = exe's install dir (matches Explorer behavior). DisplayXRClient.dll
+	// drops displayxr.log relative to CWD; without this it would land
+	// wherever the shell happened to be launched from.
+	char exe_dir[MAX_PATH];
+	dirname_of(abs_path, exe_dir, sizeof(exe_dir));
+
 	// Quote the exe path in case of spaces
 	char cmd[MAX_PATH + 16];
 	snprintf(cmd, sizeof(cmd), "\"%s\"", abs_path);
@@ -552,7 +642,7 @@ launch_app(struct app_entry *app, const char *runtime_json)
 	    NULL, cmd, NULL, NULL, FALSE,
 	    CREATE_NEW_CONSOLE,  // Each app gets its own console
 	    NULL,                // Inherit our (modified) environment
-	    NULL, &si, &pi);
+	    exe_dir, &si, &pi);
 
 	// Clean up env vars so they don't leak to future CreateProcess calls
 	// (though it doesn't matter since we set them every time)
@@ -1453,11 +1543,18 @@ shell_launch_registered_app(struct ipc_connection *ipc_c,
 		}
 		snprintf(cmd, sizeof(cmd), "\"%s\"", abs_path);
 
+		// 2D apps don't share textures, but pin them to the same adapter
+		// anyway for consistency with 3D apps and to keep DXGI happy.
+		ensure_app_gpu_pref_high(abs_path);
+
+		char exe_dir[MAX_PATH];
+		dirname_of(abs_path, exe_dir, sizeof(exe_dir));
+
 		// Clear shell env vars so 2D app doesn't accidentally pick them up
 		SetEnvironmentVariableA("DISPLAYXR_SHELL_SESSION", NULL);
 
 		BOOL ok = CreateProcessA(NULL, cmd, NULL, NULL, FALSE,
-		    CREATE_NEW_CONSOLE, NULL, NULL, &si, &pi);
+		    CREATE_NEW_CONSOLE, NULL, exe_dir, &si, &pi);
 		if (!ok) {
 			PE("  Failed to launch 2D app: %lu\n", GetLastError());
 			return;

--- a/src/xrt/targets/shell/shell_app_scan.c
+++ b/src/xrt/targets/shell/shell_app_scan.c
@@ -28,6 +28,11 @@
 
 #include <windows.h>
 
+// Forward declaration — used by the sidecar walk below to dedup against
+// already-registered entries; defined alongside the registered-mode helpers.
+static bool
+already_present(const struct shell_scanned_app *out, int count, const char *exe);
+
 // -----------------------------------------------------------------------------
 // Sidecar parsing
 // -----------------------------------------------------------------------------
@@ -104,11 +109,23 @@ resolve_icon_path(const char *sidecar_dir, const char *rel, char *out, size_t ou
 	copy_str(out, out_size, candidate);
 }
 
-// Validate and populate a scanned_app from a parsed sidecar JSON object.
+// Validate and populate a scanned_app from a parsed manifest JSON object.
+//
+// @p exe_path is the resolved absolute exe path. In sidecar mode the caller
+// derives it from the manifest's sibling .exe; in registered mode the caller
+// reads it from the manifest's "exe_path" field.
+//
+// @p sidecar_dir is the directory containing the manifest — used for resolving
+// relative icon paths.
+//
+// @p manifest_path is the absolute path to the .displayxr.json file — recorded
+// so the launcher's remove action can delete it (registered mode) or skip
+// deletion (sidecar mode, by checking the path location).
+//
 // Returns true on success.
 static bool
 parse_sidecar(const cJSON *root, const char *exe_path, const char *sidecar_dir,
-              struct shell_scanned_app *app)
+              const char *manifest_path, struct shell_scanned_app *app)
 {
 	memset(app, 0, sizeof(*app));
 
@@ -205,6 +222,7 @@ parse_sidecar(const cJSON *root, const char *exe_path, const char *sidecar_dir,
 	}
 
 	copy_str(app->exe_path, sizeof(app->exe_path), exe_path);
+	copy_str(app->manifest_path, sizeof(app->manifest_path), manifest_path ? manifest_path : "");
 	return true;
 }
 
@@ -257,7 +275,7 @@ try_load_app_from_exe(const char *exe_path, struct shell_scanned_app *app)
 	if (!last_sep) last_sep = strrchr(sidecar_dir, '/');
 	if (last_sep) *last_sep = '\0';
 
-	bool ok = parse_sidecar(root, exe_path, sidecar_dir, app);
+	bool ok = parse_sidecar(root, exe_path, sidecar_dir, sidecar_path, app);
 	cJSON_Delete(root);
 
 	if (!ok) return false;
@@ -301,6 +319,9 @@ scan_dir_for_exes(const char *dir, struct shell_scanned_app *out, int max_out, i
 
 		if (*count >= max_out) break;
 
+		// Skip if a registered-mode (or earlier) entry already targets this exe.
+		if (already_present(out, *count, exe_path)) continue;
+
 		if (try_load_app_from_exe(exe_path, &out[*count])) {
 			(*count)++;
 		}
@@ -340,6 +361,158 @@ scan_parent_build_dirs(const char *parent, struct shell_scanned_app *out, int ma
 		scan_dir_for_exes(build_dir, out, max_out, count);
 
 		if (*count >= max_out) break;
+	} while (FindNextFileA(h, &fd));
+
+	FindClose(h);
+}
+
+// -----------------------------------------------------------------------------
+// Dedup
+// -----------------------------------------------------------------------------
+
+// Case-insensitive, slash-normalized comparison of two exe paths. Mirrors the
+// logic in main.c::exe_path_equal — kept duplicated rather than #include'd
+// because shell_app_scan is a separate TU and main.c does not export this.
+static bool
+exe_path_eq_ci(const char *a, const char *b)
+{
+	if (a == NULL || b == NULL) return a == b;
+	while (*a && *b) {
+		int ca = (unsigned char)*a;
+		int cb = (unsigned char)*b;
+		if (ca == '/') ca = '\\';
+		if (cb == '/') cb = '\\';
+		if (ca >= 'A' && ca <= 'Z') ca += 32;
+		if (cb >= 'A' && cb <= 'Z') cb += 32;
+		if (ca != cb) return false;
+		a++; b++;
+	}
+	return *a == '\0' && *b == '\0';
+}
+
+// True if @p exe is already represented in @p out[0..count). Used to drop
+// duplicates so the first registration (per walk order) wins.
+static bool
+already_present(const struct shell_scanned_app *out, int count, const char *exe)
+{
+	for (int i = 0; i < count; i++) {
+		if (exe_path_eq_ci(out[i].exe_path, exe)) return true;
+	}
+	return false;
+}
+
+// -----------------------------------------------------------------------------
+// Registered-mode scan (manifest in a discovery dir, exe via "exe_path")
+// -----------------------------------------------------------------------------
+
+// Try to load a registered manifest from @p manifest_path. Reads the JSON,
+// requires "exe_path" to be present and resolve to an existing file, then
+// reuses parse_sidecar(). On success, populates @p app and returns true.
+static bool
+try_load_registered_manifest(const char *manifest_path, struct shell_scanned_app *app)
+{
+	char *text = read_file_text(manifest_path, 64 * 1024);
+	if (!text) {
+		LOG_W("failed to read manifest: %s\n", manifest_path);
+		return false;
+	}
+
+	cJSON *root = cJSON_Parse(text);
+	free(text);
+	if (!root) {
+		LOG_W("invalid JSON in manifest: %s\n", manifest_path);
+		return false;
+	}
+
+	const cJSON *j_exe = cJSON_GetObjectItemCaseSensitive(root, "exe_path");
+	if (!cJSON_IsString(j_exe) || !j_exe->valuestring || !*j_exe->valuestring) {
+		LOG_W("rejecting %s: registered manifest missing exe_path\n", manifest_path);
+		cJSON_Delete(root);
+		return false;
+	}
+
+	// Normalize slashes to backslashes so the value matches what Windows APIs
+	// produce. Also bounds-check.
+	char exe_path[SHELL_PATH_MAX];
+	if (strlen(j_exe->valuestring) >= sizeof(exe_path)) {
+		LOG_W("rejecting %s: exe_path too long\n", manifest_path);
+		cJSON_Delete(root);
+		return false;
+	}
+	copy_str(exe_path, sizeof(exe_path), j_exe->valuestring);
+	for (char *p = exe_path; *p; p++) {
+		if (*p == '/') *p = '\\';
+	}
+
+	DWORD attrs = GetFileAttributesA(exe_path);
+	if (attrs == INVALID_FILE_ATTRIBUTES || (attrs & FILE_ATTRIBUTE_DIRECTORY)) {
+		LOG_W("rejecting %s: exe_path does not exist (%s)\n", manifest_path, exe_path);
+		cJSON_Delete(root);
+		return false;
+	}
+
+	// Manifest dir = parent of manifest_path; relative icon paths resolve here.
+	char manifest_dir[SHELL_PATH_MAX];
+	copy_str(manifest_dir, sizeof(manifest_dir), manifest_path);
+	char *last_sep = strrchr(manifest_dir, '\\');
+	if (!last_sep) last_sep = strrchr(manifest_dir, '/');
+	if (last_sep) *last_sep = '\0';
+
+	bool ok = parse_sidecar(root, exe_path, manifest_dir, manifest_path, app);
+	cJSON_Delete(root);
+	if (!ok) return false;
+
+	// Same warning as sidecar mode — manifest is authoritative but a missing
+	// openxr import on a "3d" app is usually a misconfiguration.
+	if (strcmp(app->type, "3d") == 0) {
+		if (!shell_pe_exe_imports(exe_path, "openxr_loader.dll")) {
+			LOG_W("warning: %s has type=3d but does not import openxr_loader.dll\n",
+			      exe_path);
+		}
+	}
+	return true;
+}
+
+// Enumerate *.displayxr.json files in @p dir (non-recursive). For each, try to
+// load it as a registered manifest. Skip duplicates by exe_path.
+static void
+scan_registered_dir(const char *dir, struct shell_scanned_app *out, int max_out, int *count)
+{
+	if (*count >= max_out) return;
+
+	DWORD dir_attrs = GetFileAttributesA(dir);
+	if (dir_attrs == INVALID_FILE_ATTRIBUTES || !(dir_attrs & FILE_ATTRIBUTE_DIRECTORY)) {
+		// Discovery dir doesn't exist yet — that's fine, just skip.
+		return;
+	}
+
+	LOG_I("scanning registered dir: %s\n", dir);
+
+	char glob[SHELL_PATH_MAX];
+	snprintf(glob, sizeof(glob), "%s\\*.displayxr.json", dir);
+
+	WIN32_FIND_DATAA fd;
+	HANDLE h = FindFirstFileA(glob, &fd);
+	if (h == INVALID_HANDLE_VALUE) return;
+
+	do {
+		if (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) continue;
+		if (*count >= max_out) break;
+
+		char manifest_path[SHELL_PATH_MAX];
+		snprintf(manifest_path, sizeof(manifest_path), "%s\\%s", dir, fd.cFileName);
+
+		struct shell_scanned_app candidate;
+		if (!try_load_registered_manifest(manifest_path, &candidate)) continue;
+
+		if (already_present(out, *count, candidate.exe_path)) {
+			LOG_I("dedup: %s already registered, skipping %s\n",
+			      candidate.exe_path, manifest_path);
+			continue;
+		}
+
+		out[*count] = candidate;
+		(*count)++;
 	} while (FindNextFileA(h, &fd));
 
 	FindClose(h);
@@ -389,7 +562,26 @@ shell_scan_apps(const char *shell_exe_dir, struct shell_scanned_app *out, int ma
 
 	int count = 0;
 
-	// 1) Dev-repo layout — walk up from the shell exe dir looking for test_apps/.
+	// 1) Registered-mode dirs (drop-in *.displayxr.json with exe_path).
+	//    Walked first so per-user registrations win over system-wide,
+	//    which win over sidecar-mode dev paths. See
+	//    docs/specs/displayxr-app-manifest.md §5.
+	{
+		const char *local_appdata = getenv("LOCALAPPDATA");
+		if (local_appdata && *local_appdata) {
+			char dir[SHELL_PATH_MAX];
+			snprintf(dir, sizeof(dir), "%s\\DisplayXR\\apps", local_appdata);
+			scan_registered_dir(dir, out, max_out, &count);
+		}
+		const char *program_data = getenv("ProgramData");
+		if (program_data && *program_data) {
+			char dir[SHELL_PATH_MAX];
+			snprintf(dir, sizeof(dir), "%s\\DisplayXR\\apps", program_data);
+			scan_registered_dir(dir, out, max_out, &count);
+		}
+	}
+
+	// 2) Sidecar-mode dev paths — walk up from the shell exe dir looking for test_apps/.
 	char repo_root[SHELL_PATH_MAX] = {0};
 	bool have_repo = false;
 	if (shell_exe_dir && *shell_exe_dir) {
@@ -420,7 +612,9 @@ shell_scan_apps(const char *shell_exe_dir, struct shell_scanned_app *out, int ma
 		LOG_I("no repo root found — skipping dev paths\n");
 	}
 
-	// 2) Production install path.
+	// 3) Sidecar-mode production install path. Kept for backward compat with
+	//    the original v1 install layout. New installers should prefer
+	//    registered mode (step 1).
 	const char *pf = getenv("ProgramFiles");
 	if (pf && *pf) {
 		char prod[SHELL_PATH_MAX];
@@ -428,9 +622,6 @@ shell_scan_apps(const char *shell_exe_dir, struct shell_scanned_app *out, int ma
 		DWORD attrs = GetFileAttributesA(prod);
 		if (attrs != INVALID_FILE_ATTRIBUTES && (attrs & FILE_ATTRIBUTE_DIRECTORY)) {
 			LOG_I("scanning production path: %s\n", prod);
-			// v1: flat layout — exes directly under DisplayXR\apps\. Future
-			// installer shape (per-app subdirectories) can be added when it
-			// exists.
 			scan_dir_for_exes(prod, out, max_out, &count);
 		}
 	}

--- a/src/xrt/targets/shell/shell_app_scan.h
+++ b/src/xrt/targets/shell/shell_app_scan.h
@@ -34,31 +34,42 @@ extern "C" {
 #endif
 
 /*!
- * A single app discovered by the scanner. Populated from the sidecar manifest
- * plus filesystem resolution. All string fields are NUL-terminated.
+ * A single app discovered by the scanner. Populated from the manifest plus
+ * filesystem resolution. All string fields are NUL-terminated.
  */
 struct shell_scanned_app
 {
-	char name[SHELL_APP_NAME_MAX];                    // sidecar "name"
+	char name[SHELL_APP_NAME_MAX];                    // manifest "name"
 	char exe_path[SHELL_PATH_MAX];                    // absolute path to the .exe
+	char manifest_path[SHELL_PATH_MAX];               // absolute path to the .displayxr.json (so the launcher can delete it on remove)
 	char type[SHELL_APP_TYPE_MAX];                    // "3d" or "2d"
-	char category[SHELL_APP_CATEGORY_MAX];            // sidecar "category", default "app"
-	char description[SHELL_APP_DESCRIPTION_MAX];      // sidecar "description"
-	char display_mode[SHELL_APP_DISPLAY_MODE_MAX];    // sidecar "display_mode", default "auto"
+	char category[SHELL_APP_CATEGORY_MAX];            // manifest "category", default "app"
+	char description[SHELL_APP_DESCRIPTION_MAX];      // manifest "description"
+	char display_mode[SHELL_APP_DISPLAY_MODE_MAX];    // manifest "display_mode", default "auto"
 	char icon_path[SHELL_PATH_MAX];                   // absolute path or "" if none
 	char icon_3d_path[SHELL_PATH_MAX];                // absolute path or "" if none
 	char icon_3d_layout[SHELL_APP_ICON_LAYOUT_MAX];   // "sbs-lr"|"sbs-rl"|"tb"|"bt", empty if no icon_3d
 };
 
 /*!
- * Scan the standard DisplayXR app-discovery paths and populate @p out.
+ * Scan the DisplayXR app-discovery paths and populate @p out.
  *
- * @p shell_exe_dir is the directory containing the shell binary; relative scan
- * paths are resolved against it (e.g. @c <shell_exe_dir>/../test_apps/).
+ * Two manifest modes are walked (see docs/specs/displayxr-app-manifest.md §5):
+ *
+ *  - **Registered-mode dirs** — `%LOCALAPPDATA%\DisplayXR\apps\` and
+ *    `%ProgramData%\DisplayXR\apps\`. Each `*.displayxr.json` carries an
+ *    `exe_path` field pointing anywhere on disk.
+ *  - **Sidecar-mode dev paths** — `<shell_exe_dir>/../test_apps/*\/build\`,
+ *    `<shell_exe_dir>/../demos/*\/build\`, `<shell_exe_dir>/../_package/bin\`,
+ *    `%PROGRAMFILES%\DisplayXR\apps\`. The manifest is the sibling
+ *    `<basename>.displayxr.json` of each `.exe`.
+ *
+ * Entries are deduplicated by `exe_path` (registered dirs win over sidecar dirs
+ * by walk order; per-user wins over system-wide).
  *
  * Returns the number of apps written to @p out (at most @p max_out). Rejected
- * manifests (missing required fields, schema_version mismatch, unreadable icon
- * files) are logged and skipped.
+ * manifests (missing required fields, schema_version mismatch, missing exe,
+ * unreadable icon files) are logged and skipped.
  */
 int
 shell_scan_apps(const char *shell_exe_dir, struct shell_scanned_app *out, int max_out);


### PR DESCRIPTION
## Summary

Three independent shell-side improvements bundled together because they all surfaced (and were tested) in the same session.

### 1. Drop-in manifest discovery (#182)
Apps no longer need to live under `Program Files\DisplayXR\apps\` to appear in the launcher. New `exe_path` field in the `.displayxr.json` schema lets a manifest dropped into `%LOCALAPPDATA%\DisplayXR\apps\` (per-user, no elevation) or `%ProgramData%\DisplayXR\apps\` (system-wide) point at any executable on disk.

- Spec bump (additive, still `schema_version: 1`): `docs/specs/displayxr-app-manifest.md`
- Implementation plan: `docs/roadmap/shell-app-discovery-v2-plan.md`
- Sidecar mode (manifest next to exe in dev paths) still works unchanged.
- Dedup-by-`exe_path` precedence: per-user > system-wide > sidecar dev paths > legacy `%PROGRAMFILES%\DisplayXR\apps\`.
- Browse-for-app rewrite: now extracts the embedded PE icon (`PrivateExtractIcons` + `DrawIconEx` + `stbi_write_png`) and writes a registered manifest. `registered_apps.json` becomes a debug snapshot only; the `source:\"user\"` vs `source:\"scan\"` distinction is gone.
- Launcher \"remove\" deletes the manifest + sibling icons when they live in a registered dir.

### 2. Service orchestrator: WM_APP IDs collision fix
`WM_ORCHESTRATOR_SPAWN_SHELL` was `WM_APP+1`, the same value `service_tray_win.c` uses for `WM_TRAYICON`. The orchestrator subclass was eating tray notifications. Moved the orchestrator's three message IDs to `WM_APP+100..102` and documented the constraint inline.

### 3. Shell launch path: dGPU pinning + CWD = exe install dir

Two papercuts in `launch_app` / the 2D-launch branch:

- **GPU pinning** — after c49afc193 the service compositor is on the dGPU and only apps linking `sr_common_base` carry `NvOptimusEnablement`. Third-party apps (Unity, Unreal, anything outside this repo) land on the iGPU on hybrid laptops, and the IPC shared swapchain texture cannot bridge two physical adapters. Fix: write `HKCU\Software\Microsoft\DirectX\UserGpuPreferences\<exe> = \"GpuPreference=2;\"` before `CreateProcessA`. Per-user, no elevation, idempotent. Skips the write if any value is already set so a user-chosen \"power saving\" preference is respected.
- **CWD inheritance** — `CreateProcessA` was called with `lpCurrentDirectory=NULL`, so launched apps inherited the shell's CWD. When the shell was spawned by Ctrl+Space from a terminal in the repo root, `DisplayXRClient.dll`'s relative-path `displayxr.log` landed in the repo instead of next to the exe. Pass `dirname(abs_path)` so per-app logs live next to their exe, matching Explorer.

Both fixes apply to 3D and 2D launch paths.

## Plugin follow-ups (separate issues)

- DisplayXR/displayxr-unity#54 — \"Register with DisplayXR shell\" toggle for the Unity manifest build processor.
- DisplayXR/displayxr-unreal#5 — Net-new manifest pipeline (no infra exists today).

## Known limitations not addressed by this PR

Unity and Unreal builds still render black/grey in the shell launcher slot even with the dGPU pin. Comparison testing in the same session shows `cube_handle_d3d12_win` works perfectly; Unity (also D3D12) does not. The structural difference is the swapchain layout — cube uses a single 3840×2160 atlas-tiled UNORM swapchain, Unity uses two independent 1920×1080 per-view UNORM_SRGB swapchains and submits both views with `arrayIdx=0 rect=(0,0 1920x1080)`. The per-view-swapchain blit path in `comp_d3d11_service::compositor_layer_commit` (around lines 9510-9670) silently drops content for that layout. To be tracked + fixed in a separate issue.

## Test plan

- [x] Hand-author a manifest in `%LOCALAPPDATA%\DisplayXR\apps\` pointing at a Unity build outside Program Files — tile appears with correct icon.
- [x] Browse-for-app on a fresh exe — manifest + extracted PE icon appear in the discovery dir; persists across shell restarts.
- [x] Click \"remove\" on a Browse-added tile — manifest file is deleted.
- [x] `cube_handle_d3d12_win` launched via tile renders correctly (regression check for the GPU pref + CWD changes).
- [x] Registry inspection: `HKCU:\Software\Microsoft\DirectX\UserGpuPreferences` shows the launched exe with `GpuPreference=2;`.
- [x] Per-app `displayxr.log` lives next to its exe, not in the repo root.
- [ ] Unity / Unreal launcher tile renders content (blocked on the per-view-swapchain compositor bug — separate issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)