### PR TITLE
VK clients in workspace mode signal cross-process fence

### DIFF
--- a/src/xrt/auxiliary/util/u_sandbox.c
+++ b/src/xrt/auxiliary/util/u_sandbox.c
@@ -124,6 +124,14 @@ u_sandbox_should_use_ipc(void)
 
 	// Workspace session: app launched by workspace controller with hidden HWND, route to IPC
 	const char *workspace_session = getenv("DISPLAYXR_WORKSPACE_SESSION");
+#ifdef XRT_OS_WINDOWS
+	char workspace_session_buf[16] = {0};
+	if (workspace_session == NULL) {
+		DWORD n = GetEnvironmentVariableA("DISPLAYXR_WORKSPACE_SESSION", workspace_session_buf,
+		                                   sizeof(workspace_session_buf));
+		if (n > 0) workspace_session = workspace_session_buf;
+	}
+#endif
 	if (workspace_session != NULL && strcmp(workspace_session, "1") == 0) {
 		U_LOG_I("DISPLAYXR_WORKSPACE_SESSION=1: forcing IPC mode for workspace controller");
 		return true;

--- a/src/xrt/auxiliary/vk/vk_function_loaders.c
+++ b/src/xrt/auxiliary/vk/vk_function_loaders.c
@@ -260,9 +260,23 @@ vk_get_device_functions(struct vk_bundle *vk)
 
 	vk->vkCreateSemaphore                           = GET_DEV_PROC(vk, vkCreateSemaphore);
 #if defined(VK_KHR_timeline_semaphore)
+	// VK 1.2 promoted timeline semaphores to core. Some drivers only expose
+	// the core (no-KHR-suffix) entrypoints when the device is created at
+	// API >= 1.2 (NVIDIA on Windows behaves this way). Fall back to the
+	// core name when the KHR alias is not loaded so the IPC client's
+	// workspace_sync_semaphore signal actually reaches the service.
 	vk->vkSignalSemaphore                           = GET_DEV_PROC(vk, vkSignalSemaphoreKHR);
+	if (vk->vkSignalSemaphore == NULL) {
+		vk->vkSignalSemaphore                   = GET_DEV_PROC(vk, vkSignalSemaphore);
+	}
 	vk->vkWaitSemaphores                            = GET_DEV_PROC(vk, vkWaitSemaphoresKHR);
+	if (vk->vkWaitSemaphores == NULL) {
+		vk->vkWaitSemaphores                    = GET_DEV_PROC(vk, vkWaitSemaphores);
+	}
 	vk->vkGetSemaphoreCounterValue                  = GET_DEV_PROC(vk, vkGetSemaphoreCounterValueKHR);
+	if (vk->vkGetSemaphoreCounterValue == NULL) {
+		vk->vkGetSemaphoreCounterValue          = GET_DEV_PROC(vk, vkGetSemaphoreCounterValue);
+	}
 #endif // defined(VK_KHR_timeline_semaphore)
 
 	vk->vkDestroySemaphore                          = GET_DEV_PROC(vk, vkDestroySemaphore);

--- a/src/xrt/compositor/client/comp_vk_client.c
+++ b/src/xrt/compositor/client/comp_vk_client.c
@@ -16,6 +16,18 @@
 
 #include "comp_vk_client.h"
 
+#include "util/u_logging.h"
+
+// Phase 2 — forward decls of the IPC client compositor bridges. Mirrors the
+// pair the D3D11 client uses (see comp_d3d11_client.cpp). Resolved at link
+// time so this TU does not pull the IPC client headers.
+extern xrt_result_t
+comp_ipc_client_compositor_get_workspace_sync_fence(struct xrt_compositor *xc,
+                                                    bool *out_have_fence,
+                                                    xrt_graphics_sync_handle_t *out_handle);
+extern void
+comp_ipc_client_compositor_set_workspace_sync_fence_value(struct xrt_compositor *xc, uint64_t value);
+
 // Prefixed with OXR since the only user right now is the OpenXR state tracker.
 DEBUG_GET_ONCE_LOG_OPTION(vulkan_log, "OXR_VULKAN_LOG", U_LOGGING_INFO)
 
@@ -265,6 +277,37 @@ submit_fallback(struct client_vk_compositor *c, xrt_result_t *out_xret)
 		vk_queue_unlock(vk->main_queue);
 	}
 
