### PR TITLE
leia: replace chroma-key with WGC compose-under-bg on D3D11/D3D12/Vulkan DPs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -378,6 +378,7 @@ See `docs/README.md` for a complete index. Key docs by task:
 | Add a new OpenXR extension | `docs/guides/implementing-extension.md` |
 | Write a device driver | `docs/guides/writing-driver.md` |
 | Understand Leia SR weaver internals (DX11, DX12, GL, Vulkan) | `docs/reference/LeiaWeaver.md` |
+| Understand Leia transparency model (compose-under-bg + chroma-key) | `docs/reference/leia-transparency.md` |
 | Understand Kooima projection math | `docs/architecture/kooima-projection.md` |
 | Understand the compositor pipeline | `docs/architecture/compositor-pipeline.md` |
 | Understand the swapchain model / canvas | `docs/specs/swapchain-model.md` |

--- a/docs/README.md
+++ b/docs/README.md
@@ -111,7 +111,8 @@ Design docs, status trackers, and plans — some shipped, some in progress.
 - [Window Drag Rendering](reference/window-drag-rendering.md) — rendering during window drag
 - [Debug Logging](reference/debug-logging.md) — log level conventions
 - [Leia SR Weaver](reference/LeiaWeaver.md) — DX11, DX12, OpenGL & Vulkan weaver internals
-- [Transparent HWND Overlay](reference/chroma-key-transparent-overlay.md) — opt-in transparent presentation for desktop-overlay apps (DComp + post-weave chroma-key)
+- [Leia Transparency Model](reference/leia-transparency.md) — current primary path: WGC compose-under-bg on D3D11/D3D12/VK, chroma-key fallback
+- [Transparent HWND Overlay (legacy chroma-key)](reference/chroma-key-transparent-overlay.md) — fallback path + still the only path on the OpenGL Leia DP
 
 ## Archive
 

--- a/docs/reference/chroma-key-transparent-overlay.md
+++ b/docs/reference/chroma-key-transparent-overlay.md
@@ -1,4 +1,6 @@
-# Transparent HWND Overlay (Post-Weave Chroma-Key)
+# Transparent HWND Overlay (Post-Weave Chroma-Key) — Fallback Path
+
+> **Note:** D3D11 / D3D12 / Vulkan Leia DPs now use **compose-under-bg** as the primary transparency path. See [`leia-transparency.md`](leia-transparency.md) for the current model. Chroma-key remains the documented fallback when Windows Graphics Capture is unavailable (older Windows, DRM, env-disabled), and is still the only path for the OpenGL Leia DP (blocked on the deferred DComp+`WGL_NV_DX_interop2` bridge).
 
 How DisplayXR makes a bound app HWND composite transparently against the Windows desktop on a Leia 3D display, and how an app opts in.
 

