### PR TITLE
test_apps: macOS SSOT for rendering mode + XR_EXT_display_info v13 (#239)

### DIFF
--- a/test_apps/cube_handle_gl_macos/main.mm
+++ b/test_apps/cube_handle_gl_macos/main.mm
@@ -716,9 +716,13 @@ struct InputState {
     bool resetViewRequested = false;
     ViewParams viewParams;
     bool hudVisible = true;
-    uint32_t currentRenderingMode = 1;
-    uint32_t renderingModeCount = 0;
-    bool renderingModeChangeRequested = false;
+    // Rendering mode REQUESTS — single source of truth lives on the runtime
+    // side (read back as app.currentModeIndex after the runtime's
+    // XrEventDataRenderingModeChangedEXT lands). Keys emit transient requests;
+    // the actual current mode is never mirrored here.
+    uint32_t renderingModeCount = 0;             // mirror of app.renderingModeCount for keypress bounds
+    bool cycleRenderingModeRequested = false;    // V key
+    int32_t absoluteRenderingModeRequested = -1; // 0-8 keys; -1 = none
     bool cameraMode = false;
     float nominalViewerZ = 0.5f;
     // 'I' key: snapshot the **app's projection-layer atlas only** (cols ×
@@ -944,10 +948,7 @@ static void PumpMacOSEvents()
                         g_input.hudVisible = !g_input.hudVisible;
                     }
                     else if (ch == 'v' && !isRepeat) {
-                        if (g_input.renderingModeCount > 0) {
-                            g_input.currentRenderingMode = (g_input.currentRenderingMode + 1) % g_input.renderingModeCount;
-                        }
-                        g_input.renderingModeChangeRequested = true;
+                        g_input.cycleRenderingModeRequested = true;
                     }
                     else if ((ch == 'i' || ch == 'I') && !isRepeat) {
                         g_input.captureAtlasRequested = true;
@@ -969,11 +970,7 @@ static void PumpMacOSEvents()
                         }
                     }
                     else if (ch >= '0' && ch <= '8' && !isRepeat) {
-                        uint32_t idx = ch - '0';
-                        if (idx < g_input.renderingModeCount) {
-                            g_input.currentRenderingMode = idx;
-                            g_input.renderingModeChangeRequested = true;
-                        }
+                        g_input.absoluteRenderingModeRequested = (int32_t)(ch - '0');
                     }
                 }
             } else if (type == NSEventTypeKeyUp) {
@@ -1086,6 +1083,10 @@ struct AppXrSession {
     PFN_xrRequestDisplayModeEXT pfnRequestDisplayModeEXT;
     PFN_xrRequestDisplayRenderingModeEXT pfnRequestDisplayRenderingModeEXT;
     PFN_xrEnumerateDisplayRenderingModesEXT pfnEnumerateDisplayRenderingModesEXT;
+    // Enumerated rendering mode info. currentModeIndex is initialized to mode 1
+    // as a fallback for runtimes that don't expose isActive; v13+ runtimes
+    // replace it via the enumerate step (initial-mode-sync, #234/#239).
+    uint32_t currentModeIndex = 1;
     uint32_t renderingModeCount;
     char renderingModeNames[8][XR_MAX_SYSTEM_NAME_SIZE];
     uint32_t renderingModeViewCounts[8] = {};
@@ -1094,6 +1095,7 @@ struct AppXrSession {
     float renderingModeScaleX[8] = {};
     float renderingModeScaleY[8] = {};
     bool renderingModeDisplay3D[8] = {};
+    bool renderingModeIsRequestable[8] = {};  // v13: false when workspace-locked
 
     // Eye tracking
     float eyePositions[8][3] = {};  // [view][x,y,z] — raw per-eye positions in display space
@@ -1308,6 +1310,11 @@ static bool CreateSession(AppXrSession &app)
                     app.renderingModeScaleX[i] = modes[i].viewScaleX;
                     app.renderingModeScaleY[i] = modes[i].viewScaleY;
                     app.renderingModeDisplay3D[i] = modes[i].hardwareDisplay3D ? true : false;
+                    app.renderingModeIsRequestable[i] = modes[i].isRequestable ? true : false;
+                    // v13 initial-mode-sync: trust runtime-reported active mode.
+                    if (modes[i].isActive) {
+                        app.currentModeIndex = modes[i].modeIndex;
+                    }
                     LOG_INFO("  [%u] %s (views=%u, tiles=%ux%u, scale=%.2fx%.2f, 3D=%s)",
                         modes[i].modeIndex, modes[i].modeName,
                         modes[i].viewCount, modes[i].tileColumns, modes[i].tileRows,
@@ -1436,6 +1443,13 @@ static void PollEvents(AppXrSession &app)
             }
             break;
         }
+        case (XrStructureType)XR_TYPE_EVENT_DATA_RENDERING_MODE_CHANGED_EXT: {
+            auto* modeEvent = (XrEventDataRenderingModeChangedEXT*)&event;
+            LOG_INFO("Rendering mode changed: %u -> %u",
+                modeEvent->previousModeIndex, modeEvent->currentModeIndex);
+            app.currentModeIndex = modeEvent->currentModeIndex;
+            break;
+        }
         default: break;
         }
         event = {XR_TYPE_EVENT_DATA_BUFFER};
@@ -1545,22 +1559,9 @@ int main(int argc, char **argv)
         LOG_WARN("Failed to create HUD swapchain - HUD disabled");
     }
 
-    // Initialize output mode from env var
-    {
-        const char *mode_str = getenv("SIM_DISPLAY_OUTPUT");
-        if (mode_str) {
-            if (strcmp(mode_str, "anaglyph") == 0)
-                g_input.currentRenderingMode = 1;
-            else if (strcmp(mode_str, "sbs") == 0)
-                g_input.currentRenderingMode = 2;
-            else if (strcmp(mode_str, "blend") == 0)
-                g_input.currentRenderingMode = 3;
-            else
-                g_input.currentRenderingMode = 1; // default to anaglyph
-        }
-    }
-
-    g_input.renderingModeChangeRequested = true;
+    // Initial rendering mode is sourced from the runtime via v13 `isActive`
+    // (set during xrEnumerateDisplayRenderingModesEXT above). Fallback is
+    // mode 1 (default of app.currentModeIndex).
 
     g_input.viewParams.virtualDisplayHeight = 0.24f;
     g_input.nominalViewerZ = app.nominalViewerZ;
@@ -1578,16 +1579,25 @@ int main(int argc, char **argv)
         PumpMacOSEvents();
         PollEvents(app);
 
