### PR TITLE
fix(compositor): preserve dst alpha in layer blend (issue #225)

### DIFF
--- a/src/xrt/compositor/d3d11/comp_d3d11_renderer.cpp
+++ b/src/xrt/compositor/d3d11/comp_d3d11_renderer.cpp
@@ -461,14 +461,23 @@ create_resources(struct comp_d3d11_renderer *r)
 		return XRT_ERROR_D3D;
 	}
 
-	// Create blend states
+	// Create blend states.
+	//
+	// Alpha channel uses INV_SRC_ALPHA (proper Porter-Duff "over") so
+	// dst.a is preserved through layered composition:
+	//   out.a = src.a + dst.a * (1 - src.a)
+	// Using ZERO here would clobber dst.a with src.a, leaving the atlas
+	// alpha at the topmost layer's alpha — which breaks the Leia DP
+	// compose-under-bg pass (it lerps desktop under atlas.a, so a
+	// semi-transparent HUD over opaque content would bleed desktop
+	// through). See issue #225.
 	D3D11_BLEND_DESC blendDesc = {};
 	blendDesc.RenderTarget[0].BlendEnable = TRUE;
 	blendDesc.RenderTarget[0].SrcBlend = D3D11_BLEND_SRC_ALPHA;
 	blendDesc.RenderTarget[0].DestBlend = D3D11_BLEND_INV_SRC_ALPHA;
 	blendDesc.RenderTarget[0].BlendOp = D3D11_BLEND_OP_ADD;
 	blendDesc.RenderTarget[0].SrcBlendAlpha = D3D11_BLEND_ONE;
-	blendDesc.RenderTarget[0].DestBlendAlpha = D3D11_BLEND_ZERO;
+	blendDesc.RenderTarget[0].DestBlendAlpha = D3D11_BLEND_INV_SRC_ALPHA;
 	blendDesc.RenderTarget[0].BlendOpAlpha = D3D11_BLEND_OP_ADD;
 	blendDesc.RenderTarget[0].RenderTargetWriteMask = D3D11_COLOR_WRITE_ENABLE_ALL;
 

--- a/src/xrt/compositor/d3d12/comp_d3d12_renderer.cpp
+++ b/src/xrt/compositor/d3d12/comp_d3d12_renderer.cpp
@@ -705,7 +705,11 @@ comp_d3d12_renderer_create(struct comp_d3d12_compositor *c,
 		return XRT_ERROR_D3D;
 	}
 
-	// Standard alpha blend PSO
+	// Standard alpha blend PSO.
+	//
+	// Alpha channel uses INV_SRC_ALPHA (proper Porter-Duff "over") so
+	// dst.a is preserved through layered composition. See the matching
+	// comment in comp_d3d11_renderer.cpp and issue #225.
 	D3D12_GRAPHICS_PIPELINE_STATE_DESC quad_pso_desc = {};
 	quad_pso_desc.pRootSignature = r->quad_root_signature;
 	quad_pso_desc.VS.pShaderBytecode = quad_vs_blob->GetBufferPointer();