--- a/docs/reference/leia-transparency.md
+++ b/docs/reference/leia-transparency.md
@@ -1,0 +1,135 @@
+# Leia Transparent Backgrounds — Compose-Under-Bg + Chroma-Key Fallback
+
+How the Leia display processor composites a transparent app window over the Windows desktop, what each graphics API path does, and how an app opts in.
+
+This supersedes [`chroma-key-transparent-overlay.md`](chroma-key-transparent-overlay.md) as the primary path. Chroma-key is still the documented fallback when WGC desktop capture is unavailable.
+
+## Per-API status
+
+| API | Primary path | Notes |
+|---|---|---|
+| D3D11 | compose-under-bg | Falls back to chroma-key on WGC failure. |
+| D3D12 | compose-under-bg | Queue-level shared-fence `Wait` for sync. |
+| Vulkan | compose-under-bg | D3D11 NT-handle → VK external image import. No GPU semaphore wait yet (relies on temporal separation; see [Limits](#limits)). |
+| OpenGL | chroma-key only | Compose-under-bg blocked on the deferred DComp + `WGL_NV_DX_interop2` bridge. |
+| Metal (macOS) | alpha-native | SR weaver preserves alpha end-to-end (commit `e94d07292`); no compose or chroma trick needed. |
+
+## Why compose-under-bg
+
+The SR weaver flattens alpha during interlacing. Two ways to expose the desktop through transparent app regions:
+
+1. **Chroma-key (legacy).** Replace `α=0` atlas pixels with a magenta sentinel pre-weave, then post-weave detect that color and rewrite `α=0` for DWM. Survives the weaver as RGB. **Hard mask on AA edges** — the lerp toward key + exact-RGB strip can't represent `0<α<1`. Also vulnerable to disocclusion fringe at silhouette boundaries (see [`chroma-key-transparent-overlay.md`](chroma-key-transparent-overlay.md) §Limits).
+2. **Compose-under-bg (preferred).** Capture the desktop region behind the window via Windows Graphics Capture and composite it UNDER each per-view atlas tile before the weaver runs. Output is genuinely opaque RGB with the desktop already integrated; the weaver consumes it normally. AA edges and semi-transparent pixels work correctly.
+
+## Architecture
+
+```
+              ┌──────────────────────────────────────────┐
+              │ leia_bg_capture (Win-only helper)         │
+              │  - Internal D3D11 device                  │
+              │  - WGC: monitor capture → staging tex     │
+              │  - SHARED_NTHANDLE BGRA8 (monitor size)   │
+              │  - D3D11_FENCE_FLAG_SHARED for sync       │
+              └────────────┬─────────────────────────────┘
+                           │ NT handles (texture + fence)
+       ┌───────────────────┼───────────────────┐
+       ▼                   ▼                   ▼
+  D3D11 Leia DP      D3D12 Leia DP      Vulkan Leia DP
+  OpenSharedResource1 OpenSharedHandle   VK_KHR_external_memory_win32
+  ID3D11Fence Wait    ID3D12CommandQueue ::Wait   (no Wait yet — caveat)
+       │                   │                   │
+       └─── compose pass: lerp(bg, atlas.rgb, atlas.a), a=1 ───┐
+                                                               ▼
+                                                      SR weaver (opaque RGB in)
+                                                               │
+                                                               ▼
+                                                  DComp swap chain → DWM
+```
+
+The per-DP `compose_*` pipelines reuse the existing chroma-key intermediate target (`ck_fill_*`) as the render target — same `R8G8B8A8_UNORM` format, no extra allocation. Distinct pipelines/descriptor sets/samplers (compose uses linear filtering; ck uses point).
+
+## How "per eye" works out
+
+The desktop sits at `z=0` (display plane), so the same captured background region is sampled into both tile 0 and tile 1. Per-eye-ness comes from the atlas content (which already has parallax per view), not the background. After the weaver interleaves, each eye sees `desktop + its own view's overlay` with correct parallax on the overlay and the desktop pinned at the display plane.
+
+Shader logic (HLSL/GLSL identical in spirit):
+
+```glsl
+float4 a = atlas.Sample(samp, uv);
+float2 tile_local = frac(uv * float2(tile_count));   // wrap into per-tile 0..1
+float2 bg_uv = bg_uv_origin + tile_local * bg_uv_extent;
+float3 b = bg.SampleLevel(samp, bg_uv, 0).rgb;
+return float4(mix(b, a.rgb, a.a), 1.0);
+```
+
+`bg_uv_origin` / `bg_uv_extent` map the **client area** of the window onto the captured monitor texture (NOT the outer window rect — that would shift by the title-bar height).
+
+## Self-capture defense
+
+`leia_bg_capture_create` calls `SetWindowDisplayAffinity(hwnd, WDA_EXCLUDEFROMCAPTURE)` so WGC does not recursively capture our own woven output back into the background. Requires Windows 10 build 19041+ (2004); on older Windows the bg-capture module fails to create and the DP falls back to chroma-key.
+
+## Cross-API sync
+
+The producer is the internal D3D11 device inside `leia_bg_capture_win`. Consumers are the DP's own device (D3D11/D3D12/VK). After each `CopyResource` from the WGC frame into the shared staging texture, the producer signals an `ID3D11Fence` (created with `D3D11_FENCE_FLAG_SHARED`) and flushes its context. Consumers wait before sampling:
+
+- **D3D11:** `ID3D11DeviceContext4::Wait(fence, value)` in the DP's command stream.
+- **D3D12:** `ID3D12CommandQueue::Wait(fence, value)` at the queue level before the cmd list executes.
+- **VK:** Not implemented — the VK DP relies on the temporal gap between WGC's ~60Hz producer and the consumer's ~120Hz render rate (the producer's copy is sub-ms; the chance of mid-copy sample is negligible). A proper `VK_KHR_external_semaphore_win32` import via `VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT` is a follow-up.
+
+## App-side recipe
+
+To get transparency on D3D11 / D3D12 / Vulkan apps with a Leia 3D display:
+
+1. **Window style.** Standard top-level window with `WS_EX_NOREDIRECTIONBITMAP`, null background brush. (DComp owns the redirection bitmap; a non-null brush would paint over the composition swap chain.)
+2. **Clear to `RGBA(0,0,0,0)`** in the app's render target. The compose pass turns the cleared regions into the captured desktop.
+3. **Opt-in via `XR_EXT_win32_window_binding`:**
+   ```c
+   XrWin32WindowBindingCreateInfoEXT bind = {
+       .type = XR_TYPE_WIN32_WINDOW_BINDING_CREATE_INFO_EXT,
+       .windowHandle = hwnd,
+       .transparentBackgroundEnabled = XR_TRUE,
+       .chromaKeyColor = 0,   // 0 = DP picks default (used only on fallback)
+   };
+   ```
+4. **No `WS_EX_LAYERED`, no `SetLayeredWindowAttributes`** — those don't compose with the runtime's flip-model swap chain.
+
+The test apps `cube_handle_d3d11_win`, `cube_handle_d3d12_win`, `cube_handle_vk_win` opt in via the `DISPLAYXR_TRANSPARENT_BG=1` env var.
+
+## Fallback behavior
+
+Compose-under-bg fails to initialize → DP transparently falls back to chroma-key. Triggers:
+
+- `LEIA_DP_DISABLE_BG_CAPTURE=1` env var (for testing the fallback path).
+- Windows version < 10 2004 (no `WDA_EXCLUDEFROMCAPTURE`).
+- WGC `RoGetActivationFactory` failure (graphics class not registered).
+- `SetWindowDisplayAffinity` failure (rare; some virtualization stacks).
+
+The session log will show one of:
+```
+Leia D3D11 DP: transparency = compose-under-bg (WGC)
+Leia D3D11 DP: transparency = chroma-key (key=0x00ff00ff — DP default)
+```
+
+## Limits
+
+- **DRM-protected content** under the window appears black in WGC capture (standard WGC limitation — same as any screen recorder).
+- **Window crossing monitors mid-session** — the capture session is bound to the monitor at create. `leia_bg_capture_poll` detects the monitor change and skips the compose pass for that frame so the DP doesn't sample the wrong desktop. Recreating the WGC session mid-stream is a follow-up.
+- **Vulkan GPU sync** — see [Cross-API sync](#cross-api-sync). Visible only in pathological timing.
+- **OpenGL apps** still use chroma-key. They inherit the AA-edge and disocclusion-fringe limitations documented in [`chroma-key-transparent-overlay.md`](chroma-key-transparent-overlay.md).
+
+## Key source files
+
+| File | Role |
+|---|---|
+| `src/xrt/drivers/leia/leia_bg_capture_win.{h,cpp}` | WGC capture, shared NT-handle staging tex, shared fence. Win-only. |
+| `src/xrt/drivers/leia/leia_display_processor_d3d11.cpp` | D3D11 compose pipeline + fallback. |
+| `src/xrt/drivers/leia/leia_display_processor_d3d12.cpp` | D3D12 compose pipeline (PSO, root sig, descriptor heap) + fallback. |
+| `src/xrt/drivers/leia/leia_display_processor.cpp` | Vulkan compose pipeline (render pass reuse, external image import) + fallback. |
+| `src/xrt/drivers/leia/shaders/compose_under_bg.frag` | GLSL fragment shader (Vulkan). HLSL inlined in the D3D11/D3D12 .cpp files. |
+
+## References
+
+- `XR_EXT_win32_window_binding` spec_version 5 — `src/external/openxr_includes/openxr/XR_EXT_win32_window_binding.h`
+- [`chroma-key-transparent-overlay.md`](chroma-key-transparent-overlay.md) — the legacy fallback path, kept as reference for the GL DP and as historical context.
+- [Windows Graphics Capture (WGC)](https://learn.microsoft.com/en-us/windows/uwp/audio-video-camera/screen-capture)
+- [`VK_KHR_external_memory_win32`](https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_external_memory_win32.html)

--- a/src/xrt/drivers/CMakeLists.txt
+++ b/src/xrt/drivers/CMakeLists.txt
@@ -83,6 +83,7 @@ if(XRT_HAVE_LEIA_SR)
 			leia/shaders/fullscreen_tri.vert
 			leia/shaders/ck_fill.frag
 			leia/shaders/ck_strip.frag
+			leia/shaders/compose_under_bg.frag
 		)
 		list(APPEND LEIA_SOURCES ${LEIA_SHADER_HEADERS})
 		set(LEIA_SR_VULKAN_AVAILABLE TRUE)

--- a/src/xrt/drivers/CMakeLists.txt
+++ b/src/xrt/drivers/CMakeLists.txt
@@ -190,6 +190,17 @@ if(XRT_HAVE_LEIA_SR)
 			target_compile_definitions(drv_leia PUBLIC XRT_HAVE_LEIA_SR_D3D12)
 		endif()
 
+		# Windows Graphics Capture (WGC) background capture, used by D3D11 / D3D12
+		# Leia DPs to compose desktop pixels under transparent app tiles in place
+		# of the chroma-key trick. Win-only; consumes runtimeobject.lib for the
+		# WinRT activation factories.
+		if(WIN32 AND (LEIA_SR_D3D11_AVAILABLE OR LEIA_SR_D3D12_AVAILABLE))
+			target_sources(drv_leia PRIVATE
+				leia/leia_bg_capture_win.cpp
+				leia/leia_bg_capture_win.h)
+			target_link_libraries(drv_leia PRIVATE runtimeobject dxguid)
+		endif()
+
 		# GL weaver library (conditional)
 		if(LEIA_SR_GL_AVAILABLE)
 			target_link_libraries(drv_leia PRIVATE

--- a/src/xrt/drivers/leia/leia_bg_capture_win.cpp
+++ b/src/xrt/drivers/leia/leia_bg_capture_win.cpp
@@ -1,0 +1,542 @@
+// Copyright 2026, Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  Implementation of @ref leia_bg_capture_win.h
+ * @ingroup drv_leia
+ */
+
+#include "leia_bg_capture_win.h"
+
+#include "util/u_logging.h"
+
+#include <atomic>
+
+#include <windows.h>
+#include <wrl/client.h>
+#include <wrl/wrappers/corewrappers.h>
+
+#include <d3d11_4.h>
+#include <d3d12.h>
+#include <dxgi1_2.h>
+
+#include <inspectable.h>
+#include <roapi.h>
+#include <windows.foundation.h>
+#include <windows.graphics.h>
+#include <windows.graphics.directx.h>
+#include <windows.graphics.directx.direct3d11.interop.h>
+#include <windows.graphics.capture.h>
+#include <windows.graphics.capture.interop.h>
+
+using Microsoft::WRL::ComPtr;
+using Microsoft::WRL::Wrappers::HStringReference;
+
+namespace WGC = ABI::Windows::Graphics::Capture;
+namespace WGDX = ABI::Windows::Graphics::DirectX;
+namespace WGD3D = ABI::Windows::Graphics::DirectX::Direct3D11;
+namespace WG = ABI::Windows::Graphics;
+namespace WF = ABI::Windows::Foundation;
+
+// IDirect3DDxgiInterfaceAccess is a Win32 COM interface (not ABI), declared in
+// the global Windows::Graphics::DirectX::Direct3D11 namespace by the SDK
+// interop header.
+using IDxgiAccess = Windows::Graphics::DirectX::Direct3D11::IDirect3DDxgiInterfaceAccess;
+
+struct leia_bg_capture
+{
+	HWND hwnd;
+	HMONITOR monitor;
+	UINT monitor_w;
+	UINT monitor_h;
+	RECT monitor_rect; // virtual-screen coords
+
+	// Producer-side D3D11 (internal — separate from any DP).
+	ComPtr<ID3D11Device> d3d11_device;
+	ComPtr<ID3D11DeviceContext> d3d11_context;
+	ComPtr<ID3D11DeviceContext4> d3d11_context4; //!< For Signal().
+
+	// WGC plumbing.
+	ComPtr<WGD3D::IDirect3DDevice> wg_device;
+	ComPtr<WGC::IGraphicsCaptureItem> capture_item;
+	ComPtr<WGC::IDirect3D11CaptureFramePool> frame_pool;
+	ComPtr<WGC::IGraphicsCaptureSession> capture_session;
+
+	// Shared staging texture (monitor-sized, BGRA8, SHARED_NTHANDLE).
+	ComPtr<ID3D11Texture2D> staging_tex;
+	HANDLE staging_shared_handle;
+
+	// Cross-API GPU sync — D3D11 shared fence. Producer signals after each
+	// CopyResource; consumers (D3D11 or D3D12) Wait before sampling.
+	ComPtr<ID3D11Fence> shared_fence;
+	HANDLE shared_fence_handle;
+	std::atomic<UINT64> signaled_value;
+
+	std::atomic<bool> has_frame;
+};
+
+// ---------- helpers --------------------------------------------------------
+
+static bool
+env_disable()
+{
+	char buf[8];
+	DWORD n = GetEnvironmentVariableA("LEIA_DP_DISABLE_BG_CAPTURE", buf, sizeof(buf));
+	return n > 0 && n < sizeof(buf) && (buf[0] == '1' || buf[0] == 't' || buf[0] == 'T');
+}
+
+static bool
+os_supports_wda_exclude_from_capture()
+{
+	// WDA_EXCLUDEFROMCAPTURE requires Windows 10 2004 (build 19041).
+	HMODULE ntdll = GetModuleHandleW(L"ntdll.dll");
+	if (ntdll == nullptr) {
+		return false;
+	}
+	typedef LONG(WINAPI * RtlGetVersion_t)(OSVERSIONINFOEXW *);
+	auto fn = (RtlGetVersion_t)GetProcAddress(ntdll, "RtlGetVersion");
+	if (fn == nullptr) {
+		return false;
+	}
+	OSVERSIONINFOEXW vi = {};
+	vi.dwOSVersionInfoSize = sizeof(vi);
+	if (fn(&vi) != 0) {
+		return false;
+	}
+	return vi.dwBuildNumber >= 19041;
+}
+
+static HRESULT
+create_internal_d3d11(ID3D11Device **out_dev, ID3D11DeviceContext **out_ctx)
+{
+	UINT flags = D3D11_CREATE_DEVICE_BGRA_SUPPORT;
+	D3D_FEATURE_LEVEL fl;
+	const D3D_FEATURE_LEVEL levels[] = {D3D_FEATURE_LEVEL_11_1, D3D_FEATURE_LEVEL_11_0};
+	return D3D11CreateDevice(nullptr, D3D_DRIVER_TYPE_HARDWARE, nullptr, flags, levels, 2,
+	                         D3D11_SDK_VERSION, out_dev, &fl, out_ctx);
+}
+
+static HRESULT
+wrap_d3d11_as_winrt(ID3D11Device *d3d11, WGD3D::IDirect3DDevice **out)
+{
+	ComPtr<IDXGIDevice> dxgi_device;
+	HRESULT hr = d3d11->QueryInterface(IID_PPV_ARGS(&dxgi_device));
+	if (FAILED(hr)) {
+		return hr;
+	}
+	ComPtr<IInspectable> inspectable;
+	hr = CreateDirect3D11DeviceFromDXGIDevice(dxgi_device.Get(), &inspectable);
+	if (FAILED(hr)) {
+		return hr;
+	}
+	return inspectable->QueryInterface(__uuidof(WGD3D::IDirect3DDevice), reinterpret_cast<void **>(out));
+}
+
+static HRESULT
+create_staging_texture(ID3D11Device *dev, UINT w, UINT h, ID3D11Texture2D **out_tex, HANDLE *out_handle)
+{
+	D3D11_TEXTURE2D_DESC desc = {};
+	desc.Width = w;
+	desc.Height = h;
+	desc.MipLevels = 1;
+	desc.ArraySize = 1;
+	desc.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
+	desc.SampleDesc.Count = 1;
+	desc.Usage = D3D11_USAGE_DEFAULT;
+	desc.BindFlags = D3D11_BIND_SHADER_RESOURCE;
+	// SHARED_NTHANDLE for cross-process / cross-API import; SHARED is implied.
+	// Sync is via a separate shared fence (no keyed mutex — keyed mutex is
+	// awkward to access from D3D12).
+	desc.MiscFlags = D3D11_RESOURCE_MISC_SHARED_NTHANDLE | D3D11_RESOURCE_MISC_SHARED;
+	HRESULT hr = dev->CreateTexture2D(&desc, nullptr, out_tex);
+	if (FAILED(hr)) {
+		return hr;
+	}
+	ComPtr<IDXGIResource1> resource1;
+	hr = (*out_tex)->QueryInterface(IID_PPV_ARGS(&resource1));
+	if (FAILED(hr)) {
+		return hr;
+	}
+	return resource1->CreateSharedHandle(nullptr,
+	                                     DXGI_SHARED_RESOURCE_READ | DXGI_SHARED_RESOURCE_WRITE,
+	                                     nullptr,
+	                                     out_handle);
+}
+
+static HRESULT
+create_shared_fence(ID3D11Device *dev, ID3D11Fence **out_fence, HANDLE *out_handle)
+{
+	ComPtr<ID3D11Device5> dev5;
+	HRESULT hr = dev->QueryInterface(IID_PPV_ARGS(&dev5));
+	if (FAILED(hr)) {
+		return hr;
+	}
+	hr = dev5->CreateFence(0, D3D11_FENCE_FLAG_SHARED, IID_PPV_ARGS(out_fence));
+	if (FAILED(hr)) {
+		return hr;
+	}
+	return (*out_fence)->CreateSharedHandle(nullptr, GENERIC_ALL, nullptr, out_handle);
+}
+
+// ---------- public API -----------------------------------------------------
+
+extern "C" struct leia_bg_capture *
+leia_bg_capture_create(HWND hwnd)
+{
+	if (env_disable()) {
+		U_LOG_W("leia_bg_capture: disabled via LEIA_DP_DISABLE_BG_CAPTURE — falling back to chroma-key");
+		return nullptr;
+	}
+	if (hwnd == nullptr) {
+		U_LOG_W("leia_bg_capture: NULL hwnd — falling back to chroma-key");
+		return nullptr;
+	}
+	if (!os_supports_wda_exclude_from_capture()) {
+		U_LOG_W("leia_bg_capture: OS < Win10 2004 lacks WDA_EXCLUDEFROMCAPTURE — falling back to chroma-key");
+		return nullptr;
+	}
+	if (!SetWindowDisplayAffinity(hwnd, WDA_EXCLUDEFROMCAPTURE)) {
+		U_LOG_W("leia_bg_capture: SetWindowDisplayAffinity failed (err=%lu) — falling back to chroma-key",
+		        GetLastError());
+		return nullptr;
+	}
+
+	HMONITOR monitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
+	MONITORINFO mi = {};
+	mi.cbSize = sizeof(mi);
+	if (monitor == nullptr || !GetMonitorInfoW(monitor, &mi)) {
+		U_LOG_W("leia_bg_capture: monitor info lookup failed");
+		SetWindowDisplayAffinity(hwnd, WDA_NONE);
+		return nullptr;
+	}
+	UINT monitor_w = mi.rcMonitor.right - mi.rcMonitor.left;
+	UINT monitor_h = mi.rcMonitor.bottom - mi.rcMonitor.top;
+
+	HRESULT hr = RoInitialize(RO_INIT_MULTITHREADED);
+	if (FAILED(hr) && hr != RPC_E_CHANGED_MODE && hr != S_FALSE) {
+		U_LOG_W("leia_bg_capture: RoInitialize failed: 0x%08x", (unsigned)hr);
+		SetWindowDisplayAffinity(hwnd, WDA_NONE);
+		return nullptr;
+	}
+
+	ComPtr<ID3D11Device> d3d11_device;
+	ComPtr<ID3D11DeviceContext> d3d11_context;
+	hr = create_internal_d3d11(d3d11_device.GetAddressOf(), d3d11_context.GetAddressOf());
+	if (FAILED(hr)) {
+		U_LOG_W("leia_bg_capture: D3D11CreateDevice failed: 0x%08x", (unsigned)hr);
+		SetWindowDisplayAffinity(hwnd, WDA_NONE);
+		return nullptr;
+	}
+
+	ComPtr<WGD3D::IDirect3DDevice> wg_device;
+	hr = wrap_d3d11_as_winrt(d3d11_device.Get(), wg_device.GetAddressOf());
+	if (FAILED(hr)) {
+		U_LOG_W("leia_bg_capture: WinRT D3D11 device wrap failed: 0x%08x", (unsigned)hr);
+		SetWindowDisplayAffinity(hwnd, WDA_NONE);
+		return nullptr;
+	}
+
+	ComPtr<IGraphicsCaptureItemInterop> interop;
+	{
+		HStringReference cls(RuntimeClass_Windows_Graphics_Capture_GraphicsCaptureItem);
+		ComPtr<IActivationFactory> factory;
+		hr = RoGetActivationFactory(cls.Get(), IID_PPV_ARGS(&factory));
+		if (FAILED(hr)) {
+			U_LOG_W("leia_bg_capture: WGC item activation factory unavailable: 0x%08x — falling back to chroma-key",
+			        (unsigned)hr);
+			SetWindowDisplayAffinity(hwnd, WDA_NONE);
+			return nullptr;
+		}
+		hr = factory.As(&interop);
+		if (FAILED(hr)) {
+			U_LOG_W("leia_bg_capture: IGraphicsCaptureItemInterop QI failed: 0x%08x", (unsigned)hr);
+			SetWindowDisplayAffinity(hwnd, WDA_NONE);
+			return nullptr;
+		}
+	}
+
+	ComPtr<WGC::IGraphicsCaptureItem> capture_item;
+	hr = interop->CreateForMonitor(monitor, IID_PPV_ARGS(capture_item.GetAddressOf()));
+	if (FAILED(hr)) {
+		U_LOG_W("leia_bg_capture: CreateForMonitor failed: 0x%08x", (unsigned)hr);
+		SetWindowDisplayAffinity(hwnd, WDA_NONE);
+		return nullptr;
+	}
+
+	WG::SizeInt32 item_size = {};
+	capture_item->get_Size(&item_size);
+
+	ComPtr<WGC::IDirect3D11CaptureFramePoolStatics2> pool_statics;
+	{
+		HStringReference cls(RuntimeClass_Windows_Graphics_Capture_Direct3D11CaptureFramePool);
+		hr = RoGetActivationFactory(cls.Get(), IID_PPV_ARGS(&pool_statics));
+		if (FAILED(hr)) {
+			U_LOG_W("leia_bg_capture: FramePool statics unavailable: 0x%08x", (unsigned)hr);
+			SetWindowDisplayAffinity(hwnd, WDA_NONE);
+			return nullptr;
+		}
+	}
+
+	ComPtr<WGC::IDirect3D11CaptureFramePool> frame_pool;
+	hr = pool_statics->CreateFreeThreaded(wg_device.Get(),
+	                                      WGDX::DirectXPixelFormat_B8G8R8A8UIntNormalized,
+	                                      2,
+	                                      item_size,
+	                                      frame_pool.GetAddressOf());
+	if (FAILED(hr)) {
+		U_LOG_W("leia_bg_capture: FramePool::CreateFreeThreaded failed: 0x%08x", (unsigned)hr);
+		SetWindowDisplayAffinity(hwnd, WDA_NONE);
+		return nullptr;
+	}
+
+	ComPtr<WGC::IGraphicsCaptureSession> capture_session;
+	hr = frame_pool->CreateCaptureSession(capture_item.Get(), capture_session.GetAddressOf());
+	if (FAILED(hr)) {
+		U_LOG_W("leia_bg_capture: CreateCaptureSession failed: 0x%08x", (unsigned)hr);
+		SetWindowDisplayAffinity(hwnd, WDA_NONE);
+		return nullptr;
+	}
+
+	// Don't capture the cursor — we draw our own UI; the desktop cursor under us
+	// would be doubled.
+	ComPtr<WGC::IGraphicsCaptureSession2> session2;
+	if (SUCCEEDED(capture_session.As(&session2))) {
+		session2->put_IsCursorCaptureEnabled(false);
+	}
+
+	ComPtr<ID3D11Texture2D> staging_tex;
+	HANDLE staging_handle = nullptr;
+	hr = create_staging_texture(d3d11_device.Get(), monitor_w, monitor_h,
+	                            staging_tex.GetAddressOf(), &staging_handle);
+	if (FAILED(hr)) {
+		U_LOG_W("leia_bg_capture: staging tex create failed: 0x%08x", (unsigned)hr);
+		SetWindowDisplayAffinity(hwnd, WDA_NONE);
+		return nullptr;
+	}
+
+	ComPtr<ID3D11Fence> shared_fence;
+	HANDLE shared_fence_handle = nullptr;
+	hr = create_shared_fence(d3d11_device.Get(), shared_fence.GetAddressOf(), &shared_fence_handle);
+	if (FAILED(hr)) {
+		U_LOG_W("leia_bg_capture: shared fence create failed: 0x%08x", (unsigned)hr);
+		CloseHandle(staging_handle);
+		SetWindowDisplayAffinity(hwnd, WDA_NONE);
+		return nullptr;
+	}
+
+	ComPtr<ID3D11DeviceContext4> ctx4;
+	hr = d3d11_context.As(&ctx4);
+	if (FAILED(hr)) {
+		U_LOG_W("leia_bg_capture: ID3D11DeviceContext4 QI failed: 0x%08x", (unsigned)hr);
+		CloseHandle(shared_fence_handle);
+		CloseHandle(staging_handle);
+		SetWindowDisplayAffinity(hwnd, WDA_NONE);
+		return nullptr;
+	}
+
+	hr = capture_session->StartCapture();
+	if (FAILED(hr)) {
+		U_LOG_W("leia_bg_capture: StartCapture failed: 0x%08x", (unsigned)hr);
+		CloseHandle(shared_fence_handle);
+		CloseHandle(staging_handle);
+		SetWindowDisplayAffinity(hwnd, WDA_NONE);
+		return nullptr;
+	}
+
+	auto *c = new leia_bg_capture();
+	c->hwnd = hwnd;
+	c->monitor = monitor;
+	c->monitor_w = monitor_w;
+	c->monitor_h = monitor_h;
+	c->monitor_rect = mi.rcMonitor;
+	c->d3d11_device = d3d11_device;
+	c->d3d11_context = d3d11_context;
+	c->d3d11_context4 = ctx4;
+	c->wg_device = wg_device;
+	c->capture_item = capture_item;
+	c->frame_pool = frame_pool;
+	c->capture_session = capture_session;
+	c->staging_tex = staging_tex;
+	c->staging_shared_handle = staging_handle;
+	c->shared_fence = shared_fence;
+	c->shared_fence_handle = shared_fence_handle;
+	c->signaled_value = 0;
+	c->has_frame = false;
+
+	U_LOG_W("leia_bg_capture: ready (monitor=%ux%u, hwnd=0x%p)", monitor_w, monitor_h, hwnd);
+	return c;
+}
+
+extern "C" long
+leia_bg_capture_open_d3d11(struct leia_bg_capture *c,
+                           ID3D11Device *dev,
+                           ID3D11Texture2D **out_tex,
+                           ID3D11ShaderResourceView **out_srv)
+{
+	if (c == nullptr || dev == nullptr || out_tex == nullptr || out_srv == nullptr) {
+		return E_INVALIDARG;
+	}
+	ComPtr<ID3D11Device1> dev1;
+	HRESULT hr = dev->QueryInterface(IID_PPV_ARGS(&dev1));
+	if (FAILED(hr)) {
+		return hr;
+	}
+	hr = dev1->OpenSharedResource1(c->staging_shared_handle, IID_PPV_ARGS(out_tex));
+	if (FAILED(hr)) {
+		return hr;
+	}
+	D3D11_SHADER_RESOURCE_VIEW_DESC sd = {};
+	sd.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
+	sd.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
+	sd.Texture2D.MipLevels = 1;
+	return dev->CreateShaderResourceView(*out_tex, &sd, out_srv);
+}
+
+extern "C" long
+leia_bg_capture_open_d3d12(struct leia_bg_capture *c, ID3D12Device *dev, ID3D12Resource **out_res)
+{
+	if (c == nullptr || dev == nullptr || out_res == nullptr) {
+		return E_INVALIDARG;
+	}
+	return dev->OpenSharedHandle(c->staging_shared_handle, IID_PPV_ARGS(out_res));
+}
+
+extern "C" long
+leia_bg_capture_open_fence_d3d11(struct leia_bg_capture *c, ID3D11Device *dev, ID3D11Fence **out_fence)
+{
+	if (c == nullptr || dev == nullptr || out_fence == nullptr) {
+		return E_INVALIDARG;
+	}
+	ComPtr<ID3D11Device5> dev5;
+	HRESULT hr = dev->QueryInterface(IID_PPV_ARGS(&dev5));
+	if (FAILED(hr)) {
+		return hr;
+	}
+	return dev5->OpenSharedFence(c->shared_fence_handle, IID_PPV_ARGS(out_fence));
+}
+
+extern "C" long
+leia_bg_capture_open_fence_d3d12(struct leia_bg_capture *c, ID3D12Device *dev, ID3D12Fence **out_fence)
+{
+	if (c == nullptr || dev == nullptr || out_fence == nullptr) {
+		return E_INVALIDARG;
+	}
+	return dev->OpenSharedHandle(c->shared_fence_handle, IID_PPV_ARGS(out_fence));
+}
+
+extern "C" bool
+leia_bg_capture_poll(struct leia_bg_capture *c,
+                     float out_bg_uv_origin[2],
+                     float out_bg_uv_extent[2],
+                     uint64_t *out_fence_wait_value)
+{
+	if (c == nullptr) {
+		return false;
+	}
+
+	// Drain framepool, keep newest.
+	ComPtr<WGC::IDirect3D11CaptureFrame> latest_frame;
+	for (;;) {
+		ComPtr<WGC::IDirect3D11CaptureFrame> f;
+		HRESULT hr = c->frame_pool->TryGetNextFrame(f.GetAddressOf());
+		if (FAILED(hr) || f == nullptr) {
+			break;
+		}
+		latest_frame = std::move(f);
+	}
+	if (latest_frame != nullptr) {
+		ComPtr<WGD3D::IDirect3DSurface> wg_surface;
+		if (SUCCEEDED(latest_frame->get_Surface(wg_surface.GetAddressOf()))) {
+			ComPtr<IDxgiAccess> access;
+			if (SUCCEEDED(wg_surface.As(&access))) {
+				ComPtr<ID3D11Texture2D> wgc_tex;
+				if (SUCCEEDED(access->GetInterface(IID_PPV_ARGS(&wgc_tex)))) {
+					c->d3d11_context->CopyResource(c->staging_tex.Get(), wgc_tex.Get());
+					// Signal after the copy queues — consumers wait on this value
+					// before sampling the staging tex.
+					UINT64 next = c->signaled_value.fetch_add(1, std::memory_order_acq_rel) + 1;
+					c->d3d11_context4->Signal(c->shared_fence.Get(), next);
+					// Flush the device context so the signal makes it to the GPU
+					// queue before the consumer (on a different device) waits.
+					c->d3d11_context->Flush();
+					c->has_frame.store(true, std::memory_order_release);
+				}
+			}
+		}
+		ComPtr<WF::IClosable> closable;
+		if (SUCCEEDED(latest_frame.As(&closable))) {
+			closable->Close();
+		}
+	}
+
+	if (out_fence_wait_value != nullptr) {
+		*out_fence_wait_value = c->signaled_value.load(std::memory_order_acquire);
+	}
+
+	// Window-on-monitor rect → normalized UVs.
+	HMONITOR cur = MonitorFromWindow(c->hwnd, MONITOR_DEFAULTTONEAREST);
+	if (cur != c->monitor) {
+		// Cross-monitor move: capture session is still bound to the old monitor.
+		// Recreating the session mid-stream is non-trivial; for now skip compose
+		// (caller can fall through to opaque-only weave).
+		// TODO follow-up: tear-down + re-create on monitor change.
+		out_bg_uv_origin[0] = 0;
+		out_bg_uv_origin[1] = 0;
+		out_bg_uv_extent[0] = 0;
+		out_bg_uv_extent[1] = 0;
+		return false;
+	}
+	// Compositor's swap chain renders into the window's CLIENT area only —
+	// the title bar and borders are non-client and drawn by DWM. Mapping the
+	// bg sample to GetWindowRect would shift / scale by the title-bar height.
+	// Use GetClientRect + ClientToScreen so the UV rect covers exactly the
+	// pixels the atlas's tile content maps onto. Pixel-perfect in both
+	// titled-window and borderless cases.
+	RECT cr;
+	if (!GetClientRect(c->hwnd, &cr)) {
+		return false;
+	}
+	POINT tl = {cr.left, cr.top};
+	POINT br = {cr.right, cr.bottom};
+	if (!ClientToScreen(c->hwnd, &tl) || !ClientToScreen(c->hwnd, &br)) {
+		return false;
+	}
+	const float inv_w = 1.0f / (float)c->monitor_w;
+	const float inv_h = 1.0f / (float)c->monitor_h;
+	out_bg_uv_origin[0] = (float)(tl.x - c->monitor_rect.left) * inv_w;
+	out_bg_uv_origin[1] = (float)(tl.y - c->monitor_rect.top) * inv_h;
+	out_bg_uv_extent[0] = (float)(br.x - tl.x) * inv_w;
+	out_bg_uv_extent[1] = (float)(br.y - tl.y) * inv_h;
+
+	return c->has_frame.load(std::memory_order_acquire);
+}
+
+extern "C" void
+leia_bg_capture_destroy(struct leia_bg_capture *c)
+{
+	if (c == nullptr) {
+		return;
+	}
+	{
+		ComPtr<WF::IClosable> closable;
+		if (c->frame_pool != nullptr && SUCCEEDED(c->frame_pool.As(&closable))) {
+			closable->Close();
+		}
+	}
+	{
+		ComPtr<WF::IClosable> closable;
+		if (c->capture_session != nullptr && SUCCEEDED(c->capture_session.As(&closable))) {
+			closable->Close();
+		}
+	}
+	if (c->staging_shared_handle != nullptr) {
+		CloseHandle(c->staging_shared_handle);
+	}
+	if (c->shared_fence_handle != nullptr) {
+		CloseHandle(c->shared_fence_handle);
+	}
+	if (c->hwnd != nullptr) {
+		SetWindowDisplayAffinity(c->hwnd, WDA_NONE);
+	}
+	delete c;
+}

--- a/src/xrt/drivers/leia/leia_bg_capture_win.cpp
+++ b/src/xrt/drivers/leia/leia_bg_capture_win.cpp
@@ -424,6 +424,24 @@ leia_bg_capture_open_fence_d3d12(struct leia_bg_capture *c, ID3D12Device *dev, I
 	return dev->OpenSharedHandle(c->shared_fence_handle, IID_PPV_ARGS(out_fence));
 }
 
+extern "C" HANDLE
+leia_bg_capture_get_shared_handle(struct leia_bg_capture *c)
+{
+	return c != nullptr ? c->staging_shared_handle : nullptr;
+}
+
+extern "C" void
+leia_bg_capture_get_size(struct leia_bg_capture *c, uint32_t *out_w, uint32_t *out_h)
+{
+	if (c == nullptr) {
+		if (out_w) *out_w = 0;
+		if (out_h) *out_h = 0;
+		return;
+	}
+	if (out_w) *out_w = c->monitor_w;
+	if (out_h) *out_h = c->monitor_h;
+}
+
 extern "C" bool
 leia_bg_capture_poll(struct leia_bg_capture *c,
                      float out_bg_uv_origin[2],

--- a/src/xrt/drivers/leia/leia_bg_capture_win.h
+++ b/src/xrt/drivers/leia/leia_bg_capture_win.h
@@ -86,6 +86,22 @@ long leia_bg_capture_open_fence_d3d12(struct leia_bg_capture *c,
                                       struct ID3D12Fence **out_fence);
 
 /*!
+ * Expose the shared NT handle of the staging texture so the caller can
+ * import it into Vulkan via @c VK_KHR_external_memory_win32 (handle type
+ * @c VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_BIT). The handle is owned
+ * by the capture module; do NOT @c CloseHandle on it.
+ */
+HANDLE leia_bg_capture_get_shared_handle(struct leia_bg_capture *c);
+
+/*!
+ * Monitor dimensions used to size the staging texture (BGRA8). Use these
+ * for the imported VkImage extent.
+ */
+void leia_bg_capture_get_size(struct leia_bg_capture *c,
+                              uint32_t *out_width,
+                              uint32_t *out_height);
+
+/*!
  * Per-frame: pull the latest WGC frame into the shared staging tex, return
  * window-on-monitor region as normalized UVs and the fence value the caller
  * must Wait on before sampling.

--- a/src/xrt/drivers/leia/leia_bg_capture_win.h
+++ b/src/xrt/drivers/leia/leia_bg_capture_win.h
@@ -1,0 +1,108 @@
+// Copyright 2026, Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  Windows Graphics Capture (WGC) helper for Leia DP transparency.
+ *
+ * Captures the desktop region behind the app's HWND and exposes the
+ * latest frame as a cross-API shared D3D11 texture (SHARED_NTHANDLE +
+ * KEYEDMUTEX). The D3D11 and D3D12 Leia DPs import that handle and
+ * sample the desktop content into the per-tile compose-under-bg pass —
+ * replacing the older chroma-key trick.
+ *
+ * On any failure path (Windows < 10 2004, WGC unavailable, DRM, env
+ * override), create() returns NULL and the DP falls back to chroma-key.
+ *
+ * Self-capture defense: SetWindowDisplayAffinity(WDA_EXCLUDEFROMCAPTURE)
+ * is applied to the HWND so WGC does not recursively capture our own
+ * woven output back into the background.
+ *
+ * @author David Fattal
+ * @ingroup drv_leia
+ */
+
+#pragma once
+
+#ifdef _WIN32
+
+#include <windows.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+struct ID3D11Device;
+struct ID3D11Texture2D;
+struct ID3D11ShaderResourceView;
+struct ID3D11Fence;
+struct ID3D12Device;
+struct ID3D12Resource;
+struct ID3D12Fence;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct leia_bg_capture;
+
+/*!
+ * Create a WGC capture session targeting the monitor containing @p hwnd.
+ * Returns NULL on any failure — caller falls back to chroma-key.
+ *
+ * Side-effect on success: SetWindowDisplayAffinity(hwnd, WDA_EXCLUDEFROMCAPTURE).
+ */
+struct leia_bg_capture *leia_bg_capture_create(HWND hwnd);
+
+/*!
+ * Open the shared staging texture on the caller's D3D11 device + create an SRV.
+ * Call once at DP init. *out_tex and *out_srv are owned by the caller.
+ */
+long leia_bg_capture_open_d3d11(struct leia_bg_capture *c,
+                                struct ID3D11Device *dev,
+                                struct ID3D11Texture2D **out_tex,
+                                struct ID3D11ShaderResourceView **out_srv);
+
+/*!
+ * Open the shared staging texture on the caller's D3D12 device.
+ * Caller creates the SRV in its own descriptor heap.
+ */
+long leia_bg_capture_open_d3d12(struct leia_bg_capture *c,
+                                struct ID3D12Device *dev,
+                                struct ID3D12Resource **out_res);
+
+/*!
+ * Open the producer's shared fence on the caller's D3D11 device. Consumer
+ * waits on this fence (via @c ID3D11DeviceContext4::Wait) before sampling
+ * the shared staging texture so it sees the producer's copy result.
+ */
+long leia_bg_capture_open_fence_d3d11(struct leia_bg_capture *c,
+                                      struct ID3D11Device *dev,
+                                      struct ID3D11Fence **out_fence);
+
+/*!
+ * Open the producer's shared fence on the caller's D3D12 device. Consumer
+ * waits via @c ID3D12CommandQueue::Wait before sampling.
+ */
+long leia_bg_capture_open_fence_d3d12(struct leia_bg_capture *c,
+                                      struct ID3D12Device *dev,
+                                      struct ID3D12Fence **out_fence);
+
+/*!
+ * Per-frame: pull the latest WGC frame into the shared staging tex, return
+ * window-on-monitor region as normalized UVs and the fence value the caller
+ * must Wait on before sampling.
+ *
+ * @return  true if a captured frame is available; false if no frame yet
+ *          or the window has crossed monitors (caller should skip compose
+ *          for this frame and either fall back or pass-through).
+ */
+bool leia_bg_capture_poll(struct leia_bg_capture *c,
+                          float out_bg_uv_origin[2],
+                          float out_bg_uv_extent[2],
+                          uint64_t *out_fence_wait_value);
+
+void leia_bg_capture_destroy(struct leia_bg_capture *c);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // _WIN32

--- a/src/xrt/drivers/leia/leia_display_processor.cpp
+++ b/src/xrt/drivers/leia/leia_display_processor.cpp
@@ -32,6 +32,11 @@
 #include "leia/shaders/ck_fill.frag.h"
 #include "leia/shaders/ck_strip.frag.h"
 
+#ifdef _WIN32
+#include "leia_bg_capture_win.h"
+#include "leia/shaders/compose_under_bg.frag.h"
+#endif
+
 
 // Default chroma key when the app didn't supply one (set_chroma_key key=0).
 // Magenta — matches the D3D11/D3D12 DPs' kDefaultChromaKey for cross-API parity.
@@ -110,6 +115,33 @@ struct leia_display_processor
 		uint32_t w, h;
 	} ck_strip_fbs[kMaxStripFramebuffers];
 	uint32_t ck_strip_fbs_count;
+
+	//
+	// Compose-under-bg transparency support (preferred over chroma-key on
+	// Windows when WGC desktop capture is available). Reuses ck_fill_image
+	// /ck_fill_view / ck_fill_fb / ck_fill_rp as the intermediate target —
+	// same R8G8B8A8_UNORM format. Distinct pipeline (2 SRVs + 24-byte push
+	// constants for bg_uv + tile_count) and descriptor set.
+	//
+	// On non-Windows or WGC-init failure, bg_compose_enabled stays false and
+	// the chroma-key path runs unchanged.
+	//
+	void *hwnd_opaque;                       //!< HWND from factory (Win-only). void* so the struct stays cross-platform.
+	struct leia_bg_capture *bg_capture;      //!< Owned (Win-only). NULL → fall back to ck.
+	bool bg_compose_enabled;
+
+	VkImage bg_image;
+	VkImageView bg_view;
+	VkDeviceMemory bg_mem;
+	uint32_t bg_w, bg_h;
+
+	VkSampler compose_sampler;               //!< Linear/clamp (vs ck's NEAREST).
+	VkDescriptorSetLayout compose_desc_layout;
+	VkPipelineLayout compose_pipeline_layout;
+	VkDescriptorPool compose_desc_pool;
+	VkDescriptorSet compose_set;
+	VkPipeline compose_pipeline;
+	bool compose_inited;
 };
 
 static inline struct leia_display_processor *
@@ -991,6 +1023,526 @@ ck_release_resources(struct leia_display_processor *ldp)
 
 /*
  *
+ * Compose-under-bg pipeline (preferred over chroma-key on Windows).
+ *
+ * Reuses ck_fill_image / ck_fill_view / ck_fill_fb / ck_fill_rp as the
+ * intermediate target — ck_ensure_fill_target + ck_init_pipeline still
+ * create those. Distinct pipeline + descriptor set with 2 SRVs.
+ *
+ * Cross-API sync note: WGC capture (~60 Hz, sub-ms copy) is much slower
+ * than the consumer's render rate (~120 Hz). The producer's D3D11 context
+ * is Flushed after every Copy. Without a GPU-level semaphore wait, the
+ * consumer may very occasionally see a torn frame mid-copy; in practice
+ * the temporal gap dwarfs the copy duration. Proper VK_KHR_external_
+ * semaphore_win32 import via D3D12_FENCE handle type is a follow-up.
+ *
+ */
+
+#ifdef _WIN32
+
+static bool
+compose_should_run(struct leia_display_processor *ldp)
+{
+	return ldp->bg_compose_enabled && ldp->bg_capture != nullptr && ldp->bg_view != VK_NULL_HANDLE;
+}
+
+// Import the bg_capture's shared NT-handle texture as VkImage + VkImageView.
+// One-shot on session start; the imported memory's lifetime is tied to the DP.
+static bool
+compose_import_bg_image(struct leia_display_processor *ldp)
+{
+	struct vk_bundle *vk = ldp->vk;
+	HANDLE handle = leia_bg_capture_get_shared_handle(ldp->bg_capture);
+	if (handle == nullptr) {
+		U_LOG_W("Leia VK DP: bg_capture has no shared handle");
+		return false;
+	}
+	leia_bg_capture_get_size(ldp->bg_capture, &ldp->bg_w, &ldp->bg_h);
+	if (ldp->bg_w == 0 || ldp->bg_h == 0) {
+		U_LOG_W("Leia VK DP: bg_capture has zero size");
+		return false;
+	}
+
+	// NT-handle import path: VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_BIT.
+	// Format must match the D3D11 staging tex (BGRA8).
+	VkExternalMemoryImageCreateInfo ext_ci = {
+	    .sType = VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO,
+	    .handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_BIT,
+	};
+	VkImageCreateInfo image_ci = {
+	    .sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
+	    .pNext = &ext_ci,
+	    .imageType = VK_IMAGE_TYPE_2D,
+	    .format = VK_FORMAT_B8G8R8A8_UNORM,
+	    .extent = {ldp->bg_w, ldp->bg_h, 1},
+	    .mipLevels = 1,
+	    .arrayLayers = 1,
+	    .samples = VK_SAMPLE_COUNT_1_BIT,
+	    .tiling = VK_IMAGE_TILING_OPTIMAL,
+	    .usage = VK_IMAGE_USAGE_SAMPLED_BIT,
+	    .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
+	    .initialLayout = VK_IMAGE_LAYOUT_UNDEFINED,
+	};
+	VkResult res = vk->vkCreateImage(vk->device, &image_ci, NULL, &ldp->bg_image);
+	if (res != VK_SUCCESS) {
+		U_LOG_W("Leia VK DP: bg vkCreateImage failed: %d", res);
+		return false;
+	}
+
+	VkMemoryRequirements reqs = {};
+	vk->vkGetImageMemoryRequirements(vk->device, ldp->bg_image, &reqs);
+
+	VkImportMemoryWin32HandleInfoKHR import = {
+	    .sType = VK_STRUCTURE_TYPE_IMPORT_MEMORY_WIN32_HANDLE_INFO_KHR,
+	    .handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_BIT,
+	    .handle = handle,
+	};
+	VkMemoryDedicatedAllocateInfoKHR dedicated = {
+	    .sType = VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO_KHR,
+	    .pNext = &import,
+	    .image = ldp->bg_image,
+	};
+	VkPhysicalDeviceMemoryProperties mp = {};
+	vk->vkGetPhysicalDeviceMemoryProperties(vk->physical_device, &mp);
+	uint32_t mti = UINT32_MAX;
+	for (uint32_t i = 0; i < mp.memoryTypeCount; i++) {
+		if ((reqs.memoryTypeBits & (1u << i)) != 0) {
+			mti = i;
+			break;
+		}
+	}
+	if (mti == UINT32_MAX) {
+		U_LOG_W("Leia VK DP: no memory type for bg import");
+		vk->vkDestroyImage(vk->device, ldp->bg_image, NULL);
+		ldp->bg_image = VK_NULL_HANDLE;
+		return false;
+	}
+	VkMemoryAllocateInfo alloc = {
+	    .sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
+	    .pNext = &dedicated,
+	    .allocationSize = reqs.size,
+	    .memoryTypeIndex = mti,
+	};
+	res = vk->vkAllocateMemory(vk->device, &alloc, NULL, &ldp->bg_mem);
+	if (res != VK_SUCCESS) {
+		U_LOG_W("Leia VK DP: bg vkAllocateMemory failed: %d", res);
+		vk->vkDestroyImage(vk->device, ldp->bg_image, NULL);
+		ldp->bg_image = VK_NULL_HANDLE;
+		return false;
+	}
+	res = vk->vkBindImageMemory(vk->device, ldp->bg_image, ldp->bg_mem, 0);
+	if (res != VK_SUCCESS) {
+		U_LOG_W("Leia VK DP: bg vkBindImageMemory failed: %d", res);
+		vk->vkFreeMemory(vk->device, ldp->bg_mem, NULL);
+		vk->vkDestroyImage(vk->device, ldp->bg_image, NULL);
+		ldp->bg_mem = VK_NULL_HANDLE;
+		ldp->bg_image = VK_NULL_HANDLE;
+		return false;
+	}
+
+	VkImageViewCreateInfo vi = {
+	    .sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,
+	    .image = ldp->bg_image,
+	    .viewType = VK_IMAGE_VIEW_TYPE_2D,
+	    .format = VK_FORMAT_B8G8R8A8_UNORM,
+	    .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1},
+	};
+	res = vk->vkCreateImageView(vk->device, &vi, NULL, &ldp->bg_view);
+	if (res != VK_SUCCESS) {
+		U_LOG_W("Leia VK DP: bg vkCreateImageView failed: %d", res);
+		vk->vkFreeMemory(vk->device, ldp->bg_mem, NULL);
+		vk->vkDestroyImage(vk->device, ldp->bg_image, NULL);
+		ldp->bg_mem = VK_NULL_HANDLE;
+		ldp->bg_image = VK_NULL_HANDLE;
+		return false;
+	}
+
+	U_LOG_W("Leia VK DP: bg D3D11 texture imported (%ux%u)", ldp->bg_w, ldp->bg_h);
+	return true;
+}
+
+// Build compose-specific descriptor layout / pipeline layout / sampler /
+// descriptor pool / pipeline. Reuses ck_fill_rp as the render pass (same
+// R8G8B8A8_UNORM attachment). Requires ck_init_pipeline to have run first
+// so ck_fill_rp exists. Idempotent.
+static bool
+compose_init_pipeline(struct leia_display_processor *ldp)
+{
+	if (ldp->compose_inited) return true;
+	if (ldp->ck_fill_rp == VK_NULL_HANDLE) {
+		U_LOG_W("Leia VK DP: compose_init_pipeline before ck_fill_rp exists");
+		return false;
+	}
+
+	struct vk_bundle *vk = ldp->vk;
+	VkResult res;
+
+	// 2-binding descriptor set: atlas (0) + bg (1).
+	{
+		VkDescriptorSetLayoutBinding bs[2] = {
+		    {.binding = 0, .descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+		     .descriptorCount = 1, .stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT},
+		    {.binding = 1, .descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+		     .descriptorCount = 1, .stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT},
+		};
+		VkDescriptorSetLayoutCreateInfo ci = {
+		    .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO,
+		    .bindingCount = 2, .pBindings = bs,
+		};
+		res = vk->vkCreateDescriptorSetLayout(vk->device, &ci, NULL, &ldp->compose_desc_layout);
+		if (res != VK_SUCCESS) {
+			U_LOG_E("Leia VK DP: compose desc layout failed: %d", res);
+			return false;
+		}
+	}
+
+	// Push constants: 2*vec2 + uvec2 + uvec2 pad = 32 bytes.
+	{
+		VkPushConstantRange pc = {
+		    .stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT,
+		    .offset = 0,
+		    .size = 32,
+		};
+		VkPipelineLayoutCreateInfo pli = {
+		    .sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO,
+		    .setLayoutCount = 1, .pSetLayouts = &ldp->compose_desc_layout,
+		    .pushConstantRangeCount = 1, .pPushConstantRanges = &pc,
+		};
+		res = vk->vkCreatePipelineLayout(vk->device, &pli, NULL, &ldp->compose_pipeline_layout);
+		if (res != VK_SUCCESS) {
+			U_LOG_E("Leia VK DP: compose pipeline layout failed: %d", res);
+			return false;
+		}
+	}
+
+	// Linear sampler.
+	{
+		VkSamplerCreateInfo si = {
+		    .sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO,
+		    .magFilter = VK_FILTER_LINEAR,
+		    .minFilter = VK_FILTER_LINEAR,
+		    .mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR,
+		    .addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE,
+		    .addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE,
+		    .addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE,
+		    .maxLod = 1.0f,
+		};
+		res = vk->vkCreateSampler(vk->device, &si, NULL, &ldp->compose_sampler);
+		if (res != VK_SUCCESS) {
+			U_LOG_E("Leia VK DP: compose sampler failed: %d", res);
+			return false;
+		}
+	}
+
+	// Descriptor pool + 1 set.
+	{
+		VkDescriptorPoolSize size = {
+		    .type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+		    .descriptorCount = 2,
+		};
+		VkDescriptorPoolCreateInfo dpi = {
+		    .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO,
+		    .maxSets = 1, .poolSizeCount = 1, .pPoolSizes = &size,
+		};
+		res = vk->vkCreateDescriptorPool(vk->device, &dpi, NULL, &ldp->compose_desc_pool);
+		if (res != VK_SUCCESS) {
+			U_LOG_E("Leia VK DP: compose desc pool failed: %d", res);
+			return false;
+		}
+		VkDescriptorSetAllocateInfo ai = {
+		    .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO,
+		    .descriptorPool = ldp->compose_desc_pool,
+		    .descriptorSetCount = 1,
+		    .pSetLayouts = &ldp->compose_desc_layout,
+		};
+		res = vk->vkAllocateDescriptorSets(vk->device, &ai, &ldp->compose_set);
+		if (res != VK_SUCCESS) {
+			U_LOG_E("Leia VK DP: compose desc set alloc failed: %d", res);
+			return false;
+		}
+	}
+
+	// Bind the bg view to slot 1 once — it doesn't change across frames.
+	{
+		VkDescriptorImageInfo info = {
+		    .sampler = ldp->compose_sampler,
+		    .imageView = ldp->bg_view,
+		    .imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+		};
+		VkWriteDescriptorSet w = {
+		    .sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
+		    .dstSet = ldp->compose_set,
+		    .dstBinding = 1,
+		    .descriptorCount = 1,
+		    .descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+		    .pImageInfo = &info,
+		};
+		vk->vkUpdateDescriptorSets(vk->device, 1, &w, 0, NULL);
+	}
+
+	// Build pipeline.
+	VkShaderModule vs = VK_NULL_HANDLE, fs = VK_NULL_HANDLE;
+	res = ck_create_shader_module(vk, leia_shaders_fullscreen_tri_vert,
+	                              sizeof(leia_shaders_fullscreen_tri_vert), &vs);
+	if (res != VK_SUCCESS) {
+		U_LOG_E("Leia VK DP: compose vs create failed: %d", res);
+		return false;
+	}
+	res = ck_create_shader_module(vk, leia_shaders_compose_under_bg_frag,
+	                              sizeof(leia_shaders_compose_under_bg_frag), &fs);
+	if (res != VK_SUCCESS) {
+		U_LOG_E("Leia VK DP: compose fs create failed: %d", res);
+		vk->vkDestroyShaderModule(vk->device, vs, NULL);
+		return false;
+	}
+
+	VkPipelineVertexInputStateCreateInfo vi = {.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO};
+	VkPipelineInputAssemblyStateCreateInfo ia = {
+	    .sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO,
+	    .topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST,
+	};
+	VkPipelineViewportStateCreateInfo vps = {
+	    .sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO,
+	    .viewportCount = 1, .scissorCount = 1,
+	};
+	VkPipelineRasterizationStateCreateInfo rs = {
+	    .sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO,
+	    .polygonMode = VK_POLYGON_MODE_FILL,
+	    .cullMode = VK_CULL_MODE_NONE,
+	    .frontFace = VK_FRONT_FACE_COUNTER_CLOCKWISE,
+	    .lineWidth = 1.0f,
+	};
+	VkPipelineMultisampleStateCreateInfo ms = {
+	    .sType = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO,
+	    .rasterizationSamples = VK_SAMPLE_COUNT_1_BIT,
+	};
+	VkPipelineColorBlendAttachmentState ba = {
+	    .colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT |
+	                      VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT,
+	};
+	VkPipelineColorBlendStateCreateInfo cb = {
+	    .sType = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO,
+	    .attachmentCount = 1, .pAttachments = &ba,
+	};
+	VkDynamicState dyn[] = {VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR};
+	VkPipelineDynamicStateCreateInfo dynstate = {
+	    .sType = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO,
+	    .dynamicStateCount = 2, .pDynamicStates = dyn,
+	};
+	VkPipelineShaderStageCreateInfo stages[2] = {
+	    {.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
+	     .stage = VK_SHADER_STAGE_VERTEX_BIT, .module = vs, .pName = "main"},
+	    {.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
+	     .stage = VK_SHADER_STAGE_FRAGMENT_BIT, .module = fs, .pName = "main"},
+	};
+	VkGraphicsPipelineCreateInfo pi = {
+	    .sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO,
+	    .stageCount = 2, .pStages = stages,
+	    .pVertexInputState = &vi,
+	    .pInputAssemblyState = &ia,
+	    .pViewportState = &vps,
+	    .pRasterizationState = &rs,
+	    .pMultisampleState = &ms,
+	    .pColorBlendState = &cb,
+	    .pDynamicState = &dynstate,
+	    .layout = ldp->compose_pipeline_layout,
+	    .renderPass = ldp->ck_fill_rp,
+	    .subpass = 0,
+	};
+	res = vk->vkCreateGraphicsPipelines(vk->device, VK_NULL_HANDLE, 1, &pi, NULL, &ldp->compose_pipeline);
+	vk->vkDestroyShaderModule(vk->device, fs, NULL);
+	vk->vkDestroyShaderModule(vk->device, vs, NULL);
+	if (res != VK_SUCCESS) {
+		U_LOG_E("Leia VK DP: compose pipeline create failed: %d", res);
+		return false;
+	}
+
+	ldp->compose_inited = true;
+	U_LOG_W("Leia VK DP: compose-under-bg pipeline ready");
+	return true;
+}
+
+// Pre-weave compose. Polls WGC, transitions bg → SHADER_READ once, renders the
+// compose pass into ck_fill_image. Returns ck_fill_view for the weaver.
+static VkImageView
+compose_run_pre_weave(struct leia_display_processor *ldp,
+                      VkCommandBuffer cmd,
+                      VkImageView atlas_view,
+                      uint32_t atlas_w,
+                      uint32_t atlas_h,
+                      uint32_t tile_columns,
+                      uint32_t tile_rows)
+{
+	struct vk_bundle *vk = ldp->vk;
+	if (!ck_ensure_fill_target(ldp, atlas_w, atlas_h)) return VK_NULL_HANDLE;
+	if (!compose_init_pipeline(ldp)) return VK_NULL_HANDLE;
+
+	float bg_origin[2] = {0.0f, 0.0f};
+	float bg_extent[2] = {0.0f, 0.0f};
+	uint64_t unused = 0;
+	bool have_bg = leia_bg_capture_poll(ldp->bg_capture, bg_origin, bg_extent, &unused);
+	if (!have_bg) {
+		return VK_NULL_HANDLE;
+	}
+
+	// First-use barrier on the imported bg image: UNDEFINED → SHADER_READ_ONLY.
+	// Subsequent frames keep it in SHADER_READ_ONLY (the D3D11 producer writes
+	// through the shared memory without going through VK layouts).
+	static thread_local bool bg_transitioned = false;
+	if (!bg_transitioned) {
+		VkImageMemoryBarrier b = {
+		    .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+		    .srcAccessMask = 0,
+		    .dstAccessMask = VK_ACCESS_SHADER_READ_BIT,
+		    .oldLayout = VK_IMAGE_LAYOUT_UNDEFINED,
+		    .newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+		    .image = ldp->bg_image,
+		    .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1},
+		};
+		vk->vkCmdPipelineBarrier(cmd,
+		    VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+		    VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+		    0, 0, NULL, 0, NULL, 1, &b);
+		bg_transitioned = true;
+	}
+
+	// Refresh atlas SRV in compose set (slot 0). bg SRV (slot 1) is stable.
+	VkDescriptorImageInfo atlas_info = {
+	    .sampler = ldp->compose_sampler,
+	    .imageView = atlas_view,
+	    .imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+	};
+	VkWriteDescriptorSet w = {
+	    .sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
+	    .dstSet = ldp->compose_set,
+	    .dstBinding = 0,
+	    .descriptorCount = 1,
+	    .descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+	    .pImageInfo = &atlas_info,
+	};
+	vk->vkUpdateDescriptorSets(vk->device, 1, &w, 0, NULL);
+
+	// ck_fill_image UNDEFINED → COLOR_ATTACHMENT.
+	VkImageMemoryBarrier pre = {
+	    .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+	    .srcAccessMask = VK_ACCESS_SHADER_READ_BIT,
+	    .dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+	    .oldLayout = VK_IMAGE_LAYOUT_UNDEFINED,
+	    .newLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+	    .image = ldp->ck_fill_image,
+	    .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1},
+	};
+	vk->vkCmdPipelineBarrier(cmd,
+	    VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+	    VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+	    0, 0, NULL, 0, NULL, 1, &pre);
+
+	VkRenderPassBeginInfo rpbi = {
+	    .sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO,
+	    .renderPass = ldp->ck_fill_rp,
+	    .framebuffer = ldp->ck_fill_fb,
+	    .renderArea = {{0, 0}, {atlas_w, atlas_h}},
+	};
+	vk->vkCmdBeginRenderPass(cmd, &rpbi, VK_SUBPASS_CONTENTS_INLINE);
+
+	vk->vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, ldp->compose_pipeline);
+	vk->vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS,
+	                             ldp->compose_pipeline_layout, 0, 1, &ldp->compose_set, 0, NULL);
+
+	struct {
+		float bg_uv_origin[2];
+		float bg_uv_extent[2];
+		uint32_t tile_count[2];
+		uint32_t pad[2];
+	} push = {};
+	push.bg_uv_origin[0] = bg_origin[0]; push.bg_uv_origin[1] = bg_origin[1];
+	push.bg_uv_extent[0] = bg_extent[0]; push.bg_uv_extent[1] = bg_extent[1];
+	push.tile_count[0] = tile_columns;   push.tile_count[1] = tile_rows;
+	vk->vkCmdPushConstants(cmd, ldp->compose_pipeline_layout,
+	                        VK_SHADER_STAGE_FRAGMENT_BIT, 0, sizeof(push), &push);
+
+	VkViewport vp = {0.0f, 0.0f, (float)atlas_w, (float)atlas_h, 0.0f, 1.0f};
+	VkRect2D sc = {{0, 0}, {atlas_w, atlas_h}};
+	vk->vkCmdSetViewport(cmd, 0, 1, &vp);
+	vk->vkCmdSetScissor(cmd, 0, 1, &sc);
+
+	vk->vkCmdDraw(cmd, 3, 1, 0, 0);
+	vk->vkCmdEndRenderPass(cmd);
+
+	// ck_fill_image COLOR_ATTACHMENT → SHADER_READ for weaver.
+	VkImageMemoryBarrier post = {
+	    .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+	    .srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+	    .dstAccessMask = VK_ACCESS_SHADER_READ_BIT,
+	    .oldLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+	    .newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+	    .image = ldp->ck_fill_image,
+	    .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1},
+	};
+	vk->vkCmdPipelineBarrier(cmd,
+	    VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+	    VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+	    0, 0, NULL, 0, NULL, 1, &post);
+
+	return ldp->ck_fill_view;
+}
+
+static void
+compose_release_resources(struct leia_display_processor *ldp)
+{
+	if (ldp == NULL || ldp->vk == NULL) return;
+	struct vk_bundle *vk = ldp->vk;
+
+	if (ldp->compose_pipeline != VK_NULL_HANDLE) {
+		vk->vkDestroyPipeline(vk->device, ldp->compose_pipeline, NULL);
+		ldp->compose_pipeline = VK_NULL_HANDLE;
+	}
+	if (ldp->compose_desc_pool != VK_NULL_HANDLE) {
+		vk->vkDestroyDescriptorPool(vk->device, ldp->compose_desc_pool, NULL);
+		ldp->compose_desc_pool = VK_NULL_HANDLE;
+	}
+	if (ldp->compose_pipeline_layout != VK_NULL_HANDLE) {
+		vk->vkDestroyPipelineLayout(vk->device, ldp->compose_pipeline_layout, NULL);
+		ldp->compose_pipeline_layout = VK_NULL_HANDLE;
+	}
+	if (ldp->compose_desc_layout != VK_NULL_HANDLE) {
+		vk->vkDestroyDescriptorSetLayout(vk->device, ldp->compose_desc_layout, NULL);
+		ldp->compose_desc_layout = VK_NULL_HANDLE;
+	}
+	if (ldp->compose_sampler != VK_NULL_HANDLE) {
+		vk->vkDestroySampler(vk->device, ldp->compose_sampler, NULL);
+		ldp->compose_sampler = VK_NULL_HANDLE;
+	}
+	if (ldp->bg_view != VK_NULL_HANDLE) {
+		vk->vkDestroyImageView(vk->device, ldp->bg_view, NULL);
+		ldp->bg_view = VK_NULL_HANDLE;
+	}
+	if (ldp->bg_image != VK_NULL_HANDLE) {
+		vk->vkDestroyImage(vk->device, ldp->bg_image, NULL);
+		ldp->bg_image = VK_NULL_HANDLE;
+	}
+	if (ldp->bg_mem != VK_NULL_HANDLE) {
+		vk->vkFreeMemory(vk->device, ldp->bg_mem, NULL);
+		ldp->bg_mem = VK_NULL_HANDLE;
+	}
+	if (ldp->bg_capture != nullptr) {
+		leia_bg_capture_destroy(ldp->bg_capture);
+		ldp->bg_capture = nullptr;
+	}
+	ldp->bg_compose_enabled = false;
+	ldp->compose_inited = false;
+}
+
+#else // !_WIN32
+
+static inline bool compose_should_run(struct leia_display_processor *) { return false; }
+static inline void compose_release_resources(struct leia_display_processor *) {}
+
+#endif // _WIN32
+
+
+/*
+ *
  * xrt_display_processor interface methods.
  *
  */