-        // Handle rendering mode change (V=cycle, 0-8=direct)
-        if (g_input.renderingModeChangeRequested) {
-            g_input.renderingModeChangeRequested = false;
-            if (app.pfnRequestDisplayRenderingModeEXT && app.session != XR_NULL_HANDLE) {
-                const char *modeName = (g_input.currentRenderingMode < app.renderingModeCount)
-                    ? app.renderingModeNames[g_input.currentRenderingMode] : "?";
-                XrResult res = app.pfnRequestDisplayRenderingModeEXT(app.session, g_input.currentRenderingMode);
-                LOG_INFO("Rendering mode -> %s (%s)",
-                    modeName,
-                    XR_SUCCEEDED(res) ? "OK" : "failed");
+        // Handle rendering mode requests (V=cycle next, 0-8=jump absolute).
+        // Single source of truth: the runtime owns the current mode. Keypresses
+        // are REQUESTS — we call xrRequestDisplayRenderingModeEXT and let the
+        // XrEventDataRenderingModeChangedEXT event update app.currentModeIndex.
+        // Render paths and HUD read app.currentModeIndex directly.
+        if (g_input.cycleRenderingModeRequested) {
+            g_input.cycleRenderingModeRequested = false;
+            if (app.pfnRequestDisplayRenderingModeEXT && app.session != XR_NULL_HANDLE &&
+                app.renderingModeCount > 0) {
+                uint32_t next = (app.currentModeIndex + 1) % app.renderingModeCount;
+                app.pfnRequestDisplayRenderingModeEXT(app.session, next);
+            }
+        }
+        if (g_input.absoluteRenderingModeRequested >= 0) {
+            uint32_t target = (uint32_t)g_input.absoluteRenderingModeRequested;
+            g_input.absoluteRenderingModeRequested = -1;
+            if (app.pfnRequestDisplayRenderingModeEXT && app.session != XR_NULL_HANDLE &&
+                target < app.renderingModeCount) {
+                app.pfnRequestDisplayRenderingModeEXT(app.session, target);
             }
         }
 
@@ -1644,16 +1654,16 @@ int main(int argc, char **argv)
         xrWaitSwapchainImage(app.swapchain.swapchain, &waitImgInfo);
 
         bool rendered = false;
-        bool display3D = (g_input.currentRenderingMode < app.renderingModeCount)
-            ? app.renderingModeDisplay3D[g_input.currentRenderingMode] : true;
+        bool display3D = (app.currentModeIndex < app.renderingModeCount)
+            ? app.renderingModeDisplay3D[app.currentModeIndex] : true;
 
         // Get N-view mode info from enumerated rendering modes
-        uint32_t modeViewCount = (g_input.currentRenderingMode < app.renderingModeCount)
-            ? app.renderingModeViewCounts[g_input.currentRenderingMode] : 2;
-        uint32_t tileColumns = (g_input.currentRenderingMode < app.renderingModeCount)
-            ? app.renderingModeTileColumns[g_input.currentRenderingMode] : 2;
-        uint32_t tileRows = (g_input.currentRenderingMode < app.renderingModeCount)
-            ? app.renderingModeTileRows[g_input.currentRenderingMode] : 1;
+        uint32_t modeViewCount = (app.currentModeIndex < app.renderingModeCount)
+            ? app.renderingModeViewCounts[app.currentModeIndex] : 2;
+        uint32_t tileColumns = (app.currentModeIndex < app.renderingModeCount)
+            ? app.renderingModeTileColumns[app.currentModeIndex] : 2;
+        uint32_t tileRows = (app.currentModeIndex < app.renderingModeCount)
+            ? app.renderingModeTileRows[app.currentModeIndex] : 1;
         int eyeCount = display3D ? (int)modeViewCount : 1;
 
         // Dynamic arrays for N-view rendering
@@ -1693,10 +1703,10 @@ int main(int argc, char **argv)
 
             XrVector3f nominalViewer = {app.nominalViewerX, app.nominalViewerY, app.nominalViewerZ};
 
-            float scaleX = (g_input.currentRenderingMode < app.renderingModeCount)
-                ? app.renderingModeScaleX[g_input.currentRenderingMode] : 0.5f;
-            float scaleY = (g_input.currentRenderingMode < app.renderingModeCount)
-                ? app.renderingModeScaleY[g_input.currentRenderingMode] : 0.5f;
+            float scaleX = (app.currentModeIndex < app.renderingModeCount)
+                ? app.renderingModeScaleX[app.currentModeIndex] : 0.5f;
+            float scaleY = (app.currentModeIndex < app.renderingModeCount)
+                ? app.renderingModeScaleY[app.currentModeIndex] : 0.5f;
             app.recommendedViewScaleX = scaleX;
             app.recommendedViewScaleY = scaleY;
             uint32_t maxTileW = tileColumns > 0 ? app.swapchain.width / tileColumns : app.swapchain.width;
@@ -1947,14 +1957,17 @@ int main(int argc, char **argv)
                 app.systemName, sessionStateName);
             g_hudSessionText = utf8ToW(buf);
 
-            const char* outputModeName = (g_input.currentRenderingMode < app.renderingModeCount)
-                ? app.renderingModeNames[g_input.currentRenderingMode] : "?";
+            const char* outputModeName = (app.currentModeIndex < app.renderingModeCount)
+                ? app.renderingModeNames[app.currentModeIndex] : "?";
+            bool isReq = (app.currentModeIndex < app.renderingModeCount)
+                ? app.renderingModeIsRequestable[app.currentModeIndex] : true;
+            const char* lockSuffix = isReq ? "" : " [locked by workspace]";
             const char* kooimaMode = g_input.cameraMode
                 ? "Camera-Centric [C=Toggle]" : "Display-Centric [C=Toggle]";
             snprintf(buf, sizeof(buf),
-                "XR_EXT_cocoa_window_binding: %s (OpenGL)\nMode: %s (%s)\nKooima: %s",
+                "XR_EXT_cocoa_window_binding: %s (OpenGL)\nMode: %s (%s)%s\nKooima: %s",
                 app.hasCocoaWindowBinding ? "ACTIVE" : "NOT AVAILABLE",
-                outputModeName, display3D ? "3D" : "2D", kooimaMode);
+                outputModeName, display3D ? "3D" : "2D", lockSuffix, kooimaMode);
             g_hudModeText = utf8ToW(buf);
 
             double fps = (g_avgFrameTime > 0) ? 1.0 / g_avgFrameTime : 0;

