### PR TITLE
workspace: acked-flip + curtain + force-3D + per-slot stride + #238 fix

### DIFF
--- a/HANDOFF_234.md
+++ b/HANDOFF_234.md
@@ -1,0 +1,188 @@
+# Handoff: #234 / #233 — workspace acked-flip + curtain (continuation)
+
+## Branches in flight
+
+Both branches are uncommitted-since-last-commit. Continue here.
+
+| Repo | Branch | Last commit |
+|---|---|---|
+| `openxr-3d-display` | `workspace-acked-flip-curtain` (off main) | `30e5648a1` workspace: acked-flip + curtain (#233/#234) |
+| `displayxr-shell-pvt` | `shell-v-hotkey-mode-toggle` (off main) | `43fd71b` shell: V hotkey toggles display 2D/3D via xrRequestDisplayRenderingModeEXT |
+
+**Uncommitted runtime changes** (on top of `30e5648a1`):
+- `src/xrt/state_trackers/oxr/oxr_objects.h`: new `oxr_session::is_active_workspace_controller` flag
+- `src/xrt/state_trackers/oxr/oxr_workspace.c`: set/clear flag on `xrActivateSpatialWorkspaceEXT`/`Deactivate`
+- `src/xrt/state_trackers/oxr/oxr_api_session.c`: gate at L1372 now exempts `is_active_workspace_controller`; new branch routes mode flip through `xsysc->request_workspace_mode_flip` hook
+- `src/xrt/include/xrt/xrt_compositor.h`: new `xrt_system_compositor::request_workspace_mode_flip` function pointer
+- `src/xrt/compositor/d3d11_service/comp_d3d11_service.{cpp,h}`:
+  - `comp_d3d11_service_workspace_request_mode_flip` extern C function
+  - `system_request_workspace_mode_flip` set on xsysc vtable
+  - `xrt_device_set_property(OUTPUT_MODE, target)` added to apply_pending's FLIPPING transition
+  - `MFP_HW_CEILING_FRAMES` bumped 16 → 60
+  - Diagnostic U_LOG_W at hook entry + silent no-op path
+- `src/xrt/ipc/shared/proto.json`: new `workspace_request_display_mode` RPC
+- `src/xrt/ipc/server/ipc_server_handler.c`: `ipc_handle_workspace_request_display_mode` calls `comp_d3d11_service_workspace_request_mode_flip`; `ipc_handle_workspace_activate` now force-resets to mode 1 via the same hook
+- `src/xrt/ipc/client/ipc_client_compositor.c`: `ipc_syscomp_request_workspace_mode_flip` marshals to server; wired into `c->system.request_workspace_mode_flip`; `<stdbool.h>` included
+- `test_apps/cube_handle_d3d11_win/main.cpp`: mirrors `xr.currentModeIndex` → `g_inputState.currentRenderingMode` so runtime-driven mode changes update the cube's rendering + HUD (NOT YET propagated to cube_handle_d3d12/gl/vk)
+
+**Build config**: build dir has `/Zi /DEBUG` linker flags injected via `CMakeCache.txt` for PDB generation. Cache only — not in git. To revert, reconfigure cleanly: `"C:\Program Files\CMake\bin\cmake.exe" -DCMAKE_BUILD_TYPE=Release "C:\Users\Sparks i7 3080\Documents\GitHub\openxr-3d-display\build"` (without the /Zi flags).
+
+## Architectural principle (user)
+
+> An app should be required to handle any render-mode change on its own,
+> AND when summoned via workspace it should sync render mode with the
+> workspace's render mode at session start.
+
+Two responsibilities:
+
+1. **App-driven sync from events.** Every app must update its rendering state from `XrEventDataRenderingModeChangedEXT`. This is what the cube test app was missing (event handler updated `xr.currentModeIndex`, but the rendering logic read `g_inputState.currentRenderingMode` — partially fixed via mirror in `cube_handle_d3d11_win/main.cpp` this session; needs to propagate to other variants).
+
+2. **Initial-state sync on session start.** When an app's session begins under a workspace, the runtime must communicate the current rendering mode immediately (not after the next user-driven flip). Options:
+   - Runtime pushes `XrEventDataRenderingModeChangedEXT` (with a sentinel `previousModeIndex` if needed) at `xrBeginSession` for workspace clients
+   - App queries an explicit "current mode" API at startup
+   - Add an `isActive` field to `XrDisplayRenderingModeInfoEXT` so apps can find the active mode from `xrEnumerateDisplayRenderingModesEXT`
+
+Current workaround: `ipc_handle_workspace_activate` resets to mode 1 so the controller and any new clients start aligned with the LeiaSR 3D default. This works but is opinionated — the cleaner long-term answer is option 1 or 3 so apps just learn the truth instead of being forced into mode 1.
+
+## What's working
+
+- **gauss demo L-key modal** flips 3D→2D→3D cleanly with curtain masking. Confirmed by user.
+- **Cube close-button no longer crashes.** The use-after-free at `comp_d3d11_service.cpp:8213` (`sc->images[i].texture->GetDesc()` on freed swapchain) is fixed by taking strong `xrt_swapchain_reference` on `ws_snapshot[].sc_array[]` and releasing on slot unregister under render_mutex.
+- **Shell V hotkey reaches the runtime.** Full chain works: shell `WM_HOTKEY V` → `xrRequestDisplayRenderingModeEXT` → OXR gate exempts active workspace controller → my new branch → `request_workspace_mode_flip` hook → IPC RPC `workspace_request_display_mode` → `comp_d3d11_service_workspace_request_mode_flip` → `multi_compositor_request_mode_flip` (acked-flip + curtain).
+- **Workspace activate resets to mode 1** so Ctrl+Space lands in a deterministic 3D state regardless of what mode the previous session left the runtime in.
+- **Cube test app HUD updates** when the runtime drives a mode change (via the new state mirror in main loop).
+
+## What's still broken
+
+### 1. Vendor SDK poll fires counter-correction flips (HIGH PRIORITY — blocks V toggle)
+
+**Symptom**: User presses V to flip 3D→2D. Runtime flips successfully. ~200 ms later runtime flips BACK to 3D without user input. User can flip 3D→2D once but "can't switch back".
+
+**Log signature**:
+```
+[mode_flip] hook: entering target=0          ← shell V press
+[mode_flip] request 1 -> 0 — curtain ON
+[mode_flip] FLIPPING: DP request_display_mode(0)
+                                              ← ~180ms passes
+[mode_flip] request 0 -> 1 — curtain ON       ← NO "hook: entering" — internal trigger
+[mode_flip] FLIPPING: DP request_display_mode(1)
+```
+
+**Diagnosis**: The vendor SDK poll path in `comp_d3d11_service.cpp` (`compositor_layer_commit`, ~L10470) compares vendor `is_3d` against `sys->hardware_display_3d`. My acked-flip writes `sys->hardware_display_3d = target_is_3d` in `apply_pending`'s FLIPPING transition, but the vendor's cached state may still report the OLD value. The poll sees mismatch in the OPPOSITE direction and fires `request_mode_flip` to "correct" — pulling the mode back to where it was. The existing `pending_flip` gate releases when `mode_flip.phase == MFP_IDLE`, but the cached vendor state hasn't caught up by then.
+
+**Fix candidates**:
+- Add a post-flip cooldown timer (e.g., 2 seconds after IDLE) during which the vendor poll cannot fire `request_mode_flip`. Simplest.
+- On my flip-land, also update `sys->cached_3d_state` to the new value so the poll sees no mismatch. May poison the cache vs reality.
+- Make the vendor poll itself route through `request_mode_flip` always (no-op guard catches same-target). Could still ping-pong.
+
+Cooldown is probably right. Look at how `sys->last_3d_state_poll_ns` is used and add a `last_flip_landed_ns` sibling.
+
+### 2. V transition oscillation when app doesn't ack
+
+**Symptom**: During the curtain window, content visibly oscillates between L/R views even though both eyes should be identical mono content.
+
+**Root cause** (per-slot stride coupled to global `tile_columns`): the workspace per-tile blit at `comp_d3d11_service.cpp:7823` reads each per-client atlas with stride = `src_tex_w / sys->tile_columns`. When the global mode flips from 3D (tile_columns=2) to 2D (tile_columns=1) but a client hasn't acked yet (still writes 2-view stereo into its slot atlas), the workspace reads the full atlas as ONE tile, mashing both eyes' content together.
+
+The "standalone V works" comparison the user pointed out: standalone has only ONE buffer pipeline (app swapchain → DP), so the per-tile blit stride mismatch never occurs. Shell mode introduces a `combined_atlas` middle layer where the stride matters.
+
+**Proper fix**: decouple per-slot stride from `sys->tile_columns`. Per-slot stride should be derived from the slot's submitted projection layer view rects (`l->data.proj.v[].sub.rect` snapshot — cube's view[1] is at offset (1539,0) so slot stride = 2 regardless of global mode). The workspace's per-tile blit iterates `sys->tile_columns × tile_rows` destination tiles; for each destination tile, read from the slot's view[col_for_eye] using the SLOT's stride, not the global. This is the "right architecture" fix.
+
+**Band-aid that's in place**: bumped `MFP_HW_CEILING_FRAMES` from 16 → 60 so the curtain holds longer, masking more of the catch-up window. Doesn't fix the underlying coupling.
+
+### 3. Ctrl+Space teardown crash (#238)
+
+Already filed: https://github.com/DisplayXR/displayxr-runtime/issues/238. Same class of UAF as the close-button bug. Close-button is fixed; Ctrl+Space (workspace deactivate) has the same race in a different teardown path — `ipc_server_per_client_thread.c:510` drops swapchain refs without `sys->render_mutex`, the deactivate path tears down per-client compositors without the mutex either. Workaround for now: exit via tray icon → Exit, not Ctrl+Space.
+
+### 4. Cube state mirror only on d3d11 variant
+
+`test_apps/cube_handle_d3d11_win/main.cpp` has the mirror. Need to propagate the same 4-line block to `cube_handle_d3d12_win`, `cube_handle_gl_win`, `cube_handle_vk_win`. Best done as a helper in `test_apps/common/` so future variants stay in sync. The mirror:
+
+```c
+if (xr.currentModeIndex != g_inputState.currentRenderingMode &&
+    xr.currentModeIndex < xr.renderingModeCount) {
+    g_inputState.currentRenderingMode = xr.currentModeIndex;
+}
+```
+
+### 5. Bare V global hotkey is intrusive
+
+The shell registers bare `V` (no modifier) as a global hotkey. While the shell is running, V is stolen from every other foreground app. User explicitly said: "once this works we will switch to Ctrl+V to avoid switching mode when doing regular typing". One-line change in `displayxr-shell-pvt/src/main.c:2892`: `RegisterHotKey(g_msg_hwnd, HOTKEY_MODE_TOGGLE, MOD_CONTROL | MOD_NOREPEAT, 'V')`.
+
+## Key files modified
+
+Runtime:
+- `src/xrt/compositor/d3d11_service/comp_d3d11_service.{cpp,h}` — state machine, hook, helpers
+- `src/xrt/state_trackers/oxr/oxr_api_session.c` — gate exemption for controllers
+- `src/xrt/state_trackers/oxr/oxr_workspace.c` — set/clear `is_active_workspace_controller`
+- `src/xrt/state_trackers/oxr/oxr_objects.h` — new session flag
+- `src/xrt/include/xrt/xrt_compositor.h` — new fn pointer on xsysc
+- `src/xrt/ipc/shared/proto.json` — new RPC
+- `src/xrt/ipc/server/ipc_server_handler.c` — server handler + reset-on-activate
+- `src/xrt/ipc/client/ipc_client_compositor.c` — client wrapper, vtable wire
+- `test_apps/cube_handle_d3d11_win/main.cpp` — state mirror
+- `docs/specs/runtime/workspace-controller-registration.md` — display mode authority subsection
+
+Shell:
+- `src/main.c` — V hotkey + handler
+- `src/shell_openxr.{h,cpp}` — PFN bundle additions
+
+## Verification matrix
+
+| Case | Status |
+|---|---|
+| gauss demo L-key modal in shell | ✅ user confirmed clean |
+| cube close-button | ✅ no crash (was: UAF) |
+| cube Ctrl+Space (workspace exit) | ❌ still crashes (#238) |
+| shell V toggle 3D→2D | ⚠️ runtime flips correctly, visual oscillates during curtain (issue 2) |
+| shell V toggle 2D→3D | ❌ vendor poll counter-correction undoes it (issue 1) |
+| shell startup after V test | ✅ resets to mode 1 |
+| cube HUD on runtime-driven mode change | ✅ HUD updates (state mirror works) |
+| Bridge V-toggle | not tested in this session |
+| Legacy IPC V-toggle (non-workspace) | not tested in this session |
+
+## Memory notes added/strengthened during this session
+
+- `feedback_dll_version_mismatch.md` — strengthened with a 4-step checklist + git_tag verify step. After ANY rebuild deploy BOTH `service.exe` AND `DisplayXRClient.dll` together; mismatch = `IPC_IGNORE_VERSION=1` error or `ReadFile: 109 The pipe has been ended`.
+
+## Build/deploy cheat sheet
+
+```bash
+# 1. Kill before rebuild (build_windows.bat can't overwrite locked exes)
+powershell -c "Get-Process displayxr-service,displayxr-shell -ErrorAction SilentlyContinue | Stop-Process -Force"
+
+# 2. Build
+"C:/Users/Sparks i7 3080/Documents/GitHub/openxr-3d-display/scripts/build_windows.bat" build
+
+# 3. Deploy pair (both binaries together)
+cp _package/bin/displayxr-service.exe _package/bin/DisplayXRClient.dll "/c/Program Files/DisplayXR/Runtime/"
+
+# 4. Verify git_tag match (saves a debugging cycle if they diverge)
+grep -ao "v[0-9]\+\.[0-9]\+\.[0-9]\+-[0-9]\+-g[0-9a-f]\+" "/c/Program Files/DisplayXR/Runtime/displayxr-service.exe" | head -1
+grep -ao "v[0-9]\+\.[0-9]\+\.[0-9]\+-[0-9]\+-g[0-9a-f]\+" "/c/Program Files/DisplayXR/Runtime/DisplayXRClient.dll"  | head -1
+
+# 5. For shell-side changes (separate repo)
+cd "/c/Users/Sparks i7 3080/Documents/GitHub/displayxr-shell-pvt"
+scripts/build-shell.bat
+cp _package/bin/displayxr-shell.exe "/c/Program Files/DisplayXR/Runtime/"
+
+# 6. Restart
+"_package/bin/displayxr-service.exe" --shell &
+"/c/Program Files/DisplayXR/Runtime/displayxr-shell.exe" \
+  test_apps/cube_handle_d3d11_win/build/cube_handle_d3d11_win.exe
+```
+
+## Debugging with PDBs
+
+```bash
+# Procdump catches the crash + writes dump
+"/c/Users/Sparks i7 3080/Tools/procdump64.exe" -accepteula -e -ma -x /tmp \
+  "_package/bin/displayxr-service.exe" --shell
+
+# Analyze
+CDB="/c/Program Files/WindowsApps/Microsoft.WinDbg_1.2603.20001.0_x64__8wekyb3d8bbwe/amd64/cdb.exe"
+"$CDB" -y "_package/bin" -srcpath "C:\\Users\\Sparks i7 3080\\Documents\\GitHub\\openxr-3d-display" \
+  -z /tmp/displayxr-service*.dmp \
+  -c ".lines -e; .ecxr; .srcfix; ln eip; kPnL 20; q"
+```
+
+The PDB next to the exe at `_package/bin/displayxr-service.pdb` (copy alongside if not present) is what cdb resolves against.

--- a/docs/specs/runtime/workspace-controller-registration.md
+++ b/docs/specs/runtime/workspace-controller-registration.md
@@ -292,6 +292,41 @@ trust-boundary regression. Per-tile alpha against an opaque workspace
 background covers the realistic use case (transparent window contents
 inside a workspace) without that risk.
 
+## Display mode authority
+
+The workspace controller is the sole authority on display rendering mode
+(2D vs 3D, tile layout) for the clients it hosts. App-driven attempts
+to change mode from a workspace client are silently no-opped.
+
+**Enforcement (single point):** `oxr_api_session.c::oxr_xrRequestDisplayRenderingModeEXT`
+returns `XR_SUCCESS` without state change when the calling session is a
+workspace client (`sys->xsysc->info.is_service_mode && sess->compositor != NULL`).
+`xrRequestDisplayModeEXT` is a thin wrapper and inherits the gate.
+Headless bridge-relay sessions are exempt and may drive mode (they act
+as mode controller on behalf of an out-of-process WebXR page).
+
+**Non-enforcement (deliberate):** `xrEnumerateDisplayRenderingModesEXT`
+continues to return the FULL mode list to workspace clients. Apps index
+their local rendering-mode arrays by VENDOR-ASSIGNED `mode_index`
+delivered via `XrEventDataRenderingModeChangedEXT` — filtering the
+enumerator to `count=1` causes apps to read `renderingModeViewCounts[active_idx]=0`
+and submit `view[1]` with zero orientation, triggering `XR_ERROR_POSE_INVALID`
+at `xrEndFrame`. Authority is enforced by REQUEST-gating, not enumeration-filtering.
+
+**Transition protocol (#234):** When the workspace decides to flip mode
+(focus-adaptive, modal-open, qwerty V-toggle, vendor-initiated), the
+workspace D3D11 compositor (`comp_d3d11_service.cpp::multi_compositor_request_mode_flip`)
+broadcasts `XrEventDataRenderingModeChangedEXT` immediately and enters a
+WAITING_ACK phase with a "curtain" that flattens the per-tile blit pass
+to a uniform mono frame. Per-slot ack is detected at `compositor_layer_commit`
+when a slot submits a projection layer whose extent matches the target
+mode's `view_width_pixels` / `view_height_pixels`. Once all active IPC
+slots have acked (or a fairness timeout fires), the DP / device state /
+tile layout are flipped in lockstep; the curtain stays on through the
+vendor's hardware transition (bounded by `get_hardware_3d_state` polling
+plus a safety frame ceiling). Eliminates the historical raw-atlas glitch
+visible to users on every IPC-mode flip.
+
 ## Future evolution
 
 If multiple workspace apps need to coexist (one user has the

--- a/src/external/openxr_includes/openxr/XR_EXT_display_info.h
+++ b/src/external/openxr_includes/openxr/XR_EXT_display_info.h
@@ -22,7 +22,7 @@ extern "C" {
 #endif
 
 #define XR_EXT_display_info 1
-#define XR_EXT_display_info_SPEC_VERSION 12
+#define XR_EXT_display_info_SPEC_VERSION 13
 #define XR_EXT_DISPLAY_INFO_EXTENSION_NAME "XR_EXT_display_info"
 
 // Reuse the type value from the deleted XR_EXT_dynamic_render_resolution
@@ -239,6 +239,27 @@ typedef struct XrDisplayRenderingModeInfoEXT {
     uint32_t                    tileRows;        //!< Tile rows in atlas layout (v12)
     uint32_t                    viewWidthPixels; //!< Per-view width in pixels (v12)
     uint32_t                    viewHeightPixels;//!< Per-view height in pixels (v12)
+    /*!
+     * (v13) True for the mode that is currently active for this session.
+     *
+     * Apps can read this at startup (after xrCreateSession + first
+     * xrEnumerateDisplayRenderingModesEXT call) to learn the current mode
+     * without waiting for an XrEventDataRenderingModeChangedEXT — useful
+     * when the session begins under a workspace that already chose a mode.
+     * Re-enumerating after a mode change reflects the new active mode.
+     */
+    XrBool32                    isActive;
+    /*!
+     * (v13) True iff this session may request this mode via
+     * xrRequestDisplayRenderingModeEXT.
+     *
+     * False for non-controller sessions running under a workspace — the
+     * workspace controller is the sole mode authority and app requests are
+     * dropped by the runtime. Apps can use this to gate their UI (e.g.
+     * disable the V toggle and show "Mode locked by workspace"). Always
+     * true for standalone sessions and for workspace-controller sessions.
+     */
+    XrBool32                    isRequestable;
 } XrDisplayRenderingModeInfoEXT;
 
 /*!

--- a/src/xrt/compositor/d3d11/comp_d3d11_window.cpp
+++ b/src/xrt/compositor/d3d11/comp_d3d11_window.cpp
@@ -595,7 +595,14 @@ wnd_proc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 
 			// Process qwerty first
 #ifdef XRT_BUILD_DRIVER_QWERTY
-			if (w->qwerty_enabled && w->xsysd != NULL && !bridge_page_attached(hWnd)) {
+			// Suppress qwerty entirely under workspace mode: the shell + apps
+			// handle their own input, and qwerty intercepting V here would
+			// fire qwerty_toggle_display_mode behind the workspace's back
+			// (bypassing the acked-flip pipeline + cooldown). Bare V should
+			// fall through to the focused app's WindowProc / qwerty stays
+			// active only in standalone monado-gui / non-workspace paths.
+			if (w->qwerty_enabled && w->xsysd != NULL && !bridge_page_attached(hWnd) &&
+			    !InterlockedCompareExchange(&w->workspace_mode_active, 0, 0)) {
 				bool handled = false;
 				qwerty_process_win32(w->xsysd->xdevs, w->xsysd->xdev_count,
 				                     message, wParam, lParam, &handled);
@@ -663,7 +670,9 @@ wnd_proc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 		if (bridge_page_attached(hWnd)) {
 			return 0;
 		}
-		if (w->qwerty_enabled && w->xsysd != NULL) {
+		// Suppress qwerty under workspace mode — see L596 comment.
+		if (w->qwerty_enabled && w->xsysd != NULL &&
+		    !InterlockedCompareExchange(&w->workspace_mode_active, 0, 0)) {
 			bool handled = false;
 			qwerty_process_win32(w->xsysd->xdevs, w->xsysd->xdev_count,
 			                     message, wParam, lParam, &handled);
@@ -928,9 +937,11 @@ wnd_proc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 			}
 			return 0;
 		}
-		// Normal mode: pass to qwerty driver
+		// Normal mode: pass to qwerty driver — but not under workspace
+		// (workspace apps own input; qwerty intercepting here is a regression).
 #ifdef XRT_BUILD_DRIVER_QWERTY
-		if (w->qwerty_enabled && w->xsysd != NULL && !bridge_page_attached(hWnd)) {
+		if (w->qwerty_enabled && w->xsysd != NULL && !bridge_page_attached(hWnd) &&
+		    !InterlockedCompareExchange(&w->workspace_mode_active, 0, 0)) {
 			bool handled = false;
 			qwerty_process_win32(w->xsysd->xdevs, w->xsysd->xdev_count,
 			                     message, wParam, lParam, &handled);

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -748,6 +748,41 @@ enum d3d11_client_type
 };
 
 /*!
+ * Acked-flip + curtain state machine for workspace display-mode transitions
+ * (issue #234). Replaces the historical "flip DP + sync_tile_layout
+ * immediately, hope apps catch up" pattern that exposed a raw-atlas glitch
+ * on every IPC-mode mode-flip (bridge V-toggle, workspace V-toggle / focus-
+ * adaptive, modal-open). State lives on d3d11_multi_compositor::mode_flip.
+ *
+ * IDLE         → no transition pending.
+ * WAITING_ACK  → event broadcast at request time; curtain ON; per-frame tick
+ *                waits for all active slots (less auto-acked capture/2D
+ *                slots) to submit a frame whose projection-layer extent
+ *                matches the target mode's per-view dims, OR for a fairness
+ *                timeout. Then advances to FLIPPING.
+ * FLIPPING     → DP request_display_mode + sync_tile_layout + active mode
+ *                index write have landed; curtain stays ON while the vendor
+ *                hardware transition completes (polled via
+ *                get_hardware_3d_state, bounded by a safety ceiling).
+ */
+enum mode_flip_phase
+{
+	MFP_IDLE = 0,
+	MFP_WAITING_ACK,
+	MFP_FLIPPING,
+};
+
+//! Frames to wait for all slots to ack the new layout before force-flipping
+//! the DP anyway (curtain still masks the un-acked slot's brief mismatch).
+//! ~500 ms at 60 Hz.
+#define MFP_ACK_TIMEOUT_FRAMES 30
+
+//! Frames to hold the curtain ON after DP request_display_mode lands before
+//! lifting it unconditionally — covers the vendor's hardware transition
+//! window when get_hardware_3d_state lies or hasn't converged. ~270 ms.
+#define MFP_HW_CEILING_FRAMES 16
+
+/*!
  * Per-client slot in the multi-compositor.
  */
 struct d3d11_multi_client_slot
@@ -764,6 +799,28 @@ struct d3d11_multi_client_slot
 	//! Actual rendered content dimensions per view (from last layer_commit).
 	uint32_t content_view_w;
 	uint32_t content_view_h;
+
+	//! Workspace acked-flip state (#234): true once this slot has submitted a
+	//! projection layer whose per-view dims differ from the snapshot taken at
+	//! request_mode_flip time. Workspace apps submit window-scaled extents
+	//! (not the canonical rendering_modes[i].view_width_pixels), so we detect
+	//! "app caught up to the broadcast event" by extent CHANGE rather than
+	//! by absolute match. Reset by multi_compositor_request_mode_flip; set by
+	//! the ack-detect block in compositor_layer_commit's workspace branch.
+	//! Read by multi_compositor_apply_pending_mode_flip to decide quorum.
+	bool acked_target_mode;
+
+	//! Per-slot extent snapshots used by the ack detector (#234).
+	//! `last_commit_view_w/h` are refreshed on every workspace-mode
+	//! compositor_layer_commit. `pre_flip_view_w/h` are snapshotted by
+	//! multi_compositor_request_mode_flip from the current last_commit
+	//! values; the ack fires when a subsequent commit's extent differs from
+	//! the pre_flip snapshot (meaning the app re-rendered after consuming
+	//! XrEventDataRenderingModeChangedEXT).
+	uint32_t last_commit_view_w;
+	uint32_t last_commit_view_h;
+	uint32_t pre_flip_view_w;
+	uint32_t pre_flip_view_h;
 
 	//! Window-space layer snapshot for `multi_compositor_render`'s WS pass.
 	//! Updated under `ws_snapshot_mutex` at the end of compositor_layer_commit
@@ -1161,6 +1218,22 @@ struct d3d11_multi_compositor
 	//! Tracks which capture HWND currently has foreground focus for SendInput.
 	//! NULL means no capture client is foreground (workspace window is foreground).
 	HWND current_foreground_capture;
+
+	//! Acked-flip + curtain state machine (#234). Replaces the historical
+	//! "flip DP + sync_tile_layout immediately, hope apps catch up" pattern.
+	//! See multi_compositor_request_mode_flip / multi_compositor_apply_pending_mode_flip.
+	struct
+	{
+		enum mode_flip_phase phase;   //!< IDLE / WAITING_ACK / FLIPPING (see enum).
+		uint32_t target_mode_index;   //!< Mode we're transitioning TO.
+		uint32_t source_mode_index;   //!< Mode we were in when transition started.
+		uint32_t ack_frame_counter;   //!< Frames spent in WAITING_ACK.
+		uint32_t flip_frame_counter;  //!< Frames spent in FLIPPING.
+		bool target_is_3d;            //!< Resolved at request time for vendor poll target.
+		int origin_slot;              //!< Slot that initiated (-1 = system: focus-adaptive, vendor poll).
+		uint32_t saved_mode_index;    //!< Pre-modal mode to restore on modal-close.
+		bool curtain_active;          //!< Per-tile blit pass collapses to eye-0 / tile-(0,0) when true.
+	} mode_flip;
 };
 
 
@@ -1363,6 +1436,199 @@ broadcast_rendering_mode_change(struct d3d11_service_system *sys,
 			xse2.hardware_display_state_change.type = XRT_SESSION_EVENT_HARDWARE_DISPLAY_STATE_CHANGE;
 			xse2.hardware_display_state_change.hardware_display_3d = new_3d;
 			u_system_broadcast_event(sys->usys, &xse2);
+		}
+	}
+}
+
+/*!
+ * Begin a workspace display-mode transition to @p target_mode_idx (#234).
+ *
+ * Single entry point for every IPC-mode mode flip — focus-adaptive, qwerty V,
+ * app-initiated XR_EXT, vendor SDK auto, modal-open/close. Replaces the
+ * previous "flip DP + sync_tile_layout + broadcast immediately, hope apps
+ * catch up" pattern that exposed a 1–N frame raw-atlas artifact while clients
+ * lagged the layout change.
+ *
+ * Caller is responsible for any pre-flip bookkeeping (e.g. saving
+ * sys->last_3d_mode_index before transitioning to 2D). This helper:
+ *   1. Broadcasts XrEventDataRenderingModeChangedEXT immediately so clients
+ *      can begin re-submitting at the new layout.
+ *   2. Marks the multi-comp as MFP_WAITING_ACK with the curtain ON.
+ *   3. Does NOT touch active_rendering_mode_index / sync_tile_layout / DP.
+ *      Those land in MFP_FLIPPING, triggered by
+ *      multi_compositor_apply_pending_mode_flip once the per-slot ack quorum
+ *      forms (or fairness timeout fires).
+ *
+ * No-op outside workspace/IPC mode (sys->multi_comp == nullptr).
+ */
+static void
+multi_compositor_request_mode_flip(struct d3d11_service_system *sys,
+                                   uint32_t target_mode_idx,
+                                   int origin_slot)
+{
+	if (sys == nullptr || sys->multi_comp == nullptr) {
+		return;
+	}
+	struct d3d11_multi_compositor *mc = sys->multi_comp;
+	struct xrt_device *head = (sys->xsysd != nullptr) ? sys->xsysd->static_roles.head : nullptr;
+	if (head == nullptr || head->hmd == NULL) {
+		return;
+	}
+	if (target_mode_idx >= head->rendering_mode_count) {
+		return;
+	}
+
+	uint32_t source_mode_idx = head->hmd->active_rendering_mode_index;
+	bool target_is_3d = head->rendering_modes[target_mode_idx].hardware_display_3d;
+
+	// Toggle-back guard: user mashed V (or focus-bounced) and the target is
+	// the same mode we were in before the still-pending flip. Abort cleanly.
+	if (mc->mode_flip.phase != MFP_IDLE &&
+	    target_mode_idx == mc->mode_flip.source_mode_index) {
+		U_LOG_W("[mode_flip] toggle-back to source %u while pending — aborting",
+		        target_mode_idx);
+		mc->mode_flip.phase = MFP_IDLE;
+		mc->mode_flip.curtain_active = false;
+		return;
+	}
+
+	// No-op: already at target and nothing pending.
+	if (mc->mode_flip.phase == MFP_IDLE && target_mode_idx == source_mode_idx) {
+		return;
+	}
+
+	mc->mode_flip.phase = MFP_WAITING_ACK;
+	mc->mode_flip.target_mode_index = target_mode_idx;
+	mc->mode_flip.source_mode_index = source_mode_idx;
+	mc->mode_flip.ack_frame_counter = 0;
+	mc->mode_flip.flip_frame_counter = 0;
+	mc->mode_flip.target_is_3d = target_is_3d;
+	mc->mode_flip.origin_slot = origin_slot;
+	mc->mode_flip.curtain_active = true;
+
+	// Reset per-slot ack flags. Auto-ack capture / 2D-only slots — their
+	// per-slot atlas layout does not change across rendering modes, so they
+	// would never produce a "new layout" frame for the quorum. Snapshot the
+	// pre-flip per-view extent for IPC slots so the ack detector can detect
+	// "app has re-rendered after consuming XrEventDataRenderingModeChangedEXT"
+	// by extent change, not by absolute match against view_width_pixels
+	// (workspace apps submit window-scaled extents, not canonical mode dims).
+	for (int s = 0; s < D3D11_MULTI_MAX_CLIENTS; s++) {
+		bool ipc_3d = mc->clients[s].active &&
+		              mc->clients[s].client_type == CLIENT_TYPE_IPC;
+		mc->clients[s].acked_target_mode = !ipc_3d;
+		mc->clients[s].pre_flip_view_w = mc->clients[s].last_commit_view_w;
+		mc->clients[s].pre_flip_view_h = mc->clients[s].last_commit_view_h;
+	}
+
+	// Broadcast event NOW so clients begin their re-submit cycle while the
+	// curtain masks the geometry mismatch. Device active index intentionally
+	// not yet written — apps consume the event payload, not the device state.
+	broadcast_rendering_mode_change(sys, head, source_mode_idx, target_mode_idx);
+
+	U_LOG_W("[mode_flip] request %u -> %u (target_is_3d=%d, origin_slot=%d) — broadcast, curtain ON",
+	        source_mode_idx, target_mode_idx, (int)target_is_3d, origin_slot);
+}
+
+/*!
+ * Per-frame tick for the workspace mode-flip state machine (#234).
+ *
+ * Called once near the top of multi_compositor_render, before the per-tile
+ * blit pass reads sys->tile_columns. Owns the WAITING_ACK -> FLIPPING and
+ * FLIPPING -> IDLE transitions; curtain_active stays true across both so the
+ * blit pass collapses to a uniform single-eye view until the DP and the
+ * hardware lens transition have both settled.
+ */
+static void
+multi_compositor_apply_pending_mode_flip(struct d3d11_service_system *sys)
+{
+	if (sys == nullptr || sys->multi_comp == nullptr) {
+		return;
+	}
+	struct d3d11_multi_compositor *mc = sys->multi_comp;
+	if (mc->mode_flip.phase == MFP_IDLE) {
+		return;
+	}
+	struct xrt_device *head = (sys->xsysd != nullptr) ? sys->xsysd->static_roles.head : nullptr;
+	if (head == nullptr || head->hmd == NULL) {
+		return;
+	}
+
+	if (mc->mode_flip.phase == MFP_WAITING_ACK) {
+		mc->mode_flip.ack_frame_counter++;
+		// Teardown guard: if no active IPC slots remain (last app exited
+		// mid-flip) or the DP is gone, abort the pending flip rather than
+		// kicking a torn-down DP. Race vs slot-removal observed at session
+		// end on close-button click.
+		int active_ipc_count = 0;
+		for (int s = 0; s < D3D11_MULTI_MAX_CLIENTS; s++) {
+			if (mc->clients[s].active &&
+			    mc->clients[s].client_type == CLIENT_TYPE_IPC) {
+				active_ipc_count++;
+			}
+		}
+		if (active_ipc_count == 0 || mc->display_processor == nullptr) {
+			U_LOG_W("[mode_flip] aborting pending flip — teardown (active_ipc=%d, dp=%p)",
+			        active_ipc_count, (void *)mc->display_processor);
+			mc->mode_flip.phase = MFP_IDLE;
+			mc->mode_flip.curtain_active = false;
+			return;
+		}
+		bool quorum = true;
+		for (int s = 0; s < D3D11_MULTI_MAX_CLIENTS; s++) {
+			if (!mc->clients[s].active) continue;
+			if (mc->clients[s].client_type != CLIENT_TYPE_IPC) continue;
+			if (!mc->clients[s].acked_target_mode) {
+				quorum = false;
+				break;
+			}
+		}
+		bool timeout = mc->mode_flip.ack_frame_counter >= MFP_ACK_TIMEOUT_FRAMES;
+		if (!quorum && !timeout) {
+			return; // keep waiting, curtain stays on
+		}
+		if (timeout && !quorum) {
+			U_LOG_W("[mode_flip] WAITING_ACK timeout at %u frames — force-flipping (curtain still masks)",
+			        mc->mode_flip.ack_frame_counter);
+		}
+
+		// Land the flip: device state, DP, tile layout all in lockstep.
+		head->hmd->active_rendering_mode_index = mc->mode_flip.target_mode_index;
+		xrt_display_processor_d3d11_request_display_mode(
+		    mc->display_processor, mc->mode_flip.target_is_3d);
+		sync_tile_layout(sys);
+		sys->hardware_display_3d = mc->mode_flip.target_is_3d;
+
+		mc->mode_flip.phase = MFP_FLIPPING;
+		mc->mode_flip.flip_frame_counter = 0;
+		U_LOG_W("[mode_flip] FLIPPING: DP request_display_mode(%d), sync_tile_layout done",
+		        (int)mc->mode_flip.target_is_3d);
+		return;
+	}
+
+	if (mc->mode_flip.phase == MFP_FLIPPING) {
+		mc->mode_flip.flip_frame_counter++;
+		// Teardown guard: DP went away mid-FLIPPING. Bail without polling.
+		if (mc->display_processor == nullptr) {
+			U_LOG_W("[mode_flip] aborting FLIPPING — display_processor gone");
+			mc->mode_flip.curtain_active = false;
+			mc->mode_flip.phase = MFP_IDLE;
+			return;
+		}
+		bool hw_settled = false;
+		bool current_is_3d = false;
+		if (xrt_display_processor_d3d11_get_hardware_3d_state(
+		        mc->display_processor, &current_is_3d)) {
+			hw_settled = (current_is_3d == mc->mode_flip.target_is_3d);
+		}
+		bool ceiling = mc->mode_flip.flip_frame_counter >= MFP_HW_CEILING_FRAMES;
+		if (hw_settled || ceiling) {
+			if (ceiling && !hw_settled) {
+				U_LOG_W("[mode_flip] FLIPPING ceiling at %u frames — lifting curtain unconditionally",
+				        mc->mode_flip.flip_frame_counter);
+			}
+			mc->mode_flip.curtain_active = false;
+			mc->mode_flip.phase = MFP_IDLE;
 		}
 	}
 }
