### PR TITLE
workspace: fall back to KeyedMutex when client did not signal fence

### DIFF
--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -10922,7 +10922,25 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 			}
 
 			if (view_scs[eye]->service_created && view_scs[eye]->images[view_img_indices[eye]].keyed_mutex) {
-				if (c->workspace_sync_fence) {
+				// Phase 2 fence path is opt-in per client. The service
+				// always creates a workspace_sync_fence at session-create,
+				// but only clients that import + signal it
+				// (comp_d3d11_client, comp_vk_client) participate. The
+				// remaining clients (comp_d3d12_client, comp_gl_*_client)
+				// never call get_workspace_sync_fence and never signal,
+				// so `last_signaled_fence_value` stays 0 for the session.
+				// Treat that 0 as the "no fence in use" sentinel the
+				// original Phase 2 commit message described and fall
+				// through to the legacy KeyedMutex path — without this
+				// gate, every d3d12/gl projection-view blit is marked
+				// stale and skipped, leaving the per-client atlas empty
+				// (chrome panel shows through; HUD WS-layers still work
+				// because they bypass this loop).
+				uint64_t fence_signaled = c->workspace_sync_fence
+				    ? c->last_signaled_fence_value.load(std::memory_order_acquire)
+				    : 0;
+				bool use_fence_path = c->workspace_sync_fence && fence_signaled != 0;
+				if (use_fence_path) {
 					// Phase 2 — GPU-side fence path. No CPU
 					// wait, no IDXGIKeyedMutex acquire. The
 					// client signals `last_signaled_fence_value`
@@ -10936,10 +10954,8 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 					// timeout handler uses, but driven by the
 					// fence rather than a 4 ms wall-clock
 					// timeout).
-					uint64_t signaled = c->last_signaled_fence_value.load(
-					    std::memory_order_acquire);
-					if (signaled == 0 ||
-					    signaled == c->last_composed_fence_value[eye]) {
+					uint64_t signaled = fence_signaled;
+					if (signaled == c->last_composed_fence_value[eye]) {
 						// Client hasn't produced a new frame
 						// since we last composed this view —
 						// reuse persistent atlas slot content.


### PR DESCRIPTION
## Summary
- D3D12 and OpenGL cube apps were rendering blank-white content (only HUD visible) in shell mode — a regression from the Phase 2 cross-process D3D11 fence work (commit `4c4625112`).
- Root cause: service creates a `workspace_sync_fence` for every workspace client at session-create, but only `comp_d3d11_client` and `comp_vk_client` actually import + signal it. For d3d12/gl clients the fence value stays at 0 forever, and the per-view check `signaled == 0 || signaled == last_composed[eye]` conflated that with "no new frame" → every projection-view blit was marked stale and skipped. HUD survived only because the WS-layer compose path bypasses the per-view fence gate.
- Fix matches the original Phase 2 commit message's documented intent: treat `signaled == 0` as the "no fence in use" sentinel and fall through to the legacy KeyedMutex path. Phase 2 fence path is now opt-in per client (active only after the client signals at least once).

## Test plan
- [x] Local build via `scripts\build_windows.bat build`
- [x] Shell + D3D12 cube + GL cube: both windows render cube + grid + HUD in both eyes (`[FENCE] stale_views=0 last_value=0`, `[MUTEX] acquires=519 timeouts=0`)
- [x] Shell + 2× D3D11 cubes (regression check): unchanged, Phase 2 fence path still active (`[FENCE] waits_queued=547 last_value=1004`, `[MUTEX] acquires=0`)
- [x] Verified against installed runtime in `C:\Program Files\DisplayXR\Runtime\` (no env overrides)
- [ ] CI Windows + macOS green

🤖 Generated with [Claude Code](https://claude.com/claude-code)