### PR TITLE
Fix #237: local runtime via XR_RUNTIME_JSON (no Program Files copy)

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -143,7 +143,7 @@ jobs:
           # loader can't be found via find_package or OpenXR_ROOT — which
           # drops both the bridge and the install(FILES openxr_loader.dll)
           # rule from the build, leaving the installer without those files.
-          $openxrVersion = "1.1.38"
+          $openxrVersion = "1.1.43"
           $openxrUrl = "https://github.com/KhronosGroup/OpenXR-SDK-Source/releases/download/release-$openxrVersion/openxr_loader_windows-$openxrVersion.zip"
           Invoke-WebRequest -Uri $openxrUrl -OutFile openxr_loader.zip
           Expand-Archive -Path openxr_loader.zip -DestinationPath openxr_sdk -Force
@@ -268,7 +268,7 @@ jobs:
       - name: Install OpenXR loader
         run: |
           # Download and extract OpenXR SDK
-          $openxrVersion = "1.1.38"
+          $openxrVersion = "1.1.43"
           $openxrUrl = "https://github.com/KhronosGroup/OpenXR-SDK-Source/releases/download/release-$openxrVersion/openxr_loader_windows-$openxrVersion.zip"
           Write-Host "Downloading OpenXR loader from $openxrUrl"
           Invoke-WebRequest -Uri $openxrUrl -OutFile openxr_loader.zip
@@ -364,7 +364,7 @@ jobs:
 
       - name: Install OpenXR loader
         run: |
-          $openxrVersion = "1.1.38"
+          $openxrVersion = "1.1.43"
           $openxrUrl = "https://github.com/KhronosGroup/OpenXR-SDK-Source/releases/download/release-$openxrVersion/openxr_loader_windows-$openxrVersion.zip"
           Invoke-WebRequest -Uri $openxrUrl -OutFile openxr_loader.zip
           Expand-Archive -Path openxr_loader.zip -DestinationPath openxr_sdk -Force
@@ -426,7 +426,7 @@ jobs:
 
       - name: Install OpenXR loader
         run: |
-          $openxrVersion = "1.1.38"
+          $openxrVersion = "1.1.43"
           $openxrUrl = "https://github.com/KhronosGroup/OpenXR-SDK-Source/releases/download/release-$openxrVersion/openxr_loader_windows-$openxrVersion.zip"
           Invoke-WebRequest -Uri $openxrUrl -OutFile openxr_loader.zip
           Expand-Archive -Path openxr_loader.zip -DestinationPath openxr_sdk -Force
@@ -488,7 +488,7 @@ jobs:
 
       - name: Install OpenXR loader
         run: |
-          $openxrVersion = "1.1.38"
+          $openxrVersion = "1.1.43"
           $openxrUrl = "https://github.com/KhronosGroup/OpenXR-SDK-Source/releases/download/release-$openxrVersion/openxr_loader_windows-$openxrVersion.zip"
           Invoke-WebRequest -Uri $openxrUrl -OutFile openxr_loader.zip
           Expand-Archive -Path openxr_loader.zip -DestinationPath openxr_sdk -Force
@@ -556,7 +556,7 @@ jobs:
 
       - name: Install OpenXR loader
         run: |
-          $openxrVersion = "1.1.38"
+          $openxrVersion = "1.1.43"
           $openxrUrl = "https://github.com/KhronosGroup/OpenXR-SDK-Source/releases/download/release-$openxrVersion/openxr_loader_windows-$openxrVersion.zip"
           Invoke-WebRequest -Uri $openxrUrl -OutFile openxr_loader.zip
           Expand-Archive -Path openxr_loader.zip -DestinationPath openxr_sdk -Force
@@ -610,7 +610,7 @@ jobs:
 
       - name: Install OpenXR loader
         run: |
-          $openxrVersion = "1.1.38"
+          $openxrVersion = "1.1.43"
           $openxrUrl = "https://github.com/KhronosGroup/OpenXR-SDK-Source/releases/download/release-$openxrVersion/openxr_loader_windows-$openxrVersion.zip"
           Invoke-WebRequest -Uri $openxrUrl -OutFile openxr_loader.zip
           Expand-Archive -Path openxr_loader.zip -DestinationPath openxr_sdk -Force
@@ -664,7 +664,7 @@ jobs:
 
       - name: Install OpenXR loader
         run: |
-          $openxrVersion = "1.1.38"
+          $openxrVersion = "1.1.43"
           $openxrUrl = "https://github.com/KhronosGroup/OpenXR-SDK-Source/releases/download/release-$openxrVersion/openxr_loader_windows-$openxrVersion.zip"
           Invoke-WebRequest -Uri $openxrUrl -OutFile openxr_loader.zip
           Expand-Archive -Path openxr_loader.zip -DestinationPath openxr_sdk -Force