@@ -4516,6 +4782,27 @@ multi_compositor_unregister_client(struct d3d11_service_system *sys, struct d3d1
 
 	for (int i = 0; i < D3D11_MULTI_MAX_CLIENTS; i++) {
 		if (mc->clients[i].active && mc->clients[i].compositor == c) {
+			// Release strong swapchain refs the WS-layer snapshot holds
+			// (#234 follow-on). Once cleared, the IPC layer's swapchain
+			// ref drop (ipc_server_per_client_thread.c:510) will be the
+			// last ref, destroying the swapchain SAFELY because we run
+			// inside sys->render_mutex (caller's contract) so no render
+			// thread can be mid-snapshot-deref.
+			{
+				std::lock_guard<std::mutex> snap_lock(
+				    mc->clients[i].ws_snapshot_mutex);
+				for (uint32_t j = 0; j < mc->clients[i].ws_snapshot_count; j++) {
+					for (size_t k = 0;
+					     k < ARRAY_SIZE(mc->clients[i].ws_snapshot[j].sc_array);
+					     k++) {
+						xrt_swapchain_reference(
+						    &mc->clients[i].ws_snapshot[j].sc_array[k], NULL);
+					}
+				}
+				mc->clients[i].ws_snapshot_count = 0;
+				mc->clients[i].projection_flags_valid = false;
+			}
+
 			mc->clients[i].active = false;
 			mc->clients[i].compositor = nullptr;
 			mc->client_count--;
@@ -7447,13 +7734,20 @@ after_key_shortcuts:
 		}
 	}
 
+	// Per-frame tick for the workspace mode-flip state machine (#234). Owns
+	// the WAITING_ACK -> FLIPPING and FLIPPING -> IDLE transitions and the
+	// curtain on/off lifecycle. Must run BEFORE the per-tile blit pass reads
+	// sys->tile_columns so the read sees the just-landed (or still-pending)
+	// tile geometry consistently with the curtain state used by the blit.
+	multi_compositor_apply_pending_mode_flip(sys);
+
 	// 2D/3D display mode auto-switch based on focused client type.
 	// When a capture (2D) window gets focus → switch to 2D mode.
 	// When an IPC (3D) app gets focus → restore 3D mode.
-	// Uses the same mechanism as V-key toggle: changes active_rendering_mode_index,
-	// calls request_display_mode on DP, and sync_tile_layout. Extension apps
-	// receive XrEventDataRenderingModeChangedEXT + XrEventDataHardwareDisplayStateChangedEXT
-	// automatically via the OXR session's per-frame mode index polling.
+	// Routes through multi_compositor_request_mode_flip (#234) so the DP /
+	// sync_tile_layout / device-state writes are deferred to the apply step
+	// above once all active IPC slots have re-submitted at the new layout
+	// (or the fairness timeout fires). The curtain masks the catch-up window.
 	{
 		bool want_2d = false;
 		if (mc->focused_slot >= 0 && mc->focused_slot < D3D11_MULTI_MAX_CLIENTS &&
@@ -7469,31 +7763,19 @@ after_key_shortcuts:
 			    ? sys->xsysd->static_roles.head : nullptr;
 
 			if (head != nullptr && head->hmd != NULL) {
-				uint32_t prev_idx = head->hmd->active_rendering_mode_index;
+				uint32_t target_idx;
 				if (want_2d) {
-					// Save current 3D mode index before switching to 2D
 					uint32_t cur = head->hmd->active_rendering_mode_index;
 					if (cur < head->rendering_mode_count &&
 					    head->rendering_modes[cur].hardware_display_3d) {
 						sys->last_3d_mode_index = cur;
 					}
-					head->hmd->active_rendering_mode_index = 0; // Mode 0 = 2D mono
+					target_idx = 0; // mode 0 = 2D mono
 				} else {
-					// Restore 3D mode
-					head->hmd->active_rendering_mode_index = sys->last_3d_mode_index;
+					target_idx = sys->last_3d_mode_index;
 				}
-				broadcast_rendering_mode_change(sys, head, prev_idx,
-				                                head->hmd->active_rendering_mode_index);
+				multi_compositor_request_mode_flip(sys, target_idx, mc->focused_slot);
 			}
-
-			// Switch display HW mode
-			if (mc->display_processor != nullptr) {
-				xrt_display_processor_d3d11_request_display_mode(
-				    mc->display_processor, !want_2d);
-			}
-
-			sync_tile_layout(sys);
-			sys->hardware_display_3d = !want_2d;
 
 			U_LOG_W("Multi-comp: auto display mode → %s (focused slot %d, type=%s)",
 			        want_2d ? "2D" : "3D", mc->focused_slot,
@@ -8037,7 +8319,14 @@ after_key_shortcuts:
 			// `src_rect.zw = cvw,cvh` (set below) drives sampling, the
 			// per-tile origin sets `src_rect.xy`.
 			float src_px_x, src_px_y;
-			if (slot_is_mono) {
+			if (slot_is_mono || mc->mode_flip.curtain_active) {
+				// Curtain (#234): during a workspace mode flip, force every
+				// destination tile to sample source tile (0,0). Combined
+				// with the eye_idx=0 collapse below, this writes identical
+				// content to both halves of combined_atlas so the SR weaver
+				// sees a uniform mono frame regardless of which slots have
+				// caught up to the new layout. Avoids the "raw atlas
+				// visible" double-image artifact during the catch-up window.
 				src_px_x = 0.0f;
 				src_px_y = 0.0f;
 			} else {
@@ -8045,8 +8334,17 @@ after_key_shortcuts:
 				src_px_y = static_cast<float>(src_row * slot_h_atlas);
 			}
 
-			// Per-eye destination rect (parallax-shifted for Z != 0)
-			int eye_idx = (src_col < 2) ? (int)src_col : 0;
+			// Per-eye destination rect (parallax-shifted for Z != 0).
+			// Curtain (#234): force eye_idx=0 for both halves during a mode
+			// flip — without this, the per-eye parallax shift still produces
+			// column-by-column doubling under the SR weaver even with
+			// identical source content. Source AND destination must collapse.
+			int eye_idx;
+			if (mc->mode_flip.curtain_active) {
+				eye_idx = 0;
+			} else {
+				eye_idx = (src_col < 2) ? (int)src_col : 0;
+			}
 			float win_frac_x = (float)eye_rect_x[eye_idx] / (float)ca_w;
 			float win_frac_y = (float)eye_rect_y[eye_idx] / (float)ca_h;
 			float win_frac_w = (float)eye_rect_w[eye_idx] / (float)ca_w;
@@ -8063,8 +8361,13 @@ after_key_shortcuts:
 			scissor.bottom = (LONG)((src_row + 1) * half_h);
 			sys->context->RSSetScissorRects(1, &scissor);
 
-			// Check for rotated window → perspective quad mode
-			int ei_for_quad = (src_col < 2) ? (int)src_col : 0;
+			// Check for rotated window → perspective quad mode.
+			// Curtain (#234): use eye 0 for both halves so the projected quad
+			// is identical across the dual-write — same rationale as the
+			// eye_idx collapse above.
+			int ei_for_quad = mc->mode_flip.curtain_active
+			                      ? 0
+			                      : ((src_col < 2) ? (int)src_col : 0);
 			int ei_q = (ei_for_quad < (int)eye_pos.count) ? ei_for_quad : 0;
 			float quad_corners[8] = {};
 			float quad_w_vals[4] = {1, 1, 1, 1};
@@ -10110,8 +10413,11 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 	}
 
 	// App-initiated mode change: bridge relays requestRenderingMode() from the
-	// WebXR sample via HWND property. Polls each frame, triggers same server-side
-	// path as qwerty V key (device update + DP toggle + broadcast).
+	// WebXR sample via HWND property. Polls each frame; when the multi-comp is
+	// active, routes through the acked-flip path (#234) so the broadcast →
+	// per-slot re-submit → DP flip sequence is masked by the curtain. Without
+	// multi-comp (legacy bridge with its own per-client DP), preserve the
+	// immediate-flip behavior.
 	if (bridge_live && c->render.hwnd != nullptr && sys->xsysd != NULL) {
 		uint32_t req = (uint32_t)(uintptr_t)GetPropW(c->render.hwnd, L"DXR_RequestMode");
 		if (req > 0) {
@@ -10121,30 +10427,34 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 			if (head != nullptr && head->hmd != NULL &&
 			    modeIdx < head->rendering_mode_count &&
 			    modeIdx != head->hmd->active_rendering_mode_index) {
-				uint32_t prev_idx = head->hmd->active_rendering_mode_index;
-				head->hmd->active_rendering_mode_index = modeIdx;
-				broadcast_rendering_mode_change(sys, head, prev_idx, modeIdx);
+				if (sys->multi_comp != nullptr) {
+					multi_compositor_request_mode_flip(sys, modeIdx, /*origin=*/-1);
+					U_LOG_W("App-initiated mode change: request %u (via acked-flip)", modeIdx);
+				} else {
+					uint32_t prev_idx = head->hmd->active_rendering_mode_index;
+					head->hmd->active_rendering_mode_index = modeIdx;
+					broadcast_rendering_mode_change(sys, head, prev_idx, modeIdx);
 
-				// Toggle DP 2D/3D
-				bool want_3d = head->rendering_modes[modeIdx].hardware_display_3d;
-				struct xrt_display_processor_d3d11 *dp = nullptr;
-				if (sys->workspace_mode && sys->multi_comp != nullptr)
-					dp = sys->multi_comp->display_processor;
-				else if (c->render.display_processor != nullptr)
-					dp = c->render.display_processor;
-				if (dp != nullptr)
-					xrt_display_processor_d3d11_request_display_mode(dp, want_3d);
+					bool want_3d = head->rendering_modes[modeIdx].hardware_display_3d;
+					if (c->render.display_processor != nullptr) {
+						xrt_display_processor_d3d11_request_display_mode(
+						    c->render.display_processor, want_3d);
+					}
 
-				sync_tile_layout(sys);
-				sys->hardware_display_3d = want_3d;
-				U_LOG_W("App-initiated mode change: %u -> %u (3D=%d)", prev_idx, modeIdx, (int)want_3d);
+					sync_tile_layout(sys);
+					sys->hardware_display_3d = want_3d;
+					U_LOG_W("App-initiated mode change: %u -> %u (3D=%d, immediate)",
+					        prev_idx, modeIdx, (int)want_3d);
+				}
 			}
 		}
 	}
 
 	// Runtime-side 2D/3D toggle (V key) — polls qwerty driver each frame.
 	// Disabled when bridge is active: mode changes go through the HWND
-	// property relay above (app-initiated path).
+	// property relay above (app-initiated path). When the multi-comp is
+	// active, routes through the acked-flip path (#234); otherwise preserves
+	// the immediate-flip behavior on the per-client DP.
 #ifdef XRT_BUILD_DRIVER_QWERTY
 	if (sys->xsysd != NULL && !bridge_live) {
 		bool force_2d = false;
@@ -10153,35 +10463,32 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 		if (toggled) {
 			struct xrt_device *head = sys->xsysd->static_roles.head;
 			if (head != nullptr && head->hmd != NULL) {
-				uint32_t prev_idx = head->hmd->active_rendering_mode_index;
+				uint32_t target_idx;
 				if (force_2d) {
-					// Save current 3D mode index before switching to 2D
 					uint32_t cur = head->hmd->active_rendering_mode_index;
 					if (cur < head->rendering_mode_count &&
 					    head->rendering_modes[cur].hardware_display_3d) {
 						sys->last_3d_mode_index = cur;
 					}
-					head->hmd->active_rendering_mode_index = 0;
+					target_idx = 0; // mode 0 = 2D mono
 				} else {
-					// Restore last 3D mode index
-					head->hmd->active_rendering_mode_index = sys->last_3d_mode_index;
+					target_idx = sys->last_3d_mode_index;
 				}
-				broadcast_rendering_mode_change(sys, head, prev_idx,
-				                                head->hmd->active_rendering_mode_index);
+
+				if (sys->multi_comp != nullptr) {
+					multi_compositor_request_mode_flip(sys, target_idx, /*origin=*/-1);
+				} else {
+					uint32_t prev_idx = head->hmd->active_rendering_mode_index;
+					head->hmd->active_rendering_mode_index = target_idx;
+					broadcast_rendering_mode_change(sys, head, prev_idx, target_idx);
+					if (c->render.display_processor != nullptr) {
+						xrt_display_processor_d3d11_request_display_mode(
+						    c->render.display_processor, !force_2d);
+					}
+					sync_tile_layout(sys);
+					sys->hardware_display_3d = !force_2d;
+				}
 			}
-			// Switch display mode on the active DP.
-			// In workspace mode, the multi-comp owns the DP (per-client has none).
-			struct xrt_display_processor_d3d11 *dp = nullptr;
-			if (sys->workspace_mode && sys->multi_comp != nullptr) {
-				dp = sys->multi_comp->display_processor;
-			} else if (c->render.display_processor != nullptr) {
-				dp = c->render.display_processor;
-			}
-			if (dp != nullptr) {
-				xrt_display_processor_d3d11_request_display_mode(dp, !force_2d);
-			}
-			sync_tile_layout(sys);
-			sys->hardware_display_3d = !force_2d;
 		}
 
 		// Rendering mode change from qwerty 1/2/3 keys (disabled for legacy apps).
@@ -10249,34 +10556,56 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 		}
 
 		if (got_state) {
-			if (vendor_is_3d != sys->hardware_display_3d) {
+			// Suppress vendor-poll detection while an acked-flip is in progress
+			// (#234). During WAITING_ACK / FLIPPING the workspace has written
+			// sys->hardware_display_3d to the TARGET state but the vendor
+			// hardware is still mid-transition — the poll would (re)trigger a
+			// flip in the OPPOSITE direction, creating a feedback loop. Let
+			// the in-flight flip land; the post-flip apply_pending tick polls
+			// get_hardware_3d_state itself and bounds the wait.
+			bool pending_flip = sys->multi_comp != nullptr &&
+			                    sys->multi_comp->mode_flip.phase != MFP_IDLE;
+			if (vendor_is_3d != sys->hardware_display_3d && !pending_flip) {
 				U_LOG_W("Vendor SDK hardware 3D state changed: %s → %s",
 				        sys->hardware_display_3d ? "3D" : "2D",
 				        vendor_is_3d ? "3D" : "2D");
-				sys->hardware_display_3d = vendor_is_3d;
 				// When bridge is active, don't force the rendering mode
 				// transition — let the app decide via requestRenderingMode().
 				// The app receives a hardwarestatechange event and can react.
 				// Forcing causes a brief glitch (2D content through 3D weaver).
 				if (!bridge_live) {
-				// Update the device's active rendering mode to match
 				struct xrt_device *head = sys->xsysd ? sys->xsysd->static_roles.head : nullptr;
 				if (head != nullptr && head->hmd != NULL) {
-					uint32_t prev_idx = head->hmd->active_rendering_mode_index;
+					uint32_t target_idx;
 					if (!vendor_is_3d) {
 						uint32_t cur = head->hmd->active_rendering_mode_index;
 						if (cur < head->rendering_mode_count &&
 						    head->rendering_modes[cur].hardware_display_3d) {
 							sys->last_3d_mode_index = cur;
 						}
-						head->hmd->active_rendering_mode_index = 0; // mode 0 = 2D
+						target_idx = 0; // mode 0 = 2D
 					} else {
-						head->hmd->active_rendering_mode_index = sys->last_3d_mode_index;
+						target_idx = sys->last_3d_mode_index;
 					}
-					broadcast_rendering_mode_change(sys, head, prev_idx,
-					                                head->hmd->active_rendering_mode_index);
+					if (sys->multi_comp != nullptr) {
+						// Vendor-initiated: hardware is ALREADY at vendor_is_3d
+						// (the poll just discovered it). We still route through
+						// the acked-flip path so apps re-submit at the new
+						// layout; FLIPPING-phase vendor poll will see the
+						// hardware already settled and lift the curtain quickly.
+						multi_compositor_request_mode_flip(sys, target_idx, /*origin=*/-1);
+					} else {
+						uint32_t prev_idx = head->hmd->active_rendering_mode_index;
+						head->hmd->active_rendering_mode_index = target_idx;
+						broadcast_rendering_mode_change(sys, head, prev_idx, target_idx);
+						sync_tile_layout(sys);
+						sys->hardware_display_3d = vendor_is_3d;
+					}
 				}
-				sync_tile_layout(sys);
+				} else {
+					// Bridge path: just mirror sys->hardware_display_3d so the
+					// app's hardwarestatechange event fires; don't touch mode.
+					sys->hardware_display_3d = vendor_is_3d;
 				}
 			}
 		}
@@ -11178,6 +11507,25 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 				continue;
 			}
 			std::lock_guard<std::mutex> snap_lock(slot_snap->ws_snapshot_mutex);
+			// Release strong refs the previous snapshot held on its
+			// swapchains (#234 follow-on). comp_layer's sc_array is raw
+			// pointers; we take xrt_swapchain refs on snapshot write so
+			// the underlying swapchains stay alive while the render
+			// thread reads them. Otherwise the IPC per-client cleanup
+			// path (ipc_server_per_client_thread.c:510) drops xscs refs
+			// WITHOUT sys->render_mutex, freeing the swapchains while
+			// multi_compositor_render is still mid-HUD-pass — observed
+			// as a UAF on `sc->images[img_idx].texture->GetDesc(...)` at
+			// comp_d3d11_service.cpp:8213 (close-button crash).
+			for (uint32_t j = 0; j < slot_snap->ws_snapshot_count; j++) {
+				for (size_t k = 0;
+				     k < ARRAY_SIZE(slot_snap->ws_snapshot[j].sc_array);
+				     k++) {
+					xrt_swapchain_reference(
+					    &slot_snap->ws_snapshot[j].sc_array[k], NULL);
+				}
+			}
+			slot_snap->ws_snapshot_count = 0;
 			uint32_t snap_n = 0;
 			bool saw_projection = false;
 			for (uint32_t i = 0;
@@ -11190,11 +11538,52 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 					slot_snap->projection_flags_snapshot = l->data.flags;
 					slot_snap->projection_flags_valid = true;
 					saw_projection = true;
+
+					// Acked-flip detection (#234): refresh the per-
+					// slot extent snapshot every commit; when a
+					// workspace mode-flip is pending, ack when the
+					// extent has CHANGED since the pre_flip snapshot
+					// (taken at request_mode_flip time). Workspace
+					// apps submit window-scaled extents not the
+					// canonical rendering_modes[].view_width_pixels,
+					// so an absolute match doesn't work — but the
+					// extent does change when the app re-renders at
+					// the new tile_columns after consuming
+					// XrEventDataRenderingModeChangedEXT.
+					uint32_t got_w = l->data.proj.v[0].sub.rect.extent.w;
+					uint32_t got_h = l->data.proj.v[0].sub.rect.extent.h;
+					slot_snap->last_commit_view_w = got_w;
+					slot_snap->last_commit_view_h = got_h;
+					struct d3d11_multi_compositor *mc_ack = sys->multi_comp;
+					if (mc_ack != nullptr &&
+					    mc_ack->mode_flip.phase == MFP_WAITING_ACK &&
+					    !slot_snap->acked_target_mode) {
+						if (slot_snap->pre_flip_view_w != got_w ||
+						    slot_snap->pre_flip_view_h != got_h) {
+							slot_snap->acked_target_mode = true;
+						}
+					}
 				}
 				if (l->data.type != XRT_LAYER_WINDOW_SPACE) {
 					continue;
 				}
+				// Copy non-pointer layer data, then take strong refs on
+				// the sc_array pointers (#234 follow-on, see comment
+				// above the snapshot-clear loop). The raw `*l` would
+				// dangle when IPC drops the swapchain ref unsynchronized.
 				slot_snap->ws_snapshot[snap_n] = *l;
+				for (size_t k = 0;
+				     k < ARRAY_SIZE(slot_snap->ws_snapshot[snap_n].sc_array);
+				     k++) {
+					struct xrt_swapchain *raw =
+					    slot_snap->ws_snapshot[snap_n].sc_array[k];
+					slot_snap->ws_snapshot[snap_n].sc_array[k] = NULL;
+					if (raw != NULL) {
+						xrt_swapchain_reference(
+						    &slot_snap->ws_snapshot[snap_n].sc_array[k],
+						    raw);
+					}
+				}
 				snap_n++;
 			}
 			slot_snap->ws_snapshot_count = snap_n;
@@ -11538,37 +11927,67 @@ compositor_destroy(struct xrt_compositor *xc)
 #endif
 	}
 
-	// Unregister from multi-compositor before cleanup.
+	// Unregister from multi-compositor AND tear down all per-client GPU
+	// resources under sys->render_mutex (#234 follow-on). Previously only
+	// the unregister was inside the lock; fini_client_render_resources and
+	// fence cleanup happened outside, leaving a window where the render
+	// thread (capture_render_thread_func acquires the same mutex) could
+	// iterate mc->clients[] AFTER unregister null'd the slot but BEFORE
+	// the per-client D3D11 resources were released — and a stale snapshot
+	// of slot->compositor taken in the per-tile blit pass could deref a
+	// just-freed COM interface (observed: vtable call on rcx=feeefeee at
+	// multi_compositor_render +0x4781 when user clicks the close button).
+	// Holding the render mutex through the full teardown serializes the
+	// destroy with any in-progress render so the slot is guaranteed both
+	// unregistered AND fully torn down before the render thread can next
+	// observe it.
+	//
 	// Always unregister if there's a multi_comp — the client may have been
-	// registered in workspace mode but is now closing in standalone mode (after
-	// hot-switch). Without this, the slot stays stale and shows a ghost
-	// remnant on workspace re-activate.
+	// registered in workspace mode but is now closing in standalone mode
+	// (after hot-switch). Without this, the slot stays stale and shows a
+	// ghost remnant on workspace re-activate.
 	if (sys->multi_comp != nullptr) {
 		std::lock_guard<std::recursive_mutex> lock(sys->render_mutex);
 		multi_compositor_unregister_client(sys, c);
-	}
 
-	// Clear active compositor if it's this one
-	{
-		std::lock_guard<std::mutex> lock(sys->active_compositor_mutex);
-		if (sys->active_compositor == c) {
-			sys->active_compositor = nullptr;
+		// Clear active compositor if it's this one (still under render mutex
+		// so the render thread can't snapshot a stale active_compositor).
+		{
+			std::lock_guard<std::mutex> aclock(sys->active_compositor_mutex);
+			if (sys->active_compositor == c) {
+				sys->active_compositor = nullptr;
+			}
 		}
-	}
 
-	// Clean up per-client render resources (window, swap chain, display processor)
-	fini_client_render_resources(&c->render);
+		// Tear down per-client render resources (window, swap chain, DP,
+		// atlas textures / SRVs / RTVs) while still holding render_mutex.
+		fini_client_render_resources(&c->render);
 
-	// Phase 2: workspace_sync_fence cleanup. The com_ptr release drops the
-	// fence object; the shared NT handle was DuplicateHandle'd into the
-	// client process by the IPC layer (each ipc_send_handles_* call mints a
-	// fresh dup), so closing the source handle here doesn't disturb the
-	// client's open fence.
-	if (c->workspace_sync_fence_handle != nullptr) {
-		CloseHandle(c->workspace_sync_fence_handle);
-		c->workspace_sync_fence_handle = nullptr;
+		// workspace_sync_fence: drop the shared D3D11 fence. com_ptr release
+		// drops the fence object; the shared NT handle was DuplicateHandle'd
+		// into the client process by the IPC layer, so closing the source
+		// handle here doesn't disturb the client's open fence.
+		if (c->workspace_sync_fence_handle != nullptr) {
+			CloseHandle(c->workspace_sync_fence_handle);
+			c->workspace_sync_fence_handle = nullptr;
+		}
+		c->workspace_sync_fence.reset();
+	} else {
+		// No multi_comp: legacy single-client teardown, no render-thread
+		// race to guard against.
+		{
+			std::lock_guard<std::mutex> aclock(sys->active_compositor_mutex);
+			if (sys->active_compositor == c) {
+				sys->active_compositor = nullptr;
+			}
+		}
+		fini_client_render_resources(&c->render);
+		if (c->workspace_sync_fence_handle != nullptr) {
+			CloseHandle(c->workspace_sync_fence_handle);
+			c->workspace_sync_fence_handle = nullptr;
+		}
+		c->workspace_sync_fence.reset();
 	}
-	c->workspace_sync_fence.reset();
 
 	delete c;
 }
@@ -11942,6 +12361,22 @@ system_create_native_compositor(struct xrt_system_compositor *xsysc,
 
 	*out_xcn = &c->base;
 	return XRT_SUCCESS;
+}
+
+/*!
+ * Hook for oxr_xrRequestDisplayRenderingModeEXT when called by a workspace
+ * controller session (#234). Routes through the acked-flip + curtain path
+ * on the multi-compositor; the OXR layer then SKIPS the legacy immediate
+ * device-mode-update path, avoiding the raw-atlas glitch that's otherwise
+ * visible whenever the controller drives a mode change (shell V-toggle,
+ * focus-adaptive 2D, etc.).
+ *
+ * Returns false if there's no multi_comp (caller falls back to legacy path).
+ */
+static bool
+system_request_workspace_mode_flip(struct xrt_system_compositor *xsysc, uint32_t mode_index)
+{
+	return comp_d3d11_service_workspace_request_mode_flip(xsysc, mode_index);
 }
 
 static void
@@ -12362,6 +12797,7 @@ comp_d3d11_service_create_system(struct xrt_device *xdev,
 	// Set up system compositor vtable
 	sys->base.create_native_compositor = system_create_native_compositor;
 	sys->base.destroy = system_destroy;
+	sys->base.request_workspace_mode_flip = system_request_workspace_mode_flip;
 
 	// Set up multi-compositor control for session state management
 	sys->xmcc.set_state = system_set_state;
@@ -14163,6 +14599,54 @@ comp_d3d11_service_set_client_modal_state(struct xrt_system_compositor *xsysc, i
 	}
 	mc->clients[slot].modal_open = is_open;
 
+	// Modal-driven 2D-flip (#234, ADR-017 §"Required response" item 2):
+	// when the FOCUSED slot opens a modal, present a flat workspace so the
+	// OS-native dialog reads cleanly. Routes through the acked-flip path so
+	// the catch-up artifact is masked by the curtain. On modal-close,
+	// restore the pre-modal mode unless the user has manually changed mode
+	// in the meantime (defensive: don't yank a user-initiated 3D toggle).
+	// Non-focused-slot modals do not drive mode.
+	if (slot == mc->focused_slot && sys->xsysd != NULL) {
+		struct xrt_device *head = sys->xsysd->static_roles.head;
+		if (head != nullptr && head->hmd != NULL && head->rendering_mode_count > 0) {
+			uint32_t cur_idx = head->hmd->active_rendering_mode_index;
+			// Resolve the 2D mode index (first mode with hardware_display_3d == false).
+			uint32_t idx_2d = UINT32_MAX;
+			for (uint32_t i = 0; i < head->rendering_mode_count; i++) {
+				if (!head->rendering_modes[i].hardware_display_3d) {
+					idx_2d = i;
+					break;
+				}
+			}
+			if (idx_2d != UINT32_MAX) {
+				if (is_open) {
+					// Only save the pre-modal mode when we actually transition
+					// FROM a 3D mode to 2D. If we're already in 2D (e.g., a
+					// second modal opens while the first is still up, or focus-
+					// adaptive already put us in 2D), preserve the existing
+					// saved_mode_index so the eventual modal-close still
+					// restores the original 3D mode.
+					if (cur_idx != idx_2d) {
+						mc->mode_flip.saved_mode_index = cur_idx;
+						multi_compositor_request_mode_flip(sys, idx_2d, slot);
+						U_LOG_W("[mode_flip] modal-open on focused slot %d: %u -> 2D (%u)",
+						        slot, cur_idx, idx_2d);
+					}
+				} else {
+					// Only restore if we're still in 2D (presumed to be the
+					// mode we forced on MODAL_OPEN); otherwise leave alone.
+					uint32_t want = mc->mode_flip.saved_mode_index;
+					if (cur_idx == idx_2d && want != idx_2d &&
+					    want < head->rendering_mode_count) {
+						multi_compositor_request_mode_flip(sys, want, slot);
+						U_LOG_W("[mode_flip] modal-close on focused slot %d: 2D -> %u (restore)",
+						        slot, want);
+					}
+				}
+			}
+		}
+	}
+
 	// Item 4 (#232) cont'd: when transitioning to modal-open, grant the
 	// app process foreground-activation rights so its in-flight dialog
 	// CreateWindow can claim foreground. The IPC RPC fires synchronously
@@ -14198,6 +14682,23 @@ comp_d3d11_service_set_client_modal_state(struct xrt_system_compositor *xsysc, i
 	// so calling from this IPC thread is safe even though the WndProc
 	// thread reads concurrently.
 	multi_compositor_update_input_forward(mc);
+}
+
+extern "C" bool
+comp_d3d11_service_workspace_request_mode_flip(struct xrt_system_compositor *xsysc, uint32_t mode_index)
+{
+	if (xsysc == nullptr) {
+		return false;
+	}
+	struct d3d11_service_system *sys = d3d11_service_system_from_xrt(xsysc);
+	if (sys == nullptr || sys->multi_comp == nullptr) {
+		return false;
+	}
+	std::lock_guard<std::recursive_mutex> lock(sys->render_mutex);
+	// origin_slot = -1 (system origin) — the workspace controller is logically
+	// the system, not a renderable slot.
+	multi_compositor_request_mode_flip(sys, mode_index, /*origin=*/-1);
+	return true;
 }
 
 extern "C" void *

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -787,11 +787,12 @@ enum mode_flip_phase
 
 //! Frames to hold the curtain ON after DP request_display_mode lands before
 //! lifting it unconditionally — covers the vendor's hardware transition
-//! window when get_hardware_3d_state lies or hasn't converged, AND gives
-//! poorly-behaved apps (test apps that don't process
-//! XrEventDataRenderingModeChangedEXT) time to re-render at the new layout
-//! before the curtain drops. ~1 second at 60 Hz.
-#define MFP_HW_CEILING_FRAMES 60
+//! window when get_hardware_3d_state lies or hasn't converged. The 60-frame
+//! bump was a band-aid for Issue 3 (per-slot stride mismatch during the
+//! catch-up window). Now that the workspace per-tile blit uses each slot's
+//! OWN stride snapshot (write/read stay coupled per-slot), the curtain
+//! only needs to mask SR SDK hardware settle (~250 ms ≈ 16 frames).
+#define MFP_HW_CEILING_FRAMES 16
 
 /*!
  * Per-client slot in the multi-compositor.
@@ -832,6 +833,20 @@ struct d3d11_multi_client_slot
 	uint32_t last_commit_view_h;
 	uint32_t pre_flip_view_w;
 	uint32_t pre_flip_view_h;
+
+	//! Per-slot stride snapshot (#234, Issue 3). Captured at content-clamp
+	//! time in compositor_layer_commit using `atlas_w / sys->tile_columns`
+	//! AT THE TIME OF WRITE — same formula the clamp itself uses, so write
+	//! and read stay coupled through the slot's own snapshot even when the
+	//! global sys->tile_columns flips ahead of an unacked slot. Without
+	//! this, multi_compositor_render reads with the NEW global stride while
+	//! the slot's atlas still holds OLD-stride content; visible as L/R
+	//! mashing during the post-flip curtain drop. Set to 0 pre-first-commit
+	//! so the blit can fall back to the global formula.
+	uint32_t blit_slot_w;
+	uint32_t blit_slot_h;
+	uint32_t blit_tile_columns;
+	uint32_t blit_tile_rows;
 
 	//! Window-space layer snapshot for `multi_compositor_render`'s WS pass.
 	//! Updated under `ws_snapshot_mutex` at the end of compositor_layer_commit
@@ -8128,17 +8143,22 @@ after_key_shortcuts:
 			src_tex_h = client_atlas_desc.Height;
 			slot_flip_y = cc->atlas_flip_y;
 
-			// Tile-overflow guard. The per-tile source origin below is
-			// `src_col * slot_w_atlas` where `slot_w_atlas = atlas_w /
-			// tile_columns` — same stride compositor_layer_commit writes
-			// at. cvw > slot_w_atlas would make multi-comp read past the
-			// slot boundary into the neighbouring tile's content
-			// (`feedback_atlas_stride_invariant`: stride and clamp must
-			// use the SAME atlas-derived slot width).
-			slot_w_atlas = src_tex_w / sys->tile_columns;
-			slot_h_atlas = src_tex_h / sys->tile_rows;
-			assert(cvw <= slot_w_atlas);
-			assert(cvh <= slot_h_atlas);
+			// Per-slot stride (#234, Issue 3): use the slot's OWN
+			// snapshot of atlas/tile_columns captured at commit time,
+			// not the current global sys->tile_columns. The two diverge
+			// during the curtain window of a workspace mode flip — the
+			// slot's atlas was WRITTEN at the snapshotted stride, so
+			// reading at the global stride would mash L/R together.
+			// Fallback to the atlas-derived global formula for the very
+			// first commit (snapshot is zero until then).
+			slot_w_atlas = mc->clients[s].blit_slot_w;
+			slot_h_atlas = mc->clients[s].blit_slot_h;
+			if (slot_w_atlas == 0 || slot_h_atlas == 0) {
+				uint32_t tc_fb = sys->tile_columns > 0 ? sys->tile_columns : 1;
+				uint32_t tr_fb = sys->tile_rows > 0 ? sys->tile_rows : 1;
+				slot_w_atlas = src_tex_w / tc_fb;
+				slot_h_atlas = src_tex_h / tr_fb;
+			}
 			if (cvw > slot_w_atlas) cvw = slot_w_atlas;
 			if (cvh > slot_h_atlas) cvh = slot_h_atlas;
 
@@ -8335,22 +8355,27 @@ after_key_shortcuts:
 
 		// Shader blit each view → combined atlas.
 		uint32_t num_views = sys->tile_columns * sys->tile_rows;
+		// Per-slot tile layout (#234, Issue 3): captured at commit time so
+		// the source coord stays aligned with the slot's actual atlas
+		// contents even when sys->tile_columns is ahead of an unacked slot.
+		uint32_t slot_tc = mc->clients[s].blit_tile_columns;
+		uint32_t slot_tr = mc->clients[s].blit_tile_rows;
+		if (slot_tc == 0) slot_tc = sys->tile_columns > 0 ? sys->tile_columns : 1;
+		if (slot_tr == 0) slot_tr = sys->tile_rows > 0 ? sys->tile_rows : 1;
 		for (uint32_t v = 0; v < num_views && v < XRT_MAX_VIEWS; v++) {
 			uint32_t src_col = v % sys->tile_columns;
 			uint32_t src_row = v / sys->tile_columns;
 
-			// Per-tile source origin in the per-client atlas.
-			// Mono clients use (0,0) for all views; IPC clients place
-			// each tile at `slot_w_atlas × slot_h_atlas` stride — same
-			// stride compositor_layer_commit writes at, derived from
-			// atlas/tile_columns NOT sys->view_width
-			// (`feedback_atlas_stride_invariant`: in workspace mode the
-			// per-client atlas is created at native pixel dims while
-			// sys->view_width tracks the SCALED view dim; they diverge).
-			// Content within each tile may be smaller than the slot
-			// (top-left), and its extent is cvw × cvh; the shader's
-			// `src_rect.zw = cvw,cvh` (set below) drives sampling, the
-			// per-tile origin sets `src_rect.xy`.
+			// Map destination tile → slot's source tile. If the slot
+			// last wrote with FEWER tiles than the global expects (slot
+			// is behind a mode flip), replicate view 0 into the extra
+			// dest tiles — still valid content from the slot, just at a
+			// smaller layout. Reverse case (slot has more views than
+			// global) drops the extras naturally because num_views is
+			// the global count.
+			uint32_t slot_col = (src_col < slot_tc) ? src_col : 0;
+			uint32_t slot_row = (src_row < slot_tr) ? src_row : 0;
+
 			float src_px_x, src_px_y;
 			if (slot_is_mono || mc->mode_flip.curtain_active) {
 				// Curtain (#234): during a workspace mode flip, force every
@@ -8358,13 +8383,15 @@ after_key_shortcuts:
 				// with the eye_idx=0 collapse below, this writes identical
 				// content to both halves of combined_atlas so the SR weaver
 				// sees a uniform mono frame regardless of which slots have
-				// caught up to the new layout. Avoids the "raw atlas
-				// visible" double-image artifact during the catch-up window.
+				// caught up to the new layout.
 				src_px_x = 0.0f;
 				src_px_y = 0.0f;
 			} else {
-				src_px_x = static_cast<float>(src_col * slot_w_atlas);
-				src_px_y = static_cast<float>(src_row * slot_h_atlas);
+				// Use slot's OWN stride snapshot — same value the slot's
+				// commit-time clamp computed, guaranteeing write/read stay
+				// coupled regardless of the global tile_columns state.
+				src_px_x = static_cast<float>(slot_col * slot_w_atlas);
+				src_px_y = static_cast<float>(slot_row * slot_h_atlas);
 			}
 
 			// Per-eye destination rect (parallax-shifted for Z != 0).
@@ -11414,6 +11441,24 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 					    &sys->multi_comp->clients[s];
 					slot->content_view_w = content_view_w;
 					slot->content_view_h = content_view_h;
+
+					// Snapshot per-slot stride for the workspace
+					// per-tile blit (#234, Issue 3). Same formula
+					// the clamp at L11385 uses — write/clamp/read
+					// must agree, and capturing here keeps the slot
+					// self-consistent even when sys->tile_columns
+					// flips ahead of this slot's next commit.
+					if (c->render.atlas_texture) {
+						D3D11_TEXTURE2D_DESC sc_desc = {};
+						c->render.atlas_texture->GetDesc(&sc_desc);
+						uint32_t tc = sys->tile_columns > 0 ? sys->tile_columns : 1;
+						uint32_t tr = sys->tile_rows > 0 ? sys->tile_rows : 1;
+						slot->blit_slot_w = sc_desc.Width / tc;
+						slot->blit_slot_h = sc_desc.Height / tr;
+						slot->blit_tile_columns = tc;
+						slot->blit_tile_rows = tr;
+					}
+
 					if (!slot->has_first_frame_committed) {
 						slot->has_first_frame_committed = true;
 						slot->first_frame_ns =

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -10610,7 +10610,33 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 			const int64_t kPostFlipCooldownNs = 2000LL * 1000000LL;
 			int64_t last_landed = sys->last_flip_landed_ns.load(std::memory_order_acquire);
 			bool in_cooldown = last_landed > 0 && (now_ns - last_landed) < kPostFlipCooldownNs;
-			if (vendor_is_3d != sys->hardware_display_3d && !pending_flip && !in_cooldown) {
+			// Under workspace mode the controller is the sole mode authority.
+			// If the vendor SDK silently flips itself (SR auto-fallback,
+			// SR Dashboard external toggle), re-assert the runtime's desired
+			// state on the DP rather than counter-correcting the runtime.
+			// Observed at shell-with-apps launch: vendor reports 3D briefly,
+			// then drops to 2D ~2s later (right as the post-flip cooldown
+			// expires) — display would look 2D even though apps render 3D.
+			// Re-asserting via DP request keeps the hardware locked to what
+			// the workspace controller asked for. #234.
+			if (sys->workspace_mode && vendor_is_3d != sys->hardware_display_3d &&
+			    !pending_flip && !in_cooldown) {
+				if (sys->multi_comp != nullptr && sys->multi_comp->display_processor != nullptr) {
+					U_LOG_W("[force_3d] vendor drifted (vendor=%s runtime=%s) — re-asserting DP to runtime state",
+					        vendor_is_3d ? "3D" : "2D",
+					        sys->hardware_display_3d ? "3D" : "2D");
+					xrt_display_processor_d3d11_request_display_mode(
+					    sys->multi_comp->display_processor,
+					    sys->hardware_display_3d);
+					// Refresh cooldown so we don't hammer the DP on every poll
+					// while the vendor settles back.
+					sys->cached_3d_state.store(sys->hardware_display_3d, std::memory_order_relaxed);
+					sys->last_3d_state_poll_ns.store(now_ns, std::memory_order_release);
+					sys->last_flip_landed_ns.store(now_ns, std::memory_order_release);
+				}
+				got_state = false; // skip the legacy counter-correction below
+			}
+			if (vendor_is_3d != sys->hardware_display_3d && !pending_flip && !in_cooldown && got_state) {
 				U_LOG_W("Vendor SDK hardware 3D state changed: %s → %s",
 				        sys->hardware_display_3d ? "3D" : "2D",
 				        vendor_is_3d ? "3D" : "2D");
@@ -14748,6 +14774,85 @@ comp_d3d11_service_workspace_request_mode_flip(struct xrt_system_compositor *xsy
 	// origin_slot = -1 (system origin) — the workspace controller is logically
 	// the system, not a renderable slot.
 	multi_compositor_request_mode_flip(sys, mode_index, /*origin=*/-1);
+	return true;
+}
+
+extern "C" bool
+comp_d3d11_service_force_display_3d(struct xrt_system_compositor *xsysc)
+{
+	if (xsysc == nullptr) {
+		return false;
+	}
+	struct d3d11_service_system *sys = d3d11_service_system_from_xrt(xsysc);
+	if (sys == nullptr || sys->multi_comp == nullptr) {
+		return false;
+	}
+	std::lock_guard<std::recursive_mutex> lock(sys->render_mutex);
+	struct d3d11_multi_compositor *mc = sys->multi_comp;
+	struct xrt_device *head = (sys->xsysd != nullptr) ? sys->xsysd->static_roles.head : nullptr;
+	if (head == nullptr || head->hmd == NULL) {
+		return false;
+	}
+	uint32_t target_idx = 1;
+	if (target_idx >= head->rendering_mode_count) {
+		return false;
+	}
+	uint32_t source_idx = head->hmd->active_rendering_mode_index;
+	bool was_3d = sys->hardware_display_3d;
+
+	// Route through the acked-flip state machine so the DP write happens
+	// with curtain ON and the FLIPPING handler waits for hardware settle.
+	// Calling xrt_display_processor_d3d11_request_display_mode() directly
+	// on a freshly-created DP isn't reliable (Phase 6.1 #140 — the SR
+	// SDK's recalibration cycle can swallow the request), so we mimic the
+	// state machine's WAITING_ACK→FLIPPING transition and let apply_pending
+	// drop the curtain once `get_hardware_3d_state` confirms.
+	if (source_idx != target_idx) {
+		// Normal case: source mode != target. Engage WAITING_ACK; the
+		// state machine broadcasts the event, waits for app ack /
+		// timeout, then transitions to FLIPPING.
+		multi_compositor_request_mode_flip(sys, target_idx, /*origin=*/-1);
+		U_LOG_W("[force_3d] engaged via state machine (was idx=%u 3d=%d → target=1)",
+		        source_idx, (int)was_3d);
+		return true;
+	}
+
+	// source_idx == target_idx case: the no-op guard in
+	// multi_compositor_request_mode_flip would skip the DP write. But the
+	// runtime's view can disagree with actual hardware (e.g. service just
+	// started, sys->hardware_display_3d=false because of struct zero-init;
+	// or SR Dashboard external toggle). We need the DP write to land
+	// regardless. Skip WAITING_ACK (no apps need to re-render) and set up
+	// FLIPPING directly, replicating the WAITING_ACK→FLIPPING transition
+	// (DP request, sync_tile_layout, hardware_display_3d update); the
+	// apply_pending FLIPPING handler then waits for the hardware to
+	// actually settle before dropping the curtain.
+	if (mc->display_processor == nullptr) {
+		U_LOG_W("[force_3d] no DP yet — caller should retry after DP attach");
+		return false;
+	}
+
+	mc->mode_flip.phase = MFP_FLIPPING;
+	mc->mode_flip.target_mode_index = target_idx;
+	mc->mode_flip.source_mode_index = source_idx;
+	mc->mode_flip.target_is_3d = true;
+	mc->mode_flip.origin_slot = -1;
+	mc->mode_flip.ack_frame_counter = 0;
+	mc->mode_flip.flip_frame_counter = 0;
+	mc->mode_flip.curtain_active = true;
+	for (int s = 0; s < D3D11_MULTI_MAX_CLIENTS; s++) {
+		mc->clients[s].acked_target_mode = true;
+		mc->clients[s].pre_flip_view_w = mc->clients[s].last_commit_view_w;
+		mc->clients[s].pre_flip_view_h = mc->clients[s].last_commit_view_h;
+	}
+
+	xrt_device_set_property(head, XRT_DEVICE_PROPERTY_OUTPUT_MODE, (int32_t)target_idx);
+	xrt_display_processor_d3d11_request_display_mode(mc->display_processor, /*hardware_display_3d=*/true);
+	sync_tile_layout(sys);
+	sys->hardware_display_3d = true;
+
+	U_LOG_W("[force_3d] same-target fast path (idx=%u, was 3d=%d) — FLIPPING engaged, curtain ON",
+	        target_idx, (int)was_3d);
 	return true;
 }
 

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -639,6 +639,14 @@ struct d3d11_service_system
 	std::atomic<bool>    cached_3d_state{false};
 	std::atomic<bool>    cached_3d_state_valid{false};
 
+	//! Monotonic ns when the most recent acked-flip landed (FLIPPING -> IDLE).
+	//! The vendor poll suppresses counter-correction flips for
+	//! `kPostFlipCooldownNs` after this stamp — the vendor SDK's cached
+	//! `is_3d` state can lag the post-flip reality by a frame or two, and
+	//! without the gate the poll would request a flip back to the prior mode
+	//! within ~200 ms of the user's V keypress. Zero = no flip has landed yet.
+	std::atomic<int64_t> last_flip_landed_ns{0};
+
 	//! Phase 2.C spec_version 8: auto-reset Win32 event signaled whenever an
 	//! async workspace state change occurs that the controller might want to
 	//! react to (input event pushed onto the public ring, focused-slot
@@ -1638,6 +1646,20 @@ multi_compositor_apply_pending_mode_flip(struct d3d11_service_system *sys)
 				U_LOG_W("[mode_flip] FLIPPING ceiling at %u frames — lifting curtain unconditionally",
 				        mc->mode_flip.flip_frame_counter);
 			}
