### PR TITLE
leia: post-weave alpha-gate (kill captured-bg drag-lag without chroma fringe)

### DIFF
--- a/src/xrt/drivers/CMakeLists.txt
+++ b/src/xrt/drivers/CMakeLists.txt
@@ -84,6 +84,7 @@ if(XRT_HAVE_LEIA_SR)
 			leia/shaders/ck_fill.frag
 			leia/shaders/ck_strip.frag
 			leia/shaders/compose_under_bg.frag
+			leia/shaders/alpha_gate.frag
 		)
 		list(APPEND LEIA_SOURCES ${LEIA_SHADER_HEADERS})
 		set(LEIA_SR_VULKAN_AVAILABLE TRUE)

--- a/src/xrt/drivers/leia/leia_bg_capture_win.cpp
+++ b/src/xrt/drivers/leia/leia_bg_capture_win.cpp
@@ -303,6 +303,13 @@ leia_bg_capture_create(HWND hwnd)
 	if (SUCCEEDED(capture_session.As(&session2))) {
 		session2->put_IsCursorCaptureEnabled(false);
 	}
+	// Suppress the yellow "this screen is being captured" border DWM draws
+	// around the captured region. Requires Windows 11 22H2+; on older Windows
+	// the QI fails or the put silently no-ops — fine, we just keep the border.
+	ComPtr<WGC::IGraphicsCaptureSession3> session3;
+	if (SUCCEEDED(capture_session.As(&session3))) {
+		session3->put_IsBorderRequired(false);
+	}
 
 	ComPtr<ID3D11Texture2D> staging_tex;
 	HANDLE staging_handle = nullptr;

--- a/src/xrt/drivers/leia/leia_display_processor.cpp
+++ b/src/xrt/drivers/leia/leia_display_processor.cpp
@@ -35,6 +35,7 @@
 #ifdef _WIN32
 #include "leia_bg_capture_win.h"
 #include "leia/shaders/compose_under_bg.frag.h"
+#include "leia/shaders/alpha_gate.frag.h"
 #endif
 
 
@@ -142,6 +143,16 @@ struct leia_display_processor
 	VkDescriptorSet compose_set;
 	VkPipeline compose_pipeline;
 	bool compose_inited;
+
+	// Post-weave alpha-gate (compose-mode replacement for ck_strip).
+	// 2-binding descriptor set (back-buffer copy + atlas), 16-byte push
+	// constants (tile_count). Uses ck_strip_rp as the output render pass
+	// (writes the swap-chain image, finalLayout = PRESENT_SRC_KHR).
+	VkDescriptorSetLayout alpha_gate_desc_layout;
+	VkPipelineLayout alpha_gate_pipeline_layout;
+	VkDescriptorPool alpha_gate_desc_pool;
+	VkDescriptorSet alpha_gate_set;
+	VkPipeline alpha_gate_pipeline;
 };
 
 static inline struct leia_display_processor *
@@ -1196,7 +1207,8 @@ compose_init_pipeline(struct leia_display_processor *ldp)
 		}
 	}
 
-	// Push constants: 2*vec2 + uvec2 + uvec2 pad = 32 bytes.
+	// Push constants: 2*vec2 + uvec2 + uvec2 pad = 32 bytes (no more chroma_rgb
+	// — alpha-gate handles transparency holes, not the compose shader).
 	{
 		VkPushConstantRange pc = {
 		    .stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT,
@@ -1357,8 +1369,155 @@ compose_init_pipeline(struct leia_display_processor *ldp)
 		return false;
 	}
 
+	// Alpha-gate pipeline — pairs with compose pass. Reuses ck_strip_rp as
+	// the output render pass (writes swap-chain image, finalLayout =
+	// PRESENT_SRC_KHR), and the ck_strip_image / ck_strip_view backbuffer
+	// copy plumbing. Distinct descriptor set (2 image samplers — backbuffer
+	// copy + atlas) and push constants (tile_count).
+	if (ldp->alpha_gate_pipeline == VK_NULL_HANDLE) {
+		// 2-binding descriptor set.
+		{
+			VkDescriptorSetLayoutBinding bs[2] = {
+			    {.binding = 0, .descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+			     .descriptorCount = 1, .stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT},
+			    {.binding = 1, .descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+			     .descriptorCount = 1, .stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT},
+			};
+			VkDescriptorSetLayoutCreateInfo ci = {
+			    .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO,
+			    .bindingCount = 2, .pBindings = bs,
+			};
+			res = vk->vkCreateDescriptorSetLayout(vk->device, &ci, NULL, &ldp->alpha_gate_desc_layout);
+			if (res != VK_SUCCESS) {
+				U_LOG_E("Leia VK DP: alpha-gate desc layout failed: %d", res);
+				return false;
+			}
+		}
+		// Push constants: uvec2 tile_count + uvec2 pad = 16 bytes.
+		{
+			VkPushConstantRange pc = {
+			    .stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT,
+			    .offset = 0,
+			    .size = 16,
+			};
+			VkPipelineLayoutCreateInfo pli = {
+			    .sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO,
+			    .setLayoutCount = 1, .pSetLayouts = &ldp->alpha_gate_desc_layout,
+			    .pushConstantRangeCount = 1, .pPushConstantRanges = &pc,
+			};
+			res = vk->vkCreatePipelineLayout(vk->device, &pli, NULL, &ldp->alpha_gate_pipeline_layout);
+			if (res != VK_SUCCESS) {
+				U_LOG_E("Leia VK DP: alpha-gate pipeline layout failed: %d", res);
+				return false;
+			}
+		}
+		// Descriptor pool + 1 set.
+		{
+			VkDescriptorPoolSize size = {
+			    .type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+			    .descriptorCount = 2,
+			};
+			VkDescriptorPoolCreateInfo dpi = {
+			    .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO,
+			    .maxSets = 1, .poolSizeCount = 1, .pPoolSizes = &size,
+			};
+			res = vk->vkCreateDescriptorPool(vk->device, &dpi, NULL, &ldp->alpha_gate_desc_pool);
+			if (res != VK_SUCCESS) {
+				U_LOG_E("Leia VK DP: alpha-gate desc pool failed: %d", res);
+				return false;
+			}
+			VkDescriptorSetAllocateInfo ai = {
+			    .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO,
+			    .descriptorPool = ldp->alpha_gate_desc_pool,
+			    .descriptorSetCount = 1,
+			    .pSetLayouts = &ldp->alpha_gate_desc_layout,
+			};
+			res = vk->vkAllocateDescriptorSets(vk->device, &ai, &ldp->alpha_gate_set);
+			if (res != VK_SUCCESS) {
+				U_LOG_E("Leia VK DP: alpha-gate desc set alloc failed: %d", res);
+				return false;
+			}
+		}
+		// Build pipeline against ck_strip_rp (writes swap-chain image).
+		VkShaderModule ag_vs = VK_NULL_HANDLE, ag_fs = VK_NULL_HANDLE;
+		res = ck_create_shader_module(vk, leia_shaders_fullscreen_tri_vert,
+		                              sizeof(leia_shaders_fullscreen_tri_vert), &ag_vs);
+		if (res != VK_SUCCESS) {
+			U_LOG_E("Leia VK DP: alpha-gate vs create failed: %d", res);
+			return false;
+		}
+		res = ck_create_shader_module(vk, leia_shaders_alpha_gate_frag,
+		                              sizeof(leia_shaders_alpha_gate_frag), &ag_fs);
+		if (res != VK_SUCCESS) {
+			U_LOG_E("Leia VK DP: alpha-gate fs create failed: %d", res);
+			vk->vkDestroyShaderModule(vk->device, ag_vs, NULL);
+			return false;
+		}
+
+		VkPipelineVertexInputStateCreateInfo vi = {.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO};
+		VkPipelineInputAssemblyStateCreateInfo ia = {
+		    .sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO,
+		    .topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST,
+		};
+		VkPipelineViewportStateCreateInfo vps = {
+		    .sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO,
+		    .viewportCount = 1, .scissorCount = 1,
+		};
+		VkPipelineRasterizationStateCreateInfo rs = {
+		    .sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO,
+		    .polygonMode = VK_POLYGON_MODE_FILL,
+		    .cullMode = VK_CULL_MODE_NONE,
+		    .frontFace = VK_FRONT_FACE_COUNTER_CLOCKWISE,
+		    .lineWidth = 1.0f,
+		};
+		VkPipelineMultisampleStateCreateInfo ms = {
+		    .sType = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO,
+		    .rasterizationSamples = VK_SAMPLE_COUNT_1_BIT,
+		};
+		VkPipelineColorBlendAttachmentState ba = {
+		    .colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT |
+		                      VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT,
+		};
+		VkPipelineColorBlendStateCreateInfo cb = {
+		    .sType = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO,
+		    .attachmentCount = 1, .pAttachments = &ba,
+		};
+		VkDynamicState dyn[] = {VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR};
+		VkPipelineDynamicStateCreateInfo dynstate = {
+		    .sType = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO,
+		    .dynamicStateCount = 2, .pDynamicStates = dyn,
+		};
+		VkPipelineShaderStageCreateInfo stages[2] = {
+		    {.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
+		     .stage = VK_SHADER_STAGE_VERTEX_BIT, .module = ag_vs, .pName = "main"},
+		    {.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
+		     .stage = VK_SHADER_STAGE_FRAGMENT_BIT, .module = ag_fs, .pName = "main"},
+		};
+		VkGraphicsPipelineCreateInfo pi = {
+		    .sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO,
+		    .stageCount = 2, .pStages = stages,
+		    .pVertexInputState = &vi,
+		    .pInputAssemblyState = &ia,
+		    .pViewportState = &vps,
+		    .pRasterizationState = &rs,
+		    .pMultisampleState = &ms,
+		    .pColorBlendState = &cb,
+		    .pDynamicState = &dynstate,
+		    .layout = ldp->alpha_gate_pipeline_layout,
+		    .renderPass = ldp->ck_strip_rp,
+		    .subpass = 0,
+		};
+		res = vk->vkCreateGraphicsPipelines(vk->device, VK_NULL_HANDLE, 1, &pi, NULL, &ldp->alpha_gate_pipeline);
+		vk->vkDestroyShaderModule(vk->device, ag_fs, NULL);
+		vk->vkDestroyShaderModule(vk->device, ag_vs, NULL);
+		if (res != VK_SUCCESS) {
+			U_LOG_E("Leia VK DP: alpha-gate pipeline create failed: %d", res);
+			return false;
+		}
+	}
+
 	ldp->compose_inited = true;
-	U_LOG_W("Leia VK DP: compose-under-bg pipeline ready");
+	U_LOG_W("Leia VK DP: compose-under-bg + alpha-gate pipelines ready");
 	return true;
 }
 
