### PR TITLE
workspace: runtime-side response to Win32 modal dialogs (#232)

### DIFF
--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -4129,8 +4129,16 @@ multi_compositor_update_input_forward(struct d3d11_multi_compositor *mc)
 	HWND target = NULL;
 	int32_t rx = 0, ry = 0, rw = 0, rh = 0;
 	bool is_capture = false;
+	// Gate on modal_open (ADR-017, #232): while the focused client has a
+	// Win32 modal popup, suppress click forwarding to its (hidden) app
+	// HWND. Without this, the user clicking the dimmed app's content in
+	// the workspace view forwards LMB-down to the app HWND, which shifts
+	// the app's child-window focus and breaks the modal's modal-disable.
+	// Target stays NULL → comp_d3d11_window's WndProc forwards nothing for
+	// this frame, which is the right behavior while a modal is up.
 	if (mc->focused_slot >= 0 && mc->focused_slot < D3D11_MULTI_MAX_CLIENTS &&
-	    mc->clients[mc->focused_slot].active) {
+	    mc->clients[mc->focused_slot].active &&
+	    !mc->clients[mc->focused_slot].modal_open) {
 		target = mc->clients[mc->focused_slot].app_hwnd;
 		rx = (int32_t)mc->clients[mc->focused_slot].window_rect_x;
 		ry = (int32_t)mc->clients[mc->focused_slot].window_rect_y;
@@ -6956,8 +6964,14 @@ after_key_shortcuts:
 					// sub-control. When focus DID change we send DOWN only — the
 					// natural WndProc-forwarded UP arrives when the user releases
 					// LMB, which completes the drag.
+					//
+					// Modal gate (ADR-017, #232): skip when the hit slot has a Win32
+					// modal popup open. Forwarding the synthetic click to a sub-
+					// control would shift the app's focus out of the modal-disabled
+					// chain.
 					if (mc->clients[hit_slot].client_type == CLIENT_TYPE_CAPTURE &&
-					    mc->clients[hit_slot].app_hwnd != nullptr) {
+					    mc->clients[hit_slot].app_hwnd != nullptr &&
+					    !mc->clients[hit_slot].modal_open) {
 						float title_h_m = UI_TITLE_BAR_H_M;
 						float content_local_x = hit.local_x_m;
 						float content_local_y = hit.local_y_m - title_h_m;
@@ -6993,7 +7007,8 @@ after_key_shortcuts:
 							PostMessage(click_target, WM_LBUTTONUP, 0, lp);
 						}
 					} else if (focus_changed &&
-					           mc->clients[hit_slot].app_hwnd != nullptr) {
+					           mc->clients[hit_slot].app_hwnd != nullptr &&
+					           !mc->clients[hit_slot].modal_open) {
 						// IPC app: focus changed mid-click. WndProc had
 						// already forwarded the initial DOWN to the OLD
 						// fwd target (or nowhere if none); the NEW target
@@ -7003,6 +7018,10 @@ after_key_shortcuts:
 						// scaled if app HWND ≠ rect dims) so the app
 						// doesn't see a sudden jump between DOWN and the
 						// first natural MOVE.
+						//
+						// Modal gate (ADR-017, #232): suppress when the hit
+						// slot has a modal open — same reason as the capture
+						// path above.
 						HWND target = mc->clients[hit_slot].app_hwnd;
 						const int32_t inset = 20;
 						int32_t rx = (int32_t)mc->clients[hit_slot].window_rect_x + inset;
@@ -13741,6 +13760,35 @@ comp_d3d11_service_workspace_drain_input_events(struct xrt_system_compositor *xs
 		out_batch->count++;
 
 		cs->modal_open_last_emitted = cs->modal_open;
+
+		// Item 4 (#232): on MODAL_CLOSE, restore enough state that the
+		// next user input reaches the app's dialog activation path.
+		//
+		//   (a) Workspace-internal focus → this slot, so the runtime's
+		//       click-forward + chrome-emission paths point at the right
+		//       app HWND for subsequent input.
+		//   (b) Grant the app process foreground-set rights via
+		//       AllowSetForegroundWindow. The app's HWND is hidden in
+		//       workspace mode (SW_HIDE in oxr_session.c), so calling
+		//       SetForegroundWindow on it directly silently fails on a
+		//       hidden window AND can leave Windows' foreground lock in
+		//       a state that DENIES the next dialog activation from the
+		//       app — producing "subsequent dialogs open invisible". The
+		//       safer move: don't try to surface the hidden HWND; grant
+		//       the app process the right to activate its own dialog
+		//       windows on its next user-input edge. The grant is one-
+		//       shot per call and the runtime is the foreground process
+		//       at this point, so the grant is what Windows actually
+		//       needs to let the next dialog claim foreground.
+		if (!cs->modal_open && cs->app_hwnd != NULL) {
+			mc->focused_slot = s;
+			multi_compositor_update_input_forward(mc);
+			DWORD app_pid = 0;
+			GetWindowThreadProcessId(cs->app_hwnd, &app_pid);
+			if (app_pid != 0) {
+				(void)AllowSetForegroundWindow(app_pid);
+			}
+		}
 	}
 
 	// FRAME_TICK: one per displayed frame since the last drain, capped at
@@ -14114,6 +14162,42 @@ comp_d3d11_service_set_client_modal_state(struct xrt_system_compositor *xsysc, i
 		return;
 	}
 	mc->clients[slot].modal_open = is_open;
+
+	// Item 4 (#232) cont'd: when transitioning to modal-open, grant the
+	// app process foreground-activation rights so its in-flight dialog
+	// CreateWindow can claim foreground. The IPC RPC fires synchronously
+	// from the app's CBT hook, BEFORE the dialog HWND is materialized —
+	// so granting here lands in the gauss process foreground-lock state
+	// just in time for the dialog activation. Without this, the FIRST
+	// dialog ever still works (gauss inherits foreground from process
+	// startup), but subsequent ones after a CLOSE → OPEN cycle activate
+	// invisibly because the workspace compositor is foreground by then
+	// and Windows' lock denies cross-process activation. The MODAL_CLOSE
+	// emit path also grants, but the 5-second AllowSetForegroundWindow
+	// window can lapse between CLOSE and the next OPEN; granting on OPEN
+	// too closes the timing hole.
+	if (is_open && mc->clients[slot].app_hwnd != NULL) {
+		DWORD app_pid = 0;
+		GetWindowThreadProcessId(mc->clients[slot].app_hwnd, &app_pid);
+		if (app_pid != 0) {
+			(void)AllowSetForegroundWindow(app_pid);
+		}
+	}
+
+	// Item 3 (#232) cont'd: kick the input-forward refresh immediately so
+	// the cached input_forward_hwnd in the window goes to NULL while
+	// modal_open is true (preventing keystrokes and clicks from reaching
+	// the app HWND and spawning nested modals). Without this kick, the
+	// modal_open flag is set on this IPC thread but the window's cached
+	// forwarding target keeps pointing at the app until something else
+	// happens to call update_input_forward (e.g., a focus change or the
+	// next chrome layout push) — leaving a window where subsequent L-
+	// presses on a hidden gauss app open more dialogs.
+	//
+	// comp_d3d11_window_set_input_forward writes via InterlockedExchange,
+	// so calling from this IPC thread is safe even though the WndProc
+	// thread reads concurrently.
+	multi_compositor_update_input_forward(mc);
 }
 
 extern "C" void *

--- a/src/xrt/state_trackers/oxr/oxr_workspace_modal_win32.c
+++ b/src/xrt/state_trackers/oxr/oxr_workspace_modal_win32.c
@@ -139,6 +139,23 @@ cbt_hook_proc(int code, WPARAM wParam, LPARAM lParam)
 			// HWND) are left alone. No class allowlist needed.
 			cbt->lpcs->hwndParent = s_dialog_owner_hwnd;
 
+			// #232 item 2: also flag the dialog as WS_EX_TOPMOST so it
+			// sits visually above the workspace compositor's swap-chain
+			// window regardless of activation z-order swaps. Without
+			// this, the user clicking into the compositor raises the
+			// compositor in non-topmost z and obscures the dialog while
+			// the dialog still holds keyboard focus — keystrokes route
+			// to an invisible window, which reads as broken.
+			//
+			// Mutating dwExStyle here works the same way as the parent
+			// rewrite above: CreateWindowEx reads the modified lpcs
+			// value when it actually creates the window. No SetWindowPos
+			// is needed (and wouldn't work — the HWND doesn't exist yet
+			// at HCBT_CREATEWND). Nested modals each get the same flag
+			// individually; on close they're destroyed which discards
+			// the bit, so there's no cleanup pair.
+			cbt->lpcs->dwExStyle |= WS_EX_TOPMOST;
+
 			EnterCriticalSection(&s_lock);
 			bool was_first = (s_modal_open_depth == 0);
 			if (track_dialog(new_hwnd)) {
@@ -148,6 +165,34 @@ cbt_hook_proc(int code, WPARAM wParam, LPARAM lParam)
 				notify_modal_state_locked(true);
 			}
 			LeaveCriticalSection(&s_lock);
+		}
+	} else if (code == HCBT_ACTIVATE) {
+		// #232 follow-up: re-assert HWND_TOPMOST on every activation of a
+		// tracked dialog. The lpcs.dwExStyle |= WS_EX_TOPMOST mutation at
+		// HCBT_CREATEWND sets the initial state correctly for the FIRST
+		// dialog (which is why it appears in front the first time), but
+		// the dialog's own activation churn (modal-disable of the owner
+		// chain, focus-restore from the previous dialog's destroy, etc.)
+		// can drop the topmost bit on subsequent dialogs in the same
+		// process. The visible symptom is "second L-press dialog opens
+		// BEHIND the workspace compositor" — keyboard focus is correct
+		// (Alt+Tab brings it forward) but z-order is wrong. Forcing
+		// HWND_TOPMOST here, with NOMOVE | NOSIZE | NOACTIVATE so we
+		// don't perturb the dialog's own positioning or focus state,
+		// keeps every dialog in this session above non-topmost windows.
+		HWND hwnd = (HWND)wParam;
+		EnterCriticalSection(&s_lock);
+		bool is_tracked = false;
+		for (int i = 0; i < s_tracked_dialog_count; i++) {
+			if (s_tracked_dialogs[i] == hwnd) {
+				is_tracked = true;
+				break;
+			}
+		}
+		LeaveCriticalSection(&s_lock);
+		if (is_tracked) {
+			(void)SetWindowPos(hwnd, HWND_TOPMOST, 0, 0, 0, 0,
+			                   SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
 		}
 	} else if (code == HCBT_DESTROYWND) {
 		HWND hwnd = (HWND)wParam;


### PR DESCRIPTION
Closes #232.

Runtime side of ADR-017 / shell-pvt#9. Modal popups spawned by workspace clients (file dialogs, MessageBox, …) now appear in front of the workspace compositor, stay focusable, and the workspace correctly suppresses click + keystroke forwarding to the (hidden) app HWND while a modal is up. After Cancel/OK, the next user-input edge reaches the right app.

## What this PR does

| File | Change |
|---|---|
| `src/xrt/state_trackers/oxr/oxr_workspace_modal_win32.c` | `lpcs->dwExStyle \|= WS_EX_TOPMOST` at HCBT_CREATEWND + re-assert `HWND_TOPMOST` on every HCBT_ACTIVATE for tracked dialogs. First dialog's topmost survives via lpcs mutation; subsequent dialogs need the re-assert because Windows' modal-disable + focus-restore churn drops the bit. |
| `comp_d3d11_service.cpp::multi_compositor_update_input_forward` | Gate on `cs->modal_open`. While the focused client has a modal up, NULL out the window's `input_forward_hwnd` so keystrokes / clicks stop reaching the app HWND. Prevents nested-dialog spam from repeated L-presses. |
| `comp_d3d11_service.cpp` two synthetic-click sites | Same `modal_open` gate at the capture-client click and the IPC-focus-changed-mid-click PostMessage sites. Same reasoning — keep app focus out of the modal-disabled chain. |
| `comp_d3d11_service_set_client_modal_state` | Call `multi_compositor_update_input_forward(mc)` immediately on every transition so the window's cached forwarding target tracks `modal_open` this IPC tick, not next focus-change. On `is_open=true`, also `AllowSetForegroundWindow(app_pid)` so the in-flight dialog can claim foreground. |
| `workspace_drain_input_events` MODAL_CLOSE emit block | Restore `mc->focused_slot = s`, re-run `update_input_forward`, and grant `AllowSetForegroundWindow(app_pid)`. Re-establishes workspace focus on the modal-owner so the next user input reaches the right app. |

## What this PR does NOT do

- **No 2D-mode flip on modal.** Deferred to #234. The naive immediate-flip exposes the long-standing IPC-mode atlas-coherence artifact (same one visible on WebXR-bridge V-toggle), not workspace-specific. Modal dialogs in this PR float over 3D-weaved workspace content — functional, just not the polished "modal-feels-flat" UX from ADR-017's "(Recommended)" item 2.
- **No mode-enum filter** for workspace clients. Tried it (filter `xrEnumerateDisplayRenderingModesEXT` to `count=1`); broke gauss + cube because apps index local mode arrays by vendor-assigned `mode_index`, not array index, and end up reading `renderingModeViewCounts[active_idx]=0` and submitting `view[1]` with zero orientation. See #233 for the architectural framing of why request-gating is the right enforcement point.
- **No acked-flip / curtain protocol.** Deferred to #234 along with the 2D-flip.

## Verification

`displayxr-demo-gaussiansplat` `L`-key (GetOpenFileNameA) in workspace via `displayxr-shell.exe`:

- [x] First L-press: dialog appears in front of the workspace compositor
- [x] Subsequent L-presses (close → re-open): dialog appears in front EVERY TIME (this was the regression my earlier WS_EX_TOPMOST-only attempt missed)
- [x] Click on dimmed gauss content area while modal up: no nested dialog, no focus steal
- [x] L-press while modal already up: no nested dialog
- [x] After Cancel/OK: next L-press routes to gauss correctly (workspace focus restored)
- [x] Multi-app workspace not tested directly but the gates are per-slot, so independent

## Test plan

- [x] Local Windows build (`scripts\build_windows.bat build`) — clean
- [ ] CI green (this PR)

## Related

- Closes #232
- Companion to merged #231 (XR-surface bridge for MODAL_OPEN/CLOSE events)
- Defers to #234 (modal 2D-flip + acked-flip + curtain)
- Defers to #233 (workspace-owns-display-mode architectural framing)
- shell-pvt#9 was closed earlier pointing here; UX polish (dim glow on modal-active client via `xrSetWorkspaceClientStyleEXT`, suppress chrome-button clicks, hover-fade suppression) remains optional shell-side follow-up but the user-visible bugs the issue identified are all fixed by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)