### PR TITLE
installer: fix CI-built installer missing files + PATH cleanup regressions

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -135,6 +135,19 @@ jobs:
       - if: needs.DetectChanges.outputs.docs_only != 'true'
         uses: ilammy/msvc-dev-cmd@v1
 
+      - name: Install OpenXR loader
+        if: needs.DetectChanges.outputs.docs_only != 'true'
+        run: |
+          # displayxr-webxr-bridge is an OpenXR client and links the loader.
+          # src/xrt/targets/webxr_bridge/CMakeLists.txt early-returns if the
+          # loader can't be found via find_package or OpenXR_ROOT — which
+          # drops both the bridge and the install(FILES openxr_loader.dll)
+          # rule from the build, leaving the installer without those files.
+          $openxrVersion = "1.1.38"
+          $openxrUrl = "https://github.com/KhronosGroup/OpenXR-SDK-Source/releases/download/release-$openxrVersion/openxr_loader_windows-$openxrVersion.zip"
+          Invoke-WebRequest -Uri $openxrUrl -OutFile openxr_loader.zip
+          Expand-Archive -Path openxr_loader.zip -DestinationPath openxr_sdk -Force
+
       - name: Generate
         if: needs.DetectChanges.outputs.docs_only != 'true'
         env:
@@ -149,6 +162,7 @@ jobs:
             -DXRT_BUILD_INSTALLER=ON `
             -DXRT_FEATURE_SERVICE=ON `
             -DXRT_FEATURE_HYBRID_MODE=ON `
+            -DOpenXR_ROOT="${{ github.workspace }}/openxr_sdk" `
             -DBUILD_NUM="${{ github.run_number }}"
 
       - name: Build

--- a/cmake/openxr_manifest.in.json
+++ b/cmake/openxr_manifest.in.json
@@ -1,7 +1,7 @@
 {
     "file_format_version": "1.0.0",
     "runtime": {
-        "name": "Monado",
+        "name": "DisplayXR",
         "library_path": "@target_path@"@extra_fields@
     }
 }

--- a/installer/DisplayXRInstaller.nsi
+++ b/installer/DisplayXRInstaller.nsi
@@ -197,93 +197,135 @@ FunctionEnd
 ; PATH manipulation functions
 ; Based on NSIS Wiki and SR Platform installer
 
-; AddToPath - Adds a directory to the system PATH
-; Uses System::Call to read REG_EXPAND_SZ properly (ReadRegStr can fail on
-; REG_EXPAND_SZ values, returning empty and causing PATH to be overwritten).
+; AddToPath — appends a directory to the system PATH if no segment of PATH
+; already names it. Walks segments (split on ';') and compares with
+; case-insensitive StrCmp ignoring a trailing backslash, so it's robust
+; against the casing/trailing-slash variations old installer versions wrote.
+;
+; Replaces an older implementation that used StrStr (case-sensitive
+; substring search) to dedupe, which mismatched whenever earlier installs
+; had written the entry with different casing, accumulating duplicates over
+; time. The previous implementation also used a REG_EXPAND_SZ-safe
+; System::Call read of the registry; that part is preserved here.
+;
 ; Usage: Push "C:\path\to\add"
 ;        Call AddToPath
 Function AddToPath
 	Exch $0  ; Path to add
 	Push $1  ; Current PATH
-	Push $2  ; Temp for search result
-	Push $3  ; Registry handle
-	Push $4  ; Data type / buffer pointer
-	Push $5  ; Data length
+	Push $2  ; Scratch (status / temp char)
+	Push $3  ; Current segment
+	Push $4  ; Target without trailing backslash
+	Push $5  ; Current segment without trailing backslash
+	Push $6  ; Scan index
+	Push $7  ; Temp char / strlen scratch
+	Push $8  ; System::Call buffer pointer
+	Push $9  ; Registry handle
 
-	; Open the Environment registry key
+	SetRegView 64
+
+	; Open the Environment registry key (KEY_READ).
 	; 0x80000002 = HKEY_LOCAL_MACHINE, 0x20019 = KEY_READ
-	System::Call 'Advapi32::RegOpenKeyExW(i 0x80000002, w "SYSTEM\CurrentControlSet\Control\Session Manager\Environment", i 0, i 0x20019, *i .r3) i .r2'
-	StrCmp $2 0 0 reg_failed
+	System::Call 'Advapi32::RegOpenKeyExW(i 0x80000002, w "SYSTEM\CurrentControlSet\Control\Session Manager\Environment", i 0, i 0x20019, *i .r9) i .r2'
+	StrCmp $2 0 0 atp_reg_fallback
 
