### PR TITLE
Runtime-side post-compose atlas capture parity (in-process)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,7 +118,10 @@ find_package(cJSON MODULE)
 include(FetchContent)
 FetchContent_Declare(displayxr_mcp
     GIT_REPOSITORY https://github.com/DisplayXR/displayxr-mcp.git
-    GIT_TAG v0.3.0)
+    # TODO: bump back to a tagged release once feat/capture-mode is
+    # merged + tagged as v0.3.1. Pinned to the branch SHA in the meantime
+    # so the runtime can iterate against the new mode plumbing.
+    GIT_TAG 0c06c59)
 # Build the stdio↔socket adapter alongside the lib so the Phase A test
 # scripts under tests/mcp/ can find a binary at a known path during dev
 # (build/_deps/displayxr_mcp-build/displayxr-mcp). Production

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,10 +118,7 @@ find_package(cJSON MODULE)
 include(FetchContent)
 FetchContent_Declare(displayxr_mcp
     GIT_REPOSITORY https://github.com/DisplayXR/displayxr-mcp.git
-    # TODO: bump back to a tagged release once feat/capture-mode is
-    # merged + tagged as v0.3.1. Pinned to the branch SHA in the meantime
-    # so the runtime can iterate against the new mode plumbing.
-    GIT_TAG 0c06c59)
+    GIT_TAG v0.3.1)
 # Build the stdio↔socket adapter alongside the lib so the Phase A test
 # scripts under tests/mcp/ can find a binary at a known path during dev
 # (build/_deps/displayxr_mcp-build/displayxr-mcp). Production