@@ -717,7 +721,7 @@ comp_d3d12_renderer_create(struct comp_d3d12_compositor *c,
 	quad_pso_desc.BlendState.RenderTarget[0].DestBlend = D3D12_BLEND_INV_SRC_ALPHA;
 	quad_pso_desc.BlendState.RenderTarget[0].BlendOp = D3D12_BLEND_OP_ADD;
 	quad_pso_desc.BlendState.RenderTarget[0].SrcBlendAlpha = D3D12_BLEND_ONE;
-	quad_pso_desc.BlendState.RenderTarget[0].DestBlendAlpha = D3D12_BLEND_ZERO;
+	quad_pso_desc.BlendState.RenderTarget[0].DestBlendAlpha = D3D12_BLEND_INV_SRC_ALPHA;
 	quad_pso_desc.BlendState.RenderTarget[0].BlendOpAlpha = D3D12_BLEND_OP_ADD;
 	quad_pso_desc.BlendState.RenderTarget[0].RenderTargetWriteMask = D3D12_COLOR_WRITE_ENABLE_ALL;
 	quad_pso_desc.RasterizerState.FillMode = D3D12_FILL_MODE_SOLID;

--- a/src/xrt/compositor/multi/comp_multi_system.c
+++ b/src/xrt/compositor/multi/comp_multi_system.c
@@ -575,6 +575,11 @@ init_composite_resources(struct multi_compositor *mc, struct vk_bundle *vk, uint
 	    .rasterizationSamples = VK_SAMPLE_COUNT_1_BIT,
 	};
 
+	// Porter-Duff "over" for both color and alpha so dst.a is preserved
+	// through layered composition (see issue #225). The previous
+	// (srcA=ONE_MINUS_SRC_ALPHA, dstA=ONE) was quadratic in src.a and
+	// clobbered opaque destinations when a semi-transparent layer landed
+	// on top — breaking compose-under-bg downstream.
 	VkPipelineColorBlendAttachmentState blend_att = {
 	    .blendEnable = VK_TRUE,
 	    .colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT |
@@ -582,8 +587,8 @@ init_composite_resources(struct multi_compositor *mc, struct vk_bundle *vk, uint
 	    .srcColorBlendFactor = VK_BLEND_FACTOR_SRC_ALPHA,
 	    .dstColorBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA,
 	    .colorBlendOp = VK_BLEND_OP_ADD,
-	    .srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA,
-	    .dstAlphaBlendFactor = VK_BLEND_FACTOR_ONE,
+	    .srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE,
+	    .dstAlphaBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA,
 	    .alphaBlendOp = VK_BLEND_OP_ADD,
 	};
 

--- a/src/xrt/compositor/render/render_gfx.c
+++ b/src/xrt/compositor/render/render_gfx.c
@@ -400,9 +400,19 @@ create_layer_pipeline(struct vk_bundle *vk,
 	    VK_COLOR_COMPONENT_A_BIT;                //
 
 	/*
-	 * We are using VK_BLEND_FACTOR_ONE for the dst alpha write
-	 * to make sure that there is a valid value there, makes
-	 * the debug UI work when inspecting the scratch images.
+	 * Porter-Duff "over" for both color and alpha so dst.a is preserved
+	 * through layered composition:
+	 *   out.a = src.a + dst.a * (1 - src.a)
+	 *
+	 * The previous (srcA=ONE_MINUS_SRC_ALPHA, dstA=ONE) yielded
+	 *   out.a = src.a * (1 - src.a) + dst.a
+	 * which is quadratic in src.a and clobbers opaque destinations when
+	 * a semi-transparent layer lands on top — breaking the Leia DP
+	 * compose-under-bg pass (see issue #225). The original comment
+	 * "use ONE for the dst alpha write to make sure that there is a
+	 * valid value there" is still satisfied by ONE_MINUS_SRC_ALPHA:
+	 * fully-opaque content still yields out.a=1, so the debug UI
+	 * inspecting scratch images still sees sensible alpha.
 	 */
 	const VkPipelineColorBlendAttachmentState blend_attachment_state = {
 	    .blendEnable = VK_TRUE,
@@ -410,8 +420,8 @@ create_layer_pipeline(struct vk_bundle *vk,
 	    .srcColorBlendFactor = src_blend_factor,
 	    .dstColorBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA,
 	    .colorBlendOp = VK_BLEND_OP_ADD,
-	    .srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA,
-	    .dstAlphaBlendFactor = VK_BLEND_FACTOR_ONE,
+	    .srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE,
+	    .dstAlphaBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA,
 	    .alphaBlendOp = VK_BLEND_OP_ADD,
 	};
 


### PR DESCRIPTION
## Summary

Fixes #225. The layer-composition blend states in all four compositor paths wrote the topmost layer's `src.a` directly into the atlas instead of properly accumulating Porter-Duff "over". When a semi-transparent window-space HUD landed on top of opaque projection content, the atlas alpha ended up at the HUD's alpha (~0.5) — and the Leia DP compose-under-bg pass then lerped the captured desktop in where the projection was opaque, making the desktop visually bleed through the HUD over opaque content.

Two flavors of the same Porter-Duff defect:

| Path | Was | Was effectively |
|---|---|---|
| D3D11 / D3D12 native | `SrcA=ONE, DstA=ZERO` | `out.a = src.a` (clobbers dst) |
| multi compositor (IPC / shell) + Vulkan `render_gfx` | `SrcA=1-α, DstA=ONE` | `out.a = a·(1-a) + dst.a` (quadratic, also clobbers) |

All four fixed to standard Porter-Duff "over":
```
SrcA=ONE, DstA=ONE_MINUS_SRC_ALPHA  →  out.a = src.a + dst.a·(1-src.a)
```

The original `render_gfx.c` comment "use ONE for the dst alpha write to make sure that there is a valid value there [for debug UI]" is still satisfied — fully-opaque content still yields `out.a=1`, so scratch-image inspection sees sensible alpha.

## Test plan

Validated locally on a Leia SR display before pushing:

- [x] `cube_handle_d3d11_win` — `DISPLAYXR_TRANSPARENT_BG=1`, transparent regions composite correctly against desktop
- [x] `cube_handle_d3d12_win` — same
- [x] `cube_handle_vk_win` — same (exercises `render_gfx.c` fix)
- [x] DisplayXR Shell with apps — exercises the multi compositor fix
- [x] Unity transparent test (`displayxr-unity-test-transparent`, Shift+Tab HUD over the tiger) — projection content now visible through the semi-transparent panel instead of captured-desktop bleed (this is the #225 repro)

🤖 Generated with [Claude Code](https://claude.com/claude-code)