+			// Pre-load the vendor-poll cache and stamp the cooldown timer
+			// before going IDLE. The vendor SDK's `is_3d` reading at this
+			// point is what we just commanded; writing it into the cache so
+			// the next CAS-protected poll reads a consistent value (instead
+			// of the stale pre-flip cache) avoids a single-frame mismatch
+			// against `sys->hardware_display_3d`. The cooldown stamp gives
+			// the vendor SDK's internal state time to fully settle so a
+			// genuine vendor-initiated change (which would arrive after the
+			// 2-second window) can still take effect.
+			int64_t landed_ns = os_monotonic_get_ns();
+			sys->cached_3d_state.store(mc->mode_flip.target_is_3d, std::memory_order_relaxed);
+			sys->cached_3d_state_valid.store(true, std::memory_order_release);
+			sys->last_3d_state_poll_ns.store(landed_ns, std::memory_order_release);
+			sys->last_flip_landed_ns.store(landed_ns, std::memory_order_release);
 			mc->mode_flip.curtain_active = false;
 			mc->mode_flip.phase = MFP_IDLE;
 		}
@@ -10576,7 +10598,19 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 			// get_hardware_3d_state itself and bounds the wait.
 			bool pending_flip = sys->multi_comp != nullptr &&
 			                    sys->multi_comp->mode_flip.phase != MFP_IDLE;