-	; Query the size of the Path value first (pass null buffer to get size)
-	System::Call 'Advapi32::RegQueryValueExW(i r3, w "Path", i 0, i 0, i 0, *i .r5) i .r2'
-	StrCmp $2 0 0 reg_close_failed
+	System::Call 'Advapi32::RegQueryValueExW(i r9, w "Path", i 0, i 0, i 0, *i .r6) i .r2'
+	StrCmp $2 0 0 atp_reg_close_fallback
 
-	; Allocate buffer and read the value
-	System::Alloc $5
-	Pop $4  ; $4 = buffer pointer
-	System::Call 'Advapi32::RegQueryValueExW(i r3, w "Path", i 0, i 0, i r4, *i r5) i .r2'
-	StrCmp $2 0 0 reg_free_failed
+	System::Alloc $6
+	Pop $8
+	System::Call 'Advapi32::RegQueryValueExW(i r9, w "Path", i 0, i 0, i r8, *i r6) i .r2'
+	StrCmp $2 0 0 atp_reg_free_fallback
 
-	; Copy the buffer contents to $1 as a string
-	System::Call '*$4(&w${NSIS_MAX_STRLEN} .r1)'
+	System::Call '*$8(&w${NSIS_MAX_STRLEN} .r1)'
+	System::Free $8
+	System::Call 'Advapi32::RegCloseKey(i r9)'
+	Goto atp_got_path
 
-	; Free buffer and close key
-	System::Free $4
-	System::Call 'Advapi32::RegCloseKey(i r3)'
-
-	Goto got_path
-
-reg_free_failed:
-	System::Free $4
-reg_close_failed:
-	System::Call 'Advapi32::RegCloseKey(i r3)'
-reg_failed:
-	; Fall back to ReadRegStr if the System::Call approach fails
+atp_reg_free_fallback:
+	System::Free $8
+atp_reg_close_fallback:
+	System::Call 'Advapi32::RegCloseKey(i r9)'
+atp_reg_fallback:
 	ReadRegStr $1 HKLM "SYSTEM\CurrentControlSet\Control\Session Manager\Environment" "Path"
 
-got_path:
-	; Check if PATH is empty - if so, this is suspicious on a normal Windows system.
-	; Read from the expanded environment as a safety fallback to avoid wiping PATH.
-	StrCmp $1 "" try_expanded
-
-	Goto check_exists
-
-try_expanded:
-	; Last resort: read the current PATH from the process environment
-	; This won't have unexpanded %vars% but is better than losing PATH entirely
+atp_got_path:
+	; Defensive fallback: if PATH read returned empty (a real environment
+	; never has an empty PATH), try the process env so we don't overwrite
+	; PATH with just our entry. If that's also empty, treat as fresh-system
+	; and just write our path.
+	StrCmp $1 "" atp_try_expanded atp_normalize_target
+atp_try_expanded:
 	ReadEnvStr $1 PATH
-	StrCmp $1 "" empty_path
+	StrCmp $1 "" atp_empty_path atp_normalize_target
 
-check_exists:
-	; Check if path already exists in PATH (avoid duplicates)
-	; Extra Push $0: StrStr returns via Exch $0 which clobbers $0 and
-	; consumes one stack item below the args. This extra push provides
-	; the item for Exch $0 to restore $0 to path_to_add.
-	Push $0
-	Push $1
-	Push $0
-	Call StrStr
-	Pop $2
-	StrCmp $2 "" 0 already_exists
+atp_normalize_target:
+	; Strip a single trailing backslash from the target so we don't add
+	; "C:\foo" when PATH already has "C:\foo\" (or vice versa).
+	StrCpy $4 $0
+	StrLen $7 $4
+	IntOp $7 $7 - 1
+	StrCpy $6 $4 1 $7
+	StrCmp $6 "\" 0 +2
+		StrCpy $4 $4 $7
 