@@ -1487,11 +1646,152 @@ compose_run_pre_weave(struct leia_display_processor *ldp,
 	return ldp->ck_fill_view;
 }
 
+/*
+ * Post-weave alpha-gate. Mirrors ck_run_post_weave_strip's backbuffer copy
+ * dance but binds 2 SRVs (strip_view = back-buffer copy, atlas_view) and
+ * the alpha-gate pipeline. Output is premultiplied RGBA — pixels matching
+ * the "all views α==0" mask get (0,0,0,0); others get woven RGB at α=1.
+ *
+ * On entry: target_image is in PRESENT_SRC_KHR. On exit: same.
+ */
+static void
+alpha_gate_run_post_weave(struct leia_display_processor *ldp,
+                          VkCommandBuffer cmd,
+                          VkImage target_image,
+                          VkImageView atlas_view,
+                          uint32_t w, uint32_t h,
+                          uint32_t tile_columns, uint32_t tile_rows)
+{
+	struct vk_bundle *vk = ldp->vk;
+
+	if (!ck_ensure_strip_source(ldp, w, h)) return;
+	VkFramebuffer strip_fb = ck_get_strip_fb(ldp, target_image, w, h);
+	if (strip_fb == VK_NULL_HANDLE) return;
+
+	// Update alpha-gate descriptor set: slot 0 = strip_view (backbuffer copy),
+	// slot 1 = atlas_view.
+	VkDescriptorImageInfo infos[2] = {
+	    {.sampler = ldp->compose_sampler, .imageView = ldp->ck_strip_view,
+	     .imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL},
+	    {.sampler = ldp->compose_sampler, .imageView = atlas_view,
+	     .imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL},
+	};
+	VkWriteDescriptorSet writes[2] = {
+	    {.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
+	     .dstSet = ldp->alpha_gate_set, .dstBinding = 0, .descriptorCount = 1,
+	     .descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+	     .pImageInfo = &infos[0]},
+	    {.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
+	     .dstSet = ldp->alpha_gate_set, .dstBinding = 1, .descriptorCount = 1,
+	     .descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+	     .pImageInfo = &infos[1]},
+	};
+	vk->vkUpdateDescriptorSets(vk->device, 2, writes, 0, NULL);
+
+	// target PRESENT_SRC_KHR → TRANSFER_SRC; strip_image UNDEFINED/SR → TRANSFER_DST.
+	VkImageMemoryBarrier pre[2] = {
+	    {.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+	     .srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+	     .dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT,
+	     .oldLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
+	     .newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+	     .image = target_image,
+	     .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1}},
+	    {.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+	     .srcAccessMask = VK_ACCESS_SHADER_READ_BIT,
+	     .dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
+	     .oldLayout = VK_IMAGE_LAYOUT_UNDEFINED,
+	     .newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+	     .image = ldp->ck_strip_image,
+	     .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1}},
+	};
+	vk->vkCmdPipelineBarrier(cmd,
+	    VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT | VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+	    VK_PIPELINE_STAGE_TRANSFER_BIT,
+	    0, 0, NULL, 0, NULL, 2, pre);
+
+	VkImageCopy region = {
+	    .srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1},
+	    .dstSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1},
+	    .extent = {w, h, 1},
+	};
+	vk->vkCmdCopyImage(cmd,
+	    target_image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+	    ldp->ck_strip_image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+	    1, &region);
+
+	// target TRANSFER_SRC → COLOR_ATTACHMENT (will be written by the gate
+	// draw via ck_strip_rp); strip_image TRANSFER_DST → SHADER_READ.
+	VkImageMemoryBarrier mid[2] = {
+	    {.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+	     .srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT,
+	     .dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+	     .oldLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+	     .newLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+	     .image = target_image,
+	     .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1}},
+	    {.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+	     .srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
+	     .dstAccessMask = VK_ACCESS_SHADER_READ_BIT,
+	     .oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+	     .newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+	     .image = ldp->ck_strip_image,
+	     .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1}},
+	};
+	vk->vkCmdPipelineBarrier(cmd,
+	    VK_PIPELINE_STAGE_TRANSFER_BIT,
+	    VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT | VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+	    0, 0, NULL, 0, NULL, 2, mid);
+
+	VkRenderPassBeginInfo rpbi = {
+	    .sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO,
+	    .renderPass = ldp->ck_strip_rp,
+	    .framebuffer = strip_fb,
+	    .renderArea = {{0, 0}, {w, h}},
+	};
+	vk->vkCmdBeginRenderPass(cmd, &rpbi, VK_SUBPASS_CONTENTS_INLINE);
+
+	vk->vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, ldp->alpha_gate_pipeline);
+	vk->vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS,
+	                             ldp->alpha_gate_pipeline_layout, 0, 1, &ldp->alpha_gate_set, 0, NULL);
+
+	struct { uint32_t tile_count[2]; uint32_t pad[2]; } push = {};
+	push.tile_count[0] = tile_columns;
+	push.tile_count[1] = tile_rows;
+	vk->vkCmdPushConstants(cmd, ldp->alpha_gate_pipeline_layout,
+	                        VK_SHADER_STAGE_FRAGMENT_BIT, 0, sizeof(push), &push);
+
+	VkViewport vp = {0.0f, 0.0f, (float)w, (float)h, 0.0f, 1.0f};
+	VkRect2D sc = {{0, 0}, {w, h}};
+	vk->vkCmdSetViewport(cmd, 0, 1, &vp);
+	vk->vkCmdSetScissor(cmd, 0, 1, &sc);
+
+	vk->vkCmdDraw(cmd, 3, 1, 0, 0);
+	vk->vkCmdEndRenderPass(cmd);
+}
+
 static void
 compose_release_resources(struct leia_display_processor *ldp)
 {
 	if (ldp == NULL || ldp->vk == NULL) return;
 	struct vk_bundle *vk = ldp->vk;
+
+	if (ldp->alpha_gate_pipeline != VK_NULL_HANDLE) {
+		vk->vkDestroyPipeline(vk->device, ldp->alpha_gate_pipeline, NULL);
+		ldp->alpha_gate_pipeline = VK_NULL_HANDLE;
+	}
+	if (ldp->alpha_gate_desc_pool != VK_NULL_HANDLE) {
+		vk->vkDestroyDescriptorPool(vk->device, ldp->alpha_gate_desc_pool, NULL);
+		ldp->alpha_gate_desc_pool = VK_NULL_HANDLE;
+	}
+	if (ldp->alpha_gate_pipeline_layout != VK_NULL_HANDLE) {
+		vk->vkDestroyPipelineLayout(vk->device, ldp->alpha_gate_pipeline_layout, NULL);
+		ldp->alpha_gate_pipeline_layout = VK_NULL_HANDLE;
+	}
+	if (ldp->alpha_gate_desc_layout != VK_NULL_HANDLE) {
+		vk->vkDestroyDescriptorSetLayout(vk->device, ldp->alpha_gate_desc_layout, NULL);
+		ldp->alpha_gate_desc_layout = VK_NULL_HANDLE;
+	}
 
 	if (ldp->compose_pipeline != VK_NULL_HANDLE) {
 		vk->vkDestroyPipeline(vk->device, ldp->compose_pipeline, NULL);
@@ -1719,6 +2019,20 @@ leia_dp_process_atlas(struct xrt_display_processor *xdp,
 	             (int)target_height,
 	             (VkFormat)target_format);
 
+	// Post-weave transparency pass:
+	//   - compose path: alpha-gate samples the ORIGINAL atlas to derive
+	//     the screen-space "all views α==0" mask, zeroes alpha on those
+	//     pixels — DWM blends the LIVE desktop (no captured-bg lag, no
+	//     magenta fringe at silhouettes).
+	//   - chroma-key fallback: legacy strip.
+#ifdef _WIN32
+	if (compose_active && target_image != (VkImage_XDP)VK_NULL_HANDLE) {
+		alpha_gate_run_post_weave(ldp, cmd_buffer,
+		                          (VkImage)target_image, atlas_view,
+		                          target_width, target_height,
+		                          tile_columns, tile_rows);
+	} else
+#endif
 	if (ck_active) {
 		ck_run_post_weave_strip(ldp, cmd_buffer, (VkImage)target_image,
 		                         target_width, target_height);

--- a/src/xrt/drivers/leia/leia_display_processor_d3d11.cpp
+++ b/src/xrt/drivers/leia/leia_display_processor_d3d11.cpp
@@ -152,9 +152,16 @@ cbuffer Constants : register(b0) {
 	float2 bg_uv_origin;  // window TL on monitor, normalized
 	float2 bg_uv_extent;  // window size on monitor, normalized
 	uint2  tile_count;    // (tile_columns, tile_rows)
-	uint2  pad_;
+	uint2  pad0;
+	float3 chroma_rgb;    // sentinel for fully-transparent atlas pixels
+	float  pad1;
 };
 float4 main(float4 pos : SV_Position, float2 uv : TEXCOORD0) : SV_Target {
+	// Plain compose-with-bg. Transparency holes are produced by the
+	// post-weave alpha-gate pass, NOT by any chroma sentinel — so this
+	// shader never emits a key color and the weaver only ever sees real
+	// captured-bg ↔ atlas-content data (no exact-match-miss fringe at
+	// silhouettes).
 	float4 a = atlas.Sample(samp, uv);
 	float2 tile_local = frac(uv * float2(tile_count));
 	float2 bg_uv = bg_uv_origin + tile_local * bg_uv_extent;
@@ -167,7 +174,53 @@ struct ComposeConstants {
 	float bg_uv_origin[2];
 	float bg_uv_extent[2];
 	uint32_t tile_count[2];
-	uint32_t pad_[2];
+	uint32_t pad0[2];
+	float chroma_rgb[3];
+	float pad1;
+};
+
+/*
+ * Post-weave alpha-gate pixel shader (compose-mode replacement for the
+ * legacy chroma-key strip).
+ *
+ * Samples the woven back-buffer and the original atlas. For each screen
+ * pixel, tests the "fully transparent in ALL views" condition by reading
+ * the atlas at the same tile-local UV across every tile. When all views
+ * agree the pixel is transparent → output (0,0,0,0) so DWM blends the
+ * live desktop (no captured-bg lag in large flat regions). Otherwise →
+ * output the woven RGB at α=1.
+ *
+ * Screen UV equals tile-local UV when target = (tile_columns × view_w,
+ * tile_rows × view_h), which is the canvas-fills-target case (default).
+ */
+static const char *alpha_gate_ps_source = R"(
+Texture2D<float4> backbuffer : register(t0);
+Texture2D<float4> atlas      : register(t1);
+SamplerState samp            : register(s0);
+cbuffer Constants : register(b0) {
+	uint2 tile_count;
+	uint2 pad;
+};
+struct VSOut { float4 pos : SV_Position; float2 uv : TEXCOORD0; };
+float4 main(VSOut i) : SV_Target {
+	bool all_transparent = true;
+	for (uint ty = 0; ty < tile_count.y; ty++) {
+		for (uint tx = 0; tx < tile_count.x; tx++) {
+			float2 uv_at_tile = (float2(tx, ty) + i.uv) / float2(tile_count);
+			if (atlas.SampleLevel(samp, uv_at_tile, 0).a > 0.0) {
+				all_transparent = false;
+			}
+		}
+	}
+	float3 rgb = backbuffer.Sample(samp, i.uv).rgb;
+	float m = all_transparent ? 0.0 : 1.0;
+	return float4(rgb * m, m);
+}
+)";
+
+struct AlphaGateConstants {
+	uint32_t tile_count[2];
+	uint32_t pad[2];
 };
 
 
@@ -238,6 +291,9 @@ struct leia_display_processor_d3d11_impl
 	ID3D11PixelShader *compose_ps;
 	ID3D11SamplerState *compose_sampler; //!< Linear sampler (atlas + bg both filtered).
 	ID3D11Buffer *compose_constants;     //!< sizeof(ComposeConstants).
+	// Post-weave alpha-gate (replaces ck_strip when compose is active).
+	ID3D11PixelShader *alpha_gate_ps;
+	ID3D11Buffer *alpha_gate_constants;  //!< sizeof(AlphaGateConstants).
 	//! @}
 };
 
@@ -668,7 +724,42 @@ compose_init_pipeline(struct leia_display_processor_d3d11_impl *ldp)
 		}
 	}
 