+	// Phase 2 — once the queue is idle, host-signal the workspace_sync
+	// semaphore and ship the new value to the service before the IPC commit.
+	// The service's per-view loop reads `last_signaled_fence_value` and
+	// queues an `ID3D11DeviceContext4::Wait` on it; without this advance the
+	// service treats every view as stale and skips the blit (manifests as
+	// black gauss-splat windows in shell mode). Mirrors the D3D11 client's
+	// signal in `client_d3d11_compositor_layer_commit`. No-op when
+	// `workspace_sync_semaphore` is null (legacy KeyedMutex path stays in
+	// effect — same fallback as the D3D11 client).
+#ifdef VK_KHR_timeline_semaphore
+	if (c->workspace_sync_semaphore != VK_NULL_HANDLE && vk->vkSignalSemaphore != NULL) {
+		c->workspace_sync_fence_value++;
+		VkSemaphoreSignalInfoKHR sig_info = {
+		    .sType = VK_STRUCTURE_TYPE_SEMAPHORE_SIGNAL_INFO_KHR,
+		    .semaphore = c->workspace_sync_semaphore,
+		    .value = c->workspace_sync_fence_value,
+		};
+		VkResult sig_ret = vk->vkSignalSemaphore(vk->device, &sig_info);
+		if (sig_ret != VK_SUCCESS) {
+			VK_WARN(vk,
+			        "Phase 2: vkSignalSemaphore(workspace_sync_semaphore) failed: %s; "
+			        "service will treat this frame as stale.",
+			        vk_result_string(sig_ret));
+			c->workspace_sync_fence_value--;
+		} else {
+			comp_ipc_client_compositor_set_workspace_sync_fence_value(
+			    &c->xcn->base, c->workspace_sync_fence_value);
+		}
+	}
+#endif
+
 	*out_xret = xrt_comp_layer_commit(&c->xcn->base, XRT_GRAPHICS_SYNC_HANDLE_INVALID);
 	return true;
 }
@@ -421,6 +464,11 @@ client_vk_compositor_destroy(struct xrt_compositor *xc)
 		c->sync.semaphore = VK_NULL_HANDLE;
 	}
 	xrt_compositor_semaphore_reference(&c->sync.xcsem, NULL);
+
+	if (c->workspace_sync_semaphore != VK_NULL_HANDLE) {
+		vk->vkDestroySemaphore(vk->device, c->workspace_sync_semaphore, NULL);
+		c->workspace_sync_semaphore = VK_NULL_HANDLE;
+	}
 
 	// Now safe to free the pool.
 	vk_cmd_pool_destroy(vk, &c->pool);