-	; Append to existing PATH
+	StrCmp $4 "" atp_done  ; refuse to append an empty target
+
+	; Walk PATH segments — if any matches the target (case-insensitive,
+	; ignoring trailing backslash), do not append.
+	StrCpy $2 $1  ; $2 = remaining unscanned PATH
+
+atp_loop:
+	StrCmp $2 "" atp_append  ; ran out of segments, no match — append
+	StrCpy $6 0
+	StrCpy $3 ""
+atp_find_semi:
+	StrCpy $7 $2 1 $6
+	StrCmp $7 "" atp_seg_end
+	StrCmp $7 ";" atp_seg_end
+	IntOp $6 $6 + 1
+	Goto atp_find_semi
+atp_seg_end:
+	StrCpy $3 $2 $6
+	IntOp $6 $6 + 1
+	StrCpy $2 $2 "" $6
+	StrCmp $3 "" atp_loop  ; skip empty segments
+
+	; Strip trailing backslash from the segment for comparison
+	StrCpy $5 $3
+	StrLen $7 $5
+	IntOp $7 $7 - 1
+	StrCpy $6 $5 1 $7
+	StrCmp $6 "\" 0 +2
+		StrCpy $5 $5 $7
+
+	StrCmp $5 $4 atp_already_present  ; case-insensitive
+	Goto atp_loop
+
+atp_already_present:
+	DetailPrint "Path already exists in system PATH, skipping"
+	Goto atp_done
+
+atp_empty_path:
+	; Truly empty PATH on a fresh system — write just our entry.
+	StrCpy $1 ""
+
+atp_append:
+	StrCmp $1 "" 0 +3
+		StrCpy $0 "$0"
+		Goto atp_write
 	StrCpy $0 "$1;$0"
-	Goto write_path
-
-empty_path:
-	; PATH is truly empty (fresh system?), just use our path (already in $0)
-
-write_path:
-	; Write new PATH
+atp_write:
 	WriteRegExpandStr HKLM "SYSTEM\CurrentControlSet\Control\Session Manager\Environment" "Path" "$0"
 	DetailPrint "Added to system PATH"
-	Goto done
 
-already_exists:
-	DetailPrint "Path already exists in system PATH, skipping"
-
-done:
+atp_done:
+	SendMessage ${HWND_BROADCAST} ${WM_SETTINGCHANGE} 0 "STR:Environment" /TIMEOUT=5000
+	SetRegView 32
+	Pop $9
+	Pop $8
+	Pop $7
+	Pop $6
 	Pop $5
 	Pop $4
 	Pop $3
@@ -292,124 +334,125 @@ done:
 	Pop $0
 FunctionEnd
 
-; RemoveFromPath - Removes a directory from the system PATH
-; Uses System::Call to read REG_EXPAND_SZ properly (ReadRegStr can fail on
-; REG_EXPAND_SZ values, returning empty and causing PATH to be overwritten).
-; Handles multiple occurrences, trailing backslashes, and case variations
-; Usage: Push "C:\path\to\remove" 
+; un.RemoveFromPath — removes every segment of the system PATH that matches
+; the target directory. Case-insensitive (NSIS StrCmp is case-insensitive by
+; default), trailing-backslash-tolerant, REG_EXPAND_SZ-safe. Replaces the
+; older implementation which called a broken un.StrLower helper that mangled
+; the normalized-target string via a misused CharLowerW system call.
+;
+; Usage: Push "C:\path\to\remove"
 ;        Call un.RemoveFromPath
-; RemoveFromPath - Removes a directory from the system PATH
-; Handles 64-bit registry, Unicode characters, and case-insensitive matching.
-; RemoveFromPath - Removes a directory from the system PATH
-; Handles 64-bit registry, Unicode characters, and case-insensitive matching.
 Function un.RemoveFromPath
   Exch $0 ; Target path
-  Push $1 ; Full PATH 
-  Push $2 ; Rebuilt PATH 
-  Push $3 ; Current Segment 
-  Push $4 ; Normalized Target 
-  Push $5 ; Normalized Segment 
-  Push $6 ; Loop Index 
-  Push $7 ; Temp Char 
-  Push $8 ; Log Handle (Unused but kept for stack balance)
+  Push $1 ; Full PATH
+  Push $2 ; Rebuilt PATH
+  Push $3 ; Current Segment
+  Push $4 ; Target without trailing backslash
+  Push $5 ; Current Segment without trailing backslash
+  Push $6 ; Scan index
+  Push $7 ; Temp char / strlen scratch
+  Push $8 ; System::Call buffer pointer
+  Push $9 ; Registry handle
 
   SetRegView 64
-  
-  ; Logging disabled for production
-  ; StrCpy $8 "$TEMP\RemoveFromPath.log"
-  ; FileOpen $8 $8 "w"
-  ; FileWrite $8 "=== RemoveFromPath started ===$\r$\n"
-  ; FileWrite $8 "Target to remove: '$0'$\r$\n"
 
