### PR TITLE
ci: relax public-repo CI policy + restore macOS CI + add badges

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -1,0 +1,81 @@
+name: Build macOS
+
+# Verifies that the runtime + sim_display driver compile cleanly on
+# macOS. The historical workflow also built every test app + the macOS
+# installer + the 3DGS demo (which now lives in displayxr-demo-
+# gaussiansplat); those add a lot of surface area for breakage. Keep
+# this one minimal — building the runtime is the contract that matters
+# here. Test apps and installer can be added back later as separate
+# jobs once the build itself is reliable in CI again.
+
+on:
+  push:
+    branches: [main]
+    tags:
+      - 'v*'
+  pull_request: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  DetectChanges:
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.filter.outputs.docs_only }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - id: filter
+        run: |
+          if [ "${{ github.ref_type }}" = "tag" ]; then
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE=${{ github.event.pull_request.base.sha }}
+          else
+            BASE=${{ github.event.before }}
+          fi
+          CHANGED=$(git diff --name-only "$BASE" HEAD)
+          NON_DOC=$(echo "$CHANGED" | grep -vE '^(docs/|.*\.md$|LICENSE$|\.github/ISSUE_TEMPLATE/)' || true)
+          if [ -n "$CHANGED" ] && [ -z "$NON_DOC" ]; then
+            echo "docs_only=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  Build:
+    needs: DetectChanges
+    runs-on: macos-14
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Doc-only PR — skipping macOS build
+        if: needs.DetectChanges.outputs.docs_only == 'true'
+        run: echo "Skipping heavy steps; reporting success so branch protection's required-status-check on Build is satisfied."
+
+      - name: Install dependencies
+        if: needs.DetectChanges.outputs.docs_only != 'true'
+        run: |
+          brew install cmake ninja eigen
+          brew install glslang molten-vk vulkan-headers vulkan-loader
+          BREW_PREFIX=$(brew --prefix)
+          echo "VULKAN_SDK=$BREW_PREFIX" >> $GITHUB_ENV
+
+      - name: Configure
+        if: needs.DetectChanges.outputs.docs_only != 'true'
+        run: |
+          cmake -B build -G Ninja \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DXRT_FEATURE_SERVICE=ON \
+            -DXRT_FEATURE_HYBRID_MODE=ON
+
+      - name: Build
+        if: needs.DetectChanges.outputs.docs_only != 'true'
+        run: cmake --build build

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,23 +1,22 @@
 name: Build Windows
 
 on:
-  # CI cost policy: ONLY fires on pull requests + tag pushes.
-  # No branch-push trigger — local builds for iteration; open a draft
-  # PR to get CI feedback before review.
-  #
-  # Cost-saver combo (see CLAUDE.md):
-  # - Drafts skip CI (job-level `!github.event.pull_request.draft` guard).
-  #   Iterate as a draft; CI fires when you mark Ready for review.
+  # Public-repo CI policy: fire freely. CI is free for public repos on
+  # GitHub-hosted runners, so we optimize for contributor experience
+  # rather than minute-burn:
+  # - Drafts run CI too. Contributors get fast feedback without the
+  #   Ready-for-review handshake.
+  # - Push to main fires the workflow as a sanity check (catches the
+  #   rare admin-bypass merge that lands red).
   # - Doc-only PRs are detected by DetectChanges (`docs_only` output);
-  #   the heavy steps inside Runtime + test-app jobs skip when true,
-  #   but the workflow still fires + Runtime still reports a status so
-  #   branch protection's required-status-check on `Runtime` is
-  #   satisfied. (The naive trigger-level `paths-ignore` would block
-  #   doc-only PRs forever once the check is required — see
-  #   reference_org_protection_state.md.)
+  #   the heavy steps skip when true, but the workflow still fires and
+  #   Runtime still reports a status so branch protection's required-
+  #   status-check on `Runtime` is satisfied. Saves wall-clock time +
+  #   keeps logs clean even if not money.
   # - Rapid pushes to a PR cancel the in-progress run; only the latest
   #   commit's CI completes (concurrency group below).
   push:
+    branches: [main]
     tags:
       - 'v*'
   pull_request: {}
@@ -33,7 +32,6 @@ permissions:
 
 jobs:
   DetectChanges:
-    if: (github.event_name != 'pull_request' || !github.event.pull_request.draft)
     runs-on: ubuntu-latest
     outputs:
       test_apps_changed: ${{ steps.filter.outputs.test_apps }}
@@ -79,13 +77,10 @@ jobs:
           echo "Detected test_apps_changed=$(grep ^test_apps= "$GITHUB_OUTPUT" | cut -d= -f2) docs_only=$(grep ^docs_only= "$GITHUB_OUTPUT" | cut -d= -f2)"
 
   Runtime:
-    # Drafts skip CI; non-draft fork PRs run the build (SR SDK is fetched from
-    # upstream's release page — see the Download SR SDK step).
-    # Always runs on non-draft PRs so it can report a status check
-    # (branch protection requires this); heavy steps below skip when
-    # DetectChanges flagged the PR as docs_only.
+    # Always runs on PRs (drafts included) and main pushes so it can
+    # report a status check; heavy steps below skip when DetectChanges
+    # flagged the PR as docs_only. Free CI for public repos.
     needs: DetectChanges
-    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: windows-2022
 
     env:
@@ -223,7 +218,7 @@ jobs:
 
   # D3D11 test app with XR_EXT_win32_window_binding (app provides window handle)
   TestAppCubeHandleD3D11:
-    if: (github.event_name != 'pull_request' || !github.event.pull_request.draft) && needs.DetectChanges.outputs.test_apps_changed == 'true'
+    if: needs.DetectChanges.outputs.test_apps_changed == 'true'
     runs-on: windows-2022
     needs: [Runtime, DetectChanges]  # Wait for runtime build to get artifacts
 
@@ -325,7 +320,7 @@ jobs:
 
   # D3D11 hosted test app - Standard OpenXR app (runtime creates window)
   TestAppCubeHostedD3D11:
-    if: (github.event_name != 'pull_request' || !github.event.pull_request.draft) && needs.DetectChanges.outputs.test_apps_changed == 'true'
+    if: needs.DetectChanges.outputs.test_apps_changed == 'true'
     runs-on: windows-2022
     needs: [Runtime, DetectChanges]
 
@@ -387,7 +382,7 @@ jobs:
 
   # D3D12 test app with XR_EXT_win32_window_binding
   TestAppCubeHandleD3D12:
-    if: (github.event_name != 'pull_request' || !github.event.pull_request.draft) && needs.DetectChanges.outputs.test_apps_changed == 'true'
+    if: needs.DetectChanges.outputs.test_apps_changed == 'true'
     runs-on: windows-2022
     needs: [Runtime, DetectChanges]
 
@@ -449,7 +444,7 @@ jobs:
 
   # OpenGL test app with XR_EXT_win32_window_binding
   TestAppCubeHandleGL:
-    if: (github.event_name != 'pull_request' || !github.event.pull_request.draft) && needs.DetectChanges.outputs.test_apps_changed == 'true'
+    if: needs.DetectChanges.outputs.test_apps_changed == 'true'
     runs-on: windows-2022
     needs: [Runtime, DetectChanges]
 
@@ -511,7 +506,7 @@ jobs:
 
   # Vulkan test app with XR_EXT_win32_window_binding (requires Vulkan SDK)
   TestAppCubeHandleVK:
-    if: (github.event_name != 'pull_request' || !github.event.pull_request.draft) && needs.DetectChanges.outputs.test_apps_changed == 'true'
+    if: needs.DetectChanges.outputs.test_apps_changed == 'true'
     runs-on: windows-2022
     needs: [Runtime, DetectChanges]
 