--- a/src/xrt/auxiliary/util/u_capture_intent.h
+++ b/src/xrt/auxiliary/util/u_capture_intent.h
@@ -1,0 +1,202 @@
+// Copyright 2026, Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  Shared capture-intent polling for in-process compositors.
+ *
+ * Each in-process compositor (d3d11, d3d12, gl, metal, vk_native) wants
+ * to expose two capture surfaces — a trigger-file path for devs and
+ * the MCP @c capture_frame tool — and two modes per surface:
+ *  - @c POST_COMPOSE: full atlas (projection + window-space + quads),
+ *    captured at end of frame.
+ *  - @c PROJECTION_ONLY: atlas state before window-space layers are
+ *    composed in, captured mid-frame at the projection-done boundary.
+ *
+ * This header bundles the per-frame intent struct + the polling helper
+ * so each compositor can ship the same behavior with one struct field
+ * and two function calls.
+ *
+ * Usage:
+ *   1. Add @ref u_capture_intent as a field on the compositor struct.
+ *   2. Call @ref u_capture_intent_poll once at the top of layer_commit.
+ *   3. At the projection-done boundary call
+ *      @ref u_capture_intent_should_capture with mode=PROJECTION_ONLY;
+ *      if true, run the compositor's capture_atlas_to_png and then
+ *      @ref u_capture_intent_complete.
+ *   4. At end of frame, same with mode=POST_COMPOSE.
+ *
+ * Caller owns the @c mcp_capture_request used for the MCP path; this
+ * helper just forwards to @ref mcp_capture_poll / _complete.
+ *
+ * @ingroup aux_util
+ */
+
+#pragma once
+
+#include "displayxr_mcp/mcp_capture.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#ifdef XRT_OS_WINDOWS
+#include <windows.h>
+#else
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*!
+ * Per-frame "the user asked for a capture" record. Set by
+ * @ref u_capture_intent_poll at the top of a frame; consumed by
+ * @ref u_capture_intent_should_capture at the right boundary.
+ */
+struct u_capture_intent
+{
+	bool pending;
+	uint32_t mode; // enum mcp_capture_mode
+	char path[MCP_CAPTURE_PATH_MAX];
+	bool from_mcp; // true → call mcp_capture_complete on done
+};
+
+/*!
+ * Poll for a pending capture this frame. Checks the MCP request first
+ * (highest priority — there's a blocked client thread waiting), then
+ * the two trigger files. Returns silently if nothing is requested.
+ *
+ * Trigger filenames (relative to %TEMP% / $TMPDIR):
+ *   - "displayxr_atlas_trigger"            → POST_COMPOSE
+ *     output: "displayxr_atlas.png"
+ *   - "displayxr_atlas_trigger.projection" → PROJECTION_ONLY
+ *     output: "displayxr_atlas.projection.png"
+ */
+static inline void
+u_capture_intent_poll(struct u_capture_intent *intent,
+                       struct mcp_capture_request *mcp_req)
+{
+	intent->pending = false;
+	intent->from_mcp = false;
+	intent->mode = MCP_CAPTURE_MODE_POST_COMPOSE;
+	intent->path[0] = '\0';
+
+	if (mcp_req != NULL) {
+		char mcp_path[MCP_CAPTURE_PATH_MAX];
+		uint32_t mcp_mode = MCP_CAPTURE_MODE_POST_COMPOSE;
+		if (mcp_capture_poll(mcp_req, mcp_path, &mcp_mode)) {
+			intent->pending = true;
+			intent->from_mcp = true;
+			intent->mode = mcp_mode;
+			memcpy(intent->path, mcp_path, sizeof(mcp_path));
+			return;
+		}
+	}
+
+	// Trigger-file paths cached once per process — getenv is cheap but
+	// the formatted strings are stable for the lifetime of the runtime.
+	static char tg_post[MCP_CAPTURE_PATH_MAX] = {0};
+	static char tg_proj[MCP_CAPTURE_PATH_MAX] = {0};
+	static char out_post[MCP_CAPTURE_PATH_MAX] = {0};
+	static char out_proj[MCP_CAPTURE_PATH_MAX] = {0};
+	if (tg_post[0] == '\0') {
+#ifdef XRT_OS_WINDOWS
+		const char *tmp = getenv("TEMP");
+		if (tmp == NULL || tmp[0] == '\0') {
+			tmp = "C:\\Temp";
+		}
+		snprintf(tg_post, sizeof(tg_post), "%s\\displayxr_atlas_trigger", tmp);
+		snprintf(tg_proj, sizeof(tg_proj), "%s\\displayxr_atlas_trigger.projection", tmp);
+		snprintf(out_post, sizeof(out_post), "%s\\displayxr_atlas.png", tmp);
+		snprintf(out_proj, sizeof(out_proj), "%s\\displayxr_atlas.projection.png", tmp);
+#else
+		const char *tmp = getenv("TMPDIR");
+		if (tmp == NULL || tmp[0] == '\0') {
+			tmp = "/tmp";
+		}
+		// Trim a trailing slash so we don't end up with double slashes.
+		size_t tlen = strlen(tmp);
+		char tmp_clean[MCP_CAPTURE_PATH_MAX];
+		size_t copy = tlen < sizeof(tmp_clean) - 1 ? tlen : sizeof(tmp_clean) - 1;
+		memcpy(tmp_clean, tmp, copy);
+		tmp_clean[copy] = '\0';
+		while (copy > 0 && tmp_clean[copy - 1] == '/') {
+			tmp_clean[--copy] = '\0';
+		}
+		snprintf(tg_post, sizeof(tg_post), "%s/displayxr_atlas_trigger", tmp_clean);
+		snprintf(tg_proj, sizeof(tg_proj), "%s/displayxr_atlas_trigger.projection", tmp_clean);
+		snprintf(out_post, sizeof(out_post), "%s/displayxr_atlas.png", tmp_clean);
+		snprintf(out_proj, sizeof(out_proj), "%s/displayxr_atlas.projection.png", tmp_clean);
+#endif
+	}
+
+	// Projection-only takes priority when both files exist (rare race).
+#ifdef XRT_OS_WINDOWS
+	if (GetFileAttributesA(tg_proj) != INVALID_FILE_ATTRIBUTES) {
+		DeleteFileA(tg_proj);
+		intent->pending = true;
+		intent->mode = MCP_CAPTURE_MODE_PROJECTION_ONLY;
+		memcpy(intent->path, out_proj, sizeof(out_proj));
+		return;
+	}
+	if (GetFileAttributesA(tg_post) != INVALID_FILE_ATTRIBUTES) {
+		DeleteFileA(tg_post);
+		intent->pending = true;
+		intent->mode = MCP_CAPTURE_MODE_POST_COMPOSE;
+		memcpy(intent->path, out_post, sizeof(out_post));
+		return;
+	}
+#else
+	struct stat st;
+	if (stat(tg_proj, &st) == 0) {
+		unlink(tg_proj);
+		intent->pending = true;
+		intent->mode = MCP_CAPTURE_MODE_PROJECTION_ONLY;
+		memcpy(intent->path, out_proj, sizeof(out_proj));
+		return;
+	}
+	if (stat(tg_post, &st) == 0) {
+		unlink(tg_post);
+		intent->pending = true;
+		intent->mode = MCP_CAPTURE_MODE_POST_COMPOSE;
+		memcpy(intent->path, out_post, sizeof(out_post));
+		return;
+	}
+#endif
+}
+
+/*!
+ * Returns true iff there is a pending capture matching @p mode_filter.
+ * Caller should run its capture_atlas_to_png with @c intent->path on
+ * true and then call @ref u_capture_intent_complete.
+ */
+static inline bool
+u_capture_intent_should_capture(const struct u_capture_intent *intent, uint32_t mode_filter)
+{
+	return intent->pending && intent->mode == mode_filter;
+}
+
+/*!
+ * Mark the intent as consumed and signal the MCP waiter (if any).
+ * Pass the success/failure of the PNG write so the MCP client gets
+ * an accurate status.
+ */
+static inline void
+u_capture_intent_complete(struct u_capture_intent *intent,
+                            struct mcp_capture_request *mcp_req,
+                            bool ok)
+{
+	if (intent->from_mcp && mcp_req != NULL) {
+		mcp_capture_complete(mcp_req, ok);
+	}
+	intent->pending = false;
+	intent->from_mcp = false;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/xrt/auxiliary/vk/vk_hud_blend.c
+++ b/src/xrt/auxiliary/vk/vk_hud_blend.c
@@ -497,6 +497,50 @@ vk_hud_blend_draw(struct vk_hud_blend *blend,
 }
 
 void
+vk_hud_blend_draw_no_layout(struct vk_hud_blend *blend,
+                              struct vk_bundle *vk,
+                              VkCommandBuffer cmd,
+                              VkFramebuffer fb,
+                              uint32_t fb_w,
+                              uint32_t fb_h,
+                              VkImage hud_image,
+                              int32_t dst_x,
+                              int32_t dst_y,
+                              uint32_t dst_w,
+                              uint32_t dst_h)
+{
+	if (!blend->initialized || hud_image == VK_NULL_HANDLE || fb == VK_NULL_HANDLE ||
+	    dst_w == 0 || dst_h == 0) {
+		return;
+	}
+
+	VkDescriptorSet desc_set = get_or_create_image_desc(blend, vk, hud_image);
+	if (desc_set == VK_NULL_HANDLE) {
+		return;
+	}
+
+	VkRenderPassBeginInfo rp_bi = {
+	    .sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO,
+	    .renderPass = blend->render_pass,
+	    .framebuffer = fb,
+	    .renderArea = {{0, 0}, {fb_w, fb_h}},
+	};
+	vk->vkCmdBeginRenderPass(cmd, &rp_bi, VK_SUBPASS_CONTENTS_INLINE);
+
+	VkViewport vp = {(float)dst_x, (float)dst_y, (float)dst_w, (float)dst_h, 0.0f, 1.0f};
+	vk->vkCmdSetViewport(cmd, 0, 1, &vp);
+	VkRect2D scissor = {{dst_x, dst_y}, {dst_w, dst_h}};
+	vk->vkCmdSetScissor(cmd, 0, 1, &scissor);
+
+	vk->vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, blend->pipeline);
+	vk->vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, blend->pipe_layout, 0, 1,
+	                             &desc_set, 0, NULL);
+	vk->vkCmdDraw(cmd, 3, 1, 0, 0);
+
+	vk->vkCmdEndRenderPass(cmd);
+}
+
+void
 vk_hud_blend_fini(struct vk_hud_blend *blend, struct vk_bundle *vk)
 {
 	if (!blend->initialized) {

--- a/src/xrt/auxiliary/vk/vk_hud_blend.h
+++ b/src/xrt/auxiliary/vk/vk_hud_blend.h
@@ -112,6 +112,39 @@ vk_hud_blend_draw(struct vk_hud_blend *blend,
                    uint32_t dst_h);
 
 /*!
+ * Draw without managing target image layout transitions or framebuffer
+ * caching. Use this when blending into a non-swapchain target (e.g. an
+ * atlas image) where the caller manages layout transitions outside the
+ * render pass and pre-creates the framebuffer.
+ *
+ * Target must be in COLOR_ATTACHMENT_OPTIMAL on entry; left in
+ * COLOR_ATTACHMENT_OPTIMAL on exit. The framebuffer's attachment must
+ * use the same format the blend was initialized with.
+ *
+ * @param blend         Initialized HUD blend resources.
+ * @param vk            Vulkan bundle.
+ * @param cmd           Open command buffer.
+ * @param fb            Caller-managed framebuffer (color attachment is the target).
+ * @param fb_w, fb_h    Framebuffer width/height in pixels.
+ * @param hud_image     HUD source image (in SHADER_READ_ONLY_OPTIMAL).
+ * @param dst_x, dst_y  Top-left of destination rect in target px.
+ * @param dst_w, dst_h  Size of destination rect in target px.
+ * @ingroup aux_vk
+ */
+void
+vk_hud_blend_draw_no_layout(struct vk_hud_blend *blend,
+                              struct vk_bundle *vk,
+                              VkCommandBuffer cmd,
+                              VkFramebuffer fb,
+                              uint32_t fb_w,
+                              uint32_t fb_h,
+                              VkImage hud_image,
+                              int32_t dst_x,
+                              int32_t dst_y,
+                              uint32_t dst_w,
+                              uint32_t dst_h);
+
+/*!
  * Destroy HUD blend resources.
  * @ingroup aux_vk
  */

--- a/src/xrt/compositor/d3d11/comp_d3d11_compositor.cpp
+++ b/src/xrt/compositor/d3d11/comp_d3d11_compositor.cpp
@@ -881,25 +881,18 @@ d3d11_crop_atlas_for_dp(struct comp_d3d11_compositor *c,
 	return c->dp_input_srv;
 }
 
-// Service a pending MCP capture_frame request. Copies the content
-// region of the renderer's atlas (tile_columns × view_width by
-// tile_rows × view_height — what the app actually wrote, same region
-// the compositor crops and sends to the DP) into a staging texture,
-// then writes a single PNG. D3D11 renderer uses
-// DXGI_FORMAT_R8G8B8A8_UNORM so no channel swap is needed.
-static void
-d3d11_compositor_service_mcp_capture(struct comp_d3d11_compositor *c)
+// Copy the content region of the renderer's atlas (tile_columns × view_width
+// by tile_rows × view_height — what the app actually wrote, same region the
+// compositor crops and sends to the DP) into a staging texture, then write
+// @p path as PNG. D3D11 renderer uses DXGI_FORMAT_R8G8B8A8_UNORM so no
+// channel swap is needed.
+static bool
+d3d11_compositor_capture_atlas_to_png(struct comp_d3d11_compositor *c, const char *path)
 {
-	char path[MCP_CAPTURE_PATH_MAX];
-	if (!mcp_capture_poll(&c->mcp_capture, path)) {
-		return;
-	}
-
 	ID3D11Texture2D *atlas_tex = static_cast<ID3D11Texture2D *>(
 	    comp_d3d11_renderer_get_atlas_texture(c->renderer));
 	if (atlas_tex == nullptr || c->renderer == nullptr) {
-		mcp_capture_complete(&c->mcp_capture, false);
-		return;
+		return false;
 	}
 
 	uint32_t tile_columns = 1, tile_rows = 1;
@@ -907,8 +900,7 @@ d3d11_compositor_service_mcp_capture(struct comp_d3d11_compositor *c)
 	uint32_t view_w = 0, view_h = 0;
 	comp_d3d11_renderer_get_view_dimensions(c->renderer, &view_w, &view_h);
 	if (tile_columns == 0 || tile_rows == 0 || view_w == 0 || view_h == 0) {
-		mcp_capture_complete(&c->mcp_capture, false);
-		return;
+		return false;
 	}
 
 	uint32_t content_w = tile_columns * view_w;
@@ -929,8 +921,7 @@ d3d11_compositor_service_mcp_capture(struct comp_d3d11_compositor *c)
 
 	ID3D11Texture2D *staging = nullptr;
 	if (FAILED(c->device->CreateTexture2D(&sd, nullptr, &staging)) || staging == nullptr) {
-		mcp_capture_complete(&c->mcp_capture, false);
-		return;
+		return false;
 	}
 
 	D3D11_BOX src_box = {0, 0, 0, content_w, content_h, 1};
@@ -939,8 +930,7 @@ d3d11_compositor_service_mcp_capture(struct comp_d3d11_compositor *c)
 	D3D11_MAPPED_SUBRESOURCE m = {};
 	if (FAILED(c->context->Map(staging, 0, D3D11_MAP_READ, 0, &m))) {
 		staging->Release();
-		mcp_capture_complete(&c->mcp_capture, false);
-		return;
+		return false;
 	}
 
 	bool ok = stbi_write_png(path, (int)content_w, (int)content_h, 4,
@@ -948,8 +938,53 @@ d3d11_compositor_service_mcp_capture(struct comp_d3d11_compositor *c)
 
 	c->context->Unmap(staging, 0);
 	staging->Release();
+	return ok;
+}
 
+// Service a pending MCP capture_frame request — thin wrapper around
+// d3d11_compositor_capture_atlas_to_png that handles the cross-thread
+// hand-off with the MCP server.
+static void
+d3d11_compositor_service_mcp_capture(struct comp_d3d11_compositor *c)
+{
+	char path[MCP_CAPTURE_PATH_MAX];
+	if (!mcp_capture_poll(&c->mcp_capture, path)) {
+		return;
+	}
+	bool ok = d3d11_compositor_capture_atlas_to_png(c, path);
 	mcp_capture_complete(&c->mcp_capture, ok);
+}
+
+// Trigger-file capture path — same readback as the MCP path, driven by
+// the existence of %TEMP%\displayxr_atlas_trigger so devs can snapshot
+// the post-compose atlas without an MCP client. Mirrors the service-
+// mode `workspace_screenshot_trigger` path in comp_d3d11_service.cpp.
+// See issue #210.
+static void
+d3d11_compositor_service_trigger_file(struct comp_d3d11_compositor *c)
+{
+	static char trigger_path[MCP_CAPTURE_PATH_MAX] = {0};
+	static char out_path[MCP_CAPTURE_PATH_MAX] = {0};
+	if (trigger_path[0] == '\0') {
+		const char *tmp = getenv("TEMP");
+		if (tmp == nullptr || tmp[0] == '\0') {
+			tmp = "C:\\Temp";
+		}
+		snprintf(trigger_path, sizeof(trigger_path), "%s\\displayxr_atlas_trigger", tmp);
+		snprintf(out_path, sizeof(out_path), "%s\\displayxr_atlas.png", tmp);
+	}
+
+	if (GetFileAttributesA(trigger_path) == INVALID_FILE_ATTRIBUTES) {
+		return;
+	}
+	DeleteFileA(trigger_path);
+
+	bool ok = d3d11_compositor_capture_atlas_to_png(c, out_path);
+	if (ok) {
+		U_LOG_I("Atlas captured to %s", out_path);
+	} else {
+		U_LOG_W("Atlas capture failed (trigger %s)", trigger_path);
+	}
 }
 
 static xrt_result_t
@@ -1405,6 +1440,10 @@ d3d11_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 	// Service pending MCP capture_frame after Present so the atlas
 	// we stage-copy reflects exactly what the user just saw.
 	d3d11_compositor_service_mcp_capture(c);
+
+	// Same readback driven by a trigger file (no MCP client required).
+	// See issue #210.
+	d3d11_compositor_service_trigger_file(c);
 
 	return XRT_SUCCESS;
 }

--- a/src/xrt/compositor/d3d11/comp_d3d11_compositor.cpp
+++ b/src/xrt/compositor/d3d11/comp_d3d11_compositor.cpp
@@ -47,6 +47,7 @@
 #include "math/m_api.h"
 #include "util/u_tiling.h"
 #include "util/u_canvas.h"
+#include "util/u_capture_intent.h"
 
 #ifdef XRT_BUILD_DRIVER_QWERTY
 #include "qwerty_interface.h"
@@ -229,6 +230,10 @@ struct comp_d3d11_compositor
 
 	//! MCP capture_frame request box (serviced at end of layer_commit).
 	struct mcp_capture_request mcp_capture;
+
+	//! Per-frame capture intent populated at top of layer_commit. See
+	//! u_capture_intent.h.
+	struct u_capture_intent capture_intent;
 };
 
 /*
@@ -942,49 +947,23 @@ d3d11_compositor_capture_atlas_to_png(struct comp_d3d11_compositor *c, const cha
 }
 
 // Service a pending MCP capture_frame request — thin wrapper around
-// d3d11_compositor_capture_atlas_to_png that handles the cross-thread
-// hand-off with the MCP server.
+// Run the capture readback if the per-frame intent matches @p mode_filter.
+// Mirrors vk_native_dispatch_capture / gl_compositor_dispatch_capture.
 static void
-d3d11_compositor_service_mcp_capture(struct comp_d3d11_compositor *c)
+d3d11_compositor_dispatch_capture(struct comp_d3d11_compositor *c, uint32_t mode_filter)
 {
-	char path[MCP_CAPTURE_PATH_MAX];
-	if (!mcp_capture_poll(&c->mcp_capture, path)) {
+	if (!u_capture_intent_should_capture(&c->capture_intent, mode_filter)) {
 		return;
 	}
-	bool ok = d3d11_compositor_capture_atlas_to_png(c, path);
-	mcp_capture_complete(&c->mcp_capture, ok);
-}
-
-// Trigger-file capture path — same readback as the MCP path, driven by
-// the existence of %TEMP%\displayxr_atlas_trigger so devs can snapshot
-// the post-compose atlas without an MCP client. Mirrors the service-
-// mode `workspace_screenshot_trigger` path in comp_d3d11_service.cpp.
-// See issue #210.
-static void
-d3d11_compositor_service_trigger_file(struct comp_d3d11_compositor *c)
-{
-	static char trigger_path[MCP_CAPTURE_PATH_MAX] = {0};
-	static char out_path[MCP_CAPTURE_PATH_MAX] = {0};
-	if (trigger_path[0] == '\0') {
-		const char *tmp = getenv("TEMP");
-		if (tmp == nullptr || tmp[0] == '\0') {
-			tmp = "C:\\Temp";
-		}
-		snprintf(trigger_path, sizeof(trigger_path), "%s\\displayxr_atlas_trigger", tmp);
-		snprintf(out_path, sizeof(out_path), "%s\\displayxr_atlas.png", tmp);
-	}
-
-	if (GetFileAttributesA(trigger_path) == INVALID_FILE_ATTRIBUTES) {
-		return;
-	}
-	DeleteFileA(trigger_path);
-
-	bool ok = d3d11_compositor_capture_atlas_to_png(c, out_path);
+	bool ok = d3d11_compositor_capture_atlas_to_png(c, c->capture_intent.path);
 	if (ok) {
-		U_LOG_I("Atlas captured to %s", out_path);
+		U_LOG_I("Atlas captured (mode=%u) to %s",
+		        c->capture_intent.mode, c->capture_intent.path);
 	} else {
-		U_LOG_W("Atlas capture failed (trigger %s)", trigger_path);
+		U_LOG_W("Atlas capture failed (mode=%u path=%s)",
+		        c->capture_intent.mode, c->capture_intent.path);
 	}
+	u_capture_intent_complete(&c->capture_intent, &c->mcp_capture, ok);
 }
 
 static xrt_result_t
@@ -993,6 +972,11 @@ d3d11_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 	struct comp_d3d11_compositor *c = d3d11_comp(xc);
 
 	std::lock_guard<std::mutex> lock(c->mutex);
+
+	// Capture-intent poll — see u_capture_intent.h. Consumed at the
+	// projection-done boundary (PROJECTION_ONLY, once renderer split
+	// lands) or end of frame (POST_COMPOSE).
+	u_capture_intent_poll(&c->capture_intent, &c->mcp_capture);
 
 	// Phase 1 diagnostic — env-gated per-client commit interval. Mirrors
 	// the same `[CLIENT_FRAME_NS]` line emitted by the SERVICE compositor's
@@ -1284,14 +1268,27 @@ d3d11_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 		}
 	}
 
-	// Render layers to atlas texture (skip if zero-copy).
-	// Pass hardware_display_3d so the renderer knows the current display mode.
+	// Render layers to atlas texture (skip if zero-copy). Split into a
+	// projection pass + window-space pass so a projection-only capture
+	// can read the atlas in between.
 	xrt_result_t xret = XRT_SUCCESS;
 	if (!zero_copy) {
-		xret = comp_d3d11_renderer_draw(
+		xret = comp_d3d11_renderer_draw_projection_pass(
 		    c->renderer, &c->layer_accum, &left_eye, &right_eye, tgt_width, tgt_height, c->hardware_display_3d);
 		if (xret != XRT_SUCCESS) {
-			U_LOG_E("Failed to render layers");
+			U_LOG_E("Failed to render projection pass");
+			return xret;
+		}
+
+		// Projection-only capture point — atlas now contains projection-
+		// class layers (projection, projection-depth, quad) for every
+		// tile; window-space layers haven't been composed yet.
+		d3d11_compositor_dispatch_capture(c, MCP_CAPTURE_MODE_PROJECTION_ONLY);
+
+		xret = comp_d3d11_renderer_draw_window_space_pass(
+		    c->renderer, &c->layer_accum, tgt_width, tgt_height, c->hardware_display_3d);
+		if (xret != XRT_SUCCESS) {
+			U_LOG_E("Failed to render window-space pass");
 			return xret;
 		}
 	}
@@ -1437,13 +1434,10 @@ d3d11_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 		return xret;
 	}
 
-	// Service pending MCP capture_frame after Present so the atlas
-	// we stage-copy reflects exactly what the user just saw.
-	d3d11_compositor_service_mcp_capture(c);
-
-	// Same readback driven by a trigger file (no MCP client required).
-	// See issue #210.
-	d3d11_compositor_service_trigger_file(c);
+	// Post-compose capture (#210) — fully composed atlas as DP saw it.
+	// PROJECTION_ONLY intent is consumed earlier in this function once
+	// the renderer split lands; until then both modes hit this point.
+	d3d11_compositor_dispatch_capture(c, MCP_CAPTURE_MODE_POST_COMPOSE);
 
 	return XRT_SUCCESS;
 }

--- a/src/xrt/compositor/d3d11/comp_d3d11_renderer.cpp
+++ b/src/xrt/compositor/d3d11/comp_d3d11_renderer.cpp
@@ -989,14 +989,70 @@ comp_d3d11_renderer_destroy(struct comp_d3d11_renderer **renderer_ptr)
 	*renderer_ptr = nullptr;
 }
 
+// Compute effective_views consistently between the two passes (must
+// agree so window-space layers land on the same per-tile viewports
+// the projection pass painted).
+static uint32_t
+compute_effective_views(struct comp_layer_accum *layers, bool hardware_display_3d)
+{
+	uint32_t effective_views = 2;
+	for (uint32_t i = 0; i < layers->layer_count; i++) {
+		if (layers->layers[i].data.type == XRT_LAYER_PROJECTION ||
+		    layers->layers[i].data.type == XRT_LAYER_PROJECTION_DEPTH) {
+			effective_views = layers->layers[i].data.view_count;
+			break;
+		}
+	}
+	if (!hardware_display_3d && effective_views > 1) {
+		effective_views = 1;
+	}
+	return effective_views;
+}
+
+// Set the per-view viewport on the immediate context for either pass.
+static void
+set_view_viewport(struct comp_d3d11_renderer *renderer,
+                  uint32_t view_index,
+                  uint32_t effective_views,
+                  uint32_t target_width,
+                  uint32_t target_height)
+{
+	auto internals = get_internals(renderer->c);
+	D3D11_VIEWPORT viewport = {};
+	if (effective_views == 1) {
+		// MONO: use target (window) dimensions so 2D content fills
+		// the full window. Width is capped to the atlas texture width
+		// (tile_columns*view_width); height is capped to texture_height.
+		uint32_t atlas_w = renderer->tile_columns * renderer->view_width;
+		uint32_t mono_w = (target_width < atlas_w) ? target_width : atlas_w;
+		uint32_t mono_h = (target_height < renderer->texture_height)
+		                      ? target_height
+		                      : renderer->texture_height;
+		viewport.TopLeftX = 0.0f;
+		viewport.Width = static_cast<float>(mono_w);
+		viewport.Height = static_cast<float>(mono_h);
+	} else {
+		// MULTI-VIEW: tile-based atlas layout
+		uint32_t col = view_index % renderer->tile_columns;
+		uint32_t row = view_index / renderer->tile_columns;
+		viewport.TopLeftX = static_cast<float>(col * renderer->view_width);
+		viewport.TopLeftY = static_cast<float>(row * renderer->view_height);
+		viewport.Width = static_cast<float>(renderer->view_width);
+		viewport.Height = static_cast<float>(renderer->view_height);
+	}
+	viewport.MinDepth = 0.0f;
+	viewport.MaxDepth = 1.0f;
+	internals->context->RSSetViewports(1, &viewport);
+}
+
 extern "C" xrt_result_t
-comp_d3d11_renderer_draw(struct comp_d3d11_renderer *renderer,
-                         struct comp_layer_accum *layers,
-                         struct xrt_vec3 *left_eye,
-                         struct xrt_vec3 *right_eye,
-                         uint32_t target_width,
-                         uint32_t target_height,
-                         bool hardware_display_3d)
+comp_d3d11_renderer_draw_projection_pass(struct comp_d3d11_renderer *renderer,
+                                          struct comp_layer_accum *layers,
+                                          struct xrt_vec3 *left_eye,
+                                          struct xrt_vec3 *right_eye,
+                                          uint32_t target_width,
+                                          uint32_t target_height,
+                                          bool hardware_display_3d)
 {
 	auto internals = get_internals(renderer->c);
 
@@ -1018,28 +1074,14 @@ comp_d3d11_renderer_draw(struct comp_d3d11_renderer *renderer,
 	internals->context->OMSetDepthStencilState(renderer->depth_stencil_state, 0);
 	internals->context->OMSetBlendState(renderer->blend_opaque, nullptr, 0xFFFFFFFF);
 
-	// Set up default view poses and FOVs for UI layer rendering
+	// Default view poses and FOVs for non-projection 3D-positioned layers
+	// (quad / cylinder / equirect / cube). Projection layers carry their
+	// own per-view pose/FOV inside layer->data.proj.v[i]; these defaults
+	// are only consumed when a layer doesn't.
 	struct xrt_pose view_poses[2];
 	struct xrt_fov fovs[2];
-
-	// Default identity pose with slight IPD offset
-	view_poses[0].orientation.x = 0.0f;
-	view_poses[0].orientation.y = 0.0f;
-	view_poses[0].orientation.z = 0.0f;
-	view_poses[0].orientation.w = 1.0f;
-	view_poses[0].position.x = -0.032f; // IPD/2
-	view_poses[0].position.y = 0.0f;
-	view_poses[0].position.z = 0.0f;
-
-	view_poses[1].orientation.x = 0.0f;
-	view_poses[1].orientation.y = 0.0f;
-	view_poses[1].orientation.z = 0.0f;
-	view_poses[1].orientation.w = 1.0f;
-	view_poses[1].position.x = 0.032f; // IPD/2
-	view_poses[1].position.y = 0.0f;
-	view_poses[1].position.z = 0.0f;
-
-	// Default symmetric FOV (roughly 90 degrees)
+	view_poses[0] = {{0.0f, 0.0f, 0.0f, 1.0f}, {-0.032f, 0.0f, 0.0f}};
+	view_poses[1] = {{0.0f, 0.0f, 0.0f, 1.0f}, {0.032f, 0.0f, 0.0f}};
 	const float fov_angle = 0.785f; // ~45 degrees
 	for (uint32_t view = 0; view < 2; view++) {
 		fovs[view].angle_left = -fov_angle;
@@ -1048,54 +1090,12 @@ comp_d3d11_renderer_draw(struct comp_d3d11_renderer *renderer,
 		fovs[view].angle_down = -fov_angle;
 	}
 
-	// Determine effective view count from first projection layer.
-	// In 2D mode (!hardware_display_3d), override to 1 view.
-	uint32_t effective_views = 2;
-	for (uint32_t i = 0; i < layers->layer_count; i++) {
-		if (layers->layers[i].data.type == XRT_LAYER_PROJECTION ||
-		    layers->layers[i].data.type == XRT_LAYER_PROJECTION_DEPTH) {
-			effective_views = layers->layers[i].data.view_count;
-			break;
-		}
-	}
-	if (!hardware_display_3d && effective_views > 1) {
-		effective_views = 1;
-	}
+	uint32_t effective_views = compute_effective_views(layers, hardware_display_3d);
 
-	// Render each view (1 for mono, 2+ for stereo/multi-view)
 	for (uint32_t view_index = 0; view_index < effective_views; view_index++) {
-		// Set viewport for this view
-		D3D11_VIEWPORT viewport = {};
-		if (effective_views == 1) {
-			// MONO: use target (window) dimensions so 2D content fills
-			// the full window. Width is capped to the atlas texture width
-			// (tile_columns*view_width); height is capped to texture_height.
-			uint32_t atlas_w = renderer->tile_columns * renderer->view_width;
-			uint32_t mono_w = (target_width < atlas_w)
-			                      ? target_width
-			                      : atlas_w;
-			uint32_t mono_h = (target_height < renderer->texture_height)
-			                      ? target_height
-			                      : renderer->texture_height;
-			viewport.TopLeftX = 0.0f;
-			viewport.Width = static_cast<float>(mono_w);
-			viewport.Height = static_cast<float>(mono_h);
-		} else {
-			// MULTI-VIEW: tile-based atlas layout
-			uint32_t col = view_index % renderer->tile_columns;
-			uint32_t row = view_index / renderer->tile_columns;
-			viewport.TopLeftX = static_cast<float>(col * renderer->view_width);
-			viewport.TopLeftY = static_cast<float>(row * renderer->view_height);
-			viewport.Width = static_cast<float>(renderer->view_width);
-			viewport.Height = static_cast<float>(renderer->view_height);
-		}
-		viewport.MinDepth = 0.0f;
-		viewport.MaxDepth = 1.0f;
-		internals->context->RSSetViewports(1, &viewport);
-
+		set_view_viewport(renderer, view_index, effective_views, target_width, target_height);
 		struct xrt_vec3 *eye = (view_index == 0) ? left_eye : right_eye;
 
-		// Render all layers for this view
 		for (uint32_t i = 0; i < layers->layer_count; i++) {
 			struct comp_layer *layer = &layers->layers[i];
 
@@ -1138,18 +1138,57 @@ comp_d3d11_renderer_draw(struct comp_d3d11_renderer *renderer,
 				break;
 			}
 
+			// Window-space deferred to draw_window_space_pass so the
+			// compositor can capture the projection-only atlas state
+			// between the two passes.
 			case XRT_LAYER_WINDOW_SPACE:
-				render_window_space_layer(renderer, layer, view_index);
 				break;
 
 			default:
-				// Unsupported layer type
 				break;
 			}
 		}
 	}
 
 	return XRT_SUCCESS;
+}
+
+extern "C" xrt_result_t
+comp_d3d11_renderer_draw_window_space_pass(struct comp_d3d11_renderer *renderer,
+                                            struct comp_layer_accum *layers,
+                                            uint32_t target_width,
+                                            uint32_t target_height,
+                                            bool hardware_display_3d)
+{
+	uint32_t effective_views = compute_effective_views(layers, hardware_display_3d);
+	for (uint32_t view_index = 0; view_index < effective_views; view_index++) {
+		set_view_viewport(renderer, view_index, effective_views, target_width, target_height);
+		for (uint32_t i = 0; i < layers->layer_count; i++) {
+			struct comp_layer *layer = &layers->layers[i];
+			if (layer->data.type == XRT_LAYER_WINDOW_SPACE) {
+				render_window_space_layer(renderer, layer, view_index);
+			}
+		}
+	}
+	return XRT_SUCCESS;
+}
+
+extern "C" xrt_result_t
+comp_d3d11_renderer_draw(struct comp_d3d11_renderer *renderer,
+                         struct comp_layer_accum *layers,
+                         struct xrt_vec3 *left_eye,
+                         struct xrt_vec3 *right_eye,
+                         uint32_t target_width,
+                         uint32_t target_height,
+                         bool hardware_display_3d)
+{
+	xrt_result_t xret = comp_d3d11_renderer_draw_projection_pass(
+	    renderer, layers, left_eye, right_eye, target_width, target_height, hardware_display_3d);
+	if (xret != XRT_SUCCESS) {
+		return xret;
+	}
+	return comp_d3d11_renderer_draw_window_space_pass(
+	    renderer, layers, target_width, target_height, hardware_display_3d);
 }
 
 extern "C" void *

--- a/src/xrt/compositor/d3d11/comp_d3d11_renderer.h
+++ b/src/xrt/compositor/d3d11/comp_d3d11_renderer.h
@@ -81,6 +81,47 @@ comp_d3d11_renderer_draw(struct comp_d3d11_renderer *renderer,
                          bool hardware_display_3d);
 
 /*!
+ * Render the projection-class pass of the atlas (projection /
+ * projection-depth / quad / cylinder / equirect / cube layers). Window-
+ * space layers are skipped so the compositor can capture an
+ * intermediate "projection-only" atlas state between this call and
+ * @ref comp_d3d11_renderer_draw_window_space_pass for the runtime-side
+ * @c capture_frame projection-only mode (see u_capture_intent.h, #210).
+ *
+ * Clears the atlas RTV and depth buffer, sets common state, then runs
+ * the per-view loop with all non-window-space layer types. After this
+ * returns the atlas contains the projection-only composite.
+ *
+ * @ingroup comp_d3d11
+ */
+xrt_result_t
+comp_d3d11_renderer_draw_projection_pass(struct comp_d3d11_renderer *renderer,
+                                          struct comp_layer_accum *layers,
+                                          struct xrt_vec3 *left_eye,
+                                          struct xrt_vec3 *right_eye,
+                                          uint32_t target_width,
+                                          uint32_t target_height,
+                                          bool hardware_display_3d);
+
+/*!
+ * Render only window-space layers into the atlas, on top of whatever
+ * the projection pass left behind. Does NOT clear the atlas. State
+ * (shaders, blend) is set per-layer inside @c render_window_space_layer.
+ *
+ * Pair with @ref comp_d3d11_renderer_draw_projection_pass when an
+ * intermediate capture point is needed; otherwise call
+ * @ref comp_d3d11_renderer_draw which runs both back-to-back.
+ *
+ * @ingroup comp_d3d11
+ */
+xrt_result_t
+comp_d3d11_renderer_draw_window_space_pass(struct comp_d3d11_renderer *renderer,
+                                            struct comp_layer_accum *layers,
+                                            uint32_t target_width,
+                                            uint32_t target_height,
+                                            bool hardware_display_3d);
+
+/*!
  * Get the atlas texture SRV for weaving.
  *
  * Returns the shader resource view of the tiled atlas texture

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -14267,7 +14267,10 @@ comp_d3d11_service_poll_mcp_capture(struct xrt_system_compositor *xsysc)
 	}
 
 	char base[MCP_CAPTURE_PATH_MAX];
-	if (!mcp_capture_poll(&sys->mcp_capture, base)) {
+	// Workspace compositor only supports POST_COMPOSE today; ignore mode
+	// for now (the workspace already captures the combined atlas at the
+	// post-compose point regardless of any per-client window-space layers).
+	if (!mcp_capture_poll(&sys->mcp_capture, base, NULL)) {
 		return;
 	}
 

--- a/src/xrt/compositor/d3d12/CMakeLists.txt
+++ b/src/xrt/compositor/d3d12/CMakeLists.txt
@@ -27,6 +27,7 @@ if(WIN32 AND XRT_HAVE_D3D12)
 			aux_util
 			aux_os
 			aux_math
+			xrt-external-stb
 			d3d12
 			dxgi
 			d3dcompiler

--- a/src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp
+++ b/src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp
@@ -33,6 +33,12 @@
 #include "util/u_tiling.h"
 #include "util/u_canvas.h"
 #include "util/u_hud.h"
+#include <displayxr_mcp/mcp_capture.h>
+
+// STB_IMAGE_WRITE_STATIC scopes all stbi_write_* to this TU.
+#define STB_IMAGE_WRITE_STATIC
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+#include "stb_image_write.h"
 
 #ifdef XRT_BUILD_DRIVER_QWERTY
 #include "qwerty_interface.h"
@@ -215,6 +221,10 @@ struct comp_d3d12_compositor
 
 	//! Thread safety.
 	std::mutex mutex;
+
+	//! MCP capture_frame request box (serviced at end of layer_commit).
+	//! Mirrors the pattern in comp_metal/gl/d3d11_compositor. See issue #210.
+	struct mcp_capture_request mcp_capture;
 };
 
 /*
@@ -912,6 +922,181 @@ d3d12_crop_atlas_for_dp(struct comp_d3d12_compositor *c,
 	return c->dp_input_resource;
 }
 
+/*
+ *
+ * MCP capture helpers
+ *
+ */
+
+// Copy the content region of the renderer's atlas (tile_columns × view_width
+// by tile_rows × view_height — what the app actually wrote, same region the
+// compositor crops and sends to the DP) into a READBACK heap buffer, then
+// write @p path as PNG. D3D12 renderer uses DXGI_FORMAT_R8G8B8A8_UNORM so no
+// channel swap is needed.
+//
+// Caller must ensure the GPU is idle on entry (gpu_wait_idle has been called
+// or the existing layer_commit fence-waits before returning). On exit the
+// atlas is left in PIXEL_SHADER_RESOURCE state (matching the renderer's
+// expected steady state between frames).
+static bool
+d3d12_compositor_capture_atlas_to_png(struct comp_d3d12_compositor *c, const char *path)
+{
+	ID3D12Resource *atlas = static_cast<ID3D12Resource *>(
+	    comp_d3d12_renderer_get_atlas_resource(c->renderer));
+	if (atlas == nullptr || c->renderer == nullptr) {
+		return false;
+	}
+
+	uint32_t tile_columns = 1, tile_rows = 1;
+	comp_d3d12_renderer_get_tile_layout(c->renderer, &tile_columns, &tile_rows);
+	uint32_t view_w = 0, view_h = 0;
+	comp_d3d12_renderer_get_view_dimensions(c->renderer, &view_w, &view_h);
+	if (tile_columns == 0 || tile_rows == 0 || view_w == 0 || view_h == 0) {
+		return false;
+	}
+
+	D3D12_RESOURCE_DESC adesc = atlas->GetDesc();
+	uint32_t content_w = tile_columns * view_w;
+	uint32_t content_h = tile_rows * view_h;
+	if (content_w > adesc.Width)  content_w = (uint32_t)adesc.Width;
+	if (content_h > adesc.Height) content_h = adesc.Height;
+
+	// D3D12 readback row pitch must be aligned to 256.
+	const UINT64 align = D3D12_TEXTURE_DATA_PITCH_ALIGNMENT;
+	UINT64 row_pitch = ((UINT64)content_w * 4 + align - 1) & ~(align - 1);
+	UINT64 rb_bytes = row_pitch * content_h;
+
+	// Allocate a transient READBACK buffer. Lifetime = single capture.
+	D3D12_HEAP_PROPERTIES heap_props = {};
+	heap_props.Type = D3D12_HEAP_TYPE_READBACK;
+	D3D12_RESOURCE_DESC rb_desc = {};
+	rb_desc.Dimension = D3D12_RESOURCE_DIMENSION_BUFFER;
+	rb_desc.Width = rb_bytes;
+	rb_desc.Height = 1;
+	rb_desc.DepthOrArraySize = 1;
+	rb_desc.MipLevels = 1;
+	rb_desc.Format = DXGI_FORMAT_UNKNOWN;
+	rb_desc.SampleDesc.Count = 1;
+	rb_desc.Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
+	rb_desc.Flags = D3D12_RESOURCE_FLAG_NONE;
+
+	ID3D12Resource *readback = nullptr;
+	if (FAILED(c->device->CreateCommittedResource(
+	        &heap_props, D3D12_HEAP_FLAG_NONE, &rb_desc,
+	        D3D12_RESOURCE_STATE_COPY_DEST, nullptr,
+	        IID_PPV_ARGS(&readback))) || readback == nullptr) {
+		return false;
+	}
+
+	// Re-arm the cmd_allocator + cmd_list for our private use. GPU is
+	// guaranteed idle at this point because layer_commit's existing
+	// fence wait runs before we get here.
+	c->cmd_allocator->Reset();
+	c->cmd_list->Reset(c->cmd_allocator, nullptr);
+
+	// Atlas: PIXEL_SHADER_RESOURCE → COPY_SOURCE.
+	D3D12_RESOURCE_BARRIER b = {};
+	b.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+	b.Transition.pResource = atlas;
+	b.Transition.Subresource = 0;
+	b.Transition.StateBefore = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+	b.Transition.StateAfter = D3D12_RESOURCE_STATE_COPY_SOURCE;
+	c->cmd_list->ResourceBarrier(1, &b);
+
+	D3D12_TEXTURE_COPY_LOCATION src_loc = {};
+	src_loc.pResource = atlas;
+	src_loc.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
+	src_loc.SubresourceIndex = 0;
+
+	D3D12_TEXTURE_COPY_LOCATION dst_loc = {};
+	dst_loc.pResource = readback;
+	dst_loc.Type = D3D12_TEXTURE_COPY_TYPE_PLACED_FOOTPRINT;
+	dst_loc.PlacedFootprint.Offset = 0;
+	dst_loc.PlacedFootprint.Footprint.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	dst_loc.PlacedFootprint.Footprint.Width = content_w;
+	dst_loc.PlacedFootprint.Footprint.Height = content_h;
+	dst_loc.PlacedFootprint.Footprint.Depth = 1;
+	dst_loc.PlacedFootprint.Footprint.RowPitch = (UINT)row_pitch;
+
+	D3D12_BOX src_box = {0, 0, 0, content_w, content_h, 1};
+	c->cmd_list->CopyTextureRegion(&dst_loc, 0, 0, 0, &src_loc, &src_box);
+
+	// Atlas: COPY_SOURCE → PIXEL_SHADER_RESOURCE (steady state).
+	std::swap(b.Transition.StateBefore, b.Transition.StateAfter);
+	c->cmd_list->ResourceBarrier(1, &b);
+
+	c->cmd_list->Close();
+	ID3D12CommandList *lists[] = {c->cmd_list};
+	c->command_queue->ExecuteCommandLists(1, lists);
+	gpu_wait_idle(c);
+
+	// Map readback, repack to tightly-packed rows, encode PNG.
+	bool ok = false;
+	void *mapped = nullptr;
+	D3D12_RANGE read_range = {0, (SIZE_T)rb_bytes};
+	if (SUCCEEDED(readback->Map(0, &read_range, &mapped)) && mapped != nullptr) {
+		size_t tight_pitch = (size_t)content_w * 4;
+		uint8_t *tight = (uint8_t *)malloc(tight_pitch * content_h);
+		if (tight != nullptr) {
+			const uint8_t *rb_pixels = (const uint8_t *)mapped;
+			for (uint32_t y = 0; y < content_h; y++) {
+				memcpy(tight + (size_t)y * tight_pitch,
+				       rb_pixels + (size_t)y * row_pitch,
+				       tight_pitch);
+			}
+			ok = stbi_write_png(path, (int)content_w, (int)content_h, 4,
+			                    tight, (int)tight_pitch) != 0;
+			free(tight);
+		}
+		D3D12_RANGE empty_range = {0, 0};
+		readback->Unmap(0, &empty_range);
+	}
+
+	readback->Release();
+	return ok;
+}
+
+// Service a pending MCP capture_frame request — thin wrapper around
+// d3d12_compositor_capture_atlas_to_png.
+static void
+d3d12_compositor_service_mcp_capture(struct comp_d3d12_compositor *c)
+{
+	char path[MCP_CAPTURE_PATH_MAX];
+	if (!mcp_capture_poll(&c->mcp_capture, path)) {
+		return;
+	}
+	bool ok = d3d12_compositor_capture_atlas_to_png(c, path);
+	mcp_capture_complete(&c->mcp_capture, ok);
+}
+
+// Trigger-file capture path — mirrors the d3d11_service workspace_screenshot
+// pattern (comp_d3d11_service.cpp:9696-9716). See issue #210.
+static void
+d3d12_compositor_service_trigger_file(struct comp_d3d12_compositor *c)
+{
+	static char trigger_path[MCP_CAPTURE_PATH_MAX] = {0};
+	static char out_path[MCP_CAPTURE_PATH_MAX] = {0};
+	if (trigger_path[0] == '\0') {
+		const char *tmp = getenv("TEMP");
+		if (tmp == nullptr || tmp[0] == '\0') tmp = "C:\\Temp";
+		snprintf(trigger_path, sizeof(trigger_path), "%s\\displayxr_atlas_trigger", tmp);
+		snprintf(out_path, sizeof(out_path), "%s\\displayxr_atlas.png", tmp);
+	}
+
+	if (GetFileAttributesA(trigger_path) == INVALID_FILE_ATTRIBUTES) {
+		return;
+	}
+	DeleteFileA(trigger_path);
+
+	bool ok = d3d12_compositor_capture_atlas_to_png(c, out_path);
+	if (ok) {
+		U_LOG_I("Atlas captured to %s", out_path);
+	} else {
+		U_LOG_W("Atlas capture failed (trigger %s)", trigger_path);
+	}
+}
+
+
 static xrt_result_t
 d3d12_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sync_handle)
 {
@@ -1546,6 +1731,12 @@ d3d12_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 		}
 	}
 