-  ; 1. Read Registry
+  ; --- Read PATH via System::Call (REG_EXPAND_SZ-safe; mirrors AddToPath).
+  ; Plain ReadRegStr can return empty on REG_EXPAND_SZ values and truncates
+  ; PATHs longer than NSIS_MAX_STRLEN. Both leave $1 empty, the loop below
+  ; produces an empty rebuilt $2, and the safety guard then skips the write
+  ; so dupes accumulate forever. We do still fall back to ReadRegStr if the
+  ; System::Call path errors out, with the same safety guard catching the
+  ; truncated-string case.
+  ; 0x80000002 = HKEY_LOCAL_MACHINE, 0x20019 = KEY_READ
+  System::Call 'Advapi32::RegOpenKeyExW(i 0x80000002, w "SYSTEM\CurrentControlSet\Control\Session Manager\Environment", i 0, i 0x20019, *i .r9) i .r2'
+  StrCmp $2 0 0 rfp_reg_fallback
+
+  System::Call 'Advapi32::RegQueryValueExW(i r9, w "Path", i 0, i 0, i 0, *i .r6) i .r2'
+  StrCmp $2 0 0 rfp_reg_close_fallback
+
+  System::Alloc $6
+  Pop $8
+  System::Call 'Advapi32::RegQueryValueExW(i r9, w "Path", i 0, i 0, i r8, *i r6) i .r2'
+  StrCmp $2 0 0 rfp_reg_free_fallback
+
+  System::Call '*$8(&w${NSIS_MAX_STRLEN} .r1)'
+  System::Free $8
+  System::Call 'Advapi32::RegCloseKey(i r9)'
+  Goto rfp_got_path
+
+rfp_reg_free_fallback:
+  System::Free $8
+rfp_reg_close_fallback:
+  System::Call 'Advapi32::RegCloseKey(i r9)'
+rfp_reg_fallback:
   ReadRegStr $1 HKLM "SYSTEM\CurrentControlSet\Control\Session Manager\Environment" "Path"
-  ; FileWrite $8 "FULL REGISTRY PATH: '$1'$\r$\n"
 
-  ; 2. Normalize Target
+rfp_got_path:
+
+  ; Strip a single trailing backslash from the target so "C:\foo" matches
+  ; "C:\foo\" segments. StrCmp below is case-insensitive in NSIS — no
+  ; lowercasing required.
   StrCpy $4 $0
   StrLen $7 $4
   IntOp $7 $7 - 1
   StrCpy $6 $4 1 $7
   StrCmp $6 "\" 0 +2
-    StrCpy $4 $4 $7 
-  
-  Push $4
-  Call un.StrLower
-  Pop $4 
-  ; FileWrite $8 "Normalized Target: '$4'$\r$\n"
+    StrCpy $4 $4 $7
 
-  ; SAFETY GUARD: Do not proceed if target is empty!
-  StrCmp $4 "" 0 +2
-    ; FileWrite $8 "ERROR: Normalized target is empty. Aborting to save PATH.$\r$\n"
-    Goto done_cleanup
-
-  StrCpy $2 "" 
+  StrCmp $4 "" done_cleanup
+  StrCpy $2 ""
 
 loop_segments:
   StrCmp $1 "" done_loop
-  StrCpy $6 0 
-  StrCpy $3 "" 
+  StrCpy $6 0
+  StrCpy $3 ""
 
 find_semi:
-  StrCpy $7 $1 1 $6 
-  StrCmp $7 "" segment_found 
-  StrCmp $7 ";" segment_found 
+  StrCpy $7 $1 1 $6
+  StrCmp $7 "" segment_found
+  StrCmp $7 ";" segment_found
   IntOp $6 $6 + 1
   Goto find_semi
 
 segment_found:
-  StrCpy $3 $1 $6 
+  StrCpy $3 $1 $6
   IntOp $6 $6 + 1
-  StrCpy $1 $1 "" $6 
+  StrCpy $1 $1 "" $6
 
-  StrCmp $3 "" loop_segments ; Skip empty segments
+  StrCmp $3 "" loop_segments  ; Skip empty segments
 
-  ; Normalize Segment
+  ; Strip trailing backslash for the case-insensitive comparison
   StrCpy $5 $3
   StrLen $7 $5
   IntOp $7 $7 - 1
   StrCpy $6 $5 1 $7
   StrCmp $6 "\" 0 +2
     StrCpy $5 $5 $7
