### PR TITLE
build(cmake): define xrt-pthreads before displayxr_mcp FetchContent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,24 @@ FetchContent_Declare(displayxr_mcp
 # instead, so suppress install rules here.
 set(DISPLAYXR_MCP_BUILD_ADAPTER ON CACHE BOOL "" FORCE)
 set(DISPLAYXR_MCP_INSTALL OFF CACHE BOOL "" FORCE)
+
+# xrt-pthreads must exist before FetchContent_MakeAvailable processes
+# displayxr_mcp's CMakeLists.txt — its check at line 87 picks up the
+# parent project's `xrt-pthreads` target via the first branch when
+# present, otherwise falls back to vcpkg `PThreads4W`. Without this
+# ordering, MinGW cross-compile fails configure (no vcpkg, no
+# xrt-pthreads yet defined). See #208.
+add_library(xrt-pthreads INTERFACE)
+if(WIN32 AND NOT MINGW)
+	find_package(pthreads_windows REQUIRED)
+	target_link_libraries(xrt-pthreads INTERFACE PThreads4W::PThreads4W_CXXEXC)
+else()
+	set(CMAKE_THREAD_PREFER_PTHREAD ON)
+	find_package(Threads)
+	target_link_libraries(xrt-pthreads INTERFACE Threads::Threads)
+	target_compile_definitions(xrt-pthreads INTERFACE _GNU_SOURCE)
+endif()
+
 FetchContent_MakeAvailable(displayxr_mcp)
 
 if(NOT WIN32)
@@ -168,16 +186,9 @@ endif()
 #https://github.com/arsenm/sanitizers-cmake
 find_package(Sanitizers MODULE)
 
-add_library(xrt-pthreads INTERFACE)
-if(WIN32 AND NOT MINGW)
-	find_package(pthreads_windows REQUIRED)
-	target_link_libraries(xrt-pthreads INTERFACE PThreads4W::PThreads4W_CXXEXC)
-else()
-	set(CMAKE_THREAD_PREFER_PTHREAD ON)
-	find_package(Threads)
-	target_link_libraries(xrt-pthreads INTERFACE Threads::Threads)
-	target_compile_definitions(xrt-pthreads INTERFACE _GNU_SOURCE)
-endif()
+# xrt-pthreads is now defined above, just before
+# FetchContent_MakeAvailable(displayxr_mcp), so its target check
+# resolves on every platform including MinGW. See #208.
 
 find_package(OpenGL)
 set(OPENGL_WITHOUT_GLX_FOUND ${OPENGL_FOUND})


### PR DESCRIPTION
## Summary

- Closes #208. Moves the `add_library(xrt-pthreads INTERFACE)` block above `FetchContent_MakeAvailable(displayxr_mcp)` so `displayxr_mcp/CMakeLists.txt:87`'s `if(TARGET xrt-pthreads)` check resolves on every platform — including MinGW cross-compile, where neither `xrt-pthreads` (not yet defined) nor vcpkg's `PThreads4W` (no vcpkg on the toolchain) was reachable, leading to FATAL_ERROR at configure.
- MSVC behavior unchanged: `xrt-pthreads` already wraps `PThreads4W::PThreads4W_CXXEXC` for the MSVC branch, so the link chain through `xrt-pthreads` is the same as the previous direct `PThreads4W::PThreads4W` resolution downstream did.
- MinGW now resolves to `Threads::Threads` (winpthreads), which is the correct fallback the previous ordering made unreachable.

Note: marking this PR ready (not draft) since it's a small, self-contained CMake-ordering change with no MSVC behavior delta.

## Test plan

- [x] Local: `./scripts/build-mingw-check.sh aux_util` now progresses past the displayxr_mcp pthreads check (next failure is a separate, pre-existing cJSON `IMPORTED_IMPLIB` issue on the Homebrew env — out of scope for this PR).
- [ ] CI Windows + macOS builds green on this PR (no behavior change expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)