### PR TITLE
leia: advertise XR_ENVIRONMENT_BLEND_MODE_ALPHA_BLEND

### DIFF
--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -12387,9 +12387,15 @@ comp_d3d11_service_create_system(struct xrt_device *xdev,
 		sys->base.info.views[i].max.height_pixels = per_view_h * 2;
 	}
 
-	// Set supported blend modes (Chrome WebXR requires at least OPAQUE)
+	// Set supported blend modes. Chrome WebXR requires at least OPAQUE.
+	// ALPHA_BLEND is also advertised because the service compositor honours
+	// XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT per projection
+	// layer (see the per-tile blend-mode selection guarded by ws_snapshot
+	// elsewhere in this file), so workspace apps can opt into transparency
+	// without any extension chain.
 	sys->base.info.supported_blend_modes[0] = XRT_BLEND_MODE_OPAQUE;
-	sys->base.info.supported_blend_mode_count = 1;
+	sys->base.info.supported_blend_modes[1] = XRT_BLEND_MODE_ALPHA_BLEND;
+	sys->base.info.supported_blend_mode_count = 2;
 
 	// Populate display info for XR_EXT_display_info
 	// (display_width_m and display_height_m are already set above from the temporary display processor query)

--- a/src/xrt/drivers/leia/leia_device.c
+++ b/src/xrt/drivers/leia/leia_device.c
@@ -255,6 +255,17 @@ leia_hmd_create(void)
 		return NULL;
 	}
 
+	// Advertise ALPHA_BLEND alongside the default OPAQUE that the device
+	// helper installed. The Leia DPs deliver alpha-correct output two ways:
+	//   - Standalone (XR_EXT_win32_window_binding + transparentBackgroundEnabled):
+	//     WGC compose-under-bg + post-weave alpha-gate on D3D11/D3D12/VK.
+	//   - Workspace (IPC): service compositor honours
+	//     XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT per layer.
+	// Advertising ALPHA_BLEND lets well-behaved apps discover transparency
+	// support via the standard xrEnumerateEnvironmentBlendModes path instead
+	// of relying on extension detection alone.
+	hmd->base.hmd->blend_modes[hmd->base.hmd->blend_mode_count++] = XRT_BLEND_MODE_ALPHA_BLEND;
+
 	// No distortion for Leia display.
 	u_distortion_mesh_set_none(&hmd->base);
 


### PR DESCRIPTION
## Summary

The Leia HMD device and the D3D11 service compositor were each advertising `XRT_BLEND_MODE_OPAQUE` only. Now that the runtime actually delivers alpha-correct output along two paths, advertise `ALPHA_BLEND` so apps can discover transparency support through the standard `xrEnumerateEnvironmentBlendModes` path instead of relying on extension detection.

## The two alpha-correct paths

1. **Standalone**: `XR_EXT_win32_window_binding` with `transparentBackgroundEnabled=XR_TRUE`. The D3D11/D3D12/VK Leia DPs run WGC compose-under-bg + post-weave alpha-gate (#220).
2. **Workspace / IPC**: service compositor honours per-projection-layer `XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT` and `UNPREMULTIPLIED_ALPHA_BIT` when stacking client atlases. No HWND binding required.

## What this PR changes

- `src/xrt/drivers/leia/leia_device.c`: after `u_device_setup_split_side_by_side` installs the OPAQUE default, append `XRT_BLEND_MODE_ALPHA_BLEND` to `hmd->blend_modes`.
- `src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp`: advertise both modes in `sys->base.info.supported_blend_modes`.

## Failure mode

Apps that opt for ALPHA_BLEND but don't set up a transparency-capable session (no HWND binding, no workspace) get opaque output — the runtime falls through gracefully. This matches the behaviour `sim_display` has shipped since day one (it also advertises both modes).

## Test plan

- [x] Local Windows build (\`scripts\build_windows.bat build\`) — green.
- [x] Cube smoke test under transparency confirms no regression on the existing path.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)