@@ -1103,26 +1655,53 @@ leia_dp_process_atlas(struct xrt_display_processor *xdp,
 	viewport.extent.width = target_width;
 	viewport.extent.height = target_height;
 
-	// Chroma-key transparency support: pre-weave fill substitutes the atlas with
-	// an opaque-RGB version, then post-weave strip rewrites alpha=0 pixels.
-	// Lazy-init pipelines on first frame the trick runs.
+	// Transparency support — two paths:
+	//
+	//   1. Compose-under-bg (preferred, Windows + WGC): pre-composite the
+	//      captured desktop region UNDER each per-view atlas tile so the
+	//      weaver consumes opaque RGB with the desktop already integrated.
+	//      No post-weave strip needed. Activated by set_chroma_key when WGC
+	//      init succeeded. Correct on AA edges and semi-transparent pixels.
+	//
+	//   2. Chroma-key (fallback): replace alpha=0 with key color pre-weave,
+	//      strip back to alpha=0 post-weave. Hard mask on AA edges. Used
+	//      when WGC is unavailable.
 	VkImageView weaver_input = atlas_view;
-	bool ck_active = ck_should_run(ldp) && (target_image != (VkImage_XDP)VK_NULL_HANDLE);
+	bool ck_active = false;
 	uint32_t atlas_w = view_width * tile_columns;
 	uint32_t atlas_h = view_height * tile_rows;
-	if (ck_active) {
+#ifdef _WIN32
+	bool compose_active = compose_should_run(ldp) && (target_image != (VkImage_XDP)VK_NULL_HANDLE);
+	if (compose_active) {
+		// Compose needs the ck pipeline pieces too (ck_fill_rp + ck_fill_image).
+		// ck_init_pipeline is idempotent and self-contained.
 		if (ck_init_pipeline(ldp, (VkFormat)target_format)) {
-			VkImageView filled = ck_run_pre_weave_fill(ldp, cmd_buffer, atlas_view,
-			                                            atlas_w, atlas_h);
-			if (filled != VK_NULL_HANDLE) {
-				weaver_input = filled;
+			VkImageView composed = compose_run_pre_weave(ldp, cmd_buffer, atlas_view,
+			                                              atlas_w, atlas_h,
+			                                              tile_columns, tile_rows);
+			if (composed != VK_NULL_HANDLE) {
+				weaver_input = composed;
+			}
+			// On compose failure (e.g. no WGC frame yet) just pass through
+			// — atlas alpha=0 regions render as black RGB through the weaver,
+			// recovers next frame once WGC produces a frame.
+		}
+	} else
+#endif
+	{
+		ck_active = ck_should_run(ldp) && (target_image != (VkImage_XDP)VK_NULL_HANDLE);
+		if (ck_active) {
+			if (ck_init_pipeline(ldp, (VkFormat)target_format)) {
+				VkImageView filled = ck_run_pre_weave_fill(ldp, cmd_buffer, atlas_view,
+				                                            atlas_w, atlas_h);
+				if (filled != VK_NULL_HANDLE) {
+					weaver_input = filled;
+				} else {
+					ck_active = false;
+				}
 			} else {
-				// Fall back: weaver runs on original atlas; strip will produce
-				// hard mask but won't be a correctness regression.
 				ck_active = false;
 			}
-		} else {
-			ck_active = false;
 		}
 	}
 
@@ -1238,13 +1817,32 @@ leia_dp_set_chroma_key(struct xrt_display_processor *xdp,
                        bool transparent_bg_enabled)
 {
 	struct leia_display_processor *ldp = leia_display_processor(xdp);
-	ldp->ck_enabled = transparent_bg_enabled;
-	// 0 means "DP picks default" — use magenta to match D3D11/D3D12 DPs.
+	// Keep ck_color/ck_enabled current — chroma-key is the fallback.
 	ldp->ck_color = (key_color != 0) ? key_color : kDefaultChromaKey;
+	ldp->ck_enabled = transparent_bg_enabled;
+
+#ifdef _WIN32
+	// Preferred path: WGC desktop capture + per-tile compose-under-bg.
+	// On any failure (older Windows, capture blocked, env-disabled), fall
+	// through to chroma-key.
+	if (transparent_bg_enabled && !ldp->bg_compose_enabled && ldp->hwnd_opaque != nullptr) {
+		ldp->bg_capture = leia_bg_capture_create((HWND)ldp->hwnd_opaque);
+		if (ldp->bg_capture != nullptr) {
+			if (compose_import_bg_image(ldp)) {
+				ldp->bg_compose_enabled = true;
+				ldp->ck_enabled = false;
+				U_LOG_W("Leia VK DP: transparency = compose-under-bg (WGC)");
+				return;
+			}
+			U_LOG_W("Leia VK DP: bg image import failed — falling back to chroma-key");
+			leia_bg_capture_destroy(ldp->bg_capture);
+			ldp->bg_capture = nullptr;
+		}
+	}
+#endif
 
 	if (transparent_bg_enabled) {
-		U_LOG_W("Leia VK DP: chroma-key %s (key=0x%06x %s)",
-		        "ENABLED",
+		U_LOG_W("Leia VK DP: transparency = chroma-key (key=0x%06x %s)",
 		        ldp->ck_color & 0x00FFFFFFu,
 		        (key_color != 0) ? "— app override" : "— DP default magenta");
 	} else {
@@ -1259,6 +1857,7 @@ leia_dp_destroy(struct xrt_display_processor *xdp)
 	struct vk_bundle *vk = ldp->vk;
 
 	if (vk != NULL) {
+		compose_release_resources(ldp);
 		ck_release_resources(ldp);
 		if (ldp->render_pass != VK_NULL_HANDLE) {
 			vk->vkDestroyRenderPass(vk->device, ldp->render_pass, NULL);
@@ -1355,6 +1954,7 @@ leia_dp_factory_vk(void *vk_bundle_ptr,
 	ldp->vk = vk;
 	ldp->render_pass = render_pass;
 	ldp->view_count = 2;
+	ldp->hwnd_opaque = window_handle;
 
 	*out_xdp = &ldp->base;
 

--- a/src/xrt/drivers/leia/leia_display_processor_d3d11.cpp
+++ b/src/xrt/drivers/leia/leia_display_processor_d3d11.cpp
@@ -19,11 +19,13 @@
 
 #include "leia_display_processor_d3d11.h"
 #include "leia_sr_d3d11.h"
+#include "leia_bg_capture_win.h"
 
 #include "xrt/xrt_display_metrics.h"
 #include "util/u_logging.h"
 
 #include <d3d11.h>
+#include <d3d11_4.h>  // ID3D11DeviceContext4 + ID3D11Fence — used by the bg-compose path.
 #include <d3dcompiler.h>
 #include <cstdlib>
 #include <cstring>
@@ -128,6 +130,46 @@ struct ChromaKeyConstants {
  */
 static constexpr uint32_t kDefaultChromaKey = 0x00FF00FF;
 
+/*
+ * Compose-under-bg pre-weave fill pixel shader.
+ *
+ * Per-tile composes the captured desktop region behind the window UNDER the
+ * app's RGBA atlas, outputting opaque RGB the SR weaver can consume. Replaces
+ * the chroma-key trick for sessions that have a working WGC capture.
+ *
+ *   out = lerp(bg, atlas.rgb, atlas.a),  out.a = 1
+ *
+ * The desktop sits at z=0 (display plane) so the same captured region is
+ * sampled into every tile; per-eye parallax comes from the atlas content,
+ * not the background. Each tile_local UV covers [0,1] within its tile, and
+ * we map it to the same window-on-monitor UV rect for all tiles.
+ */
+static const char *compose_under_bg_ps_source = R"(
+Texture2D<float4> atlas : register(t0);
+Texture2D<float4> bg    : register(t1);
+SamplerState samp       : register(s0);
+cbuffer Constants : register(b0) {
+	float2 bg_uv_origin;  // window TL on monitor, normalized
+	float2 bg_uv_extent;  // window size on monitor, normalized
+	uint2  tile_count;    // (tile_columns, tile_rows)
+	uint2  pad_;
+};
+float4 main(float4 pos : SV_Position, float2 uv : TEXCOORD0) : SV_Target {
+	float4 a = atlas.Sample(samp, uv);
+	float2 tile_local = frac(uv * float2(tile_count));
+	float2 bg_uv = bg_uv_origin + tile_local * bg_uv_extent;
+	float3 b = bg.SampleLevel(samp, bg_uv, 0).rgb;
+	return float4(lerp(b, a.rgb, a.a), 1.0);
+}
+)";
+
+struct ComposeConstants {
+	float bg_uv_origin[2];
+	float bg_uv_extent[2];
+	uint32_t tile_count[2];
+	uint32_t pad_[2];
+};
+
 
 /*!
  * Implementation struct wrapping leiasr_d3d11 as xrt_display_processor_d3d11.
@@ -138,6 +180,7 @@ struct leia_display_processor_d3d11_impl
 	struct leiasr_d3d11 *leiasr; //!< Owned — destroyed in leia_dp_d3d11_destroy.
 
 	ID3D11Device *device;              //!< Cached device reference (not owned, for blit init).
+	HWND hwnd;                         //!< Native window handle from factory, used by bg-capture for self-exclusion + window-on-monitor rect.
 
 	//! @name 2D blit shader resources (passthrough stretch-blit)
 	//! @{
@@ -175,6 +218,26 @@ struct leia_display_processor_d3d11_impl
 	ID3D11Texture2D *ck_strip_tex;
 	ID3D11ShaderResourceView *ck_strip_srv;
 	uint32_t ck_strip_w, ck_strip_h;
+	//! @}
+
+	//! @name Compose-under-bg transparency support (lazy-allocated on first frame)
+	//!
+	//! Preferred path when WGC is available: replaces ck_fill/ck_strip with a
+	//! single pre-weave pass that composites captured desktop pixels under the
+	//! app's RGBA atlas, producing opaque RGB the weaver consumes. No post-weave
+	//! pass needed (output is opaque all the way through).
+	//!
+	//! Reuses ck_fill_tex/ck_fill_rtv/ck_fill_srv as the intermediate target —
+	//! same size, same format. Independent shader + constant buffer.
+	//! @{
+	struct leia_bg_capture *bg_capture; //!< Owned; NULL if WGC init failed → fall back to ck.
+	bool bg_compose_enabled;            //!< True when the new path is active for this session.
+	ID3D11Texture2D *bg_shared_tex;     //!< Opened from bg_capture's shared NT handle.
+	ID3D11ShaderResourceView *bg_shared_srv;
+	ID3D11Fence *bg_fence;              //!< Opened from bg_capture's shared fence handle.
+	ID3D11PixelShader *compose_ps;
+	ID3D11SamplerState *compose_sampler; //!< Linear sampler (atlas + bg both filtered).
+	ID3D11Buffer *compose_constants;     //!< sizeof(ComposeConstants).
 	//! @}
 };
 
@@ -531,6 +594,194 @@ ck_release_resources(struct leia_display_processor_d3d11_impl *ldp)
 
 /*
  *
+ * Compose-under-bg pipeline (preferred path when WGC is available).
+ *
+ * Reuses ck_fill_tex/ck_fill_rtv/ck_fill_srv as the intermediate target
+ * (created lazily via ck_ensure_fill_target — same size & format as needed).
+ *
+ */
+
+static bool
+compose_should_run(struct leia_display_processor_d3d11_impl *ldp)
+{
+	return ldp->bg_compose_enabled && ldp->bg_capture != nullptr && ldp->bg_shared_srv != nullptr;
+}
+
+static bool
+compose_init_pipeline(struct leia_display_processor_d3d11_impl *ldp)
+{
+	if (ldp->compose_ps != nullptr && ldp->compose_sampler != nullptr && ldp->compose_constants != nullptr) {
+		return true;
+	}
+	if (ldp->device == nullptr) {
+		return false;
+	}
+
+	HRESULT hr;
+	if (ldp->compose_ps == nullptr) {
+		ID3DBlob *blob = nullptr;
+		ID3DBlob *err = nullptr;
+		hr = D3DCompile(compose_under_bg_ps_source,
+		                strlen(compose_under_bg_ps_source),
+		                nullptr, nullptr, nullptr,
+		                "main", "ps_5_0", 0, 0, &blob, &err);
+		if (FAILED(hr)) {
+			U_LOG_E("Leia D3D11 DP: compose PS compile failed: 0x%08x %s",
+			        (unsigned)hr, err ? (const char *)err->GetBufferPointer() : "");
+			if (err) err->Release();
+			return false;
+		}
+		if (err) err->Release();
+		hr = ldp->device->CreatePixelShader(blob->GetBufferPointer(), blob->GetBufferSize(),
+		                                     nullptr, &ldp->compose_ps);
+		blob->Release();
+		if (FAILED(hr)) {
+			U_LOG_E("Leia D3D11 DP: compose PS create failed: 0x%08x", (unsigned)hr);
+			return false;
+		}
+	}
+
+	if (ldp->compose_sampler == nullptr) {
+		D3D11_SAMPLER_DESC sd = {};
+		sd.Filter = D3D11_FILTER_MIN_MAG_MIP_LINEAR;
+		sd.AddressU = D3D11_TEXTURE_ADDRESS_CLAMP;
+		sd.AddressV = D3D11_TEXTURE_ADDRESS_CLAMP;
+		sd.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
+		sd.MaxLOD = D3D11_FLOAT32_MAX;
+		hr = ldp->device->CreateSamplerState(&sd, &ldp->compose_sampler);
+		if (FAILED(hr)) {
+			U_LOG_E("Leia D3D11 DP: compose sampler create failed: 0x%08x", (unsigned)hr);
+			return false;
+		}
+	}
+
+	if (ldp->compose_constants == nullptr) {
+		D3D11_BUFFER_DESC cb = {};
+		cb.ByteWidth = sizeof(ComposeConstants);
+		cb.Usage = D3D11_USAGE_DYNAMIC;
+		cb.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
+		cb.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
+		hr = ldp->device->CreateBuffer(&cb, nullptr, &ldp->compose_constants);
+		if (FAILED(hr)) {
+			U_LOG_E("Leia D3D11 DP: compose CB create failed: 0x%08x", (unsigned)hr);
+			return false;
+		}
+	}
+
+	U_LOG_W("Leia D3D11 DP: compose-under-bg pipeline ready");
+	return true;
+}
+
+/*
+ * Pre-weave compose-under-bg: poll WGC, composite captured desktop under
+ * the RGBA atlas tiles. Returns the SRV the weaver should sample (the
+ * ck_fill_srv, repurposed as the intermediate target). On any failure
+ * (no captured frame yet, monitor-cross, init failure) returns the
+ * original atlas_srv — weaver still runs, just without the desktop
+ * background composited in.
+ */
+static ID3D11ShaderResourceView *
+compose_run_pre_weave(struct leia_display_processor_d3d11_impl *ldp,
+                      ID3D11DeviceContext *ctx,
+                      ID3D11ShaderResourceView *atlas_srv,
+                      uint32_t atlas_w,
+                      uint32_t atlas_h,
+                      uint32_t tile_columns,
+                      uint32_t tile_rows)
+{
+	if (!compose_init_pipeline(ldp) || !ck_ensure_fill_target(ldp, atlas_w, atlas_h)) {
+		return atlas_srv;
+	}
+
+	float bg_origin[2] = {0.0f, 0.0f};
+	float bg_extent[2] = {0.0f, 0.0f};
+	uint64_t fence_wait_value = 0;
+	bool have_bg = leia_bg_capture_poll(ldp->bg_capture, bg_origin, bg_extent, &fence_wait_value);
+	if (!have_bg) {
+		// No captured frame yet (or window crossed monitors). Pass atlas
+		// straight to the weaver; transparent regions stay alpha=0 RGB=0
+		// — visually black but won't crash. The DP will recover next frame.
+		return atlas_srv;
+	}
+
+	// Update constants.
+	D3D11_MAPPED_SUBRESOURCE m = {};
+	if (FAILED(ctx->Map(ldp->compose_constants, 0, D3D11_MAP_WRITE_DISCARD, 0, &m))) {
+		return atlas_srv;
+	}
+	ComposeConstants *cb = reinterpret_cast<ComposeConstants *>(m.pData);
+	cb->bg_uv_origin[0] = bg_origin[0];
+	cb->bg_uv_origin[1] = bg_origin[1];
+	cb->bg_uv_extent[0] = bg_extent[0];
+	cb->bg_uv_extent[1] = bg_extent[1];
+	cb->tile_count[0] = tile_columns;
+	cb->tile_count[1] = tile_rows;
+	cb->pad_[0] = 0;
+	cb->pad_[1] = 0;
+	ctx->Unmap(ldp->compose_constants, 0);
+
+	// Save state.
+	ID3D11RenderTargetView *prev_rtv = nullptr;
+	ID3D11DepthStencilView *prev_dsv = nullptr;
+	ctx->OMGetRenderTargets(1, &prev_rtv, &prev_dsv);
+	UINT prev_vp_count = 1;
+	D3D11_VIEWPORT prev_vp = {};
+	ctx->RSGetViewports(&prev_vp_count, &prev_vp);
+
+	D3D11_VIEWPORT vp = {};
+	vp.Width = (float)atlas_w;
+	vp.Height = (float)atlas_h;
+	vp.MaxDepth = 1.0f;
+	ctx->RSSetViewports(1, &vp);
+	ctx->OMSetRenderTargets(1, &ldp->ck_fill_rtv, nullptr);
+
+	// Wait on the producer's shared fence so our sample sees the latest
+	// captured frame. Requires ID3D11DeviceContext4 (Win10 1809+).
+	if (ldp->bg_fence != nullptr) {
+		ID3D11DeviceContext4 *ctx4 = nullptr;
+		if (SUCCEEDED(ctx->QueryInterface(__uuidof(ID3D11DeviceContext4), (void **)&ctx4))) {
+			ctx4->Wait(ldp->bg_fence, fence_wait_value);
+			ctx4->Release();
+		}
+	}
+
+	ctx->IASetInputLayout(nullptr);
+	ctx->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
+	ctx->VSSetShader(ldp->blit_vs, nullptr, 0);
+	ctx->PSSetShader(ldp->compose_ps, nullptr, 0);
+	ID3D11ShaderResourceView *srvs[2] = {atlas_srv, ldp->bg_shared_srv};
+	ctx->PSSetShaderResources(0, 2, srvs);
+	ctx->PSSetSamplers(0, 1, &ldp->compose_sampler);
+	ctx->PSSetConstantBuffers(0, 1, &ldp->compose_constants);
+	ctx->Draw(4, 0);
+
+	ID3D11ShaderResourceView *null_srvs[2] = {nullptr, nullptr};
+	ctx->PSSetShaderResources(0, 2, null_srvs);
+
+	ctx->OMSetRenderTargets(1, &prev_rtv, prev_dsv);
+	ctx->RSSetViewports(prev_vp_count, &prev_vp);
+	if (prev_rtv) prev_rtv->Release();
+	if (prev_dsv) prev_dsv->Release();
+
+	return ldp->ck_fill_srv;
+}
+
+static void
+compose_release_resources(struct leia_display_processor_d3d11_impl *ldp)
+{
+	if (ldp->bg_fence)          { ldp->bg_fence->Release();          ldp->bg_fence = nullptr; }
+	if (ldp->bg_shared_srv)     { ldp->bg_shared_srv->Release();     ldp->bg_shared_srv = nullptr; }
+	if (ldp->bg_shared_tex)     { ldp->bg_shared_tex->Release();     ldp->bg_shared_tex = nullptr; }
+	if (ldp->compose_constants) { ldp->compose_constants->Release(); ldp->compose_constants = nullptr; }
+	if (ldp->compose_sampler)   { ldp->compose_sampler->Release();   ldp->compose_sampler = nullptr; }
+	if (ldp->compose_ps)        { ldp->compose_ps->Release();        ldp->compose_ps = nullptr; }
+	if (ldp->bg_capture)        { leia_bg_capture_destroy(ldp->bg_capture); ldp->bg_capture = nullptr; }
+	ldp->bg_compose_enabled = false;
+}
+
+
+/*
+ *
  * xrt_display_processor_d3d11 interface methods.
  *
  */
@@ -582,6 +833,17 @@ leia_dp_d3d11_process_atlas(struct xrt_display_processor_d3d11 *xdp,
 		// In 2D mode, content occupies min(viewport, atlas) of the atlas.
 		uint32_t atlas_w = tile_columns * view_width;
 		uint32_t atlas_h = tile_rows * view_height;
+
+		// Compose-under-bg: pre-composite captured desktop under the atlas,
+		// then stretch-blit the opaque result. Replaces the post-weave strip
+		// path for 2D mode when WGC capture is active.
+		if (compose_should_run(ldp)) {
+			ID3D11ShaderResourceView *composed =
+			    compose_run_pre_weave(ldp, ctx, srv, atlas_w, atlas_h, tile_columns, tile_rows);
+			if (composed != nullptr) {
+				srv = composed;
+			}
+		}
 		uint32_t content_w = (vp_w < atlas_w) ? vp_w : atlas_w;
 		uint32_t content_h = (vp_h < atlas_h) ? vp_h : atlas_h;
 		struct { float u_scale; float v_scale; float pad0; float pad1; } cb_data;
@@ -620,8 +882,9 @@ leia_dp_d3d11_process_atlas(struct xrt_display_processor_d3d11 *xdp,
 		// flow (app pre-fills with key RGB on opaque alpha=1 surface) still
 		// needs the strip pass to recover alpha=0 for DWM. The new flow
 		// (true alpha through blit) works without it; running strip in that
-		// case is a no-op for non-key pixels.
-		if (ck_should_run(ldp)) {
+		// case is a no-op for non-key pixels. The compose-under-bg path
+		// already produced opaque RGB, so the strip pass is unnecessary.
+		if (!compose_should_run(ldp) && ck_should_run(ldp)) {
 			ck_run_post_weave_strip(ldp, ctx);
 		}
 		return;
@@ -630,16 +893,32 @@ leia_dp_d3d11_process_atlas(struct xrt_display_processor_d3d11 *xdp,
 	// Atlas is guaranteed content-sized SBS (2*view_width x view_height)
 	// by compositor crop-blit.
 	//
-	// When chroma-key is enabled, run the pre-weave fill pass: replace
-	// alpha=0 atlas pixels with the key color so the SR weaver (which only
-	// consumes opaque RGB) can process them, then pass the filled SRV to
-	// the weaver instead of the original atlas. For legacy apps that
-	// pre-filled with the key color on an alpha=1 surface, the fill is
-	// a no-op (lerp(key, src.rgb, 1.0) == src.rgb) — backward-compatible.
+	// Two transparency paths feed the SR weaver opaque RGB:
+	//
+	//   1. Compose-under-bg (preferred): captures the desktop region behind
+	//      the window via WGC and composites it under each per-view tile in
+	//      the atlas. Output is genuinely opaque pixels — the user sees
+	//      desktop through transparent app regions, with no chroma-key
+	//      artifacts on antialiased edges.
+	//
+	//   2. Chroma-key (fallback): replace alpha=0 atlas pixels with the key
+	//      color so the opaque-only weaver runs, then post-weave strip
+	//      reconstructs alpha=0 holes for DWM. AA edges collapse to hard
+	//      masks. Used when WGC is unavailable (Win<2004, DRM, env-disabled).
+	//
+	// Legacy apps that pre-filled their swapchain with the key color on an
+	// alpha=1 surface stay backward-compatible under either path: chroma-key
+	// is a no-op (lerp(key, src.rgb, 1.0) == src.rgb); compose-under-bg
+	// overwrites their fill with the actual captured desktop (better!).
 	void *weaver_srv = atlas_srv;
-	if (ck_should_run(ldp)) {
-		uint32_t atlas_w = tile_columns * view_width;
-		uint32_t atlas_h = tile_rows * view_height;
+	uint32_t atlas_w = tile_columns * view_width;
+	uint32_t atlas_h = tile_rows * view_height;
+	if (compose_should_run(ldp)) {
+		weaver_srv = compose_run_pre_weave(
+		    ldp, ctx,
+		    static_cast<ID3D11ShaderResourceView *>(atlas_srv),
+		    atlas_w, atlas_h, tile_columns, tile_rows);
+	} else if (ck_should_run(ldp)) {
 		weaver_srv = ck_run_pre_weave_fill(
 		    ldp, ctx,
 		    static_cast<ID3D11ShaderResourceView *>(atlas_srv),
@@ -687,8 +966,10 @@ leia_dp_d3d11_process_atlas(struct xrt_display_processor_d3d11 *xdp,
 
 	// Post-weave chroma-key strip: convert key-color RGB pixels in the
 	// woven back-buffer to alpha=0 (with RGB premultiplied for DWM's
-	// premultiplied alpha mode). No-op when chroma-key is disabled.
-	if (ck_should_run(ldp)) {
+	// premultiplied alpha mode). No-op when chroma-key is disabled, and
+	// suppressed entirely when compose-under-bg ran (the weaver already
+	// consumed opaque pre-composited input; the back buffer is opaque RGB).
+	if (!compose_should_run(ldp) && ck_should_run(ldp)) {
 		ck_run_post_weave_strip(ldp, ctx);
 	}
 }
@@ -795,16 +1076,43 @@ leia_dp_d3d11_set_chroma_key(struct xrt_display_processor_d3d11 *xdp,
                               bool transparent_bg_enabled)
 {
 	struct leia_display_processor_d3d11_impl *ldp = leia_dp_d3d11(xdp);
-	ldp->ck_enabled = transparent_bg_enabled;
-	// App-supplied override (non-zero) wins over DP-picked default. The
-	// override matches the legacy XR_EXT_win32_window_binding.chromaKeyColor
-	// behavior so v1.2.9 Unity plugins and any third-party app that
-	// integrated the v5 extension keep working unchanged.
+
+	// Preserve the ck_color/ck_enabled values regardless of path — they
+	// are the fallback if WGC fails or gets disabled mid-session.
 	ldp->ck_color = (key_color != 0) ? key_color : kDefaultChromaKey;
-	U_LOG_W("Leia D3D11 DP: chroma-key %s (key=0x%08X%s)",
-	        ldp->ck_enabled ? "ENABLED" : "disabled",
-	        ldp->ck_color,
-	        (key_color == 0) ? " — DP default" : " — app override");
+	ldp->ck_enabled = transparent_bg_enabled;
+
+	// Preferred path: try to initialize WGC-based desktop capture so we can
+	// pre-composite the desktop UNDER the atlas tiles instead of using the
+	// chroma-key trick. On any failure (older Windows, capture blocked,
+	// env-disabled), fall through to chroma-key.
+	if (transparent_bg_enabled && !ldp->bg_compose_enabled && ldp->hwnd != nullptr) {
+		ldp->bg_capture = leia_bg_capture_create(ldp->hwnd);
+		if (ldp->bg_capture != nullptr && ldp->device != nullptr) {
+			HRESULT hr = leia_bg_capture_open_d3d11(
+			    ldp->bg_capture, ldp->device, &ldp->bg_shared_tex, &ldp->bg_shared_srv);
+			if (SUCCEEDED(hr)) {
+				hr = leia_bg_capture_open_fence_d3d11(
+				    ldp->bg_capture, ldp->device, &ldp->bg_fence);
+			}
+			if (SUCCEEDED(hr)) {
+				ldp->bg_compose_enabled = true;
+				// Disable the chroma-key path so we don't run both.
+				ldp->ck_enabled = false;
+				U_LOG_W("Leia D3D11 DP: transparency = compose-under-bg (WGC)");
+			} else {
+				U_LOG_W("Leia D3D11 DP: WGC import failed (0x%08x) — falling back to chroma-key",
+				        (unsigned)hr);
+				compose_release_resources(ldp);
+			}
+		}
+	}
+	if (!ldp->bg_compose_enabled) {
+		U_LOG_W("Leia D3D11 DP: transparency = chroma-key %s (key=0x%08X%s)",
+		        ldp->ck_enabled ? "ENABLED" : "disabled",
+		        ldp->ck_color,
+		        (key_color == 0) ? " — DP default" : " — app override");
+	}
 }
 
 static void
@@ -825,6 +1133,7 @@ leia_dp_d3d11_destroy(struct xrt_display_processor_d3d11 *xdp)
 		ldp->blit_cb->Release();
 	}
 
+	compose_release_resources(ldp);
 	ck_release_resources(ldp);
 
 	if (ldp->leiasr != NULL) {
@@ -976,6 +1285,7 @@ leia_dp_factory_d3d11(void *d3d11_device,
 	leia_dp_d3d11_init_vtable(ldp);
 	ldp->leiasr = weaver;
 	ldp->device = static_cast<ID3D11Device *>(d3d11_device);
+	ldp->hwnd = static_cast<HWND>(window_handle);
 	ldp->view_count = 2;
 
 	// Compile blit shaders for 2D passthrough mode

--- a/src/xrt/drivers/leia/leia_display_processor_d3d12.cpp
+++ b/src/xrt/drivers/leia/leia_display_processor_d3d12.cpp
@@ -829,6 +829,25 @@ compose_init_pipeline(struct leia_display_processor_d3d12_impl *ldp)
 			return false;
 		}
 	}
+	// We reuse ck_fill_tex / ck_rtv_heap_fill as the intermediate target. In
+	// the chroma-key path those are created inside ck_init_pipeline; in the
+	// compose path we never call ck_init_pipeline, so the RTV heap must be
+	// created here. (Without this, ck_ensure_fill_target null-derefs
+	// ldp->ck_rtv_heap_fill on the first compose frame.)
+	if (ldp->ck_rtv_heap_fill == nullptr) {
+		D3D12_DESCRIPTOR_HEAP_DESC hd = {};
+		hd.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+		hd.NumDescriptors = 1;
+		hd.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		HRESULT hr = ldp->device->CreateDescriptorHeap(
+		    &hd, __uuidof(ID3D12DescriptorHeap),
+		    reinterpret_cast<void **>(&ldp->ck_rtv_heap_fill));
+		if (FAILED(hr)) {
+			U_LOG_E("Leia D3D12 DP: compose fill RTV heap create failed: 0x%08x", (unsigned)hr);
+			return false;
+		}
+	}
+
 	if (ldp->compose_srv_heap == nullptr) {
 		D3D12_DESCRIPTOR_HEAP_DESC hd = {};
 		hd.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;

--- a/src/xrt/drivers/leia/leia_display_processor_d3d12.cpp
+++ b/src/xrt/drivers/leia/leia_display_processor_d3d12.cpp
@@ -19,6 +19,7 @@
 
 #include "leia_display_processor_d3d12.h"
 #include "leia_sr_d3d12.h"
+#include "leia_bg_capture_win.h"
 
 #include "xrt/xrt_display_metrics.h"
 #include "util/u_logging.h"
@@ -122,6 +123,36 @@ float4 main(VSOut i) : SV_Target {
  */
 static constexpr uint32_t kDefaultChromaKey = 0x00FF00FF;
 
+/*
+ * Compose-under-bg pre-weave shader (preferred path when WGC is available).
+ *
+ * Reads the app's RGBA atlas + the captured desktop region behind the window,
+ * composes them per-tile and outputs opaque RGB the SR weaver consumes:
+ *
+ *   out = lerp(bg, atlas.rgb, atlas.a),  out.a = 1
+ *
+ * Same VS as the ck pipeline (single fullscreen triangle).
+ */
+static const char *compose_under_bg_ps_source = R"(
+struct VSOut { float4 pos : SV_Position; float2 uv : TEXCOORD0; };
+Texture2D<float4> atlas : register(t0);
+Texture2D<float4> bg    : register(t1);
+SamplerState samp       : register(s0);
+cbuffer Constants : register(b0) {
+    float2 bg_uv_origin;
+    float2 bg_uv_extent;
+    uint2  tile_count;
+    uint2  pad_;
+};
+float4 main(VSOut i) : SV_Target {
+    float4 a = atlas.Sample(samp, i.uv);
+    float2 tile_local = frac(i.uv * float2(tile_count));
+    float2 bg_uv = bg_uv_origin + tile_local * bg_uv_extent;
+    float3 b = bg.SampleLevel(samp, bg_uv, 0).rgb;
+    return float4(lerp(b, a.rgb, a.a), 1.0);
+}
+)";
+
 
 /*!
  * Implementation struct wrapping leiasr_d3d12 as xrt_display_processor_d3d12.
@@ -132,6 +163,7 @@ struct leia_display_processor_d3d12_impl
 	struct leiasr_d3d12 *leiasr; //!< Owned — destroyed in leia_dp_d3d12_destroy.
 
 	ID3D12Device *device;              //!< Cached device reference (not owned, for blit init).
+	HWND hwnd;                         //!< Native window handle from factory, used by bg-capture for self-exclusion + window-on-monitor rect.
 
 	//! @name 2D blit pipeline resources (passthrough stretch-blit)
 	//! @{
@@ -172,6 +204,22 @@ struct leia_display_processor_d3d12_impl
 	ID3D12Resource *ck_strip_tex;
 	uint32_t ck_strip_w, ck_strip_h;
 	D3D12_RESOURCE_STATES ck_strip_state;
+	//! @}
+
+	//! @name Compose-under-bg transparency support (preferred over chroma-key)
+	//!
+	//! Reuses ck_fill_tex/ck_rtv_heap_fill as the intermediate target. Own
+	//! root sig + PSO + descriptor heap (2 SRV slots: atlas at 0, bg at 1).
+	//! @{
+	ID3D12CommandQueue *command_queue;   //!< Saved from factory; needed for fence Wait().
+	struct leia_bg_capture *bg_capture;  //!< Owned; NULL → fall back to chroma-key.
+	bool bg_compose_enabled;             //!< Active when the new path is in use.
+	ID3D12Resource *bg_shared_tex;       //!< Opened from bg_capture's shared NT handle.
+	ID3D12Fence *bg_fence;               //!< Opened from bg_capture's shared fence handle.
+	ID3D12RootSignature *compose_root_sig;
+	ID3D12PipelineState *compose_pso;
+	ID3D12DescriptorHeap *compose_srv_heap; //!< Shader-visible, 2 entries (atlas, bg).
+	UINT cbv_srv_desc_size;              //!< Cached for offset arithmetic in compose heap.
 	//! @}
 };
 
@@ -670,6 +718,257 @@ ck_release_resources(struct leia_display_processor_d3d12_impl *ldp)
 
 /*
  *
+ * Compose-under-bg pipeline (preferred path when WGC is available).
+ * Reuses ck_fill_tex / ck_rtv_heap_fill as the intermediate render target.
+ *
+ */
+
+static bool
+compose_should_run(struct leia_display_processor_d3d12_impl *ldp)
+{
+	return ldp->bg_compose_enabled && ldp->bg_capture != nullptr && ldp->bg_shared_tex != nullptr;
+}
+
+// Root signature: 8 32-bit constants (bg_uv_origin xy + bg_uv_extent xy +
+// tile_count xy + pad xy = 32 bytes) at b0 + 2-SRV descriptor table (t0,t1)
+// + static linear sampler at s0.
+static bool
+compose_build_root_sig(struct leia_display_processor_d3d12_impl *ldp)
+{
+	D3D12_DESCRIPTOR_RANGE srv_range = {};
+	srv_range.RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
+	srv_range.NumDescriptors = 2;
+	srv_range.BaseShaderRegister = 0;
+	srv_range.OffsetInDescriptorsFromTableStart = 0;
+
+	D3D12_ROOT_PARAMETER params[2] = {};
+	params[0].ParameterType = D3D12_ROOT_PARAMETER_TYPE_32BIT_CONSTANTS;
+	params[0].Constants.ShaderRegister = 0;
+	params[0].Constants.Num32BitValues = 8;
+	params[0].ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
+	params[1].ParameterType = D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;
+	params[1].DescriptorTable.NumDescriptorRanges = 1;
+	params[1].DescriptorTable.pDescriptorRanges = &srv_range;
+	params[1].ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
+
+	D3D12_STATIC_SAMPLER_DESC sampler = {};
+	sampler.Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
+	sampler.AddressU = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
+	sampler.AddressV = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
+	sampler.AddressW = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
+	sampler.MaxLOD = D3D12_FLOAT32_MAX;
+	sampler.ShaderRegister = 0;
+	sampler.ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
+
+	D3D12_ROOT_SIGNATURE_DESC desc = {};
+	desc.NumParameters = 2;
+	desc.pParameters = params;
+	desc.NumStaticSamplers = 1;
+	desc.pStaticSamplers = &sampler;
+	desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_DENY_VERTEX_SHADER_ROOT_ACCESS;
+
+	ID3DBlob *blob = nullptr;
+	ID3DBlob *err = nullptr;
+	HRESULT hr = D3D12SerializeRootSignature(&desc, D3D_ROOT_SIGNATURE_VERSION_1, &blob, &err);
+	if (FAILED(hr)) {
+		U_LOG_E("Leia D3D12 DP: compose root sig serialize failed: 0x%08x %s",
+		        (unsigned)hr, err ? (const char *)err->GetBufferPointer() : "");
+		if (err) err->Release();
+		return false;
+	}
+	if (err) err->Release();
+	hr = ldp->device->CreateRootSignature(0, blob->GetBufferPointer(), blob->GetBufferSize(),
+	                                       __uuidof(ID3D12RootSignature),
+	                                       reinterpret_cast<void **>(&ldp->compose_root_sig));
+	blob->Release();
+	if (FAILED(hr)) {
+		U_LOG_E("Leia D3D12 DP: compose root sig create failed: 0x%08x", (unsigned)hr);
+		return false;
+	}
+	return true;
+}
+
+static bool
+compose_init_pipeline(struct leia_display_processor_d3d12_impl *ldp)
+{
+	if (ldp->compose_pso != nullptr && ldp->compose_srv_heap != nullptr) {
+		return true;
+	}
+	if (ldp->device == nullptr) {
+		return false;
+	}
+	if (ldp->compose_root_sig == nullptr && !compose_build_root_sig(ldp)) {
+		return false;
+	}
+	if (ldp->compose_pso == nullptr) {
+		ID3DBlob *vs_blob = ck_compile_shader(ck_vs_source, "main", "vs_5_0");
+		if (vs_blob == nullptr) return false;
+		ID3DBlob *ps_blob = ck_compile_shader(compose_under_bg_ps_source, "main", "ps_5_0");
+		if (ps_blob == nullptr) { vs_blob->Release(); return false; }
+
+		D3D12_GRAPHICS_PIPELINE_STATE_DESC pd = {};
+		pd.pRootSignature = ldp->compose_root_sig;
+		pd.VS = {vs_blob->GetBufferPointer(), vs_blob->GetBufferSize()};
+		pd.PS = {ps_blob->GetBufferPointer(), ps_blob->GetBufferSize()};
+		pd.BlendState.RenderTarget[0].RenderTargetWriteMask = D3D12_COLOR_WRITE_ENABLE_ALL;
+		pd.SampleMask = UINT_MAX;
+		pd.RasterizerState.FillMode = D3D12_FILL_MODE_SOLID;
+		pd.RasterizerState.CullMode = D3D12_CULL_MODE_NONE;
+		pd.RasterizerState.DepthClipEnable = TRUE;
+		pd.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+		pd.NumRenderTargets = 1;
+		pd.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+		pd.SampleDesc.Count = 1;
+		HRESULT hr = ldp->device->CreateGraphicsPipelineState(
+		    &pd, __uuidof(ID3D12PipelineState),
+		    reinterpret_cast<void **>(&ldp->compose_pso));
+		vs_blob->Release();
+		ps_blob->Release();
+		if (FAILED(hr)) {
+			U_LOG_E("Leia D3D12 DP: compose PSO create failed: 0x%08x", (unsigned)hr);
+			return false;
+		}
+	}
+	if (ldp->compose_srv_heap == nullptr) {
+		D3D12_DESCRIPTOR_HEAP_DESC hd = {};
+		hd.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+		hd.NumDescriptors = 2;
+		hd.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		HRESULT hr = ldp->device->CreateDescriptorHeap(
+		    &hd, __uuidof(ID3D12DescriptorHeap),
+		    reinterpret_cast<void **>(&ldp->compose_srv_heap));
+		if (FAILED(hr)) {
+			U_LOG_E("Leia D3D12 DP: compose SRV heap create failed: 0x%08x", (unsigned)hr);
+			return false;
+		}
+		ldp->cbv_srv_desc_size = ldp->device->GetDescriptorHandleIncrementSize(
+		    D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+
+		// Slot 1: bg SRV (stable across frames — bg_shared_tex doesn't change).
+		D3D12_SHADER_RESOURCE_VIEW_DESC bg_srv = {};
+		bg_srv.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
+		bg_srv.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+		bg_srv.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+		bg_srv.Texture2D.MipLevels = 1;
+		D3D12_CPU_DESCRIPTOR_HANDLE bg_cpu =
+		    ldp->compose_srv_heap->GetCPUDescriptorHandleForHeapStart();
+		bg_cpu.ptr += ldp->cbv_srv_desc_size;
+		ldp->device->CreateShaderResourceView(ldp->bg_shared_tex, &bg_srv, bg_cpu);
+	}
+	U_LOG_W("Leia D3D12 DP: compose-under-bg pipeline ready");
+	return true;
+}
+
+/*
+ * Pre-weave compose-under-bg. Captures the latest desktop frame, composes
+ * it under the atlas per tile, writes opaque RGB into ck_fill_tex. Returns
+ * ck_fill_tex on success (weaver samples it), original atlas on fallback.
+ *
+ * Caller passes prev_rtv (current back-buffer RTV) to restore after we
+ * change the binding to ck_fill_tex.
+ */
+static ID3D12Resource *
+compose_run_pre_weave(struct leia_display_processor_d3d12_impl *ldp,
+                      ID3D12GraphicsCommandList *cmd,
+                      ID3D12Resource *atlas_resource,
+                      uint32_t atlas_w, uint32_t atlas_h,
+                      DXGI_FORMAT atlas_format,
+                      uint32_t tile_columns, uint32_t tile_rows,
+                      D3D12_CPU_DESCRIPTOR_HANDLE prev_rtv)
+{
+	if (!compose_init_pipeline(ldp) || !ck_ensure_fill_target(ldp, atlas_w, atlas_h)) {
+		return atlas_resource;
+	}
+
+	float bg_origin[2] = {0.0f, 0.0f};
+	float bg_extent[2] = {0.0f, 0.0f};
+	uint64_t fence_value = 0;
+	bool have_bg = leia_bg_capture_poll(ldp->bg_capture, bg_origin, bg_extent, &fence_value);
+	if (!have_bg) {
+		return atlas_resource;
+	}
+
+	// Order the consumer's GPU work after the producer's signal. Queue Wait
+	// gates all subsequently-executed cmd lists on this queue.
+	if (ldp->bg_fence != nullptr && ldp->command_queue != nullptr && fence_value > 0) {
+		ldp->command_queue->Wait(ldp->bg_fence, fence_value);
+	}
+
+	// Slot 0: atlas SRV (refreshed each frame — atlas resource may change).
+	D3D12_SHADER_RESOURCE_VIEW_DESC atlas_srv = {};
+	atlas_srv.Format = atlas_format;
+	atlas_srv.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+	atlas_srv.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+	atlas_srv.Texture2D.MipLevels = 1;
+	ldp->device->CreateShaderResourceView(
+	    atlas_resource, &atlas_srv,
+	    ldp->compose_srv_heap->GetCPUDescriptorHandleForHeapStart());
+
+	// ck_fill_tex PIXEL_SHADER_RESOURCE → RENDER_TARGET
+	D3D12_RESOURCE_BARRIER barrier = {};
+	barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+	barrier.Transition.pResource = ldp->ck_fill_tex;
+	barrier.Transition.StateBefore = ldp->ck_fill_state;
+	barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_RENDER_TARGET;
+	barrier.Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+	cmd->ResourceBarrier(1, &barrier);
+	ldp->ck_fill_state = D3D12_RESOURCE_STATE_RENDER_TARGET;
+
+	cmd->SetPipelineState(ldp->compose_pso);
+	cmd->SetGraphicsRootSignature(ldp->compose_root_sig);
+	ID3D12DescriptorHeap *heaps[] = {ldp->compose_srv_heap};
+	cmd->SetDescriptorHeaps(1, heaps);
+	uint32_t consts[8];
+	memcpy(&consts[0], &bg_origin[0], sizeof(float));
+	memcpy(&consts[1], &bg_origin[1], sizeof(float));
+	memcpy(&consts[2], &bg_extent[0], sizeof(float));
+	memcpy(&consts[3], &bg_extent[1], sizeof(float));
+	consts[4] = tile_columns;
+	consts[5] = tile_rows;
+	consts[6] = 0;
+	consts[7] = 0;
+	cmd->SetGraphicsRoot32BitConstants(0, 8, consts, 0);
+	cmd->SetGraphicsRootDescriptorTable(
+	    1, ldp->compose_srv_heap->GetGPUDescriptorHandleForHeapStart());
+
+	D3D12_VIEWPORT vp = {0.0f, 0.0f, (float)atlas_w, (float)atlas_h, 0.0f, 1.0f};
+	D3D12_RECT scissor = {0, 0, (LONG)atlas_w, (LONG)atlas_h};
+	cmd->RSSetViewports(1, &vp);
+	cmd->RSSetScissorRects(1, &scissor);
+
+	D3D12_CPU_DESCRIPTOR_HANDLE rtv =
+	    ldp->ck_rtv_heap_fill->GetCPUDescriptorHandleForHeapStart();
+	cmd->OMSetRenderTargets(1, &rtv, FALSE, nullptr);
+	cmd->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+	cmd->IASetVertexBuffers(0, 0, nullptr);
+	cmd->IASetIndexBuffer(nullptr);
+	cmd->DrawInstanced(3, 1, 0, 0);
+
+	// ck_fill_tex RENDER_TARGET → PIXEL_SHADER_RESOURCE (weaver will sample).
+	barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
+	barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+	cmd->ResourceBarrier(1, &barrier);
+	ldp->ck_fill_state = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+
+	cmd->OMSetRenderTargets(1, &prev_rtv, FALSE, nullptr);
+	return ldp->ck_fill_tex;
+}
+
+static void
+compose_release_resources(struct leia_display_processor_d3d12_impl *ldp)
+{
+	if (ldp->compose_srv_heap) { ldp->compose_srv_heap->Release(); ldp->compose_srv_heap = nullptr; }
+	if (ldp->compose_pso)      { ldp->compose_pso->Release();      ldp->compose_pso = nullptr; }
+	if (ldp->compose_root_sig) { ldp->compose_root_sig->Release(); ldp->compose_root_sig = nullptr; }
+	if (ldp->bg_fence)         { ldp->bg_fence->Release();         ldp->bg_fence = nullptr; }
+	if (ldp->bg_shared_tex)    { ldp->bg_shared_tex->Release();    ldp->bg_shared_tex = nullptr; }
+	if (ldp->bg_capture)       { leia_bg_capture_destroy(ldp->bg_capture); ldp->bg_capture = nullptr; }
+	ldp->bg_compose_enabled = false;
+}
+
+
+/*
+ *
  * xrt_display_processor_d3d12 interface methods.
  *
  */
@@ -720,9 +1019,28 @@ leia_dp_d3d12_process_atlas(struct xrt_display_processor_d3d12 *xdp,
 		ID3D12GraphicsCommandList *cmd = static_cast<ID3D12GraphicsCommandList *>(d3d12_command_list);
 		ID3D12Resource *atlas_res = static_cast<ID3D12Resource *>(atlas_texture_resource);
 
-		// Create SRV for the atlas resource in our shader-visible heap
+		// Compose-under-bg: pre-composite captured desktop under the atlas,
+		// then stretch-blit the opaque result. Replaces the post-weave strip
+		// path for 2D mode when WGC capture is active.
+		if (compose_should_run(ldp)) {
+			uint32_t atlas_w = tile_columns * view_width;
+			uint32_t atlas_h = tile_rows * view_height;
+			D3D12_CPU_DESCRIPTOR_HANDLE bb_rtv;
+			bb_rtv.ptr = static_cast<SIZE_T>(target_rtv_cpu_handle);
+			ID3D12Resource *composed = compose_run_pre_weave(
+			    ldp, cmd, atlas_res, atlas_w, atlas_h,
+			    static_cast<DXGI_FORMAT>(format), tile_columns, tile_rows, bb_rtv);
+			if (composed != nullptr) {
+				atlas_res = composed;
+			}
+		}
+
+		// Create SRV for the (possibly pre-composed) atlas resource in our
+		// shader-visible heap. The compose path produces an opaque RGBA8 result
+		// in ck_fill_tex; the original-atlas format may differ (e.g. SRGB).
 		D3D12_SHADER_RESOURCE_VIEW_DESC srv_desc = {};
-		srv_desc.Format = static_cast<DXGI_FORMAT>(format);
+		srv_desc.Format = compose_should_run(ldp) ? DXGI_FORMAT_R8G8B8A8_UNORM
+		                                          : static_cast<DXGI_FORMAT>(format);
 		srv_desc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
 		srv_desc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
 		srv_desc.Texture2D.MipLevels = 1;
@@ -786,7 +1104,8 @@ leia_dp_d3d12_process_atlas(struct xrt_display_processor_d3d12 *xdp,
 		// the strip pass to recover alpha=0 for DWM. The new flow (true
 		// alpha through the blit) works without it; running strip in that
 		// case is a no-op for non-key pixels (RGB=0 doesn't match magenta).
-		if (ck_should_run(ldp) && target_resource != NULL) {
+		// Compose-under-bg path is fully opaque already — strip is unnecessary.
+		if (!compose_should_run(ldp) && ck_should_run(ldp) && target_resource != NULL) {
 			D3D12_CPU_DESCRIPTOR_HANDLE bb_rtv;
 			bb_rtv.ptr = static_cast<SIZE_T>(target_rtv_cpu_handle);
 			ck_run_post_weave_strip(
@@ -805,18 +1124,24 @@ leia_dp_d3d12_process_atlas(struct xrt_display_processor_d3d12 *xdp,
 	// Atlas is guaranteed content-sized SBS (2*view_width x view_height)
 	// by compositor crop-blit.
 	//
-	// When chroma-key is enabled, run the pre-weave fill: replace alpha=0
-	// atlas pixels with the key color so the SR weaver (opaque RGB only)
-	// can process them, then pass the filled resource to the weaver instead
-	// of the original atlas. For legacy apps that pre-filled with the key
-	// color on alpha=1, the fill is a no-op (lerp(key, src.rgb, 1.0) ==
-	// src.rgb) — backward-compatible.
+	// Two transparency paths feed the SR weaver opaque RGB:
+	//   1. Compose-under-bg (preferred): pre-composite captured desktop under
+	//      each per-view tile so the weaver consumes opaque RGB with the
+	//      desktop already integrated. No post-weave pass. Quality-correct
+	//      on AA edges and semi-transparent pixels.
+	//   2. Chroma-key (fallback): replace alpha=0 with key color before
+	//      weaver, strip back to alpha=0 after. Hard edges, used when WGC
+	//      is unavailable.
 	ID3D12Resource *weaver_input = static_cast<ID3D12Resource *>(atlas_texture_resource);
-	if (ck_should_run(ldp) && weaver_input != NULL) {
-		uint32_t atlas_w = tile_columns * view_width;
-		uint32_t atlas_h = tile_rows * view_height;
-		D3D12_CPU_DESCRIPTOR_HANDLE bb_rtv;
-		bb_rtv.ptr = static_cast<SIZE_T>(target_rtv_cpu_handle);
+	uint32_t atlas_w = tile_columns * view_width;
+	uint32_t atlas_h = tile_rows * view_height;
+	D3D12_CPU_DESCRIPTOR_HANDLE bb_rtv;
+	bb_rtv.ptr = static_cast<SIZE_T>(target_rtv_cpu_handle);
+	if (compose_should_run(ldp) && weaver_input != NULL) {
+		weaver_input = compose_run_pre_weave(
+		    ldp, cmd_3d, weaver_input, atlas_w, atlas_h,
+		    static_cast<DXGI_FORMAT>(format), tile_columns, tile_rows, bb_rtv);
+	} else if (ck_should_run(ldp) && weaver_input != NULL) {
 		weaver_input = ck_run_pre_weave_fill(
 		    ldp, cmd_3d, weaver_input, atlas_w, atlas_h,
 		    static_cast<DXGI_FORMAT>(format), bb_rtv);
@@ -835,14 +1160,15 @@ leia_dp_d3d12_process_atlas(struct xrt_display_processor_d3d12 *xdp,
 
 	// Post-weave chroma-key strip: convert key-color RGB pixels in the woven
 	// back buffer to alpha=0 with RGB premultiplied for DWM. No-op when
-	// disabled.
-	if (ck_should_run(ldp) && target_resource != NULL) {
-		D3D12_CPU_DESCRIPTOR_HANDLE bb_rtv;
-		bb_rtv.ptr = static_cast<SIZE_T>(target_rtv_cpu_handle);
+	// disabled, suppressed entirely when compose-under-bg ran (the back
+	// buffer is already opaque from end-to-end compose pipeline).
+	if (!compose_should_run(ldp) && ck_should_run(ldp) && target_resource != NULL) {
+		D3D12_CPU_DESCRIPTOR_HANDLE bb_rtv_strip;
+		bb_rtv_strip.ptr = static_cast<SIZE_T>(target_rtv_cpu_handle);
 		ck_run_post_weave_strip(
 		    ldp, cmd_3d,
 		    static_cast<ID3D12Resource *>(target_resource),
-		    bb_rtv, target_width, target_height);
+		    bb_rtv_strip, target_width, target_height);
 	}
 }
 
@@ -1014,16 +1340,41 @@ leia_dp_d3d12_set_chroma_key(struct xrt_display_processor_d3d12 *xdp,
                               bool transparent_bg_enabled)
 {
 	struct leia_display_processor_d3d12_impl *ldp = leia_dp_d3d12(xdp);
-	ldp->ck_enabled = transparent_bg_enabled;
-	// App-supplied override (non-zero) wins over DP-picked default. Matches
-	// the legacy XR_EXT_win32_window_binding.chromaKeyColor behavior so
-	// v1.2.9 Unity plugins and any third-party app that integrated the v5
-	// extension keep working unchanged.
+
+	// Preserve ck_color/ck_enabled regardless of path — chroma-key is the
+	// fallback if WGC init fails.
 	ldp->ck_color = (key_color != 0) ? key_color : kDefaultChromaKey;
-	U_LOG_W("Leia D3D12 DP: chroma-key %s (key=0x%08X%s)",
-	        ldp->ck_enabled ? "ENABLED" : "disabled",
-	        ldp->ck_color,
-	        (key_color == 0) ? " — DP default" : " — app override");
+	ldp->ck_enabled = transparent_bg_enabled;
+
+	// Preferred path: WGC desktop capture + per-tile compose-under-bg.
+	// On any failure (older Windows, capture blocked, env-disabled), fall
+	// back to chroma-key.
+	if (transparent_bg_enabled && !ldp->bg_compose_enabled && ldp->hwnd != nullptr) {
+		ldp->bg_capture = leia_bg_capture_create(ldp->hwnd);
+		if (ldp->bg_capture != nullptr && ldp->device != nullptr) {
+			HRESULT hr = leia_bg_capture_open_d3d12(
+			    ldp->bg_capture, ldp->device, &ldp->bg_shared_tex);
+			if (SUCCEEDED(hr)) {
+				hr = leia_bg_capture_open_fence_d3d12(
+				    ldp->bg_capture, ldp->device, &ldp->bg_fence);
+			}
+			if (SUCCEEDED(hr)) {
+				ldp->bg_compose_enabled = true;
+				ldp->ck_enabled = false;
+				U_LOG_W("Leia D3D12 DP: transparency = compose-under-bg (WGC)");
+			} else {
+				U_LOG_W("Leia D3D12 DP: WGC import failed (0x%08x) — falling back to chroma-key",
+				        (unsigned)hr);
+				compose_release_resources(ldp);
+			}
+		}
+	}
+	if (!ldp->bg_compose_enabled) {
+		U_LOG_W("Leia D3D12 DP: transparency = chroma-key %s (key=0x%08X%s)",
+		        ldp->ck_enabled ? "ENABLED" : "disabled",
+		        ldp->ck_color,
+		        (key_color == 0) ? " — DP default" : " — app override");
+	}
 }
 
 static void
@@ -1031,6 +1382,7 @@ leia_dp_d3d12_destroy(struct xrt_display_processor_d3d12 *xdp)
 {
 	struct leia_display_processor_d3d12_impl *ldp = leia_dp_d3d12(xdp);
 
+	compose_release_resources(ldp);
 	ck_release_resources(ldp);
 
 	if (ldp->blit_pso != NULL) {
@@ -1178,6 +1530,8 @@ leia_dp_factory_d3d12(void *d3d12_device,
 	ldp->base.destroy = leia_dp_d3d12_destroy;
 	ldp->leiasr = weaver;
 	ldp->device = static_cast<ID3D12Device *>(d3d12_device);
+	ldp->hwnd = static_cast<HWND>(window_handle);
+	ldp->command_queue = static_cast<ID3D12CommandQueue *>(d3d12_command_queue);
 	ldp->view_count = 2;
 
 	// Init blit root signature and SRV heap for 2D passthrough mode

--- a/src/xrt/drivers/leia/shaders/compose_under_bg.frag
+++ b/src/xrt/drivers/leia/shaders/compose_under_bg.frag
@@ -1,0 +1,37 @@
+// Copyright 2026, Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+
+// Pre-weave compose-under-bg: composite the captured desktop region UNDER
+// each per-view atlas tile, outputting opaque RGB the SR weaver can consume.
+// Replaces the chroma-key trick on the Vulkan DP — preserves AA edges and
+// genuinely semi-transparent (0<a<1) pixels.
+//
+//   out = mix(bg, atlas.rgb, atlas.a),  out.a = 1
+//
+// The desktop is at z=0 (display plane), so the same captured region is
+// sampled into every tile; per-eye parallax comes from the atlas content,
+// not the background.
+
+#version 450
+
+layout(binding = 0) uniform sampler2D atlas;
+layout(binding = 1) uniform sampler2D bg;
+
+layout(push_constant) uniform PC {
+	vec2  bg_uv_origin;   // window TL on monitor, normalized
+	vec2  bg_uv_extent;   // window size on monitor, normalized
+	uvec2 tile_count;     // (tile_columns, tile_rows)
+	uvec2 pad;
+} pc;
+
+layout(location = 0) in vec2 in_uv;
+layout(location = 0) out vec4 out_color;
+
+void main()
+{
+	vec4 a = texture(atlas, in_uv);
+	vec2 tile_local = fract(in_uv * vec2(pc.tile_count));
+	vec2 bg_uv = pc.bg_uv_origin + tile_local * pc.bg_uv_extent;
+	vec3 b = textureLod(bg, bg_uv, 0.0).rgb;
+	out_color = vec4(mix(b, a.rgb, a.a), 1.0);
+}

--- a/test_apps/cube_handle_d3d11_win/main.cpp
+++ b/test_apps/cube_handle_d3d11_win/main.cpp
@@ -176,9 +176,21 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
     return DefWindowProc(hwnd, msg, wParam, lParam);
 }
 
+// DISPLAYXR_TRANSPARENT_BG=1 → cube clears RGBA(0,0,0,0), window uses
+// WS_EX_NOREDIRECTIONBITMAP + null brush so DComp can show the desktop
+// through the cube's transparent regions. Mirrors cube_handle_vk_win.
+static bool TransparentBackgroundEnabled() {
+    static const bool e = []() {
+        const char *v = getenv("DISPLAYXR_TRANSPARENT_BG");
+        return v != nullptr && *v != '\0' && *v != '0';
+    }();
+    return e;
+}
+
 // Create the application window
 static HWND CreateAppWindow(HINSTANCE hInstance, int width, int height) {
-    LOG_INFO("Creating application window (%dx%d)", width, height);
+    const bool transparent = TransparentBackgroundEnabled();
+    LOG_INFO("Creating application window (%dx%d, transparent=%d)", width, height, transparent);
 
     WNDCLASSEX wc = {};
     wc.cbSize = sizeof(WNDCLASSEX);
@@ -186,7 +198,9 @@ static HWND CreateAppWindow(HINSTANCE hInstance, int width, int height) {
     wc.lpfnWndProc = WindowProc;
     wc.hInstance = hInstance;
     wc.hCursor = LoadCursor(nullptr, IDC_ARROW);
-    wc.hbrBackground = (HBRUSH)GetStockObject(BLACK_BRUSH);
+    // Null brush in transparent mode so the redirection bitmap doesn't paint
+    // black under the DComp composition swap chain.
+    wc.hbrBackground = transparent ? nullptr : (HBRUSH)GetStockObject(BLACK_BRUSH);
     wc.lpszClassName = WINDOW_CLASS;
 
     if (!RegisterClassEx(&wc)) {
@@ -200,8 +214,9 @@ static HWND CreateAppWindow(HINSTANCE hInstance, int width, int height) {
     RECT rect = { 0, 0, width, height };
     AdjustWindowRect(&rect, WS_OVERLAPPEDWINDOW, FALSE);
 
+    DWORD exStyle = transparent ? WS_EX_NOREDIRECTIONBITMAP : 0;
     HWND hwnd = CreateWindowEx(
-        0,
+        exStyle,
         WINDOW_CLASS,
         WINDOW_TITLE,
         WS_OVERLAPPEDWINDOW,
@@ -597,8 +612,18 @@ static void RenderOneFrame(RenderState& rs) {
                         CreateRenderTargetView(renderer, swapchainTexture,
                             static_cast<DXGI_FORMAT>(xr.swapchain.format), &rtv);
 
-                        // Clear entire color+depth once before eye loop
-                        float clearColor[4] = {0.05f, 0.05f, 0.25f, 1.0f};
+                        // Clear entire color+depth once before eye loop.
+                        // Transparent mode (DISPLAYXR_TRANSPARENT_BG=1): clear to
+                        // RGBA(0,0,0,0) so the Leia DP's compose-under-bg pass
+                        // shows the desktop wherever the cube didn't draw.
+                        float clearColor[4];
+                        if (TransparentBackgroundEnabled()) {
+                            clearColor[0] = 0.0f; clearColor[1] = 0.0f;
+                            clearColor[2] = 0.0f; clearColor[3] = 0.0f;
+                        } else {
+                            clearColor[0] = 0.05f; clearColor[1] = 0.05f;
+                            clearColor[2] = 0.25f; clearColor[3] = 1.0f;
+                        }
                         renderer.context->ClearRenderTargetView(rtv, clearColor);
                         renderer.context->ClearDepthStencilView(rs.depthDSV.Get(),
                             D3D11_CLEAR_DEPTH | D3D11_CLEAR_STENCIL, 1.0f, 0);

--- a/test_apps/cube_handle_d3d11_win/xr_session.cpp
+++ b/test_apps/cube_handle_d3d11_win/xr_session.cpp
@@ -236,6 +236,19 @@ bool CreateSession(XrSessionManager& xr, ID3D11Device* d3d11Device, HWND hwnd) {
     XrWin32WindowBindingCreateInfoEXT sessionTarget = {XR_TYPE_WIN32_WINDOW_BINDING_CREATE_INFO_EXT};
     sessionTarget.windowHandle = hwnd;
 
+    // Opt-in transparency. Pair with WS_EX_NOREDIRECTIONBITMAP + null brush
+    // (main.cpp) and the α=0 clear (render loop). chromaKeyColor=0 lets the
+    // Leia DP pick its default magenta (used only if WGC bg-capture fails
+    // and the DP falls back to the chroma-key trick).
+    {
+        const char *e = getenv("DISPLAYXR_TRANSPARENT_BG");
+        if (e != nullptr && *e != '\0' && *e != '0') {
+            sessionTarget.transparentBackgroundEnabled = XR_TRUE;
+            sessionTarget.chromaKeyColor = 0;
+            LOG_INFO("Transparent background ENABLED (DISPLAYXR_TRANSPARENT_BG=1)");
+        }
+    }
+
     if (xr.hasWin32WindowBindingExt && hwnd) {
         // Chain: sessionInfo -> d3d11Binding -> sessionTarget
         d3d11Binding.next = &sessionTarget;

--- a/test_apps/cube_handle_d3d12_win/d3d12_renderer.cpp
+++ b/test_apps/cube_handle_d3d12_win/d3d12_renderer.cpp
@@ -878,9 +878,20 @@ void RenderScene(
     // Set render targets
     cmdList->OMSetRenderTargets(1, &rtvHandle, FALSE, &dsvHandle);
 
-    // Clear only on first eye (clear==true)
+    // Clear only on first eye (clear==true). Transparent mode
+    // (DISPLAYXR_TRANSPARENT_BG=1): clear RGBA(0,0,0,0) so the Leia DP's
+    // compose-under-bg pass shows the desktop wherever the cube didn't draw.
     if (clear) {
-        float clearColor[4] = {0.05f, 0.05f, 0.25f, 1.0f};
+        const char *dxbg = getenv("DISPLAYXR_TRANSPARENT_BG");
+        const bool transparent_bg = dxbg != nullptr && *dxbg != '\0' && *dxbg != '0';
+        float clearColor[4];
+        if (transparent_bg) {
+            clearColor[0] = 0.0f; clearColor[1] = 0.0f;
+            clearColor[2] = 0.0f; clearColor[3] = 0.0f;
+        } else {
+            clearColor[0] = 0.05f; clearColor[1] = 0.05f;
+            clearColor[2] = 0.25f; clearColor[3] = 1.0f;
+        }
         cmdList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
         cmdList->ClearDepthStencilView(dsvHandle, D3D12_CLEAR_FLAG_DEPTH | D3D12_CLEAR_FLAG_STENCIL,
             1.0f, 0, 0, nullptr);

--- a/test_apps/cube_handle_d3d12_win/main.cpp
+++ b/test_apps/cube_handle_d3d12_win/main.cpp
@@ -151,8 +151,21 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
     return DefWindowProc(hwnd, msg, wParam, lParam);
 }
 
+// DISPLAYXR_TRANSPARENT_BG=1 → cube clears RGBA(0,0,0,0), window uses
+// WS_EX_NOREDIRECTIONBITMAP + null brush so DComp can show the desktop
+// through the cube's transparent regions. Mirrors cube_handle_vk_win and
+// cube_handle_d3d11_win.
+static bool TransparentBackgroundEnabled() {
+    static const bool e = []() {
+        const char *v = getenv("DISPLAYXR_TRANSPARENT_BG");
+        return v != nullptr && *v != '\0' && *v != '0';
+    }();
+    return e;
+}
+
 static HWND CreateAppWindow(HINSTANCE hInstance, int width, int height) {
-    LOG_INFO("Creating application window (%dx%d)", width, height);
+    const bool transparent = TransparentBackgroundEnabled();
+    LOG_INFO("Creating application window (%dx%d, transparent=%d)", width, height, transparent);
 
     WNDCLASSEX wc = {};
     wc.cbSize = sizeof(WNDCLASSEX);
@@ -160,7 +173,7 @@ static HWND CreateAppWindow(HINSTANCE hInstance, int width, int height) {
     wc.lpfnWndProc = WindowProc;
     wc.hInstance = hInstance;
     wc.hCursor = LoadCursor(nullptr, IDC_ARROW);
-    wc.hbrBackground = (HBRUSH)GetStockObject(BLACK_BRUSH);
+    wc.hbrBackground = transparent ? nullptr : (HBRUSH)GetStockObject(BLACK_BRUSH);
     wc.lpszClassName = WINDOW_CLASS;
 
     if (!RegisterClassEx(&wc)) {
@@ -174,7 +187,8 @@ static HWND CreateAppWindow(HINSTANCE hInstance, int width, int height) {
     RECT rect = { 0, 0, width, height };
     AdjustWindowRect(&rect, WS_OVERLAPPEDWINDOW, FALSE);
 
-    HWND hwnd = CreateWindowEx(0, WINDOW_CLASS, WINDOW_TITLE, WS_OVERLAPPEDWINDOW,
+    DWORD exStyle = transparent ? WS_EX_NOREDIRECTIONBITMAP : 0;
+    HWND hwnd = CreateWindowEx(exStyle, WINDOW_CLASS, WINDOW_TITLE, WS_OVERLAPPEDWINDOW,
         CW_USEDEFAULT, CW_USEDEFAULT,
         rect.right - rect.left, rect.bottom - rect.top,
         nullptr, nullptr, hInstance, nullptr);

--- a/test_apps/cube_handle_d3d12_win/xr_session.cpp
+++ b/test_apps/cube_handle_d3d12_win/xr_session.cpp
@@ -214,6 +214,19 @@ bool CreateSession(XrSessionManager& xr, ID3D12Device* device, ID3D12CommandQueu
     XrWin32WindowBindingCreateInfoEXT sessionTarget = {XR_TYPE_WIN32_WINDOW_BINDING_CREATE_INFO_EXT};
     sessionTarget.windowHandle = hwnd;
 
+    // Opt-in transparency. Pair with WS_EX_NOREDIRECTIONBITMAP + null brush
+    // (main.cpp) and the α=0 clear (d3d12_renderer.cpp). chromaKeyColor=0
+    // lets the Leia DP pick its default magenta (used only if WGC bg-capture
+    // fails and the DP falls back to the chroma-key trick).
+    {
+        const char *e = getenv("DISPLAYXR_TRANSPARENT_BG");
+        if (e != nullptr && *e != '\0' && *e != '0') {
+            sessionTarget.transparentBackgroundEnabled = XR_TRUE;
+            sessionTarget.chromaKeyColor = 0;
+            LOG_INFO("Transparent background ENABLED (DISPLAYXR_TRANSPARENT_BG=1)");
+        }
+    }
+
     if (xr.hasWin32WindowBindingExt && hwnd) {
         d3d12Binding.next = &sessionTarget;
         LOG_INFO("Using XR_EXT_win32_window_binding with window handle");


### PR DESCRIPTION
## Summary

Replaces the chroma-key transparency trick with **Windows Graphics Capture (WGC) compose-under-bg** on the D3D11, D3D12, and Vulkan Leia DPs. The captured desktop region behind the app's window is composited under each per-view atlas tile before the SR weaver runs, so the weaver always consumes opaque RGB and the woven output carries a true per-pixel transparency representation — eliminating the hard-edge AA collapse the chroma-key fill/strip pass caused on antialiased boundaries, and supporting genuinely semi-transparent (0<α<1) pixels.

Chroma-key remains as the documented fallback. The GL Leia DP is unchanged in this PR — it stays on chroma-key, blocked on the deferred DComp + \`WGL_NV_DX_interop2\` bridge (commit \`670d0158d\`).

## What's in the PR

- **\`leia_bg_capture_win\`** (new) — WGC monitor capture module. Internal D3D11 device, \`SHARED_NTHANDLE\` BGRA8 staging texture, \`D3D11_FENCE_FLAG_SHARED\` shared fence for cross-API GPU sync, \`SetWindowDisplayAffinity(WDA_EXCLUDEFROMCAPTURE)\` for self-exclusion. Polls inline (no event handler); falls back gracefully on env-disable / pre-19041 Windows / WGC unavailability.
- **D3D11 / D3D12 / VK Leia DPs** — compose pipeline added alongside the existing chroma-key path; \`process_atlas\` selects compose when WGC init succeeded, falls back to chroma-key otherwise. Reuses each DP's existing \`ck_fill_*\` intermediate target. VK uses \`VK_KHR_external_memory_win32\` with \`VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_BIT\` to import the shared D3D11 texture as a \`VkImage\`.
- **Cube test apps** — \`cube_handle_d3d11_win\` and \`cube_handle_d3d12_win\` ported to the \`DISPLAYXR_TRANSPARENT_BG=1\` opt-in pattern already used by \`cube_handle_vk_win\`: \`WS_EX_NOREDIRECTIONBITMAP\` + null background brush + α=0 swap-chain clear.
- **Docs** — new \`docs/reference/leia-transparency.md\` documenting the current model + per-API status; existing \`chroma-key-transparent-overlay.md\` reframed as the documented fallback.

## Scope decisions

- **Vendor-isolated.** All runtime changes are in \`src/xrt/drivers/leia/\`. The compositor-target DComp wiring (\`comp_d3d11_target.cpp\`, \`comp_d3d12_target.cpp\`, \`comp_vk_native_target.cpp\`) is untouched — it remains the vendor-agnostic transparent-output mechanism.
- **D3D11/D3D12/VK only.** GL DP intentionally not ported (see above).
- **Fallback retained.** On any WGC failure or \`LEIA_DP_DISABLE_BG_CAPTURE=1\` the DP transparently falls back to chroma-key. The full chroma-key code path is preserved.

## Verification

Tested on a Windows 11 / Leia SR display:
- \`DISPLAYXR_TRANSPARENT_BG=1 cube_handle_d3d11_win\` — desktop visible behind cube + HUD, no magenta AA artifacts, pixel-perfect alignment across title-bar and borderless cases.
- Same for \`cube_handle_d3d12_win\` and \`cube_handle_vk_win\`.
- 3D parallax preserved; the captured desktop sits at z=0 as intended.

## Known caveats / follow-ups

- **VK GPU sync.** The Vulkan consumer doesn't yet wait on the shared D3D11 fence — relies on WGC's ~60Hz producer / ~120Hz consumer temporal separation. Proper \`VK_KHR_external_semaphore_win32\` import via \`VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT\` is a follow-up. No visible artifacts in practice.
- **Cross-monitor window move.** The capture session binds to the monitor at create. Moving the window to another monitor skips compose for that frame (poll returns false); recreating the session is a follow-up.
- **GL Leia DP** still uses chroma-key. Unblocking it requires reinstating the GL DComp + \`WGL_NV_DX_interop2\` bridge that was deferred in \`670d0158d\`.
- **DRM-protected content** under the window appears black in the capture (standard WGC limitation).

## Test plan

- [x] Local D3D11 cube — visual + log
- [x] Local D3D12 cube — visual + log (caught & fixed an RTV heap null-deref during testing)
- [x] Local VK cube — visual + log
- [x] Title-bar alignment (GetClientRect + ClientToScreen, not GetWindowRect)
- [x] Chroma-key fallback via \`LEIA_DP_DISABLE_BG_CAPTURE=1\` (D3D11)
- [ ] CI (build-windows.yml) green
- [ ] CI (build-macos.yml) green — Metal path unchanged but full build must still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)