### PR TITLE
d3d12: dump DRED breadcrumbs when atlas creation fails with device-removed

### DIFF
--- a/src/xrt/compositor/d3d12/comp_d3d12_renderer.cpp
+++ b/src/xrt/compositor/d3d12/comp_d3d12_renderer.cpp
@@ -211,6 +211,67 @@ compile_shader(const char *source, const char *entry, const char *target, ID3DBl
 }
 
 
+// Dump DRED auto-breadcrumbs + page-fault info to the log. Useful when the
+// D3D12 device gets removed and we need to know which GPU command was
+// executing at the time.
+//
+// DRED itself must be enabled BEFORE device creation; we don't own that step
+// (Unity / the app creates the device). Enable it via either:
+//
+//   - Per-process: ID3D12DeviceRemovedExtendedDataSettings::
+//                  SetAutoBreadcrumbsEnablement(FORCED_ON) before the first
+//                  D3D12CreateDevice call in the process.
+//   - Per-app:     HKLM\SOFTWARE\Microsoft\Direct3D\AppCompat\<exe>.exe with
+//                  REG_DWORD AutoBreadcrumbsEnablement=1 and PageFaultEnablement=1.
+//   - Globally:    Windows Development Build / DirectX Control Panel.
+//
+// When DRED isn't enabled, QueryInterface returns DXGI_ERROR_NOT_FOUND and we
+// log that fact (so users know how to turn it on) but don't error.
+static void
+log_dred_state(ID3D12Device *device, const char *context)
+{
+	if (device == nullptr) return;
+	ID3D12DeviceRemovedExtendedData *dred = nullptr;
+	HRESULT qr = device->QueryInterface(__uuidof(ID3D12DeviceRemovedExtendedData), (void**)&dred);
+	if (FAILED(qr) || dred == nullptr) {
+		U_LOG_E("%s: DRED not available (qr=0x%08x). Enable via HKLM\\SOFTWARE"
+		        "\\Microsoft\\Direct3D\\AppCompat\\<exe>\\AutoBreadcrumbsEnablement=1.",
+		        context, (unsigned)qr);
+		return;
+	}
+
+	D3D12_DRED_AUTO_BREADCRUMBS_OUTPUT crumbs = {};
+	HRESULT cb = dred->GetAutoBreadcrumbsOutput(&crumbs);
+	if (SUCCEEDED(cb)) {
+		const D3D12_AUTO_BREADCRUMB_NODE *node = crumbs.pHeadAutoBreadcrumbNode;
+		int nidx = 0;
+		while (node != nullptr && nidx < 20) {
+			UINT last = node->pLastBreadcrumbValue ? *node->pLastBreadcrumbValue : 0;
+			U_LOG_E("%s: DRED node[%d] count=%u last_completed=%u",
+			        context, nidx, node->BreadcrumbCount, last);
+			UINT start = (last > 16) ? last - 16 : 0;
+			UINT end = (last + 4 < node->BreadcrumbCount) ? last + 4 : node->BreadcrumbCount;
+			for (UINT i = start; i < end; i++) {
+				const char *marker = (i == last) ? " <-- KILLED HERE" : "";
+				U_LOG_E("%s:   op[%u] = %u%s",
+				        context, i, (unsigned)node->pCommandHistory[i], marker);
+			}
+			node = node->pNext;
+			nidx++;
+		}
+	} else {
+		U_LOG_E("%s: DRED GetAutoBreadcrumbsOutput failed: 0x%08x", context, (unsigned)cb);
+	}
+
+	D3D12_DRED_PAGE_FAULT_OUTPUT pf = {};
+	HRESULT pr = dred->GetPageFaultAllocationOutput(&pf);
+	if (SUCCEEDED(pr) && pf.PageFaultVA != 0) {
+		U_LOG_E("%s: DRED page fault VA=0x%llx", context, (unsigned long long)pf.PageFaultVA);
+	}
+
+	dred->Release();
+}
+
 static xrt_result_t
 create_atlas_texture(struct comp_d3d12_renderer *r, ID3D12Device *device, uint32_t width, uint32_t height)
 {
@@ -236,6 +297,11 @@ create_atlas_texture(struct comp_d3d12_renderer *r, ID3D12Device *device, uint32
 	    __uuidof(ID3D12Resource), reinterpret_cast<void **>(&r->atlas_texture));
 	if (FAILED(hr)) {
 		U_LOG_E("Failed to create atlas texture: 0x%08x", hr);
+		if (hr == DXGI_ERROR_DEVICE_REMOVED) {
+			HRESULT dr_hr = device->GetDeviceRemovedReason();
+			U_LOG_E("  GetDeviceRemovedReason: 0x%08x", (unsigned)dr_hr);
+			log_dred_state(device, "create_atlas_texture");
+		}
 		return XRT_ERROR_D3D;
 	}
 


### PR DESCRIPTION
## Summary

Adds an \`ID3D12DeviceRemovedExtendedData\` query at the \`create_atlas_texture\` device-removed branch. When DRED is enabled at device creation, the runtime now logs the last GPU commands recorded by the driver before the device went away — useful for diagnosing the next device-removed crash without having to instrument from scratch.

## Background

During the [#216](https://github.com/DisplayXR/displayxr-runtime/issues/216) / [displayxr-unity#82](https://github.com/DisplayXR/displayxr-unity/issues/82) investigation, I needed to know which GPU command was removing the device. The standard approach is DRED auto-breadcrumbs, but they're only useful if (a) DRED was enabled before \`D3D12CreateDevice\` and (b) something on the host side actually queries them when a device-removed surfaces. (a) is on the app/system side; (b) is on us. This PR is (b).

The actual DisplayXR/displayxr-runtime#216 / DisplayXR/displayxr-leia-plugin#89 bug ended up being a plugin-side format mismatch in \`CopyTextureRegion\`, which DRED couldn't see directly (the driver rejected the command before queuing it as a breadcrumb-tracked op). But the breadcrumb hook is generally useful, and \`create_atlas_texture\` is the first D3D12 API call after each frame's queue work — so it's the natural place for the runtime to first detect a device-removed and report context.

## What's in the PR

- Adds \`static void log_dred_state(ID3D12Device *, const char *context)\` to \`comp_d3d12_renderer.cpp\`. Queries \`GetAutoBreadcrumbsOutput\` + \`GetPageFaultAllocationOutput\`, logs the last ~16 GPU commands around each node's last-completed marker.
- Calls it from \`create_atlas_texture\`'s \`DXGI_ERROR_DEVICE_REMOVED\` branch.
- When DRED isn't enabled, the query returns \`DXGI_ERROR_NOT_FOUND\` and we log how to turn it on rather than erroring.

## How to enable DRED for a given app

Documented in the helper's comment. Three options:

1. **Per-process** (recommended for an app under active investigation):
   \`\`\`cpp
   ID3D12DeviceRemovedExtendedDataSettings *dred_settings = nullptr;
   D3D12GetDebugInterface(IID_PPV_ARGS(&dred_settings));
   dred_settings->SetAutoBreadcrumbsEnablement(D3D12_DRED_ENABLEMENT_FORCED_ON);
   dred_settings->SetPageFaultEnablement(D3D12_DRED_ENABLEMENT_FORCED_ON);
   // ... then D3D12CreateDevice()
   \`\`\`
2. **Per-app** (registry, no code changes):
   \`HKLM\SOFTWARE\Microsoft\Direct3D\AppCompat\<exe>.exe\` with REG_DWORD \`AutoBreadcrumbsEnablement = 1\` and \`PageFaultEnablement = 1\`.
3. **Globally**: Windows Development Build or the DirectX Control Panel.

## Test plan

- [x] Builds cleanly on Windows (\`scripts/build_windows.bat build\`).
- [x] No regression to opaque or transparent rendering paths in casual smoke test (cube_handle_d3d12_win still runs).
- Future: ideally a runtime unit test that intentionally provokes device-removed (out-of-bounds dispatch?) and asserts that breadcrumb output is logged. Not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)