-			if (vendor_is_3d != sys->hardware_display_3d && !pending_flip) {
+			// Post-flip cooldown (#234). After a flip lands the vendor SDK's
+			// `is_3d` reading can briefly disagree with sys->hardware_display_3d
+			// because the vendor's cached state lags ~1 frame behind the
+			// hardware command. Without this gate the very next 100 ms poll
+			// window observes the disagreement and requests a counter-correction
+			// flip back to the prior mode. Two seconds is generous — enough for
+			// any vendor-side settle, short enough that a genuine vendor-
+			// initiated change (e.g. user covers the eye-tracking camera) is
+			// still picked up promptly.
+			const int64_t kPostFlipCooldownNs = 2000LL * 1000000LL;
+			int64_t last_landed = sys->last_flip_landed_ns.load(std::memory_order_acquire);
+			bool in_cooldown = last_landed > 0 && (now_ns - last_landed) < kPostFlipCooldownNs;
+			if (vendor_is_3d != sys->hardware_display_3d && !pending_flip && !in_cooldown) {
 				U_LOG_W("Vendor SDK hardware 3D state changed: %s → %s",
 				        sys->hardware_display_3d ? "3D" : "2D",
 				        vendor_is_3d ? "3D" : "2D");

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -779,8 +779,11 @@ enum mode_flip_phase
 
 //! Frames to hold the curtain ON after DP request_display_mode lands before
 //! lifting it unconditionally — covers the vendor's hardware transition
-//! window when get_hardware_3d_state lies or hasn't converged. ~270 ms.
-#define MFP_HW_CEILING_FRAMES 16
+//! window when get_hardware_3d_state lies or hasn't converged, AND gives
+//! poorly-behaved apps (test apps that don't process
+//! XrEventDataRenderingModeChangedEXT) time to re-render at the new layout
+//! before the curtain drops. ~1 second at 60 Hz.
+#define MFP_HW_CEILING_FRAMES 60
 
 /*!
  * Per-client slot in the multi-compositor.
@@ -1494,6 +1497,7 @@ multi_compositor_request_mode_flip(struct d3d11_service_system *sys,
 
 	// No-op: already at target and nothing pending.
 	if (mc->mode_flip.phase == MFP_IDLE && target_mode_idx == source_mode_idx) {
+		U_LOG_W("[mode_flip] no-op: already at target %u (IDLE)", target_mode_idx);
 		return;
 	}
 
@@ -1593,7 +1597,14 @@ multi_compositor_apply_pending_mode_flip(struct d3d11_service_system *sys)
 		}
 
 		// Land the flip: device state, DP, tile layout all in lockstep.
+		// Mirror the legacy xrRequestDisplayRenderingModeEXT path's
+		// xrt_device_set_property() call so apps that poll the device
+		// OUTPUT_MODE property (instead of consuming the event) also see
+		// the change. Apps that DO consume the event still get it via the
+		// broadcast in request_mode_flip.
 		head->hmd->active_rendering_mode_index = mc->mode_flip.target_mode_index;
+		xrt_device_set_property(head, XRT_DEVICE_PROPERTY_OUTPUT_MODE,
+		                        (int32_t)mc->mode_flip.target_mode_index);
 		xrt_display_processor_d3d11_request_display_mode(
 		    mc->display_processor, mc->mode_flip.target_is_3d);
 		sync_tile_layout(sys);
@@ -14688,12 +14699,17 @@ extern "C" bool
 comp_d3d11_service_workspace_request_mode_flip(struct xrt_system_compositor *xsysc, uint32_t mode_index)
 {
 	if (xsysc == nullptr) {
+		U_LOG_W("[mode_flip] hook: xsysc=NULL — returning false (caller falls back to legacy)");
 		return false;
 	}
 	struct d3d11_service_system *sys = d3d11_service_system_from_xrt(xsysc);
 	if (sys == nullptr || sys->multi_comp == nullptr) {
+		U_LOG_W("[mode_flip] hook: target=%u — sys=%p multi_comp=%p — returning false",
+		        mode_index, (void *)sys, (void *)(sys ? sys->multi_comp : nullptr));
 		return false;
 	}
+	U_LOG_W("[mode_flip] hook: entering request_mode_flip(target=%u) from controller session",
+	        mode_index);
 	std::lock_guard<std::recursive_mutex> lock(sys->render_mutex);
 	// origin_slot = -1 (system origin) — the workspace controller is logically
 	// the system, not a renderable slot.

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.h
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.h
@@ -625,6 +625,21 @@ comp_d3d11_service_workspace_request_mode_flip(struct xrt_system_compositor *xsy
                                                uint32_t mode_index);
 
 /*!
+ * Force-reset the display to 3D on workspace activate (#234).
+ *
+ * Bypasses the acked-flip state machine's no-op guard so the DP gets
+ * `request_display_mode(true)` even if `active_rendering_mode_index` already
+ * says mode 1. The runtime's view of the index can disagree with the actual
+ * hardware state across service restarts (struct zero-init leaves
+ * sys->hardware_display_3d=false while device defaults to mode 1) or after
+ * external vendor-SDK toggles. This guarantees a clean 3D start.
+ *
+ * Returns true if the force-reset ran, false if no multi_comp or no DP.
+ */
+bool
+comp_d3d11_service_force_display_3d(struct xrt_system_compositor *xsysc);
+
+/*!
  * Phase 2.C spec_version 9: set per-capture-client style. @p slot_index is
  * the same convention as comp_d3d11_service_set_capture_client_window_pose
  * (client_id - 1000 from the IPC layer).

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.h
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.h
@@ -611,6 +611,20 @@ void
 comp_d3d11_service_set_client_modal_state(struct xrt_system_compositor *xsysc, int slot, bool is_open);
 
 /*!
+ * Workspace controller request to flip display rendering mode (#234).
+ * Routes through the acked-flip + curtain path on the multi-compositor so
+ * the broadcast / per-slot ack / DP flip are properly sequenced with curtain
+ * masking. Returns true if the request was accepted; false if the system
+ * doesn't have a multi-compositor (caller should fall back to the legacy
+ * immediate path). Called from oxr_xrRequestDisplayRenderingModeEXT when
+ * the calling session is a workspace controller — keeps the controller's
+ * legitimate mode authority but ensures the catch-up window is masked.
+ */
+bool
+comp_d3d11_service_workspace_request_mode_flip(struct xrt_system_compositor *xsysc,
+                                               uint32_t mode_index);
+
+/*!
  * Phase 2.C spec_version 9: set per-capture-client style. @p slot_index is
  * the same convention as comp_d3d11_service_set_capture_client_window_pose
  * (client_id - 1000 from the IPC layer).

--- a/src/xrt/include/xrt/xrt_compositor.h
+++ b/src/xrt/include/xrt/xrt_compositor.h
@@ -2666,6 +2666,24 @@ struct xrt_system_compositor
 	 * The state tracker must make sure that no compositors are alive.
 	 */
 	void (*destroy)(struct xrt_system_compositor *xsc);
+
+	/*!
+	 * Optional. Issue #234: workspace controller's request to flip display
+	 * rendering mode via the acked-flip + curtain path on the multi-
+	 * compositor. NULL on backends without multi-compositor support — caller
+	 * should fall back to the legacy immediate mode update.
+	 *
+	 * Set by `comp_d3d11_service` during system compositor creation.
+	 * Called from `oxr_xrRequestDisplayRenderingModeEXT` when the calling
+	 * session is a workspace controller (compositor==NULL && service_mode);
+	 * the controller has legitimate mode authority but the immediate flip
+	 * would expose the raw-atlas glitch (#234) — routing through this hook
+	 * sequences the broadcast / per-slot ack / DP flip with curtain masking.
+	 *
+	 * Returns true if the request was accepted (caller must NOT also do the
+	 * legacy immediate flip); false to fall back.
+	 */
+	bool (*request_workspace_mode_flip)(struct xrt_system_compositor *xsc, uint32_t mode_index);
 };
 
 /*!

--- a/src/xrt/ipc/client/ipc_client_compositor.c
+++ b/src/xrt/ipc/client/ipc_client_compositor.c
@@ -13,6 +13,8 @@
 #include "xrt/xrt_defines.h"
 #include "xrt/xrt_config_os.h"
 
+#include <stdbool.h>
+
 
 #include "os/os_time.h"
 
@@ -1871,7 +1873,27 @@ ipc_syscomp_create_native_compositor(struct xrt_system_compositor *xsc,
 	return XRT_ERROR_IPC_FAILURE;
 }
 
-void
+/*!
+ * Workspace controller mode-flip hook (#234). Marshals to the server-side
+ * comp_d3d11_service_workspace_request_mode_flip via the workspace_request_
+ * display_mode IPC RPC. Returns true on success so the OXR layer's
+ * xrRequestDisplayRenderingModeEXT skips its legacy immediate-flip path.
+ */
+static bool
+ipc_syscomp_request_workspace_mode_flip(struct xrt_system_compositor *xsc, uint32_t mode_index)
+{
+	if (xsc == NULL) {
+		return false;
+	}
+	struct ipc_client_compositor *icc = container_of(xsc, struct ipc_client_compositor, system);
+	if (icc == NULL || icc->ipc_c == NULL) {
+		return false;
+	}
+	xrt_result_t r = ipc_call_workspace_request_display_mode(icc->ipc_c, mode_index);
+	return r == XRT_SUCCESS;
+}
+
+static void
 ipc_syscomp_destroy(struct xrt_system_compositor *xsc)
 {
 	struct ipc_client_compositor *icc = container_of(xsc, struct ipc_client_compositor, system);
@@ -1946,6 +1968,11 @@ ipc_client_create_system_compositor(struct ipc_connection *ipc_c,
 
 	c->system.create_native_compositor = ipc_syscomp_create_native_compositor;
 	c->system.destroy = ipc_syscomp_destroy;
+	// #234: workspace controllers' xrRequestDisplayRenderingModeEXT hook.
+	// IPC clients (including the shell, which IS a workspace controller)
+	// marshal the request to the server-side comp_d3d11_service hook so
+	// it routes through the acked-flip + curtain path.
+	c->system.request_workspace_mode_flip = ipc_syscomp_request_workspace_mode_flip;
 	c->ipc_c = ipc_c;
 	c->xina = xina;
 

--- a/src/xrt/ipc/server/ipc_server_handler.c
+++ b/src/xrt/ipc/server/ipc_server_handler.c
@@ -2269,6 +2269,16 @@ ipc_handle_workspace_activate(volatile struct ipc_client_state *_ics)
 #ifdef XRT_OS_WINDOWS
 			comp_d3d11_service_ensure_workspace_window(s->xsysc);
 #endif
+#if defined(XRT_HAVE_LEIA_SR_D3D11) && defined(XRT_HAVE_D3D11_SERVICE_COMPOSITOR)
+			// Force-reset to 3D on EVERY activate, including this
+			// already-in-workspace-mode path. The service is normally
+			// started with --shell which sets s->workspace_mode=true
+			// from boot, so every shell's activate call lands here
+			// (not the "not yet in workspace mode" branch below). If
+			// we don't force_3d here too, the shell inherits whatever
+			// state the previous session / DP defaults left behind.
+			(void)comp_d3d11_service_force_display_3d(s->xsysc);
+#endif
 		}
 		return XRT_SUCCESS;
 	}
@@ -2287,18 +2297,16 @@ ipc_handle_workspace_activate(volatile struct ipc_client_state *_ics)
 #endif
 
 #if defined(XRT_HAVE_LEIA_SR_D3D11) && defined(XRT_HAVE_D3D11_SERVICE_COMPOSITOR)
-		// Reset to mode 1 (first hardwareDisplay3D mode) on every workspace
-		// activate (#234). The active rendering mode index persists on the
-		// head device across shell launches (service doesn't restart), so
-		// if a previous session left the runtime in 2D (mode 0) and the
-		// shell relaunches, the new shell's own chrome AND any client that
-		// connects defaults to mode 1's stereo layout — but the runtime is
-		// still in mode 0's mono layout. Result: tile-stride mismatch
-		// rendered as "wild disparity" from the very first frame. Forcing
-		// mode 1 here gives the user a deterministic clean-3D start;
-		// they can V-toggle to 2D from there if they want. Routes through
-		// the acked-flip path so the transition (if any) is curtain-masked.
-		(void)comp_d3d11_service_workspace_request_mode_flip(s->xsysc, 1);
+		// Force-reset to 3D (mode 1) on every workspace activate (#234).
+		// Use the direct DP-force helper instead of routing through the
+		// acked-flip state machine: the state machine's no-op guard skips
+		// when active_rendering_mode_index already says mode 1, but the
+		// runtime's view can disagree with the actual hardware (zero-init
+		// at service start leaves sys->hardware_display_3d=false; external
+		// SR Dashboard toggles aren't tracked by the runtime). Force-3D
+		// unconditionally guarantees "shell always opens in 3D" regardless
+		// of what the previous session, or external state, left behind.
+		(void)comp_d3d11_service_force_display_3d(s->xsysc);
 #endif
 	}
 

