### PR TITLE
test_apps: submit ALPHA_BLEND at xrEndFrame in transparent mode

### DIFF
--- a/test_apps/common/xr_session_common.cpp
+++ b/test_apps/common/xr_session_common.cpp
@@ -10,9 +10,52 @@
 #include "logging.h"
 #include <cstring>
 #include <cmath>
+#include <cstdlib>
 // #include <chrono>  // [Commented out — was only used for convergence plane logging throttle]
 
 using namespace DirectX;
+
+// Pick the environment blend mode to submit at xrEndFrame.
+//
+// DisplayXR advertises both OPAQUE and ALPHA_BLEND through
+// xrEnumerateEnvironmentBlendModes when the runtime can deliver alpha-correct
+// output (standalone via XR_EXT_win32_window_binding.transparentBackgroundEnabled
+// on D3D11/D3D12/VK, or workspace via the projection-layer source-alpha bit).
+// Apps that want their alpha honored should submit ALPHA_BLEND; apps that
+// don't (or runtimes that only advertise OPAQUE) get OPAQUE.
+//
+// Lazy: enumerates once on first call, caches on the session-manager struct.
+static XrEnvironmentBlendMode SelectEnvBlendMode(XrSessionManager& xr) {
+    static const bool transparency_wanted = []() {
+        const char *e = getenv("DISPLAYXR_TRANSPARENT_BG");
+        return e != nullptr && *e != '\0' && *e != '0';
+    }();
+    if (!transparency_wanted) {
+        return XR_ENVIRONMENT_BLEND_MODE_OPAQUE;
+    }
+    if (xr.envBlendModeCount == 0 && xr.instance != XR_NULL_HANDLE && xr.systemId != XR_NULL_SYSTEM_ID) {
+        uint32_t count = 0;
+        XrResult r = xrEnumerateEnvironmentBlendModes(
+            xr.instance, xr.systemId, xr.viewConfigType,
+            (uint32_t)(sizeof(xr.envBlendModes) / sizeof(xr.envBlendModes[0])),
+            &count, xr.envBlendModes);
+        if (XR_SUCCEEDED(r)) {
+            xr.envBlendModeCount = count;
+            for (uint32_t i = 0; i < count; i++) {
+                if (xr.envBlendModes[i] == XR_ENVIRONMENT_BLEND_MODE_ALPHA_BLEND) {
+                    xr.runtimeSupportsAlphaBlend = true;
+                    LOG_INFO("Runtime advertises XR_ENVIRONMENT_BLEND_MODE_ALPHA_BLEND — submitting it at xrEndFrame");
+                    break;
+                }
+            }
+            if (!xr.runtimeSupportsAlphaBlend) {
+                LOG_WARN("DISPLAYXR_TRANSPARENT_BG=1 but runtime does not advertise ALPHA_BLEND — submitting OPAQUE");
+            }
+        }
+    }
+    return xr.runtimeSupportsAlphaBlend ? XR_ENVIRONMENT_BLEND_MODE_ALPHA_BLEND
+                                        : XR_ENVIRONMENT_BLEND_MODE_OPAQUE;
+}
 
 // Helper macro for XR error checking with logging
 #define XR_CHECK(call) \
@@ -515,7 +558,7 @@ bool EndFrame(XrSessionManager& xr, XrTime displayTime, const XrCompositionLayer
 
     XrFrameEndInfo endInfo = {XR_TYPE_FRAME_END_INFO};
     endInfo.displayTime = displayTime;
-    endInfo.environmentBlendMode = XR_ENVIRONMENT_BLEND_MODE_OPAQUE;
+    endInfo.environmentBlendMode = SelectEnvBlendMode(xr);
     endInfo.layerCount = 1;
     endInfo.layers = layers;
 
@@ -644,7 +687,7 @@ bool EndFrameWithWindowSpaceHud(
 
     XrFrameEndInfo endInfo = {XR_TYPE_FRAME_END_INFO};
     endInfo.displayTime = displayTime;
-    endInfo.environmentBlendMode = XR_ENVIRONMENT_BLEND_MODE_OPAQUE;
+    endInfo.environmentBlendMode = SelectEnvBlendMode(xr);
     endInfo.layerCount = xr.hasHudSwapchain ? 2 : 1;
     endInfo.layers = layers;
 

--- a/test_apps/common/xr_session_common.h
+++ b/test_apps/common/xr_session_common.h
@@ -112,6 +112,14 @@ struct XrSessionManager {
     // Canvas sub-rect (XR_EXT_win32_window_binding / XR_EXT_cocoa_window_binding)
     PFN_xrSetSharedTextureOutputRectEXT pfnSetSharedTextureOutputRectEXT = nullptr;
 
+    // Environment blend modes advertised by the runtime. Populated at session
+    // create time via xrEnumerateEnvironmentBlendModes. Used to pick the
+    // correct mode for xrEndFrame: ALPHA_BLEND when transparent_bg is desired
+    // AND the runtime advertises it; OPAQUE otherwise.
+    uint32_t envBlendModeCount = 0;
+    XrEnvironmentBlendMode envBlendModes[4] = {};
+    bool runtimeSupportsAlphaBlend = false;
+
     // Enumerated rendering mode info
     uint32_t currentModeIndex = 1;  // Default: mode 1 (first 3D mode, matches runtime default)
     uint32_t renderingModeCount = 0;


### PR DESCRIPTION
## Summary

Cleanup PR after #222 advertised `XR_ENVIRONMENT_BLEND_MODE_ALPHA_BLEND`. The cube tests had been opting into transparency via \`XR_EXT_win32_window_binding.transparentBackgroundEnabled\` while still hardcoding \`OPAQUE\` at \`xrEndFrame\` — the extension flag drove the transparency machinery, the blend mode was inert. That worked but was spec-incongruent: app saying OPAQUE at frame end while the runtime delivers alpha-blended output.

Now that the runtime advertises ALPHA_BLEND, submit it at \`xrEndFrame\` instead. Pattern via a single \`SelectEnvBlendMode()\` helper in \`xr_session_common.cpp\`:

- First call lazily enumerates \`xrEnumerateEnvironmentBlendModes\` and caches the result on the \`XrSessionManager\` struct.
- If \`DISPLAYXR_TRANSPARENT_BG=1\` **and** ALPHA_BLEND is advertised → return ALPHA_BLEND.
- Else → return OPAQUE.
- Warn once if transparency was requested but the runtime only advertises OPAQUE (e.g. older runtime).

All three \`cube_handle_d3d11/d3d12/vk_win\` apps share this code via \`xr_session_common\`, so no per-app changes needed.

## Not in scope

Making **ALPHA_BLEND itself** activate transparency in the runtime (currently the win32 extension flag still does that). That'd be a bigger change — the swap-chain transparency choice is at session-create time, before the blend mode is known. Today's behavior: app uses the extension AND submits ALPHA_BLEND; both signals agree, transparency works. A future PR could either always create a transparent swap chain when ALPHA_BLEND is advertised, or add a session-create-time hint.

## Verification

- Local build green.
- D3D11 cube under \`DISPLAYXR_TRANSPARENT_BG=1\`: app log shows \`"Runtime advertises XR_ENVIRONMENT_BLEND_MODE_ALPHA_BLEND — submitting it at xrEndFrame"\`; runtime log shows no \`XR_ERROR_ENVIRONMENT_BLEND_MODE_UNSUPPORTED\`; transparency path active end-to-end.

## Test plan

- [x] Local D3D11 smoke test
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)