-	U_LOG_W("Leia D3D11 DP: compose-under-bg pipeline ready");
+	// Alpha-gate (post-weave) — pairs with the compose pass.
+	if (ldp->alpha_gate_ps == nullptr) {
+		ID3DBlob *blob = nullptr;
+		ID3DBlob *err = nullptr;
+		hr = D3DCompile(alpha_gate_ps_source, strlen(alpha_gate_ps_source),
+		                nullptr, nullptr, nullptr,
+		                "main", "ps_5_0", 0, 0, &blob, &err);
+		if (FAILED(hr)) {
+			U_LOG_E("Leia D3D11 DP: alpha-gate PS compile failed: 0x%08x %s",
+			        (unsigned)hr, err ? (const char *)err->GetBufferPointer() : "");
+			if (err) err->Release();
+			return false;
+		}
+		if (err) err->Release();
+		hr = ldp->device->CreatePixelShader(blob->GetBufferPointer(), blob->GetBufferSize(),
+		                                     nullptr, &ldp->alpha_gate_ps);
+		blob->Release();
+		if (FAILED(hr)) {
+			U_LOG_E("Leia D3D11 DP: alpha-gate PS create failed: 0x%08x", (unsigned)hr);
+			return false;
+		}
+	}
+	if (ldp->alpha_gate_constants == nullptr) {
+		D3D11_BUFFER_DESC cb = {};
+		cb.ByteWidth = sizeof(AlphaGateConstants);
+		cb.Usage = D3D11_USAGE_DYNAMIC;
+		cb.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
+		cb.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
+		hr = ldp->device->CreateBuffer(&cb, nullptr, &ldp->alpha_gate_constants);
+		if (FAILED(hr)) {
+			U_LOG_E("Leia D3D11 DP: alpha-gate CB create failed: 0x%08x", (unsigned)hr);
+			return false;
+		}
+	}
+
+	U_LOG_W("Leia D3D11 DP: compose-under-bg + alpha-gate pipelines ready");
 	return true;
 }
 
