### PR TITLE
Workspace extensions: Phase 1 + Phase 2.0 (brand separation)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -349,7 +349,7 @@ _package\bin\displayxr-shell.exe --pose -0.1,0.05,0,0.14,0.08 app1.exe --pose 0.
 
 **Shell controls:** Left-click=focus window, title bar drag=move window, edge drag=resize, Right-click=focus+forward to app, Double-click title bar=maximize/restore, Scroll=resize window, Ctrl+1-4=layout presets, TAB=cycle focus, DELETE=close app, ESC=dismiss shell, V=toggle 2D/3D, WASD/left-click-drag=app input. Title bar buttons: close (X), minimize (—). Spatial raycasting hit-test (eye→cursor→window plane in meters).
 
-**When launching from Claude Code:** Use `displayxr-shell.exe` — it handles service auto-start, `XR_RUNTIME_JSON`, and `DISPLAYXR_SHELL_SESSION=1` automatically. Use `run_in_background: true` on the Bash tool call and `timeout: 600000`. See `docs/roadmap/shell-phase1-status.md` for the full test procedure.
+**When launching from Claude Code:** Use `displayxr-shell.exe` — it handles service auto-start, `XR_RUNTIME_JSON`, and `DISPLAYXR_WORKSPACE_SESSION=1` automatically. Use `run_in_background: true` on the Bash tool call and `timeout: 600000`. See `docs/roadmap/shell-phase1-status.md` for the full test procedure.
 
 ## Documentation
 
@@ -373,7 +373,7 @@ See `docs/README.md` for a complete index. Key docs by task:
 | Track shell implementation progress | `docs/roadmap/shell-tasks.md` |
 | Shell Phase 2 plan and status | `docs/roadmap/shell-phase2-plan.md`, `shell-phase2-status.md` |
 | Understand the 3D capture pipeline | `docs/roadmap/3d-capture.md` |
-| Understand shell/runtime IPC contract | `docs/roadmap/shell-runtime-contract.md` |
+| Understand workspace/runtime IPC contract | `docs/roadmap/workspace-runtime-contract.md` |
 | Understand the overall product vision | `docs/roadmap/spatial-desktop-prd.md` |
 
 ## Debug Logs
@@ -474,7 +474,7 @@ For ACCESS_VIOLATION or other crashes in the runtime or test apps:
 # Launch app under procdump — catches first-chance exception and writes full dump
 procdump64.exe -accepteula -e -ma -x . path/to/app.exe
 ```
-For shell mode: start the service first (`displayxr-service.exe --shell`), set `XR_RUNTIME_JSON` and `DISPLAYXR_SHELL_SESSION=1`, then launch the app under procdump.
+For shell mode: start the service first (`displayxr-service.exe --shell`), set `XR_RUNTIME_JSON` and `DISPLAYXR_WORKSPACE_SESSION=1`, then launch the app under procdump.
 
 **Step 2: Analyze the dump** with cdb (installed with WinDbg):
 ```bash

--- a/docs/README.md
+++ b/docs/README.md
@@ -89,6 +89,9 @@ Design docs, status trackers, and plans — some shipped, some in progress.
 - [Spatial Desktop PRD](roadmap/spatial-desktop-prd.md) — product vision
 - [Spatial Workspace Extensions Plan](roadmap/spatial-workspace-extensions-plan.md) — three-phase plan to decouple the shell from the runtime: boundary rename (Phase 1, done), policy migration behind extensions (Phase 2), repo severance (Phase 3)
 - [Workspace Extensions Header Sketch](roadmap/spatial-workspace-extensions-headers-draft.md) — `XR_EXT_spatial_workspace.h` + `XR_EXT_app_launcher.h` C-level API draft, mapping table from the existing IPC RPCs, mechanism-vs-policy lists, open design questions
+- [Workspace Controller Detection](roadmap/spatial-workspace-controller-detection.md) — Phase 2.0 prep: orchestrator detects installed controller via sidecar `.controller.json` manifest; tray submenu shows / hides accordingly. Makes the bare-runtime install (no shell) a real product
+- [Workspace Activation Auth Handshake](roadmap/spatial-workspace-auth-handshake.md) — Phase 2.0 prep: orchestrator-PID match replaces the brand-coupled `application_name == "displayxr-shell"` check
+- [Phase 2 Audit](roadmap/spatial-workspace-extensions-phase2-audit.md) — line-by-line classification of the 162 remaining `shell` mentions in `comp_d3d11_service.cpp` as mechanism / policy / gone, with sub-step migration order (2.A through 2.H)
 - [Workspace/Runtime Contract](roadmap/workspace-runtime-contract.md) — IPC message set between a workspace controller and the runtime (the current implementation; promoted to public extensions in Phase 2)
 - [Display Spatial Model](roadmap/display-spatial-model.md) — displays in the spatial graph (#46)
 - [Multi-Display Single Machine](roadmap/multi-display-single-machine.md) — multiple displays, one machine (#69)

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@ Build apps for 3D displays using the OpenXR standard.
 
 Contribute to the DisplayXR runtime — compositors, state tracker, auxiliary code.
 
-- **[Production Components](architecture/production-components.md)** — what ships, what runs, how the pieces connect (service, shell, bridge, runtime DLL)
+- **[Production Components](architecture/production-components.md)** — what ships, what runs, how the pieces connect (service, workspace controller, bridge, runtime DLL)
 - **[Contributing Guide](guides/contributing.md)** — workflow, code style, CI expectations
 - **[Separation of Concerns](architecture/separation-of-concerns.md)** — layer boundaries (authoritative)
 - **[Project Structure](architecture/project-structure.md)** — source tree organization
@@ -78,7 +78,7 @@ Design docs, status trackers, and plans — some shipped, some in progress.
 - [Spatial OS](roadmap/spatial-os.md) — multi-compositor architecture (#43)
 - [3D Shell](roadmap/3d-shell.md) — spatial window manager (#44)
 - [3D Capture](roadmap/3d-capture.md) — capture pipeline (shipped in Shell Phase 8)
-- [Shell/Runtime Contract](roadmap/shell-runtime-contract.md) — IPC between shell and runtime
+- [Workspace/Runtime Contract](roadmap/workspace-runtime-contract.md) — IPC between a workspace controller and the runtime
 - [MCP Spec v0.2](roadmap/mcp-spec-v0.2.md) — AI-native runtime control & introspection over Model Context Protocol
 - [MCP Phase A Status](roadmap/mcp-phase-a-status.md) — handle-app introspection (complete)
 - [MCP Phase B Plan](roadmap/mcp-phase-b-plan.md) — service-mode shell tools (complete)

--- a/docs/README.md
+++ b/docs/README.md
@@ -87,6 +87,9 @@ Design docs, status trackers, and plans — some shipped, some in progress.
 
 - **[Roadmap Overview](roadmap/overview.md)** — milestone status and project trajectory
 - [Spatial Desktop PRD](roadmap/spatial-desktop-prd.md) — product vision
+- [Spatial Workspace Extensions Plan](roadmap/spatial-workspace-extensions-plan.md) — three-phase plan to decouple the shell from the runtime: boundary rename (Phase 1, done), policy migration behind extensions (Phase 2), repo severance (Phase 3)
+- [Workspace Extensions Header Sketch](roadmap/spatial-workspace-extensions-headers-draft.md) — `XR_EXT_spatial_workspace.h` + `XR_EXT_app_launcher.h` C-level API draft, mapping table from the existing IPC RPCs, mechanism-vs-policy lists, open design questions
+- [Workspace/Runtime Contract](roadmap/workspace-runtime-contract.md) — IPC message set between a workspace controller and the runtime (the current implementation; promoted to public extensions in Phase 2)
 - [Display Spatial Model](roadmap/display-spatial-model.md) — displays in the spatial graph (#46)
 - [Multi-Display Single Machine](roadmap/multi-display-single-machine.md) — multiple displays, one machine (#69)
 - [Multi-Display Networked](roadmap/multi-display-networked.md) — displays across the network (#70)

--- a/docs/adr/ADR-016-workspace-controllers-own-tray-surface-and-lifecycle.md
+++ b/docs/adr/ADR-016-workspace-controllers-own-tray-surface-and-lifecycle.md
@@ -1,0 +1,57 @@
+---
+status: Accepted
+date: 2026-04-28
+---
+# ADR-016: Workspace Controllers Own Their Tray Surface and Lifecycle
+
+## Context
+
+DisplayXR ships a system tray icon (in `displayxr-service.exe`) that surfaces runtime state and lets the user manage the workspace controller — the DisplayXR Shell today, and any future third-party workspace app registered via the `XR_EXT_spatial_workspace`-family extensions. The service currently hardcodes a `Workspace Controller` submenu with **Enable / Auto / Disable** radio items, and the orchestrator (`service_orchestrator.c`) implements those verbs directly:
+
+- **Enable** spawns the controller binary and keeps it running.
+- **Auto** registers a `Ctrl+Space` low-level keyboard hook that spawns the controller on demand.
+- **Disable** issues `TerminateProcess` on the controller, hard-killing it from outside its own process model.
+
+Phase 2.0 of the brand-separation milestone (`feature/shell-brand-separation`) decoupled the runtime from the literal "displayxr-shell" name: the controller path is discoverable, the friendly tray label comes from a sidecar manifest, and `workspace_activate` is gated by orchestrator-PID match instead of `applicationName == "displayxr-shell"`. But the service still **owns the menu structure and the verbs themselves**. That is workable while there is exactly one controller (the DisplayXR Shell) whose teardown happens to be "killing the process is fine." It breaks as soon as a third-party workspace controller registers and has any of:
+
+- Unsaved state to flush (open user windows, in-flight network requests, IPC peers expecting a clean disconnect).
+- A different desired action set — "Disable" might be wrong; "Lock", "Sleep", "Switch User", or vendor-defined verbs might be right.
+- A different set of compositor and OS resources whose lifecycle only the controller knows how to release.
+
+A symptom of the current architecture surfaced during Phase 2.0 functional testing: clicking **Disable** hard-kills the shell process via `TerminateProcess`, but the workspace D3D11 window — owned by the *service* compositor, not the controller — keeps rendering the controller's last frame indefinitely, because nothing tells the compositor that workspace mode is over. The compositor's existing deactivate path is reached today only when the workspace window receives `WM_CLOSE` (current code: ESC / window close-button on the compositor window), and that path is itself slated to change for unrelated UX reasons: ESC must stop closing the shell and revert to closing only hosted windows in direct-IPC apps. Patching the lingering-window symptom from the service side (synthetic `WM_CLOSE`, cross-module compositor callback, polled PID heartbeat) would couple the runtime more tightly to one controller's UX rather than less.
+
+## Decision
+
+The runtime owns the tray icon and renders the tray menu. Workspace controllers — first-party (DisplayXR Shell) and third-party — own:
+
+1. **The tray menu items** they want to expose: their submenu's structure, labels, radio/checkbox state.
+2. **The handlers** for those items: what each click does.
+3. **Their own lifecycle**, including how to respond to a "Disable" / "Quit" / equivalent click. The service does not call `TerminateProcess` on a registered controller; it relays the click to the controller via IPC and the controller exits itself.
+
+The service's responsibilities reduce to:
+
+- Detecting that a controller is installed (manifest discovery — already shipped in Phase 2.0).
+- Receiving menu definitions from the controller via the workspace extension protocol.
+- Rendering those items in the tray submenu and routing OS click events back to the controller.
+- Forwarding clicks back to the controller as IPC messages.
+- Hard-killing the controller **only as a last-resort fallback** if the controller is unresponsive within a timeout, or if no controller is registered.
+
+The current `Enable / Auto / Disable` set, the `Ctrl+Space` keyboard-hook-based spawn, and the orchestrator's `TerminateProcess` path remain the **transitional implementation** until the controller-driven menu protocol lands. They are first-party-shell defaults that get stripped out the moment a third-party controller registers its own menu definitions.
+
+## Consequences
+
+- The runtime stops being opinionated about workspace verbs. "Disable" is no longer a runtime concept — it is a controller-defined verb that some controllers may expose and others may not.
+- Third-party workspace controllers can ship without the runtime knowing anything about their UX semantics. The runtime's only invariant about controllers is: "there is at most one active, it has a manifest, it follows the workspace extension protocol."
+- The lingering-window bug present at the time this ADR is filed — Disable click hard-kills the controller, the compositor window keeps the last frame on screen — is **resolved by construction** under the new model: the controller deactivates workspace mode itself before exiting (it has an IPC channel, it knows how), the compositor cleans up through the existing in-protocol path, and no service-side compensation is needed.
+- Until the cooperative-shutdown protocol ships, the runtime retains the current `TerminateProcess`-on-Disable behavior with the documented limitation that the compositor window may briefly outlive the controller. This is acceptable as a transitional state because (a) only the first-party shell is affected, (b) the next workspace event (`Ctrl+Space` re-spawn or another Enable click) clears the stale frame, and (c) the proper fix is a Phase 2.A+ deliverable, not a hotfix on the brand-separation branch.
+- The Phase 2.0 fix to the `workspace_watch_thread_func` ↔ `terminate_child` double-close race (`DuplicateHandle` on the watch thread's wait handle) stands under either model: any time one component watches a process and another terminates it, those two paths must own independent kernel handle references. The fix is forward-compatible with cooperative shutdown.
+- `XR_EXT_spatial_workspace` (or whatever the extension ends up named) must include at least: (1) a way for the controller to register tray menu definitions; (2) a way for the service to forward menu clicks to the controller; (3) a "request orderly shutdown" message the controller can use as a single internal entry point for teardown invoked from any source — tray click, system shutdown, OEM device-management agent, debugger detach, etc. Symmetry: the same message a third-party launcher would send to politely ask the controller to leave.
+- The transitional first-party shell defaults (`Enable / Auto / Disable`, `Ctrl+Space`, `TerminateProcess`) move from runtime-owned code into shell-owned code as the protocol lands. The runtime keeps the *fallback* path (last-resort kill) and the *render* path (drawing whatever menu definitions the controller supplied). Nothing else.
+
+## Related
+
+- Phase 2.0 (`feature/shell-brand-separation`): manifest-driven controller detection, PID-match auth, `service_orchestrator_get_workspace_pid()`.
+- Phase 2.A+: workspace extension surface migration; this protocol lands here.
+- `docs/roadmap/spatial-workspace-extensions-plan.md` — overall plan and phase boundaries.
+- `docs/roadmap/workspace-runtime-contract.md` — the controller↔runtime IPC contract that this protocol extends.
+- `docs/roadmap/spatial-workspace-controller-detection.md` — manifest schema (the discovery half of this story).

--- a/docs/architecture/in-process-vs-service.md
+++ b/docs/architecture/in-process-vs-service.md
@@ -98,7 +98,7 @@ The IPC plumbing is identical whether the client is a Chrome tab or an app launc
 
 - **N clients, not one.** The service runs in multi-compositor mode and composites every connected client (shell plus one or more 3D apps) into a single output.
 - **Not sandboxed.** Shell-launched apps run with the user's normal token — no AppContainer. `ipc_server_mainloop_windows.cpp` still sets a named-pipe DACL that grants access to both the normal user SID and AppContainer, so the same pipe works for both clients. The shared-handle `SECURITY_ATTRIBUTES` for Chrome adds a `ALL APPLICATION PACKAGES` ACE; shell-launched apps don't need that ACE but don't reject it either.
-- **Shell is a privileged IPC client.** Beyond the standard frame path, the shell sends window pose, focus, layout, and 2D-capture commands over the shell↔service control channel (see [shell-runtime-contract.md](../roadmap/shell-runtime-contract.md)).
+- **Shell is a privileged IPC client.** Beyond the standard frame path, the shell sends window pose, focus, layout, and 2D-capture commands over the shell↔service control channel (see [workspace-runtime-contract.md](../roadmap/workspace-runtime-contract.md)).
 - **Mode gate.** `DISPLAYXR_SHELL_SESSION=1` is the flag the shell sets in the environment of every app it launches; the runtime DLL sees it in `u_sandbox_should_use_ipc()` and routes to IPC even though the process isn't sandboxed.
 
 ---

--- a/docs/architecture/production-components.md
+++ b/docs/architecture/production-components.md
@@ -9,8 +9,8 @@ The DisplayXR installer delivers four artifacts:
 | Component | Binary | What it does |
 |-----------|--------|-------------|
 | **Runtime DLL** | `DisplayXRClient.dll` | OpenXR API implementation. Loaded in-process by every OpenXR app. |
-| **Service** | `displayxr-service.exe` | IPC server + multi-compositor. Hosts the display for sandboxed apps and multi-app shell sessions. |
-| **Shell** | `displayxr-shell.exe` | Spatial window manager. Arranges 3D and 2D apps in a shared 3D scene with window chrome, layout presets, and an app launcher. |
+| **Service** | `displayxr-service.exe` | IPC server + multi-compositor. Hosts the display for sandboxed apps and multi-app workspace sessions. |
+| **Workspace controller** (reference: **DisplayXR Shell**) | `displayxr-shell.exe` | Spatial window manager. Privileged IPC client that arranges 3D and 2D apps in a shared 3D scene with window chrome, layout presets, and an app launcher. The runtime exposes the workspace primitives (window pose, focus, capture) via `XR_DISPLAYXR_spatial_workspace`; any privileged client implementing those extensions can replace the reference shell — for verticals, kiosks, OEM-branded workspaces, or AI-agent drivers. |
 | **WebXR Bridge** | `displayxr-webxr-bridge.exe` | Metadata sideband for Chrome. Gives WebXR pages access to display info, rendering modes, and eye poses that Chrome's native WebXR path doesn't expose. |
 
 ## Two Compositor Paths
@@ -31,12 +31,12 @@ App (D3D11 / D3D12 / Metal / GL / Vulkan)
 
 The app, compositor, and display processor all live in one process. No service needed. The compositor uses the app's own graphics device (AddRef'd). Swapchain textures are local — no cross-process sharing.
 
-**This path is used by:** all handle, texture, and hosted apps running outside a sandbox and outside the shell.
+**This path is used by:** all handle, texture, and hosted apps running outside a sandbox and outside any active workspace.
 
-### IPC (service) — sandboxed and shell-managed apps
+### IPC (service) — sandboxed and workspace-managed apps
 
 ```
-App (sandboxed or shell-launched)
+App (sandboxed or workspace-launched)
   │
   └─► DisplayXRClient.dll
         │
@@ -51,7 +51,7 @@ App (sandboxed or shell-launched)
 
 The app gets a thin IPC client instead of a real compositor. Swapchain textures are shared cross-process via DXGI NT handles + KeyedMutex. The service owns the display and composites all clients into a single output.
 
-**This path is used by:** Chrome/Edge WebXR (AppContainer sandbox), apps launched by the shell (`DISPLAYXR_SHELL_SESSION=1`), and apps explicitly forced via `XRT_FORCE_MODE=ipc`.
+**This path is used by:** Chrome/Edge WebXR (AppContainer sandbox), apps launched by a workspace controller (`DISPLAYXR_WORKSPACE_SESSION=1`), and apps explicitly forced via `XRT_FORCE_MODE=ipc`.
 
 ### How the DLL decides
 
@@ -59,7 +59,7 @@ The decision happens in `u_sandbox_should_use_ipc()` (`src/xrt/auxiliary/util/u_
 
 1. **`XRT_FORCE_MODE=native`** → in-process (override)
 2. **`XRT_FORCE_MODE=ipc`** → IPC (override)
-3. **`DISPLAYXR_SHELL_SESSION=1`** → IPC (set by shell at launch)
+3. **`DISPLAYXR_WORKSPACE_SESSION=1`** → IPC (set by workspace controller at launch)
 4. **AppContainer / sandbox detected** → IPC (automatic)
 5. **Otherwise** → in-process
 
@@ -67,7 +67,7 @@ On Windows, sandbox detection queries `TokenIsAppContainer` on the process token
 
 ## How the Components Connect
 
-### Standalone native app (no service, no shell)
+### Standalone native app (no service, no workspace)
 
 ```
 Native app ──► DisplayXRClient.dll ──► Native compositor ──► Display
@@ -92,21 +92,21 @@ Two separate connections to the service:
 
 The bridge is a separate binary because Chrome's WebXR implementation doesn't support vendor extensions. The extension injects a `session.displayXR` API surface into the page's WebXR session via a navigator.xr Proxy in the MAIN content script world.
 
-### Shell mode (service required)
+### Workspace mode (service required)
 
 ```
                         ┌─── 3D app A ──► DLL (IPC) ──┐
                         │                              │
-Shell ── IPC ──► Service ◄─── 3D app B ──► DLL (IPC) ──┤──► Multi-compositor ──► Display
+Workspace ─ IPC ─► Service ◄─── 3D app B ──► DLL (IPC) ──┤──► Multi-compositor ──► Display
                         │                              │
                         └─── 2D app C ── HWND capture ─┘
 ```
 
-The shell is a privileged IPC client that:
-1. Activates multi-compositor mode on the service
-2. Launches 3D apps with `DISPLAYXR_SHELL_SESSION=1` (forces IPC)
+A workspace controller is a privileged IPC client that:
+1. Activates workspace mode on the service via `workspace_activate`
+2. Launches 3D apps with `DISPLAYXR_WORKSPACE_SESSION=1` (forces IPC)
 3. Captures 2D desktop windows via `Windows.Graphics.Capture`
-4. Sends window poses, focus, and layout commands over IPC
+4. Sends window poses, focus, and layout commands via the `XR_DISPLAYXR_spatial_workspace` extensions
 
 The service composites all clients — 3D OpenXR apps and captured 2D windows — into a single spatial scene with per-window Kooima projection.
 
@@ -117,13 +117,13 @@ The service composites all clients — 3D OpenXR apps and captured 2D windows �
 The installer registers:
 - `DisplayXR_win64.json` as the active OpenXR runtime (`HKLM\Software\Khronos\OpenXR\1\ActiveRuntime`)
 - Service in the Windows logon Run key (`HKLM\...\Run\DisplayXR Service`)
-- Start Menu shortcuts for shell and switcher
+- Start Menu shortcuts for the reference shell + switcher
 
 ### At Windows logon
 
 The **service** auto-starts via the Run key. It sits in the system tray with near-zero CPU, listening for IPC connections. This is necessary because Chrome's AppContainer sandbox blocks on-demand service launch (`ACCESS_DENIED` on `CreateProcess`). Without pre-launch, WebXR would silently fail.
 
-The **shell** and **bridge** do not auto-start.
+The reference **shell** and **bridge** do not auto-start.
 
 ### On demand
 
@@ -131,7 +131,7 @@ The **shell** and **bridge** do not auto-start.
 |---------|------------|
 | Native app calls `xrCreateInstance()` | Nothing new — DLL composites in-process |
 | Chrome opens a WebXR page | Service already running; app connects via IPC |
-| User launches shell (Start Menu or shortcut) | Shell starts, auto-launches service in shell mode if not running |
+| User launches the workspace controller (Start Menu or shortcut) | Workspace controller starts, auto-launches service in workspace mode if not running |
 | User opens WebXR page with extension | User must manually start bridge (or extension shows connection error) |
 
 ## Key Files
@@ -141,7 +141,7 @@ The **shell** and **bridge** do not auto-start.
 | Mode decision | `src/xrt/auxiliary/util/u_sandbox.c` | `u_sandbox_should_use_ipc()` — the branch point |
 | Hybrid entry | `src/xrt/targets/openxr/target.c` | `xrt_instance_create()` — picks native vs IPC |
 | Service entry | `src/xrt/targets/service/main.c` | Service process with tray icon and IPC mainloop |
-| Shell entry | `src/xrt/targets/shell/main.c` | Shell process with hotkeys, launcher, capture |
+| Workspace controller entry | `src/xrt/targets/shell/main.c` | Reference workspace controller — hotkeys, launcher, 2D capture |
 | Bridge entry | `src/xrt/targets/webxr_bridge/main.cpp` | WebSocket server + headless OpenXR client |
 | Installer | `installer/DisplayXRInstaller.nsi` | NSIS script — registry, Run key, shortcuts |
 | IPC security | `src/xrt/ipc/server/ipc_server_mainloop_windows.cpp` | Named pipe DACL (AppContainer access) |
@@ -151,5 +151,5 @@ The **shell** and **bridge** do not auto-start.
 - [In-Process vs Service](in-process-vs-service.md) — deep dive into D3D11 compositor internals (swapchain sharing, eye tracking pipeline, KeyedMutex)
 - [App Classes](../getting-started/app-classes.md) — the four app integration modes (handle, texture, hosted, IPC)
 - [Separation of Concerns](separation-of-concerns.md) — layer boundaries and what each layer owns
-- [Shell/Runtime Contract](../roadmap/shell-runtime-contract.md) — IPC protocol between shell and service
+- [Workspace/Runtime Contract](../roadmap/workspace-runtime-contract.md) — IPC protocol between a workspace controller and the service
 - [MCP Spec v0.2](../roadmap/mcp-spec-v0.2.md) — AI-native runtime control over Model Context Protocol

--- a/docs/getting-started/overview.md
+++ b/docs/getting-started/overview.md
@@ -65,7 +65,7 @@ Use WASD + mouse to move the simulated eye position and observe perspective-corr
 
 ## Production Components
 
-The diagram above shows the in-process path — a single app talking directly to the display. In production, DisplayXR also includes a **service** (for multi-app and sandboxed browsers), a **spatial shell** (3D window manager), and a **WebXR bridge** (metadata sideband for Chrome). See [Production Components](../architecture/production-components.md) for how all the pieces fit together.
+The diagram above shows the in-process path — a single app talking directly to the display. In production, DisplayXR also includes a **service** (for multi-app and sandboxed browsers) and a **WebXR bridge** (metadata sideband for Chrome). A privileged client can act as a **workspace controller** via the `XR_DISPLAYXR_spatial_workspace` extensions, composing multiple apps in a shared 3D space — the **DisplayXR Shell** is our reference workspace controller. See [Production Components](../architecture/production-components.md) for how all the pieces fit together.
 
 ## Next Steps
 

--- a/docs/roadmap/3d-capture.md
+++ b/docs/roadmap/3d-capture.md
@@ -18,7 +18,7 @@ This doc covers the **3D capture pipeline** — how the runtime captures spatial
 |-----|-------------|
 | [spatial-os.md](spatial-os.md) (#43) | **Compositing mechanism.** Capture taps into the multi-compositor pipeline defined here. |
 | [3d-shell.md](3d-shell.md) (#44) | **Shell layer.** Owns capture UX (hotkeys, browse, share). |
-| [shell-runtime-contract.md](shell-runtime-contract.md) | **IPC contract.** Defines capture command/completion messages between shell and runtime. |
+| [workspace-runtime-contract.md](workspace-runtime-contract.md) | **IPC contract.** Defines capture command/completion messages between shell and runtime. |
 
 ## Vision
 

--- a/docs/roadmap/3d-shell.md
+++ b/docs/roadmap/3d-shell.md
@@ -18,7 +18,7 @@ This doc covers the **window manager / policy layer** — placement, interaction
 |-----|-------------|
 | [spatial-os.md](spatial-os.md) (#43) | **Compositing mechanism.** Defines the multi-compositor pipeline this shell drives. This doc depends on it. |
 | [3d-capture.md](3d-capture.md) | **3D capture pipeline.** Runtime captures spatial content; shell provides capture UX (hotkeys, browse, share). |
-| [shell-runtime-contract.md](shell-runtime-contract.md) | **Shell/runtime IPC contract.** Defines the message set this shell uses to communicate with the runtime. |
+| [workspace-runtime-contract.md](workspace-runtime-contract.md) | **Workspace/runtime IPC contract.** Defines the message set this shell uses to communicate with the runtime. |
 | [multi-display-single-machine.md](multi-display-single-machine.md) (#69) | **Multi-display extension.** Extends shell + compositor to multiple local displays. Depends on #43 + #44. |
 | [multi-display-networked.md](multi-display-networked.md) (#70) | **Networked extension.** Extends multi-display to remote machines. Depends on #69. |
 

--- a/docs/roadmap/mcp-phase-b-plan.md
+++ b/docs/roadmap/mcp-phase-b-plan.md
@@ -150,6 +150,6 @@ Each slice lands with at least one scripted test under `tests/mcp/`:
 
 - Phase A plan/status: `docs/roadmap/mcp-phase-a-plan.md`, `mcp-phase-a-status.md`
 - Spec: `docs/roadmap/mcp-spec-v0.2.md` §3.2, §4.B, §5
-- Shell-runtime contract: `docs/roadmap/shell-runtime-contract.md`
+- Workspace/runtime contract: `docs/roadmap/workspace-runtime-contract.md`
 - Existing atlas capture path: `src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp:7929`
 - 3D capture roadmap (for deferred recording): `docs/roadmap/3d-capture.md`

--- a/docs/roadmap/overview.md
+++ b/docs/roadmap/overview.md
@@ -64,7 +64,7 @@ All documents in `docs/roadmap/` describe planned features that are not yet impl
 - [Spatial OS](spatial-os.md) — multi-compositor architecture
 - [3D Shell](3d-shell.md) — spatial window manager
 - [3D Capture](3d-capture.md) — capture pipeline
-- [Shell/Runtime Contract](shell-runtime-contract.md) — IPC between shell and runtime
+- [Workspace/Runtime Contract](workspace-runtime-contract.md) — IPC between a workspace controller and the runtime
 - [Display Spatial Model](display-spatial-model.md) — displays in the spatial graph
 - [Multi-Display Single Machine](multi-display-single-machine.md) — multiple displays, one machine
 - [Multi-Display Networked](multi-display-networked.md) — displays across the network

--- a/docs/roadmap/prfaq.md
+++ b/docs/roadmap/prfaq.md
@@ -1,0 +1,103 @@
+# DisplayXR PRFAQ — An Open Platform for 3D Displays
+
+> **Status**: draft, internal review. Source for upcoming website copy. Last updated 2026-04-28.
+
+---
+
+## Press release
+
+### DisplayXR Becomes a True Platform: Open Runtime, Standardized Extensions, Swappable Workspace Controllers
+
+**A lightweight OpenXR runtime, a documented extension surface, and a reference workspace controller — so anyone building on a 3D display can ship without forking the stack.**
+
+3D displays have spent a decade trapped in vendor silos. Every panel ships with its own runtime, its own compositor, its own windowing model — and the application developer pays for it. Building a CAD viewer or a medical-imaging app for a 3D screen has meant committing to one vendor's stack, learning their proprietary APIs, and rewriting when the next display generation lands.
+
+DisplayXR breaks that pattern. The DisplayXR runtime is a lightweight OpenXR implementation purpose-built for 3D displays — installable on its own, useful on its own, vendor-agnostic at every layer. Application developers write standard OpenXR. Display OEMs implement a documented vendor-integration interface. And on top of the runtime, an optional **workspace controller** layer adds spatial-desktop features — windowing, multi-app composition, launcher UX — through open extensions any party can implement.
+
+The first workspace controller, **DisplayXR Shell**, is shipped by Leia Inc. as the reference implementation. It's proprietary, branded, and tightly tuned for Leia's lightfield panels. It is also entirely optional. Install the DisplayXR runtime by itself and you get a standards-compliant OpenXR + WebXR bridge for your 3D display — no shell, no spatial desktop, no Leia-specific behavior. Install a different controller (third-party, vertical integrator, your own) and the runtime treats it as a first-class citizen with the same authority as the reference shell.
+
+"We shipped our 3D-display product line in weeks, not quarters, because we didn't have to write the OpenXR layer," said a hypothetical OEM partner who has not yet given us a real quote. "Our team wrote a custom workspace controller for our vertical, and the DisplayXR runtime authenticated and composited it as if it were the reference shell. There was nothing to reverse-engineer."
+
+The platform is built on three commitments:
+
+- **Open at the runtime layer.** OpenXR + WebXR. Standard extension headers for display-specific capabilities (`XR_EXT_display_info`, `XR_EXT_win32_window_binding`, `XR_EXT_cocoa_window_binding`). Vendor integration through a documented display-processor vtable.
+- **Open at the workspace layer.** `XR_EXT_spatial_workspace` and `XR_EXT_app_launcher` define how any controller process drives multi-app composition, hit-test, capture, and tile launching. The reference shell uses these surfaces; so does anyone else.
+- **Swappable, not coupled.** Workspace activation is gated by orchestrator-PID match — the runtime trusts the binary it was configured to spawn, not a brand string. OEMs and developers replace the controller without runtime modifications.
+
+DisplayXR runs on Windows today, with macOS and Android in active development. The runtime ships under the Boost Software License. Extension headers are mirrored to `github.com/DisplayXR/displayxr-extensions` and version-tagged for stability. The reference shell is distributed separately from the runtime; a bare runtime install is the supported configuration for OEM and third-party deployments.
+
+Get started at `github.com/DisplayXR/displayxr-runtime`.
+
+---
+
+## FAQ
+
+### For application developers
+
+**Q: I'm writing an OpenXR app. What changes for me?**
+Nothing. Write standard OpenXR. The DisplayXR runtime registers as an OpenXR runtime via the standard loader — set `XR_RUNTIME_JSON` and your app finds it. Native compositors for D3D11, D3D12, Metal, Vulkan, and OpenGL mean your graphics API works without interop layers.
+
+**Q: How do I make my app aware of the 3D display's capabilities?**
+Opt into `XR_EXT_display_info` for display dimensions, eye-tracking modes, and the data needed for asymmetric (Kooima) projection. The header is published at `github.com/DisplayXR/displayxr-extensions` and frozen at v12. For window binding (passing your HWND or NSView to the runtime so it can composit into your window), use `XR_EXT_win32_window_binding` or `XR_EXT_cocoa_window_binding`.
+
+**Q: Does my app need to know whether a workspace controller is installed?**
+No. The runtime serves apps the same way whether the user is running the bare runtime, the DisplayXR Shell, or a third-party controller. Apps in a workspace get composited as one of N tiles; apps without a workspace render full-screen. From the app's perspective, OpenXR's session-state machine drives both cases identically.
+
+**Q: I'm using WebXR in Chrome. How does that work?**
+DisplayXR ships a WebXR bridge that connects Chrome's native WebXR implementation to the runtime. No extension to install in Chrome — the bridge runs as a separate process, started on-demand by the service when a WebXR app requests it. Standard WebXR session APIs work on a 3D display the same way they work on a headset.
+
+### For 3D display OEMs
+
+**Q: I make 3D display hardware. How do I integrate?**
+Implement the display-processor vtable for your weaving / depth-mapping / eye-tracking integration. The vtable has five API variants (D3D11, D3D12, Metal, Vulkan, OpenGL) so your weaver runs natively in whatever graphics API the application is using. See `docs/guides/vendor-integration.md` for the full contract. Leia SR is the first integration; it's a reference, not a precedent — there is no privileged path.
+
+**Q: Do I have to use the DisplayXR Shell?**
+No. The shell is one of two reasonable end-states for an OEM:
+- **Ship the bare runtime.** Your customers install standard OpenXR apps and use Chrome WebXR. The tray reflects what's there: WebXR Bridge + Quit. Lightweight, OEM-neutral.
+- **Ship the bare runtime plus your own workspace controller.** Build to the `XR_EXT_spatial_workspace` and `XR_EXT_app_launcher` extension surfaces. Your controller gets first-class treatment.
+
+OEMs that want to ship the Leia shell are welcome to bundle it alongside; the runtime treats it the same as any other controller.
+
+**Q: How do third-party workspace controllers prove they're trustworthy?**
+The runtime authenticates workspace activation by **orchestrator-PID match**: the controller is the binary the orchestrator was configured to spawn (via `service.json`'s `workspace_binary` field). The PID match — not the binary's `applicationName` string — is the credential. OEMs configure their installer to drop their controller into the runtime's directory and update `service.json`; the runtime trusts whatever process starts as a result.
+
+**Q: What if I want to brand the tray and lifecycle UI?**
+Drop a `<your-binary>.controller.json` sidecar manifest next to your controller binary. The runtime reads `display_name`, `vendor`, `version`, and `icon_path` and uses them in the tray submenu. No runtime rebuild required.
+
+### For vertical integrators (CAD, medical, automotive HMI)
+
+**Q: I want to ship a focused single-purpose 3D display experience — not a general-purpose desktop. Can I skip the workspace controller entirely?**
+Yes. Run the bare runtime + your application. The runtime gives you OpenXR session management, native compositing, and display calibration. You skip the multi-app, windowing, and launcher complexity. This is the "kiosk" configuration.
+
+**Q: I want a focused experience but with multi-app composition for my vertical (e.g., a medical imaging suite that runs imaging + chart + reference apps side-by-side). Can I write a controller for just that?**
+Yes. A workspace controller is just a process that implements `XR_EXT_spatial_workspace` to define how it tiles and composites apps. Write a controller that hardcodes the layout your vertical needs. You keep full control of the UX without having to also implement a runtime.
+
+**Q: Can I distribute my controller as a closed binary?**
+Yes. The runtime ships under BSL-1.0; the extension headers are open. Your controller can be any license, any distribution model. The DisplayXR Shell is itself a closed-source proprietary product — it's the first proof point that the runtime supports closed controllers as first-class citizens.
+
+### Why this exists / strategic context
+
+**Q: Why an open runtime when the shell is proprietary?**
+The 3D-display category needs platform standardization to grow. As long as every display ships its own non-portable stack, the addressable application catalog stays small and developers stay away. Opening the runtime layer — the part that's actually a platform — lets the catalog grow. The workspace layer is where vertical differentiation happens; that's a reasonable place for proprietary IP, including ours.
+
+**Q: How does this compare to the headset-focused OpenXR runtimes?**
+DisplayXR is built specifically for **glasses-free 3D displays**: lightfield panels, autostereo monitors, holographic displays. The shape of the problem is different from a headset (no HMD pose, no controllers, asymmetric projection per eye via Kooima math, eye-tracking-driven view selection). DisplayXR keeps the OpenXR contract that apps know but specializes the implementation for the 3D-display context. You can run a DisplayXR app and a headset OpenXR app from the same source — the differences are inside the runtime, not in the app code.
+
+**Q: Why fork from Monado instead of starting from scratch?**
+The conformance / state-tracker / extension-dispatch infrastructure in Monado represents years of OpenXR work that's worth carrying. We stripped 34 VR drivers, removed the Vulkan server compositor, replaced it with five native compositors (one per graphics API), and rebranded — but the OpenXR plumbing is still upstream-quality. We track upstream Monado and cherry-pick conformance fixes; see issue #47 for the strategy.
+
+**Q: What's the licensing story?**
+Runtime + bridge + extension headers: BSL-1.0 (permissive, similar to MIT). Reference DisplayXR Shell: proprietary, distributed separately. Third-party workspace controllers: any license the author chooses. The platform is permissively licensed by design — companies need to be able to ship runtime + bridge as part of their hardware product without legal review on every build.
+
+**Q: What's on the near-term roadmap?**
+- **Phase 2.A–2.H** (in progress): migrate launcher / chrome / capture / hit-test policy out of the runtime's compositor and into the workspace controller process, behind the as-yet-finalizing `XR_EXT_spatial_workspace.h` / `XR_EXT_app_launcher.h` headers.
+- **Phase 3**: separate the shell repo from the runtime repo entirely. After Phase 3, the shell is just one of N possible controllers from a code-locality standpoint, not just from a runtime-policy standpoint.
+- **macOS workspace controller**: Phase 6's spatial shell is Windows-only today. macOS port is on the M6 milestone.
+
+**Q: How can I track progress / contribute?**
+- Public runtime: `github.com/DisplayXR/displayxr-runtime` (releases, public issues, milestones).
+- Extension headers: `github.com/DisplayXR/displayxr-extensions` (header-only, version-tagged).
+- Reference shell binaries: `github.com/DisplayXR/displayxr-shell-releases` (user-facing bug reports).
+- Demos: `github.com/DisplayXR/displayxr-demo-*` (one repo per demo, including a Gaussian-splatting renderer).
+
+External contributions to the runtime go through PRs on the public `displayxr-runtime` repo; accepted PRs are mirrored into the private development repo via a documented apply script.

--- a/docs/roadmap/prfaq.md
+++ b/docs/roadmap/prfaq.md
@@ -12,17 +12,17 @@
 
 3D displays have spent a decade trapped in vendor silos. Every panel ships with its own runtime, its own compositor, its own windowing model — and the application developer pays for it. Building a CAD viewer or a medical-imaging app for a 3D screen has meant committing to one vendor's stack, learning their proprietary APIs, and rewriting when the next display generation lands.
 
-DisplayXR breaks that pattern. The DisplayXR runtime is a lightweight OpenXR implementation purpose-built for 3D displays — installable on its own, useful on its own, vendor-agnostic at every layer. Application developers write standard OpenXR. Display OEMs implement a documented vendor-integration interface. And on top of the runtime, an optional **workspace controller** layer adds spatial-desktop features — windowing, multi-app composition, launcher UX — through open extensions any party can implement.
+DisplayXR breaks that pattern. The DisplayXR runtime is a lightweight OpenXR implementation purpose-built for 3D displays — installable on its own, useful on its own, vendor-agnostic at every layer. Application developers write standard OpenXR. Display vendors (Leia, BOE, and others making the lightfield / autostereo panels) implement a documented integration interface. OEMs (Lenovo, Samsung, ZTE, and others integrating displays into finished laptops, monitors, tablets, phones, and TVs) ship the runtime as part of their product. And on top of the runtime, an optional **workspace controller** layer adds spatial-desktop features — windowing, multi-app composition, launcher UX — through open extensions any party can implement.
 
-The first workspace controller, **DisplayXR Shell**, is shipped by Leia Inc. as the reference implementation. It's proprietary, branded, and tightly tuned for Leia's lightfield panels. It is also entirely optional. Install the DisplayXR runtime by itself and you get a standards-compliant OpenXR + WebXR bridge for your 3D display — no shell, no spatial desktop, no Leia-specific behavior. Install a different controller (third-party, vertical integrator, your own) and the runtime treats it as a first-class citizen with the same authority as the reference shell.
+A reference workspace controller, **DisplayXR Shell**, ships alongside the runtime from the DisplayXR project as a proprietary, polished example of what's possible on the platform. It is also entirely optional. Install the DisplayXR runtime by itself and you get a standards-compliant OpenXR + WebXR bridge for your 3D display — no shell, no spatial desktop. Install a different controller (third-party, vertical integrator, your own) and the runtime treats it as a first-class citizen with the same authority as the reference shell.
 
-"We shipped our 3D-display product line in weeks, not quarters, because we didn't have to write the OpenXR layer," said a hypothetical OEM partner who has not yet given us a real quote. "Our team wrote a custom workspace controller for our vertical, and the DisplayXR runtime authenticated and composited it as if it were the reference shell. There was nothing to reverse-engineer."
+"We brought our spatial-3D laptop SKU to market in weeks, not quarters, because we didn't have to build the OpenXR layer or the windowing system from scratch," said a hypothetical OEM partner who has not yet given us a real quote. "We bundled the reference shell, dropped a sidecar manifest to brand the tray for our product, and shipped. The DisplayXR runtime authenticated and composited it without modification."
 
 The platform is built on three commitments:
 
-- **Open at the runtime layer.** OpenXR + WebXR. Standard extension headers for display-specific capabilities (`XR_EXT_display_info`, `XR_EXT_win32_window_binding`, `XR_EXT_cocoa_window_binding`). Vendor integration through a documented display-processor vtable.
+- **Open at the runtime layer.** OpenXR + WebXR. Standard extension headers for display-specific capabilities (`XR_EXT_display_info`, `XR_EXT_win32_window_binding`, `XR_EXT_cocoa_window_binding`). Display-vendor integration through a documented display-processor vtable.
 - **Open at the workspace layer.** `XR_EXT_spatial_workspace` and `XR_EXT_app_launcher` define how any controller process drives multi-app composition, hit-test, capture, and tile launching. The reference shell uses these surfaces; so does anyone else.
-- **Swappable, not coupled.** Workspace activation is gated by orchestrator-PID match — the runtime trusts the binary it was configured to spawn, not a brand string. OEMs and developers replace the controller without runtime modifications.
+- **Swappable, not coupled.** Workspace activation is gated by orchestrator-PID match — the runtime trusts the binary it was configured to spawn, not a brand string. OEMs, vertical integrators, and developers can replace the controller without runtime modifications.
 
 DisplayXR runs on Windows today, with macOS and Android in active development. The runtime ships under the Boost Software License. Extension headers are mirrored to `github.com/DisplayXR/displayxr-extensions` and version-tagged for stability. The reference shell is distributed separately from the runtime; a bare runtime install is the supported configuration for OEM and third-party deployments.
 
@@ -31,6 +31,13 @@ Get started at `github.com/DisplayXR/displayxr-runtime`.
 ---
 
 ## FAQ
+
+### Glossary (terms used below)
+
+- **Display vendor** — companies that manufacture the 3D display panel and write the display-processor (DP) integration for DisplayXR. Examples: Leia, BOE.
+- **OEM** — companies that procure 3D displays from a display vendor and integrate them into a finished consumer product (laptop, monitor, tablet, phone, TV). Examples: Lenovo, Samsung, ZTE. OEMs are *customers* of the DisplayXR runtime and (optionally) the reference shell.
+- **Vertical integrator** — companies building a focused single- or limited-purpose experience on a 3D display: CAD viewers, medical imaging, automotive HMI, retail kiosks. They consume the runtime and may write their own workspace controller.
+- **Workspace controller** — a process that adds spatial-desktop features (windowing, multi-app composition, launcher) on top of the bare runtime. The reference DisplayXR Shell is one such controller; third parties can build their own.
 
 ### For application developers
 
@@ -46,23 +53,37 @@ No. The runtime serves apps the same way whether the user is running the bare ru
 **Q: I'm using WebXR in Chrome. How does that work?**
 DisplayXR ships a WebXR bridge that connects Chrome's native WebXR implementation to the runtime. No extension to install in Chrome — the bridge runs as a separate process, started on-demand by the service when a WebXR app requests it. Standard WebXR session APIs work on a 3D display the same way they work on a headset.
 
-### For 3D display OEMs
+### For 3D display vendors
 
-**Q: I make 3D display hardware. How do I integrate?**
+**Q: I make a 3D display panel. How do I integrate with DisplayXR?**
 Implement the display-processor vtable for your weaving / depth-mapping / eye-tracking integration. The vtable has five API variants (D3D11, D3D12, Metal, Vulkan, OpenGL) so your weaver runs natively in whatever graphics API the application is using. See `docs/guides/vendor-integration.md` for the full contract. Leia SR is the first integration; it's a reference, not a precedent — there is no privileged path.
 
-**Q: Do I have to use the DisplayXR Shell?**
-No. The shell is one of two reasonable end-states for an OEM:
-- **Ship the bare runtime.** Your customers install standard OpenXR apps and use Chrome WebXR. The tray reflects what's there: WebXR Bridge + Quit. Lightweight, OEM-neutral.
-- **Ship the bare runtime plus your own workspace controller.** Build to the `XR_EXT_spatial_workspace` and `XR_EXT_app_launcher` extension surfaces. Your controller gets first-class treatment.
+**Q: Once my display is integrated, who picks DisplayXR up?**
+Two distinct downstream audiences: OEMs who ship finished products built around your display panel, and vertical integrators who build a focused experience on it. Both groups consume the runtime via standard distribution channels (your driver bundles it, an OEM bundles it, or end users install it directly). Your DP integration enables both paths simultaneously.
 
-OEMs that want to ship the Leia shell are welcome to bundle it alongside; the runtime treats it the same as any other controller.
+**Q: Do I need to ship a workspace controller alongside my DP?**
+No. The reference DisplayXR Shell works with any DP that conforms to the vtable. Most display vendors ship the DP plus the runtime and let OEMs decide whether to bundle the reference shell, a custom controller, or nothing. Display vendors who want their own branded controller can build one — see the OEM and vertical-integrator sections below for the controller story.
+
+### For OEMs (Lenovo, Samsung, ZTE, integrators of finished products)
+
+**Q: I'm shipping a 3D laptop / monitor / tablet. What do I bundle?**
+Three reasonable configurations:
+
+- **Bare runtime.** Ship the DisplayXR runtime plus the relevant display-vendor DP. End users get OpenXR + WebXR support out of the box; no spatial desktop. Lightest install. Best for products where the 3D display is one feature among many and you don't want to define a new desktop UX.
+- **Runtime + reference shell.** Bundle the DisplayXR Shell from the DisplayXR project as your spatial-desktop layer. Brand the tray label via a sidecar manifest. Quickest path to a polished spatial-desktop experience without writing UX code.
+- **Runtime + custom controller.** Write your own workspace controller against `XR_EXT_spatial_workspace` and `XR_EXT_app_launcher`. Differentiate your product line with a branded launcher, layout presets tailored to your form factor, custom chrome. Your controller gets the same first-class authentication as the reference shell.
+
+**Q: Can I bundle the DisplayXR Shell with my product?**
+Yes. The shell is distributed as a separate, redistributable binary. Bundle it with your installer or offer it as an optional download. Branding via the sidecar manifest (`display_name`, `vendor`, `icon_path`) means the tray UI carries your product name without any runtime modification.
+
+**Q: How do I brand the tray and lifecycle UI for my product?**
+Drop a `<controller-binary>.controller.json` sidecar manifest next to whichever workspace controller you ship — reference shell or custom. The runtime reads `display_name`, `vendor`, `version`, and `icon_path` and uses them in the tray submenu. No runtime rebuild required, no source access needed.
+
+**Q: My product line spans multiple SKUs. Can I ship different controllers per SKU?**
+Yes. The controller is selected via the runtime's `service.json` `workspace_binary` field. Your installer per SKU can write a different `service.json` that points at a different controller binary, or none at all. The runtime authenticates whatever it's configured to spawn.
 
 **Q: How do third-party workspace controllers prove they're trustworthy?**
-The runtime authenticates workspace activation by **orchestrator-PID match**: the controller is the binary the orchestrator was configured to spawn (via `service.json`'s `workspace_binary` field). The PID match — not the binary's `applicationName` string — is the credential. OEMs configure their installer to drop their controller into the runtime's directory and update `service.json`; the runtime trusts whatever process starts as a result.
-
-**Q: What if I want to brand the tray and lifecycle UI?**
-Drop a `<your-binary>.controller.json` sidecar manifest next to your controller binary. The runtime reads `display_name`, `vendor`, `version`, and `icon_path` and uses them in the tray submenu. No runtime rebuild required.
+The runtime authenticates workspace activation by **orchestrator-PID match**: the controller is the binary the runtime's orchestrator was configured to spawn (via `service.json`'s `workspace_binary` field). The PID match — not the binary's `applicationName` string — is the credential. Your installer drops your controller into the runtime's directory and updates `service.json`; the runtime trusts whatever process starts as a result. No code-signing handshake, no shared-secret provisioning.
 
 ### For vertical integrators (CAD, medical, automotive HMI)
 

--- a/docs/roadmap/shell-phase4-agent-prompt.md
+++ b/docs/roadmap/shell-phase4-agent-prompt.md
@@ -15,7 +15,7 @@ Read these docs first (in order):
 1. `CLAUDE.md` — project overview, build commands, architecture
 2. `docs/roadmap/shell-phase4-plan.md` — full Phase 4 design (you're implementing 4A)
 3. `docs/roadmap/shell-phase3b-status.md` — what was just completed (cross-API shell)
-4. `docs/roadmap/shell-runtime-contract.md` — IPC protocol boundary
+4. `docs/roadmap/workspace-runtime-contract.md` — IPC protocol boundary
 
 ## Branch
 

--- a/docs/roadmap/shell-phase4b-agent-prompt.md
+++ b/docs/roadmap/shell-phase4b-agent-prompt.md
@@ -15,7 +15,7 @@ Read these docs first (in order):
 1. `CLAUDE.md` — project overview, build commands, architecture
 2. `docs/roadmap/shell-phase4-plan.md` — full Phase 4 design
 3. `docs/roadmap/shell-phase4a-status.md` — what Phase 4A built (capture pipeline, 2D mode switch, resize sync)
-4. `docs/roadmap/shell-runtime-contract.md` — IPC protocol boundary
+4. `docs/roadmap/workspace-runtime-contract.md` — IPC protocol boundary
 
 ## Branch
 

--- a/docs/roadmap/shell-phase4c-agent-prompt.md
+++ b/docs/roadmap/shell-phase4c-agent-prompt.md
@@ -16,7 +16,7 @@ Read these docs first (in order):
 2. `docs/roadmap/shell-phase4c-plan.md` — **the plan you're implementing** (full task list, sequences, design)
 3. `docs/roadmap/shell-phase4c-status.md` — current progress (update as you complete tasks)
 4. `docs/roadmap/shell-phase4a-status.md` — Phase 4A/4B status (what's already built)
-5. `docs/roadmap/shell-runtime-contract.md` — IPC protocol boundary
+5. `docs/roadmap/workspace-runtime-contract.md` — IPC protocol boundary
 
 ## Branch
 

--- a/docs/roadmap/shell-phase5-agent-prompt.md
+++ b/docs/roadmap/shell-phase5-agent-prompt.md
@@ -16,7 +16,7 @@ Read these docs first (in order):
 2. `docs/roadmap/shell-phase5-plan.md` — **the plan you're implementing** (exploration phase + launcher UI)
 3. `docs/roadmap/shell-phase5-status.md` — task checklist (update as you complete tasks)
 4. `docs/roadmap/shell-phase4c-status.md` — what Phase 4C delivered (the foundation you build on)
-5. `docs/roadmap/shell-runtime-contract.md` — IPC protocol boundary (runtime vs shell)
+5. `docs/roadmap/workspace-runtime-contract.md` — IPC protocol boundary (runtime vs shell)
 6. `docs/reference/window-drag-rendering.md` — how the multi-compositor handles windows (useful for launcher panel rendering)
 7. `docs/roadmap/3d-shell.md` and `docs/roadmap/spatial-desktop-prd.md` — product vision for the shell
 

--- a/docs/roadmap/shell-tasks.md
+++ b/docs/roadmap/shell-tasks.md
@@ -8,7 +8,7 @@ platform: Windows (D3D11 first, macOS deferred)
 
 # 3D Shell Implementation Tasks
 
-Living task tracker for the spatial shell. For architecture and design rationale, see [spatial-os.md](spatial-os.md) (#43), [3d-shell.md](3d-shell.md) (#44), and [shell-runtime-contract.md](shell-runtime-contract.md).
+Living task tracker for the spatial shell. For architecture and design rationale, see [spatial-os.md](spatial-os.md) (#43), [3d-shell.md](3d-shell.md) (#44), and [workspace-runtime-contract.md](workspace-runtime-contract.md).
 
 ### Key Architecture Decisions (ADRs)
 

--- a/docs/roadmap/spatial-desktop-prd.md
+++ b/docs/roadmap/spatial-desktop-prd.md
@@ -131,7 +131,7 @@ Physical 3D Display
 |-----------|-----|
 | Multi-compositor pipeline | [spatial-os.md](spatial-os.md) |
 | Window manager / shell | [3d-shell.md](3d-shell.md) |
-| Shell/runtime IPC contract | [shell-runtime-contract.md](shell-runtime-contract.md) |
+| Shell/runtime IPC contract | [workspace-runtime-contract.md](workspace-runtime-contract.md) |
 | 3D capture pipeline | [3d-capture.md](3d-capture.md) |
 | Multi-display (local) | [multi-display-single-machine.md](multi-display-single-machine.md) |
 | Multi-display (networked) | [multi-display-networked.md](multi-display-networked.md) |
@@ -160,7 +160,7 @@ The platform is designed so that **no SDK is required for basic spatial app supp
 
 ### 5.2 Terminology: Spatial OS vs Shell
 
-- **Shell** = the window manager + launcher. Manages window layout, focus, input routing, app lifecycle UX. A single component, replaceable (OEM shells, kiosk mode, alternate shells). Developed in a private repo, communicates with the runtime via the [shell-runtime contract](shell-runtime-contract.md).
+- **Shell** = the window manager + launcher. Manages window layout, focus, input routing, app lifecycle UX. A single component, replaceable (OEM shells, kiosk mode, alternate shells). Developed in a private repo, communicates with the runtime via the [workspace-runtime contract](workspace-runtime-contract.md).
 - **Spatial OS** = the full platform stack: runtime + shell + extensions + capture pipeline. The product/platform name encompassing all components. Issues #43 (multi-compositor) and #44 (shell/spatial OS) track the two main subsystems.
 
 The shell is the first visible deliverable of the spatial OS, but the spatial OS also includes the runtime's multi-compositor, the extension APIs, the capture pipeline, and future components like spatial audio and shared world models.
@@ -231,7 +231,7 @@ Multi-display extends the single-display spatial desktop into a workspace where 
 
 The shell/runtime contract defines the IPC message set and boundary rules between the rendering runtime and the desktop shell, ensuring clean separation of mechanism from policy.
 
-**Full specification:** [shell-runtime-contract.md](shell-runtime-contract.md)
+**Full specification:** [workspace-runtime-contract.md](workspace-runtime-contract.md)
 
 ---
 

--- a/docs/roadmap/spatial-os.md
+++ b/docs/roadmap/spatial-os.md
@@ -18,7 +18,7 @@ This doc covers the **compositing mechanism** — how N app textures become one 
 |-----|-------------|
 | [3d-shell.md](3d-shell.md) (#44) | **Window manager / policy layer.** Decides where windows go and how users interact. Depends on this doc. |
 | [3d-capture.md](3d-capture.md) | **3D capture pipeline.** Taps into the multi-compositor output defined here for spatial capture. |
-| [shell-runtime-contract.md](shell-runtime-contract.md) | **Shell/runtime IPC contract.** Defines the message set between shell and runtime, including capture commands. |
+| [workspace-runtime-contract.md](workspace-runtime-contract.md) | **Workspace/runtime IPC contract.** Defines the message set between shell and runtime, including capture commands. |
 | [multi-display-single-machine.md](multi-display-single-machine.md) (#69) | **Multi-display extension.** Routes this compositor's output to multiple local displays. Depends on #43 + #44. |
 | [multi-display-networked.md](multi-display-networked.md) (#70) | **Networked extension.** Extends multi-display to remote machines. Depends on #69. |
 

--- a/docs/roadmap/spatial-workspace-auth-handshake.md
+++ b/docs/roadmap/spatial-workspace-auth-handshake.md
@@ -1,6 +1,6 @@
 # Workspace Activation — Auth Handshake (draft)
 
-**Status:** Draft, 2026-04-28. Resolves Open Question #1 from [spatial-workspace-extensions-headers-draft.md](spatial-workspace-extensions-headers-draft.md).
+**Status:** Draft, 2026-04-28. Resolves Open Question #1 from [spatial-workspace-extensions-headers-draft.md](spatial-workspace-extensions-headers-draft.md). Sister doc to [spatial-workspace-controller-detection.md](spatial-workspace-controller-detection.md) — together these define **Phase 2.0** of the extensions effort, the architectural prep that gates the larger Phase 2.A–2.H code migrations.
 
 Defines how the runtime decides whether a connecting client is allowed to activate workspace mode. Today the answer is hardcoded brand-matching on `application_name == "displayxr-shell"` — exactly the coupling the workspace-extensions effort is trying to remove.
 
@@ -188,7 +188,7 @@ Recommend the new vendor error code, defined alongside the extension. Maps inter
 
 ## Migration path
 
-Lands as a small Phase 2 sub-step (call it "Phase 2.0 — auth handshake"). Three-commit sequence:
+Lands as part of **Phase 2.0** (alongside [controller detection](spatial-workspace-controller-detection.md)). Three-commit sequence within the auth-handshake half:
 
 1. **Add `service_orchestrator_get_workspace_pid()` getter.** Pure addition, no behavior change. Covered by header + impl.
 2. **Wire PID check into `ipc_handle_workspace_activate`.** Behavior change: workspace activation now requires PID match (or manual mode). The legacy `application_name == "displayxr-shell"` check stays in place during this commit as a fallback so existing setups don't break.

--- a/docs/roadmap/spatial-workspace-auth-handshake.md
+++ b/docs/roadmap/spatial-workspace-auth-handshake.md
@@ -1,0 +1,203 @@
+# Workspace Activation — Auth Handshake (draft)
+
+**Status:** Draft, 2026-04-28. Resolves Open Question #1 from [spatial-workspace-extensions-headers-draft.md](spatial-workspace-extensions-headers-draft.md).
+
+Defines how the runtime decides whether a connecting client is allowed to activate workspace mode. Today the answer is hardcoded brand-matching on `application_name == "displayxr-shell"` — exactly the coupling the workspace-extensions effort is trying to remove.
+
+## The check today
+
+`src/xrt/ipc/server/ipc_server_handler.c:294-300`:
+
+```c
+bool is_workspace_controller_session =
+    ics->client_state.info.application_name[0] != '\0' &&
+    strcmp((const char *)ics->client_state.info.application_name, "displayxr-shell") == 0;
+```
+
+Two things wrong with this:
+1. **Brand-coupled.** Says "this runtime knows about one specific binary." A third-party workspace controller has to lie about its `XrApplicationInfo::applicationName` to get accepted, which conflicts with OpenXR's expectation that `applicationName` reflects the actual app identity.
+2. **No actual auth.** Anything can claim to be `"displayxr-shell"`. A malicious local app could activate workspace mode and arrange windows however it likes. Today this is mitigated by the workspace controller's UX (it self-positions on launch), but the IPC channel itself imposes no check.
+
+## Proposed approach: orchestrator-PID match (with manual-mode fallback)
+
+### Service-managed mode (default — what end-users see)
+
+The service orchestrator spawns the workspace binary by `service.json::workspace_binary`. After Phase 1, `service_orchestrator.c:262` does this:
+
+```c
+if (!launch_child(workspace_path, "--service-managed", &s_workspace_pi)) {
+    return;
+}
+```
+
+`s_workspace_pi.dwProcessId` is the spawned PID. The IPC server has access to `s_workspace_pi` through the orchestrator's static state (both run in the service process). When a client connects and calls `workspace_activate`, the server compares the connecting client's PID to `s_workspace_pi.dwProcessId`:
+
+- **Match** → grant workspace role.
+- **Mismatch** → return `XR_ERROR_FEATURE_UNSUPPORTED` (or the IPC equivalent `XRT_ERROR_NOT_AUTHORIZED` — see "Error code" below).
+
+The connecting client's PID is already known to the server: on Windows it comes from `GetNamedPipeClientProcessId` on the IPC pipe; on macOS via `peerinfo` on the unix socket; the existing IPC infrastructure surfaces it as `ics->client_state.pid` (or equivalent). Verify in implementation.
+
+### Manual-mode fallback (developer / multi-terminal workflow)
+
+The `--workspace` flag (or legacy `--shell` alias) on `displayxr-service` was historically used in the multi-terminal dev workflow: terminal 1 starts the service, terminals 2/3 launch test apps. In that mode, the service didn't spawn the workspace controller — the user did.
+
+For developer ergonomics, the manual flow keeps working:
+
+- If the service was launched with `--workspace` (or `--shell`), and the orchestrator did NOT spawn a workspace controller, the IPC server falls back to **first-claim wins**: the first client that calls `workspace_activate` gets the role, regardless of PID. Subsequent clients get `XR_ERROR_LIMIT_REACHED`.
+- This is a developer-only loosening; production deployments use service-managed mode.
+
+A third option — `application_name` allowlist — is rejected. It re-creates the brand coupling we're trying to remove and doesn't add real authentication.
+
+### Combined decision tree
+
+```
+xrActivateSpatialWorkspaceEXT called
+        │
+        ├── Another workspace already active? ──── yes ──► XR_ERROR_LIMIT_REACHED
+        │                                          no
+        ▼
+┌───────────────────────┐
+│ Was orchestrator      │
+│ asked to spawn        │   no    First client to call workspace_activate
+│ a workspace binary?   ├──────► wins (developer / manual mode).
+└────────┬──────────────┘
+         │ yes
+         ▼
+┌────────────────────────┐
+│ caller PID ==          │   no
+│ s_workspace_pi.PID ?   ├──────► XR_ERROR_FEATURE_UNSUPPORTED
+└────────┬───────────────┘
+         │ yes
+         ▼
+   Activate. Workspace session bound to this XrSession.
+```
+
+## Implementation sketch
+
+### 1. Expose the spawned PID from orchestrator to IPC server
+
+Add a getter to `service_orchestrator.h`:
+
+```c
+//! Returns the PID of the workspace controller spawned by this service,
+//! or 0 if the orchestrator has not (yet) spawned one (e.g. AUTO mode
+//! before the hotkey, or the service was launched with --workspace
+//! manually so the orchestrator stayed out of the way).
+unsigned long
+service_orchestrator_get_workspace_pid(void);
+```
+
+Implementation in `service_orchestrator.c` reads `s_workspace_pi.dwProcessId` (Windows) — guard with the running flag:
+
+```c
+unsigned long
+service_orchestrator_get_workspace_pid(void)
+{
+#ifdef XRT_OS_WINDOWS
+    if (s_workspace_running) {
+        return (unsigned long)s_workspace_pi.dwProcessId;
+    }
+#endif
+    return 0;
+}
+```
+
+The function returns `unsigned long` (not `DWORD`) so it can live in a public header without dragging in `<windows.h>` — matches the cross-platform `pid_t`-vs-`long` discipline already in `aux/util/`.
+
+### 2. Capture the connecting-client PID
+
+Existing IPC infrastructure already knows the client PID (named-pipe queries on Windows, peerinfo on POSIX). Confirm during implementation that `ics->client_state.pid` (or equivalent) is populated by the time `ipc_handle_workspace_activate` runs. If not, plumb it through — small enough to not need separate design.
+
+### 3. Replace the application_name match in `ipc_handle_workspace_activate`
+
+`src/xrt/ipc/server/ipc_server_handler.c`, replace the activate handler's authorization check with:
+
+```c
+xrt_result_t
+ipc_handle_workspace_activate(volatile struct ipc_client_state *_ics)
+{
+    struct ipc_server *s = _ics->server;
+
+    if (s->workspace_mode) {
+        // Already active — re-ensure window for relaunch (existing behavior).
+        ...
+    }
+
+    // Authorization: orchestrator-PID match, with manual-mode fallback.
+    unsigned long expected_pid = service_orchestrator_get_workspace_pid();
+    unsigned long caller_pid   = (unsigned long)_ics->client_state.pid;
+
+    if (expected_pid != 0 && caller_pid != expected_pid) {
+        IPC_WARN(s, "workspace_activate: PID mismatch (caller=%lu, expected=%lu) — denied",
+                 caller_pid, expected_pid);
+        return XRT_ERROR_NOT_AUTHORIZED; // see "Error code" below
+    }
+
+    // expected_pid == 0 → manual mode, first-claim wins (which it does
+    // implicitly since we hit this code only on a first activate call).
+
+    s->workspace_mode = true;
+    ...
+}
+```
+
+### 4. Replace the `application_name` match in `ipc_handle_session_create` qwerty-routing logic
+
+`ipc_server_handler.c:294` currently uses the application_name match for a different purpose: deciding whether to route qwerty input to a session (workspace controller doesn't get qwerty input, app sessions do). Same fix:
+
+```c
+unsigned long workspace_pid = 0;
+if (s->workspace_mode) {
+    workspace_pid = service_orchestrator_get_workspace_pid();
+}
+bool is_workspace_controller_session =
+    workspace_pid != 0 &&
+    (unsigned long)ics->client_state.pid == workspace_pid;
+```
+
+This finally removes the literal `"displayxr-shell"` string from the runtime — the last brand-coupling point identified in Phase 1.
+
+### 5. Tell the workspace controller it was authorized
+
+Adds nothing on the controller side — `xrActivateSpatialWorkspaceEXT` returning `XR_SUCCESS` is the only signal needed. The controller doesn't need to know whether the runtime checked PID or application_name.
+
+## Error code
+
+OpenXR's standard error codes don't include "not authorized as workspace controller" cleanly. Options:
+
+- **`XR_ERROR_FEATURE_UNSUPPORTED`** — semi-honest: from the caller's POV, the *capability* of being a workspace controller is unsupported (for them). Re-uses an existing code.
+- **`XR_ERROR_LIMIT_REACHED`** — appropriate when another workspace is already active; not appropriate here (no resource limit issue).
+- **`XR_ERROR_VALIDATION_FAILURE`** — wrong; the input is well-formed.
+- **A new vendor error.** Cleanest; `XR_ERROR_WORKSPACE_NOT_AUTHORIZED_EXT` reserved by the spatial_workspace extension.
+
+Recommend the new vendor error code, defined alongside the extension. Maps internally to `XRT_ERROR_NOT_AUTHORIZED` (an `xrt_result_t` value the runtime can use; the IPC layer translates).
+
+## Edge cases
+
+**Workspace controller crashes and respawns.** Orchestrator's watchdog thread (`workspace_watch_thread_func`) restarts the controller in Enable mode. The new process gets a new PID; `s_workspace_pi.dwProcessId` updates. The old session was already gone (socket closed when process died); the new session activates with the new PID. No race — single writer (the watchdog) per spawn cycle.
+
+**Manual `displayxr-service --workspace` mode.** The orchestrator stays out of the spawning loop (it's a developer-only legacy flow). `service_orchestrator_get_workspace_pid()` returns 0; the activate handler treats it as first-claim wins. If a user wants to lock this down, they should not pass `--workspace` and let the orchestrator manage it.
+
+**Configuration drift.** Suppose `service.json::workspace_binary` is changed between service start and a controller process connecting — the running orchestrator already has a `s_workspace_pi.dwProcessId` from the *original* binary. New binary's PID won't match. Resolved by: orchestrator re-reads config on `service_orchestrator_apply_config`, terminates the old process, spawns the new one — the new PID becomes authoritative. The IPC server queries the orchestrator at activate time, so it always sees current state.
+
+**PID reuse.** PIDs are recycled by the OS. An attacker who can predict reuse could in theory connect with a forged PID. Mitigation: the orchestrator holds the spawned process's HANDLE (`s_workspace_pi.hProcess`) for its lifetime, which prevents the OS from immediately reusing the PID. As long as the watchdog is alive and holds the handle, the PID is uniquely ours. (This is a Win32-specific guarantee; macOS port uses an analogous mechanism via process handle.)
+
+**Service-restart race.** If the service restarts but the workspace controller doesn't, the new service has no `s_workspace_pi.dwProcessId`. The still-alive controller calls `xrActivateSpatialWorkspaceEXT` from a previous session, gets PID-mismatch (or zero-expected-PID = manual mode = first-claim wins). Whether the controller is allowed depends on which mode the service started in. Acceptable: workspace controller crashes were already a recovery scenario; workspace will need to be redirected anyway.
+
+**Multi-user.** Out of scope. The service is single-user-per-session. If multiple users on the same machine each run their own service, each gets their own orchestrator + workspace controller pair, each authoritative within its session.
+
+## Migration path
+
+Lands as a small Phase 2 sub-step (call it "Phase 2.0 — auth handshake"). Three-commit sequence:
+
+1. **Add `service_orchestrator_get_workspace_pid()` getter.** Pure addition, no behavior change. Covered by header + impl.
+2. **Wire PID check into `ipc_handle_workspace_activate`.** Behavior change: workspace activation now requires PID match (or manual mode). The legacy `application_name == "displayxr-shell"` check stays in place during this commit as a fallback so existing setups don't break.
+3. **Remove the application_name fallback** + remove the literal `"displayxr-shell"` from `ipc_server_handler.c:296`. Final brand-decoupling commit. Tested with: orchestrator-spawned shell still works, manual `--workspace` flow still works, a forged `application_name="displayxr-shell"` from a different PID is now rejected.
+
+After step 3, the runtime contains zero references to the shell binary by name (the only remaining `"displayxr-shell.exe"` is the *default value* of `cfg.workspace_binary`, which is correct: third parties override it via `service.json`).
+
+## Out of scope
+
+- **Code-signing / Authenticode verification.** Nice-to-have for a future tightening pass, not needed for Phase 2. The orchestrator-PID check already prevents arbitrary local processes from claiming workspace mode in service-managed deployments — that's the threat model we care about for Phase 2.
+- **Cross-machine workspace controllers.** All workspace concerns are local to one machine.
+- **Switching between workspace controllers at runtime.** Phase 2 keeps the "one workspace at a time" model. A controller change requires deactivate + activate.

--- a/docs/roadmap/spatial-workspace-controller-detection.md
+++ b/docs/roadmap/spatial-workspace-controller-detection.md
@@ -1,0 +1,204 @@
+# Workspace Controller Detection — Conditional Tray + Sidecar Manifest (draft)
+
+**Status:** Draft, 2026-04-28. Sister doc to [spatial-workspace-auth-handshake.md](spatial-workspace-auth-handshake.md). Together these define **Phase 2.0** of the workspace-extensions effort.
+
+Defines how the runtime detects whether a workspace controller is installed, and how the tray UI adapts to show or hide workspace lifecycle controls based on that detection. Resolves the architectural awkwardness of the runtime always having a "Workspace" submenu even when no controller binary is present.
+
+## Why this matters
+
+Today the service tray always shows a Workspace submenu (Enable/Auto/Disable) regardless of whether a workspace controller is actually installed. This made sense when the runtime and shell shipped together — the shell binary was always present. As the platform separates (Phase 3 severs the shell repo from the runtime repo), the runtime needs to ship and run *standalone* — without any workspace controller — and still be a useful product:
+
+| What DisplayXR-without-shell delivers | Status today |
+|---|---|
+| In-process OpenXR for any 3D-display app | works |
+| WebXR for Chrome / sandboxed apps via the bridge | works |
+| OpenXR routing for sandboxed apps via the service | works |
+| Multi-app spatial composition | requires a workspace controller |
+| App launcher, chrome, layouts, capture | requires a workspace controller |
+
+A user who installs only the runtime gets the first three. The tray should reflect that: the Bridge submenu always shows (the bridge ships with the runtime); the Workspace submenu shows only when a controller is detected.
+
+This makes the runtime a real platform — installable on its own, useful on its own, with the shell as one optional product that the platform recognizes when present.
+
+## Detection mechanism
+
+**File-presence check + sidecar manifest, evaluated at service startup.**
+
+At init, the orchestrator:
+
+1. Resolves the workspace controller binary path from `service.json::workspace_binary` (already plumbed in Phase 1; defaults to `"displayxr-shell.exe"` resolved as a sibling of `displayxr-service.exe`).
+2. Checks whether the file exists. If not → workspace is unavailable; skip the rest.
+3. If the file exists, looks for a sidecar manifest at `<binary path with .exe stripped>.controller.json` in the same directory. The manifest is the workspace controller's self-description.
+4. If the manifest exists and parses, extract the display name (and any other published metadata). If the manifest is missing or malformed, log a warning and fall back to `"Workspace Controller"` as the display name — the controller is still considered available since the binary is there.
+
+The result is two pieces of orchestrator state:
+- `s_workspace_available` — bool, whether to show the submenu and register hotkeys.
+- `s_workspace_display_name` — UTF-8 string, what to label the submenu with.
+
+Both are computed once at init. Live updates (user installs the shell while the service is running) require a service restart for now — `service_orchestrator_apply_config` could re-detect on config change in a later iteration if it becomes a real friction point, but it's not worth the complexity in Phase 2.0.
+
+## Sidecar manifest format
+
+Filename: `<binary>.controller.json` next to the binary. For `displayxr-shell.exe`, the manifest is `displayxr-shell.controller.json` in the same directory. The shell installer drops it at install time.
+
+Schema (additive — extra fields are ignored, missing fields use defaults):
+
+```json
+{
+  "schema_version": 1,
+  "display_name": "DisplayXR Shell",
+  "vendor": "Leia Inc.",
+  "version": "1.4.0",
+  "icon_path": "shell-icon.png"
+}
+```
+
+| Field | Required | Default | Used for |
+|---|---|---|---|
+| `schema_version` | yes | — | Forward-compat gate. Currently must be 1. |
+| `display_name` | yes | "Workspace Controller" if missing | Tray menu label, log strings ("Launched <display_name>") |
+| `vendor` | no | "" | Reserved for future use (about-box, ecosystem registry) |
+| `version` | no | "" | Logged at spawn for debugging mismatches; eventually used to gate compat against runtime SPEC_VERSION |
+| `icon_path` | no | "" | Tray submenu icon; relative to the manifest. Reserved for future use. |
+
+Pattern matches the existing `.displayxr.json` app manifest schema (commit `acd954548`) — same JSON shape, same additive-growth rule. App manifests describe **launcher tiles**; controller manifests describe **the controller binary itself**. Distinct files, distinct purposes — don't conflate.
+
+## Tray UI shape
+
+**Without a workspace controller installed:**
+
+```
+DisplayXR (tray icon)
+├── Bridge          ▶
+│   ├── Enable
+│   ├── ● Auto
+│   └── Disable
+├── Start on login   ✓
+├── ─────────────
+└── Quit
+```
+
+**With the DisplayXR Shell installed:**
+
+```
+DisplayXR (tray icon)
+├── DisplayXR Shell  ▶            ← display_name from manifest; falls back to "Workspace Controller"
+│   ├── Enable
+│   ├── ● Auto
+│   └── Disable
+├── Bridge           ▶
+│   ├── Enable
+│   ├── ● Auto
+│   └── Disable
+├── Start on login   ✓
+├── ─────────────
+└── Quit
+```
+
+**With a third-party workspace controller (e.g., a vertical cockpit) installed:**
+
+```
+DisplayXR (tray icon)
+├── Surgical Cockpit  ▶            ← whatever display_name the cockpit's manifest declared
+│   ├── Enable
+│   ├── ● Auto
+│   └── Disable
+├── Bridge            ▶
+…
+```
+
+The Bridge submenu always shows because the bridge binary ships with the runtime. The Workspace submenu's presence and label are entirely driven by detection.
+
+## Code changes
+
+Rough sketch — finalised during implementation. Lives in Phase 2.0 alongside the auth handshake.
+
+### `service_orchestrator.h` additions
+
+```c
+//! Returns true iff a workspace controller binary was found at the
+//! configured path at service init time.
+bool
+service_orchestrator_is_workspace_available(void);
+
+//! Returns the workspace controller's user-visible display name —
+//! either from its sidecar manifest or "Workspace Controller" as
+//! a fallback when the manifest is missing/malformed. Empty string
+//! if no controller is available.
+const char *
+service_orchestrator_get_workspace_display_name(void);
+```
+
+### `service_orchestrator.c` changes
+
+- New static state: `s_workspace_available`, `s_workspace_display_name[256]`.
+- New helper `detect_workspace_controller(const struct service_config *cfg)` — runs at init, populates the static state.
+- `service_orchestrator_init`: call `detect_workspace_controller(cfg)` before `apply_workspace_mode(cfg->workspace)`.
+- `apply_workspace_mode`: short-circuit when `!s_workspace_available` — log once, don't register hotkey, don't try to spawn.
+
+### New helper file: `service_workspace_manifest.{c,h}`
+
+Small parser that reads `<binary>.controller.json` via cJSON and populates a `struct workspace_manifest { char display_name[256]; char vendor[64]; char version[32]; char icon_path[MAX_PATH]; }`. ~100 lines. Lives in `targets/service/` next to `service_config.{c,h}`.
+
+### `service_tray_win.c` changes
+
+- At menu-build time, call `service_orchestrator_is_workspace_available()`. If false, skip appending the Workspace submenu.
+- When appending, use `service_orchestrator_get_workspace_display_name()` for the parent menu-item label instead of the hardcoded `L"Workspace Controller"` from commit `4cf3ba93d`. Convert UTF-8 → wide via `MultiByteToWideChar`.
+
+### Default fallback when no manifest
+
+If the workspace controller binary is `displayxr-shell.exe` and no `.controller.json` is found, the tray label is `"Workspace Controller"` (generic). The DisplayXR Shell installer always drops a manifest, so end-users see "DisplayXR Shell" — but a developer who built the shell from source gets the generic label until they place a manifest. That's fine and lossless.
+
+## Hotkey registration interaction
+
+Today `apply_workspace_mode(SERVICE_CHILD_AUTO)` installs the WH_KEYBOARD_LL hook so Ctrl+Space launches the controller. With detection added:
+
+- `s_workspace_available == false` → never install the hook regardless of mode. Ctrl+Space does nothing system-wide. Logged once at startup as `"workspace controller not installed; Ctrl+Space disabled"`.
+- `s_workspace_available == true` → existing logic applies.
+
+This avoids the buggy state where the hook is installed but the spawn target doesn't exist (today's behavior in that edge case prints "Cannot find workspace controller binary 'X' next to service" on every Ctrl+Space, in commit `4cf3ba93d`'s addition).
+
+## Edge cases
+
+**Service running, user installs the shell.** Detected only at next service restart. Live-refresh would be nice but adds file-watching complexity. Document the restart requirement in the shell installer's UX (e.g., installer prompts a service restart at the end). Acceptable for Phase 2.
+
+**Service running, user uninstalls the shell.** Same — detected at next service restart. Until then the tray still shows the submenu, but clicking Enable fails. Mitigation: orchestrator's per-spawn file-presence check (already there in `spawn_workspace`) catches the missing binary and logs an error. User sees no spawn happen, restarts service, submenu disappears.
+
+**Manifest parses but `display_name` is empty.** Treat as missing → fall back to `"Workspace Controller"`.
+
+**Manifest's `display_name` contains weird characters.** Tray uses `MultiByteToWideChar(CP_UTF8, ...)` — handles emoji, diacritics, etc. Length-cap at 64 chars to avoid a workspace-controller name overflowing the tray menu (longer names truncate with ellipsis).
+
+**Two manifests in one directory.** Shouldn't happen — one workspace controller binary per directory. If it does (developer accident), the orchestrator reads only the manifest matching `cfg.workspace_binary`'s basename. The other is silently ignored.
+
+**Binary exists but is the wrong architecture (32-bit on a 64-bit service).** Detection passes (file exists). Spawn fails when the user activates. Treat as a runtime failure, not a detection failure — too rare to warrant a header-parse / PE-architecture check at detect time.
+
+## Future evolution: multi-controller registry
+
+Phase 2/3 single-controller-at-a-time is fine. If multiple controllers ever need to coexist (DisplayXR Shell + a Lenovo workspace + a vertical cockpit, all installed simultaneously), the natural extension:
+
+- A registry directory at `%LOCALAPPDATA%\DisplayXR\workspaces\` (analogous to the `apps\` directory the launcher uses for app manifests, per commit `acd954548`).
+- Each controller's installer drops a `.controller.json` there pointing at the binary path.
+- The orchestrator scans the directory at init, builds a list of available controllers.
+- The tray shows the active controller as the submenu parent, with a chooser for switching ("Switch workspace controller →").
+- `service.json::workspace_binary` becomes the *active* controller path; the registry is the *available* set.
+
+Not building this yet — it's overkill for Phase 2 and YAGNI risk. But the manifest format and detection mechanism settled here compose toward it cleanly: just generalize from "look at one path" to "scan a directory and pick one."
+
+## Migration path
+
+Lands as part of Phase 2.0 alongside the auth handshake. Both are small (~few hundred lines each), share the orchestrator-modification surface, and gate the Phase 2.A–2.H code migrations.
+
+Order within Phase 2.0:
+
+1. **(this doc) Controller detection** — add `service_workspace_manifest.{c,h}`, the orchestrator getters, and the conditional tray UI. Standalone; no auth-handshake dependency. Pure addition; existing behavior is preserved when a manifest exists with `display_name = "Workspace Controller"`.
+2. **(auth-handshake doc) Auth handshake** — add `service_orchestrator_get_workspace_pid()`, wire PID check into `ipc_handle_workspace_activate`, replace the literal `"displayxr-shell"` match. Removes the last brand coupling in the runtime.
+3. **DisplayXR Shell installer drops the manifest.** One-line installer change in the shell's NSIS / WiX. Until this ships, the shell's detected display name falls back to `"Workspace Controller"` — fine, lossless.
+
+After all three: the runtime ships standalone; the shell adds the workspace submenu and authoritative activation rights; OEMs / verticals / kiosks can ship their own controllers with their own manifests and get exactly the same first-class treatment.
+
+## What this is NOT
+
+- **Not a plugin system.** The runtime doesn't load anything from the controller binary into its own process — the controller is a separate process that talks IPC. The manifest is metadata, not code.
+- **Not a workspace controller registry / app store.** The controller binary path is configured (`service.json::workspace_binary`), not auto-discovered yet. A registry is the future-evolution path described above; not part of Phase 2.0.
+- **Not a way to disable the bridge submenu.** The bridge ships with the runtime and is conceptually part of "the runtime experience." Bridge lifecycle stays unconditional in the tray.
+- **Not coupled to the launcher's app-manifest scanner.** The launcher scans `%LOCALAPPDATA%\DisplayXR\apps\` for app tiles. The orchestrator looks at one specific file next to the controller binary. Different mechanisms because they solve different problems (apps are many, controllers are one).

--- a/docs/roadmap/spatial-workspace-extensions-headers-draft.md
+++ b/docs/roadmap/spatial-workspace-extensions-headers-draft.md
@@ -1,0 +1,546 @@
+# Workspace Extensions — Header Sketch (draft)
+
+**Status:** Draft v0, 2026-04-27. Branch `feature/shell-brand-separation`. Not frozen.
+
+Companion to [spatial-workspace-extensions-plan.md](spatial-workspace-extensions-plan.md). That doc explains *why* the runtime needs neutral workspace primitives; this doc proposes *what* the C-level API surface looks like — full enough that the next implementer (or reviewer) can argue with specifics rather than prose.
+
+## What this draft is for
+
+Phase 2 moves policy out of `comp_d3d11_service.cpp` (launcher registry, layout-preset semantics, chrome rendering, capture lifecycle, ESC/empty-workspace logic) into the workspace controller process. Each policy migration removes runtime code **and** adds extension API surface — the workspace controller calls the extension instead of the runtime owning the policy.
+
+Without a header sketch first, we'd design the API one migration at a time and end up with an inconsistent surface. Sketching now lets us:
+- Pick names that work across all migrations (e.g., the same `XrWorkspaceClientId` is used by hit-test, capture, pose-set, visibility, etc.).
+- Decide what's two extensions versus one.
+- Settle the activation handshake before writing any of it.
+- Spec what a non-DisplayXR-Shell workspace controller actually has to call to bootstrap.
+
+It is *not* a frozen specification. SPEC_VERSION 1 freezes when the first non-shell consumer (a vertical workspace, a kiosk, an OEM controller, or our own test harness) successfully drives the runtime end-to-end.
+
+## Naming and scope
+
+Two extensions, both prefixed `XR_EXT_` to match the existing DisplayXR extensions (`XR_EXT_display_info`, `XR_EXT_win32_window_binding`, etc.). The `EXT_` prefix signals "any DisplayXR-compatible runtime should implement", same as the others — not single-vendor `XR_DISPLAYXR_`.
+
+| Extension | Purpose |
+|---|---|
+| `XR_EXT_spatial_workspace` | Privileged client opts into workspace mode; manages window poses, visibility, hit-test, 2D capture clients, frame capture, client enumeration, lifecycle events. |
+| `XR_EXT_app_launcher` | Tile registry rendered by the runtime over the atlas. Workspace pushes tiles, polls click events, sets the running-tile mask. Optional second extension — see "Why two extensions" below. |
+
+### Why two extensions
+
+Could be one. Keeping them separate buys two things:
+
+1. **Independent versioning.** Launcher UX is most likely to evolve (we may want richer tile metadata, glow states, drag-to-reorder, group tabs). The workspace surface should stabilize first; the launcher can iterate without bumping `XR_EXT_spatial_workspace_SPEC_VERSION`.
+2. **A non-launcher controller is a real use case.** A medical cockpit, a kiosk, or a test harness wants `spatial_workspace` but doesn't need a launcher. Two extensions = the controller declares only what it uses; the runtime can run a workspace without instantiating launcher state.
+
+Counter-argument: more surface area to keep coherent. Mitigated by the fact that a workspace controller almost always uses both, and they share the lifecycle (launcher commands no-op when no workspace is active).
+
+We start with two and merge if the boundary feels artificial after Phase 2 is in real use.
+
+## Activation handshake
+
+The workspace controller is a regular OpenXR client that opts into privileged mode. Bootstrap:
+
+1. Process launches; binary path is whatever `service.json::workspace_binary` points at (defaults to `displayxr-shell.exe`, configurable per Phase 1).
+2. Process calls `xrCreateInstance` with `XR_EXT_SPATIAL_WORKSPACE_EXTENSION_NAME` in `enabledExtensionNames` (and optionally `XR_EXT_APP_LAUNCHER_EXTENSION_NAME`).
+3. Process creates a session normally (graphics binding can be `XR_NULL_HANDLE` — workspace controllers don't render swapchains; they only instruct).
+4. Process calls `xrActivateSpatialWorkspaceEXT(session)`. The runtime checks:
+   - At most one workspace is active per system. Returns `XR_ERROR_LIMIT_REACHED` if another controller already holds the role.
+   - Caller authorization: in the current implementation the runtime checks `application_name == config.workspace_app_name` (defaults to `"displayxr-shell"`). Phase 2 promotes this to a proper handshake — see "Open questions". For now, the simple match is enough to gate the privileged surface.
+5. On success the session is *the* workspace session. All subsequent extension calls go through this `XrSession` handle.
+
+Lifecycle:
+- `xrDeactivateSpatialWorkspaceEXT(session)` — voluntarily release the role. Other clients keep running; per-client compositors resume direct rendering.
+- `xrDestroySession` on the workspace session — implicit deactivate.
+- Workspace process crash — service detects via IPC pipe close and treats as deactivate.
+
+A non-workspace OpenXR session has *no access* to any of the functions below; calling them returns `XR_ERROR_FEATURE_UNSUPPORTED` (extension not enabled) or `XR_ERROR_VALIDATION_FAILURE` (extension enabled but session is not the active workspace).
+
+## Header sketch — `XR_EXT_spatial_workspace.h`
+
+```c
+// Copyright 2026, DisplayXR
+// SPDX-License-Identifier: BSL-1.0
+#ifndef XR_EXT_SPATIAL_WORKSPACE_H
+#define XR_EXT_SPATIAL_WORKSPACE_H 1
+
+#include <openxr/openxr.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define XR_EXT_spatial_workspace 1
+#define XR_EXT_spatial_workspace_SPEC_VERSION 1
+#define XR_EXT_SPATIAL_WORKSPACE_EXTENSION_NAME "XR_EXT_spatial_workspace"
+
+// ---- Type values (provisional — coordinate with extension registry) ----
+#define XR_TYPE_WORKSPACE_CLIENT_INFO_EXT          ((XrStructureType)1000999100)
+#define XR_TYPE_WORKSPACE_CAPTURE_REQUEST_EXT      ((XrStructureType)1000999101)
+#define XR_TYPE_WORKSPACE_CAPTURE_RESULT_EXT       ((XrStructureType)1000999102)
+#define XR_TYPE_EVENT_DATA_WORKSPACE_CLIENT_CONNECTED_EXT    ((XrStructureType)1000999103)
+#define XR_TYPE_EVENT_DATA_WORKSPACE_CLIENT_DISCONNECTED_EXT ((XrStructureType)1000999104)
+
+// Workspace-local identifier for a client. Stable for the lifetime of the
+// connection; reused after disconnect. 0 is reserved (invalid).
+typedef uint32_t XrWorkspaceClientId;
+
+#define XR_NULL_WORKSPACE_CLIENT_ID ((XrWorkspaceClientId)0)
+
+// ---- Lifecycle ----
+
+/*!
+ * Activate workspace mode on this session. The session becomes the privileged
+ * workspace controller. At most one workspace is active per system.
+ *
+ * Returns:
+ *   XR_SUCCESS                    Activated.
+ *   XR_ERROR_LIMIT_REACHED        Another workspace is already active.
+ *   XR_ERROR_FEATURE_UNSUPPORTED  Caller is not authorized as a workspace
+ *                                 controller (see "Activation handshake").
+ *   XR_ERROR_FUNCTION_UNSUPPORTED Extension was not enabled at instance create.
+ */
+typedef XrResult (XRAPI_PTR *PFN_xrActivateSpatialWorkspaceEXT)(XrSession session);
+
+/*!
+ * Voluntarily release workspace role. Other clients keep running.
+ */
+typedef XrResult (XRAPI_PTR *PFN_xrDeactivateSpatialWorkspaceEXT)(XrSession session);
+
+/*!
+ * Query whether this session is currently the active workspace controller.
+ */
+typedef XrResult (XRAPI_PTR *PFN_xrGetSpatialWorkspaceStateEXT)(
+    XrSession session, XrBool32 *out_active);
+
+
+// ---- Client enumeration ----
+
+typedef enum XrWorkspaceClientTypeEXT {
+    XR_WORKSPACE_CLIENT_TYPE_OPENXR_3D_EXT  = 0,  // a regular OpenXR app session
+    XR_WORKSPACE_CLIENT_TYPE_CAPTURED_2D_EXT = 1, // a 2D OS window adopted via xrAddWorkspaceCaptureClientEXT
+    XR_WORKSPACE_CLIENT_TYPE_MAX_ENUM_EXT   = 0x7FFFFFFF
+} XrWorkspaceClientTypeEXT;
+
+/*!
+ * Per-client metadata. Returned by xrEnumerateWorkspaceClientsEXT.
+ */
+typedef struct XrWorkspaceClientInfoEXT {
+    XrStructureType             type;        //!< XR_TYPE_WORKSPACE_CLIENT_INFO_EXT
+    void* XR_MAY_ALIAS          next;
+    XrWorkspaceClientId         clientId;
+    XrWorkspaceClientTypeEXT    clientType;
+    char                        applicationName[XR_MAX_APPLICATION_NAME_SIZE];
+    char                        processName[XR_MAX_SYSTEM_NAME_SIZE]; //!< OS process name (best-effort)
+    XrPosef                     pose;        //!< Current window pose in display space
+    XrExtent2Df                 sizeMeters;  //!< Current width/height in meters
+    XrBool32                    visible;     //!< True if not minimized
+    XrBool32                    focused;     //!< True if input is currently routed to this client
+} XrWorkspaceClientInfoEXT;
+
+/*!
+ * Standard two-call enumerate. First call with capacityInput=0 gets count;
+ * second call with allocated array gets details.
+ */
+typedef XrResult (XRAPI_PTR *PFN_xrEnumerateWorkspaceClientsEXT)(
+    XrSession                   session,
+    uint32_t                    clientCapacityInput,
+    uint32_t                   *clientCountOutput,
+    XrWorkspaceClientInfoEXT   *clients);
+
+
+// ---- Window pose ----
+
+/*!
+ * Set position, orientation, and physical size of a client's window in display
+ * space. The runtime composites that client's swapchain into a quad at this
+ * pose; on the next frame the result is visible.
+ *
+ * pose origin is the display center; +x right, +y up, +z toward the viewer.
+ * Sizes are physical (meters). Width/height are the quad's extent — the
+ * runtime stretches the client's atlas to fit.
+ *
+ * Returns XR_ERROR_VALIDATION_FAILURE if clientId is unknown or not a
+ * positionable client (some platform-internal clients may be excluded).
+ */
+typedef XrResult (XRAPI_PTR *PFN_xrSetWorkspaceClientWindowPoseEXT)(
+    XrSession           session,
+    XrWorkspaceClientId clientId,
+    const XrPosef      *pose,
+    float               widthMeters,
+    float               heightMeters);
+
+typedef XrResult (XRAPI_PTR *PFN_xrGetWorkspaceClientWindowPoseEXT)(
+    XrSession           session,
+    XrWorkspaceClientId clientId,
+    XrPosef            *outPose,
+    float              *outWidthMeters,
+    float              *outHeightMeters);
+
+/*!
+ * Show or hide a client's window without destroying it. A hidden client keeps
+ * running but does not contribute to the composite (minimize semantics).
+ */
+typedef XrResult (XRAPI_PTR *PFN_xrSetWorkspaceClientVisibilityEXT)(
+    XrSession           session,
+    XrWorkspaceClientId clientId,
+    XrBool32            visible);
+
+
+// ---- Capture clients (adopt a 2D OS window) ----
+
+/*!
+ * Adopt a 2D OS window as a workspace client. The runtime starts a platform-
+ * appropriate capture (Windows.Graphics.Capture on Windows; CGDisplayCreate-
+ * Image / SCStream on macOS) and treats the captured texture as a client
+ * swapchain — the workspace can position/hide it like any other client.
+ *
+ * nativeWindow is platform-defined: HWND on Windows passed as uint64_t, NSView*
+ * on macOS via chained struct (see XR_EXT_cocoa_window_binding for the chain
+ * pattern). For now we ship Windows-only and pass HWND as uint64_t directly;
+ * macOS support adds a chained XrWorkspaceCocoaCaptureBindingEXT struct.
+ *
+ * The returned clientId enters the same numbering space as OpenXR clients —
+ * the workspace controller cannot tell them apart from xrEnumerate's result
+ * except via XrWorkspaceClientTypeEXT.
+ */
+typedef XrResult (XRAPI_PTR *PFN_xrAddWorkspaceCaptureClientEXT)(
+    XrSession            session,
+    uint64_t             nativeWindow,    // Windows: HWND. macOS: 0 + chained binding.
+    const char          *nameOptional,    // user-visible label, may be NULL
+    XrWorkspaceClientId *outClientId);
+
+typedef XrResult (XRAPI_PTR *PFN_xrRemoveWorkspaceCaptureClientEXT)(
+    XrSession           session,
+    XrWorkspaceClientId clientId);
+
+
+// ---- Hit-test ----
+
+/*!
+ * Given a screen-space cursor position (display pixels, origin top-left),
+ * raycast through the workspace and return which client window was hit and
+ * where on its surface in normalized UV (0..1, origin top-left of the window
+ * quad).
+ *
+ * Returns:
+ *   XR_SUCCESS — outClientId valid (XR_NULL_WORKSPACE_CLIENT_ID = miss)
+ *
+ * The workspace controller calls this from its input handler, then decides
+ * what the hit means (focus, drag, right-click forward, title-bar grab,
+ * resize-edge etc.). The runtime does NOT classify hits — that is policy.
+ */
+typedef XrResult (XRAPI_PTR *PFN_xrWorkspaceHitTestEXT)(
+    XrSession            session,
+    int32_t              cursorX,
+    int32_t              cursorY,
+    XrWorkspaceClientId *outClientId,
+    XrVector2f          *outLocalUV);
+
+
+// ---- Frame capture ----
+
+#define XR_WORKSPACE_CAPTURE_FLAG_LEFT_VIEW_BIT_EXT   0x00000001
+#define XR_WORKSPACE_CAPTURE_FLAG_RIGHT_VIEW_BIT_EXT  0x00000002
+#define XR_WORKSPACE_CAPTURE_FLAG_ATLAS_BIT_EXT       0x00000004
+#define XR_WORKSPACE_CAPTURE_FLAG_INCLUDE_METADATA_BIT_EXT  0x00000008
+typedef XrFlags64 XrWorkspaceCaptureFlagsEXT;
+
+typedef struct XrWorkspaceCaptureRequestEXT {
+    XrStructureType                type;        //!< XR_TYPE_WORKSPACE_CAPTURE_REQUEST_EXT
+    const void* XR_MAY_ALIAS       next;
+    char                           pathPrefix[XR_MAX_PATH_LENGTH]; //!< filename prefix without extension
+    XrWorkspaceCaptureFlagsEXT     flags;
+} XrWorkspaceCaptureRequestEXT;
+
+typedef struct XrWorkspaceCaptureResultEXT {
+    XrStructureType                type;        //!< XR_TYPE_WORKSPACE_CAPTURE_RESULT_EXT
+    void* XR_MAY_ALIAS             next;
+    uint32_t                       viewsWritten;
+    uint32_t                       atlasWidthPixels;
+    uint32_t                       atlasHeightPixels;
+    char                           atlasPath[XR_MAX_PATH_LENGTH];
+    char                           metadataJsonPath[XR_MAX_PATH_LENGTH]; //!< empty if not requested
+} XrWorkspaceCaptureResultEXT;
+
+/*!
+ * Capture the current pre-weave atlas to disk. The runtime writes one or more
+ * PNGs and an optional JSON sidecar with per-client window bounding boxes.
+ * Synchronous within the workspace render thread.
+ */
+typedef XrResult (XRAPI_PTR *PFN_xrCaptureWorkspaceFrameEXT)(
+    XrSession                            session,
+    const XrWorkspaceCaptureRequestEXT  *request,
+    XrWorkspaceCaptureResultEXT         *outResult);
+
+
+// ---- Events ----
+
+typedef struct XrEventDataWorkspaceClientConnectedEXT {
+    XrStructureType             type;       //!< XR_TYPE_EVENT_DATA_WORKSPACE_CLIENT_CONNECTED_EXT
+    const void* XR_MAY_ALIAS    next;
+    XrSession                   session;    //!< the workspace session
+    XrWorkspaceClientId         clientId;
+    XrWorkspaceClientTypeEXT    clientType;
+} XrEventDataWorkspaceClientConnectedEXT;
+
+typedef struct XrEventDataWorkspaceClientDisconnectedEXT {
+    XrStructureType             type;       //!< XR_TYPE_EVENT_DATA_WORKSPACE_CLIENT_DISCONNECTED_EXT
+    const void* XR_MAY_ALIAS    next;
+    XrSession                   session;
+    XrWorkspaceClientId         clientId;
+} XrEventDataWorkspaceClientDisconnectedEXT;
+
+
+#ifndef XR_NO_PROTOTYPES
+XRAPI_ATTR XrResult XRAPI_CALL xrActivateSpatialWorkspaceEXT(XrSession);
+XRAPI_ATTR XrResult XRAPI_CALL xrDeactivateSpatialWorkspaceEXT(XrSession);
+XRAPI_ATTR XrResult XRAPI_CALL xrGetSpatialWorkspaceStateEXT(XrSession, XrBool32*);
+XRAPI_ATTR XrResult XRAPI_CALL xrEnumerateWorkspaceClientsEXT(
+    XrSession, uint32_t, uint32_t*, XrWorkspaceClientInfoEXT*);
+XRAPI_ATTR XrResult XRAPI_CALL xrSetWorkspaceClientWindowPoseEXT(
+    XrSession, XrWorkspaceClientId, const XrPosef*, float, float);
+XRAPI_ATTR XrResult XRAPI_CALL xrGetWorkspaceClientWindowPoseEXT(
+    XrSession, XrWorkspaceClientId, XrPosef*, float*, float*);
+XRAPI_ATTR XrResult XRAPI_CALL xrSetWorkspaceClientVisibilityEXT(
+    XrSession, XrWorkspaceClientId, XrBool32);
+XRAPI_ATTR XrResult XRAPI_CALL xrAddWorkspaceCaptureClientEXT(
+    XrSession, uint64_t, const char*, XrWorkspaceClientId*);
+XRAPI_ATTR XrResult XRAPI_CALL xrRemoveWorkspaceCaptureClientEXT(
+    XrSession, XrWorkspaceClientId);
+XRAPI_ATTR XrResult XRAPI_CALL xrWorkspaceHitTestEXT(
+    XrSession, int32_t, int32_t, XrWorkspaceClientId*, XrVector2f*);
+XRAPI_ATTR XrResult XRAPI_CALL xrCaptureWorkspaceFrameEXT(
+    XrSession, const XrWorkspaceCaptureRequestEXT*, XrWorkspaceCaptureResultEXT*);
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // XR_EXT_SPATIAL_WORKSPACE_H
+```
+
+## Header sketch — `XR_EXT_app_launcher.h`
+
+```c
+// Copyright 2026, DisplayXR
+// SPDX-License-Identifier: BSL-1.0
+#ifndef XR_EXT_APP_LAUNCHER_H
+#define XR_EXT_APP_LAUNCHER_H 1
+
+#include <openxr/openxr.h>
+#include <openxr/XR_EXT_spatial_workspace.h>  // for XrWorkspaceClientId — not strictly required, but launcher state is workspace-scoped
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define XR_EXT_app_launcher 1
+#define XR_EXT_app_launcher_SPEC_VERSION 1
+#define XR_EXT_APP_LAUNCHER_EXTENSION_NAME "XR_EXT_app_launcher"
+
+#define XR_TYPE_LAUNCHER_APP_INFO_EXT       ((XrStructureType)1000999110)
+#define XR_TYPE_EVENT_DATA_LAUNCHER_CLICK_EXT ((XrStructureType)1000999111)
+
+#define XR_LAUNCHER_MAX_APPS_EXT 64
+#define XR_LAUNCHER_INVALID_TILE_INDEX_EXT ((int32_t)-1)
+
+/*!
+ * One launcher tile. The runtime renders an icon + label; the workspace
+ * controller decides what clicking means (typically: launch the named binary).
+ */
+typedef struct XrLauncherAppInfoEXT {
+    XrStructureType             type;       //!< XR_TYPE_LAUNCHER_APP_INFO_EXT
+    void* XR_MAY_ALIAS          next;
+    char                        name[XR_MAX_APPLICATION_NAME_SIZE];
+    char                        iconPath[XR_MAX_PATH_LENGTH];   //!< absolute path to a PNG; runtime loads + caches
+    uint32_t                    appIndex;                       //!< caller-defined opaque id; returned in click events
+} XrLauncherAppInfoEXT;
+
+
+// ---- Tile registry ----
+
+/*!
+ * Empty the launcher's tile list. Called by the workspace controller at the
+ * start of each registry push (clear-then-add-N pattern keeps each call's
+ * payload below the IPC message buffer cap and makes registry diffs trivial).
+ */
+typedef XrResult (XRAPI_PTR *PFN_xrClearLauncherAppsEXT)(XrSession session);
+
+/*!
+ * Append one tile. Silently ignored if the registry is full (max
+ * XR_LAUNCHER_MAX_APPS_EXT entries). The workspace controller is expected to
+ * push a clear+add-N sequence whenever its registered-app set changes.
+ */
+typedef XrResult (XRAPI_PTR *PFN_xrAddLauncherAppEXT)(
+    XrSession                       session,
+    const XrLauncherAppInfoEXT     *app);
+
+
+// ---- Visibility ----
+
+/*!
+ * Show or hide the launcher panel. The runtime renders the tile grid as a
+ * compositor overlay at zero-disparity (z=0 in display space).
+ */
+typedef XrResult (XRAPI_PTR *PFN_xrSetLauncherVisibleEXT)(
+    XrSession session, XrBool32 visible);
+
+
+// ---- Click polling ----
+
+/*!
+ * Poll-and-clear the most recent unconsumed tile click. Returns the appIndex
+ * the user clicked, or XR_LAUNCHER_INVALID_TILE_INDEX_EXT if none.
+ *
+ * Workspace controllers typically poll once per main-loop iteration. On a hit,
+ * the controller looks up the app in its own registry (the one it pushed via
+ * xrAddLauncherAppEXT) and launches the corresponding binary.
+ *
+ * Alternative shape under consideration: push as XrEventDataLauncherClickEXT
+ * via xrPollEvent. Decision deferred — see "Open questions".
+ */
+typedef XrResult (XRAPI_PTR *PFN_xrPollLauncherClickEXT)(
+    XrSession   session,
+    int32_t    *outAppIndex);
+
+
+// ---- Running indicator ----
+
+/*!
+ * Set bitmask of tiles whose corresponding apps are currently running. The
+ * runtime draws a glow border on tiles whose bit is set so the user can see
+ * which apps are open. The workspace controller pushes this whenever its
+ * computed running set changes.
+ *
+ * Bit i corresponds to the tile whose appIndex was i (so the workspace's
+ * appIndex assignment defines the bitmask layout).
+ */
+typedef XrResult (XRAPI_PTR *PFN_xrSetLauncherRunningTileMaskEXT)(
+    XrSession session,
+    uint64_t  mask);
+
+
+#ifndef XR_NO_PROTOTYPES
+XRAPI_ATTR XrResult XRAPI_CALL xrClearLauncherAppsEXT(XrSession);
+XRAPI_ATTR XrResult XRAPI_CALL xrAddLauncherAppEXT(XrSession, const XrLauncherAppInfoEXT*);
+XRAPI_ATTR XrResult XRAPI_CALL xrSetLauncherVisibleEXT(XrSession, XrBool32);
+XRAPI_ATTR XrResult XRAPI_CALL xrPollLauncherClickEXT(XrSession, int32_t*);
+XRAPI_ATTR XrResult XRAPI_CALL xrSetLauncherRunningTileMaskEXT(XrSession, uint64_t);
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // XR_EXT_APP_LAUNCHER_H
+```
+
+## Mapping: existing IPC RPCs → extension functions
+
+The Phase 1 boundary rename produced these IPC RPCs. Phase 2 wraps them in extension functions:
+
+| Phase 1 IPC RPC | Extension function | Notes |
+|---|---|---|
+| `workspace_activate` | `xrActivateSpatialWorkspaceEXT` | Adds caller-authorization check |
+| `workspace_deactivate` | `xrDeactivateSpatialWorkspaceEXT` | |
+| `workspace_get_state` | `xrGetSpatialWorkspaceStateEXT` | |
+| *(new)* | `xrEnumerateWorkspaceClientsEXT` | Phase 2 unifies what's currently fragmented across `system_get_clients` + per-client info pulls |
+| `workspace_set_window_pose` | `xrSetWorkspaceClientWindowPoseEXT` | `client_id` → `clientId` |
+| `workspace_get_window_pose` | `xrGetWorkspaceClientWindowPoseEXT` | |
+| `workspace_set_window_visibility` | `xrSetWorkspaceClientVisibilityEXT` | |
+| `workspace_add_capture_client` | `xrAddWorkspaceCaptureClientEXT` | |
+| `workspace_remove_capture_client` | `xrRemoveWorkspaceCaptureClientEXT` | |
+| `workspace_capture_frame` | `xrCaptureWorkspaceFrameEXT` | Wraps the flag bitfield as `XrWorkspaceCaptureFlagsEXT` |
+| *(new)* | `xrWorkspaceHitTestEXT` | Promotes today's internal `workspace_raycast_hit_test` (still C++ inside the compositor) to a public extension; lets the workspace controller use the runtime's geometry instead of duplicating it |
+| `launcher_set_visible` | `xrSetLauncherVisibleEXT` | |
+| `launcher_clear_apps` | `xrClearLauncherAppsEXT` | |
+| `launcher_add_app` | `xrAddLauncherAppEXT` | `ipc_launcher_app` → `XrLauncherAppInfoEXT` |
+| `launcher_poll_click` | `xrPollLauncherClickEXT` | |
+| `launcher_set_running_tile_mask` | `xrSetLauncherRunningTileMaskEXT` | |
+
+Result: 14 RPCs become 16 extension functions (+2 for hit-test and client enumeration, both currently internal). The wire format goes through the existing IPC pipe — the loader's extension dispatch is the only new code on the runtime side; the IPC handler layer reuses what Phase 1 already renamed.
+
+## What stays out of the extensions
+
+These survive in the runtime under non-extension-exposed neutral C names — they are mechanism that no workspace controller needs to invoke directly:
+
+- Per-client virtual-window-pose → atlas-region computation
+- Deferred HWND resize on next frame after a pose change
+- Spatial cursor → display-plane intersection math (the *implementation* of hit-test; `xrWorkspaceHitTestEXT` is the entry point)
+- The 2D Windows.Graphics.Capture pumping thread
+- The capture client's offscreen render pass
+- Multi-compositor scheduling
+- Per-frame composite + present
+- Atlas write-to-PNG path (the *implementation* of capture)
+- Input event ring buffer that forwards mouse/keyboard from the workspace's window to the focused client's HWND
+- Window-relative Kooima projection per client
+
+These are all currently in `comp_d3d11_service.cpp`. They keep their internal `shell_*` names through Phase 1 (Phase 1 deferral) and get cleaned up by Phase 2 either by deletion (when policy moves) or by renaming once the surrounding code is unambiguously mechanism.
+
+## What moves to the workspace controller process
+
+Counterpart list — these stop being runtime concerns once Phase 2 lands:
+
+- Launcher tile registry storage (today: `comp_d3d11_service.cpp` `registered_apps`). Becomes: workspace process owns the array, pushes via `xrAddLauncherAppEXT` whenever its registry changes.
+- Layout-preset semantics (`grid` / `immersive` / `carousel`). Becomes: workspace process computes per-window poses for a chosen preset and pushes them via `xrSetWorkspaceClientWindowPoseEXT` for each client.
+- Right-click context menu, double-click maximize/restore, edge-drag resize, title-bar drag. Becomes: workspace process receives input events (or hit-test results), interprets them, and pushes the resulting pose changes.
+- Title-bar chrome rendering (close/minimize buttons, app name). Becomes: workspace process renders chrome into its own client window which the runtime composites alongside the app window via the workspace pose API. The runtime stops drawing chrome.
+- Eye-tracking-mode focus policy (when to switch MANAGED ↔ MANUAL based on which client is focused). Becomes: workspace process tracks focus, the runtime exposes mode-set per session. The integration is via `XR_EXT_display_info`'s eye-tracking-mode functions, called by the workspace on the focused client's behalf — design TBD in the migration that touches it.
+- "Empty workspace" ESC-handling carve-out, `pending_shell_reentry` state, deactivate-and-restore-2D-windows lifecycle. Becomes: deleted. The runtime's "no clients connected → idle composite path" is generic.
+
+## Lifecycle and threading
+
+- All workspace extension calls execute on the workspace's main session thread (the thread that owns the `XrSession`). No worker threads inside the workspace process need access.
+- Calls are synchronous from the workspace's perspective; the runtime returns when the state change is committed (it may take effect on the next render frame).
+- Events (`XrEventDataWorkspaceClientConnectedEXT`, etc.) are delivered via the standard `xrPollEvent` mechanism on the workspace session.
+- The runtime is free to coalesce or defer state changes internally (e.g., merging multiple pose updates per render frame). The workspace controller does not need to throttle.
+
+## Versioning and compatibility
+
+- `SPEC_VERSION` starts at 1 when the first non-shell consumer drives the runtime end-to-end.
+- The two extensions version independently.
+- Breaking changes to a struct (adding non-final fields) bump SPEC_VERSION; extension hosts gate on the version they need.
+- New optional fields can be added at the end of structs without a SPEC_VERSION bump as long as the runtime initializes them safely on read.
+- New functions can be added at any version; consumers gate on `xrGetInstanceProcAddr` returning non-null for the new function name.
+
+The shell repo, once severed (Phase 3), pins a minimum SPEC_VERSION in its CMake. Bumping the SPEC_VERSION on the runtime side is a coordinated release.
+
+## Open questions
+
+1. **Authorization model.** Today the IPC server gates the privileged role on `application_name == "displayxr-shell"`. For Phase 2, options:
+   - Keep matching `application_name`, but make the allowed name configurable in `service.json` (`workspace_app_name = "..."`).
+   - Add a per-binary capability the OS verifies (Authenticode / code-signing on Windows, codesign entitlement on macOS).
+   - Trust the orchestrator: only the binary the orchestrator spawned (matching its PID) can activate.
+   The orchestrator-PID approach is the easiest defensible thing — the service knows which PID it spawned via `service_orchestrator.c`, and `xrActivateSpatialWorkspaceEXT` only succeeds for that PID. Configurable name is the fallback for legacy multi-terminal flows.
+
+2. **Click events: poll-and-clear vs xrPollEvent.** Current Phase 1 IPC uses poll-and-clear (`launcher_poll_click`). Two patterns to choose between:
+   - Keep poll-and-clear (simple, current model).
+   - Promote to event (`XrEventDataLauncherClickEXT` queued on `xrPollEvent`). More consistent with OpenXR conventions and naturally handles multiple-click-before-poll.
+   Recommend: promote to event in SPEC_VERSION 1. The poll-and-clear shape was shaped by the IPC's bidirectional pipe constraint, not by user-facing requirements.
+
+3. **Should `xrEnumerateWorkspaceClientsEXT` be in the workspace extension or its own?** A vertical that uses workspace primitives but doesn't want enumeration is unusual; keep it in `XR_EXT_spatial_workspace`.
+
+4. **Capture API surface.** The flags-and-paths shape mirrors the existing IPC. An alternative is exposing a `XrSwapchain`-shaped capture target the workspace can read directly; deferred — file-based capture covers the current MCP and ad-hoc-screenshot use cases.
+
+5. **macOS native window for capture clients.** Phase 2's first cut is Windows-only because the current capture pipeline is Windows-only. When macOS lands, `xrAddWorkspaceCaptureClientEXT` grows a chained `XrWorkspaceCocoaCaptureBindingEXT` struct (NSView*) the same way `XR_EXT_cocoa_window_binding` chains.
+
+6. **Focus / input routing.** Not yet in the extension. The current implementation has the runtime forward mouse/keyboard from the workspace window to the focused client's HWND. In Phase 2, the workspace likely needs to:
+   - Tell the runtime which client is focused (`xrSetWorkspaceFocusedClientEXT`?).
+   - Get raw input events from the runtime (currently consumed by the runtime's window proc).
+   This is significant policy migration work — the workspace currently has no choice over input routing; the runtime makes the call. Design deferred to its own Phase 2 sub-step.
+
+7. **macOS workspace controller.** Out of scope for Phase 2 spec freeze. The extensions are platform-neutral by design but the only working implementation will be Windows for the foreseeable future.
+
+## What this draft implies for Phase 2 sequencing
+
+Re-reading the plan doc's recommended Phase 2 order against the header sketch:
+
+1. **Layout presets** — pure policy, no new extension surface needed (workspace just calls `xrSetWorkspaceClientWindowPoseEXT` per client). Easiest first migration.
+2. **Launcher tile registry + click polling** — exercises `XR_EXT_app_launcher` end-to-end. Small and well-bounded; good second step to validate the launcher extension's shape.
+3. **Title-bar chrome rendering** — the most invasive. Requires the workspace controller to render chrome as its own client window, positioned via `xrSetWorkspaceClientWindowPoseEXT`. Probably the migration that exposes the most surface gaps in the spec.
+4. **Capture client lifecycle** — `xrAddWorkspaceCaptureClientEXT` / `xrRemoveWorkspaceCaptureClientEXT`; mostly already neutral, light cleanup.
+5. **Focus / input routing** — open question above; design before migrating.
+6. **ESC / empty-workspace cleanup** — dies naturally as the rest moves; no explicit migration needed.
+
+After all six, the runtime side of `comp_d3d11_service.cpp` should be measurably smaller (not just renamed), the workspace controller process should be measurably bigger, and the extension surface should be in real use — at which point we can freeze SPEC_VERSION 1 and ship to `displayxr-extensions`.

--- a/docs/roadmap/spatial-workspace-extensions-headers-draft.md
+++ b/docs/roadmap/spatial-workspace-extensions-headers-draft.md
@@ -40,12 +40,12 @@ We start with two and merge if the boundary feels artificial after Phase 2 is in
 
 The workspace controller is a regular OpenXR client that opts into privileged mode. Bootstrap:
 
-1. Process launches; binary path is whatever `service.json::workspace_binary` points at (defaults to `displayxr-shell.exe`, configurable per Phase 1).
+1. Process launches; binary path is whatever `service.json::workspace_binary` points at (defaults to `displayxr-shell.exe`, configurable per Phase 1). Detection of whether *any* controller is installed happens at service startup — see [spatial-workspace-controller-detection.md](spatial-workspace-controller-detection.md).
 2. Process calls `xrCreateInstance` with `XR_EXT_SPATIAL_WORKSPACE_EXTENSION_NAME` in `enabledExtensionNames` (and optionally `XR_EXT_APP_LAUNCHER_EXTENSION_NAME`).
 3. Process creates a session normally (graphics binding can be `XR_NULL_HANDLE` — workspace controllers don't render swapchains; they only instruct).
 4. Process calls `xrActivateSpatialWorkspaceEXT(session)`. The runtime checks:
    - At most one workspace is active per system. Returns `XR_ERROR_LIMIT_REACHED` if another controller already holds the role.
-   - Caller authorization: in the current implementation the runtime checks `application_name == config.workspace_app_name` (defaults to `"displayxr-shell"`). Phase 2 promotes this to a proper handshake — see "Open questions". For now, the simple match is enough to gate the privileged surface.
+   - Caller authorization: orchestrator-PID match (with manual-mode fallback). Full design in [spatial-workspace-auth-handshake.md](spatial-workspace-auth-handshake.md).
 5. On success the session is *the* workspace session. All subsequent extension calls go through this `XrSession` handle.
 
 Lifecycle:
@@ -508,11 +508,7 @@ The shell repo, once severed (Phase 3), pins a minimum SPEC_VERSION in its CMake
 
 ## Open questions
 
-1. **Authorization model.** Today the IPC server gates the privileged role on `application_name == "displayxr-shell"`. For Phase 2, options:
-   - Keep matching `application_name`, but make the allowed name configurable in `service.json` (`workspace_app_name = "..."`).
-   - Add a per-binary capability the OS verifies (Authenticode / code-signing on Windows, codesign entitlement on macOS).
-   - Trust the orchestrator: only the binary the orchestrator spawned (matching its PID) can activate.
-   The orchestrator-PID approach is the easiest defensible thing — the service knows which PID it spawned via `service_orchestrator.c`, and `xrActivateSpatialWorkspaceEXT` only succeeds for that PID. Configurable name is the fallback for legacy multi-terminal flows.
+1. **Authorization model.** ✅ **Resolved** — see [spatial-workspace-auth-handshake.md](spatial-workspace-auth-handshake.md). Orchestrator-PID match with manual-mode fallback for `--workspace`-flagged dev sessions; the literal `"displayxr-shell"` `application_name` match in `ipc_server_handler.c:296` is removed in the third commit of the auth-handshake migration.
 
 2. **Click events: poll-and-clear vs xrPollEvent.** Current Phase 1 IPC uses poll-and-clear (`launcher_poll_click`). Two patterns to choose between:
    - Keep poll-and-clear (simple, current model).

--- a/docs/roadmap/spatial-workspace-extensions-phase2-agent-prompt.md
+++ b/docs/roadmap/spatial-workspace-extensions-phase2-agent-prompt.md
@@ -1,0 +1,269 @@
+# Phase 2.0 Agent Prompt — Workspace Detection + Auth Handshake
+
+Self-contained prompt for a fresh agent session implementing Phase 2.0 of the workspace-extensions effort. Drop this into a new session as the user message after a `/clear`, or use it as a `Task` agent prompt. The agent has no memory of the design conversations — this prompt assumes nothing.
+
+---
+
+## Background you need before touching code
+
+You're picking up Phase 2.0 of the **DisplayXR shell brand separation** effort. Phase 1 finished and merged: a boundary rename so the runtime no longer reads like an SDK for one specific proprietary application. Phase 2.0 is the architectural prep that makes the runtime a *standalone platform* — installable without the proprietary DisplayXR Shell, useful on its own as an OpenXR runtime + WebXR bridge, with the shell adding spatial-desktop features as a separate optional product.
+
+**Read these docs FIRST, in this order, before writing any code:**
+
+1. `docs/roadmap/spatial-workspace-extensions-plan.md` — the master three-phase plan. You're implementing Phase 2.0.
+2. `docs/roadmap/spatial-workspace-controller-detection.md` — half of Phase 2.0. The conditional tray UI + sidecar `.controller.json` manifest model.
+3. `docs/roadmap/spatial-workspace-auth-handshake.md` — other half of Phase 2.0. Orchestrator-PID match replaces the brand-coupled `application_name == "displayxr-shell"` check.
+4. `docs/roadmap/spatial-workspace-extensions-headers-draft.md` — Phase 2.A-onwards extension surfaces. **Reference only — do NOT implement these in Phase 2.0.** The sketch tells you where Phase 2.A picks up after Phase 2.0 lands.
+5. `docs/roadmap/spatial-workspace-extensions-phase2-audit.md` — labels every remaining `shell_*` mention in `comp_d3d11_service.cpp` as mechanism / policy / gone. Phase 2.0 doesn't touch this file; the audit is for the migrations after you.
+
+Also pull up `MEMORY.md` and read `project_shell_brand_separation.md` + `reference_workspace_terminology.md` + `feedback_perl_rename_gotchas.md`.
+
+## What Phase 2.0 changes — and what it does NOT
+
+**You touch:**
+- `src/xrt/targets/service/service_orchestrator.{c,h}` — add detection state, manifest reader integration, getters, hotkey gating, PID accessor.
+- `src/xrt/targets/service/service_workspace_manifest.{c,h}` — **new file** — JSON parser for the `<binary>.controller.json` sidecar.
+- `src/xrt/targets/service/service_tray_win.c` — conditional Workspace submenu, dynamic display-name label.
+- `src/xrt/ipc/server/ipc_server_handler.c` — wire PID-match auth into `ipc_handle_workspace_activate`; replace the literal `"displayxr-shell"` `application_name` match in the qwerty-routing logic at line ~296.
+- `src/xrt/targets/service/CMakeLists.txt` — register the new manifest file.
+
+**You do NOT touch:**
+- `src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp` — 162 internal `shell_*` mentions stay as-is. Phase 2.A onwards handles those.
+- `src/xrt/compositor/d3d11/comp_d3d11_window.{cpp,h}` — `shell_mode_active`, `set_shell_mode_active`, `set_shell_dp`, `shell_input_event`, `SHELL_INPUT_RING_SIZE` all stay. Phase 2.D / 2.E touches them.
+- Any IPC RPC names. Phase 1 finalized them; Phase 2.0 just adds a check inside one existing handler.
+- Anything in `proto.json` or `proto.py`.
+- The `XR_EXT_spatial_workspace.h` / `XR_EXT_app_launcher.h` extension headers don't exist yet and aren't part of Phase 2.0. Don't write them.
+- The extension dispatch table in `xrGetInstanceProcAddr`. Phase 2.A onwards.
+- `src/xrt/targets/shell/` — the shell binary. Manifest deployment is the shell's responsibility (the shell installer drops `displayxr-shell.controller.json` next to its binary at install time). For Phase 2.0 you create the manifest in `_package/` for testing, but the shell installer change is a separate Leia-side task.
+- `src/xrt/targets/webxr_bridge/main.cpp` — its "shell mode" / "WebXR-in-shell" terminology refers to a named feature, not the boundary concept. Skip per the explicit note in `d4ebf84bd`.
+
+## Recommended commit sequence
+
+Five commits. Don't combine — keep them reviewable in isolation.
+
+### Commit 1 — `service_workspace_manifest.{c,h}` (pure addition)
+
+New file. JSON parser via cJSON (already linked, see `service_config.c` for the include pattern). Schema per `spatial-workspace-controller-detection.md`:
+
+```c
+struct workspace_manifest {
+    char display_name[256];
+    char vendor[64];
+    char version[32];
+    char icon_path[260];
+};
+
+// Reads <binary path with .exe stripped>.controller.json next to the binary.
+// Returns true on success (manifest found, parsed, schema_version==1).
+// On false, *out is zeroed — caller should fall back to defaults.
+bool
+service_workspace_manifest_load(const char *workspace_binary_path,
+                                struct workspace_manifest *out);
+```
+
+Implementation tips:
+- File-existence check first; don't bother parsing if absent.
+- Length-cap reads (`snprintf`) to prevent overflow. The struct sizes are limits.
+- `schema_version` MUST equal 1; reject anything else with a one-line warn log.
+- Empty/missing optional fields → empty strings (the caller defaults).
+- Look at `service_config.c::config_path` and `read_file` for the I/O patterns to follow.
+
+CMakeLists.txt change: add `service_workspace_manifest.c` to the `displayxr-service` target's source list. Keep the new `.h` next to it.
+
+### Commit 2 — Detection + conditional tray + hotkey gating
+
+In `service_orchestrator.{h,c}`:
+
+```c
+// New static state
+static bool s_workspace_available = false;
+static struct workspace_manifest s_workspace_manifest = {0};
+
+// New init helper, called from service_orchestrator_init BEFORE apply_workspace_mode.
+static void
+detect_workspace_controller(const struct service_config *cfg)
+{
+    char workspace_path[MAX_PATH];
+    if (!sibling_exe_path(cfg->workspace_binary, workspace_path, sizeof(workspace_path))) {
+        s_workspace_available = false;
+        return;
+    }
+    if (!file_exists(workspace_path)) {
+        s_workspace_available = false;
+        OW("Workspace controller not installed (looked for %s)", workspace_path);
+        return;
+    }
+    s_workspace_available = true;
+    if (!service_workspace_manifest_load(workspace_path, &s_workspace_manifest)) {
+        // Fallback display name when manifest absent / malformed.
+        snprintf(s_workspace_manifest.display_name,
+                 sizeof(s_workspace_manifest.display_name),
+                 "Workspace Controller");
+    }
+    OW("Workspace controller detected: %s (binary=%s)",
+       s_workspace_manifest.display_name, workspace_path);
+}
+
+// New public API
+bool
+service_orchestrator_is_workspace_available(void)
+{
+    return s_workspace_available;
+}
+
+const char *
+service_orchestrator_get_workspace_display_name(void)
+{
+    return s_workspace_manifest.display_name;
+}
+```
+
+`apply_workspace_mode`: short-circuit when `!s_workspace_available`. Don't register the keyboard hook, don't try to spawn. Log once at startup.
+
+`spawn_workspace`: existing code already file-checks via `sibling_exe_path` failure — but with `s_workspace_available` available, you can early-return without the call.
+
+In `service_tray_win.c`: at the menu-build site (currently around line 117 where the Workspace submenu is appended), wrap in `if (service_orchestrator_is_workspace_available()) { ... }`. Use `service_orchestrator_get_workspace_display_name()` for the parent menu label instead of the hardcoded `L"Workspace Controller"` from commit `4cf3ba93d`. Convert UTF-8 → wide via `MultiByteToWideChar(CP_UTF8, 0, name, -1, wbuf, ARRAYSIZE(wbuf))`.
+
+Test before the next commit:
+- `_package/bin/displayxr-shell.exe` present + no manifest → tray says "Workspace Controller".
+- Manifest with `display_name: "DisplayXR Shell"` → tray says "DisplayXR Shell".
+- Delete `displayxr-shell.exe` (or rename), restart service → tray has no Workspace submenu, Ctrl+Space does nothing.
+
+### Commit 3 — Add `service_orchestrator_get_workspace_pid()` (pure addition)
+
+```c
+// In service_orchestrator.h:
+unsigned long
+service_orchestrator_get_workspace_pid(void);
+
+// In service_orchestrator.c:
+unsigned long
+service_orchestrator_get_workspace_pid(void)
+{
+#ifdef XRT_OS_WINDOWS
+    if (s_workspace_running) {
+        return (unsigned long)s_workspace_pi.dwProcessId;
+    }
+#endif
+    return 0;
+}
+```
+
+Returns 0 if no workspace was orchestrator-spawned (manual mode, or none running). Use `unsigned long` not `DWORD` so the header doesn't need `<windows.h>` — matches the cross-platform discipline elsewhere in `aux/util/`. No callers in this commit; the next one wires it.
+
+### Commit 4 — Wire PID auth into workspace_activate (keeps application_name fallback)
+
+In `ipc_server_handler.c::ipc_handle_workspace_activate`, before the existing "already in workspace mode" check, add:
+
+```c
+unsigned long expected_pid = service_orchestrator_get_workspace_pid();
+unsigned long caller_pid   = (unsigned long)_ics->client_state.pid;
+
+if (expected_pid != 0) {
+    // Service-managed mode: orchestrator spawned a known PID; only that PID may activate.
+    if (caller_pid != expected_pid) {
+        // BUT keep the legacy application_name match as a fallback for one release,
+        // so existing setups (where the shell connects before service rev N+1 is rolled out)
+        // don't break mid-upgrade.
+        bool legacy_match =
+            ics->client_state.info.application_name[0] != '\0' &&
+            strcmp((const char *)ics->client_state.info.application_name, "displayxr-shell") == 0;
+        if (!legacy_match) {
+            IPC_WARN(s, "workspace_activate: PID mismatch (caller=%lu, expected=%lu) — denied",
+                     caller_pid, expected_pid);
+            return XRT_ERROR_NOT_AUTHORIZED;
+        }
+        IPC_WARN(s, "workspace_activate: PID mismatch but legacy application_name match accepted (deprecated)");
+    }
+}
+// expected_pid == 0 → manual mode, first-claim wins. Continue.
+```
+
+Verify `_ics->client_state.pid` is populated. If not, plumb it through from the IPC connection setup (Windows: `GetNamedPipeClientProcessId`).
+
+`XRT_ERROR_NOT_AUTHORIZED` may not exist as an `xrt_result_t` value yet — add it to the enum if missing (it's a reasonable runtime error code for this case). The user-facing OpenXR error code is `XR_ERROR_FEATURE_UNSUPPORTED`; the `xrt_result_t` is internal.
+
+### Commit 5 — Remove application_name fallback + replace `is_workspace_controller_session` literal match
+
+Drop the `legacy_match` fallback added in commit 4. Workspace activation now strictly requires PID match (or manual mode).
+
+Then update `ipc_server_handler.c:294-296` (the qwerty-routing logic):
+
+```c
+unsigned long workspace_pid = service_orchestrator_get_workspace_pid();
+bool is_workspace_controller_session =
+    workspace_pid != 0 &&
+    (unsigned long)ics->client_state.pid == workspace_pid;
+```
+
+Remove the `strcmp((const char *)ics->client_state.info.application_name, "displayxr-shell")`. **This is the last literal `"displayxr-shell"` reference in the runtime code** (the only remaining occurrence of `"displayxr-shell"` after this commit is the *default value* of `cfg.workspace_binary` — that's correct since OEMs override via `service.json`).
+
+After this commit, `grep -rn '"displayxr-shell"' src/` should show one match (the config default in `service_config.c`) and zero in any other context.
+
+## Constraints from the user's preferences
+
+- **Branch naming**: do work in `.claude/worktrees/shell-brand-separation-phase2/` on branch `feature/shell-brand-separation-phase2` (NO `-ci` suffix — pushing should not trigger CI per the user's repeated guidance). When ready to validate, rename branch to add `-ci`, push, watch via `/ci-monitor`, rename back.
+- **Worktree**: use `git worktree add` from the runtime-pvt root.
+- **Commits**: include issue number in commit message if you can identify one from `gh issue list` or context. Otherwise omit.
+- **MinGW pre-check**: run `./scripts/build-mingw-check.sh` locally before any CI push. Note that MinGW disables `XRT_MODULE_IPC` and `XRT_MODULE_COMPOSITOR` so it WON'T compile the IPC handler or orchestrator — the check covers `aux_util` and `mcp_adapter` only. CI is the canonical check.
+- **Don't touch the shell repo** (still in `targets/shell/` of this repo). Manifest deployment is a future shell-installer change — for testing, drop a manifest manually into `_package/bin/`.
+
+## How to test (the user will run on their Windows box; you set up the cases)
+
+Document in your Phase 2.0 commit messages how to test. Recommended scenarios:
+
+1. **Bare runtime (no shell)**: rename `_package/bin/displayxr-shell.exe` → `_displayxr-shell.exe.bak`. Start service. Tray right-click → no Workspace submenu, only Bridge + Start-on-login + Quit. `Ctrl+Space` does nothing.
+
+2. **Shell present, no manifest**: Restore `displayxr-shell.exe`. Ensure no `displayxr-shell.controller.json` exists. Start service. Tray shows "Workspace Controller" submenu. Ctrl+Space launches the shell.
+
+3. **Shell + manifest**: Drop a `displayxr-shell.controller.json` next to the exe with:
+   ```json
+   {
+     "schema_version": 1,
+     "display_name": "DisplayXR Shell",
+     "vendor": "Leia Inc.",
+     "version": "1.0.0"
+   }
+   ```
+   Restart service. Tray shows "DisplayXR Shell" submenu. Lifecycle (Enable/Auto/Disable) works.
+
+4. **PID auth — happy path**: With service running and shell auto-spawned, shell calls `workspace_activate` and gets `XR_SUCCESS`. Open multiple test apps; they get composited.
+
+5. **PID auth — forged claim**: Build a tiny test program (or modify a cube test app) that sets `applicationName = "displayxr-shell"` in `XrApplicationInfo` and calls into the runtime trying to activate workspace mode. Verify it gets `XR_ERROR_FEATURE_UNSUPPORTED` after commit 5 (and gets a deprecation warning between commits 4 and 5).
+
+6. **service.json backwards-compat**: Create a service.json with the legacy `"shell"` key (no `"workspace"` key). Restart service. Verify orchestrator reads the value correctly. (This was Phase 1 work — verify Phase 2.0 didn't regress it.)
+
+7. **Manual mode**: Start service with `--workspace`. Don't let orchestrator spawn anything. Manually launch shell. Verify it activates (first-claim-wins). This is the developer flow.
+
+## Success criteria for this Phase 2.0 session
+
+- 5 commits land cleanly on the branch.
+- Local MinGW check passes (won't catch much; IPC/orchestrator not in scope).
+- Windows CI passes after the rename trick.
+- All 7 test scenarios pass on the user's Windows box.
+- `grep -rn '"displayxr-shell"' src/` shows exactly one occurrence after commit 5: the `service_config.c` default. **This is the final brand-decoupling milestone for the runtime.**
+- A short paragraph in your final commit message explains what the next session (Phase 2.A — capture client lifecycle) inherits.
+
+## What "done" looks like
+
+After Phase 2.0:
+- The runtime is a real platform: a developer / OEM can build the runtime + service + bridge, install it, and have a working DisplayXR experience for any OpenXR app + Chrome WebXR — with **no shell or workspace controller installed at all**. Tray UI honestly reflects this.
+- Installing the DisplayXR Shell adds a branded Workspace submenu and lifecycle controls.
+- Installing a different controller (third-party, OEM, vertical) gets the same first-class treatment via its own manifest.
+- The runtime grants workspace activation to whoever the orchestrator spawned, regardless of the binary's `applicationName`. No brand coupling.
+
+That unblocks the Phase 2.A-2.H code migrations (described in the audit doc) — those move launcher / chrome / capture / hit-test policy into the workspace controller process behind the as-yet-unwritten `XR_EXT_spatial_workspace.h` / `XR_EXT_app_launcher.h` extensions. But Phase 2.0 itself doesn't write any extensions — it's pure orchestrator + tray + IPC-handler work, and it's the prerequisite for everything else.
+
+## If you get stuck
+
+- The auth handshake doc has explicit code sketches for the orchestrator getter and the activate-handler check.
+- The detection doc has the manifest schema and the menu shape diagrams.
+- The audit doc tells you what NOT to touch (everything in `comp_d3d11_service.cpp`).
+- `feedback_perl_rename_gotchas.md` in memory captures lessons from Phase 1 — read it if you find yourself doing perl renames.
+- The user is available for design questions but is not blocking on this work — they expect you to make judgment calls when the docs are ambiguous, then call out the choice in your commit message.
+
+Stop and ask the user before:
+- Adding new IPC RPCs (Phase 2.A onwards).
+- Touching `comp_d3d11_service.cpp` for any reason.
+- Designing the actual extension headers (Phase 2.A onwards needs them; Phase 2.0 doesn't).
+- Modifying the launcher's `.displayxr.json` app-manifest format (different concept; don't conflate).

--- a/docs/roadmap/spatial-workspace-extensions-phase2-audit.md
+++ b/docs/roadmap/spatial-workspace-extensions-phase2-audit.md
@@ -54,7 +54,18 @@ After Phase 2: the file shrinks meaningfully. The launcher cluster (4660 lines w
 
 ## Migration order — Phase 2 sub-steps
 
-The plan doc proposed an order; the audit confirms it. Here it is again with the audit's classification linked back:
+The plan doc proposed an order; the audit confirms it. Phase 2 is preceded by **Phase 2.0** (architectural prep — neither sub-step touches `comp_d3d11_service.cpp` directly):
+
+### Phase 2.0 — Architectural prep (gates Phase 2.A onward)
+
+**Two sister docs, lands as one or two short branches:**
+
+- **[Workspace controller detection](spatial-workspace-controller-detection.md)** — orchestrator file-presence check + sidecar `.controller.json` manifest read; conditional tray UI; hotkey gated on availability. Makes the runtime a real platform (installable without the shell, with a useful WebXR + standalone-OpenXR experience).
+- **[Workspace activation auth handshake](spatial-workspace-auth-handshake.md)** — orchestrator-PID match replaces the literal `"displayxr-shell"` `application_name` match in `ipc_server_handler.c:296`. Removes the last brand coupling in the runtime.
+
+Lands as a few hundred lines of orchestrator + tray + IPC-handler changes. Doesn't touch the compositor body — the 162 mentions in this audit are untouched by Phase 2.0. Phase 2.A starts the compositor migration.
+
+Below: the original 8 sub-steps, lowest-blast-radius first.
 
 ### Phase 2.A — Capture client lifecycle
 

--- a/docs/roadmap/spatial-workspace-extensions-phase2-audit.md
+++ b/docs/roadmap/spatial-workspace-extensions-phase2-audit.md
@@ -1,0 +1,164 @@
+# Phase 2 Audit — `comp_d3d11_service.cpp` mechanism vs policy
+
+**Status:** Draft, 2026-04-28. Companion to [spatial-workspace-extensions-plan.md](spatial-workspace-extensions-plan.md) and [spatial-workspace-extensions-headers-draft.md](spatial-workspace-extensions-headers-draft.md).
+
+After Phase 1, `comp_d3d11_service.cpp` (12,212 lines) still holds 162 `shell`/`Shell` mentions. Each one belongs to one of three categories:
+
+- **Mechanism** — composition / lifecycle / rendering machinery the runtime owns. Survives Phase 2 under a neutral name (`workspace_*`).
+- **Policy** — what to display, when, with what UX. Moves to the workspace controller process behind the spatial-workspace + app-launcher extensions.
+- **Gone** — exists only because the runtime tries to handle workspace concerns; deleted outright when policy migrates.
+
+This doc walks the file cluster by cluster, labels each, and proposes a migration order. The next implementer picking up Phase 2 reads this and starts migrating without re-reading the whole file.
+
+## Cluster summary
+
+| Cluster | Lines | Classification | Migration step |
+|---|---|---|---|
+| Lifecycle state-machine fields (`pending_shell_reentry`, `last_shell_render_ns`) | 258-259, 500-502 | Mechanism — rename | Phase 2 final cleanup |
+| Launcher app registry (state + comments) | 327-367 | **Policy — moves out** | Phase 2.B (launcher) |
+| Suspend-deactivated lifecycle state | 742-747 | Mechanism — rename | Phase 2 final cleanup |
+| Cursor + capture-thread state comments | 761, 866, 880 | Mechanism — rename | Phase 2 final cleanup |
+| `service_set_workspace_mode` mirror + comp_d3d11_window flag set | 916-923, 4315-4317, 4586 | Mechanism — rename (already partial in Phase 1) | Phase 2.E (D3D11 window deferred set) |
+| Per-mode resource creation (atlas-only, DP creation skip) | 1983-2049, 2180-2184, 2532 | Mechanism — rename | Phase 2 final cleanup |
+| `shell_input_event` struct + ring buffer | 3558, 3587 | Mechanism — rename to `workspace_input_event` | Phase 2.D (input routing) |
+| Multi-comp first-layer-commit init | 4271-4278 | Mechanism — rename | Phase 2 final cleanup |
+| `comp_d3d11_window_set_shell_dp` call | 4558 | Mechanism — rename when callee renames | Phase 2.E |
+| **Spatial raycast hit-test** (`shell_hit_result`, `shell_raycast_hit_test`) + callers | 4660-4904, 6003, 6046, 6154, 6497 | Mechanism — rename + promote to `xrWorkspaceHitTestEXT` | Phase 2.F (hit-test promotion) |
+| **Title-bar height math** (`has_shell_title_bar`) | 5010-5037, 7473 | **Policy — gone** when chrome migrates | Phase 2.C (chrome) |
+| `compositor_layer_commit` workspace-mode branches | 5616-5732 | Mechanism — rename; some branches simplify when policy migrates | Phase 2 final cleanup |
+| File-dialog foreground-permission grants | 5789, 6140 | Mechanism — rename | Phase 2 final cleanup |
+| Scroll-wheel input policy comment | 6553 | Mechanism — rename | Phase 2 final cleanup |
+| Atlas / SRGB shader-blit comments | 6987, 7058-7173, 9569-9658 | Mechanism — rename | Phase 2 final cleanup |
+| Launcher-rendering tile-grid lifecycle | 8198, 8200, 8484 | **Policy — gone** when launcher migrates | Phase 2.B |
+| File-trigger screenshot path (`shell_screenshot_*`) | 8831-8840 | Mechanism — rename to `workspace_screenshot_*` | Phase 2 final cleanup |
+| Atlas-clear / DP ownership comments | 9090, 9169 | Mechanism — rename | Phase 2 final cleanup |
+| Bridge-override stage-3 comment | 9305-9313 | Mechanism — rename | Phase 2 final cleanup |
+| Reverse-hot-switch lifecycle (`pending_shell_reentry`) | 9860-9905, 10126-10128, 11777 | Mechanism — rename | Phase 2 final cleanup |
+| `compositor_create_native` workspace-mode activation | 10238-10285 | Mechanism — rename | Phase 2 final cleanup |
+| DP/window ownership comments | 10756-11025, 11560-11569 | Mechanism — rename | Phase 2 final cleanup |
+| `set_client_window_pose` / `set_visibility` log strings | 11413, 11441 | Mechanism — rename log prefix | Phase 2 final cleanup |
+| `add_capture_client` log strings | 11620-11641 | Mechanism — rename log prefix | Phase 2.A (capture) |
+| `ensure_workspace_window` lifecycle log strings | 11751-11849 | Mechanism — rename log prefix; some lifecycle simplifies | Phase 2 final cleanup |
+| `deactivate_workspace` lifecycle log strings | 11872-11960 | Mechanism — rename log prefix | Phase 2 final cleanup |
+| **Launcher functions** (`add/clear/poll/show/running_tile_mask` + `apply_layout_preset`) | 11960-12118 | **Policy — moves out** (and most code deletes) | Phase 2.B + Phase 2.G |
+
+## Counts by category
+
+| Category | Approximate line count | What happens |
+|---|---|---|
+| Mechanism (stays + gets renamed) | ~115 mentions across ~25 clusters | Renamed in a final cleanup pass after policy migrations land. Most are doc comments and log-string prefixes; the actual code keeps doing the same thing. |
+| Policy (moves to workspace process) | ~30 mentions across 4 clusters (launcher registry+rendering, chrome title-bar math, layout-preset semantics) | Function bodies + state move to the workspace controller. The runtime exposes neutral primitives via `XR_EXT_spatial_workspace` / `XR_EXT_app_launcher`. |
+| Gone (delete when policy moves) | ~17 mentions in chrome + launcher rendering | Deleted as a side effect of policy migration — no equivalent in the workspace process, no equivalent in the runtime. |
+
+After Phase 2: the file shrinks meaningfully. The launcher cluster (4660 lines worth of state + UI) and the chrome math (~30 lines of title-bar geometry) leave the runtime entirely; everything else gets renamed in place.
+
+## Migration order — Phase 2 sub-steps
+
+The plan doc proposed an order; the audit confirms it. Here it is again with the audit's classification linked back:
+
+### Phase 2.A — Capture client lifecycle
+
+**Touches:** 11620-11641, plus the public `xrAddWorkspaceCaptureClientEXT` / `xrRemoveWorkspaceCaptureClientEXT` extension surface.
+
+**Why first:** Already nearly neutral — the bulk of the work is renaming log prefixes and wiring the existing `comp_d3d11_service_add_capture_client` to its extension entry point. Lowest blast radius. Validates the basic extension dispatch plumbing before any policy migration.
+
+**Risk:** Low. No logic changes.
+
+### Phase 2.B — Launcher tile registry + click polling + running-tile mask
+
+**Touches:** 327-367 (state), 8198-8484 (rendering), 11960-12118 (functions). Plus the workspace-controller side: the controller starts owning the registry array and pushing via `xrAddLauncherAppEXT`.
+
+**Why second:** The launcher is well-bounded. Only the workspace controller pushes to it; only the runtime renders it; the surface between them is small. Validates the `XR_EXT_app_launcher` extension end-to-end. Most of the runtime-side state in the field deletes; runtime keeps only the rendered tile-grid overlay (mechanism: how to draw N tiles), not the registry (policy: which N tiles).
+
+**Risk:** Medium. The "empty workspace shows registered apps before any client connects" UX needs careful handling — runtime can render the tile grid while the workspace controller is connected even with zero app clients, but the controller can't push tiles before it itself connects, so there's a chicken-and-egg moment to handle. Open question: should the runtime cache the last-pushed registry across deactivate/activate cycles, or does the controller re-push on every activate? Recommend the latter (simpler runtime, controller already does this).
+
+### Phase 2.C — Title-bar chrome rendering
+
+**Touches:** 5010-5037, 7473, plus the workspace-controller side (controller draws chrome into its own client window which the runtime composites).
+
+**Why third:** Most invasive. Today the runtime draws title bars over the app's atlas as a separate composite pass. Moving chrome to a workspace-rendered layer requires:
+- The workspace controller renders chrome (close button, app name) into one of its own swapchain images.
+- The runtime composites that swapchain alongside the app's, at a slightly higher Z (or as an overlay layer).
+- The runtime stops drawing title bars at all — the chrome-rendering code path deletes.
+
+**Risk:** High. Affects the composite pipeline and the input pipeline (title-bar drag is a common case). Allocate a full sub-session.
+
+### Phase 2.D — Input routing (focus + raw event forwarding)
+
+**Touches:** 3558, 3587 (`shell_input_event`), plus all input-handling paths. Plus the new `xrSetWorkspaceFocusedClientEXT` extension function.
+
+**Why fourth:** Largely independent design work. Today the runtime forwards mouse/keyboard from the workspace's window to the focused client's HWND, with the runtime making the focus call. Phase 2 has the workspace controller decide focus and the runtime forward raw events to whoever the controller designated. The extension surface for this isn't yet in the header sketch — needs design first.
+
+**Risk:** High. Input is fragile; regressions are user-visible.
+
+### Phase 2.E — D3D11 window deferred functions
+
+**Touches:** 4315-4317, 4558, 4586, 916-923, plus `comp_d3d11_window.{h,cpp}` (the deferred-Phase-1 set: `shell_mode_active` field, `set_shell_mode_active`, `set_shell_dp`, `shell_input_event` struct, `SHELL_INPUT_RING_SIZE` constant).
+
+**Why fifth:** These are internal D3D11 window concerns the runtime keeps. Renaming them to `workspace_*` is a mechanical pass once Phase 2.D's input routing is settled — the `shell_input_event` struct rename has to land alongside the input-routing code that passes it around.
+
+**Risk:** Low. Pure mechanical rename if input routing is stable.
+
+### Phase 2.F — Hit-test extension promotion
+
+**Touches:** 4660-4904 (function definition), 6003, 6046, 6154, 6497 (callers). Plus `xrWorkspaceHitTestEXT` entry point in the extension dispatch.
+
+**Why sixth:** The function and its callers stay in the runtime — they're mechanism. The work is exposing `shell_raycast_hit_test()` as a public extension function so the workspace controller can call it directly instead of duplicating the geometry. Independent of the chrome migration; could move earlier if needed.
+
+**Risk:** Low. Net-add — the existing callers keep using the function internally; the extension entry point is a thin wrapper.
+
+### Phase 2.G — Layout presets + ESC/empty-workspace cleanup
+
+**Touches:** 12118 (`apply_layout_preset`), plus the ESC-handling carve-out in `compositor_layer_commit` (5616-5732), plus `pending_shell_reentry` lifecycle (258-259, 9866-9868, 11777).
+
+**Why last:** Cleanup. Layout-preset semantics move to the workspace controller (which computes per-window poses and pushes them via `xrSetWorkspaceClientWindowPoseEXT`); the runtime stops owning preset names. The ESC carve-out and reentry state machine simplify or delete because the runtime no longer needs an "empty workspace" mode — the workspace controller handles the case where it has no client apps connected.
+
+**Risk:** Medium. The ESC / dismiss / restore flow is one of the touchier corners of the current code; simplification needs end-to-end testing.
+
+### Phase 2.H (final cleanup pass)
+
+**Touches:** All remaining mechanism mentions (~115 across 25+ clusters). Pure rename pass: `shell` → `workspace` in comments and log prefixes; `pending_shell_reentry` → `pending_workspace_reentry`; `last_shell_render_ns` → `last_workspace_render_ns`; `shell_input_event` → `workspace_input_event`; `shell_screenshot_*` filenames → `workspace_screenshot_*`; etc.
+
+**Risk:** Trivial — same perl-rename pattern Phase 1 used, with the lessons-learned-the-hard-way from `feedback_perl_rename_gotchas.md` (drop left `\b`, inline file lists).
+
+## Specific issues called out for Phase 2 sessions
+
+These are gotchas that won't be obvious until you start the migration. Capturing them here so the next session doesn't re-discover them.
+
+### Launcher's chicken-and-egg startup
+
+The runtime today renders the launcher tile grid *before* any app client connects. This is possible because the workspace controller has already pushed its registry via IPC. Phase 2.B preserves this by having the controller push on every `xrActivateSpatialWorkspaceEXT`, before any client work happens. Don't try to "lazy-load" tiles — keeps the empty-workspace UX broken.
+
+### `pending_shell_reentry` is two lifecycle features in one field
+
+Reading the code at 9866 and 11777 it looks like one flag, but it actually serves two transitions:
+1. Standalone → workspace re-activate (a previously-direct-rendering app gets re-claimed by a re-activated workspace).
+2. Workspace dismissed → workspace re-activated (after Ctrl+Space toggles the workspace off and back on).
+
+When the lifecycle simplifies in Phase 2.G, separate these into two flags or two state-machine arms — folding them together saved code in the original spatial-shell-phase4D work but obscures the transitions for anyone refactoring.
+
+### Title-bar height affects the hit-test, not just the renderer
+
+Lines 5010-5037 wire `has_shell_title_bar` into the hit-test geometry — they expand the window's effective "ext_top" by the title-bar height so a click in the title-bar area registers. When chrome migrates to a workspace-rendered layer (Phase 2.C), the hit-test geometry needs to know about that layer too — *or* the workspace-rendered chrome is its own workspace client (with its own pose), so the hit-test naturally handles it. Recommend the latter: the workspace controller renders chrome into a per-app companion swapchain, positions it just above the app via `xrSetWorkspaceClientWindowPoseEXT`, and the existing hit-test machinery treats it as a regular client.
+
+### File-trigger screenshot is a dev-tool fallback
+
+The `shell_screenshot_trigger` file-poll mechanism at 8831-8840 was added for ad-hoc debugging when the IPC path wasn't available. The `xrCaptureWorkspaceFrameEXT` extension function will be the proper path. The file-trigger fallback can stay (with renamed paths) for emergency debug; not worth deleting.
+
+## Estimated post-Phase-2 file size
+
+Rough math:
+- Today: 12,212 lines
+- Launcher state + functions deleted: ~150 lines
+- Chrome / title-bar math deleted: ~40 lines
+- Layout-preset semantics deleted: ~80 lines
+- Lifecycle simplification (ESC carve-out, reentry state): ~30 lines
+- ~300 lines of saved code
+
+That's ~2.5% smaller. Most of the value is *not* size reduction — it's that the runtime's behavior is now explained by extension semantics, not by reading the file. After Phase 2, anyone wanting to understand "what happens when an app connects in workspace mode" reads `XR_EXT_spatial_workspace.h`, not 12K lines of compositor code.
+
+## What this audit doesn't cover
+
+- **`comp_d3d11_window.{h,cpp}`** — has its own deferred set (`shell_mode_active`, `set_shell_mode_active`, `set_shell_dp`, `shell_input_event` struct, `SHELL_INPUT_RING_SIZE`). Phase 2.D + 2.E touch these; they're 5-ish symbols total, not enough to need their own audit.
+- **`ipc_server_handler.c:296`** — the literal `"displayxr-shell"` application_name match. Resolved by [spatial-workspace-auth-handshake.md](spatial-workspace-auth-handshake.md) (orchestrator-PID match). Not part of this file.
+- **WebXR bridge references** — `webxr_bridge/main.cpp` has its own "shell mode" / "shell-window" / "WebXR-in-shell" terminology tied to the named WebXR-in-shell feature. Coordinated rename belongs with the WebXR bridge's own lifecycle, not Phase 2 of this effort. Noted as deferred in the second-pass cleanup commit (`d4ebf84bd`).

--- a/docs/roadmap/spatial-workspace-extensions-phase2-test-plan.md
+++ b/docs/roadmap/spatial-workspace-extensions-phase2-test-plan.md
@@ -1,0 +1,359 @@
+# Phase 2.0 Test Plan — Workspace Detection + Auth Handshake
+
+Self-contained test plan for a Windows-side agent. Drop into a fresh session as the user message after `/clear`. Validates the 5 commits that landed Phase 2.0 (controller detection, conditional tray, sidecar manifest, PID-match auth).
+
+Branch under test: `feature/shell-brand-separation` (Windows MSVC CI is green; functional behavior on a real Leia SR display is what's being validated here).
+
+---
+
+## What you're testing
+
+Phase 2.0 of the shell brand separation effort made the runtime a standalone platform:
+
+- The service can be installed without the DisplayXR Shell. With no controller binary present, the tray honestly reflects "bare runtime" — Bridge submenu only — and `Ctrl+Space` is a no-op.
+- An optional `<binary>.controller.json` sidecar manifest lets the controller advertise a friendly display name for the tray submenu.
+- Workspace activation is gated by **orchestrator-PID match** instead of the literal `application_name == "displayxr-shell"` check. A forged `applicationName` no longer grants workspace privileges.
+
+Read these in order if you need more context:
+1. `docs/roadmap/spatial-workspace-extensions-phase2-agent-prompt.md` — the implementation brief that drove the 5 commits.
+2. `docs/roadmap/spatial-workspace-controller-detection.md` — manifest schema + detection design.
+3. `docs/roadmap/spatial-workspace-auth-handshake.md` — auth design.
+
+The 5 commits to validate:
+
+| SHA prefix | Subject |
+|---|---|
+| `82a858eb` | service: workspace controller sidecar manifest loader |
+| `20a2445f` | service: detect workspace controller, gate tray + hotkey |
+| `e27ba153` | service: add service_orchestrator_get_workspace_pid() |
+| `f08f8d7d` | ipc: PID-match auth for workspace_activate (with legacy fallback) |
+| `cc435623` | ipc: drop legacy app-name fallback, finalize PID-only auth |
+
+---
+
+## Setup (one-time)
+
+### Build
+
+From the repo root in a Windows shell:
+
+```bat
+scripts\build_windows.bat all
+```
+
+First-time `all` downloads SR SDK / vcpkg / OpenXR loader. Subsequent iterations: `scripts\build_windows.bat build` (runtime only) or `test-apps` (test apps only). Output lands in `_package\` and `test_apps\*\build\`.
+
+### Verify the binaries are where the test plan expects
+
+```bat
+dir _package\bin\displayxr-service.exe
+dir _package\bin\displayxr-shell.exe
+dir _package\bin\displayxr-webxr-bridge.exe
+```
+
+All three should exist. If not, the build didn't finish — re-run with `all`.
+
+### Where logs live
+
+The orchestrator and tray write to the U_LOG sink, which on Windows lands in:
+
+```
+%LOCALAPPDATA%\DisplayXR\service.log    (if set up; some setups log to stdout/Windows Event)
+```
+
+If `service.log` doesn't exist, run the service from a console with `displayxr-service.exe` directly so you can see stderr. The orchestrator log lines you care about are prefixed with `WARN:` (the `OW(...)` macro maps to `U_LOG_W`).
+
+### How to read the tray submenu
+
+Right-click the DisplayXR icon in the system tray. The menu structure under test is the workspace submenu — its presence and label.
+
+### Stop the service between scenarios
+
+Right-click tray → "Exit DisplayXR Service". Wait ~2 s before starting the next scenario so the service unwinds the orchestrator and the named pipe.
+
+---
+
+## The minimum useful run (30 minutes)
+
+If you only have time for three tests, run **Scenario 1, 3, 4**. They cover the tray detection path, the manifest path, and the happy auth path — together they prove the major behavioral changes work end-to-end.
+
+---
+
+## Test scenarios
+
+Each scenario lists **Setup → Run → Verify → Cleanup**. Capture screenshots of the tray menu where relevant — see the bottom of this doc for the screenshot procedure.
+
+### Scenario 1 — Bare runtime (no controller installed)
+
+**The big one.** Proves the runtime stands on its own without the shell.
+
+**Setup**
+```bat
+ren _package\bin\displayxr-shell.exe displayxr-shell.exe.bak
+del /q _package\bin\displayxr-shell.controller.json 2>nul
+```
+
+**Run**
+```bat
+_package\bin\displayxr-service.exe
+```
+(Don't pass `--workspace`. Plain default.)
+
+**Verify**
+- Tray right-click menu shows: **WebXR Bridge** submenu, **Start on Windows login** toggle, **Exit DisplayXR Service**. **No Workspace Controller submenu.**
+- Service log contains: `WARN: Workspace controller not installed (looked for ...displayxr-shell.exe)`.
+- Press `Ctrl+Space` somewhere on the desktop. Nothing happens. No process spawns. (Check Task Manager for `displayxr-shell.exe` — should not appear.)
+
+**Cleanup**
+```bat
+ren _package\bin\displayxr-shell.exe.bak displayxr-shell.exe
+```
+
+---
+
+### Scenario 2 — Shell present, no manifest (fallback label)
+
+Proves the manifest is optional and the fallback display name kicks in.
+
+**Setup**
+- `_package\bin\displayxr-shell.exe` present (default state after build).
+- No `_package\bin\displayxr-shell.controller.json`.
+
+**Run**
+```bat
+_package\bin\displayxr-service.exe
+```
+
+**Verify**
+- Tray right-click → submenu labeled **"Workspace Controller"** appears (the fallback).
+- Submenu has Enable / Auto / Disable radio items; current selection matches `service.json` config.
+- Service log contains: `WARN: Workspace controller detected: Workspace Controller (binary=...displayxr-shell.exe)`.
+- Press `Ctrl+Space`: shell launches, compositor enters workspace mode. Verify by seeing the shell's UI (cursor / window chrome) on the SR display. ESC dismisses.
+
+**Cleanup**
+- Stop service from tray.
+
+---
+
+### Scenario 3 — Shell + valid manifest (custom display name)
+
+Proves the manifest's `display_name` flows into the tray label.
+
+**Setup**
+
+Create `_package\bin\displayxr-shell.controller.json`:
+```json
+{
+  "schema_version": 1,
+  "display_name": "DisplayXR Shell",
+  "vendor": "Leia Inc.",
+  "version": "1.0.0"
+}
+```
+
+**Run**
+```bat
+_package\bin\displayxr-service.exe
+```
+
+**Verify**
+- Tray submenu labeled **"DisplayXR Shell"** (not "Workspace Controller").
+- Submenu still has Enable / Auto / Disable.
+- Service log: `WARN: Workspace controller detected: DisplayXR Shell (binary=...)`.
+- Toggle Enable → shell auto-launches. Toggle Disable → shell terminates. Toggle Auto → shell exits, hotkey re-registered.
+
+**Cleanup**
+- Leave the manifest in place for Scenarios 4 / 5 / 6 (they assume Scenario 3's setup).
+
+---
+
+### Scenario 3b — Manifest with malformed schema (regression check)
+
+Quick negative test: the loader should reject `schema_version != 1` and fall back to the default label.
+
+**Setup**
+
+Edit the manifest's `schema_version` to `99`.
+
+**Run / Verify**
+- Restart service.
+- Service log: `WARN: workspace manifest: unsupported schema_version in ... (expected 1)`.
+- Tray submenu reverts to **"Workspace Controller"** (fallback).
+
+**Cleanup**
+- Restore `schema_version` to `1`.
+
+---
+
+### Scenario 4 — PID auth happy path
+
+The non-attacker case: orchestrator spawns the shell; the shell calls `workspace_activate`; auth allows it because `caller_pid == expected_pid`.
+
+**Setup**
+- Service running with shell mode = Auto and the manifest from Scenario 3 in place.
+
+**Run**
+1. Start the service: `_package\bin\displayxr-service.exe`.
+2. Press `Ctrl+Space` to spawn the shell.
+3. Launch a couple of test apps from the shell launcher (or via `_package\bin\displayxr-shell.exe app1.exe app2.exe` legacy mode).
+
+**Verify**
+- Shell window appears on the SR display.
+- Apps composit normally — multi-app rendering, hit-test, etc. all work as in Phase 1.
+- Service log shows **no `workspace_activate: PID mismatch`** warnings.
+- Verify the orchestrator-spawned PID matches the shell's actual PID:
+  ```bat
+  tasklist | findstr displayxr-shell
+  ```
+  Compare to the orchestrator log line `Launched workspace controller (PID NNNN)` — same PID.
+
+**Cleanup**
+- ESC to dismiss shell, then exit service from tray.
+
+---
+
+### Scenario 5 — Manual mode (developer flow, no orchestrator-spawn)
+
+Proves first-claim-wins still works for the dev workflow described in CLAUDE.md ("legacy multi-terminal").
+
+**Setup**
+- Use `_package\run_shell_service.bat` if it exists (starts service with `--workspace`), or run manually:
+  ```bat
+  _package\bin\displayxr-service.exe --workspace
+  ```
+  In `--workspace` mode the orchestrator does **not** spawn anything; `expected_pid == 0` (provider returns 0 because `s_workspace_running` stays false).
+
+**Run**
+- Manually launch the shell from a separate terminal:
+  ```bat
+  _package\bin\displayxr-shell.exe
+  ```
+
+**Verify**
+- Shell connects, calls `workspace_activate`, gets `XR_SUCCESS` (compositor enters workspace mode).
+- Service log shows **no PID-mismatch warnings** (auth check fell through because `expected_pid == 0`).
+
+**Cleanup**
+- Close shell, exit service.
+
+---
+
+### Scenario 6 — service.json backwards-compat (Phase 1 regression check)
+
+Phase 1 added a fallback for the legacy `"shell"` JSON key. Phase 2.0 shouldn't have broken it.
+
+**Setup**
+
+Edit `%LOCALAPPDATA%\DisplayXR\service.json`. If the file doesn't exist, create it:
+```json
+{
+  "shell": "enable",
+  "bridge": "auto",
+  "start_on_login": true
+}
+```
+(The legacy `"shell"` key, no `"workspace"` key.)
+
+**Run / Verify**
+- Restart service.
+- Tray Workspace Controller submenu shows **Enable** as the active radio (mapped from the legacy `"shell": "enable"` key).
+- Shell auto-spawns on service start (Enable mode behavior).
+
+**Cleanup**
+- Either delete `service.json` or rewrite with the new key:
+  ```json
+  { "workspace": "auto", "bridge": "auto", "start_on_login": true }
+  ```
+
+---
+
+### Scenario 7 (stretch) — Forged applicationName attack
+
+Optional. Validates that the brand check is truly gone — a malicious app that sets `XrApplicationInfo.applicationName = "displayxr-shell"` is no longer treated as the workspace controller in qwerty routing.
+
+**Setup**
+
+Modify a copy of `cube_handle_d3d11_win` (in `test_apps\cube_handle_d3d11_win\`):
+- Locate the `XrApplicationInfo` initialization (search for `applicationName`).
+- Change `strcpy(...applicationName, "cube_handle_d3d11_win")` (or similar) to `strcpy(...applicationName, "displayxr-shell")`.
+- Rebuild only that test app: `scripts\build_windows.bat test-apps`.
+
+**Run**
+- Service running with shell auto-spawned (Scenario 4 setup).
+- Launch the modified cube app inside the workspace.
+
+**Verify**
+- The cube app is treated as a regular workspace tenant — qwerty head still applies (since `is_workspace_controller_session` is false because the cube app's PID is not the orchestrator-spawned shell's PID).
+- The shell remains the only session that enjoys workspace-controller treatment.
+- Inspect the cube's behavior on screen: it should respond to qwerty head input as a normal app would in workspace mode, not as the shell.
+
+**Why this matters**: under Phase 1 / pre-2.0 code, the brand string match would have routed the cube app as the workspace controller, breaking its qwerty head input. Phase 2.0 closes that.
+
+**Cleanup**
+- Revert the test-app source change.
+
+---
+
+## Reporting back
+
+After running, post a summary in this format. Be terse — the user reads the diff and the screenshots; the report is for "did it work / did it break".
+
+```
+## Phase 2.0 functional test results — <date> on <hardware>
+
+| # | Scenario | Result | Notes |
+|---|---|---|---|
+| 1 | Bare runtime | PASS / FAIL | … |
+| 2 | Shell + no manifest | PASS / FAIL | … |
+| 3 | Shell + manifest | PASS / FAIL | … |
+| 3b | Malformed schema | PASS / FAIL | … |
+| 4 | PID auth happy | PASS / FAIL | … |
+| 5 | Manual mode | PASS / FAIL | … |
+| 6 | service.json back-compat | PASS / FAIL | … |
+| 7 | Forged applicationName (stretch) | PASS / FAIL / SKIP | … |
+
+Build SHA: <git rev-parse HEAD>
+Screenshots: <paths or attached files>
+Anything surprising: <free text — bugs, UX oddities, log noise, etc.>
+```
+
+If anything fails, **don't fix it** — return the failure detail to the main session. Phase 2.0 lives on `feature/shell-brand-separation`; fixes get reviewed and committed there before merging to main.
+
+---
+
+## Capturing tray menu screenshots
+
+PowerShell + PrintWindow against the tray HWND is unreliable for popup menus (they're transient). Easier: use Windows' built-in **Snipping Tool** (`Win+Shift+S`) to grab the tray menu while it's open.
+
+Save into `_package\` (gitignored) and reference in the report. Don't commit the screenshots.
+
+---
+
+## Capturing compositor frames (for Scenarios 4 / 5 / 7)
+
+Use the file-trigger screenshot path documented in `CLAUDE.md`:
+
+```bash
+rm -f "/c/Users/SPARKS~1/AppData/Local/Temp/shell_screenshot.png"
+touch "/c/Users/SPARKS~1/AppData/Local/Temp/shell_screenshot_trigger"
+sleep 3
+# Capture lands at C:\Users\SPARKS~1\AppData\Local\Temp\shell_screenshot.png
+```
+
+Read the resulting 3840×2160 SBS atlas with the Read tool to verify the compositor output. (Replace `SPARKS~1` with the actual short user-name on the machine.)
+
+---
+
+## Known non-issues
+
+Save you the false-positive:
+
+- clangd on the Mac side reports "unused includes" / "unknown identifiers" for the new `service_workspace_manifest.h`, `windows.h` symbols, etc. These are clangd-on-Mac analyzing Windows-only code without the right `#define`s. **Real CI is green** (Windows MSVC build passed at the SHA being tested).
+- `grep -rn '"displayxr-shell"' src/` shows one hit in `targets/shell/main.c:1904`. That's the shell naming **itself** in `XrApplicationInfo` — correct, kept on purpose. After Phase 2.0 there are zero `"displayxr-shell"` literals in any auth or routing context.
+- The `service_config.c:41` default value `"displayxr-shell.exe"` is the OEM-overridable workspace_binary path. Not a brand check.
+
+---
+
+## What unblocks once this passes
+
+Phase 2.A (capture client lifecycle, first `XR_EXT_spatial_workspace.h` extension surface, beginning of policy migration out of `comp_d3d11_service.cpp`). The 162 internal `shell_*` mentions classified in `docs/roadmap/spatial-workspace-extensions-phase2-audit.md` start moving in 2.A onwards. Phase 2.0 was the prerequisite — runtime is now a real platform.

--- a/docs/roadmap/spatial-workspace-extensions-phase2A-agent-prompt.md
+++ b/docs/roadmap/spatial-workspace-extensions-phase2A-agent-prompt.md
@@ -1,0 +1,195 @@
+# Phase 2.A Agent Prompt — Workspace Extension Scaffolding + Capture Client Migration
+
+Self-contained prompt for a fresh agent session implementing Phase 2.A of the workspace-extensions effort. Drop into a new session as the user message after `/clear`. The agent has no memory of the design conversations — this prompt assumes nothing.
+
+---
+
+## What Phase 2.A is for
+
+You're picking up Phase 2.A of the **workspace-extensions migration**. Phase 2.0 (just-merged: brand separation, controller manifest, PID-match auth, plus a `service_orchestrator.c` double-close race fix) made the runtime a standalone platform. Phase 2.A starts the **policy migration out of `comp_d3d11_service.cpp`** by standing up the first piece of public extension surface — `XR_EXT_spatial_workspace` — and wiring its lowest-risk function set (capture-client lifecycle) end-to-end through it.
+
+Phase 2.A is deliberately the smallest useful cut. The scaffolding it builds is reused by every subsequent migration (2.B launcher, 2.C chrome, 2.D input, 2.F hit-test, etc.). Validating the dispatch path with the simplest function set first means later migrations only need to bring code, not infrastructure.
+
+## Read these in order before touching code
+
+1. `docs/roadmap/spatial-workspace-extensions-plan.md` — master plan, three-phase roadmap. You're inside Phase 2.
+2. `docs/roadmap/spatial-workspace-extensions-headers-draft.md` — the API surface sketch. Phase 2.A implements a **subset only** (see "What ships in Phase 2.A" below). Treat the rest of the draft as spec for future sub-phases — do not implement unprompted.
+3. `docs/roadmap/spatial-workspace-extensions-phase2-audit.md` — labels every remaining `shell_*` mention in `comp_d3d11_service.cpp` as mechanism / policy / gone. Phase 2.A only touches the **capture cluster** (lines 11620-11641); do not migrate anything else.
+4. `docs/adr/ADR-016-workspace-controllers-own-tray-surface-and-lifecycle.md` — captures the cooperative-shutdown decision. Phase 2.A does not implement it (that's deferred to a later sub-phase that adds tray-menu extensions), but the ADR explains why some hooks you'll see in the orchestrator look provisional.
+5. `docs/roadmap/workspace-runtime-contract.md` — IPC contract. The extension functions you wire wrap RPCs already named in this contract; you are not redesigning them.
+
+Also pull `MEMORY.md` and skim `feedback_use_build_windows_bat.md`, `reference_local_build_deps.md`, and `feedback_test_before_ci.md`.
+
+## Branch + prerequisites
+
+- Start from `main` after Phase 2.0 has merged (`feature/shell-brand-separation` → `main`).
+- New branch: `feature/workspace-extension-scaffolding-2a`.
+- Confirm `main` includes the Phase 2.0 commits — `git log --oneline main | grep -E 'controller|workspace_activate|orchestrator_get_workspace_pid|double-close'` should return ~6 hits.
+
+## What ships in Phase 2.A
+
+### Subset of `XR_EXT_spatial_workspace` to implement
+
+Only the capture-related surface plus the lifecycle functions capture depends on. No window-pose, no hit-test, no frame-capture, no app-launcher, no enumerate-clients (yet).
+
+| Function | Wraps existing IPC RPC | Notes |
+|---|---|---|
+| `xrActivateSpatialWorkspaceEXT(session)` | `workspace_activate` | Auth check already in place from Phase 2.0 |
+| `xrDeactivateSpatialWorkspaceEXT(session)` | `workspace_deactivate` | |
+| `xrGetSpatialWorkspaceStateEXT(session, *active)` | `workspace_get_state` | Read-only |
+| `xrAddWorkspaceCaptureClientEXT(session, hwnd, name, *clientId)` | `workspace_add_capture_client` | Windows HWND only — macOS chained struct is post-2.A |
+| `xrRemoveWorkspaceCaptureClientEXT(session, clientId)` | `workspace_remove_capture_client` | |
+
+Plus the type definitions those functions reference:
+- `XrWorkspaceClientId` (uint32_t typedef)
+- `XR_NULL_WORKSPACE_CLIENT_ID`
+- `XrWorkspaceClientTypeEXT` enum (used now for capture-vs-OpenXR; full enumerate-clients work is deferred)
+- The `XR_EXT_SPATIAL_WORKSPACE_EXTENSION_NAME` literal + `_SPEC_VERSION 1`
+
+### Log-string rename (the trivial cleanup)
+
+`comp_d3d11_service.cpp` lines **11620-11641** — capture-client lifecycle log strings. Rename `shell` → `workspace` in the log prefixes only. Code logic untouched.
+
+### What you do NOT touch
+
+- The other 156 `shell_*` mentions in `comp_d3d11_service.cpp`. The audit labels them; later sub-phases handle them.
+- `comp_d3d11_window.{cpp,h}` — `shell_mode_active`, `set_shell_mode_active`, `set_shell_dp`, `shell_input_event`, `SHELL_INPUT_RING_SIZE` all stay. Phase 2.D / 2.E.
+- `service_orchestrator.c` — Phase 2.0 finished its surface. The cooperative-shutdown protocol from ADR-016 is a later phase.
+- `src/xrt/targets/shell/main.c` — the DisplayXR Shell keeps using internal IPC for now. The extension is for **future third-party controllers**; Shell migration to extensions is deferred (and out of scope for the first non-shell consumer to drive validation, see "Validation" below).
+- `proto.json` / `proto.py` — IPC wire format unchanged; you wrap existing RPCs.
+- `webxr_bridge/main.cpp` — its "shell mode" terminology is an unrelated feature name. Skip.
+- `XR_EXT_app_launcher.h` — separate header, separate phase (2.B).
+- All other functions in the headers-draft (window pose, hit-test, frame capture, enumerate clients, eye-tracking-mode forwarding) — those land in their own sub-phases.
+
+## Recommended commit sequence
+
+Six commits. Keep each reviewable in isolation; do not bundle.
+
+### Commit 1 — `XR_EXT_spatial_workspace.h` header (pure addition)
+
+New file: `src/external/openxr_includes/openxr/XR_EXT_spatial_workspace.h`.
+
+Copy the structure of `src/external/openxr_includes/openxr/XR_EXT_display_info.h` for the BSD-style header, include guards, `extern "C"` block, `XR_NO_PROTOTYPES` gate, and the `EXTENSION_NAME` / `SPEC_VERSION` defines. Then add the **Phase 2.A subset only** from `spatial-workspace-extensions-headers-draft.md`:
+
+- Type values for the capture-related struct types (use the headers-draft's provisional `1000999100`-range values; coordinate with Khronos registry later).
+- `XrWorkspaceClientId` typedef + `XR_NULL_WORKSPACE_CLIENT_ID`.
+- `XrWorkspaceClientTypeEXT` enum with the two values defined.
+- The five PFN typedefs and prototypes for the functions in the table above.
+
+Acceptance: `_package/` headers ship the new file (CI's `publish-extensions.yml` will pick it up automatically). Header compiles standalone (`gcc -E` or MSVC `/EP` does not error).
+
+### Commit 2 — Extension registration
+
+Touch: `src/xrt/state_trackers/oxr/oxr_extension_support.h`.
+
+Mirror the existing `XR_EXT_display_info` block (search for `OXR_EXTENSION_SUPPORT_EXT_display_info`):
+
+```c
+/*
+ * XR_EXT_spatial_workspace
+ */
+#if defined(XR_EXT_spatial_workspace)
+#define OXR_HAVE_EXT_spatial_workspace
+#define OXR_EXTENSION_SUPPORT_EXT_spatial_workspace(_) \
+    _(EXT_spatial_workspace, EXT_SPATIAL_WORKSPACE)
+#else
+#define OXR_EXTENSION_SUPPORT_EXT_spatial_workspace(_)
+#endif
+```
+
+Add to the master support list (the macro at line ~1039):
+
+```c
+    OXR_EXTENSION_SUPPORT_EXT_spatial_workspace(_) \
+```
+
+Acceptance: `xrEnumerateInstanceExtensionProperties` lists `XR_EXT_spatial_workspace`. `xrCreateInstance` with that name in `enabledExtensionNames` succeeds.
+
+### Commit 3 — State-tracker implementation file (new)
+
+New file: `src/xrt/state_trackers/oxr/oxr_workspace.c`. Add to `oxr_state_tracker.dir` in `src/xrt/state_trackers/oxr/CMakeLists.txt`.
+
+Implement the five functions. Each is a thin wrapper that:
+
+1. Validates the session is current and the extension is enabled (`OXR_VERIFY_*` macros — see `oxr_api_session.c` for the pattern).
+2. Translates parameters to the IPC RPC's wire format.
+3. Calls the existing IPC RPC via `oxr_session->sys->...->ipc_*`.
+4. Translates the IPC return back to `XrResult`.
+
+Reference for IPC call patterns: `oxr_api_passthrough.c` does similar wrapping for `XR_FB_passthrough`. The capture-client RPCs already have a C entry in `ipc_client/` — search `ipc_call_workspace_add_capture_client`.
+
+Make the activate/deactivate functions return:
+- `XR_SUCCESS` on success
+- `XR_ERROR_LIMIT_REACHED` if another workspace is already active (Phase 2.0 PID-auth path returns a distinct error code today; map it)
+- `XR_ERROR_FEATURE_UNSUPPORTED` if not authorized (Phase 2.0 returns this; pass through)
+
+Acceptance: function bodies compile, link, and return `XR_SUCCESS` against the in-process Shell when called from a test client. Failure path returns the documented error.
+
+### Commit 4 — Dispatch wiring
+
+Touch: `src/xrt/state_trackers/oxr/oxr_api_funcs.h`.
+
+Add a block near the existing `OXR_HAVE_EXT_display_info` gate:
+
+```c
+#ifdef OXR_HAVE_EXT_spatial_workspace
+XRAPI_ATTR XrResult XRAPI_CALL oxr_xrActivateSpatialWorkspaceEXT(XrSession session);
+XRAPI_ATTR XrResult XRAPI_CALL oxr_xrDeactivateSpatialWorkspaceEXT(XrSession session);
+XRAPI_ATTR XrResult XRAPI_CALL oxr_xrGetSpatialWorkspaceStateEXT(XrSession session, XrBool32 *active);
+XRAPI_ATTR XrResult XRAPI_CALL oxr_xrAddWorkspaceCaptureClientEXT(
+    XrSession, uint64_t, const char *, XrWorkspaceClientId *);
+XRAPI_ATTR XrResult XRAPI_CALL oxr_xrRemoveWorkspaceCaptureClientEXT(
+    XrSession, XrWorkspaceClientId);
+#endif
+```
+
+Then add the dispatch table entries in `oxr_api_negotiate.c` (search for the table that maps function names to function pointers — typically `xrGetInstanceProcAddr` body or a generated lookup table; Phase 2.0's existing extensions show the pattern).
+
+Acceptance: `xrGetInstanceProcAddr(instance, "xrAddWorkspaceCaptureClientEXT", ...)` returns a non-null function pointer when the extension is enabled, NULL when it isn't. Calling the function pointer dispatches to your `oxr_xrAdd...` from Commit 3.
+
+### Commit 5 — Log-string rename in `comp_d3d11_service.cpp`
+
+Touch lines 11620-11641 only. Pure cosmetic — rename `Shell` / `shell` to `Workspace` / `workspace` in log prefixes for the capture-client cluster. Use `git diff -W` to confirm only that range moves; nothing functional.
+
+If clang-format wants to reflow the area, allow it (run `git clang-format` before the commit).
+
+### Commit 6 — Validation test
+
+Add a small standalone OpenXR client that exercises the new extension. Either:
+- Extend `tests/tests_comp_client_d3d11.cpp` with a workspace-mode test, or
+- Add a new test app `test_apps/workspace_minimal_d3d11_win/` that:
+  1. `xrCreateInstance` with `XR_EXT_spatial_workspace`
+  2. `xrCreateSession` with D3D11 binding
+  3. Call `xrActivateSpatialWorkspaceEXT` (expect `XR_SUCCESS` if launched under the orchestrator, `XR_ERROR_FEATURE_UNSUPPORTED` if launched standalone — both paths are valid test signals)
+  4. If active, call `xrAddWorkspaceCaptureClientEXT` with a dummy HWND (Notepad's HWND works for ad-hoc), assert non-zero `clientId` returned, then `xrRemoveWorkspaceCaptureClientEXT`
+  5. `xrDeactivateSpatialWorkspaceEXT`
+
+The test app naming follows the pattern in CLAUDE.md (`workspace_minimal_d3d11_win`). Wire it up in `test_apps/CMakeLists.txt` and `_package/`.
+
+Acceptance: test app builds + runs against the patched runtime. Stub builds (build-mingw-check.sh `aux_util workspace_minimal_d3d11_win`) compile clean.
+
+## Acceptance criteria for the whole phase
+
+- ✅ `_package/` ships `XR_EXT_spatial_workspace.h`. The `publish-extensions.yml` workflow picks it up next push.
+- ✅ A test client compiled against the new header can: enumerate the extension, create instance with it enabled, activate workspace mode (PID-auth path), add + remove a capture client, deactivate.
+- ✅ The first-party DisplayXR Shell continues to work unchanged. (It still uses internal IPC; that path is parallel to the extension path until a later sub-phase migrates it.)
+- ✅ Capture-cluster log strings in `comp_d3d11_service.cpp` say "workspace" not "shell".
+- ✅ Windows MSVC CI green. macOS CI green (the new header is platform-neutral; macOS test app is a Phase 2.A.macOS follow-up if needed).
+- ✅ `build-mingw-check.sh aux_util` green for the new state-tracker file.
+- ✅ Branch is one or two PRs against `main` — six commits total, each reviewable.
+
+## Hand-off notes
+
+- **Don't auto-commit individual sub-steps without testing.** The user's preference (per `feedback_test_before_ci.md`): build locally, smoke-test, then commit. Use `scripts\build_windows.bat build` for incremental rebuilds (per `feedback_use_build_windows_bat.md`). Don't push until the full sequence is locally green.
+- **`/ci-monitor` is for after the user has tested and approved.** The user will run it themselves or invite you to.
+- **The PRD layer order is being preserved.** State tracker → IPC → compositor; the new extension code lives in the state tracker; it does not bypass IPC and does not call compositor-private headers directly.
+- **If you find an `OXR_VERIFY_SESSION_AND_INIT_LOG` (or whatever the project calls it) macro doesn't exist for workspace context, follow `oxr_api_passthrough.c`'s recipe verbatim** — that extension is the closest existing template. Don't invent new validation macros.
+- **Naming consistency check before commit:** `grep -rn 'Shell\|shell' src/xrt/state_trackers/oxr/oxr_workspace.c` should return zero. The new file is brand-neutral by construction.
+
+## What unblocks once Phase 2.A passes
+
+- **Phase 2.B (launcher tile registry).** First *policy* migration. Pushes `xrAddLauncherAppEXT` / `xrPollLauncherClickEXT` / `xrSetLauncherRunningTileMaskEXT` and deletes the runtime's `registered_apps` array.
+- **Phase 2.F (hit-test).** Lowest-risk policy-adjacent migration. Promotes the existing internal `workspace_raycast_hit_test` to `xrWorkspaceHitTestEXT`.
+- The **window-pose** and **frame-capture** functions become next priority once Phase 2.B validates the launcher extension.
+
+After Phase 2.A merges, the next prompt (`spatial-workspace-extensions-phase2B-agent-prompt.md`) writes itself: same shape, swapping in launcher functions and deleting the policy that moved out.

--- a/docs/roadmap/spatial-workspace-extensions-plan.md
+++ b/docs/roadmap/spatial-workspace-extensions-plan.md
@@ -1,0 +1,309 @@
+# Spatial Workspace Extensions — Plan
+
+**Status:** Draft, 2026-04-27. Branch `feature/shell-brand-separation`.
+
+## Goal
+
+Decouple the DisplayXR runtime from the proprietary shell so that:
+
+1. The **public runtime** stops reading like an SDK for one specific proprietary application. Today the public runtime exposes 14 `shell_*` IPC RPCs, a `shell_mode` field in the core compositor interface, hardcoded `displayxr-shell.exe` spawn paths, and ~217 internal mentions of "shell" in the D3D11 service compositor — even though the shell binary itself is stripped from public releases. This implies a single-vendor stack to outside readers.
+2. **Third parties** can build their own privileged compositor clients — vertical workspaces (medical, industrial, trading), kiosks / signage, OEM-branded shells, test harnesses, AI-agent drivers — using a public extension surface. The DisplayXR Shell becomes one reference implementation of a workspace controller, not the only thing the runtime knows how to serve.
+3. The runtime repo can eventually be **severed** from the shell repo so external contributors can PR directly against the public runtime, eliminating the current `apply-public-pr.sh` apply-from-public-to-private dance.
+
+## Terminology
+
+The privileged client that arranges multiple apps in a shared 3D space, drives layout, registers launcher tiles, and captures frames is called a **workspace controller** (or just **workspace** when context is clear). The runtime mode in which the compositor serves such a client is **workspace mode**.
+
+**Why `workspace`** — alternatives considered:
+
+- `host` — collides with the existing `_hosted` app class (where the runtime owns the window). The shell is itself a hosted-style consumer of the runtime, so calling its role "host" produces unreadable architectural docs.
+- `composer` — too close to `compositor`, which is already overloaded as the per-API graphics module.
+- `window_manager` / `wm` — accurate (matches X11/Wayland tradition), but presupposes draggable windows. Doesn't fit kiosks, single-app fullscreen layouts, or AI-agent drivers that don't surface UI.
+- `orchestrator` — already taken by `service_orchestrator.c` for a different concern (spawning child processes).
+- **`workspace`** — covers all the use cases above, "spatial workspace" already appears in product copy, doesn't collide with anything in the codebase, doesn't presuppose windows or chrome.
+
+**Two-tier vocabulary**:
+- The DisplayXR Shell remains a brand and a product (binary, marketing, OEM relationships).
+- "Workspace controller" is the architectural role the shell plays — and that any third-party privileged client could play.
+
+## Phasing
+
+The work splits into three phases with sharply different costs and risk profiles. Each is independently shippable.
+
+### Phase 1 — Boundary rename (this branch, ~half day)
+
+Rename only the symbols that **cross the runtime/shell process boundary**. Internal compositor code keeps its current names. The 217 internal "shell" mentions in `comp_d3d11_service.cpp` are deliberately left alone — most of them belong to policy that will move out of the runtime entirely in Phase 2, so renaming them now would be throwaway churn.
+
+Scope is ~30 callsites: the IPC namespace, the public functions in `comp_d3d11_service.h`, one field in `xrt_compositor.h`, the `DISPLAYXR_SHELL_SESSION` env var, and the hardcoded `displayxr-shell.exe` spawn path. Detailed map below.
+
+After Phase 1: the public runtime's IPC protocol, core interface, and orchestrator config all read as neutral. A reader can no longer infer "this runtime is built for one specific proprietary shell" from any public surface. The shell binary still lives in `targets/shell/` and is still stripped from public releases — Phase 1 doesn't change topology.
+
+### Phase 2 — Mechanism vs policy split (separate branches, weeks)
+
+Move policy (which apps exist, what tiles to show, layout-preset semantics, registered_apps.json management, capture client lifecycle) **out of the compositor** into the shell process behind the workspace extensions. Mechanism (multi-client atlas composition, raycast hit-test against window planes, offscreen capture, IPC plumbing) **stays in the runtime** under neutral names.
+
+This is where the 217 internal mentions get cleaned up — most by deletion (the code moves to the shell process), the rest by renaming once they're clearly mechanism with no policy embedded.
+
+Output: two extension surfaces frozen and published — `XR_DISPLAYXR_spatial_workspace` (the compositor-side extension: window pose, focus, capture) and `XR_DISPLAYXR_app_launcher` (launcher tile registry, click events).
+
+### Phase 3 — Severance (separate branches, weeks)
+
+Once Phase 2 is stable and the extensions are frozen, the shell repo can consume the runtime as a published artifact rather than building from source in-tree. After that, the topology becomes:
+
+| Repo | Visibility | Role |
+|---|---|---|
+| `DisplayXR/displayxr-runtime` | **Public** | Full source. The only runtime repo. |
+| `DisplayXR/displayxr-shell-pvt` (new) | Private | Proprietary shell source, consumes published runtime |
+| `DisplayXR/displayxr-shell-releases` | Public | Binary shell releases (unchanged) |
+| `DisplayXR/displayxr-runtime-pvt` (current) | **Archived** | Historical |
+
+External contributors PR directly against `displayxr-runtime`. The current `apply-public-pr.sh` flow disappears.
+
+## Phase 1 — Detailed boundary-rename map
+
+Each row is a single mechanical edit. Order is bottom-up so dependents land last.
+
+### IPC protocol (`src/xrt/ipc/shared/proto.json`)
+
+The 14 `shell_*` RPCs become two extension namespaces. Workspace lifecycle and window/capture management go under `workspace_`; launcher concerns go under `launcher_`.
+
+| Old | New |
+|---|---|
+| `shell_activate` | `workspace_activate` |
+| `shell_deactivate` | `workspace_deactivate` |
+| `shell_get_state` | `workspace_get_state` |
+| `shell_set_window_pose` | `workspace_set_window_pose` |
+| `shell_get_window_pose` | `workspace_get_window_pose` |
+| `shell_set_visibility` | `workspace_set_window_visibility` |
+| `shell_add_capture_client` | `workspace_add_capture_client` |
+| `shell_remove_capture_client` | `workspace_remove_capture_client` |
+| `shell_capture_frame` | `workspace_capture_frame` |
+| `shell_set_launcher_visible` | `launcher_set_visible` |
+| `shell_clear_launcher_apps` | `launcher_clear_apps` |
+| `shell_add_launcher_app` | `launcher_add_app` |
+| `shell_poll_launcher_click` | `launcher_poll_click` |
+| `shell_set_running_tile_mask` | `launcher_set_running_tile_mask` |
+
+This drives the corresponding rename of `ipc_call_shell_*` and `ipc_handle_shell_*` symbols in the generated IPC code (regenerates from proto.json) plus the 15 handler implementations in `src/xrt/ipc/server/ipc_server_handler.c`.
+
+### Core compositor interface (`src/xrt/include/xrt/xrt_compositor.h`)
+
+| Old | New |
+|---|---|
+| `bool shell_mode;` (line 2506) | `bool workspace_mode;` |
+
+This field is the single most visible "shell" in the public runtime headers. Renaming it is the point of Phase 1.
+
+### Public functions in `comp_d3d11_service.h` (the API used by IPC handlers)
+
+| Old | New |
+|---|---|
+| `comp_d3d11_service_ensure_shell_window` | `comp_d3d11_service_ensure_workspace_window` |
+| `comp_d3d11_service_deactivate_shell` | `comp_d3d11_service_deactivate_workspace` |
+| `comp_d3d11_service_set_launcher_visible` | _unchanged_ (already neutral) |
+| `comp_d3d11_service_clear_launcher_apps` | _unchanged_ |
+| `comp_d3d11_service_add_launcher_app` | _unchanged_ |
+| `comp_d3d11_service_poll_launcher_click` | _unchanged_ |
+| `comp_d3d11_service_set_running_tile_mask` | _unchanged_ |
+| Doc comments referencing "shell mode" / "in shell mode" | "workspace mode" / "while a workspace is active" |
+
+The launcher functions are already neutrally named — the `shell_*` prefix only ever appeared in the IPC namespace, not the C function names.
+
+### Service orchestrator + config (`src/xrt/targets/service/`)
+
+Today `service_orchestrator.c` hardcodes `displayxr-shell.exe` in two `sibling_exe_path()` calls (lines 235, 257). After Phase 1 this is read from config:
+
+| File | Change |
+|---|---|
+| `service_config.{c,h}` | Add `char workspace_binary[MAX_PATH]` field (default: `"displayxr-shell.exe"`); add `"workspace_binary"` JSON key alongside the existing `"shell"` enable/auto/disable mode key |
+| `service_config.{c,h}` | Rename existing `cfg->shell` (a `service_child_mode` enum) to `cfg->workspace`. Keep the JSON key `"shell"` for backwards-compat *or* migrate with a one-version overlap accepting both. **Recommend**: read both keys, write only `"workspace"`, log a one-time deprecation if `"shell"` is found. |
+| `service_orchestrator.c` | Replace hardcoded `"displayxr-shell.exe"` with `s_cfg.workspace_binary`. Rename `s_shell_pi`, `s_shell_running`, `shell_watch_thread_func`, `spawn_shell` → `s_workspace_pi`, `s_workspace_running`, `workspace_watch_thread_func`, `spawn_workspace`. Hotkey ID comment at line 37 ("shared with the shell") becomes "shared with the workspace controller". |
+| `service/main.c` | `--shell` CLI flag becomes `--workspace` (keep `--shell` as a deprecated alias for one release). Variable `shell_mode` → `workspace_mode`. |
+
+Once `workspace_binary` is config-driven, an OEM shipping their own workspace controller drops a config file naming their binary — no runtime change needed.
+
+### Env var (`src/xrt/auxiliary/util/u_sandbox.c:126`)
+
+| Old | New |
+|---|---|
+| `DISPLAYXR_SHELL_SESSION` | `DISPLAYXR_WORKSPACE_SESSION` |
+
+Affects: this file, the shell's `targets/shell/main.c` (which sets the env var on launched apps), CLAUDE.md docs in two places, and any test scripts that reference it.
+
+Recommend: read both, prefer the new name, log deprecation if the old name is set. Drop the alias one release later.
+
+### Documents that lead with "shell" framing
+
+| File | Change |
+|---|---|
+| `docs/roadmap/shell-runtime-contract.md` | Rename to `docs/roadmap/workspace-runtime-contract.md`. Body: rename `shell_*` → `workspace_*` / `launcher_*` to match the new IPC names. Reframe intro from "the contract between the shell and the runtime" to "the contract between a workspace controller and the runtime — implemented by the DisplayXR Shell as the reference workspace controller, but available to any privileged IPC client". |
+| `docs/getting-started/overview.md:68` | Replace _"DisplayXR also includes a service, a spatial shell, and a WebXR bridge"_ with _"DisplayXR also includes a service (for multi-app and sandboxed browsers) and a WebXR bridge. A workspace controller can compose multiple apps in a shared 3D space via XR_DISPLAYXR_spatial_workspace; the DisplayXR Shell is our reference implementation."_ |
+| `docs/architecture/production-components.md` | Reframe the "shell" component as "workspace controller (reference: DisplayXR Shell)". 14 mentions to update. |
+| `docs/roadmap/spatial-desktop-prd.md` | Internal product vision — leave story intact, but switch architectural references from "the shell" to "the workspace controller". 37 mentions. Stays internal. |
+| `CLAUDE.md` (root + worktree CLAUDE.md mirrors) | Update "Spatial Shell" milestone label to "Spatial Workspace Controller (reference: DisplayXR Shell)". Update `DISPLAYXR_SHELL_SESSION` references to the new env var name. |
+
+### Symbols **not** renamed in Phase 1 (deliberately deferred)
+
+These stay as `shell_*` in Phase 1 because they are policy that moves out of the runtime in Phase 2 — renaming them now is throwaway work:
+
+- 217 internal mentions in `compositor/d3d11_service/comp_d3d11_service.cpp`
+- `comp_d3d11_window_set_shell_mode_active`, `comp_d3d11_window_set_shell_dp`, `shell_input_event` struct, `SHELL_INPUT_RING_SIZE` constant in `comp_d3d11/comp_d3d11_window.{h,cpp}`
+- All comments inside `comp_d3d11_service.cpp` body
+- `comp_d3d11_service.cpp` references to `pending_shell_reentry`, `last_shell_render_ns`, `shell_raycast_hit_test`, etc.
+
+These get touched only by Phase 2 (when their containing code moves) or by a final cleanup pass after Phase 2 lands.
+
+## Phase 2 — Mechanism-vs-policy audit
+
+This is the design work that determines whether the workspace extensions can be cleanly factored. Each block of "shell"-coupled compositor code falls into one of three buckets:
+
+### Mechanism (stays in runtime, gets neutral name)
+
+Survives in the runtime under non-shell names. Forms the backing implementation of `XR_DISPLAYXR_spatial_workspace` and `XR_DISPLAYXR_app_launcher`.
+
+- Multi-client atlas composition with per-client virtual window poses (`comp_d3d11_service_set_client_window_pose`, slot management, deferred HWND resize on next frame).
+- Spatial raycast hit-test mapping cursor screen position to which window plane was hit (`shell_raycast_hit_test` → `workspace_raycast_hit_test`). Pure geometry; no policy.
+- Offscreen capture of the pre-weave atlas to PNG (`comp_d3d11_service_capture_frame`). Already neutrally named.
+- 2D Windows.Graphics.Capture client slot management (`comp_d3d11_service_add_capture_client` / remove / set pose). Already largely neutral.
+- Per-frame composite + present pipeline (`multi_compositor_render`).
+- Input event ring buffer for forwarding mouse/keyboard from the workspace window to the focused app's HWND.
+- Window-relative Kooima projection per client.
+
+### Policy (moves to workspace process)
+
+Currently lives in compositor; should be entirely owned by the workspace controller process. The runtime gives it primitives (window pose API, capture API, hit-test API) but doesn't decide *what* to show, *which* tiles to display, or *what* a layout preset means.
+
+- Launcher tile registry (`registered_apps`, push/clear/poll-click/running-tile-mask). The runtime today renders the tiles; in Phase 2 the workspace process renders the launcher into a regular client window, and the runtime just composites it like any other window.
+- Layout-preset semantics (`grid`, `immersive`, `carousel` from `comp_d3d11_service_apply_layout_preset`). The runtime today owns the math for each preset; in Phase 2 the workspace process computes per-window poses and pushes them via `workspace_set_window_pose`.
+- Right-click context menu logic, double-click maximize/restore, edge-drag resize, title-bar drag — all currently in the compositor's input pipeline. In Phase 2 the workspace controller receives raw input events (or hit-test results) and decides how to interpret them.
+- Title-bar chrome rendering (close button, minimize button, app name). The compositor today draws this. In Phase 2 the workspace controller draws chrome into its own client window layer that the compositor composites alongside the app window.
+- Eye tracking mode policy (when to switch MANAGED ↔ MANUAL based on focus). Belongs to the workspace controller — it knows what's focused.
+- Empty-workspace ESC-handling carve-out, `pending_shell_reentry` state, deactivate-shell/restore-2D-windows lifecycle.
+
+### Gone (delete)
+
+Code that exists only because the runtime tries to handle workspace-specific concerns; deleted outright when policy moves out.
+
+- `service_set_shell_mode` plumbing the shell-mode flag into the window's WndProc so its ESC-close path can distinguish empty-shell from non-shell mode (`comp_d3d11_service.cpp:919`). After Phase 2 the compositor doesn't need to know anything about "empty shell"; it has clients or it doesn't.
+- Hardcoded shell title-bar height computations sprinkled through the raycast and rendering paths (`title_bar_h_m` in `shell_raycast_hit_test`). Title bars are workspace-decided.
+- `pending_shell_reentry` and the shell-deactivated render-skip logic. Replaced by generic "no clients connected → skip render" check.
+
+## Draft extension surfaces
+
+Sketch only — final shape settled during Phase 2 implementation. Listed here so the rename in Phase 1 picks names that survive.
+
+### `XR_DISPLAYXR_spatial_workspace`
+
+Lifecycle:
+- `xrDisplayXREnableSpatialWorkspaceEXT(session, enable)` — privileged client opts into workspace mode. Subsequent `xrLocateViews` etc. behave as workspace-controller (composites multiple client views), not as a regular OpenXR client.
+- `xrDisplayXRGetWorkspaceStateEXT(session, out_state)` — query active flag, connected client count.
+
+Window management (each "window" is one connected IPC client):
+- `xrDisplayXRSetClientWindowPoseEXT(session, client_id, pose, width_m, height_m)`
+- `xrDisplayXRGetClientWindowPoseEXT(session, client_id, out_pose, out_w, out_h)`
+- `xrDisplayXRSetClientVisibilityEXT(session, client_id, visible)`
+- `xrDisplayXREnumerateClientsEXT(session, count_in, out_count, out_clients)` — enumerate connected app sessions.
+
+Hit-test (raycast cursor → which client window):
+- `xrDisplayXRWorkspaceHitTestEXT(session, cursor_screen_pos, out_client_id, out_local_uv)` — pure geometry, runtime-side. The workspace controller calls this from its input handler, then decides whether the hit means focus / drag / right-click forward.
+
+Capture:
+- `xrDisplayXRAddCaptureClientEXT(session, hwnd, name, out_client_id)` — start a 2D Windows.Graphics.Capture session as a workspace-resident slot.
+- `xrDisplayXRRemoveCaptureClientEXT(session, client_id)`
+- `xrDisplayXRCaptureFrameEXT(session, path_prefix, flags, out_result)` — capture pre-weave atlas to PNG. Already a runtime primitive.
+
+### `XR_DISPLAYXR_app_launcher`
+
+Optional second extension. Smaller surface; could even be merged into `spatial_workspace`. Kept separate for now because it's the one most likely to evolve as launcher UX matures.
+
+- `xrDisplayXRClearLauncherAppsEXT(session)`
+- `xrDisplayXRAddLauncherAppEXT(session, app_descriptor)` — push one tile (icon + name + opaque id).
+- `xrDisplayXRPollLauncherClickEXT(session, out_app_id)` — poll-and-clear most recent click. -1 if none.
+- `xrDisplayXRSetLauncherVisibleEXT(session, visible)`
+- `xrDisplayXRSetRunningTileMaskEXT(session, mask)` — bitmask of which tiles correspond to currently-running clients (drives glow border in launcher UI).
+
+**Open question for Phase 2**: should the launcher even be a runtime extension at all? Alternative: the workspace controller renders the launcher into a regular client window and uses `spatial_workspace` to position it. That's cleaner architecturally but loses the runtime's ability to render the launcher with no clients connected. The current code path exists because of the empty-workspace startup flow.
+
+## Narrative copy (ships with Phase 1)
+
+Code rename without doc rename leaves a confusing public artifact. Phase 1 commits include these doc updates.
+
+### `DisplayXR/.github/profile/README.md`
+
+Add one-line preamble above the existing repo table:
+
+> DisplayXR is an open OpenXR runtime + extension stack for 3D displays. Build apps, build a workspace controller, or use the reference shell.
+
+Change the `displayxr-shell` row text from _"Spatial shell / 3D window manager"_ to:
+
+> Reference workspace controller (built on the spatial workspace extensions). One example of a privileged compositor client; build your own for verticals, kiosks, OEM workspaces, or AI-agent drivers.
+
+### `displayxr-website` — `components/home/SolutionSection.tsx`
+
+Replace the existing "Spatial Desktop Shell" feature card (line 43) with a new card that frames the extensions as the runtime feature, not the shell:
+
+```ts
+{
+  title: "Workspace Extensions",
+  description:
+    "XR_DISPLAYXR_spatial_workspace + XR_DISPLAYXR_app_launcher — extensions that let any privileged client compose multi-app 3D layouts, drive window placement, and register launcher tiles. Build a vertical workspace, an OEM-branded shell, a kiosk, or a test harness.",
+  icon: <AppWindow size={20} />,
+},
+```
+
+Then add a new `<section>` after `SolutionSection` titled **"DisplayXR Shell — our reference workspace"**, one paragraph framing the shell as one possible workspace controller built on these extensions, with a link to `displayxr-shell-releases`.
+
+### `displayxr-website` — `components/home/EcosystemMap.tsx`
+
+Section copy:
+
+> ~~DisplayXR is developing as a full ecosystem — runtime, extensions, engine plugins, projection math, demos, and a spatial desktop shell.~~
+
+becomes:
+
+> DisplayXR is developing as a full ecosystem — runtime, extensions, engine plugins, projection math, demos, and reference workspace controllers.
+
+### `displayxr-website` — `lib/data/ecosystem.ts`
+
+The `displayxr-shell-releases` entry's `description` becomes:
+
+> Reference spatial workspace controller — built on `XR_DISPLAYXR_spatial_workspace`. One example of a privileged compositor client; build your own for verticals, kiosks, or OEM-branded workspaces.
+
+### Runtime — `docs/getting-started/overview.md:68`
+
+> ~~The diagram above shows the in-process path — a single app talking directly to the display. In production, DisplayXR also includes a service (for multi-app and sandboxed browsers), a spatial shell (3D window manager), and a WebXR bridge (metadata sideband for Chrome).~~
+
+becomes:
+
+> The diagram above shows the in-process path — a single app talking directly to the display. In production, DisplayXR also includes a service (for multi-app and sandboxed browsers) and a WebXR bridge (metadata sideband for Chrome). A privileged client can act as a **workspace controller** via `XR_DISPLAYXR_spatial_workspace`, composing multiple apps in a shared 3D space — the DisplayXR Shell is our reference workspace controller.
+
+## Severance checklist (Phase 3 prerequisites)
+
+Severance becomes possible when **all** of these are true:
+
+- [ ] Phase 1 boundary rename complete (this branch)
+- [ ] Phase 2 mechanism-vs-policy split complete: launcher registry, layout-preset semantics, chrome rendering, capture-client lifecycle have moved out of the runtime into the shell process
+- [ ] `XR_DISPLAYXR_spatial_workspace` and `XR_DISPLAYXR_app_launcher` headers published to `displayxr-extensions` with frozen wire format
+- [ ] `service_orchestrator.c` no longer hardcodes `displayxr-shell.exe` (Phase 1 covers this)
+- [ ] `targets/shell/CMakeLists.txt` switches from in-tree paths to consuming a published runtime artifact (release zip / git submodule against a tagged runtime version)
+- [ ] Shell repo gets its own CI that builds against the latest published runtime, not source-coupled
+
+After all six: the shell repo can move to `DisplayXR/displayxr-shell-pvt`, the runtime repo's `targets/shell/` directory disappears, `displayxr-runtime-pvt` archives, and `apply-public-pr.sh` retires.
+
+**Costs to weigh before committing to severance:**
+
+- Loss of cross-cutting atomic refactors. Today a refactor touching both compositor and shell is one PR; after severance the runtime change must ship in a release before the shell can adopt it. Every ABI-impacting refactor needs a version-overlap design.
+- Release-cadence coupling becomes user-visible. Users see "shell vX.Y.Z requires runtime ≥ vA.B.C" instead of trusting that same-SHA = compatible. Already partially the case for demos.
+- The two extensions become a hard contract — same discipline as Khronos extensions. Mostly upside, but reduces future flexibility.
+
+## Out of scope for this plan
+
+- macOS workspace controller. The current shell is Windows-only. The extension surfaces should be platform-neutral by design, but the macOS port is its own project.
+- WebXR bridge interaction with workspace mode. Phase 2 should ensure WebXR clients can be workspace tiles, but the bridge itself isn't being renamed.
+- Adding new workspace primitives (e.g. depth-aware drop shadows, cross-window highlights). The extensions ship with what the current shell needs and grow from there.
+
+## Open questions
+
+1. Should `XR_DISPLAYXR_app_launcher` be a separate extension or merged into `spatial_workspace`? Argument for separate: launcher UX is most likely to evolve. Argument for merged: it's a small surface and "the workspace owns its launcher" is a clean conceptual model.
+2. When `service_orchestrator.c` reads `workspace_binary` from config and the binary is missing, current behavior is to log a warning and continue. After Phase 1, should it be an error? (Probably warn-and-continue stays — service mode without a workspace is a valid configuration for `_ipc` apps and WebXR.)
+3. Naming nit: `comp_d3d11_window_set_shell_mode_active` exists at the D3D11 *graphics* compositor layer (not the service compositor) — it's used to gate the ESC-close behavior. Does this rename to `_set_workspace_mode_active`, or does it become a more abstract "is_managed_by_external_controller" flag? The flag's actual semantic is closer to the latter; renaming purely to "workspace" perpetuates the conflation. Defer to Phase 2.

--- a/docs/roadmap/spatial-workspace-extensions-plan.md
+++ b/docs/roadmap/spatial-workspace-extensions-plan.md
@@ -219,6 +219,16 @@ Capture:
 - `xrDisplayXRRemoveCaptureClientEXT(session, client_id)`
 - `xrDisplayXRCaptureFrameEXT(session, path_prefix, flags, out_result)` — capture pre-weave atlas to PNG. Already a runtime primitive.
 
+### `XR_DISPLAYXR_workspace_tray` (sketch)
+
+The runtime owns the system tray icon — it has to, because the icon exists before any controller is loaded. But the *content* of the workspace submenu (items, labels, handlers) and the *response* to clicks (start, suspend, "Disable", "Lock", whatever the controller chooses to expose) belong to the controller. The current `Enable / Auto / Disable` set and the orchestrator's `TerminateProcess`-on-Disable are first-party-shell defaults that this extension replaces.
+
+- `xrDisplayXRSetWorkspaceTrayMenuEXT(session, menu_descriptor)` — controller registers the tray submenu shape (radio groups, checkboxes, separators, labels, item ids).
+- `xrDisplayXRPollWorkspaceTrayClickEXT(session, out_item_id)` — poll-and-clear the most recent menu click. The controller decides what each id means; the runtime just relays.
+- `xrDisplayXRRequestControllerShutdownEXT(session)` — runtime asks the controller to exit cooperatively (system shutdown, OEM device-management agent, last-resort-before-kill). Symmetric to a third-party launcher politely asking the controller to leave.
+
+The runtime keeps a last-resort `TerminateProcess` fallback for unresponsive or unregistered controllers, but never calls it on a controller that has registered a menu and is responsive. **See ADR-016** for the architectural rationale and the current transitional state.
+
 ### `XR_DISPLAYXR_app_launcher`
 
 Optional second extension. Smaller surface; could even be merged into `spatial_workspace`. Kept separate for now because it's the one most likely to evolve as launcher UX matures.

--- a/docs/roadmap/spatial-workspace-extensions-plan.md
+++ b/docs/roadmap/spatial-workspace-extensions-plan.md
@@ -40,11 +40,18 @@ After Phase 1: the public runtime's IPC protocol, core interface, and orchestrat
 
 ### Phase 2 — Mechanism vs policy split (separate branches, weeks)
 
-Move policy (which apps exist, what tiles to show, layout-preset semantics, registered_apps.json management, capture client lifecycle) **out of the compositor** into the shell process behind the workspace extensions. Mechanism (multi-client atlas composition, raycast hit-test against window planes, offscreen capture, IPC plumbing) **stays in the runtime** under neutral names.
+Phase 2 is preceded by **Phase 2.0** — two short pieces of architectural prep that gate the larger code migrations. Both modify the orchestrator and tray; both are designed in their own docs:
 
-This is where the 217 internal mentions get cleaned up — most by deletion (the code moves to the shell process), the rest by renaming once they're clearly mechanism with no policy embedded.
+- **[Workspace controller detection](spatial-workspace-controller-detection.md)** — orchestrator detects whether a workspace controller binary is installed and reads its sidecar `.controller.json` manifest for display metadata. Tray submenu shows / hides accordingly. Makes the runtime a real platform: bare-runtime install (no shell) gives a useful product (OpenXR + WebXR bridge) with no Workspace submenu; installing the shell adds the submenu.
+- **[Workspace activation auth handshake](spatial-workspace-auth-handshake.md)** — replaces the literal `"displayxr-shell"` `application_name` match in `ipc_server_handler.c:296` with an orchestrator-PID match. Removes the last brand coupling in the runtime.
 
-Output: two extension surfaces frozen and published — `XR_DISPLAYXR_spatial_workspace` (the compositor-side extension: window pose, focus, capture) and `XR_DISPLAYXR_app_launcher` (launcher tile registry, click events).
+After Phase 2.0 the runtime ships standalone, recognises any installed workspace controller by its manifest, and grants the activation right by spawn-PID rather than by hardcoded name. With that scaffolding in place, Phase 2 then moves policy out of the compositor:
+
+Move policy (which apps exist, what tiles to show, layout-preset semantics, registered_apps.json management, capture client lifecycle) **out of the compositor** into the workspace controller process behind the workspace extensions. Mechanism (multi-client atlas composition, raycast hit-test against window planes, offscreen capture, IPC plumbing) **stays in the runtime** under neutral names.
+
+This is where the 162 internal mentions in `comp_d3d11_service.cpp` (down from 217 after Phase 1) get cleaned up — most by deletion (the code moves to the workspace process), the rest by renaming once they're clearly mechanism with no policy embedded. The line-by-line classification is in the [Phase 2 audit](spatial-workspace-extensions-phase2-audit.md), which proposes 8 sub-steps (2.A through 2.H) ordered lowest-blast-radius-first.
+
+Output: two extension surfaces frozen and published — `XR_EXT_spatial_workspace` (the compositor-side extension: window pose, focus, capture) and `XR_EXT_app_launcher` (launcher tile registry, click events). Header sketches in [spatial-workspace-extensions-headers-draft.md](spatial-workspace-extensions-headers-draft.md).
 
 ### Phase 3 — Severance (separate branches, weeks)
 

--- a/docs/roadmap/workspace-runtime-contract.md
+++ b/docs/roadmap/workspace-runtime-contract.md
@@ -8,56 +8,59 @@ code-paths: [src/xrt/compositor/multi/, src/xrt/ipc/]
 
 > **Status: Proposal** — not yet implemented. Tracking issue: [#43](https://github.com/DisplayXR/displayxr-runtime-pvt/issues/43), [#44](https://github.com/DisplayXR/displayxr-runtime-pvt/issues/44)
 
-# Shell / Runtime Contract
+# Workspace / Runtime Contract
 
 ## Scope and Related Docs
 
-This doc defines the **IPC message set** between the 3D shell and the spatial runtime. It establishes a clean boundary so rendering machinery does not drift into shell code, and UX policy does not drift into runtime code.
+This doc defines the **IPC message set** between a workspace controller and the spatial runtime. The DisplayXR Shell is our reference workspace controller, but the contract is the boundary — any privileged IPC client implementing it can play the role (verticals, kiosks, OEM-branded workspaces, AI-agent drivers).
+
+The boundary exists so rendering machinery does not drift into workspace-controller code, and UX policy does not drift into runtime code.
 
 | Doc | Relationship |
 |-----|-------------|
 | [spatial-os.md](spatial-os.md) (#43) | **Compositing mechanism.** The runtime side of this contract — multi-compositor, shared textures, display processing. |
-| [3d-shell.md](3d-shell.md) (#44) | **Shell layer.** The shell side of this contract — window placement, chrome, interaction. |
+| [3d-shell.md](3d-shell.md) (#44) | **Reference workspace controller.** The DisplayXR Shell side of this contract — window placement, chrome, interaction. |
 | [3d-capture.md](3d-capture.md) | **Capture pipeline.** Capture commands and completion events flow through this contract. |
+| [spatial-workspace-extensions-plan.md](spatial-workspace-extensions-plan.md) | **Extension plan.** Roadmap for promoting this contract into the public `XR_DISPLAYXR_spatial_workspace` + `XR_DISPLAYXR_app_launcher` extensions. |
 
 ## Purpose
 
 Define a clean boundary so:
-- Rendering machinery does not drift into shell code
+- Rendering machinery does not drift into workspace-controller code
 - UX policy does not drift into runtime code
-- The shell can be replaced (OEM shells, alternate shells, kiosk mode) without touching the runtime
-- The runtime can evolve its compositing internals without breaking shell compatibility
+- The workspace controller can be replaced (OEM-branded workspaces, vertical-specific cockpits, kiosks, AI-agent drivers) without touching the runtime
+- The runtime can evolve its compositing internals without breaking workspace-controller compatibility
 
 ## Boundary Rule
 
 - **Runtime implements rendering truth** — compositing, projection, weaving, capture, hit testing
-- **Shell implements desktop behavior** — placement policy, chrome, focus, persistence, launcher
-- **Apps require no SDK** — a normal OpenXR handle app works in the shell with zero code changes (Level 0 universal app, see [spatial-desktop-prd.md § 5.1](spatial-desktop-prd.md)). Shell-aware extensions (Level 1) and spatial UI toolkits (Level 2) are optional enhancements, never requirements.
+- **Workspace controller implements desktop behavior** — placement policy, chrome, focus, persistence, launcher
+- **Apps require no SDK** — a normal OpenXR handle app works inside any workspace with zero code changes (Level 0 universal app, see [spatial-desktop-prd.md § 5.1](spatial-desktop-prd.md)). Workspace-aware extensions (Level 1) and spatial UI toolkits (Level 2) are optional enhancements, never requirements.
 
-## Shell → Runtime (Control Path)
+## Controller → Runtime (Control Path)
 
-The shell must be able to send:
+The workspace controller must be able to send:
 
 | Message | Description | Status |
 |---------|-------------|--------|
-| **`shell_activate`** | Enter shell mode (multi-comp takes over DP + display) | Implemented |
-| **`shell_deactivate`** | Exit shell mode (per-client compositors resume direct rendering) | Phase 4D |
-| **`shell_set_window_pose`** | Position, orientation, size of a window quad in 3D space | Implemented |
-| **`shell_get_window_pose`** | Query current window transform | Implemented |
-| **`shell_set_visibility`** | Show/hide a window without destroying it (minimize) | Implemented |
-| **`shell_add_capture_client`** | Adopt a 2D OS window: runtime starts `Windows.Graphics.Capture` for the given HWND, returns client_id | Phase 4A |
-| **`shell_remove_capture_client`** | Stop capturing a 2D window, remove virtual client slot | Phase 4A |
+| **`workspace_activate`** | Enter workspace mode (multi-comp takes over DP + display) | Implemented |
+| **`workspace_deactivate`** | Exit workspace mode (per-client compositors resume direct rendering) | Phase 4D |
+| **`workspace_set_window_pose`** | Position, orientation, size of a window quad in 3D space | Implemented |
+| **`workspace_get_window_pose`** | Query current window transform | Implemented |
+| **`workspace_set_window_visibility`** | Show/hide a window without destroying it (minimize) | Implemented |
+| **`workspace_add_capture_client`** | Adopt a 2D OS window: runtime starts `Windows.Graphics.Capture` for the given HWND, returns client_id | Phase 4A |
+| **`workspace_remove_capture_client`** | Stop capturing a 2D window, remove virtual client slot | Phase 4A |
 | **Capture commands** *(future)* | Start/stop frame capture, recording, session capture | Phase 5+ |
 | **Layout updates** | Batch update of multiple window transforms (layout preset apply) | Phase 2+ |
 
-## Runtime → Shell (Service Path)
+## Runtime → Controller (Service Path)
 
 The runtime must be able to expose:
 
 | Message | Description | Status |
 |---------|-------------|--------|
 | **`system_get_clients`** | List of connected IPC apps (id, name, state) | Implemented |
-| **`shell_get_client_type`** | Returns `CLIENT_TYPE_OPENXR_3D` or `CLIENT_TYPE_CAPTURED_2D` | Phase 4A |
+| **`workspace_get_client_type`** | Returns `CLIENT_TYPE_OPENXR_3D` or `CLIENT_TYPE_CAPTURED_2D` | Phase 4A |
 | **Hit-test results** | Which window a mouse ray intersects, and where on the surface | Implemented (server-side) |
 | **App presence** | App connected/disconnected, session created/destroyed | Implemented (poll-based) |
 | **Display state** | Display resolution, refresh rate, capabilities | Implemented (shared memory) |
@@ -68,9 +71,9 @@ The runtime must be able to expose:
 
 The contract is transport-agnostic. Implementation options:
 
-1. **Privileged IPC** — Shell connects as a privileged client over the existing IPC infrastructure (`src/xrt/ipc/`). Shell messages become additional IPC calls with elevated permissions.
+1. **Privileged IPC** — The workspace controller connects as a privileged client over the existing IPC infrastructure (`src/xrt/ipc/`). Controller messages are additional IPC calls with elevated permissions. **(Current implementation.)**
 
-2. **Custom OpenXR extension** — `XR_EXT_spatial_window_management` extension that the shell uses as a regular OpenXR client with shell-specific capabilities.
+2. **Custom OpenXR extension** — `XR_DISPLAYXR_spatial_workspace` (window pose / focus / capture) and `XR_DISPLAYXR_app_launcher` (launcher tile registry), used by the controller as a regular OpenXR client with privileged capabilities. **(Phase 2 target — see [spatial-workspace-extensions-plan.md](spatial-workspace-extensions-plan.md).)**
 
 3. **Platform service abstraction** — Platform-specific mechanism (e.g., named pipes on Windows, XPC on macOS) if OpenXR extension overhead is too high for real-time window pose updates.
 

--- a/docs/specs/displayxr-app-manifest.md
+++ b/docs/specs/displayxr-app-manifest.md
@@ -4,21 +4,23 @@
 |---|---|
 | **Spec** | DisplayXR App Manifest |
 | **Version** | 1.0 (draft) |
-| **Status** | Phase 5 — spatial launcher discovery |
-| **Owner** | Shell team |
-| **Applies to** | Any application that wants to appear in the DisplayXR shell launcher |
+| **Status** | Stable contract — implemented by the DisplayXR Shell (reference workspace controller); usable by any workspace controller that opts in. |
+| **Owner** | Workspace extensions (this is a public ecosystem contract, not a shell-internal format). |
+| **Applies to** | Any application that wants to appear in a DisplayXR workspace controller's launcher. |
 
 ## 1. Purpose
 
-The DisplayXR shell's spatial launcher discovers installable apps by scanning a small set of filesystem locations and reading per-app **manifest sidecar files** named `.displayxr.json`. The manifest is the authoritative source of an app's display name, icons, category, and display-mode preferences.
+A **DisplayXR workspace controller** — the DisplayXR Shell is the reference implementation; third-party verticals, kiosks, OEM-branded shells, and AI-agent drivers can all play this role — discovers installable apps by scanning a small set of filesystem locations and reading per-app **manifest sidecar files** named `.displayxr.json`. The manifest is the authoritative source of an app's display name, icons, category, and display-mode preferences.
 
-**Discovery is manifest-gated.** An executable with no manifest is NOT shown in the launcher, even if it imports `openxr_loader.dll`. This is intentional: it keeps the launcher curated, avoids false positives from unrelated OpenXR apps, and gives developers a single explicit contract to satisfy. Users can still manually add any executable through the launcher's **Browse for app…** entry; those entries bypass the manifest requirement.
+This document specifies the manifest format and the discovery directory convention. Both are part of the **DisplayXR app-installation contract**: an installer that drops a manifest into one of the system-known directories below makes the app discoverable to *any* compliant workspace controller, not just the DisplayXR Shell. The contract is intentionally workspace-controller-agnostic so that an app installed once is found by every controller a user might run.
+
+**Discovery is manifest-gated.** An executable with no manifest is NOT shown in the launcher, even if it imports `openxr_loader.dll`. This is intentional: it keeps the launcher curated, avoids false positives from unrelated OpenXR apps, and gives developers a single explicit contract to satisfy. Users can still manually add any executable through a workspace controller's **Browse for app…** flow (the DisplayXR Shell implements this; see §11); those entries bypass the manifest requirement at scan time but typically *write* a manifest so subsequent scans pick them up.
 
 DisplayXR Unity and Unreal plugins are expected to generate a manifest automatically as part of their build/export pipelines. Native app developers author the manifest by hand.
 
-**Not every executable in a DisplayXR SDK install ships a manifest.** In particular, test-only variants (`cube_hosted_legacy_*`, `cube_texture_*`, `cube_hosted_*`, and similar) intentionally omit a sidecar so they do not appear in the launcher — they exist to exercise runtime paths that are not meaningful to end users. Only apps that a user would plausibly launch from the shell should ship a manifest. Inside this repo, only the `cube_handle_*_win` reference apps carry sidecars.
+**Not every executable in a DisplayXR SDK install ships a manifest.** In particular, test-only variants (`cube_hosted_legacy_*`, `cube_texture_*`, `cube_hosted_*`, and similar) intentionally omit a sidecar so they do not appear in the launcher — they exist to exercise runtime paths that are not meaningful to end users. Only apps that a user would plausibly launch from a workspace controller should ship a manifest. Inside this repo, only the `cube_handle_*_win` reference apps carry sidecars.
 
-**The shell ships no built-in default apps.** When `registered_apps.json` does not exist (first run), the registry starts empty. The scanner immediately populates whatever it finds via sidecars; if it finds nothing, the launcher renders the empty-state hint instead of a tile grid. There is no pre-seeded "Notepad" or other system app — the launcher is exclusively a curated DisplayXR app surface, never a generic Windows app drawer.
+**Workspace controllers ship no built-in default apps.** When the controller's launcher state cache (e.g. the DisplayXR Shell's `registered_apps.json`) does not exist (first run), the registry starts empty. The scanner immediately populates whatever it finds via manifests; if it finds nothing, the launcher renders the empty-state hint instead of a tile grid. There is no pre-seeded "Notepad" or other system app — the DisplayXR app surface is exclusively a curated workspace surface, never a generic Windows app drawer.
 
 ## 2. Manifest modes and file locations
 
@@ -36,13 +38,13 @@ my_app/
 └── icon_sbs.png              ← optional 3D icon
 ```
 
-- The scanner looks for `<exe_basename>.displayxr.json` next to each discovered `.exe` in the dev-tree paths (see §5).
+- A workspace controller's scanner looks for `<exe_basename>.displayxr.json` next to each discovered `.exe` in the dev-tree paths (see §5).
 - `exe_path` MUST be absent in sidecar mode — the exe is the sibling file.
 - Sidecar mode is the natural fit for in-tree dev (`test_apps/`, `demos/`) and for app installs that bundle the manifest into their own install directory.
 
 ### 2.2 Registered mode (drop-in directory)
 
-The manifest sits in a system-known discovery directory and points at any executable on disk via an absolute `exe_path`. This is how third-party apps install themselves into the launcher without having to live under `Program Files`.
+The manifest sits in a system-known discovery directory and points at any executable on disk via an absolute `exe_path`. This is how third-party apps install themselves into a DisplayXR workspace controller's launcher without having to live under `Program Files`.
 
 ```
 %LOCALAPPDATA%\DisplayXR\apps\           ← per-user installs (no elevation)
@@ -82,7 +84,7 @@ The manifest sits in a system-known discovery directory and points at any execut
 |---|---|---|
 | `schema_version` | integer | Must be `1` for v1.0. Allows future schema migrations. |
 | `name` | string | Display name shown on the tile. 1–64 characters. UTF-8. |
-| `type` | string | `"3d"` for extension/hosted apps that create an OpenXR session, `"2d"` for legacy Win32 apps the shell captures by HWND. Must match one of these values. |
+| `type` | string | `"3d"` for extension/hosted apps that create an OpenXR session, `"2d"` for legacy Win32 apps a workspace controller captures by HWND. Must match one of these values. |
 
 ### 3.2 Optional fields
 
@@ -90,7 +92,7 @@ The manifest sits in a system-known discovery directory and points at any execut
 |---|---|---|---|
 | `exe_path` | string | *none* | Absolute path to the executable. **Required in registered mode (§2.2), MUST be absent in sidecar mode (§2.1).** Forward or back slashes accepted; the scanner normalizes to backslashes. The referenced file must exist at scan time or the entry is skipped. |
 | `icon` | string | *none* | Relative path to a 2D icon image. PNG or JPEG. Recommended 512×512. When absent, the tile is rendered with the app name as a text label on a category-colored background. |
-| `icon_3d` | string | *none* | Relative path to a stereoscopic icon image. When present, the shell renders the tile stereoscopically. Resolution matches `icon` aspect but doubled along the layout axis (e.g. 1024×512 for `sbs-lr`). Requires `icon` to also be set (as the 2D fallback). |
+| `icon_3d` | string | *none* | Relative path to a stereoscopic icon image. When present, the workspace controller renders the tile stereoscopically. Resolution matches `icon` aspect but doubled along the layout axis (e.g. 1024×512 for `sbs-lr`). Requires `icon` to also be set (as the 2D fallback). |
 | `icon_3d_layout` | string | `"sbs-lr"` | How the stereo pair is packed in `icon_3d`. One of `"sbs-lr"` (left-right), `"sbs-rl"` (right-left), `"tb"` (top-bottom, left eye on top), `"bt"` (bottom-top). Ignored if `icon_3d` is absent. |
 | `category` | string | `"app"` | Free-form tag used for grouping. Reserved values: `"test"`, `"demo"`, `"app"`, `"tool"`. Unknown values are accepted and displayed as-is. |
 | `display_mode` | string | `"auto"` | Preferred display mode at launch. `"auto"` lets the runtime choose. Other values are forwarded to the runtime's mode selection. |
@@ -98,7 +100,7 @@ The manifest sits in a system-known discovery directory and points at any execut
 
 ### 3.3 Reserved for future versions
 
-Names the shell may consume in later schema versions — do not use for custom data:
+Names a workspace controller may consume in later schema versions — do not use for custom data:
 
 `version`, `publisher`, `homepage`, `min_runtime`, `required_extensions`, `screenshots`, `trailer`, `pose`, `window_size`, `args`, `working_dir`.
 
@@ -114,11 +116,11 @@ The launcher's key visual hook is that app tiles are themselves 3D. A high-quali
 
 ### 4.2 Convergence guidance
 
-The shell renders launcher tiles at ~40 cm in front of the viewer. Stereo icons should be authored for a comfortable convergence at roughly that distance. Parallax budget: ±2% of image width.
+A workspace controller's launcher renders tiles at ~40 cm in front of the viewer (the DisplayXR Shell's reference convergence; other controllers may differ). Stereo icons should be authored for a comfortable convergence at roughly that distance. Parallax budget: ±2% of image width.
 
 ## 5. Discovery behavior
 
-The shell scanner walks two kinds of paths in this order:
+A workspace controller's scanner walks two kinds of paths in this order. The directory conventions below are the ecosystem standard — every compliant controller scans the same registered-mode dirs so an app installed once is discovered everywhere.
 
 **Registered-mode discovery dirs** (manifests own the exe via `exe_path`):
 ```
@@ -126,11 +128,13 @@ The shell scanner walks two kinds of paths in this order:
 %ProgramData%\DisplayXR\apps\           ← system-wide, installer-writable (elevated)
 ```
 
-**Sidecar-mode dev paths** (manifests sit next to the exe):
+These paths are **DisplayXR-runtime-branded, not workspace-controller-branded**. Installers write here regardless of which workspace controller(s) the user runs. Third-party controllers that don't honor this convention can still ship — they just won't see apps installed for the ecosystem.
+
+**Sidecar-mode dev paths** (manifests sit next to the exe). The reference DisplayXR Shell scans these relative to its own exe:
 ```
-<shell-exe>/../test_apps/*/build/
-<shell-exe>/../demos/*/build/
-<shell-exe>/../_package/bin/
+<workspace-controller-exe>/../test_apps/*/build/
+<workspace-controller-exe>/../demos/*/build/
+<workspace-controller-exe>/../_package/bin/
 %PROGRAMFILES%\DisplayXR\apps\
 ```
 
@@ -149,7 +153,7 @@ For each sidecar-mode dir, the scanner enumerates `*.exe`. For each exe:
 
 **Dedup**: across all dirs, entries are deduplicated by case-insensitive `exe_path`. Discovery order above defines precedence — `%LOCALAPPDATA%` wins over `%ProgramData%`, which wins over the dev/Program-Files sidecar paths. Later duplicates are dropped silently.
 
-Manifest parse errors are logged to the shell log and the entry is dropped. Malformed manifests do not crash the scanner.
+Manifest parse errors are logged by the workspace controller and the entry is dropped. Malformed manifests do not crash the scanner.
 
 ## 6. Validation rules
 
@@ -164,7 +168,7 @@ The scanner rejects a manifest if any of the following are true:
 - `icon_3d` is specified but the file does not exist or is not a readable PNG/JPEG, or `icon` is not also set.
 - `icon_3d_layout` is specified but not one of the four allowed values.
 
-Rejected manifests are logged as warnings. The shell does not attempt to recover partial data.
+Rejected manifests are logged as warnings. The scanner does not attempt to recover partial data.
 
 ## 7. Example: minimal manifest
 
@@ -196,7 +200,7 @@ This is enough for the launcher to show a named tile. Without `icon` the tile re
 
 ## 9. Reusing the 2D icon as the Windows app icon
 
-The shell launcher renders `icon` as the tile face. The same image should also be the **embedded application icon** in the executable, so Windows uses it for the Start Menu, Desktop shortcut, and taskbar — i.e. the user sees the same icon whether they launch from the DisplayXR shell or from a regular Windows shortcut.
+A workspace controller's launcher renders `icon` as the tile face. The same image should also be the **embedded application icon** in the executable, so Windows uses it for the Start Menu, Desktop shortcut, and taskbar — i.e. the user sees the same icon whether they launch from a DisplayXR workspace controller or from a regular Windows shortcut.
 
 There is no DisplayXR plumbing for this — engines already embed an icon resource into the PE during build. Authors should configure both sides from a single source asset:
 
@@ -204,23 +208,27 @@ There is no DisplayXR plumbing for this — engines already embed an icon resour
 - **Unreal** — set the icon in *Project Settings → Platforms → Windows → Game Icon*. The DisplayXR Unreal plugin's manifest settings has a separate `icon` field that should reference the **same source asset**. Mismatch produces an editor warning.
 - **Native apps** — embed an `.ico` resource in your `.rc`/manifest the way you normally would, and point `icon` in the manifest at the corresponding `.png` next to your manifest.
 
-The shell does NOT extract icons from the PE for sidecar/registered manifests — it always reads the path in `icon`. The PE-icon-extraction path is only used by the **Browse for app…** flow when registering an arbitrary executable that does not already ship a manifest (see §11).
+A workspace controller does NOT extract icons from the PE for sidecar/registered manifests — it always reads the path in `icon`. PE-icon-extraction is only used by an **interactive browse-and-register flow** when the user adds an arbitrary executable that does not already ship a manifest. The DisplayXR Shell implements this flow as **Browse for app…** (see §11); other workspace controllers may implement equivalent flows differently or omit the feature entirely.
 
 ## 10. Versioning
 
-Breaking changes bump `schema_version`. The shell will refuse to parse manifests with a `schema_version` it does not understand, and log the unsupported version. Additive changes (new optional fields) keep `schema_version: 1`. The `exe_path` field added in this revision is additive — older shells that read a registered manifest will fall back to sidecar resolution (look for sibling exe, fail, skip the entry); they will never crash. Registered-mode manifests therefore require shell ≥ the version that introduced this field.
+Breaking changes bump `schema_version`. A workspace controller will refuse to parse manifests with a `schema_version` it does not understand, and log the unsupported version. Additive changes (new optional fields) keep `schema_version: 1`. The `exe_path` field added in this revision is additive — older controllers that read a registered manifest will fall back to sidecar resolution (look for sibling exe, fail, skip the entry); they will never crash. Registered-mode manifests therefore require a workspace controller ≥ the version that introduced this field.
 
-## 11. Browse-for-app and `registered_apps.json`
+## 11. Browse-for-app and registered-apps state cache (DisplayXR Shell reference implementation)
 
-`registered_apps.json` at `%LOCALAPPDATA%\DisplayXR\registered_apps.json` is the shell's **state cache** — saved window poses, MRU order, hide flags, and other per-tile UI state. It is **not** the source of truth for which apps exist; that role belongs entirely to manifests under §5's discovery dirs.
+This section describes the **DisplayXR Shell's** implementation of optional per-controller features that other workspace controllers may implement, omit, or replace. The manifest format itself is fixed by the spec; the state-cache filename, location, and Browse-for-app flow are *not* — they are reference-implementation choices.
 
-The launcher's **Browse for app…** entry registers an arbitrary executable by **writing a manifest** into `%LOCALAPPDATA%\DisplayXR\apps\`:
+`registered_apps.json` at `%LOCALAPPDATA%\DisplayXR\registered_apps.json` is the DisplayXR Shell's **state cache** — saved window poses, MRU order, hide flags, and other per-tile UI state. It is **not** the source of truth for which apps exist; that role belongs entirely to manifests under §5's discovery dirs. Other workspace controllers may use a different cache filename or skip persistence entirely.
+
+The DisplayXR Shell's launcher exposes a **Browse for app…** entry that registers an arbitrary executable by **writing a manifest** into `%LOCALAPPDATA%\DisplayXR\apps\`:
 
 1. The user picks an `.exe`.
 2. The shell extracts the embedded PE icon to `<sanitized_basename>.png` next to the new manifest. If extraction fails the manifest omits `icon`.
 3. The shell writes `<sanitized_basename>.displayxr.json` with `schema_version:1`, `name` derived from the exe basename, `type:"3d"`, `category:"app"`, `exe_path` set to the picked path, and `icon` if extraction succeeded.
 4. The scanner re-runs and the new manifest is picked up like any other registered entry.
 
-The launcher's "remove" action on a tile **deletes the manifest file** when it lives under `%LOCALAPPDATA%\DisplayXR\apps\` (per-user, no elevation needed) or `%ProgramData%\DisplayXR\apps\` (system-wide, may fail without elevation — falls back to hiding the tile via state cache). Sidecar manifests in dev paths are never deleted by the launcher; they are developer-owned.
+Because the manifest gets written into the ecosystem-standard discovery dir, **other workspace controllers will pick up the result** — Browse-for-app in the DisplayXR Shell registers the app for any compliant controller the user later runs.
 
-Developers should never edit `registered_apps.json` directly — edit the manifest and relaunch the shell.
+The DisplayXR Shell's "remove" action on a tile **deletes the manifest file** when it lives under `%LOCALAPPDATA%\DisplayXR\apps\` (per-user, no elevation needed) or `%ProgramData%\DisplayXR\apps\` (system-wide, may fail without elevation — falls back to hiding the tile via state cache). Sidecar manifests in dev paths are never deleted by the launcher; they are developer-owned.
+
+Developers should never edit `registered_apps.json` directly — edit the manifest and relaunch the workspace controller.

--- a/scripts/build_windows.bat
+++ b/scripts/build_windows.bat
@@ -333,9 +333,9 @@ if exist "%PKG%\bin\displayxr-webxr-bridge.exe" (
 > "%PKG%\run_shell_app.bat" (
     echo @echo off
     echo set "XR_RUNTIME_JSON=%RT_JSON%"
-    echo set "DISPLAYXR_SHELL_SESSION=1"
+    echo set "DISPLAYXR_WORKSPACE_SESSION=1"
     echo echo XR_RUNTIME_JSON=%%XR_RUNTIME_JSON%%
-    echo echo DISPLAYXR_SHELL_SESSION=%%DISPLAYXR_SHELL_SESSION%%
+    echo echo DISPLAYXR_WORKSPACE_SESSION=%%DISPLAYXR_WORKSPACE_SESSION%%
     echo if "%%~1"=="" (
     echo     "%REPO%test_apps\cube_handle_d3d11_win\build\cube_handle_d3d11_win.exe"
     echo ^) else (
@@ -347,11 +347,11 @@ if exist "%PKG%\bin\displayxr-webxr-bridge.exe" (
 > "%PKG%\run_shell_2apps.bat" (
     echo @echo off
     echo set "XR_RUNTIME_JSON=%RT_JSON%"
-    echo set "DISPLAYXR_SHELL_SESSION=1"
+    echo set "DISPLAYXR_WORKSPACE_SESSION=1"
     echo echo Starting two shell apps...
-    echo start "" cmd /c "set XR_RUNTIME_JSON=%RT_JSON%^&^& set DISPLAYXR_SHELL_SESSION=1^&^& "%REPO%test_apps\cube_handle_d3d11_win\build\cube_handle_d3d11_win.exe""
+    echo start "" cmd /c "set XR_RUNTIME_JSON=%RT_JSON%^&^& set DISPLAYXR_WORKSPACE_SESSION=1^&^& "%REPO%test_apps\cube_handle_d3d11_win\build\cube_handle_d3d11_win.exe""
     echo timeout /t 3 /nobreak ^>nul
-    echo start "" cmd /c "set XR_RUNTIME_JSON=%RT_JSON%^&^& set DISPLAYXR_SHELL_SESSION=1^&^& "%REPO%test_apps\cube_handle_d3d11_win\build\cube_handle_d3d11_win.exe""
+    echo start "" cmd /c "set XR_RUNTIME_JSON=%RT_JSON%^&^& set DISPLAYXR_WORKSPACE_SESSION=1^&^& "%REPO%test_apps\cube_handle_d3d11_win\build\cube_handle_d3d11_win.exe""
     echo echo Both apps launched. Press any key to exit.
     echo pause ^>nul
 )

--- a/src/xrt/auxiliary/util/u_sandbox.c
+++ b/src/xrt/auxiliary/util/u_sandbox.c
@@ -122,10 +122,10 @@ u_sandbox_should_use_ipc(void)
 		U_LOG_W("Unknown XRT_FORCE_MODE value '%s', using automatic detection", force_mode);
 	}
 
-	// Shell session: app launched by shell with hidden HWND, route to IPC
-	const char *shell_session = getenv("DISPLAYXR_SHELL_SESSION");
-	if (shell_session != NULL && strcmp(shell_session, "1") == 0) {
-		U_LOG_I("DISPLAYXR_SHELL_SESSION=1: forcing IPC mode for shell");
+	// Workspace session: app launched by workspace controller with hidden HWND, route to IPC
+	const char *workspace_session = getenv("DISPLAYXR_WORKSPACE_SESSION");
+	if (workspace_session != NULL && strcmp(workspace_session, "1") == 0) {
+		U_LOG_I("DISPLAYXR_WORKSPACE_SESSION=1: forcing IPC mode for workspace controller");
 		return true;
 	}
 

--- a/src/xrt/compositor/d3d11/comp_d3d11_window.cpp
+++ b/src/xrt/compositor/d3d11/comp_d3d11_window.cpp
@@ -807,7 +807,7 @@ wnd_proc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 		if (GetOpenFileNameA(&ofn)) {
 			// Set shell session env var and ensure XR_RUNTIME_JSON points to
 			// the dev build runtime (matching the running service).
-			SetEnvironmentVariableA("DISPLAYXR_SHELL_SESSION", "1");
+			SetEnvironmentVariableA("DISPLAYXR_WORKSPACE_SESSION", "1");
 			if (getenv("XR_RUNTIME_JSON") == NULL) {
 				// Use dev build manifest (has absolute path to DLL).
 				// Service is at _package/bin/, dev manifest is at build/Release/.

--- a/src/xrt/compositor/d3d11/comp_d3d11_window.h
+++ b/src/xrt/compositor/d3d11/comp_d3d11_window.h
@@ -324,7 +324,7 @@ comp_d3d11_window_request_foreground(struct comp_d3d11_window *window,
  * Request the window thread to open a file dialog and launch an app.
  *
  * The file dialog runs on the window thread (modal, blocks message pump).
- * On success, launches the selected .exe with DISPLAYXR_SHELL_SESSION=1
+ * On success, launches the selected .exe with DISPLAYXR_WORKSPACE_SESSION=1
  * and XR_RUNTIME_JSON set. The app connects via IPC automatically.
  *
  * @param window The window object

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -487,10 +487,10 @@ struct d3d11_service_system
 	uint32_t last_3d_mode_index;
 
 	//! Shell mode: multi-compositor with shared window for all clients.
-	//! Read from base.info.shell_mode on first client connect.
-	bool shell_mode;
+	//! Read from base.info.workspace_mode on first client connect.
+	bool workspace_mode;
 
-	//! Multi-compositor (NULL when shell_mode is false).
+	//! Multi-compositor (NULL when workspace_mode is false).
 	struct d3d11_multi_compositor *multi_comp;
 
 	//! Mutex for multi-compositor render (serializes D3D11 context access).
@@ -700,7 +700,7 @@ struct d3d11_multi_client_slot
 /*!
  * Multi-compositor: shared window + DP that composites all client atlases.
  *
- * Created lazily on first client layer_commit when shell_mode is true.
+ * Created lazily on first client layer_commit when workspace_mode is true.
  */
 struct d3d11_multi_compositor
 {
@@ -912,13 +912,13 @@ d3d11_service_semaphore_from_xrt(struct xrt_compositor_semaphore *xcsem)
 	return reinterpret_cast<struct d3d11_service_semaphore *>(xcsem);
 }
 
-// Write sys->shell_mode and mirror the flag onto the multi-comp window so
+// Write sys->workspace_mode and mirror the flag onto the multi-comp window so
 // its WndProc's ESC-close path can distinguish empty-shell (no focused app)
 // from true non-shell mode — see comp_d3d11_window.cpp ESC handling.
 static inline void
-service_set_shell_mode(struct d3d11_service_system *sys, bool active)
+service_set_workspace_mode(struct d3d11_service_system *sys, bool active)
 {
-	sys->shell_mode = active;
+	sys->workspace_mode = active;
 	if (sys->multi_comp != nullptr && sys->multi_comp->window != nullptr) {
 		comp_d3d11_window_set_shell_mode_active(sys->multi_comp->window, active);
 	}
@@ -1983,7 +1983,7 @@ init_client_render_resources(struct d3d11_service_system *sys,
 	// Shell mode: only create atlas texture. No window, swap chain, or DP.
 	// The multi-compositor owns those shared resources.
 	// Atlas sized to native display (app HWND is fullscreen, renders at native * scale).
-	if (sys->shell_mode) {
+	if (sys->workspace_mode) {
 		uint32_t atlas_w = sys->base.info.display_pixel_width;
 		uint32_t atlas_h = sys->base.info.display_pixel_height;
 		if (atlas_w == 0 || atlas_h == 0) {
@@ -2182,7 +2182,7 @@ init_client_render_resources(struct d3d11_service_system *sys,
 	// creating a SECOND DP instance causes the SR SDK to recalibrate its
 	// weaver, producing a multi-second stretched-left-eye artifact. The
 	// per-client DP is only needed for standalone (non-shell) rendering.
-	if (sys->base.info.dp_factory_d3d11 != NULL && !sys->shell_mode) {
+	if (sys->base.info.dp_factory_d3d11 != NULL && !sys->workspace_mode) {
 		auto factory = (xrt_dp_factory_d3d11_fn_t)sys->base.info.dp_factory_d3d11;
 		xrt_result_t dp_ret = factory(sys->device.get(), sys->context.get(), res->hwnd, &res->display_processor);
 		if (dp_ret != XRT_SUCCESS) {
@@ -4312,9 +4312,9 @@ multi_compositor_ensure_output(struct d3d11_service_system *sys)
 	}
 	mc->hwnd = (HWND)comp_d3d11_window_get_hwnd(mc->window);
 	sys->compositor_hwnd = mc->hwnd;
-	// Seed the window's shell-mode flag from current sys state (service_set_shell_mode
+	// Seed the window's shell-mode flag from current sys state (service_set_workspace_mode
 	// no-ops while multi_comp is null, so earlier activation hasn't reached the window).
-	comp_d3d11_window_set_shell_mode_active(mc->window, sys->shell_mode);
+	comp_d3d11_window_set_shell_mode_active(mc->window, sys->workspace_mode);
 
 	if (sys->xsysd != nullptr) {
 		comp_d3d11_window_set_system_devices(mc->window, sys->xsysd);
@@ -4583,7 +4583,7 @@ multi_compositor_ensure_output(struct d3d11_service_system *sys)
 				}
 				mc->hwnd = (HWND)comp_d3d11_window_get_hwnd(mc->window);
 				sys->compositor_hwnd = mc->hwnd;
-				comp_d3d11_window_set_shell_mode_active(mc->window, sys->shell_mode);
+				comp_d3d11_window_set_shell_mode_active(mc->window, sys->workspace_mode);
 
 				if (sys->xsysd != nullptr) {
 					comp_d3d11_window_set_system_devices(mc->window, sys->xsysd);
@@ -5729,12 +5729,12 @@ multi_compositor_render(struct d3d11_service_system *sys)
 	// not the old permanent dismiss. The shell can re-activate via Ctrl+Space.
 	if (mc->window != nullptr && !comp_d3d11_window_is_valid(mc->window)) {
 		U_LOG_W("Multi-comp: window closed (ESC) — deactivating shell");
-		// Set shell_mode flags to false so the shell process detects the change
-		service_set_shell_mode(sys, false);
-		sys->base.info.shell_mode = false;
+		// Set workspace_mode flags to false so the shell process detects the change
+		service_set_workspace_mode(sys, false);
+		sys->base.info.workspace_mode = false;
 		// Run the full deactivate path (capture teardown, DP release, etc.)
 		// We need to recreate the window on resume since it was destroyed by ESC,
-		// so use the dismissed path which ensure_shell_window handles.
+		// so use the dismissed path which ensure_workspace_window handles.
 		mc->window_dismissed = true;
 		// Switch display back to 2D (lens off)
 		if (mc->display_processor != nullptr) {
@@ -9091,7 +9091,7 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 	// each frame, so previous content is a safe fallback. Clearing to black here
 	// creates a race: if multi_compositor_render reads this atlas between the clear
 	// and the blit, the window flashes black.
-	if (c->render.atlas_rtv && !sys->shell_mode) {
+	if (c->render.atlas_rtv && !sys->workspace_mode) {
 		float clear_color[4] = {0.0f, 0.0f, 0.0f, 1.0f};
 		sys->context->ClearRenderTargetView(c->render.atlas_rtv.get(), clear_color);
 	}
@@ -9124,7 +9124,7 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 				// Toggle DP 2D/3D
 				bool want_3d = head->rendering_modes[modeIdx].hardware_display_3d;
 				struct xrt_display_processor_d3d11 *dp = nullptr;
-				if (sys->shell_mode && sys->multi_comp != nullptr)
+				if (sys->workspace_mode && sys->multi_comp != nullptr)
 					dp = sys->multi_comp->display_processor;
 				else if (c->render.display_processor != nullptr)
 					dp = c->render.display_processor;
@@ -9168,7 +9168,7 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 			// Switch display mode on the active DP.
 			// In shell mode, the multi-comp owns the DP (per-client has none).
 			struct xrt_display_processor_d3d11 *dp = nullptr;
-			if (sys->shell_mode && sys->multi_comp != nullptr) {
+			if (sys->workspace_mode && sys->multi_comp != nullptr) {
 				dp = sys->multi_comp->display_processor;
 			} else if (c->render.display_processor != nullptr) {
 				dp = c->render.display_processor;
@@ -9200,7 +9200,7 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 	// This detects changes the vendor SDK made independently of the runtime.
 	{
 		struct xrt_display_processor_d3d11 *dp = nullptr;
-		if (sys->shell_mode && sys->multi_comp != nullptr) {
+		if (sys->workspace_mode && sys->multi_comp != nullptr) {
 			dp = sys->multi_comp->display_processor;
 		} else if (c->render.display_processor != nullptr) {
 			dp = c->render.display_processor;
@@ -9445,7 +9445,7 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 		// Skip the blit and pass the app's texture directly to the display processor.
 		bool zero_copy = false;
 
-		if (proj_view_count > 1 && !has_ui_layers && !any_mutex_acquired && !sys->shell_mode) {
+		if (proj_view_count > 1 && !has_ui_layers && !any_mutex_acquired && !sys->workspace_mode) {
 			// Check all views reference the same swapchain image
 			bool all_same = true;
 			for (uint32_t eye = 1; eye < proj_view_count; eye++) {
@@ -9609,8 +9609,8 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 			//     would double-handle gamma.
 			bool can_shader_blit = sys->blit_vs &&
 			    view_scs[eye]->images[view_img_indices[eye]].srv;
-			bool use_srgb_shader = can_shader_blit && view_is_srgb[eye] && !sys->shell_mode;
-			bool use_scale_shader = can_shader_blit && needs_scale && sys->shell_mode;
+			bool use_srgb_shader = can_shader_blit && view_is_srgb[eye] && !sys->workspace_mode;
+			bool use_scale_shader = can_shader_blit && needs_scale && sys->workspace_mode;
 
 			if (use_srgb_shader) {
 				// Non-shell SRGB: shader blit with SRGB SRV for linearization.
@@ -9718,7 +9718,7 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 		// visible as a narrow black rectangle that jumps to full size when
 		// the first frame lands. Mirrors the capture-client `capture_srv`
 		// readiness gate.
-		if (sys->shell_mode && sys->multi_comp != nullptr) {
+		if (sys->workspace_mode && sys->multi_comp != nullptr) {
 			for (int s = 0; s < D3D11_MULTI_MAX_CLIENTS; s++) {
 				if (sys->multi_comp->clients[s].active &&
 				    sys->multi_comp->clients[s].compositor == c) {
@@ -9885,7 +9885,7 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 		U_LOG_W("Reverse hot-switch: done — back to export mode");
 	}
 
-	if (sys->shell_mode) {
+	if (sys->workspace_mode) {
 		// Throttle renders to ~1 per VSync (~14ms). With N clients each calling
 		// layer_commit at 60fps, we'd otherwise render N times per frame cycle.
 		// Throttling reduces the chance of reading a client's atlas mid-blit.
@@ -9901,12 +9901,12 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 	}
 
 	// --- Lazy standalone init (hot-switch from shell → standalone) ---
-	// Shell was deactivated: shell_mode is false but this client was created
+	// Shell was deactivated: workspace_mode is false but this client was created
 	// in shell mode (no swap chain, no DP). Create standalone resources now,
 	// on the app's own IPC thread — safe from WM deadlocks.
 	if (!c->render.swap_chain) {
-		U_LOG_W("Hot-switch check: swap_chain=NULL, app_hwnd=%p, shell_mode=%d",
-		        (void *)c->app_hwnd, sys->shell_mode);
+		U_LOG_W("Hot-switch check: swap_chain=NULL, app_hwnd=%p, workspace_mode=%d",
+		        (void *)c->app_hwnd, sys->workspace_mode);
 	}
 	if (!c->render.swap_chain && c->app_hwnd != nullptr && IsWindow(c->app_hwnd)) {
 		U_LOG_W("Hot-switch: lazy standalone init for HWND=%p", (void *)c->app_hwnd);
@@ -10237,8 +10237,8 @@ system_create_native_compositor(struct xrt_system_compositor *xsysc,
 	if (!is_headless_relay) {
 		// Activate shell mode from system compositor info (set by ipc_server_process.c
 		// after init_all, before any client connects)
-		if (sys->base.info.shell_mode && !sys->shell_mode) {
-			service_set_shell_mode(sys, true);
+		if (sys->base.info.workspace_mode && !sys->workspace_mode) {
+			service_set_workspace_mode(sys, true);
 			U_LOG_W("Shell mode activated for D3D11 service system");
 		}
 
@@ -10258,7 +10258,7 @@ system_create_native_compositor(struct xrt_system_compositor *xsysc,
 	// can occlude the launcher when the user summons it post-exit.
 	// compositor_destroy's unregister call is already a no-op on a
 	// never-registered compositor (its loop won't find a matching slot).
-	if (sys->shell_mode && !is_headless_relay) {
+	if (sys->workspace_mode && !is_headless_relay) {
 		// Ensure multi_comp struct exists for registration
 		// Eagerly create multi-comp output (window + DP) on first client connect.
 		// This ensures the DP is available for ipc_try_get_sr_view_poses
@@ -10756,7 +10756,7 @@ comp_d3d11_service_get_predicted_eye_positions(struct xrt_system_compositor *xsy
 	// In shell mode, use the multi-comp's DP (per-client compositors have no DP).
 	// In normal mode, use the active compositor's DP.
 	struct xrt_display_processor_d3d11 *dp = nullptr;
-	if (sys->shell_mode && sys->multi_comp != nullptr) {
+	if (sys->workspace_mode && sys->multi_comp != nullptr) {
 		dp = sys->multi_comp->display_processor;
 	}
 	if (dp == nullptr) {
@@ -10931,7 +10931,7 @@ comp_d3d11_service_get_display_dimensions(struct xrt_system_compositor *xsysc,
 	// Try to get display dimensions from display processor.
 	// In shell mode, use multi-comp's DP; in normal mode, use active compositor's DP.
 	struct xrt_display_processor_d3d11 *dp = nullptr;
-	if (sys->shell_mode && sys->multi_comp != nullptr) {
+	if (sys->workspace_mode && sys->multi_comp != nullptr) {
 		dp = sys->multi_comp->display_processor;
 	}
 	if (dp == nullptr) {
@@ -10976,7 +10976,7 @@ comp_d3d11_service_get_window_metrics(struct xrt_system_compositor *xsysc,
 	struct xrt_display_processor_d3d11 *dp = nullptr;
 	HWND metrics_hwnd = nullptr;
 
-	if (sys->shell_mode && sys->multi_comp != nullptr &&
+	if (sys->workspace_mode && sys->multi_comp != nullptr &&
 	    sys->multi_comp->display_processor != nullptr && sys->multi_comp->hwnd != nullptr) {
 		dp = sys->multi_comp->display_processor;
 		metrics_hwnd = sys->multi_comp->hwnd;
@@ -11378,7 +11378,7 @@ comp_d3d11_service_set_client_window_pose(struct xrt_system_compositor *xsysc,
 	}
 
 	struct d3d11_service_system *sys = d3d11_service_system_from_xrt(xsysc);
-	if (!sys->shell_mode || sys->multi_comp == nullptr) {
+	if (!sys->workspace_mode || sys->multi_comp == nullptr) {
 		return false;
 	}
 
@@ -11427,7 +11427,7 @@ comp_d3d11_service_set_client_visibility(struct xrt_system_compositor *xsysc,
 	if (xsysc == nullptr || xc == nullptr) return false;
 
 	struct d3d11_service_system *sys = d3d11_service_system_from_xrt(xsysc);
-	if (!sys->shell_mode || sys->multi_comp == nullptr) return false;
+	if (!sys->workspace_mode || sys->multi_comp == nullptr) return false;
 
 	struct d3d11_service_compositor *c = d3d11_service_compositor_from_xrt(xc);
 	struct d3d11_multi_compositor *mc = sys->multi_comp;
@@ -11463,7 +11463,7 @@ comp_d3d11_service_get_client_window_pose(struct xrt_system_compositor *xsysc,
 	if (xsysc == nullptr || xc == nullptr) return false;
 
 	struct d3d11_service_system *sys = d3d11_service_system_from_xrt(xsysc);
-	if (!sys->shell_mode || sys->multi_comp == nullptr) return false;
+	if (!sys->workspace_mode || sys->multi_comp == nullptr) return false;
 
 	struct d3d11_service_compositor *c = d3d11_service_compositor_from_xrt(xc);
 	struct d3d11_multi_compositor *mc = sys->multi_comp;
@@ -11492,7 +11492,7 @@ comp_d3d11_service_get_client_window_metrics(struct xrt_system_compositor *xsysc
 	}
 
 	struct d3d11_service_system *sys = d3d11_service_system_from_xrt(xsysc);
-	if (!sys->shell_mode || sys->multi_comp == nullptr) {
+	if (!sys->workspace_mode || sys->multi_comp == nullptr) {
 		out_metrics->valid = false;
 		return false;
 	}
@@ -11562,7 +11562,7 @@ comp_d3d11_service_owns_window(struct xrt_system_compositor *xsysc)
 	// Returning false ensures the IPC view pose path uses the display-centric
 	// Kooima with real DP eye tracking, not the camera-centric qwerty path.
 	struct d3d11_service_system *sys = d3d11_service_system_from_xrt(xsysc);
-	if (sys->shell_mode) {
+	if (sys->workspace_mode) {
 		return false;
 	}
 
@@ -11612,14 +11612,14 @@ comp_d3d11_service_add_capture_client(struct xrt_system_compositor *xsysc,
 
 	struct d3d11_service_system *sys = d3d11_service_system_from_xrt(xsysc);
 
-	// Activate shell_mode from base.info if not already done.
+	// Activate workspace_mode from base.info if not already done.
 	// Normally this happens on first IPC client connect, but capture
 	// clients may arrive before any IPC client.
-	if (!sys->shell_mode && sys->base.info.shell_mode) {
-		service_set_shell_mode(sys, true);
+	if (!sys->workspace_mode && sys->base.info.workspace_mode) {
+		service_set_workspace_mode(sys, true);
 		U_LOG_W("Shell mode activated for D3D11 service system (via capture client)");
 	}
-	if (!sys->shell_mode) {
+	if (!sys->workspace_mode) {
 		U_LOG_E("Shell: add_capture_client — shell mode not active");
 		return -1;
 	}
@@ -11652,7 +11652,7 @@ comp_d3d11_service_remove_capture_client(struct xrt_system_compositor *xsysc,
 	}
 
 	struct d3d11_service_system *sys = d3d11_service_system_from_xrt(xsysc);
-	if (!sys->shell_mode || sys->multi_comp == nullptr) {
+	if (!sys->workspace_mode || sys->multi_comp == nullptr) {
 		return false;
 	}
 
@@ -11672,7 +11672,7 @@ comp_d3d11_service_set_capture_client_window_pose(struct xrt_system_compositor *
 	}
 
 	struct d3d11_service_system *sys = d3d11_service_system_from_xrt(xsysc);
-	if (!sys->shell_mode || sys->multi_comp == nullptr) {
+	if (!sys->workspace_mode || sys->multi_comp == nullptr) {
 		return false;
 	}
 
@@ -11716,7 +11716,7 @@ comp_d3d11_service_get_capture_client_window_pose(struct xrt_system_compositor *
 	}
 
 	struct d3d11_service_system *sys = d3d11_service_system_from_xrt(xsysc);
-	if (!sys->shell_mode || sys->multi_comp == nullptr) {
+	if (!sys->workspace_mode || sys->multi_comp == nullptr) {
 		return false;
 	}
 
@@ -11739,16 +11739,16 @@ comp_d3d11_service_get_capture_client_window_pose(struct xrt_system_compositor *
 }
 
 bool
-comp_d3d11_service_ensure_shell_window(struct xrt_system_compositor *xsysc)
+comp_d3d11_service_ensure_workspace_window(struct xrt_system_compositor *xsysc)
 {
 	if (xsysc == nullptr) {
 		return false;
 	}
 
 	struct d3d11_service_system *sys = d3d11_service_system_from_xrt(xsysc);
-	if (!sys->shell_mode) {
-		service_set_shell_mode(sys, true);
-		U_LOG_W("Shell mode activated for D3D11 service system (via ensure_shell_window)");
+	if (!sys->workspace_mode) {
+		service_set_workspace_mode(sys, true);
+		U_LOG_W("Shell mode activated for D3D11 service system (via ensure_workspace_window)");
 	}
 
 	std::lock_guard<std::recursive_mutex> lock(sys->render_mutex);
@@ -11760,7 +11760,7 @@ comp_d3d11_service_ensure_shell_window(struct xrt_system_compositor *xsysc)
 		U_LOG_W("Shell: resuming from suspended state");
 
 		mc->suspended = false;
-		service_set_shell_mode(sys, true);
+		service_set_workspace_mode(sys, true);
 
 		// Reverse hot-switch is LAZY: just flag each client compositor.
 		// Each client's next layer_commit will tear down its own DP and
@@ -11851,7 +11851,7 @@ comp_d3d11_service_ensure_shell_window(struct xrt_system_compositor *xsysc)
 }
 
 void
-comp_d3d11_service_deactivate_shell(struct xrt_system_compositor *xsysc)
+comp_d3d11_service_deactivate_workspace(struct xrt_system_compositor *xsysc)
 {
 	if (xsysc == nullptr) {
 		return;
@@ -11880,9 +11880,9 @@ comp_d3d11_service_deactivate_shell(struct xrt_system_compositor *xsysc)
 
 		U_LOG_W("Shell deactivate: beginning teardown");
 
-		// Clear the compositor's local shell_mode flag so layer_commit
+		// Clear the compositor's local workspace_mode flag so layer_commit
 		// takes the standalone path instead of the (now suspended) multi-comp.
-		service_set_shell_mode(sys, false);
+		service_set_workspace_mode(sys, false);
 
 	// --- 4C.2: Stop all capture sessions and restore 2D windows ---
 	for (int i = 0; i < D3D11_MULTI_MAX_CLIENTS; i++) {
@@ -11916,7 +11916,7 @@ comp_d3d11_service_deactivate_shell(struct xrt_system_compositor *xsysc)
 	// --- 4C.3: IPC clients hot-switch to standalone (lazy) ---
 	// Don't create resources here — that deadlocks (DXGI sends WM to app thread
 	// which is blocked on IPC). Instead, just suspend the multi-comp.
-	// Each app's next layer_commit detects shell_mode=false and lazily creates
+	// Each app's next layer_commit detects workspace_mode=false and lazily creates
 	// its own swap chain + DP on its own thread (no cross-thread WM).
 
 		// Reset drag/focus state
@@ -12128,7 +12128,7 @@ comp_d3d11_service_apply_layout_preset(struct xrt_system_compositor *xsysc,
 	std::lock_guard<std::recursive_mutex> lock(sys->render_mutex);
 
 	struct d3d11_multi_compositor *mc = sys->multi_comp;
-	if (mc == nullptr || !sys->shell_mode) {
+	if (mc == nullptr || !sys->workspace_mode) {
 		return false;
 	}
 
@@ -12156,7 +12156,7 @@ comp_d3d11_service_poll_mcp_capture(struct xrt_system_compositor *xsysc)
 		return;
 	}
 	struct d3d11_service_system *sys = d3d11_service_system_from_xrt(xsysc);
-	if (!sys->shell_mode || sys->multi_comp == nullptr) {
+	if (!sys->workspace_mode || sys->multi_comp == nullptr) {
 		return;
 	}
 

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -327,13 +327,13 @@ struct d3d11_service_system
 	//! Phase 5.8: spatial launcher app registry, pushed from the shell
 	//! process via clear+add IPC calls. Lives on the service (not the
 	//! multi-comp) so it survives multi-comp create/destroy cycles —
-	//! the shell can push at any time, even before shell_activate.
+	//! the shell can push at any time, even before workspace_activate.
 	struct ipc_launcher_app launcher_apps[IPC_LAUNCHER_MAX_APPS];
 	uint32_t launcher_app_count;
 
 	//! Phase 5.9/5.10: pending launcher tile click. Set by the WM_LBUTTONDOWN
 	//! handler when the user clicks a tile, consumed by the shell via
-	//! ipc_call_shell_poll_launcher_click(). -1 means no pending click.
+	//! ipc_call_launcher_poll_click(). -1 means no pending click.
 	//! Also carries IPC_LAUNCHER_ACTION_BROWSE for the Browse tile.
 	//! Phase 6.6: also carries IPC_LAUNCHER_ACTION_REMOVE + the removed
 	//! tile's full index in pending_launcher_remove_full_index.
@@ -744,7 +744,7 @@ struct d3d11_multi_compositor
 	bool suspended;
 
 	//! Phase 5.7: spatial launcher panel visible.
-	//! Toggled by Ctrl+L via ipc_call_shell_set_launcher_visible. When true, the
+	//! Toggled by Ctrl+L via ipc_call_launcher_set_visible. When true, the
 	//! render loop draws a rounded-corner panel at the zero-disparity plane.
 	//! The app list it renders lives on d3d11_service_system (sys->launcher_apps).
 	bool launcher_visible;

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.h
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.h
@@ -300,7 +300,7 @@ comp_d3d11_service_get_capture_client_window_pose(struct xrt_system_compositor *
 
 /*!
  * Eagerly create the shell compositor window (for empty shell startup).
- * Called after shell_activate when no clients are connected yet, so the
+ * Called after workspace_activate when no clients are connected yet, so the
  * window exists to receive Ctrl+O app launch requests.
  */
 bool
@@ -309,7 +309,7 @@ comp_d3d11_service_ensure_shell_window(struct xrt_system_compositor *xsysc);
 /*!
  * Deactivate the shell: stop captures and restore 2D windows, suspend
  * multi-compositor (hide window, release DP, stop render loop).
- * Called by ipc_handle_shell_deactivate().
+ * Called by ipc_handle_workspace_deactivate().
  *
  * @param xsysc The system compositor (must be D3D11 service in shell mode).
  *
@@ -322,7 +322,7 @@ comp_d3d11_service_deactivate_shell(struct xrt_system_compositor *xsysc);
  * Show or hide the spatial launcher panel. When visible, the multi-compositor
  * draws a rounded-corner launcher overlay at the zero-disparity plane
  * (z = 0 in display coordinates). Called by
- * ipc_handle_shell_set_launcher_visible() in response to Ctrl+L from the shell.
+ * ipc_handle_launcher_set_visible() in response to Ctrl+L from the shell.
  *
  * No-op if the shell is not currently active.
  *

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.h
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.h
@@ -215,7 +215,7 @@ comp_d3d11_service_get_client_window_pose(struct xrt_system_compositor *xsysc,
  * an MCP agent can trigger the same layouts an interactive user gets.
  *
  * @return true on success, false if the preset name is unknown or the
- *         compositor is not in shell mode.
+ *         compositor is not in workspace mode.
  */
 bool
 comp_d3d11_service_apply_layout_preset(struct xrt_system_compositor *xsysc,
@@ -233,7 +233,7 @@ comp_d3d11_service_apply_layout_preset(struct xrt_system_compositor *xsysc,
  * Starts Windows.Graphics.Capture for the given HWND and assigns a slot.
  * The captured window is displayed as a mono textured quad with spatial parallax.
  *
- * @param xsysc      The system compositor (must be D3D11 service in shell mode).
+ * @param xsysc      The system compositor (must be D3D11 service in workspace mode).
  * @param hwnd_value  Window handle as uint64_t (cast from HWND).
  * @param name        Display name for the captured window (may be NULL).
  * @return Slot index (0-7) on success, -1 on failure.
@@ -304,19 +304,19 @@ comp_d3d11_service_get_capture_client_window_pose(struct xrt_system_compositor *
  * window exists to receive Ctrl+O app launch requests.
  */
 bool
-comp_d3d11_service_ensure_shell_window(struct xrt_system_compositor *xsysc);
+comp_d3d11_service_ensure_workspace_window(struct xrt_system_compositor *xsysc);
 
 /*!
  * Deactivate the shell: stop captures and restore 2D windows, suspend
  * multi-compositor (hide window, release DP, stop render loop).
  * Called by ipc_handle_workspace_deactivate().
  *
- * @param xsysc The system compositor (must be D3D11 service in shell mode).
+ * @param xsysc The system compositor (must be D3D11 service in workspace mode).
  *
  * @ingroup comp_d3d11_service
  */
 void
-comp_d3d11_service_deactivate_shell(struct xrt_system_compositor *xsysc);
+comp_d3d11_service_deactivate_workspace(struct xrt_system_compositor *xsysc);
 
 /*!
  * Show or hide the spatial launcher panel. When visible, the multi-compositor

--- a/src/xrt/drivers/qwerty/qwerty_device.c
+++ b/src/xrt/drivers/qwerty/qwerty_device.c
@@ -668,9 +668,9 @@ qwerty_system_create(struct qwerty_hmd *qhmd,
 		// the virtual HMD, but wrong for desktop 3D displays where the
 		// user sits ~nominal_viewer_z (positive = in front of display,
 		// matching the oxr_session fallback eye placement convention).
-		// Legacy Chrome WebXR in shell mode compounded its own scene
+		// Legacy Chrome WebXR in workspace mode compounded its own scene
 		// origin with the (0, 1.6, 0) default and placed content
-		// mispositioned relative to the shell window.
+		// mispositioned relative to the workspace window.
 		if (qs->nominal_viewer_z > 0.0f) {
 			qhmd->base.pose.position.x = 0.0f;
 			qhmd->base.pose.position.y = 1.6f;

--- a/src/xrt/drivers/qwerty/qwerty_win32.c
+++ b/src/xrt/drivers/qwerty/qwerty_win32.c
@@ -555,7 +555,7 @@ qwerty_process_win32(struct xrt_device **xdevs,
 				qwerty_reset_view_state(qsys);
 			break;
 
-		// ESC: no-op in shell mode. Shell lifecycle is controlled by
+		// ESC: no-op in workspace mode. Workspace lifecycle is controlled by
 		// Ctrl+Space (system hotkey) and the tray icon, not ESC.
 		case VK_ESCAPE:
 			break;

--- a/src/xrt/include/xrt/xrt_compositor.h
+++ b/src/xrt/include/xrt/xrt_compositor.h
@@ -2503,7 +2503,7 @@ struct xrt_system_compositor_info
 
 	//! Shell mode: multi-compositor with shared window for all clients.
 	//! Set by the IPC server when --shell flag is used. Server-side only.
-	bool shell_mode;
+	bool workspace_mode;
 
 	//! Bitmask of supported eye tracking modes (MANAGED_BIT=1, MANUAL_BIT=2). 0 = no tracking.
 	uint32_t supported_eye_tracking_modes;

--- a/src/xrt/include/xrt/xrt_results.h
+++ b/src/xrt/include/xrt/xrt_results.h
@@ -231,4 +231,11 @@ typedef enum xrt_result
 	 * The IPC server couldn't starts it mainloop.
 	 */
 	XRT_ERROR_IPC_MAINLOOP_FAILED_TO_INIT = -38,
+
+	/*!
+	 * The caller is not authorized to perform the requested operation. Used
+	 * for IPC requests like `workspace_activate` that are only valid for the
+	 * orchestrator-spawned workspace controller.
+	 */
+	XRT_ERROR_NOT_AUTHORIZED = -39,
 } xrt_result_t;

--- a/src/xrt/ipc/server/ipc_server.h
+++ b/src/xrt/ipc/server/ipc_server.h
@@ -546,6 +546,25 @@ xrt_result_t
 ipc_server_get_system_properties(struct ipc_server *vs, struct xrt_system_properties *out_properties);
 //! @}
 
+/*!
+ * Function pointer the IPC server calls to learn the PID of the
+ * orchestrator-spawned workspace controller, for `workspace_activate`
+ * authentication. Returns 0 if no orchestrator-managed workspace is
+ * running (= manual mode → first-claim wins).
+ */
+typedef unsigned long (*ipc_server_workspace_pid_provider_fn)(void);
+
+/*!
+ * Register the workspace-PID provider. The standalone service registers
+ * this from main() after orchestrator init. Other consumers of ipc_server
+ * (sdl_test, the Android service module) that don't run an orchestrator
+ * leave it unset — workspace_activate then operates in manual mode.
+ *
+ * Pass NULL to clear the registration (e.g. on shutdown).
+ */
+void
+ipc_server_set_workspace_pid_provider(ipc_server_workspace_pid_provider_fn fn);
+
 /*
  *
  * Helpers

--- a/src/xrt/ipc/server/ipc_server.h
+++ b/src/xrt/ipc/server/ipc_server.h
@@ -407,7 +407,7 @@ struct ipc_server
 	enum u_logging_level log_level;
 
 	//! Shell mode: multi-compositor with shared window for all clients.
-	bool shell_mode;
+	bool workspace_mode;
 
 	struct ipc_thread threads[IPC_MAX_CLIENTS];
 

--- a/src/xrt/ipc/server/ipc_server_handler.c
+++ b/src/xrt/ipc/server/ipc_server_handler.c
@@ -319,9 +319,10 @@ ipc_try_get_sr_view_poses(volatile struct ipc_client_state *ics,
 	// mode (intentional — it suppresses qwerty for shell-self rendering).
 	// Here we re-enable qwerty on a per-session basis.
 	bool workspace_mode = s->xsysc != NULL && s->xsysc->info.workspace_mode;
+	unsigned long workspace_pid = get_orchestrator_workspace_pid();
 	bool is_workspace_controller_session =
-	    ics->client_state.info.application_name[0] != '\0' &&
-	    strcmp((const char *)ics->client_state.info.application_name, "displayxr-shell") == 0;
+	    workspace_pid != 0 &&
+	    (unsigned long)ics->client_state.pid == workspace_pid;
 	bool is_appcontainer_app =
 	    ics->client_state.info.ext_win32_appcontainer_compatible_enabled;
 	bool use_qwerty_head = compositor_owns_window ||
@@ -2190,29 +2191,14 @@ ipc_handle_workspace_activate(volatile struct ipc_client_state *_ics)
 	// mode. In manual mode (no orchestrator-spawned process, e.g. dev
 	// running displayxr-service --workspace and launching the shell by
 	// hand) the provider returns 0 → first-claim wins.
-	//
-	// A legacy `application_name == "displayxr-shell"` fallback is kept
-	// for one release so existing setups don't break mid-upgrade between
-	// service and shell versions. The next commit removes the fallback,
-	// making PID match strictly required in service-managed mode.
 	unsigned long expected_pid = get_orchestrator_workspace_pid();
 	unsigned long caller_pid = (unsigned long)_ics->client_state.pid;
 
 	if (expected_pid != 0 && caller_pid != expected_pid) {
-		bool legacy_match =
-		    _ics->client_state.info.application_name[0] != '\0' &&
-		    strcmp((const char *)_ics->client_state.info.application_name,
-		           "displayxr-shell") == 0;
-		if (!legacy_match) {
-			IPC_WARN(s,
-			         "workspace_activate: PID mismatch (caller=%lu, expected=%lu) — denied",
-			         caller_pid, expected_pid);
-			return XRT_ERROR_NOT_AUTHORIZED;
-		}
 		IPC_WARN(s,
-		         "workspace_activate: PID mismatch (caller=%lu, expected=%lu) but legacy "
-		         "application_name match accepted (deprecated, will be removed)",
+		         "workspace_activate: PID mismatch (caller=%lu, expected=%lu) — denied",
 		         caller_pid, expected_pid);
+		return XRT_ERROR_NOT_AUTHORIZED;
 	}
 
 	if (s->workspace_mode) {

--- a/src/xrt/ipc/server/ipc_server_handler.c
+++ b/src/xrt/ipc/server/ipc_server_handler.c
@@ -2153,7 +2153,7 @@ ipc_handle_system_toggle_io_device(volatile struct ipc_client_state *ics, uint32
 }
 
 xrt_result_t
-ipc_handle_shell_activate(volatile struct ipc_client_state *_ics)
+ipc_handle_workspace_activate(volatile struct ipc_client_state *_ics)
 {
 	struct ipc_server *s = _ics->server;
 
@@ -2186,7 +2186,7 @@ ipc_handle_shell_activate(volatile struct ipc_client_state *_ics)
 }
 
 xrt_result_t
-ipc_handle_shell_deactivate(volatile struct ipc_client_state *_ics)
+ipc_handle_workspace_deactivate(volatile struct ipc_client_state *_ics)
 {
 	struct ipc_server *s = _ics->server;
 
@@ -2210,7 +2210,7 @@ ipc_handle_shell_deactivate(volatile struct ipc_client_state *_ics)
 }
 
 xrt_result_t
-ipc_handle_shell_get_state(volatile struct ipc_client_state *_ics, bool *out_active)
+ipc_handle_workspace_get_state(volatile struct ipc_client_state *_ics, bool *out_active)
 {
 	struct ipc_server *s = _ics->server;
 	*out_active = s->shell_mode;
@@ -2218,7 +2218,7 @@ ipc_handle_shell_get_state(volatile struct ipc_client_state *_ics, bool *out_act
 }
 
 xrt_result_t
-ipc_handle_shell_set_launcher_visible(volatile struct ipc_client_state *_ics, bool visible)
+ipc_handle_launcher_set_visible(volatile struct ipc_client_state *_ics, bool visible)
 {
 	struct ipc_server *s = _ics->server;
 
@@ -2238,7 +2238,7 @@ ipc_handle_shell_set_launcher_visible(volatile struct ipc_client_state *_ics, bo
 }
 
 xrt_result_t
-ipc_handle_shell_clear_launcher_apps(volatile struct ipc_client_state *_ics)
+ipc_handle_launcher_clear_apps(volatile struct ipc_client_state *_ics)
 {
 	struct ipc_server *s = _ics->server;
 
@@ -2256,7 +2256,7 @@ ipc_handle_shell_clear_launcher_apps(volatile struct ipc_client_state *_ics)
 }
 
 xrt_result_t
-ipc_handle_shell_add_launcher_app(volatile struct ipc_client_state *_ics,
+ipc_handle_launcher_add_app(volatile struct ipc_client_state *_ics,
                                    const struct ipc_launcher_app *app)
 {
 	struct ipc_server *s = _ics->server;
@@ -2276,7 +2276,7 @@ ipc_handle_shell_add_launcher_app(volatile struct ipc_client_state *_ics,
 }
 
 xrt_result_t
-ipc_handle_shell_set_running_tile_mask(volatile struct ipc_client_state *_ics, uint64_t mask)
+ipc_handle_launcher_set_running_tile_mask(volatile struct ipc_client_state *_ics, uint64_t mask)
 {
 	struct ipc_server *s = _ics->server;
 
@@ -2295,7 +2295,7 @@ ipc_handle_shell_set_running_tile_mask(volatile struct ipc_client_state *_ics, u
 }
 
 xrt_result_t
-ipc_handle_shell_poll_launcher_click(volatile struct ipc_client_state *_ics,
+ipc_handle_launcher_poll_click(volatile struct ipc_client_state *_ics,
                                       int64_t *out_tile_index)
 {
 	struct ipc_server *s = _ics->server;
@@ -2315,7 +2315,7 @@ ipc_handle_shell_poll_launcher_click(volatile struct ipc_client_state *_ics,
 }
 
 xrt_result_t
-ipc_handle_shell_set_window_pose(volatile struct ipc_client_state *_ics,
+ipc_handle_workspace_set_window_pose(volatile struct ipc_client_state *_ics,
                                   uint32_t client_id,
                                   const struct xrt_pose *pose,
                                   float width_m,
@@ -2375,7 +2375,7 @@ ipc_handle_shell_set_window_pose(volatile struct ipc_client_state *_ics,
 }
 
 xrt_result_t
-ipc_handle_shell_set_visibility(volatile struct ipc_client_state *_ics,
+ipc_handle_workspace_set_window_visibility(volatile struct ipc_client_state *_ics,
                                  uint32_t client_id,
                                  bool visible)
 {
@@ -2418,7 +2418,7 @@ ipc_handle_shell_set_visibility(volatile struct ipc_client_state *_ics,
 }
 
 xrt_result_t
-ipc_handle_shell_get_window_pose(volatile struct ipc_client_state *_ics,
+ipc_handle_workspace_get_window_pose(volatile struct ipc_client_state *_ics,
                                   uint32_t client_id,
                                   struct xrt_pose *out_pose,
                                   float *out_width_m,
@@ -2471,7 +2471,7 @@ ipc_handle_shell_get_window_pose(volatile struct ipc_client_state *_ics,
 }
 
 xrt_result_t
-ipc_handle_shell_add_capture_client(volatile struct ipc_client_state *_ics,
+ipc_handle_workspace_add_capture_client(volatile struct ipc_client_state *_ics,
                                      uint64_t hwnd,
                                      uint32_t *out_client_id)
 {
@@ -2505,7 +2505,7 @@ ipc_handle_shell_add_capture_client(volatile struct ipc_client_state *_ics,
 }
 
 xrt_result_t
-ipc_handle_shell_remove_capture_client(volatile struct ipc_client_state *_ics,
+ipc_handle_workspace_remove_capture_client(volatile struct ipc_client_state *_ics,
                                         uint32_t client_id)
 {
 	struct ipc_server *s = _ics->server;
@@ -2534,7 +2534,7 @@ ipc_handle_shell_remove_capture_client(volatile struct ipc_client_state *_ics,
 }
 
 xrt_result_t
-ipc_handle_shell_capture_frame(volatile struct ipc_client_state *_ics,
+ipc_handle_workspace_capture_frame(volatile struct ipc_client_state *_ics,
                                 const struct ipc_capture_request *request,
                                 struct ipc_capture_result *out_capture_result)
 {

--- a/src/xrt/ipc/server/ipc_server_handler.c
+++ b/src/xrt/ipc/server/ipc_server_handler.c
@@ -44,6 +44,34 @@
 
 /*
  *
+ * Workspace controller authentication
+ *
+ * The standalone displayxr-service registers a provider that returns the PID
+ * of the orchestrator-spawned workspace controller. Other consumers of the
+ * IPC server (sdl_test, Android service module) leave this NULL → manual
+ * mode, where the first client to call workspace_activate wins. Calling out
+ * to a function pointer (rather than an unconditional symbol reference)
+ * keeps ipc_server independent of the service-only orchestrator code.
+ *
+ */
+
+static ipc_server_workspace_pid_provider_fn s_workspace_pid_provider = NULL;
+
+void
+ipc_server_set_workspace_pid_provider(ipc_server_workspace_pid_provider_fn fn)
+{
+	s_workspace_pid_provider = fn;
+}
+
+static unsigned long
+get_orchestrator_workspace_pid(void)
+{
+	return s_workspace_pid_provider ? s_workspace_pid_provider() : 0;
+}
+
+
+/*
+ *
  * Helper functions.
  *
  */
@@ -2156,6 +2184,36 @@ xrt_result_t
 ipc_handle_workspace_activate(volatile struct ipc_client_state *_ics)
 {
 	struct ipc_server *s = _ics->server;
+
+	// PID-match auth. In service-managed mode the orchestrator spawned a
+	// known workspace controller; only that PID may activate workspace
+	// mode. In manual mode (no orchestrator-spawned process, e.g. dev
+	// running displayxr-service --workspace and launching the shell by
+	// hand) the provider returns 0 → first-claim wins.
+	//
+	// A legacy `application_name == "displayxr-shell"` fallback is kept
+	// for one release so existing setups don't break mid-upgrade between
+	// service and shell versions. The next commit removes the fallback,
+	// making PID match strictly required in service-managed mode.
+	unsigned long expected_pid = get_orchestrator_workspace_pid();
+	unsigned long caller_pid = (unsigned long)_ics->client_state.pid;
+
+	if (expected_pid != 0 && caller_pid != expected_pid) {
+		bool legacy_match =
+		    _ics->client_state.info.application_name[0] != '\0' &&
+		    strcmp((const char *)_ics->client_state.info.application_name,
+		           "displayxr-shell") == 0;
+		if (!legacy_match) {
+			IPC_WARN(s,
+			         "workspace_activate: PID mismatch (caller=%lu, expected=%lu) — denied",
+			         caller_pid, expected_pid);
+			return XRT_ERROR_NOT_AUTHORIZED;
+		}
+		IPC_WARN(s,
+		         "workspace_activate: PID mismatch (caller=%lu, expected=%lu) but legacy "
+		         "application_name match accepted (deprecated, will be removed)",
+		         caller_pid, expected_pid);
+	}
 
 	if (s->workspace_mode) {
 		IPC_INFO(s, "Workspace: already in workspace mode — ensuring window for relaunch");

--- a/src/xrt/ipc/server/ipc_server_handler.c
+++ b/src/xrt/ipc/server/ipc_server_handler.c
@@ -290,14 +290,14 @@ ipc_try_get_sr_view_poses(volatile struct ipc_client_state *ics,
 	// `comp_d3d11_service_owns_window` is false across the board in shell
 	// mode (intentional — it suppresses qwerty for shell-self rendering).
 	// Here we re-enable qwerty on a per-session basis.
-	bool shell_mode = s->xsysc != NULL && s->xsysc->info.shell_mode;
-	bool is_shell_host_session =
+	bool workspace_mode = s->xsysc != NULL && s->xsysc->info.workspace_mode;
+	bool is_workspace_controller_session =
 	    ics->client_state.info.application_name[0] != '\0' &&
 	    strcmp((const char *)ics->client_state.info.application_name, "displayxr-shell") == 0;
 	bool is_appcontainer_app =
 	    ics->client_state.info.ext_win32_appcontainer_compatible_enabled;
 	bool use_qwerty_head = compositor_owns_window ||
-	                       (shell_mode && !is_shell_host_session && is_appcontainer_app);
+	                       (workspace_mode && !is_workspace_controller_session && is_appcontainer_app);
 
 	struct xrt_vec3 display_pos = qwerty_relation.pose.position;
 	struct xrt_quat display_ori = qwerty_relation.pose.orientation;
@@ -447,7 +447,7 @@ ipc_try_get_sr_view_poses(volatile struct ipc_client_state *ics,
 		         left_h, left_v,
 		         out_poses[0].position.x, out_poses[0].position.y, out_poses[0].position.z,
 		         out_poses[1].position.x, out_poses[1].position.y, out_poses[1].position.z,
-		         compositor_owns_window, shell_mode, is_shell_host_session,
+		         compositor_owns_window, workspace_mode, is_workspace_controller_session,
 		         is_appcontainer_app, use_qwerty_head,
 		         (const char *)ics->client_state.info.application_name);
 	}
@@ -1362,7 +1362,7 @@ ipc_handle_compositor_get_window_metrics(volatile struct ipc_client_state *ics,
 
 #if defined(XRT_HAVE_LEIA_SR_D3D11) && defined(XRT_HAVE_D3D11_SERVICE_COMPOSITOR)
 	// Per-client window metrics are only meaningful when the D3D11 service
-	// compositor is in shell mode and has assigned a slot to this client.
+	// compositor is in workspace mode and has assigned a slot to this client.
 	// `xc` is NULL for headless / pre-render sessions; comp_d3d11_service_*
 	// returns false in that case and we surface valid=false to the client.
 	if (ics->server != NULL && ics->server->xsysc != NULL && ics->xc != NULL) {
@@ -2065,7 +2065,7 @@ ipc_handle_system_get_client_window_metrics(volatile struct ipc_client_state *_i
 	struct ipc_server *s = _ics->server;
 
 	// Per-client window metrics are only meaningful when the D3D11 service
-	// compositor is in shell mode and has assigned a slot to the target
+	// compositor is in workspace mode and has assigned a slot to the target
 	// client. Resolve client_id → xc (NULL for headless relay clients such
 	// as the WebXR bridge itself) and ask the compositor.
 	struct xrt_compositor *target_xc = NULL;
@@ -2157,28 +2157,28 @@ ipc_handle_workspace_activate(volatile struct ipc_client_state *_ics)
 {
 	struct ipc_server *s = _ics->server;
 
-	if (s->shell_mode) {
-		IPC_INFO(s, "Shell: already in shell mode — ensuring window for relaunch");
-		// Re-ensure the shell window even when already in shell mode.
-		// If the previous session was dismissed (ESC), ensure_shell_window
+	if (s->workspace_mode) {
+		IPC_INFO(s, "Workspace: already in workspace mode — ensuring window for relaunch");
+		// Re-ensure the shell window even when already in workspace mode.
+		// If the previous session was dismissed (ESC), ensure_workspace_window
 		// tears down the stale resources and creates a fresh window.
 		if (s->xsysc != NULL) {
 #ifdef XRT_OS_WINDOWS
-			comp_d3d11_service_ensure_shell_window(s->xsysc);
+			comp_d3d11_service_ensure_workspace_window(s->xsysc);
 #endif
 		}
 		return XRT_SUCCESS;
 	}
 
-	IPC_INFO(s, "Shell: activating shell mode via IPC");
+	IPC_INFO(s, "Workspace: activating shell mode via IPC");
 
-	s->shell_mode = true;
+	s->workspace_mode = true;
 	if (s->xsysc != NULL) {
-		s->xsysc->info.shell_mode = true;
+		s->xsysc->info.workspace_mode = true;
 
 #ifdef XRT_OS_WINDOWS
 		// Eagerly create the shell window so Ctrl+O works even with no apps.
-		comp_d3d11_service_ensure_shell_window(s->xsysc);
+		comp_d3d11_service_ensure_workspace_window(s->xsysc);
 #endif
 	}
 
@@ -2190,19 +2190,19 @@ ipc_handle_workspace_deactivate(volatile struct ipc_client_state *_ics)
 {
 	struct ipc_server *s = _ics->server;
 
-	if (!s->shell_mode) {
-		IPC_INFO(s, "Shell: already deactivated — ignoring");
+	if (!s->workspace_mode) {
+		IPC_INFO(s, "Workspace: already deactivated — ignoring");
 		return XRT_SUCCESS;
 	}
 
-	IPC_INFO(s, "Shell: deactivating shell mode via IPC");
+	IPC_INFO(s, "Workspace: deactivating shell mode via IPC");
 
-	s->shell_mode = false;
+	s->workspace_mode = false;
 	if (s->xsysc != NULL) {
-		s->xsysc->info.shell_mode = false;
+		s->xsysc->info.workspace_mode = false;
 
 #if defined(XRT_HAVE_D3D11_SERVICE_COMPOSITOR)
-		comp_d3d11_service_deactivate_shell(s->xsysc);
+		comp_d3d11_service_deactivate_workspace(s->xsysc);
 #endif
 	}
 
@@ -2213,7 +2213,7 @@ xrt_result_t
 ipc_handle_workspace_get_state(volatile struct ipc_client_state *_ics, bool *out_active)
 {
 	struct ipc_server *s = _ics->server;
-	*out_active = s->shell_mode;
+	*out_active = s->workspace_mode;
 	return XRT_SUCCESS;
 }
 
@@ -2227,7 +2227,7 @@ ipc_handle_launcher_set_visible(volatile struct ipc_client_state *_ics, bool vis
 		return XRT_ERROR_IPC_FAILURE;
 	}
 
-	IPC_INFO(s, "Shell: set_launcher_visible %s", visible ? "true" : "false");
+	IPC_INFO(s, "Workspace: set_launcher_visible %s", visible ? "true" : "false");
 	comp_d3d11_service_set_launcher_visible(s->xsysc, visible);
 	return XRT_SUCCESS;
 #else
@@ -2328,7 +2328,7 @@ ipc_handle_workspace_set_window_pose(volatile struct ipc_client_state *_ics,
 		return XRT_ERROR_IPC_FAILURE;
 	}
 
-	IPC_INFO(s, "Shell: set_window_pose client_id=%u pos=(%.3f,%.3f,%.3f) size=%.3fx%.3f",
+	IPC_INFO(s, "Workspace: set_window_pose client_id=%u pos=(%.3f,%.3f,%.3f) size=%.3fx%.3f",
 	         client_id, pose->position.x, pose->position.y, pose->position.z,
 	         width_m, height_m);
 
@@ -2354,7 +2354,7 @@ ipc_handle_workspace_set_window_pose(volatile struct ipc_client_state *_ics,
 
 	if (target_ics == NULL || target_ics->xc == NULL) {
 		os_mutex_unlock(&s->global_state.lock);
-		IPC_WARN(s, "Shell: set_window_pose - client %u not found", client_id);
+		IPC_WARN(s, "Workspace: set_window_pose - client %u not found", client_id);
 		return XRT_ERROR_IPC_FAILURE;
 	}
 
@@ -2386,7 +2386,7 @@ ipc_handle_workspace_set_window_visibility(volatile struct ipc_client_state *_ic
 		return XRT_ERROR_IPC_FAILURE;
 	}
 
-	IPC_INFO(s, "Shell: set_visibility client_id=%u visible=%d", client_id, visible);
+	IPC_INFO(s, "Workspace: set_visibility client_id=%u visible=%d", client_id, visible);
 
 	os_mutex_lock(&s->global_state.lock);
 
@@ -2482,18 +2482,18 @@ ipc_handle_workspace_add_capture_client(volatile struct ipc_client_state *_ics,
 		return XRT_ERROR_IPC_FAILURE;
 	}
 
-	IPC_INFO(s, "Shell: add_capture_client hwnd=0x%llx", (unsigned long long)hwnd);
+	IPC_INFO(s, "Workspace: add_capture_client hwnd=0x%llx", (unsigned long long)hwnd);
 
 	int slot = comp_d3d11_service_add_capture_client(s->xsysc, hwnd, NULL);
 	if (slot < 0) {
-		IPC_WARN(s, "Shell: add_capture_client failed for hwnd=0x%llx",
+		IPC_WARN(s, "Workspace: add_capture_client failed for hwnd=0x%llx",
 		         (unsigned long long)hwnd);
 		return XRT_ERROR_IPC_FAILURE;
 	}
 
 	// Capture client IDs use offset 1000+ to distinguish from IPC client IDs
 	*out_client_id = 1000 + (uint32_t)slot;
-	IPC_INFO(s, "Shell: capture client added — slot=%d client_id=%u", slot, *out_client_id);
+	IPC_INFO(s, "Workspace: capture client added — slot=%d client_id=%u", slot, *out_client_id);
 
 	return XRT_SUCCESS;
 #else
@@ -2516,13 +2516,13 @@ ipc_handle_workspace_remove_capture_client(volatile struct ipc_client_state *_ic
 	}
 
 	if (client_id < 1000) {
-		IPC_WARN(s, "Shell: remove_capture_client — invalid client_id %u (not a capture client)",
+		IPC_WARN(s, "Workspace: remove_capture_client — invalid client_id %u (not a capture client)",
 		         client_id);
 		return XRT_ERROR_IPC_FAILURE;
 	}
 
 	int slot = (int)(client_id - 1000);
-	IPC_INFO(s, "Shell: remove_capture_client client_id=%u slot=%d", client_id, slot);
+	IPC_INFO(s, "Workspace: remove_capture_client client_id=%u slot=%d", client_id, slot);
 
 	bool ok = comp_d3d11_service_remove_capture_client(s->xsysc, slot);
 	return ok ? XRT_SUCCESS : XRT_ERROR_IPC_FAILURE;
@@ -2550,7 +2550,7 @@ ipc_handle_workspace_capture_frame(volatile struct ipc_client_state *_ics,
 		return XRT_ERROR_IPC_FAILURE;
 	}
 
-	IPC_INFO(s, "Shell: capture_frame prefix=%s flags=0x%x",
+	IPC_INFO(s, "Workspace: capture_frame prefix=%s flags=0x%x",
 	         request->path_prefix, request->flags);
 
 	// Ensure NUL terminator (defense in depth — IPC marshalling should already

--- a/src/xrt/ipc/server/ipc_server_interface.h
+++ b/src/xrt/ipc/server/ipc_server_interface.h
@@ -37,7 +37,7 @@ struct ipc_server_main_info
 	struct u_debug_gui_create_info udgci;
 
 	//! When true, service runs in shell mode with a shared multi-compositor window.
-	bool shell_mode;
+	bool workspace_mode;
 };
 
 /*!

--- a/src/xrt/ipc/server/ipc_server_process.c
+++ b/src/xrt/ipc/server/ipc_server_process.c
@@ -621,7 +621,7 @@ handle_focused_client_events(volatile struct ipc_client_state *ics, int active_i
 		focused = true;
 		z_order = INT64_MIN;
 	}
-	if (ics->server->xsysc != NULL && ics->server->xsysc->info.shell_mode) {
+	if (ics->server->xsysc != NULL && ics->server->xsysc->info.workspace_mode) {
 		visible = true;
 		focused = true;
 	}
@@ -1055,8 +1055,8 @@ ipc_server_main(int argc, char **argv, const struct ipc_server_main_info *ismi)
 
 	// Allocate the server itself.
 	struct ipc_server *s = U_TYPED_CALLOC(struct ipc_server);
-	s->shell_mode = ismi->shell_mode;
-	if (s->shell_mode) {
+	s->workspace_mode = ismi->workspace_mode;
+	if (s->workspace_mode) {
 		U_LOG_IFL_I(log_level, "Shell mode enabled (--shell)");
 	}
 
@@ -1084,10 +1084,10 @@ ipc_server_main(int argc, char **argv, const struct ipc_server_main_info *ismi)
 		return -1;
 	}
 
-	// Propagate shell mode to system compositor (after init_all creates it,
+	// Propagate workspace mode to system compositor (after init_all creates it,
 	// before any clients connect and create per-client compositors)
-	if (s->shell_mode && s->xsysc != NULL) {
-		s->xsysc->info.shell_mode = true;
+	if (s->workspace_mode && s->xsysc != NULL) {
+		s->xsysc->info.workspace_mode = true;
 		U_LOG_IFL_I(log_level, "Shell mode propagated to system compositor");
 	}
 

--- a/src/xrt/ipc/shared/ipc_protocol.h
+++ b/src/xrt/ipc/shared/ipc_protocol.h
@@ -308,8 +308,8 @@ struct ipc_client_list
  * Phase 5.8: registered-app record shipped one-at-a-time from the shell
  * process to the service for the spatial launcher panel. Sized to fit a
  * single ipc message under IPC_BUF_SIZE — the shell calls
- * ipc_call_shell_clear_launcher_apps then loops over its registry calling
- * ipc_call_shell_add_launcher_app per entry whenever the registry changes.
+ * ipc_call_launcher_clear_apps then loops over its registry calling
+ * ipc_call_launcher_add_app per entry whenever the registry changes.
  *
  * @ingroup ipc
  */
@@ -319,7 +319,7 @@ struct ipc_client_list
 #define IPC_LAUNCHER_PATH_MAX 256
 #define IPC_LAUNCHER_TYPE_MAX 8
 
-// Phase 5.14: sentinel returned via ipc_call_shell_poll_launcher_click to mean
+// Phase 5.14: sentinel returned via ipc_call_launcher_poll_click to mean
 // "the user clicked the Browse-for-app virtual tile" rather than a real tile.
 // Real tile indices are >= 0; -1 means no pending action.
 #define IPC_LAUNCHER_ACTION_BROWSE (-100)
@@ -354,7 +354,7 @@ struct ipc_launcher_app
 #define IPC_CAPTURE_PATH_MAX 256
 
 /*!
- * Phase 8: request struct for shell_capture_frame. Wraps the path prefix
+ * Phase 8: request struct for workspace_capture_frame. Wraps the path prefix
  * (without extension — runtime appends "_atlas.png") because the IPC
  * schema only supports struct/scalar parameter types.
  *
@@ -367,7 +367,7 @@ struct ipc_capture_request
 };
 
 /*!
- * Phase 8: result returned by shell_capture_frame. The runtime fills this
+ * Phase 8: result returned by workspace_capture_frame. The runtime fills this
  * with the metadata needed for a sidecar JSON file (timestamp, atlas/eye
  * dimensions, stereo layout, display physical size, eye poses at capture).
  *

--- a/src/xrt/ipc/shared/proto.json
+++ b/src/xrt/ipc/shared/proto.json
@@ -65,17 +65,17 @@
 		]
 	},
 
-	"shell_activate": {},
+	"workspace_activate": {},
 
-	"shell_deactivate": {},
+	"workspace_deactivate": {},
 
-	"shell_get_state": {
+	"workspace_get_state": {
 		"out": [
 			{"name": "active", "type": "bool"}
 		]
 	},
 
-	"shell_set_window_pose": {
+	"workspace_set_window_pose": {
 		"in": [
 			{"name": "client_id", "type": "uint32_t"},
 			{"name": "pose", "type": "struct xrt_pose"},
@@ -84,40 +84,40 @@
 		]
 	},
 
-	"shell_set_visibility": {
+	"workspace_set_window_visibility": {
 		"in": [
 			{"name": "client_id", "type": "uint32_t"},
 			{"name": "visible", "type": "bool"}
 		]
 	},
 
-	"shell_set_launcher_visible": {
+	"launcher_set_visible": {
 		"in": [
 			{"name": "visible", "type": "bool"}
 		]
 	},
 
-	"shell_clear_launcher_apps": {},
+	"launcher_clear_apps": {},
 
-	"shell_add_launcher_app": {
+	"launcher_add_app": {
 		"in": [
 			{"name": "app", "type": "struct ipc_launcher_app"}
 		]
 	},
 
-	"shell_poll_launcher_click": {
+	"launcher_poll_click": {
 		"out": [
 			{"name": "tile_index", "type": "int64_t"}
 		]
 	},
 
-	"shell_set_running_tile_mask": {
+	"launcher_set_running_tile_mask": {
 		"in": [
 			{"name": "mask", "type": "uint64_t"}
 		]
 	},
 
-	"shell_get_window_pose": {
+	"workspace_get_window_pose": {
 		"in": [
 			{"name": "client_id", "type": "uint32_t"}
 		],
@@ -128,7 +128,7 @@
 		]
 	},
 
-	"shell_add_capture_client": {
+	"workspace_add_capture_client": {
 		"in": [
 			{"name": "hwnd", "type": "uint64_t"}
 		],
@@ -137,13 +137,13 @@
 		]
 	},
 
-	"shell_remove_capture_client": {
+	"workspace_remove_capture_client": {
 		"in": [
 			{"name": "client_id", "type": "uint32_t"}
 		]
 	},
 
-	"shell_capture_frame": {
+	"workspace_capture_frame": {
 		"in": [
 			{"name": "request", "type": "struct ipc_capture_request"}
 		],

--- a/src/xrt/state_trackers/oxr/oxr_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_session.c
@@ -2600,12 +2600,12 @@ oxr_session_create(struct oxr_logger *log,
 	{
 		const char *shell_session = getenv("DISPLAYXR_SHELL_SESSION");
 		// Only apply borderless+hide when shell mode is currently active.
-		// After workspace_deactivate, info.shell_mode is false — apps that
+		// After workspace_deactivate, info.workspace_mode is false — apps that
 		// recreate their session (e.g., after LOSS_PENDING) come up in
 		// standalone mode with a normal visible HWND.
 		if (shell_session != NULL && strcmp(shell_session, "1") == 0 &&
 		    xsi.external_window_handle != NULL && sys->xsysc != NULL &&
-		    sys->xsysc->info.shell_mode) {
+		    sys->xsysc->info.workspace_mode) {
 			HWND hwnd = (HWND)xsi.external_window_handle;
 			// Shell mode: just hide the HWND, keep decorations and size
 			// intact. On hot-switch deactivate, ShowWindowAsync(SW_SHOW)

--- a/src/xrt/state_trackers/oxr/oxr_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_session.c
@@ -2598,12 +2598,12 @@ oxr_session_create(struct oxr_logger *log,
 	// to the target window — if done server-side during session_create, the client's
 	// thread is blocked waiting for the IPC response and can't process WM, deadlocking.
 	{
-		const char *shell_session = getenv("DISPLAYXR_SHELL_SESSION");
+		const char *workspace_session = getenv("DISPLAYXR_WORKSPACE_SESSION");
 		// Only apply borderless+hide when shell mode is currently active.
 		// After workspace_deactivate, info.workspace_mode is false — apps that
 		// recreate their session (e.g., after LOSS_PENDING) come up in
 		// standalone mode with a normal visible HWND.
-		if (shell_session != NULL && strcmp(shell_session, "1") == 0 &&
+		if (workspace_session != NULL && strcmp(workspace_session, "1") == 0 &&
 		    xsi.external_window_handle != NULL && sys->xsysc != NULL &&
 		    sys->xsysc->info.workspace_mode) {
 			HWND hwnd = (HWND)xsi.external_window_handle;

--- a/src/xrt/state_trackers/oxr/oxr_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_session.c
@@ -2600,7 +2600,7 @@ oxr_session_create(struct oxr_logger *log,
 	{
 		const char *shell_session = getenv("DISPLAYXR_SHELL_SESSION");
 		// Only apply borderless+hide when shell mode is currently active.
-		// After shell_deactivate, info.shell_mode is false — apps that
+		// After workspace_deactivate, info.shell_mode is false — apps that
 		// recreate their session (e.g., after LOSS_PENDING) come up in
 		// standalone mode with a normal visible HWND.
 		if (shell_session != NULL && strcmp(shell_session, "1") == 0 &&

--- a/src/xrt/targets/mcp_adapter/displayxr_mcp.c
+++ b/src/xrt/targets/mcp_adapter/displayxr_mcp.c
@@ -177,7 +177,7 @@ main(int argc, char **argv)
 		snprintf(buf, sizeof(buf), "pid %ld", pid);
 		connected_label = buf;
 	} else if (strcmp(target_arg, "auto") == 0) {
-		// Service first — covers the Phase B shell story.
+		// Service first — covers the Phase B workspace story.
 		conn = u_mcp_conn_connect_named("service");
 		if (conn != NULL) {
 			connected_label = "service";

--- a/src/xrt/targets/service/CMakeLists.txt
+++ b/src/xrt/targets/service/CMakeLists.txt
@@ -35,6 +35,8 @@ if(WIN32)
 		service_orchestrator.h
 		service_tray_win.c
 		service_tray_win.h
+		service_workspace_manifest.c
+		service_workspace_manifest.h
 		service_resources.rc
 	)
 	target_link_libraries(displayxr-service PRIVATE shell32 ws2_32)

--- a/src/xrt/targets/service/main.c
+++ b/src/xrt/targets/service/main.c
@@ -25,6 +25,7 @@
 #endif
 
 #include "server/ipc_server_interface.h"
+#include "server/ipc_server.h"
 
 #include "target_lists.h"
 
@@ -126,6 +127,11 @@ WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdS
 
 	// Initialize orchestrator (registers hotkeys, spawns children per config)
 	service_orchestrator_init(&cfg);
+
+	// Tell the IPC server how to look up the orchestrator-spawned workspace
+	// controller's PID, so workspace_activate can authenticate that only the
+	// controller we spawned may transition the runtime into workspace mode.
+	ipc_server_set_workspace_pid_provider(service_orchestrator_get_workspace_pid);
 
 	u_trace_marker_init();
 	u_metrics_init();

--- a/src/xrt/targets/service/main.c
+++ b/src/xrt/targets/service/main.c
@@ -28,7 +28,7 @@
 
 #include "target_lists.h"
 
-#include <string.h> // strcmp for --shell flag
+#include <string.h> // strcmp for --workspace / --shell flag
 
 
 // Insert the on load constructor to init trace marker.
@@ -98,7 +98,7 @@ WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdS
 
 	u_win_try_privilege_or_priority_from_args(U_LOGGING_INFO, argc, argv);
 
-	// Load orchestrator config (shell/bridge modes, start-on-login)
+	// Load orchestrator config (workspace/bridge modes, start-on-login)
 	struct service_config cfg;
 	service_config_load(&cfg);
 
@@ -110,11 +110,12 @@ WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdS
 		ExitProcess(0);
 	}
 
-	// Parse --shell flag for backwards compat (legacy multi-terminal workflow).
-	// The orchestrator will also enable shell mode when it spawns the shell.
+	// Parse --workspace (or legacy --shell alias) for the multi-terminal
+	// workflow. The orchestrator will also enable workspace mode when it
+	// spawns the workspace controller.
 	bool workspace_mode = false;
 	for (int i = 1; i < argc; i++) {
-		if (strcmp(argv[i], "--shell") == 0) {
+		if (strcmp(argv[i], "--workspace") == 0 || strcmp(argv[i], "--shell") == 0) {
 			workspace_mode = true;
 			break;
 		}
@@ -166,10 +167,10 @@ main(int argc, char *argv[])
 	u_trace_marker_init();
 	u_metrics_init();
 
-	// Parse --shell flag for multi-compositor shell mode
+	// Parse --workspace (or legacy --shell alias) for multi-compositor mode
 	bool workspace_mode = false;
 	for (int i = 1; i < argc; i++) {
-		if (strcmp(argv[i], "--shell") == 0) {
+		if (strcmp(argv[i], "--workspace") == 0 || strcmp(argv[i], "--shell") == 0) {
 			workspace_mode = true;
 			break;
 		}

--- a/src/xrt/targets/service/main.c
+++ b/src/xrt/targets/service/main.c
@@ -112,10 +112,10 @@ WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdS
 
 	// Parse --shell flag for backwards compat (legacy multi-terminal workflow).
 	// The orchestrator will also enable shell mode when it spawns the shell.
-	bool shell_mode = false;
+	bool workspace_mode = false;
 	for (int i = 1; i < argc; i++) {
 		if (strcmp(argv[i], "--shell") == 0) {
-			shell_mode = true;
+			workspace_mode = true;
 			break;
 		}
 	}
@@ -135,7 +135,7 @@ WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdS
 	            .window_title = "DisplayXR Service",
 	            .open = U_DEBUG_GUI_OPEN_AUTO,
 	        },
-	    .shell_mode = shell_mode,
+	    .workspace_mode = workspace_mode,
 	};
 
 	// Opt-in MCP server for agent-driven shell control / debugging.
@@ -167,10 +167,10 @@ main(int argc, char *argv[])
 	u_metrics_init();
 
 	// Parse --shell flag for multi-compositor shell mode
-	bool shell_mode = false;
+	bool workspace_mode = false;
 	for (int i = 1; i < argc; i++) {
 		if (strcmp(argv[i], "--shell") == 0) {
-			shell_mode = true;
+			workspace_mode = true;
 			break;
 		}
 	}
@@ -181,7 +181,7 @@ main(int argc, char *argv[])
 	            .window_title = "DisplayXR Service",
 	            .open = U_DEBUG_GUI_OPEN_AUTO,
 	        },
-	    .shell_mode = shell_mode,
+	    .workspace_mode = workspace_mode,
 	};
 
 	// Opt-in MCP server for agent-driven shell control / debugging.

--- a/src/xrt/targets/service/service_config.c
+++ b/src/xrt/targets/service/service_config.c
@@ -34,9 +34,11 @@
 static void
 config_defaults(struct service_config *cfg)
 {
-	cfg->shell = SERVICE_CHILD_AUTO;
+	cfg->workspace = SERVICE_CHILD_AUTO;
 	cfg->bridge = SERVICE_CHILD_AUTO;
 	cfg->start_on_login = true;
+	snprintf(cfg->workspace_binary, sizeof(cfg->workspace_binary),
+	         "displayxr-shell.exe");
 }
 
 //! Build the full path to service.json into @p buf.
@@ -176,9 +178,22 @@ service_config_load(struct service_config *cfg)
 		return;
 	}
 
-	cJSON *shell = cJSON_GetObjectItemCaseSensitive(root, "shell");
-	if (cJSON_IsString(shell)) {
-		cfg->shell = str_to_mode(shell->valuestring);
+	// Prefer the new "workspace" key; fall back to legacy "shell" key from
+	// pre-rename installs so an existing service.json keeps working.
+	cJSON *workspace = cJSON_GetObjectItemCaseSensitive(root, "workspace");
+	if (cJSON_IsString(workspace)) {
+		cfg->workspace = str_to_mode(workspace->valuestring);
+	} else {
+		cJSON *shell_legacy = cJSON_GetObjectItemCaseSensitive(root, "shell");
+		if (cJSON_IsString(shell_legacy)) {
+			cfg->workspace = str_to_mode(shell_legacy->valuestring);
+		}
+	}
+
+	cJSON *workspace_binary = cJSON_GetObjectItemCaseSensitive(root, "workspace_binary");
+	if (cJSON_IsString(workspace_binary) && workspace_binary->valuestring[0] != '\0') {
+		snprintf(cfg->workspace_binary, sizeof(cfg->workspace_binary),
+		         "%s", workspace_binary->valuestring);
 	}
 
 	cJSON *bridge = cJSON_GetObjectItemCaseSensitive(root, "bridge");
@@ -209,7 +224,8 @@ service_config_save(const struct service_config *cfg)
 		return false;
 	}
 
-	cJSON_AddStringToObject(root, "shell", mode_to_str(cfg->shell));
+	cJSON_AddStringToObject(root, "workspace", mode_to_str(cfg->workspace));
+	cJSON_AddStringToObject(root, "workspace_binary", cfg->workspace_binary);
 	cJSON_AddStringToObject(root, "bridge", mode_to_str(cfg->bridge));
 	cJSON_AddBoolToObject(root, "start_on_login", cfg->start_on_login);
 

--- a/src/xrt/targets/service/service_config.h
+++ b/src/xrt/targets/service/service_config.h
@@ -15,7 +15,7 @@ extern "C" {
 #endif
 
 /*!
- * Lifecycle mode for a managed child process (shell, bridge).
+ * Lifecycle mode for a managed child process (workspace, bridge).
  */
 enum service_child_mode
 {
@@ -24,19 +24,32 @@ enum service_child_mode
 	SERVICE_CHILD_AUTO,    //!< On-demand — launched when triggered (hotkey, client detection).
 };
 
+//! Maximum length of the workspace controller binary path.
+#define SERVICE_WORKSPACE_BINARY_MAX 260
+
 /*!
  * Persisted service configuration.
  *
  * Stored in `%LOCALAPPDATA%\DisplayXR\service.json` on Windows,
  * `~/.config/displayxr/service.json` on Linux/macOS.
  *
- * Missing file or missing keys → defaults (auto/auto/true).
+ * Missing file or missing keys → defaults (auto/auto/true,
+ * workspace_binary = "displayxr-shell.exe"). The `workspace`
+ * JSON key is read with backwards-compat fallback to the legacy
+ * `shell` key from earlier installs.
  */
 struct service_config
 {
-	enum service_child_mode shell;  //!< Shell lifecycle mode (default AUTO).
-	enum service_child_mode bridge; //!< WebXR bridge lifecycle mode (default AUTO).
-	bool start_on_login;            //!< If false, service exits immediately on auto-start.
+	enum service_child_mode workspace; //!< Workspace controller lifecycle mode (default AUTO).
+	enum service_child_mode bridge;    //!< WebXR bridge lifecycle mode (default AUTO).
+	bool start_on_login;               //!< If false, service exits immediately on auto-start.
+
+	//! Filename or path of the workspace controller binary that the orchestrator
+	//! spawns (resolved as a sibling of the service exe if it has no path
+	//! separator). Default "displayxr-shell.exe" — DisplayXR Shell is the
+	//! reference workspace controller. OEMs / third parties drop a different
+	//! name here to ship their own controller.
+	char workspace_binary[SERVICE_WORKSPACE_BINARY_MAX];
 };
 
 /*!

--- a/src/xrt/targets/service/service_orchestrator.c
+++ b/src/xrt/targets/service/service_orchestrator.c
@@ -8,6 +8,7 @@
 
 #include "service_orchestrator.h"
 #include "service_tray_win.h"
+#include "service_workspace_manifest.h"
 
 #include "util/u_debug.h"
 #include "util/u_logging.h"
@@ -68,6 +69,12 @@ static HANDLE s_workspace_watch_thread = NULL;
 static bool s_hotkey_registered = false; // true when WH_KEYBOARD_LL hook is active
 static HHOOK s_kbd_hook = NULL;
 
+// Set once at init: true iff the workspace controller binary exists next to
+// the service exe. When false, all workspace mode handling is short-circuited
+// — the runtime operates as a standalone platform.
+static bool s_workspace_available = false;
+static struct workspace_manifest s_workspace_manifest = {0};
+
 static PROCESS_INFORMATION s_bridge_pi;
 static bool s_bridge_running = false;
 static HANDLE s_bridge_watch_thread = NULL;
@@ -111,6 +118,44 @@ sibling_exe_path(const char *exe_name, char *buf, size_t buf_size)
 
 	snprintf(buf, buf_size, "%s%s", self_path, exe_name);
 	return true;
+}
+
+//! Existence check that excludes directories.
+static bool
+sibling_file_exists(const char *path)
+{
+	DWORD attrs = GetFileAttributesA(path);
+	return attrs != INVALID_FILE_ATTRIBUTES && !(attrs & FILE_ATTRIBUTE_DIRECTORY);
+}
+
+//! Detect whether a workspace controller is installed. Sets
+//! s_workspace_available + s_workspace_manifest. Logs the outcome.
+//! Called once from service_orchestrator_init before any apply_workspace_mode.
+static void
+detect_workspace_controller(const struct service_config *cfg)
+{
+	char workspace_path[MAX_PATH];
+	if (!sibling_exe_path(cfg->workspace_binary, workspace_path, sizeof(workspace_path))) {
+		s_workspace_available = false;
+		return;
+	}
+
+	if (!sibling_file_exists(workspace_path)) {
+		s_workspace_available = false;
+		OW("Workspace controller not installed (looked for %s)", workspace_path);
+		return;
+	}
+
+	s_workspace_available = true;
+	if (!service_workspace_manifest_load(workspace_path, &s_workspace_manifest)) {
+		// Controller present but no/invalid manifest — fall back to a
+		// generic name so the tray submenu still has a label.
+		snprintf(s_workspace_manifest.display_name,
+		         sizeof(s_workspace_manifest.display_name),
+		         "Workspace Controller");
+	}
+	OW("Workspace controller detected: %s (binary=%s)",
+	   s_workspace_manifest.display_name, workspace_path);
 }
 
 //! Launch a child process and return its PROCESS_INFORMATION.
@@ -249,6 +294,9 @@ workspace_watch_thread_func(LPVOID param)
 static void
 spawn_workspace(void)
 {
+	if (!s_workspace_available) {
+		return;
+	}
 	if (s_workspace_running) {
 		return;
 	}
@@ -632,6 +680,12 @@ uninstall_workspace_hotkey(void)
 static void
 apply_workspace_mode(enum service_child_mode mode)
 {
+	// No controller installed → nothing to spawn, no hotkey to register.
+	// Terminate path stays a no-op cleanup; nothing was running to begin with.
+	if (!s_workspace_available) {
+		return;
+	}
+
 	switch (mode) {
 	case SERVICE_CHILD_ENABLE:
 		// Uninstall keyboard hook if active
@@ -725,10 +779,27 @@ service_orchestrator_init(const struct service_config *cfg)
 		                                                  (LONG_PTR)orchestrator_wnd_proc_hook);
 	}
 
+	// Detect workspace controller before applying workspace mode — apply_workspace_mode
+	// short-circuits when no controller is installed, leaving the runtime as a
+	// standalone OpenXR + WebXR platform with no spatial-desktop features.
+	detect_workspace_controller(cfg);
+
 	apply_workspace_mode(cfg->workspace);
 	apply_bridge_mode(cfg->bridge);
 
 	return true;
+}
+
+bool
+service_orchestrator_is_workspace_available(void)
+{
+	return s_workspace_available;
+}
+
+const char *
+service_orchestrator_get_workspace_display_name(void)
+{
+	return s_workspace_manifest.display_name;
 }
 
 void
@@ -837,6 +908,18 @@ service_orchestrator_apply_config(const struct service_config *cfg)
 void
 service_orchestrator_shutdown(void)
 {
+}
+
+bool
+service_orchestrator_is_workspace_available(void)
+{
+	return false;
+}
+
+const char *
+service_orchestrator_get_workspace_display_name(void)
+{
+	return "";
 }
 
 #endif // XRT_OS_WINDOWS

--- a/src/xrt/targets/service/service_orchestrator.c
+++ b/src/xrt/targets/service/service_orchestrator.c
@@ -261,11 +261,27 @@ workspace_watch_thread_func(LPVOID param)
 {
 	(void)param;
 
-	// Wait for the workspace process to exit
-	WaitForSingleObject(s_workspace_pi.hProcess, INFINITE);
+	// Hold our own duplicated handle for the wait. terminate_child closes
+	// s_workspace_pi.hProcess on the main thread on a Disable click; the
+	// duplicate gives us an independent kernel-handle reference so we never
+	// race with that close (STATUS_INVALID_HANDLE / 0xC0000008).
+	HANDLE h = NULL;
+	if (s_workspace_pi.hProcess != NULL) {
+		if (!DuplicateHandle(GetCurrentProcess(), s_workspace_pi.hProcess,
+		                     GetCurrentProcess(), &h,
+		                     SYNCHRONIZE, FALSE, 0)) {
+			h = NULL;
+		}
+	}
+	if (h == NULL) {
+		// Either the process never started or terminate_child already cleared
+		// hProcess before we could duplicate it. Either way, nothing to watch.
+		return 0;
+	}
 
-	CloseHandle(s_workspace_pi.hProcess);
-	s_workspace_pi.hProcess = NULL;
+	WaitForSingleObject(h, INFINITE);
+	CloseHandle(h);
+
 	s_workspace_running = false;
 
 	OW("Workspace controller process exited");

--- a/src/xrt/targets/service/service_orchestrator.c
+++ b/src/xrt/targets/service/service_orchestrator.c
@@ -802,6 +802,15 @@ service_orchestrator_get_workspace_display_name(void)
 	return s_workspace_manifest.display_name;
 }
 
+unsigned long
+service_orchestrator_get_workspace_pid(void)
+{
+	if (s_workspace_running) {
+		return (unsigned long)s_workspace_pi.dwProcessId;
+	}
+	return 0;
+}
+
 void
 service_orchestrator_apply_config(const struct service_config *cfg)
 {
@@ -920,6 +929,12 @@ const char *
 service_orchestrator_get_workspace_display_name(void)
 {
 	return "";
+}
+
+unsigned long
+service_orchestrator_get_workspace_pid(void)
+{
+	return 0;
 }
 
 #endif // XRT_OS_WINDOWS

--- a/src/xrt/targets/service/service_orchestrator.c
+++ b/src/xrt/targets/service/service_orchestrator.c
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSL-1.0
 /*!
  * @file
- * @brief  Service orchestrator — manages shell and bridge child processes.
+ * @brief  Service orchestrator — manages workspace controller and bridge child processes.
  * @ingroup ipc
  */
 
@@ -34,7 +34,7 @@ DEBUG_GET_ONCE_LOG_OPTION(orchestrator_log, "DISPLAYXR_ORCHESTRATOR_LOG", U_LOGG
 
 /*
  *
- * Hotkey ID shared with the shell (must match shell/main.c HOTKEY_TOGGLE)
+ * Hotkey ID shared with the workspace controller (must match workspace controller HOTKEY_TOGGLE)
  *
  */
 
@@ -62,9 +62,9 @@ DEBUG_GET_ONCE_LOG_OPTION(orchestrator_log, "DISPLAYXR_ORCHESTRATOR_LOG", U_LOGG
  */
 
 static struct service_config s_cfg;
-static PROCESS_INFORMATION s_shell_pi;
-static bool s_shell_running = false;
-static HANDLE s_shell_watch_thread = NULL;
+static PROCESS_INFORMATION s_workspace_pi;
+static bool s_workspace_running = false;
+static HANDLE s_workspace_watch_thread = NULL;
 static bool s_hotkey_registered = false; // true when WH_KEYBOARD_LL hook is active
 static HHOOK s_kbd_hook = NULL;
 
@@ -207,37 +207,37 @@ terminate_child(PROCESS_INFORMATION *pi, bool *running_flag)
 
 /*
  *
- * Shell watchdog thread — monitors shell process, re-registers hotkey on exit
+ * Workspace watchdog thread — monitors workspace process, re-registers hotkey on exit
  *
  */
 
 static DWORD WINAPI
-shell_watch_thread_func(LPVOID param)
+workspace_watch_thread_func(LPVOID param)
 {
 	(void)param;
 
-	// Wait for the shell process to exit
-	WaitForSingleObject(s_shell_pi.hProcess, INFINITE);
+	// Wait for the workspace process to exit
+	WaitForSingleObject(s_workspace_pi.hProcess, INFINITE);
 
-	CloseHandle(s_shell_pi.hProcess);
-	s_shell_pi.hProcess = NULL;
-	s_shell_running = false;
+	CloseHandle(s_workspace_pi.hProcess);
+	s_workspace_pi.hProcess = NULL;
+	s_workspace_running = false;
 
 	OW("Shell process exited");
 
 	// In Auto mode, nothing to re-register: the low-level keyboard hook
-	// stays installed across shell sessions, it's gated by s_shell_running
+	// stays installed across workspace sessions, it's gated by s_workspace_running
 	// in the hook proc.
 
-	// In Enable mode, restart the shell
-	if (s_cfg.shell == SERVICE_CHILD_ENABLE) {
-		char shell_path[MAX_PATH];
-		if (sibling_exe_path("displayxr-shell.exe", shell_path, sizeof(shell_path))) {
-			if (launch_child(shell_path, "--service-managed", &s_shell_pi)) {
-				s_shell_running = true;
-				OW("Restarted shell (Enable mode)");
+	// In Enable mode, restart the workspace controller
+	if (s_cfg.workspace == SERVICE_CHILD_ENABLE) {
+		char workspace_path[MAX_PATH];
+		if (sibling_exe_path(s_cfg.workspace_binary, workspace_path, sizeof(workspace_path))) {
+			if (launch_child(workspace_path, "--service-managed", &s_workspace_pi)) {
+				s_workspace_running = true;
+				OW("Restarted workspace controller (Enable mode)");
 				// Recurse — start watching the new process
-				s_shell_watch_thread = CreateThread(NULL, 0, shell_watch_thread_func, NULL, 0, NULL);
+				s_workspace_watch_thread = CreateThread(NULL, 0, workspace_watch_thread_func, NULL, 0, NULL);
 			}
 		}
 	}
@@ -245,32 +245,32 @@ shell_watch_thread_func(LPVOID param)
 	return 0;
 }
 
-//! Spawn the shell and start watching it.
+//! Spawn the workspace controller and start watching it.
 static void
-spawn_shell(void)
+spawn_workspace(void)
 {
-	if (s_shell_running) {
+	if (s_workspace_running) {
 		return;
 	}
 
-	char shell_path[MAX_PATH];
-	if (!sibling_exe_path("displayxr-shell.exe", shell_path, sizeof(shell_path))) {
-		OW("Cannot find displayxr-shell.exe next to service");
+	char workspace_path[MAX_PATH];
+	if (!sibling_exe_path(s_cfg.workspace_binary, workspace_path, sizeof(workspace_path))) {
+		OW("Cannot find workspace controller binary '%s' next to service", s_cfg.workspace_binary);
 		return;
 	}
 
-	if (!launch_child(shell_path, "--service-managed", &s_shell_pi)) {
+	if (!launch_child(workspace_path, "--service-managed", &s_workspace_pi)) {
 		return;
 	}
 
-	s_shell_running = true;
-	OW("Launched shell (PID %lu)", (unsigned long)s_shell_pi.dwProcessId);
+	s_workspace_running = true;
+	OW("Launched workspace controller (PID %lu)", (unsigned long)s_workspace_pi.dwProcessId);
 
 	// Start watchdog thread
-	if (s_shell_watch_thread) {
-		CloseHandle(s_shell_watch_thread);
+	if (s_workspace_watch_thread) {
+		CloseHandle(s_workspace_watch_thread);
 	}
-	s_shell_watch_thread = CreateThread(NULL, 0, shell_watch_thread_func, NULL, 0, NULL);
+	s_workspace_watch_thread = CreateThread(NULL, 0, workspace_watch_thread_func, NULL, 0, NULL);
 }
 
 
@@ -532,7 +532,7 @@ stop_bridge_trampoline(void)
  *
  * The hook proc runs on the thread that installed it (the tray thread,
  * which has a GetMessage pump). From there we PostMessage a custom
- * message to the subclassed tray HWND and let spawn_shell run on a
+ * message to the subclassed tray HWND and let spawn_workspace run on a
  * normal stack — hook procs should do minimal work.
  *
  */
@@ -554,10 +554,10 @@ orchestrator_kbd_hook_proc(int nCode, WPARAM wParam, LPARAM lParam)
 			bool alt = (GetAsyncKeyState(VK_MENU) & 0x8000) != 0;
 			bool win = (GetAsyncKeyState(VK_LWIN) & 0x8000) != 0 ||
 			           (GetAsyncKeyState(VK_RWIN) & 0x8000) != 0;
-			OW("kbd hook: Space ctrl=%d shift=%d alt=%d win=%d shell_running=%d",
-			   ctrl, shift, alt, win, (int)s_shell_running);
+			OW("kbd hook: Space ctrl=%d shift=%d alt=%d win=%d workspace_running=%d",
+			   ctrl, shift, alt, win, (int)s_workspace_running);
 			// Plain Ctrl+Space only, no other modifiers.
-			if (ctrl && !shift && !alt && !win && !s_shell_running) {
+			if (ctrl && !shift && !alt && !win && !s_workspace_running) {
 				HWND hwnd = (HWND)service_tray_get_hwnd();
 				if (hwnd) {
 					PostMessageW(hwnd, WM_ORCHESTRATOR_SPAWN_SHELL, 0, 0);
@@ -573,8 +573,8 @@ static LRESULT CALLBACK
 orchestrator_wnd_proc_hook(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 {
 	if (msg == WM_ORCHESTRATOR_SPAWN_SHELL) {
-		OW("Ctrl+Space pressed — launching shell");
-		spawn_shell();
+		OW("Ctrl+Space pressed — launching workspace controller");
+		spawn_workspace();
 		return 0;
 	}
 	if (msg == WM_ORCHESTRATOR_INSTALL_HOOK) {
@@ -606,7 +606,7 @@ orchestrator_wnd_proc_hook(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 //! pump — the tray thread does, our main thread (blocked in ipc_server_main)
 //! doesn't. Returns true if the install request was posted successfully.
 static bool
-install_shell_hotkey(void)
+install_workspace_hotkey(void)
 {
 	HWND hwnd = (HWND)service_tray_get_hwnd();
 	if (hwnd == NULL) return false;
@@ -614,7 +614,7 @@ install_shell_hotkey(void)
 }
 
 static void
-uninstall_shell_hotkey(void)
+uninstall_workspace_hotkey(void)
 {
 	HWND hwnd = (HWND)service_tray_get_hwnd();
 	if (hwnd != NULL) {
@@ -630,42 +630,42 @@ uninstall_shell_hotkey(void)
  */
 
 static void
-apply_shell_mode(enum service_child_mode mode)
+apply_workspace_mode(enum service_child_mode mode)
 {
 	switch (mode) {
 	case SERVICE_CHILD_ENABLE:
 		// Uninstall keyboard hook if active
 		if (s_hotkey_registered) {
-			uninstall_shell_hotkey();
+			uninstall_workspace_hotkey();
 			s_hotkey_registered = false;
 		}
-		// Launch shell if not running
-		spawn_shell();
+		// Launch workspace controller if not running
+		spawn_workspace();
 		break;
 
 	case SERVICE_CHILD_DISABLE:
 		// Uninstall keyboard hook if active
 		if (s_hotkey_registered) {
-			uninstall_shell_hotkey();
+			uninstall_workspace_hotkey();
 			s_hotkey_registered = false;
 		}
-		// Terminate shell if running
-		if (s_shell_running) {
-			terminate_child(&s_shell_pi, &s_shell_running);
-			OW("Terminated shell (Disable mode)");
+		// Terminate workspace controller if running
+		if (s_workspace_running) {
+			terminate_child(&s_workspace_pi, &s_workspace_running);
+			OW("Terminated workspace controller (Disable mode)");
 		}
 		break;
 
 	case SERVICE_CHILD_AUTO:
-		// Install low-level keyboard hook so Ctrl+Space summons the shell.
-		// The hook's proc checks s_shell_running per-keypress and passes
-		// through if the shell is already up. The actual install happens
+		// Install low-level keyboard hook so Ctrl+Space summons the workspace controller.
+		// The hook's proc checks s_workspace_running per-keypress and passes
+		// through if the workspace is already up. The actual install happens
 		// on the tray thread via PostMessage; log only on failure here.
 		if (!s_hotkey_registered) {
-			if (install_shell_hotkey()) {
+			if (install_workspace_hotkey()) {
 				s_hotkey_registered = true;
 			} else {
-				OW("install_shell_hotkey: could not post to tray HWND");
+				OW("install_workspace_hotkey: could not post to tray HWND");
 			}
 		}
 		break;
@@ -710,7 +710,7 @@ bool
 service_orchestrator_init(const struct service_config *cfg)
 {
 	s_cfg = *cfg;
-	ZeroMemory(&s_shell_pi, sizeof(s_shell_pi));
+	ZeroMemory(&s_workspace_pi, sizeof(s_workspace_pi));
 	ZeroMemory(&s_bridge_pi, sizeof(s_bridge_pi));
 
 	if (!s_bridge_lock_inited) {
@@ -725,7 +725,7 @@ service_orchestrator_init(const struct service_config *cfg)
 		                                                  (LONG_PTR)orchestrator_wnd_proc_hook);
 	}
 
-	apply_shell_mode(cfg->shell);
+	apply_workspace_mode(cfg->workspace);
 	apply_bridge_mode(cfg->bridge);
 
 	return true;
@@ -734,12 +734,12 @@ service_orchestrator_init(const struct service_config *cfg)
 void
 service_orchestrator_apply_config(const struct service_config *cfg)
 {
-	enum service_child_mode old_shell = s_cfg.shell;
+	enum service_child_mode old_workspace = s_cfg.workspace;
 	enum service_child_mode old_bridge = s_cfg.bridge;
 	s_cfg = *cfg;
 
-	if (cfg->shell != old_shell) {
-		apply_shell_mode(cfg->shell);
+	if (cfg->workspace != old_workspace) {
+		apply_workspace_mode(cfg->workspace);
 	}
 
 	if (cfg->bridge != old_bridge) {
@@ -754,7 +754,7 @@ service_orchestrator_shutdown(void)
 
 	// Uninstall keyboard hook
 	if (s_hotkey_registered) {
-		uninstall_shell_hotkey();
+		uninstall_workspace_hotkey();
 		s_hotkey_registered = false;
 	}
 
@@ -765,15 +765,15 @@ service_orchestrator_shutdown(void)
 	}
 
 	// Terminate shell
-	if (s_shell_running) {
-		terminate_child(&s_shell_pi, &s_shell_running);
+	if (s_workspace_running) {
+		terminate_child(&s_workspace_pi, &s_workspace_running);
 	}
 
 	// Wait for watchdog thread
-	if (s_shell_watch_thread) {
-		WaitForSingleObject(s_shell_watch_thread, 3000);
-		CloseHandle(s_shell_watch_thread);
-		s_shell_watch_thread = NULL;
+	if (s_workspace_watch_thread) {
+		WaitForSingleObject(s_workspace_watch_thread, 3000);
+		CloseHandle(s_workspace_watch_thread);
+		s_workspace_watch_thread = NULL;
 	}
 
 	// Stop the trampoline and terminate the bridge. Flip mode to DISABLE

--- a/src/xrt/targets/service/service_orchestrator.c
+++ b/src/xrt/targets/service/service_orchestrator.c
@@ -50,7 +50,7 @@ DEBUG_GET_ONCE_LOG_OPTION(orchestrator_log, "DISPLAYXR_ORCHESTRATOR_LOG", U_LOGG
 // — every Shell_NotifyIcon notification (WM_RBUTTONUP, WM_MOUSEMOVE,
 // NIN_POPUPOPEN, …) is delivered as that message, and a clash makes this
 // orchestrator subclass eat them all before tray_wnd_proc ever sees them.
-#define WM_ORCHESTRATOR_SPAWN_SHELL    (WM_APP + 100)
+#define WM_ORCHESTRATOR_SPAWN_WORKSPACE    (WM_APP + 100)
 #define WM_ORCHESTRATOR_INSTALL_HOOK   (WM_APP + 101)
 #define WM_ORCHESTRATOR_UNINSTALL_HOOK (WM_APP + 102)
 
@@ -223,7 +223,7 @@ workspace_watch_thread_func(LPVOID param)
 	s_workspace_pi.hProcess = NULL;
 	s_workspace_running = false;
 
-	OW("Shell process exited");
+	OW("Workspace controller process exited");
 
 	// In Auto mode, nothing to re-register: the low-level keyboard hook
 	// stays installed across workspace sessions, it's gated by s_workspace_running
@@ -560,7 +560,7 @@ orchestrator_kbd_hook_proc(int nCode, WPARAM wParam, LPARAM lParam)
 			if (ctrl && !shift && !alt && !win && !s_workspace_running) {
 				HWND hwnd = (HWND)service_tray_get_hwnd();
 				if (hwnd) {
-					PostMessageW(hwnd, WM_ORCHESTRATOR_SPAWN_SHELL, 0, 0);
+					PostMessageW(hwnd, WM_ORCHESTRATOR_SPAWN_WORKSPACE, 0, 0);
 				}
 				return 1; // swallow — don't let other handlers see Ctrl+Space
 			}
@@ -572,7 +572,7 @@ orchestrator_kbd_hook_proc(int nCode, WPARAM wParam, LPARAM lParam)
 static LRESULT CALLBACK
 orchestrator_wnd_proc_hook(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 {
-	if (msg == WM_ORCHESTRATOR_SPAWN_SHELL) {
+	if (msg == WM_ORCHESTRATOR_SPAWN_WORKSPACE) {
 		OW("Ctrl+Space pressed — launching workspace controller");
 		spawn_workspace();
 		return 0;
@@ -764,7 +764,7 @@ service_orchestrator_shutdown(void)
 		s_original_wnd_proc = NULL;
 	}
 
-	// Terminate shell
+	// Terminate workspace controller
 	if (s_workspace_running) {
 		terminate_child(&s_workspace_pi, &s_workspace_running);
 	}

--- a/src/xrt/targets/service/service_orchestrator.h
+++ b/src/xrt/targets/service/service_orchestrator.h
@@ -65,6 +65,20 @@ service_orchestrator_is_workspace_available(void);
 const char *
 service_orchestrator_get_workspace_display_name(void);
 
+/*!
+ * PID of the workspace controller process spawned by this orchestrator, or 0
+ * if no orchestrator-spawned workspace is running.
+ *
+ * Used by the IPC layer to authenticate `workspace_activate` requests: only
+ * the process the orchestrator launched may transition the runtime into
+ * workspace mode. A return value of 0 means manual mode — first-claim wins.
+ *
+ * Return type is `unsigned long` (not `DWORD`) so this header stays free of
+ * `<windows.h>`; callers cast as needed.
+ */
+unsigned long
+service_orchestrator_get_workspace_pid(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/xrt/targets/service/service_orchestrator.h
+++ b/src/xrt/targets/service/service_orchestrator.h
@@ -41,6 +41,30 @@ service_orchestrator_apply_config(const struct service_config *cfg);
 void
 service_orchestrator_shutdown(void);
 
+/*!
+ * Whether a workspace controller binary was found next to the service exe at
+ * init time. When false, the tray hides the Workspace submenu and the
+ * Ctrl+Space hotkey is a no-op — the runtime is operating as a standalone
+ * OpenXR + WebXR platform with no spatial-desktop features.
+ *
+ * Detection is one-time at init. Reinstalling a controller while the service
+ * is running requires a service restart.
+ */
+bool
+service_orchestrator_is_workspace_available(void);
+
+/*!
+ * Display name for the installed workspace controller, suitable for tray UI.
+ * Reads from the controller's `<binary>.controller.json` sidecar manifest if
+ * present; falls back to "Workspace Controller" when the manifest is absent
+ * or malformed. Returns an empty string if no controller is installed.
+ *
+ * The returned pointer is owned by the orchestrator and remains valid for
+ * the service's lifetime.
+ */
+const char *
+service_orchestrator_get_workspace_display_name(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/xrt/targets/service/service_tray_win.c
+++ b/src/xrt/targets/service/service_tray_win.c
@@ -7,6 +7,7 @@
  */
 
 #include "service_tray_win.h"
+#include "service_orchestrator.h"
 
 #include <windows.h>
 #include <shellapi.h>
@@ -114,14 +115,6 @@ show_context_menu(HWND hwnd)
 	POINT pt;
 	GetCursorPos(&pt);
 
-	// Workspace submenu (radio group: Enable, Auto, Disable)
-	HMENU workspace_sub = CreatePopupMenu();
-	AppendMenuW(workspace_sub, MF_STRING, IDM_WORKSPACE_ENABLE, L"Enable");
-	AppendMenuW(workspace_sub, MF_STRING, IDM_WORKSPACE_AUTO, L"Auto");
-	AppendMenuW(workspace_sub, MF_STRING, IDM_WORKSPACE_DISABLE, L"Disable");
-	CheckMenuRadioItem(workspace_sub, IDM_WORKSPACE_ENABLE, IDM_WORKSPACE_AUTO,
-	                   workspace_mode_to_id(s_config.workspace), MF_BYCOMMAND);
-
 	// Bridge submenu (radio group: Enable, Auto, Disable)
 	HMENU bridge_sub = CreatePopupMenu();
 	AppendMenuW(bridge_sub, MF_STRING, IDM_BRIDGE_ENABLE, L"Enable");
@@ -132,7 +125,30 @@ show_context_menu(HWND hwnd)
 
 	// Main menu
 	HMENU menu = CreatePopupMenu();
-	AppendMenuW(menu, MF_POPUP, (UINT_PTR)workspace_sub, L"Workspace Controller");
+
+	// Workspace submenu — only built when a controller binary is detected next
+	// to the service. Bare runtime (no controller installed) gets just the
+	// Bridge entry, which is the honest reflection of what the runtime can
+	// do on its own.
+	if (service_orchestrator_is_workspace_available()) {
+		HMENU workspace_sub = CreatePopupMenu();
+		AppendMenuW(workspace_sub, MF_STRING, IDM_WORKSPACE_ENABLE, L"Enable");
+		AppendMenuW(workspace_sub, MF_STRING, IDM_WORKSPACE_AUTO, L"Auto");
+		AppendMenuW(workspace_sub, MF_STRING, IDM_WORKSPACE_DISABLE, L"Disable");
+		CheckMenuRadioItem(workspace_sub, IDM_WORKSPACE_ENABLE, IDM_WORKSPACE_AUTO,
+		                   workspace_mode_to_id(s_config.workspace), MF_BYCOMMAND);
+
+		// Convert UTF-8 manifest display name to wide for the menu item.
+		const char *name_utf8 = service_orchestrator_get_workspace_display_name();
+		wchar_t name_wide[256];
+		if (name_utf8 == NULL || name_utf8[0] == '\0' ||
+		    MultiByteToWideChar(CP_UTF8, 0, name_utf8, -1,
+		                        name_wide, ARRAYSIZE(name_wide)) == 0) {
+			wcscpy_s(name_wide, ARRAYSIZE(name_wide), L"Workspace Controller");
+		}
+		AppendMenuW(menu, MF_POPUP, (UINT_PTR)workspace_sub, name_wide);
+	}
+
 	AppendMenuW(menu, MF_POPUP, (UINT_PTR)bridge_sub, L"WebXR Bridge");
 	AppendMenuW(menu, MF_SEPARATOR, 0, NULL);
 	AppendMenuW(menu, MF_STRING | (s_config.start_on_login ? MF_CHECKED : MF_UNCHECKED),

--- a/src/xrt/targets/service/service_tray_win.c
+++ b/src/xrt/targets/service/service_tray_win.c
@@ -114,7 +114,7 @@ show_context_menu(HWND hwnd)
 	POINT pt;
 	GetCursorPos(&pt);
 
-	// Shell submenu (radio group: Enable, Auto, Disable)
+	// Workspace submenu (radio group: Enable, Auto, Disable)
 	HMENU workspace_sub = CreatePopupMenu();
 	AppendMenuW(workspace_sub, MF_STRING, IDM_WORKSPACE_ENABLE, L"Enable");
 	AppendMenuW(workspace_sub, MF_STRING, IDM_WORKSPACE_AUTO, L"Auto");
@@ -177,7 +177,7 @@ tray_wnd_proc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 
 	case WM_COMMAND:
 		switch (LOWORD(wParam)) {
-		// Shell mode radio group
+		// Workspace mode radio group
 		case IDM_WORKSPACE_ENABLE:
 			s_config.workspace = SERVICE_CHILD_ENABLE;
 			config_changed();

--- a/src/xrt/targets/service/service_tray_win.c
+++ b/src/xrt/targets/service/service_tray_win.c
@@ -16,9 +16,9 @@
 #define WM_TRAYICON              (WM_APP + 1)
 
 // Menu command IDs
-#define IDM_SHELL_ENABLE    1010
-#define IDM_SHELL_DISABLE   1011
-#define IDM_SHELL_AUTO      1012
+#define IDM_WORKSPACE_ENABLE    1010
+#define IDM_WORKSPACE_DISABLE   1011
+#define IDM_WORKSPACE_AUTO      1012
 #define IDM_BRIDGE_ENABLE   1020
 #define IDM_BRIDGE_DISABLE  1021
 #define IDM_BRIDGE_AUTO     1022
@@ -85,14 +85,14 @@ load_theme_icon(void)
  *
  */
 
-//! Map service_child_mode to the corresponding menu ID for the shell submenu.
+//! Map service_child_mode to the corresponding menu ID for the workspace submenu.
 static UINT
-shell_mode_to_id(enum service_child_mode m)
+workspace_mode_to_id(enum service_child_mode m)
 {
 	switch (m) {
-	case SERVICE_CHILD_ENABLE: return IDM_SHELL_ENABLE;
-	case SERVICE_CHILD_DISABLE: return IDM_SHELL_DISABLE;
-	default: return IDM_SHELL_AUTO;
+	case SERVICE_CHILD_ENABLE: return IDM_WORKSPACE_ENABLE;
+	case SERVICE_CHILD_DISABLE: return IDM_WORKSPACE_DISABLE;
+	default: return IDM_WORKSPACE_AUTO;
 	}
 }
 
@@ -115,12 +115,12 @@ show_context_menu(HWND hwnd)
 	GetCursorPos(&pt);
 
 	// Shell submenu (radio group: Enable, Auto, Disable)
-	HMENU shell_sub = CreatePopupMenu();
-	AppendMenuW(shell_sub, MF_STRING, IDM_SHELL_ENABLE, L"Enable");
-	AppendMenuW(shell_sub, MF_STRING, IDM_SHELL_AUTO, L"Auto");
-	AppendMenuW(shell_sub, MF_STRING, IDM_SHELL_DISABLE, L"Disable");
-	CheckMenuRadioItem(shell_sub, IDM_SHELL_ENABLE, IDM_SHELL_AUTO,
-	                   shell_mode_to_id(s_config.shell), MF_BYCOMMAND);
+	HMENU workspace_sub = CreatePopupMenu();
+	AppendMenuW(workspace_sub, MF_STRING, IDM_WORKSPACE_ENABLE, L"Enable");
+	AppendMenuW(workspace_sub, MF_STRING, IDM_WORKSPACE_AUTO, L"Auto");
+	AppendMenuW(workspace_sub, MF_STRING, IDM_WORKSPACE_DISABLE, L"Disable");
+	CheckMenuRadioItem(workspace_sub, IDM_WORKSPACE_ENABLE, IDM_WORKSPACE_AUTO,
+	                   workspace_mode_to_id(s_config.workspace), MF_BYCOMMAND);
 
 	// Bridge submenu (radio group: Enable, Auto, Disable)
 	HMENU bridge_sub = CreatePopupMenu();
@@ -132,7 +132,7 @@ show_context_menu(HWND hwnd)
 
 	// Main menu
 	HMENU menu = CreatePopupMenu();
-	AppendMenuW(menu, MF_POPUP, (UINT_PTR)shell_sub, L"Spatial Shell");
+	AppendMenuW(menu, MF_POPUP, (UINT_PTR)workspace_sub, L"Workspace Controller");
 	AppendMenuW(menu, MF_POPUP, (UINT_PTR)bridge_sub, L"WebXR Bridge");
 	AppendMenuW(menu, MF_SEPARATOR, 0, NULL);
 	AppendMenuW(menu, MF_STRING | (s_config.start_on_login ? MF_CHECKED : MF_UNCHECKED),
@@ -178,16 +178,16 @@ tray_wnd_proc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 	case WM_COMMAND:
 		switch (LOWORD(wParam)) {
 		// Shell mode radio group
-		case IDM_SHELL_ENABLE:
-			s_config.shell = SERVICE_CHILD_ENABLE;
+		case IDM_WORKSPACE_ENABLE:
+			s_config.workspace = SERVICE_CHILD_ENABLE;
 			config_changed();
 			break;
-		case IDM_SHELL_AUTO:
-			s_config.shell = SERVICE_CHILD_AUTO;
+		case IDM_WORKSPACE_AUTO:
+			s_config.workspace = SERVICE_CHILD_AUTO;
 			config_changed();
 			break;
-		case IDM_SHELL_DISABLE:
-			s_config.shell = SERVICE_CHILD_DISABLE;
+		case IDM_WORKSPACE_DISABLE:
+			s_config.workspace = SERVICE_CHILD_DISABLE;
 			config_changed();
 			break;
 
@@ -309,7 +309,7 @@ service_tray_init(service_tray_shutdown_cb shutdown_cb,
 	if (initial_cfg) {
 		s_config = *initial_cfg;
 	} else {
-		s_config.shell = SERVICE_CHILD_AUTO;
+		s_config.workspace = SERVICE_CHILD_AUTO;
 		s_config.bridge = SERVICE_CHILD_AUTO;
 		s_config.start_on_login = true;
 	}

--- a/src/xrt/targets/service/service_workspace_manifest.c
+++ b/src/xrt/targets/service/service_workspace_manifest.c
@@ -1,0 +1,170 @@
+// Copyright 2026, DisplayXR
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  Workspace controller sidecar manifest loader.
+ * @ingroup ipc
+ */
+
+#include "service_workspace_manifest.h"
+
+#include "xrt/xrt_config_os.h"
+#include "util/u_logging.h"
+#include "cjson/cJSON.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef XRT_OS_WINDOWS
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#endif
+
+#ifdef _WIN32
+#define strncasecmp _strnicmp
+#endif
+
+
+/*
+ *
+ * Helpers
+ *
+ */
+
+//! Build the path to the sidecar manifest from the workspace binary path.
+//! Strips a trailing ".exe" (case-insensitive) if present, then appends
+//! ".controller.json". Returns false on buffer overflow.
+static bool
+manifest_path_for(const char *workspace_binary_path, char *buf, size_t buf_size)
+{
+	size_t len = strlen(workspace_binary_path);
+	size_t base_len = len;
+	if (len >= 4 && strncasecmp(workspace_binary_path + len - 4, ".exe", 4) == 0) {
+		base_len = len - 4;
+	}
+
+	int written = snprintf(buf, buf_size, "%.*s.controller.json",
+	                       (int)base_len, workspace_binary_path);
+	if (written < 0 || (size_t)written >= buf_size) {
+		return false;
+	}
+	return true;
+}
+
+//! Quick existence check; avoids opening the file just to fail in fopen.
+static bool
+file_exists(const char *path)
+{
+#ifdef XRT_OS_WINDOWS
+	DWORD attrs = GetFileAttributesA(path);
+	return attrs != INVALID_FILE_ATTRIBUTES && !(attrs & FILE_ATTRIBUTE_DIRECTORY);
+#else
+	FILE *f = fopen(path, "rb");
+	if (!f) {
+		return false;
+	}
+	fclose(f);
+	return true;
+#endif
+}
+
+//! Read entire file into malloc'd buffer. Returns NULL on failure.
+//! Mirrors service_config.c::read_file.
+static char *
+read_file(const char *path)
+{
+	FILE *f = fopen(path, "rb");
+	if (!f) {
+		return NULL;
+	}
+
+	fseek(f, 0, SEEK_END);
+	long len = ftell(f);
+	fseek(f, 0, SEEK_SET);
+
+	if (len <= 0 || len > 64 * 1024) {
+		fclose(f);
+		return NULL;
+	}
+
+	char *buf = (char *)malloc((size_t)len + 1);
+	if (!buf) {
+		fclose(f);
+		return NULL;
+	}
+
+	size_t read = fread(buf, 1, (size_t)len, f);
+	fclose(f);
+
+	buf[read] = '\0';
+	return buf;
+}
+
+//! Copy a JSON string field into a fixed-size buffer, length-capped.
+//! Missing or non-string fields land as empty strings.
+static void
+copy_string_field(const cJSON *root, const char *key, char *out, size_t out_size)
+{
+	const cJSON *node = cJSON_GetObjectItemCaseSensitive(root, key);
+	if (cJSON_IsString(node) && node->valuestring != NULL) {
+		snprintf(out, out_size, "%s", node->valuestring);
+	} else {
+		out[0] = '\0';
+	}
+}
+
+
+/*
+ *
+ * Public API
+ *
+ */
+
+bool
+service_workspace_manifest_load(const char *workspace_binary_path,
+                                struct workspace_manifest *out)
+{
+	memset(out, 0, sizeof(*out));
+
+	if (workspace_binary_path == NULL || workspace_binary_path[0] == '\0') {
+		return false;
+	}
+
+	char path[512];
+	if (!manifest_path_for(workspace_binary_path, path, sizeof(path))) {
+		return false;
+	}
+
+	if (!file_exists(path)) {
+		return false;
+	}
+
+	char *json_str = read_file(path);
+	if (!json_str) {
+		return false;
+	}
+
+	cJSON *root = cJSON_Parse(json_str);
+	free(json_str);
+	if (!root) {
+		U_LOG_W("workspace manifest: parse failed for %s", path);
+		return false;
+	}
+
+	const cJSON *schema = cJSON_GetObjectItemCaseSensitive(root, "schema_version");
+	if (!cJSON_IsNumber(schema) || schema->valueint != 1) {
+		U_LOG_W("workspace manifest: unsupported schema_version in %s (expected 1)", path);
+		cJSON_Delete(root);
+		memset(out, 0, sizeof(*out));
+		return false;
+	}
+
+	copy_string_field(root, "display_name", out->display_name, sizeof(out->display_name));
+	copy_string_field(root, "vendor", out->vendor, sizeof(out->vendor));
+	copy_string_field(root, "version", out->version, sizeof(out->version));
+	copy_string_field(root, "icon_path", out->icon_path, sizeof(out->icon_path));
+
+	cJSON_Delete(root);
+	return true;
+}

--- a/src/xrt/targets/service/service_workspace_manifest.h
+++ b/src/xrt/targets/service/service_workspace_manifest.h
@@ -1,0 +1,53 @@
+// Copyright 2026, DisplayXR
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  Workspace controller sidecar manifest (`<binary>.controller.json`).
+ * @ingroup ipc
+ */
+
+#pragma once
+
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*!
+ * Metadata describing an installed workspace controller, read from a JSON
+ * sidecar dropped next to the controller binary at install time.
+ *
+ * The manifest is optional — when absent, callers fall back to defaults
+ * (e.g. display_name = "Workspace Controller"). Schema is forward-additive:
+ * unknown fields are ignored, missing optional fields land as empty strings.
+ */
+struct workspace_manifest
+{
+	char display_name[256]; //!< Human-readable name for tray UI etc.
+	char vendor[64];        //!< Vendor / publisher.
+	char version[32];       //!< Free-form version string.
+	char icon_path[260];    //!< Optional path to an icon resource.
+};
+
+/*!
+ * Load `<workspace_binary_path with .exe stripped>.controller.json` next to
+ * the workspace binary, parse it, and populate @p out.
+ *
+ * @param workspace_binary_path Absolute path to the workspace controller
+ *                              binary. The sidecar manifest is found by
+ *                              stripping `.exe` (case-insensitive) from
+ *                              this path and appending `.controller.json`.
+ * @param out                   Populated on success; zeroed on failure.
+ *
+ * @return true on success (manifest found, parsed, schema_version == 1).
+ *         false if the manifest is absent, malformed, or has an unsupported
+ *         schema version. The caller should fall back to defaults.
+ */
+bool
+service_workspace_manifest_load(const char *workspace_binary_path,
+                                struct workspace_manifest *out);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/xrt/targets/shell/README.md
+++ b/src/xrt/targets/shell/README.md
@@ -35,8 +35,8 @@ The shell is a pure IPC client — it communicates with the runtime exclusively 
 ```
 DisplayXR Shell (policy)
   │
-  │  3 IPC calls: shell_activate, shell_set_window_pose, shell_get_window_pose
-  │  + capture: shell_add_capture_client, shell_remove_capture_client
+  │  3 IPC calls: workspace_activate, workspace_set_window_pose, workspace_get_window_pose
+  │  + capture: workspace_add_capture_client, workspace_remove_capture_client
   │
   ▼
 DisplayXR Runtime (mechanism)

--- a/src/xrt/targets/shell/main.c
+++ b/src/xrt/targets/shell/main.c
@@ -797,7 +797,7 @@ try_apply_poses(struct ipc_connection *ipc_c, struct app_entry *apps, int app_co
 				pose.position.y = apps[a].py;
 				pose.position.z = apps[a].pz;
 
-				r = ipc_call_shell_set_window_pose(
+				r = ipc_call_workspace_set_window_pose(
 				    ipc_c, id, &pose,
 				    apps[a].width_m, apps[a].height_m);
 				if (r == XRT_SUCCESS) {
@@ -1024,7 +1024,7 @@ enumerate_and_adopt_windows(struct ipc_connection *ipc_c,
 		}
 
 		uint32_t cid = 0;
-		xrt_result_t r = ipc_call_shell_add_capture_client(ipc_c, ce->hwnd, &cid);
+		xrt_result_t r = ipc_call_workspace_add_capture_client(ipc_c, ce->hwnd, &cid);
 		if (r == XRT_SUCCESS) {
 			ce->client_id = cid;
 			ce->added = true;
@@ -1050,7 +1050,7 @@ cleanup_closed_captures(struct ipc_connection *ipc_c,
 		if (!captures[i].added) continue;
 		if (!IsWindow((HWND)(uintptr_t)captures[i].hwnd)) {
 			P("  Window closed: '%s' (client_id=%u)\n", captures[i].name, captures[i].client_id);
-			ipc_call_shell_remove_capture_client(ipc_c, captures[i].client_id);
+			ipc_call_workspace_remove_capture_client(ipc_c, captures[i].client_id);
 			// Shift remaining entries
 			for (int j = i; j < *capture_count - 1; j++) {
 				captures[j] = captures[j + 1];
@@ -1249,9 +1249,9 @@ shell_compute_running_tile_mask(struct ipc_connection *ipc_c)
 static void
 shell_push_registered_apps_to_service(struct ipc_connection *ipc_c)
 {
-	xrt_result_t r = ipc_call_shell_clear_launcher_apps(ipc_c);
+	xrt_result_t r = ipc_call_launcher_clear_apps(ipc_c);
 	if (r != XRT_SUCCESS) {
-		PE("ipc_call_shell_clear_launcher_apps failed: %d\n", r);
+		PE("ipc_call_launcher_clear_apps failed: %d\n", r);
 		return;
 	}
 
@@ -1272,9 +1272,9 @@ shell_push_registered_apps_to_service(struct ipc_connection *ipc_c)
 		snprintf(msg.icon_3d_path, sizeof(msg.icon_3d_path), "%s", src->icon_3d_path);
 		snprintf(msg.icon_3d_layout, sizeof(msg.icon_3d_layout), "%s", src->icon_3d_layout);
 
-		r = ipc_call_shell_add_launcher_app(ipc_c, &msg);
+		r = ipc_call_launcher_add_app(ipc_c, &msg);
 		if (r != XRT_SUCCESS) {
-			PE("ipc_call_shell_add_launcher_app[%d] failed: %d\n", i, r);
+			PE("ipc_call_launcher_add_app[%d] failed: %d\n", i, r);
 			return;
 		}
 		pushed++;
@@ -1587,7 +1587,7 @@ shell_launch_registered_app(struct ipc_connection *ipc_c,
 			GetWindowTextA(found_hwnd, ce->name, sizeof(ce->name));
 
 			uint32_t cid = 0;
-			xrt_result_t r = ipc_call_shell_add_capture_client(ipc_c, ce->hwnd, &cid);
+			xrt_result_t r = ipc_call_workspace_add_capture_client(ipc_c, ce->hwnd, &cid);
 			if (r == XRT_SUCCESS) {
 				ce->client_id = cid;
 				ce->added = true;
@@ -1832,9 +1832,9 @@ capture_frame(struct ipc_connection *ipc_c)
 	req.flags = IPC_CAPTURE_FLAG_ATLAS;
 
 	struct ipc_capture_result result = {0};
-	xrt_result_t r = ipc_call_shell_capture_frame(ipc_c, &req, &result);
+	xrt_result_t r = ipc_call_workspace_capture_frame(ipc_c, &req, &result);
 	if (r != XRT_SUCCESS) {
-		PE("capture: shell_capture_frame failed: %d\n", r);
+		PE("capture: workspace_capture_frame failed: %d\n", r);
 		return;
 	}
 
@@ -1894,7 +1894,7 @@ main(int argc, char *argv[])
 	}
 
 	// Connect to service. The IPC client library auto-starts displayxr-service
-	// if not running. We then send shell_activate to enter shell mode dynamically.
+	// if not running. We then send workspace_activate to enter shell mode dynamically.
 	P("Connecting to service...\n");
 
 	struct ipc_connection ipc_c = {0};
@@ -1976,9 +1976,9 @@ main(int argc, char *argv[])
 
 	if (start_active) {
 		P("Activating shell mode...\n");
-		xret = ipc_call_shell_activate(&ipc_c);
+		xret = ipc_call_workspace_activate(&ipc_c);
 		if (xret != XRT_SUCCESS) {
-			PE("Warning: shell_activate failed\n");
+			PE("Warning: workspace_activate failed\n");
 		}
 		g_shell_active = true;
 		tray_update_tooltip(true);
@@ -1986,7 +1986,7 @@ main(int argc, char *argv[])
 		// Add capture clients
 		for (int i = 0; i < capture_count; i++) {
 			uint32_t cid = 0;
-			xrt_result_t r = ipc_call_shell_add_capture_client(&ipc_c, captures[i].hwnd, &cid);
+			xrt_result_t r = ipc_call_workspace_add_capture_client(&ipc_c, captures[i].hwnd, &cid);
 			if (r == XRT_SUCCESS) {
 				captures[i].client_id = cid;
 				captures[i].added = true;
@@ -2019,9 +2019,9 @@ main(int argc, char *argv[])
 #else
 	// Non-Windows: simple activate + poll (no hotkey/tray)
 	P("Activating shell mode...\n");
-	xret = ipc_call_shell_activate(&ipc_c);
+	xret = ipc_call_workspace_activate(&ipc_c);
 	if (xret != XRT_SUCCESS) {
-		PE("Warning: shell_activate failed\n");
+		PE("Warning: workspace_activate failed\n");
 	}
 	bool auto_adopt = false;
 #endif
@@ -2065,7 +2065,7 @@ main(int argc, char *argv[])
 					// --- Toggle shell active/inactive ---
 					if (g_shell_active) {
 						P("Deactivating shell...\n");
-						ipc_call_shell_deactivate(&ipc_c);
+						ipc_call_workspace_deactivate(&ipc_c);
 
 						// Clear local capture tracking
 						for (int i = 0; i < capture_count; i++) {
@@ -2091,7 +2091,7 @@ main(int argc, char *argv[])
 						P("Shell deactivated — waiting in tray.\n");
 					} else {
 						P("Activating shell...\n");
-						xret = ipc_call_shell_activate(&ipc_c);
+						xret = ipc_call_workspace_activate(&ipc_c);
 
 						// If IPC pipe is dead (service exited), reconnect.
 						// The IPC client lib auto-starts the service.
@@ -2106,7 +2106,7 @@ main(int argc, char *argv[])
 								Sleep(1000);
 							}
 							if (xret == XRT_SUCCESS) {
-								xret = ipc_call_shell_activate(&ipc_c);
+								xret = ipc_call_workspace_activate(&ipc_c);
 								service_pid = find_service_pid();
 							}
 							if (xret != XRT_SUCCESS) {
@@ -2145,10 +2145,10 @@ main(int argc, char *argv[])
 							AllowSetForegroundWindow(service_pid);
 						}
 
-						xrt_result_t lret = ipc_call_shell_set_launcher_visible(
+						xrt_result_t lret = ipc_call_launcher_set_visible(
 						    &ipc_c, g_launcher_visible);
 						if (lret != XRT_SUCCESS) {
-							PE("ipc_call_shell_set_launcher_visible failed: %d\n", lret);
+							PE("ipc_call_launcher_set_visible failed: %d\n", lret);
 							g_launcher_visible = !g_launcher_visible; // roll back
 						} else {
 							P("Launcher %s\n", g_launcher_visible ? "shown" : "hidden");
@@ -2254,7 +2254,7 @@ main(int argc, char *argv[])
 		// The compositor sets shell_mode=false — sync our state.
 		if (g_shell_active) {
 			bool server_active = false;
-			if (ipc_call_shell_get_state(&ipc_c, &server_active) == XRT_SUCCESS) {
+			if (ipc_call_workspace_get_state(&ipc_c, &server_active) == XRT_SUCCESS) {
 				if (!server_active) {
 					P("Shell deactivated by compositor (ESC) — returning to tray.\n");
 					capture_count = 0;
@@ -2273,7 +2273,7 @@ main(int argc, char *argv[])
 			static uint64_t s_last_running_mask = (uint64_t)-1;
 			uint64_t mask = shell_compute_running_tile_mask(&ipc_c);
 			if (mask != s_last_running_mask) {
-				ipc_call_shell_set_running_tile_mask(&ipc_c, mask);
+				ipc_call_launcher_set_running_tile_mask(&ipc_c, mask);
 				s_last_running_mask = mask;
 			}
 		}
@@ -2293,7 +2293,7 @@ main(int argc, char *argv[])
 		// stale-binary issue resolved by the Phase 6 rebuild.
 		if (g_shell_active && g_launcher_visible) {
 			int64_t tile_index = -1;
-			if (ipc_call_shell_poll_launcher_click(&ipc_c, &tile_index) == XRT_SUCCESS &&
+			if (ipc_call_launcher_poll_click(&ipc_c, &tile_index) == XRT_SUCCESS &&
 			    tile_index != -1) {
 				// Service already hid the launcher when the action registered.
 				g_launcher_visible = false;
@@ -2313,7 +2313,7 @@ main(int argc, char *argv[])
 						AllowSetForegroundWindow(service_pid);
 					}
 #endif
-					if (ipc_call_shell_set_launcher_visible(&ipc_c, true) == XRT_SUCCESS) {
+					if (ipc_call_launcher_set_visible(&ipc_c, true) == XRT_SUCCESS) {
 						g_launcher_visible = true;
 					}
 				} else if (tile_index <= -(int64_t)IPC_LAUNCHER_ACTION_REMOVE_BASE) {
@@ -2379,7 +2379,7 @@ main(int argc, char *argv[])
 						AllowSetForegroundWindow(service_pid);
 					}
 #endif
-					if (ipc_call_shell_set_launcher_visible(&ipc_c, true) == XRT_SUCCESS) {
+					if (ipc_call_launcher_set_visible(&ipc_c, true) == XRT_SUCCESS) {
 						g_launcher_visible = true;
 					}
 				} else if (tile_index == IPC_LAUNCHER_ACTION_BROWSE) {
@@ -2392,7 +2392,7 @@ main(int argc, char *argv[])
 						AllowSetForegroundWindow(service_pid);
 					}
 #endif
-					if (ipc_call_shell_set_launcher_visible(&ipc_c, true) == XRT_SUCCESS) {
+					if (ipc_call_launcher_set_visible(&ipc_c, true) == XRT_SUCCESS) {
 						g_launcher_visible = true;
 					}
 				} else if (tile_index >= 0 && tile_index < (int64_t)g_registered_app_count) {
@@ -2455,7 +2455,7 @@ main(int argc, char *argv[])
 #ifdef _WIN32
 	// Deactivate shell if still active
 	if (g_shell_active) {
-		ipc_call_shell_deactivate(&ipc_c);
+		ipc_call_workspace_deactivate(&ipc_c);
 	}
 
 	// Cleanup hotkey and tray

--- a/src/xrt/targets/shell/main.c
+++ b/src/xrt/targets/shell/main.c
@@ -2251,7 +2251,7 @@ main(int argc, char *argv[])
 
 #ifdef _WIN32
 		// Detect server-side deactivation (ESC closed the compositor window).
-		// The compositor sets shell_mode=false — sync our state.
+		// The compositor sets workspace_mode=false — sync our state.
 		if (g_shell_active) {
 			bool server_active = false;
 			if (ipc_call_workspace_get_state(&ipc_c, &server_active) == XRT_SUCCESS) {

--- a/src/xrt/targets/shell/main.c
+++ b/src/xrt/targets/shell/main.c
@@ -8,7 +8,7 @@
  *   displayxr-shell.exe [--pose x,y,z,w,h] app1.exe [--pose x,y,z,w,h] app2.exe ...
  *
  * - Auto-starts displayxr-service --shell if not running
- * - Launches each app with DISPLAYXR_SHELL_SESSION=1 and XR_RUNTIME_JSON set
+ * - Launches each app with DISPLAYXR_WORKSPACE_SESSION=1 and XR_RUNTIME_JSON set
  * - Optionally assigns per-app window pose via --pose x,y,z,width_m,height_m
  * - Monitors client connect/disconnect until Ctrl+C
  *
@@ -592,7 +592,7 @@ ensure_app_gpu_pref_high(const char *exe_path)
 }
 
 /*!
- * Launch an app with DISPLAYXR_SHELL_SESSION=1 and XR_RUNTIME_JSON set.
+ * Launch an app with DISPLAYXR_WORKSPACE_SESSION=1 and XR_RUNTIME_JSON set.
  */
 static bool
 launch_app(struct app_entry *app, const char *runtime_json)
@@ -603,7 +603,7 @@ launch_app(struct app_entry *app, const char *runtime_json)
 	if (runtime_json != NULL) {
 		SetEnvironmentVariableA("XR_RUNTIME_JSON", runtime_json);
 	}
-	SetEnvironmentVariableA("DISPLAYXR_SHELL_SESSION", "1");
+	SetEnvironmentVariableA("DISPLAYXR_WORKSPACE_SESSION", "1");
 
 	// Resolve to absolute path (relative paths fail with CreateProcessA)
 	char abs_path[MAX_PATH];
@@ -1517,7 +1517,7 @@ shell_browse_and_add_app(struct ipc_connection *ipc_c)
 
 /*!
  * Launch a registered app from the shell.
- * For "3d" type: uses launch_app() with DISPLAYXR_SHELL_SESSION env.
+ * For "3d" type: uses launch_app() with DISPLAYXR_WORKSPACE_SESSION env.
  * For "2d" type: launches without shell env, then captures via IPC.
  * For unknown type: launches as 3d, polls for IPC connect to auto-detect.
  */
@@ -1551,7 +1551,7 @@ shell_launch_registered_app(struct ipc_connection *ipc_c,
 		dirname_of(abs_path, exe_dir, sizeof(exe_dir));
 
 		// Clear shell env vars so 2D app doesn't accidentally pick them up
-		SetEnvironmentVariableA("DISPLAYXR_SHELL_SESSION", NULL);
+		SetEnvironmentVariableA("DISPLAYXR_WORKSPACE_SESSION", NULL);
 
 		BOOL ok = CreateProcessA(NULL, cmd, NULL, NULL, FALSE,
 		    CREATE_NEW_CONSOLE, NULL, exe_dir, &si, &pi);

--- a/test_apps/cube_handle_vk_win/main.cpp
+++ b/test_apps/cube_handle_vk_win/main.cpp
@@ -982,9 +982,9 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 
     HudRenderer hudRenderer = {};
     // Skip HUD in shell mode — window-space layers crash in VK IPC path
-    bool isShellMode = (getenv("DISPLAYXR_SHELL_SESSION") != nullptr);
-    bool hudOk = !isShellMode && InitializeHudRenderer(hudRenderer, hudWidth, hudHeight);
-    if (isShellMode) {
+    bool isWorkspaceSession = (getenv("DISPLAYXR_WORKSPACE_SESSION") != nullptr);
+    bool hudOk = !isWorkspaceSession && InitializeHudRenderer(hudRenderer, hudWidth, hudHeight);
+    if (isWorkspaceSession) {
         LOG_INFO("Shell mode detected - HUD disabled (window-space layers not supported in VK IPC)");
     } else if (!hudOk) {
         LOG_WARN("HUD renderer init failed - HUD will not be displayed");


### PR DESCRIPTION
## Summary

Delivers the first two phases of the workspace-extensions effort — a runtime that no longer reads like an SDK for one specific proprietary shell.

- **Phase 1 — boundary rename.** IPC RPCs `shell_*` → `workspace_*` / `launcher_*`, internal `shell_mode` → `workspace_mode`, new `service.json::workspace_binary` + `DISPLAYXR_WORKSPACE_SESSION` env var, narrative copy reframing the DisplayXR Shell as the reference workspace controller (one of many possible privileged compositor clients).
- **Phase 2.0 — brand separation.** Sidecar `<binary>.controller.json` manifest discovery; conditional tray submenu (no controller installed → tray honestly says so, `Ctrl+Space` is a no-op); orchestrator-PID match in `ipc_handle_workspace_activate` replaces the literal `applicationName == "displayxr-shell"` check. Runtime now installs and runs as a standalone OpenXR + WebXR platform without the shell.
- **Bonus stability fix.** Caught during functional testing on Leia SR: clicking tray Disable raced `terminate_child` against `workspace_watch_thread_func`'s `CloseHandle` of the same kernel handle → `STATUS_INVALID_HANDLE` (0xC0000008) → service crash. Fixed via `DuplicateHandle` so the watch thread owns an independent handle reference. Pre-existing bug, surfaced by Phase 2.0 making Disable a routine path.
- **Forward-looking docs.** ADR-016 (workspace controllers own tray surface + lifecycle, including teardown — explains why a current Disable-symptom is deferred rather than papered over). Phase 2.A agent prompt for the next sub-phase (extension scaffolding + capture client migration).

Detailed phase plans: [`docs/roadmap/spatial-workspace-extensions-plan.md`](docs/roadmap/spatial-workspace-extensions-plan.md). Test plan run for Phase 2.0: [`docs/roadmap/spatial-workspace-extensions-phase2-test-plan.md`](docs/roadmap/spatial-workspace-extensions-phase2-test-plan.md).

## Known limitation (deferred)

Tray-Disable hard-kills the workspace controller via `TerminateProcess`; the workspace D3D11 window keeps rendering the controller's last frame until the next workspace event clears it. Diagnosed as a consequence of the wrong ownership model (service deciding teardown semantics on behalf of the controller). Captured in ADR-016 and resolved-by-construction when the cooperative-shutdown protocol lands in a later sub-phase. **Not a new regression** — it was always the case for forced kills; Phase 2.0 just made it a routine click.

## Test plan

- [ ] Windows MSVC CI green (`build-windows.yml`)
- [ ] macOS CI green (`build-macos.yml`)
- [ ] On Leia SR hardware: re-run minimum-useful scenarios from `phase2-test-plan.md`
  - [ ] Scenario 1 — bare runtime (rename `displayxr-shell.exe` → `.bak`): tray submenu absent, `Ctrl+Space` no-op, log says "Workspace controller not installed"
  - [ ] Scenario 3 — shell + manifest (`display_name: "DisplayXR Shell"`): tray submenu labeled "DisplayXR Shell", Enable launches the shell
  - [ ] Scenario 4 — Ctrl+Space spawns the shell, no `workspace_activate: PID mismatch` warnings
- [ ] (optional) Pass-2 scenarios 2 (no-manifest fallback label), 3b (malformed schema), 6 (legacy `"shell"` JSON key back-compat)
- [ ] Confirm Disable no longer crashes the service (the race fix). Lingering-window symptom is expected per ADR-016.

🤖 Generated with [Claude Code](https://claude.com/claude-code)