--- a/test_apps/cube_handle_metal_macos/main.mm
+++ b/test_apps/cube_handle_metal_macos/main.mm
@@ -737,9 +737,13 @@ struct InputState {
     bool resetViewRequested = false;
     ViewParams viewParams;
     bool hudVisible = true;
-    uint32_t currentRenderingMode = 1;
-    uint32_t renderingModeCount = 0;
-    bool renderingModeChangeRequested = false;
+    // Rendering mode REQUESTS — single source of truth lives on the runtime
+    // side (read back as app.currentModeIndex after the runtime's
+    // XrEventDataRenderingModeChangedEXT lands). Keys emit transient requests;
+    // the actual current mode is never mirrored here.
+    uint32_t renderingModeCount = 0;             // mirror of app.renderingModeCount for keypress bounds
+    bool cycleRenderingModeRequested = false;    // V key
+    int32_t absoluteRenderingModeRequested = -1; // 0-8 keys; -1 = none
     bool cameraMode = false;
     float nominalViewerZ = 0.5f;
     // 'I' key: snapshot the **app's projection-layer atlas only** (cols ×
@@ -958,10 +962,7 @@ static void PumpMacOSEvents()
                         g_input.hudVisible = !g_input.hudVisible;
                     }
                     else if (ch == 'v' && !isRepeat) {
-                        if (g_input.renderingModeCount > 0) {
-                            g_input.currentRenderingMode = (g_input.currentRenderingMode + 1) % g_input.renderingModeCount;
-                        }
-                        g_input.renderingModeChangeRequested = true;
+                        g_input.cycleRenderingModeRequested = true;
                     }
                     else if ((ch == 'i' || ch == 'I') && !isRepeat) {
                         g_input.captureAtlasRequested = true;
@@ -983,11 +984,7 @@ static void PumpMacOSEvents()
                         }
                     }
                     else if (ch >= '0' && ch <= '8' && !isRepeat) {
-                        uint32_t idx = ch - '0';
-                        if (idx < g_input.renderingModeCount) {
-                            g_input.currentRenderingMode = idx;
-                            g_input.renderingModeChangeRequested = true;
-                        }
+                        g_input.absoluteRenderingModeRequested = (int32_t)(ch - '0');
                     }
                 }
             } else if (type == NSEventTypeKeyUp) {
@@ -1101,7 +1098,10 @@ struct AppXrSession {
     PFN_xrRequestDisplayRenderingModeEXT pfnRequestDisplayRenderingModeEXT;
     PFN_xrEnumerateDisplayRenderingModesEXT pfnEnumerateDisplayRenderingModesEXT;
 
-    // Enumerated rendering mode info
+    // Enumerated rendering mode info. currentModeIndex is initialized to mode 1
+    // as a fallback for runtimes that don't expose isActive; v13+ runtimes
+    // replace it via the enumerate step (initial-mode-sync, #234/#239).
+    uint32_t currentModeIndex = 1;
     uint32_t renderingModeCount;
     char renderingModeNames[8][XR_MAX_SYSTEM_NAME_SIZE];
     uint32_t renderingModeViewCounts[8] = {};
@@ -1110,6 +1110,7 @@ struct AppXrSession {
     float renderingModeScaleX[8] = {};
     float renderingModeScaleY[8] = {};
     bool renderingModeDisplay3D[8] = {};
+    bool renderingModeIsRequestable[8] = {};  // v13: false when workspace-locked
 
     // Eye tracking
     float eyePositions[8][3] = {};  // [view][x,y,z] — raw per-eye positions in display space
@@ -1319,6 +1320,11 @@ static bool CreateSession(AppXrSession &app, MetalRenderer &r)
                     app.renderingModeScaleX[i] = modes[i].viewScaleX;
                     app.renderingModeScaleY[i] = modes[i].viewScaleY;
                     app.renderingModeDisplay3D[i] = modes[i].hardwareDisplay3D ? true : false;
+                    app.renderingModeIsRequestable[i] = modes[i].isRequestable ? true : false;
+                    // v13 initial-mode-sync: trust runtime-reported active mode.
+                    if (modes[i].isActive) {
+                        app.currentModeIndex = modes[i].modeIndex;
+                    }
                     LOG_INFO("  [%u] %s (views=%u, tiles=%ux%u, scale=%.2fx%.2f, 3D=%s)",
                         modes[i].modeIndex, modes[i].modeName,
                         modes[i].viewCount, modes[i].tileColumns, modes[i].tileRows,
@@ -1449,6 +1455,13 @@ static void PollEvents(AppXrSession &app)
             }
             break;
         }
+        case (XrStructureType)XR_TYPE_EVENT_DATA_RENDERING_MODE_CHANGED_EXT: {
+            auto* modeEvent = (XrEventDataRenderingModeChangedEXT*)&event;
+            LOG_INFO("Rendering mode changed: %u -> %u",
+                modeEvent->previousModeIndex, modeEvent->currentModeIndex);
+            app.currentModeIndex = modeEvent->currentModeIndex;
+            break;
+        }
         default: break;
         }
         event = {XR_TYPE_EVENT_DATA_BUFFER};
@@ -1537,23 +1550,10 @@ int main(int argc, char **argv)
         LOG_WARN("Failed to create HUD swapchain - HUD disabled");
     }
 
-    // Initialize output mode from env var (0=2D, 1=Anaglyph, 2=SBS, 3=Blend)
-    {
-        const char *mode_str = getenv("SIM_DISPLAY_OUTPUT");
-        if (mode_str) {
-            if (strcmp(mode_str, "anaglyph") == 0)
-                g_input.currentRenderingMode = 1;
-            else if (strcmp(mode_str, "sbs") == 0)
-                g_input.currentRenderingMode = 2;
-            else if (strcmp(mode_str, "blend") == 0)
-                g_input.currentRenderingMode = 3;
-            else
-                g_input.currentRenderingMode = 1; // default to anaglyph
-        }
-    }
-
-    // Request initial rendering mode on first frame
-    g_input.renderingModeChangeRequested = true;
+    // Initial rendering mode is sourced from the runtime via v13 `isActive`
+    // (set during xrEnumerateDisplayRenderingModesEXT above). Fallback is
+    // mode 1 (default of app.currentModeIndex). No env-var override here —
+    // SIM_DISPLAY_OUTPUT is a runtime-side construct.
 
     g_input.viewParams.virtualDisplayHeight = 0.24f;
     g_input.nominalViewerZ = app.nominalViewerZ;
@@ -1571,16 +1571,25 @@ int main(int argc, char **argv)
         PumpMacOSEvents();
         PollEvents(app);
 