--- a/src/xrt/ipc/server/ipc_server_handler.c
+++ b/src/xrt/ipc/server/ipc_server_handler.c
@@ -2285,6 +2285,21 @@ ipc_handle_workspace_activate(volatile struct ipc_client_state *_ics)
 		// Eagerly create the workspace window so Ctrl+O works even with no apps.
 		comp_d3d11_service_ensure_workspace_window(s->xsysc);
 #endif
+
+#if defined(XRT_HAVE_LEIA_SR_D3D11) && defined(XRT_HAVE_D3D11_SERVICE_COMPOSITOR)
+		// Reset to mode 1 (first hardwareDisplay3D mode) on every workspace
+		// activate (#234). The active rendering mode index persists on the
+		// head device across shell launches (service doesn't restart), so
+		// if a previous session left the runtime in 2D (mode 0) and the
+		// shell relaunches, the new shell's own chrome AND any client that
+		// connects defaults to mode 1's stereo layout — but the runtime is
+		// still in mode 0's mono layout. Result: tile-stride mismatch
+		// rendered as "wild disparity" from the very first frame. Forcing
+		// mode 1 here gives the user a deterministic clean-3D start;
+		// they can V-toggle to 2D from there if they want. Routes through
+		// the acked-flip path so the transition (if any) is curtain-masked.
+		(void)comp_d3d11_service_workspace_request_mode_flip(s->xsysc, 1);
+#endif
 	}
 
 	return XRT_SUCCESS;
@@ -2311,6 +2326,41 @@ ipc_handle_workspace_deactivate(volatile struct ipc_client_state *_ics)
 		comp_d3d11_service_deactivate_workspace(s->xsysc);
 #endif
 	}
+
+	return XRT_SUCCESS;
+}
+
+xrt_result_t
+ipc_handle_workspace_request_display_mode(volatile struct ipc_client_state *_ics, uint32_t mode_index)
+{
+	struct ipc_server *s = _ics->server;
+
+	// PID-match auth: only the registered workspace controller can drive a
+	// mode flip via this RPC. The shell typically owns this; bridge-relay
+	// uses a different (legacy) path.
+	unsigned long expected_pid = s->workspace_controller_pid;
+	unsigned long caller_pid = (unsigned long)_ics->client_state.pid;
+	if (expected_pid == 0 || caller_pid != expected_pid) {
+		IPC_WARN(s,
+		         "workspace_request_display_mode: PID mismatch (caller=%lu, controller=%lu) — denied",
+		         caller_pid, expected_pid);
+		return XRT_ERROR_NOT_AUTHORIZED;
+	}
+
+	if (s->xsysc == NULL) {
+		return XRT_ERROR_IPC_FAILURE;
+	}
+
+#if defined(XRT_HAVE_LEIA_SR_D3D11) && defined(XRT_HAVE_D3D11_SERVICE_COMPOSITOR)
+	if (!comp_d3d11_service_workspace_request_mode_flip(s->xsysc, mode_index)) {
+		// No multi_comp (workspace not active / non-d3d11 backend) —
+		// caller falls back to legacy device-property path on the client.
+		return XRT_ERROR_NOT_IMPLEMENTED;
+	}
+#else
+	(void)mode_index;
+	return XRT_ERROR_NOT_IMPLEMENTED;
+#endif
 
 	return XRT_SUCCESS;
 }