-  
-  Push $5
-  Call un.StrLower
-  Pop $5
-  
-  ; 3. Compare
-  StrCmp $5 $4 is_match
-    ; Result: NO MATCH - KEEPING
-    StrCmp $2 "" 0 +3
-      StrCpy $2 "$3" 
-      Goto loop_segments
-    StrCpy $2 "$2;$3" 
+
+  StrCmp $5 $4 is_match  ; case-insensitive
+
+  ; Keep
+  StrCmp $2 "" 0 +3
+    StrCpy $2 "$3"
     Goto loop_segments
+  StrCpy $2 "$2;$3"
+  Goto loop_segments
 
 is_match:
-  ; FileWrite $8 "MATCHED AND REMOVED: '$3'$\r$\n"
-  Goto loop_segments ; Go back to loop!
+  Goto loop_segments  ; Drop
 
 done_loop:
-  ; FileWrite $8 "FINAL REBUILT PATH: '$2'$\r$\n"
-
-  ; 4. Final Safety Check & Write
+  ; Re-read original PATH and only write if we actually changed it.
   ReadRegStr $1 HKLM "SYSTEM\CurrentControlSet\Control\Session Manager\Environment" "Path"
-  
-  ; Final sanity check: don't write an empty path if the original wasn't empty
-  StrCmp $2 "" done_write 
-  
-  StrCmp $2 $1 done_write
-    WriteRegExpandStr HKLM "SYSTEM\CurrentControlSet\Control\Session Manager\Environment" "Path" "$2"
-    ; FileWrite $8 "Registry successfully updated.$\r$\n"
-  
-done_write:
-  ; FileWrite $8 "=== RemoveFromPath completed ===$\r$\n"
+  StrCmp $2 "" done_cleanup  ; rebuilt empty — refuse to wipe PATH
+  StrCmp $2 $1 done_cleanup  ; unchanged
+  WriteRegExpandStr HKLM "SYSTEM\CurrentControlSet\Control\Session Manager\Environment" "Path" "$2"
 
 done_cleanup:
-  ; FileClose $8
   SendMessage ${HWND_BROADCAST} ${WM_SETTINGCHANGE} 0 "STR:Environment" /TIMEOUT=5000
   SetRegView 32
 
+  Pop $9
   Pop $8
   Pop $7
   Pop $6
@@ -775,7 +818,11 @@ Section "Uninstall"
 	; Also remove legacy scheduled task if it exists (from older installs)
 	nsExec::ExecToLog 'schtasks /delete /tn "DisplayXR Service" /f'
 
-	; Remove files
+	; Remove files. We name the high-value executables explicitly (so a
+	; failed Delete prints a clear log line), then wildcard-sweep the rest
+	; — including unowned bins that landed via cmake --install (cli, mcp,
+	; gui) that the NSI doesn't directly bundle but which accumulate in
+	; $INSTDIR across versions if we don't sweep them.
 	Delete "$INSTDIR\DisplayXRClient.dll"
 	Delete "$INSTDIR\displayxr-service.exe"
 	Delete "$INSTDIR\displayxr-webxr-bridge.exe"
@@ -783,8 +830,10 @@ Section "Uninstall"
 	Delete "$INSTDIR\DisplayXR_win64.json"
 	Delete "$INSTDIR\install.log"
 
-	; Remove any remaining DLLs
+	; Sweep remaining executables, DLLs, and manifests so RMDir can succeed
+	Delete "$INSTDIR\*.exe"
 	Delete "$INSTDIR\*.dll"
+	Delete "$INSTDIR\*.json"
 
 	; Save uninstall log to temp before removing directory
 	StrCpy $0 "$TEMP\DisplayXR_uninstall.log"

--- a/src/xrt/targets/service/service_orchestrator.c
+++ b/src/xrt/targets/service/service_orchestrator.c
@@ -904,6 +904,12 @@ service_orchestrator_is_workspace_available(void)
 	return s_workspace_available;
 }
 
