### PR TITLE
metal: preserve alpha end-to-end for transparent background

### DIFF
--- a/src/xrt/compositor/metal/comp_metal_compositor.m
+++ b/src/xrt/compositor/metal/comp_metal_compositor.m
@@ -163,6 +163,11 @@ struct comp_metal_compositor
 	//! True if running in offscreen mode (hidden window, no visible UI).
 	bool offscreen;
 
+	//! True if XR_EXT_cocoa_window_binding requested transparent background.
+	//! Drives atlas clear color (alpha=0 vs alpha=1) so per-pixel alpha from
+	//! projection layers reaches the CAMetalLayer + desktop composite.
+	bool transparent_background;
+
 	//! True if swapchain content comes from GL (needs Y-flip on sample).
 	bool source_is_gl;
 
@@ -455,16 +460,21 @@ compile_shaders(struct comp_metal_compositor *c)
 	}
 
 	// Projection pipeline (renders into atlas texture)
+	//
+	// Blending DISABLED — projection layer pixels are written straight to the
+	// atlas (including the source alpha channel). Mirrors D3D11 `blend_opaque`
+	// in comp_d3d11_renderer.cpp. Source-alpha blending here destroys Unity's
+	// alpha=0 in transparent regions (atlas dst.a=0 + src.a=0 with
+	// out.a = src.a*1 + dst.a*(1-src.a) collapses to 0/0, RGB to the dark
+	// atlas clear) so transparent-background mode never reaches the
+	// CAMetalLayer with alpha < 1. Disabling blending lets Unity's swapchain
+	// alpha pass through end-to-end (Phase 1 transparent overlay, #85).
 	{
 		MTLRenderPipelineDescriptor *proj_desc = [[MTLRenderPipelineDescriptor alloc] init];
 		proj_desc.vertexFunction = proj_vs;
 		proj_desc.fragmentFunction = proj_fs;
 		proj_desc.colorAttachments[0].pixelFormat = MTLPixelFormatBGRA8Unorm;
-		proj_desc.colorAttachments[0].blendingEnabled = YES;
-		proj_desc.colorAttachments[0].sourceRGBBlendFactor = MTLBlendFactorSourceAlpha;
-		proj_desc.colorAttachments[0].destinationRGBBlendFactor = MTLBlendFactorOneMinusSourceAlpha;
-		proj_desc.colorAttachments[0].sourceAlphaBlendFactor = MTLBlendFactorOne;
-		proj_desc.colorAttachments[0].destinationAlphaBlendFactor = MTLBlendFactorOneMinusSourceAlpha;
+		proj_desc.colorAttachments[0].blendingEnabled = NO;
 		proj_desc.depthAttachmentPixelFormat = MTLPixelFormatDepth32Float;
 
 		c->projection_pipeline = [c->device newRenderPipelineStateWithDescriptor:proj_desc error:&error];
@@ -1575,7 +1585,13 @@ metal_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 		pass.colorAttachments[0].texture = c->atlas_texture;
 		pass.colorAttachments[0].loadAction = MTLLoadActionClear;
 		pass.colorAttachments[0].storeAction = MTLStoreActionStore;
-		pass.colorAttachments[0].clearColor = MTLClearColorMake(0.0, 0.0, 0.0, 1.0);
+		// Clear to (0,0,0,0) when the app requested transparent background so
+		// projection-layer alpha=0 regions propagate through sim_display
+		// alpha-native to the CAMetalLayer (isOpaque=NO) → desktop composite.
+		// Otherwise clear to opaque black.
+		pass.colorAttachments[0].clearColor = c->transparent_background
+		    ? MTLClearColorMake(0.0, 0.0, 0.0, 0.0)
+		    : MTLClearColorMake(0.0, 0.0, 0.0, 1.0);
 		pass.depthAttachment.texture = c->depth_texture;
 		pass.depthAttachment.loadAction = MTLLoadActionClear;
 		pass.depthAttachment.storeAction = MTLStoreActionDontCare;
@@ -2260,6 +2276,7 @@ comp_metal_compositor_create(struct xrt_device *xdev,
 	}
 	c->display_refresh_rate = 60.0f;
 	c->offscreen = offscreen;
+	c->transparent_background = transparent_background;
 
 	// Get display dimensions from device.
 	// screens[0] holds the logical (point) size — used for NSWindow creation.

--- a/src/xrt/drivers/sim_display/sim_display_device.c
+++ b/src/xrt/drivers/sim_display/sim_display_device.c
@@ -653,8 +653,15 @@ sim_display_hmd_create(void)
 	hmd->base.inputs[0].name = XRT_INPUT_GENERIC_HEAD_POSE;
 
 	// Manual display setup (replaces u_device_setup_split_side_by_side which only handles 2 views)
+	// Advertise both OPAQUE (default) and ALPHA_BLEND so apps that want
+	// per-pixel transparency (sim_display is alpha-native end-to-end on
+	// Metal/D3D11/D3D12/GL via the cocoa_window_binding/win32_window_binding
+	// transparentBackgroundEnabled bit) can opt-in via
+	// xrEndFrame's environmentBlendMode. OPAQUE stays first so it's the
+	// default for apps that don't pick.
 	hmd->base.hmd->blend_modes[0] = XRT_BLEND_MODE_OPAQUE;
-	hmd->base.hmd->blend_mode_count = 1;
+	hmd->base.hmd->blend_modes[1] = XRT_BLEND_MODE_ALPHA_BLEND;
+	hmd->base.hmd->blend_mode_count = 2;
 	hmd->base.hmd->distortion.models = XRT_DISTORTION_MODEL_NONE;
 	hmd->base.hmd->distortion.preferred = XRT_DISTORTION_MODEL_NONE;
 	hmd->base.hmd->screens[0].w_pixels = pixel_w;

--- a/src/xrt/drivers/sim_display/sim_display_processor_metal.m
+++ b/src/xrt/drivers/sim_display/sim_display_processor_metal.m
@@ -102,7 +102,7 @@ static NSString *const shader_source = @
     "                             (in.texCoord.y + row1) * tp.tile_rows_inv);\n"
     "    float4 left  = tex.sample(smp, left_uv);\n"
     "    float4 right = tex.sample(smp, right_uv);\n"
-    "    return float4(left.r, right.g, right.b, 1.0);\n"
+    "    return float4(left.r, right.g, right.b, max(left.a, right.a));\n"
     "}\n"
     "\n"
     "// Blend: 50/50 mix\n"


### PR DESCRIPTION
## Summary

Four Metal-compositor fixes that complete the alpha chain for the cocoa_window_binding `transparentBackgroundEnabled` bit (added in v1.3.0). The runtime previously plumbed the bit only to NSWindow/CAMetalLayer `isOpaque` flags — the compositor still destroyed alpha=0 in the atlas and projection pipeline, and the anaglyph shader hard-coded alpha=1.0.

Verified end-to-end with `cube_handle_metal_macos` (`DISPLAYXR_TRANSPARENT_BG=1`): cube floats over the desktop with correct per-pixel transparency.

## Fixes

1. **Atlas clear honors `transparent_background`** — `comp_metal_compositor.m:1572-...`. Clears to `(0,0,0,0)` when transparent, `(0,0,0,1)` otherwise. Stores `transparent_background` on the compositor struct at create time.

2. **Projection pipeline blend disabled** — `comp_metal_compositor.m:463`. Previously used source-alpha blending which collapsed Unity's alpha=0 + atlas's alpha=0 into opaque. Now mirrors `comp_d3d11_renderer.cpp` `blend_opaque` (`BlendEnable=FALSE`): projection-layer pixels go straight to the atlas including the source alpha channel.

3. **Anaglyph shader preserves alpha** — `sim_display_processor_metal.m:105`. Hard-coded `1.0` replaced with `max(left.a, right.a)`. The other four shaders (sbs, blend, squeezed_sbs, quad, passthrough) already preserved alpha via `tex.sample(...)` returning the full float4.

4. **`XRT_BLEND_MODE_ALPHA_BLEND` advertised** — `sim_display_device.c:656`. Apps can now opt the session into `XR_ENVIRONMENT_BLEND_MODE_ALPHA_BLEND` via `xrEndFrame`. `OPAQUE` remains first (default).

## Test plan

- [x] `cube_handle_metal_macos` with `DISPLAYXR_TRANSPARENT_BG=1` — cube floats over desktop, correct stereo, no regressions on OPAQUE path
- [x] `cube_handle_metal_macos` without `DISPLAYXR_TRANSPARENT_BG=1` — unchanged opaque rendering (atlas clears to opaque black, projection pipeline write-through unaffected for opaque content)
- [ ] Validate other graphics APIs aren't affected (D3D11/D3D12/Vulkan/GL — these touch sibling compositors, not this file)
- [ ] Cube tests on physical Leia hardware path

## Cross-references

- Plugin PR consuming this: DisplayXR/displayxr-unity feat/macos-transparent-overlay (#85)
- Unity alpha-drop blocker (separate, plugin side): DisplayXR/displayxr-unity#86

🤖 Generated with [Claude Code](https://claude.com/claude-code)