@@ -957,6 +1005,52 @@ client_vk_compositor_create(struct xrt_compositor_native *xcn,
 		if (xret != XRT_SUCCESS) {
 			goto err_pool;
 		}
+	}
+#endif
+
+	// Phase 2 — fetch the per-IPC-client workspace_sync_fence from the
+	// service and import it as a VK timeline semaphore. Mirrors the D3D11
+	// client's setup in `client_d3d11_compositor_create`. Failure leaves
+	// `workspace_sync_semaphore` null and the legacy vkQueueWaitIdle-only
+	// path stays in effect for this client.
+#ifdef VK_KHR_timeline_semaphore
+	c->workspace_sync_semaphore = VK_NULL_HANDLE;
+	c->workspace_sync_fence_value = 0;
+	if (vk_can_import_and_export_timeline_semaphore(&c->vk)) {
+		bool have_fence = false;
+		xrt_graphics_sync_handle_t fence_handle = XRT_GRAPHICS_SYNC_HANDLE_INVALID;
+		xrt_result_t fxret =
+		    comp_ipc_client_compositor_get_workspace_sync_fence(&xcn->base, &have_fence, &fence_handle);
+		if (fxret == XRT_SUCCESS && have_fence && xrt_graphics_sync_handle_is_valid(fence_handle)) {
+			VkSemaphore wsf_sem = VK_NULL_HANDLE;
+			VkResult vret = vk_create_timeline_semaphore_from_native(&c->vk, fence_handle, &wsf_sem);
+			if (vret == VK_SUCCESS && wsf_sem != VK_NULL_HANDLE) {
+				c->workspace_sync_semaphore = wsf_sem;
+				U_LOG_W("[FENCE] client=%p workspace_sync_semaphore imported "
+				        "(VK GPU-side wait path active)",
+				        (void *)c);
+			} else {
+				U_LOG_W("Phase 2 (VK): vk_create_timeline_semaphore_from_native failed (%s); "
+				        "falling back to vkQueueWaitIdle-only path.",
+				        vk_result_string(vret));
+				// Importing took ownership of the handle on success;
+				// on failure the helper does NOT consume it, so close.
+				u_graphics_sync_unref(&fence_handle);
+			}
+		} else if (fxret != XRT_SUCCESS) {
+			U_LOG_W("Phase 2 (VK): get_workspace_sync_fence RPC failed (xret=%d); "
+			        "vkQueueWaitIdle path stays in effect.",
+			        (int)fxret);
+		} else {
+			U_LOG_W("Phase 2 (VK): server reported no workspace_sync_fence "
+			        "(have=%d valid_handle=%d); vkQueueWaitIdle path stays in effect.",
+			        (int)have_fence, (int)xrt_graphics_sync_handle_is_valid(fence_handle));
+		}
+	} else {
+		U_LOG_W("Phase 2 (VK): VkDevice does not support timeline semaphore import/export "
+		        "(d3d12_fence=%d opaque_win32=%d); vkQueueWaitIdle path stays in effect.",
+		        (int)c->vk.external.timeline_semaphore_d3d12_fence,
+		        (int)c->vk.external.timeline_semaphore_win32_handle);
 	}
 #endif
 

--- a/src/xrt/compositor/client/comp_vk_client.c
+++ b/src/xrt/compositor/client/comp_vk_client.c
@@ -1047,10 +1047,17 @@ client_vk_compositor_create(struct xrt_compositor_native *xcn,
 			        (int)have_fence, (int)xrt_graphics_sync_handle_is_valid(fence_handle));
 		}
 	} else {
+#if defined(XRT_GRAPHICS_SYNC_HANDLE_IS_WIN32_HANDLE)
 		U_LOG_W("Phase 2 (VK): VkDevice does not support timeline semaphore import/export "
 		        "(d3d12_fence=%d opaque_win32=%d); vkQueueWaitIdle path stays in effect.",
 		        (int)c->vk.external.timeline_semaphore_d3d12_fence,
 		        (int)c->vk.external.timeline_semaphore_win32_handle);
+#else
+		U_LOG_W("Phase 2 (VK): VkDevice does not support timeline semaphore import/export "
+		        "(sync_fd=%d opaque_fd=%d); vkQueueWaitIdle path stays in effect.",
+		        (int)c->vk.external.timeline_semaphore_sync_fd,
+		        (int)c->vk.external.timeline_semaphore_opaque_fd);
+#endif
 	}
 #endif
 

--- a/src/xrt/compositor/client/comp_vk_client.h
+++ b/src/xrt/compositor/client/comp_vk_client.h
@@ -76,6 +76,24 @@ struct client_vk_compositor
 		uint64_t value;
 	} sync;
 