@@ -579,7 +574,7 @@ jobs:
 
   # 3D Gaussian Splatting Vulkan demo (requires Vulkan SDK, uses FetchContent for 3DGS.cpp)
   TestAppGaussianSplattingVK:
-    if: (github.event_name != 'pull_request' || !github.event.pull_request.draft) && needs.DetectChanges.outputs.test_apps_changed == 'true'
+    if: needs.DetectChanges.outputs.test_apps_changed == 'true'
     runs-on: windows-2022
     needs: [Runtime, DetectChanges]
 
@@ -649,7 +644,7 @@ jobs:
 
   # Spatial OS demo app (multi-layer war room)
   TestAppSpatialOS:
-    if: (github.event_name != 'pull_request' || !github.event.pull_request.draft) && needs.DetectChanges.outputs.test_apps_changed == 'true'
+    if: needs.DetectChanges.outputs.test_apps_changed == 'true'
     runs-on: windows-2022
     needs: [Runtime, DetectChanges]
 
@@ -711,7 +706,7 @@ jobs:
 
   # D3D11 texture test app (offscreen shared texture mode)
   TestAppCubeTextureD3D11:
-    if: (github.event_name != 'pull_request' || !github.event.pull_request.draft) && needs.DetectChanges.outputs.test_apps_changed == 'true'
+    if: needs.DetectChanges.outputs.test_apps_changed == 'true'
     runs-on: windows-2022
     needs: [Runtime, DetectChanges]
 
@@ -765,7 +760,7 @@ jobs:
 
   # D3D12 shared texture test app
   TestAppCubeTextureD3D12:
-    if: (github.event_name != 'pull_request' || !github.event.pull_request.draft) && needs.DetectChanges.outputs.test_apps_changed == 'true'
+    if: needs.DetectChanges.outputs.test_apps_changed == 'true'
     runs-on: windows-2022
     needs: [Runtime, DetectChanges]
 
@@ -819,7 +814,7 @@ jobs:
 
   # D3D11 legacy hosted test app (no XR_EXT_display_info)
   TestAppCubeHostedLegacyD3D11:
-    if: (github.event_name != 'pull_request' || !github.event.pull_request.draft) && needs.DetectChanges.outputs.test_apps_changed == 'true'
+    if: needs.DetectChanges.outputs.test_apps_changed == 'true'
     runs-on: windows-2022
     needs: [Runtime, DetectChanges]
 
@@ -881,7 +876,7 @@ jobs:
 
   # D3D12 legacy hosted test app (no XR_EXT_display_info)
   TestAppCubeHostedLegacyD3D12:
-    if: (github.event_name != 'pull_request' || !github.event.pull_request.draft) && needs.DetectChanges.outputs.test_apps_changed == 'true'
+    if: needs.DetectChanges.outputs.test_apps_changed == 'true'
     runs-on: windows-2022
     needs: [Runtime, DetectChanges]
 
@@ -939,7 +934,7 @@ jobs:
 
   # Vulkan legacy hosted test app (no XR_EXT_display_info)
   TestAppCubeHostedLegacyVK:
-    if: (github.event_name != 'pull_request' || !github.event.pull_request.draft) && needs.DetectChanges.outputs.test_apps_changed == 'true'
+    if: needs.DetectChanges.outputs.test_apps_changed == 'true'
     runs-on: windows-2022
     needs: [Runtime, DetectChanges]
 
@@ -1003,7 +998,7 @@ jobs:
 
   # OpenGL legacy hosted test app (no XR_EXT_display_info)
   TestAppCubeHostedLegacyGL:
-    if: (github.event_name != 'pull_request' || !github.event.pull_request.draft) && needs.DetectChanges.outputs.test_apps_changed == 'true'
+    if: needs.DetectChanges.outputs.test_apps_changed == 'true'
     runs-on: windows-2022
     needs: [Runtime, DetectChanges]
 
