### PR TITLE
Transparency support: D3D11 + D3D12 + macOS (Metal/GL/Vulkan) + Win32 spec v5

### DIFF
--- a/docs/architecture/compositor-pipeline.md
+++ b/docs/architecture/compositor-pipeline.md
@@ -46,6 +46,28 @@ The DP weaver expects linear input. App swapchains can be either UNORM (linear b
 
 This keeps the shell vs non-shell pipelines distinct downstream — a load-bearing invariant; do not refactor the swapchain → atlas blit into a shared shader path. The non-shell atlas remains UNORM-typed; only the shell-mode atlas is TYPELESS-with-dual-SRV.
 
+## Per-tile alpha (workspace mode)
+
+The multi-compositor's tile-blit phase respects each IPC client's
+projection layer flags when compositing tiles into the combined atlas:
+
+- `XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT` clear → tile is
+  treated as opaque and overwrites the workspace background.
+- Bit set + `UNPREMULTIPLIED_ALPHA_BIT` clear → straight-alpha source,
+  blended with `blend_premul`.
+- Bit set + `UNPREMULTIPLIED_ALPHA_BIT` set → unpremultiplied source,
+  blended with `blend_alpha`.
+
+Capture clients (2D window snapshots) and clients that submitted no
+projection layer this frame fall through to opaque blending.
+
+The combined atlas itself is presented opaquely to the display
+processor — per-tile alpha lets one client tile reveal the workspace
+background through its transparent regions, but the workspace's
+output to the desktop is always opaque. See
+[`workspace-controller-registration.md`](../specs/workspace-controller-registration.md#workspace-output-is-opaque)
+for why.
+
 ## Display Processor Interface
 
 The `process_atlas()` method exists in 5 API-specific variants:

--- a/docs/roadmap/transparency-support-followup-2.md
+++ b/docs/roadmap/transparency-support-followup-2.md
@@ -1,0 +1,535 @@
+# Transparency Support — Follow-Up #2 Handoff (PRs #3b, #3c, #5, #6)
+
+**Predecessor:** PR #213 on `DisplayXR/displayxr-runtime` (`feature/transparency-support` → `main`).
+That PR shipped #1, #2, #3a, #4. This handoff picks up the remaining slice.
+
+**Branch model:** start a fresh `feature/transparency-support-2` branch off updated `main`.
+Don't continue on the old `feature/transparency-support` — it has been merged and deleted.
+
+## Prompt to give the next agent
+
+Copy-paste the block below into a fresh Claude Code session on the Windows + Leia SR
+machine. Self-contained — the agent does not see prior conversation context.
+
+```
+You are picking up the remaining slice of the transparency-support
+feature on displayxr-runtime. PRs #1, #2, #3a, #4 already shipped via
+PR #213 (merged to main). You are now picking up PRs #3b, #3c, #5, #6.
+
+START HERE:
+1. cd to the displayxr-runtime checkout.
+2. git fetch && git checkout main && git pull
+3. git checkout -b feature/transparency-support-2
+4. Read docs/roadmap/transparency-support-followup-2.md end-to-end.
+   That doc is the source of truth.
+5. Skim docs/specs/XR_EXT_win32_window_binding.md and the
+   "Transparent-window contract" section — the WS_EX_NOREDIRECTIONBITMAP
+   requirement applies to every test-app patch you'll write.
+6. Read CLAUDE.md for build/run conventions.
+
+WHAT YOU ARE DOING:
+Four PRs, in suggested order. PRs #5 and #6 require GitHub CLI access
+to the unity repos.
+
+  PR #3b — Leia OpenGL chroma-key (STUB ONLY, agreed scope).
+           Wire is_alpha_native=false + set_chroma_key (stores) into
+           the Leia GL DP. The actual fill/strip is a TODO with a
+           one-time U_LOG_W. Document GL transparency as "not yet
+           supported" in XR_EXT_win32_window_binding.md. Smallest PR.
+
+  PR #3c — Leia Vulkan chroma-key (FULL IMPLEMENTATION).
+           ~600 LOC. Mirror PR #3a's structure. SPIR-V shaders
+           offline-built with glslangValidator, embedded as .spv.h
+           headers. Configure DXGI / VK_KHR_swapchain compositeAlpha
+           = VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR. See
+           docs/roadmap/transparency-support-followup-2.md §3c for
+           the design.
+
+  PR #5  — displayxr-unity plugin v1.3.0.
+           Repo: /path/to/unity-3d-display (sibling of this
+           checkout). Drop default chromaKeyColor=0 instead of gray;
+           set BLEND_TEXTURE_SOURCE_ALPHA_BIT on submitted projection
+           layer; bump version; tag v1.3.0.
+
+  PR #6  — displayxr-unity-test-transparent v1.3.0.
+           Repo: /path/to/displayxr-unity-test-transparent. Switch
+           camera clear to RGBA(0,0,0,0); drop chroma-key knob; pin
+           plugin to v1.3.0; document antialiased-edge limitation;
+           build standalone Windows player; test on Leia hardware;
+           tag.
+
+KEY INVARIANTS (non-negotiable):
+- The DP owns the chroma-key trick. Compositor stays vendor-agnostic.
+- Workspace OUTPUT stays opaque — only per-tile alpha is respected.
+- Apps that pass non-zero chromaKeyColor (legacy v1.2.9 Unity flow)
+  must keep working unchanged.
+- Transparent-window apps must create their HWND with
+  WS_EX_NOREDIRECTIONBITMAP + null background brush. Not optional.
+  Documented in docs/specs/XR_EXT_win32_window_binding.md.
+- Antialiased edges become hard mask on Leia hardware regardless of
+  graphics API — fundamental lenticular-weaver limitation.
+- Always copy rebuilt _package/bin/DisplayXRClient.dll AND
+  displayxr-service.exe to "C:\Program Files\DisplayXR\Runtime\"
+  after build, otherwise apps load the registry-resolved stale DLL.
+
+WHEN YOU'RE DONE:
+Report back per-PR commit hashes and what tested green.
+End-to-end demo result: cube_handle_vk_win patched + Unity test app
+both running with transparent backgrounds against the desktop.
+```
+
+## Architecture recap (what shipped in PR #213)
+
+```
+App (any graphics API)
+        |
+   OpenXR State Tracker
+   - parses XR_EXT_win32_window_binding.transparentBackgroundEnabled (v4)
+   - parses XR_EXT_win32_window_binding.chromaKeyColor (v5)
+   - parses XR_EXT_cocoa_window_binding.transparentBackgroundEnabled (v5)
+        |
+   Native compositor
+   - configures swap chain alpha mode for transparency (DXGI_ALPHA_MODE_PREMULTIPLIED
+     on D3D11/D3D12, VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR on Vulkan,
+     CAMetalLayer.isOpaque=NO on Metal)
+   - for D3D12: uses CreateSwapChainForComposition + IDCompositionTarget for DComp
+   - calls xrt_display_processor_*_set_chroma_key(dp, color, transparent_bg)
+        |
+   Display Processor (vendor-specific)
+   - Leia D3D11, D3D12: is_alpha_native=false; chroma-key fill+strip
+                        wraps the SR weaver (PR #1 + #3a, shipped)
+   - Leia GL, Vulkan:   is_alpha_native=false; PR #3b (stub) + #3c (full) ← this slice
+   - sim_display all 5: is_alpha_native=true; set_chroma_key=no-op (PR #4, shipped)
+        |
+   Display
+```
+
+## PR #3b — Leia OpenGL chroma-key STUB
+
+### Scope agreed
+
+**Stub only.** Wire the vtable methods so the GL DP has the same surface as D3D11/D3D12,
+but the fill and strip are TODOs. Document GL transparency as "not yet supported" in
+`docs/specs/XR_EXT_win32_window_binding.md`.
+
+Why stub: WGL doesn't expose `DXGI_ALPHA_MODE_PREMULTIPLIED` directly. Three
+options were considered (`docs/roadmap/transparency-support-followup.md` §3b):
+A. WGL_NV_DX_interop2 (expensive); B. layered window with CPU readback (slow);
+C. defer. Option C is the agreed path for this PR — most apps that want
+transparency are D3D11/D3D12 anyway.
+
+### Files
+
+```
+src/xrt/drivers/leia/leia_display_processor_gl.cpp   (~50 LOC: vtable wire + stubs)
+src/xrt/compositor/gl/comp_gl_compositor.c           (~5 LOC: set_chroma_key call after factory)
+docs/specs/XR_EXT_win32_window_binding.md            (note GL transparency unsupported)
+```
+
+### Implementation
+
+In `leia_display_processor_gl.cpp`:
+
+```cpp
+static bool
+leia_dp_gl_is_alpha_native(struct xrt_display_processor_gl *xdp)
+{
+    (void)xdp;
+    return false; // SR GL weaver destroys alpha, same as D3D11/D3D12.
+}
+
+static void
+leia_dp_gl_set_chroma_key(struct xrt_display_processor_gl *xdp,
+                          uint32_t key_color,
+                          bool transparent_bg_enabled)
+{
+    struct leia_display_processor_gl_impl *ldp = leia_dp_gl(xdp);
+    ldp->ck_enabled = transparent_bg_enabled;
+    ldp->ck_color = (key_color != 0) ? key_color : 0x00FF00FF;
+
+    static bool warned_once = false;
+    if (transparent_bg_enabled && !warned_once) {
+        U_LOG_W("Leia GL DP: transparent_background requested but GL chroma-key "
+                "fill+strip not yet implemented; output will not be transparent");
+        warned_once = true;
+    }
+}
+```
+
+Wire in factory's vtable assignment block (mirror D3D11/D3D12).
+
+In `comp_gl_compositor.c` after the DP factory succeeds (around line 2308):
+
+```c
+xrt_display_processor_gl_set_chroma_key(c->display_processor,
+                                         chroma_key_color, transparent_background);
+```
+
+You'll need to plumb `chroma_key_color` and `transparent_background` through the
+compositor constructor — search how `comp_d3d12_compositor.cpp` does it for the
+exact pattern.
+
+### Test plan
+
+1. `scripts\build_windows.bat all` — clean build.
+2. Run `cube_handle_gl_win` with stock flags — same as baseline (no regression).
+3. Patch `cube_handle_gl_win` like cube_handle_d3d12_win (transparent_background
+   + RGBA(0,0,0,0) clear + BLEND_TEXTURE_SOURCE_ALPHA_BIT + WS_EX_NOREDIRECTIONBITMAP).
+4. Run — cube renders normally (NOT transparent), and the log contains the
+   one-time `Leia GL DP: ... not yet implemented` warning.
+
+### Estimated size
+
+~50 LOC. Single commit.
+
+## PR #3c — Leia Vulkan chroma-key FULL
+
+### Scope
+
+Full implementation. Mirror PR #3a's D3D12 structure exactly:
+- `is_alpha_native` returns false
+- `set_chroma_key` stores enabled + color (default magenta on key=0)
+- Pre-weave fill: VkPipeline + VkImage (color attachment + sampled), VkRenderPass,
+  shaders compiled offline to .spv.h headers
+- Post-weave strip: same pattern as fill but reads back-buffer
+- Wire from `comp_vk_native_compositor.c` after the DP factory succeeds
+- Configure `compositeAlpha = VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR` in
+  `vkCreateSwapchainKHR` (currently hardcoded to `VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR`)
+
+### Files
+
+```
+src/xrt/drivers/leia/leia_display_processor.cpp                   (~600 LOC: ck state + helpers + vtable)
+src/xrt/drivers/leia/leia_chroma_key_fill.frag.glsl               (NEW)
+src/xrt/drivers/leia/leia_chroma_key_strip.frag.glsl              (NEW)
+src/xrt/drivers/leia/leia_chroma_key_fullscreen.vert.glsl         (NEW)
+src/xrt/drivers/leia/leia_chroma_key_shaders.h                    (NEW: .spv.h embed)
+src/xrt/drivers/leia/CMakeLists.txt                               (compile_shaders rule)
+src/xrt/compositor/vk_native/comp_vk_native_compositor.c          (~10 LOC: set_chroma_key call)
+src/xrt/compositor/vk_native/comp_vk_native_target.c              (~30 LOC: query + select PRE_MULTIPLIED compositeAlpha)
+```
+
+### SPIR-V build pipeline
+
+The codebase doesn't have an existing SPIR-V build pipeline. Add one:
+
+```cmake
+# src/xrt/drivers/leia/CMakeLists.txt
+find_program(GLSLANG_VALIDATOR glslangValidator)
+if(NOT GLSLANG_VALIDATOR)
+    message(FATAL_ERROR "glslangValidator not found (Vulkan SDK)")
+endif()
+
+function(compile_glsl_to_spv_header GLSL_FILE STAGE VAR_NAME OUT_HEADER)
+    add_custom_command(
+        OUTPUT ${OUT_HEADER}
+        COMMAND ${GLSLANG_VALIDATOR} -V -S ${STAGE}
+                --vn ${VAR_NAME}
+                -o ${OUT_HEADER}
+                ${CMAKE_CURRENT_SOURCE_DIR}/${GLSL_FILE}
+        DEPENDS ${GLSL_FILE}
+    )
+endfunction()
+
+compile_glsl_to_spv_header(leia_chroma_key_fullscreen.vert.glsl vert ck_vs_spv leia_chroma_key_vs.spv.h)
+compile_glsl_to_spv_header(leia_chroma_key_fill.frag.glsl       frag ck_fill_ps_spv leia_chroma_key_fill.spv.h)
+compile_glsl_to_spv_header(leia_chroma_key_strip.frag.glsl      frag ck_strip_ps_spv leia_chroma_key_strip.spv.h)
+```
+
+Outputs `unsigned int ck_vs_spv[] = { ... };` etc. — `#include` from
+`leia_display_processor.cpp` and pass to `vkCreateShaderModule`.
+
+### Shaders (translate from D3D12 HLSL)
+
+```glsl
+// leia_chroma_key_fullscreen.vert.glsl
+#version 450
+void main() {
+    vec2 uv = vec2((gl_VertexIndex << 1) & 2, gl_VertexIndex & 2);
+    gl_Position = vec4(uv * vec2(2,-2) + vec2(-1,1), 0, 1);
+}
+```
+
+```glsl
+// leia_chroma_key_fill.frag.glsl
+#version 450
+layout(set=0, binding=0) uniform sampler2D src;
+layout(push_constant) uniform PC { vec3 chroma_rgb; float pad; } pc;
+layout(location=0) out vec4 frag;
+void main() {
+    vec2 uv = vec2(gl_FragCoord.x / textureSize(src, 0).x,
+                   gl_FragCoord.y / textureSize(src, 0).y);
+    vec4 c = texture(src, uv);
+    frag = vec4(mix(pc.chroma_rgb, c.rgb, c.a), 1.0);
+}
+```
+
+```glsl
+// leia_chroma_key_strip.frag.glsl  — same algorithm as D3D11/D3D12
+#version 450
+layout(set=0, binding=0) uniform sampler2D src;
+layout(push_constant) uniform PC { vec3 chroma_rgb; float pad; } pc;
+layout(location=0) out vec4 frag;
+void main() {
+    vec2 uv = vec2(gl_FragCoord.x / textureSize(src, 0).x,
+                   gl_FragCoord.y / textureSize(src, 0).y);
+    vec3 c = texture(src, uv).rgb;
+    vec3 d = abs(c - pc.chroma_rgb);
+    bool match = max(max(d.r, d.g), d.b) < (1.0/512.0);
+    float a = match ? 0.0 : 1.0;
+    frag = vec4(c * a, a);
+}
+```
+
+### compositeAlpha selection
+
+In `comp_vk_native_target.c:180`, replace `VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR`
+with a runtime selection:
+
+```c
+VkSurfaceCapabilitiesKHR caps;
+vk->vkGetPhysicalDeviceSurfaceCapabilitiesKHR(vk->physical_device, target->surface, &caps);
+
+VkCompositeAlphaFlagBitsKHR composite_alpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
+if (transparent_background) {
+    if (caps.supportedCompositeAlpha & VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR) {
+        composite_alpha = VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR;
+    } else if (caps.supportedCompositeAlpha & VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR) {
+        composite_alpha = VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR;
+    } else {
+        U_LOG_W("VK transparent_background requested but no PRE_MULTIPLIED/INHERIT compositeAlpha — falling back to opaque");
+    }
+}
+ci.compositeAlpha = composite_alpha;
+```
+
+`transparent_background` plumbing: thread it through `comp_vk_native_compositor_create`
+the same way `chroma_key_color` already is on D3D12, then forward to
+`comp_vk_native_target_create`.
+
+### Test plan
+
+1. `scripts\build_windows.bat all` — must build (glslangValidator should be on PATH from Vulkan SDK).
+2. Backward compat: stock `cube_handle_vk_win` — identical to baseline.
+3. New flow: patch `cube_handle_vk_win` (same as cube_handle_d3d12_win patches) +
+   `WS_EX_NOREDIRECTIONBITMAP`. Expect: cube over desktop, magenta-tinted hard
+   edges, click-through.
+
+### Estimated size
+
+~600 LOC + 4 new files. Single commit (or split into "shaders + Vulkan plumbing"
+and "wire into compositor" if desired).
+
+## PR #5 — `displayxr-unity` plugin v1.3.0
+
+**Repo:** `/path/to/unity-3d-display` (sibling of the runtime checkout, NOT
+inside the runtime tree).
+
+### Changes
+
+In `native~/displayxr_hooks.cpp::win32_inject_window_binding`:
+
+1. Default `chromaKeyColor = 0` instead of the legacy gray default. The runtime
+   DP now picks magenta when key=0.
+2. Keep the user-overridable path: `state->transparent_chroma_key_color` flows
+   through unchanged.
+
+In the C# layer (`Runtime/DisplayXRTransparentOverlay.cs`):
+
+3. Add `XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT` on the projection
+   layer when `transparent_background_requested && !displayxr_is_shell_mode()`.
+   (The plugin currently injects this via the native hook chain — find where
+   it sets `XrCompositionLayerProjection.layerFlags` per-frame.)
+
+4. Bump version to `1.3.0` in:
+   - `package.json`
+   - `CHANGELOG.md`
+   - any `Runtime/AssemblyInfo.cs` (if present)
+   - README install snippets
+
+### Backward compat
+
+Apps pinned to `v1.2.9` keep working (they explicitly set chromaKeyColor; runtime
+honors the override). Apps that upgrade to `v1.3.0` without changing their code
+get the DP-picks default (magenta) and may see fringing on dark scenes — document
+in v1.3.0 release notes: "If you see magenta fringing, set a content-safe
+chromaKeyColor explicitly via [API]".
+
+### Build + tag
+
+Plugin's existing build: `cmd.exe //c "$(pwd -W)\\native~\\build-win.bat"` (per
+memory `reference_plugin_build_quirks.md` — needs absolute path because of the
+trailing `~` in `native~`). Copy DLL to BOTH `Test-D3D11/` and
+`DisplayXR-test/Build/`.
+
+Tag `v1.3.0` once the test app (PR #6) confirms green.
+
+### Estimated size
+
+~20 LOC + version bumps.
+
+## PR #6 — `displayxr-unity-test-transparent` v1.3.0
+
+**Repo:** `/path/to/displayxr-unity-test-transparent` (sibling).
+
+### Changes
+
+In `Assets/TransparentAutoSetup.cs`:
+
+1. Change camera `clearFlags` to `SolidColor` with `Color(0, 0, 0, 0)` — true
+   transparent black. The current `m_Camera.backgroundColor = chromaKeyColor`
+   line goes away.
+2. Drop the `transparent_chroma_key_color` knob (or default to 0 = DP picks).
+
+In `Packages/manifest.json`:
+
+3. Bump dependency on `com.displayxr.unity` to `#upm/v1.3.0`.
+
+### README updates
+
+Add a "Limitations" section:
+
+> On Leia hardware, antialiased cube edges become hard-mask alpha (alpha=0 or
+> alpha=1 with no in-between). This is a fundamental limitation of the chroma-key
+> trick used by the SR weaver — fully transparent regions are punched through
+> cleanly, but partial-transparency pixels on antialiased edges either snap to
+> opaque (with possible fringing toward the magenta default key) or to fully
+> transparent. Apps that need soft alpha should choose a content-safe chroma key
+> via the plugin's override API to minimize fringing.
+
+### Test plan
+
+1. Open the project in Unity Editor on the Windows + Leia machine.
+2. Build standalone Windows player (`Unity.exe -batchmode -quit -nographics
+   -projectPath ... -executeMethod BuildScript.BuildWindows64 -logFile ...`
+   per memory `reference_unity_batchmode_build.md`).
+3. Launch over Notepad.
+4. Expected:
+   - Rotating cube renders over the desktop, transparent regions truly punched
+     through (alpha=0 → desktop visible).
+   - Cube interior opaque (alpha=1).
+   - Hard-mask edges with magenta fringing on light desktops; gray fringing if
+     the user opts into a gray override.
+   - Click-through still works.
+5. Compare to v1.2.9 baseline: edges should look DIFFERENT (no longer gray
+   fringing — now hard-mask). This is expected.
+
+### Tag
+
+`v1.3.0` of the test repo once green. Update README's "Tested with plugin v1.X.Y"
+line.
+
+### Estimated size
+
+~10 LOC + README + version bumps.
+
+## End-to-end demo (success criterion for the whole feature)
+
+After PRs #3b, #3c, #5, #6 land:
+
+1. **Standalone D3D11**: Unity test app v1.3.0 over Notepad → transparent cube,
+   hard-mask edges, click-through. Cleaner than v1.2.9 (app no longer needs to
+   know about chroma key).
+2. **Standalone D3D12**: `cube_handle_d3d12_win` patched (or any third-party
+   D3D12 app) → same.
+3. **Standalone Vulkan**: `cube_handle_vk_win` patched (this PR) → same.
+4. **Standalone GL**: stock cube renders normally; transparency NOT supported
+   (documented).
+5. **Workspace**: shell with two transparent client tiles → tiles composite
+   correctly against opaque workspace background.
+6. **macOS Metal** (already shipping): `cube_handle_metal_macos` with
+   `DISPLAYXR_TRANSPARENT_BG=1` → desktop visible through transparent regions
+   via NSWindow alpha (true alpha, no chroma key).
+
+## Lessons learned (read these before implementation)
+
+### 1. Test-app HWND must use `WS_EX_NOREDIRECTIONBITMAP` + null bg brush
+
+Already documented in `docs/specs/XR_EXT_win32_window_binding.md`. Without these
+two flags on the bound HWND, DComp's `alpha = 0` swap-chain pixels composite
+over the HWND's redirection surface (default-cleared opaque) instead of the
+desktop. Apps see opaque black where they expected transparency. The runtime
+cannot work around this — it has to be on the app side.
+
+The `cube_handle_*_win` test apps in this repo currently DO NOT set these flags.
+You'll need to patch them (or add a `DISPLAYXR_TRANSPARENT_BG=1` opt-in like the
+macOS test apps).
+
+### 2. Multi-comp races with client xrBeginFrame — use snapshots
+
+PR #2 found that reading `cc->layer_accum` directly from the multi-compositor
+races with the client's `xrBeginFrame` reset (~99% of multi-comp ticks see
+`layer_count == 0`). The fix is to snapshot per-client state under
+`ws_snapshot_mutex` in `compositor_layer_commit`, alongside the existing
+WS-layer HUD snapshot.
+
+If you add new per-tile state to the workspace blit in PR #3b/#3c (unlikely
+since GL/Vulkan don't go through the workspace today), use the same snapshot
+pattern.
+
+### 3. D3D12 has no command-list `Get*` — pass RTV handles in
+
+PR #3a found that the pre-weave fill rebound the RTV to `ck_fill_tex` and the
+weaver then ran with the wrong target. D3D11's `OMGetRenderTargets` saves and
+restores the RTV; D3D12 has no equivalent. Pass the back-buffer RTV in as a
+parameter and explicitly restore.
+
+This will apply to PR #3c (Vulkan) too: there's no implicit "save/restore RT
+binding". Track explicitly.
+
+### 4. Always copy rebuilt binaries to Program Files
+
+After every `scripts\build_windows.bat build`, copy
+`_package\bin\DisplayXRClient.dll` AND `_package\bin\displayxr-service.exe` to
+`C:\Program Files\DisplayXR\Runtime\`. Apps load the registry-resolved DLL from
+there, NOT the dev-manifest-pointed one — that warning shows up in the cube's
+log under elevated context. We lost an hour debugging stale DLL once.
+
+### 5. PrintWindow lies for DComp content; use BitBlt from desktop DC
+
+For autonomous validation of transparent windows, PrintWindow returns opaque
+black even with `PW_RENDERFULLCONTENT`. BitBlt from the desktop window DC
+captures the actual on-screen pixels. See memory entry
+`reference_dcomp_screenshot.md`.
+
+### 6. SR weaver's `setViewport` is phase-calc only
+
+Per memory `feedback_sr_sdk_d3d12_weave_viewport.md`: the SR D3D12 weaver's
+`setViewport`/`setScissorRect` APIs are used internally for phase calculation
+only — they don't call `RSSetViewports`/`RSSetScissorRects` on the cmd list.
+You MUST set both on the cmd list yourself before `weave()`. Same gotcha
+applies if you take similar shortcuts in the Vulkan path.
+
+## Files NOT to touch
+
+```
+src/xrt/include/xrt/xrt_display_processor*.h           (frozen by PR #1)
+src/xrt/drivers/leia/leia_display_processor_d3d11.cpp  (PR #1, shipped)
+src/xrt/drivers/leia/leia_display_processor_d3d12.cpp  (PR #3a, shipped)
+src/xrt/compositor/d3d11/comp_d3d11_compositor.cpp     (PR #1, shipped)
+src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp     (PR #3a, shipped)
+src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp (PR #2, shipped)
+src/xrt/compositor/metal/                              (PR #4, shipped)
+src/xrt/drivers/sim_display/                           (PR #4, shipped)
+src/external/openxr_includes/openxr/XR_EXT_*window_binding.h  (frozen at v5)
+docs/specs/XR_EXT_win32_window_binding.md              (frozen at SPEC v5)
+docs/specs/XR_EXT_cocoa_window_binding.md              (frozen at SPEC v5)
+```
+
+## Files this slice will touch
+
+```
+PR #3b: src/xrt/drivers/leia/leia_display_processor_gl.cpp
+        src/xrt/compositor/gl/comp_gl_compositor.c
+        docs/specs/XR_EXT_win32_window_binding.md  (just a note about GL TODO)
+
+PR #3c: src/xrt/drivers/leia/leia_display_processor.cpp        (Vulkan)
+        src/xrt/drivers/leia/leia_chroma_key_*.glsl            (NEW, 3 files)
+        src/xrt/drivers/leia/leia_chroma_key_*.spv.h           (NEW, generated, 3 files)
+        src/xrt/drivers/leia/CMakeLists.txt                    (compile_shaders rule)
+        src/xrt/compositor/vk_native/comp_vk_native_compositor.c
+        src/xrt/compositor/vk_native/comp_vk_native_target.c
+
+PR #5:  unity-3d-display repo (separate)
+PR #6:  displayxr-unity-test-transparent repo (separate)
+```

--- a/docs/roadmap/transparency-support-followup.md
+++ b/docs/roadmap/transparency-support-followup.md
@@ -1,0 +1,321 @@
+# Transparency Support — Follow-Up Handoff (PRs #2, #3, #5, #6)
+
+**Branch:** `feature/transparency-support` (continue here, do not branch off)
+**Predecessor:** `docs/roadmap/transparency-support-handoff.md` (PR #1, validated on Windows 2026-05-07)
+**Owner of this slice:** Windows + Leia SR machine
+**In parallel, on macOS:** PR #4 (NSWindow alpha + `XR_EXT_cocoa_window_binding`). Different files; low conflict risk.
+
+## Prompt to give the Windows agent
+
+Copy-paste the block below into a fresh Claude Code session on the Windows + Leia SR machine. Self-contained — the agent does not see prior conversation context.
+
+```
+You are continuing the transparency-support feature on
+displayxr-runtime. PR #1 (the foundation — DP vtable + Leia D3D11
+chroma-key internalization) was already done and validated on this
+machine. You are now picking up PRs #2, #3, #5, #6.
+
+START HERE:
+1. cd to the displayxr-runtime checkout.
+2. git fetch && git checkout feature/transparency-support && git pull
+   (the branch is shared with a macOS session working on PR #4 —
+   ALWAYS pull before pushing, NEVER force-push).
+3. Read docs/roadmap/transparency-support-followup.md end-to-end.
+   That doc lists per-PR scope, file targets, code patterns to follow,
+   and test plans. It is the source of truth for this slice.
+4. Skim docs/roadmap/transparency-support-handoff.md to refresh the
+   PR #1 context — the patterns you'll mirror in PR #3 are documented
+   there.
+5. Read CLAUDE.md for build/run conventions.
+
+WHAT YOU ARE DOING:
+Four PRs, in suggested order:
+
+  PR #2 — Workspace multi-compositor alpha-flag respect.
+          comp_d3d11_service.cpp:8315 unconditionally blend_alpha's
+          tiles. Read the per-client BLEND_TEXTURE_SOURCE_ALPHA_BIT
+          flag (already arrives via IPC) and pick the right blend
+          state. Document the workspace-output-opaque limitation.
+          Smallest PR; do this first.
+
+  PR #3 — Leia D3D12 / GL / Vulkan DP chroma-key internalization.
+          Three sub-pieces (a, b, c). Same pattern as PR #1's
+          ea591435c — move the existing chroma-key pass (where it
+          exists) into the Leia DP, add the pre-weave fill. Each
+          sub-piece is its own commit on the same branch.
+
+  PR #5 — displayxr-unity plugin v1.3.0 (SEPARATE repo:
+          /path/to/displayxr-unity, sibling of this checkout).
+          Drop default chromaKeyColor=0 instead of gray, set
+          BLEND_TEXTURE_SOURCE_ALPHA_BIT on submitted projection
+          layer. Bump version, build, tag.
+
+  PR #6 — displayxr-unity-test-transparent (SEPARATE repo, sibling).
+          Switch camera clear to RGBA(0,0,0,0), drop the chroma-key
+          knob, pin to plugin v1.3.0, document the antialiased-edge
+          limitation in README. Build, test on Leia hardware, tag.
+
+After each PR, run the test plan in this doc and report results.
+Commit per-PR (or per-sub-PR for #3). Push to the shared branch
+between PRs so the macOS session can rebase if needed.
+
+SCOPE BOUNDARIES — DO NOT TOUCH:
+- src/external/openxr_includes/openxr/XR_EXT_cocoa_window_binding.h
+  (PR #4, owned by macOS session)
+- src/xrt/compositor/metal/, src/xrt/compositor/gl/ macOS path,
+  src/xrt/compositor/vk_native/ macOS path (PR #4)
+- sim_display DP files in src/xrt/drivers/sim_display/ (PR #4 will
+  add is_alpha_native=true declarations there; you don't need to)
+- The XR_EXT_win32_window_binding.h header — DON'T add new fields.
+  The chromaKeyColor=0 means DP-picks contract is set; just consume.
+
+KEY INVARIANTS (same as PR #1, re-state for safety):
+- Apps that pass non-zero chromaKeyColor (v1.2.9 Unity flow) must
+  keep working unchanged across all 4 graphics APIs. App override
+  semantics are load-bearing.
+- The DP owns the chroma-key trick. Don't sneak it back into any
+  *compositor*.cpp. The compositor's job is to preserve alpha to
+  the atlas; the DP decides what to do with it.
+- Workspace OUTPUT stays opaque. Workspace clients can have
+  transparent tiles, but the workspace itself never punches through
+  to the desktop. Documented as a limitation.
+- Antialiased edges become hard mask on Leia hardware regardless of
+  graphics API — fundamental lenticular weaver limitation.
+
+WHEN YOU'RE DONE WITH ALL FOUR:
+Report back with:
+  - PR-by-PR commit hashes and what each tested green
+  - Any blockers or follow-ups worth filing as issues
+  - End-to-end demo result: cube_handle_d3d11_win + Unity test app
+    both running with transparent backgrounds against the desktop
+  - Workspace shell with two transparent client tiles (PR #2 demo)
+```
+
+## Branch coordination
+
+`feature/transparency-support` is shared between Windows (this slice) and macOS (PR #4). Conflict surface is small — different files mostly — but follow the discipline:
+
+- **`git pull --rebase` before every `git push`.** The macOS side might land PR #4 commits between your pushes.
+- **Do not force-push.** If a rebase fails, stop and resolve in-place.
+- **Push per-PR (or per-sub-PR for #3).** Don't bundle multiple PRs into one push — let the macOS side rebase incrementally.
+- **If you touch `src/xrt/state_trackers/oxr/oxr_session.c`** (none of these PRs should, but the Win32 binding parsing lives there), pull first. The macOS side may have just edited the cocoa binding parsing in the same file.
+
+If both sides hit the same file in the same session, prefer letting the macOS side land first (PR #4 is smaller and more contained).
+
+## PR #2 — Workspace multi-compositor alpha-flag respect
+
+### Why
+
+`comp_d3d11_service.cpp:8315` (in `multi_compositor_render`'s tile blit phase, lines 7706–8326) hardcodes `sys->blend_alpha` for every client tile, regardless of whether the client requested alpha-blending via `XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT`. The flag *does* arrive at the service compositor via IPC (it's part of `xrt_layer_data.flags` copied at `ipc_client_compositor.c:1390` and stored in `ipc_layer_entry`), but the service compositor never reads it.
+
+Effect today: workspace clients that submit RGBA textures get them blended against the workspace background even when they didn't ask for blending — and unpremultiplied/premultiplied distinctions are lost.
+
+### What to do
+
+In `src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp` around line 8315:
+
+1. Read the layer flag from the layer entry. The flag is on `xrt_layer_data.flags` — search for how `comp_d3d11_compositor.cpp` reads it (the `XRT_LAYER_COMPOSITION_BLEND_TEXTURE_SOURCE_ALPHA_BIT` constant is in `xrt_compositor.h`). The pattern in `comp_render_helpers.h:31–39` shows how to switch to the alpha-aware image view based on the flag.
+
+2. Switch the blend state per-tile:
+   - Flag unset → `sys->blend_opaque` (or use the no-alpha image view, which has the same effect — pick whichever matches the existing code's idiom).
+   - Flag set + premultiplied (`XR_COMPOSITION_LAYER_UNPREMULTIPLIED_ALPHA_BIT` clear) → `sys->blend_premul`.
+   - Flag set + unpremultiplied (`XR_COMPOSITION_LAYER_UNPREMULTIPLIED_ALPHA_BIT` set) → `sys->blend_alpha`.
+   The existing `set_blend_state()` function in this same file (around line 1912–1921) already implements this branching for the in-process path; reuse it or copy the pattern.
+
+3. Verify all three blend states already exist on `d3d11_service_system *sys`. If `sys->blend_opaque` doesn't exist, add it (look at how `sys->blend_alpha` is created — it's a one-liner `D3D11_BLEND_DESC` with `BlendEnable = FALSE`).
+
+### Documentation updates
+
+- `docs/specs/workspace-controller-registration.md` — add a section at the end:
+  > **Workspace output is opaque.** Workspace apps composite client tiles with per-pixel alpha against the workspace's own background. The workspace's final atlas to the DP is opaque; the workspace itself cannot present a transparent window to the desktop. Standalone apps that want a transparent output window must run outside workspace mode (using the in-process D3D11 compositor + transparent-background extension).
+
+- `docs/architecture/compositor-pipeline.md` — update the alpha lifecycle section to note that per-tile alpha is now respected at the workspace level, but the workspace's combined atlas is presented opaquely.
+
+### Test plan
+
+1. `scripts\build_windows.bat all` — build clean.
+2. Modify `cube_handle_d3d11_win` temporarily to set `XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT` and clear with RGBA(0,0,0,0).
+3. Run two instances under shell mode:
+   ```
+   _package\bin\displayxr-shell.exe test_apps\cube_handle_d3d11_win\build\cube_handle_d3d11_win.exe test_apps\cube_handle_d3d11_win\build\cube_handle_d3d11_win.exe
+   ```
+4. Expect: both cubes render against the workspace background with their tiles correctly alpha-blended (you should see the workspace background through transparent regions of each cube tile, but the workspace window itself stays opaque against the desktop).
+5. Sanity-regress with an opaque cube (don't set the flag): tile renders fully opaque against the workspace background. No regression vs PR #1 baseline.
+6. Optional: trigger `%TEMP%\workspace_screenshot_trigger` and inspect the combined SBS atlas — transparent tile regions should show the workspace background pixel, not garbage.
+
+### Estimated size
+
+Single commit, ~30 LOC delta on `comp_d3d11_service.cpp` plus two doc edits.
+
+## PR #3 — Leia D3D12 / GL / Vulkan DP chroma-key internalization
+
+Three sub-pieces. Each follows the **same pattern as PR #1** (commits `924153ef7` + `ea591435c`). Read those commits first to internalize the recipe; then each sub-PR is "do the same thing but for $API".
+
+The pattern, in case you've context-switched:
+
+1. Compositor side (`comp_<api>_compositor.cpp` if the API has an existing chroma-key pass): remove the inline pass, add `xrt_display_processor_<api>_set_chroma_key(c->display_processor, chroma_key_color, transparent_background)` after DP creation.
+2. Leia DP side (`leia_display_processor_<api>.cpp`): add `is_alpha_native` (returns false), `set_chroma_key` (stores; key=0 → kDefaultChromaKey 0x00FF00FF magenta), pre-weave fill helper, post-weave strip helper. Wire into `process_atlas`.
+3. Both shaders are already designed in `leia_display_processor_d3d11.cpp`:
+   - **Pre-fill**: `lerp(chroma_rgb, src.rgb, src.a)` → output alpha=1. Translates straightforwardly to HLSL/GLSL/SPIR-V.
+   - **Strip**: equality test on RGB → alpha=0 if match, else alpha=1, RGB premultiplied. Same pattern.
+
+### Sub-PR 3a — D3D12
+
+**Pre-existing chroma-key pass to move:** `src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp:55, 1445, 1802`. Already takes `chroma_key_color` and runs a post-weave pass. Move the body into `src/xrt/drivers/leia/leia_display_processor_d3d12.cpp`.
+
+**Add pre-weave fill** in the Leia D3D12 DP — D3D12 fill needs a `D3D12_BLEND_DESC` with no blending (overwrite) and an intermediate `ID3D12Resource` (RTV + SRV descriptor heap entries).
+
+**Wire** in `comp_d3d12_compositor.cpp` constructor (find where DP factory is called — pattern matches D3D11).
+
+**Output presentation**: D3D12 already configures `DXGI_ALPHA_MODE_PREMULTIPLIED` when `transparent_background` is on (verify by reading the swap-chain creation site in `comp_d3d12_compositor.cpp`). If not, add that — it's required for DWM punch-through.
+
+**Test:** `scripts\build_windows.bat all`, run `cube_handle_d3d12_win` patched to clear RGBA(0,0,0,0) + set the layer flag → expect transparent cube over desktop with magenta-tinted hard edges (DP-picks default).
+
+### Sub-PR 3b — Leia OpenGL
+
+**No pre-existing chroma-key pass** — this is greenfield. Look at the GL compositor and Leia GL DP:
+- `src/xrt/compositor/gl/comp_gl_compositor.c` (or .cpp) — find where DP is created and wire `xrt_display_processor_gl_set_chroma_key` after.
+- `src/xrt/drivers/leia/leia_display_processor_gl.cpp` — add chroma-key state, GL shader objects (`GL_FRAGMENT_SHADER` for fill + strip, reuse a fullscreen-triangle VS), FBO + texture for fill target, FBO + texture for strip source.
+
+**Output presentation on Windows GL**: WGL doesn't expose `DXGI_ALPHA_MODE_PREMULTIPLIED` directly. Two options:
+- A. Render to an off-screen FBO with alpha, then blit to a D3D-interop swap chain via `WGL_NV_DX_interop2` (expensive, complex).
+- B. Use a layered window (`WS_EX_LAYERED` + `UpdateLayeredWindow`) with the GL FBO read back to CPU. Slow.
+- C. Skip transparent-window support on GL for now; document as a limitation.
+
+**Pragmatic recommendation**: option C for this PR. Most apps that want transparency are D3D11 anyway. Document in `docs/specs/XR_EXT_win32_window_binding.md` that Leia GL transparency is not yet supported. Still implement `set_chroma_key` so the API surface is complete; leave the actual fill/strip TODO with a U_LOG_W warning.
+
+If you disagree and want to go deep on option A/B, do it as a separate sub-sub-PR — don't block the rest of the work.
+
+### Sub-PR 3c — Leia Vulkan
+
+**No pre-existing chroma-key pass** — also greenfield.
+- `src/xrt/compositor/vk_native/comp_vk_native_compositor.c` (or wherever the Windows Vulkan DP is wired) — wire `xrt_display_processor_set_chroma_key` (note: the Vulkan variant uses the unsuffixed name from `xrt_display_processor.h`).
+- `src/xrt/drivers/leia/leia_display_processor.cpp` (the Vulkan one) — add chroma-key state, SPIR-V shaders for fill + strip, `VkPipeline`s, `VkRenderPass`es, intermediate `VkImage`s with `VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT`, descriptor sets.
+
+**Output presentation**: `VK_KHR_swapchain` exposes `compositeAlpha` at swap-chain creation. Configure `VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR` (or `VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR` if pre-multiplied isn't supported by the surface — query via `vkGetPhysicalDeviceSurfaceCapabilitiesKHR` and pick the best available). Wire from session-level `transparent_background_enabled`.
+
+**Vulkan SPIR-V**: easiest to build the SPIR-V offline with `glslangValidator` and embed as a header (existing pattern — search for `*.spv.h` or `compile_shaders.sh`). Keep shaders in a sibling file (`leia_chroma_key_fill.frag.glsl`, `leia_chroma_key_strip.frag.glsl`) so they're readable.
+
+**Test**: `scripts\build_windows.bat all`, run `cube_handle_vk_win` patched the same way. Expect the same transparent-with-magenta-fringe result as D3D12.
+
+### Per-sub-PR commit message template
+
+Same format as `ea591435c`. Mention: which file moved (or "greenfield"), what shaders compile to, output presentation alpha mode, backward-compat verification (legacy app-supplied key still works).
+
+### Estimated size
+
+- 3a (D3D12): ~400 LOC moved + ~200 LOC added (similar to D3D11).
+- 3b (GL): ~150 LOC stub + a U_LOG_W (or full ~500 LOC if you go deep).
+- 3c (Vulkan): ~600 LOC (Vulkan plumbing is verbose). Largest sub-PR.
+
+## PR #5 — displayxr-unity plugin v1.3.0
+
+**Repo:** `displayxr-unity` (sibling of this checkout, separate Git repo). Per memory, lives at `/path/to/displayxr-unity` and consolidates from old `dfattal/unity-3d-display`.
+
+### What to change
+
+In the plugin's `displayxr_hooks.cpp` (the file that injects `XrWin32WindowBindingCreateInfoEXT` into the session create chain — see PR #1's handoff doc Section 2 for context):
+
+1. Default `chromaKeyColor = 0` instead of the gray fallback. The runtime DP will pick its own default (magenta) when key=0.
+2. Keep the override path: if a Unity user explicitly sets a non-zero chroma key via the plugin's existing public API, forward it. This lets apps that want a content-safe key (e.g. gray to avoid magenta fringing on dark scenes) keep using one.
+3. **Add a hook to set `XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT`** on the submitted projection layer when transparent background is requested. Find where the plugin populates `XrCompositionLayerProjection` per-frame; OR the bit on `layerFlags` when `state->transparent_background_requested && !displayxr_is_shell_mode()`.
+4. Bump version to `1.3.0` in the plugin manifest, package.json, AssemblyInfo.cs, and any `Readme.md` install snippets.
+
+### Backward compat for downstream apps
+
+Apps that pinned to v1.2.9 keep working — they explicitly set `chromaKeyColor`, the runtime honors it, identical behavior. Apps that upgrade to v1.3.0 without changing their code will now use the DP-picks default (magenta) and may see fringing if their scene clears with a near-magenta color. Document in v1.3.0 release notes: "If you see magenta fringing, set a content-safe chromaKeyColor explicitly via [API]".
+
+### Build + tag
+
+Plugin's existing build flow — see its README. Tag `v1.3.0` once landed and tested with the test app (PR #6).
+
+### Estimated size
+
+Small — ~20 LOC across 2-3 files plus version bumps.
+
+## PR #6 — displayxr-unity-test-transparent updates
+
+**Repo:** `displayxr-unity-test-transparent` (sibling, separate). Per the PR #1 handoff doc, currently pinned to plugin v1.2.9 with gray chroma key.
+
+### What to change
+
+In `Assets/TransparentAutoSetup.cs`:
+
+1. Change camera `clearFlags` to `SolidColor` with `Color(0, 0, 0, 0)` — true transparent black. The `m_Camera.backgroundColor = chromaKeyColor` line goes away.
+2. Drop the `transparent_chroma_key_color` knob (or default it to 0 = DP-picks).
+3. Bump `Packages/manifest.json` dependency on `com.displayxr.unity` to `#upm/v1.3.0`.
+
+### README updates
+
+Add a "Limitations" section:
+> On Leia hardware, antialiased cube edges become hard-mask alpha (alpha=0 or alpha=1 with no in-between). This is a fundamental limitation of the chroma-key trick used by the SR weaver — fully transparent regions are punched through cleanly, but partial-transparency pixels on antialiased edges either snap to opaque (with possible fringing toward the magenta default key) or to fully transparent. Apps that need soft alpha should choose a content-safe chroma key via the plugin's override API to minimize fringing.
+
+### Test plan
+
+1. Open the project in Unity Editor on the Windows + Leia machine.
+2. Build standalone Windows player.
+3. Launch over a Notepad window.
+4. Expected behavior:
+   - Rotating cube renders over the desktop with transparent regions truly punched through (alpha=0 desktop visible).
+   - Cube interior is opaque (alpha=1).
+   - Edges have **hard masks** (no soft antialiasing) — magenta fringing may be visible against light desktops; gray fringing if the user opts into a gray override.
+   - Click-through still works (cyclopean raycasting from PR #1 unaffected).
+5. Compare to v1.2.9 baseline: edges should look **different** (no longer gray fringing — now hard-mask). This is expected and documented.
+
+### Tag
+
+`v1.3.0` of the test repo once green. Update the README's "Tested with plugin v1.X.Y" line.
+
+### Estimated size
+
+Smallest PR — ~10 LOC across 2-3 files plus README.
+
+## End-to-end demo (success criterion for the whole feature)
+
+After PRs #1–#6 land:
+
+1. **Standalone D3D11**: Unity test app v1.3.0 over Notepad → transparent cube, hard-mask edges, click-through. (No regression vs v1.2.9 baseline aesthetically; functionally cleaner because app no longer needs to know about chroma key.)
+2. **Standalone D3D12 / Vulkan**: `cube_handle_d3d12_win` / `cube_handle_vk_win` patched temporarily to set the alpha bit + RGBA(0,0,0,0) clear → same transparent result.
+3. **Workspace**: shell with two transparent client tiles → tiles composite correctly against opaque workspace background.
+4. **macOS Metal** (Mac validates separately): `cube_handle_metal_macos` with alpha=0 clear → desktop visible through transparent regions via NSWindow alpha (true alpha, no chroma key).
+
+If all four work, the feature ships. File any partial-success or skipped paths (e.g. GL transparency deferred per Sub-PR 3b) as follow-up issues.
+
+## Files touched in PR #1 (don't re-touch unless rebasing conflicts)
+
+```
+src/xrt/include/xrt/xrt_display_processor*.h          (5 headers)
+src/xrt/drivers/leia/leia_display_processor_d3d11.cpp
+src/xrt/compositor/d3d11/comp_d3d11_compositor.cpp
+docs/roadmap/transparency-support-handoff.md
+```
+
+## Files this slice will touch
+
+```
+PR #2:  src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+        docs/specs/workspace-controller-registration.md
+        docs/architecture/compositor-pipeline.md
+PR #3a: src/xrt/drivers/leia/leia_display_processor_d3d12.cpp
+        src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp
+PR #3b: src/xrt/drivers/leia/leia_display_processor_gl.cpp
+        src/xrt/compositor/gl/comp_gl_compositor.{c,cpp}
+PR #3c: src/xrt/drivers/leia/leia_display_processor.cpp  (Vulkan)
+        src/xrt/compositor/vk_native/comp_vk_native_compositor.c
+PR #5:  displayxr-unity (separate repo)
+PR #6:  displayxr-unity-test-transparent (separate repo)
+```
+
+## Files PR #4 (macOS, parallel) will touch — leave alone
+
+```
+src/external/openxr_includes/openxr/XR_EXT_cocoa_window_binding.h
+src/xrt/compositor/metal/*
+src/xrt/compositor/gl/*macos*
+src/xrt/compositor/vk_native/*macos*  (if any)
+src/xrt/drivers/sim_display/sim_display_processor*.{c,m,cpp}
+src/xrt/state_trackers/oxr/oxr_session.c   (cocoa binding parsing only)
+docs/specs/XR_EXT_cocoa_window_binding.md
+```
+
+If you find yourself needing to edit any of these for a Windows-side fix, stop and `git pull` first — the macOS session may have just landed a change.

--- a/docs/roadmap/transparency-support-handoff.md
+++ b/docs/roadmap/transparency-support-handoff.md
@@ -1,0 +1,152 @@
+# Transparency Support — Handoff for Windows Agent
+
+**Branch:** `feature/transparency-support` (off `main`)
+**Started:** 2026-05-07 on macOS by Claude / David
+**Plan:** `~/.claude/plans/ok-i-need-a-melodic-volcano.md` (kept locally; summarized below)
+
+## Why this branch exists
+
+Today, transparent OpenXR surfaces work only on D3D11 standalone, only via a Win32-specific extension, and only because the **app pre-fills its swapchain with a chroma key color** that the runtime strips post-weave (was at `comp_d3d11_compositor.cpp:1431–1614`). Goals of this work:
+
+1. Apps just say "my texture has alpha" — the chroma-key trick becomes a Leia-DP implementation detail invisible to apps.
+2. Workspace apps composite transparent client tiles trivially. Workspace's own output stays opaque (documented limitation).
+3. Cover all platforms / APIs (D3D11, D3D12, GL, Vulkan on Windows; Metal/GL/Vulkan on macOS via NSWindow).
+4. Update `displayxr-unity-test-transparent` to ride the new mechanism.
+
+API surface (final design):
+
+| Concern | Mechanism |
+|---|---|
+| "This layer's texture has per-pixel alpha" | Standard `XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT` (already plumbed end-to-end including IPC) |
+| "This output window should be transparent" | `XR_EXT_win32_window_binding.transparentBackgroundEnabled` (existing) + new `XR_EXT_cocoa_window_binding.transparentBackgroundEnabled` (PR #4) |
+| Optional chroma-key override | `XR_EXT_win32_window_binding.chromaKeyColor` — non-zero = app-supplied, **zero = DP picks** (new behavior) |
+
+## What's done on this branch (2 commits)
+
+### `924153ef7` — DP vtable additions
+
+- `is_alpha_native(xdp) -> bool` — DP declares whether it preserves alpha through to its output (sim_display) vs needs the chroma-key trick (Leia).
+- `set_chroma_key(xdp, key_color, transparent_bg_enabled)` — compositor informs DP of session-level transparency config. DP that needs chroma-key uses this to enable its internal pre-weave fill + post-weave strip.
+- Added to all 5 DP variants (Vulkan, D3D11, D3D12, GL, Metal) + matching inline helpers. Both methods are optional (NULL = false / no-op). Pure plumbing — **no behavior change**.
+
+### `ea591435c` — Leia D3D11 DP internalization (the meat of PR #1)
+
+Compositor side (`comp_d3d11_compositor.cpp`, `−245 LOC`):
+- Removed `ck_*` fields, forward decls, ~190 LOC of shader / pass code, `<d3dcompiler.h>` include.
+- Constructor signature unchanged.
+- After DP factory succeeds, calls `xrt_display_processor_d3d11_set_chroma_key(c->display_processor, chroma_key_color, transparent_background)` — forwards the constructor params it was already taking.
+
+Leia D3D11 DP side (`leia_display_processor_d3d11.cpp`, `+506 LOC`):
+- New chroma-key fields on impl struct: `ck_enabled`, `ck_color`, fill PS / strip PS / sampler / constants, fill RTV+SRV+tex, strip SRV+tex.
+- New methods: `leia_dp_d3d11_is_alpha_native` (returns `false`), `leia_dp_d3d11_set_chroma_key` (stores; `key=0` → `kDefaultChromaKey = 0x00FF00FF` magenta).
+- New static helpers: `ck_init_pipeline`, `ck_ensure_fill_target`, `ck_ensure_strip_source`, `ck_run_pre_weave_fill`, `ck_run_post_weave_strip`, `ck_release_resources`.
+- `process_atlas` now wraps the SR weaver with pre-fill (3D mode) and post-strip (2D + 3D) when `ck_should_run()`. **No behavior change when `ck_enabled == false`** (the common case).
+- Reuses existing `blit_vs` (fullscreen quad VS, 4 verts, TRIANGLESTRIP) for both fill and strip — no new VS.
+
+Pre-weave fill shader (new):
+```hlsl
+float3 rgb = lerp(chroma_rgb, c.rgb, c.a);
+return float4(rgb, 1.0);  // opaque RGB to weaver
+```
+Handles both flows correctly:
+- **Legacy** (alpha=1 atlas, app pre-filled with key RGB): `lerp(key, src.rgb, 1.0) == src.rgb` → no-op, identical to today.
+- **New** (alpha-bearing atlas, transparent regions = alpha=0): `lerp(key, ?, 0) == key` → fills with key color before weaving.
+
+Post-weave strip shader: equality test on RGB → alpha=0 for matches, premultiplied for DWM. **Moved verbatim** from the compositor; no algorithmic change.
+
+## What's been validated
+
+- macOS build (`./scripts/build_macos.sh`): all 15 dependent TUs rebuilt cleanly after touching the modified DP headers. sim_display drivers (which include `xrt_display_processor*.h`) compile.
+- `git diff --stat` checks reasonable: `+513 / −245` net.
+- No leftover references to removed symbols (`d11_chroma_key`, `c->ck_*`, `c->chroma_key_color`) outside the moved code.
+- Walkthrough of three call paths (`transparent_background=false`, legacy app-supplied key, new DP-picks): all reach the same observable behavior or strictly improved behavior.
+
+## What needs Windows validation
+
+This is the entire D3D11 standalone path. **None of it has been compiled or run on Windows.** clangd on macOS doesn't have D3D11 / Win32 headers so all type errors against `ID3D11Device` etc. are macOS-only noise; the Windows toolchain will resolve them.
+
+### Step 1: Build
+
+```bat
+scripts\build_windows.bat all
+```
+
+If the build fails, the most likely culprits are (in rough order of probability):
+
+1. **Missing `<d3dcompiler.h>` include in `leia_display_processor_d3d11.cpp`** — the existing file already has it (line 27) so this should be fine, but verify if compile errors cite `D3DCompile` undefined.
+2. **`OMGetRenderTargets` / `RSGetViewports` / `__uuidof` semantics** — these are widely supported on the standard MSVC toolchain. If they trip the build, check the `XRT_HAVE_LEIA_SR` gate is on (DP file might be skipped).
+3. **`comp_d3d11_target_get_back_buffer()` return type** — if it returns something other than what `static_cast<ID3D11Texture2D *>` accepts, the strip pass needs adjustment. The original code at the old call site already used the same cast, so this should match.
+
+### Step 2: Smoke-test backward compat (Unity v1.2.9 path)
+
+The Unity `displayxr-unity-test-transparent` repo today pins to plugin `v1.2.9` and submits `chromaKeyColor = 0x00817F80` (gray 128,127,129 in 0x00BBGGRR). It should keep working unchanged after this branch lands.
+
+```bat
+REM Run the existing test app — should look identical to before
+cd \path\to\displayxr-unity-test-transparent
+REM Build Unity scene to a Windows player; launch
+```
+
+Expected: rotating cube renders over Notepad with click-through, gray-to-transparent edges visible (same fringing as today). No regression.
+
+If the cube **doesn't render at all** or shows magenta instead of gray, the override path (non-zero `chromaKeyColor`) is broken. Check `set_chroma_key` is being called with the right args — add a `U_LOG_W` if needed.
+
+If the runtime **crashes** on first frame:
+- Most likely cause: `ck_init_pipeline` failing silently, then `ck_run_pre_weave_fill` / `ck_run_post_weave_strip` proceeding anyway. Both helpers gate on `ck_init_pipeline` returning true, but a partial-init state could deref NULL. Trace via U_LOG_E messages from the init helpers.
+- Alternative: the SRV passed to the weaver post-fill is wrong. Verify `weaver_srv` in `leia_dp_d3d11_process_atlas` is `ldp->ck_fill_srv` (not the original atlas) when `ck_should_run()`.
+
+### Step 3: Verify the new flow (manual)
+
+Before PR #5 / #6 (Unity plugin v1.3.0 + test app updates), you can test the new "DP-picks" code path by hand:
+
+1. Modify `cube_handle_d3d11_win` to:
+   - Pass `transparentBackgroundEnabled = XR_TRUE`, `chromaKeyColor = 0` via `XrWin32WindowBindingCreateInfoEXT`.
+   - Set `XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT` on the projection layer in `xrEndFrame`.
+   - Clear the swapchain to RGBA(0,0,0,0) instead of opaque background each frame.
+2. Run.
+
+Expected: cube renders over the desktop with **magenta-tinted hard edges** (because key=0 → DP picks magenta, antialiasing becomes hard-mask). This confirms the new flow lights up.
+
+If you see magenta **everywhere** or no cube: the per-tile pass isn't preserving alpha. Check `BLEND_TEXTURE_SOURCE_ALPHA_BIT` reaches `XRT_LAYER_COMPOSITION_BLEND_TEXTURE_SOURCE_ALPHA_BIT` in `oxr_session_frame_end.c:125-126`, and that the per-tile pass at `render_gfx.c:407` selects the alpha view.
+
+### Step 4: Capture the atlas (optional, for visual debugging)
+
+Use the screenshot trigger from `CLAUDE.md` to capture the post-DP composited atlas:
+
+```bash
+rm -f "/c/Users/SPARKS~1/AppData/Local/Temp/workspace_screenshot.png"
+touch "/c/Users/SPARKS~1/AppData/Local/Temp/workspace_screenshot_trigger"
+sleep 3
+# Open workspace_screenshot.png — alpha=0 regions should show as transparent.
+```
+
+## What's left after PR #1
+
+Tracked in tasks (see `TaskList`):
+
+- **PR #2** — Workspace multi-compositor alpha-flag respect. `comp_d3d11_service.cpp:8315` unconditionally `blend_alpha`s tiles; needs to read `XRT_LAYER_COMPOSITION_BLEND_TEXTURE_SOURCE_ALPHA_BIT` from the layer (already arrives via IPC at `ipc_client_compositor.c:1390`). Workspace OUTPUT stays opaque — document in `docs/specs/workspace-controller-registration.md` and `docs/architecture/compositor-pipeline.md`.
+- **PR #3** — Leia D3D12 / GL / Vulkan DP chroma-key. Same pattern as the D3D11 internalization but for the other 3 Leia DPs. D3D12 already has a chroma-key pass at `comp_d3d12_compositor.cpp:1445/1802` to move; GL + Vulkan need new implementations.
+- **PR #4** — macOS NSWindow alpha. New `transparentBackgroundEnabled` field on `XR_EXT_cocoa_window_binding` (no chromaKeyColor — Cocoa does true alpha). Configure NSWindow `setOpaque:NO` + clear background + `CAMetalLayer.isOpaque = NO`. sim_display passes alpha through naturally; just declare `is_alpha_native = true` on the 5 sim_display DPs.
+- **PR #5** — `displayxr-unity` plugin v1.3.0. Drop `chromaKeyColor`, set `BLEND_TEXTURE_SOURCE_ALPHA_BIT` on submitted layer.
+- **PR #6** — `displayxr-unity-test-transparent`. Switch camera clear to RGBA(0,0,0,0), bump plugin pin to v1.3.0.
+
+PR #1 (this branch) unblocks every other piece. PR #5 + #6 can land any time after PR #1.
+
+## Files touched (cheat sheet)
+
+```
+src/xrt/include/xrt/xrt_display_processor.h           +68
+src/xrt/include/xrt/xrt_display_processor_d3d11.h     +50
+src/xrt/include/xrt/xrt_display_processor_d3d12.h     +50
+src/xrt/include/xrt/xrt_display_processor_gl.h        +50
+src/xrt/include/xrt/xrt_display_processor_metal.h     +50
+src/xrt/drivers/leia/leia_display_processor_d3d11.cpp +506
+src/xrt/compositor/d3d11/comp_d3d11_compositor.cpp    -245 (chroma-key code moved)
+```
+
+## Key invariants to preserve when working on this branch
+
+- **Backward compat with v1.2.9 Unity plugin** — apps that pass non-zero `chromaKeyColor` must keep working unchanged. `set_chroma_key`'s "key != 0 means app override" semantics are load-bearing.
+- **DP owns the chroma-key trick** — the compositor must stay vendor-agnostic. Don't sneak chroma-key code back into `comp_d3d11_compositor.cpp` or `comp_d3d11_service.cpp`.
+- **Workspace output stays opaque** — workspace clients can have transparent tiles, but the workspace itself can't be transparent. Don't try to plumb chroma-key through the multi-compositor's final output.
+- **Antialiased edges become hard mask on Leia hardware** — this is a fundamental lenticular weaver limitation, not a bug. Don't chase soft edges; document the limit.

--- a/docs/roadmap/transparency-support-handoff.md
+++ b/docs/roadmap/transparency-support-handoff.md
@@ -4,6 +4,80 @@
 **Started:** 2026-05-07 on macOS by Claude / David
 **Plan:** `~/.claude/plans/ok-i-need-a-melodic-volcano.md` (kept locally; summarized below)
 
+## Prompt to give the Windows agent
+
+Copy-paste the block below into a fresh Claude Code session running on the Windows + Leia SR machine. The agent does not see prior conversation context; this prompt is self-contained and points it back at this file.
+
+```
+You are picking up PR #1 of a multi-PR transparency-support feature on
+displayxr-runtime. The work was done on macOS; you are validating it on
+Windows + a Leia SR display, since D3D11 + the SR weaver can only run
+there.
+
+START HERE:
+1. cd to the displayxr-runtime checkout.
+2. git fetch && git checkout feature/transparency-support
+3. Read docs/roadmap/transparency-support-handoff.md end-to-end. It
+   describes what changed, why, and what to verify. Do NOT skip it.
+4. Read CLAUDE.md for build/run conventions on this repo.
+
+WHAT YOU ARE DOING:
+PR #1 moved the D3D11 chroma-key fill+strip out of the standalone
+compositor and into the Leia D3D11 display processor, plus added a
+pre-weave fill pass so apps can submit true RGBA(0,0,0,0)-cleared
+swapchains instead of pre-filling with a magic color. Three commits
+on the branch — read them with `git log --oneline main..HEAD` to
+orient.
+
+YOUR JOB IS VALIDATION, NOT NEW IMPLEMENTATION:
+Run the four-step test plan in the "What needs Windows validation"
+section of the handoff doc:
+  Step 1 — `scripts\build_windows.bat all` (the build itself is the
+           first real test — macOS clangd can't see D3D11 headers).
+  Step 2 — Smoke-test backward compat with the existing
+           displayxr-unity-test-transparent (pinned to plugin v1.2.9,
+           gray chroma key 0x00817F80). It must behave identically
+           to before this branch — same rotating cube over Notepad,
+           same gray fringing, same click-through.
+  Step 3 — Manually verify the new "DP-picks magenta" flow by
+           patching cube_handle_d3d11_win as described. Magenta-tinted
+           hard edges around the cube confirm the pre-weave fill +
+           strip pipeline is live.
+  Step 4 — Optional: capture the post-DP atlas via the
+           workspace_screenshot_trigger described in CLAUDE.md to
+           visually inspect alpha=0 regions.
+
+The handoff doc lists the most likely failure modes and where to look
+for each. If you hit one, fix it (commit + push to the same branch),
+then re-run the affected step. Don't widen scope — PRs #2-#6 in the
+task list are out of scope for this validation pass.
+
+WHEN YOU'RE DONE:
+Report back with:
+  - Build result (clean / what fixes were needed)
+  - Step 2 result: backward compat preserved? Any visual diff vs main?
+  - Step 3 result: did the new flow light up? Magenta hard edges seen?
+  - Any blockers or follow-ups worth filing as issues.
+  - The git log of any commits you added.
+
+KEY INVARIANTS — don't violate these even if it would make a fix easier:
+  - Apps that pass non-zero chromaKeyColor (v1.2.9 Unity) MUST keep
+    working unchanged. set_chroma_key's "key != 0 means app override"
+    semantics are load-bearing.
+  - The DP owns the chroma-key trick. Don't sneak chroma-key code back
+    into comp_d3d11_compositor.cpp or comp_d3d11_service.cpp. The
+    compositor must stay vendor-agnostic.
+  - Workspace output stays opaque — that's PR #2's territory.
+  - Antialiased edges become hard mask on Leia hardware. This is a
+    fundamental lenticular weaver limitation, not a bug. Don't chase
+    soft edges.
+
+If you find this branch is fundamentally broken (e.g. DP doesn't get
+created, runtime won't start), STOP and report — don't try to "fix"
+by reverting commits. The architecture is intentional and the macOS
+build validates the cross-platform pieces.
+```
+
 ## Why this branch exists
 
 Today, transparent OpenXR surfaces work only on D3D11 standalone, only via a Win32-specific extension, and only because the **app pre-fills its swapchain with a chroma key color** that the runtime strips post-weave (was at `comp_d3d11_compositor.cpp:1431–1614`). Goals of this work:

--- a/docs/specs/XR_EXT_cocoa_window_binding.md
+++ b/docs/specs/XR_EXT_cocoa_window_binding.md
@@ -3,7 +3,7 @@
 | Property | Value |
 |----------|-------|
 | Extension Name | `XR_EXT_cocoa_window_binding` |
-| Spec Version | 4 |
+| Spec Version | 5 |
 | Type Values | `XR_TYPE_COCOA_WINDOW_BINDING_CREATE_INFO_EXT` (1000999004), `XR_TYPE_COMPOSITION_LAYER_WINDOW_SPACE_EXT` (1000999002) |
 | Author | Leia Inc. |
 | Platform | macOS (Cocoa / AppKit). |
@@ -59,6 +59,7 @@ Chained to `XrSessionCreateInfo` (via the graphics binding's `next` pointer) to 
 | `readbackCallback` | `PFN_xrReadbackCallback` | Callback receiving composited RGBA pixels (offscreen mode), or `NULL`. |
 | `readbackUserdata` | `void*` | Opaque pointer passed to `readbackCallback`. |
 | `sharedIOSurface` | `void*` | `IOSurfaceRef` for zero-copy Metal texture sharing, or `NULL`. |
+| `transparentBackgroundEnabled` | `XrBool32` | When `XR_TRUE`, the runtime configures the (runtime-owned) `NSWindow` and the `CAMetalLayer` with `isOpaque=NO` so the desktop shows through alpha < 1 regions of the composited output. App-owned windows must set `setOpaque:NO` themselves; the runtime only configures the layer it presents into. *(Spec v5.)* |
 
 ```c
 typedef void (*PFN_xrReadbackCallback)(
@@ -71,8 +72,25 @@ typedef struct XrCocoaWindowBindingCreateInfoEXT {
     PFN_xrReadbackCallback   readbackCallback;
     void*                    readbackUserdata;
     void*                    sharedIOSurface;
+    XrBool32                 transparentBackgroundEnabled; // v5
 } XrCocoaWindowBindingCreateInfoEXT;
 ```
+
+### Transparent Background (v5)
+
+`transparentBackgroundEnabled = XR_TRUE` is the macOS analog of the Win32 binding's same-named field, but the implementation is much simpler:
+
+- **Mac is alpha-native.** sim_display preserves per-pixel alpha through its output stage to the `CAMetalLayer` drawable. There is no chroma-key trick (no need for the `chromaKeyColor` field on the Win32 binding).
+- App-supplied content with `alpha < 1` shows the desktop through. Antialiased edges look correct (true soft alpha — unlike Leia hardware on Windows which interlaces opaque RGB).
+- Per-layer `XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT` controls whether the per-tile pass blends or stamps; that's a separate per-frame decision.
+- For app-provided `viewHandle`, the app's `NSWindow` setup is the app's responsibility — the runtime only configures the `CAMetalLayer` it presents into. Apps embedding their own NSView should set `setOpaque:NO` and `setBackgroundColor:[NSColor clearColor]` on their NSWindow.
+
+| Layer of the system | Does what |
+|---|---|
+| App | Submits RGBA texture with alpha < 1 in transparent regions. Sets the per-layer alpha-blend bit on its projection layer. |
+| Runtime per-tile pass | Preserves alpha into the atlas (uses the alpha image view when the bit is set). |
+| sim_display DP | Passes alpha through to the Metal drawable (no fill, no strip). |
+| Cocoa | Composites the drawable against the desktop using the layer/window alpha settings. |
 
 **Three Modes:**
 

--- a/docs/specs/XR_EXT_win32_window_binding.md
+++ b/docs/specs/XR_EXT_win32_window_binding.md
@@ -123,22 +123,32 @@ The two concepts are inseparable: window-space layers only make sense when there
 
 ```c
 #define XR_EXT_win32_window_binding                          1
-#define XR_EXT_win32_window_binding_SPEC_VERSION             1
+#define XR_EXT_win32_window_binding_SPEC_VERSION             5
 #define XR_EXT_WIN32_WINDOW_BINDING_EXTENSION_NAME           "XR_EXT_win32_window_binding"
 #define XR_TYPE_WIN32_WINDOW_BINDING_CREATE_INFO_EXT         ((XrStructureType)1000999001)
 #define XR_TYPE_COMPOSITION_LAYER_WINDOW_SPACE_EXT     ((XrStructureType)1000999002)
 ```
 
+**Spec version history:**
+
+| Version | Added |
+|--------:|-------|
+| 1 | Initial: `windowHandle`, `readbackCallback`, `sharedTextureHandle`. |
+| 4 | `transparentBackgroundEnabled` — runtime configures DComp / DXGI for per-pixel desktop transparency. |
+| 5 | `chromaKeyColor` — optional app-supplied chroma-key override. `0` = runtime DP picks its own default. |
+
 ### 3.2 XrWin32WindowBindingCreateInfoEXT
 
 ```c
 typedef struct XrWin32WindowBindingCreateInfoEXT {
-    XrStructureType             type;                  // Must be XR_TYPE_WIN32_WINDOW_BINDING_CREATE_INFO_EXT
-    const void* XR_MAY_ALIAS    next;                  // Pointer to next structure in chain
-    void*                       windowHandle;          // HWND of the app's window, or NULL
-    PFN_xrReadbackCallback      readbackCallback;      // Offscreen readback callback, or NULL
-    void*                       readbackUserdata;      // Passed to readbackCallback
-    void*                       sharedTextureHandle;   // Shared D3D11/D3D12 texture HANDLE, or NULL
+    XrStructureType             type;                          // Must be XR_TYPE_WIN32_WINDOW_BINDING_CREATE_INFO_EXT
+    const void* XR_MAY_ALIAS    next;                          // Pointer to next structure in chain
+    void*                       windowHandle;                  // HWND of the app's window, or NULL
+    PFN_xrReadbackCallback      readbackCallback;              // Offscreen readback callback, or NULL
+    void*                       readbackUserdata;              // Passed to readbackCallback
+    void*                       sharedTextureHandle;           // Shared D3D11/D3D12 texture HANDLE, or NULL
+    XrBool32                    transparentBackgroundEnabled;  // SPEC v4: transparent desktop composition opt-in
+    uint32_t                    chromaKeyColor;                // SPEC v5: optional chroma-key override (0x00BBGGRR), 0 = DP picks
 } XrWin32WindowBindingCreateInfoEXT;
 ```
 
@@ -154,6 +164,8 @@ typedef struct XrWin32WindowBindingCreateInfoEXT {
 | `readbackCallback` | If non-NULL, the runtime delivers composited RGBA pixels via this callback each frame (CPU offscreen mode). |
 | `readbackUserdata` | Opaque pointer passed to `readbackCallback`. |
 | `sharedTextureHandle` | Shared D3D11/D3D12 texture `HANDLE` for zero-copy GPU texture sharing. If non-NULL, the runtime composites into this shared texture instead of rendering to a window. |
+| `transparentBackgroundEnabled` | (SPEC v4) When `XR_TRUE`, the runtime configures the bound HWND for per-pixel desktop transparency: app pixels written with `alpha = 1` appear opaque, `alpha = 0` regions composite through to the desktop. Per graphics API, the runtime picks the correct DXGI/DComp mechanism (apps shouldn't depend on which one). Only honored when `windowHandle` is non-NULL and the session is standalone (ignored in workspace/shell mode). **App-side HWND requirements** apply — see "Transparent-window contract" below. |
+| `chromaKeyColor` | (SPEC v5) Optional 0x00BBGGRR chroma-key override for the runtime's post-weave alpha-conversion pass. Only meaningful when `transparentBackgroundEnabled = XR_TRUE`. **`0` = the runtime's display processor picks its own default** (currently magenta `0x00FF00FF`). Non-zero overrides the default — useful for apps that need a content-safe key (e.g. v1.2.9 Unity plugin used gray to minimize fringing on dark scenes). The app should clear transparent regions of the swapchain to either `RGBA(0,0,0,0)` (preferred — DP fills with the key color internally) or `RGB = chromaKeyColor` with `alpha = 1` (legacy app-pre-fill flow, also supported). |
 
 **Three Modes:**
 
@@ -168,6 +180,32 @@ typedef struct XrWin32WindowBindingCreateInfoEXT {
 **Fallback when absent:**
 
 When this structure is not in the `next` chain, the runtime falls back to its default behavior: creating its own window (`_hosted` mode). Existing OpenXR applications work without modification.
+
+#### Transparent-window contract (`transparentBackgroundEnabled = XR_TRUE`)
+
+When the app opts into transparent backgrounds, **the bound HWND must be created without a DWM redirection surface**, otherwise the runtime's per-pixel alpha (delivered via `DXGI_ALPHA_MODE_PREMULTIPLIED` + `DirectComposition`) composites on top of the redirection surface (default-cleared opaque) instead of the desktop, and `alpha = 0` regions present as opaque black.
+
+The minimum app-side requirements are:
+
+```c
+// 1. NULL background brush — no GDI fill in the redirection surface.
+WNDCLASSEX wc = {};
+wc.hbrBackground = nullptr;
+RegisterClassEx(&wc);
+
+// 2. WS_EX_NOREDIRECTIONBITMAP — disables the redirection surface entirely.
+HWND hwnd = CreateWindowEx(
+    WS_EX_NOREDIRECTIONBITMAP,                     // ← required
+    wc.lpszClassName, title, WS_OVERLAPPEDWINDOW,
+    x, y, w, h,
+    parent, menu, hInstance, lparam);
+```
+
+Apps that already use a separate top-level overlay window for transparency (e.g. the displayxr-unity plugin's `displayxr_get_app_main_view`) just need to ensure that overlay HWND has `WS_EX_NOREDIRECTIONBITMAP` and a null background brush. Apps with a single-HWND design should add both flags to that HWND when transparent backgrounds are requested.
+
+**This is not optional.** The runtime cannot work around a redirection-surface-backed HWND because DWM compositing happens above the runtime's swapchain — the runtime's chroma-key strip writes correct alpha=0 pixels to the swapchain, but DWM blends them with the redirection surface before reaching the screen.
+
+The `_handle` and `_texture` modes both apply (any time `windowHandle` is non-NULL with transparency enabled). The `_offscreen` mode is unaffected — there's no HWND.
 
 ### 3.3 XrCompositionLayerWindowSpaceEXT
 

--- a/docs/specs/workspace-controller-registration.md
+++ b/docs/specs/workspace-controller-registration.md
@@ -246,6 +246,29 @@ a runtime-crash mystery.
   the future, a separate signature verification step would gate
   enumeration; for now, registration is open.
 
+## Workspace output is opaque
+
+Workspace apps composite client tiles with per-pixel alpha against the
+workspace's own background. Each client's projection layer flags
+(`XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT`,
+`XR_COMPOSITION_LAYER_UNPREMULTIPLIED_ALPHA_BIT`) are honored at the
+per-tile blit so transparent regions of one client tile reveal the
+workspace background, not the desktop.
+
+The workspace's **final atlas to the display processor is opaque** —
+the workspace itself cannot present a transparent window to the
+desktop. Standalone apps that want a transparent output window must
+run outside workspace mode (using the in-process D3D11 compositor
+with `XR_EXT_win32_window_binding::transparentBackgroundEnabled`).
+
+This is not a temporary limitation; it is a deliberate consequence of
+the multi-compositor pipeline. A transparent workspace output would
+require punching the chroma-key trick through the combined atlas, which
+would let any client paint an effective hole in the desktop — a
+trust-boundary regression. Per-tile alpha against an opaque workspace
+background covers the realistic use case (transparent window contents
+inside a workspace) without that risk.
+
 ## Future evolution
 
 If multiple workspace apps need to coexist (one user has the

--- a/scripts/build_windows.bat
+++ b/scripts/build_windows.bat
@@ -76,14 +76,29 @@ if %ERRORLEVEL% NEQ 0 (
 )
 
 :: --- Leia SR SDK ---
-if not exist "%LEIASR_SDKROOT%\lib" (
+:: Marker file (cmake config installed by the SDK zip) — checking the bare
+:: lib/ dir wasn't enough: the Vulkan-extras download below creates lib/
+:: even when the main zip extract failed, which then made this idempotency
+:: check skip a re-extract on the next run, leaving CMake to die on missing
+:: simulatedreality_DIR / srDirectX_DIR.
+set SR_SDK_MARKER=%LEIASR_SDKROOT%\lib\cmake\srDirectX\srDirectXConfig.cmake
+:: %REPO% ends in '\', so "%REPO%" passes "...\.." to gh/PS where the
+:: trailing \" is parsed as an escaped quote. Strip the trailing slash for
+:: the download destination args.
+set REPO_NOSLASH=%REPO:~0,-1%
+if not exist "%SR_SDK_MARKER%" (
     echo === Downloading Leia SR SDK %SR_TAG% ===
-    gh release download sr-sdk-v%SR_TAG% -R DisplayXR/displayxr-runtime -p "LeiaSR-SDK-%SR_TAG%-win64.zip" -D "%REPO%"
+    gh release download sr-sdk-v%SR_TAG% -R DisplayXR/displayxr-runtime -p "LeiaSR-SDK-%SR_TAG%-win64.zip" -D "%REPO_NOSLASH%"
     if %ERRORLEVEL% NEQ 0 (
         echo ERROR: Failed to download SR SDK. Run: gh auth login
         exit /b 1
     )
-    powershell -Command "Expand-Archive -Path '%REPO%LeiaSR-SDK-%SR_TAG%-win64.zip' -DestinationPath '%REPO%' -Force"
+    powershell -Command "Expand-Archive -Path '%REPO%LeiaSR-SDK-%SR_TAG%-win64.zip' -DestinationPath '%REPO_NOSLASH%' -Force"
+    if not exist "%SR_SDK_MARKER%" (
+        echo ERROR: SR SDK extract did not produce %SR_SDK_MARKER%
+        echo Check the Expand-Archive output above.
+        exit /b 1
+    )
     del "%REPO%LeiaSR-SDK-%SR_TAG%-win64.zip" 2>nul
 
     echo === Downloading Vulkan weaver extras ===

--- a/src/external/openxr_includes/openxr/XR_EXT_cocoa_window_binding.h
+++ b/src/external/openxr_includes/openxr/XR_EXT_cocoa_window_binding.h
@@ -35,7 +35,7 @@ extern "C" {
 #endif
 
 #define XR_EXT_cocoa_window_binding 1
-#define XR_EXT_cocoa_window_binding_SPEC_VERSION 4
+#define XR_EXT_cocoa_window_binding_SPEC_VERSION 5
 #define XR_EXT_COCOA_WINDOW_BINDING_EXTENSION_NAME "XR_EXT_cocoa_window_binding"
 
 // Use a value in the vendor extension range (1000000000+)
@@ -99,6 +99,15 @@ typedef struct XrCocoaWindowBindingCreateInfoEXT {
     PFN_xrReadbackCallback   readbackCallback;  //!< Called with composited RGBA pixels (offscreen mode)
     void*                    readbackUserdata;   //!< Passed to readbackCallback
     void*                    sharedIOSurface;   //!< IOSurfaceRef for zero-copy Metal texture sharing, or NULL
+    XrBool32                 transparentBackgroundEnabled; //!< When XR_TRUE, NSWindow + CAMetalLayer
+                                                           //!< are configured with isOpaque=NO so the
+                                                           //!< desktop shows through transparent
+                                                           //!< (alpha < 1) regions of the composited
+                                                           //!< output. Per-pixel alpha is preserved
+                                                           //!< end-to-end via sim_display's alpha-native
+                                                           //!< output stage; no chroma-key trick needed
+                                                           //!< on macOS. (Sibling of
+                                                           //!< XrWin32WindowBindingCreateInfoEXT.transparentBackgroundEnabled.)
 } XrCocoaWindowBindingCreateInfoEXT;
 
 // ---- Canvas Sub-Rect (Shared Texture Output Rect) ----

--- a/src/xrt/compositor/d3d11/comp_d3d11_compositor.cpp
+++ b/src/xrt/compositor/d3d11/comp_d3d11_compositor.cpp
@@ -56,7 +56,6 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <d3d11_4.h>
-#include <d3dcompiler.h>
 #include <dxgi1_6.h>
 
 #include <stdint.h>
@@ -79,11 +78,6 @@ struct comp_settings
 	//! Nominal frame interval in nanoseconds.
 	int64_t nominal_frame_interval_ns;
 };
-
-// Forward declarations for chroma-key post-weave alpha-conversion pass (defined further down)
-struct comp_d3d11_compositor;
-static void d11_chroma_key_pass_execute(struct comp_d3d11_compositor *c);
-static void d11_chroma_key_destroy(struct comp_d3d11_compositor *c);
 
 /*!
  * The D3D11 native compositor structure.
@@ -119,21 +113,6 @@ struct comp_d3d11_compositor
 
 	//! Window handle for rendering (either from app or self-created).
 	HWND hwnd;
-
-	//! Optional chroma-key color (0x00BBGGRR / Win32 COLORREF) for the post-weave
-	//! alpha-conversion shader pass. Zero disables the pass. Only meaningful when
-	//! the compositor was created with transparent_background = true.
-	uint32_t chroma_key_color;
-	//! Lazy-initialized resources for the chroma-key shader pass; allocated on
-	//! the first frame the pass runs.
-	ID3D11VertexShader     *ck_vs;
-	ID3D11PixelShader      *ck_ps;
-	ID3D11Texture2D        *ck_intermediate;
-	ID3D11ShaderResourceView *ck_intermediate_srv;
-	ID3D11Buffer           *ck_constants;
-	ID3D11SamplerState     *ck_sampler;
-	UINT                    ck_intermediate_w;
-	UINT                    ck_intermediate_h;
 
 	//! App's window handle for position tracking in shared-texture mode.
 	//! When non-NULL, the hidden weaver window is repositioned each frame
@@ -1396,8 +1375,10 @@ d3d11_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 	// HUD overlay (post-processing, always readable)
 	d3d11_render_hud_overlay(c, weaving_done, &eye_pos);
 
-	// Post-weave chroma-key alpha conversion (no-op when chroma_key_color == 0).
-	d11_chroma_key_pass_execute(c);
+	// Note: post-weave chroma-key alpha conversion now lives inside the
+	// Leia D3D11 display processor (set_chroma_key + ck_run_post_weave_strip
+	// in leia_display_processor_d3d11.cpp). The compositor is vendor-agnostic
+	// for transparency.
 
 	// Copy composited output into shared texture if active (dual output: window + shared)
 	if (c->has_shared_texture && c->shared_texture != nullptr) {
@@ -1449,212 +1430,6 @@ d3d11_compositor_layer_commit_with_semaphore(struct xrt_compositor *xc,
 {
 	// Use the same implementation as layer_commit
 	return d3d11_compositor_layer_commit(xc, XRT_GRAPHICS_SYNC_HANDLE_INVALID);
-}
-
-/*
- *
- * Chroma-key post-weave alpha-conversion pass (D3D11)
- *
- * Same purpose as the D3D12 pass: rewrite back-buffer alpha based on chroma-key
- * RGB match so DComp's per-pixel alpha presentation can punch transparent regions
- * through to the desktop. Inserted between HUD overlay and Present.
- *
- */
-
-static const char *kChromaKeyD11VS = R"(
-struct VSOut { float4 pos : SV_Position; float2 uv : TEXCOORD0; };
-VSOut main(uint vid : SV_VertexID) {
-    VSOut o;
-    o.uv = float2((vid << 1) & 2, vid & 2);
-    o.pos = float4(o.uv * float2(2, -2) + float2(-1, 1), 0, 1);
-    return o;
-}
-)";
-
-static const char *kChromaKeyD11PS = R"(
-struct VSOut { float4 pos : SV_Position; float2 uv : TEXCOORD0; };
-Texture2D<float4> src : register(t0);
-SamplerState samp : register(s0);
-cbuffer Constants : register(b0) { float3 chroma_rgb; float pad; };
-float4 main(VSOut i) : SV_Target {
-    float3 c = src.Sample(samp, i.uv).rgb;
-    float3 d = abs(c - chroma_rgb);
-    bool match = max(max(d.r, d.g), d.b) < (1.0/512.0);
-    // Swapchain is DXGI_ALPHA_MODE_PREMULTIPLIED — RGB must already be * alpha.
-    // For transparent (alpha=0) pixels RGB MUST be (0,0,0); otherwise DWM's
-    // src.rgb + (1-alpha)*dst.rgb blend adds the matched chroma color to the
-    // desktop and saturates to white instead of showing through.
-    float a = match ? 0.0 : 1.0;
-    return float4(c * a, a);
-}
-)";
-
-struct ChromaKeyConstants {
-	float chroma_rgb[3];
-	float pad;
-};
-
-static bool
-d11_chroma_key_init_pipeline(struct comp_d3d11_compositor *c)
-{
-	if (c->ck_vs != nullptr) return true;
-	HRESULT hr;
-	ID3DBlob *vs_blob = nullptr;
-	ID3DBlob *ps_blob = nullptr;
-	ID3DBlob *err_blob = nullptr;
-
-	hr = D3DCompile(kChromaKeyD11VS, strlen(kChromaKeyD11VS), nullptr, nullptr, nullptr,
-	                "main", "vs_5_0", 0, 0, &vs_blob, &err_blob);
-	if (FAILED(hr)) {
-		U_LOG_E("Chroma-key VS compile failed: 0x%08x %s", hr,
-		        err_blob ? (const char *)err_blob->GetBufferPointer() : "");
-		if (err_blob) err_blob->Release();
-		return false;
-	}
-	if (err_blob) { err_blob->Release(); err_blob = nullptr; }
-
-	hr = D3DCompile(kChromaKeyD11PS, strlen(kChromaKeyD11PS), nullptr, nullptr, nullptr,
-	                "main", "ps_5_0", 0, 0, &ps_blob, &err_blob);
-	if (FAILED(hr)) {
-		U_LOG_E("Chroma-key PS compile failed: 0x%08x %s", hr,
-		        err_blob ? (const char *)err_blob->GetBufferPointer() : "");
-		vs_blob->Release();
-		if (err_blob) err_blob->Release();
-		return false;
-	}
-	if (err_blob) err_blob->Release();
-
-	hr = c->device->CreateVertexShader(vs_blob->GetBufferPointer(), vs_blob->GetBufferSize(),
-	                                    nullptr, &c->ck_vs);
-	if (SUCCEEDED(hr)) {
-		hr = c->device->CreatePixelShader(ps_blob->GetBufferPointer(), ps_blob->GetBufferSize(),
-		                                   nullptr, &c->ck_ps);
-	}
-	vs_blob->Release();
-	ps_blob->Release();
-	if (FAILED(hr)) {
-		U_LOG_E("Chroma-key shader creation failed: 0x%08x", hr);
-		if (c->ck_vs) { c->ck_vs->Release(); c->ck_vs = nullptr; }
-		return false;
-	}
-
-	D3D11_BUFFER_DESC cb_desc = {};
-	cb_desc.ByteWidth = sizeof(ChromaKeyConstants);
-	cb_desc.Usage = D3D11_USAGE_DYNAMIC;
-	cb_desc.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
-	cb_desc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
-	hr = c->device->CreateBuffer(&cb_desc, nullptr, &c->ck_constants);
-	if (FAILED(hr)) {
-		U_LOG_E("Chroma-key constant buffer create failed: 0x%08x", hr);
-		return false;
-	}
-
-	D3D11_SAMPLER_DESC samp_desc = {};
-	samp_desc.Filter = D3D11_FILTER_MIN_MAG_MIP_POINT;
-	samp_desc.AddressU = D3D11_TEXTURE_ADDRESS_CLAMP;
-	samp_desc.AddressV = D3D11_TEXTURE_ADDRESS_CLAMP;
-	samp_desc.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
-	samp_desc.MaxLOD = D3D11_FLOAT32_MAX;
-	hr = c->device->CreateSamplerState(&samp_desc, &c->ck_sampler);
-	if (FAILED(hr)) {
-		U_LOG_E("Chroma-key sampler create failed: 0x%08x", hr);
-		return false;
-	}
-	U_LOG_W("Post-weave chroma-key conversion enabled: 0x%08X", c->chroma_key_color);
-	return true;
-}
-
-static bool
-d11_chroma_key_ensure_intermediate(struct comp_d3d11_compositor *c, UINT width, UINT height)
-{
-	if (c->ck_intermediate != nullptr &&
-	    c->ck_intermediate_w == width && c->ck_intermediate_h == height) {
-		return true;
-	}
-	if (c->ck_intermediate_srv) { c->ck_intermediate_srv->Release(); c->ck_intermediate_srv = nullptr; }
-	if (c->ck_intermediate)     { c->ck_intermediate->Release();     c->ck_intermediate = nullptr; }
-
-	D3D11_TEXTURE2D_DESC desc = {};
-	desc.Width = width;
-	desc.Height = height;
-	desc.MipLevels = 1;
-	desc.ArraySize = 1;
-	desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-	desc.SampleDesc.Count = 1;
-	desc.Usage = D3D11_USAGE_DEFAULT;
-	desc.BindFlags = D3D11_BIND_SHADER_RESOURCE;
-	HRESULT hr = c->device->CreateTexture2D(&desc, nullptr, &c->ck_intermediate);
-	if (FAILED(hr)) {
-		U_LOG_E("Chroma-key intermediate create failed: 0x%08x", hr);
-		return false;
-	}
-	hr = c->device->CreateShaderResourceView(c->ck_intermediate, nullptr, &c->ck_intermediate_srv);
-	if (FAILED(hr)) {
-		U_LOG_E("Chroma-key intermediate SRV create failed: 0x%08x", hr);
-		return false;
-	}
-	c->ck_intermediate_w = width;
-	c->ck_intermediate_h = height;
-	return true;
-}
-
-static void
-d11_chroma_key_pass_execute(struct comp_d3d11_compositor *c)
-{
-	if (c->chroma_key_color == 0) return;
-	if (!d11_chroma_key_init_pipeline(c)) return;
-
-	uint32_t target_w = 0, target_h = 0;
-	comp_d3d11_target_get_dimensions(c->target, &target_w, &target_h);
-	if (target_w == 0 || target_h == 0) return;
-	if (!d11_chroma_key_ensure_intermediate(c, target_w, target_h)) return;
-
-	ID3D11Texture2D *back_buffer = static_cast<ID3D11Texture2D *>(
-	    comp_d3d11_target_get_back_buffer(c->target));
-	if (back_buffer == nullptr) return;
-
-	// Copy current back buffer to intermediate (so we can sample it).
-	c->context->CopyResource(c->ck_intermediate, back_buffer);
-
-	// Update constant buffer with chroma RGB unpacked from 0x00BBGGRR.
-	D3D11_MAPPED_SUBRESOURCE mapped = {};
-	HRESULT hr = c->context->Map(c->ck_constants, 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped);
-	if (FAILED(hr)) return;
-	uint32_t k = c->chroma_key_color;
-	ChromaKeyConstants *cb = reinterpret_cast<ChromaKeyConstants *>(mapped.pData);
-	cb->chroma_rgb[0] = ((k >>  0) & 0xFF) / 255.0f;
-	cb->chroma_rgb[1] = ((k >>  8) & 0xFF) / 255.0f;
-	cb->chroma_rgb[2] = ((k >> 16) & 0xFF) / 255.0f;
-	cb->pad = 0.0f;
-	c->context->Unmap(c->ck_constants, 0);
-
-	// Re-bind the back-buffer RTV (target_bind handles viewport too).
-	comp_d3d11_target_bind(c->target);
-
-	// Set fullscreen-triangle pipeline state.
-	c->context->IASetInputLayout(nullptr);
-	c->context->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-	c->context->VSSetShader(c->ck_vs, nullptr, 0);
-	c->context->PSSetShader(c->ck_ps, nullptr, 0);
-	c->context->PSSetShaderResources(0, 1, &c->ck_intermediate_srv);
-	c->context->PSSetSamplers(0, 1, &c->ck_sampler);
-	c->context->PSSetConstantBuffers(0, 1, &c->ck_constants);
-	c->context->Draw(3, 0);
-
-	// Unbind the SRV so future passes that bind the same texture can use it.
-	ID3D11ShaderResourceView *null_srv = nullptr;
-	c->context->PSSetShaderResources(0, 1, &null_srv);
-}
-
-static void
-d11_chroma_key_destroy(struct comp_d3d11_compositor *c)
-{
-	if (c->ck_intermediate_srv) { c->ck_intermediate_srv->Release(); c->ck_intermediate_srv = nullptr; }
-	if (c->ck_intermediate)     { c->ck_intermediate->Release();     c->ck_intermediate = nullptr; }
-	if (c->ck_constants)        { c->ck_constants->Release();        c->ck_constants = nullptr; }
-	if (c->ck_sampler)          { c->ck_sampler->Release();          c->ck_sampler = nullptr; }
-	if (c->ck_ps)               { c->ck_ps->Release();               c->ck_ps = nullptr; }
-	if (c->ck_vs)               { c->ck_vs->Release();               c->ck_vs = nullptr; }
 }
 
 static void
@@ -1710,9 +1485,6 @@ d3d11_compositor_destroy(struct xrt_compositor *xc)
 	if (c->renderer != nullptr) {
 		comp_d3d11_renderer_destroy(&c->renderer);
 	}
-
-	// Release chroma-key pass resources before the target/swapchain.
-	d11_chroma_key_destroy(c);
 
 	if (c->target != nullptr) {
 		comp_d3d11_target_destroy(&c->target);
@@ -1777,17 +1549,6 @@ comp_d3d11_compositor_create(struct xrt_device *xdev,
 	c->canvas = {};
 	c->hardware_display_3d = true;
 	c->last_3d_mode_index = 1;
-
-	// Chroma-key pass state (lazy-allocated on first use)
-	c->chroma_key_color = chroma_key_color;
-	c->ck_vs = nullptr;
-	c->ck_ps = nullptr;
-	c->ck_intermediate = nullptr;
-	c->ck_intermediate_srv = nullptr;
-	c->ck_constants = nullptr;
-	c->ck_sampler = nullptr;
-	c->ck_intermediate_w = 0;
-	c->ck_intermediate_h = 0;
 
 	// Handle window: use provided HWND, create our own, or go offscreen (shared texture)
 	if (shared_texture_handle != nullptr) {
@@ -2011,6 +1772,11 @@ comp_d3d11_compositor_create(struct xrt_device *xdev,
 			c->display_processor = nullptr;
 		} else {
 			U_LOG_W("D3D11 display processor created via factory");
+			// Forward session-level transparency config. The DP runs the
+			// chroma-key fill+strip internally when transparent_background
+			// is set; chroma_key_color=0 means the DP picks its own key.
+			xrt_display_processor_d3d11_set_chroma_key(
+			    c->display_processor, chroma_key_color, transparent_background);
 		}
 	} else {
 		U_LOG_W("No D3D11 display processor factory provided");

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -777,6 +777,17 @@ struct d3d11_multi_client_slot
 	struct comp_layer ws_snapshot[XRT_MAX_LAYERS];
 	uint32_t ws_snapshot_count;
 
+	//! Projection-layer composition flags from the most recent client commit
+	//! (snapshot guarded by ws_snapshot_mutex, captured alongside ws_snapshot).
+	//! Multi-comp reads this when picking the per-tile blend mode — reading
+	//! cc->layer_accum directly races with the client's xrBeginFrame reset
+	//! and per-call adds (same root cause as the HUD-snapshot pattern above).
+	//! `projection_flags_valid == false` means no projection layer was seen
+	//! this frame; we keep the last-known flags rather than resetting so
+	//! the blend mode is stable across the begin→add gap.
+	enum xrt_layer_composition_flags projection_flags_snapshot;
+	bool projection_flags_valid;
+
 	//! Runtime-side cache of the WS layer's source texture, populated by
 	//! GPU `CopyResource` from the app's HUD swapchain whenever
 	//! multi_compositor_render successfully `AcquireSync`s the cross-process
@@ -1911,12 +1922,17 @@ get_color_scale_bias(const struct xrt_layer_data *data, float color_scale[4], fl
 static void
 set_blend_state(struct d3d11_service_system *sys, const struct xrt_layer_data *data)
 {
-	bool use_premul = (data->flags & XRT_LAYER_COMPOSITION_BLEND_TEXTURE_SOURCE_ALPHA_BIT) == 0;
-
-	if (use_premul) {
-		sys->context->OMSetBlendState(sys->blend_premul.get(), nullptr, 0xFFFFFFFF);
-	} else {
+	// OpenXR semantics:
+	//   BLEND_TEXTURE_SOURCE_ALPHA_BIT clear  -> layer is opaque, no blend.
+	//   BLEND_TEXTURE_SOURCE_ALPHA_BIT set + UNPREMULTIPLIED_ALPHA_BIT clear -> premultiplied.
+	//   BLEND_TEXTURE_SOURCE_ALPHA_BIT set + UNPREMULTIPLIED_ALPHA_BIT set   -> straight alpha.
+	const enum xrt_layer_composition_flags f = data->flags;
+	if ((f & XRT_LAYER_COMPOSITION_BLEND_TEXTURE_SOURCE_ALPHA_BIT) == 0) {
+		sys->context->OMSetBlendState(sys->blend_opaque.get(), nullptr, 0xFFFFFFFF);
+	} else if ((f & XRT_LAYER_COMPOSITION_UNPREMULTIPLIED_ALPHA_BIT) != 0) {
 		sys->context->OMSetBlendState(sys->blend_alpha.get(), nullptr, 0xFFFFFFFF);
+	} else {
+		sys->context->OMSetBlendState(sys->blend_premul.get(), nullptr, 0xFFFFFFFF);
 	}
 }
 
@@ -7713,6 +7729,15 @@ after_key_shortcuts:
 		uint32_t slot_w_atlas = 0, slot_h_atlas = 0; // atlas-derived per-tile stride
 		bool slot_is_mono = false;
 		bool slot_flip_y = false;
+		// Per-client projection-layer composition flags, used to drive the
+		// tile-blit blend mode. Sourced from the snapshot populated under
+		// ws_snapshot_mutex in compositor_layer_commit (reading layer_accum
+		// directly races with the client's xrBeginFrame reset, identical to
+		// the WS-layer flicker that the snapshot pattern was introduced for).
+		// `slot_flags_valid == false` means we never observed a projection
+		// layer for this slot — fall through to opaque blend.
+		enum xrt_layer_composition_flags slot_layer_flags = (enum xrt_layer_composition_flags)0;
+		bool slot_flags_valid = false;
 
 		if (mc->clients[s].client_type == CLIENT_TYPE_CAPTURE) {
 			// Capture client: get latest captured texture
@@ -7773,6 +7798,18 @@ after_key_shortcuts:
 			assert(cvh <= slot_h_atlas);
 			if (cvw > slot_w_atlas) cvw = slot_w_atlas;
 			if (cvh > slot_h_atlas) cvh = slot_h_atlas;
+
+			// Read projection-layer flags from the slot's snapshot —
+			// snapshot is populated under ws_snapshot_mutex by
+			// compositor_layer_commit when the client commits a frame.
+			{
+				struct d3d11_multi_client_slot *slot = &mc->clients[s];
+				std::lock_guard<std::mutex> snap_lock(slot->ws_snapshot_mutex);
+				if (slot->projection_flags_valid) {
+					slot_layer_flags = slot->projection_flags_snapshot;
+					slot_flags_valid = true;
+				}
+			}
 		}
 
 		// Combined atlas dimensions.
@@ -8312,7 +8349,22 @@ after_key_shortcuts:
 				sys->context->IASetInputLayout(nullptr);
 				sys->context->RSSetState(sys->rasterizer_state.get());
 				sys->context->OMSetDepthStencilState(sys->depth_test_enabled.get(), 0);
-				sys->context->OMSetBlendState(sys->blend_alpha.get(), nullptr, 0xFFFFFFFF);
+				// Per-client tile blend respects the OpenXR
+				// BLEND_TEXTURE_SOURCE_ALPHA_BIT / UNPREMULTIPLIED_ALPHA_BIT
+				// flags from the client's projection layer. Workspace OUTPUT
+				// stays opaque (the workspace's combined atlas to the DP is
+				// always opaque); per-tile alpha only affects how each
+				// client tile composes against the workspace background.
+				if (slot_flags_valid) {
+					struct xrt_layer_data fake_data = {};
+					fake_data.flags = slot_layer_flags;
+					set_blend_state(sys, &fake_data);
+				} else {
+					// Capture clients (2D window snapshots) and clients
+					// with no projection layer this frame -> opaque blend.
+					sys->context->OMSetBlendState(
+					    sys->blend_opaque.get(), nullptr, 0xFFFFFFFF);
+				}
 
 				sys->context->Draw(4, 0);
 
@@ -11099,13 +11151,22 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 			}
 			std::lock_guard<std::mutex> snap_lock(slot_snap->ws_snapshot_mutex);
 			uint32_t snap_n = 0;
+			bool saw_projection = false;
 			for (uint32_t i = 0;
 			     i < c->layer_accum.layer_count && snap_n < XRT_MAX_LAYERS;
 			     i++) {
-				if (c->layer_accum.layers[i].data.type != XRT_LAYER_WINDOW_SPACE) {
+				const struct comp_layer *l = &c->layer_accum.layers[i];
+				if ((l->data.type == XRT_LAYER_PROJECTION ||
+				     l->data.type == XRT_LAYER_PROJECTION_DEPTH) &&
+				    !saw_projection) {
+					slot_snap->projection_flags_snapshot = l->data.flags;
+					slot_snap->projection_flags_valid = true;
+					saw_projection = true;
+				}
+				if (l->data.type != XRT_LAYER_WINDOW_SPACE) {
 					continue;
 				}
-				slot_snap->ws_snapshot[snap_n] = c->layer_accum.layers[i];
+				slot_snap->ws_snapshot[snap_n] = *l;
 				snap_n++;
 			}
 			slot_snap->ws_snapshot_count = snap_n;

--- a/src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp
+++ b/src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp
@@ -49,22 +49,11 @@
 #include <windows.h>
 #include <d3d12.h>
 #include <dxgi1_6.h>
-#include <d3dcompiler.h>
-
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <mutex>
 #include <cmath>
-
-// Forward declarations for chroma-key post-weave alpha-conversion pass (defined further down)
-struct comp_d3d12_compositor;
-static bool chroma_key_pass_execute(struct comp_d3d12_compositor *c,
-                                     ID3D12GraphicsCommandList *cmd_list,
-                                     ID3D12Resource *back_buffer,
-                                     D3D12_CPU_DESCRIPTOR_HANDLE rtv_handle,
-                                     UINT width, UINT height);
-static void chroma_key_destroy(struct comp_d3d12_compositor *c);
 
 /*!
  * Minimal settings struct for D3D12 compositor.
@@ -127,20 +116,6 @@ struct comp_d3d12_compositor
 	//! Window handle (either from app or self-created).
 	//! NULL in shared texture mode — compositor doesn't own a swapchain.
 	HWND hwnd;
-
-	//! Optional chroma-key color (0x00BBGGRR / Win32 COLORREF) for the post-weave
-	//! alpha-conversion shader pass. Zero disables the pass. Only meaningful when
-	//! the compositor was created with transparent_background = true.
-	uint32_t chroma_key_color;
-	//! Lazy-initialized resources for the chroma-key shader pass; allocated on
-	//! the first frame the pass runs. See chroma_key_pass_*() below.
-	ID3D12RootSignature *ck_root_signature;
-	ID3D12PipelineState *ck_pipeline_state;
-	ID3D12Resource      *ck_intermediate;     //!< swap-chain-sized R8G8B8A8_UNORM, COPY_DEST/PIXEL_SHADER_RESOURCE
-	ID3D12DescriptorHeap *ck_srv_heap;        //!< Single SRV slot for ck_intermediate
-	UINT                 ck_intermediate_w;
-	UINT                 ck_intermediate_h;
-	D3D12_RESOURCE_STATES ck_intermediate_state;  //!< Current state of ck_intermediate
 
 	//! App HWND for position tracking in shared texture mode.
 	//! The display processor uses this for weaver alignment.
@@ -1651,21 +1626,13 @@ d3d12_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 			// HUD overlay
 			d3d12_render_hud_overlay(c, c->cmd_list, back_buffer, tgt_width, tgt_height, &eye_pos);
 
-			// Chroma-key post-weave pass (only when transparent + chroma_key_color != 0).
-			// Converts pixels matching the chroma key to alpha=0 so DComp passes
-			// them through to the desktop. Leaves back buffer in RENDER_TARGET on
-			// success; we transition to PRESENT below.
-			bool ck_ran = false;
-			if (c->chroma_key_color != 0) {
-				ck_ran = chroma_key_pass_execute(c, c->cmd_list, back_buffer,
-				                                  rtv_handle, tgt_width, tgt_height);
-			}
-
-			// Transition back buffer to PRESENT. Source state depends on whether the
-			// chroma-key pass ran (RENDER_TARGET) or not (COPY_DEST from HUD).
-			barrier.Transition.StateBefore = ck_ran
-			    ? D3D12_RESOURCE_STATE_RENDER_TARGET
-			    : D3D12_RESOURCE_STATE_COPY_DEST;
+			// Transition back buffer COPY_DEST -> PRESENT. The chroma-key
+			// post-weave alpha conversion (when needed) runs inside the Leia
+			// D3D12 display processor's process_atlas, which leaves the back
+			// buffer in RENDER_TARGET. The D3D12 weaver however leaves the
+			// back buffer in RENDER_TARGET pre-HUD; the HUD path puts it in
+			// COPY_DEST here. So source state matches the HUD's exit state.
+			barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_COPY_DEST;
 			barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_PRESENT;
 			c->cmd_list->ResourceBarrier(1, &barrier);
 		} else {
@@ -1782,317 +1749,6 @@ d3d12_compositor_layer_commit_with_semaphore(struct xrt_compositor *xc,
 	return d3d12_compositor_layer_commit(xc, XRT_GRAPHICS_SYNC_HANDLE_INVALID);
 }
 
-/*
- *
- * Chroma-key post-weave alpha-conversion pass (D3D12)
- *
- * The Leia weaver writes opaque RGB into the swapchain back buffer (alpha=1
- * everywhere). With DComp + per-pixel alpha presentation, that means DWM has
- * nothing to make transparent. This pass samples the post-weave back buffer
- * and rewrites it with alpha=0 wherever RGB exactly matches a chroma-key
- * color, alpha=1 otherwise.
- *
- * Inserted between the HUD overlay and the final PRESENT transition.
- *
- */
-
-static const char *kChromaKeyVS = R"(
-struct VSOut { float4 pos : SV_Position; float2 uv : TEXCOORD0; };
-VSOut main(uint vid : SV_VertexID) {
-    VSOut o;
-    o.uv = float2((vid << 1) & 2, vid & 2);
-    o.pos = float4(o.uv * float2(2, -2) + float2(-1, 1), 0, 1);
-    return o;
-}
-)";
-
-static const char *kChromaKeyPS = R"(
-struct VSOut { float4 pos : SV_Position; float2 uv : TEXCOORD0; };
-Texture2D<float4> src : register(t0);
-SamplerState samp : register(s0);
-cbuffer Constants : register(b0) { float3 chroma_rgb; float pad; };
-float4 main(VSOut i) : SV_Target {
-    float3 c = src.Sample(samp, i.uv).rgb;
-    float3 d = abs(c - chroma_rgb);
-    bool match = max(max(d.r, d.g), d.b) < (1.0/512.0);
-    // Swapchain is DXGI_ALPHA_MODE_PREMULTIPLIED — RGB must already be * alpha.
-    // For transparent (alpha=0) pixels RGB MUST be (0,0,0); otherwise DWM's
-    // src.rgb + (1-alpha)*dst.rgb blend adds the matched chroma color to the
-    // desktop and saturates to white instead of showing through.
-    float a = match ? 0.0 : 1.0;
-    return float4(c * a, a);
-}
-)";
-
-/*!
- * Lazy-initialize PSO + root signature for the chroma-key pass.
- * Called once per compositor (resources outlive frames).
- */
-static bool
-chroma_key_init_pipeline(struct comp_d3d12_compositor *c)
-{
-	if (c->ck_pipeline_state != nullptr) {
-		return true;
-	}
-
-	HRESULT hr;
-
-	// Root signature: 32-bit root constants (4 floats — 3 for chroma BGR + pad),
-	// descriptor table for SRV (1 entry), static sampler.
-	D3D12_ROOT_PARAMETER root_params[2] = {};
-	root_params[0].ParameterType = D3D12_ROOT_PARAMETER_TYPE_32BIT_CONSTANTS;
-	root_params[0].Constants.ShaderRegister = 0;
-	root_params[0].Constants.RegisterSpace = 0;
-	root_params[0].Constants.Num32BitValues = 4;
-	root_params[0].ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
-
-	D3D12_DESCRIPTOR_RANGE srv_range = {};
-	srv_range.RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
-	srv_range.NumDescriptors = 1;
-	srv_range.BaseShaderRegister = 0;
-	srv_range.RegisterSpace = 0;
-	srv_range.OffsetInDescriptorsFromTableStart = 0;
-	root_params[1].ParameterType = D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;
-	root_params[1].DescriptorTable.NumDescriptorRanges = 1;
-	root_params[1].DescriptorTable.pDescriptorRanges = &srv_range;
-	root_params[1].ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
-
-	D3D12_STATIC_SAMPLER_DESC sampler = {};
-	sampler.Filter = D3D12_FILTER_MIN_MAG_MIP_POINT;
-	sampler.AddressU = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
-	sampler.AddressV = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
-	sampler.AddressW = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
-	sampler.MaxLOD = D3D12_FLOAT32_MAX;
-	sampler.ShaderRegister = 0;
-	sampler.RegisterSpace = 0;
-	sampler.ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
-
-	D3D12_ROOT_SIGNATURE_DESC rs_desc = {};
-	rs_desc.NumParameters = 2;
-	rs_desc.pParameters = root_params;
-	rs_desc.NumStaticSamplers = 1;
-	rs_desc.pStaticSamplers = &sampler;
-	rs_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_DENY_VERTEX_SHADER_ROOT_ACCESS;
-
-	ID3DBlob *rs_blob = nullptr;
-	ID3DBlob *err_blob = nullptr;
-	hr = D3D12SerializeRootSignature(&rs_desc, D3D_ROOT_SIGNATURE_VERSION_1,
-	                                  &rs_blob, &err_blob);
-	if (FAILED(hr)) {
-		U_LOG_E("Chroma-key root sig serialize failed: 0x%08x %s", hr,
-		        err_blob ? (const char *)err_blob->GetBufferPointer() : "");
-		if (err_blob) err_blob->Release();
-		return false;
-	}
-	if (err_blob) err_blob->Release();
-
-	hr = c->device->CreateRootSignature(0, rs_blob->GetBufferPointer(), rs_blob->GetBufferSize(),
-	                                     __uuidof(ID3D12RootSignature),
-	                                     reinterpret_cast<void **>(&c->ck_root_signature));
-	rs_blob->Release();
-	if (FAILED(hr)) {
-		U_LOG_E("Chroma-key CreateRootSignature failed: 0x%08x", hr);
-		return false;
-	}
-
-	// Compile shaders
-	ID3DBlob *vs_blob = nullptr;
-	hr = D3DCompile(kChromaKeyVS, strlen(kChromaKeyVS), nullptr, nullptr, nullptr,
-	                "main", "vs_5_0", 0, 0, &vs_blob, &err_blob);
-	if (FAILED(hr)) {
-		U_LOG_E("Chroma-key VS compile failed: 0x%08x %s", hr,
-		        err_blob ? (const char *)err_blob->GetBufferPointer() : "");
-		if (err_blob) err_blob->Release();
-		return false;
-	}
-	if (err_blob) { err_blob->Release(); err_blob = nullptr; }
-
-	ID3DBlob *ps_blob = nullptr;
-	hr = D3DCompile(kChromaKeyPS, strlen(kChromaKeyPS), nullptr, nullptr, nullptr,
-	                "main", "ps_5_0", 0, 0, &ps_blob, &err_blob);
-	if (FAILED(hr)) {
-		U_LOG_E("Chroma-key PS compile failed: 0x%08x %s", hr,
-		        err_blob ? (const char *)err_blob->GetBufferPointer() : "");
-		vs_blob->Release();
-		if (err_blob) err_blob->Release();
-		return false;
-	}
-	if (err_blob) err_blob->Release();
-
-	// PSO
-	D3D12_GRAPHICS_PIPELINE_STATE_DESC pso_desc = {};
-	pso_desc.pRootSignature = c->ck_root_signature;
-	pso_desc.VS = {vs_blob->GetBufferPointer(), vs_blob->GetBufferSize()};
-	pso_desc.PS = {ps_blob->GetBufferPointer(), ps_blob->GetBufferSize()};
-	pso_desc.BlendState.RenderTarget[0].BlendEnable = FALSE;
-	pso_desc.BlendState.RenderTarget[0].LogicOpEnable = FALSE;
-	pso_desc.BlendState.RenderTarget[0].RenderTargetWriteMask = D3D12_COLOR_WRITE_ENABLE_ALL;
-	pso_desc.SampleMask = UINT_MAX;
-	pso_desc.RasterizerState.FillMode = D3D12_FILL_MODE_SOLID;
-	pso_desc.RasterizerState.CullMode = D3D12_CULL_MODE_NONE;
-	pso_desc.RasterizerState.FrontCounterClockwise = FALSE;
-	pso_desc.RasterizerState.DepthClipEnable = TRUE;
-	pso_desc.DepthStencilState.DepthEnable = FALSE;
-	pso_desc.DepthStencilState.StencilEnable = FALSE;
-	pso_desc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-	pso_desc.NumRenderTargets = 1;
-	pso_desc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
-	pso_desc.SampleDesc.Count = 1;
-
-	hr = c->device->CreateGraphicsPipelineState(&pso_desc, __uuidof(ID3D12PipelineState),
-	                                             reinterpret_cast<void **>(&c->ck_pipeline_state));
-	vs_blob->Release();
-	ps_blob->Release();
-	if (FAILED(hr)) {
-		U_LOG_E("Chroma-key CreateGraphicsPipelineState failed: 0x%08x", hr);
-		return false;
-	}
-
-	// Descriptor heap for the SRV (single shader-visible slot)
-	D3D12_DESCRIPTOR_HEAP_DESC heap_desc = {};
-	heap_desc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
-	heap_desc.NumDescriptors = 1;
-	heap_desc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
-	hr = c->device->CreateDescriptorHeap(&heap_desc, __uuidof(ID3D12DescriptorHeap),
-	                                      reinterpret_cast<void **>(&c->ck_srv_heap));
-	if (FAILED(hr)) {
-		U_LOG_E("Chroma-key CreateDescriptorHeap failed: 0x%08x", hr);
-		return false;
-	}
-
-	U_LOG_W("Post-weave chroma-key conversion enabled: 0x%08X", c->chroma_key_color);
-	return true;
-}
-
-/*!
- * Allocate (or reallocate on resize) the intermediate texture sized to the back buffer.
- */
-static bool
-chroma_key_ensure_intermediate(struct comp_d3d12_compositor *c, UINT width, UINT height)
-{
-	if (c->ck_intermediate != nullptr &&
-	    c->ck_intermediate_w == width && c->ck_intermediate_h == height) {
-		return true;
-	}
-	if (c->ck_intermediate != nullptr) {
-		c->ck_intermediate->Release();
-		c->ck_intermediate = nullptr;
-	}
-
-	D3D12_HEAP_PROPERTIES heap_props = {};
-	heap_props.Type = D3D12_HEAP_TYPE_DEFAULT;
-	D3D12_RESOURCE_DESC tex_desc = {};
-	tex_desc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
-	tex_desc.Width = width;
-	tex_desc.Height = height;
-	tex_desc.DepthOrArraySize = 1;
-	tex_desc.MipLevels = 1;
-	tex_desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-	tex_desc.SampleDesc.Count = 1;
-	tex_desc.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
-	tex_desc.Flags = D3D12_RESOURCE_FLAG_NONE;
-
-	HRESULT hr = c->device->CreateCommittedResource(
-	    &heap_props, D3D12_HEAP_FLAG_NONE, &tex_desc,
-	    D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
-	    nullptr, __uuidof(ID3D12Resource),
-	    reinterpret_cast<void **>(&c->ck_intermediate));
-	if (FAILED(hr)) {
-		U_LOG_E("Chroma-key intermediate texture create failed: 0x%08x", hr);
-		return false;
-	}
-	c->ck_intermediate_w = width;
-	c->ck_intermediate_h = height;
-	c->ck_intermediate_state = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
-
-	// Create SRV at slot 0 of the descriptor heap.
-	D3D12_SHADER_RESOURCE_VIEW_DESC srv_desc = {};
-	srv_desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-	srv_desc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
-	srv_desc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-	srv_desc.Texture2D.MipLevels = 1;
-	D3D12_CPU_DESCRIPTOR_HANDLE cpu_handle = c->ck_srv_heap->GetCPUDescriptorHandleForHeapStart();
-	c->device->CreateShaderResourceView(c->ck_intermediate, &srv_desc, cpu_handle);
-	return true;
-}
-
-/*!
- * Run the post-weave chroma-key pass. Called when the back buffer is in
- * D3D12_RESOURCE_STATE_COPY_DEST (post-HUD). On success, leaves back buffer
- * in D3D12_RESOURCE_STATE_RENDER_TARGET (caller transitions to PRESENT).
- *
- * Returns false on failure; caller should fall back to skipping the pass.
- */
-static bool
-chroma_key_pass_execute(struct comp_d3d12_compositor *c,
-                         ID3D12GraphicsCommandList *cmd_list,
-                         ID3D12Resource *back_buffer,
-                         D3D12_CPU_DESCRIPTOR_HANDLE rtv_handle,
-                         UINT width, UINT height)
-{
-	if (!chroma_key_init_pipeline(c)) return false;
-	if (!chroma_key_ensure_intermediate(c, width, height)) return false;
-
-	// Pack chroma color (0x00BBGGRR) → float3 RGB in [0,1].
-	uint32_t k = c->chroma_key_color;
-	float chroma_r = ((k >>  0) & 0xFF) / 255.0f;
-	float chroma_g = ((k >>  8) & 0xFF) / 255.0f;
-	float chroma_b = ((k >> 16) & 0xFF) / 255.0f;
-	float root_consts[4] = { chroma_r, chroma_g, chroma_b, 0.0f };
-
-	// Transition back_buffer COPY_DEST → COPY_SOURCE; intermediate (PIXEL_SHADER_RESOURCE) → COPY_DEST.
-	D3D12_RESOURCE_BARRIER barriers[2] = {};
-	barriers[0].Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
-	barriers[0].Transition.pResource = back_buffer;
-	barriers[0].Transition.StateBefore = D3D12_RESOURCE_STATE_COPY_DEST;
-	barriers[0].Transition.StateAfter = D3D12_RESOURCE_STATE_COPY_SOURCE;
-	barriers[0].Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
-	barriers[1].Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
-	barriers[1].Transition.pResource = c->ck_intermediate;
-	barriers[1].Transition.StateBefore = c->ck_intermediate_state;
-	barriers[1].Transition.StateAfter = D3D12_RESOURCE_STATE_COPY_DEST;
-	barriers[1].Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
-	cmd_list->ResourceBarrier(2, barriers);
-	c->ck_intermediate_state = D3D12_RESOURCE_STATE_COPY_DEST;
-
-	cmd_list->CopyResource(c->ck_intermediate, back_buffer);
-
-	// Transition back_buffer COPY_SOURCE → RENDER_TARGET; intermediate COPY_DEST → PIXEL_SHADER_RESOURCE.
-	barriers[0].Transition.StateBefore = D3D12_RESOURCE_STATE_COPY_SOURCE;
-	barriers[0].Transition.StateAfter = D3D12_RESOURCE_STATE_RENDER_TARGET;
-	barriers[1].Transition.StateBefore = D3D12_RESOURCE_STATE_COPY_DEST;
-	barriers[1].Transition.StateAfter = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
-	cmd_list->ResourceBarrier(2, barriers);
-	c->ck_intermediate_state = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
-
-	// Bind pipeline + draw fullscreen triangle (3 verts via SV_VertexID).
-	cmd_list->SetPipelineState(c->ck_pipeline_state);
-	cmd_list->SetGraphicsRootSignature(c->ck_root_signature);
-	ID3D12DescriptorHeap *heaps[] = { c->ck_srv_heap };
-	cmd_list->SetDescriptorHeaps(1, heaps);
-	cmd_list->SetGraphicsRoot32BitConstants(0, 4, root_consts, 0);
-	cmd_list->SetGraphicsRootDescriptorTable(1, c->ck_srv_heap->GetGPUDescriptorHandleForHeapStart());
-
-	D3D12_VIEWPORT vp = { 0.0f, 0.0f, (float)width, (float)height, 0.0f, 1.0f };
-	D3D12_RECT scissor = { 0, 0, (LONG)width, (LONG)height };
-	cmd_list->RSSetViewports(1, &vp);
-	cmd_list->RSSetScissorRects(1, &scissor);
-	cmd_list->OMSetRenderTargets(1, &rtv_handle, FALSE, nullptr);
-	cmd_list->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-	cmd_list->IASetVertexBuffers(0, 0, nullptr);
-	cmd_list->IASetIndexBuffer(nullptr);
-	cmd_list->DrawInstanced(3, 1, 0, 0);
-	return true;
-}
-
-static void
-chroma_key_destroy(struct comp_d3d12_compositor *c)
-{
-	if (c->ck_intermediate)    { c->ck_intermediate->Release();    c->ck_intermediate = nullptr; }
-	if (c->ck_srv_heap)        { c->ck_srv_heap->Release();        c->ck_srv_heap = nullptr; }
-	if (c->ck_pipeline_state)  { c->ck_pipeline_state->Release();  c->ck_pipeline_state = nullptr; }
-	if (c->ck_root_signature)  { c->ck_root_signature->Release();  c->ck_root_signature = nullptr; }
-}
 
 static void
 d3d12_compositor_destroy(struct xrt_compositor *xc)
@@ -2109,9 +1765,6 @@ d3d12_compositor_destroy(struct xrt_compositor *xc)
 	if (c->fence != nullptr && c->command_queue != nullptr) {
 		gpu_wait_idle(c);
 	}
-
-	// Destroy chroma-key pass resources
-	chroma_key_destroy(c);
 
 	// Destroy DP input crop resource
 	if (c->dp_input_resource != nullptr) {
@@ -2227,15 +1880,6 @@ comp_d3d12_compositor_create(struct xrt_device *xdev,
 	c->hud_initialized = false;
 	c->last_frame_time_ns = 0;
 	c->smoothed_frame_time_ms = 16.67f;
-
-	// Chroma-key pass state (lazy-allocated on first use)
-	c->chroma_key_color = chroma_key_color;
-	c->ck_root_signature = nullptr;
-	c->ck_pipeline_state = nullptr;
-	c->ck_intermediate = nullptr;
-	c->ck_srv_heap = nullptr;
-	c->ck_intermediate_w = 0;
-	c->ck_intermediate_h = 0;
 
 	// Handle window
 	c->app_hwnd = nullptr;
@@ -2444,6 +2088,12 @@ comp_d3d12_compositor_create(struct xrt_device *xdev,
 			    output_fmt);
 			U_LOG_W("D3D12 display processor: output format set to %u (target=%p)",
 			        (unsigned)output_fmt, (void *)c->target);
+
+			// Forward session-level transparency config. The DP runs the
+			// chroma-key fill+strip internally when transparent_background
+			// is set; chroma_key_color=0 means the DP picks its own key.
+			xrt_display_processor_d3d12_set_chroma_key(
+			    c->display_processor, chroma_key_color, transparent_background);
 		}
 	} else {
 		U_LOG_W("No D3D12 display processor factory provided");

--- a/src/xrt/compositor/metal/comp_metal_compositor.h
+++ b/src/xrt/compositor/metal/comp_metal_compositor.h
@@ -41,6 +41,13 @@ extern "C" {
  * @param shared_iosurface  IOSurfaceRef for shared texture output, or NULL.
  *                        When non-NULL, the compositor renders into this
  *                        IOSurface instead of the CAMetalLayer drawable.
+ * @param transparent_background When true, configures the NSWindow (if owned)
+ *                        and CAMetalLayer with isOpaque=NO so the desktop
+ *                        shows through alpha < 1 regions of the composited
+ *                        output. Per-pixel alpha flows through sim_display's
+ *                        alpha-native output stage; no chroma-key trick on
+ *                        macOS. (Sourced from
+ *                        XR_EXT_cocoa_window_binding.transparentBackgroundEnabled.)
  * @param[out] out_xc     Created compositor on success.
  * @return XRT_SUCCESS on success.
  *
@@ -53,6 +60,7 @@ comp_metal_compositor_create(struct xrt_device *xdev,
                              void *dp_factory_metal,
                              bool offscreen,
                              void *shared_iosurface,
+                             bool transparent_background,
                              struct xrt_compositor_native **out_xc);
 
 /*!

--- a/src/xrt/compositor/metal/comp_metal_compositor.m
+++ b/src/xrt/compositor/metal/comp_metal_compositor.m
@@ -605,7 +605,8 @@ ensure_ns_app(void)
 }
 
 static void
-create_window_on_main_thread(struct comp_metal_compositor *c, uint32_t width, uint32_t height, bool *out_success)
+create_window_on_main_thread(struct comp_metal_compositor *c, uint32_t width, uint32_t height,
+                             bool transparent_background, bool *out_success)
 {
 	ensure_ns_app();
 	NSRect frame = NSMakeRect(100, 100, width, height);
@@ -637,6 +638,17 @@ create_window_on_main_thread(struct comp_metal_compositor *c, uint32_t width, ui
 	c->metal_layer.device = c->device;
 	c->metal_layer.pixelFormat = MTLPixelFormatBGRA8Unorm;
 	c->metal_layer.framebufferOnly = YES;
+
+	if (transparent_background) {
+		// macOS native transparency: NSWindow non-opaque + clear background +
+		// CAMetalLayer non-opaque lets the desktop show through any pixels
+		// the compositor writes with alpha < 1. sim_display preserves alpha
+		// natively to the drawable; no chroma-key trick.
+		[c->window setOpaque:NO];
+		[c->window setBackgroundColor:[NSColor clearColor]];
+		c->metal_layer.opaque = NO;
+		U_LOG_W("Transparent background enabled: NSWindow + CAMetalLayer set isOpaque=NO");
+	}
 
 	CGFloat scale = c->window.backingScaleFactor;
 	c->metal_layer.contentsScale = scale;
@@ -671,16 +683,17 @@ create_window_on_main_thread(struct comp_metal_compositor *c, uint32_t width, ui
 }
 
 static bool
-create_window(struct comp_metal_compositor *c, uint32_t width, uint32_t height)
+create_window(struct comp_metal_compositor *c, uint32_t width, uint32_t height,
+              bool transparent_background)
 {
 	__block bool success = false;
 
 	if ([NSThread isMainThread]) {
 		// Already on main thread — call directly to avoid deadlock
-		create_window_on_main_thread(c, width, height, &success);
+		create_window_on_main_thread(c, width, height, transparent_background, &success);
 	} else {
 		dispatch_sync(dispatch_get_main_queue(), ^{
-			create_window_on_main_thread(c, width, height, &success);
+			create_window_on_main_thread(c, width, height, transparent_background, &success);
 		});
 	}
 
@@ -688,7 +701,8 @@ create_window(struct comp_metal_compositor *c, uint32_t width, uint32_t height)
 }
 
 static bool
-setup_external_window(struct comp_metal_compositor *c, NSView *external_view)
+setup_external_window(struct comp_metal_compositor *c, NSView *external_view,
+                      bool transparent_background)
 {
 	c->view = external_view;
 	c->owns_window = false;
@@ -724,6 +738,14 @@ setup_external_window(struct comp_metal_compositor *c, NSView *external_view)
 	c->metal_layer.device = c->device;
 	c->metal_layer.pixelFormat = MTLPixelFormatBGRA8Unorm;
 	c->metal_layer.framebufferOnly = NO; // Need shader read for blit
+
+	if (transparent_background) {
+		// External NSWindow is owned by the app — they're responsible for
+		// setOpaque:NO + clear background. We only configure the layer the
+		// compositor presents into.
+		c->metal_layer.opaque = NO;
+		U_LOG_W("Transparent background enabled: external CAMetalLayer set isOpaque=NO");
+	}
 
 	// Ensure Retina backing scale is applied so drawables are at physical resolution
 	CGFloat scale = 1.0;
@@ -2187,10 +2209,11 @@ comp_metal_compositor_create(struct xrt_device *xdev,
                              void *dp_factory_metal,
                              bool offscreen,
                              void *shared_iosurface,
+                             bool transparent_background,
                              struct xrt_compositor_native **out_xc)
 {
-	U_LOG_W("comp_metal_compositor_create: window_handle=%p, offscreen=%d, shared_iosurface=%p, dp_factory=%p",
-	        window_handle, offscreen, shared_iosurface, dp_factory_metal);
+	U_LOG_W("comp_metal_compositor_create: window_handle=%p, offscreen=%d, shared_iosurface=%p, dp_factory=%p, transparent_background=%d",
+	        window_handle, offscreen, shared_iosurface, dp_factory_metal, (int)transparent_background);
 
 	struct comp_metal_compositor *c = U_TYPED_CALLOC(struct comp_metal_compositor);
 	if (c == NULL) {
@@ -2263,7 +2286,7 @@ comp_metal_compositor_create(struct xrt_device *xdev,
 	        window_handle, shared_iosurface, offscreen);
 	NSView *external_view = (__bridge NSView *)window_handle;
 	if (external_view != nil) {
-		if (!setup_external_window(c, external_view)) {
+		if (!setup_external_window(c, external_view, transparent_background)) {
 			os_mutex_destroy(&c->mutex);
 			free(c);
 			return XRT_ERROR_VULKAN;
@@ -2271,7 +2294,7 @@ comp_metal_compositor_create(struct xrt_device *xdev,
 	} else if (shared_iosurface == NULL) {
 		// Only create a window when there's no shared IOSurface.
 		// With IOSurface, we render headless — no window needed.
-		if (!create_window(c, display_width, display_height)) {
+		if (!create_window(c, display_width, display_height, transparent_background)) {
 			os_mutex_destroy(&c->mutex);
 			free(c);
 			return XRT_ERROR_VULKAN;

--- a/src/xrt/drivers/leia/leia_display_processor_d3d11.cpp
+++ b/src/xrt/drivers/leia/leia_display_processor_d3d11.cpp
@@ -61,6 +61,73 @@ float4 main(float4 pos : SV_Position, float2 uv : TEXCOORD0) : SV_Target {
 }
 )";
 
+/*
+ * Chroma-key pre-weave fill pixel shader.
+ *
+ * Replaces alpha=0 atlas pixels with the chroma key color so the SR weaver
+ * (which only consumes opaque RGB) can run. Output is alpha=1 everywhere.
+ *
+ * Apps that pre-fill their swapchain with the key color (legacy v1.2.9
+ * Unity flow) submit alpha=1 atlas pixels; this shader is a no-op for them.
+ *
+ * Apps that submit true alpha (RGBA(0,0,0,0) clear + content with alpha=1)
+ * get their transparent regions filled with the key color here.
+ *
+ * Antialiased edges (0 < alpha < 1) blend toward the key color via lerp;
+ * the post-weave strip pass only matches exact key-color RGB, so soft
+ * edges become hard masks (a fundamental limitation of the chroma-key
+ * trick on lenticular weavers).
+ */
+static const char *ck_fill_ps_source = R"(
+Texture2D<float4> src : register(t0);
+SamplerState samp : register(s0);
+cbuffer Constants : register(b0) { float3 chroma_rgb; float pad; };
+float4 main(float4 pos : SV_Position, float2 uv : TEXCOORD0) : SV_Target {
+	float4 c = src.Sample(samp, uv);
+	float3 rgb = lerp(chroma_rgb, c.rgb, c.a);
+	return float4(rgb, 1.0);
+}
+)";
+
+/*
+ * Chroma-key post-weave strip pixel shader.
+ *
+ * Reads the woven back-buffer (opaque RGB), tests RGB exact-equality against
+ * the chroma key, writes alpha=0 for matches and alpha=1 otherwise. RGB is
+ * premultiplied by the recovered alpha so DWM's
+ *     src.rgb + (1-alpha) * dst.rgb
+ * blend doesn't add the matched chroma color to the desktop and saturate.
+ *
+ * Moved from the D3D11 compositor (was at comp_d3d11_compositor.cpp:1441)
+ * during the chroma-key internalization for transparency support.
+ */
+static const char *ck_strip_ps_source = R"(
+struct VSOut { float4 pos : SV_Position; float2 uv : TEXCOORD0; };
+Texture2D<float4> src : register(t0);
+SamplerState samp : register(s0);
+cbuffer Constants : register(b0) { float3 chroma_rgb; float pad; };
+float4 main(VSOut i) : SV_Target {
+	float3 c = src.Sample(samp, i.uv).rgb;
+	float3 d = abs(c - chroma_rgb);
+	bool match = max(max(d.r, d.g), d.b) < (1.0 / 512.0);
+	float a = match ? 0.0 : 1.0;
+	return float4(c * a, a);
+}
+)";
+
+struct ChromaKeyConstants {
+	float chroma_rgb[3];
+	float pad;
+};
+
+/*
+ * Default chroma key when the app didn't supply one (set_chroma_key key=0).
+ * Magenta is the canonical "key color" — universally avoided in user content,
+ * never produced by typical RGB+lenticular weaving from real scenes.
+ * 0x00BBGGRR layout: R=0xFF, G=0x00, B=0xFF.
+ */
+static constexpr uint32_t kDefaultChromaKey = 0x00FF00FF;
+
 
 /*!
  * Implementation struct wrapping leiasr_d3d11 as xrt_display_processor_d3d11.
@@ -81,12 +148,384 @@ struct leia_display_processor_d3d11_impl
 	//! @}
 
 	uint32_t view_count; //!< Active mode view count (1=2D, 2=stereo).
+
+	//! @name Chroma-key transparency support (lazy-allocated on first frame)
+	//!
+	//! Enabled via set_chroma_key() when the session asked for a transparent
+	//! output window. When @ref ck_enabled is true, process_atlas() does:
+	//!   1. Pre-weave fill: atlas SRV → ck_fill_tex (alpha=0 → chroma_rgb,
+	//!      output alpha=1) so the SR weaver receives opaque RGB.
+	//!   2. Pass ck_fill_srv to the weaver instead of the original atlas.
+	//!   3. Post-weave strip: copy current RTV → ck_strip_tex, then run
+	//!      strip shader back to RTV (chroma_rgb match → alpha=0,
+	//!      else alpha=1, RGB premultiplied for DWM).
+	//! @{
+	bool ck_enabled;
+	uint32_t ck_color; //!< 0x00BBGGRR; effective key (app override or default).
+	ID3D11PixelShader *ck_fill_ps;  //!< Pre-weave fill shader.
+	ID3D11PixelShader *ck_strip_ps; //!< Post-weave strip shader.
+	ID3D11SamplerState *ck_sampler;
+	ID3D11Buffer *ck_constants; //!< 16 bytes: chroma_rgb + pad.
+	// Pre-weave: RGBA atlas → opaque-RGB filled output, sampled by weaver.
+	ID3D11Texture2D *ck_fill_tex;
+	ID3D11ShaderResourceView *ck_fill_srv;
+	ID3D11RenderTargetView *ck_fill_rtv;
+	uint32_t ck_fill_w, ck_fill_h;
+	// Post-weave: copy of RTV used to sample for the strip pass.
+	ID3D11Texture2D *ck_strip_tex;
+	ID3D11ShaderResourceView *ck_strip_srv;
+	uint32_t ck_strip_w, ck_strip_h;
+	//! @}
 };
 
 static inline struct leia_display_processor_d3d11_impl *
 leia_dp_d3d11(struct xrt_display_processor_d3d11 *xdp)
 {
 	return (struct leia_display_processor_d3d11_impl *)xdp;
+}
+
+
+/*
+ *
+ * Chroma-key fill/strip helpers (transparency support).
+ *
+ * Lazy-allocated on first frame the pass runs. ck_should_run() gates the
+ * whole flow — when false (the common case) none of these execute and
+ * process_atlas behaves identically to the pre-transparency path.
+ *
+ * Reuses the existing blit_vs (fullscreen-quad VS, 4 verts, TRIANGLESTRIP)
+ * for both fill and strip passes.
+ *
+ */
+
+static bool
+ck_should_run(struct leia_display_processor_d3d11_impl *ldp)
+{
+	return ldp->ck_enabled && ldp->ck_color != 0;
+}
+
+static bool
+ck_init_pipeline(struct leia_display_processor_d3d11_impl *ldp)
+{
+	if (ldp->ck_fill_ps != nullptr && ldp->ck_strip_ps != nullptr) {
+		return true;
+	}
+	if (ldp->device == nullptr) {
+		return false;
+	}
+
+	HRESULT hr;
+	ID3DBlob *blob = nullptr;
+	ID3DBlob *err = nullptr;
+
+	if (ldp->ck_fill_ps == nullptr) {
+		hr = D3DCompile(ck_fill_ps_source, strlen(ck_fill_ps_source), nullptr, nullptr, nullptr,
+		                "main", "ps_5_0", 0, 0, &blob, &err);
+		if (FAILED(hr)) {
+			U_LOG_E("Leia D3D11 DP: ck fill PS compile failed: 0x%08x %s",
+			        (unsigned)hr, err ? (const char *)err->GetBufferPointer() : "");
+			if (err) err->Release();
+			return false;
+		}
+		if (err) { err->Release(); err = nullptr; }
+		hr = ldp->device->CreatePixelShader(blob->GetBufferPointer(), blob->GetBufferSize(),
+		                                     nullptr, &ldp->ck_fill_ps);
+		blob->Release(); blob = nullptr;
+		if (FAILED(hr)) {
+			U_LOG_E("Leia D3D11 DP: ck fill PS create failed: 0x%08x", (unsigned)hr);
+			return false;
+		}
+	}
+
+	if (ldp->ck_strip_ps == nullptr) {
+		hr = D3DCompile(ck_strip_ps_source, strlen(ck_strip_ps_source), nullptr, nullptr, nullptr,
+		                "main", "ps_5_0", 0, 0, &blob, &err);
+		if (FAILED(hr)) {
+			U_LOG_E("Leia D3D11 DP: ck strip PS compile failed: 0x%08x %s",
+			        (unsigned)hr, err ? (const char *)err->GetBufferPointer() : "");
+			if (err) err->Release();
+			return false;
+		}
+		if (err) err->Release();
+		hr = ldp->device->CreatePixelShader(blob->GetBufferPointer(), blob->GetBufferSize(),
+		                                     nullptr, &ldp->ck_strip_ps);
+		blob->Release();
+		if (FAILED(hr)) {
+			U_LOG_E("Leia D3D11 DP: ck strip PS create failed: 0x%08x", (unsigned)hr);
+			return false;
+		}
+	}
+
+	if (ldp->ck_sampler == nullptr) {
+		// Point filter — the strip pass tests RGB exact-equality and any
+		// linear interpolation would smear the key color across edges.
+		D3D11_SAMPLER_DESC sd = {};
+		sd.Filter = D3D11_FILTER_MIN_MAG_MIP_POINT;
+		sd.AddressU = D3D11_TEXTURE_ADDRESS_CLAMP;
+		sd.AddressV = D3D11_TEXTURE_ADDRESS_CLAMP;
+		sd.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
+		sd.MaxLOD = D3D11_FLOAT32_MAX;
+		hr = ldp->device->CreateSamplerState(&sd, &ldp->ck_sampler);
+		if (FAILED(hr)) {
+			U_LOG_E("Leia D3D11 DP: ck sampler create failed: 0x%08x", (unsigned)hr);
+			return false;
+		}
+	}
+
+	if (ldp->ck_constants == nullptr) {
+		D3D11_BUFFER_DESC cb = {};
+		cb.ByteWidth = sizeof(ChromaKeyConstants);
+		cb.Usage = D3D11_USAGE_DYNAMIC;
+		cb.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
+		cb.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
+		hr = ldp->device->CreateBuffer(&cb, nullptr, &ldp->ck_constants);
+		if (FAILED(hr)) {
+			U_LOG_E("Leia D3D11 DP: ck constants create failed: 0x%08x", (unsigned)hr);
+			return false;
+		}
+	}
+
+	U_LOG_W("Leia D3D11 DP: chroma-key pipeline ready (key=0x%08X)", ldp->ck_color);
+	return true;
+}
+
+static bool
+ck_ensure_fill_target(struct leia_display_processor_d3d11_impl *ldp, uint32_t w, uint32_t h)
+{
+	if (ldp->ck_fill_tex != nullptr && ldp->ck_fill_w == w && ldp->ck_fill_h == h) {
+		return true;
+	}
+	if (ldp->ck_fill_rtv) { ldp->ck_fill_rtv->Release(); ldp->ck_fill_rtv = nullptr; }
+	if (ldp->ck_fill_srv) { ldp->ck_fill_srv->Release(); ldp->ck_fill_srv = nullptr; }
+	if (ldp->ck_fill_tex) { ldp->ck_fill_tex->Release(); ldp->ck_fill_tex = nullptr; }
+
+	D3D11_TEXTURE2D_DESC td = {};
+	td.Width = w;
+	td.Height = h;
+	td.MipLevels = 1;
+	td.ArraySize = 1;
+	td.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	td.SampleDesc.Count = 1;
+	td.Usage = D3D11_USAGE_DEFAULT;
+	td.BindFlags = D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET;
+	HRESULT hr = ldp->device->CreateTexture2D(&td, nullptr, &ldp->ck_fill_tex);
+	if (FAILED(hr)) {
+		U_LOG_E("Leia D3D11 DP: ck fill tex create (%ux%u) failed: 0x%08x", w, h, (unsigned)hr);
+		return false;
+	}
+	hr = ldp->device->CreateShaderResourceView(ldp->ck_fill_tex, nullptr, &ldp->ck_fill_srv);
+	if (FAILED(hr)) {
+		U_LOG_E("Leia D3D11 DP: ck fill SRV create failed: 0x%08x", (unsigned)hr);
+		return false;
+	}
+	hr = ldp->device->CreateRenderTargetView(ldp->ck_fill_tex, nullptr, &ldp->ck_fill_rtv);
+	if (FAILED(hr)) {
+		U_LOG_E("Leia D3D11 DP: ck fill RTV create failed: 0x%08x", (unsigned)hr);
+		return false;
+	}
+	ldp->ck_fill_w = w;
+	ldp->ck_fill_h = h;
+	return true;
+}
+
+static bool
+ck_ensure_strip_source(struct leia_display_processor_d3d11_impl *ldp, uint32_t w, uint32_t h)
+{
+	if (ldp->ck_strip_tex != nullptr && ldp->ck_strip_w == w && ldp->ck_strip_h == h) {
+		return true;
+	}
+	if (ldp->ck_strip_srv) { ldp->ck_strip_srv->Release(); ldp->ck_strip_srv = nullptr; }
+	if (ldp->ck_strip_tex) { ldp->ck_strip_tex->Release(); ldp->ck_strip_tex = nullptr; }
+
+	D3D11_TEXTURE2D_DESC td = {};
+	td.Width = w;
+	td.Height = h;
+	td.MipLevels = 1;
+	td.ArraySize = 1;
+	td.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	td.SampleDesc.Count = 1;
+	td.Usage = D3D11_USAGE_DEFAULT;
+	td.BindFlags = D3D11_BIND_SHADER_RESOURCE;
+	HRESULT hr = ldp->device->CreateTexture2D(&td, nullptr, &ldp->ck_strip_tex);
+	if (FAILED(hr)) {
+		U_LOG_E("Leia D3D11 DP: ck strip tex create (%ux%u) failed: 0x%08x", w, h, (unsigned)hr);
+		return false;
+	}
+	hr = ldp->device->CreateShaderResourceView(ldp->ck_strip_tex, nullptr, &ldp->ck_strip_srv);
+	if (FAILED(hr)) {
+		U_LOG_E("Leia D3D11 DP: ck strip SRV create failed: 0x%08x", (unsigned)hr);
+		return false;
+	}
+	ldp->ck_strip_w = w;
+	ldp->ck_strip_h = h;
+	return true;
+}
+
+static void
+ck_update_constants(struct leia_display_processor_d3d11_impl *ldp, ID3D11DeviceContext *ctx)
+{
+	D3D11_MAPPED_SUBRESOURCE m = {};
+	HRESULT hr = ctx->Map(ldp->ck_constants, 0, D3D11_MAP_WRITE_DISCARD, 0, &m);
+	if (FAILED(hr)) {
+		return;
+	}
+	ChromaKeyConstants *cb = reinterpret_cast<ChromaKeyConstants *>(m.pData);
+	uint32_t k = ldp->ck_color;
+	cb->chroma_rgb[0] = ((k >>  0) & 0xFF) / 255.0f;
+	cb->chroma_rgb[1] = ((k >>  8) & 0xFF) / 255.0f;
+	cb->chroma_rgb[2] = ((k >> 16) & 0xFF) / 255.0f;
+	cb->pad = 0.0f;
+	ctx->Unmap(ldp->ck_constants, 0);
+}
+
+/*
+ * Pre-weave fill: read RGBA atlas, write opaque RGB to ck_fill_tex with
+ * alpha=0 regions filled by chroma_rgb. Returns the SRV the weaver should
+ * sample (ck_fill_srv on success, original atlas_srv on fallback).
+ *
+ * Saves and restores RTV/DSV/viewport so the caller's swap-chain bindings
+ * survive the pass.
+ */
+static ID3D11ShaderResourceView *
+ck_run_pre_weave_fill(struct leia_display_processor_d3d11_impl *ldp,
+                       ID3D11DeviceContext *ctx,
+                       ID3D11ShaderResourceView *atlas_srv,
+                       uint32_t atlas_w,
+                       uint32_t atlas_h)
+{
+	if (!ck_init_pipeline(ldp) || !ck_ensure_fill_target(ldp, atlas_w, atlas_h)) {
+		return atlas_srv;
+	}
+
+	ID3D11RenderTargetView *prev_rtv = nullptr;
+	ID3D11DepthStencilView *prev_dsv = nullptr;
+	ctx->OMGetRenderTargets(1, &prev_rtv, &prev_dsv);
+
+	UINT prev_vp_count = 1;
+	D3D11_VIEWPORT prev_vp = {};
+	ctx->RSGetViewports(&prev_vp_count, &prev_vp);
+
+	ck_update_constants(ldp, ctx);
+
+	D3D11_VIEWPORT vp = {};
+	vp.TopLeftX = 0.0f;
+	vp.TopLeftY = 0.0f;
+	vp.Width = static_cast<float>(atlas_w);
+	vp.Height = static_cast<float>(atlas_h);
+	vp.MaxDepth = 1.0f;
+	ctx->RSSetViewports(1, &vp);
+
+	ctx->OMSetRenderTargets(1, &ldp->ck_fill_rtv, nullptr);
+
+	ctx->IASetInputLayout(nullptr);
+	ctx->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
+	ctx->VSSetShader(ldp->blit_vs, nullptr, 0);
+	ctx->PSSetShader(ldp->ck_fill_ps, nullptr, 0);
+	ctx->PSSetShaderResources(0, 1, &atlas_srv);
+	ctx->PSSetSamplers(0, 1, &ldp->ck_sampler);
+	ctx->PSSetConstantBuffers(0, 1, &ldp->ck_constants);
+	ctx->Draw(4, 0);
+
+	ID3D11ShaderResourceView *null_srv = nullptr;
+	ctx->PSSetShaderResources(0, 1, &null_srv);
+
+	ctx->OMSetRenderTargets(1, &prev_rtv, prev_dsv);
+	ctx->RSSetViewports(prev_vp_count, &prev_vp);
+	if (prev_rtv) prev_rtv->Release();
+	if (prev_dsv) prev_dsv->Release();
+
+	return ldp->ck_fill_srv;
+}
+
+/*
+ * Post-weave strip: copy currently bound RTV → ck_strip_tex, then sample
+ * back into the same RTV writing alpha=0 where RGB matches chroma_rgb,
+ * else alpha=1 with RGB premultiplied for DWM's premultiplied alpha mode.
+ */
+static void
+ck_run_post_weave_strip(struct leia_display_processor_d3d11_impl *ldp,
+                        ID3D11DeviceContext *ctx)
+{
+	if (!ck_init_pipeline(ldp)) {
+		return;
+	}
+
+	ID3D11RenderTargetView *rtv = nullptr;
+	ID3D11DepthStencilView *dsv = nullptr;
+	ctx->OMGetRenderTargets(1, &rtv, &dsv);
+	if (rtv == nullptr) {
+		if (dsv) dsv->Release();
+		return;
+	}
+
+	ID3D11Resource *rtv_res = nullptr;
+	rtv->GetResource(&rtv_res);
+	ID3D11Texture2D *back_buffer = nullptr;
+	if (rtv_res) {
+		rtv_res->QueryInterface(__uuidof(ID3D11Texture2D),
+		                         reinterpret_cast<void **>(&back_buffer));
+	}
+	if (back_buffer == nullptr) {
+		if (rtv_res) rtv_res->Release();
+		rtv->Release();
+		if (dsv) dsv->Release();
+		return;
+	}
+
+	D3D11_TEXTURE2D_DESC bb_desc = {};
+	back_buffer->GetDesc(&bb_desc);
+	if (!ck_ensure_strip_source(ldp, bb_desc.Width, bb_desc.Height)) {
+		back_buffer->Release();
+		rtv_res->Release();
+		rtv->Release();
+		if (dsv) dsv->Release();
+		return;
+	}
+
+	ctx->CopyResource(ldp->ck_strip_tex, back_buffer);
+
+	ck_update_constants(ldp, ctx);
+
+	D3D11_VIEWPORT vp = {};
+	vp.TopLeftX = 0.0f;
+	vp.TopLeftY = 0.0f;
+	vp.Width = static_cast<float>(bb_desc.Width);
+	vp.Height = static_cast<float>(bb_desc.Height);
+	vp.MaxDepth = 1.0f;
+	ctx->RSSetViewports(1, &vp);
+
+	ctx->OMSetRenderTargets(1, &rtv, nullptr);
+
+	ctx->IASetInputLayout(nullptr);
+	ctx->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
+	ctx->VSSetShader(ldp->blit_vs, nullptr, 0);
+	ctx->PSSetShader(ldp->ck_strip_ps, nullptr, 0);
+	ctx->PSSetShaderResources(0, 1, &ldp->ck_strip_srv);
+	ctx->PSSetSamplers(0, 1, &ldp->ck_sampler);
+	ctx->PSSetConstantBuffers(0, 1, &ldp->ck_constants);
+	ctx->Draw(4, 0);
+
+	ID3D11ShaderResourceView *null_srv = nullptr;
+	ctx->PSSetShaderResources(0, 1, &null_srv);
+
+	back_buffer->Release();
+	rtv_res->Release();
+	rtv->Release();
+	if (dsv) dsv->Release();
+}
+
+static void
+ck_release_resources(struct leia_display_processor_d3d11_impl *ldp)
+{
+	if (ldp->ck_fill_rtv)   { ldp->ck_fill_rtv->Release();   ldp->ck_fill_rtv = nullptr; }
+	if (ldp->ck_fill_srv)   { ldp->ck_fill_srv->Release();   ldp->ck_fill_srv = nullptr; }
+	if (ldp->ck_fill_tex)   { ldp->ck_fill_tex->Release();   ldp->ck_fill_tex = nullptr; }
+	if (ldp->ck_strip_srv)  { ldp->ck_strip_srv->Release();  ldp->ck_strip_srv = nullptr; }
+	if (ldp->ck_strip_tex)  { ldp->ck_strip_tex->Release();  ldp->ck_strip_tex = nullptr; }
+	if (ldp->ck_constants)  { ldp->ck_constants->Release();  ldp->ck_constants = nullptr; }
+	if (ldp->ck_sampler)    { ldp->ck_sampler->Release();    ldp->ck_sampler = nullptr; }
+	if (ldp->ck_strip_ps)   { ldp->ck_strip_ps->Release();   ldp->ck_strip_ps = nullptr; }
+	if (ldp->ck_fill_ps)    { ldp->ck_fill_ps->Release();    ldp->ck_fill_ps = nullptr; }
 }
 
 
@@ -176,12 +615,37 @@ leia_dp_d3d11_process_atlas(struct xrt_display_processor_d3d11 *xdp,
 		// Unbind SRV to prevent D3D11 hazard warnings
 		ID3D11ShaderResourceView *null_srv = NULL;
 		ctx->PSSetShaderResources(0, 1, &null_srv);
+
+		// 2D mode has no weaver, but if chroma-key is enabled the legacy
+		// flow (app pre-fills with key RGB on opaque alpha=1 surface) still
+		// needs the strip pass to recover alpha=0 for DWM. The new flow
+		// (true alpha through blit) works without it; running strip in that
+		// case is a no-op for non-key pixels.
+		if (ck_should_run(ldp)) {
+			ck_run_post_weave_strip(ldp, ctx);
+		}
 		return;
 	}
 
 	// Atlas is guaranteed content-sized SBS (2*view_width x view_height)
-	// by compositor crop-blit. Pass directly to weaver.
-	leiasr_d3d11_set_input_texture(ldp->leiasr, atlas_srv, view_width, view_height, format);
+	// by compositor crop-blit.
+	//
+	// When chroma-key is enabled, run the pre-weave fill pass: replace
+	// alpha=0 atlas pixels with the key color so the SR weaver (which only
+	// consumes opaque RGB) can process them, then pass the filled SRV to
+	// the weaver instead of the original atlas. For legacy apps that
+	// pre-filled with the key color on an alpha=1 surface, the fill is
+	// a no-op (lerp(key, src.rgb, 1.0) == src.rgb) — backward-compatible.
+	void *weaver_srv = atlas_srv;
+	if (ck_should_run(ldp)) {
+		uint32_t atlas_w = tile_columns * view_width;
+		uint32_t atlas_h = tile_rows * view_height;
+		weaver_srv = ck_run_pre_weave_fill(
+		    ldp, ctx,
+		    static_cast<ID3D11ShaderResourceView *>(atlas_srv),
+		    atlas_w, atlas_h);
+	}
+	leiasr_d3d11_set_input_texture(ldp->leiasr, weaver_srv, view_width, view_height, format);
 
 	// Set viewport to canvas sub-rect — the SR SDK weaver reads this
 	// and uses vpX/vpY for correct interlacing phase alignment.
@@ -220,6 +684,13 @@ leia_dp_d3d11_process_atlas(struct xrt_display_processor_d3d11 *xdp,
 	}
 
 	leiasr_d3d11_weave(ldp->leiasr);
+
+	// Post-weave chroma-key strip: convert key-color RGB pixels in the
+	// woven back-buffer to alpha=0 (with RGB premultiplied for DWM's
+	// premultiplied alpha mode). No-op when chroma-key is disabled.
+	if (ck_should_run(ldp)) {
+		ck_run_post_weave_strip(ldp, ctx);
+	}
 }
 
 static bool
@@ -309,6 +780,33 @@ leia_dp_d3d11_get_display_pixel_info(struct xrt_display_processor_d3d11 *xdp,
 	                                           out_screen_top, &w_m, &h_m);
 }
 
+static bool
+leia_dp_d3d11_is_alpha_native(struct xrt_display_processor_d3d11 *xdp)
+{
+	(void)xdp;
+	// SR SDK weaver interlaces into opaque RGB — alpha is destroyed.
+	// Transparency is recovered via the chroma-key trick (see set_chroma_key).
+	return false;
+}
+
+static void
+leia_dp_d3d11_set_chroma_key(struct xrt_display_processor_d3d11 *xdp,
+                              uint32_t key_color,
+                              bool transparent_bg_enabled)
+{
+	struct leia_display_processor_d3d11_impl *ldp = leia_dp_d3d11(xdp);
+	ldp->ck_enabled = transparent_bg_enabled;
+	// App-supplied override (non-zero) wins over DP-picked default. The
+	// override matches the legacy XR_EXT_win32_window_binding.chromaKeyColor
+	// behavior so v1.2.9 Unity plugins and any third-party app that
+	// integrated the v5 extension keep working unchanged.
+	ldp->ck_color = (key_color != 0) ? key_color : kDefaultChromaKey;
+	U_LOG_W("Leia D3D11 DP: chroma-key %s (key=0x%08X%s)",
+	        ldp->ck_enabled ? "ENABLED" : "disabled",
+	        ldp->ck_color,
+	        (key_color == 0) ? " — DP default" : " — app override");
+}
+
 static void
 leia_dp_d3d11_destroy(struct xrt_display_processor_d3d11 *xdp)
 {
@@ -326,6 +824,8 @@ leia_dp_d3d11_destroy(struct xrt_display_processor_d3d11 *xdp)
 	if (ldp->blit_cb != NULL) {
 		ldp->blit_cb->Release();
 	}
+
+	ck_release_resources(ldp);
 
 	if (ldp->leiasr != NULL) {
 		leiasr_d3d11_destroy(&ldp->leiasr);
@@ -350,6 +850,8 @@ leia_dp_d3d11_init_vtable(struct leia_display_processor_d3d11_impl *ldp)
 	ldp->base.get_hardware_3d_state = leia_dp_d3d11_get_hardware_3d_state;
 	ldp->base.get_display_dimensions = leia_dp_d3d11_get_display_dimensions;
 	ldp->base.get_display_pixel_info = leia_dp_d3d11_get_display_pixel_info;
+	ldp->base.is_alpha_native = leia_dp_d3d11_is_alpha_native;
+	ldp->base.set_chroma_key = leia_dp_d3d11_set_chroma_key;
 	ldp->base.destroy = leia_dp_d3d11_destroy;
 }
 

--- a/src/xrt/drivers/leia/leia_display_processor_d3d12.cpp
+++ b/src/xrt/drivers/leia/leia_display_processor_d3d12.cpp
@@ -61,6 +61,67 @@ float4 main(float4 pos : SV_Position, float2 uv : TEXCOORD0) : SV_Target {
 }
 )";
 
+/*
+ * Chroma-key shaders — same algorithm as the D3D11 DP, retargeted to D3D12.
+ * The fill pass replaces alpha=0 atlas pixels with the chroma key so the SR
+ * weaver (opaque RGB only) can run. The strip pass examines the woven back
+ * buffer and rewrites RGB-matching pixels to alpha=0 (with RGB premultiplied
+ * for DWM's premultiplied alpha mode).
+ *
+ * Both shaders share a fullscreen-triangle VS (3 verts via SV_VertexID).
+ * Root signature: b0 = 32-bit constants (chroma_rgb + pad), t0 = SRV
+ * descriptor table, s0 = static sampler (point filter).
+ */
+static const char *ck_vs_source = R"(
+struct VSOut { float4 pos : SV_Position; float2 uv : TEXCOORD0; };
+VSOut main(uint vid : SV_VertexID) {
+    VSOut o;
+    o.uv = float2((vid << 1) & 2, vid & 2);
+    o.pos = float4(o.uv * float2(2, -2) + float2(-1, 1), 0, 1);
+    return o;
+}
+)";
+
+// Pre-weave fill: atlas RGBA → opaque RGB with alpha=0 regions filled
+// by chroma_rgb. lerp(key, src.rgb, src.a) is no-op for alpha=1 (legacy
+// app-pre-filled flow) and full key for alpha=0 (true-alpha flow).
+static const char *ck_fill_ps_source = R"(
+struct VSOut { float4 pos : SV_Position; float2 uv : TEXCOORD0; };
+Texture2D<float4> src : register(t0);
+SamplerState samp : register(s0);
+cbuffer Constants : register(b0) { float3 chroma_rgb; float pad; };
+float4 main(VSOut i) : SV_Target {
+    float4 c = src.Sample(samp, i.uv);
+    float3 rgb = lerp(chroma_rgb, c.rgb, c.a);
+    return float4(rgb, 1.0);
+}
+)";
+
+// Post-weave strip: woven RGB → alpha=0 where RGB exact-matches chroma_rgb,
+// alpha=1 elsewhere with RGB premultiplied so DWM's
+//     src.rgb + (1-alpha)*dst.rgb
+// blend doesn't add the matched chroma color to the desktop and saturate.
+static const char *ck_strip_ps_source = R"(
+struct VSOut { float4 pos : SV_Position; float2 uv : TEXCOORD0; };
+Texture2D<float4> src : register(t0);
+SamplerState samp : register(s0);
+cbuffer Constants : register(b0) { float3 chroma_rgb; float pad; };
+float4 main(VSOut i) : SV_Target {
+    float3 c = src.Sample(samp, i.uv).rgb;
+    float3 d = abs(c - chroma_rgb);
+    bool match = max(max(d.r, d.g), d.b) < (1.0/512.0);
+    float a = match ? 0.0 : 1.0;
+    return float4(c * a, a);
+}
+)";
+
+/*
+ * Default chroma key when the app didn't supply one (set_chroma_key key=0).
+ * Magenta — matches the D3D11 DP's kDefaultChromaKey for cross-API parity.
+ * 0x00BBGGRR layout: R=0xFF, G=0x00, B=0xFF.
+ */
+static constexpr uint32_t kDefaultChromaKey = 0x00FF00FF;
+
 
 /*!
  * Implementation struct wrapping leiasr_d3d12 as xrt_display_processor_d3d12.
@@ -81,12 +142,529 @@ struct leia_display_processor_d3d12_impl
 	//! @}
 
 	uint32_t view_count; //!< Active mode view count (1=2D, 2=stereo).
+
+	//! @name Chroma-key transparency support (lazy-allocated on first frame)
+	//!
+	//! When @ref ck_enabled and @ref ck_color != 0, process_atlas() does:
+	//!   1. Pre-weave fill: atlas RGBA → ck_fill_tex (alpha=0 → chroma_rgb,
+	//!      output alpha=1) so the SR weaver receives opaque RGB.
+	//!   2. Pass ck_fill_tex (resource pointer) to the weaver instead of the
+	//!      original atlas via leiasr_d3d12_set_input_texture.
+	//!   3. Post-weave strip: copy back buffer → ck_strip_tex, then run strip
+	//!      shader back to back-buffer RTV (chroma match → alpha=0, RGB
+	//!      premultiplied for DWM).
+	//! @{
+	bool ck_enabled;
+	uint32_t ck_color;                       //!< 0x00BBGGRR; effective key.
+	ID3D12RootSignature *ck_root_sig;        //!< Shared by fill + strip PSOs.
+	ID3D12PipelineState *ck_fill_pso;
+	ID3D12PipelineState *ck_strip_pso;
+	ID3D12DescriptorHeap *ck_srv_heap_fill;  //!< Shader-visible, 1 SRV (atlas).
+	ID3D12DescriptorHeap *ck_srv_heap_strip; //!< Shader-visible, 1 SRV (strip_tex).
+	ID3D12DescriptorHeap *ck_rtv_heap_fill;  //!< Non-shader-visible, 1 RTV (fill_tex).
+	// Pre-weave fill target — RT-bindable + SRV-readable; the weaver samples
+	// this resource directly via leiasr_d3d12_set_input_texture.
+	ID3D12Resource *ck_fill_tex;
+	uint32_t ck_fill_w, ck_fill_h;
+	D3D12_RESOURCE_STATES ck_fill_state;
+	// Post-weave strip source — copy of the back buffer for the strip pass
+	// to sample.
+	ID3D12Resource *ck_strip_tex;
+	uint32_t ck_strip_w, ck_strip_h;
+	D3D12_RESOURCE_STATES ck_strip_state;
+	//! @}
 };
 
 static inline struct leia_display_processor_d3d12_impl *
 leia_dp_d3d12(struct xrt_display_processor_d3d12 *xdp)
 {
 	return (struct leia_display_processor_d3d12_impl *)xdp;
+}
+
+
+/*
+ *
+ * Chroma-key fill/strip helpers (transparency support).
+ *
+ * Lazy-allocated on first frame the pass runs. ck_should_run() gates the
+ * whole flow — when false (the common case) none of these execute and
+ * process_atlas behaves identically to the pre-transparency path.
+ *
+ */
+
+static bool
+ck_should_run(struct leia_display_processor_d3d12_impl *ldp)
+{
+	return ldp->ck_enabled && ldp->ck_color != 0;
+}
+
+// Compile a single shader source via D3DCompile. Returns owning blob (caller releases).
+static ID3DBlob *
+ck_compile_shader(const char *src, const char *entry, const char *target)
+{
+	ID3DBlob *blob = nullptr;
+	ID3DBlob *err = nullptr;
+	HRESULT hr = D3DCompile(src, strlen(src), nullptr, nullptr, nullptr,
+	                        entry, target, 0, 0, &blob, &err);
+	if (FAILED(hr)) {
+		U_LOG_E("Leia D3D12 DP: ck shader compile (%s) failed: 0x%08x %s",
+		        target, (unsigned)hr,
+		        err ? (const char *)err->GetBufferPointer() : "");
+		if (err) err->Release();
+		return nullptr;
+	}
+	if (err) err->Release();
+	return blob;
+}
+
+// Build the shared root signature: 32-bit constants for chroma_rgb (b0) +
+// SRV descriptor table (t0) + static point sampler (s0).
+static bool
+ck_build_root_sig(struct leia_display_processor_d3d12_impl *ldp)
+{
+	D3D12_DESCRIPTOR_RANGE srv_range = {};
+	srv_range.RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
+	srv_range.NumDescriptors = 1;
+	srv_range.BaseShaderRegister = 0;
+	srv_range.OffsetInDescriptorsFromTableStart = 0;
+
+	D3D12_ROOT_PARAMETER root_params[2] = {};
+	root_params[0].ParameterType = D3D12_ROOT_PARAMETER_TYPE_32BIT_CONSTANTS;
+	root_params[0].Constants.ShaderRegister = 0;
+	root_params[0].Constants.RegisterSpace = 0;
+	root_params[0].Constants.Num32BitValues = 4;
+	root_params[0].ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
+	root_params[1].ParameterType = D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;
+	root_params[1].DescriptorTable.NumDescriptorRanges = 1;
+	root_params[1].DescriptorTable.pDescriptorRanges = &srv_range;
+	root_params[1].ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
+
+	D3D12_STATIC_SAMPLER_DESC sampler = {};
+	// Point filter — strip's RGB exact-equality test would smear with linear.
+	sampler.Filter = D3D12_FILTER_MIN_MAG_MIP_POINT;
+	sampler.AddressU = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
+	sampler.AddressV = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
+	sampler.AddressW = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
+	sampler.MaxLOD = D3D12_FLOAT32_MAX;
+	sampler.ShaderRegister = 0;
+	sampler.RegisterSpace = 0;
+	sampler.ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
+
+	D3D12_ROOT_SIGNATURE_DESC rs_desc = {};
+	rs_desc.NumParameters = 2;
+	rs_desc.pParameters = root_params;
+	rs_desc.NumStaticSamplers = 1;
+	rs_desc.pStaticSamplers = &sampler;
+	rs_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_DENY_VERTEX_SHADER_ROOT_ACCESS;
+
+	ID3DBlob *rs_blob = nullptr;
+	ID3DBlob *err = nullptr;
+	HRESULT hr = D3D12SerializeRootSignature(&rs_desc, D3D_ROOT_SIGNATURE_VERSION_1,
+	                                          &rs_blob, &err);
+	if (FAILED(hr)) {
+		U_LOG_E("Leia D3D12 DP: ck root sig serialize failed: 0x%08x %s",
+		        (unsigned)hr, err ? (const char *)err->GetBufferPointer() : "");
+		if (err) err->Release();
+		return false;
+	}
+	if (err) err->Release();
+
+	hr = ldp->device->CreateRootSignature(0, rs_blob->GetBufferPointer(),
+	                                       rs_blob->GetBufferSize(),
+	                                       __uuidof(ID3D12RootSignature),
+	                                       reinterpret_cast<void **>(&ldp->ck_root_sig));
+	rs_blob->Release();
+	if (FAILED(hr)) {
+		U_LOG_E("Leia D3D12 DP: ck root sig create failed: 0x%08x", (unsigned)hr);
+		return false;
+	}
+	return true;
+}
+
+// Build a chroma-key PSO for the given pixel-shader source. RTV format is
+// R8G8B8A8_UNORM in both passes (fill_tex format and back-buffer format).
+static bool
+ck_build_pso(struct leia_display_processor_d3d12_impl *ldp,
+             const char *ps_source,
+             ID3D12PipelineState **out_pso)
+{
+	ID3DBlob *vs_blob = ck_compile_shader(ck_vs_source, "main", "vs_5_0");
+	if (vs_blob == nullptr) return false;
+	ID3DBlob *ps_blob = ck_compile_shader(ps_source, "main", "ps_5_0");
+	if (ps_blob == nullptr) {
+		vs_blob->Release();
+		return false;
+	}
+
+	D3D12_GRAPHICS_PIPELINE_STATE_DESC pso_desc = {};
+	pso_desc.pRootSignature = ldp->ck_root_sig;
+	pso_desc.VS = {vs_blob->GetBufferPointer(), vs_blob->GetBufferSize()};
+	pso_desc.PS = {ps_blob->GetBufferPointer(), ps_blob->GetBufferSize()};
+	pso_desc.BlendState.RenderTarget[0].BlendEnable = FALSE;
+	pso_desc.BlendState.RenderTarget[0].LogicOpEnable = FALSE;
+	pso_desc.BlendState.RenderTarget[0].RenderTargetWriteMask = D3D12_COLOR_WRITE_ENABLE_ALL;
+	pso_desc.SampleMask = UINT_MAX;
+	pso_desc.RasterizerState.FillMode = D3D12_FILL_MODE_SOLID;
+	pso_desc.RasterizerState.CullMode = D3D12_CULL_MODE_NONE;
+	pso_desc.RasterizerState.DepthClipEnable = TRUE;
+	pso_desc.DepthStencilState.DepthEnable = FALSE;
+	pso_desc.DepthStencilState.StencilEnable = FALSE;
+	pso_desc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+	pso_desc.NumRenderTargets = 1;
+	pso_desc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+	pso_desc.SampleDesc.Count = 1;
+
+	HRESULT hr = ldp->device->CreateGraphicsPipelineState(
+	    &pso_desc, __uuidof(ID3D12PipelineState),
+	    reinterpret_cast<void **>(out_pso));
+	vs_blob->Release();
+	ps_blob->Release();
+	if (FAILED(hr)) {
+		U_LOG_E("Leia D3D12 DP: ck PSO create failed: 0x%08x", (unsigned)hr);
+		return false;
+	}
+	return true;
+}
+
+// Lazy init root sig + 2 PSOs + 2 shader-visible SRV heaps + 1 RTV heap.
+static bool
+ck_init_pipeline(struct leia_display_processor_d3d12_impl *ldp)
+{
+	if (ldp->ck_fill_pso != nullptr && ldp->ck_strip_pso != nullptr) {
+		return true;
+	}
+	if (ldp->device == nullptr) {
+		return false;
+	}
+
+	if (ldp->ck_root_sig == nullptr && !ck_build_root_sig(ldp)) {
+		return false;
+	}
+	if (ldp->ck_fill_pso == nullptr && !ck_build_pso(ldp, ck_fill_ps_source, &ldp->ck_fill_pso)) {
+		return false;
+	}
+	if (ldp->ck_strip_pso == nullptr && !ck_build_pso(ldp, ck_strip_ps_source, &ldp->ck_strip_pso)) {
+		return false;
+	}
+
+	if (ldp->ck_srv_heap_fill == nullptr) {
+		D3D12_DESCRIPTOR_HEAP_DESC hd = {};
+		hd.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+		hd.NumDescriptors = 1;
+		hd.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		HRESULT hr = ldp->device->CreateDescriptorHeap(
+		    &hd, __uuidof(ID3D12DescriptorHeap),
+		    reinterpret_cast<void **>(&ldp->ck_srv_heap_fill));
+		if (FAILED(hr)) {
+			U_LOG_E("Leia D3D12 DP: ck fill SRV heap create failed: 0x%08x", (unsigned)hr);
+			return false;
+		}
+	}
+	if (ldp->ck_srv_heap_strip == nullptr) {
+		D3D12_DESCRIPTOR_HEAP_DESC hd = {};
+		hd.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+		hd.NumDescriptors = 1;
+		hd.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		HRESULT hr = ldp->device->CreateDescriptorHeap(
+		    &hd, __uuidof(ID3D12DescriptorHeap),
+		    reinterpret_cast<void **>(&ldp->ck_srv_heap_strip));
+		if (FAILED(hr)) {
+			U_LOG_E("Leia D3D12 DP: ck strip SRV heap create failed: 0x%08x", (unsigned)hr);
+			return false;
+		}
+	}
+	if (ldp->ck_rtv_heap_fill == nullptr) {
+		D3D12_DESCRIPTOR_HEAP_DESC hd = {};
+		hd.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+		hd.NumDescriptors = 1;
+		hd.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		HRESULT hr = ldp->device->CreateDescriptorHeap(
+		    &hd, __uuidof(ID3D12DescriptorHeap),
+		    reinterpret_cast<void **>(&ldp->ck_rtv_heap_fill));
+		if (FAILED(hr)) {
+			U_LOG_E("Leia D3D12 DP: ck fill RTV heap create failed: 0x%08x", (unsigned)hr);
+			return false;
+		}
+	}
+
+	U_LOG_W("Leia D3D12 DP: chroma-key pipeline ready (key=0x%08X)", ldp->ck_color);
+	return true;
+}
+
+// Allocate ck_fill_tex sized to the atlas. State at exit: PIXEL_SHADER_RESOURCE
+// (so the weaver, which samples it next, sees it ready). Recreates RTV + SRV
+// descriptors on every (re)alloc.
+static bool
+ck_ensure_fill_target(struct leia_display_processor_d3d12_impl *ldp,
+                       uint32_t w, uint32_t h)
+{
+	if (ldp->ck_fill_tex != nullptr && ldp->ck_fill_w == w && ldp->ck_fill_h == h) {
+		return true;
+	}
+	if (ldp->ck_fill_tex != nullptr) {
+		ldp->ck_fill_tex->Release();
+		ldp->ck_fill_tex = nullptr;
+	}
+
+	D3D12_HEAP_PROPERTIES heap_props = {};
+	heap_props.Type = D3D12_HEAP_TYPE_DEFAULT;
+	D3D12_RESOURCE_DESC td = {};
+	td.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
+	td.Width = w;
+	td.Height = h;
+	td.DepthOrArraySize = 1;
+	td.MipLevels = 1;
+	td.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	td.SampleDesc.Count = 1;
+	td.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
+	td.Flags = D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET;
+
+	HRESULT hr = ldp->device->CreateCommittedResource(
+	    &heap_props, D3D12_HEAP_FLAG_NONE, &td,
+	    D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, nullptr,
+	    __uuidof(ID3D12Resource),
+	    reinterpret_cast<void **>(&ldp->ck_fill_tex));
+	if (FAILED(hr)) {
+		U_LOG_E("Leia D3D12 DP: ck fill tex create (%ux%u) failed: 0x%08x",
+		        w, h, (unsigned)hr);
+		return false;
+	}
+	ldp->ck_fill_w = w;
+	ldp->ck_fill_h = h;
+	ldp->ck_fill_state = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+
+	D3D12_RENDER_TARGET_VIEW_DESC rtv_desc = {};
+	rtv_desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	rtv_desc.ViewDimension = D3D12_RTV_DIMENSION_TEXTURE2D;
+	ldp->device->CreateRenderTargetView(
+	    ldp->ck_fill_tex, &rtv_desc,
+	    ldp->ck_rtv_heap_fill->GetCPUDescriptorHandleForHeapStart());
+	return true;
+}
+
+// Allocate ck_strip_tex sized to the back buffer. State at exit:
+// PIXEL_SHADER_RESOURCE.
+static bool
+ck_ensure_strip_source(struct leia_display_processor_d3d12_impl *ldp,
+                        uint32_t w, uint32_t h)
+{
+	if (ldp->ck_strip_tex != nullptr && ldp->ck_strip_w == w && ldp->ck_strip_h == h) {
+		return true;
+	}
+	if (ldp->ck_strip_tex != nullptr) {
+		ldp->ck_strip_tex->Release();
+		ldp->ck_strip_tex = nullptr;
+	}
+
+	D3D12_HEAP_PROPERTIES heap_props = {};
+	heap_props.Type = D3D12_HEAP_TYPE_DEFAULT;
+	D3D12_RESOURCE_DESC td = {};
+	td.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
+	td.Width = w;
+	td.Height = h;
+	td.DepthOrArraySize = 1;
+	td.MipLevels = 1;
+	td.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	td.SampleDesc.Count = 1;
+	td.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
+	td.Flags = D3D12_RESOURCE_FLAG_NONE;
+
+	HRESULT hr = ldp->device->CreateCommittedResource(
+	    &heap_props, D3D12_HEAP_FLAG_NONE, &td,
+	    D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, nullptr,
+	    __uuidof(ID3D12Resource),
+	    reinterpret_cast<void **>(&ldp->ck_strip_tex));
+	if (FAILED(hr)) {
+		U_LOG_E("Leia D3D12 DP: ck strip tex create (%ux%u) failed: 0x%08x",
+		        w, h, (unsigned)hr);
+		return false;
+	}
+	ldp->ck_strip_w = w;
+	ldp->ck_strip_h = h;
+	ldp->ck_strip_state = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+
+	D3D12_SHADER_RESOURCE_VIEW_DESC srv_desc = {};
+	srv_desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	srv_desc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+	srv_desc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+	srv_desc.Texture2D.MipLevels = 1;
+	ldp->device->CreateShaderResourceView(
+	    ldp->ck_strip_tex, &srv_desc,
+	    ldp->ck_srv_heap_strip->GetCPUDescriptorHandleForHeapStart());
+	return true;
+}
+
+// Pack ck_color (0x00BBGGRR) → 4 root constants (R, G, B, pad).
+static void
+ck_root_constants(struct leia_display_processor_d3d12_impl *ldp, float out[4])
+{
+	uint32_t k = ldp->ck_color;
+	out[0] = ((k >>  0) & 0xFF) / 255.0f; // R
+	out[1] = ((k >>  8) & 0xFF) / 255.0f; // G
+	out[2] = ((k >> 16) & 0xFF) / 255.0f; // B
+	out[3] = 0.0f;
+}
+
+/*
+ * Pre-weave fill: read RGBA atlas, write opaque RGB to ck_fill_tex with
+ * alpha=0 regions filled by chroma_rgb. Returns the resource the weaver
+ * should sample (ck_fill_tex on success, original atlas on fallback).
+ *
+ * The caller (process_atlas) has already set viewport+scissor and bound
+ * the back-buffer RTV. This pass switches the RT binding to ck_fill_tex,
+ * draws, then restores the caller's RTV via prev_rtv so the subsequent
+ * weaver call writes to the right back buffer (D3D11's analog uses
+ * OMGetRenderTargets to save+restore; D3D12 has no Getter on command
+ * lists so prev_rtv is passed in explicitly).
+ */
+static ID3D12Resource *
+ck_run_pre_weave_fill(struct leia_display_processor_d3d12_impl *ldp,
+                       ID3D12GraphicsCommandList *cmd,
+                       ID3D12Resource *atlas_resource,
+                       uint32_t atlas_w, uint32_t atlas_h,
+                       DXGI_FORMAT atlas_format,
+                       D3D12_CPU_DESCRIPTOR_HANDLE prev_rtv)
+{
+	if (!ck_init_pipeline(ldp) || !ck_ensure_fill_target(ldp, atlas_w, atlas_h)) {
+		return atlas_resource;
+	}
+
+	// Create SRV on the atlas resource in the fill heap (slot 0).
+	D3D12_SHADER_RESOURCE_VIEW_DESC srv_desc = {};
+	srv_desc.Format = atlas_format;
+	srv_desc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+	srv_desc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+	srv_desc.Texture2D.MipLevels = 1;
+	ldp->device->CreateShaderResourceView(
+	    atlas_resource, &srv_desc,
+	    ldp->ck_srv_heap_fill->GetCPUDescriptorHandleForHeapStart());
+
+	// fill_tex PIXEL_SHADER_RESOURCE → RENDER_TARGET
+	D3D12_RESOURCE_BARRIER barrier = {};
+	barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+	barrier.Transition.pResource = ldp->ck_fill_tex;
+	barrier.Transition.StateBefore = ldp->ck_fill_state;
+	barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_RENDER_TARGET;
+	barrier.Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+	cmd->ResourceBarrier(1, &barrier);
+	ldp->ck_fill_state = D3D12_RESOURCE_STATE_RENDER_TARGET;
+
+	// Bind PSO + root sig + descriptor heap + chroma constants.
+	cmd->SetPipelineState(ldp->ck_fill_pso);
+	cmd->SetGraphicsRootSignature(ldp->ck_root_sig);
+	ID3D12DescriptorHeap *heaps[] = {ldp->ck_srv_heap_fill};
+	cmd->SetDescriptorHeaps(1, heaps);
+	float root_consts[4];
+	ck_root_constants(ldp, root_consts);
+	cmd->SetGraphicsRoot32BitConstants(0, 4, root_consts, 0);
+	cmd->SetGraphicsRootDescriptorTable(
+	    1, ldp->ck_srv_heap_fill->GetGPUDescriptorHandleForHeapStart());
+
+	D3D12_VIEWPORT vp = {0.0f, 0.0f, (float)atlas_w, (float)atlas_h, 0.0f, 1.0f};
+	D3D12_RECT scissor = {0, 0, (LONG)atlas_w, (LONG)atlas_h};
+	cmd->RSSetViewports(1, &vp);
+	cmd->RSSetScissorRects(1, &scissor);
+
+	D3D12_CPU_DESCRIPTOR_HANDLE rtv =
+	    ldp->ck_rtv_heap_fill->GetCPUDescriptorHandleForHeapStart();
+	cmd->OMSetRenderTargets(1, &rtv, FALSE, nullptr);
+	cmd->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+	cmd->IASetVertexBuffers(0, 0, nullptr);
+	cmd->IASetIndexBuffer(nullptr);
+	cmd->DrawInstanced(3, 1, 0, 0);
+
+	// fill_tex RENDER_TARGET → PIXEL_SHADER_RESOURCE (so weaver can sample).
+	barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
+	barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+	cmd->ResourceBarrier(1, &barrier);
+	ldp->ck_fill_state = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+
+	// Restore the back-buffer RTV so the subsequent weave writes to the
+	// right target. D3D11's analog uses OMGetRenderTargets to save/restore;
+	// D3D12 has no Get on the command list so the caller passes prev_rtv in.
+	cmd->OMSetRenderTargets(1, &prev_rtv, FALSE, nullptr);
+
+	return ldp->ck_fill_tex;
+}
+
+/*
+ * Post-weave strip: copy back buffer → ck_strip_tex, then sample strip_tex
+ * back to back-buffer RTV with alpha=0 where RGB matches chroma_rgb. Caller
+ * passes back_buffer in RENDER_TARGET state; we transition through
+ * COPY_SOURCE and back to RENDER_TARGET.
+ */
+static void
+ck_run_post_weave_strip(struct leia_display_processor_d3d12_impl *ldp,
+                         ID3D12GraphicsCommandList *cmd,
+                         ID3D12Resource *back_buffer,
+                         D3D12_CPU_DESCRIPTOR_HANDLE back_buffer_rtv,
+                         uint32_t bb_w, uint32_t bb_h)
+{
+	if (!ck_init_pipeline(ldp) || !ck_ensure_strip_source(ldp, bb_w, bb_h)) {
+		return;
+	}
+
+	// back_buffer RENDER_TARGET → COPY_SOURCE; strip_tex
+	// PIXEL_SHADER_RESOURCE → COPY_DEST.
+	D3D12_RESOURCE_BARRIER barriers[2] = {};
+	barriers[0].Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+	barriers[0].Transition.pResource = back_buffer;
+	barriers[0].Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
+	barriers[0].Transition.StateAfter = D3D12_RESOURCE_STATE_COPY_SOURCE;
+	barriers[0].Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+	barriers[1].Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+	barriers[1].Transition.pResource = ldp->ck_strip_tex;
+	barriers[1].Transition.StateBefore = ldp->ck_strip_state;
+	barriers[1].Transition.StateAfter = D3D12_RESOURCE_STATE_COPY_DEST;
+	barriers[1].Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+	cmd->ResourceBarrier(2, barriers);
+	ldp->ck_strip_state = D3D12_RESOURCE_STATE_COPY_DEST;
+
+	cmd->CopyResource(ldp->ck_strip_tex, back_buffer);
+
+	// back_buffer COPY_SOURCE → RENDER_TARGET; strip_tex COPY_DEST →
+	// PIXEL_SHADER_RESOURCE.
+	barriers[0].Transition.StateBefore = D3D12_RESOURCE_STATE_COPY_SOURCE;
+	barriers[0].Transition.StateAfter = D3D12_RESOURCE_STATE_RENDER_TARGET;
+	barriers[1].Transition.StateBefore = D3D12_RESOURCE_STATE_COPY_DEST;
+	barriers[1].Transition.StateAfter = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+	cmd->ResourceBarrier(2, barriers);
+	ldp->ck_strip_state = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+
+	// Bind strip PSO + descriptors + chroma constants.
+	cmd->SetPipelineState(ldp->ck_strip_pso);
+	cmd->SetGraphicsRootSignature(ldp->ck_root_sig);
+	ID3D12DescriptorHeap *heaps[] = {ldp->ck_srv_heap_strip};
+	cmd->SetDescriptorHeaps(1, heaps);
+	float root_consts[4];
+	ck_root_constants(ldp, root_consts);
+	cmd->SetGraphicsRoot32BitConstants(0, 4, root_consts, 0);
+	cmd->SetGraphicsRootDescriptorTable(
+	    1, ldp->ck_srv_heap_strip->GetGPUDescriptorHandleForHeapStart());
+
+	D3D12_VIEWPORT vp = {0.0f, 0.0f, (float)bb_w, (float)bb_h, 0.0f, 1.0f};
+	D3D12_RECT scissor = {0, 0, (LONG)bb_w, (LONG)bb_h};
+	cmd->RSSetViewports(1, &vp);
+	cmd->RSSetScissorRects(1, &scissor);
+
+	cmd->OMSetRenderTargets(1, &back_buffer_rtv, FALSE, nullptr);
+	cmd->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+	cmd->IASetVertexBuffers(0, 0, nullptr);
+	cmd->IASetIndexBuffer(nullptr);
+	cmd->DrawInstanced(3, 1, 0, 0);
+}
+
+static void
+ck_release_resources(struct leia_display_processor_d3d12_impl *ldp)
+{
+	if (ldp->ck_fill_tex)        { ldp->ck_fill_tex->Release();        ldp->ck_fill_tex = nullptr; }
+	if (ldp->ck_strip_tex)       { ldp->ck_strip_tex->Release();       ldp->ck_strip_tex = nullptr; }
+	if (ldp->ck_rtv_heap_fill)   { ldp->ck_rtv_heap_fill->Release();   ldp->ck_rtv_heap_fill = nullptr; }
+	if (ldp->ck_srv_heap_strip)  { ldp->ck_srv_heap_strip->Release();  ldp->ck_srv_heap_strip = nullptr; }
+	if (ldp->ck_srv_heap_fill)   { ldp->ck_srv_heap_fill->Release();   ldp->ck_srv_heap_fill = nullptr; }
+	if (ldp->ck_strip_pso)       { ldp->ck_strip_pso->Release();       ldp->ck_strip_pso = nullptr; }
+	if (ldp->ck_fill_pso)        { ldp->ck_fill_pso->Release();        ldp->ck_fill_pso = nullptr; }
+	if (ldp->ck_root_sig)        { ldp->ck_root_sig->Release();        ldp->ck_root_sig = nullptr; }
 }
 
 
@@ -202,16 +780,50 @@ leia_dp_d3d12_process_atlas(struct xrt_display_processor_d3d12 *xdp,
 		cmd->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
 		cmd->IASetVertexBuffers(0, 0, nullptr);
 		cmd->DrawInstanced(4, 1, 0, 0);
+
+		// 2D mode has no weaver, but if chroma-key is enabled the legacy
+		// flow (app pre-fills with key RGB on alpha=1 surface) still needs
+		// the strip pass to recover alpha=0 for DWM. The new flow (true
+		// alpha through the blit) works without it; running strip in that
+		// case is a no-op for non-key pixels (RGB=0 doesn't match magenta).
+		if (ck_should_run(ldp) && target_resource != NULL) {
+			D3D12_CPU_DESCRIPTOR_HANDLE bb_rtv;
+			bb_rtv.ptr = static_cast<SIZE_T>(target_rtv_cpu_handle);
+			ck_run_post_weave_strip(
+			    ldp, cmd,
+			    static_cast<ID3D12Resource *>(target_resource),
+			    bb_rtv, target_width, target_height);
+		}
 		return;
 	}
 
 	(void)atlas_srv_gpu_handle;
-	(void)target_rtv_cpu_handle;
+
+	ID3D12GraphicsCommandList *cmd_3d =
+	    static_cast<ID3D12GraphicsCommandList *>(d3d12_command_list);
 
 	// Atlas is guaranteed content-sized SBS (2*view_width x view_height)
-	// by compositor crop-blit. Pass directly to weaver.
-	if (atlas_texture_resource != NULL) {
-		leiasr_d3d12_set_input_texture(ldp->leiasr, atlas_texture_resource,
+	// by compositor crop-blit.
+	//
+	// When chroma-key is enabled, run the pre-weave fill: replace alpha=0
+	// atlas pixels with the key color so the SR weaver (opaque RGB only)
+	// can process them, then pass the filled resource to the weaver instead
+	// of the original atlas. For legacy apps that pre-filled with the key
+	// color on alpha=1, the fill is a no-op (lerp(key, src.rgb, 1.0) ==
+	// src.rgb) — backward-compatible.
+	ID3D12Resource *weaver_input = static_cast<ID3D12Resource *>(atlas_texture_resource);
+	if (ck_should_run(ldp) && weaver_input != NULL) {
+		uint32_t atlas_w = tile_columns * view_width;
+		uint32_t atlas_h = tile_rows * view_height;
+		D3D12_CPU_DESCRIPTOR_HANDLE bb_rtv;
+		bb_rtv.ptr = static_cast<SIZE_T>(target_rtv_cpu_handle);
+		weaver_input = ck_run_pre_weave_fill(
+		    ldp, cmd_3d, weaver_input, atlas_w, atlas_h,
+		    static_cast<DXGI_FORMAT>(format), bb_rtv);
+	}
+
+	if (weaver_input != NULL) {
+		leiasr_d3d12_set_input_texture(ldp->leiasr, weaver_input,
 		                               view_width, view_height, format);
 	}
 
@@ -220,6 +832,18 @@ leia_dp_d3d12_process_atlas(struct xrt_display_processor_d3d12 *xdp,
 	// the weaver's setViewport/setScissorRect alone do NOT scope the draw.
 	// See gotcha at leiasr_d3d12_weave().
 	leiasr_d3d12_weave(ldp->leiasr, d3d12_command_list, vp_x, vp_y, vp_w, vp_h);
+
+	// Post-weave chroma-key strip: convert key-color RGB pixels in the woven
+	// back buffer to alpha=0 with RGB premultiplied for DWM. No-op when
+	// disabled.
+	if (ck_should_run(ldp) && target_resource != NULL) {
+		D3D12_CPU_DESCRIPTOR_HANDLE bb_rtv;
+		bb_rtv.ptr = static_cast<SIZE_T>(target_rtv_cpu_handle);
+		ck_run_post_weave_strip(
+		    ldp, cmd_3d,
+		    static_cast<ID3D12Resource *>(target_resource),
+		    bb_rtv, target_width, target_height);
+	}
 }
 
 static void
@@ -375,10 +999,39 @@ leia_dp_d3d12_get_display_pixel_info(struct xrt_display_processor_d3d12 *xdp,
 	                                           out_screen_left, out_screen_top, &w_m, &h_m);
 }
 
+static bool
+leia_dp_d3d12_is_alpha_native(struct xrt_display_processor_d3d12 *xdp)
+{
+	(void)xdp;
+	// SR SDK D3D12 weaver interlaces into opaque RGB — alpha is destroyed.
+	// Transparency is recovered via the chroma-key trick (see set_chroma_key).
+	return false;
+}
+
+static void
+leia_dp_d3d12_set_chroma_key(struct xrt_display_processor_d3d12 *xdp,
+                              uint32_t key_color,
+                              bool transparent_bg_enabled)
+{
+	struct leia_display_processor_d3d12_impl *ldp = leia_dp_d3d12(xdp);
+	ldp->ck_enabled = transparent_bg_enabled;
+	// App-supplied override (non-zero) wins over DP-picked default. Matches
+	// the legacy XR_EXT_win32_window_binding.chromaKeyColor behavior so
+	// v1.2.9 Unity plugins and any third-party app that integrated the v5
+	// extension keep working unchanged.
+	ldp->ck_color = (key_color != 0) ? key_color : kDefaultChromaKey;
+	U_LOG_W("Leia D3D12 DP: chroma-key %s (key=0x%08X%s)",
+	        ldp->ck_enabled ? "ENABLED" : "disabled",
+	        ldp->ck_color,
+	        (key_color == 0) ? " — DP default" : " — app override");
+}
+
 static void
 leia_dp_d3d12_destroy(struct xrt_display_processor_d3d12 *xdp)
 {
 	struct leia_display_processor_d3d12_impl *ldp = leia_dp_d3d12(xdp);
+
+	ck_release_resources(ldp);
 
 	if (ldp->blit_pso != NULL) {
 		ldp->blit_pso->Release();
@@ -520,6 +1173,8 @@ leia_dp_factory_d3d12(void *d3d12_device,
 	ldp->base.get_hardware_3d_state = leia_dp_d3d12_get_hardware_3d_state;
 	ldp->base.get_display_dimensions = leia_dp_d3d12_get_display_dimensions;
 	ldp->base.get_display_pixel_info = leia_dp_d3d12_get_display_pixel_info;
+	ldp->base.is_alpha_native = leia_dp_d3d12_is_alpha_native;
+	ldp->base.set_chroma_key = leia_dp_d3d12_set_chroma_key;
 	ldp->base.destroy = leia_dp_d3d12_destroy;
 	ldp->leiasr = weaver;
 	ldp->device = static_cast<ID3D12Device *>(d3d12_device);

--- a/src/xrt/drivers/sim_display/sim_display_processor.c
+++ b/src/xrt/drivers/sim_display/sim_display_processor.c
@@ -566,6 +566,31 @@ sim_dp_destroy(struct xrt_display_processor *xdp)
 
 
 /*
+ * sim_display passes per-pixel alpha through its output stage to the
+ * framebuffer (anaglyph / SBS / blend shaders sample atlas alpha and write
+ * it to the target). No chroma-key trick needed — declare alpha-native via
+ * the vtable so callers can route transparency requests directly.
+ */
+static bool
+sim_dp_is_alpha_native(struct xrt_display_processor *xdp)
+{
+	(void)xdp;
+	return true;
+}
+
+static void
+sim_dp_set_chroma_key(struct xrt_display_processor *xdp,
+                      uint32_t key_color,
+                      bool transparent_bg_enabled)
+{
+	(void)xdp;
+	(void)key_color;
+	(void)transparent_bg_enabled;
+	// Alpha-native — no chroma-key fill/strip required.
+}
+
+
+/*
  *
  * Exported creation function.
  *
@@ -589,6 +614,8 @@ sim_display_processor_create(enum sim_display_output_mode mode,
 	sdp->base.destroy = sim_dp_destroy;
 	sdp->base.get_render_pass = sim_dp_get_render_pass;
 	sdp->base.get_predicted_eye_positions = sim_dp_get_predicted_eye_positions;
+	sdp->base.is_alpha_native = sim_dp_is_alpha_native;
+	sdp->base.set_chroma_key = sim_dp_set_chroma_key;
 
 	// Nominal viewer parameters (same defaults as sim_display_hmd_create)
 	sdp->ipd_m = 0.06f;

--- a/src/xrt/drivers/sim_display/sim_display_processor_d3d11.cpp
+++ b/src/xrt/drivers/sim_display/sim_display_processor_d3d11.cpp
@@ -368,6 +368,31 @@ compile_shader(const char *source, const char *entry, const char *target, ID3DBl
 
 
 /*
+ * sim_display D3D11 passes atlas alpha through its blend/anaglyph/SBS
+ * pixel shaders to the back buffer — alpha-native by construction.
+ * Declared via the vtable so callers don't need to fall back on the
+ * chroma-key trick on this DP variant.
+ */
+static bool
+sim_dp_d3d11_is_alpha_native(struct xrt_display_processor_d3d11 *xdp)
+{
+	(void)xdp;
+	return true;
+}
+
+static void
+sim_dp_d3d11_set_chroma_key(struct xrt_display_processor_d3d11 *xdp,
+                            uint32_t key_color,
+                            bool transparent_bg_enabled)
+{
+	(void)xdp;
+	(void)key_color;
+	(void)transparent_bg_enabled;
+	// Alpha-native — no chroma-key fill/strip required.
+}
+
+
+/*
  *
  * Exported creation function.
  *
@@ -396,6 +421,8 @@ sim_display_processor_d3d11_create(enum sim_display_output_mode mode,
 	sdp->base.destroy = sim_dp_d3d11_destroy;
 	sdp->base.process_atlas = sim_dp_d3d11_process_atlas;
 	sdp->base.get_predicted_eye_positions = sim_dp_d3d11_get_predicted_eye_positions;
+	sdp->base.is_alpha_native = sim_dp_d3d11_is_alpha_native;
+	sdp->base.set_chroma_key = sim_dp_d3d11_set_chroma_key;
 
 	// Nominal viewer parameters (same defaults as sim_display_hmd_create)
 	sdp->ipd_m = 0.06f;

--- a/src/xrt/drivers/sim_display/sim_display_processor_d3d12.cpp
+++ b/src/xrt/drivers/sim_display/sim_display_processor_d3d12.cpp
@@ -444,6 +444,31 @@ create_root_signature(ID3D12Device *device, ID3D12RootSignature **out_rs)
 
 
 /*
+ * sim_display D3D12 passes atlas alpha through to the back buffer via its
+ * blend/anaglyph/SBS pixel shaders — alpha-native by construction.
+ * Declared via the vtable so callers don't need to fall back on the
+ * chroma-key trick on this DP variant.
+ */
+static bool
+sim_dp_d3d12_is_alpha_native(struct xrt_display_processor_d3d12 *xdp)
+{
+	(void)xdp;
+	return true;
+}
+
+static void
+sim_dp_d3d12_set_chroma_key(struct xrt_display_processor_d3d12 *xdp,
+                            uint32_t key_color,
+                            bool transparent_bg_enabled)
+{
+	(void)xdp;
+	(void)key_color;
+	(void)transparent_bg_enabled;
+	// Alpha-native — no chroma-key fill/strip required.
+}
+
+
+/*
  *
  * Exported creation function.
  *
@@ -472,6 +497,8 @@ sim_display_processor_d3d12_create(enum sim_display_output_mode mode,
 	sdp->base.destroy = sim_dp_d3d12_destroy;
 	sdp->base.process_atlas = sim_dp_d3d12_process_atlas;
 	sdp->base.get_predicted_eye_positions = sim_dp_d3d12_get_predicted_eye_positions;
+	sdp->base.is_alpha_native = sim_dp_d3d12_is_alpha_native;
+	sdp->base.set_chroma_key = sim_dp_d3d12_set_chroma_key;
 
 	// Nominal viewer parameters (same defaults as sim_display_hmd_create)
 	sdp->ipd_m = 0.06f;

--- a/src/xrt/drivers/sim_display/sim_display_processor_gl.c
+++ b/src/xrt/drivers/sim_display/sim_display_processor_gl.c
@@ -381,6 +381,31 @@ create_program(const char *vs_source, const char *fs_source)
 
 
 /*
+ * sim_display GL preserves alpha to the default framebuffer — the blend /
+ * anaglyph / SBS fragment shaders write atlas alpha straight through.
+ * Declare alpha-native so callers can route transparency requests
+ * directly without chroma-key fallback.
+ */
+static bool
+sim_dp_gl_is_alpha_native(struct xrt_display_processor_gl *xdp)
+{
+	(void)xdp;
+	return true;
+}
+
+static void
+sim_dp_gl_set_chroma_key(struct xrt_display_processor_gl *xdp,
+                         uint32_t key_color,
+                         bool transparent_bg_enabled)
+{
+	(void)xdp;
+	(void)key_color;
+	(void)transparent_bg_enabled;
+	// Alpha-native — no chroma-key fill/strip required.
+}
+
+
+/*
  *
  * Exported creation function.
  *
@@ -402,6 +427,8 @@ sim_display_processor_gl_create(enum sim_display_output_mode mode,
 	sdp->base.destroy = sim_dp_gl_destroy;
 	sdp->base.process_atlas = sim_dp_gl_process_atlas;
 	sdp->base.get_predicted_eye_positions = sim_dp_gl_get_predicted_eye_positions;
+	sdp->base.is_alpha_native = sim_dp_gl_is_alpha_native;
+	sdp->base.set_chroma_key = sim_dp_gl_set_chroma_key;
 
 	// Nominal viewer parameters (same defaults as sim_display_hmd_create)
 	sdp->ipd_m = 0.06f;

--- a/src/xrt/drivers/sim_display/sim_display_processor_metal.m
+++ b/src/xrt/drivers/sim_display/sim_display_processor_metal.m
@@ -395,6 +395,31 @@ create_pipelines(struct sim_display_processor_metal *sdp)
 
 
 /*
+ * sim_display Metal preserves alpha to the CAMetalLayer drawable — the
+ * blend / anaglyph / SBS shaders write atlas alpha straight through.
+ * Declare alpha-native so the runtime can rely on Cocoa-level NSWindow
+ * transparency without chroma-keying.
+ */
+static bool
+sim_dp_metal_is_alpha_native(struct xrt_display_processor_metal *xdp)
+{
+	(void)xdp;
+	return true;
+}
+
+static void
+sim_dp_metal_set_chroma_key(struct xrt_display_processor_metal *xdp,
+                            uint32_t key_color,
+                            bool transparent_bg_enabled)
+{
+	(void)xdp;
+	(void)key_color;
+	(void)transparent_bg_enabled;
+	// Alpha-native — no chroma-key fill/strip required.
+}
+
+
+/*
  *
  * Exported creation function.
  *
@@ -422,6 +447,8 @@ sim_display_processor_metal_create(enum sim_display_output_mode mode,
 	sdp->base.destroy = sim_dp_metal_destroy;
 	sdp->base.process_atlas = sim_dp_metal_process_atlas;
 	sdp->base.get_predicted_eye_positions = sim_dp_metal_get_predicted_eye_positions;
+	sdp->base.is_alpha_native = sim_dp_metal_is_alpha_native;
+	sdp->base.set_chroma_key = sim_dp_metal_set_chroma_key;
 
 	// Nominal viewer parameters (same defaults as sim_display_hmd_create)
 	sdp->ipd_m = 0.06f;

--- a/src/xrt/include/xrt/xrt_display_processor.h
+++ b/src/xrt/include/xrt/xrt_display_processor.h
@@ -205,6 +205,44 @@ struct xrt_display_processor
 	                               int32_t *out_screen_top);
 
 	/*!
+	 * Whether this display processor passes per-pixel alpha through to its
+	 * output stage. true for processors that sample atlas alpha and write it
+	 * to the framebuffer (sim_display); false (or NULL) for processors that
+	 * interlace into opaque RGB and need the chroma-key trick to recover
+	 * transparency post-weave (Leia).
+	 *
+	 * Optional — NULL means false.
+	 *
+	 * @param xdp Pointer to self.
+	 * @return true if alpha is preserved end-to-end through process_atlas.
+	 */
+	bool (*is_alpha_native)(struct xrt_display_processor *xdp);
+
+	/*!
+	 * Inform the DP of session-level transparency configuration.
+	 * Called once at session start when @p transparent_bg_enabled is set on
+	 * the corresponding window-binding extension. DPs that need the
+	 * chroma-key trick (Leia) use this to enable an internal pre-weave
+	 * fill (transparent atlas pixels → key color) and post-weave strip
+	 * (key color → alpha=0). DPs that are alpha_native may treat this as
+	 * a no-op.
+	 *
+	 * @p key_color is honored as an app-supplied override when non-zero
+	 * (matches today's XR_EXT_win32_window_binding.chromaKeyColor); when
+	 * zero, the DP picks its own internal color.
+	 *
+	 * Optional — NULL means the DP doesn't respect transparency requests.
+	 *
+	 * @param xdp                     Pointer to self.
+	 * @param key_color                App-supplied chroma key (0x00BBGGRR);
+	 *                                 0 means DP-picks (recommended).
+	 * @param transparent_bg_enabled  True when transparency was requested.
+	 */
+	void (*set_chroma_key)(struct xrt_display_processor *xdp,
+	                       uint32_t key_color,
+	                       bool transparent_bg_enabled);
+
+	/*!
 	 * Destroy this display processor and free all resources.
 	 *
 	 * @param xdp Pointer to self.
@@ -357,6 +395,36 @@ xrt_display_processor_get_display_pixel_info(struct xrt_display_processor *xdp,
 		return false;
 	}
 	return xdp->get_display_pixel_info(xdp, out_pixel_width, out_pixel_height, out_screen_left, out_screen_top);
+}
+
+/*!
+ * @copydoc xrt_display_processor::is_alpha_native
+ * Returns false if not supported (function pointer is NULL).
+ * @public @memberof xrt_display_processor
+ */
+static inline bool
+xrt_display_processor_is_alpha_native(struct xrt_display_processor *xdp)
+{
+	if (xdp == NULL || xdp->is_alpha_native == NULL) {
+		return false;
+	}
+	return xdp->is_alpha_native(xdp);
+}
+
+/*!
+ * @copydoc xrt_display_processor::set_chroma_key
+ * No-op if not supported (function pointer is NULL).
+ * @public @memberof xrt_display_processor
+ */
+static inline void
+xrt_display_processor_set_chroma_key(struct xrt_display_processor *xdp,
+                                     uint32_t key_color,
+                                     bool transparent_bg_enabled)
+{
+	if (xdp == NULL || xdp->set_chroma_key == NULL) {
+		return;
+	}
+	xdp->set_chroma_key(xdp, key_color, transparent_bg_enabled);
 }
 
 /*!

--- a/src/xrt/include/xrt/xrt_display_processor_d3d11.h
+++ b/src/xrt/include/xrt/xrt_display_processor_d3d11.h
@@ -134,6 +134,26 @@ struct xrt_display_processor_d3d11
 	                               int32_t *out_screen_top);
 
 	/*!
+	 * Whether this display processor passes per-pixel alpha through to its
+	 * output stage. true for sim_display-style processors; false (or NULL)
+	 * for Leia-style weavers that need the chroma-key trick.
+	 * Optional — NULL means false.
+	 */
+	bool (*is_alpha_native)(struct xrt_display_processor_d3d11 *xdp);
+
+	/*!
+	 * Inform the DP of session-level transparency configuration.
+	 * @p key_color is the app-supplied chroma key (0x00BBGGRR); 0 means
+	 * the DP picks its own internal color. @p transparent_bg_enabled
+	 * tells the DP whether to run its pre-weave fill / post-weave strip
+	 * pass.
+	 * Optional — NULL means the DP doesn't respect transparency requests.
+	 */
+	void (*set_chroma_key)(struct xrt_display_processor_d3d11 *xdp,
+	                       uint32_t key_color,
+	                       bool transparent_bg_enabled);
+
+	/*!
 	 * Destroy this display processor and free all resources.
 	 *
 	 * @param xdp Pointer to self.
@@ -260,6 +280,36 @@ xrt_display_processor_d3d11_get_display_pixel_info(struct xrt_display_processor_
 		return false;
 	}
 	return xdp->get_display_pixel_info(xdp, out_pixel_width, out_pixel_height, out_screen_left, out_screen_top);
+}
+
+/*!
+ * @copydoc xrt_display_processor_d3d11::is_alpha_native
+ * Returns false if not supported (function pointer is NULL).
+ * @public @memberof xrt_display_processor_d3d11
+ */
+static inline bool
+xrt_display_processor_d3d11_is_alpha_native(struct xrt_display_processor_d3d11 *xdp)
+{
+	if (xdp == NULL || xdp->is_alpha_native == NULL) {
+		return false;
+	}
+	return xdp->is_alpha_native(xdp);
+}
+
+/*!
+ * @copydoc xrt_display_processor_d3d11::set_chroma_key
+ * No-op if not supported (function pointer is NULL).
+ * @public @memberof xrt_display_processor_d3d11
+ */
+static inline void
+xrt_display_processor_d3d11_set_chroma_key(struct xrt_display_processor_d3d11 *xdp,
+                                            uint32_t key_color,
+                                            bool transparent_bg_enabled)
+{
+	if (xdp == NULL || xdp->set_chroma_key == NULL) {
+		return;
+	}
+	xdp->set_chroma_key(xdp, key_color, transparent_bg_enabled);
 }
 
 /*!

--- a/src/xrt/include/xrt/xrt_display_processor_d3d12.h
+++ b/src/xrt/include/xrt/xrt_display_processor_d3d12.h
@@ -146,6 +146,26 @@ struct xrt_display_processor_d3d12
 	                               int32_t *out_screen_top);
 
 	/*!
+	 * Whether this display processor passes per-pixel alpha through to its
+	 * output stage. true for sim_display-style processors; false (or NULL)
+	 * for Leia-style weavers that need the chroma-key trick.
+	 * Optional — NULL means false.
+	 */
+	bool (*is_alpha_native)(struct xrt_display_processor_d3d12 *xdp);
+
+	/*!
+	 * Inform the DP of session-level transparency configuration.
+	 * @p key_color is the app-supplied chroma key (0x00BBGGRR); 0 means
+	 * the DP picks its own internal color. @p transparent_bg_enabled
+	 * tells the DP whether to run its pre-weave fill / post-weave strip
+	 * pass.
+	 * Optional — NULL means the DP doesn't respect transparency requests.
+	 */
+	void (*set_chroma_key)(struct xrt_display_processor_d3d12 *xdp,
+	                       uint32_t key_color,
+	                       bool transparent_bg_enabled);
+
+	/*!
 	 * Destroy this display processor and free all resources.
 	 *
 	 * @param xdp Pointer to self.
@@ -290,6 +310,36 @@ xrt_display_processor_d3d12_get_display_pixel_info(struct xrt_display_processor_
 		return false;
 	}
 	return xdp->get_display_pixel_info(xdp, out_pixel_width, out_pixel_height, out_screen_left, out_screen_top);
+}
+
+/*!
+ * @copydoc xrt_display_processor_d3d12::is_alpha_native
+ * Returns false if not supported (function pointer is NULL).
+ * @public @memberof xrt_display_processor_d3d12
+ */
+static inline bool
+xrt_display_processor_d3d12_is_alpha_native(struct xrt_display_processor_d3d12 *xdp)
+{
+	if (xdp == NULL || xdp->is_alpha_native == NULL) {
+		return false;
+	}
+	return xdp->is_alpha_native(xdp);
+}
+
+/*!
+ * @copydoc xrt_display_processor_d3d12::set_chroma_key
+ * No-op if not supported (function pointer is NULL).
+ * @public @memberof xrt_display_processor_d3d12
+ */
+static inline void
+xrt_display_processor_d3d12_set_chroma_key(struct xrt_display_processor_d3d12 *xdp,
+                                            uint32_t key_color,
+                                            bool transparent_bg_enabled)
+{
+	if (xdp == NULL || xdp->set_chroma_key == NULL) {
+		return;
+	}
+	xdp->set_chroma_key(xdp, key_color, transparent_bg_enabled);
 }
 
 /*!

--- a/src/xrt/include/xrt/xrt_display_processor_gl.h
+++ b/src/xrt/include/xrt/xrt_display_processor_gl.h
@@ -128,6 +128,26 @@ struct xrt_display_processor_gl
 	                               int32_t *out_screen_top);
 
 	/*!
+	 * Whether this display processor passes per-pixel alpha through to its
+	 * output stage. true for sim_display-style processors; false (or NULL)
+	 * for Leia-style weavers that need the chroma-key trick.
+	 * Optional — NULL means false.
+	 */
+	bool (*is_alpha_native)(struct xrt_display_processor_gl *xdp);
+
+	/*!
+	 * Inform the DP of session-level transparency configuration.
+	 * @p key_color is the app-supplied chroma key (0x00BBGGRR); 0 means
+	 * the DP picks its own internal color. @p transparent_bg_enabled
+	 * tells the DP whether to run its pre-weave fill / post-weave strip
+	 * pass.
+	 * Optional — NULL means the DP doesn't respect transparency requests.
+	 */
+	void (*set_chroma_key)(struct xrt_display_processor_gl *xdp,
+	                       uint32_t key_color,
+	                       bool transparent_bg_enabled);
+
+	/*!
 	 * Destroy this display processor and free all resources.
 	 *
 	 * @param xdp Pointer to self.
@@ -253,6 +273,36 @@ xrt_display_processor_gl_get_display_pixel_info(struct xrt_display_processor_gl 
 		return false;
 	}
 	return xdp->get_display_pixel_info(xdp, out_pixel_width, out_pixel_height, out_screen_left, out_screen_top);
+}
+
+/*!
+ * @copydoc xrt_display_processor_gl::is_alpha_native
+ * Returns false if not supported (function pointer is NULL).
+ * @public @memberof xrt_display_processor_gl
+ */
+static inline bool
+xrt_display_processor_gl_is_alpha_native(struct xrt_display_processor_gl *xdp)
+{
+	if (xdp == NULL || xdp->is_alpha_native == NULL) {
+		return false;
+	}
+	return xdp->is_alpha_native(xdp);
+}
+
+/*!
+ * @copydoc xrt_display_processor_gl::set_chroma_key
+ * No-op if not supported (function pointer is NULL).
+ * @public @memberof xrt_display_processor_gl
+ */
+static inline void
+xrt_display_processor_gl_set_chroma_key(struct xrt_display_processor_gl *xdp,
+                                         uint32_t key_color,
+                                         bool transparent_bg_enabled)
+{
+	if (xdp == NULL || xdp->set_chroma_key == NULL) {
+		return;
+	}
+	xdp->set_chroma_key(xdp, key_color, transparent_bg_enabled);
 }
 
 /*!

--- a/src/xrt/include/xrt/xrt_display_processor_metal.h
+++ b/src/xrt/include/xrt/xrt_display_processor_metal.h
@@ -128,6 +128,26 @@ struct xrt_display_processor_metal
 	                               int32_t *out_screen_top);
 
 	/*!
+	 * Whether this display processor passes per-pixel alpha through to its
+	 * output stage. true for sim_display-style processors; false (or NULL)
+	 * for Leia-style weavers that need the chroma-key trick.
+	 * Optional — NULL means false.
+	 */
+	bool (*is_alpha_native)(struct xrt_display_processor_metal *xdp);
+
+	/*!
+	 * Inform the DP of session-level transparency configuration.
+	 * @p key_color is the app-supplied chroma key (0x00BBGGRR); 0 means
+	 * the DP picks its own internal color. @p transparent_bg_enabled
+	 * tells the DP whether to run its pre-weave fill / post-weave strip
+	 * pass.
+	 * Optional — NULL means the DP doesn't respect transparency requests.
+	 */
+	void (*set_chroma_key)(struct xrt_display_processor_metal *xdp,
+	                       uint32_t key_color,
+	                       bool transparent_bg_enabled);
+
+	/*!
 	 * Destroy this display processor and free all resources.
 	 *
 	 * @param xdp Pointer to self.
@@ -255,6 +275,36 @@ xrt_display_processor_metal_get_display_pixel_info(struct xrt_display_processor_
 		return false;
 	}
 	return xdp->get_display_pixel_info(xdp, out_pixel_width, out_pixel_height, out_screen_left, out_screen_top);
+}
+
+/*!
+ * @copydoc xrt_display_processor_metal::is_alpha_native
+ * Returns false if not supported (function pointer is NULL).
+ * @public @memberof xrt_display_processor_metal
+ */
+static inline bool
+xrt_display_processor_metal_is_alpha_native(struct xrt_display_processor_metal *xdp)
+{
+	if (xdp == NULL || xdp->is_alpha_native == NULL) {
+		return false;
+	}
+	return xdp->is_alpha_native(xdp);
+}
+
+/*!
+ * @copydoc xrt_display_processor_metal::set_chroma_key
+ * No-op if not supported (function pointer is NULL).
+ * @public @memberof xrt_display_processor_metal
+ */
+static inline void
+xrt_display_processor_metal_set_chroma_key(struct xrt_display_processor_metal *xdp,
+                                            uint32_t key_color,
+                                            bool transparent_bg_enabled)
+{
+	if (xdp == NULL || xdp->set_chroma_key == NULL) {
+		return;
+	}
+	xdp->set_chroma_key(xdp, key_color, transparent_bg_enabled);
 }
 
 /*!

--- a/src/xrt/state_trackers/oxr/oxr_objects.h
+++ b/src/xrt/state_trackers/oxr/oxr_objects.h
@@ -1302,6 +1302,7 @@ oxr_session_populate_gl_macos(struct oxr_logger *log,
                                const void *next,
                                void *window_handle,
                                void *shared_iosurface,
+                               bool transparent_background,
                                struct oxr_session *sess);
 #endif
 
@@ -1394,6 +1395,7 @@ oxr_session_populate_vk_native(struct oxr_logger *log,
                                 XrGraphicsBindingVulkanKHR const *next,
                                 void *window_handle,
                                 void *shared_texture_handle,
+                                bool transparent_background,
                                 struct oxr_session *sess);
 #endif
 
@@ -1552,6 +1554,7 @@ oxr_session_populate_metal_native(struct oxr_logger *log,
                                   void *window_handle,
                                   bool offscreen,
                                   void *shared_texture_handle,
+                                  bool transparent_background,
                                   struct oxr_session *sess);
 #endif
 
@@ -1567,6 +1570,7 @@ oxr_session_populate_vk_with_metal_native(struct oxr_logger *log,
                                            XrGraphicsBindingVulkanKHR const *next,
                                            void *window_handle,
                                            void *shared_iosurface,
+                                           bool transparent_background,
                                            struct oxr_session *sess);
 #endif
 

--- a/src/xrt/state_trackers/oxr/oxr_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_session.c
@@ -2197,7 +2197,7 @@ oxr_session_create_impl(struct oxr_logger *log,
 					shared_iosurface = (void *)cocoa_binding->sharedIOSurface;
 				}
 			}
-			XrResult ret = oxr_session_populate_gl_macos(log, sys, opengl_macos, window_handle, shared_iosurface, *out_session);
+			XrResult ret = oxr_session_populate_gl_macos(log, sys, opengl_macos, window_handle, shared_iosurface, xsi->transparent_background_enabled, *out_session);
 			if (ret == XR_SUCCESS && window_handle != NULL) {
 				(*out_session)->has_external_window = true;
 				struct xrt_device *head = GET_XDEV_BY_ROLE((*out_session)->sys, head);
@@ -2280,7 +2280,8 @@ oxr_session_create_impl(struct oxr_logger *log,
 				                 "Failed to create xrt_session! '%i'", xret);
 			}
 			return oxr_session_populate_vk_native(
-			    log, sys, vulkan, window_handle, shared_texture_handle, *out_session);
+			    log, sys, vulkan, window_handle, shared_texture_handle,
+			    xsi->transparent_background_enabled, *out_session);
 		}
 #endif
 
@@ -2308,7 +2309,8 @@ oxr_session_create_impl(struct oxr_logger *log,
 				}
 			}
 			XrResult ret = oxr_session_populate_vk_with_metal_native(
-			    log, sys, vulkan, window_handle, shared_iosurface, *out_session);
+			    log, sys, vulkan, window_handle, shared_iosurface,
+			    xsi->transparent_background_enabled, *out_session);
 			if (ret == XR_SUCCESS && window_handle != NULL) {
 				(*out_session)->has_external_window = true;
 				struct xrt_device *head = GET_XDEV_BY_ROLE((*out_session)->sys, head);
@@ -2489,7 +2491,8 @@ oxr_session_create_impl(struct oxr_logger *log,
 			                 (xsi->readback_callback != NULL || xsi->shared_texture_handle != NULL);
 
 			return oxr_session_populate_metal_native(log, sys, metal, xsi->external_window_handle, offscreen,
-			                                        xsi->shared_texture_handle, *out_session);
+			                                        xsi->shared_texture_handle,
+			                                        xsi->transparent_background_enabled, *out_session);
 		}
 #else
 		U_LOG_IFL_I(U_LOGGING_INFO, "Metal native compositor NOT compiled in (XRT_HAVE_METAL_NATIVE_COMPOSITOR not defined)");
@@ -2628,6 +2631,9 @@ oxr_session_create(struct oxr_logger *log,
 		}
 		if (macos_target_info->sharedIOSurface) {
 			xsi.shared_texture_handle = macos_target_info->sharedIOSurface;
+		}
+		if (macos_target_info->transparentBackgroundEnabled) {
+			xsi.transparent_background_enabled = true;
 		}
 	} else {
 		U_LOG_W("No cocoa window binding found in session create chain");

--- a/src/xrt/state_trackers/oxr/oxr_session_gfx_gl_macos.m
+++ b/src/xrt/state_trackers/oxr/oxr_session_gfx_gl_macos.m
@@ -38,9 +38,20 @@ oxr_session_populate_gl_macos(struct oxr_logger *log,
                                const void *next_ptr,
                                void *window_handle,
                                void *shared_iosurface,
+                               bool transparent_background,
                                struct oxr_session *sess)
 {
 	const XrGraphicsBindingOpenGLMacOSEXT *next = (const XrGraphicsBindingOpenGLMacOSEXT *)next_ptr;
+
+	// TODO: plumb transparent_background through comp_gl_compositor_create.
+	// The GL native macOS compositor uses NSOpenGLView, which would need
+	// setOpaque:NO + clear pixel-format alpha to match the Metal path. Not
+	// implemented in PR #4 — request via XR_EXT_cocoa_window_binding will
+	// be a no-op on the GL native path until then.
+	if (transparent_background) {
+		U_LOG_W("oxr_session_populate_gl_macos: transparentBackgroundEnabled requested but "
+		        "GL native compositor doesn't yet implement NSOpenGLView alpha — ignoring");
+	}
 
 	// Both windowed and shared IOSurface modes use the GL native compositor
 	struct xrt_device *xdev = get_role_head(sess->sys);
@@ -122,7 +133,7 @@ oxr_session_populate_gl_macos(struct oxr_logger *log,
 
 	xrt_result_t xret = comp_metal_compositor_create(
 	    xdev, window_handle, NULL, dp_factory_metal,
-	    offscreen, shared_iosurface, &xcn);
+	    offscreen, shared_iosurface, transparent_background, &xcn);
 	if (xret != XRT_SUCCESS) {
 		return oxr_error(log, XR_ERROR_INITIALIZATION_FAILED,
 		                 "Failed to create Metal native compositor for GL app: %d", xret);

--- a/src/xrt/state_trackers/oxr/oxr_session_gfx_metal_native.c
+++ b/src/xrt/state_trackers/oxr/oxr_session_gfx_metal_native.c
@@ -100,6 +100,7 @@ oxr_session_populate_metal_native(struct oxr_logger *log,
                                   void *window_handle,
                                   bool offscreen,
                                   void *shared_texture_handle,
+                                  bool transparent_background,
                                   struct oxr_session *sess)
 {
 	struct xrt_device *xdev = get_role_head(sess->sys);
@@ -114,7 +115,7 @@ oxr_session_populate_metal_native(struct oxr_logger *log,
 	// Create the Metal native compositor
 	xrt_result_t xret = comp_metal_compositor_create(
 	    xdev, window_handle, (void *)next->commandQueue, dp_factory_metal, offscreen,
-	    shared_texture_handle, &xcn);
+	    shared_texture_handle, transparent_background, &xcn);
 	if (xret != XRT_SUCCESS) {
 		return oxr_error(log, XR_ERROR_INITIALIZATION_FAILED,
 		                 "Failed to create Metal native compositor: %d", xret);

--- a/src/xrt/state_trackers/oxr/oxr_session_gfx_vk_native.c
+++ b/src/xrt/state_trackers/oxr/oxr_session_gfx_vk_native.c
@@ -63,6 +63,7 @@ oxr_session_populate_vk_with_metal_native(struct oxr_logger *log,
                                            XrGraphicsBindingVulkanKHR const *next,
                                            void *window_handle,
                                            void *shared_iosurface,
+                                           bool transparent_background,
                                            struct oxr_session *sess)
 {
 	struct xrt_device *xdev = get_role_head(sess->sys);
@@ -85,6 +86,7 @@ oxr_session_populate_vk_with_metal_native(struct oxr_logger *log,
 	    dp_factory_metal,
 	    offscreen,
 	    shared_iosurface,
+	    transparent_background,
 	    &xcn);
 	if (xret != XRT_SUCCESS) {
 		return oxr_error(log, XR_ERROR_INITIALIZATION_FAILED,
@@ -246,6 +248,7 @@ oxr_session_populate_vk_native(struct oxr_logger *log,
                                 XrGraphicsBindingVulkanKHR const *next,
                                 void *window_handle,
                                 void *shared_texture_handle,
+                                bool transparent_background,
                                 struct oxr_session *sess)
 {
 	struct xrt_device *xdev = get_role_head(sess->sys);

--- a/test_apps/cube_handle_metal_macos/main.mm
+++ b/test_apps/cube_handle_metal_macos/main.mm
@@ -625,7 +625,16 @@ static void RenderScene(MetalRenderer &r, id<MTLTexture> target,
     rpd.colorAttachments[0].texture = target;
     rpd.colorAttachments[0].loadAction = MTLLoadActionClear;
     rpd.colorAttachments[0].storeAction = MTLStoreActionStore;
-    rpd.colorAttachments[0].clearColor = MTLClearColorMake(0.05, 0.05, 0.08, 1.0);
+    // Transparent-background mode (DISPLAYXR_TRANSPARENT_BG=1) clears RGBA(0,0,0,0)
+    // so the desktop shows through everywhere the cube isn't drawn. Pairs with
+    // XrCocoaWindowBindingCreateInfoEXT.transparentBackgroundEnabled = XR_TRUE.
+    static const bool transparent_bg = []() {
+        const char *e = getenv("DISPLAYXR_TRANSPARENT_BG");
+        return e != nullptr && *e != '\0' && *e != '0';
+    }();
+    rpd.colorAttachments[0].clearColor = transparent_bg
+        ? MTLClearColorMake(0.0, 0.0, 0.0, 0.0)
+        : MTLClearColorMake(0.05, 0.05, 0.08, 1.0);
     rpd.depthAttachment.texture = r.depthTexture;
     rpd.depthAttachment.loadAction = MTLLoadActionClear;
     rpd.depthAttachment.storeAction = MTLStoreActionDontCare;
@@ -1257,6 +1266,22 @@ static bool CreateSession(AppXrSession &app, MetalRenderer &r)
     cocoaBinding.type = XR_TYPE_COCOA_WINDOW_BINDING_CREATE_INFO_EXT;
     cocoaBinding.next = nullptr;
     cocoaBinding.viewHandle = (__bridge void *)g_metalView;
+
+    // Optional transparent-background mode (spec v5).
+    {
+        const char *e = getenv("DISPLAYXR_TRANSPARENT_BG");
+        if (e != nullptr && *e != '\0' && *e != '0') {
+            cocoaBinding.transparentBackgroundEnabled = XR_TRUE;
+            // Make our app-owned NSWindow non-opaque too — the runtime only
+            // configures the CAMetalLayer it presents into for app-provided
+            // views; the NSWindow alpha is the app's responsibility.
+            if (g_metalView != nil && g_metalView.window != nil) {
+                [g_metalView.window setOpaque:NO];
+                [g_metalView.window setBackgroundColor:[NSColor clearColor]];
+            }
+            LOG_INFO("Transparent background ENABLED (DISPLAYXR_TRANSPARENT_BG=1)");
+        }
+    }
 
     if (app.hasCocoaWindowBinding) {
         metalBinding.next = &cocoaBinding;


### PR DESCRIPTION
## Summary

End-to-end transparent-window support across all platform / graphics-API combinations the runtime ships, with the chroma-key trick fully internalized in the Leia display processor (D3D11 + D3D12) and per-tile alpha respected at the workspace level.

**Scope:** PRs #1–#4 of the transparency-support feature plan.

| PR | What | Status |
|---|---|---|
| #1 | DP vtable additions (`is_alpha_native`, `set_chroma_key`) + Leia D3D11 chroma-key internalization with pre-weave fill | ✓ Validated |
| #2 | Workspace multi-compositor respects per-tile `BLEND_TEXTURE_SOURCE_ALPHA_BIT` | ✓ Validated |
| #3a | Leia D3D12 chroma-key internalization (mirror of PR #1 for D3D12) | ✓ Validated |
| #4 | macOS NSWindow alpha + `XR_EXT_cocoa_window_binding` v5 (transparent\_background) + sim_display alpha-native declarations | ✓ Landed (macOS-side work) |

PR #3b (GL stub), #3c (Vulkan), #5 (`displayxr-unity` plugin v1.3.0), #6 (`displayxr-unity-test-transparent` v1.3.0) are deferred to a follow-up branch.

## What apps gain

| Concern | Mechanism |
|---|---|
| "This layer's texture has per-pixel alpha" | Standard `XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT` (already plumbed end-to-end) |
| "This output window should be transparent" (Windows) | `XR_EXT_win32_window_binding.transparentBackgroundEnabled` |
| "This output window should be transparent" (macOS) | `XR_EXT_cocoa_window_binding.transparentBackgroundEnabled` |
| Optional chroma-key override (Windows only) | `XR_EXT_win32_window_binding.chromaKeyColor` — non-zero = app override, **zero = DP picks** (new behavior) |

The Leia display processor (D3D11 + D3D12) now owns the chroma-key trick internally — apps just submit RGBA(0,0,0,0)-cleared swapchains plus the alpha bit on the projection layer. macOS sim_display passes alpha through natively (true per-pixel alpha via NSWindow + CAMetalLayer).

## Notable findings (in commits)

- **Workspace per-tile alpha snapshot** (a2d3dbf88): reading `cc->layer_accum` directly from the multi-compositor races with the client's `xrBeginFrame` reset (same root cause as the WS-layer HUD flicker fix). Fix is a snapshot of the projection layer flags under `ws_snapshot_mutex`, alongside the existing HUD snapshot. Without it, ~99% of multi-comp ticks see `layer_count == 0` and fall through to opaque blend.
- **D3D12 RTV restoration** (a8951cd7e): the pre-weave fill draws to `ck_fill_tex`. D3D11's analog uses `OMGetRenderTargets` to save+restore the back-buffer RTV across the pass; D3D12 has no `Get` on the command list, so the back-buffer RTV handle has to be threaded in explicitly, otherwise the SR weaver runs with `ck_fill_tex` still bound and the woven output never reaches the swap chain.
- **WS_EX_NOREDIRECTIONBITMAP contract** (a7d1c7ee8): apps that want transparent D3D12 windows must create their HWND with `WS_EX_NOREDIRECTIONBITMAP` + null background brush. Without that, DComp's `alpha = 0` swap chain pixels composite over the HWND's redirection surface (default-cleared opaque) instead of the desktop. Documented in the spec.

## End-to-end validation (Leia hardware)

| App | Mode | Result |
|---|---|---|
| `cube_handle_d3d11_win` × 2 in workspace | Stock (no flags) | ✓ Identical to baseline |
| `cube_handle_d3d11_win` × 2 in workspace | Patched: alpha=0 clear + `BLEND_TEXTURE_SOURCE_ALPHA_BIT` | ✓ Workspace bg shows through transparent regions of each tile |
| `cube_handle_d3d12_win` standalone | Stock (no flags) | ✓ Identical to baseline |
| `cube_handle_d3d12_win` standalone | Patched: `transparentBackgroundEnabled=TRUE`, `chromaKeyColor=0`, alpha=0 clear, `BLEND_TEXTURE_SOURCE_ALPHA_BIT`, `WS_EX_NOREDIRECTIONBITMAP` | ✓ Cube floats over desktop, magenta-tinted hard edges (DP-default key), click-through |

## Test plan

- [x] Build clean (Windows local, all targets)
- [x] PR #2 backward compat (workspace + 2 stock cubes)
- [x] PR #2 new-flag path (workspace + 2 patched cubes — workspace bg through tile transparent regions)
- [x] PR #3a backward compat (cube_handle_d3d12_win standalone, stock)
- [x] PR #3a new-flag path (cube_handle_d3d12_win standalone, patched, over Notepad — desktop visible through transparent regions)
- [ ] CI: build-windows.yml
- [ ] CI: build-macos.yml

## Files touched

```
docs/architecture/compositor-pipeline.md          (per-tile alpha note)
docs/specs/workspace-controller-registration.md   (workspace output is opaque)
docs/specs/XR_EXT_win32_window_binding.md         (v4/v5 fields + WS_EX_NOREDIRECTIONBITMAP contract)
docs/specs/XR_EXT_cocoa_window_binding.md         (v5: transparentBackgroundEnabled)
docs/roadmap/transparency-support-handoff.md      (development handoff, transient)
docs/roadmap/transparency-support-followup.md     (development handoff, transient)
src/external/openxr_includes/openxr/XR_EXT_cocoa_window_binding.h
src/xrt/include/xrt/xrt_display_processor*.h      (5 headers)
src/xrt/drivers/leia/leia_display_processor_d3d11.cpp
src/xrt/drivers/leia/leia_display_processor_d3d12.cpp
src/xrt/drivers/sim_display/sim_display_processor*.{c,m,cpp}  (5 variants)
src/xrt/compositor/d3d11/comp_d3d11_compositor.cpp
src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp
src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
src/xrt/compositor/metal/comp_metal_compositor.{h,m}
src/xrt/state_trackers/oxr/oxr_session.c
src/xrt/state_trackers/oxr/oxr_session_gfx_*macos*.{c,m}
test_apps/cube_handle_metal_macos/main.mm
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)