### PR TITLE
fix(test_apps): legacy cubes over-allocate XrView for runtime max view_count

### DIFF
--- a/test_apps/cube_hosted_legacy_d3d11_win/main.cpp
+++ b/test_apps/cube_hosted_legacy_d3d11_win/main.cpp
@@ -224,10 +224,12 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
                         locateInfo.space = xr.localSpace;
 
                         XrViewState viewState = {XR_TYPE_VIEW_STATE};
-                        uint32_t rawViewCount = 2;
-                        XrView rawViews[2];
-                        for (uint32_t i = 0; i < 2; i++) rawViews[i] = {XR_TYPE_VIEW};
-                        xrLocateViews(xr.session, &locateInfo, &viewState, 2, &rawViewCount, rawViews);
+                        // Over-allocate to the runtime's max view_count (sim_display reports 4
+                        // for Quad mode). Legacy app still renders only the first 2 (SBS).
+                        uint32_t rawViewCount = 8;
+                        XrView rawViews[8];
+                        for (uint32_t i = 0; i < 8; i++) rawViews[i] = {XR_TYPE_VIEW};
+                        xrLocateViews(xr.session, &locateInfo, &viewState, 8, &rawViewCount, rawViews);
 
                         // Legacy SBS layout: viewWidth per eye, left at (0,0), right at (viewWidth,0)
                         uint32_t viewWidth = xr.swapchain.width / 2;

--- a/test_apps/cube_hosted_legacy_d3d12_win/main.cpp
+++ b/test_apps/cube_hosted_legacy_d3d12_win/main.cpp
@@ -215,10 +215,12 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
                         locateInfo.space = xr.localSpace;
 
                         XrViewState viewState = {XR_TYPE_VIEW_STATE};
-                        uint32_t rawViewCount = 2;
-                        XrView rawViews[2];
-                        for (uint32_t i = 0; i < 2; i++) rawViews[i] = {XR_TYPE_VIEW};
-                        xrLocateViews(xr.session, &locateInfo, &viewState, 2, &rawViewCount, rawViews);
+                        // Over-allocate to the runtime's max view_count (sim_display reports 4
+                        // for Quad mode). Legacy app still renders only the first 2 (SBS).
+                        uint32_t rawViewCount = 8;
+                        XrView rawViews[8];
+                        for (uint32_t i = 0; i < 8; i++) rawViews[i] = {XR_TYPE_VIEW};
+                        xrLocateViews(xr.session, &locateInfo, &viewState, 8, &rawViewCount, rawViews);
 
                         // Legacy SBS layout: viewWidth per eye, left at (0,0), right at (viewWidth,0)
                         uint32_t viewWidth = xr.swapchain.width / 2;

--- a/test_apps/cube_hosted_legacy_gl_win/main.cpp
+++ b/test_apps/cube_hosted_legacy_gl_win/main.cpp
@@ -393,10 +393,12 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
                         locateInfo.space = xr.localSpace;
 
                         XrViewState viewState = {XR_TYPE_VIEW_STATE};
-                        uint32_t rawViewCount = 2;
-                        XrView rawViews[2];
-                        for (uint32_t i = 0; i < 2; i++) rawViews[i] = {XR_TYPE_VIEW};
-                        xrLocateViews(xr.session, &locateInfo, &viewState, 2, &rawViewCount, rawViews);
+                        // Over-allocate to the runtime's max view_count (sim_display reports 4
+                        // for Quad mode). Legacy app still renders only the first 2 (SBS).
+                        uint32_t rawViewCount = 8;
+                        XrView rawViews[8];
+                        for (uint32_t i = 0; i < 8; i++) rawViews[i] = {XR_TYPE_VIEW};
+                        xrLocateViews(xr.session, &locateInfo, &viewState, 8, &rawViewCount, rawViews);
 
                         // Legacy SBS layout: viewWidth per eye, left at (0,0), right at (viewWidth,0)
                         uint32_t viewWidth = xr.swapchain.width / 2;

--- a/test_apps/cube_hosted_legacy_vk_win/main.cpp
+++ b/test_apps/cube_hosted_legacy_vk_win/main.cpp
@@ -1579,10 +1579,12 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
                     locateInfo.space = xr.localSpace;
 
                     XrViewState viewState = {XR_TYPE_VIEW_STATE};
-                    uint32_t viewCount = 2;
-                    XrView views[2];
-                    for (uint32_t i = 0; i < 2; i++) views[i] = {XR_TYPE_VIEW};
-                    xrLocateViews(xr.session, &locateInfo, &viewState, 2, &viewCount, views);
+                    // Over-allocate to the runtime's max view_count (sim_display reports 4
+                    // for Quad mode). Legacy app still renders only the first 2 (SBS).
+                    uint32_t viewCount = 8;
+                    XrView views[8];
+                    for (uint32_t i = 0; i < 8; i++) views[i] = {XR_TYPE_VIEW};
+                    xrLocateViews(xr.session, &locateInfo, &viewState, 8, &viewCount, views);
                     submitViewCount = 2;
 
                     // Legacy SBS layout: viewWidth per eye, left at (0,0), right at (viewWidth,0)


### PR DESCRIPTION
## Summary

- 4 legacy cube apps (`cube_hosted_legacy_{d3d11,d3d12,gl,vk}_win`) hardcoded `viewCapacityInput=2` to `xrLocateViews`. Under sim_display this fails with `XR_ERROR_SIZE_INSUFFICIENT` because sim_display advertises max view_count=4 (Quad rendering mode).
- Buffer is now `[8]` to match modern test apps. `submitViewCount` stays at 2 — these apps are stereo-only by design and only need a wider locate buffer.

## Why this matters

`FORCE_SIM_DISPLAY=1` is the diagnostic-baseline path for benchmarking GPU contention without LeiaSR display arbitration. It was unusable because every spec-conformant locate call from these apps was failing.

## Test plan

- [x] Modern cube apps (`cube_handle_*_win`) already over-allocate `[8]` and run fine under sim_display
- [ ] Legacy cubes are not in `scripts\build_windows.bat test-apps` so weren't smoke-tested here — ran the parallel gauss-demo fix in `displayxr-demo-gaussiansplat#fix-sim-display-view-count` end-to-end through all V-cycle modes including Quad, no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)