### PR TITLE
workspace: plumb MODAL_OPEN/CLOSE through the OpenXR-surface event drain

### DIFF
--- a/src/external/openxr_includes/openxr/XR_EXT_spatial_workspace.h
+++ b/src/external/openxr_includes/openxr/XR_EXT_spatial_workspace.h
@@ -25,7 +25,7 @@ extern "C" {
 #endif
 
 #define XR_EXT_spatial_workspace 1
-#define XR_EXT_spatial_workspace_SPEC_VERSION 9
+#define XR_EXT_spatial_workspace_SPEC_VERSION 10
 #define XR_EXT_SPATIAL_WORKSPACE_EXTENSION_NAME "XR_EXT_spatial_workspace"
 
 // Provisional XrStructureType values. The 1000999100..105 range is reserved for
@@ -305,6 +305,8 @@ typedef enum XrWorkspaceInputEventTypeEXT {
     XR_WORKSPACE_INPUT_EVENT_FRAME_TICK_EXT     = 5, // spec_version 6
     XR_WORKSPACE_INPUT_EVENT_FOCUS_CHANGED_EXT  = 6, // spec_version 6
     XR_WORKSPACE_INPUT_EVENT_WINDOW_POSE_CHANGED_EXT = 7, // spec_version 8: runtime-driven pose / size change (edge resize, etc.)
+    XR_WORKSPACE_INPUT_EVENT_MODAL_OPEN_EXT      = 8, // spec_version 10: client opened a Win32 modal popup (refcounted, fires on 0→1 only)
+    XR_WORKSPACE_INPUT_EVENT_MODAL_CLOSE_EXT     = 9, // spec_version 10: client's last Win32 modal popup closed (refcounted, fires on 1→0 only)
     XR_WORKSPACE_INPUT_EVENT_TYPE_MAX_ENUM_EXT  = 0x7FFFFFFF
 } XrWorkspaceInputEventTypeEXT;
 
@@ -406,6 +408,13 @@ typedef struct XrWorkspaceInputEventEXT {
             float                   widthMeters;
             float                   heightMeters;
         } windowPoseChanged;
+        struct {  // spec_version 10: Win32 modal popup state. Refcounted
+            // runtime-side across nested popups, so the controller sees
+            // exactly one MODAL_OPEN on 0→1 and one MODAL_CLOSE on 1→0
+            // per logical modal session, regardless of nesting depth.
+            // Companion to ADR-017 (Tier 0 modal-dialog strategy).
+            XrWorkspaceClientId     clientId;
+        } modal;
     };
 } XrWorkspaceInputEventEXT;
 

--- a/src/xrt/ipc/client/ipc_client_compositor.c
+++ b/src/xrt/ipc/client/ipc_client_compositor.c
@@ -585,6 +585,10 @@ comp_ipc_client_compositor_workspace_enumerate_input_events(struct xrt_composito
 			out->windowPoseChanged.widthMeters = src->u.window_pose_changed.width_m;
 			out->windowPoseChanged.heightMeters = src->u.window_pose_changed.height_m;
 			break;
+		case IPC_WORKSPACE_INPUT_EVENT_MODAL_OPEN:
+		case IPC_WORKSPACE_INPUT_EVENT_MODAL_CLOSE:
+			out->modal.clientId = (XrWorkspaceClientId)src->u.modal.client_id;
+			break;
 		default:
 			break;
 		}


### PR DESCRIPTION
Companion to #227 (ADR-017 Tier 0 modal dialogs) and a hard prereq for displayxr-shell-pvt #9.

## Summary

#227 wired the IPC side — `IPC_WORKSPACE_INPUT_EVENT_MODAL_OPEN/CLOSE` (8/9) emit per-slot from the `d3d11_service` compositor on `session_set_modal_state` transitions. But the **OpenXR-surface bridge in `ipc_client_compositor.c` was never updated to match**, so events arrived at workspace controllers with `eventType=8/9` cast straight through and a zeroed payload (translator hit `default`; the destination union member didn't exist).

This PR closes that bridge.

## Changes

- **`src/external/openxr_includes/openxr/XR_EXT_spatial_workspace.h`**
  - `XR_EXT_spatial_workspace_SPEC_VERSION` 9 → 10
  - Add `XR_WORKSPACE_INPUT_EVENT_MODAL_OPEN_EXT = 8` / `_CLOSE_EXT = 9` to `XrWorkspaceInputEventTypeEXT`
  - Add a `modal { XrWorkspaceClientId clientId }` union member to `XrWorkspaceInputEventEXT`
- **`src/xrt/ipc/client/ipc_client_compositor.c`** — add the two cases that copy `src->u.modal.client_id` → `out->modal.clientId`

## Out of scope

- The shell-side response (drop topmost, 2D-mode flip, dim glow, suspend raycast). That's `displayxr-shell-pvt#9`, which lands after this PR + the `publish-extensions.yml` auto-sync to `displayxr-extensions`.
- No new emission path — the IPC events already exist and have a one-shot Windows test in #227.

## Test plan

- [x] Local Windows build clean (`scripts\build_windows.bat build`)
- [ ] CI green (this PR)
- [ ] `publish-extensions.yml` syncs the updated header to `DisplayXR/displayxr-extensions` on merge to `main`
- [ ] Functional verification happens via `displayxr-shell-pvt#9` (gauss demo `L`-key smoke per ADR-017 §"Verification")

🤖 Generated with [Claude Code](https://claude.com/claude-code)