### PR TITLE
mcp: gate Phase A on Capabilities registry key (env var still wins)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,7 +118,7 @@ find_package(cJSON MODULE)
 include(FetchContent)
 FetchContent_Declare(displayxr_mcp
     GIT_REPOSITORY https://github.com/DisplayXR/displayxr-mcp.git
-    GIT_TAG v0.2.3)
+    GIT_TAG v0.3.0)
 # Build the stdio↔socket adapter alongside the lib so the Phase A test
 # scripts under tests/mcp/ can find a binary at a known path during dev
 # (build/_deps/displayxr_mcp-build/displayxr-mcp). Production

--- a/src/xrt/state_trackers/oxr/oxr_instance.c
+++ b/src/xrt/state_trackers/oxr/oxr_instance.c
@@ -589,10 +589,16 @@ oxr_instance_create(struct oxr_logger *log,
 
 	*out_instance = inst;
 
-	// Opt-in AI introspection surface — Phase A.  No-op when the
-	// DISPLAYXR_MCP env var is unset, so normal runtime cost is zero.
+	// Opt-in AI introspection surface — Phase A. Gate is registry-first,
+	// env-var-overrides: install the MCP Tools package (writes
+	// HKLM\Software\DisplayXR\Capabilities\MCP\Enabled=1) and the MCP
+	// server starts in every handle-app process. DISPLAYXR_MCP=1/0 in
+	// the environment wins as an explicit override (CI, dev iteration,
+	// quick disable). No registry + no env var ⇒ zero runtime cost.
 	oxr_mcp_tools_register_all();
-	mcp_server_maybe_start();
+	if (mcp_check_env_or(oxr_mcp_capability_enabled())) {
+		mcp_server_start();
+	}
 
 	return XR_SUCCESS;
 }

--- a/src/xrt/state_trackers/oxr/oxr_mcp_tools.c
+++ b/src/xrt/state_trackers/oxr/oxr_mcp_tools.c
@@ -28,6 +28,10 @@
 
 #include "util/u_logging.h"
 
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
 #include "os/os_time.h"
 
 #include "xrt/xrt_compositor.h"
@@ -780,6 +784,35 @@ oxr_mcp_log_sink(const char *file,
 	(void)func;
 	(void)data;
 	mcp_log_ring_append(xlate_log_level(level), fmt, args);
+}
+
+// Reads HKLM\Software\DisplayXR\Capabilities\MCP\Enabled (DWORD) under
+// the 64-bit registry view. The MCP installer (DisplayXRMCPSetup-*.exe)
+// from displayxr-mcp writes this key. Non-Windows builds always return
+// false — there's no Capabilities key on POSIX; rely on the env var.
+bool
+oxr_mcp_capability_enabled(void)
+{
+#ifdef _WIN32
+	HKEY key = NULL;
+	LSTATUS rc = RegOpenKeyExA(HKEY_LOCAL_MACHINE,
+	                           "Software\\DisplayXR\\Capabilities\\MCP",
+	                           0,
+	                           KEY_READ | KEY_WOW64_64KEY,
+	                           &key);
+	if (rc != ERROR_SUCCESS) {
+		return false;
+	}
+	DWORD value = 0;
+	DWORD value_size = sizeof(value);
+	DWORD value_type = 0;
+	rc = RegQueryValueExA(key, "Enabled", NULL, &value_type,
+	                      (LPBYTE)&value, &value_size);
+	RegCloseKey(key);
+	return rc == ERROR_SUCCESS && value_type == REG_DWORD && value == 1;
+#else
+	return false;
+#endif
 }
 
 void

--- a/src/xrt/state_trackers/oxr/oxr_mcp_tools.h
+++ b/src/xrt/state_trackers/oxr/oxr_mcp_tools.h
@@ -75,6 +75,24 @@ typedef bool (*oxr_mcp_capture_fn)(const char *path, void *userdata);
 void
 oxr_mcp_tools_set_capture_handler(oxr_mcp_capture_fn fn, void *userdata);
 
+/*!
+ * Read the @c HKLM\Software\DisplayXR\Capabilities\MCP\Enabled DWORD on
+ * Windows. Returns @c true iff the key exists and the value is 1. On
+ * non-Windows platforms (no installer infrastructure) returns @c false.
+ *
+ * Combine with @ref mcp_check_env_or so the @c DISPLAYXR_MCP env var
+ * still wins as an explicit override:
+ *
+ *   if (mcp_check_env_or(oxr_mcp_capability_enabled())) {
+ *       mcp_server_start();
+ *   }
+ *
+ * Caller-side helper rather than framework-side because the registry
+ * path is DisplayXR-specific; the framework stays consumer-agnostic.
+ */
+bool
+oxr_mcp_capability_enabled(void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Replaces \`DISPLAYXR_MCP\` env var as the primary opt-in mechanism for the runtime's Phase A MCP server with a Windows-installer-driven registry check. The companion bits ship in the new [\`displayxr-mcp\` v0.3.0](https://github.com/DisplayXR/displayxr-mcp/releases/tag/v0.3.0) (framework + NSIS installer) and [\`displayxr-shell-pvt#?\`](https://github.com/DisplayXR/displayxr-shell-pvt) (parallel Phase B gate).

## Resulting policy

```
DISPLAYXR_MCP=1   ⇒ enabled  (force-enable override; CI / dev)
DISPLAYXR_MCP=0   ⇒ disabled (force-disable override; quick off)
env unset:
  Windows + Capabilities\MCP\Enabled=1 ⇒ enabled
  otherwise                            ⇒ disabled
```

## Changes

- **\`CMakeLists.txt\`** — \`FetchContent\` pin bumped \`v0.2.3 → v0.3.0\`.
- **\`oxr_mcp_tools.{h,c}\`** — new \`oxr_mcp_capability_enabled()\` helper. Win32 \`RegOpenKeyExA\` + \`RegQueryValueExA\` against \`HKLM\\Software\\DisplayXR\\Capabilities\\MCP\\Enabled\` (DWORD, 64-bit view). Non-Windows returns \`false\` — no Capabilities key on POSIX.
- **\`oxr_instance.c\`** — \`mcp_server_maybe_start()\` → \`if (mcp_check_env_or(oxr_mcp_capability_enabled())) mcp_server_start();\`.

## Why caller-side, not framework-side

The registry path is DisplayXR-specific. Keeping the framework consumer-agnostic means third-party workspace controllers that consume \`displayxr_mcp\` aren't forced to inherit DisplayXR's registry layout — they wire their own gate against their own registration scheme.

## Verification

- macOS local build: full runtime green (\`scripts/build_macos.sh\` defaults).
- macOS Phase A E2E: not re-run here (logic unchanged from v0.2.3 once gate evaluates true; the gate itself is a registry read + env-var fallback, both trivially testable).
- Windows: validated via CI on this PR.

## Sibling extension points

\`Capabilities\\<name>\` joins \`WorkspaceControllers\\<name>\` as the second registered extension class:

```
HKLM\Software\DisplayXR\
  Runtime\
  WorkspaceControllers\<name>\   ← process plugins (existing, third-party-facing)
    shell\
  Capabilities\<name>\            ← capability flags (new)
    MCP\
      Enabled = 1
      AdapterPath = C:\Program Files\DisplayXR\MCP\bin\displayxr-mcp.exe
      Version = 0.3.0
```

The framework PR's installer writes the \`Capabilities\\MCP\` subtree; this PR is the runtime's read-side counterpart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)