### PR TITLE
fix(macos): HUD orientation, size, and SHIFT+TAB on WS-layer apps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -394,6 +394,65 @@ See `docs/reference/debug-logging.md` for full conventions.
 - Use U_LOG_I (INFO) for recurring/throttled diagnostic logs (per-frame, per-keystroke, etc.)
 - Never add per-frame U_LOG_W calls — they cause massive log bloat
 
+## Capturing macOS Test-App Pixels Autonomously
+
+`screencapture`, `CGWindowListCreateImage` (obsoleted in macOS 15), and
+`osascript ... keystroke` all need TCC permissions Claude Code's parent
+process doesn't have. They fail silently or with a generic "could not
+create image" error.
+
+Workaround: dump pixels from inside the test app via `stbi_write_png`.
+`stb_image_write.h` already lives in `test_apps/common/` and
+`_stbi_write_png` is linked into every macOS test app via the
+`atlas_capture_*.mm` siblings, so just forward-declare with C linkage at
+file scope of the `.mm` you want to instrument:
+
+```cpp
+extern "C" int stbi_write_png(char const*, int, int, int, void const*, int);
+```
+
+Then dump from the render loop, gated on a frame counter:
+
+```cpp
+static int n = 0;
+if (n++ == 120) {  // ~2 s in, after throttled HUD section strings populate
+    stbi_write_png("/tmp/hud_source.png", W, H, 4, pixels, rowPitch);
+}
+```
+
+Run: `_package/DisplayXR-macOS/run_cube_handle_metal.sh > /tmp/log 2>&1 &`,
+sleep ~6 s, `pkill -f cube_handle_metal_macos`, then `Read /tmp/hud_source.png`
+— the Read tool renders the PNG inline.
+
+Caveat: HUD section strings (`g_hudSessionText` etc.) are throttled to
+~2 Hz, so frame-0 dumps are blank. Wait for frame ~120 or later.
+
+For the rendered per-eye atlas (after compositor blit, before weaver) the
+existing 'I' key path writes to
+`~/Pictures/DisplayXR/<stem>-N_<cols>x<rows>.png` via
+`dxr_capture::CaptureAtlasRegionMetal`. You can't trigger the 'I' key via
+osascript without Accessibility, so the same in-app dump trick works —
+call `CaptureAtlasRegionMetal` directly from a frame-counter gate.
+
+**Compositor-side composited atlas (preferred):** the metal and GL native
+compositors poll `/tmp/dxr_atlas_trigger` each frame. Touch the trigger
+and the next frame writes the composited content region (cube + WS HUD
+layers, post per-tile pass, pre display processor) to `/tmp/dxr_atlas.png`,
+then unlinks the trigger.
+
+```bash
+rm -f /tmp/dxr_atlas.png /tmp/dxr_atlas_trigger
+_package/DisplayXR-macOS/run_cube_handle_metal.sh > /tmp/log 2>&1 &
+sleep 4 && touch /tmp/dxr_atlas_trigger && sleep 2
+pkill -f cube_handle_metal_macos
+# Read /tmp/dxr_atlas.png inline.
+```
+
+This shows the composited atlas (what would go to the SR weaver / sim_display)
+which is what you want for verifying WS-layer composition. The vk_native
+compositor doesn't have a trigger yet; for cube_handle_vk_macos rely on
+visual inspection or the in-app `stbi_write_png` trick.
+
 ## Capturing Compositor Screenshots (Preferred)
 
 The D3D11 service compositor supports file-triggered screenshots of its combined atlas (full-resolution SBS back buffer). This reads the D3D11 texture directly — no DPI issues, no PrintWindow limitations.

--- a/src/xrt/compositor/gl/comp_gl_compositor.c
+++ b/src/xrt/compositor/gl/comp_gl_compositor.c
@@ -42,6 +42,10 @@
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include "stb_image_write.h"
 #include "os/os_time.h"
+#include <sys/stat.h>
+#ifndef XRT_OS_WINDOWS
+#include <unistd.h>
+#endif
 #include "os/os_threading.h"
 #include "math/m_api.h"
 
