### PR TITLE
runtime: forward SHIFT+TAB to focused app; bare TAB still cycles

### DIFF
--- a/src/xrt/compositor/d3d11/comp_d3d11_window.cpp
+++ b/src/xrt/compositor/d3d11/comp_d3d11_window.cpp
@@ -324,9 +324,12 @@ workspace_compute_modifiers(void)
 /*!
  * Check if a virtual key code is reserved for workspace controls.
  * These keys are NOT forwarded to the focused app in workspace mode.
+ *
+ * SHIFT+TAB is forwarded (apps use it as a HUD toggle); only bare TAB
+ * is reserved for workspace focus cycling.
  */
 static bool
-is_workspace_reserved_key(WPARAM vk)
+is_workspace_reserved_key(WPARAM vk, bool shift)
 {
 	// Only true workspace-management keys are reserved.
 	// V, P, 0-9 are forwarded to the app (it may use them for its own purposes).
@@ -334,11 +337,9 @@ is_workspace_reserved_key(WPARAM vk)
 	// tries to change rendering mode via xrRequestDisplayRenderingModeEXT,
 	// that call is blocked in workspace/IPC mode.
 	switch (vk) {
-	case VK_TAB:    // Cycle focus
-	case VK_DELETE: // Close focused app
-		return true;
-	default:
-		return false;
+	case VK_TAB:    return !shift;  // bare TAB cycles focus; Shift+TAB → app
+	case VK_DELETE: return true;    // Close focused app
+	default:        return false;
 	}
 }
 
@@ -600,8 +601,10 @@ wnd_proc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 				                     message, wParam, lParam, &handled);
 			}
 #endif
-			if (is_workspace_reserved_key(wParam)) {
-				// Workspace-only keys (TAB, DELETE) → don't forward to app
+			bool shift = (GetKeyState(VK_SHIFT) & 0x8000) != 0;
+			if (is_workspace_reserved_key(wParam, shift)) {
+				// Workspace-only keys (bare TAB, DELETE) → don't forward to app.
+				// SHIFT+TAB falls through and gets PostMessage'd below.
 				return 0;
 			}
 			// ESC: only suppress when a window is maximized (fullscreen restore).

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -6503,24 +6503,24 @@ multi_compositor_render(struct d3d11_service_system *sys)
 		goto after_key_shortcuts;
 	}
 
-	// TAB / Shift+TAB: cycle focus forward/backward. Never unfocuses when windows exist.
-	// Ignore ALT+TAB (system task switcher) — only process bare TAB.
-	if ((GetAsyncKeyState(VK_TAB) & 1) && !(GetAsyncKeyState(VK_MENU) & 0x8000)) {
+	// Bare TAB: cycle focus forward. Never unfocuses when windows exist.
+	// SHIFT+TAB is no longer reserved here — it falls through to wnd_proc's
+	// forward-to-app path so apps can use it (e.g. HUD toggle in cube tests).
+	// Ignore ALT+TAB (system task switcher).
+	if ((GetAsyncKeyState(VK_TAB) & 1) &&
+	    !(GetAsyncKeyState(VK_MENU) & 0x8000) &&
+	    !(GetAsyncKeyState(VK_SHIFT) & 0x8000)) {
 		if (mc->client_count > 0) {
-			bool reverse = (GetAsyncKeyState(VK_SHIFT) & 0x8000) != 0;
 			int n = D3D11_MULTI_MAX_CLIENTS;
-			// base: for -1, forward searches from slot 0, reverse from last slot
-			int base = (mc->focused_slot >= 0) ? mc->focused_slot : (reverse ? n : -1);
+			int base = (mc->focused_slot >= 0) ? mc->focused_slot : -1;
 			for (int i = 1; i <= n; i++) {
-				int idx = reverse
-				        ? ((base - i) % n + n) % n
-				        : (base + i) % n;
+				int idx = (base + i) % n;
 				if (mc->clients[idx].active && !mc->clients[idx].minimized) {
 					mc->focused_slot = idx;
 					break;
 				}
 			}
-			U_LOG_W("Multi-comp: %sTAB → focused slot %d", reverse ? "Shift+" : "", mc->focused_slot);
+			U_LOG_W("Multi-comp: TAB → focused slot %d", mc->focused_slot);
 			multi_compositor_update_input_forward(mc);
 		}
 	}


### PR DESCRIPTION
## Summary
- `is_workspace_reserved_key` now takes a `shift` arg; VK_TAB is reserved only when SHIFT is up. The wnd_proc forwarding gate reads `GetKeyState(VK_SHIFT)` and passes it in, so SHIFT+TAB falls through to the existing `PostMessage` path to the focused app.
- The `GetAsyncKeyState` focus cycler in the d3d11 service now also requires SHIFT to be up. Bare TAB keeps cycling forward; SHIFT+TAB is no longer reserve-cycled (reverse-cycle UX dropped).
- Pairs with displayxr-shell-pvt#<n> which removes the shell-side TAB handler. Cube test apps' SHIFT+TAB HUD toggle now works in shell mode.

## Test plan
- [x] Local build (`scripts\build_windows.bat build`)
- [x] Standalone cube apps unaffected (SHIFT+TAB toggles HUD, TAB no-op)
- [x] Shell mode: TAB cycles focus between two cubes
- [x] Shell mode: SHIFT+TAB toggles HUD on focused cube
- [x] DELETE / F11 / ESC / ALT+TAB unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)