@@ -716,8 +807,17 @@ compose_run_pre_weave(struct leia_display_processor_d3d11_impl *ldp,
 	cb->bg_uv_extent[1] = bg_extent[1];
 	cb->tile_count[0] = tile_columns;
 	cb->tile_count[1] = tile_rows;
-	cb->pad_[0] = 0;
-	cb->pad_[1] = 0;
+	cb->pad0[0] = 0;
+	cb->pad0[1] = 0;
+	{
+		// Same key as the chroma-key post-weave strip uses (ck_color stays
+		// set in compose mode — see set_chroma_key).
+		uint32_t k = ldp->ck_color;
+		cb->chroma_rgb[0] = ((k >>  0) & 0xFF) / 255.0f;
+		cb->chroma_rgb[1] = ((k >>  8) & 0xFF) / 255.0f;
+		cb->chroma_rgb[2] = ((k >> 16) & 0xFF) / 255.0f;
+		cb->pad1 = 0.0f;
+	}
 	ctx->Unmap(ldp->compose_constants, 0);
 
 	// Save state.
@@ -766,16 +866,108 @@ compose_run_pre_weave(struct leia_display_processor_d3d11_impl *ldp,
 	return ldp->ck_fill_srv;
 }
 
+/*
+ * Post-weave alpha-gate: copy current RTV → ck_strip_tex, then run the
+ * alpha_gate_ps over the back buffer with the atlas SRV bound. Pixels
+ * where ALL views' atlas α==0 at the same tile-local UV become α=0 in
+ * the output → DWM blends the live desktop. Other pixels keep α=1 with
+ * the woven composed-bg content. Replaces ck_run_post_weave_strip when
+ * compose-under-bg is the active path — no chroma keying involved.
+ */
+static void
+alpha_gate_run_post_weave(struct leia_display_processor_d3d11_impl *ldp,
+                          ID3D11DeviceContext *ctx,
+                          ID3D11ShaderResourceView *atlas_srv,
+                          uint32_t tile_columns,
+                          uint32_t tile_rows)
+{
+	if (atlas_srv == nullptr || ldp->alpha_gate_ps == nullptr) {
+		return;
+	}
+
+	ID3D11RenderTargetView *rtv = nullptr;
+	ID3D11DepthStencilView *dsv = nullptr;
+	ctx->OMGetRenderTargets(1, &rtv, &dsv);
+	if (rtv == nullptr) {
+		if (dsv) dsv->Release();
+		return;
+	}
+
+	ID3D11Resource *rtv_res = nullptr;
+	rtv->GetResource(&rtv_res);
+	ID3D11Texture2D *back_buffer = nullptr;
+	if (rtv_res) {
+		rtv_res->QueryInterface(__uuidof(ID3D11Texture2D),
+		                         reinterpret_cast<void **>(&back_buffer));
+	}
+	if (back_buffer == nullptr) {
+		if (rtv_res) rtv_res->Release();
+		rtv->Release();
+		if (dsv) dsv->Release();
+		return;
+	}
+
+	D3D11_TEXTURE2D_DESC bb_desc = {};
+	back_buffer->GetDesc(&bb_desc);
+	if (!ck_ensure_strip_source(ldp, bb_desc.Width, bb_desc.Height)) {
+		back_buffer->Release();
+		rtv_res->Release();
+		rtv->Release();
+		if (dsv) dsv->Release();
+		return;
+	}
+
+	ctx->CopyResource(ldp->ck_strip_tex, back_buffer);
+
+	// Update alpha-gate constants with tile_count.
+	D3D11_MAPPED_SUBRESOURCE m = {};
+	if (SUCCEEDED(ctx->Map(ldp->alpha_gate_constants, 0, D3D11_MAP_WRITE_DISCARD, 0, &m))) {
+		AlphaGateConstants *cb = reinterpret_cast<AlphaGateConstants *>(m.pData);
+		cb->tile_count[0] = tile_columns;
+		cb->tile_count[1] = tile_rows;
+		cb->pad[0] = 0;
+		cb->pad[1] = 0;
+		ctx->Unmap(ldp->alpha_gate_constants, 0);
+	}
+
+	D3D11_VIEWPORT vp = {};
+	vp.Width = (float)bb_desc.Width;
+	vp.Height = (float)bb_desc.Height;
+	vp.MaxDepth = 1.0f;
+	ctx->RSSetViewports(1, &vp);
+	ctx->OMSetRenderTargets(1, &rtv, nullptr);
+
+	ctx->IASetInputLayout(nullptr);
+	ctx->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
+	ctx->VSSetShader(ldp->blit_vs, nullptr, 0);
+	ctx->PSSetShader(ldp->alpha_gate_ps, nullptr, 0);
+	ID3D11ShaderResourceView *srvs[2] = {ldp->ck_strip_srv, atlas_srv};
+	ctx->PSSetShaderResources(0, 2, srvs);
+	ctx->PSSetSamplers(0, 1, &ldp->compose_sampler);
+	ctx->PSSetConstantBuffers(0, 1, &ldp->alpha_gate_constants);
+	ctx->Draw(4, 0);
+
+	ID3D11ShaderResourceView *null_srvs[2] = {nullptr, nullptr};
+	ctx->PSSetShaderResources(0, 2, null_srvs);
+
+	back_buffer->Release();
+	rtv_res->Release();
+	rtv->Release();
+	if (dsv) dsv->Release();
+}
+
 static void
 compose_release_resources(struct leia_display_processor_d3d11_impl *ldp)
 {
-	if (ldp->bg_fence)          { ldp->bg_fence->Release();          ldp->bg_fence = nullptr; }
-	if (ldp->bg_shared_srv)     { ldp->bg_shared_srv->Release();     ldp->bg_shared_srv = nullptr; }
-	if (ldp->bg_shared_tex)     { ldp->bg_shared_tex->Release();     ldp->bg_shared_tex = nullptr; }
-	if (ldp->compose_constants) { ldp->compose_constants->Release(); ldp->compose_constants = nullptr; }
-	if (ldp->compose_sampler)   { ldp->compose_sampler->Release();   ldp->compose_sampler = nullptr; }
-	if (ldp->compose_ps)        { ldp->compose_ps->Release();        ldp->compose_ps = nullptr; }
-	if (ldp->bg_capture)        { leia_bg_capture_destroy(ldp->bg_capture); ldp->bg_capture = nullptr; }
+	if (ldp->alpha_gate_constants) { ldp->alpha_gate_constants->Release(); ldp->alpha_gate_constants = nullptr; }
+	if (ldp->alpha_gate_ps)        { ldp->alpha_gate_ps->Release();        ldp->alpha_gate_ps = nullptr; }
+	if (ldp->bg_fence)             { ldp->bg_fence->Release();             ldp->bg_fence = nullptr; }
+	if (ldp->bg_shared_srv)        { ldp->bg_shared_srv->Release();        ldp->bg_shared_srv = nullptr; }
+	if (ldp->bg_shared_tex)        { ldp->bg_shared_tex->Release();        ldp->bg_shared_tex = nullptr; }
+	if (ldp->compose_constants)    { ldp->compose_constants->Release();    ldp->compose_constants = nullptr; }
+	if (ldp->compose_sampler)      { ldp->compose_sampler->Release();      ldp->compose_sampler = nullptr; }
+	if (ldp->compose_ps)           { ldp->compose_ps->Release();           ldp->compose_ps = nullptr; }
+	if (ldp->bg_capture)           { leia_bg_capture_destroy(ldp->bg_capture); ldp->bg_capture = nullptr; }
 	ldp->bg_compose_enabled = false;
 }
 
@@ -878,13 +1070,16 @@ leia_dp_d3d11_process_atlas(struct xrt_display_processor_d3d11 *xdp,
 		ID3D11ShaderResourceView *null_srv = NULL;
 		ctx->PSSetShaderResources(0, 1, &null_srv);
 
-		// 2D mode has no weaver, but if chroma-key is enabled the legacy
-		// flow (app pre-fills with key RGB on opaque alpha=1 surface) still
-		// needs the strip pass to recover alpha=0 for DWM. The new flow
-		// (true alpha through blit) works without it; running strip in that
-		// case is a no-op for non-key pixels. The compose-under-bg path
-		// already produced opaque RGB, so the strip pass is unnecessary.
-		if (!compose_should_run(ldp) && ck_should_run(ldp)) {
+		// Post-weave transparency pass:
+		//   - compose path: alpha-gate samples the atlas to find "all views
+		//     α==0" screen pixels and zeroes their alpha — no chroma keying.
+		//   - chroma-key fallback: legacy strip pass on the magenta sentinel.
+		if (compose_should_run(ldp)) {
+			alpha_gate_run_post_weave(
+			    ldp, ctx,
+			    static_cast<ID3D11ShaderResourceView *>(atlas_srv),
+			    tile_columns, tile_rows);
+		} else if (ck_should_run(ldp)) {
 			ck_run_post_weave_strip(ldp, ctx);
 		}
 		return;
@@ -964,12 +1159,21 @@ leia_dp_d3d11_process_atlas(struct xrt_display_processor_d3d11 *xdp,
 
 	leiasr_d3d11_weave(ldp->leiasr);
 
-	// Post-weave chroma-key strip: convert key-color RGB pixels in the
-	// woven back-buffer to alpha=0 (with RGB premultiplied for DWM's
-	// premultiplied alpha mode). No-op when chroma-key is disabled, and
-	// suppressed entirely when compose-under-bg ran (the weaver already
-	// consumed opaque pre-composited input; the back buffer is opaque RGB).
-	if (!compose_should_run(ldp) && ck_should_run(ldp)) {
+	// Post-weave transparency pass:
+	//   - compose path: alpha-gate samples the atlas directly to derive an
+	//     "all views α==0" mask in screen space, then zeroes alpha on those
+	//     pixels so DWM blends the LIVE desktop (no captured-bg lag in flat
+	//     regions). At silhouettes the mask says α=1 (one view is opaque),
+	//     so the user sees the weaver's smooth bg↔cube lenticular blend.
+	//     No chroma keying — no magenta enters the weaver, no exact-match
+	//     fringe artifact at silhouettes.
+	//   - chroma-key fallback: legacy strip pass.
+	if (compose_should_run(ldp)) {
+		alpha_gate_run_post_weave(
+		    ldp, ctx,
+		    static_cast<ID3D11ShaderResourceView *>(atlas_srv),
+		    tile_columns, tile_rows);
+	} else if (ck_should_run(ldp)) {
 		ck_run_post_weave_strip(ldp, ctx);
 	}
 }

--- a/src/xrt/drivers/leia/leia_display_processor_d3d12.cpp
+++ b/src/xrt/drivers/leia/leia_display_processor_d3d12.cpp
@@ -133,6 +133,41 @@ static constexpr uint32_t kDefaultChromaKey = 0x00FF00FF;
  *
  * Same VS as the ck pipeline (single fullscreen triangle).
  */
+/*
+ * Post-weave alpha-gate (compose-mode replacement for the chroma-key strip).
+ * Samples the woven back-buffer (in copy form via ck_strip_tex) and the
+ * original atlas, then for each screen pixel tests whether ALL tiles' atlas
+ * α==0 at the matching tile-local UV. Pixels passing the test get α=0 (DWM
+ * blends live desktop); others keep α=1.
+ *
+ * Screen UV == tile-local UV when target = (tile_columns × view_w,
+ * tile_rows × view_h), which is the canvas-fills-target case.
+ */
+static const char *alpha_gate_ps_source = R"(
+struct VSOut { float4 pos : SV_Position; float2 uv : TEXCOORD0; };
+Texture2D<float4> backbuffer : register(t0);
+Texture2D<float4> atlas      : register(t1);
+SamplerState samp            : register(s0);
+cbuffer Constants : register(b0) {
+    uint2 tile_count;
+    uint2 pad;
+};
+float4 main(VSOut i) : SV_Target {
+    bool all_transparent = true;
+    for (uint ty = 0; ty < tile_count.y; ty++) {
+        for (uint tx = 0; tx < tile_count.x; tx++) {
+            float2 uv_at_tile = (float2(tx, ty) + i.uv) / float2(tile_count);
+            if (atlas.SampleLevel(samp, uv_at_tile, 0).a > 0.0) {
+                all_transparent = false;
+            }
+        }
+    }
+    float3 rgb = backbuffer.Sample(samp, i.uv).rgb;
+    float m = all_transparent ? 0.0 : 1.0;
+    return float4(rgb * m, m);
+}
+)";
+
 static const char *compose_under_bg_ps_source = R"(
 struct VSOut { float4 pos : SV_Position; float2 uv : TEXCOORD0; };
 Texture2D<float4> atlas : register(t0);
@@ -142,9 +177,13 @@ cbuffer Constants : register(b0) {
     float2 bg_uv_origin;
     float2 bg_uv_extent;
     uint2  tile_count;
-    uint2  pad_;
+    uint2  pad0;
+    float3 chroma_rgb;    // sentinel for fully-transparent atlas pixels
+    float  pad1;
 };
 float4 main(VSOut i) : SV_Target {
+    // Plain compose-with-bg. Transparency holes are produced by the
+    // post-weave alpha-gate pass — this shader never emits a chroma sentinel.
     float4 a = atlas.Sample(samp, i.uv);
     float2 tile_local = frac(i.uv * float2(tile_count));
     float2 bg_uv = bg_uv_origin + tile_local * bg_uv_extent;
@@ -220,6 +259,11 @@ struct leia_display_processor_d3d12_impl
 	ID3D12PipelineState *compose_pso;
 	ID3D12DescriptorHeap *compose_srv_heap; //!< Shader-visible, 2 entries (atlas, bg).
 	UINT cbv_srv_desc_size;              //!< Cached for offset arithmetic in compose heap.
+
+	// Post-weave alpha-gate (replaces ck_strip when compose is active).
+	// Reuses compose_root_sig (12 32-bit constants, 2-SRV table, linear sampler).
+	ID3D12PipelineState *alpha_gate_pso;
+	ID3D12DescriptorHeap *alpha_gate_srv_heap; //!< Shader-visible, 2 entries (backbuffer, atlas).
 	//! @}
 };
 
@@ -729,9 +773,9 @@ compose_should_run(struct leia_display_processor_d3d12_impl *ldp)
 	return ldp->bg_compose_enabled && ldp->bg_capture != nullptr && ldp->bg_shared_tex != nullptr;
 }
 
-// Root signature: 8 32-bit constants (bg_uv_origin xy + bg_uv_extent xy +
-// tile_count xy + pad xy = 32 bytes) at b0 + 2-SRV descriptor table (t0,t1)
-// + static linear sampler at s0.
+// Root signature: 12 32-bit constants (bg_uv_origin xy + bg_uv_extent xy +
+// tile_count xy + pad xy + chroma_rgb + pad = 48 bytes) at b0 + 2-SRV
+// descriptor table (t0,t1) + static linear sampler at s0.
 static bool
 compose_build_root_sig(struct leia_display_processor_d3d12_impl *ldp)
 {
@@ -744,7 +788,7 @@ compose_build_root_sig(struct leia_display_processor_d3d12_impl *ldp)
 	D3D12_ROOT_PARAMETER params[2] = {};
 	params[0].ParameterType = D3D12_ROOT_PARAMETER_TYPE_32BIT_CONSTANTS;
 	params[0].Constants.ShaderRegister = 0;
-	params[0].Constants.Num32BitValues = 8;
+	params[0].Constants.Num32BitValues = 12;
 	params[0].ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
 	params[1].ParameterType = D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;
 	params[1].DescriptorTable.NumDescriptorRanges = 1;
@@ -847,6 +891,23 @@ compose_init_pipeline(struct leia_display_processor_d3d12_impl *ldp)
 			return false;
 		}
 	}
+	// Same reason: ck_ensure_strip_source writes the strip SRV into
+	// ck_srv_heap_strip. The alpha-gate path uses its own srv heap but
+	// ck_ensure_strip_source still writes the legacy heap. Create it here
+	// so the ck path doesn't null-deref on the compose-mode first frame.
+	if (ldp->ck_srv_heap_strip == nullptr) {
+		D3D12_DESCRIPTOR_HEAP_DESC hd = {};
+		hd.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+		hd.NumDescriptors = 1;
+		hd.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		HRESULT hr = ldp->device->CreateDescriptorHeap(
+		    &hd, __uuidof(ID3D12DescriptorHeap),
+		    reinterpret_cast<void **>(&ldp->ck_srv_heap_strip));
+		if (FAILED(hr)) {
+			U_LOG_E("Leia D3D12 DP: compose strip SRV heap create failed: 0x%08x", (unsigned)hr);
+			return false;
+		}
+	}
 
 	if (ldp->compose_srv_heap == nullptr) {
 		D3D12_DESCRIPTOR_HEAP_DESC hd = {};
@@ -874,7 +935,59 @@ compose_init_pipeline(struct leia_display_processor_d3d12_impl *ldp)
 		bg_cpu.ptr += ldp->cbv_srv_desc_size;
 		ldp->device->CreateShaderResourceView(ldp->bg_shared_tex, &bg_srv, bg_cpu);
 	}
-	U_LOG_W("Leia D3D12 DP: compose-under-bg pipeline ready");
+
+	// Alpha-gate PSO (reuses compose_root_sig). Same fullscreen-tri VS,
+	// alpha_gate_ps_source for the PS. Different render-target — back buffer
+	// can be either DXGI_FORMAT_R8G8B8A8_UNORM or _B8G8R8A8_UNORM; we build
+	// the PSO for the swap-chain format the compositor set via set_output_format.
+	if (ldp->alpha_gate_pso == nullptr) {
+		ID3DBlob *vs_blob = ck_compile_shader(ck_vs_source, "main", "vs_5_0");
+		if (vs_blob == nullptr) return false;
+		ID3DBlob *ps_blob = ck_compile_shader(alpha_gate_ps_source, "main", "ps_5_0");
+		if (ps_blob == nullptr) { vs_blob->Release(); return false; }
+
+		D3D12_GRAPHICS_PIPELINE_STATE_DESC pd = {};
+		pd.pRootSignature = ldp->compose_root_sig;
+		pd.VS = {vs_blob->GetBufferPointer(), vs_blob->GetBufferSize()};
+		pd.PS = {ps_blob->GetBufferPointer(), ps_blob->GetBufferSize()};
+		pd.BlendState.RenderTarget[0].RenderTargetWriteMask = D3D12_COLOR_WRITE_ENABLE_ALL;
+		pd.SampleMask = UINT_MAX;
+		pd.RasterizerState.FillMode = D3D12_FILL_MODE_SOLID;
+		pd.RasterizerState.CullMode = D3D12_CULL_MODE_NONE;
+		pd.RasterizerState.DepthClipEnable = TRUE;
+		pd.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+		pd.NumRenderTargets = 1;
+		// Use the swap-chain format the strip pipeline uses (ck_strip_target_format
+		// equivalent — set via set_output_format → blit_output_format).
+		pd.RTVFormats[0] = ldp->blit_output_format != DXGI_FORMAT_UNKNOWN
+		                       ? ldp->blit_output_format
+		                       : DXGI_FORMAT_R8G8B8A8_UNORM;
+		pd.SampleDesc.Count = 1;
+		HRESULT hr = ldp->device->CreateGraphicsPipelineState(
+		    &pd, __uuidof(ID3D12PipelineState),
+		    reinterpret_cast<void **>(&ldp->alpha_gate_pso));
+		vs_blob->Release();
+		ps_blob->Release();
+		if (FAILED(hr)) {
+			U_LOG_E("Leia D3D12 DP: alpha-gate PSO create failed: 0x%08x", (unsigned)hr);
+			return false;
+		}
+	}
+	if (ldp->alpha_gate_srv_heap == nullptr) {
+		D3D12_DESCRIPTOR_HEAP_DESC hd = {};
+		hd.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+		hd.NumDescriptors = 2;
+		hd.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		HRESULT hr = ldp->device->CreateDescriptorHeap(
+		    &hd, __uuidof(ID3D12DescriptorHeap),
+		    reinterpret_cast<void **>(&ldp->alpha_gate_srv_heap));
+		if (FAILED(hr)) {
+			U_LOG_E("Leia D3D12 DP: alpha-gate SRV heap create failed: 0x%08x", (unsigned)hr);
+			return false;
+		}
+	}
+
+	U_LOG_W("Leia D3D12 DP: compose-under-bg + alpha-gate pipelines ready");
 	return true;
 }
 