--- a/src/xrt/ipc/server/ipc_server_per_client_thread.c
+++ b/src/xrt/ipc/server/ipc_server_per_client_thread.c
@@ -501,6 +501,28 @@ client_loop(volatile struct ipc_client_state *ics)
 void
 ipc_server_client_destroy_session_and_compositor(volatile struct ipc_client_state *ics)
 {
+	// Destroy the compositor BEFORE dropping our xscs swapchain
+	// references (#238). The compositor's destroy path runs under its
+	// own render_mutex (close-button fix in commit 30e5648a1) and
+	// releases any strong refs the multi-compositor held on our
+	// swapchains via its ws_snapshot.sc_array. Until then, our xscs
+	// refs keep the swapchains alive. Doing it the other way around
+	// (drop xscs first, then destroy compositor) left a window where:
+	//   - our xscs drop took the strong ref count from 2 → 1,
+	//   - the snapshot's lingering strong ref kept the swapchain alive,
+	//   - the render thread could be mid-snapshot-deref on a slot
+	//     that's already partially torn down (Ctrl+Space deactivate
+	//     hits this because the workspace controller's compositor
+	//     destroy runs in a different order than per-client destroys).
+	// Reversing the order means the snapshot's strong refs are gone
+	// before we touch xscs — the only ref left at the xscs drop is
+	// ours, and the render thread cannot reach the freed swapchain
+	// because the slot was already unregistered under render_mutex
+	// during xrt_comp_destroy.
+
+	// Cast away volatile.
+	xrt_comp_destroy((struct xrt_compositor **)&ics->xc);
+
 	// Multiple threads might be looking at these fields.
 	os_mutex_lock(&ics->server->global_state.lock);
 
@@ -521,9 +543,6 @@ ipc_server_client_destroy_session_and_compositor(volatile struct ipc_client_stat
 	}
 
 	os_mutex_unlock(&ics->server->global_state.lock);
-
-	// Cast away volatile.
-	xrt_comp_destroy((struct xrt_compositor **)&ics->xc);
 
 	// Cast away volatile.
 	xrt_session_destroy((struct xrt_session **)&ics->xs);

--- a/src/xrt/ipc/shared/proto.json
+++ b/src/xrt/ipc/shared/proto.json
@@ -69,6 +69,12 @@
 
 	"workspace_deactivate": {},
 
+	"workspace_request_display_mode": {
+		"in": [
+			{"name": "mode_index", "type": "uint32_t"}
+		]
+	},
+
 	"workspace_get_state": {
 		"out": [
 			{"name": "active", "type": "bool"}

--- a/src/xrt/state_trackers/oxr/oxr_api_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_api_session.c
@@ -1369,6 +1369,10 @@ oxr_xrRequestDisplayRenderingModeEXT(XrSession session, uint32_t modeIndex)
 	// (synced from server via IPC shared memory).
 	// Exception: headless sessions (bridge relay) ARE allowed to change modes —
 	// the bridge acts as the mode controller on behalf of the WebXR page.
+	// Exception: graphics-bound workspace controllers (the shell, after
+	// xrActivateSpatialWorkspaceEXT) also retain mode authority. They have
+	// `compositor != NULL` because they render chrome, so the original
+	// headless-only exemption misses them (#234).
 	//
 	// This is THE enforcement point for the "workspace owns display mode" rule
 	// (#233). DO NOT enforce by filtering xrEnumerateDisplayRenderingModesEXT
@@ -1378,19 +1382,20 @@ oxr_xrRequestDisplayRenderingModeEXT(XrSession session, uint32_t modeIndex)
 	// at xrEndFrame across cube/gauss/others. Apps need the full enumerator
 	// to interpret indices that arrive via XrEventDataRenderingModeChangedEXT.
 	if (sess->sys->xsysc != NULL && sess->sys->xsysc->info.is_service_mode &&
-	    sess->compositor != NULL) {
+	    sess->compositor != NULL &&
+	    !sess->is_active_workspace_controller) {
 		return XR_SUCCESS;
 	}
 
-	// Workspace controller path (#234): workspace controller sessions are
-	// headless (compositor == NULL) but legitimately own mode authority.
-	// Route through the compositor's acked-flip hook so the broadcast /
-	// per-slot ack / DP flip are properly sequenced with curtain masking,
-	// instead of doing the immediate device-mode-update below (which exposes
-	// the raw-atlas glitch every controller-driven mode change). Bridge-
-	// relay sessions also hit this branch and benefit equally.
+	// Workspace controller path (#234): controllers legitimately own mode
+	// authority. Route through the compositor's acked-flip hook so the
+	// broadcast / per-slot ack / DP flip are properly sequenced with curtain
+	// masking, instead of doing the immediate device-mode-update below
+	// (which exposes the raw-atlas glitch every controller-driven mode
+	// change). Both headless controllers (bridge relay, compositor==NULL)
+	// and graphics-bound controllers (shell with active workspace) hit this.
 	if (sess->sys->xsysc != NULL && sess->sys->xsysc->info.is_service_mode &&
-	    sess->compositor == NULL &&
+	    (sess->compositor == NULL || sess->is_active_workspace_controller) &&
 	    sess->sys->xsysc->request_workspace_mode_flip != NULL) {
 		if (sess->sys->xsysc->request_workspace_mode_flip(sess->sys->xsysc, modeIndex)) {
 			return XR_SUCCESS;

--- a/src/xrt/state_trackers/oxr/oxr_api_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_api_session.c
@@ -1369,9 +1369,34 @@ oxr_xrRequestDisplayRenderingModeEXT(XrSession session, uint32_t modeIndex)
 	// (synced from server via IPC shared memory).
 	// Exception: headless sessions (bridge relay) ARE allowed to change modes —
 	// the bridge acts as the mode controller on behalf of the WebXR page.
+	//
+	// This is THE enforcement point for the "workspace owns display mode" rule
+	// (#233). DO NOT enforce by filtering xrEnumerateDisplayRenderingModesEXT
+	// to count=1 — apps index local rendering-mode arrays by VENDOR-ASSIGNED
+	// `mode_index` (not array index). Filtering causes
+	// `renderingModeViewCounts[active_idx]=0` reads and `XR_ERROR_POSE_INVALID`
+	// at xrEndFrame across cube/gauss/others. Apps need the full enumerator
+	// to interpret indices that arrive via XrEventDataRenderingModeChangedEXT.
 	if (sess->sys->xsysc != NULL && sess->sys->xsysc->info.is_service_mode &&
 	    sess->compositor != NULL) {
 		return XR_SUCCESS;
+	}
+
+	// Workspace controller path (#234): workspace controller sessions are
+	// headless (compositor == NULL) but legitimately own mode authority.
+	// Route through the compositor's acked-flip hook so the broadcast /
+	// per-slot ack / DP flip are properly sequenced with curtain masking,
+	// instead of doing the immediate device-mode-update below (which exposes
+	// the raw-atlas glitch every controller-driven mode change). Bridge-
+	// relay sessions also hit this branch and benefit equally.
+	if (sess->sys->xsysc != NULL && sess->sys->xsysc->info.is_service_mode &&
+	    sess->compositor == NULL &&
+	    sess->sys->xsysc->request_workspace_mode_flip != NULL) {
+		if (sess->sys->xsysc->request_workspace_mode_flip(sess->sys->xsysc, modeIndex)) {
+			return XR_SUCCESS;
+		}
+		// Fall through to legacy immediate path if the compositor declined
+		// (no multi_comp — non-workspace bridge mode, etc.).
 	}
 
 	struct xrt_device *head = GET_XDEV_BY_ROLE(sess->sys, head);

--- a/src/xrt/state_trackers/oxr/oxr_api_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_api_session.c
@@ -1482,6 +1482,18 @@ oxr_xrEnumerateDisplayRenderingModesEXT(XrSession session,
 		return oxr_error(&log, XR_ERROR_SIZE_INSUFFICIENT, "modeCapacityInput");
 	}
 
+	// `isRequestable` per session (v13): the gate in
+	// oxr_xrRequestDisplayRenderingModeEXT drops non-controller sessions
+	// running under workspace mode. Mirror that gate here so apps can
+	// passively learn whether their request would be a no-op.
+	XrBool32 session_is_requestable = XR_TRUE;
+	if (sess->sys->xsysc != NULL && sess->sys->xsysc->info.is_service_mode &&
+	    sess->compositor != NULL &&
+	    !sess->is_active_workspace_controller) {
+		session_is_requestable = XR_FALSE;
+	}
+	uint32_t active_idx = (head->hmd != NULL) ? head->hmd->active_rendering_mode_index : 0;
+
 	for (uint32_t i = 0; i < count; i++) {
 		modes[i].type = XR_TYPE_DISPLAY_RENDERING_MODE_INFO_EXT;
 		modes[i].next = NULL;
@@ -1496,6 +1508,9 @@ oxr_xrEnumerateDisplayRenderingModesEXT(XrSession session,
 		modes[i].tileRows = head->rendering_modes[i].tile_rows;
 		modes[i].viewWidthPixels = head->rendering_modes[i].view_width_pixels;
 		modes[i].viewHeightPixels = head->rendering_modes[i].view_height_pixels;
+		// v13 fields.
+		modes[i].isActive = (head->rendering_modes[i].mode_index == active_idx) ? XR_TRUE : XR_FALSE;
+		modes[i].isRequestable = session_is_requestable;
 	}
 
 	return XR_SUCCESS;

--- a/src/xrt/state_trackers/oxr/oxr_objects.h
+++ b/src/xrt/state_trackers/oxr/oxr_objects.h
@@ -2014,6 +2014,17 @@ struct oxr_session
 	//! view poses like a handle app (display-local, no world_head_pos offset).
 	bool is_bridge_relay;
 
+	//! True if this session has successfully called xrActivateSpatialWorkspaceEXT
+	//! and is currently the active workspace controller (#234).
+	//! Workspace controllers are graphics-bound IPC sessions (typically the
+	//! shell process rendering its own chrome), so `compositor != NULL`.
+	//! The original `xrRequestDisplayRenderingModeEXT` gate exempts headless
+	//! sessions via `compositor == NULL` — that misses graphics-bound
+	//! controllers like the shell. This flag distinguishes them so they keep
+	//! their legitimate mode authority. Set in oxr_xrActivateSpatialWorkspaceEXT;
+	//! cleared in oxr_xrDeactivateSpatialWorkspaceEXT.
+	bool is_active_workspace_controller;
+
 	//! True if display hardware is currently in 3D mode.
 	bool hardware_display_3d;
 

--- a/src/xrt/state_trackers/oxr/oxr_workspace.c
+++ b/src/xrt/state_trackers/oxr/oxr_workspace.c
@@ -230,6 +230,14 @@ oxr_xrActivateSpatialWorkspaceEXT(XrSession session)
 	}
 
 	xrt_result_t xret = comp_ipc_client_compositor_workspace_activate(&sess->xcn->base);
+	if (xret == XRT_SUCCESS) {
+		// Mark this session as the active workspace controller (#234) so
+		// xrRequestDisplayRenderingModeEXT exempts it from the workspace-
+		// client gate. Graphics-bound controllers (like the shell rendering
+		// its own chrome) have `compositor != NULL` and would otherwise be
+		// gated alongside actual workspace apps.
+		sess->is_active_workspace_controller = true;
+	}
 	return xret_to_xr_result(&log, xret, "workspace_activate");
 }
 
@@ -250,6 +258,9 @@ oxr_xrDeactivateSpatialWorkspaceEXT(XrSession session)
 	}
 
 	xrt_result_t xret = comp_ipc_client_compositor_workspace_deactivate(&sess->xcn->base);
+	if (xret == XRT_SUCCESS) {
+		sess->is_active_workspace_controller = false;
+	}
 	return xret_to_xr_result(&log, xret, "workspace_deactivate");
 }
 

--- a/test_apps/common/input_handler.cpp
+++ b/test_apps/common/input_handler.cpp
@@ -221,11 +221,10 @@ bool UpdateInputState(InputState& state, UINT msg, WPARAM wParam, LPARAM lParam)
             }
             break;
         case 'V':
-            // Cycle through all rendering modes
-            if (state.renderingModeCount > 0) {
-                state.currentRenderingMode = (state.currentRenderingMode + 1) % state.renderingModeCount;
-            }
-            state.renderingModeChangeRequested = true;
+            // Request a cycle to the next mode. Main loop reads the runtime's
+            // current mode index (xr.currentModeIndex) to compute the target
+            // and calls xrRequestDisplayRenderingModeEXT.
+            state.cycleRenderingModeRequested = true;
             break;
         case 'I':
             // Snapshot the multi-view atlas to a PNG. Render thread
@@ -233,40 +232,31 @@ bool UpdateInputState(InputState& state, UINT msg, WPARAM wParam, LPARAM lParam)
             state.captureAtlasRequested = true;
             break;
         case '0':
-            state.currentRenderingMode = 0; // 2D mode
-            state.renderingModeChangeRequested = true;
+            state.absoluteRenderingModeRequested = 0; // 2D mode
             break;
         case '1':
-            if (state.renderingModeCount > 1) state.currentRenderingMode = 1;
-            state.renderingModeChangeRequested = true;
+            if (state.renderingModeCount > 1) state.absoluteRenderingModeRequested = 1;
             break;
         case '2':
-            if (state.renderingModeCount > 2) state.currentRenderingMode = 2;
-            state.renderingModeChangeRequested = true;
+            if (state.renderingModeCount > 2) state.absoluteRenderingModeRequested = 2;
             break;
         case '3':
-            if (state.renderingModeCount > 3) state.currentRenderingMode = 3;
-            state.renderingModeChangeRequested = true;
+            if (state.renderingModeCount > 3) state.absoluteRenderingModeRequested = 3;
             break;
         case '4':
-            if (state.renderingModeCount > 4) state.currentRenderingMode = 4;
-            state.renderingModeChangeRequested = true;
+            if (state.renderingModeCount > 4) state.absoluteRenderingModeRequested = 4;
             break;
         case '5':
-            if (state.renderingModeCount > 5) state.currentRenderingMode = 5;
-            state.renderingModeChangeRequested = true;
+            if (state.renderingModeCount > 5) state.absoluteRenderingModeRequested = 5;
             break;
         case '6':
-            if (state.renderingModeCount > 6) state.currentRenderingMode = 6;
-            state.renderingModeChangeRequested = true;
+            if (state.renderingModeCount > 6) state.absoluteRenderingModeRequested = 6;
             break;
         case '7':
-            if (state.renderingModeCount > 7) state.currentRenderingMode = 7;
-            state.renderingModeChangeRequested = true;
+            if (state.renderingModeCount > 7) state.absoluteRenderingModeRequested = 7;
             break;
         case '8':
-            if (state.renderingModeCount > 8) state.currentRenderingMode = 8;
-            state.renderingModeChangeRequested = true;
+            if (state.renderingModeCount > 8) state.absoluteRenderingModeRequested = 8;
             break;
         case 'T':
             state.eyeTrackingModeToggleRequested = true;

--- a/test_apps/common/input_handler.h
+++ b/test_apps/common/input_handler.h
@@ -74,10 +74,15 @@ struct InputState {
     // HUD visibility toggle (TAB key)
     bool hudVisible = true;
 
-    // Unified rendering mode (V key cycles, 0-8 keys select directly)
-    uint32_t currentRenderingMode = 1;   // Default: mode 1 (first 3D mode)
-    uint32_t renderingModeCount = 0;     // Set from xrEnumerateDisplayRenderingModesEXT
-    bool renderingModeChangeRequested = false;
+    // Rendering mode REQUESTS (single source of truth lives on the runtime
+    // side — read back as `xr.currentModeIndex` after the runtime's
+    // XrEventDataRenderingModeChangedEXT lands). The keyboard handler emits
+    // transient requests that the main loop translates into
+    // xrRequestDisplayRenderingModeEXT calls; the actual current mode is
+    // never mirrored here.
+    uint32_t renderingModeCount = 0;            // Set from xrEnumerateDisplayRenderingModesEXT
+    bool cycleRenderingModeRequested = false;   // V key: cycle to next mode
+    int32_t absoluteRenderingModeRequested = -1; // 0-8 keys: jump to this mode (-1 = none)
 
     // Camera vs display mode toggle (C key)
     bool cameraMode = false;

--- a/test_apps/common/text_overlay.cpp
+++ b/test_apps/common/text_overlay.cpp
@@ -347,7 +347,7 @@ std::wstring FormatParallaxInfo(bool parallaxEnabled, float eyePosX, float eyePo
     return oss.str();
 }
 
-std::wstring FormatMode(int outputMode, bool simDisplayAvailable, const char* modeName, uint32_t modeCount, bool display3D) {
+std::wstring FormatMode(int outputMode, bool simDisplayAvailable, const char* modeName, uint32_t modeCount, bool display3D, bool isRequestable) {
     if (!simDisplayAvailable) {
         return L"Mode: Weaved";
     }
@@ -363,6 +363,11 @@ std::wstring FormatMode(int outputMode, bool simDisplayAvailable, const char* mo
     oss << L" (" << (display3D ? L"3D" : L"2D") << L")";
     if (modeCount > 1) {
         oss << L" [1-" << modeCount << L"]";
+    }
+    // XR_EXT_display_info v13: surface workspace mode lock so the user knows
+    // local V / 0-8 keypresses are no-ops under a workspace controller.
+    if (!isRequestable) {
+        oss << L" [locked by workspace]";
     }
     return oss.str();
 }

--- a/test_apps/common/text_overlay.h
+++ b/test_apps/common/text_overlay.h
@@ -80,7 +80,7 @@ std::wstring FormatDisplayInfo(float widthM, float heightM, float nomX, float no
 std::wstring FormatEyeTrackingInfo(const float eyePositions[][3], uint32_t eyeCount,
     bool active, bool isTracking, uint32_t activeMode, uint32_t supportedModes);
 std::wstring FormatParallaxInfo(bool parallaxEnabled, float eyePosX, float eyePosY);
-std::wstring FormatMode(int outputMode, bool simDisplayAvailable, const char* modeName = nullptr, uint32_t modeCount = 0, bool display3D = true);
+std::wstring FormatMode(int outputMode, bool simDisplayAvailable, const char* modeName = nullptr, uint32_t modeCount = 0, bool display3D = true, bool isRequestable = true);
 std::wstring FormatCameraInfo(float cameraPosX, float cameraPosY, float cameraPosZ,
     float forwardX, float forwardY, float forwardZ, bool cameraMode = false);
 std::wstring FormatViewParams(float ipdFactor, float parallaxFactor,

--- a/test_apps/common/xr_session_common.h
+++ b/test_apps/common/xr_session_common.h
@@ -120,8 +120,11 @@ struct XrSessionManager {
     XrEnvironmentBlendMode envBlendModes[4] = {};
     bool runtimeSupportsAlphaBlend = false;
 
-    // Enumerated rendering mode info
-    uint32_t currentModeIndex = 1;  // Default: mode 1 (first 3D mode, matches runtime default)
+    // Enumerated rendering mode info. `currentModeIndex` is initialized to
+    // mode 1 as a fallback for runtimes that don't expose `isActive`; on
+    // runtimes with XR_EXT_display_info v13+ the enumerate step replaces
+    // this with the runtime-reported active mode (initial-mode-sync, #234).
+    uint32_t currentModeIndex = 1;
     uint32_t renderingModeCount = 0;
     char renderingModeNames[8][XR_MAX_SYSTEM_NAME_SIZE] = {};
     uint32_t renderingModeViewCounts[8] = {};
@@ -130,6 +133,10 @@ struct XrSessionManager {
     float renderingModeScaleX[8] = {};
     float renderingModeScaleY[8] = {};
     bool renderingModeDisplay3D[8] = {};
+    // v13: per-mode isRequestable flag. False for all modes when this
+    // session is a non-controller workspace client (runtime drops requests).
+    // Apps use this to gate mode-toggle UI ("Mode locked by workspace").
+    bool renderingModeIsRequestable[8] = {};
 
     // Window handle for session target (used by ext app, ignored by non-ext app)
     HWND windowHandle = nullptr;

--- a/test_apps/cube_handle_d3d11_win/main.cpp
+++ b/test_apps/cube_handle_d3d11_win/main.cpp
@@ -305,6 +305,20 @@ static void RenderOneFrame(RenderState& rs) {
         }
     }
 
+    // Mirror runtime-driven mode changes (workspace controller's V hotkey,
+    // focus-adaptive auto-switch, etc.) into the cube's local input state so
+    // the rendering logic and HUD pick up the change. PollEvents() updates
+    // xr.currentModeIndex from XrEventDataRenderingModeChangedEXT, but the
+    // cube's render paths read g_inputState.currentRenderingMode (set only
+    // by local 'V' / 0–8 keys). Without this mirror, an externally-driven
+    // mode change leaves the cube rendering at its old mode while the
+    // runtime is at the new one — visible as the workspace tile-stride
+    // mismatch (#234).
+    if (xr.currentModeIndex != g_inputState.currentRenderingMode &&
+        xr.currentModeIndex < xr.renderingModeCount) {
+        g_inputState.currentRenderingMode = xr.currentModeIndex;
+    }
+
     // Handle eye tracking mode toggle (T key)
     if (g_inputState.eyeTrackingModeToggleRequested) {
         g_inputState.eyeTrackingModeToggleRequested = false;

--- a/test_apps/cube_handle_d3d11_win/main.cpp
+++ b/test_apps/cube_handle_d3d11_win/main.cpp
@@ -297,26 +297,26 @@ static void RenderOneFrame(RenderState& rs) {
         g_inputState.fullscreenToggleRequested = false;
     }
 
-    // Handle rendering mode change (V=cycle, 0-8=direct)
-    if (g_inputState.renderingModeChangeRequested) {
-        g_inputState.renderingModeChangeRequested = false;
-        if (xr.pfnRequestDisplayRenderingModeEXT && xr.session != XR_NULL_HANDLE) {
-            xr.pfnRequestDisplayRenderingModeEXT(xr.session, g_inputState.currentRenderingMode);
+    // Handle rendering mode requests (V=cycle next, 0-8=jump absolute).
+    // Single source of truth: the runtime owns the current mode. Keypresses
+    // are REQUESTS — we call xrRequestDisplayRenderingModeEXT and let the
+    // XrEventDataRenderingModeChangedEXT event update xr.currentModeIndex.
+    // Render paths and HUD read xr.currentModeIndex directly.
+    if (g_inputState.cycleRenderingModeRequested) {
+        g_inputState.cycleRenderingModeRequested = false;
+        if (xr.pfnRequestDisplayRenderingModeEXT && xr.session != XR_NULL_HANDLE &&
+            xr.renderingModeCount > 0) {
+            uint32_t next = (xr.currentModeIndex + 1) % xr.renderingModeCount;
+            xr.pfnRequestDisplayRenderingModeEXT(xr.session, next);
         }
     }
-
-    // Mirror runtime-driven mode changes (workspace controller's V hotkey,
-    // focus-adaptive auto-switch, etc.) into the cube's local input state so
-    // the rendering logic and HUD pick up the change. PollEvents() updates
-    // xr.currentModeIndex from XrEventDataRenderingModeChangedEXT, but the
-    // cube's render paths read g_inputState.currentRenderingMode (set only
-    // by local 'V' / 0–8 keys). Without this mirror, an externally-driven
-    // mode change leaves the cube rendering at its old mode while the
-    // runtime is at the new one — visible as the workspace tile-stride
-    // mismatch (#234).
-    if (xr.currentModeIndex != g_inputState.currentRenderingMode &&
-        xr.currentModeIndex < xr.renderingModeCount) {
-        g_inputState.currentRenderingMode = xr.currentModeIndex;
+    if (g_inputState.absoluteRenderingModeRequested >= 0) {
+        uint32_t target = (uint32_t)g_inputState.absoluteRenderingModeRequested;
+        g_inputState.absoluteRenderingModeRequested = -1;
+        if (xr.pfnRequestDisplayRenderingModeEXT && xr.session != XR_NULL_HANDLE &&
+            target < xr.renderingModeCount) {
+            xr.pfnRequestDisplayRenderingModeEXT(xr.session, target);
+        }
     }
 
     // Handle eye tracking mode toggle (T key)
@@ -342,16 +342,16 @@ static void RenderOneFrame(RenderState& rs) {
     if (xr.sessionRunning) {
         XrFrameState frameState;
         if (BeginFrame(xr, frameState)) {
-                uint32_t modeViewCount = (xr.renderingModeCount > 0 && g_inputState.currentRenderingMode < xr.renderingModeCount)
-                    ? xr.renderingModeViewCounts[g_inputState.currentRenderingMode] : 2;
-                uint32_t tileColumns = (xr.renderingModeCount > 0 && g_inputState.currentRenderingMode < xr.renderingModeCount)
-                    ? xr.renderingModeTileColumns[g_inputState.currentRenderingMode] : 2;
-                uint32_t tileRows = (xr.renderingModeCount > 0 && g_inputState.currentRenderingMode < xr.renderingModeCount)
-                    ? xr.renderingModeTileRows[g_inputState.currentRenderingMode] : 1;
-                bool monoMode = (xr.renderingModeCount > 0 && !xr.renderingModeDisplay3D[g_inputState.currentRenderingMode]);
-                if (xr.renderingModeCount > 0 && g_inputState.currentRenderingMode < xr.renderingModeCount) {
-                    xr.recommendedViewScaleX = xr.renderingModeScaleX[g_inputState.currentRenderingMode];
-                    xr.recommendedViewScaleY = xr.renderingModeScaleY[g_inputState.currentRenderingMode];
+                uint32_t modeViewCount = (xr.renderingModeCount > 0 && xr.currentModeIndex < xr.renderingModeCount)
+                    ? xr.renderingModeViewCounts[xr.currentModeIndex] : 2;
+                uint32_t tileColumns = (xr.renderingModeCount > 0 && xr.currentModeIndex < xr.renderingModeCount)
+                    ? xr.renderingModeTileColumns[xr.currentModeIndex] : 2;
+                uint32_t tileRows = (xr.renderingModeCount > 0 && xr.currentModeIndex < xr.renderingModeCount)
+                    ? xr.renderingModeTileRows[xr.currentModeIndex] : 1;
+                bool monoMode = (xr.renderingModeCount > 0 && !xr.renderingModeDisplay3D[xr.currentModeIndex]);
+                if (xr.renderingModeCount > 0 && xr.currentModeIndex < xr.renderingModeCount) {
+                    xr.recommendedViewScaleX = xr.renderingModeScaleX[xr.currentModeIndex];
+                    xr.recommendedViewScaleY = xr.renderingModeScaleY[xr.currentModeIndex];
                 }
                 int eyeCount = monoMode ? 1 : (int)modeViewCount;
                 std::vector<XrCompositionLayerProjectionView> projectionViews(eyeCount, {XR_TYPE_COMPOSITION_LAYER_PROJECTION_VIEW});
@@ -494,7 +494,7 @@ static void RenderOneFrame(RenderState& rs) {
                                 L"\nKooima: Display-Centric [C=Toggle]";
 
                             // Dynamic render dims matching the actual viewport computation
-                            bool dispMonoMode = (xr.renderingModeCount > 0 && !xr.renderingModeDisplay3D[g_inputState.currentRenderingMode]);
+                            bool dispMonoMode = (xr.renderingModeCount > 0 && !xr.renderingModeDisplay3D[xr.currentModeIndex]);
                             uint32_t dispRenderW, dispRenderH;
                             if (dispMonoMode) {
                                 dispRenderW = g_windowWidth;
@@ -513,10 +513,10 @@ static void RenderOneFrame(RenderState& rs) {
                             std::wstring dispText = FormatDisplayInfo(xr.displayWidthM, xr.displayHeightM,
                                 xr.nominalViewerX, xr.nominalViewerY, xr.nominalViewerZ);
                             dispText += L"\n" + FormatScaleInfo(xr.recommendedViewScaleX, xr.recommendedViewScaleY);
-                            dispText += L"\n" + FormatMode(g_inputState.currentRenderingMode, xr.pfnRequestDisplayRenderingModeEXT != nullptr,
-                                (xr.renderingModeCount > 0 && g_inputState.currentRenderingMode < xr.renderingModeCount) ? xr.renderingModeNames[g_inputState.currentRenderingMode] : nullptr,
+                            dispText += L"\n" + FormatMode(xr.currentModeIndex, xr.pfnRequestDisplayRenderingModeEXT != nullptr,
+                                (xr.renderingModeCount > 0 && xr.currentModeIndex < xr.renderingModeCount) ? xr.renderingModeNames[xr.currentModeIndex] : nullptr,
                                 xr.renderingModeCount,
-                                xr.renderingModeCount > 0 ? xr.renderingModeDisplay3D[g_inputState.currentRenderingMode] : true);
+                                xr.renderingModeCount > 0 ? xr.renderingModeDisplay3D[xr.currentModeIndex] : true);
                             std::wstring eyeText = FormatEyeTrackingInfo(
                                 xr.eyePositions, (uint32_t)eyeCount,
                                 xr.eyeTrackingActive, xr.isEyeTracking,

--- a/test_apps/cube_handle_d3d11_win/main.cpp
+++ b/test_apps/cube_handle_d3d11_win/main.cpp
@@ -516,7 +516,8 @@ static void RenderOneFrame(RenderState& rs) {
                             dispText += L"\n" + FormatMode(xr.currentModeIndex, xr.pfnRequestDisplayRenderingModeEXT != nullptr,
                                 (xr.renderingModeCount > 0 && xr.currentModeIndex < xr.renderingModeCount) ? xr.renderingModeNames[xr.currentModeIndex] : nullptr,
                                 xr.renderingModeCount,
-                                xr.renderingModeCount > 0 ? xr.renderingModeDisplay3D[xr.currentModeIndex] : true);
+                                xr.renderingModeCount > 0 ? xr.renderingModeDisplay3D[xr.currentModeIndex] : true,
+                                xr.renderingModeCount > 0 ? xr.renderingModeIsRequestable[xr.currentModeIndex] : true);
                             std::wstring eyeText = FormatEyeTrackingInfo(
                                 xr.eyePositions, (uint32_t)eyeCount,
                                 xr.eyeTrackingActive, xr.isEyeTracking,

--- a/test_apps/cube_handle_d3d11_win/xr_session.cpp
+++ b/test_apps/cube_handle_d3d11_win/xr_session.cpp
@@ -292,6 +292,11 @@ bool CreateSession(XrSessionManager& xr, ID3D11Device* d3d11Device, HWND hwnd) {
                     xr.renderingModeScaleX[i] = modes[i].viewScaleX;
                     xr.renderingModeScaleY[i] = modes[i].viewScaleY;
                     xr.renderingModeDisplay3D[i] = modes[i].hardwareDisplay3D ? true : false;
+                    xr.renderingModeIsRequestable[i] = modes[i].isRequestable ? true : false;
+                    // v13 initial-mode-sync: trust runtime-reported active mode.
+                    if (modes[i].isActive) {
+                        xr.currentModeIndex = modes[i].modeIndex;
+                    }
                 }
             }
         }

--- a/test_apps/cube_handle_d3d12_win/main.cpp
+++ b/test_apps/cube_handle_d3d12_win/main.cpp
@@ -252,7 +252,8 @@ static void RenderThreadFunc(
         InputState inputSnapshot;
         bool resetRequested = false;
         uint32_t windowW, windowH;
-        bool outputModeChanged = false;
+        bool cycleModeRequested = false;
+        int32_t absoluteModeRequest = -1;
         {
             std::lock_guard<std::mutex> lock(g_inputMutex);
             inputSnapshot = g_inputState;
@@ -260,14 +261,25 @@ static void RenderThreadFunc(
             g_inputState.resetViewRequested = false;
             g_inputState.fullscreenToggleRequested = false;
             g_inputState.eyeTrackingModeToggleRequested = false;
-            outputModeChanged = g_inputState.renderingModeChangeRequested;
-            g_inputState.renderingModeChangeRequested = false;
+            cycleModeRequested = g_inputState.cycleRenderingModeRequested;
+            g_inputState.cycleRenderingModeRequested = false;
+            absoluteModeRequest = g_inputState.absoluteRenderingModeRequested;
+            g_inputState.absoluteRenderingModeRequested = -1;
             windowW = g_windowWidth;
             windowH = g_windowHeight;
         }
 
-        if (outputModeChanged && xr->pfnRequestDisplayRenderingModeEXT && xr->session != XR_NULL_HANDLE) {
-            xr->pfnRequestDisplayRenderingModeEXT(xr->session, inputSnapshot.currentRenderingMode);
+        // Rendering mode requests (V=cycle, 0-8=absolute). Single source of
+        // truth: the runtime owns current mode via xr->currentModeIndex.
+        if (cycleModeRequested && xr->pfnRequestDisplayRenderingModeEXT &&
+            xr->session != XR_NULL_HANDLE && xr->renderingModeCount > 0) {
+            uint32_t next = (xr->currentModeIndex + 1) % xr->renderingModeCount;
+            xr->pfnRequestDisplayRenderingModeEXT(xr->session, next);
+        }
+        if (absoluteModeRequest >= 0 && xr->pfnRequestDisplayRenderingModeEXT &&
+            xr->session != XR_NULL_HANDLE &&
+            (uint32_t)absoluteModeRequest < xr->renderingModeCount) {
+            xr->pfnRequestDisplayRenderingModeEXT(xr->session, (uint32_t)absoluteModeRequest);
         }
 
         // Handle eye tracking mode toggle (T key)
@@ -303,16 +315,16 @@ static void RenderThreadFunc(
         if (xr->sessionRunning) {
             XrFrameState frameState;
             if (BeginFrame(*xr, frameState)) {
-                uint32_t modeViewCount = (xr->renderingModeCount > 0 && inputSnapshot.currentRenderingMode < xr->renderingModeCount)
-                    ? xr->renderingModeViewCounts[inputSnapshot.currentRenderingMode] : 2;
-                uint32_t tileColumns = (xr->renderingModeCount > 0 && inputSnapshot.currentRenderingMode < xr->renderingModeCount)
-                    ? xr->renderingModeTileColumns[inputSnapshot.currentRenderingMode] : 2;
-                uint32_t tileRows = (xr->renderingModeCount > 0 && inputSnapshot.currentRenderingMode < xr->renderingModeCount)
-                    ? xr->renderingModeTileRows[inputSnapshot.currentRenderingMode] : 1;
-                bool monoMode = (xr->renderingModeCount > 0 && !xr->renderingModeDisplay3D[inputSnapshot.currentRenderingMode]);
-                if (xr->renderingModeCount > 0 && inputSnapshot.currentRenderingMode < xr->renderingModeCount) {
-                    xr->recommendedViewScaleX = xr->renderingModeScaleX[inputSnapshot.currentRenderingMode];
-                    xr->recommendedViewScaleY = xr->renderingModeScaleY[inputSnapshot.currentRenderingMode];
+                uint32_t modeViewCount = (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount)
+                    ? xr->renderingModeViewCounts[xr->currentModeIndex] : 2;
+                uint32_t tileColumns = (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount)
+                    ? xr->renderingModeTileColumns[xr->currentModeIndex] : 2;
+                uint32_t tileRows = (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount)
+                    ? xr->renderingModeTileRows[xr->currentModeIndex] : 1;
+                bool monoMode = (xr->renderingModeCount > 0 && !xr->renderingModeDisplay3D[xr->currentModeIndex]);
+                if (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount) {
+                    xr->recommendedViewScaleX = xr->renderingModeScaleX[xr->currentModeIndex];
+                    xr->recommendedViewScaleY = xr->renderingModeScaleY[xr->currentModeIndex];
                 }
                 int eyeCount = monoMode ? 1 : (int)modeViewCount;
                 std::vector<XrCompositionLayerProjectionView> projectionViews(eyeCount, {XR_TYPE_COMPOSITION_LAYER_PROJECTION_VIEW});
@@ -583,10 +595,10 @@ static void RenderThreadFunc(
                                 std::wstring dispText = FormatDisplayInfo(xr->displayWidthM, xr->displayHeightM,
                                     xr->nominalViewerX, xr->nominalViewerY, xr->nominalViewerZ);
                                 dispText += L"\n" + FormatScaleInfo(xr->recommendedViewScaleX, xr->recommendedViewScaleY);
-                                dispText += L"\n" + FormatMode(inputSnapshot.currentRenderingMode, xr->pfnRequestDisplayRenderingModeEXT != nullptr,
-                                    (xr->renderingModeCount > 0 && inputSnapshot.currentRenderingMode < xr->renderingModeCount) ? xr->renderingModeNames[inputSnapshot.currentRenderingMode] : nullptr,
+                                dispText += L"\n" + FormatMode(xr->currentModeIndex, xr->pfnRequestDisplayRenderingModeEXT != nullptr,
+                                    (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount) ? xr->renderingModeNames[xr->currentModeIndex] : nullptr,
                                     xr->renderingModeCount,
-                                    xr->renderingModeCount > 0 ? xr->renderingModeDisplay3D[inputSnapshot.currentRenderingMode] : true);
+                                    xr->renderingModeCount > 0 ? xr->renderingModeDisplay3D[xr->currentModeIndex] : true);
                                 std::wstring eyeText = FormatEyeTrackingInfo(
                                     xr->eyePositions, (uint32_t)eyeCount,
                                     xr->eyeTrackingActive, xr->isEyeTracking,
@@ -685,7 +697,7 @@ static void RenderThreadFunc(
                 }
 
                 // End frame: use window-space HUD layer if available
-                uint32_t submitViewCount = (xr->renderingModeCount > 0 && inputSnapshot.currentRenderingMode < xr->renderingModeCount) ? xr->renderingModeViewCounts[inputSnapshot.currentRenderingMode] : 2;
+                uint32_t submitViewCount = (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount) ? xr->renderingModeViewCounts[xr->currentModeIndex] : 2;
                 LOG_INFO("[FRAME] EndFrame: rendered=%d hudSubmitted=%d viewCount=%u", rendered, hudSubmitted, submitViewCount);
                 if (rendered && hudSubmitted) {
                     float hudAR = (float)HUD_PIXEL_WIDTH / (float)HUD_PIXEL_HEIGHT;

--- a/test_apps/cube_handle_d3d12_win/main.cpp
+++ b/test_apps/cube_handle_d3d12_win/main.cpp
@@ -598,7 +598,8 @@ static void RenderThreadFunc(
                                 dispText += L"\n" + FormatMode(xr->currentModeIndex, xr->pfnRequestDisplayRenderingModeEXT != nullptr,
                                     (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount) ? xr->renderingModeNames[xr->currentModeIndex] : nullptr,
                                     xr->renderingModeCount,
-                                    xr->renderingModeCount > 0 ? xr->renderingModeDisplay3D[xr->currentModeIndex] : true);
+                                    xr->renderingModeCount > 0 ? xr->renderingModeDisplay3D[xr->currentModeIndex] : true,
+                                    xr->renderingModeCount > 0 ? xr->renderingModeIsRequestable[xr->currentModeIndex] : true);
                                 std::wstring eyeText = FormatEyeTrackingInfo(
                                     xr->eyePositions, (uint32_t)eyeCount,
                                     xr->eyeTrackingActive, xr->isEyeTracking,

--- a/test_apps/cube_handle_d3d12_win/xr_session.cpp
+++ b/test_apps/cube_handle_d3d12_win/xr_session.cpp
@@ -267,6 +267,11 @@ bool CreateSession(XrSessionManager& xr, ID3D12Device* device, ID3D12CommandQueu
                     xr.renderingModeScaleX[i] = modes[i].viewScaleX;
                     xr.renderingModeScaleY[i] = modes[i].viewScaleY;
                     xr.renderingModeDisplay3D[i] = modes[i].hardwareDisplay3D ? true : false;
+                    xr.renderingModeIsRequestable[i] = modes[i].isRequestable ? true : false;
+                    // v13 initial-mode-sync: trust runtime-reported active mode.
+                    if (modes[i].isActive) {
+                        xr.currentModeIndex = modes[i].modeIndex;
+                    }
                 }
             }
         }

--- a/test_apps/cube_handle_gl_win/main.cpp
+++ b/test_apps/cube_handle_gl_win/main.cpp
@@ -322,7 +322,8 @@ static void RenderThreadFunc(
     while (g_running.load() && !xr->exitRequested) {
         InputState inputSnapshot;
         bool resetRequested = false;
-        bool outputModeChanged = false;
+        bool cycleModeRequested = false;
+        int32_t absoluteModeRequest = -1;
         uint32_t windowW, windowH;
         {
             std::lock_guard<std::mutex> lock(g_inputMutex);
@@ -331,14 +332,25 @@ static void RenderThreadFunc(
             g_inputState.resetViewRequested = false;
             g_inputState.fullscreenToggleRequested = false;
             g_inputState.eyeTrackingModeToggleRequested = false;
-            outputModeChanged = g_inputState.renderingModeChangeRequested;
-            g_inputState.renderingModeChangeRequested = false;
+            cycleModeRequested = g_inputState.cycleRenderingModeRequested;
+            g_inputState.cycleRenderingModeRequested = false;
+            absoluteModeRequest = g_inputState.absoluteRenderingModeRequested;
+            g_inputState.absoluteRenderingModeRequested = -1;
             windowW = g_windowWidth;
             windowH = g_windowHeight;
         }
 
-        if (outputModeChanged && xr->pfnRequestDisplayRenderingModeEXT && xr->session != XR_NULL_HANDLE) {
-            xr->pfnRequestDisplayRenderingModeEXT(xr->session, inputSnapshot.currentRenderingMode);
+        // Rendering mode requests (V=cycle, 0-8=absolute). Single source of
+        // truth: the runtime owns current mode via xr->currentModeIndex.
+        if (cycleModeRequested && xr->pfnRequestDisplayRenderingModeEXT &&
+            xr->session != XR_NULL_HANDLE && xr->renderingModeCount > 0) {
+            uint32_t next = (xr->currentModeIndex + 1) % xr->renderingModeCount;
+            xr->pfnRequestDisplayRenderingModeEXT(xr->session, next);
+        }
+        if (absoluteModeRequest >= 0 && xr->pfnRequestDisplayRenderingModeEXT &&
+            xr->session != XR_NULL_HANDLE &&
+            (uint32_t)absoluteModeRequest < xr->renderingModeCount) {
+            xr->pfnRequestDisplayRenderingModeEXT(xr->session, (uint32_t)absoluteModeRequest);
         }
 
         UpdatePerformanceStats(perfStats);
@@ -377,16 +389,16 @@ static void RenderThreadFunc(
                 bool hudSubmitted = false;
 
                 // Get N-view mode info from enumerated rendering modes
-                uint32_t modeViewCount = (xr->renderingModeCount > 0 && inputSnapshot.currentRenderingMode < xr->renderingModeCount)
-                    ? xr->renderingModeViewCounts[inputSnapshot.currentRenderingMode] : 2;
-                uint32_t tileColumns = (xr->renderingModeCount > 0 && inputSnapshot.currentRenderingMode < xr->renderingModeCount)
-                    ? xr->renderingModeTileColumns[inputSnapshot.currentRenderingMode] : 2;
-                uint32_t tileRows = (xr->renderingModeCount > 0 && inputSnapshot.currentRenderingMode < xr->renderingModeCount)
-                    ? xr->renderingModeTileRows[inputSnapshot.currentRenderingMode] : 1;
-                bool monoMode = (xr->renderingModeCount > 0 && !xr->renderingModeDisplay3D[inputSnapshot.currentRenderingMode]);
-                if (xr->renderingModeCount > 0 && inputSnapshot.currentRenderingMode < xr->renderingModeCount) {
-                    xr->recommendedViewScaleX = xr->renderingModeScaleX[inputSnapshot.currentRenderingMode];
-                    xr->recommendedViewScaleY = xr->renderingModeScaleY[inputSnapshot.currentRenderingMode];
+                uint32_t modeViewCount = (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount)
+                    ? xr->renderingModeViewCounts[xr->currentModeIndex] : 2;
+                uint32_t tileColumns = (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount)
+                    ? xr->renderingModeTileColumns[xr->currentModeIndex] : 2;
+                uint32_t tileRows = (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount)
+                    ? xr->renderingModeTileRows[xr->currentModeIndex] : 1;
+                bool monoMode = (xr->renderingModeCount > 0 && !xr->renderingModeDisplay3D[xr->currentModeIndex]);
+                if (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount) {
+                    xr->recommendedViewScaleX = xr->renderingModeScaleX[xr->currentModeIndex];
+                    xr->recommendedViewScaleY = xr->renderingModeScaleY[xr->currentModeIndex];
                 }
                 int eyeCount = monoMode ? 1 : (int)modeViewCount;
                 std::vector<XrCompositionLayerProjectionView> projectionViews(eyeCount, {XR_TYPE_COMPOSITION_LAYER_PROJECTION_VIEW});
@@ -656,10 +668,10 @@ static void RenderThreadFunc(
                                 std::wstring dispText = FormatDisplayInfo(xr->displayWidthM, xr->displayHeightM,
                                     xr->nominalViewerX, xr->nominalViewerY, xr->nominalViewerZ);
                                 dispText += L"\n" + FormatScaleInfo(xr->recommendedViewScaleX, xr->recommendedViewScaleY);
-                                dispText += L"\n" + FormatMode(inputSnapshot.currentRenderingMode, xr->pfnRequestDisplayRenderingModeEXT != nullptr,
-                                    (xr->renderingModeCount > 0 && inputSnapshot.currentRenderingMode < xr->renderingModeCount) ? xr->renderingModeNames[inputSnapshot.currentRenderingMode] : nullptr,
+                                dispText += L"\n" + FormatMode(xr->currentModeIndex, xr->pfnRequestDisplayRenderingModeEXT != nullptr,
+                                    (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount) ? xr->renderingModeNames[xr->currentModeIndex] : nullptr,
                                     xr->renderingModeCount,
-                                    xr->renderingModeCount > 0 ? xr->renderingModeDisplay3D[inputSnapshot.currentRenderingMode] : true);
+                                    xr->renderingModeCount > 0 ? xr->renderingModeDisplay3D[xr->currentModeIndex] : true);
                                 std::wstring eyeText = FormatEyeTrackingInfo(
                                     xr->eyePositions, (uint32_t)eyeCount,
                                     xr->eyeTrackingActive, xr->isEyeTracking,

--- a/test_apps/cube_handle_gl_win/main.cpp
+++ b/test_apps/cube_handle_gl_win/main.cpp
@@ -671,7 +671,8 @@ static void RenderThreadFunc(
                                 dispText += L"\n" + FormatMode(xr->currentModeIndex, xr->pfnRequestDisplayRenderingModeEXT != nullptr,
                                     (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount) ? xr->renderingModeNames[xr->currentModeIndex] : nullptr,
                                     xr->renderingModeCount,
-                                    xr->renderingModeCount > 0 ? xr->renderingModeDisplay3D[xr->currentModeIndex] : true);
+                                    xr->renderingModeCount > 0 ? xr->renderingModeDisplay3D[xr->currentModeIndex] : true,
+                                    xr->renderingModeCount > 0 ? xr->renderingModeIsRequestable[xr->currentModeIndex] : true);
                                 std::wstring eyeText = FormatEyeTrackingInfo(
                                     xr->eyePositions, (uint32_t)eyeCount,
                                     xr->eyeTrackingActive, xr->isEyeTracking,

--- a/test_apps/cube_handle_gl_win/xr_session.cpp
+++ b/test_apps/cube_handle_gl_win/xr_session.cpp
@@ -244,6 +244,11 @@ bool CreateSession(XrSessionManager& xr, HDC hDC, HGLRC hGLRC, HWND hwnd) {
                     xr.renderingModeScaleX[i] = modes[i].viewScaleX;
                     xr.renderingModeScaleY[i] = modes[i].viewScaleY;
                     xr.renderingModeDisplay3D[i] = modes[i].hardwareDisplay3D ? true : false;
+                    xr.renderingModeIsRequestable[i] = modes[i].isRequestable ? true : false;
+                    // v13 initial-mode-sync: trust runtime-reported active mode.
+                    if (modes[i].isActive) {
+                        xr.currentModeIndex = modes[i].modeIndex;
+                    }
                 }
             }
         }

--- a/test_apps/cube_handle_vk_win/main.cpp
+++ b/test_apps/cube_handle_vk_win/main.cpp
@@ -256,7 +256,8 @@ static void RenderThreadFunc(
     while (g_running.load() && !xr->exitRequested) {
         InputState inputSnapshot;
         bool resetRequested = false;
-        bool outputModeChanged = false;
+        bool cycleModeRequested = false;
+        int32_t absoluteModeRequest = -1;
         uint32_t windowW, windowH;
         {
             std::lock_guard<std::mutex> lock(g_inputMutex);
@@ -265,16 +266,25 @@ static void RenderThreadFunc(
             g_inputState.resetViewRequested = false;
             g_inputState.fullscreenToggleRequested = false;
             g_inputState.eyeTrackingModeToggleRequested = false;
-            g_inputState.eyeTrackingModeToggleRequested = false;
-            outputModeChanged = g_inputState.renderingModeChangeRequested;
-            g_inputState.renderingModeChangeRequested = false;
+            cycleModeRequested = g_inputState.cycleRenderingModeRequested;
+            g_inputState.cycleRenderingModeRequested = false;
+            absoluteModeRequest = g_inputState.absoluteRenderingModeRequested;
+            g_inputState.absoluteRenderingModeRequested = -1;
             windowW = g_windowWidth;
             windowH = g_windowHeight;
         }
 
-        if (outputModeChanged && xr->pfnRequestDisplayRenderingModeEXT &&
-            xr->session != XR_NULL_HANDLE) {
-            xr->pfnRequestDisplayRenderingModeEXT(xr->session, inputSnapshot.currentRenderingMode);
+        // Rendering mode requests (V=cycle, 0-8=absolute). Single source of
+        // truth: the runtime owns current mode via xr->currentModeIndex.
+        if (cycleModeRequested && xr->pfnRequestDisplayRenderingModeEXT &&
+            xr->session != XR_NULL_HANDLE && xr->renderingModeCount > 0) {
+            uint32_t next = (xr->currentModeIndex + 1) % xr->renderingModeCount;
+            xr->pfnRequestDisplayRenderingModeEXT(xr->session, next);
+        }
+        if (absoluteModeRequest >= 0 && xr->pfnRequestDisplayRenderingModeEXT &&
+            xr->session != XR_NULL_HANDLE &&
+            (uint32_t)absoluteModeRequest < xr->renderingModeCount) {
+            xr->pfnRequestDisplayRenderingModeEXT(xr->session, (uint32_t)absoluteModeRequest);
         }
         // Handle eye tracking mode toggle (T key)
         if (inputSnapshot.eyeTrackingModeToggleRequested) {
@@ -313,17 +323,17 @@ static void RenderThreadFunc(
                 LOG_INFO("[FRAME] BeginFrame OK, shouldRender=%d, displayTime=%lld",
                     frameState.shouldRender, (long long)frameState.predictedDisplayTime);
                 // Get N-view mode info from enumerated rendering modes
-                bool monoMode = (xr->renderingModeCount > 0 && !xr->renderingModeDisplay3D[inputSnapshot.currentRenderingMode]);
-                if (xr->renderingModeCount > 0 && inputSnapshot.currentRenderingMode < xr->renderingModeCount) {
-                    xr->recommendedViewScaleX = xr->renderingModeScaleX[inputSnapshot.currentRenderingMode];
-                    xr->recommendedViewScaleY = xr->renderingModeScaleY[inputSnapshot.currentRenderingMode];
+                bool monoMode = (xr->renderingModeCount > 0 && !xr->renderingModeDisplay3D[xr->currentModeIndex]);
+                if (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount) {
+                    xr->recommendedViewScaleX = xr->renderingModeScaleX[xr->currentModeIndex];
+                    xr->recommendedViewScaleY = xr->renderingModeScaleY[xr->currentModeIndex];
                 }
-                uint32_t modeViewCount = (xr->renderingModeCount > 0 && inputSnapshot.currentRenderingMode < xr->renderingModeCount)
-                    ? xr->renderingModeViewCounts[inputSnapshot.currentRenderingMode] : 2;
-                uint32_t tileColumns = (xr->renderingModeCount > 0 && inputSnapshot.currentRenderingMode < xr->renderingModeCount)
-                    ? xr->renderingModeTileColumns[inputSnapshot.currentRenderingMode] : 2;
-                uint32_t tileRows = (xr->renderingModeCount > 0 && inputSnapshot.currentRenderingMode < xr->renderingModeCount)
-                    ? xr->renderingModeTileRows[inputSnapshot.currentRenderingMode] : 1;
+                uint32_t modeViewCount = (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount)
+                    ? xr->renderingModeViewCounts[xr->currentModeIndex] : 2;
+                uint32_t tileColumns = (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount)
+                    ? xr->renderingModeTileColumns[xr->currentModeIndex] : 2;
+                uint32_t tileRows = (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount)
+                    ? xr->renderingModeTileRows[xr->currentModeIndex] : 1;
                 int eyeCount = monoMode ? 1 : (int)modeViewCount;
 
                 // Dynamic arrays for N-view rendering
@@ -643,10 +653,10 @@ static void RenderThreadFunc(
                                 std::wstring dispText = FormatDisplayInfo(xr->displayWidthM, xr->displayHeightM,
                                     xr->nominalViewerX, xr->nominalViewerY, xr->nominalViewerZ);
                                 dispText += L"\n" + FormatScaleInfo(xr->recommendedViewScaleX, xr->recommendedViewScaleY);
-                                dispText += L"\n" + FormatMode(inputSnapshot.currentRenderingMode, xr->pfnRequestDisplayRenderingModeEXT != nullptr,
-                                    (xr->renderingModeCount > 0 && inputSnapshot.currentRenderingMode < xr->renderingModeCount) ? xr->renderingModeNames[inputSnapshot.currentRenderingMode] : nullptr,
+                                dispText += L"\n" + FormatMode(xr->currentModeIndex, xr->pfnRequestDisplayRenderingModeEXT != nullptr,
+                                    (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount) ? xr->renderingModeNames[xr->currentModeIndex] : nullptr,
                                     xr->renderingModeCount,
-                                    xr->renderingModeCount > 0 ? xr->renderingModeDisplay3D[inputSnapshot.currentRenderingMode] : true);
+                                    xr->renderingModeCount > 0 ? xr->renderingModeDisplay3D[xr->currentModeIndex] : true);
                                 std::wstring eyeText = FormatEyeTrackingInfo(
                                     xr->eyePositions, (uint32_t)eyeCount,
                                     xr->eyeTrackingActive, xr->isEyeTracking,
@@ -756,7 +766,7 @@ static void RenderThreadFunc(
                 }
 
                 // viewCount: 1 for mono (2D mode), 2 for stereo (3D mode)
-                uint32_t submitViewCount = (xr->renderingModeCount > 0 && inputSnapshot.currentRenderingMode < xr->renderingModeCount) ? xr->renderingModeViewCounts[inputSnapshot.currentRenderingMode] : 2;
+                uint32_t submitViewCount = (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount) ? xr->renderingModeViewCounts[xr->currentModeIndex] : 2;
                 // When transparent_bg is on, ask the runtime to honor the cube's
                 // per-pixel alpha when blending the projection layer. Pre-#213
                 // apps default to 0 (no source-alpha blend = treat as opaque).

--- a/test_apps/cube_handle_vk_win/main.cpp
+++ b/test_apps/cube_handle_vk_win/main.cpp
@@ -656,7 +656,8 @@ static void RenderThreadFunc(
                                 dispText += L"\n" + FormatMode(xr->currentModeIndex, xr->pfnRequestDisplayRenderingModeEXT != nullptr,
                                     (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount) ? xr->renderingModeNames[xr->currentModeIndex] : nullptr,
                                     xr->renderingModeCount,
-                                    xr->renderingModeCount > 0 ? xr->renderingModeDisplay3D[xr->currentModeIndex] : true);
+                                    xr->renderingModeCount > 0 ? xr->renderingModeDisplay3D[xr->currentModeIndex] : true,
+                                    xr->renderingModeCount > 0 ? xr->renderingModeIsRequestable[xr->currentModeIndex] : true);
                                 std::wstring eyeText = FormatEyeTrackingInfo(
                                     xr->eyePositions, (uint32_t)eyeCount,
                                     xr->eyeTrackingActive, xr->isEyeTracking,

--- a/test_apps/cube_handle_vk_win/xr_session.cpp
+++ b/test_apps/cube_handle_vk_win/xr_session.cpp
@@ -452,6 +452,11 @@ bool CreateSession(XrSessionManager& xr, VkInstance vkInstance, VkPhysicalDevice
                     xr.renderingModeScaleX[i] = modes[i].viewScaleX;
                     xr.renderingModeScaleY[i] = modes[i].viewScaleY;
                     xr.renderingModeDisplay3D[i] = modes[i].hardwareDisplay3D ? true : false;
+                    xr.renderingModeIsRequestable[i] = modes[i].isRequestable ? true : false;
+                    // v13 initial-mode-sync: trust runtime-reported active mode.
+                    if (modes[i].isActive) {
+                        xr.currentModeIndex = modes[i].modeIndex;
+                    }
                 }
             }
         }

--- a/test_apps/cube_hosted_d3d11_win/xr_session.cpp
+++ b/test_apps/cube_hosted_d3d11_win/xr_session.cpp
@@ -214,6 +214,11 @@ bool CreateSession(XrSessionManager& xr, ID3D11Device* d3d11Device) {
                     xr.renderingModeScaleX[i] = modes[i].viewScaleX;
                     xr.renderingModeScaleY[i] = modes[i].viewScaleY;
                     xr.renderingModeDisplay3D[i] = modes[i].hardwareDisplay3D ? true : false;
+                    xr.renderingModeIsRequestable[i] = modes[i].isRequestable ? true : false;
+                    // v13 initial-mode-sync: trust runtime-reported active mode.
+                    if (modes[i].isActive) {
+                        xr.currentModeIndex = modes[i].modeIndex;
+                    }
                     LOG_INFO("  [%u] %s (views=%u, tiles=%ux%u, scale=%.2fx%.2f, 3D=%d)",
                         modes[i].modeIndex, modes[i].modeName, modes[i].viewCount,
                         modes[i].tileColumns, modes[i].tileRows,

--- a/test_apps/cube_texture_d3d11_win/main.cpp
+++ b/test_apps/cube_texture_d3d11_win/main.cpp
@@ -563,7 +563,8 @@ static void RenderOneFrame(RenderState& rs) {
                             dispText += L"\n" + FormatMode(xr.currentModeIndex, xr.pfnRequestDisplayRenderingModeEXT != nullptr,
                                 (xr.renderingModeCount > 0 && xr.currentModeIndex < xr.renderingModeCount) ? xr.renderingModeNames[xr.currentModeIndex] : nullptr,
                                 xr.renderingModeCount,
-                                xr.renderingModeCount > 0 ? xr.renderingModeDisplay3D[xr.currentModeIndex] : true);
+                                xr.renderingModeCount > 0 ? xr.renderingModeDisplay3D[xr.currentModeIndex] : true,
+                                xr.renderingModeCount > 0 ? xr.renderingModeIsRequestable[xr.currentModeIndex] : true);
                             std::wstring eyeText = FormatEyeTrackingInfo(
                                 xr.eyePositions, (uint32_t)eyeCount,
                                 xr.eyeTrackingActive, xr.isEyeTracking,

--- a/test_apps/cube_texture_d3d11_win/main.cpp
+++ b/test_apps/cube_texture_d3d11_win/main.cpp
@@ -368,10 +368,22 @@ static void RenderOneFrame(RenderState& rs) {
         ToggleFullscreen(rs.hwnd);
         g_inputState.fullscreenToggleRequested = false;
     }
-    if (g_inputState.renderingModeChangeRequested) {
-        g_inputState.renderingModeChangeRequested = false;
-        if (xr.pfnRequestDisplayRenderingModeEXT && xr.session != XR_NULL_HANDLE) {
-            xr.pfnRequestDisplayRenderingModeEXT(xr.session, g_inputState.currentRenderingMode);
+    // Rendering mode requests (V=cycle, 0-8=absolute). Single source of
+    // truth: the runtime owns current mode via xr.currentModeIndex.
+    if (g_inputState.cycleRenderingModeRequested) {
+        g_inputState.cycleRenderingModeRequested = false;
+        if (xr.pfnRequestDisplayRenderingModeEXT && xr.session != XR_NULL_HANDLE &&
+            xr.renderingModeCount > 0) {
+            uint32_t next = (xr.currentModeIndex + 1) % xr.renderingModeCount;
+            xr.pfnRequestDisplayRenderingModeEXT(xr.session, next);
+        }
+    }
+    if (g_inputState.absoluteRenderingModeRequested >= 0) {
+        uint32_t target = (uint32_t)g_inputState.absoluteRenderingModeRequested;
+        g_inputState.absoluteRenderingModeRequested = -1;
+        if (xr.pfnRequestDisplayRenderingModeEXT && xr.session != XR_NULL_HANDLE &&
+            target < xr.renderingModeCount) {
+            xr.pfnRequestDisplayRenderingModeEXT(xr.session, target);
         }
     }
     if (g_inputState.eyeTrackingModeToggleRequested) {
@@ -394,16 +406,16 @@ static void RenderOneFrame(RenderState& rs) {
     if (xr.sessionRunning) {
         XrFrameState frameState;
         if (BeginFrame(xr, frameState)) {
-            uint32_t modeViewCount = (xr.renderingModeCount > 0 && g_inputState.currentRenderingMode < xr.renderingModeCount)
-                ? xr.renderingModeViewCounts[g_inputState.currentRenderingMode] : 2;
-            uint32_t tileColumns = (xr.renderingModeCount > 0 && g_inputState.currentRenderingMode < xr.renderingModeCount)
-                ? xr.renderingModeTileColumns[g_inputState.currentRenderingMode] : 2;
-            uint32_t tileRows = (xr.renderingModeCount > 0 && g_inputState.currentRenderingMode < xr.renderingModeCount)
-                ? xr.renderingModeTileRows[g_inputState.currentRenderingMode] : 1;
-            bool monoMode = (xr.renderingModeCount > 0 && !xr.renderingModeDisplay3D[g_inputState.currentRenderingMode]);
-            if (xr.renderingModeCount > 0 && g_inputState.currentRenderingMode < xr.renderingModeCount) {
-                xr.recommendedViewScaleX = xr.renderingModeScaleX[g_inputState.currentRenderingMode];
-                xr.recommendedViewScaleY = xr.renderingModeScaleY[g_inputState.currentRenderingMode];
+            uint32_t modeViewCount = (xr.renderingModeCount > 0 && xr.currentModeIndex < xr.renderingModeCount)
+                ? xr.renderingModeViewCounts[xr.currentModeIndex] : 2;
+            uint32_t tileColumns = (xr.renderingModeCount > 0 && xr.currentModeIndex < xr.renderingModeCount)
+                ? xr.renderingModeTileColumns[xr.currentModeIndex] : 2;
+            uint32_t tileRows = (xr.renderingModeCount > 0 && xr.currentModeIndex < xr.renderingModeCount)
+                ? xr.renderingModeTileRows[xr.currentModeIndex] : 1;
+            bool monoMode = (xr.renderingModeCount > 0 && !xr.renderingModeDisplay3D[xr.currentModeIndex]);
+            if (xr.renderingModeCount > 0 && xr.currentModeIndex < xr.renderingModeCount) {
+                xr.recommendedViewScaleX = xr.renderingModeScaleX[xr.currentModeIndex];
+                xr.recommendedViewScaleY = xr.renderingModeScaleY[xr.currentModeIndex];
             }
             int eyeCount = monoMode ? 1 : (int)modeViewCount;
             std::vector<XrCompositionLayerProjectionView> projectionViews(eyeCount, {XR_TYPE_COMPOSITION_LAYER_PROJECTION_VIEW});
@@ -548,10 +560,10 @@ static void RenderOneFrame(RenderState& rs) {
                             std::wstring dispText = FormatDisplayInfo(xr.displayWidthM, xr.displayHeightM,
                                 xr.nominalViewerX, xr.nominalViewerY, xr.nominalViewerZ);
                             dispText += L"\n" + FormatScaleInfo(xr.recommendedViewScaleX, xr.recommendedViewScaleY);
-                            dispText += L"\n" + FormatMode(g_inputState.currentRenderingMode, xr.pfnRequestDisplayRenderingModeEXT != nullptr,
-                                (xr.renderingModeCount > 0 && g_inputState.currentRenderingMode < xr.renderingModeCount) ? xr.renderingModeNames[g_inputState.currentRenderingMode] : nullptr,
+                            dispText += L"\n" + FormatMode(xr.currentModeIndex, xr.pfnRequestDisplayRenderingModeEXT != nullptr,
+                                (xr.renderingModeCount > 0 && xr.currentModeIndex < xr.renderingModeCount) ? xr.renderingModeNames[xr.currentModeIndex] : nullptr,
                                 xr.renderingModeCount,
-                                xr.renderingModeCount > 0 ? xr.renderingModeDisplay3D[g_inputState.currentRenderingMode] : true);
+                                xr.renderingModeCount > 0 ? xr.renderingModeDisplay3D[xr.currentModeIndex] : true);
                             std::wstring eyeText = FormatEyeTrackingInfo(
                                 xr.eyePositions, (uint32_t)eyeCount,
                                 xr.eyeTrackingActive, xr.isEyeTracking,

--- a/test_apps/cube_texture_d3d11_win/xr_session.cpp
+++ b/test_apps/cube_texture_d3d11_win/xr_session.cpp
@@ -226,6 +226,11 @@ bool CreateSession(XrSessionManager& xr, ID3D11Device* d3d11Device, HANDLE share
                     xr.renderingModeScaleX[i] = modes[i].viewScaleX;
                     xr.renderingModeScaleY[i] = modes[i].viewScaleY;
                     xr.renderingModeDisplay3D[i] = modes[i].hardwareDisplay3D ? true : false;
+                    xr.renderingModeIsRequestable[i] = modes[i].isRequestable ? true : false;
+                    // v13 initial-mode-sync: trust runtime-reported active mode.
+                    if (modes[i].isActive) {
+                        xr.currentModeIndex = modes[i].modeIndex;
+                    }
                 }
             }
         }

--- a/test_apps/cube_texture_d3d12_win/main.cpp
+++ b/test_apps/cube_texture_d3d12_win/main.cpp
@@ -783,7 +783,8 @@ static void RenderOneFrame(RenderState& rs) {
                             dispText += L"\n" + FormatMode(xr.currentModeIndex, xr.pfnRequestDisplayRenderingModeEXT != nullptr,
                                 (xr.renderingModeCount > 0 && xr.currentModeIndex < xr.renderingModeCount) ? xr.renderingModeNames[xr.currentModeIndex] : nullptr,
                                 xr.renderingModeCount,
-                                xr.renderingModeCount > 0 ? xr.renderingModeDisplay3D[xr.currentModeIndex] : true);
+                                xr.renderingModeCount > 0 ? xr.renderingModeDisplay3D[xr.currentModeIndex] : true,
+                                xr.renderingModeCount > 0 ? xr.renderingModeIsRequestable[xr.currentModeIndex] : true);
                             std::wstring eyeText = FormatEyeTrackingInfo(
                                 xr.eyePositions, (uint32_t)eyeCount,
                                 xr.eyeTrackingActive, xr.isEyeTracking,

--- a/test_apps/cube_texture_d3d12_win/main.cpp
+++ b/test_apps/cube_texture_d3d12_win/main.cpp
@@ -533,10 +533,22 @@ static void RenderOneFrame(RenderState& rs) {
         ToggleFullscreen(rs.hwnd);
         g_inputState.fullscreenToggleRequested = false;
     }
-    if (g_inputState.renderingModeChangeRequested) {
-        g_inputState.renderingModeChangeRequested = false;
-        if (xr.pfnRequestDisplayRenderingModeEXT && xr.session != XR_NULL_HANDLE) {
-            xr.pfnRequestDisplayRenderingModeEXT(xr.session, g_inputState.currentRenderingMode);
+    // Rendering mode requests (V=cycle, 0-8=absolute). Single source of
+    // truth: the runtime owns current mode via xr.currentModeIndex.
+    if (g_inputState.cycleRenderingModeRequested) {
+        g_inputState.cycleRenderingModeRequested = false;
+        if (xr.pfnRequestDisplayRenderingModeEXT && xr.session != XR_NULL_HANDLE &&
+            xr.renderingModeCount > 0) {
+            uint32_t next = (xr.currentModeIndex + 1) % xr.renderingModeCount;
+            xr.pfnRequestDisplayRenderingModeEXT(xr.session, next);
+        }
+    }
+    if (g_inputState.absoluteRenderingModeRequested >= 0) {
+        uint32_t target = (uint32_t)g_inputState.absoluteRenderingModeRequested;
+        g_inputState.absoluteRenderingModeRequested = -1;
+        if (xr.pfnRequestDisplayRenderingModeEXT && xr.session != XR_NULL_HANDLE &&
+            target < xr.renderingModeCount) {
+            xr.pfnRequestDisplayRenderingModeEXT(xr.session, target);
         }
     }
     if (g_inputState.eyeTrackingModeToggleRequested) {
@@ -559,16 +571,16 @@ static void RenderOneFrame(RenderState& rs) {
     if (xr.sessionRunning) {
         XrFrameState frameState;
         if (BeginFrame(xr, frameState)) {
-            uint32_t modeViewCount = (xr.renderingModeCount > 0 && g_inputState.currentRenderingMode < xr.renderingModeCount)
-                ? xr.renderingModeViewCounts[g_inputState.currentRenderingMode] : 2;
-            uint32_t tileColumns = (xr.renderingModeCount > 0 && g_inputState.currentRenderingMode < xr.renderingModeCount)
-                ? xr.renderingModeTileColumns[g_inputState.currentRenderingMode] : 2;
-            uint32_t tileRows = (xr.renderingModeCount > 0 && g_inputState.currentRenderingMode < xr.renderingModeCount)
-                ? xr.renderingModeTileRows[g_inputState.currentRenderingMode] : 1;
-            bool monoMode = (xr.renderingModeCount > 0 && !xr.renderingModeDisplay3D[g_inputState.currentRenderingMode]);
-            if (xr.renderingModeCount > 0 && g_inputState.currentRenderingMode < xr.renderingModeCount) {
-                xr.recommendedViewScaleX = xr.renderingModeScaleX[g_inputState.currentRenderingMode];
-                xr.recommendedViewScaleY = xr.renderingModeScaleY[g_inputState.currentRenderingMode];
+            uint32_t modeViewCount = (xr.renderingModeCount > 0 && xr.currentModeIndex < xr.renderingModeCount)
+                ? xr.renderingModeViewCounts[xr.currentModeIndex] : 2;
+            uint32_t tileColumns = (xr.renderingModeCount > 0 && xr.currentModeIndex < xr.renderingModeCount)
+                ? xr.renderingModeTileColumns[xr.currentModeIndex] : 2;
+            uint32_t tileRows = (xr.renderingModeCount > 0 && xr.currentModeIndex < xr.renderingModeCount)
+                ? xr.renderingModeTileRows[xr.currentModeIndex] : 1;
+            bool monoMode = (xr.renderingModeCount > 0 && !xr.renderingModeDisplay3D[xr.currentModeIndex]);
+            if (xr.renderingModeCount > 0 && xr.currentModeIndex < xr.renderingModeCount) {
+                xr.recommendedViewScaleX = xr.renderingModeScaleX[xr.currentModeIndex];
+                xr.recommendedViewScaleY = xr.renderingModeScaleY[xr.currentModeIndex];
             }
             int eyeCount = monoMode ? 1 : (int)modeViewCount;
             std::vector<XrCompositionLayerProjectionView> projectionViews(eyeCount, {XR_TYPE_COMPOSITION_LAYER_PROJECTION_VIEW});
@@ -768,10 +780,10 @@ static void RenderOneFrame(RenderState& rs) {
                             std::wstring dispText = FormatDisplayInfo(xr.displayWidthM, xr.displayHeightM,
                                 xr.nominalViewerX, xr.nominalViewerY, xr.nominalViewerZ);
                             dispText += L"\n" + FormatScaleInfo(xr.recommendedViewScaleX, xr.recommendedViewScaleY);
-                            dispText += L"\n" + FormatMode(g_inputState.currentRenderingMode, xr.pfnRequestDisplayRenderingModeEXT != nullptr,
-                                (xr.renderingModeCount > 0 && g_inputState.currentRenderingMode < xr.renderingModeCount) ? xr.renderingModeNames[g_inputState.currentRenderingMode] : nullptr,
+                            dispText += L"\n" + FormatMode(xr.currentModeIndex, xr.pfnRequestDisplayRenderingModeEXT != nullptr,
+                                (xr.renderingModeCount > 0 && xr.currentModeIndex < xr.renderingModeCount) ? xr.renderingModeNames[xr.currentModeIndex] : nullptr,
                                 xr.renderingModeCount,
-                                xr.renderingModeCount > 0 ? xr.renderingModeDisplay3D[g_inputState.currentRenderingMode] : true);
+                                xr.renderingModeCount > 0 ? xr.renderingModeDisplay3D[xr.currentModeIndex] : true);
                             std::wstring eyeText = FormatEyeTrackingInfo(
                                 xr.eyePositions, (uint32_t)eyeCount,
                                 xr.eyeTrackingActive, xr.isEyeTracking,

--- a/test_apps/cube_texture_d3d12_win/xr_session.cpp
+++ b/test_apps/cube_texture_d3d12_win/xr_session.cpp
@@ -229,6 +229,11 @@ bool CreateSession(XrSessionManager& xr, ID3D12Device* device, ID3D12CommandQueu
                     xr.renderingModeScaleX[i] = modes[i].viewScaleX;
                     xr.renderingModeScaleY[i] = modes[i].viewScaleY;
                     xr.renderingModeDisplay3D[i] = modes[i].hardwareDisplay3D ? true : false;
+                    xr.renderingModeIsRequestable[i] = modes[i].isRequestable ? true : false;
+                    // v13 initial-mode-sync: trust runtime-reported active mode.
+                    if (modes[i].isActive) {
+                        xr.currentModeIndex = modes[i].modeIndex;
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary

Bundles the #234 / #238 workspace polish series committed across this session. Each commit is independently reviewable.

### Runtime (this repo)

- `7dfa922c3` — workspace: post-flip cooldown for vendor 3D-state poll (#234)
- `7561d0a14` — test_apps: single-source-of-truth for rendering mode in Win32 cubes (#234)
- `2efdca537` — workspace: suppress qwerty key intercepts under workspace mode (#234)
- `2645c4f03` — workspace: force display to 3D on activate + vendor-drift re-assert (#234)
- `f27e645ef` — workspace: per-slot stride decouple via commit-time snapshot (#234)
- `3ba666bfe` — ext: XR_EXT_display_info v13 — isActive / isRequestable on mode info (#234)
- `d05617e46` — ipc: destroy compositor before dropping xscs refs (#238)
- `b423369cf` — test_apps: show [locked by workspace] in HUD when isRequestable=false

### Sibling repos (separate PRs)

- displayxr-shell-pvt — V → Ctrl+V hotkey
- displayxr-demo-gaussiansplat — SSoT refactor + v13 consume + HUD [locked] indicator
- displayxr-unity — v13 ABI sync
- displayxr-unreal — v13 ABI sync

### What was tested on Leia SR

- Vendor poll no longer fires counter-correction within 2s of a user-driven flip.
- Bare V no longer toggles display mode (qwerty driver gated under workspace).
- Shell always opens in 3D regardless of prior session state (force_3d at activate).
- Vendor-drift (SR SDK auto-flipping to 2D) re-asserted back to runtime's intent.
- d3d11 + vk cubes + gauss render correctly through Ctrl+V transitions (curtain back to 16 frames).
- Apps sync to runtime's active mode at session start via `isActive` (no more "default to 1 and hope").
- Ctrl+Space teardown no longer crashes the service.

### ABI note (consumers required to update)

Bumping `XR_EXT_display_info_SPEC_VERSION 12 → 13` grew `sizeof(XrDisplayRenderingModeInfoEXT)`. Every consumer compiled against v12 must sync the header and rebuild before testing against this PR's runtime. Otherwise enumerate-call writes overflow the consumer's `modes[i+1]` slot. Sibling PRs handle the known consumers (shell, gauss, unity, unreal).

Memory note saved: extension struct ABI bumps are fragile; consider chained `next`-pointer extension structs for future field additions to keep the base struct `sizeof` stable.

## Test plan

- [x] Build green (Windows + macOS CI on this branch)
- [x] User-verified on Leia SR hardware (all symptoms gone, both eyes render, V locked-by-workspace indicator visible)
- [ ] Sibling PRs land + plugins rebuilt before user-facing release

Closes #238.
Refs #234.

🤖 Generated with [Claude Code](https://claude.com/claude-code)