### PR TITLE
vk_native: handle window resize on the DComp transparent path

### DIFF
--- a/src/xrt/compositor/vk_native/comp_vk_native_target.cpp
+++ b/src/xrt/compositor/vk_native/comp_vk_native_target.cpp
@@ -975,6 +975,42 @@ comp_vk_native_target_resize(struct comp_vk_native_target *target,
 		return XRT_SUCCESS;
 	}
 
+#ifdef XRT_OS_WINDOWS
+	// Transparent path: DComp bridge has no WSI surface/swapchain — the
+	// dcomp DXGI swapchain and KMT-shared D3D11 textures (imported as
+	// VkImages) are size-bound. Tear down the bridge and re-run
+	// dcomp_setup at the new dimensions. target->views/images alias
+	// dcomp_vk_view/image, and dcomp_destroy frees the underlying handles,
+	// so we must NOT call destroy_swapchain_views here (would double-free)
+	// and must NOT fall through to create_swapchain (target->surface is
+	// VK_NULL_HANDLE in DComp mode → vkGetPhysicalDeviceSurfaceCapabilitiesKHR
+	// would crash).
+	if (target->dcomp_active) {
+		if (target->hwnd == NULL) {
+			U_LOG_E("DComp bridge resize: target->hwnd is NULL");
+			return XRT_ERROR_VULKAN;
+		}
+		vk->vkDeviceWaitIdle(vk->device);
+		dcomp_destroy(target);
+		// dcomp_vk_view/image were aliased into target->views/images;
+		// dcomp_destroy freed the underlying handles, so clear the
+		// public aliases too. Otherwise a subsequent
+		// destroy_swapchain_views would double-free.
+		for (uint32_t i = 0; i < DCOMP_RING; i++) {
+			target->views[i] = VK_NULL_HANDLE;
+			target->images[i] = VK_NULL_HANDLE;
+		}
+		target->image_count = 0;
+		if (!dcomp_setup(target, (HWND)target->hwnd, width, height)) {
+			dcomp_destroy(target);
+			U_LOG_E("DComp bridge resize: dcomp_setup(%ux%u) failed", width, height);
+			return XRT_ERROR_VULKAN;
+		}
+		// dcomp_setup re-publishes images/views/format/width/height/image_count.
+		return XRT_SUCCESS;
+	}
+#endif
+
 	vk->vkDeviceWaitIdle(vk->device);
 
 	destroy_swapchain_views(target);


### PR DESCRIPTION
## Summary

- Fix ACCESS_VIOLATION crash and top-left-corner rendering when an app with `WS_EX_NOREDIRECTIONBITMAP` + `transparentBackgroundEnabled = XR_TRUE` resizes its HWND (e.g. Gaussian Splat demo's F11 fullscreen toggle).
- `comp_vk_native_target_resize` was hardcoded for the WSI path: it freed `target->views[]` (which alias `dcomp_vk_view[]`), then called `vkGetPhysicalDeviceSurfaceCapabilitiesKHR` with a `VK_NULL_HANDLE` surface (DComp mode never creates a Win32 VK surface) → crash inside the ICD.
- Now branches on `target->dcomp_active`: tears down the DComp ring via `dcomp_destroy`, clears the aliased `target->views/images` to avoid a double-free, and re-runs `dcomp_setup` at the new dimensions.

## Why test apps did not catch this

`cube_handle_vk_win` defaults to opaque background (no `WS_EX_NOREDIRECTIONBITMAP`); only opts in via `DISPLAYXR_TRANSPARENT_BG=1`. It always hit the WSI branch, where resize already worked. The Gaussian Splat demo sets the transparent contract unconditionally (per its v1.3.0 dependency), so it was the only thing exercising the broken branch. Shell-launched apps go through the out-of-process `d3d11_service` compositor and never touch this code path, which is why F11 worked inside the shell.

## Test plan

- [x] Local rebuild + push DLL to `C:\Program Files\DisplayXR\Runtime\`
- [x] Gaussian Splat demo (standalone, `XR_RUNTIME_JSON` pointed at the fixed build) — F11 fullscreens cleanly, no crash, no top-left-corner artifact
- [x] No regression for the opaque path (only behavioural change is gated behind `target->dcomp_active`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)