+	/*!
+	 * Phase 2 — workspace_sync_fence imported from the IPC service. Mirrors
+	 * the D3D11 client's @ref client_d3d11_compositor::workspace_sync_fence.
+	 * Imported as a VK timeline semaphore (D3D12_FENCE handle type when the
+	 * driver supports it). Signaled on the app's queue once per
+	 * @ref client_vk_compositor_layer_commit AFTER the app's render
+	 * submission; the new value is shipped to the service via
+	 * @ref comp_ipc_client_compositor_set_workspace_sync_fence_value so the
+	 * service per-view loop can `ID3D11DeviceContext4::Wait` on it instead of
+	 * reading a half-rendered shared texture.
+	 *
+	 * VK_NULL_HANDLE ⇒ either we are not in workspace mode, the service is
+	 * not D3D11-backed, or the import failed; in that case the legacy
+	 * vkQueueWaitIdle path stays in effect.
+	 */
+	VkSemaphore workspace_sync_semaphore;
+	uint64_t workspace_sync_fence_value;
+
 	struct vk_bundle vk;
 
 	struct vk_cmd_pool pool;

--- a/src/xrt/compositor/client/comp_vk_glue.c
+++ b/src/xrt/compositor/client/comp_vk_glue.c
@@ -65,17 +65,25 @@ const char *xrt_gfx_vk_device_extensions = VK_KHR_DEDICATED_ALLOCATION_EXTENSION
 #error "Need port!"
 #endif
 
-// Platform version of "external_fence" and "external_semaphore"
+// Platform version of "external_fence" and "external_semaphore". The
+// timeline_semaphore extension is required so the IPC client can import the
+// service's per-client cross-process workspace_sync_fence as a VK timeline
+// semaphore (Phase 2 — see comp_vk_client.c::client_vk_compositor_create).
+// Without it the IPC client falls back to vkQueueWaitIdle-only sync, which
+// produces black gauss-splat / VK windows because the service treats every
+// view as stale.
 #if defined(XRT_GRAPHICS_SYNC_HANDLE_IS_FD)
 #if !defined(XRT_OS_MACOS)
     // FD sync extensions are optional on macOS — MoltenVK may not support them.
     // They're handled as optional by oxr_vulkan.c's optional_device_extensions[].
     " " VK_KHR_EXTERNAL_SEMAPHORE_FD_EXTENSION_NAME " " VK_KHR_EXTERNAL_FENCE_FD_EXTENSION_NAME
+    " " VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME
 #endif
     ;
 
 #elif defined(XRT_GRAPHICS_SYNC_HANDLE_IS_WIN32_HANDLE)
-    " " VK_KHR_EXTERNAL_SEMAPHORE_WIN32_EXTENSION_NAME " " VK_KHR_EXTERNAL_FENCE_WIN32_EXTENSION_NAME;
+    " " VK_KHR_EXTERNAL_SEMAPHORE_WIN32_EXTENSION_NAME " " VK_KHR_EXTERNAL_FENCE_WIN32_EXTENSION_NAME
+    " " VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME;
 
 #else
 #error "Need port!"

--- a/src/xrt/state_trackers/oxr/oxr_session_gfx_vk.c
+++ b/src/xrt/state_trackers/oxr/oxr_session_gfx_vk.c
@@ -115,6 +115,20 @@ oxr_session_populate_vk(struct oxr_logger *log,
 		timeline_semaphore_enabled = true;
 	}
 