@@ -726,7 +726,7 @@ jobs:
 
       - name: Install OpenXR loader
         run: |
-          $openxrVersion = "1.1.38"
+          $openxrVersion = "1.1.43"
           $openxrUrl = "https://github.com/KhronosGroup/OpenXR-SDK-Source/releases/download/release-$openxrVersion/openxr_loader_windows-$openxrVersion.zip"
           Invoke-WebRequest -Uri $openxrUrl -OutFile openxr_loader.zip
           Expand-Archive -Path openxr_loader.zip -DestinationPath openxr_sdk -Force
@@ -788,7 +788,7 @@ jobs:
 
       - name: Install OpenXR loader
         run: |
-          $openxrVersion = "1.1.38"
+          $openxrVersion = "1.1.43"
           $openxrUrl = "https://github.com/KhronosGroup/OpenXR-SDK-Source/releases/download/release-$openxrVersion/openxr_loader_windows-$openxrVersion.zip"
           Invoke-WebRequest -Uri $openxrUrl -OutFile openxr_loader.zip
           Expand-Archive -Path openxr_loader.zip -DestinationPath openxr_sdk -Force
@@ -852,7 +852,7 @@ jobs:
 
       - name: Install OpenXR loader
         run: |
-          $openxrVersion = "1.1.38"
+          $openxrVersion = "1.1.43"
           $openxrUrl = "https://github.com/KhronosGroup/OpenXR-SDK-Source/releases/download/release-$openxrVersion/openxr_loader_windows-$openxrVersion.zip"
           Invoke-WebRequest -Uri $openxrUrl -OutFile openxr_loader.zip
           Expand-Archive -Path openxr_loader.zip -DestinationPath openxr_sdk -Force
@@ -904,7 +904,7 @@ jobs:
 
       - name: Install OpenXR loader
         run: |
-          $openxrVersion = "1.1.38"
+          $openxrVersion = "1.1.43"
           $openxrUrl = "https://github.com/KhronosGroup/OpenXR-SDK-Source/releases/download/release-$openxrVersion/openxr_loader_windows-$openxrVersion.zip"
           Invoke-WebRequest -Uri $openxrUrl -OutFile openxr_loader.zip
           Expand-Archive -Path openxr_loader.zip -DestinationPath openxr_sdk -Force

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -266,9 +266,22 @@ Eye tracking MANAGED vs MANUAL contract: `docs/specs/vendor/eye-tracking-modes.m
 - C11 for core code, C++17 where needed, Python 3.6+ for build scripts
 
 ### Running Without Installing
+
 ```bash