@@ -937,7 +1050,7 @@ compose_run_pre_weave(struct leia_display_processor_d3d12_impl *ldp,
 	cmd->SetGraphicsRootSignature(ldp->compose_root_sig);
 	ID3D12DescriptorHeap *heaps[] = {ldp->compose_srv_heap};
 	cmd->SetDescriptorHeaps(1, heaps);
-	uint32_t consts[8];
+	uint32_t consts[12];
 	memcpy(&consts[0], &bg_origin[0], sizeof(float));
 	memcpy(&consts[1], &bg_origin[1], sizeof(float));
 	memcpy(&consts[2], &bg_extent[0], sizeof(float));
@@ -946,7 +1059,17 @@ compose_run_pre_weave(struct leia_display_processor_d3d12_impl *ldp,
 	consts[5] = tile_rows;
 	consts[6] = 0;
 	consts[7] = 0;
-	cmd->SetGraphicsRoot32BitConstants(0, 8, consts, 0);
+	// chroma_rgb (same key as the strip pass). ck_color stays set in compose
+	// mode — see set_chroma_key. Atlas α==0 pixels are emitted as this sentinel
+	// so the post-weave strip can rewrite them to α=0 → live desktop via DWM.
+	float chroma_r = ((ldp->ck_color >>  0) & 0xFF) / 255.0f;
+	float chroma_g = ((ldp->ck_color >>  8) & 0xFF) / 255.0f;
+	float chroma_b = ((ldp->ck_color >> 16) & 0xFF) / 255.0f;
+	memcpy(&consts[8],  &chroma_r, sizeof(float));
+	memcpy(&consts[9],  &chroma_g, sizeof(float));
+	memcpy(&consts[10], &chroma_b, sizeof(float));
+	consts[11] = 0;
+	cmd->SetGraphicsRoot32BitConstants(0, 12, consts, 0);
 	cmd->SetGraphicsRootDescriptorTable(
 	    1, ldp->compose_srv_heap->GetGPUDescriptorHandleForHeapStart());
 
@@ -973,15 +1096,114 @@ compose_run_pre_weave(struct leia_display_processor_d3d12_impl *ldp,
 	return ldp->ck_fill_tex;
 }
 
+/*
+ * Post-weave alpha-gate. Transitions back buffer through COPY_SOURCE to
+ * fill ck_strip_tex, then samples (ck_strip_tex, atlas) and writes back to
+ * the back buffer with per-pixel α derived from the "all views α==0" mask.
+ * Replaces ck_run_post_weave_strip when compose-under-bg is the active
+ * transparency path — no chroma keying involved.
+ */
+static void
+alpha_gate_run_post_weave(struct leia_display_processor_d3d12_impl *ldp,
+                          ID3D12GraphicsCommandList *cmd,
+                          ID3D12Resource *back_buffer,
+                          D3D12_CPU_DESCRIPTOR_HANDLE back_buffer_rtv,
+                          ID3D12Resource *atlas_resource,
+                          DXGI_FORMAT atlas_format,
+                          uint32_t bb_w, uint32_t bb_h,
+                          uint32_t tile_columns, uint32_t tile_rows)
+{
+	if (atlas_resource == nullptr || ldp->alpha_gate_pso == nullptr) {
+		return;
+	}
+	if (!ck_ensure_strip_source(ldp, bb_w, bb_h)) {
+		return;
+	}
+
+	// Refresh the alpha-gate SRV heap per-frame: slot 0 = back-buffer copy
+	// (ck_strip_tex), slot 1 = atlas. ck_strip_tex doesn't change, but its
+	// content does; SRV is stable. Atlas SRV must be (re)created since the
+	// resource may change per-frame.
+	D3D12_CPU_DESCRIPTOR_HANDLE cpu_base =
+	    ldp->alpha_gate_srv_heap->GetCPUDescriptorHandleForHeapStart();
+	{
+		D3D12_SHADER_RESOURCE_VIEW_DESC sd = {};
+		sd.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+		sd.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+		sd.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+		sd.Texture2D.MipLevels = 1;
+		ldp->device->CreateShaderResourceView(ldp->ck_strip_tex, &sd, cpu_base);
+	}
+	{
+		D3D12_SHADER_RESOURCE_VIEW_DESC sd = {};
+		sd.Format = atlas_format;
+		sd.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+		sd.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+		sd.Texture2D.MipLevels = 1;
+		D3D12_CPU_DESCRIPTOR_HANDLE atlas_cpu = cpu_base;
+		atlas_cpu.ptr += ldp->cbv_srv_desc_size;
+		ldp->device->CreateShaderResourceView(atlas_resource, &sd, atlas_cpu);
+	}
+
+	// back_buffer RENDER_TARGET → COPY_SOURCE; ck_strip_tex → COPY_DEST.
+	D3D12_RESOURCE_BARRIER barriers[2] = {};
+	barriers[0].Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+	barriers[0].Transition.pResource = back_buffer;
+	barriers[0].Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
+	barriers[0].Transition.StateAfter = D3D12_RESOURCE_STATE_COPY_SOURCE;
+	barriers[0].Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+	barriers[1].Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+	barriers[1].Transition.pResource = ldp->ck_strip_tex;
+	barriers[1].Transition.StateBefore = ldp->ck_strip_state;
+	barriers[1].Transition.StateAfter = D3D12_RESOURCE_STATE_COPY_DEST;
+	barriers[1].Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+	cmd->ResourceBarrier(2, barriers);
+	ldp->ck_strip_state = D3D12_RESOURCE_STATE_COPY_DEST;
+
+	cmd->CopyResource(ldp->ck_strip_tex, back_buffer);
+
+	barriers[0].Transition.StateBefore = D3D12_RESOURCE_STATE_COPY_SOURCE;
+	barriers[0].Transition.StateAfter = D3D12_RESOURCE_STATE_RENDER_TARGET;
+	barriers[1].Transition.StateBefore = D3D12_RESOURCE_STATE_COPY_DEST;
+	barriers[1].Transition.StateAfter = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+	cmd->ResourceBarrier(2, barriers);
+	ldp->ck_strip_state = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+
+	cmd->SetPipelineState(ldp->alpha_gate_pso);
+	cmd->SetGraphicsRootSignature(ldp->compose_root_sig);
+	ID3D12DescriptorHeap *heaps[] = {ldp->alpha_gate_srv_heap};
+	cmd->SetDescriptorHeaps(1, heaps);
+	// Pack tile_count into the first 2 root-constant slots. Remaining 10
+	// slots in compose_root_sig (bg_uv_*, chroma_rgb, etc.) are unused by
+	// the alpha-gate shader — fine.
+	uint32_t consts[12] = {tile_columns, tile_rows};
+	cmd->SetGraphicsRoot32BitConstants(0, 12, consts, 0);
+	cmd->SetGraphicsRootDescriptorTable(
+	    1, ldp->alpha_gate_srv_heap->GetGPUDescriptorHandleForHeapStart());
+
+	D3D12_VIEWPORT vp = {0.0f, 0.0f, (float)bb_w, (float)bb_h, 0.0f, 1.0f};
+	D3D12_RECT scissor = {0, 0, (LONG)bb_w, (LONG)bb_h};
+	cmd->RSSetViewports(1, &vp);
+	cmd->RSSetScissorRects(1, &scissor);
+
+	cmd->OMSetRenderTargets(1, &back_buffer_rtv, FALSE, nullptr);
+	cmd->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+	cmd->IASetVertexBuffers(0, 0, nullptr);
+	cmd->IASetIndexBuffer(nullptr);
+	cmd->DrawInstanced(3, 1, 0, 0);
+}
+
 static void
 compose_release_resources(struct leia_display_processor_d3d12_impl *ldp)
 {
-	if (ldp->compose_srv_heap) { ldp->compose_srv_heap->Release(); ldp->compose_srv_heap = nullptr; }
-	if (ldp->compose_pso)      { ldp->compose_pso->Release();      ldp->compose_pso = nullptr; }
-	if (ldp->compose_root_sig) { ldp->compose_root_sig->Release(); ldp->compose_root_sig = nullptr; }
-	if (ldp->bg_fence)         { ldp->bg_fence->Release();         ldp->bg_fence = nullptr; }
-	if (ldp->bg_shared_tex)    { ldp->bg_shared_tex->Release();    ldp->bg_shared_tex = nullptr; }
-	if (ldp->bg_capture)       { leia_bg_capture_destroy(ldp->bg_capture); ldp->bg_capture = nullptr; }
+	if (ldp->alpha_gate_srv_heap) { ldp->alpha_gate_srv_heap->Release(); ldp->alpha_gate_srv_heap = nullptr; }
+	if (ldp->alpha_gate_pso)      { ldp->alpha_gate_pso->Release();      ldp->alpha_gate_pso = nullptr; }
+	if (ldp->compose_srv_heap)    { ldp->compose_srv_heap->Release();    ldp->compose_srv_heap = nullptr; }
+	if (ldp->compose_pso)         { ldp->compose_pso->Release();         ldp->compose_pso = nullptr; }
+	if (ldp->compose_root_sig)    { ldp->compose_root_sig->Release();    ldp->compose_root_sig = nullptr; }
+	if (ldp->bg_fence)            { ldp->bg_fence->Release();            ldp->bg_fence = nullptr; }
+	if (ldp->bg_shared_tex)       { ldp->bg_shared_tex->Release();       ldp->bg_shared_tex = nullptr; }
+	if (ldp->bg_capture)          { leia_bg_capture_destroy(ldp->bg_capture); ldp->bg_capture = nullptr; }
 	ldp->bg_compose_enabled = false;
 }
 
@@ -1036,7 +1258,8 @@ leia_dp_d3d12_process_atlas(struct xrt_display_processor_d3d12 *xdp,
 		}
 
 		ID3D12GraphicsCommandList *cmd = static_cast<ID3D12GraphicsCommandList *>(d3d12_command_list);
-		ID3D12Resource *atlas_res = static_cast<ID3D12Resource *>(atlas_texture_resource);
+		ID3D12Resource *original_atlas_res = static_cast<ID3D12Resource *>(atlas_texture_resource);
+		ID3D12Resource *atlas_res = original_atlas_res;
 
 		// Compose-under-bg: pre-composite captured desktop under the atlas,
 		// then stretch-blit the opaque result. Replaces the post-weave strip
@@ -1118,19 +1341,28 @@ leia_dp_d3d12_process_atlas(struct xrt_display_processor_d3d12 *xdp,
 		cmd->IASetVertexBuffers(0, 0, nullptr);
 		cmd->DrawInstanced(4, 1, 0, 0);
 
-		// 2D mode has no weaver, but if chroma-key is enabled the legacy
-		// flow (app pre-fills with key RGB on alpha=1 surface) still needs
-		// the strip pass to recover alpha=0 for DWM. The new flow (true
-		// alpha through the blit) works without it; running strip in that
-		// case is a no-op for non-key pixels (RGB=0 doesn't match magenta).
-		// Compose-under-bg path is fully opaque already — strip is unnecessary.
-		if (!compose_should_run(ldp) && ck_should_run(ldp) && target_resource != NULL) {
+		// Post-weave transparency pass:
+		//   - compose path: alpha-gate samples the ORIGINAL atlas (not the
+		//     composed result) to derive the screen-space "all views α==0"
+		//     mask and zeroes alpha on those pixels → DWM blends the LIVE
+		//     desktop (no captured-bg lag, no magenta fringe at silhouettes).
+		//   - chroma-key fallback: legacy strip.
+		if (target_resource != NULL) {
 			D3D12_CPU_DESCRIPTOR_HANDLE bb_rtv;
 			bb_rtv.ptr = static_cast<SIZE_T>(target_rtv_cpu_handle);
-			ck_run_post_weave_strip(
-			    ldp, cmd,
-			    static_cast<ID3D12Resource *>(target_resource),
-			    bb_rtv, target_width, target_height);
+			if (compose_should_run(ldp)) {
+				alpha_gate_run_post_weave(
+				    ldp, cmd,
+				    static_cast<ID3D12Resource *>(target_resource), bb_rtv,
+				    original_atlas_res, static_cast<DXGI_FORMAT>(format),
+				    target_width, target_height,
+				    tile_columns, tile_rows);
+			} else if (ck_should_run(ldp)) {
+				ck_run_post_weave_strip(
+				    ldp, cmd,
+				    static_cast<ID3D12Resource *>(target_resource),
+				    bb_rtv, target_width, target_height);
+			}
 		}
 		return;
 	}
@@ -1151,7 +1383,8 @@ leia_dp_d3d12_process_atlas(struct xrt_display_processor_d3d12 *xdp,
 	//   2. Chroma-key (fallback): replace alpha=0 with key color before
 	//      weaver, strip back to alpha=0 after. Hard edges, used when WGC
 	//      is unavailable.
-	ID3D12Resource *weaver_input = static_cast<ID3D12Resource *>(atlas_texture_resource);
+	ID3D12Resource *original_atlas_3d = static_cast<ID3D12Resource *>(atlas_texture_resource);
+	ID3D12Resource *weaver_input = original_atlas_3d;
 	uint32_t atlas_w = tile_columns * view_width;
 	uint32_t atlas_h = tile_rows * view_height;
 	D3D12_CPU_DESCRIPTOR_HANDLE bb_rtv;
@@ -1177,17 +1410,28 @@ leia_dp_d3d12_process_atlas(struct xrt_display_processor_d3d12 *xdp,
 	// See gotcha at leiasr_d3d12_weave().
 	leiasr_d3d12_weave(ldp->leiasr, d3d12_command_list, vp_x, vp_y, vp_w, vp_h);
 
-	// Post-weave chroma-key strip: convert key-color RGB pixels in the woven
-	// back buffer to alpha=0 with RGB premultiplied for DWM. No-op when
-	// disabled, suppressed entirely when compose-under-bg ran (the back
-	// buffer is already opaque from end-to-end compose pipeline).
-	if (!compose_should_run(ldp) && ck_should_run(ldp) && target_resource != NULL) {
-		D3D12_CPU_DESCRIPTOR_HANDLE bb_rtv_strip;
-		bb_rtv_strip.ptr = static_cast<SIZE_T>(target_rtv_cpu_handle);
-		ck_run_post_weave_strip(
-		    ldp, cmd_3d,
-		    static_cast<ID3D12Resource *>(target_resource),
-		    bb_rtv_strip, target_width, target_height);
+	// Post-weave transparency pass:
+	//   - compose path: alpha-gate samples the ORIGINAL atlas (not the
+	//     composed result) to derive the screen-space "all views α==0" mask
+	//     and zeroes alpha on those pixels — DWM blends the LIVE desktop in
+	//     large flat transparent regions (no lag, no magenta fringe).
+	//   - chroma-key fallback: legacy strip.
+	if (target_resource != NULL) {
+		D3D12_CPU_DESCRIPTOR_HANDLE bb_rtv_post;
+		bb_rtv_post.ptr = static_cast<SIZE_T>(target_rtv_cpu_handle);
+		if (compose_should_run(ldp) && original_atlas_3d != NULL) {
+			alpha_gate_run_post_weave(
+			    ldp, cmd_3d,
+			    static_cast<ID3D12Resource *>(target_resource), bb_rtv_post,
+			    original_atlas_3d, static_cast<DXGI_FORMAT>(format),
+			    target_width, target_height,
+			    tile_columns, tile_rows);
+		} else if (ck_should_run(ldp)) {
+			ck_run_post_weave_strip(
+			    ldp, cmd_3d,
+			    static_cast<ID3D12Resource *>(target_resource),
+			    bb_rtv_post, target_width, target_height);
+		}
 	}
 }
 

--- a/src/xrt/drivers/leia/shaders/alpha_gate.frag
+++ b/src/xrt/drivers/leia/shaders/alpha_gate.frag
@@ -1,0 +1,44 @@
+// Copyright 2026, Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+
+// Post-weave alpha-gate: compose-mode replacement for the chroma-key strip.
+// Samples the woven back-buffer and the original atlas. For each screen pixel
+// at tile-local UV, tests whether EVERY view's atlas has α==0 at the matching
+// tile-local position. Pixels passing the test get (0,0,0,0) so DWM blends the
+// live desktop. Others keep the woven RGB at α=1.
+//
+// No chroma keying — captured-bg lag is bypassed in flat transparent regions
+// and silhouettes show the smooth lenticular blend the weaver produced from
+// captured-bg ↔ atlas-content inputs.
+//
+// Screen UV equals tile-local UV when target = (tile_columns × view_w,
+// tile_rows × view_h), the canvas-fills-target case.
+
+#version 450
+
+layout(binding = 0) uniform sampler2D backbuffer;
+layout(binding = 1) uniform sampler2D atlas;
+
+layout(push_constant) uniform PC {
+	uvec2 tile_count;
+	uvec2 pad;
+} pc;
+
+layout(location = 0) in vec2 in_uv;
+layout(location = 0) out vec4 out_color;
+
+void main()
+{
+	bool all_transparent = true;
+	for (uint ty = 0u; ty < pc.tile_count.y; ty++) {
+		for (uint tx = 0u; tx < pc.tile_count.x; tx++) {
+			vec2 uv_at_tile = (vec2(tx, ty) + in_uv) / vec2(pc.tile_count);
+			if (textureLod(atlas, uv_at_tile, 0.0).a > 0.0) {
+				all_transparent = false;
+			}
+		}
+	}
+	vec3 rgb = texture(backbuffer, in_uv).rgb;
+	float m = all_transparent ? 0.0 : 1.0;
+	out_color = vec4(rgb * m, m);   // premultiplied for DWM
+}

--- a/src/xrt/drivers/leia/shaders/compose_under_bg.frag
+++ b/src/xrt/drivers/leia/shaders/compose_under_bg.frag
@@ -20,7 +20,7 @@ layout(binding = 1) uniform sampler2D bg;
 layout(push_constant) uniform PC {
 	vec2  bg_uv_origin;   // window TL on monitor, normalized
 	vec2  bg_uv_extent;   // window size on monitor, normalized
-	uvec2 tile_count;     // (tile_columns, tile_rows)
+	uvec2 tile_count;     // (tile_columns, tile_rows) — unused here but kept for layout symmetry
 	uvec2 pad;
 } pc;
 
@@ -29,6 +29,8 @@ layout(location = 0) out vec4 out_color;
 
 void main()
 {
+	// Plain compose-with-bg. Transparency holes are produced by the
+	// post-weave alpha-gate pass — this shader never emits a chroma sentinel.
 	vec4 a = texture(atlas, in_uv);
 	vec2 tile_local = fract(in_uv * vec2(pc.tile_count));
 	vec2 bg_uv = pc.bg_uv_origin + tile_local * pc.bg_uv_extent;


### PR DESCRIPTION
## Summary

Refines the WGC compose-under-bg path on D3D11 / D3D12 / Vulkan Leia DPs by replacing the post-weave chroma-key strip with a **post-weave alpha-gate** that derives the screen-space "fully transparent in ALL views" mask by re-sampling the atlas. Eliminates the captured-bg drag-lag in flat transparent regions **without** the legacy chroma-key disocclusion fringe at silhouette boundaries.

Builds on #219 (compose-under-bg replacing chroma-key). Same scope: D3D11 / D3D12 / VK Leia DPs; GL still uses chroma-key (blocked on the deferred DComp+WGL bridge).

## The problem this fixes

Pure compose-under-bg samples the captured desktop for every transparent pixel, so the captured texture's ~1-frame lag is visible as a tearing warp during window-drag — most severe in apps with a small opaque object on a large transparent background.

An iteration on this branch tried a hybrid: emit a chroma sentinel for atlas α==0, post-weave strip it back to α=0 so DWM blends the live desktop. That fixed the lag in flat regions but re-introduced the legacy chroma-key disocclusion fringe at silhouettes — the SR weaver mixes the sentinel with opaque content across view boundaries, and the exact-RGB strip can't catch the in-between values, leaving a magenta tint at every silhouette.

## The fix

No chroma sentinel ever enters the weaver. The compose shader emits the plain `lerp(captured_bg, atlas.rgb, atlas.a)` always. A new post-weave **alpha-gate** pass runs after the weaver:

```glsl
// for each screen pixel at tile-local UV:
bool all_transparent = true;
for each tile (tx, ty):
    uv_at_tile = (vec2(tx, ty) + screen_uv) / vec2(tile_count);
    if (atlas.SampleLevel(uv_at_tile).a > 0) all_transparent = false;
return all_transparent ? vec4(0,0,0,0) : vec4(woven_rgb, 1.0);
```

Per-pixel outcomes:

| Screen-pos pixel | Mask | DWM blend |
|---|---|---|
| Flat α==0 regions | 0 | **Live desktop** (no lag) |
| Cube interior | 1 | Opaque atlas content |
| Silhouette band (one view opaque) | 1 | Weaver's smooth captured-bg ↔ atlas blend (no exact-match fringe — no sentinel was ever in the weaver) |

Captured-bg is still used by the compose pass for the AA-edge / semi-transparent band, where the ~1-frame lag is imperceptible across a thin band of pixels.

## Implementation

- **`compose_under_bg.frag` / `compose_under_bg_ps_source`**: stripped of the chroma branch and push-constant/CB chroma_rgb member.
- **`alpha_gate.frag` (new GLSL)** + **`alpha_gate_ps_source` (inline HLSL ×2)**: the all-views-α==0 mask + premultiplied alpha output.
- **D3D11 / D3D12 / VK**: new alpha-gate pipeline alongside the existing compose pipeline. Reuses each DP's legacy strip plumbing (back-buffer copy texture, per-target framebuffer cache) since the input shape is identical.
- **D3D12 first-frame fix**: `ck_srv_heap_strip` must also be created in `compose_init_pipeline` (`ck_ensure_strip_source` writes it). Same shape of fix as the earlier `ck_rtv_heap_fill` null-deref from #219.

Chroma-key path is retained as the fallback for WGC-unavailable sessions. Default key `0x00FF00FF` stays for cross-API parity but is no longer used by the compose-under-bg pipeline.

## Verification

Tested on Windows 11 / Leia SR hardware with `DISPLAYXR_TRANSPARENT_BG=1` on all three cube tests:

- `cube_handle_d3d11_win`: ✓
- `cube_handle_d3d12_win`: ✓ (caught and fixed the `ck_srv_heap_strip` null-deref during iteration)
- `cube_handle_vk_win`: ✓

For each:
- Drag a window underneath the transparent cube → live desktop visible in real time, no warp lag.
- No magenta anywhere — silhouettes are smooth.
- Cube interior opaque, parallax preserved.

## Test plan

- [x] Local D3D11 visual verification
- [x] Local D3D12 visual verification (incl. null-deref fix iteration)
- [x] Local VK visual verification
- [ ] CI (`build-windows.yml`) green
- [ ] CI (`build-macos.yml`) green — Vulkan path is `#ifdef _WIN32`-guarded; Linux/macOS should build unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)