-        // Handle rendering mode change (V=cycle, 0-8=direct)
-        if (g_input.renderingModeChangeRequested) {
-            g_input.renderingModeChangeRequested = false;
-            if (app.pfnRequestDisplayRenderingModeEXT && app.session != XR_NULL_HANDLE) {
-                const char *modeName = (g_input.currentRenderingMode < app.renderingModeCount)
-                    ? app.renderingModeNames[g_input.currentRenderingMode] : "?";
-                XrResult res = app.pfnRequestDisplayRenderingModeEXT(app.session, g_input.currentRenderingMode);
-                LOG_INFO("Rendering mode -> %s (%s)",
-                    modeName,
-                    XR_SUCCEEDED(res) ? "OK" : "failed");
+        // Handle rendering mode requests (V=cycle next, 0-8=jump absolute).
+        // Single source of truth: the runtime owns the current mode. Keypresses
+        // are REQUESTS — we call xrRequestDisplayRenderingModeEXT and let the
+        // XrEventDataRenderingModeChangedEXT event update app.currentModeIndex.
+        // Render paths and HUD read app.currentModeIndex directly.
+        if (g_input.cycleRenderingModeRequested) {
+            g_input.cycleRenderingModeRequested = false;
+            if (app.pfnRequestDisplayRenderingModeEXT && app.session != XR_NULL_HANDLE &&
+                app.renderingModeCount > 0) {
+                uint32_t next = (app.currentModeIndex + 1) % app.renderingModeCount;
+                app.pfnRequestDisplayRenderingModeEXT(app.session, next);
+            }
+        }
+        if (g_input.absoluteRenderingModeRequested >= 0) {
+            uint32_t target = (uint32_t)g_input.absoluteRenderingModeRequested;
+            g_input.absoluteRenderingModeRequested = -1;
+            if (app.pfnRequestDisplayRenderingModeEXT && app.session != XR_NULL_HANDLE &&
+                target < app.renderingModeCount) {
+                app.pfnRequestDisplayRenderingModeEXT(app.session, target);
             }
         }
 
@@ -1633,16 +1642,16 @@ int main(int argc, char **argv)
         xrWaitSwapchainImage(app.swapchain.swapchain, &waitImgInfo);
 
         bool rendered = false;
-        bool display3D = (g_input.currentRenderingMode < app.renderingModeCount)
-            ? app.renderingModeDisplay3D[g_input.currentRenderingMode] : true;
+        bool display3D = (app.currentModeIndex < app.renderingModeCount)
+            ? app.renderingModeDisplay3D[app.currentModeIndex] : true;
 
         // Get N-view mode info from enumerated rendering modes
-        uint32_t modeViewCount = (g_input.currentRenderingMode < app.renderingModeCount)
-            ? app.renderingModeViewCounts[g_input.currentRenderingMode] : 2;
-        uint32_t tileColumns = (g_input.currentRenderingMode < app.renderingModeCount)
-            ? app.renderingModeTileColumns[g_input.currentRenderingMode] : 2;
-        uint32_t tileRows = (g_input.currentRenderingMode < app.renderingModeCount)
-            ? app.renderingModeTileRows[g_input.currentRenderingMode] : 1;
+        uint32_t modeViewCount = (app.currentModeIndex < app.renderingModeCount)
+            ? app.renderingModeViewCounts[app.currentModeIndex] : 2;
+        uint32_t tileColumns = (app.currentModeIndex < app.renderingModeCount)
+            ? app.renderingModeTileColumns[app.currentModeIndex] : 2;
+        uint32_t tileRows = (app.currentModeIndex < app.renderingModeCount)
+            ? app.renderingModeTileRows[app.currentModeIndex] : 1;
         int eyeCount = display3D ? (int)modeViewCount : 1;
 
         // Dynamic arrays for N-view rendering
@@ -1684,10 +1693,10 @@ int main(int argc, char **argv)
             XrVector3f nominalViewer = {app.nominalViewerX, app.nominalViewerY, app.nominalViewerZ};
 
             // Compute render dims from enumerated mode info
-            float scaleX = (g_input.currentRenderingMode < app.renderingModeCount)
-                ? app.renderingModeScaleX[g_input.currentRenderingMode] : 0.5f;
-            float scaleY = (g_input.currentRenderingMode < app.renderingModeCount)
-                ? app.renderingModeScaleY[g_input.currentRenderingMode] : 0.5f;
+            float scaleX = (app.currentModeIndex < app.renderingModeCount)
+                ? app.renderingModeScaleX[app.currentModeIndex] : 0.5f;
+            float scaleY = (app.currentModeIndex < app.renderingModeCount)
+                ? app.renderingModeScaleY[app.currentModeIndex] : 0.5f;
             app.recommendedViewScaleX = scaleX;
             app.recommendedViewScaleY = scaleY;
             uint32_t maxTileW = tileColumns > 0 ? app.swapchain.width / tileColumns : app.swapchain.width;
@@ -1938,14 +1947,17 @@ int main(int argc, char **argv)
                 app.systemName, sessionStateName);
             g_hudSessionText = utf8ToW(buf);
 
-            const char* outputModeName = (g_input.currentRenderingMode < app.renderingModeCount)
-                ? app.renderingModeNames[g_input.currentRenderingMode] : "?";
+            const char* outputModeName = (app.currentModeIndex < app.renderingModeCount)
+                ? app.renderingModeNames[app.currentModeIndex] : "?";
+            bool isReq = (app.currentModeIndex < app.renderingModeCount)
+                ? app.renderingModeIsRequestable[app.currentModeIndex] : true;
+            const char* lockSuffix = isReq ? "" : " [locked by workspace]";
             const char* kooimaMode = g_input.cameraMode
                 ? "Camera-Centric [C=Toggle]" : "Display-Centric [C=Toggle]";
             snprintf(buf, sizeof(buf),
-                "XR_EXT_cocoa_window_binding: %s (Metal)\nMode: %s (%s)\nKooima: %s",
+                "XR_EXT_cocoa_window_binding: %s (Metal)\nMode: %s (%s)%s\nKooima: %s",
                 app.hasCocoaWindowBinding ? "ACTIVE" : "NOT AVAILABLE",
-                outputModeName, display3D ? "3D" : "2D", kooimaMode);
+                outputModeName, display3D ? "3D" : "2D", lockSuffix, kooimaMode);
             g_hudModeText = utf8ToW(buf);
 
             double fps = (g_avgFrameTime > 0) ? 1.0 / g_avgFrameTime : 0;