+	// MCP capture_frame + trigger-file post-compose atlas capture (#210).
+	// Runs after the existing fence wait so the GPU is idle when we
+	// reset the compositor's command allocator/list for the readback.
+	d3d12_compositor_service_mcp_capture(c);
+	d3d12_compositor_service_trigger_file(c);
+
 	return XRT_SUCCESS;
 }
 
@@ -1875,6 +2066,10 @@ d3d12_compositor_destroy(struct xrt_compositor *xc)
 	struct comp_d3d12_compositor *c = d3d12_comp(xc);
 
 	U_LOG_I("Destroying D3D12 compositor");
+
+	// Uninstall MCP capture hook before the GPU resources go away.
+	mcp_capture_uninstall();
+	mcp_capture_fini(&c->mcp_capture);
 
 	// Wait for GPU idle
 	if (c->fence != nullptr && c->command_queue != nullptr) {
@@ -2319,6 +2514,10 @@ comp_d3d12_compositor_create(struct xrt_device *xdev,
 	c->base.base.layer_commit = d3d12_compositor_layer_commit;
 	c->base.base.layer_commit_with_semaphore = d3d12_compositor_layer_commit_with_semaphore;
 	c->base.base.destroy = d3d12_compositor_destroy;
+
+	// Install MCP capture_frame hook + arm the trigger-file path (#210).
+	mcp_capture_init(&c->mcp_capture);
+	mcp_capture_install(&c->mcp_capture);
 
 	*out_xc = &c->base;
 

--- a/src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp
+++ b/src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp
@@ -32,6 +32,7 @@
 #include "math/m_api.h"
 #include "util/u_tiling.h"
 #include "util/u_canvas.h"
+#include "util/u_capture_intent.h"
 #include "util/u_hud.h"
 #include <displayxr_mcp/mcp_capture.h>
 
@@ -225,6 +226,9 @@ struct comp_d3d12_compositor
 	//! MCP capture_frame request box (serviced at end of layer_commit).
 	//! Mirrors the pattern in comp_metal/gl/d3d11_compositor. See issue #210.
 	struct mcp_capture_request mcp_capture;
+
+	//! Per-frame capture intent. See u_capture_intent.h.
+	struct u_capture_intent capture_intent;
 };
 
 /*
@@ -1056,44 +1060,22 @@ d3d12_compositor_capture_atlas_to_png(struct comp_d3d12_compositor *c, const cha
 	return ok;
 }
 
-// Service a pending MCP capture_frame request — thin wrapper around
-// d3d12_compositor_capture_atlas_to_png.
+// Run the capture readback if the per-frame intent matches @p mode_filter.
 static void
-d3d12_compositor_service_mcp_capture(struct comp_d3d12_compositor *c)
+d3d12_compositor_dispatch_capture(struct comp_d3d12_compositor *c, uint32_t mode_filter)
 {
-	char path[MCP_CAPTURE_PATH_MAX];
-	if (!mcp_capture_poll(&c->mcp_capture, path)) {
+	if (!u_capture_intent_should_capture(&c->capture_intent, mode_filter)) {
 		return;
 	}
-	bool ok = d3d12_compositor_capture_atlas_to_png(c, path);
-	mcp_capture_complete(&c->mcp_capture, ok);
-}
-
-// Trigger-file capture path — mirrors the d3d11_service workspace_screenshot
-// pattern (comp_d3d11_service.cpp:9696-9716). See issue #210.
-static void
-d3d12_compositor_service_trigger_file(struct comp_d3d12_compositor *c)
-{
-	static char trigger_path[MCP_CAPTURE_PATH_MAX] = {0};
-	static char out_path[MCP_CAPTURE_PATH_MAX] = {0};
-	if (trigger_path[0] == '\0') {
-		const char *tmp = getenv("TEMP");
-		if (tmp == nullptr || tmp[0] == '\0') tmp = "C:\\Temp";
-		snprintf(trigger_path, sizeof(trigger_path), "%s\\displayxr_atlas_trigger", tmp);
-		snprintf(out_path, sizeof(out_path), "%s\\displayxr_atlas.png", tmp);
-	}
-
-	if (GetFileAttributesA(trigger_path) == INVALID_FILE_ATTRIBUTES) {
-		return;
-	}
-	DeleteFileA(trigger_path);
-
-	bool ok = d3d12_compositor_capture_atlas_to_png(c, out_path);
+	bool ok = d3d12_compositor_capture_atlas_to_png(c, c->capture_intent.path);
 	if (ok) {
-		U_LOG_I("Atlas captured to %s", out_path);
+		U_LOG_I("Atlas captured (mode=%u) to %s",
+		        c->capture_intent.mode, c->capture_intent.path);
 	} else {
-		U_LOG_W("Atlas capture failed (trigger %s)", trigger_path);
+		U_LOG_W("Atlas capture failed (mode=%u path=%s)",
+		        c->capture_intent.mode, c->capture_intent.path);
 	}
+	u_capture_intent_complete(&c->capture_intent, &c->mcp_capture, ok);
 }
 
 
@@ -1103,6 +1085,11 @@ d3d12_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 	struct comp_d3d12_compositor *c = d3d12_comp(xc);
 
 	std::lock_guard<std::mutex> lock(c->mutex);
+
+	// Capture-intent poll — see u_capture_intent.h. Consumed at the
+	// projection-done boundary (PROJECTION_ONLY, once renderer split
+	// lands) or end of frame (POST_COMPOSE).
+	u_capture_intent_poll(&c->capture_intent, &c->mcp_capture);
 
 	// Get predicted eye positions
 	struct xrt_eye_positions eye_pos = {};
@@ -1327,13 +1314,56 @@ d3d12_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 		}
 	}
 
-	// Render layers to atlas texture (skip if zero-copy)
+	// Render layers to atlas texture (skip if zero-copy). Split into a
+	// projection pass + window-space pass so a projection-only capture
+	// can read the atlas in between.
 	xrt_result_t xret = XRT_SUCCESS;
 	if (!zero_copy) {
-		xret = comp_d3d12_renderer_draw(
+		xret = comp_d3d12_renderer_draw_projection_pass(
 		    c->renderer, c->cmd_list, &c->layer_accum, &left_eye, &right_eye, tgt_width, tgt_height, c->hardware_display_3d);
 		if (xret != XRT_SUCCESS) {
-			U_LOG_E("Failed to render layers");
+			U_LOG_E("Failed to render projection pass");
+			return xret;
+		}
+
+		// Projection-only capture point. Atlas is in RENDER_TARGET with
+		// uncommitted projection commands in the cmd_list. To read it back
+		// we need to commit those commands, transition the atlas to
+		// PIXEL_SHADER_RESOURCE, run the capture (which uses the cmd_list
+		// for its own copy + barriers), then transition back to
+		// RENDER_TARGET so the window-space pass can append draws.
+		if (c->capture_intent.pending && c->capture_intent.mode == MCP_CAPTURE_MODE_PROJECTION_ONLY) {
+			ID3D12Resource *atlas_res = static_cast<ID3D12Resource *>(
+			    comp_d3d12_renderer_get_atlas_resource(c->renderer));
+
+			D3D12_RESOURCE_BARRIER ws_barrier = {};
+			ws_barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+			ws_barrier.Transition.pResource = atlas_res;
+			ws_barrier.Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+			ws_barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
+			ws_barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+			c->cmd_list->ResourceBarrier(1, &ws_barrier);
+
+			c->cmd_list->Close();
+			ID3D12CommandList *flush_lists[] = {c->cmd_list};
+			c->command_queue->ExecuteCommandLists(1, flush_lists);
+			gpu_wait_idle(c);
+
+			// Capture handles its own cmd_list reset + barriers (PSR↔COPY_SOURCE).
+			d3d12_compositor_dispatch_capture(c, MCP_CAPTURE_MODE_PROJECTION_ONLY);
+
+			// Re-arm cmd_list and put atlas back in RENDER_TARGET.
+			c->cmd_allocator->Reset();
+			c->cmd_list->Reset(c->cmd_allocator, nullptr);
+			ws_barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+			ws_barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_RENDER_TARGET;
+			c->cmd_list->ResourceBarrier(1, &ws_barrier);
+		}
+
+		xret = comp_d3d12_renderer_draw_window_space_pass(
+		    c->renderer, c->cmd_list, &c->layer_accum, tgt_width, tgt_height, c->hardware_display_3d);
+		if (xret != XRT_SUCCESS) {
+			U_LOG_E("Failed to render window-space pass");
 			return xret;
 		}
 	}
@@ -1656,6 +1686,11 @@ d3d12_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 		// Wait for frame completion (frame pacing)
 		gpu_wait_idle(c);
 
+		// Post-compose capture (#210) — fully composed atlas as DP saw it.
+		// DP path returns early; mirror the fallback path's call site so the
+		// capture surface works regardless of which weave path ran.
+		d3d12_compositor_dispatch_capture(c, MCP_CAPTURE_MODE_POST_COMPOSE);
+
 		return XRT_SUCCESS;
 	}
 
@@ -1731,11 +1766,10 @@ d3d12_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 		}
 	}
 
-	// MCP capture_frame + trigger-file post-compose atlas capture (#210).
-	// Runs after the existing fence wait so the GPU is idle when we
-	// reset the compositor's command allocator/list for the readback.
-	d3d12_compositor_service_mcp_capture(c);
-	d3d12_compositor_service_trigger_file(c);
+	// Post-compose capture (#210) — runs after the existing fence wait so
+	// the GPU is idle when we reset the compositor's cmd allocator/list
+	// for the readback.
+	d3d12_compositor_dispatch_capture(c, MCP_CAPTURE_MODE_POST_COMPOSE);
 
 	return XRT_SUCCESS;
 }

--- a/src/xrt/compositor/d3d12/comp_d3d12_renderer.cpp
+++ b/src/xrt/compositor/d3d12/comp_d3d12_renderer.cpp
@@ -805,14 +805,14 @@ comp_d3d12_renderer_destroy(struct comp_d3d12_renderer **renderer_ptr)
 
 
 extern "C" xrt_result_t
-comp_d3d12_renderer_draw(struct comp_d3d12_renderer *renderer,
-                         void *cmd_list_ptr,
-                         struct comp_layer_accum *layers,
-                         struct xrt_vec3 *left_eye,
-                         struct xrt_vec3 *right_eye,
-                         uint32_t target_width,
-                         uint32_t target_height,
-                         bool hardware_display_3d)
+comp_d3d12_renderer_draw_projection_pass(struct comp_d3d12_renderer *renderer,
+                                          void *cmd_list_ptr,
+                                          struct comp_layer_accum *layers,
+                                          struct xrt_vec3 *left_eye,
+                                          struct xrt_vec3 *right_eye,
+                                          uint32_t target_width,
+                                          uint32_t target_height,
+                                          bool hardware_display_3d)
 {
 	ID3D12GraphicsCommandList *cmd_list = static_cast<ID3D12GraphicsCommandList *>(cmd_list_ptr);
 
@@ -1030,6 +1030,26 @@ comp_d3d12_renderer_draw(struct comp_d3d12_renderer *renderer,
 		}
 	}
 
+	// Atlas left in RENDER_TARGET; window-space pass continues into the
+	// same cmd_list (or after a capture round-trip through PSR).
+	return XRT_SUCCESS;
+}
+
+extern "C" xrt_result_t
+comp_d3d12_renderer_draw_window_space_pass(struct comp_d3d12_renderer *renderer,
+                                            void *cmd_list_ptr,
+                                            struct comp_layer_accum *layers,
+                                            uint32_t target_width,
+                                            uint32_t target_height,
+                                            bool hardware_display_3d)
+{
+	ID3D12GraphicsCommandList *cmd_list = static_cast<ID3D12GraphicsCommandList *>(cmd_list_ptr);
+	if (cmd_list == nullptr || layers == nullptr) {
+		return XRT_ERROR_IPC_FAILURE;
+	}
+
+	uint32_t view_count = hardware_display_3d ? 2 : 1;
+
 	// Compute effective viewport for window-space layers (same clamp as projection)
 	uint32_t ws_vp_w = renderer->view_width;
 	uint32_t ws_vp_h = renderer->view_height;
@@ -1039,7 +1059,7 @@ comp_d3d12_renderer_draw(struct comp_d3d12_renderer *renderer,
 		if (target_height < renderer->texture_height) ws_vp_h = target_height;
 	}
 
-	// Draw window-space layers (atlas is already in RENDER_TARGET state)
+	// Draw window-space layers (atlas is in RENDER_TARGET state)
 	for (uint32_t vi = 0; vi < view_count; vi++) {
 		for (uint32_t li = 0; li < layers->layer_count; li++) {
 			struct comp_layer *layer = &layers->layers[li];
@@ -1050,12 +1070,37 @@ comp_d3d12_renderer_draw(struct comp_d3d12_renderer *renderer,
 		}
 	}
 
-	// Final transition: RENDER_TARGET → PIXEL_SHADER_RESOURCE
+	// Final transition: RENDER_TARGET → PIXEL_SHADER_RESOURCE for DP
+	D3D12_RESOURCE_BARRIER barrier = {};
+	barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+	barrier.Transition.pResource = renderer->atlas_texture;
 	barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
 	barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+	barrier.Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
 	cmd_list->ResourceBarrier(1, &barrier);
 
 	return XRT_SUCCESS;
+}
+
+extern "C" xrt_result_t
+comp_d3d12_renderer_draw(struct comp_d3d12_renderer *renderer,
+                         void *cmd_list_ptr,
+                         struct comp_layer_accum *layers,
+                         struct xrt_vec3 *left_eye,
+                         struct xrt_vec3 *right_eye,
+                         uint32_t target_width,
+                         uint32_t target_height,
+                         bool hardware_display_3d)
+{
+	xrt_result_t xret = comp_d3d12_renderer_draw_projection_pass(
+	    renderer, cmd_list_ptr, layers, left_eye, right_eye,
+	    target_width, target_height, hardware_display_3d);
+	if (xret != XRT_SUCCESS) {
+		return xret;
+	}
+	return comp_d3d12_renderer_draw_window_space_pass(
+	    renderer, cmd_list_ptr, layers,
+	    target_width, target_height, hardware_display_3d);
 }
 
 

--- a/src/xrt/compositor/d3d12/comp_d3d12_renderer.h
+++ b/src/xrt/compositor/d3d12/comp_d3d12_renderer.h
@@ -80,6 +80,46 @@ comp_d3d12_renderer_draw(struct comp_d3d12_renderer *renderer,
                          bool hardware_display_3d);
 
 /*!
+ * Project-pass half of @ref comp_d3d12_renderer_draw. Records into
+ * @p cmd_list:
+ *   - barrier atlas PIXEL_SHADER_RESOURCE → RENDER_TARGET
+ *   - clear atlas
+ *   - per-projection-layer stretch-blit into atlas tiles
+ * Atlas is left in RENDER_TARGET (uncommitted; cmd_list still open).
+ * Pair with @ref comp_d3d12_renderer_draw_window_space_pass; insert
+ * a capture call between them for the projection-only mode (#210).
+ *
+ * @ingroup comp_d3d12
+ */
+xrt_result_t
+comp_d3d12_renderer_draw_projection_pass(struct comp_d3d12_renderer *renderer,
+                                          void *cmd_list,
+                                          struct comp_layer_accum *layers,
+                                          struct xrt_vec3 *left_eye,
+                                          struct xrt_vec3 *right_eye,
+                                          uint32_t target_width,
+                                          uint32_t target_height,
+                                          bool hardware_display_3d);
+
+/*!
+ * Window-space-pass half of @ref comp_d3d12_renderer_draw. Records:
+ *   - per-window-space-layer textured quad in each atlas tile
+ *   - final barrier atlas RENDER_TARGET → PIXEL_SHADER_RESOURCE for DP
+ * Expects atlas in RENDER_TARGET on entry (caller transitions back if
+ * a capture happened in between, since capture leaves atlas in
+ * PIXEL_SHADER_RESOURCE).
+ *
+ * @ingroup comp_d3d12
+ */
+xrt_result_t
+comp_d3d12_renderer_draw_window_space_pass(struct comp_d3d12_renderer *renderer,
+                                            void *cmd_list,
+                                            struct comp_layer_accum *layers,
+                                            uint32_t target_width,
+                                            uint32_t target_height,
+                                            bool hardware_display_3d);
+
+/*!
  * Get the atlas texture SRV GPU descriptor handle for weaving.
  *
  * @param renderer The renderer.

--- a/src/xrt/compositor/gl/comp_gl_compositor.c
+++ b/src/xrt/compositor/gl/comp_gl_compositor.c
@@ -31,6 +31,7 @@
 #include "util/u_misc.h"
 #include "util/u_tiling.h"
 #include "util/u_canvas.h"
+#include "util/u_capture_intent.h"
 #include "util/u_time.h"
 #include "util/u_hud.h"
 #include <displayxr_mcp/mcp_capture.h>
@@ -299,6 +300,9 @@ struct comp_gl_compositor
 
 	//! MCP capture_frame request box (serviced at end of layer_commit).
 	struct mcp_capture_request mcp_capture;
+
+	//! Per-frame capture intent. See u_capture_intent.h.
+	struct u_capture_intent capture_intent;
 };
 
 static inline struct comp_gl_compositor *
@@ -1003,11 +1007,10 @@ gl_compositor_capture_atlas_to_png(struct comp_gl_compositor *c, const char *pat
 	glGenFramebuffers(1, &fbo);
 	glBindFramebuffer(GL_READ_FRAMEBUFFER, fbo);
 	glFramebufferTexture2D(GL_READ_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, c->atlas_texture, 0);
-	// Atlas's lower-left origin means our content region sits in the
-	// upper-left of the texture, at (0, atlas_h - content_h).
-	GLint src_y = (GLint)c->atlas_tex_height - (GLint)content_h;
-	if (src_y < 0) src_y = 0;
-	glReadPixels(0, src_y, (GLsizei)content_w, (GLsizei)content_h, GL_RGBA, GL_UNSIGNED_BYTE, bottom_up);
+	// Renderer renders content into FBO viewport (0, 0, content_w, content_h),
+	// which in GL's lower-left origin lands at the bottom of the texture. Read
+	// from y=0; the bottom_up→top_down flip below produces a top-down PNG.
+	glReadPixels(0, 0, (GLsizei)content_w, (GLsizei)content_h, GL_RGBA, GL_UNSIGNED_BYTE, bottom_up);
 	glFinish();
 	glBindFramebuffer(GL_READ_FRAMEBUFFER, prev_read_fbo);
 	glDeleteFramebuffers(1, &fbo);
@@ -1024,70 +1027,24 @@ gl_compositor_capture_atlas_to_png(struct comp_gl_compositor *c, const char *pat
 	return ok;
 }
 
-// Service a pending MCP capture_frame request — thin wrapper around
-// gl_compositor_capture_atlas_to_png that handles the cross-thread
-// hand-off with the MCP server.
+// Run the capture readback if the per-frame intent matches @p mode_filter.
+// GL atlas is sample-able after either the projection-only loop or the full
+// compose pass — same readback function for both modes.
 static void
-gl_compositor_service_mcp_capture(struct comp_gl_compositor *c)
+gl_compositor_dispatch_capture(struct comp_gl_compositor *c, uint32_t mode_filter)
 {
-	char path[MCP_CAPTURE_PATH_MAX];
-	if (!mcp_capture_poll(&c->mcp_capture, path)) {
+	if (!u_capture_intent_should_capture(&c->capture_intent, mode_filter)) {
 		return;
 	}
-	bool ok = gl_compositor_capture_atlas_to_png(c, path);
-	mcp_capture_complete(&c->mcp_capture, ok);
-}
-
-// Trigger-file capture path — same readback as the MCP path, driven
-// by the existence of a trigger file so devs can snapshot the post-
-// compose atlas without an MCP client. POSIX side uses
-// $TMPDIR/displayxr_atlas_trigger; Windows side (XRT_OS_WINDOWS) uses
-// %TEMP%\displayxr_atlas_trigger to mirror the d3d11_service path.
-// See issue #210.
-static void
-gl_compositor_service_trigger_file(struct comp_gl_compositor *c)
-{
-	static char trigger_path[MCP_CAPTURE_PATH_MAX] = {0};
-	static char out_path[MCP_CAPTURE_PATH_MAX] = {0};
-	if (trigger_path[0] == '\0') {
-#ifdef XRT_OS_WINDOWS
-		const char *tmp = getenv("TEMP");
-		if (tmp == NULL || tmp[0] == '\0') tmp = "C:\\Temp";
-		snprintf(trigger_path, sizeof(trigger_path), "%s\\displayxr_atlas_trigger", tmp);
-		snprintf(out_path, sizeof(out_path), "%s\\displayxr_atlas.png", tmp);
-#else
-		const char *tmp = getenv("TMPDIR");
-		if (tmp == NULL || tmp[0] == '\0') tmp = "/tmp";
-		size_t tlen = strlen(tmp);
-		if (tlen > 0 && tmp[tlen - 1] == '/') tlen = tlen - 1;
-		char tmp_clean[MCP_CAPTURE_PATH_MAX];
-		if (tlen >= sizeof(tmp_clean)) tlen = sizeof(tmp_clean) - 1;
-		memcpy(tmp_clean, tmp, tlen);
-		tmp_clean[tlen] = '\0';
-		snprintf(trigger_path, sizeof(trigger_path), "%s/displayxr_atlas_trigger", tmp_clean);
-		snprintf(out_path, sizeof(out_path), "%s/displayxr_atlas.png", tmp_clean);
-#endif
-	}
-
-#ifdef XRT_OS_WINDOWS
-	if (GetFileAttributesA(trigger_path) == INVALID_FILE_ATTRIBUTES) {
-		return;
-	}
-	DeleteFileA(trigger_path);
-#else
-	struct stat st;
-	if (stat(trigger_path, &st) != 0) {
-		return;
-	}
-	unlink(trigger_path);
-#endif
-
-	bool ok = gl_compositor_capture_atlas_to_png(c, out_path);
+	bool ok = gl_compositor_capture_atlas_to_png(c, c->capture_intent.path);
 	if (ok) {
-		U_LOG_I("Atlas captured to %s", out_path);
+		U_LOG_I("Atlas captured (mode=%u) to %s",
+		        c->capture_intent.mode, c->capture_intent.path);
 	} else {
-		U_LOG_W("Atlas capture failed (trigger %s)", trigger_path);
+		U_LOG_W("Atlas capture failed (mode=%u path=%s)",
+		        c->capture_intent.mode, c->capture_intent.path);
 	}
+	u_capture_intent_complete(&c->capture_intent, &c->mcp_capture, ok);
 }
 
 
@@ -1101,6 +1058,11 @@ static xrt_result_t
 gl_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sync_handle)
 {
 	struct comp_gl_compositor *c = gl_comp(xc);
+
+	// Capture-intent poll — see u_capture_intent.h. Consumed at the
+	// projection-done boundary (PROJECTION_ONLY) or end of frame
+	// (POST_COMPOSE).
+	u_capture_intent_poll(&c->capture_intent, &c->mcp_capture);
 
 	// Frame timing
 	uint64_t now_ns = os_monotonic_get_ns();
@@ -1339,6 +1301,13 @@ gl_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t
 			glDrawArrays(GL_TRIANGLES, 0, 3);
 		}
 	}
+
+	// Projection-only capture point — atlas now contains projection
+	// content for every tile; window-space layers haven't been rendered
+	// yet. Atlas is bound as the FBO color attachment; the capture
+	// readback temporarily attaches its own FBO and reads via
+	// glReadPixels (origin lower-left).
+	gl_compositor_dispatch_capture(c, MCP_CAPTURE_MODE_PROJECTION_ONLY);
 
 	// --- Step 1b: Render window-space layers (HUD overlays) ---
 	for (uint32_t i = 0; i < c->layer_accum.layer_count; i++) {
@@ -1609,14 +1578,10 @@ gl_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t
 	if (prev_cull_face) glEnable(GL_CULL_FACE);
 	if (prev_scissor_test) glEnable(GL_SCISSOR_TEST);
 
-	// MCP capture_frame — runs while our GL context is still current so
-	// glReadPixels from atlas_texture is valid. Early-returns when no
-	// request is pending.
-	gl_compositor_service_mcp_capture(c);
-
-	// Same readback driven by a trigger file (no MCP client required).
-	// See issue #210.
-	gl_compositor_service_trigger_file(c);
+	// Post-compose capture (#210) — runs while our GL context is still
+	// current so glReadPixels from atlas_texture is valid. Skipped if the
+	// intent was projection-only (consumed earlier) or empty.
+	gl_compositor_dispatch_capture(c, MCP_CAPTURE_MODE_POST_COMPOSE);
 
 	// Restore previous GL context (critical for shared texture mode where
 	// app has its own context and needs it back after compositor work)

--- a/src/xrt/compositor/gl/comp_gl_compositor.c
+++ b/src/xrt/compositor/gl/comp_gl_compositor.c
@@ -55,6 +55,13 @@
 #include <string.h>
 #include <assert.h>
 
+#ifdef XRT_OS_WINDOWS
+#include <windows.h>
+#else
+#include <sys/stat.h>
+#include <unistd.h>
+#endif
+
 
 // GL function loading via GLAD (cross-platform)
 #ifdef XRT_OS_WINDOWS
@@ -961,21 +968,16 @@ gl_crop_and_process_dp(struct comp_gl_compositor *c,
  *
  */
 
-// Service a pending MCP capture_frame request. Reads the content
-// region of atlas_texture (tile_columns × view_width by tile_rows ×
-// view_height — what actually got composited, matching what the
-// compositor crops and sends to the DP), flips Y, and writes one PNG.
-static void
-gl_compositor_service_mcp_capture(struct comp_gl_compositor *c)
+// Read the content region of atlas_texture (tile_columns × view_width by
+// tile_rows × view_height — what actually got composited, matching what
+// the compositor crops and sends to the DP), flip Y, and write @p path
+// as PNG. Caller must have a current GL context.
+static bool
+gl_compositor_capture_atlas_to_png(struct comp_gl_compositor *c, const char *path)
 {
-	char path[MCP_CAPTURE_PATH_MAX];
-	if (!mcp_capture_poll(&c->mcp_capture, path)) {
-		return;
-	}
 	if (c->atlas_texture == 0 || c->tile_columns == 0 || c->tile_rows == 0 ||
 	    c->view_width == 0 || c->view_height == 0) {
-		mcp_capture_complete(&c->mcp_capture, false);
-		return;
+		return false;
 	}
 
 	uint32_t content_w = c->tile_columns * c->view_width;
@@ -990,8 +992,7 @@ gl_compositor_service_mcp_capture(struct comp_gl_compositor *c)
 	if (bottom_up == NULL || top_down == NULL) {
 		free(bottom_up);
 		free(top_down);
-		mcp_capture_complete(&c->mcp_capture, false);
-		return;
+		return false;
 	}
 
 	// Attach atlas to a temporary read FBO; glReadPixels returns origin-
@@ -1020,7 +1021,73 @@ gl_compositor_service_mcp_capture(struct comp_gl_compositor *c)
 
 	bool ok = stbi_write_png(path, (int)content_w, (int)content_h, 4, top_down, (int)row_pitch) != 0;
 	free(top_down);
+	return ok;
+}
+
+// Service a pending MCP capture_frame request — thin wrapper around
+// gl_compositor_capture_atlas_to_png that handles the cross-thread
+// hand-off with the MCP server.
+static void
+gl_compositor_service_mcp_capture(struct comp_gl_compositor *c)
+{
+	char path[MCP_CAPTURE_PATH_MAX];
+	if (!mcp_capture_poll(&c->mcp_capture, path)) {
+		return;
+	}
+	bool ok = gl_compositor_capture_atlas_to_png(c, path);
 	mcp_capture_complete(&c->mcp_capture, ok);
+}
+
+// Trigger-file capture path — same readback as the MCP path, driven
+// by the existence of a trigger file so devs can snapshot the post-
+// compose atlas without an MCP client. POSIX side uses
+// $TMPDIR/displayxr_atlas_trigger; Windows side (XRT_OS_WINDOWS) uses
+// %TEMP%\displayxr_atlas_trigger to mirror the d3d11_service path.
+// See issue #210.
+static void
+gl_compositor_service_trigger_file(struct comp_gl_compositor *c)
+{
+	static char trigger_path[MCP_CAPTURE_PATH_MAX] = {0};
+	static char out_path[MCP_CAPTURE_PATH_MAX] = {0};
+	if (trigger_path[0] == '\0') {
+#ifdef XRT_OS_WINDOWS
+		const char *tmp = getenv("TEMP");
+		if (tmp == NULL || tmp[0] == '\0') tmp = "C:\\Temp";
+		snprintf(trigger_path, sizeof(trigger_path), "%s\\displayxr_atlas_trigger", tmp);
+		snprintf(out_path, sizeof(out_path), "%s\\displayxr_atlas.png", tmp);
+#else
+		const char *tmp = getenv("TMPDIR");
+		if (tmp == NULL || tmp[0] == '\0') tmp = "/tmp";
+		size_t tlen = strlen(tmp);
+		if (tlen > 0 && tmp[tlen - 1] == '/') tlen = tlen - 1;
+		char tmp_clean[MCP_CAPTURE_PATH_MAX];
+		if (tlen >= sizeof(tmp_clean)) tlen = sizeof(tmp_clean) - 1;
+		memcpy(tmp_clean, tmp, tlen);
+		tmp_clean[tlen] = '\0';
+		snprintf(trigger_path, sizeof(trigger_path), "%s/displayxr_atlas_trigger", tmp_clean);
+		snprintf(out_path, sizeof(out_path), "%s/displayxr_atlas.png", tmp_clean);
+#endif
+	}
+
+#ifdef XRT_OS_WINDOWS
+	if (GetFileAttributesA(trigger_path) == INVALID_FILE_ATTRIBUTES) {
+		return;
+	}
+	DeleteFileA(trigger_path);
+#else
+	struct stat st;
+	if (stat(trigger_path, &st) != 0) {
+		return;
+	}
+	unlink(trigger_path);
+#endif
+
+	bool ok = gl_compositor_capture_atlas_to_png(c, out_path);
+	if (ok) {
+		U_LOG_I("Atlas captured to %s", out_path);
+	} else {
+		U_LOG_W("Atlas capture failed (trigger %s)", trigger_path);
+	}
 }
 
 
@@ -1546,6 +1613,10 @@ gl_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t
 	// glReadPixels from atlas_texture is valid. Early-returns when no
 	// request is pending.
 	gl_compositor_service_mcp_capture(c);
+
+	// Same readback driven by a trigger file (no MCP client required).
+	// See issue #210.
+	gl_compositor_service_trigger_file(c);
 
 	// Restore previous GL context (critical for shared texture mode where
 	// app has its own context and needs it back after compositor work)

--- a/src/xrt/compositor/metal/comp_metal_compositor.m
+++ b/src/xrt/compositor/metal/comp_metal_compositor.m
@@ -40,6 +40,7 @@
 #include "util/u_hud.h"
 #include "util/u_tiling.h"
 #include "util/u_canvas.h"
+#include "util/u_capture_intent.h"
 #include <displayxr_mcp/mcp_capture.h>
 
 // STB_IMAGE_WRITE_STATIC scopes all stbi_write_* to this TU so linking
@@ -224,8 +225,11 @@ struct comp_metal_compositor
 	//! Thread safety.
 	struct os_mutex mutex;
 
-	//! MCP capture request box (polled at end of layer_commit).
+	//! MCP capture request box (polled at top of layer_commit).
 	struct mcp_capture_request mcp_capture;
+
+	//! Per-frame capture intent. See u_capture_intent.h.
+	struct u_capture_intent capture_intent;
 };
 
 /*
@@ -1350,68 +1354,38 @@ metal_compositor_capture_atlas_to_png(struct comp_metal_compositor *c,
 	return ok;
 }
 
-// Service a pending MCP capture_frame request — thin wrapper around
-// metal_compositor_capture_atlas_to_png that handles the cross-thread
-// hand-off with the MCP server.
+// Run the capture readback if the per-frame intent matches @p mode_filter.
+// Caller passes the in-flight render cmd_buf; capture waits on it before
+// the blit-out so the atlas contents are visible.
 static void
-metal_compositor_service_mcp_capture(struct comp_metal_compositor *c, id<MTLCommandBuffer> render_cmd_buf)
+metal_compositor_dispatch_capture(struct comp_metal_compositor *c,
+                                   id<MTLCommandBuffer> render_cmd_buf,
+                                   uint32_t mode_filter)
 {
-	char path[MCP_CAPTURE_PATH_MAX];
-	if (!mcp_capture_poll(&c->mcp_capture, path)) {
+	if (!u_capture_intent_should_capture(&c->capture_intent, mode_filter)) {
 		return;
 	}
-	bool ok = metal_compositor_capture_atlas_to_png(c, render_cmd_buf, path);
-	mcp_capture_complete(&c->mcp_capture, ok);
-}
-
-// Trigger-file capture path — same readback as the MCP path, but driven
-// by the existence of $TMPDIR/displayxr_atlas_trigger. Lets developers
-// snapshot the post-compose atlas without an MCP client. Mirrors the
-// service-mode `workspace_screenshot_trigger` path in comp_d3d11_service.cpp.
-static void
-metal_compositor_service_trigger_file(struct comp_metal_compositor *c,
-                                      id<MTLCommandBuffer> render_cmd_buf)
-{
-	static char trigger_path[MCP_CAPTURE_PATH_MAX] = {0};
-	static char out_path[MCP_CAPTURE_PATH_MAX] = {0};
-	if (trigger_path[0] == '\0') {
-		const char *tmp = getenv("TMPDIR");
-		if (tmp == NULL || tmp[0] == '\0') {
-			tmp = "/tmp";
-		}
-		// Strip trailing slash so the format string below stays stable.
-		size_t tlen = strlen(tmp);
-		char tmp_clean[MCP_CAPTURE_PATH_MAX];
-		if (tlen > 0 && tmp[tlen - 1] == '/') {
-			tlen = tlen - 1;
-		}
-		if (tlen >= sizeof(tmp_clean)) {
-			tlen = sizeof(tmp_clean) - 1;
-		}
-		memcpy(tmp_clean, tmp, tlen);
-		tmp_clean[tlen] = '\0';
-		snprintf(trigger_path, sizeof(trigger_path), "%s/displayxr_atlas_trigger", tmp_clean);
-		snprintf(out_path, sizeof(out_path), "%s/displayxr_atlas.png", tmp_clean);
-	}
-
-	struct stat st;
-	if (stat(trigger_path, &st) != 0) {
-		return;
-	}
-	unlink(trigger_path);
-
-	bool ok = metal_compositor_capture_atlas_to_png(c, render_cmd_buf, out_path);
+	bool ok = metal_compositor_capture_atlas_to_png(c, render_cmd_buf,
+	                                                 c->capture_intent.path);
 	if (ok) {
-		U_LOG_I("Atlas captured to %s", out_path);
+		U_LOG_I("Atlas captured (mode=%u) to %s",
+		        c->capture_intent.mode, c->capture_intent.path);
 	} else {
-		U_LOG_W("Atlas capture failed (trigger %s)", trigger_path);
+		U_LOG_W("Atlas capture failed (mode=%u path=%s)",
+		        c->capture_intent.mode, c->capture_intent.path);
 	}
+	u_capture_intent_complete(&c->capture_intent, &c->mcp_capture, ok);
 }
 
 static xrt_result_t
 metal_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sync_handle)
 {
 	struct comp_metal_compositor *c = metal_comp(xc);
+
+	// Capture-intent poll — see u_capture_intent.h. Consumed at the
+	// projection-done boundary (PROJECTION_ONLY, once cmd-buf split
+	// lands) or end of frame (POST_COMPOSE).
+	u_capture_intent_poll(&c->capture_intent, &c->mcp_capture);
 
 	// Frame timing for HUD
 	uint64_t now_ns = os_monotonic_get_ns();
@@ -1724,6 +1698,32 @@ metal_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 			}
 		}
 
+		// Projection-only capture point — atlas now contains projection
+		// content for every tile; window-space layers haven't been drawn
+		// yet. Capture requires the projection commands to actually be on
+		// GPU (not just recorded), so we end the projection encoder, commit
+		// the cmd_buf, run the capture (which waits + blits + encodes PNG),
+		// then start a fresh cmd_buf + render encoder with LoadAction=Load
+		// so the window-space pass paints on top of the preserved atlas.
+		// Skipped when no PROJECTION_ONLY intent is pending.
+		if (c->capture_intent.pending && c->capture_intent.mode == MCP_CAPTURE_MODE_PROJECTION_ONLY) {
+			[encoder endEncoding];
+			[cmd_buf commit];
+
+			metal_compositor_dispatch_capture(c, cmd_buf, MCP_CAPTURE_MODE_PROJECTION_ONLY);
+
+			cmd_buf = [c->command_queue commandBuffer];
+
+			MTLRenderPassDescriptor *ws_pass = [MTLRenderPassDescriptor renderPassDescriptor];
+			ws_pass.colorAttachments[0].texture = c->atlas_texture;
+			ws_pass.colorAttachments[0].loadAction = MTLLoadActionLoad;
+			ws_pass.colorAttachments[0].storeAction = MTLStoreActionStore;
+			ws_pass.depthAttachment.texture = c->depth_texture;
+			ws_pass.depthAttachment.loadAction = MTLLoadActionLoad;
+			ws_pass.depthAttachment.storeAction = MTLStoreActionDontCare;
+			encoder = [cmd_buf renderCommandEncoderWithDescriptor:ws_pass];
+		}
+
 		// Window-space layers (XR_EXT_win32_window_binding) — drawn into
 		// each per-eye tile of the atlas with horizontal disparity shift,
 		// so the display processor weaves them in stereo just like projection
@@ -1977,15 +1977,9 @@ metal_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 		[cmd_buf waitUntilCompleted];
 	}
 
-	// MCP capture_frame: if the server thread has posted a request,
-	// blit the atlas into a CPU-visible buffer, encode PNG(s), and
-	// unblock the waiter. Pays for itself only when actively capturing.
-	metal_compositor_service_mcp_capture(c, cmd_buf);
-
-	// Same readback, but driven by a trigger file
-	// ($TMPDIR/displayxr_atlas_trigger) so devs can snapshot the
-	// post-compose atlas without an MCP client. See issue #210.
-	metal_compositor_service_trigger_file(c, cmd_buf);
+	// Post-compose capture (#210). Skipped if the intent was projection-
+	// only (consumed earlier once the cmd-buf split lands) or empty.
+	metal_compositor_dispatch_capture(c, cmd_buf, MCP_CAPTURE_MODE_POST_COMPOSE);
 
 	// Reset layer accumulator
 	c->layer_accum.layer_count = 0;

--- a/src/xrt/compositor/metal/comp_metal_compositor.m
+++ b/src/xrt/compositor/metal/comp_metal_compositor.m
@@ -57,6 +57,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 /*
  *
@@ -1276,24 +1278,22 @@ metal_compositor_render_hud(struct comp_metal_compositor *c, float dt,
 	[encoder endEncoding];
 }
 
-// Service a pending MCP capture_frame request. Blits the content
-// region of c->atlas_texture (tile_columns × view_width by tile_rows
-// × view_height — what the app actually wrote, matching what the
-// compositor crops and hands to the DP) into a shared MTLBuffer,
-// swaps BGRA→RGBA, and writes a single PNG.
-static void
-metal_compositor_service_mcp_capture(struct comp_metal_compositor *c, id<MTLCommandBuffer> render_cmd_buf)
+// Blit the content region of c->atlas_texture (tile_columns × view_width
+// by tile_rows × view_height — what the app actually wrote, matching what
+// the compositor crops and hands to the DP) into a shared MTLBuffer, swap
+// BGRA→RGBA, and write @p path as PNG. Caller must have already committed
+// @p render_cmd_buf — we waitUntilCompleted on it for sync.
+static bool
+metal_compositor_capture_atlas_to_png(struct comp_metal_compositor *c,
+                                      id<MTLCommandBuffer> render_cmd_buf,
+                                      const char *path)
 {
-	char path[MCP_CAPTURE_PATH_MAX];
-	if (!mcp_capture_poll(&c->mcp_capture, path)) {
-		return;
-	}
 	if (c->atlas_texture == nil || c->tile_columns == 0 || c->tile_rows == 0 ||
 	    c->view_width == 0 || c->view_height == 0) {
-		mcp_capture_complete(&c->mcp_capture, false);
-		return;
+		return false;
 	}
 
+	bool ok = false;
 	@autoreleasepool {
 		uint32_t content_w = c->tile_columns * c->view_width;
 		uint32_t content_h = c->tile_rows * c->view_height;
@@ -1311,8 +1311,7 @@ metal_compositor_service_mcp_capture(struct comp_metal_compositor *c, id<MTLComm
 		id<MTLBuffer> staging = [c->device newBufferWithLength:buf_bytes
 		                                               options:MTLResourceStorageModeShared];
 		if (staging == nil) {
-			mcp_capture_complete(&c->mcp_capture, false);
-			return;
+			return false;
 		}
 
 		// Render cmd_buf was already committed; wait for it so the
@@ -1337,19 +1336,75 @@ metal_compositor_service_mcp_capture(struct comp_metal_compositor *c, id<MTLComm
 		// Atlas format is BGRA8Unorm — swap into RGBA for stbi_write_png.
 		uint8_t *bgra = (uint8_t *)staging.contents;
 		uint8_t *rgba = malloc(buf_bytes);
-		if (rgba == NULL) {
-			mcp_capture_complete(&c->mcp_capture, false);
-			return;
+		if (rgba != NULL) {
+			for (size_t i = 0; i < buf_bytes; i += 4) {
+				rgba[i + 0] = bgra[i + 2];
+				rgba[i + 1] = bgra[i + 1];
+				rgba[i + 2] = bgra[i + 0];
+				rgba[i + 3] = bgra[i + 3];
+			}
+			ok = stbi_write_png(path, (int)content_w, (int)content_h, 4, rgba, (int)row_pitch) != 0;
+			free(rgba);
 		}
-		for (size_t i = 0; i < buf_bytes; i += 4) {
-			rgba[i + 0] = bgra[i + 2];
-			rgba[i + 1] = bgra[i + 1];
-			rgba[i + 2] = bgra[i + 0];
-			rgba[i + 3] = bgra[i + 3];
+	}
+	return ok;
+}
+
+// Service a pending MCP capture_frame request — thin wrapper around
+// metal_compositor_capture_atlas_to_png that handles the cross-thread
+// hand-off with the MCP server.
+static void
+metal_compositor_service_mcp_capture(struct comp_metal_compositor *c, id<MTLCommandBuffer> render_cmd_buf)
+{
+	char path[MCP_CAPTURE_PATH_MAX];
+	if (!mcp_capture_poll(&c->mcp_capture, path)) {
+		return;
+	}
+	bool ok = metal_compositor_capture_atlas_to_png(c, render_cmd_buf, path);
+	mcp_capture_complete(&c->mcp_capture, ok);
+}
+
+// Trigger-file capture path — same readback as the MCP path, but driven
+// by the existence of $TMPDIR/displayxr_atlas_trigger. Lets developers
+// snapshot the post-compose atlas without an MCP client. Mirrors the
+// service-mode `workspace_screenshot_trigger` path in comp_d3d11_service.cpp.
+static void
+metal_compositor_service_trigger_file(struct comp_metal_compositor *c,
+                                      id<MTLCommandBuffer> render_cmd_buf)
+{
+	static char trigger_path[MCP_CAPTURE_PATH_MAX] = {0};
+	static char out_path[MCP_CAPTURE_PATH_MAX] = {0};
+	if (trigger_path[0] == '\0') {
+		const char *tmp = getenv("TMPDIR");
+		if (tmp == NULL || tmp[0] == '\0') {
+			tmp = "/tmp";
 		}
-		bool ok = stbi_write_png(path, (int)content_w, (int)content_h, 4, rgba, (int)row_pitch) != 0;
-		free(rgba);
-		mcp_capture_complete(&c->mcp_capture, ok);
+		// Strip trailing slash so the format string below stays stable.
+		size_t tlen = strlen(tmp);
+		char tmp_clean[MCP_CAPTURE_PATH_MAX];
+		if (tlen > 0 && tmp[tlen - 1] == '/') {
+			tlen = tlen - 1;
+		}
+		if (tlen >= sizeof(tmp_clean)) {
+			tlen = sizeof(tmp_clean) - 1;
+		}
+		memcpy(tmp_clean, tmp, tlen);
+		tmp_clean[tlen] = '\0';
+		snprintf(trigger_path, sizeof(trigger_path), "%s/displayxr_atlas_trigger", tmp_clean);
+		snprintf(out_path, sizeof(out_path), "%s/displayxr_atlas.png", tmp_clean);
+	}
+
+	struct stat st;
+	if (stat(trigger_path, &st) != 0) {
+		return;
+	}
+	unlink(trigger_path);
+
+	bool ok = metal_compositor_capture_atlas_to_png(c, render_cmd_buf, out_path);
+	if (ok) {
+		U_LOG_I("Atlas captured to %s", out_path);
+	} else {
+		U_LOG_W("Atlas capture failed (trigger %s)", trigger_path);
 	}
 }
 
@@ -1926,6 +1981,11 @@ metal_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 	// blit the atlas into a CPU-visible buffer, encode PNG(s), and
 	// unblock the waiter. Pays for itself only when actively capturing.
 	metal_compositor_service_mcp_capture(c, cmd_buf);
+
+	// Same readback, but driven by a trigger file
+	// ($TMPDIR/displayxr_atlas_trigger) so devs can snapshot the
+	// post-compose atlas without an MCP client. See issue #210.
+	metal_compositor_service_trigger_file(c, cmd_buf);
 
 	// Reset layer accumulator
 	c->layer_accum.layer_count = 0;

--- a/src/xrt/compositor/vk_native/CMakeLists.txt
+++ b/src/xrt/compositor/vk_native/CMakeLists.txt
@@ -27,6 +27,7 @@ if((WIN32 OR APPLE) AND XRT_HAVE_VULKAN)
 			aux_util
 			aux_os
 			aux_math
+			xrt-external-stb
 		)
 
 	target_include_directories(comp_vk_native PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)

--- a/src/xrt/compositor/vk_native/comp_vk_native_compositor.c
+++ b/src/xrt/compositor/vk_native/comp_vk_native_compositor.c
@@ -36,6 +36,7 @@
 #include "math/m_api.h"
 #include "util/u_tiling.h"
 #include "util/u_canvas.h"
+#include "util/u_capture_intent.h"
 #include <displayxr_mcp/mcp_capture.h>
 
 // STB_IMAGE_WRITE_STATIC scopes all stbi_write_* to this TU so linking
@@ -202,15 +203,26 @@ struct comp_vk_native_compositor
 	//! Canvas output rect for shared-texture apps.
 	struct u_canvas_rect canvas;
 
-	//! Alpha-blend pipeline for window-space (HUD) layers. Lazy-initialized
-	//! the first frame a window-space layer is submitted (we don't know the
-	//! target format at compositor create time on all platforms).
+	//! Alpha-blend pipeline for window-space (HUD) layers rendered per-tile
+	//! INTO the atlas pre-weave (matches d3d11/d3d12/metal/gl). Lazy-init
+	//! with the atlas format on first window-space submission. The DP weaver
+	//! then interlaces the layer along with the projection content, giving
+	//! HUD per-eye disparity / parallax (#210).
 	struct vk_hud_blend window_space_blend;
 	bool window_space_blend_attempted;
+	//! Cached framebuffer for atlas window-space pass (one per atlas view).
+	VkFramebuffer atlas_ws_fb;
+	VkImageView atlas_ws_fb_view;
 
 	//! MCP capture_frame request box (serviced at end of layer_commit).
 	//! Mirrors the pattern in comp_metal/gl/d3d11_compositor. See issue #210.
 	struct mcp_capture_request mcp_capture;
+
+	//! Per-frame capture intent (mode + path), populated by
+	//! u_capture_intent_poll at the top of layer_commit and consumed
+	//! at the projection-done boundary (PROJECTION_ONLY) or end of
+	//! frame (POST_COMPOSE).
+	struct u_capture_intent capture_intent;
 };
 
 /*
@@ -917,26 +929,39 @@ vk_compositor_layer_window_space(struct xrt_compositor *xc,
 }
 
 /*!
- * Composite window-space (HUD) layers onto the target image POST-WEAVE
- * with proper alpha blending — replaces the previous opaque vkCmdBlitImage
- * path so transparent texels actually disappear and semi-transparent
- * backdrops read as semi-transparent. HUD must not be interlaced; it
- * appears flat on screen.
+ * Composite window-space (HUD) layers per-tile INTO the atlas image,
+ * pre-weave, with proper alpha blending. Mirrors the per-tile rendering
+ * model used by d3d11 / d3d12 / metal / gl, so atlas-capture parity
+ * shows HUD on every tile and the DP weaver gives the layer per-eye
+ * disparity (parallax) just like a projection layer.
+ *
+ * Atlas must be in SHADER_READ_ONLY_OPTIMAL on entry (the renderer
+ * leaves it there after the projection-blit pass); on exit it is
+ * returned to SHADER_READ_ONLY_OPTIMAL for the DP. No-op when no
+ * window-space layers are present.
  *
  * @param c             The compositor.
  * @param cmd           Active command buffer to record into.
- * @param target_image  Target swapchain VkImage (in PRESENT_SRC_KHR).
- * @param target_view   Target swapchain VkImageView (for the framebuffer).
- * @param target_width  Target width.
- * @param target_height Target height.
+ * @param atlas_image   Atlas VkImage.
+ * @param atlas_view    Atlas VkImageView (framebuffer attachment).
+ * @param atlas_w       Allocated atlas width in pixels.
+ * @param atlas_h       Allocated atlas height in pixels.
+ * @param view_w        Per-tile view width.
+ * @param view_h        Per-tile view height.
+ * @param tile_columns  Atlas tile columns.
+ * @param tile_rows     Atlas tile rows.
  */
 static void