+void
+service_orchestrator_refresh_workspace_controller(void)
+{
+	detect_workspace_controller(&s_cfg);
+}
+
 const char *
 service_orchestrator_get_workspace_display_name(void)
 {
@@ -1080,6 +1086,11 @@ bool
 service_orchestrator_is_workspace_available(void)
 {
 	return false;
+}
+
+void
+service_orchestrator_refresh_workspace_controller(void)
+{
 }
 
 const char *

--- a/src/xrt/targets/service/service_orchestrator.c
+++ b/src/xrt/targets/service/service_orchestrator.c
@@ -18,6 +18,7 @@
 #include <ws2tcpip.h>
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+#include <tlhelp32.h>
 #include <string.h>
 #include <stdio.h>
 #endif
@@ -379,6 +380,16 @@ spawn_workspace(void)
 	s_workspace_running = true;
 	OW("Launched workspace controller (PID %lu)", (unsigned long)s_workspace_pi.dwProcessId);
 
+	// Grant the freshly-spawned controller the right to call
+	// SetForegroundWindow when it brings its main window up. Without
+	// this Windows can suppress the call (the controller's
+	// CreateProcess parent is us, a background service with no
+	// foreground rights to confer). Matches the AllowSetForegroundWindow
+	// in the Ctrl+Space pass-through path; same Windows rule.
+	if (s_workspace_pi.dwProcessId != 0) {
+		AllowSetForegroundWindow(s_workspace_pi.dwProcessId);
+	}
+
 	// Start watchdog thread
 	if (s_workspace_watch_thread) {
 		CloseHandle(s_workspace_watch_thread);
@@ -656,6 +667,43 @@ orchestrator_wnd_proc_hook(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
 //! Original tray window proc — we subclass it to intercept our custom msg
 static WNDPROC s_original_wnd_proc = NULL;
 
+//! Find the running workspace controller's PID. Prefers the orchestrator-tracked
+//! PID (when launch_child spawned the controller); falls back to enumerating
+//! processes for the controller image name (covers the case where the user
+//! launched the controller directly outside our spawn path).
+//! Returns 0 if no instance found.
+static DWORD
+find_workspace_controller_pid(void)
+{
+	if (s_workspace_running && s_workspace_pi.dwProcessId != 0) {
+		return s_workspace_pi.dwProcessId;
+	}
+	if (!s_workspace_available || s_workspace_active.binary[0] == '\0') {
+		return 0;
+	}
+	const char *image = strrchr(s_workspace_active.binary, '\\');
+	image = image ? image + 1 : s_workspace_active.binary;
+
+	HANDLE snap = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+	if (snap == INVALID_HANDLE_VALUE) {
+		return 0;
+	}
+	PROCESSENTRY32 pe;
+	ZeroMemory(&pe, sizeof(pe));
+	pe.dwSize = sizeof(pe);
+	DWORD found = 0;
+	if (Process32First(snap, &pe)) {
+		do {
+			if (_stricmp(pe.szExeFile, image) == 0) {
+				found = pe.th32ProcessID;
+				break;
+			}
+		} while (Process32Next(snap, &pe));
+	}
+	CloseHandle(snap);
+	return found;
+}
+
 static LRESULT CALLBACK
 orchestrator_kbd_hook_proc(int nCode, WPARAM wParam, LPARAM lParam)
 {
@@ -670,24 +718,50 @@ orchestrator_kbd_hook_proc(int nCode, WPARAM wParam, LPARAM lParam)
 			OW("kbd hook: Space ctrl=%d shift=%d alt=%d win=%d workspace_running=%d",
 			   ctrl, shift, alt, win, (int)s_workspace_running);
 			// Plain Ctrl+Space only, no other modifiers.
-			if (ctrl && !shift && !alt && !win && !s_workspace_running) {
-				// Phase 2.K: a shell launched directly via command line
-				// (rather than through our launch_child path) doesn't
-				// flip s_workspace_running, so the naive check above
-				// would spawn a duplicate. The shell holds a named
-				// singleton mutex `Local\DisplayXR.Shell.Singleton`
-				// for its lifetime — if it exists, an instance is
-				// already running and we should let its RegisterHotKey
-				// handle Ctrl+Space (toggle / deactivate). Pass the
-				// keypress through.
+			if (ctrl && !shift && !alt && !win) {
+				// Check both orchestrator-tracked state and the named
+				// singleton mutex Local\DisplayXR.Shell.Singleton —
+				// the latter covers the case where the controller
+				// was launched directly outside our spawn path
+				// (Phase 2.K).
+				bool singleton_present = false;
 				HANDLE existing = OpenMutexW(SYNCHRONIZE, FALSE,
 				    L"Local\\DisplayXR.Shell.Singleton");
 				if (existing != NULL) {
 					CloseHandle(existing);
-					OW("kbd hook: shell singleton present — passing Ctrl+Space "
-					   "to existing instance");
+					singleton_present = true;
+				}
+
+				if (s_workspace_running || singleton_present) {
+					// Controller already running — let its
+					// RegisterHotKey handler take Ctrl+Space.
+					// We have to call AllowSetForegroundWindow
+					// first or Windows will silently drop the
+					// controller's SetForegroundWindow call
+					// (the controller isn't the foreground
+					// process and didn't just receive the
+					// input event — our hook did), and the
+					// user sees the taskbar entry flash
+					// without the window coming to front.
+					// Our hook owns "received the last input
+					// event", so AllowSetForegroundWindow
+					// succeeds from here.
+					DWORD pid = find_workspace_controller_pid();
+					if (pid != 0) {
+						AllowSetForegroundWindow(pid);
+					} else {
+						// Fall back to ASFW_ANY so even an
+						// orphaned process we couldn't
+						// identify can focus itself.
+						AllowSetForegroundWindow(ASFW_ANY);
+					}
+					OW("kbd hook: controller running (pid=%lu) — "
+					   "passing Ctrl+Space + AllowSetForegroundWindow",
+					   (unsigned long)pid);
 					return CallNextHookEx(s_kbd_hook, nCode, wParam, lParam);
 				}
+
+				// No controller running — spawn one.
 				HWND hwnd = (HWND)service_tray_get_hwnd();
 				if (hwnd) {
 					PostMessageW(hwnd, WM_ORCHESTRATOR_SPAWN_WORKSPACE, 0, 0);

--- a/src/xrt/targets/service/service_orchestrator.c
+++ b/src/xrt/targets/service/service_orchestrator.c
@@ -907,7 +907,20 @@ service_orchestrator_is_workspace_available(void)
 void
 service_orchestrator_refresh_workspace_controller(void)
 {
+	bool was_available = s_workspace_available;
 	detect_workspace_controller(&s_cfg);
+
+	// If availability just flipped (controller installed / uninstalled
+	// while the service was running), re-apply the current workspace
+	// mode so:
+	//   - mode=ENABLE → spawns the controller now that we know it exists
+	//   - mode=AUTO   → installs the Ctrl+Space hotkey
+	//   - mode=DISABLE → terminates any stray controller (no-op if none)
+	// apply_workspace_mode itself early-returns when !s_workspace_available,
+	// so the false→true and true→false transitions are both safe.
+	if (was_available != s_workspace_available) {
+		apply_workspace_mode(s_cfg.workspace);
+	}
 }
 
 const char *

--- a/src/xrt/targets/service/service_orchestrator.h
+++ b/src/xrt/targets/service/service_orchestrator.h
@@ -45,16 +45,27 @@ void
 service_orchestrator_shutdown(void);
 
 /*!
- * Whether a workspace controller binary was found next to the service exe at
- * init time. When false, the tray hides the Workspace submenu and the
- * Ctrl+Space hotkey is a no-op — the runtime is operating as a standalone
- * OpenXR + WebXR platform with no spatial-desktop features.
+ * Whether a workspace controller binary is currently registered. The tray
+ * code calls service_orchestrator_refresh_workspace_controller() before
+ * reading this so installing/uninstalling a controller while the service
+ * is running takes effect on the next menu open — no service restart
+ * required.
  *
- * Detection is one-time at init. Reinstalling a controller while the service
- * is running requires a service restart.
+ * When false, the tray hides the Workspace submenu and the Ctrl+Space
+ * hotkey is a no-op — the runtime is operating as a standalone OpenXR +
+ * WebXR platform with no spatial-desktop features.
  */
 bool
 service_orchestrator_is_workspace_available(void);
+
+/*!
+ * Re-enumerate HKLM\Software\DisplayXR\WorkspaceControllers\* and update
+ * the cached workspace-controller state. Cheap (one registry walk).
+ * Intended to be called by the tray before each menu open so a shell
+ * installed after service startup shows up without a service restart.
+ */
+void
+service_orchestrator_refresh_workspace_controller(void);
 
 /*!
  * Display name for the active workspace controller, suitable for tray UI.

--- a/src/xrt/targets/service/service_tray_win.c
+++ b/src/xrt/targets/service/service_tray_win.c
@@ -187,6 +187,12 @@ show_context_menu(HWND hwnd)
 	POINT pt;
 	GetCursorPos(&pt);
 
+	// Re-enumerate the workspace controller registry so a shell installed
+	// (or uninstalled) after the service started shows up immediately on
+	// the next right-click — no service restart required. One registry
+	// walk per menu open is cheap.
+	service_orchestrator_refresh_workspace_controller();
+
 	// Bridge submenu (radio group: Enable, Auto, Disable)
 	HMENU bridge_sub = CreatePopupMenu();
 	AppendMenuW(bridge_sub, MF_STRING, IDM_BRIDGE_ENABLE, L"Enable");


### PR DESCRIPTION
## Summary

Multiple regressions across the v1.3.1 release installer + the workspace controller integration. Seven fixes on one branch (4 commits):

**Commit 1 — installer regressions (`6b982880c`)**
- **CI**: `Generate` step downloads OpenXR loader SDK + passes `-DOpenXR_ROOT`. The bridge target's `CMakeLists.txt` early-returns when `find_package(OpenXR)` fails, dragging its `install(FILES openxr_loader.dll)` rule out with it — that's why v1.3.1 shipped without `openxr_loader.dll` or `displayxr-webxr-bridge.exe`. Local `scripts\build_windows.bat` already passes `-DOpenXR_ROOT` so local builds were fine.
- **AddToPath**: rewritten to walk PATH segments with case-insensitive `StrCmp` instead of case-sensitive `StrStr` substring search (which mismatched whenever earlier installs wrote the entry with different casing, accumulating duplicates).
- **un.RemoveFromPath**: rewritten to read PATH via `System::Call` (matching `AddToPath`; plain `ReadRegStr` truncates long PATHs and silently fails on `REG_EXPAND_SZ`). Dropped the `un.StrLower` helper — it called `CharLowerW` one ANSI byte at a time with a parameter pattern that returned wide-char garbage in an ANSI NSIS build, but was only ever invoked from `un.RemoveFromPath` so the bug stayed hidden. Now uses NSIS's built-in case-insensitive `StrCmp` directly.
- **Uninstaller Delete list**: added `*.exe` and `*.json` wildcards so leftover `displayxr-cli.exe` / `displayxr-mcp.exe` / `monado-gui.exe` (installed via `cmake --install` but never named in NSI `File` directives) no longer block `RMDir`.
- **Manifest**: `"name": "Monado"` → `"name": "DisplayXR"`.

**Commit 2 — tray workspace controller refresh (`14b2dffe3`)**
- `service_orchestrator` enumerated `HKLM\Software\DisplayXR\WorkspaceControllers\*` only once at service init. Now refreshed before each tray right-click — one registry walk per menu open, cheap.

**Commit 3 — re-apply workspace mode when availability flips (`e183446b8`)**
- The refresh from commit 2 only updated `s_workspace_available` but never re-ran `apply_workspace_mode`. So `mode=AUTO` never installed the Ctrl+Space hotkey, and clicking "Enable" in the tray was a no-op (saved-config workspace mode was already ENABLE → `apply_config` saw old==new and skipped the call). Now refresh also calls `apply_workspace_mode(s_cfg.workspace)` whenever availability flips. Hotkey installs and/or controller spawns immediately on the next menu open after shell registration — no service restart required.

**Commit 4 — AllowSetForegroundWindow so Ctrl+Space focuses reliably (`d1cbf7b6d`)**
- The controller's RegisterHotKey handler calls `SetForegroundWindow` on its main window, but Windows suppresses that call when the controller isn't the foreground process and didn't just receive the input event. The orchestrator's keyboard hook DID receive the input event, so it now calls `AllowSetForegroundWindow(controller_pid)` before passing the keypress through (and immediately after spawning a fresh controller). PID is looked up via a new `find_workspace_controller_pid()` helper that prefers the orchestrator-tracked PID and falls back to a Toolhelp32 process enum matching the controller image name.

## Test plan

Verified locally on a Leia SR dev machine:

- [x] Install ×2 → PATH still has exactly 1 entry (AddToPath dedup)
- [x] Uninstall → PATH empty, install directory fully removed
- [x] Fresh install ships `openxr_loader.dll` + `displayxr-webxr-bridge.exe`
- [x] `vulkan-1.dll` still absent by design (#105)
- [x] Manifest reads `"name": "DisplayXR"`
- [x] HKLM\Software\DisplayXR\Runtime\{InstallPath,Version} written
- [x] HKLM\Software\Khronos\OpenXR\1\ActiveRuntime → manifest path
- [x] Shell install after service running → next right-click shows the Workspace submenu (commit 2)
- [x] After the flip, Ctrl+Space hotkey installs and clicking Enable spawns the controller (commit 3)
- [x] Ctrl+Space consistently brings the controller to front whether freshly spawned or already running (commit 4, user-confirmed)
- [ ] CI build of this branch produces an installer with `openxr_loader.dll` (will verify on PR CI / v1.3.2 release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)