--- a/test_apps/cube_handle_vk_macos/main.mm
+++ b/test_apps/cube_handle_vk_macos/main.mm
@@ -101,10 +101,13 @@ struct InputState {
     // HUD toggle (Tab)
     bool hudVisible = true;
 
-    // Rendering mode (V=cycle, 0-8=direct)
-    uint32_t currentRenderingMode = 1;
-    uint32_t renderingModeCount = 0;
-    bool renderingModeChangeRequested = false;
+    // Rendering mode REQUESTS — single source of truth lives on the runtime
+    // side (read back as xr.currentModeIndex after the runtime's
+    // XrEventDataRenderingModeChangedEXT lands). Keys emit transient requests;
+    // the actual current mode is never mirrored here.
+    uint32_t renderingModeCount = 0;             // mirror of xr.renderingModeCount for keypress bounds
+    bool cycleRenderingModeRequested = false;    // V key
+    int32_t absoluteRenderingModeRequested = -1; // 0-8 keys; -1 = none
 
     // Camera vs display mode toggle (C key)
     bool cameraMode = false;
@@ -1702,10 +1705,7 @@ static void PumpMacOSEvents() {
                         g_input.hudVisible = !g_input.hudVisible;
                     }
                     else if (ch == 'v' && !isRepeat) {
-                        if (g_input.renderingModeCount > 0) {
-                            g_input.currentRenderingMode = (g_input.currentRenderingMode + 1) % g_input.renderingModeCount;
-                        }
-                        g_input.renderingModeChangeRequested = true;
+                        g_input.cycleRenderingModeRequested = true;
                     }
                     else if (ch == 't' && !isRepeat) {
                         g_input.eyeTrackingModeToggleRequested = true;
@@ -1733,11 +1733,7 @@ static void PumpMacOSEvents() {
                         }
                     }
                     else if (ch >= '0' && ch <= '8' && !isRepeat) {
-                        uint32_t idx = ch - '0';
-                        if (idx < g_input.renderingModeCount) {
-                            g_input.currentRenderingMode = idx;
-                            g_input.renderingModeChangeRequested = true;
-                        }
+                        g_input.absoluteRenderingModeRequested = (int32_t)(ch - '0');
                     }
                 }
             } else if (type == NSEventTypeKeyUp) {
@@ -1861,6 +1857,10 @@ struct AppXrSession {
     PFN_xrRequestDisplayModeEXT pfnRequestDisplayModeEXT = nullptr;
     PFN_xrRequestDisplayRenderingModeEXT pfnRequestDisplayRenderingModeEXT = nullptr;
     PFN_xrEnumerateDisplayRenderingModesEXT pfnEnumerateDisplayRenderingModesEXT = nullptr;
+    // Enumerated rendering mode info. currentModeIndex is initialized to mode 1
+    // as a fallback for runtimes that don't expose isActive; v13+ runtimes
+    // replace it via the enumerate step (initial-mode-sync, #234/#239).
+    uint32_t currentModeIndex = 1;
     uint32_t renderingModeCount = 0;
     char renderingModeNames[8][XR_MAX_SYSTEM_NAME_SIZE] = {};
     uint32_t renderingModeViewCounts[8] = {};
@@ -1869,6 +1869,7 @@ struct AppXrSession {
     float renderingModeScaleX[8] = {};
     float renderingModeScaleY[8] = {};
     bool renderingModeDisplay3D[8] = {};
+    bool renderingModeIsRequestable[8] = {};  // v13: false when workspace-locked
 
     // Eye tracking mode control (XR_EXT_display_info v6)
     uint32_t supportedEyeTrackingModes = 0;
@@ -2249,6 +2250,11 @@ static bool CreateSession(AppXrSession& xr, VkInstance vkInstance, VkPhysicalDev
                     xr.renderingModeScaleX[i] = modes[i].viewScaleX;
                     xr.renderingModeScaleY[i] = modes[i].viewScaleY;
                     xr.renderingModeDisplay3D[i] = modes[i].hardwareDisplay3D ? true : false;
+                    xr.renderingModeIsRequestable[i] = modes[i].isRequestable ? true : false;
+                    // v13 initial-mode-sync: trust runtime-reported active mode.
+                    if (modes[i].isActive) {
+                        xr.currentModeIndex = modes[i].modeIndex;
+                    }
                     LOG_INFO("  [%u] %s (views=%u, tiles=%ux%u, scale=%.2fx%.2f, 3D=%s)",
                         modes[i].modeIndex, modes[i].modeName,
                         modes[i].viewCount, modes[i].tileColumns, modes[i].tileRows,
@@ -2352,6 +2358,13 @@ static bool PollEvents(AppXrSession& xr) {
             default:
                 break;
             }
+            break;
+        }
+        case (XrStructureType)XR_TYPE_EVENT_DATA_RENDERING_MODE_CHANGED_EXT: {
+            auto* modeEvent = (XrEventDataRenderingModeChangedEXT*)&event;
+            LOG_INFO("Rendering mode changed: %u -> %u",
+                modeEvent->previousModeIndex, modeEvent->currentModeIndex);
+            xr.currentModeIndex = modeEvent->currentModeIndex;
             break;
         }
         default:
@@ -2585,20 +2598,9 @@ int main() {
 
     LOG_INFO("=== Sim Cube OpenXR + External macOS Window ===");
 
-    // Initialize output mode from env var (matches runtime's parsing).
-    {
-        const char *mode_str = getenv("SIM_DISPLAY_OUTPUT");
-        if (mode_str) {
-            if (strcmp(mode_str, "anaglyph") == 0)
-                g_input.currentRenderingMode = 1;
-            else if (strcmp(mode_str, "sbs") == 0)
-                g_input.currentRenderingMode = 2;
-            else if (strcmp(mode_str, "blend") == 0)
-                g_input.currentRenderingMode = 3;
-            else
-                g_input.currentRenderingMode = 1; // default to anaglyph
-        }
-    }
+    // Initial rendering mode is sourced from the runtime via v13 `isActive`
+    // (set during xrEnumerateDisplayRenderingModesEXT). Fallback is mode 1
+    // (default of xr.currentModeIndex).
 
     // Step 1: Create the macOS window FIRST (app owns it)
     g_windowW = 1280;
@@ -2752,8 +2754,6 @@ int main() {
         LOG_WARN("Failed to create HUD swapchain - HUD disabled");
     }
 
-    g_input.renderingModeChangeRequested = true;
-
     g_input.viewParams.virtualDisplayHeight = 0.24f;
     g_input.nominalViewerZ = xr.nominalViewerZ;
 
@@ -2796,16 +2796,25 @@ int main() {
         if (vkRenderer.cubeRotation > 2.0f * 3.14159265f)
             vkRenderer.cubeRotation -= 2.0f * 3.14159265f;
 
-        // Handle rendering mode change (V=cycle, 0-8=direct)
-        if (g_input.renderingModeChangeRequested) {
-            g_input.renderingModeChangeRequested = false;
-            if (xr.pfnRequestDisplayRenderingModeEXT && xr.session != XR_NULL_HANDLE) {
-                const char *modeName = (g_input.currentRenderingMode < xr.renderingModeCount)
-                    ? xr.renderingModeNames[g_input.currentRenderingMode] : "?";
-                XrResult res = xr.pfnRequestDisplayRenderingModeEXT(xr.session, g_input.currentRenderingMode);
-                LOG_INFO("Rendering mode -> %s (%s)",
-                    modeName,
-                    XR_SUCCEEDED(res) ? "OK" : "failed");
+        // Handle rendering mode requests (V=cycle next, 0-8=jump absolute).
+        // Single source of truth: the runtime owns the current mode. Keypresses
+        // are REQUESTS — we call xrRequestDisplayRenderingModeEXT and let the
+        // XrEventDataRenderingModeChangedEXT event update xr.currentModeIndex.
+        // Render paths and HUD read xr.currentModeIndex directly.
+        if (g_input.cycleRenderingModeRequested) {
+            g_input.cycleRenderingModeRequested = false;
+            if (xr.pfnRequestDisplayRenderingModeEXT && xr.session != XR_NULL_HANDLE &&
+                xr.renderingModeCount > 0) {
+                uint32_t next = (xr.currentModeIndex + 1) % xr.renderingModeCount;
+                xr.pfnRequestDisplayRenderingModeEXT(xr.session, next);
+            }
+        }
+        if (g_input.absoluteRenderingModeRequested >= 0) {
+            uint32_t target = (uint32_t)g_input.absoluteRenderingModeRequested;
+            g_input.absoluteRenderingModeRequested = -1;
+            if (xr.pfnRequestDisplayRenderingModeEXT && xr.session != XR_NULL_HANDLE &&
+                target < xr.renderingModeCount) {
+                xr.pfnRequestDisplayRenderingModeEXT(xr.session, target);
             }
         }
 
@@ -2828,16 +2837,16 @@ int main() {
             XrFrameState frameState;
             if (BeginFrame(xr, frameState)) {
                 bool rendered = false;
-                bool display3D = (g_input.currentRenderingMode < xr.renderingModeCount)
-                    ? xr.renderingModeDisplay3D[g_input.currentRenderingMode] : true;
+                bool display3D = (xr.currentModeIndex < xr.renderingModeCount)
+                    ? xr.renderingModeDisplay3D[xr.currentModeIndex] : true;
 
                 // Get N-view mode info from enumerated rendering modes
-                uint32_t modeViewCount = (g_input.currentRenderingMode < xr.renderingModeCount)
-                    ? xr.renderingModeViewCounts[g_input.currentRenderingMode] : 2;
-                uint32_t tileColumns = (g_input.currentRenderingMode < xr.renderingModeCount)
-                    ? xr.renderingModeTileColumns[g_input.currentRenderingMode] : 2;
-                uint32_t tileRows = (g_input.currentRenderingMode < xr.renderingModeCount)
-                    ? xr.renderingModeTileRows[g_input.currentRenderingMode] : 1;
+                uint32_t modeViewCount = (xr.currentModeIndex < xr.renderingModeCount)
+                    ? xr.renderingModeViewCounts[xr.currentModeIndex] : 2;
+                uint32_t tileColumns = (xr.currentModeIndex < xr.renderingModeCount)
+                    ? xr.renderingModeTileColumns[xr.currentModeIndex] : 2;
+                uint32_t tileRows = (xr.currentModeIndex < xr.renderingModeCount)
+                    ? xr.renderingModeTileRows[xr.currentModeIndex] : 1;
                 int eyeCount = display3D ? (int)modeViewCount : 1;
 
                 // Dynamic arrays for N-view rendering
@@ -2904,10 +2913,10 @@ int main() {
 
                         // Compute render dims for SBS single-swapchain.
                         // Scale depends on current output mode (may change at runtime):
-                        float scaleX = (g_input.currentRenderingMode < xr.renderingModeCount)
-                            ? xr.renderingModeScaleX[g_input.currentRenderingMode] : 0.5f;
-                        float scaleY = (g_input.currentRenderingMode < xr.renderingModeCount)
-                            ? xr.renderingModeScaleY[g_input.currentRenderingMode] : 0.5f;
+                        float scaleX = (xr.currentModeIndex < xr.renderingModeCount)
+                            ? xr.renderingModeScaleX[xr.currentModeIndex] : 0.5f;
+                        float scaleY = (xr.currentModeIndex < xr.renderingModeCount)
+                            ? xr.renderingModeScaleY[xr.currentModeIndex] : 0.5f;
                         xr.recommendedViewScaleX = scaleX;
                         xr.recommendedViewScaleY = scaleY;
 
@@ -3150,16 +3159,19 @@ int main() {
                 xr.systemName, sessionStateName);
             g_hudSessionText = utf8ToW(buf);
 
-            const char *outputModeName = (g_input.currentRenderingMode < xr.renderingModeCount)
-                ? xr.renderingModeNames[g_input.currentRenderingMode] : "?";
-            bool display3D = (g_input.currentRenderingMode < xr.renderingModeCount)
-                ? xr.renderingModeDisplay3D[g_input.currentRenderingMode] : true;
+            const char *outputModeName = (xr.currentModeIndex < xr.renderingModeCount)
+                ? xr.renderingModeNames[xr.currentModeIndex] : "?";
+            bool display3D = (xr.currentModeIndex < xr.renderingModeCount)
+                ? xr.renderingModeDisplay3D[xr.currentModeIndex] : true;
+            bool isReq = (xr.currentModeIndex < xr.renderingModeCount)
+                ? xr.renderingModeIsRequestable[xr.currentModeIndex] : true;
+            const char *lockSuffix = isReq ? "" : " [locked by workspace]";
             const char *kooimaMode = g_input.cameraMode
                 ? "Camera-Centric [C=Toggle]" : "Display-Centric [C=Toggle]";
             snprintf(buf, sizeof(buf),
-                "XR_EXT_cocoa_window_binding: %s (Vulkan)\nMode: %s (%s)\nKooima: %s",
+                "XR_EXT_cocoa_window_binding: %s (Vulkan)\nMode: %s (%s)%s\nKooima: %s",
                 xr.hasCocoaWindowBinding ? "ACTIVE" : "NOT AVAILABLE",
-                outputModeName, display3D ? "3D" : "2D", kooimaMode);
+                outputModeName, display3D ? "3D" : "2D", lockSuffix, kooimaMode);
             g_hudModeText = utf8ToW(buf);
 
             double fps = (g_avgFrameTime > 0) ? 1.0 / g_avgFrameTime : 0;

--- a/test_apps/cube_texture_metal_macos/main.mm
+++ b/test_apps/cube_texture_metal_macos/main.mm
@@ -785,9 +785,13 @@ struct InputState {
     bool resetViewRequested = false;
     ViewParams viewParams;
     bool hudVisible = true;
-    uint32_t currentRenderingMode = 1;
-    uint32_t renderingModeCount = 0;
-    bool renderingModeChangeRequested = false;
+    // Rendering mode REQUESTS — single source of truth lives on the runtime
+    // side (read back as app.currentModeIndex after the runtime's
+    // XrEventDataRenderingModeChangedEXT lands). Keys emit transient requests;
+    // the actual current mode is never mirrored here.
+    uint32_t renderingModeCount = 0;             // mirror of app.renderingModeCount for keypress bounds
+    bool cycleRenderingModeRequested = false;    // V key
+    int32_t absoluteRenderingModeRequested = -1; // 0-8 keys; -1 = none
     bool cameraMode = false;
     float nominalViewerZ = 0.5f;
 };
@@ -1220,10 +1224,7 @@ static void PumpMacOSEvents()
                         g_input.hudVisible = !g_input.hudVisible;
                     }
                     else if (ch == 'v' && !isRepeat) {
-                        if (g_input.renderingModeCount > 0) {
-                            g_input.currentRenderingMode = (g_input.currentRenderingMode + 1) % g_input.renderingModeCount;
-                        }
-                        g_input.renderingModeChangeRequested = true;
+                        g_input.cycleRenderingModeRequested = true;
                     }
                     else if (ch == 'c' && !isRepeat) {
                         g_input.cameraMode = !g_input.cameraMode;
@@ -1242,11 +1243,7 @@ static void PumpMacOSEvents()
                         }
                     }
                     else if (ch >= '0' && ch <= '8' && !isRepeat) {
-                        uint32_t idx = ch - '0';
-                        if (idx < g_input.renderingModeCount) {
-                            g_input.currentRenderingMode = idx;
-                            g_input.renderingModeChangeRequested = true;
-                        }
+                        g_input.absoluteRenderingModeRequested = (int32_t)(ch - '0');
                     }
                 }
             } else if (type == NSEventTypeKeyUp) {
@@ -1371,6 +1368,10 @@ struct AppXrSession {
     PFN_xrRequestDisplayRenderingModeEXT pfnRequestDisplayRenderingModeEXT;
     PFN_xrEnumerateDisplayRenderingModesEXT pfnEnumerateDisplayRenderingModesEXT;
     PFN_xrSetSharedTextureOutputRectEXT pfnSetSharedTextureOutputRectEXT;
+    // Enumerated rendering mode info. currentModeIndex is initialized to mode 1
+    // as a fallback for runtimes that don't expose isActive; v13+ runtimes
+    // replace it via the enumerate step (initial-mode-sync, #234/#239).
+    uint32_t currentModeIndex = 1;
     uint32_t renderingModeCount;
     char renderingModeNames[8][XR_MAX_SYSTEM_NAME_SIZE];
     uint32_t renderingModeViewCounts[8] = {};
@@ -1379,6 +1380,7 @@ struct AppXrSession {
     float renderingModeScaleX[8] = {};
     float renderingModeScaleY[8] = {};
     bool renderingModeDisplay3D[8] = {};
+    bool renderingModeIsRequestable[8] = {};  // v13: false when workspace-locked
 
     // Eye tracking
     float eyePositions[8][3] = {};  // [view][x,y,z] — raw per-eye positions in display space
@@ -1572,6 +1574,11 @@ static bool CreateSession(AppXrSession &app, MetalRenderer &r)
                     app.renderingModeScaleX[i] = modes[i].viewScaleX;
                     app.renderingModeScaleY[i] = modes[i].viewScaleY;
                     app.renderingModeDisplay3D[i] = modes[i].hardwareDisplay3D ? true : false;
+                    app.renderingModeIsRequestable[i] = modes[i].isRequestable ? true : false;
+                    // v13 initial-mode-sync: trust runtime-reported active mode.
+                    if (modes[i].isActive) {
+                        app.currentModeIndex = modes[i].modeIndex;
+                    }
                     LOG_INFO("  [%u] %s (views=%u, tiles=%ux%u, scale=%.2fx%.2f, 3D=%s)",
                         modes[i].modeIndex, modes[i].modeName,
                         modes[i].viewCount, modes[i].tileColumns, modes[i].tileRows,
@@ -1696,6 +1703,13 @@ static void PollEvents(AppXrSession &app)
                        ssc->state == XR_SESSION_STATE_LOSS_PENDING) {
                 app.exitRequested = true;
             }
+            break;
+        }
+        case (XrStructureType)XR_TYPE_EVENT_DATA_RENDERING_MODE_CHANGED_EXT: {
+            auto* modeEvent = (XrEventDataRenderingModeChangedEXT*)&event;
+            LOG_INFO("Rendering mode changed: %u -> %u",
+                modeEvent->previousModeIndex, modeEvent->currentModeIndex);
+            app.currentModeIndex = modeEvent->currentModeIndex;
             break;
         }
         default: break;
@@ -1827,22 +1841,9 @@ int main(int argc, char **argv)
         LOG_WARN("Failed to create HUD swapchain - HUD disabled");
     }
 
-    // Initialize output mode from env var
-    {
-        const char *mode_str = getenv("SIM_DISPLAY_OUTPUT");
-        if (mode_str) {
-            if (strcmp(mode_str, "anaglyph") == 0)
-                g_input.currentRenderingMode = 1;
-            else if (strcmp(mode_str, "sbs") == 0)
-                g_input.currentRenderingMode = 2;
-            else if (strcmp(mode_str, "blend") == 0)
-                g_input.currentRenderingMode = 3;
-            else
-                g_input.currentRenderingMode = 1; // default to anaglyph
-        }
-    }
-
-    g_input.renderingModeChangeRequested = true;
+    // Initial rendering mode is sourced from the runtime via v13 `isActive`
+    // (set during xrEnumerateDisplayRenderingModesEXT above). Fallback is
+    // mode 1 (default of app.currentModeIndex).
 
     g_input.viewParams.virtualDisplayHeight = 0.24f;
     g_input.nominalViewerZ = app.nominalViewerZ;
@@ -1873,16 +1874,25 @@ int main(int argc, char **argv)
 
         PollEvents(app);
 
-        // Handle rendering mode change (V=cycle, 0-8=direct)
-        if (g_input.renderingModeChangeRequested) {
-            g_input.renderingModeChangeRequested = false;
-            if (app.pfnRequestDisplayRenderingModeEXT && app.session != XR_NULL_HANDLE) {
-                const char *modeName = (g_input.currentRenderingMode < app.renderingModeCount)
-                    ? app.renderingModeNames[g_input.currentRenderingMode] : "?";
-                XrResult res = app.pfnRequestDisplayRenderingModeEXT(app.session, g_input.currentRenderingMode);
-                LOG_INFO("Rendering mode -> %s (%s)",
-                    modeName,
-                    XR_SUCCEEDED(res) ? "OK" : "failed");
+        // Handle rendering mode requests (V=cycle next, 0-8=jump absolute).
+        // Single source of truth: the runtime owns the current mode. Keypresses
+        // are REQUESTS — we call xrRequestDisplayRenderingModeEXT and let the
+        // XrEventDataRenderingModeChangedEXT event update app.currentModeIndex.
+        // Render paths and HUD read app.currentModeIndex directly.
+        if (g_input.cycleRenderingModeRequested) {
+            g_input.cycleRenderingModeRequested = false;
+            if (app.pfnRequestDisplayRenderingModeEXT && app.session != XR_NULL_HANDLE &&
+                app.renderingModeCount > 0) {
+                uint32_t next = (app.currentModeIndex + 1) % app.renderingModeCount;
+                app.pfnRequestDisplayRenderingModeEXT(app.session, next);
+            }
+        }
+        if (g_input.absoluteRenderingModeRequested >= 0) {
+            uint32_t target = (uint32_t)g_input.absoluteRenderingModeRequested;
+            g_input.absoluteRenderingModeRequested = -1;
+            if (app.pfnRequestDisplayRenderingModeEXT && app.session != XR_NULL_HANDLE &&
+                target < app.renderingModeCount) {
+                app.pfnRequestDisplayRenderingModeEXT(app.session, target);
             }
         }
 
@@ -1935,15 +1945,15 @@ int main(int argc, char **argv)
         waitImgInfo.timeout = XR_INFINITE_DURATION;
         xrWaitSwapchainImage(app.swapchain.swapchain, &waitImgInfo);
 
-        uint32_t modeViewCount = (g_input.currentRenderingMode < app.renderingModeCount)
-            ? app.renderingModeViewCounts[g_input.currentRenderingMode] : 2;
-        uint32_t tileColumns = (g_input.currentRenderingMode < app.renderingModeCount)
-            ? app.renderingModeTileColumns[g_input.currentRenderingMode] : 2;
-        uint32_t tileRows = (g_input.currentRenderingMode < app.renderingModeCount)
-            ? app.renderingModeTileRows[g_input.currentRenderingMode] : 1;
+        uint32_t modeViewCount = (app.currentModeIndex < app.renderingModeCount)
+            ? app.renderingModeViewCounts[app.currentModeIndex] : 2;
+        uint32_t tileColumns = (app.currentModeIndex < app.renderingModeCount)
+            ? app.renderingModeTileColumns[app.currentModeIndex] : 2;
+        uint32_t tileRows = (app.currentModeIndex < app.renderingModeCount)
+            ? app.renderingModeTileRows[app.currentModeIndex] : 1;
         bool rendered = false;
-        bool display3D = (g_input.currentRenderingMode < app.renderingModeCount)
-            ? app.renderingModeDisplay3D[g_input.currentRenderingMode] : true;
+        bool display3D = (app.currentModeIndex < app.renderingModeCount)
+            ? app.renderingModeDisplay3D[app.currentModeIndex] : true;
         int eyeCount = display3D ? (int)modeViewCount : 1;
         std::vector<XrCompositionLayerProjectionView> projViews(eyeCount, {XR_TYPE_COMPOSITION_LAYER_PROJECTION_VIEW});
 
@@ -1979,10 +1989,10 @@ int main(int argc, char **argv)
 
             XrVector3f nominalViewer = {app.nominalViewerX, app.nominalViewerY, app.nominalViewerZ};
 
-            float scaleX = (g_input.currentRenderingMode < app.renderingModeCount)
-                ? app.renderingModeScaleX[g_input.currentRenderingMode] : 0.5f;
-            float scaleY = (g_input.currentRenderingMode < app.renderingModeCount)
-                ? app.renderingModeScaleY[g_input.currentRenderingMode] : 0.5f;
+            float scaleX = (app.currentModeIndex < app.renderingModeCount)
+                ? app.renderingModeScaleX[app.currentModeIndex] : 0.5f;
+            float scaleY = (app.currentModeIndex < app.renderingModeCount)
+                ? app.renderingModeScaleY[app.currentModeIndex] : 0.5f;
             app.recommendedViewScaleX = scaleX;
             app.recommendedViewScaleY = scaleY;
             uint32_t maxTileW = tileColumns > 0 ? app.swapchain.width / tileColumns : app.swapchain.width;
@@ -2193,16 +2203,19 @@ int main(int argc, char **argv)
             g_hudUpdateTimer = 0.0f;
             @autoreleasepool {
                 double fps = (g_avgFrameTime > 0) ? 1.0 / g_avgFrameTime : 0;
-                const char *outputModeName = (g_input.currentRenderingMode < app.renderingModeCount)
-                    ? app.renderingModeNames[g_input.currentRenderingMode] : "?";
+                const char *outputModeName = (app.currentModeIndex < app.renderingModeCount)
+                    ? app.renderingModeNames[app.currentModeIndex] : "?";
+                bool isReq = (app.currentModeIndex < app.renderingModeCount)
+                    ? app.renderingModeIsRequestable[app.currentModeIndex] : true;
+                const char *lockSuffix = isReq ? "" : " [locked by workspace]";
 
                 // Update toolbar
                 if (g_toolbarView != nil) {
                     dispatch_async(dispatch_get_main_queue(), ^{
                         g_toolbarView.toolbarText = [NSString stringWithFormat:
-                            @"Mode: %s (%s) | FPS: %.0f (%.1fms) | IOSurf: %ux%u | Swapchain: %ux%u | Canvas: %ux%u",
+                            @"Mode: %s (%s)%s | FPS: %.0f (%.1fms) | IOSurf: %ux%u | Swapchain: %ux%u | Canvas: %ux%u",
                             outputModeName,
-                            display3D ? "3D" : "2D", fps, g_avgFrameTime * 1000.0,
+                            display3D ? "3D" : "2D", lockSuffix, fps, g_avgFrameTime * 1000.0,
                             g_ioSurfaceWidth, g_ioSurfaceHeight,
                             app.swapchain.width, app.swapchain.height,
                             g_canvasW, g_canvasH];
@@ -2257,8 +2270,8 @@ int main(int argc, char **argv)
                 const char *kooimaMode = g_input.cameraMode
                     ? "Camera-Centric [C=Toggle]" : "Display-Centric [C=Toggle]";
                 snprintf(buf, sizeof(buf),
-                    "XR_EXT_cocoa_window_binding: ACTIVE (Metal IOSurface)\nMode: %s (%s)\nKooima: %s",
-                    outputModeName, display3D ? "3D" : "2D", kooimaMode);
+                    "XR_EXT_cocoa_window_binding: ACTIVE (Metal IOSurface)\nMode: %s (%s)%s\nKooima: %s",
+                    outputModeName, display3D ? "3D" : "2D", lockSuffix, kooimaMode);
                 g_hudModeText = utf8ToW(buf);
 
                 snprintf(buf, sizeof(buf),


### PR DESCRIPTION
## Summary
- Ports the Win32 SSOT-rendering-mode refactor (#234, commit 3782a3b9) and the `XR_EXT_display_info` v13 `isActive`/`isRequestable` consume (#234, commit 386c8517 + 08d8e6ce HUD lock chip) to the four macOS `.mm` test apps that were intentionally deferred.
- Runtime is now the sole owner of the current rendering mode in the macOS handle/texture cubes — V / 0-8 keys emit transient request flags; `XR_TYPE_EVENT_DATA_RENDERING_MODE_CHANGED_EXT` is the sole writer of `currentModeIndex`.
- v13 `isActive` initial-mode-sync wired up; HUD appends `[locked by workspace]` when `isRequestable=false`.

Closes #239.

## Files touched
- `test_apps/cube_handle_metal_macos/main.mm`
- `test_apps/cube_handle_gl_macos/main.mm`
- `test_apps/cube_handle_vk_macos/main.mm`
- `test_apps/cube_texture_metal_macos/main.mm`

No shared headers, no Win32 apps, no CMake touched.

## Test plan
- [x] `./scripts/build_macos.sh` clean — no new warnings/errors in the four ported files.
- [x] Each app runs to FOCUSED, enumerates 5 modes, shuts down cleanly.
- [x] `SIM_DISPLAY_OUTPUT=anaglyph` → compositor atlas `3024x982 (tiles 2x1)`; `SIM_DISPLAY_OUTPUT=sbs` → `1512x1964 (tiles 1x2)`. Atlas geometry follows runtime-reported `isActive`, proving the app reads it (would distort otherwise).
- [x] Atlas captures look correct in both Anaglyph and SBS modes (HUD legible in both views).
- [x] `git grep` of deprecated identifiers in Win32 apps + `test_apps/common/` returns 0 hits.
- [ ] CI: Windows build green (`shell-path-guard`, doc-only sentinel pass-through, full runtime+test-apps).
- [ ] CI: macOS build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)