+# Linux / macOS
 XR_RUNTIME_JSON=./build/openxr_displayxr-dev.json ./your_openxr_app
 ```
+
+```cmd
+:: Windows — run from a non-elevated terminal (see caveat below).
+_package\run_cube_handle_d3d11_win.bat   :: sets XR_RUNTIME_JSON to dev manifest
+```
+
+**Elevated terminal caveat (Windows):** the bundled Khronos `openxr_loader.dll` (both 1.1.38 and 1.1.43) silently refuses `XR_RUNTIME_JSON` when the calling process is elevated (admin / UAC) and falls back to `HKLM\Software\Khronos\OpenXR\1\ActiveRuntime` → Program Files. No env-var override exists. Use a non-elevated terminal for dev iteration, or push the rebuilt DLL to Program Files.
+
+**Verifying which DLL is loaded:** every `xrCreateInstance` logs one WARN line near the top of `%LOCALAPPDATA%\DisplayXR\DisplayXR_<exe>.<pid>_<ts>.log` with the absolute path of the actually-loaded `DisplayXRClient.dll` plus the value of `XR_RUNTIME_JSON`. Search for `loaded from:` — the path is authoritative.
+
+Full reference: [`docs/getting-started/building.md` § Local Dev Iteration](docs/getting-started/building.md#local-dev-iteration).
 
 ### Key CMake Options
 - `XRT_HAVE_LEIA_SR` — LeiaSR SDK support

--- a/docs/getting-started/building.md
+++ b/docs/getting-started/building.md
@@ -93,13 +93,78 @@ The SDK provides display-specific weavers (D3D11, D3D12, Vulkan) and eye trackin
 - `LEIASR_SDKROOT` — Environment variable pointing to Leia SR SDK path
 - `SR_PATH` — Internal, auto-set from `LEIASR_SDKROOT`
 
-## Running Without Installing
+## Local Dev Iteration
 
-Point `XR_RUNTIME_JSON` at the build output:
+The recommended workflow for iterating on the runtime — without ever installing it system-wide and without copying anything into `C:\Program Files\DisplayXR\Runtime\`.
 
-```bash
-XR_RUNTIME_JSON=./build/openxr_displayxr-dev.json ./your_openxr_app
+### How the OpenXR loader picks a runtime
+
+When an OpenXR app calls `xrCreateInstance`, the bundled Khronos `openxr_loader.dll` selects which runtime DLL to load using this precedence (Windows):
+
+1. **`XR_RUNTIME_JSON` environment variable** — if set to the path of a valid manifest file, that manifest's `library_path` is the runtime DLL the loader maps. This is the primary dev-iteration knob.
+2. **Registry fallback** — `HKLM\Software\Khronos\OpenXR\1\ActiveRuntime`. The DisplayXR installer writes this to point at `C:\Program Files\DisplayXR\Runtime\DisplayXR_win64.json`, which in turn points at the installed `DisplayXRClient.dll`. End-user installations land here; `XR_RUNTIME_JSON` is not needed for them.
+
+`scripts\build_windows.bat` auto-generates a dev manifest at `build\Release\openxr_displayxr-dev.json` with an absolute `library_path` to the worktree's freshly-built `DisplayXRClient.dll`. Every `_package\run_*_win.bat` script sets `XR_RUNTIME_JSON` to that dev manifest before launching the test app.
+
+### Recommended workflow
+
+Run dev test apps from a **non-elevated** terminal. From an admin terminal the Khronos loader silently refuses `XR_RUNTIME_JSON` (see [Elevated terminal caveat](#elevated-terminal-caveat) below).
+
+```cmd
+:: From a non-elevated terminal (cmd or PowerShell):
+scripts\build_windows.bat build              :: rebuild runtime only (fast)
+_package\run_cube_handle_d3d11_win.bat       :: launch cube against worktree's runtime
 ```
+
+`scripts\build_windows.bat` doesn't itself need elevation. The only operations that do — writing to Program Files, modifying `HKLM\Software\...`, running the NSIS installer — are exactly the ones the dev-iteration workflow is built to avoid.
+
+### Verifying which DLL was actually loaded
+
+Every `xrCreateInstance` writes one WARN line near the top of the per-process runtime log at `%LOCALAPPDATA%\DisplayXR\DisplayXR_<exe>.<pid>_<timestamp>.log`:
+
+```
+[oxr_instance_create] DisplayXR runtime v1.3.3 'v1.3.3' loaded from:
+  <absolute path to loaded DLL>
+  (XR_RUNTIME_JSON=<env var value, or "<unset>">)
+```
+
+The path is authoritative — it's `GetModuleFileNameW` on the live DLL handle, so it reflects what was actually mapped into the process regardless of what the loader claims. If you see your worktree's `build\…\DisplayXRClient.dll`, you're iterating against the dev build. If you see `C:\Program Files\DisplayXR\Runtime\DisplayXRClient.dll` while `XR_RUNTIME_JSON` was set, the env var was refused — either you're running elevated, or the manifest path is invalid.
+
+### Parallel worktrees
+
+Each worktree's `XR_RUNTIME_JSON` and `_package\run_*_win.bat` resolve to that worktree's own dev manifest and runtime DLL, so multiple worktrees iterate independently — no Program Files conflict, no DLL-stomping between simultaneously-running agents.
+
+### Elevated terminal caveat
+
+The Khronos `openxr_loader.dll` (confirmed in **both 1.1.38 and 1.1.43**) silently refuses `XR_RUNTIME_JSON` when the calling process token has high integrity (admin / UAC-elevated). The loader prints to stderr:
+
+```
+Error [GENERAL | platform_utils | OpenXR-Loader] : !!! WARNING !!!
+Environment variable XR_RUNTIME_JSON is being ignored due to running
+from an elevated context. The value '...' will NOT be used.
+```
+
+and falls through to the registry → Program Files runtime. There is no env-var or registry-side override; this is a Khronos loader security mitigation.
+
+If you must run dev test apps from an elevated context, the legacy workaround is:
+
+```cmd
+copy /Y build\src\xrt\targets\openxr\Release\DisplayXRClient.dll ^
+       "C:\Program Files\DisplayXR\Runtime\DisplayXRClient.dll"
+```
+
+…after each build. The signature log will then show the Program Files path. This breaks parallel-worktree iteration (one shared Program Files DLL), which is the original motivation for keeping the terminal non-elevated.
+
+### Installing the runtime for end-user testing
+
+For exercising the *installed* code paths (installer, registry, `ActiveRuntime`-driven discovery), build and run the installer instead:
+
+```cmd
+scripts\build_windows.bat installer
+_package\DisplayXRSetup-*.exe                :: UAC prompt, one-click install
+```
+
+This writes `HKLM\Software\Khronos\OpenXR\1\ActiveRuntime` and `HKLM\Software\DisplayXR\*`, adds Program Files to system PATH, and registers the runtime as discoverable. After install, OpenXR apps with no `XR_RUNTIME_JSON` set will resolve through the registry to the installed runtime.
 
 ## Running Tests
 

--- a/scripts/build_windows.bat
+++ b/scripts/build_windows.bat
@@ -17,7 +17,7 @@ setlocal enabledelayedexpansion
 
 set REPO=%~dp0..\
 set SR_TAG=1.35.0.2011
-set OPENXR_VERSION=1.1.38
+set OPENXR_VERSION=1.1.43
 set LEIASR_SDKROOT=%REPO%LeiaSR-SDK-%SR_TAG%-win64
 set VULKAN_SDK=C:\VulkanSDK\1.4.341.1
 set OPENXR_SDK=%REPO%openxr_sdk
@@ -130,8 +130,9 @@ if not exist "%OPENXR_SDK%\x64\lib\openxr_loader.lib" (
 
 :: --- OpenXR loader short-path copy (avoids spaces-in-path linker issues) ---
 :: The in-tree webxr_bridge target and the standalone test apps both link
-:: against the OpenXR loader via a short path with no spaces.
-set OPENXR_SDK_SHORT=C:\dev\openxr_sdk
+:: against the OpenXR loader via a short path with no spaces. Versioned so
+:: bumping OPENXR_VERSION doesn't silently reuse an older cached loader.
+set OPENXR_SDK_SHORT=C:\dev\openxr_sdk_%OPENXR_VERSION%
 if not exist "%OPENXR_SDK_SHORT%\x64\lib\openxr_loader.lib" (
     xcopy /E /I /Y "%OPENXR_SDK%" "%OPENXR_SDK_SHORT%" >nul
 )

--- a/scripts/build_windows.bat
+++ b/scripts/build_windows.bat
@@ -299,24 +299,25 @@ echo === Generating run scripts ===
 set "RT_JSON=%REPO%build\Release\openxr_displayxr-dev.json"
 set "PKG=%REPO%_package"
 
-:: Run scripts for standalone test apps (each sets XR_RUNTIME_JSON to dev build)
+:: Run scripts for standalone test apps (each sets XR_RUNTIME_JSON to dev build).
 :: Non-Vulkan apps also disable Vulkan implicit layers to prevent crashes from
 :: buggy third-party layers (e.g., FPS Monitor). See issue #105.
+:: All scripts prepend _package\bin to PATH so the runtime DLL's delay-loaded
+:: SR SDK deps (SimulatedRealityVulkanBeta.dll, etc.) resolve without requiring
+:: the installer to have run — important for third-party devs cloning the repo
+:: and iterating against the dev-build runtime via XR_RUNTIME_JSON.
 for %%A in (cube_handle_d3d11_win cube_hosted_d3d11_win cube_handle_d3d12_win cube_handle_gl_win cube_texture_d3d11_win cube_texture_d3d12_win workspace_minimal_d3d11_win) do (
     if exist "%REPO%test_apps\%%A\build\%%A.exe" (
         > "%PKG%\run_%%A.bat" (
             echo @echo off
             echo set "XR_RUNTIME_JSON=%RT_JSON%"
             echo set "VK_LOADER_LAYERS_DISABLE=*"
+            echo set "PATH=%PKG%\bin;%%PATH%%"
             echo "%REPO%test_apps\%%A\build\%%A.exe" %%*
         )
     )
 )
 :: Vulkan app — don't disable implicit layers (app needs them for its own VkInstance).
-:: Prepend _package/bin to PATH so SimulatedRealityVulkanBeta.dll
-:: (delay-loaded by the runtime DLL when the VK weaver path fires) is
-:: discoverable. The runtime installer adds its install dir to system
-:: PATH for installed users; this run-script mirrors that for dev.
 for %%A in (cube_handle_vk_win) do (
     if exist "%REPO%test_apps\%%A\build\%%A.exe" (
         > "%PKG%\run_%%A.bat" (

--- a/src/xrt/state_trackers/oxr/oxr_instance.c
+++ b/src/xrt/state_trackers/oxr/oxr_instance.c
@@ -20,6 +20,7 @@
 #include "util/u_misc.h"
 #include "util/u_debug.h"
 #include "util/u_git_tag.h"
+#include "util/u_logging.h"
 #include "util/u_builders.h"
 #include <displayxr_mcp/mcp_server.h>
 #include "oxr_mcp_tools.h"
@@ -316,6 +317,28 @@ oxr_instance_create(struct oxr_logger *log,
 	XrResult ret;
 
 	OXR_ALLOCATE_HANDLE_OR_RETURN(log, inst, OXR_XR_DEBUG_INSTANCE, oxr_instance_destroy, NULL);
+
+#ifdef XRT_OS_WINDOWS
+	// Identify which DisplayXRClient.dll the loader actually mapped, and what
+	// XR_RUNTIME_JSON pointed at. Resolves the "is my dev build actually loaded
+	// or did the loader fall back to Program Files?" question without guesswork.
+	// Uses FROM_ADDRESS so we always find *this* DLL regardless of how it was
+	// loaded (LoadLibrary by full path, by name, etc.).
+	{
+		HMODULE h = NULL;
+		wchar_t path[MAX_PATH] = {0};
+		const wchar_t *env = _wgetenv(L"XR_RUNTIME_JSON");
+		GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+		                       GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+		                   (LPCWSTR)&oxr_instance_create, &h);
+		if (h) {
+			GetModuleFileNameW(h, path, MAX_PATH);
+		}
+		U_LOG_W("DisplayXR runtime v%u.%u.%u '%s' loaded from: %ls (XR_RUNTIME_JSON=%ls)",
+		        u_version_major, u_version_minor, u_version_patch, u_git_tag,
+		        path[0] ? path : L"<unknown>", env ? env : L"<unset>");
+	}
+#endif
 
 	inst->extensions = *extensions; // Sets the enabled extensions.
 	inst->openxr_version.major_minor = major_minor;

--- a/test_apps/cube_handle_d3d11_win/main.cpp
+++ b/test_apps/cube_handle_d3d11_win/main.cpp
@@ -778,20 +778,6 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         return 1;
     }
 
-    // Add DisplayXR to DLL search path
-    {
-        HKEY hKey;
-        char installPath[MAX_PATH] = {0};
-        DWORD pathSize = sizeof(installPath);
-        if (RegOpenKeyExA(HKEY_LOCAL_MACHINE, "Software\\DisplayXR\\Runtime", 0, KEY_READ, &hKey) == ERROR_SUCCESS) {
-            if (RegQueryValueExA(hKey, "InstallPath", nullptr, nullptr, (LPBYTE)installPath, &pathSize) == ERROR_SUCCESS) {
-                LOG_INFO("Adding DisplayXR install path to DLL search: %s", installPath);
-                SetDllDirectoryA(installPath);
-            }
-            RegCloseKey(hKey);
-        }
-    }
-
     // Initialize OpenXR
     LOG_INFO("Initializing OpenXR...");
     XrSessionManager xr = {};

--- a/test_apps/cube_handle_d3d12_win/main.cpp
+++ b/test_apps/cube_handle_d3d12_win/main.cpp
@@ -748,20 +748,6 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         return 1;
     }
 
-    // Add DisplayXR to DLL search path
-    {
-        HKEY hKey;
-        char installPath[MAX_PATH] = {0};
-        DWORD pathSize = sizeof(installPath);
-        if (RegOpenKeyExA(HKEY_LOCAL_MACHINE, "Software\\DisplayXR\\Runtime", 0, KEY_READ, &hKey) == ERROR_SUCCESS) {
-            if (RegQueryValueExA(hKey, "InstallPath", nullptr, nullptr, (LPBYTE)installPath, &pathSize) == ERROR_SUCCESS) {
-                LOG_INFO("Adding DisplayXR install path to DLL search: %s", installPath);
-                SetDllDirectoryA(installPath);
-            }
-            RegCloseKey(hKey);
-        }
-    }
-
     // Initialize OpenXR
     XrSessionManager xr = {};
     g_xr = &xr;

--- a/test_apps/cube_handle_gl_win/main.cpp
+++ b/test_apps/cube_handle_gl_win/main.cpp
@@ -800,20 +800,6 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         return 1;
     }
 
-    // Add DisplayXR to DLL search path
-    {
-        HKEY hKey;
-        char installPath[MAX_PATH] = {0};
-        DWORD pathSize = sizeof(installPath);
-        if (RegOpenKeyExA(HKEY_LOCAL_MACHINE, "Software\\DisplayXR\\Runtime", 0, KEY_READ, &hKey) == ERROR_SUCCESS) {
-            if (RegQueryValueExA(hKey, "InstallPath", nullptr, nullptr, (LPBYTE)installPath, &pathSize) == ERROR_SUCCESS) {
-                LOG_INFO("Adding DisplayXR install path to DLL search: %s", installPath);
-                SetDllDirectoryA(installPath);
-            }
-            RegCloseKey(hKey);
-        }
-    }
-
     // Create OpenGL context (temp → core profile 3.3)
     HDC hDC = nullptr;
     HGLRC hGLRC = nullptr;

--- a/test_apps/cube_handle_vk_win/main.cpp
+++ b/test_apps/cube_handle_vk_win/main.cpp
@@ -860,20 +860,6 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         return 1;
     }
 
-    // Add DisplayXR to DLL search path
-    {
-        HKEY hKey;
-        char installPath[MAX_PATH] = {0};
-        DWORD pathSize = sizeof(installPath);
-        if (RegOpenKeyExA(HKEY_LOCAL_MACHINE, "Software\\DisplayXR\\Runtime", 0, KEY_READ, &hKey) == ERROR_SUCCESS) {
-            if (RegQueryValueExA(hKey, "InstallPath", nullptr, nullptr, (LPBYTE)installPath, &pathSize) == ERROR_SUCCESS) {
-                LOG_INFO("Adding DisplayXR install path to DLL search: %s", installPath);
-                SetDllDirectoryA(installPath);
-            }
-            RegCloseKey(hKey);
-        }
-    }
-
     // Initialize OpenXR (discovers Vulkan extension availability)
     XrSessionManager xr = {};
     g_xr = &xr;

--- a/test_apps/cube_hosted_d3d11_win/main.cpp
+++ b/test_apps/cube_hosted_d3d11_win/main.cpp
@@ -77,20 +77,6 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
     LOG_INFO("OpenXR standard mode (DisplayXR creates window)");
     LOG_INFO("Input handled by DisplayXR's qwerty driver");
 
-    // Add DisplayXR to DLL search path
-    {
-        HKEY hKey;
-        char installPath[MAX_PATH] = {0};
-        DWORD pathSize = sizeof(installPath);
-        if (RegOpenKeyExA(HKEY_LOCAL_MACHINE, "Software\\DisplayXR\\Runtime", 0, KEY_READ, &hKey) == ERROR_SUCCESS) {
-            if (RegQueryValueExA(hKey, "InstallPath", nullptr, nullptr, (LPBYTE)installPath, &pathSize) == ERROR_SUCCESS) {
-                LOG_INFO("Adding DisplayXR install path to DLL search: %s", installPath);
-                SetDllDirectoryA(installPath);
-            }
-            RegCloseKey(hKey);
-        }
-    }
-
     // Initialize OpenXR
     LOG_INFO("Initializing OpenXR...");
     XrSessionManager xr = {};

--- a/test_apps/cube_hosted_legacy_d3d11_win/main.cpp
+++ b/test_apps/cube_hosted_legacy_d3d11_win/main.cpp
@@ -78,20 +78,6 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
     LOG_INFO("OpenXR standard mode (DisplayXR creates window)");
     LOG_INFO("Input handled by DisplayXR's qwerty driver");
 
-    // Add DisplayXR to DLL search path
-    {
-        HKEY hKey;
-        char installPath[MAX_PATH] = {0};
-        DWORD pathSize = sizeof(installPath);
-        if (RegOpenKeyExA(HKEY_LOCAL_MACHINE, "Software\\DisplayXR\\Runtime", 0, KEY_READ, &hKey) == ERROR_SUCCESS) {
-            if (RegQueryValueExA(hKey, "InstallPath", nullptr, nullptr, (LPBYTE)installPath, &pathSize) == ERROR_SUCCESS) {
-                LOG_INFO("Adding DisplayXR install path to DLL search: %s", installPath);
-                SetDllDirectoryA(installPath);
-            }
-            RegCloseKey(hKey);
-        }
-    }
-
     // Initialize OpenXR
     LOG_INFO("Initializing OpenXR...");
     XrSessionManager xr = {};

--- a/test_apps/cube_hosted_legacy_d3d12_win/main.cpp
+++ b/test_apps/cube_hosted_legacy_d3d12_win/main.cpp
@@ -72,20 +72,6 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
     LOG_INFO("OpenXR standard mode (DisplayXR creates window)");
     LOG_INFO("Input handled by DisplayXR's qwerty driver");
 
-    // Add DisplayXR to DLL search path
-    {
-        HKEY hKey;
-        char installPath[MAX_PATH] = {0};
-        DWORD pathSize = sizeof(installPath);
-        if (RegOpenKeyExA(HKEY_LOCAL_MACHINE, "Software\\DisplayXR\\Runtime", 0, KEY_READ, &hKey) == ERROR_SUCCESS) {
-            if (RegQueryValueExA(hKey, "InstallPath", nullptr, nullptr, (LPBYTE)installPath, &pathSize) == ERROR_SUCCESS) {
-                LOG_INFO("Adding DisplayXR install path to DLL search: %s", installPath);
-                SetDllDirectoryA(installPath);
-            }
-            RegCloseKey(hKey);
-        }
-    }
-
     // Initialize OpenXR
     LOG_INFO("Initializing OpenXR...");
     XrSessionManager xr = {};

--- a/test_apps/cube_hosted_legacy_gl_win/main.cpp
+++ b/test_apps/cube_hosted_legacy_gl_win/main.cpp
@@ -202,20 +202,6 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
     LOG_INFO("OpenXR standard mode (DisplayXR creates window)");
     LOG_INFO("Input handled by DisplayXR's qwerty driver");
 
-    // Add DisplayXR to DLL search path
-    {
-        HKEY hKey;
-        char installPath[MAX_PATH] = {0};
-        DWORD pathSize = sizeof(installPath);
-        if (RegOpenKeyExA(HKEY_LOCAL_MACHINE, "Software\\DisplayXR\\Runtime", 0, KEY_READ, &hKey) == ERROR_SUCCESS) {
-            if (RegQueryValueExA(hKey, "InstallPath", nullptr, nullptr, (LPBYTE)installPath, &pathSize) == ERROR_SUCCESS) {
-                LOG_INFO("Adding DisplayXR install path to DLL search: %s", installPath);
-                SetDllDirectoryA(installPath);
-            }
-            RegCloseKey(hKey);
-        }
-    }
-
     // Create hidden dummy window for GL context
     LOG_INFO("Creating dummy window for GL context...");
     HWND dummyHwnd = CreateDummyWindow(hInstance);

--- a/test_apps/cube_hosted_legacy_vk_win/main.cpp
+++ b/test_apps/cube_hosted_legacy_vk_win/main.cpp
@@ -1405,20 +1405,6 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
     LOG_INFO("OpenXR standard mode (DisplayXR creates window)");
     LOG_INFO("Input handled by DisplayXR's qwerty driver");
 
-    // Add DisplayXR to DLL search path
-    {
-        HKEY hKey;
-        char installPath[MAX_PATH] = {0};
-        DWORD pathSize = sizeof(installPath);
-        if (RegOpenKeyExA(HKEY_LOCAL_MACHINE, "Software\\DisplayXR\\Runtime", 0, KEY_READ, &hKey) == ERROR_SUCCESS) {
-            if (RegQueryValueExA(hKey, "InstallPath", nullptr, nullptr, (LPBYTE)installPath, &pathSize) == ERROR_SUCCESS) {
-                LOG_INFO("Adding DisplayXR install path to DLL search: %s", installPath);
-                SetDllDirectoryA(installPath);
-            }
-            RegCloseKey(hKey);
-        }
-    }
-
     // Initialize OpenXR
     XrSessionManager xr = {};
     if (!InitializeOpenXR(xr)) {

--- a/test_apps/cube_texture_d3d11_win/main.cpp
+++ b/test_apps/cube_texture_d3d11_win/main.cpp
@@ -784,19 +784,6 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         return 1;
     }
 
-    // Add DisplayXR to DLL search path
-    {
-        HKEY hKey;
-        char installPath[MAX_PATH] = {0};
-        DWORD pathSize = sizeof(installPath);
-        if (RegOpenKeyExA(HKEY_LOCAL_MACHINE, "Software\\DisplayXR\\Runtime", 0, KEY_READ, &hKey) == ERROR_SUCCESS) {
-            if (RegQueryValueExA(hKey, "InstallPath", nullptr, nullptr, (LPBYTE)installPath, &pathSize) == ERROR_SUCCESS) {
-                SetDllDirectoryA(installPath);
-            }
-            RegCloseKey(hKey);
-        }
-    }
-
     // Initialize OpenXR
     XrSessionManager xr = {};
     g_xr = &xr;

--- a/test_apps/cube_texture_d3d12_win/main.cpp
+++ b/test_apps/cube_texture_d3d12_win/main.cpp
@@ -979,19 +979,6 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         return 1;
     }
 
-    // Add DisplayXR to DLL search path
-    {
-        HKEY hKey;
-        char installPath[MAX_PATH] = {0};
-        DWORD pathSize = sizeof(installPath);
-        if (RegOpenKeyExA(HKEY_LOCAL_MACHINE, "Software\\DisplayXR\\Runtime", 0, KEY_READ, &hKey) == ERROR_SUCCESS) {
-            if (RegQueryValueExA(hKey, "InstallPath", nullptr, nullptr, (LPBYTE)installPath, &pathSize) == ERROR_SUCCESS) {
-                SetDllDirectoryA(installPath);
-            }
-            RegCloseKey(hKey);
-        }
-    }
-
     // Initialize OpenXR
     XrSessionManager xr = {};
     g_xr = &xr;


### PR DESCRIPTION
Closes #237.

## Summary

Makes `XR_RUNTIME_JSON` actually work for dev iteration — so a worktree (or any local clone) can be tested against its own freshly-built runtime DLL, without copying anything into `C:\Program Files\DisplayXR\Runtime\`.

The original bug had two layers:

1. **Every Win32 test app's `main.cpp`** read `HKLM\Software\DisplayXR\Runtime\InstallPath` and called `SetDllDirectoryA(installPath)` before `xrCreateInstance`. That put `C:\Program Files\DisplayXR\Runtime` on the DLL search path, so `DisplayXRClient.dll`'s delay-loaded SR SDK deps resolved from Program Files even when `XR_RUNTIME_JSON` pointed at a dev manifest. The hack predates the CMake `POST_BUILD` step that copies `openxr_loader.dll` next to every test app — it's no longer needed.
2. **The bundled Khronos `openxr_loader.dll` was 1.1.38** on Windows. Spec says `XR_RUNTIME_JSON`, when set, must be honored or fail hard; 1.1.38 silently falls back to registry on a missing/invalid manifest. 1.1.43 tightened this. (macOS already used 1.1.43.)

There's also a known caveat about both 1.1.38 and 1.1.43: the loader hard-refuses `XR_RUNTIME_JSON` when the calling process is elevated. No env-var override exists. The runtime's new signature log makes the override-vs-fallback question always visible.

## Changes (4 commits)

- **`2bc5d8abe` test_apps: drop SetDllDirectoryA(Program Files) hack** — 11 test apps: delete the `RegOpenKeyExA`→`SetDllDirectoryA` block. SR SDK transitive deps still resolve via system PATH for installed users; the next commit handles dev iteration.
- **`856fb2377` build: bump bundled Khronos OpenXR loader 1.1.38 → 1.1.43** — fail-hard on bad manifests. `scripts/build_windows.bat` + `.github/workflows/build-windows.yml`. The short-path copy at `C:\dev\openxr_sdk_<version>\` is now versioned, so bumping the loader doesn't silently reuse a cached older copy.
- **`d1e5d5061` oxr: log loaded DisplayXRClient.dll path at xrCreateInstance** — one-shot `U_LOG_W` at the top of `oxr_instance_create` (Windows-only) that prints the absolute path of the actually-loaded runtime DLL plus the current value of `XR_RUNTIME_JSON`. Uses `GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, &fn)` so it always finds *this* DLL regardless of how the loader brought it in.
- **`6c3e0acce` scripts: prepend _package\bin to PATH in non-vk run scripts** — mirrors what `run_cube_handle_vk_win.bat` already did, so a fresh clone resolves `SimulatedRealityVulkanBeta.dll` and friends without the installer ever running. Makes the "git clone, build, run" path work end-to-end on a fresh machine.

## Example signature output

After this change, every `xrCreateInstance` writes one WARN line to `%LOCALAPPDATA%\DisplayXR\*.log`:

```
[oxr_instance_create] DisplayXR runtime v1.3.3 'v1.3.3' loaded from:
  C:\Users\<user>\openxr-3d-display-237\build\src\xrt\targets\openxr\Release\DisplayXRClient.dll
  (XR_RUNTIME_JSON=C:\Users\<user>\openxr-3d-display-237\build\Release\openxr_displayxr-dev.json)