-vk_compositor_blit_window_space_layers(struct comp_vk_native_compositor *c,
-                                        VkCommandBuffer cmd,
-                                        VkImage target_image,
-                                        VkImageView target_view,
-                                        uint32_t target_width,
-                                        uint32_t target_height)
+vk_compositor_render_window_space_into_atlas(struct comp_vk_native_compositor *c,
+                                               VkCommandBuffer cmd,
+                                               VkImage atlas_image,
+                                               VkImageView atlas_view,
+                                               uint32_t atlas_w,
+                                               uint32_t atlas_h,
+                                               uint32_t view_w,
+                                               uint32_t view_h,
+                                               uint32_t tile_columns,
+                                               uint32_t tile_rows)
 {
 	struct vk_bundle *vk = &c->vk;
 
@@ -947,16 +972,14 @@ vk_compositor_blit_window_space_layers(struct comp_vk_native_compositor *c,
 			break;
 		}
 	}
-	if (!has_ws) {
+	if (!has_ws || tile_columns == 0 || tile_rows == 0 || view_w == 0 || view_h == 0) {
 		return;
 	}
 
-	// Lazy-init the alpha-blend pipeline on first use (target format isn't
-	// available at compositor create time on all paths).
 	if (!c->window_space_blend.initialized && !c->window_space_blend_attempted) {
 		c->window_space_blend_attempted = true;
-		VkFormat target_fmt = comp_vk_native_target_get_format(c->target);
-		if (!vk_hud_blend_init(&c->window_space_blend, vk, target_fmt)) {
+		VkFormat atlas_fmt = (VkFormat)comp_vk_native_renderer_get_format(c->renderer);
+		if (!vk_hud_blend_init(&c->window_space_blend, vk, atlas_fmt)) {
 			U_LOG_E("[VK native] window-space alpha-blend init failed; "
 			        "layers will be skipped");
 		}
@@ -964,6 +987,45 @@ vk_compositor_blit_window_space_layers(struct comp_vk_native_compositor *c,
 	if (!c->window_space_blend.initialized) {
 		return;
 	}
+
+	if (c->atlas_ws_fb == VK_NULL_HANDLE || c->atlas_ws_fb_view != atlas_view) {
+		if (c->atlas_ws_fb != VK_NULL_HANDLE) {
+			vk->vkDestroyFramebuffer(vk->device, c->atlas_ws_fb, NULL);
+			c->atlas_ws_fb = VK_NULL_HANDLE;
+		}
+		VkFramebufferCreateInfo fb_ci = {
+		    .sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO,
+		    .renderPass = c->window_space_blend.render_pass,
+		    .attachmentCount = 1,
+		    .pAttachments = &atlas_view,
+		    .width = atlas_w,
+		    .height = atlas_h,
+		    .layers = 1,
+		};
+		if (vk->vkCreateFramebuffer(vk->device, &fb_ci, NULL, &c->atlas_ws_fb) != VK_SUCCESS) {
+			U_LOG_E("[VK native] atlas framebuffer creation failed (%ux%u); "
+			        "window-space layers will be skipped",
+			        atlas_w, atlas_h);
+			c->atlas_ws_fb = VK_NULL_HANDLE;
+			return;
+		}
+		c->atlas_ws_fb_view = atlas_view;
+	}
+
+	// Atlas: SHADER_READ_ONLY_OPTIMAL → COLOR_ATTACHMENT_OPTIMAL.
+	VkImageMemoryBarrier atlas_to_color = {
+	    .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+	    .srcAccessMask = VK_ACCESS_SHADER_READ_BIT,
+	    .dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+	    .oldLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+	    .newLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+	    .image = atlas_image,
+	    .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1},
+	};
+	vk->vkCmdPipelineBarrier(cmd,
+	    VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+	    VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+	    0, 0, NULL, 0, NULL, 1, &atlas_to_color);
 
 	for (uint32_t i = 0; i < c->layer_accum.layer_count; i++) {
 		struct comp_layer *layer = &c->layer_accum.layers[i];
@@ -984,19 +1046,7 @@ vk_compositor_blit_window_space_layers(struct comp_vk_native_compositor *c,
 			continue;
 		}
 
-		uint32_t src_w = ws->sub.rect.extent.w;
-		uint32_t src_h = ws->sub.rect.extent.h;
-
-		// Destination rect: window-fraction → swapchain pixels.
-		int32_t dx0 = (int32_t)(ws->x * (float)target_width);
-		int32_t dy0 = (int32_t)(ws->y * (float)target_height);
-		int32_t dw = (int32_t)(ws->width * (float)target_width);
-		int32_t dh = (int32_t)(ws->height * (float)target_height);
-		if (dw <= 0 || dh <= 0) {
-			continue;
-		}
-
-		// Transition source from COLOR_ATTACHMENT_OPTIMAL → SHADER_READ_ONLY_OPTIMAL.
+		// Source: COLOR_ATTACHMENT_OPTIMAL → SHADER_READ_ONLY_OPTIMAL.
 		VkImageMemoryBarrier src_to_sample = {
 		    .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
 		    .srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
@@ -1012,15 +1062,30 @@ vk_compositor_blit_window_space_layers(struct comp_vk_native_compositor *c,
 		    VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
 		    0, 0, NULL, 0, NULL, 1, &src_to_sample);
 
-		vk_hud_blend_draw(&c->window_space_blend, vk, cmd,
-		                   target_view, target_image,
-		                   target_width, target_height,
-		                   src_image, src_w, src_h,
-		                   dx0, dy0, (uint32_t)dw, (uint32_t)dh);
+		// Per-tile pass with disparity shift in tile-fraction → atlas px.
+		float half_disp = ws->disparity / 2.0f;
+		for (uint32_t row = 0; row < tile_rows; row++) {
+			for (uint32_t col = 0; col < tile_columns; col++) {
+				uint32_t tile_index = row * tile_columns + col;
+				float eye_shift = (tile_index == 0) ? -half_disp : half_disp;
 
-		// Transition source back to COLOR_ATTACHMENT_OPTIMAL so the app
-		// can render into it on the next frame (matches what callers
-		// expect after this function returns).
+				int32_t dx = (int32_t)((ws->x + eye_shift) * (float)view_w)
+				             + (int32_t)(col * view_w);
+				int32_t dy = (int32_t)(ws->y * (float)view_h)
+				             + (int32_t)(row * view_h);
+				int32_t dw_i = (int32_t)(ws->width * (float)view_w);
+				int32_t dh_i = (int32_t)(ws->height * (float)view_h);
+				if (dw_i <= 0 || dh_i <= 0) {
+					continue;
+				}
+
+				vk_hud_blend_draw_no_layout(&c->window_space_blend, vk, cmd,
+				    c->atlas_ws_fb, atlas_w, atlas_h,
+				    src_image, dx, dy, (uint32_t)dw_i, (uint32_t)dh_i);
+			}
+		}
+
+		// Source back to COLOR_ATTACHMENT_OPTIMAL so the app can rerender.
 		VkImageMemoryBarrier src_back = {
 		    .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
 		    .srcAccessMask = VK_ACCESS_SHADER_READ_BIT,
@@ -1036,6 +1101,21 @@ vk_compositor_blit_window_space_layers(struct comp_vk_native_compositor *c,
 		    VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
 		    0, 0, NULL, 0, NULL, 1, &src_back);
 	}
+
+	// Atlas: COLOR_ATTACHMENT_OPTIMAL → SHADER_READ_ONLY_OPTIMAL for DP.
+	VkImageMemoryBarrier atlas_back = {
+	    .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+	    .srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+	    .dstAccessMask = VK_ACCESS_SHADER_READ_BIT,
+	    .oldLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+	    .newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+	    .image = atlas_image,
+	    .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1},
+	};
+	vk->vkCmdPipelineBarrier(cmd,
+	    VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+	    VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+	    0, 0, NULL, 0, NULL, 1, &atlas_back);
 }
 
 /*
@@ -1752,66 +1832,23 @@ vk_native_capture_atlas_to_png(struct comp_vk_native_compositor *c, const char *
 	return ok;
 }
 
-// Service a pending MCP capture_frame request — thin wrapper around
-// vk_native_capture_atlas_to_png that handles the cross-thread hand-off
-// with the MCP server.
+// Run the capture readback if the per-frame intent matches @p mode_filter.
+// Caller polls intent at top of layer_commit; this fires at each boundary.
 static void
-vk_native_service_mcp_capture(struct comp_vk_native_compositor *c)
+vk_native_dispatch_capture(struct comp_vk_native_compositor *c, uint32_t mode_filter)
 {
-	char path[MCP_CAPTURE_PATH_MAX];
-	if (!mcp_capture_poll(&c->mcp_capture, path)) {
+	if (!u_capture_intent_should_capture(&c->capture_intent, mode_filter)) {
 		return;
 	}
-	bool ok = vk_native_capture_atlas_to_png(c, path);
-	mcp_capture_complete(&c->mcp_capture, ok);
-}
-
-// Trigger-file capture path — same readback driven by file existence so
-// devs can snapshot without an MCP client. See issue #210.
-static void
-vk_native_service_trigger_file(struct comp_vk_native_compositor *c)
-{
-	static char trigger_path[MCP_CAPTURE_PATH_MAX] = {0};
-	static char out_path[MCP_CAPTURE_PATH_MAX] = {0};
-	if (trigger_path[0] == '\0') {
-#ifdef XRT_OS_WINDOWS
-		const char *tmp = getenv("TEMP");
-		if (tmp == NULL || tmp[0] == '\0') tmp = "C:\\Temp";
-		snprintf(trigger_path, sizeof(trigger_path), "%s\\displayxr_atlas_trigger", tmp);
-		snprintf(out_path, sizeof(out_path), "%s\\displayxr_atlas.png", tmp);
-#else
-		const char *tmp = getenv("TMPDIR");
-		if (tmp == NULL || tmp[0] == '\0') tmp = "/tmp";
-		size_t tlen = strlen(tmp);
-		if (tlen > 0 && tmp[tlen - 1] == '/') tlen = tlen - 1;
-		char tmp_clean[MCP_CAPTURE_PATH_MAX];
-		if (tlen >= sizeof(tmp_clean)) tlen = sizeof(tmp_clean) - 1;
-		memcpy(tmp_clean, tmp, tlen);
-		tmp_clean[tlen] = '\0';
-		snprintf(trigger_path, sizeof(trigger_path), "%s/displayxr_atlas_trigger", tmp_clean);
-		snprintf(out_path, sizeof(out_path), "%s/displayxr_atlas.png", tmp_clean);
-#endif
-	}
-
-#ifdef XRT_OS_WINDOWS
-	if (GetFileAttributesA(trigger_path) == INVALID_FILE_ATTRIBUTES) {
-		return;
-	}
-	DeleteFileA(trigger_path);
-#else
-	struct stat st;
-	if (stat(trigger_path, &st) != 0) {
-		return;
-	}
-	unlink(trigger_path);
-#endif
-
-	bool ok = vk_native_capture_atlas_to_png(c, out_path);
+	bool ok = vk_native_capture_atlas_to_png(c, c->capture_intent.path);
 	if (ok) {
-		U_LOG_I("Atlas captured to %s", out_path);
+		U_LOG_I("Atlas captured (mode=%u) to %s",
+		        c->capture_intent.mode, c->capture_intent.path);
 	} else {
-		U_LOG_W("Atlas capture failed (trigger %s)", trigger_path);
+		U_LOG_W("Atlas capture failed (mode=%u path=%s)",
+		        c->capture_intent.mode, c->capture_intent.path);
 	}
+	u_capture_intent_complete(&c->capture_intent, &c->mcp_capture, ok);
 }
 
 
@@ -1820,6 +1857,11 @@ vk_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t
 {
 	struct comp_vk_native_compositor *c = vk_comp(xc);
 	struct vk_bundle *vk = &c->vk;
+
+	// Capture-intent poll — checks MCP request + trigger files once per
+	// frame; consumed at the projection-done boundary or end of frame
+	// depending on requested mode. See u_capture_intent.h.
+	u_capture_intent_poll(&c->capture_intent, &c->mcp_capture);
 
 	// Phase 1 diagnostic — env-gated per-client commit interval. Mirrors
 	// the same `[CLIENT_FRAME_NS]` line emitted by the D3D11 in-process and
@@ -2009,6 +2051,13 @@ vk_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t
 			U_LOG_E("Failed to render layers");
 			return xret;
 		}
+
+		// Projection-only capture point — atlas now contains projection
+		// layers across all tiles; window-space layers haven't been
+		// composed in yet. Atlas is in SHADER_READ_ONLY_OPTIMAL after
+		// renderer's terminating barrier (see comp_vk_native_renderer.c).
+		// Skipped in zero-copy mode (no renderer atlas to read).
+		vk_native_dispatch_capture(c, MCP_CAPTURE_MODE_PROJECTION_ONLY);
 	}
 
 	// Shared texture output path — render to IOSurface-backed VkImage
@@ -2056,6 +2105,19 @@ vk_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t
 
 			comp_vk_native_renderer_get_view_dimensions(c->renderer, &view_width, &view_height);
 			comp_vk_native_renderer_get_tile_layout(c->renderer, &tc, &tr);
+
+			// Pre-weave: composite window-space layers per-tile INTO the atlas
+			// so the DP weaves them along with the projection content. Skipped
+			// in zero-copy (no atlas) and when no window-space layers exist.
+			if (!zero_copy) {
+				uint32_t atlas_w_pre, atlas_h_pre;
+				comp_vk_native_renderer_get_atlas_dimensions(c->renderer, &atlas_w_pre, &atlas_h_pre);
+				vk_compositor_render_window_space_into_atlas(c, cmd,
+				    (VkImage)(uintptr_t)src_image_u64,
+				    (VkImageView)(uintptr_t)src_view_u64,
+				    atlas_w_pre, atlas_h_pre,
+				    view_width, view_height, tc, tr);
+			}
 
 			// Crop atlas to content dimensions before passing to DP
 			{
@@ -2216,6 +2278,19 @@ vk_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t
 				comp_vk_native_renderer_get_view_dimensions(c->renderer, &view_width, &view_height);
 				comp_vk_native_renderer_get_tile_layout(c->renderer, &tc, &tr);
 
+				// Pre-weave: composite window-space layers per-tile INTO the
+				// atlas. Skipped in zero-copy (no atlas) and when no
+				// window-space layers exist.
+				if (!zero_copy) {
+					uint32_t atlas_w_pre, atlas_h_pre;
+					comp_vk_native_renderer_get_atlas_dimensions(c->renderer, &atlas_w_pre, &atlas_h_pre);
+					vk_compositor_render_window_space_into_atlas(c, cmd,
+					    (VkImage)(uintptr_t)src_image_u64,
+					    (VkImageView)(uintptr_t)src_view_u64,
+					    atlas_w_pre, atlas_h_pre,
+					    view_width, view_height, tc, tr);
+				}
+
 				// Crop atlas to content dimensions before passing to DP
 				{
 					uint32_t content_w = tc * view_width;
@@ -2279,12 +2354,9 @@ vk_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t
 				    c->canvas.valid ? c->canvas.h : 0);
 
 				// Render pass finalLayout handles transition to PRESENT_SRC_KHR
-
-				// Post-weave: composite HUD overlays onto target (alpha-blended, flat 2D)
-				vk_compositor_blit_window_space_layers(c, cmd,
-				    (VkImage)(uintptr_t)target_image,
-				    (VkImageView)(uintptr_t)target_view,
-				    tgt_width, tgt_height);
+				// Window-space layers are composed pre-weave into the atlas
+				// (see vk_compositor_render_window_space_into_atlas), so we
+				// only need the diagnostic HUD on the target post-weave.
 
 				// Diagnostic HUD overlay (TAB key toggle)
 				vk_compositor_render_hud(c, cmd,
@@ -2293,12 +2365,6 @@ vk_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t
 				// No display processor (or mono/2D mode): blit atlas texture to target
 				comp_vk_native_renderer_blit_to_target(c->renderer, cmd,
 				                                        target_image, tgt_width, tgt_height);
-
-				// Post-blit: HUD overlays onto target (alpha-blended, flat 2D)
-				vk_compositor_blit_window_space_layers(c, cmd,
-				    (VkImage)(uintptr_t)target_image,
-				    (VkImageView)(uintptr_t)target_view,
-				    tgt_width, tgt_height);
 
 				// Diagnostic HUD overlay (TAB key toggle)
 				vk_compositor_render_hud(c, cmd,
@@ -2341,10 +2407,10 @@ vk_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t
 		}
 	}
 
-	// MCP capture_frame + trigger-file post-compose atlas capture (#210).
-	// Both early-return when nothing's pending; pay only when capturing.
-	vk_native_service_mcp_capture(c);
-	vk_native_service_trigger_file(c);
+	// Post-compose capture (#210) — captures the fully composed atlas
+	// (projection + window-space + quads) the DP just received. Skipped
+	// when intent is for projection-only (consumed earlier) or empty.
+	vk_native_dispatch_capture(c, MCP_CAPTURE_MODE_POST_COMPOSE);
 
 	return XRT_SUCCESS;
 }
@@ -2381,7 +2447,11 @@ vk_compositor_destroy(struct xrt_compositor *xc)
 	}
 	u_hud_destroy(&c->hud);
 
-	// Destroy window-space (HUD) alpha-blend pipeline
+	// Destroy window-space (HUD) alpha-blend pipeline + cached atlas FB
+	if (c->atlas_ws_fb != VK_NULL_HANDLE) {
+		vk->vkDestroyFramebuffer(vk->device, c->atlas_ws_fb, NULL);
+		c->atlas_ws_fb = VK_NULL_HANDLE;
+	}
 	vk_hud_blend_fini(&c->window_space_blend, vk);
 
 	// Destroy DP input crop image

--- a/src/xrt/compositor/vk_native/comp_vk_native_compositor.c
+++ b/src/xrt/compositor/vk_native/comp_vk_native_compositor.c
@@ -36,6 +36,14 @@
 #include "math/m_api.h"
 #include "util/u_tiling.h"
 #include "util/u_canvas.h"
+#include <displayxr_mcp/mcp_capture.h>
+
+// STB_IMAGE_WRITE_STATIC scopes all stbi_write_* to this TU so linking
+// alongside other compositors that also implement stb doesn't produce
+// duplicate symbols.
+#define STB_IMAGE_WRITE_STATIC
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+#include "stb_image_write.h"
 
 #ifdef XRT_BUILD_DRIVER_QWERTY
 #include "qwerty_interface.h"
@@ -54,6 +62,13 @@
 
 #include <string.h>
 #include <math.h>
+
+#ifdef XRT_OS_WINDOWS
+#include <windows.h>
+#else
+#include <sys/stat.h>
+#include <unistd.h>
+#endif
 
 /*!
  * Minimal settings struct for Vulkan compositor.
@@ -192,6 +207,10 @@ struct comp_vk_native_compositor
 	//! target format at compositor create time on all platforms).
 	struct vk_hud_blend window_space_blend;
 	bool window_space_blend_attempted;
+
+	//! MCP capture_frame request box (serviced at end of layer_commit).
+	//! Mirrors the pattern in comp_metal/gl/d3d11_compositor. See issue #210.
+	struct mcp_capture_request mcp_capture;
 };
 
 /*
@@ -1536,6 +1555,266 @@ vk_crop_atlas_for_dp(struct comp_vk_native_compositor *c,
 	*src_view_u64 = (uint64_t)(uintptr_t)c->dp_input_view;
 }
 
+/*
+ *
+ * MCP capture helpers
+ *
+ */
+
+// Helper: find a host-visible memory type.
+static bool
+vk_native_find_host_visible_memory_type(struct vk_bundle *vk, uint32_t type_bits, uint32_t *out_index)
+{
+	VkPhysicalDeviceMemoryProperties props;
+	vk->vkGetPhysicalDeviceMemoryProperties(vk->physical_device, &props);
+	const VkMemoryPropertyFlags want =
+	    VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+	for (uint32_t i = 0; i < props.memoryTypeCount; i++) {
+		if ((type_bits & (1u << i)) && (props.memoryTypes[i].propertyFlags & want) == want) {
+			*out_index = i;
+			return true;
+		}
+	}
+	return false;
+}
+
+// Read the content region of the renderer's atlas (tile_columns × view_width
+// by tile_rows × view_height — what actually got composited, matching what
+// the compositor crops and sends to the DP) into a host-visible staging
+// buffer, swap channels if format is BGRA, and write @p path as PNG. Uses
+// the renderer's command pool and the main queue.
+static bool
+vk_native_capture_atlas_to_png(struct comp_vk_native_compositor *c, const char *path)
+{
+	struct vk_bundle *vk = &c->vk;
+
+	uint64_t atlas_image_u64 = comp_vk_native_renderer_get_atlas_image(c->renderer);
+	VkImage atlas_image = (VkImage)(uintptr_t)atlas_image_u64;
+	if (atlas_image == VK_NULL_HANDLE) {
+		return false;
+	}
+
+	uint32_t tile_columns = 1, tile_rows = 1;
+	comp_vk_native_renderer_get_tile_layout(c->renderer, &tile_columns, &tile_rows);
+	uint32_t view_w = 0, view_h = 0;
+	comp_vk_native_renderer_get_view_dimensions(c->renderer, &view_w, &view_h);
+	if (tile_columns == 0 || tile_rows == 0 || view_w == 0 || view_h == 0) {
+		return false;
+	}
+	uint32_t atlas_w = 0, atlas_h = 0;
+	comp_vk_native_renderer_get_atlas_dimensions(c->renderer, &atlas_w, &atlas_h);
+
+	uint32_t content_w = tile_columns * view_w;
+	uint32_t content_h = tile_rows * view_h;
+	if (atlas_w > 0 && content_w > atlas_w) content_w = atlas_w;
+	if (atlas_h > 0 && content_h > atlas_h) content_h = atlas_h;
+
+	VkFormat atlas_format = (VkFormat)comp_vk_native_renderer_get_format(c->renderer);
+	bool swap_bgra =
+	    (atlas_format == VK_FORMAT_B8G8R8A8_UNORM || atlas_format == VK_FORMAT_B8G8R8A8_SRGB);
+
+	VkCommandPool cmd_pool = (VkCommandPool)(uintptr_t)comp_vk_native_renderer_get_cmd_pool(c->renderer);
+	if (cmd_pool == VK_NULL_HANDLE) {
+		return false;
+	}
+
+	// Allocate host-visible staging buffer (content_w × content_h × 4).
+	VkDeviceSize bytes = (VkDeviceSize)content_w * (VkDeviceSize)content_h * 4;
+	VkBuffer staging_buf = VK_NULL_HANDLE;
+	VkDeviceMemory staging_mem = VK_NULL_HANDLE;
+	uint8_t *mapped = NULL;
+
+	VkBufferCreateInfo bi = {
+	    .sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
+	    .size = bytes,
+	    .usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT,
+	    .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
+	};
+	if (vk->vkCreateBuffer(vk->device, &bi, NULL, &staging_buf) != VK_SUCCESS) {
+		return false;
+	}
+
+	VkMemoryRequirements mreq;
+	vk->vkGetBufferMemoryRequirements(vk->device, staging_buf, &mreq);
+	uint32_t mem_type = 0;
+	if (!vk_native_find_host_visible_memory_type(vk, mreq.memoryTypeBits, &mem_type)) {
+		vk->vkDestroyBuffer(vk->device, staging_buf, NULL);
+		return false;
+	}
+	VkMemoryAllocateInfo ai = {
+	    .sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
+	    .allocationSize = mreq.size,
+	    .memoryTypeIndex = mem_type,
+	};
+	if (vk->vkAllocateMemory(vk->device, &ai, NULL, &staging_mem) != VK_SUCCESS ||
+	    vk->vkBindBufferMemory(vk->device, staging_buf, staging_mem, 0) != VK_SUCCESS) {
+		if (staging_mem != VK_NULL_HANDLE) vk->vkFreeMemory(vk->device, staging_mem, NULL);
+		vk->vkDestroyBuffer(vk->device, staging_buf, NULL);
+		return false;
+	}
+
+	// One-shot command buffer to copy atlas -> buffer.
+	VkCommandBufferAllocateInfo cbai = {
+	    .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO,
+	    .commandPool = cmd_pool,
+	    .level = VK_COMMAND_BUFFER_LEVEL_PRIMARY,
+	    .commandBufferCount = 1,
+	};
+	VkCommandBuffer cmd = VK_NULL_HANDLE;
+	if (vk->vkAllocateCommandBuffers(vk->device, &cbai, &cmd) != VK_SUCCESS) {
+		vk->vkFreeMemory(vk->device, staging_mem, NULL);
+		vk->vkDestroyBuffer(vk->device, staging_buf, NULL);
+		return false;
+	}
+
+	VkCommandBufferBeginInfo cbi = {
+	    .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
+	    .flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT,
+	};
+	vk->vkBeginCommandBuffer(cmd, &cbi);
+
+	// Atlas was sampled by the DP/weaver this frame, so its layout is
+	// SHADER_READ_ONLY_OPTIMAL by the time we're called from layer_commit.
+	// Transition: SHADER_READ_ONLY_OPTIMAL → TRANSFER_SRC_OPTIMAL → SHADER_READ_ONLY_OPTIMAL.
+	VkImageMemoryBarrier b = {
+	    .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+	    .oldLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+	    .newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+	    .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+	    .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+	    .image = atlas_image,
+	    .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1},
+	    .srcAccessMask = VK_ACCESS_SHADER_READ_BIT,
+	    .dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT,
+	};
+	vk->vkCmdPipelineBarrier(cmd,
+	                         VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+	                         VK_PIPELINE_STAGE_TRANSFER_BIT,
+	                         0, 0, NULL, 0, NULL, 1, &b);
+
+	VkBufferImageCopy region = {
+	    .bufferOffset = 0,
+	    .bufferRowLength = 0,
+	    .bufferImageHeight = 0,
+	    .imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1},
+	    .imageOffset = {0, 0, 0},
+	    .imageExtent = {content_w, content_h, 1},
+	};
+	vk->vkCmdCopyImageToBuffer(cmd, atlas_image,
+	                           VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+	                           staging_buf, 1, &region);
+
+	b.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+	b.newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+	b.srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+	b.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+	vk->vkCmdPipelineBarrier(cmd,
+	                         VK_PIPELINE_STAGE_TRANSFER_BIT,
+	                         VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+	                         0, 0, NULL, 0, NULL, 1, &b);
+
+	vk->vkEndCommandBuffer(cmd);
+
+	VkSubmitInfo si = {
+	    .sType = VK_STRUCTURE_TYPE_SUBMIT_INFO,
+	    .commandBufferCount = 1,
+	    .pCommandBuffers = &cmd,
+	};
+	vk->vkQueueSubmit(vk->main_queue->queue, 1, &si, VK_NULL_HANDLE);
+	vk->vkQueueWaitIdle(vk->main_queue->queue);
+	vk->vkFreeCommandBuffers(vk->device, cmd_pool, 1, &cmd);
+
+	// Read pixels and encode PNG.
+	bool ok = false;
+	if (vk->vkMapMemory(vk->device, staging_mem, 0, bytes, 0, (void **)&mapped) == VK_SUCCESS) {
+		uint8_t *pixels = mapped;
+		uint8_t *swapped = NULL;
+		if (swap_bgra) {
+			swapped = malloc((size_t)bytes);
+			if (swapped != NULL) {
+				for (VkDeviceSize i = 0; i < bytes; i += 4) {
+					swapped[i + 0] = mapped[i + 2];
+					swapped[i + 1] = mapped[i + 1];
+					swapped[i + 2] = mapped[i + 0];
+					swapped[i + 3] = mapped[i + 3];
+				}
+				pixels = swapped;
+			}
+		}
+		ok = stbi_write_png(path, (int)content_w, (int)content_h, 4,
+		                    pixels, (int)content_w * 4) != 0;
+		free(swapped);
+		vk->vkUnmapMemory(vk->device, staging_mem);
+	}
+
+	vk->vkFreeMemory(vk->device, staging_mem, NULL);
+	vk->vkDestroyBuffer(vk->device, staging_buf, NULL);
+	return ok;
+}
+
+// Service a pending MCP capture_frame request — thin wrapper around
+// vk_native_capture_atlas_to_png that handles the cross-thread hand-off
+// with the MCP server.
+static void
+vk_native_service_mcp_capture(struct comp_vk_native_compositor *c)
+{
+	char path[MCP_CAPTURE_PATH_MAX];
+	if (!mcp_capture_poll(&c->mcp_capture, path)) {
+		return;
+	}
+	bool ok = vk_native_capture_atlas_to_png(c, path);
+	mcp_capture_complete(&c->mcp_capture, ok);
+}
+
+// Trigger-file capture path — same readback driven by file existence so
+// devs can snapshot without an MCP client. See issue #210.
+static void
+vk_native_service_trigger_file(struct comp_vk_native_compositor *c)
+{
+	static char trigger_path[MCP_CAPTURE_PATH_MAX] = {0};
+	static char out_path[MCP_CAPTURE_PATH_MAX] = {0};
+	if (trigger_path[0] == '\0') {
+#ifdef XRT_OS_WINDOWS
+		const char *tmp = getenv("TEMP");
+		if (tmp == NULL || tmp[0] == '\0') tmp = "C:\\Temp";
+		snprintf(trigger_path, sizeof(trigger_path), "%s\\displayxr_atlas_trigger", tmp);
+		snprintf(out_path, sizeof(out_path), "%s\\displayxr_atlas.png", tmp);
+#else
+		const char *tmp = getenv("TMPDIR");
+		if (tmp == NULL || tmp[0] == '\0') tmp = "/tmp";
+		size_t tlen = strlen(tmp);
+		if (tlen > 0 && tmp[tlen - 1] == '/') tlen = tlen - 1;
+		char tmp_clean[MCP_CAPTURE_PATH_MAX];
+		if (tlen >= sizeof(tmp_clean)) tlen = sizeof(tmp_clean) - 1;
+		memcpy(tmp_clean, tmp, tlen);
+		tmp_clean[tlen] = '\0';
+		snprintf(trigger_path, sizeof(trigger_path), "%s/displayxr_atlas_trigger", tmp_clean);
+		snprintf(out_path, sizeof(out_path), "%s/displayxr_atlas.png", tmp_clean);
+#endif
+	}
+
+#ifdef XRT_OS_WINDOWS
+	if (GetFileAttributesA(trigger_path) == INVALID_FILE_ATTRIBUTES) {
+		return;
+	}
+	DeleteFileA(trigger_path);
+#else
+	struct stat st;
+	if (stat(trigger_path, &st) != 0) {
+		return;
+	}
+	unlink(trigger_path);
+#endif
+
+	bool ok = vk_native_capture_atlas_to_png(c, out_path);
+	if (ok) {
+		U_LOG_I("Atlas captured to %s", out_path);
+	} else {
+		U_LOG_W("Atlas capture failed (trigger %s)", trigger_path);
+	}
+}
+
+
 static xrt_result_t
 vk_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sync_handle)
 {
@@ -2062,6 +2341,11 @@ vk_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t
 		}
 	}
 