@@ -166,6 +170,12 @@ static const char *FS_BLIT =
 
 //! Vertex shader: positioned quad for window-space layers.
 //! Takes uniform position/size in NDC.
+//! v_uv.y is flipped: top of NDC rect samples UV.y=0 (top of texture),
+//! bottom samples UV.y=1. WS-layer source textures land in GL via
+//! glTexSubImage2D in top-down memory order (CG/D2D bitmap layout, row 0 =
+//! top of image), so UV.y=0 is the top. Without the flip the HUD renders
+//! upside-down on the atlas (then sim_display passes that inversion straight
+//! through to screen).
 static const char *VS_WINDOW_SPACE =
     "#version 330 core\n"
     "out vec2 v_uv;\n"
@@ -173,7 +183,7 @@ static const char *VS_WINDOW_SPACE =
     "void main() {\n"
     "    float x = float((gl_VertexID & 1) << 1) - 1.0;\n" // -1 or 1
     "    float y = float((gl_VertexID & 2)) - 1.0;\n"       // -1 or 1
-    "    v_uv = vec2((x + 1.0) * 0.5, (y + 1.0) * 0.5);\n"
+    "    v_uv = vec2((x + 1.0) * 0.5, (1.0 - y) * 0.5);\n"
     "    gl_Position = vec4(u_rect.x + (x * 0.5 + 0.5) * u_rect.z,\n"
     "                       u_rect.y + (y * 0.5 + 0.5) * u_rect.w,\n"
     "                       0.0, 1.0);\n"
@@ -1342,6 +1352,42 @@ gl_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t
 		}
 
 		glDisable(GL_BLEND);
+	}
+
+	// File-triggered atlas dump for autonomous screenshot verification.
+	// `touch /tmp/dxr_atlas_trigger` and the next frame writes the
+	// composited content region to /tmp/dxr_atlas.png. Mirrors the
+	// Windows D3D11-service screenshot trigger pattern. Runs while
+	// c->fbo is still bound with atlas as the color attachment, after
+	// both projection and WS-layer passes have completed.
+	{
+		struct stat _st;
+		if (c->atlas_texture != 0 && c->tile_columns > 0 && c->tile_rows > 0 &&
+		    c->view_width > 0 && c->view_height > 0 &&
+		    stat("/tmp/dxr_atlas_trigger", &_st) == 0) {
+			unlink("/tmp/dxr_atlas_trigger");
+			uint32_t cw = c->tile_columns * c->view_width;
+			uint32_t ch = c->tile_rows * c->view_height;
+			if (cw > c->atlas_tex_width)  cw = c->atlas_tex_width;
+			if (ch > c->atlas_tex_height) ch = c->atlas_tex_height;
+			size_t row_pitch = (size_t)cw * 4;
+			size_t bytes = row_pitch * ch;
+			uint8_t *bu = malloc(bytes);
+			uint8_t *td = malloc(bytes);
+			if (bu != NULL && td != NULL) {
+				glReadBuffer(GL_COLOR_ATTACHMENT0);
+				GLint sy = (GLint)c->atlas_tex_height - (GLint)ch;
+				if (sy < 0) sy = 0;
+				glReadPixels(0, sy, (GLsizei)cw, (GLsizei)ch, GL_RGBA, GL_UNSIGNED_BYTE, bu);
+				glFinish();
+				for (uint32_t y = 0; y < ch; y++) {
+					memcpy(td + (size_t)y * row_pitch,
+					       bu + (size_t)(ch - 1 - y) * row_pitch, row_pitch);
+				}
+				stbi_write_png("/tmp/dxr_atlas.png", (int)cw, (int)ch, 4, td, (int)row_pitch);
+			}
+			free(bu); free(td);
+		}
 	}
 	} // end if (!zero_copy)
 