@@ -1055,7 +1050,7 @@ jobs:
 
   # Bundle all test apps into a single artifact with per-app subfolders
   BundleTestApps:
-    if: (github.event_name != 'pull_request' || !github.event.pull_request.draft) && !cancelled() && needs.DetectChanges.outputs.test_apps_changed == 'true' && (github.event_name == 'pull_request' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
+    if: ${{ !cancelled() && needs.DetectChanges.outputs.test_apps_changed == 'true' && (github.event_name == 'pull_request' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')) }}
     runs-on: ubuntu-latest
     needs: [DetectChanges, TestAppCubeHandleD3D11, TestAppCubeHostedD3D11, TestAppCubeHandleD3D12, TestAppCubeHandleGL, TestAppCubeHandleVK, TestAppGaussianSplattingVK, TestAppSpatialOS, TestAppCubeTextureD3D11, TestAppCubeTextureD3D12, TestAppCubeHostedLegacyD3D11, TestAppCubeHostedLegacyD3D12, TestAppCubeHostedLegacyVK, TestAppCubeHostedLegacyGL]
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 # DisplayXR Runtime
 
+[![Build Windows](https://github.com/DisplayXR/displayxr-runtime/actions/workflows/build-windows.yml/badge.svg)](https://github.com/DisplayXR/displayxr-runtime/actions/workflows/build-windows.yml)
+[![Build macOS](https://github.com/DisplayXR/displayxr-runtime/actions/workflows/build-macos.yml/badge.svg)](https://github.com/DisplayXR/displayxr-runtime/actions/workflows/build-macos.yml)
+[![License: BSL-1.0](https://img.shields.io/badge/License-BSL--1.0-blue.svg)](LICENSE)
+
 An open-source [OpenXR](https://www.khronos.org/openxr/) runtime for spatial displays — 3D monitors and laptops with tracked stereo and multiview lightfield display technology.
 
 Built on [Monado](https://monado.freedesktop.org/) by Collabora, DisplayXR strips away headset-centric infrastructure (34 VR drivers, Vulkan server compositor, tracking subsystems) and replaces it with a lightweight runtime purpose-built for 3D displays: ~150 files, 3 drivers, native compositors for every graphics API.

--- a/src/xrt/ipc/server/ipc_server_handler.c
+++ b/src/xrt/ipc/server/ipc_server_handler.c
@@ -3230,7 +3230,7 @@ ipc_handle_workspace_acquire_wakeup_event(volatile struct ipc_client_state *_ics
 	(void)s;
 	(void)max_handle_count;
 	(void)out_handles;
-	return XRT_ERROR_FEATURE_UNSUPPORTED;
+	return XRT_ERROR_FEATURE_NOT_SUPPORTED;
 #endif
 }
 

--- a/src/xrt/state_trackers/oxr/oxr_workspace.c
+++ b/src/xrt/state_trackers/oxr/oxr_workspace.c
@@ -161,10 +161,14 @@ uint32_t
 comp_ipc_client_compositor_get_swapchain_id(struct xrt_swapchain *xsc);
 
 // Forward decl from compositor/client/comp_d3d11_client.cpp. Linked into the
-// runtime DLL alongside the IPC client. Unwraps the D3D11 wrapper so the
-// chrome dispatch can read the inner ipc_client_swapchain.id.
+// runtime DLL alongside the IPC client on Windows only. Unwraps the D3D11
+// wrapper so the chrome dispatch can read the inner ipc_client_swapchain.id.
+// On non-Windows the swapchain is already an ipc_client_swapchain (no D3D11
+// wrapper exists) — see the call sites below for the gated unwrap.
+#ifdef _WIN32
 struct xrt_swapchain *
 comp_d3d11_client_get_inner_xrt_swapchain(struct xrt_swapchain *xsc);
+#endif
 
 
 /*
@@ -968,11 +972,16 @@ oxr_xrCreateWorkspaceClientChromeSwapchainEXT(XrSession session,
 	// d3d11 client helper to reach the ipc_client_swapchain whose `id`
 	// field is what the runtime uses to look up the swapchain server-side.
 	// Valid IPC swapchain ids range from 0 to IPC_MAX_CLIENT_SWAPCHAINS-1
-	// (id 0 IS valid — first slot in the controller's xscs[] table).
-	struct xrt_swapchain *inner = comp_d3d11_client_get_inner_xrt_swapchain(sc->swapchain);
-	if (inner == NULL) {
-		inner = sc->swapchain; // fallback if it was already an ipc_client_swapchain
+	// (id 0 IS valid — first slot in the controller's xscs[] table). On
+	// non-Windows there's no D3D11 wrapper to unwrap, so the swapchain is
+	// already the ipc_client form.
+	struct xrt_swapchain *inner = sc->swapchain;
+#ifdef _WIN32
+	struct xrt_swapchain *unwrapped = comp_d3d11_client_get_inner_xrt_swapchain(inner);
+	if (unwrapped != NULL) {
+		inner = unwrapped;
 	}
+#endif
 	uint32_t swapchain_id = comp_ipc_client_compositor_get_swapchain_id(inner);
 
 	xrt_result_t xret = comp_ipc_client_compositor_workspace_register_chrome_swapchain(
@@ -999,11 +1008,14 @@ oxr_xrDestroyWorkspaceClientChromeSwapchainEXT(XrSwapchain swapchain)
 	// Drop the runtime-side chrome registration before destroying the
 	// swapchain. The runtime is tolerant of a missing entry — if the swapchain
 	// was never registered (e.g. created via xrCreateSwapchain directly), the
-	// unregister is a no-op there.
-	struct xrt_swapchain *inner = comp_d3d11_client_get_inner_xrt_swapchain(sc->swapchain);
-	if (inner == NULL) {
-		inner = sc->swapchain;
+	// unregister is a no-op there. Same _WIN32 gate as the create path.
+	struct xrt_swapchain *inner = sc->swapchain;
+#ifdef _WIN32
+	struct xrt_swapchain *unwrapped = comp_d3d11_client_get_inner_xrt_swapchain(inner);
+	if (unwrapped != NULL) {
+		inner = unwrapped;
 	}
+#endif
 	uint32_t swapchain_id = comp_ipc_client_compositor_get_swapchain_id(inner);
 	if (session_is_ipc_client(sc->sess)) {
 		(void)comp_ipc_client_compositor_workspace_unregister_chrome_swapchain(


### PR DESCRIPTION
## Why

Public-repo CI is free on GitHub-hosted runners (no minutes consumed for the org). The cost-saver guards we built (draft-skip, no main-push trigger) are over-engineered for the contributor experience now that runtime is public. Loosen them in favor of fast feedback + the patterns contributors expect from popular OSS projects.

## Changes

1. **Drop draft-skip guards.** Drafts now fire CI immediately. `cancel-in-progress` keeps rapid pushes cheap.
2. **Add `push: branches: [main]` trigger.** Sanity check that catches the rare admin-bypass merge that lands red. (Including this branch's own probe commit `fed22b2c5`.)
3. **Restore macOS CI** (`build-macos.yml`) as a minimal build-only workflow with the same `docs_only` sentinel pattern as Windows. The historical macOS workflow built test apps + demo + .pkg installer — too much surface area to revive at once. Start with just the runtime build.
4. **CI + license badges** in the runtime README.

## Out of scope

`displayxr-shell-pvt` is private; minutes are still billed. It keeps its cost-saver guards.

`displayxr-unity` build-native.yml has a `paths:` filter that already gates fork PRs efficiently. Untouched here.

## Test plan

- This PR's own CI run validates: workflow fires on a draft-equivalent (regular PR), Runtime + Build (macOS) both report status.
- macOS build hasn't run in CI for ~6 months. **If it fails, I'll revert just the macOS file from this PR** and we land the rest. The Windows changes are independent.