+	// In workspace / IPC mode, force timeline semaphores on. The runtime
+	// requires VK_KHR_timeline_semaphore via xrGetVulkanDeviceExtensionsKHR
+	// (see xrt_gfx_vk_device_extensions in comp_vk_glue.c), and the IPC
+	// client compositor needs it to import the service's per-client
+	// cross-process workspace_sync_fence as a VK timeline semaphore. Apps
+	// that follow the runtime's required-extension list will have enabled
+	// the feature; if they didn't, vkSignalSemaphore returns an error and
+	// the IPC client falls back to vkQueueWaitIdle-only sync — same
+	// behaviour as before this change.
+	if (!timeline_semaphore_enabled && sys->xsysc != NULL && sys->xsysc->info.is_service_mode) {
+		oxr_log(log, "Workspace/IPC mode: forcing timeline semaphores on (runtime-required extension).");
+		timeline_semaphore_enabled = true;
+	}
+
 #ifdef OXR_HAVE_KHR_vulkan_enable2
 	if (sys->inst->extensions.KHR_vulkan_enable2) {
 		debug_utils_enabled = sess->sys->vk.debug_utils_enabled;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -94,8 +94,12 @@ if(XRT_HAVE_D3D12)
 endif()
 
 if(XRT_HAVE_VULKAN)
+	# Phase 2 — comp_vk_client.c references the
+	# comp_ipc_client_compositor_{get,set}_workspace_sync_fence{,_value}
+	# bridge symbols defined in ipc_client_compositor.c (same setup as
+	# tests_comp_client_d3d11 above).
 	target_link_libraries(
-		tests_comp_client_vulkan PRIVATE comp_client comp_mock comp_util aux_vk
+		tests_comp_client_vulkan PRIVATE comp_client comp_mock comp_util aux_vk ipc_client
 		)
 	target_link_libraries(tests_uv_to_tangent PRIVATE comp_render)
 endif()


### PR DESCRIPTION
## Summary

VK handle apps in shell mode (`DISPLAYXR_WORKSPACE_SESSION=1`) rendered black because the IPC client compositor never advanced the per-client `workspace_sync_fence` that the D3D11 service waits on. The service treated every view as stale and skipped the blit (`stale_views >> 0`, `fence_total_waits = 0` in `bench_shell_present.ps1` output).

The D3D11 client implemented the Phase 2 cross-process fence; the VK client did not. This PR mirrors that path on the VK side.

## Changes

- **`comp_vk_client`**: import the service's `workspace_sync_fence` as a VK timeline semaphore at create; host-signal it after `vkQueueWaitIdle` in `submit_fallback`; ship the value via `comp_ipc_client_compositor_set_workspace_sync_fence_value` so the per-view loop can `ID3D11DeviceContext4::Wait` on it.
- **`comp_vk_glue`**: declare `VK_KHR_timeline_semaphore` as a required device extension via `xrGetVulkanDeviceExtensionsKHR`.
- **`oxr_session_gfx_vk`**: force `timeline_semaphore_enabled = true` in IPC mode (the runtime now requires the extension; v1-path apps don't surface the feature flag any other way).
- **`vk_function_loaders`**: fall back to core `vkSignalSemaphore` / `vkWaitSemaphores` / `vkGetSemaphoreCounterValue` when the KHR aliases aren't exposed (NVIDIA on VK 1.2+ devices behaves this way).
- **`u_sandbox`**: add the same Win32 `GetEnvironmentVariableA` fallback the `XRT_FORCE_MODE` check already has, so `SetEnvironmentVariableA`-set `DISPLAYXR_WORKSPACE_SESSION` reaches /MT-CRT VK apps that miss it via `getenv()`.
- **`tests/CMakeLists`**: link `tests_comp_client_vulkan` against `ipc_client` (matches `tests_comp_client_d3d11` — same bridge symbols now referenced).

Companion change in `displayxr-demo-gaussiansplat` enables `features12.timelineSemaphore` on the demo's `VkDevice`. Other VK demos that use `xrGetVulkanDeviceExtensionsKHR` will need the equivalent feature-enable before they can use this path.

## Test plan
- [x] Build runtime: `scripts\build_windows.bat build`
- [x] Build gauss splat demo (with companion PR)
- [x] Launch shell with 4 gauss splats — all four windows render content (was black)
- [x] Verify service log: `stale_views=0`, `waits_queued=210+` per 10 s window per client
- [x] Mixed workload: 2 cubes + 2 gauss splats in shell — both APIs render correctly
- [ ] Cube-only regression check (D3D11 path unaffected by these changes — but please verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)