--- a/src/xrt/compositor/metal/comp_metal_compositor.m
+++ b/src/xrt/compositor/metal/comp_metal_compositor.m
@@ -57,6 +57,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 /*
  *
@@ -1781,6 +1783,56 @@ metal_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 		}
 
 		[encoder endEncoding];
+	}
+
+	// File-triggered atlas dump for autonomous screenshot verification.
+	// `touch /tmp/dxr_atlas_trigger` and the next frame writes the
+	// composited content region (post WS-layer pass, pre display
+	// processor) to /tmp/dxr_atlas.png. Mirrors the Windows D3D11-
+	// service screenshot trigger pattern; lets Claude Code inspect
+	// composited output without TCC permissions for screencapture.
+	{
+		const char *trigger = "/tmp/dxr_atlas_trigger";
+		struct stat st;
+		if (c->atlas_texture != nil && c->tile_columns > 0 && c->tile_rows > 0 &&
+		    c->view_width > 0 && c->view_height > 0 && stat(trigger, &st) == 0) {
+			unlink(trigger);
+			uint32_t cw = c->tile_columns * c->view_width;
+			uint32_t ch = c->tile_rows * c->view_height;
+			if (cw > (uint32_t)c->atlas_texture.width)  cw = (uint32_t)c->atlas_texture.width;
+			if (ch > (uint32_t)c->atlas_texture.height) ch = (uint32_t)c->atlas_texture.height;
+			size_t pitch = (size_t)cw * 4;
+			size_t bytes = pitch * ch;
+			id<MTLBuffer> stg = [c->device newBufferWithLength:bytes
+			                                           options:MTLResourceStorageModeShared];
+			if (stg != nil) {
+				[cmd_buf commit];
+				[cmd_buf waitUntilCompleted];
+				id<MTLCommandBuffer> bcb = [c->command_queue commandBuffer];
+				id<MTLBlitCommandEncoder> bl = [bcb blitCommandEncoder];
+				[bl copyFromTexture:c->atlas_texture
+				        sourceSlice:0 sourceLevel:0
+				       sourceOrigin:MTLOriginMake(0, 0, 0)
+				         sourceSize:MTLSizeMake(cw, ch, 1)
+				           toBuffer:stg destinationOffset:0
+				 destinationBytesPerRow:pitch
+				destinationBytesPerImage:bytes];
+				[bl endEncoding];
+				[bcb commit];
+				[bcb waitUntilCompleted];
+				uint8_t *src = (uint8_t *)stg.contents;
+				uint8_t *out = malloc(bytes);
+				if (out != NULL) {
+					for (size_t i = 0; i < bytes; i += 4) {
+						out[i+0] = src[i+2]; out[i+1] = src[i+1];
+						out[i+2] = src[i+0]; out[i+3] = src[i+3];
+					}
+					stbi_write_png("/tmp/dxr_atlas.png", (int)cw, (int)ch, 4, out, (int)pitch);
+					free(out);
+				}
+				cmd_buf = [c->command_queue commandBuffer];
+			}
+		}
 	}
 
 	// Step 2: Process atlas through display processor, or simple blit fallback

--- a/test_apps/common/hud_renderer_macos.mm
+++ b/test_apps/common/hud_renderer_macos.mm
@@ -83,7 +83,14 @@ static void DrawAttributedTextBox(CGContextRef ctx, CTFontRef font,
     CGMutablePathRef path = CGPathCreateMutable();
     CGPathAddRect(path, NULL, rect);
     CTFrameRef frame = CTFramesetterCreateFrame(fs, CFRangeMake(0, attr.length), path, NULL);
+    // The caller flips Y on the CTM for top-down layout; CT rasterizes
+    // glyphs through the text matrix × CTM, so an identity text matrix
+    // would render each glyph upside-down. Pre-flip the text matrix on Y
+    // so the two cancel and glyphs come out upright.
+    CGAffineTransform savedTextMatrix = CGContextGetTextMatrix(ctx);
+    CGContextSetTextMatrix(ctx, CGAffineTransformMakeScale(1.0, -1.0));
     CTFrameDraw(frame, ctx);
+    CGContextSetTextMatrix(ctx, savedTextMatrix);
     CFRelease(frame);
     CGPathRelease(path);
     CFRelease(fs);

--- a/test_apps/cube_handle_gl_macos/main.mm
+++ b/test_apps/cube_handle_gl_macos/main.mm
@@ -733,7 +733,7 @@ static const float CAMERA_HALF_TAN_VFOV = 0.32491969623f; // tan(18deg) -> 36deg
 // path on macOS. Same constants as the other macOS test apps.
 static const uint32_t HUD_PIXEL_WIDTH = 380;
 static const uint32_t HUD_PIXEL_HEIGHT = 470;
-static const float HUD_WIDTH_FRACTION = 0.95f;
+static const float HUD_WIDTH_FRACTION = 0.20f;
 
 // Performance stats
 static double g_avgFrameTime = 0.0;
@@ -931,10 +931,12 @@ static void PumpMacOSEvents()
                     else if (ch == 'e') { g_input.keyE = true; }
                     else if (ch == 'q') { g_input.keyQ = true; }
                     else if (ch == ' ') { g_input.resetViewRequested = true; }
-                    else if (ch == '\t' && !isRepeat &&
+                    else if ([event keyCode] == 48 /* kVK_Tab */ && !isRepeat &&
                              ([event modifierFlags] & NSEventModifierFlagShift)) {
                         // SHIFT+TAB so bare TAB stays free for the workspace shell's
                         // focus-cycle binding (matches the Windows test apps).
+                        // NSEvent.characters returns 0x19 (NSBackTabCharacter) for
+                        // SHIFT+TAB, not '\t' — gate on the hardware keyCode.
                         g_input.hudVisible = !g_input.hudVisible;
                     }
                     else if (ch == 'v' && !isRepeat) {

--- a/test_apps/cube_handle_metal_macos/main.mm
+++ b/test_apps/cube_handle_metal_macos/main.mm
@@ -745,7 +745,7 @@ static const float CAMERA_HALF_TAN_VFOV = 0.32491969623f; // tan(18deg) -> 36deg
 // composes the HUD through the proper extension path on macOS, matching Windows.
 static const uint32_t HUD_PIXEL_WIDTH = 380;
 static const uint32_t HUD_PIXEL_HEIGHT = 470;
-static const float HUD_WIDTH_FRACTION = 0.95f;
+static const float HUD_WIDTH_FRACTION = 0.20f;
 
 // Performance stats
 static double g_avgFrameTime = 0.0;
@@ -936,10 +936,12 @@ static void PumpMacOSEvents()
                     else if (ch == 'e') { g_input.keyE = true; }
                     else if (ch == 'q') { g_input.keyQ = true; }
                     else if (ch == ' ') { g_input.resetViewRequested = true; }
-                    else if (ch == '\t' && !isRepeat &&
+                    else if ([event keyCode] == 48 /* kVK_Tab */ && !isRepeat &&
                              ([event modifierFlags] & NSEventModifierFlagShift)) {
                         // SHIFT+TAB so bare TAB stays free for the workspace shell's
                         // focus-cycle binding (matches the Windows test apps).
+                        // NSEvent.characters returns 0x19 (NSBackTabCharacter) for
+                        // SHIFT+TAB, not '\t' — gate on the hardware keyCode.
                         g_input.hudVisible = !g_input.hudVisible;
                     }
                     else if (ch == 'v' && !isRepeat) {

--- a/test_apps/cube_handle_vk_macos/main.mm
+++ b/test_apps/cube_handle_vk_macos/main.mm
@@ -168,7 +168,7 @@ static uint32_t g_windowW = 0, g_windowH = 0;
 // path on macOS. Same constants as the other macOS test apps.
 static const uint32_t HUD_PIXEL_WIDTH = 380;
 static const uint32_t HUD_PIXEL_HEIGHT = 470;
-static const float HUD_WIDTH_FRACTION = 0.95f;
+static const float HUD_WIDTH_FRACTION = 0.20f;
 
 // Cached HUD section strings, refreshed at HUD throttle rate (~2 Hz).
 static std::wstring g_hudSessionText, g_hudModeText, g_hudPerfText;
@@ -1693,10 +1693,12 @@ static void PumpMacOSEvents() {
                     else if (ch == 'e') { g_input.keyE = true; }
                     else if (ch == 'q') { g_input.keyQ = true; }
                     else if (ch == ' ') { g_input.resetViewRequested = true; }
-                    else if (ch == '\t' && !isRepeat &&
+                    else if ([event keyCode] == 48 /* kVK_Tab */ && !isRepeat &&
                              ([event modifierFlags] & NSEventModifierFlagShift)) {
                         // SHIFT+TAB so bare TAB stays free for the workspace shell's
                         // focus-cycle binding (matches the Windows test apps).
+                        // NSEvent.characters returns 0x19 (NSBackTabCharacter) for
+                        // SHIFT+TAB, not '\t' — gate on the hardware keyCode.
                         g_input.hudVisible = !g_input.hudVisible;
                     }
                     else if (ch == 'v' && !isRepeat) {

--- a/test_apps/cube_texture_metal_macos/main.mm
+++ b/test_apps/cube_texture_metal_macos/main.mm
@@ -799,7 +799,7 @@ static const float CAMERA_HALF_TAN_VFOV = 0.32491969623f; // tan(18deg) -> 36deg
 // path on macOS. Same constants as the other macOS test apps.
 static const uint32_t HUD_PIXEL_WIDTH = 380;
 static const uint32_t HUD_PIXEL_HEIGHT = 470;
-static const float HUD_WIDTH_FRACTION = 0.95f;
+static const float HUD_WIDTH_FRACTION = 0.20f;
 
 // Performance stats
 static double g_avgFrameTime = 0.0;
@@ -1211,10 +1211,12 @@ static void PumpMacOSEvents()
                     else if (ch == 'e') { g_input.keyE = true; }
                     else if (ch == 'q') { g_input.keyQ = true; }
                     else if (ch == ' ') { g_input.resetViewRequested = true; }
-                    else if (ch == '\t' && !isRepeat &&
+                    else if ([event keyCode] == 48 /* kVK_Tab */ && !isRepeat &&
                              ([event modifierFlags] & NSEventModifierFlagShift)) {
                         // SHIFT+TAB so bare TAB stays free for the workspace shell's
                         // focus-cycle binding (matches the Windows test apps).
+                        // NSEvent.characters returns 0x19 (NSBackTabCharacter) for
+                        // SHIFT+TAB, not '\t' — gate on the hardware keyCode.
                         g_input.hudVisible = !g_input.hudVisible;
                     }
                     else if (ch == 'v' && !isRepeat) {


### PR DESCRIPTION
## Summary
Three bugs in the macOS HUD migration to `XR_EXT_window_space_layer`, plus one masked GL-compositor shader bug:

- **`hud_renderer_macos.mm`**: glyphs rendered upside-down — Core Text rasterized through the CTM Y-flip + identity text matrix. Fix: set text matrix to `Scale(1,-1)` before `CTFrameDraw`.
- **SHIFT+TAB never toggled HUD**: `NSEvent.characters` returns `0x19` (NSBackTabCharacter) for SHIFT+TAB on macOS, not `\t`. Fix: gate on `[event keyCode] == 48 /* kVK_Tab */` in all four macOS apps.
- **HUD too large**: `HUD_WIDTH_FRACTION 0.40` left `fracH ≈ 0.91` via the windowAR/hudAR formula. Drop to `0.20`.
- **`comp_gl` `VS_WINDOW_SPACE` shader Y-flip**: top-down HUD swapchain memory + bottom-of-NDC mapped to UV.y=0 inverted the layer. Wasn't visible before because the bitmap was already inverted (masking the second flip). Flip `v_uv.y` so top-of-NDC maps to UV.y=0.

## Tooling (kept)
- File-trigger atlas dump in `comp_metal` and `comp_gl`: `touch /tmp/dxr_atlas_trigger` → `/tmp/dxr_atlas.png` next frame. Mirrors the Windows D3D11-service screenshot trigger pattern.
- `CLAUDE.md` documents the in-app `stbi_write_png` trick + compositor file-trigger.

## Test plan
- [x] `cube_handle_metal_macos`: HUD reads upright, ~20% width, SHIFT+TAB toggles.
- [x] `cube_handle_gl_macos`: HUD upright after VS_WINDOW_SPACE fix.
- [ ] `cube_handle_vk_macos`: visual verify (VK NDC y-down + top-down memory should be naturally upright; no shader fix applied).
- [ ] `cube_texture_metal_macos`: visual verify.
- [x] `/tmp/dxr_atlas_trigger` produces composited atlas PNG on metal & GL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)