```

If the loader ever falls back to Program Files (e.g. running from an admin terminal where 1.1.43 refuses the env var), it's instantly visible in the `loaded from:` path.

## Caveat: elevated processes

Both 1.1.38 and 1.1.43 refuse `XR_RUNTIME_JSON` when the calling process token has high integrity (admin / UAC-elevated). This is a Khronos loader security mitigation, not something we control, and there is no env-var or registry bypass. For dev iteration in an elevated terminal, the existing "rebuild → copy DLL to Program Files" workflow is still required. The recommended workflow with this fix is: run dev test apps from a **non-elevated** terminal; the loader honors `XR_RUNTIME_JSON` and parallel worktrees iterate independently against their own runtime DLLs, no Program Files conflict.

## Test plan

- [x] Worktree build, run `_package\run_cube_handle_d3d11_win.bat` from a non-elevated terminal — signature log shows worktree's DLL path.
- [x] Fresh clone to a separate directory (simulating third-party dev), full `build_windows.bat all`, then launch cube at Medium IL via `schtasks /RL LIMITED` — signature log shows fresh-clone's DLL path, no elevation warning, Program Files untouched.
- [x] Loader version verified as 1.1.43 (`(Get-Item openxr_loader.dll).VersionInfo.FileVersion`).
- [ ] Smoke matrix: `cube_handle_d3d12_win`, `cube_handle_gl_win`, `cube_handle_vk_win` from a non-elevated terminal — confirm each loads worktree's runtime via its own run script.
- [ ] CI green.

## Follow-ups (not in this PR)

- `displayxr-demo-gaussiansplat` has the same `SetDllDirectoryA` hack — file an issue on that repo so its next release picks up the fix.
- Plan-agent suggestion: factor the per-test-app `openxr_loader.dll` POST_BUILD copy into a shared CMake helper (`displayxr_test_app_post_build(target)`). Removes 11× duplication. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)