+	// MCP capture_frame + trigger-file post-compose atlas capture (#210).
+	// Both early-return when nothing's pending; pay only when capturing.
+	vk_native_service_mcp_capture(c);
+	vk_native_service_trigger_file(c);
+
 	return XRT_SUCCESS;
 }
 
@@ -2080,6 +2364,11 @@ vk_compositor_destroy(struct xrt_compositor *xc)
 	struct vk_bundle *vk = &c->vk;
 
 	U_LOG_I("Destroying VK native compositor");
+
+	// Uninstall MCP capture hook before any GPU resources go away — the
+	// MCP thread can no longer post requests against us after this returns.
+	mcp_capture_uninstall();
+	mcp_capture_fini(&c->mcp_capture);
 
 	vk->vkDeviceWaitIdle(vk->device);
 
@@ -2523,6 +2812,10 @@ comp_vk_native_compositor_create(struct xrt_device *xdev,
 	c->base.base.layer_commit = vk_compositor_layer_commit;
 	c->base.base.layer_commit_with_semaphore = vk_compositor_layer_commit_with_semaphore;
 	c->base.base.destroy = vk_compositor_destroy;
+
+	// Install MCP capture_frame hook + arm the trigger-file path (#210).
+	mcp_capture_init(&c->mcp_capture);
+	mcp_capture_install(&c->mcp_capture);
 
 	*out_xc = &c->base;
 

--- a/src/xrt/state_trackers/oxr/oxr_mcp_tools.c
+++ b/src/xrt/state_trackers/oxr/oxr_mcp_tools.c
@@ -672,8 +672,31 @@ oxr_mcp_tools_set_capture_handler(oxr_mcp_capture_fn fn, void *userdata)
 static cJSON *
 tool_capture_frame(const cJSON *params, void *userdata)
 {
-	(void)params;
 	(void)userdata;
+
+	// Parse optional mode parameter. Default = post-compose (current
+	// behavior). "projection-only" returns the atlas state before
+	// window-space (HUD) layers are composed in.
+	uint32_t mode = MCP_CAPTURE_MODE_POST_COMPOSE;
+	const char *mode_label = "post-compose";
+	if (params != NULL) {
+		const cJSON *mode_node = cJSON_GetObjectItemCaseSensitive(params, "mode");
+		if (cJSON_IsString(mode_node) && mode_node->valuestring != NULL) {
+			if (strcmp(mode_node->valuestring, "projection-only") == 0) {
+				mode = MCP_CAPTURE_MODE_PROJECTION_ONLY;
+				mode_label = "projection-only";
+			} else if (strcmp(mode_node->valuestring, "post-compose") == 0) {
+				// explicit default — fall through
+			} else {
+				cJSON *o = cJSON_CreateObject();
+				cJSON_AddStringToObject(
+				    o, "error",
+				    "mode must be \"post-compose\" or \"projection-only\"");
+				return o;
+			}
+		}
+	}
+
 	pthread_mutex_lock(&g_capture_lock);
 	oxr_mcp_capture_fn fn = g_capture_fn;
 	void *ud = g_capture_userdata;
@@ -694,13 +717,34 @@ tool_capture_frame(const cJSON *params, void *userdata)
 	int64_t begun = sess ? sess->frame_id.begun : 0;
 	uint64_t seq = begun >= 0 ? (uint64_t)begun : 0;
 	unlock_session();
-	snprintf(path, sizeof(path), "/tmp/displayxr-mcp-capture-%ld-%llu.png", pid, (unsigned long long)seq);
+	const char *suffix = (mode == MCP_CAPTURE_MODE_PROJECTION_ONLY) ? ".projection" : "";
+#ifdef _WIN32
+	const char *tmp = getenv("TEMP");
+	if (tmp == NULL || tmp[0] == '\0') {
+		tmp = "C:\\Temp";
+	}
+	snprintf(path, sizeof(path), "%s\\displayxr-mcp-capture-%ld-%llu%s.png",
+	         tmp, pid, (unsigned long long)seq, suffix);
+#else
+	const char *tmp = getenv("TMPDIR");
+	if (tmp == NULL || tmp[0] == '\0') {
+		tmp = "/tmp";
+	}
+	// Strip trailing slash to keep the format stable.
+	size_t tlen = strlen(tmp);
+	while (tlen > 0 && tmp[tlen - 1] == '/') {
+		tlen--;
+	}
+	snprintf(path, sizeof(path), "%.*s/displayxr-mcp-capture-%ld-%llu%s.png",
+	         (int)tlen, tmp, pid, (unsigned long long)seq, suffix);
+#endif
 
-	bool ok = fn(path, ud);
+	bool ok = fn(path, mode, ud);
 
 	cJSON *r = cJSON_CreateObject();
 	cJSON_AddNumberToObject(r, "frame_id", (double)seq);
 	cJSON_AddStringToObject(r, "path", path);
+	cJSON_AddStringToObject(r, "mode", mode_label);
 	// Absorb any brief fclose→stat lag before reporting size.
 	struct stat st = {0};
 	for (int attempt = 0; attempt < 20; attempt++) {
@@ -719,10 +763,19 @@ tool_capture_frame(const cJSON *params, void *userdata)
 static const struct mcp_tool TOOL_CAPTURE_FRAME = {
     .name = "capture_frame",
     .description =
-        "Capture the compositor's most recent composited frame — the content region of the "
-        "atlas that the compositor crops and hands to the display processor (i.e. what the "
-        "app actually wrote to its swapchain). Returns the PNG path and byte size.",
-    .input_schema_json = "{\"type\":\"object\",\"properties\":{}}",
+        "Capture the compositor's atlas state and write it as a PNG. "
+        "Optional mode parameter selects what gets captured: "
+        "\"post-compose\" (default) returns the fully composed atlas the "
+        "display processor receives — projection layers + window-space "
+        "(HUD) + quads, across every tile. "
+        "\"projection-only\" returns the atlas before window-space layers "
+        "are composed in (projection-class layers only, per tile). "
+        "Returns the PNG path, requested mode, and byte size.",
+    .input_schema_json =
+        "{\"type\":\"object\",\"properties\":{"
+        "\"mode\":{\"type\":\"string\","
+        "\"enum\":[\"post-compose\",\"projection-only\"],"
+        "\"description\":\"Atlas state to capture; default post-compose.\"}}}",
     .fn = tool_capture_frame,
 };
 

--- a/src/xrt/state_trackers/oxr/oxr_mcp_tools.h
+++ b/src/xrt/state_trackers/oxr/oxr_mcp_tools.h
@@ -63,14 +63,15 @@ oxr_mcp_tools_record_submitted(struct oxr_session *sess, const struct xrt_layer_
 
 /*!
  * Register a per-compositor capture handler. The handler is invoked on
- * the MCP server thread with a target path; it must write a PNG to
- * that path (synchronously or with its own synchronization) and return
- * true on success. The state tracker passes a stable path of the form
- * `/tmp/displayxr-mcp-capture-<pid>-<frame>.png`.
+ * the MCP server thread with a target path and a capture mode (see
+ * @ref mcp_capture_mode); it must write a PNG matching the requested
+ * mode to that path (synchronously or with its own synchronization)
+ * and return true on success. The state tracker passes a stable path
+ * of the form `/tmp/displayxr-mcp-capture-<pid>-<frame>{,.projection}.png`.
  *
  * Pass NULL to unregister.
  */
-typedef bool (*oxr_mcp_capture_fn)(const char *path, void *userdata);
+typedef bool (*oxr_mcp_capture_fn)(const char *path, uint32_t mode, void *userdata);
 
 void
 oxr_mcp_tools_set_capture_handler(oxr_mcp_capture_fn fn, void *userdata);

--- a/test_apps/common/atlas_capture.h
+++ b/test_apps/common/atlas_capture.h
@@ -14,10 +14,21 @@
  * window-space overlays, no per-eye disparity, no compose-time blending.
  * Useful for debugging an app's own tile-aware rendering.
  *
- * **For "what the DP weaves" (post-compose, all layers)**: use the
- * runtime-side trigger-file at `${TMPDIR:-/tmp}/displayxr_atlas_trigger`
- * (POSIX) or `%TEMP%\displayxr_atlas_trigger` (Windows). See issue #210
- * and `comp_*_compositor.{c,cpp,m}::*_service_trigger_file`.
+ * **For runtime-side captures**, use the trigger files (or the MCP
+ * @c capture_frame tool with a @c mode parameter):
+ *   - `${TMPDIR:-/tmp}/displayxr_atlas_trigger` (POSIX) or
+ *     `%TEMP%\displayxr_atlas_trigger` (Windows) → @b post-compose
+ *     atlas the DP weaver receives — projection + window-space (HUD) +
+ *     quads, composed across every tile. Output PNG:
+ *     `displayxr_atlas.png`.
+ *   - `…\displayxr_atlas_trigger.projection` → @b projection-only:
+ *     atlas state before window-space layers are composed in (per-tile
+ *     projection content only). Output PNG:
+ *     `displayxr_atlas.projection.png`. Useful for verifying tile-aware
+ *     app rendering independent of chrome.
+ *
+ * See `u_capture_intent.h` and the per-compositor
+ * `*_compositor_dispatch_capture` plumbing.
  *
  * Each backend (D3D11/D3D12/GL/Metal/Vulkan) lives in its own `.cpp`/`.mm`
  * and is only compiled in by apps that need it. Filename helpers and the

--- a/test_apps/common/atlas_capture.h
+++ b/test_apps/common/atlas_capture.h
@@ -2,11 +2,22 @@
 // SPDX-License-Identifier: BSL-1.0
 /*!
  * @file
- * @brief  In-app multi-view atlas capture (the 'I' key feature).
+ * @brief  In-app per-projection-layer atlas capture (the 'I' key feature).
  *
  * Reads back a sub-rect of an OpenXR swapchain image to host memory and
  * writes a PNG via stb_image_write. Captures land in the user's Pictures
  * folder and auto-increment as `<stem>-<N>_<cols>x<rows>.png`.
+ *
+ * **What this captures**: the *app's primary projection swapchain* —
+ * the per-tile multi-view atlas the app rendered, *before* the runtime
+ * composites any other layers. So one projection layer, no HUD / quad /
+ * window-space overlays, no per-eye disparity, no compose-time blending.
+ * Useful for debugging an app's own tile-aware rendering.
+ *
+ * **For "what the DP weaves" (post-compose, all layers)**: use the
+ * runtime-side trigger-file at `${TMPDIR:-/tmp}/displayxr_atlas_trigger`
+ * (POSIX) or `%TEMP%\displayxr_atlas_trigger` (Windows). See issue #210
+ * and `comp_*_compositor.{c,cpp,m}::*_service_trigger_file`.
  *
  * Each backend (D3D11/D3D12/GL/Metal/Vulkan) lives in its own `.cpp`/`.mm`
  * and is only compiled in by apps that need it. Filename helpers and the

--- a/test_apps/common/input_handler.h
+++ b/test_apps/common/input_handler.h
@@ -92,9 +92,11 @@ struct InputState {
     // / quad layers and per-eye disparity are NOT included. Skipped for 1×1
     // (mono) layouts. Filename auto-increments per (cols×rows).
     //
-    // For the runtime's full post-compose atlas (all layers + DP-bound
-    // pixels), use the trigger file `displayxr_atlas_trigger` instead;
-    // see issue #210.
+    // For runtime-side captures, use the trigger files (or MCP capture_frame):
+    //   `displayxr_atlas_trigger` → post-compose (all layers, what DP weaves)
+    //   `displayxr_atlas_trigger.projection` → projection-only (per-tile,
+    //                                          no window-space layers)
+    // See u_capture_intent.h and issue #210.
     bool captureAtlasRequested = false;
 
     // --- Gaussian-splat demo extensions (additive; unused by cube_* apps) ---

--- a/test_apps/common/input_handler.h
+++ b/test_apps/common/input_handler.h
@@ -86,9 +86,15 @@ struct InputState {
     // Eye tracking mode toggle (T key)
     bool eyeTrackingModeToggleRequested = false;
 
-    // 'I' key: snapshot the rendered atlas (cols × rows × renderW × renderH)
-    // to %USERPROFILE%\Pictures\DisplayXR\<app>-<N>_<cols>x<rows>.png. Skipped
-    // for 1×1 (mono) layouts. Filename auto-increments per (cols×rows).
+    // 'I' key: snapshot the **app's projection-layer atlas only** (cols ×
+    // rows × renderW × renderH) to %USERPROFILE%\Pictures\DisplayXR\
+    // <app>-<N>_<cols>x<rows>.png. One projection layer; HUD / window-space
+    // / quad layers and per-eye disparity are NOT included. Skipped for 1×1
+    // (mono) layouts. Filename auto-increments per (cols×rows).
+    //
+    // For the runtime's full post-compose atlas (all layers + DP-bound
+    // pixels), use the trigger file `displayxr_atlas_trigger` instead;
+    // see issue #210.
     bool captureAtlasRequested = false;
 
     // --- Gaussian-splat demo extensions (additive; unused by cube_* apps) ---

--- a/test_apps/cube_handle_gl_macos/main.mm
+++ b/test_apps/cube_handle_gl_macos/main.mm
@@ -719,8 +719,12 @@ struct InputState {
     bool renderingModeChangeRequested = false;
     bool cameraMode = false;
     float nominalViewerZ = 0.5f;
-    // 'I' key: snapshot the rendered atlas (cols × rows × renderW × renderH)
-    // to ~/Pictures/DisplayXR/<app>-<N>_<cols>x<rows>.png. Skipped for 1×1.
+    // 'I' key: snapshot the **app's projection-layer atlas only** (cols ×
+    // rows × renderW × renderH) to ~/Pictures/DisplayXR/<app>-<N>_
+    // <cols>x<rows>.png. One projection layer; HUD / window-space layers
+    // and per-eye disparity are NOT included. Skipped for 1×1. For the
+    // runtime's full post-compose atlas use the trigger file
+    // $TMPDIR/displayxr_atlas_trigger (see issue #210).
     bool captureAtlasRequested = false;
 };
 static InputState g_input;

--- a/test_apps/cube_handle_metal_macos/main.mm
+++ b/test_apps/cube_handle_metal_macos/main.mm
@@ -731,8 +731,12 @@ struct InputState {
     bool renderingModeChangeRequested = false;
     bool cameraMode = false;
     float nominalViewerZ = 0.5f;
-    // 'I' key: snapshot the rendered atlas (cols × rows × renderW × renderH)
-    // to ~/Pictures/DisplayXR/<app>-<N>_<cols>x<rows>.png. Skipped for 1×1.
+    // 'I' key: snapshot the **app's projection-layer atlas only** (cols ×
+    // rows × renderW × renderH) to ~/Pictures/DisplayXR/<app>-<N>_
+    // <cols>x<rows>.png. One projection layer; HUD / window-space layers
+    // and per-eye disparity are NOT included. Skipped for 1×1. For the
+    // runtime's full post-compose atlas use the trigger file
+    // $TMPDIR/displayxr_atlas_trigger (see issue #210).
     bool captureAtlasRequested = false;
 };
 static InputState g_input;

--- a/tests/mcp/smoke_capture_modes.py
+++ b/tests/mcp/smoke_capture_modes.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Smoke-test the capture_frame mode parameter against a running handle app.
+
+Usage:
+    smoke_capture_modes.py <adapter_path> <pid>
+
+Calls capture_frame three times — default (no mode), mode=post-compose,
+mode=projection-only — and asserts each returned PNG exists, is a real
+PNG, and the projection-only path has the expected suffix.
+"""
+import json
+import os
+import subprocess
+import sys
+
+if len(sys.argv) != 3:
+    print("usage: smoke_capture_modes.py <adapter> <pid>", file=sys.stderr)
+    sys.exit(2)
+adapter, pid = sys.argv[1], sys.argv[2]
+
+
+def frame(obj):
+    b = json.dumps(obj).encode()
+    return b"Content-Length: %d\r\n\r\n" % len(b) + b
+
+
+p = subprocess.Popen(
+    [adapter, "--target", f"pid:{pid}"],
+    stdin=subprocess.PIPE,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+)
+
+
+def read():
+    h = b""
+    while b"\r\n\r\n" not in h and b"\n\n" not in h:
+        c = p.stdout.read(1)
+        if not c:
+            raise RuntimeError(p.stderr.read().decode("utf-8", "replace") or "EOF")
+        h += c
+    n = next(
+        int(l.split(b":", 1)[1])
+        for l in h.splitlines()
+        if l.lower().startswith(b"content-length:")
+    )
+    return json.loads(p.stdout.read(n))
+
+
+def call(i, method, params=None):
+    msg = {"jsonrpc": "2.0", "id": i, "method": method}
+    if params is not None:
+        msg["params"] = params
+    p.stdin.write(frame(msg))
+    p.stdin.flush()
+    return read()
+
+
+def assert_capture_ok(reply, expected_mode_label, expected_suffix):
+    d = reply["result"].get("structured") or reply["result"]
+    if "content" in reply["result"] and not d.get("path"):
+        # Some MCP servers fold structured into content[0].text.
+        d = json.loads(reply["result"]["content"][0]["text"])
+    assert "error" not in d, d
+    assert d.get("path"), d
+    assert d.get("path").endswith(expected_suffix), (d, expected_suffix)
+    assert d.get("mode") == expected_mode_label, (d, expected_mode_label)
+    assert d.get("size_bytes", 0) > 1024, d
+    assert os.path.isfile(d["path"]), d
+    with open(d["path"], "rb") as fh:
+        sig = fh.read(8)
+    assert sig == b"\x89PNG\r\n\x1a\n", d
+    print(f"  PASS mode={expected_mode_label!r} path={os.path.basename(d['path'])} size={d['size_bytes']}")
+
+
+try:
+    call(
+        1,
+        "initialize",
+        {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": {"name": "smoke", "version": "0"},
+        },
+    )
+
+    r = call(2, "tools/list")
+    tools = {t["name"]: t for t in r["result"]["tools"]}
+    assert "capture_frame" in tools, list(tools)
+    schema = tools["capture_frame"].get("inputSchema") or {}
+    print(f"capture_frame schema: {json.dumps(schema)[:200]}")
+
+    print("default (no mode arg) -> expect post-compose:")
+    r = call(3, "tools/call", {"name": "capture_frame", "arguments": {}})
+    assert_capture_ok(r, "post-compose", ".png")
+
+    print("explicit mode=post-compose:")
+    r = call(4, "tools/call", {"name": "capture_frame", "arguments": {"mode": "post-compose"}})
+    assert_capture_ok(r, "post-compose", ".png")
+
+    print("mode=projection-only:")
+    r = call(5, "tools/call", {"name": "capture_frame", "arguments": {"mode": "projection-only"}})
+    assert_capture_ok(r, "projection-only", ".projection.png")
+
+    print("mode=bogus -> expect error in payload:")
+    r = call(6, "tools/call", {"name": "capture_frame", "arguments": {"mode": "bogus"}})
+    d = r["result"].get("structured") or json.loads(r["result"]["content"][0]["text"])
+    assert "error" in d, d
+    print(f"  PASS error={d['error']!r}")
+
+    print("\nALL CHECKS PASSED")
+finally:
+    try:
+        p.stdin.close()
+    except Exception:
+        pass
+    p.wait(timeout=3)


### PR DESCRIPTION
Closes #210.

## Summary

Brings the in-process Metal, GL, D3D11, D3D12, and Vulkan native compositors up to parity with the D3D11 service compositor's post-compose atlas-capture surface. The runtime-side capture sees the *full composed atlas* — every submitted layer (projection + window-space HUD + quad + …, with per-eye disparity and blend modes applied) — exactly what the display processor weaves. The app-side `I` key only ever read the app's primary projection swapchain, which silently drops content from multi-layer apps and apps using `XR_EXT_window_space_layer`.

## Commits

1. **`80b1ddf8d` feat(compositor): trigger-file post-compose atlas capture (in-process)** — covers (a) macOS Metal/GL + (b) Windows in-process D3D11. Refactors each compositor's existing MCP `capture_frame` body into a path-taking helper (`*_compositor_capture_atlas_to_png`), then has both the MCP path and a new trigger-file path call it. Drop `${TMPDIR:-/tmp}/displayxr_atlas_trigger` (POSIX) or `%TEMP%\displayxr_atlas_trigger` (Windows) and the next frame's compose pass writes `displayxr_atlas.png`.
2. **`a4660c968` feat(compositor): post-compose atlas capture in d3d12 + vk_native** — covers (c). Adds the missing MCP capture infrastructure to both compositors (request box, `*_capture_atlas_to_png` helper, MCP wrapper, trigger-file wrapper, layer_commit hooks, init/destroy lifecycle), bringing them to parity with the others.
3. **`65ea8cbd3` docs(test_apps): clarify 'I' key captures projection layer only** — covers (d). Re-documents the app-side `I` capture in `atlas_capture.h`, `input_handler.h`, and the macOS apps' local `InputState` structs to make clear it captures *one projection layer*, not the composed atlas, and points readers to the trigger-file path for the latter.

## Trigger-file convention

Same on every in-process compositor:

| Platform | Trigger | Output |
|---|---|---|
| macOS / Linux | `\${TMPDIR:-/tmp}/displayxr_atlas_trigger` | `\${TMPDIR}/displayxr_atlas.png` |
| Windows | `%TEMP%\\displayxr_atlas_trigger` | `%TEMP%\\displayxr_atlas.png` |

The existing `workspace_screenshot_trigger` path in `comp_d3d11_service.cpp` (used by the workspace shell's Ctrl+Shift+3 binding) is unchanged — out of scope for this PR.

## Validation

- **macOS full build_macos.sh — green** (validates a, c-vk_native, d).
- **End-to-end smoke test on macOS Metal**:
  - Launched `cube_handle_metal_macos` in Anaglyph mode.
  - `touch /tmp/displayxr_atlas_trigger` → trigger consumed within one frame, `/tmp/displayxr_atlas.png` written.
  - PNG metadata: 3024×823 RGBA8 (= `tile_columns × view_w` by `tile_rows × view_h` for the active mode — content region only, not worst-case allocation).
  - Pixels show the per-eye color-correct cube renders before DP anaglyph compose, exactly the input the weaver receives.
- **Windows D3D11 / D3D12 (b + c-d3d12) not validated locally** — Windows-only paths. Structurally identical to the proven D3D11 service trigger-file path (`comp_d3d11_service.cpp:9696-9716`) and the validated vk_native + macOS work. Needs Windows CI to validate.

## Test plan

- [ ] Windows CI — `build-windows.yml` builds clean.
- [ ] On a Leia SR Windows box, run `cube_handle_d3d11_win`, drop `%TEMP%\displayxr_atlas_trigger`, confirm `%TEMP%\displayxr_atlas.png` written and shows the post-compose atlas.
- [ ] Same with `cube_handle_d3d12_win` and `cube_handle_vk_win`.
- [ ] Optional: with the macOS HUD migration on `feature/window-space-in-workspace` merged, confirm the captured PNG shows the HUD with per-eye disparity (the user-facing payoff that motivated #210).

## Out of scope

- Capturing per-app data from a multi-app workspace — already covered by the workspace shell's IPC-driven capture.
- Re-running the DP weaver against the captured atlas to produce per-pane previews.
- Including the HUD in the app-side `I` capture — without runtime compose math, reproducing it app-side defeats the purpose. The runtime-side capture is the right answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)