### PR TITLE
XR_EXT_workspace_file_dialog (Tier 1 spatial picker) — runtime side

### DIFF
--- a/docs/specs/extensions/XR_EXT_workspace_file_dialog.md
+++ b/docs/specs/extensions/XR_EXT_workspace_file_dialog.md
@@ -1,0 +1,130 @@
+# XR_EXT_workspace_file_dialog
+
+| Field | Value |
+|---|---|
+| **Extension Name** | `XR_EXT_workspace_file_dialog` |
+| **Spec Version** | 1 |
+| **Authors** | David Fattal (DisplayXR / Leia Inc.) |
+| **Status** | Provisional — published with the DisplayXR runtime; subject to revision before Khronos registry submission. Spec is expected to bump once before first release tag as the picker UI lands in `displayxr-shell-pvt`. |
+| **Header** | `src/external/openxr_includes/openxr/XR_EXT_workspace_file_dialog.h` |
+| **OpenXR Version** | 1.0 |
+| **Dependencies** | OpenXR 1.0 core. The session must be running under a workspace controller (`DISPLAYXR_WORKSPACE_SESSION=1`); `XR_EXT_spatial_workspace` is the parent contract that establishes that role on the controller side. |
+| **Platforms** | Windows only (Tier 1 spatial picker). The Tier 0 flat-OS fallback path is also Windows-only — macOS workspace mode does not exist yet. |
+
+---
+
+## 1. Motivation
+
+When an OpenXR app runs under a DisplayXR workspace controller, the runtime hides the app's HWND (`ShowWindow(hwnd, SW_HIDE)` at `oxr_session.c:2669`) and the controller puppets it. Any modal popup the app spawns — `GetOpenFileName`, `IFileOpenDialog::Show`, `MessageBox` — is owned by that hidden HWND, which breaks z-order, focus, and the taskbar/IME parent-chain. Tier 0 (ADR-017, #227) handles the mechanical side by re-parenting the popup onto a visible offscreen owner HWND so it survives. That covers ~90% of cases pragmatically.
+
+What Tier 0 cannot do is preserve the 3D presentation: a flat Win32 dialog pops over a workspace window that has just transitioned to 2D. For specific moments worth polishing — file open, save-as, folder pick — we want a spatial-native picker rendered as its own 3D workspace window, adjacent to the requester, with consistent chrome and focus styling.
+
+`XR_EXT_workspace_file_dialog` is that surface. The picker is a peer workspace participant (its own OpenXR handle app), **not** a layer inside the requester's window. Window-space layers (`XRT_LAYER_WINDOW_SPACE`, `xrt_compositor.h:86`) are per-window HUD sized as window-fraction — the wrong substrate for an OS-level picker.
+
+---
+
+## 2. Surface (spec_version 1)
+
+### Lifecycle
+
+- `xrRequestFilePickerEXT(session, &info, &requestId)` — begin an async pick. Returns immediately. The runtime allocates a monotonic 64-bit request ID, forwards the request to the active workspace controller over IPC, and the controller spawns its picker binary (`displayxr-file-picker.exe` in the DisplayXR Shell case). The picker runs as a normal OpenXR workspace participant inheriting the requester's display mode.
+
+### Completion
+
+The app polls `xrPollEvent` for `XR_TYPE_EVENT_DATA_FILE_PICKER_COMPLETE_EXT`. The event carries the matching `requestId`, an `XrFilePickerResultEXT` outcome, and (on success) the picked path as NUL-terminated UTF-8.
+
+| Field | Type | Meaning |
+|---|---|---|
+| `requestId` | `XrAsyncRequestIdEXT` | Correlates with the `xrRequestFilePickerEXT` out-param. |
+| `result` | `XrFilePickerResultEXT` | `SUCCESS_EXT` (path valid), `CANCELLED_EXT`, `PICKER_FAILED_EXT` (process crashed / synthesised by the workspace controller on child-exit without completion), `INVALID_PATH_EXT` (selection did not fit in the path buffer). |
+| `path` | `char[2048]` | UTF-8. Empty unless `result == SUCCESS_EXT`. |
+
+Async / event-based on purpose: a blocking entrypoint would deadlock single-threaded render loops and stall `xrWaitFrame`.
+
+### Request parameters
+
+`XrFilePickerInfoEXT` is a flat copyable value — the OpenXR `next` pointer chain is reserved for future use (must be `NULL` in spec_version 1). The IPC codegen does not follow pointer chains across the process boundary.
+
+| Field | Notes |
+|---|---|
+| `mode` | `OPEN_EXT` / `SAVE_EXT` / `FOLDER_EXT`. |
+| `flags` | `XR_FILE_PICKER_FLAG_MULTI_SELECT_BIT_EXT` is reserved for spec_version 2. spec_version 1 implementations may return `XR_ERROR_FEATURE_UNSUPPORTED` if the bit is set. |
+| `title` | Window title; empty = picker chooses. |
+| `defaultPath` | Starting directory; empty = picker chooses. |
+| `filterCount` / `filters[]` | Up to 8 filter rows. Each row carries a user-visible `description` and a semicolon-delimited extension list (e.g. `"*.png;*.jpg;*.jpeg"`). |
+
+### Fallback semantics
+
+Not every workspace controller will ship a picker. The controller publishes its capability via the registry value `SupportsFileDialog = REG_DWORD 1` under its `HKLM\Software\DisplayXR\WorkspaceControllers\<id>` key (see `docs/specs/runtime/workspace-controller-registration.md`).
+
+- **No controller registered, or controller present but capability bit absent.** `xrRequestFilePickerEXT` returns `XR_FILE_PICKER_FALLBACK_TIER0_EXT` (success-class) and writes `XR_NULL_ASYNC_REQUEST_ID_EXT` into `*requestId`. No completion event will be posted. The app is expected to fall back to a flat OS dialog (`GetOpenFileName` / `IFileOpenDialog`); the Tier 0 CBT hook (always installed under workspace mode — see ADR-017) handles z-order and focus restoration onto a visible offscreen owner HWND.
+- **Session not under a workspace.** Returns `XR_ERROR_FEATURE_UNSUPPORTED`. Standalone sessions should call `GetOpenFileName` directly with no DisplayXR involvement.
+
+This split keeps the extension surface decisive: a successful path means a completion event is guaranteed (modulo session destruction); the fallback code is the one signal the app needs to switch strategies. No fake events, no sentinel paths.
+
+---
+
+## 3. Lifecycle in detail
+
+```
+App                          Runtime                        Controller                       Picker exe
+ |  xrRequestFilePickerEXT       |                              |                                 |
+ |----------------------------->  |  IPC: file_picker_request    |                                 |
+ |  (returns immediately)        |---------------------------->  |  CreateProcess + CLI args       |
+ |                               |                              |--------------------------------> |
+ |                               |                              |                                 |
+ |  per-frame render loop       (workspace_modal_open against requester:                          |
+ |  + xrPollEvent              |  dim, drop topmost, optional 3D→2D — same as Tier 0)             |
+ |                               |                              |                                 |
+ |                               |                              |  picker UI runs as workspace    |
+ |                               |                              |  client. User picks / cancels.  |
+ |                               |                              |                                 |
+ |                               |                              |  IPC: file_picker_result        |
+ |                               |   <-------------------------- |  (controller is sole authority) |
+ |                               |                              |                                 |
+ |                               |  pushes XrEventDataFilePickerCompleteEXT to requesting session  |
+ |                               |                              |                                 |
+ |  <- xrPollEvent receives -    |                              |                                 |
+ |   completion event            |                              |                                 |
+```
+
+The controller is the sole authority for `file_picker_result` — the runtime rejects result IPCs from non-controller clients. The picker process never speaks to the runtime directly about results; it speaks to its parent controller via a controller-internal channel (private IPC inside `displayxr-shell-pvt`).
+
+Crash handling:
+
+- **Picker exit without result.** Controller observes the child PID exit, synthesises `result = XR_FILE_PICKER_RESULT_PICKER_FAILED_EXT`, sends the IPC.
+- **Requester exit while picker open.** Controller monitors client liveness (M6 graceful-exit), issues `WM_CLOSE` then `TerminateProcess` on the picker child. The runtime drops the outstanding request on session destroy; the late picker result becomes a no-op (logged once).
+- **Recursion guard.** The runtime rejects `xrRequestFilePickerEXT` calls from sessions launched by the picker spawn path (the controller sets `DISPLAYXR_WORKSPACE_CLIENT_IS_PICKER=1` on the picker's environment; the runtime gates the entrypoint on its absence).
+
+---
+
+## 4. Versioning
+
+| Version | Change |
+|---|---|
+| 1 | Initial provisional surface: `xrRequestFilePickerEXT`, `XrEventDataFilePickerCompleteEXT`, fallback result code. Multi-select reserved but unimplemented. |
+
+Expected near-term revisions before any spec-freeze attempt:
+
+- Multi-select (`MULTI_SELECT_BIT_EXT` → variable-length result transport).
+- Optional `next`-chain extension struct for picker-side hints (initial focus on a particular tile, recent-files surfacing).
+- Spec-version bump once the picker UI lands in `displayxr-shell-pvt` and exercises edge cases of `XrFilePickerInfoEXT` (filter parsing, default-path normalisation).
+
+The struct ABI is intentionally narrow in v1 to leave room.
+
+---
+
+## 5. Out of scope
+
+- **Color / font / print pickers.** Tier 0 already handles these because they are standard `comdlg32` dialogs — the CBT hook re-parents onto a visible owner; z-order and focus restoration work. We only ship sibling extensions if a customer asks.
+- **UWP `FileOpenPicker`.** Sandboxed in `explorer.exe`; no in-process HWND to hook, no spawnable handle-app equivalent. Apps should use legacy `GetOpenFileName` under workspace mode.
+- **macOS.** Workspace shell does not exist on macOS yet.
+
+---
+
+## 6. References
+
+- ADR-017 — modal-dialogs tiered strategy (T0/T1/T2 decision, T2 rejection rationale).
+- `docs/specs/runtime/modal-dialog-handling.md` — Tier 0 mechanism, coverage matrix, COM/UWP boundary.
+- `docs/specs/runtime/workspace-controller-registration.md` — capability flag schema, controller discovery.
+- Issue [#228](https://github.com/DisplayXR/displayxr-runtime/issues/228) — Tier 1 design and distribution decisions (picker ships in shell installer, not runtime).

--- a/docs/specs/extensions/XR_EXT_workspace_file_dialog.md
+++ b/docs/specs/extensions/XR_EXT_workspace_file_dialog.md
@@ -37,7 +37,7 @@ The app polls `xrPollEvent` for `XR_TYPE_EVENT_DATA_FILE_PICKER_COMPLETE_EXT`. T
 |---|---|---|
 | `requestId` | `XrAsyncRequestIdEXT` | Correlates with the `xrRequestFilePickerEXT` out-param. |
 | `result` | `XrFilePickerResultEXT` | `SUCCESS_EXT` (path valid), `CANCELLED_EXT`, `PICKER_FAILED_EXT` (process crashed / synthesised by the workspace controller on child-exit without completion), `INVALID_PATH_EXT` (selection did not fit in the path buffer). |
-| `path` | `char[2048]` | UTF-8. Empty unless `result == SUCCESS_EXT`. |
+| `path` | `char[512]` | UTF-8. Empty unless `result == SUCCESS_EXT`. Sized to comfortably hold Windows `MAX_PATH`; long-path picks (`\\?\…` style) return `INVALID_PATH_EXT` and the app should fall back to Tier 0. |
 
 Async / event-based on purpose: a blocking entrypoint would deadlock single-threaded render loops and stall `xrWaitFrame`.
 
@@ -51,7 +51,7 @@ Async / event-based on purpose: a blocking entrypoint would deadlock single-thre
 | `flags` | `XR_FILE_PICKER_FLAG_MULTI_SELECT_BIT_EXT` is reserved for spec_version 2. spec_version 1 implementations may return `XR_ERROR_FEATURE_UNSUPPORTED` if the bit is set. |
 | `title` | Window title; empty = picker chooses. |
 | `defaultPath` | Starting directory; empty = picker chooses. |
-| `filterCount` / `filters[]` | Up to 8 filter rows. Each row carries a user-visible `description` and a semicolon-delimited extension list (e.g. `"*.png;*.jpg;*.jpeg"`). |
+| `filterCount` / `filters[]` | Up to 4 filter rows. Each row carries a user-visible `description` (`char[64]`) and a semicolon-delimited extension list (e.g. `"*.png;*.jpg;*.jpeg"`, `char[64]`). Tightening these vs. the proposal in #228 keeps the IPC payload inside the runtime's 1024-byte RPC budget — bumping it is a future change, not v1. |
 
 ### Fallback semantics
 

--- a/docs/specs/extensions/XR_EXT_workspace_file_dialog.md
+++ b/docs/specs/extensions/XR_EXT_workspace_file_dialog.md
@@ -37,7 +37,7 @@ The app polls `xrPollEvent` for `XR_TYPE_EVENT_DATA_FILE_PICKER_COMPLETE_EXT`. T
 |---|---|---|
 | `requestId` | `XrAsyncRequestIdEXT` | Correlates with the `xrRequestFilePickerEXT` out-param. |
 | `result` | `XrFilePickerResultEXT` | `SUCCESS_EXT` (path valid), `CANCELLED_EXT`, `PICKER_FAILED_EXT` (process crashed / synthesised by the workspace controller on child-exit without completion), `INVALID_PATH_EXT` (selection did not fit in the path buffer). |
-| `path` | `char[512]` | UTF-8. Empty unless `result == SUCCESS_EXT`. Sized to comfortably hold Windows `MAX_PATH`; long-path picks (`\\?\…` style) return `INVALID_PATH_EXT` and the app should fall back to Tier 0. |
+| `path` | `char[256]` | UTF-8. Empty unless `result == SUCCESS_EXT`. Sized to fit Windows `MAX_PATH` (260) inside the runtime's per-message IPC budget; long-path picks (`\\?\…` style) return `INVALID_PATH_EXT` and the app should fall back to Tier 0. |
 
 Async / event-based on purpose: a blocking entrypoint would deadlock single-threaded render loops and stall `xrWaitFrame`.
 

--- a/docs/specs/runtime/workspace-controller-registration.md
+++ b/docs/specs/runtime/workspace-controller-registration.md
@@ -40,6 +40,9 @@ A workspace app's installer:
    | `Version` | REG_SZ | no | Free-form version string (logged at spawn). |
    | `IconPath` | REG_SZ | no | Tray submenu icon (reserved). |
    | `UninstallString` | REG_SZ | yes | Used by the runtime uninstaller for cascade uninstall. **Must honor `/S` (silent).** |
+   | `SupportsFileDialog` | REG_DWORD | no | Optional capability bit. `1` means this controller hosts `XR_EXT_workspace_file_dialog` Tier 1 (spawns a spatial picker exe on `xrRequestFilePickerEXT`). Missing or `0` means the runtime returns `XR_FILE_PICKER_FALLBACK_TIER0_EXT` and the app falls back to a flat OS dialog. |
+
+   Capability flags are forward-compatible: future bits (`SupportsColorDialog`, …) are added as additional `REG_DWORD` values under this same subkey. Unknown values are ignored. Controllers never need to declare bits they don't implement.
 
 4. **Writes its own Add/Remove Programs entry under
    `HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\<ProductId>`.**

--- a/src/external/openxr_includes/openxr/XR_EXT_spatial_workspace.h
+++ b/src/external/openxr_includes/openxr/XR_EXT_spatial_workspace.h
@@ -25,7 +25,7 @@ extern "C" {
 #endif
 
 #define XR_EXT_spatial_workspace 1
-#define XR_EXT_spatial_workspace_SPEC_VERSION 10
+#define XR_EXT_spatial_workspace_SPEC_VERSION 11
 #define XR_EXT_SPATIAL_WORKSPACE_EXTENSION_NAME "XR_EXT_spatial_workspace"
 
 // Provisional XrStructureType values. The 1000999100..105 range is reserved for
@@ -307,6 +307,7 @@ typedef enum XrWorkspaceInputEventTypeEXT {
     XR_WORKSPACE_INPUT_EVENT_WINDOW_POSE_CHANGED_EXT = 7, // spec_version 8: runtime-driven pose / size change (edge resize, etc.)
     XR_WORKSPACE_INPUT_EVENT_MODAL_OPEN_EXT      = 8, // spec_version 10: client opened a Win32 modal popup (refcounted, fires on 0→1 only)
     XR_WORKSPACE_INPUT_EVENT_MODAL_CLOSE_EXT     = 9, // spec_version 10: client's last Win32 modal popup closed (refcounted, fires on 1→0 only)
+    XR_WORKSPACE_INPUT_EVENT_FILE_PICKER_REQUEST_EXT = 10, // spec_version 11: a workspace client called xrRequestFilePickerEXT — fetch full info via xrGetFilePickerRequestEXT, deliver result via xrCompleteFilePickerEXT
     XR_WORKSPACE_INPUT_EVENT_TYPE_MAX_ENUM_EXT  = 0x7FFFFFFF
 } XrWorkspaceInputEventTypeEXT;
 
@@ -415,6 +416,17 @@ typedef struct XrWorkspaceInputEventEXT {
             // Companion to ADR-017 (Tier 0 modal-dialog strategy).
             XrWorkspaceClientId     clientId;
         } modal;
+        struct {  // spec_version 11: a workspace client called
+            // xrRequestFilePickerEXT (XR_EXT_workspace_file_dialog).
+            // Payload is intentionally small so the event batch stays
+            // under IPC_BUF_SIZE; the controller calls
+            // xrGetFilePickerRequestEXT(requestId, …) to retrieve the
+            // full XrFilePickerInfoEXT-equivalent, spawns its picker
+            // implementation, and delivers the result via
+            // xrCompleteFilePickerEXT.
+            XrWorkspaceClientId     clientId;
+            uint64_t                requestId;
+        } filePickerRequest;
     };
 } XrWorkspaceInputEventEXT;
 

--- a/src/external/openxr_includes/openxr/XR_EXT_workspace_file_dialog.h
+++ b/src/external/openxr_includes/openxr/XR_EXT_workspace_file_dialog.h
@@ -58,21 +58,29 @@ extern "C" {
 /*!
  * @brief Maximum path length carried in the completion event (UTF-8 bytes).
  *
- * Sized for Windows long paths plus UTF-8 worst case. The picker truncates
- * results past this length and returns XR_ERROR_PATH_FORMAT_INVALID.
+ * Sized to comfortably hold Windows `MAX_PATH` plus UTF-8 worst case.
+ * Apps that need long-path support (`\\?\…` style) should call the
+ * Tier 0 path directly; the completion event returns
+ * `XR_FILE_PICKER_RESULT_INVALID_PATH_EXT` if the user picks a path
+ * that does not fit in this buffer.
  */
-#define XR_MAX_FILE_PICKER_PATH_LENGTH_EXT 2048
+#define XR_MAX_FILE_PICKER_PATH_LENGTH_EXT 512
 
 /*!
  * @brief Maximum length of a single filter description / extension list
  * field in XrFilePickerInfoEXT.
  */
-#define XR_MAX_FILE_PICKER_FILTER_LENGTH_EXT 128
+#define XR_MAX_FILE_PICKER_FILTER_LENGTH_EXT 64
+
+/*!
+ * @brief Maximum length of the optional picker title.
+ */
+#define XR_MAX_FILE_PICKER_TITLE_LENGTH_EXT 128
 
 /*!
  * @brief Maximum number of filter entries the picker UI displays.
  */
-#define XR_MAX_FILE_PICKER_FILTERS_EXT 8
+#define XR_MAX_FILE_PICKER_FILTERS_EXT 4
 
 /*!
  * @brief Async-request handle returned by xrRequestFilePickerEXT.
@@ -131,7 +139,7 @@ typedef struct XrFilePickerInfoEXT {
     const void* XR_MAY_ALIAS   next;       //!< Reserved; must be NULL in spec_version 1
     XrFilePickerModeEXT        mode;       //!< Open / Save / Folder
     XrFilePickerFlagsEXT       flags;      //!< See XR_FILE_PICKER_FLAG_*
-    char                       title[XR_MAX_FILE_PICKER_FILTER_LENGTH_EXT]; //!< Window title; empty = picker chooses
+    char                       title[XR_MAX_FILE_PICKER_TITLE_LENGTH_EXT]; //!< Window title; empty = picker chooses
     char                       defaultPath[XR_MAX_FILE_PICKER_PATH_LENGTH_EXT]; //!< Starting directory; empty = picker chooses
     uint32_t                   filterCount; //!< Number of valid entries in filters[]
     XrFilePickerFilterEXT      filters[XR_MAX_FILE_PICKER_FILTERS_EXT];

--- a/src/external/openxr_includes/openxr/XR_EXT_workspace_file_dialog.h
+++ b/src/external/openxr_includes/openxr/XR_EXT_workspace_file_dialog.h
@@ -217,6 +217,90 @@ typedef struct XrEventDataFilePickerCompleteEXT {
     char                        path[XR_MAX_FILE_PICKER_PATH_LENGTH_EXT]; //!< NUL-terminated UTF-8; empty on cancel/failure
 } XrEventDataFilePickerCompleteEXT;
 
+// ---- Controller-side surface ----
+//
+// Workspace controllers drain XR_WORKSPACE_INPUT_EVENT_FILE_PICKER_REQUEST_EXT
+// from xrEnumerateWorkspaceInputEventsEXT, fetch the full request via
+// xrGetFilePickerRequestEXT, spawn (or otherwise drive) their picker UI, and
+// deliver the result through xrCompleteFilePickerEXT. Both functions require
+// the calling session to hold the active workspace role
+// (xrActivateSpatialWorkspaceEXT). A non-controller caller receives
+// XR_ERROR_FEATURE_UNSUPPORTED.
+
+/*!
+ * @brief Fetch the full picker request that a workspace client posted via
+ * xrRequestFilePickerEXT.
+ *
+ * Called by the workspace controller in response to an
+ * XR_WORKSPACE_INPUT_EVENT_FILE_PICKER_REQUEST_EXT event. The runtime
+ * returns the requesting client's id and the picker info struct so the
+ * controller can spawn / drive a picker UI.
+ *
+ * @param session    Workspace-controller session.
+ * @param requestId  Value carried by the request event.
+ * @param outClientId  Output: the requesting workspace client.
+ * @param outInfo     Output: filled with the requester's
+ *                    XrFilePickerInfoEXT-equivalent. `type` and `next`
+ *                    are reset by the runtime so the caller can pass
+ *                    the buffer along to its picker without further
+ *                    re-initialisation.
+ * @return XR_SUCCESS on hit;
+ *         XR_ERROR_VALIDATION_FAILURE if requestId is 0 or no pending
+ *         entry matches (already completed, or the requester
+ *         disconnected);
+ *         XR_ERROR_FEATURE_UNSUPPORTED if the calling session is not
+ *         the active workspace controller.
+ */
+typedef XrResult (XRAPI_PTR *PFN_xrGetFilePickerRequestEXT)(
+    XrSession              session,
+    XrAsyncRequestIdEXT    requestId,
+    uint32_t              *outClientId,    //!< XrWorkspaceClientId (header-independence: plain uint32_t)
+    XrFilePickerInfoEXT   *outInfo);
+
+#ifndef XR_NO_PROTOTYPES
+XRAPI_ATTR XrResult XRAPI_CALL xrGetFilePickerRequestEXT(
+    XrSession              session,
+    XrAsyncRequestIdEXT    requestId,
+    uint32_t              *outClientId,
+    XrFilePickerInfoEXT   *outInfo);
+#endif
+
+/*!
+ * @brief Deliver a picker result back to the requesting client.
+ *
+ * The runtime translates this into an XrEventDataFilePickerCompleteEXT
+ * pushed onto the requester's session event queue. Late results (i.e.,
+ * the requester disconnected before the controller responded) are
+ * dropped silently and logged once.
+ *
+ * @param session    Workspace-controller session.
+ * @param requestId  Value carried by the request event.
+ * @param result     XR_FILE_PICKER_RESULT_*. SUCCESS_EXT must be paired
+ *                   with a non-empty path; the runtime overrides
+ *                   `path` to an empty string for non-SUCCESS results.
+ * @param path       NUL-terminated UTF-8; ignored when @p result is not
+ *                   SUCCESS_EXT. May be NULL or empty in that case.
+ * @return XR_SUCCESS on a successful deliver-or-late-result-drop;
+ *         XR_ERROR_VALIDATION_FAILURE if requestId is 0;
+ *         XR_ERROR_FEATURE_UNSUPPORTED if the calling session is not
+ *         the active workspace controller;
+ *         XR_ERROR_PATH_FORMAT_INVALID if @p path exceeds the runtime's
+ *         wire budget (see XR_MAX_FILE_PICKER_PATH_LENGTH_EXT).
+ */
+typedef XrResult (XRAPI_PTR *PFN_xrCompleteFilePickerEXT)(
+    XrSession                  session,
+    XrAsyncRequestIdEXT        requestId,
+    XrFilePickerResultEXT      result,
+    const char                *path);
+
+#ifndef XR_NO_PROTOTYPES
+XRAPI_ATTR XrResult XRAPI_CALL xrCompleteFilePickerEXT(
+    XrSession              session,
+    XrAsyncRequestIdEXT    requestId,
+    XrFilePickerResultEXT  result,
+    const char            *path);
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/external/openxr_includes/openxr/XR_EXT_workspace_file_dialog.h
+++ b/src/external/openxr_includes/openxr/XR_EXT_workspace_file_dialog.h
@@ -1,0 +1,216 @@
+// Copyright 2026, DisplayXR
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  Header for XR_EXT_workspace_file_dialog extension (Tier 1 spatial file picker).
+ * @author DisplayXR
+ * @ingroup external_openxr
+ *
+ * Async spatial-native file picker. The app calls xrRequestFilePickerEXT and
+ * receives an XrEventDataFilePickerCompleteEXT through xrPollEvent when the
+ * user picks (or cancels). The picker itself is a peer workspace window
+ * (its own OpenXR handle app) spawned by the active workspace controller —
+ * NOT a layer inside the requester's window.
+ *
+ * Async / event-based on purpose: a blocking call would deadlock single-
+ * threaded render loops and stall xrWaitFrame.
+ *
+ * The extension is workspace-scoped: an instance must enable
+ * XR_EXT_spatial_workspace and the session must be the active workspace
+ * (xrActivateSpatialWorkspaceEXT) before xrRequestFilePickerEXT returns
+ * XR_SUCCESS. Outside a workspace it returns XR_ERROR_FEATURE_UNSUPPORTED.
+ *
+ * Fallback to Tier 0: if no workspace controller is registered, or the
+ * active controller does not advertise file-dialog support (registry value
+ * `SupportsFileDialog=1` under its WorkspaceControllers\<id> key), the call
+ * returns XR_FILE_PICKER_FALLBACK_TIER0_EXT immediately. Apps should then
+ * call GetOpenFileName / IFileOpenDialog themselves; the Tier 0 CBT hook
+ * (always installed under DISPLAYXR_WORKSPACE_SESSION=1) handles z-order
+ * and focus restoration onto a visible offscreen owner HWND.
+ */
+#ifndef XR_EXT_WORKSPACE_FILE_DIALOG_H
+#define XR_EXT_WORKSPACE_FILE_DIALOG_H 1
+
+#include <openxr/openxr.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define XR_EXT_workspace_file_dialog 1
+#define XR_EXT_workspace_file_dialog_SPEC_VERSION 1
+#define XR_EXT_WORKSPACE_FILE_DIALOG_EXTENSION_NAME "XR_EXT_workspace_file_dialog"
+
+// Provisional XrStructureType values. The 1000999120..121 range is reserved
+// for this extension. Reconciles with the Khronos registry before any
+// spec-freeze attempt.
+#define XR_TYPE_FILE_PICKER_INFO_EXT                ((XrStructureType)1000999120)
+#define XR_TYPE_EVENT_DATA_FILE_PICKER_COMPLETE_EXT ((XrStructureType)1000999121)
+
+/*!
+ * @brief Success-class XrResult returned when no Tier 1 picker is available.
+ *
+ * Cast as XrResult so callers can compare against the function return value
+ * directly. Positive (non-error) per OpenXR's result-code convention.
+ */
+#define XR_FILE_PICKER_FALLBACK_TIER0_EXT ((XrResult)1000999122)
+
+/*!
+ * @brief Maximum path length carried in the completion event (UTF-8 bytes).
+ *
+ * Sized for Windows long paths plus UTF-8 worst case. The picker truncates
+ * results past this length and returns XR_ERROR_PATH_FORMAT_INVALID.
+ */
+#define XR_MAX_FILE_PICKER_PATH_LENGTH_EXT 2048
+
+/*!
+ * @brief Maximum length of a single filter description / extension list
+ * field in XrFilePickerInfoEXT.
+ */
+#define XR_MAX_FILE_PICKER_FILTER_LENGTH_EXT 128
+
+/*!
+ * @brief Maximum number of filter entries the picker UI displays.
+ */
+#define XR_MAX_FILE_PICKER_FILTERS_EXT 8
+
+/*!
+ * @brief Async-request handle returned by xrRequestFilePickerEXT.
+ *
+ * Opaque monotonic ID. Apps correlate completion events by matching the
+ * `requestId` field of XrEventDataFilePickerCompleteEXT against the value
+ * the runtime wrote here. The runtime drops outstanding requests on
+ * session destroy; late completions for a destroyed session are no-ops.
+ */
+typedef uint64_t XrAsyncRequestIdEXT;
+
+#define XR_NULL_ASYNC_REQUEST_ID_EXT ((XrAsyncRequestIdEXT)0)
+
+/*!
+ * @brief Picker mode.
+ */
+typedef enum XrFilePickerModeEXT {
+    XR_FILE_PICKER_MODE_OPEN_EXT   = 0,
+    XR_FILE_PICKER_MODE_SAVE_EXT   = 1,
+    XR_FILE_PICKER_MODE_FOLDER_EXT = 2,
+    XR_FILE_PICKER_MODE_MAX_ENUM_EXT = 0x7FFFFFFF
+} XrFilePickerModeEXT;
+
+/*!
+ * @brief Flags controlling picker UI behavior.
+ *
+ * MULTI_SELECT_BIT is reserved for spec_version 2. spec_version 1 picker
+ * implementations may return XR_ERROR_FEATURE_UNSUPPORTED if the flag is
+ * set.
+ */
+typedef XrFlags64 XrFilePickerFlagsEXT;
+static const XrFilePickerFlagsEXT XR_FILE_PICKER_FLAG_NONE_EXT             = 0;
+static const XrFilePickerFlagsEXT XR_FILE_PICKER_FLAG_MULTI_SELECT_BIT_EXT = 0x00000001;
+
+/*!
+ * @brief One filter row in the picker's dropdown.
+ *
+ * `extensions` is a semicolon-delimited list of patterns, e.g.
+ * `"*.png;*.jpg;*.jpeg"`. Empty = match all.
+ */
+typedef struct XrFilePickerFilterEXT {
+    char description[XR_MAX_FILE_PICKER_FILTER_LENGTH_EXT]; //!< User-visible label, e.g. "Images"
+    char extensions[XR_MAX_FILE_PICKER_FILTER_LENGTH_EXT];  //!< Semicolon-delimited patterns
+} XrFilePickerFilterEXT;
+
+/*!
+ * @brief Request parameters for xrRequestFilePickerEXT.
+ *
+ * The runtime forwards this struct to the active workspace controller
+ * over IPC. All character fields are NUL-terminated UTF-8. The IPC
+ * codegen does not follow `next` pointer chains — this struct must be
+ * a flat copyable value.
+ */
+typedef struct XrFilePickerInfoEXT {
+    XrStructureType            type;       //!< Must be XR_TYPE_FILE_PICKER_INFO_EXT
+    const void* XR_MAY_ALIAS   next;       //!< Reserved; must be NULL in spec_version 1
+    XrFilePickerModeEXT        mode;       //!< Open / Save / Folder
+    XrFilePickerFlagsEXT       flags;      //!< See XR_FILE_PICKER_FLAG_*
+    char                       title[XR_MAX_FILE_PICKER_FILTER_LENGTH_EXT]; //!< Window title; empty = picker chooses
+    char                       defaultPath[XR_MAX_FILE_PICKER_PATH_LENGTH_EXT]; //!< Starting directory; empty = picker chooses
+    uint32_t                   filterCount; //!< Number of valid entries in filters[]
+    XrFilePickerFilterEXT      filters[XR_MAX_FILE_PICKER_FILTERS_EXT];
+} XrFilePickerInfoEXT;
+
+/*!
+ * @brief Begin an async file-picker request.
+ *
+ * Returns immediately. The runtime allocates a monotonic request ID, hands
+ * the request off to the active workspace controller, and queues an
+ * XrEventDataFilePickerCompleteEXT on the requesting session's event
+ * stream when the picker completes.
+ *
+ * Apps poll xrPollEvent on the same session to receive the completion.
+ *
+ * @param session    A valid XrSession handle that has activated a
+ *                   spatial workspace via xrActivateSpatialWorkspaceEXT.
+ * @param info       Picker parameters. Must not be NULL.
+ * @param requestId  Output: monotonic ID for correlating the completion
+ *                   event. Must not be NULL. Never zero on success.
+ * @return XR_SUCCESS — request accepted; event will follow.
+ *         XR_FILE_PICKER_FALLBACK_TIER0_EXT — no spatial picker available;
+ *         the app should fall back to a flat OS dialog (Tier 0 handles
+ *         z-order and focus restoration automatically). No completion
+ *         event will be queued; *requestId is set to
+ *         XR_NULL_ASYNC_REQUEST_ID_EXT.
+ *         XR_ERROR_FEATURE_UNSUPPORTED — session is not running under a
+ *         workspace.
+ *         XR_ERROR_VALIDATION_FAILURE — info->type is wrong, mode is
+ *         invalid, or the picker is being called from the picker
+ *         process itself (recursion guard).
+ *         XR_ERROR_HANDLE_INVALID — session is invalid.
+ */
+typedef XrResult (XRAPI_PTR *PFN_xrRequestFilePickerEXT)(
+    XrSession                       session,
+    const XrFilePickerInfoEXT*      info,
+    XrAsyncRequestIdEXT*            requestId);
+
+#ifndef XR_NO_PROTOTYPES
+XRAPI_ATTR XrResult XRAPI_CALL xrRequestFilePickerEXT(
+    XrSession                       session,
+    const XrFilePickerInfoEXT*      info,
+    XrAsyncRequestIdEXT*            requestId);
+#endif
+
+/*!
+ * @brief Picker completion result codes carried in the event.
+ *
+ * Distinct from `XrResult` to avoid stepping on the Khronos result-code
+ * range; encoded as int32_t in the event.
+ */
+typedef enum XrFilePickerResultEXT {
+    XR_FILE_PICKER_RESULT_SUCCESS_EXT     = 0,  //!< User picked. `path` is valid.
+    XR_FILE_PICKER_RESULT_CANCELLED_EXT   = 1,  //!< User cancelled. `path` is empty.
+    XR_FILE_PICKER_RESULT_PICKER_FAILED_EXT = 2, //!< Picker exited abnormally / crashed.
+    XR_FILE_PICKER_RESULT_INVALID_PATH_EXT = 3, //!< User picked a path that did not fit in the buffer.
+    XR_FILE_PICKER_RESULT_MAX_ENUM_EXT    = 0x7FFFFFFF
+} XrFilePickerResultEXT;
+
+/*!
+ * @brief Completion event delivered via xrPollEvent.
+ *
+ * The runtime routes this event to the session whose xrRequestFilePickerEXT
+ * call produced the matching `requestId`. If the requesting session is
+ * destroyed before the picker completes, the event is dropped silently.
+ *
+ * @extends XrEventDataBaseHeader
+ */
+typedef struct XrEventDataFilePickerCompleteEXT {
+    XrStructureType             type;       //!< Must be XR_TYPE_EVENT_DATA_FILE_PICKER_COMPLETE_EXT
+    const void* XR_MAY_ALIAS    next;
+    XrSession                   session;
+    XrAsyncRequestIdEXT         requestId;
+    XrFilePickerResultEXT       result;
+    char                        path[XR_MAX_FILE_PICKER_PATH_LENGTH_EXT]; //!< NUL-terminated UTF-8; empty on cancel/failure
+} XrEventDataFilePickerCompleteEXT;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // XR_EXT_WORKSPACE_FILE_DIALOG_H

--- a/src/external/openxr_includes/openxr/XR_EXT_workspace_file_dialog.h
+++ b/src/external/openxr_includes/openxr/XR_EXT_workspace_file_dialog.h
@@ -58,13 +58,14 @@ extern "C" {
 /*!
  * @brief Maximum path length carried in the completion event (UTF-8 bytes).
  *
- * Sized to comfortably hold Windows `MAX_PATH` plus UTF-8 worst case.
- * Apps that need long-path support (`\\?\…` style) should call the
- * Tier 0 path directly; the completion event returns
- * `XR_FILE_PICKER_RESULT_INVALID_PATH_EXT` if the user picks a path
- * that does not fit in this buffer.
+ * Sized to Windows `MAX_PATH` (260) rounded down to a power-of-two-ish
+ * value so the encompassing IPC request message stays comfortably inside
+ * the runtime's per-message wire budget. Apps that need long-path
+ * support (`\\?\…` style) should call the Tier 0 path directly; the
+ * completion event returns `XR_FILE_PICKER_RESULT_INVALID_PATH_EXT` if
+ * the user picks a path that does not fit in this buffer.
  */
-#define XR_MAX_FILE_PICKER_PATH_LENGTH_EXT 512
+#define XR_MAX_FILE_PICKER_PATH_LENGTH_EXT 256
 
 /*!
  * @brief Maximum length of a single filter description / extension list

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -14894,6 +14894,11 @@ comp_d3d11_service_workspace_post_file_picker_request(struct xrt_system_composit
 		U_LOG_W("file_picker: queued request_id=%llu (slot=%d, mode=%u, filters=%u)",
 		        (unsigned long long)mc->file_picker[i].request_id, slot,
 		        info->mode, info->filter_count);
+		// Wake the workspace controller so it drains the new event in
+		// the same frame the request arrives, instead of waiting for
+		// its next periodic input poll (the shell sleeps on the
+		// wakeup-event handle when nothing else is happening).
+		service_signal_workspace_wakeup(sys);
 		return XRT_SUCCESS;
 	}
 

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -1260,6 +1260,22 @@ struct d3d11_multi_compositor
 		uint32_t saved_mode_index;    //!< Pre-modal mode to restore on modal-close.
 		bool curtain_active;          //!< Per-tile blit pass collapses to eye-0 / tile-(0,0) when true.
 	} mode_flip;
+
+	//! XR_EXT_workspace_file_dialog: pending Tier 1 picker requests. Bounded
+	//! buffer keyed by request_id. Allocated in
+	//! comp_d3d11_service_workspace_post_file_picker_request and consumed by
+	//! comp_d3d11_service_workspace_file_picker_result. The drain loop emits
+	//! IPC_WORKSPACE_INPUT_EVENT_FILE_PICKER_REQUEST for entries whose
+	//! `needs_emit` flag is set. All access is guarded by `sys->render_mutex`.
+	struct
+	{
+		bool                         in_use;       //!< Slot occupied.
+		bool                         needs_emit;   //!< Drain loop should emit a request event.
+		int                          owner_slot;   //!< Workspace slot that issued the request.
+		uint64_t                     request_id;
+		struct ipc_file_picker_info  info;
+	} file_picker[8];
+	uint64_t next_file_picker_request_id;
 };
 
 
@@ -14381,6 +14397,33 @@ comp_d3d11_service_workspace_drain_input_events(struct xrt_system_compositor *xs
 		mc->frame_tick_last_ns = now_ns;
 	}
 
+	// XR_EXT_workspace_file_dialog: drain pending picker requests one at a
+	// time. Payload is tiny (client_id + request_id) so it fits comfortably
+	// in IPC_WORKSPACE_INPUT_EVENT_BATCH_MAX; the controller fetches the
+	// full XrFilePickerInfoEXT-equivalent via
+	// workspace_get_file_picker_request once it sees the event.
+	for (size_t i = 0; i < sizeof(mc->file_picker) / sizeof(mc->file_picker[0]) &&
+	     out_batch->count < IPC_WORKSPACE_INPUT_EVENT_BATCH_MAX; i++) {
+		if (!mc->file_picker[i].in_use || !mc->file_picker[i].needs_emit) continue;
+		int s = mc->file_picker[i].owner_slot;
+		if (s < 0 || s >= D3D11_MULTI_MAX_CLIENTS || !mc->clients[s].active) {
+			// Slot disappeared between post and drain — drop the
+			// pending entry; a late workspace_file_dialog_result
+			// will hit the same active-slot check and be discarded.
+			mc->file_picker[i].in_use = false;
+			mc->file_picker[i].needs_emit = false;
+			continue;
+		}
+		struct ipc_workspace_input_event *ev = &out_batch->events[out_batch->count];
+		memset(ev, 0, sizeof(*ev));
+		ev->event_type = IPC_WORKSPACE_INPUT_EVENT_FILE_PICKER_REQUEST;
+		ev->timestamp_ms = (uint32_t)GetTickCount();
+		ev->u.file_picker_request.client_id = mc->clients[s].workspace_client_id;
+		ev->u.file_picker_request.request_id = mc->file_picker[i].request_id;
+		out_batch->count++;
+		mc->file_picker[i].needs_emit = false;
+	}
+
 	return true;
 }
 
@@ -14814,6 +14857,144 @@ comp_d3d11_service_set_client_modal_state(struct xrt_system_compositor *xsysc, i
 	// so calling from this IPC thread is safe even though the WndProc
 	// thread reads concurrently.
 	multi_compositor_update_input_forward(mc);
+}
+
+extern "C" xrt_result_t
+comp_d3d11_service_workspace_post_file_picker_request(struct xrt_system_compositor *xsysc,
+                                                      int slot,
+                                                      const struct ipc_file_picker_info *info,
+                                                      uint64_t *out_request_id)
+{
+	if (xsysc == nullptr || info == nullptr || out_request_id == nullptr) {
+		return XRT_ERROR_IPC_FAILURE;
+	}
+	struct d3d11_service_system *sys = d3d11_service_system_from_xrt(xsysc);
+	struct d3d11_multi_compositor *mc = sys->multi_comp;
+	if (mc == nullptr) {
+		return XRT_ERROR_IPC_FAILURE;
+	}
+	std::lock_guard<std::recursive_mutex> lock(sys->render_mutex);
+	if (slot < 0 || slot >= D3D11_MULTI_MAX_CLIENTS || !mc->clients[slot].active) {
+		return XRT_ERROR_IPC_FAILURE;
+	}
+
+	size_t entry_count = sizeof(mc->file_picker) / sizeof(mc->file_picker[0]);
+	for (size_t i = 0; i < entry_count; i++) {
+		if (mc->file_picker[i].in_use) continue;
+		mc->next_file_picker_request_id++;
+		if (mc->next_file_picker_request_id == 0) {
+			mc->next_file_picker_request_id = 1; // never hand out 0 (XR_NULL_ASYNC_REQUEST_ID_EXT).
+		}
+		mc->file_picker[i].in_use = true;
+		mc->file_picker[i].needs_emit = true;
+		mc->file_picker[i].owner_slot = slot;
+		mc->file_picker[i].request_id = mc->next_file_picker_request_id;
+		mc->file_picker[i].info = *info;
+		*out_request_id = mc->file_picker[i].request_id;
+		U_LOG_W("file_picker: queued request_id=%llu (slot=%d, mode=%u, filters=%u)",
+		        (unsigned long long)mc->file_picker[i].request_id, slot,
+		        info->mode, info->filter_count);
+		return XRT_SUCCESS;
+	}
+
+	U_LOG_W("file_picker: pending table full (%zu entries); rejecting request",
+	        entry_count);
+	*out_request_id = 0;
+	return XRT_ERROR_IPC_FAILURE;
+}
+
+extern "C" xrt_result_t
+comp_d3d11_service_workspace_get_file_picker_request(struct xrt_system_compositor *xsysc,
+                                                     uint64_t request_id,
+                                                     uint32_t *out_found,
+                                                     uint32_t *out_client_id,
+                                                     struct ipc_file_picker_info *out_info)
+{
+	if (out_found != nullptr) *out_found = 0;
+	if (out_client_id != nullptr) *out_client_id = 0;
+	if (out_info != nullptr) memset(out_info, 0, sizeof(*out_info));
+
+	if (xsysc == nullptr || request_id == 0) {
+		return XRT_SUCCESS; // not-found semantics, not an error.
+	}
+	struct d3d11_service_system *sys = d3d11_service_system_from_xrt(xsysc);
+	struct d3d11_multi_compositor *mc = sys->multi_comp;
+	if (mc == nullptr) {
+		return XRT_SUCCESS;
+	}
+	std::lock_guard<std::recursive_mutex> lock(sys->render_mutex);
+	size_t entry_count = sizeof(mc->file_picker) / sizeof(mc->file_picker[0]);
+	for (size_t i = 0; i < entry_count; i++) {
+		if (!mc->file_picker[i].in_use) continue;
+		if (mc->file_picker[i].request_id != request_id) continue;
+		int s = mc->file_picker[i].owner_slot;
+		if (s < 0 || s >= D3D11_MULTI_MAX_CLIENTS) continue;
+		if (out_found != nullptr) *out_found = 1;
+		if (out_client_id != nullptr) *out_client_id = mc->clients[s].workspace_client_id;
+		if (out_info != nullptr) *out_info = mc->file_picker[i].info;
+		return XRT_SUCCESS;
+	}
+	return XRT_SUCCESS;
+}
+
+extern "C" xrt_result_t
+comp_d3d11_service_workspace_file_picker_result(struct xrt_system_compositor *xsysc,
+                                                uint64_t request_id,
+                                                uint32_t result_code,
+                                                const struct ipc_file_picker_result_path *path)
+{
+	if (xsysc == nullptr || request_id == 0) {
+		return XRT_ERROR_IPC_FAILURE;
+	}
+	struct d3d11_service_system *sys = d3d11_service_system_from_xrt(xsysc);
+	struct d3d11_multi_compositor *mc = sys->multi_comp;
+	if (mc == nullptr) {
+		return XRT_ERROR_IPC_FAILURE;
+	}
+	std::lock_guard<std::recursive_mutex> lock(sys->render_mutex);
+	size_t entry_count = sizeof(mc->file_picker) / sizeof(mc->file_picker[0]);
+	for (size_t i = 0; i < entry_count; i++) {
+		if (!mc->file_picker[i].in_use) continue;
+		if (mc->file_picker[i].request_id != request_id) continue;
+
+		int s = mc->file_picker[i].owner_slot;
+		mc->file_picker[i].in_use = false;
+		mc->file_picker[i].needs_emit = false;
+
+		if (s < 0 || s >= D3D11_MULTI_MAX_CLIENTS || !mc->clients[s].active ||
+		    mc->clients[s].compositor == nullptr) {
+			U_LOG_W("file_picker: dropping result for request_id=%llu (requesting slot %d is gone)",
+			        (unsigned long long)request_id, s);
+			return XRT_SUCCESS; // not an error path — late result is expected on requester crash.
+		}
+
+		struct xrt_session_event_sink *xses = mc->clients[s].compositor->xses;
+		if (xses == nullptr) {
+			U_LOG_W("file_picker: slot %d has no event sink — dropping result for %llu",
+			        s, (unsigned long long)request_id);
+			return XRT_SUCCESS;
+		}
+
+		union xrt_session_event xse = {};
+		xse.file_picker_complete.type = XRT_SESSION_EVENT_FILE_PICKER_COMPLETE;
+		xse.file_picker_complete.request_id = request_id;
+		xse.file_picker_complete.result = result_code;
+		if (path != nullptr) {
+			static_assert(sizeof(xse.file_picker_complete.path) >= IPC_FILE_PICKER_PATH_MAX,
+			              "session-event path buffer must hold a full IPC path");
+			memcpy(xse.file_picker_complete.path, path->path,
+			       sizeof(xse.file_picker_complete.path) - 1);
+			xse.file_picker_complete.path[sizeof(xse.file_picker_complete.path) - 1] = '\0';
+		}
+		xrt_session_event_sink_push(xses, &xse);
+		U_LOG_W("file_picker: delivered result_code=%u to slot %d (request_id=%llu)",
+		        result_code, s, (unsigned long long)request_id);
+		return XRT_SUCCESS;
+	}
+
+	U_LOG_W("file_picker: result for unknown request_id=%llu (already delivered or stale)",
+	        (unsigned long long)request_id);
+	return XRT_SUCCESS;
 }
 
 extern "C" bool

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.h
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.h
@@ -31,6 +31,8 @@ struct u_system;
 struct ipc_launcher_app;
 struct ipc_capture_result;
 struct ipc_workspace_chrome_layout;
+struct ipc_file_picker_info;
+struct ipc_file_picker_result_path;
 
 
 /*!
@@ -609,6 +611,56 @@ comp_d3d11_service_set_focused_slot(struct xrt_system_compositor *xsysc, int slo
  */
 void
 comp_d3d11_service_set_client_modal_state(struct xrt_system_compositor *xsysc, int slot, bool is_open);
+
+/*!
+ * XR_EXT_workspace_file_dialog (Tier 1): app-side
+ * `xrRequestFilePickerEXT` arrived as `session_request_file_picker`.
+ * The compositor allocates a monotonic request_id, stores a record
+ * keyed by (request_id → slot, info), and emits an
+ * IPC_WORKSPACE_INPUT_EVENT_FILE_PICKER_REQUEST event for the controller
+ * to drain. Returns XRT_SUCCESS and writes the allocated id to
+ * @p out_request_id; the controller fetches the full info via
+ * comp_d3d11_service_workspace_get_file_picker_request.
+ *
+ * Returns XRT_ERROR_IPC_FAILURE if no slot is bound (the call should
+ * not have reached the runtime in that case) or if the pending-request
+ * table is full.
+ */
+xrt_result_t
+comp_d3d11_service_workspace_post_file_picker_request(struct xrt_system_compositor *xsysc,
+                                                       int slot,
+                                                       const struct ipc_file_picker_info *info,
+                                                       uint64_t *out_request_id);
+
+/*!
+ * Controller-side fetch: resolve a request_id back to (client_id,
+ * info). Returns XRT_SUCCESS regardless of hit/miss; @p *out_found is
+ * set to 1 on hit, 0 on miss. The IPC layer returns the same struct on
+ * miss with a zeroed info, so the controller doesn't have to special-
+ * case error paths.
+ */
+xrt_result_t
+comp_d3d11_service_workspace_get_file_picker_request(struct xrt_system_compositor *xsysc,
+                                                      uint64_t request_id,
+                                                      uint32_t *out_found,
+                                                      uint32_t *out_client_id,
+                                                      struct ipc_file_picker_info *out_info);
+
+/*!
+ * Controller-side: deliver a file-picker result. The runtime looks up
+ * the requesting slot, pushes XRT_SESSION_EVENT_FILE_PICKER_COMPLETE on
+ * its session-event sink, and drops the pending entry. Late results
+ * for a slot that no longer exists (requester crashed / session
+ * destroyed) are logged once and discarded.
+ *
+ * `result_code` is an `XrFilePickerResultEXT` value; `path` is
+ * NUL-terminated UTF-8 (empty for non-SUCCESS outcomes).
+ */
+xrt_result_t
+comp_d3d11_service_workspace_file_picker_result(struct xrt_system_compositor *xsysc,
+                                                 uint64_t request_id,
+                                                 uint32_t result_code,
+                                                 const struct ipc_file_picker_result_path *path);
 
 /*!
  * Workspace controller request to flip display rendering mode (#234).

--- a/src/xrt/include/xrt/xrt_openxr_includes.h
+++ b/src/xrt/include/xrt/xrt_openxr_includes.h
@@ -76,3 +76,4 @@ typedef __eglMustCastToProperFunctionPointerType (*PFNEGLGETPROCADDRESSPROC)(con
 #include "openxr/XR_EXT_display_info.h"
 #include "openxr/XR_EXT_spatial_workspace.h"
 #include "openxr/XR_EXT_app_launcher.h"
+#include "openxr/XR_EXT_workspace_file_dialog.h"

--- a/src/xrt/include/xrt/xrt_session.h
+++ b/src/xrt/include/xrt/xrt_session.h
@@ -78,6 +78,10 @@ enum xrt_session_event_type
 
 	//! The hardware display 3D state has changed (XR_EXT_display_info).
 	XRT_SESSION_EVENT_HARDWARE_DISPLAY_STATE_CHANGE = 13,
+
+	//! XR_EXT_workspace_file_dialog: pending xrRequestFilePickerEXT
+	//! completed (success / cancel / picker-failed).
+	XRT_SESSION_EVENT_FILE_PICKER_COMPLETE = 14,
 };
 
 /*!
@@ -220,6 +224,23 @@ struct xrt_session_event_hardware_display_state_change
 };
 
 /*!
+ * Spatial file-picker completion event, type @ref XRT_SESSION_EVENT_FILE_PICKER_COMPLETE.
+ *
+ * `path` is plain UTF-8, NUL-terminated within
+ * `XRT_FILE_PICKER_PATH_MAX_BYTES`. The OXR state tracker copies it
+ * into `XrEventDataFilePickerCompleteEXT.path` on
+ * receipt and pushes the OpenXR event to the requesting session.
+ */
+#define XRT_FILE_PICKER_PATH_MAX_BYTES 512  // Matches IPC_FILE_PICKER_PATH_MAX.
+struct xrt_session_event_file_picker_complete
+{
+	enum xrt_session_event_type type;
+	uint32_t result;                          //!< XrFilePickerResultEXT
+	XRT_ALIGNAS(8) uint64_t request_id;       //!< xrRequestFilePickerEXT out-param
+	char path[XRT_FILE_PICKER_PATH_MAX_BYTES];
+};
+
+/*!
  * Union of all session events, used to return multiple events through one call.
  * Each event struct must start with a @ref xrt_session_event_type field.
  *
@@ -240,6 +261,7 @@ union xrt_session_event {
 	struct xrt_session_event_user_presence_change presence_change;
 	struct xrt_session_event_rendering_mode_change rendering_mode_change;
 	struct xrt_session_event_hardware_display_state_change hardware_display_state_change;
+	struct xrt_session_event_file_picker_complete file_picker_complete;
 };
 
 /*!

--- a/src/xrt/include/xrt/xrt_session.h
+++ b/src/xrt/include/xrt/xrt_session.h
@@ -231,7 +231,7 @@ struct xrt_session_event_hardware_display_state_change
  * into `XrEventDataFilePickerCompleteEXT.path` on
  * receipt and pushes the OpenXR event to the requesting session.
  */
-#define XRT_FILE_PICKER_PATH_MAX_BYTES 512  // Matches IPC_FILE_PICKER_PATH_MAX.
+#define XRT_FILE_PICKER_PATH_MAX_BYTES 256  // Matches IPC_FILE_PICKER_PATH_MAX.
 struct xrt_session_event_file_picker_complete
 {
 	enum xrt_session_event_type type;

--- a/src/xrt/ipc/client/ipc_client.h
+++ b/src/xrt/ipc/client/ipc_client.h
@@ -200,6 +200,19 @@ comp_ipc_client_compositor_workspace_deactivate(struct xrt_compositor *xc);
 xrt_result_t
 comp_ipc_client_compositor_session_set_modal_state(struct xrt_compositor *xc, bool is_open);
 
+/*!
+ * XR_EXT_workspace_file_dialog Tier 1: app-side `xrRequestFilePickerEXT`
+ * dispatches here. The runtime forwards the (info) struct to the active
+ * workspace controller and returns a monotonic 64-bit request_id; the
+ * eventual completion is delivered through the session event channel as
+ * @ref XRT_SESSION_EVENT_FILE_PICKER_COMPLETE.
+ */
+struct ipc_file_picker_info;
+xrt_result_t
+comp_ipc_client_compositor_session_request_file_picker(struct xrt_compositor *xc,
+                                                       const struct ipc_file_picker_info *info,
+                                                       uint64_t *out_request_id);
+
 xrt_result_t
 comp_ipc_client_compositor_workspace_get_state(struct xrt_compositor *xc, bool *out_active);
 

--- a/src/xrt/ipc/client/ipc_client.h
+++ b/src/xrt/ipc/client/ipc_client.h
@@ -208,10 +208,31 @@ comp_ipc_client_compositor_session_set_modal_state(struct xrt_compositor *xc, bo
  * @ref XRT_SESSION_EVENT_FILE_PICKER_COMPLETE.
  */
 struct ipc_file_picker_info;
+struct ipc_file_picker_result_path;
 xrt_result_t
 comp_ipc_client_compositor_session_request_file_picker(struct xrt_compositor *xc,
                                                        const struct ipc_file_picker_info *info,
                                                        uint64_t *out_request_id);
+
+/*!
+ * Controller-only: read the picker info for a pending request by id.
+ * Backs xrGetFilePickerRequestEXT.
+ */
+xrt_result_t
+comp_ipc_client_compositor_workspace_get_file_picker_request(struct xrt_compositor *xc,
+                                                             uint64_t request_id,
+                                                             uint32_t *out_found,
+                                                             uint32_t *out_client_id,
+                                                             struct ipc_file_picker_info *out_info);
+
+/*!
+ * Controller-only: deliver a picker result. Backs xrCompleteFilePickerEXT.
+ */
+xrt_result_t
+comp_ipc_client_compositor_workspace_file_dialog_result(struct xrt_compositor *xc,
+                                                        uint64_t request_id,
+                                                        uint32_t result_code,
+                                                        const struct ipc_file_picker_result_path *path);
 
 xrt_result_t
 comp_ipc_client_compositor_workspace_get_state(struct xrt_compositor *xc, bool *out_active);

--- a/src/xrt/ipc/client/ipc_client_compositor.c
+++ b/src/xrt/ipc/client/ipc_client_compositor.c
@@ -336,6 +336,39 @@ comp_ipc_client_compositor_session_request_file_picker(struct xrt_compositor *xc
 }
 
 xrt_result_t
+comp_ipc_client_compositor_workspace_get_file_picker_request(struct xrt_compositor *xc,
+                                                             uint64_t request_id,
+                                                             uint32_t *out_found,
+                                                             uint32_t *out_client_id,
+                                                             struct ipc_file_picker_info *out_info)
+{
+	if (xc == NULL || out_found == NULL || out_client_id == NULL || out_info == NULL) {
+		return XRT_ERROR_IPC_FAILURE;
+	}
+	struct ipc_client_compositor *icc = ipc_client_compositor(xc);
+	if (icc == NULL || icc->ipc_c == NULL) {
+		return XRT_ERROR_IPC_FAILURE;
+	}
+	return ipc_call_workspace_get_file_picker_request(icc->ipc_c, request_id, out_found, out_client_id, out_info);
+}
+
+xrt_result_t
+comp_ipc_client_compositor_workspace_file_dialog_result(struct xrt_compositor *xc,
+                                                        uint64_t request_id,
+                                                        uint32_t result_code,
+                                                        const struct ipc_file_picker_result_path *path)
+{
+	if (xc == NULL || path == NULL) {
+		return XRT_ERROR_IPC_FAILURE;
+	}
+	struct ipc_client_compositor *icc = ipc_client_compositor(xc);
+	if (icc == NULL || icc->ipc_c == NULL) {
+		return XRT_ERROR_IPC_FAILURE;
+	}
+	return ipc_call_workspace_file_dialog_result(icc->ipc_c, request_id, result_code, path);
+}
+
+xrt_result_t
 comp_ipc_client_compositor_workspace_get_state(struct xrt_compositor *xc, bool *out_active)
 {
 	if (xc == NULL || out_active == NULL) {
@@ -606,6 +639,10 @@ comp_ipc_client_compositor_workspace_enumerate_input_events(struct xrt_composito
 		case IPC_WORKSPACE_INPUT_EVENT_MODAL_OPEN:
 		case IPC_WORKSPACE_INPUT_EVENT_MODAL_CLOSE:
 			out->modal.clientId = (XrWorkspaceClientId)src->u.modal.client_id;
+			break;
+		case IPC_WORKSPACE_INPUT_EVENT_FILE_PICKER_REQUEST:
+			out->filePickerRequest.clientId = (XrWorkspaceClientId)src->u.file_picker_request.client_id;
+			out->filePickerRequest.requestId = src->u.file_picker_request.request_id;
 			break;
 		default:
 			break;

--- a/src/xrt/ipc/client/ipc_client_compositor.c
+++ b/src/xrt/ipc/client/ipc_client_compositor.c
@@ -320,6 +320,22 @@ comp_ipc_client_compositor_session_set_modal_state(struct xrt_compositor *xc, bo
 }
 
 xrt_result_t
+comp_ipc_client_compositor_session_request_file_picker(struct xrt_compositor *xc,
+                                                       const struct ipc_file_picker_info *info,
+                                                       uint64_t *out_request_id)
+{
+	if (xc == NULL || info == NULL || out_request_id == NULL) {
+		return XRT_ERROR_IPC_FAILURE;
+	}
+	*out_request_id = 0;
+	struct ipc_client_compositor *icc = ipc_client_compositor(xc);
+	if (icc == NULL || icc->ipc_c == NULL) {
+		return XRT_ERROR_IPC_FAILURE;
+	}
+	return ipc_call_session_request_file_picker(icc->ipc_c, info, out_request_id);
+}
+
+xrt_result_t
 comp_ipc_client_compositor_workspace_get_state(struct xrt_compositor *xc, bool *out_active)
 {
 	if (xc == NULL || out_active == NULL) {

--- a/src/xrt/ipc/server/ipc_server.h
+++ b/src/xrt/ipc/server/ipc_server.h
@@ -572,6 +572,24 @@ typedef unsigned long (*ipc_server_workspace_pid_provider_fn)(void);
 void
 ipc_server_set_workspace_pid_provider(ipc_server_workspace_pid_provider_fn fn);
 
+/*!
+ * Function pointer the IPC server calls to learn whether the active
+ * workspace controller advertises Tier 1 file-dialog support (registry
+ * value `SupportsFileDialog = REG_DWORD 1` under its registration).
+ * Returns false if no orchestrator-managed workspace is running or
+ * the controller did not opt in. Drives the early fallback in
+ * `xrRequestFilePickerEXT` — without it, requests would queue for a
+ * controller that has no handler.
+ */
+typedef bool (*ipc_server_workspace_supports_file_dialog_fn)(void);
+
+/*!
+ * Register the file-dialog-capability provider. Same lifetime model
+ * as `ipc_server_set_workspace_pid_provider`. Pass NULL to clear.
+ */
+void
+ipc_server_set_workspace_supports_file_dialog_provider(ipc_server_workspace_supports_file_dialog_fn fn);
+
 /*
  *
  * Helpers

--- a/src/xrt/ipc/server/ipc_server_handler.c
+++ b/src/xrt/ipc/server/ipc_server_handler.c
@@ -69,6 +69,20 @@ get_orchestrator_workspace_pid(void)
 	return s_workspace_pid_provider ? s_workspace_pid_provider() : 0;
 }
 
+static ipc_server_workspace_supports_file_dialog_fn s_workspace_file_dialog_provider = NULL;
+
+void
+ipc_server_set_workspace_supports_file_dialog_provider(ipc_server_workspace_supports_file_dialog_fn fn)
+{
+	s_workspace_file_dialog_provider = fn;
+}
+
+static bool
+orchestrator_workspace_supports_file_dialog(void)
+{
+	return s_workspace_file_dialog_provider ? s_workspace_file_dialog_provider() : false;
+}
+
 
 /*
  *
@@ -964,6 +978,15 @@ ipc_handle_session_request_file_picker(volatile struct ipc_client_state *ics,
 		// compositor) — there's no controller to forward to. Surface
 		// as IPC failure so the OXR layer can return the fallback
 		// result code to the app.
+		return XRT_ERROR_IPC_FAILURE;
+	}
+	if (!orchestrator_workspace_supports_file_dialog()) {
+		// Controller is registered but did not advertise
+		// `SupportsFileDialog = 1`. Queuing the event would
+		// strand it on the drain channel forever; surface as
+		// failure so the OXR layer returns
+		// XR_FILE_PICKER_FALLBACK_TIER0_EXT and the app falls
+		// back to a flat OS dialog (Tier 0 hook handles z/focus).
 		return XRT_ERROR_IPC_FAILURE;
 	}
 	return comp_d3d11_service_workspace_post_file_picker_request(s->xsysc, slot, info, out_request_id);

--- a/src/xrt/ipc/server/ipc_server_handler.c
+++ b/src/xrt/ipc/server/ipc_server_handler.c
@@ -935,6 +935,46 @@ ipc_handle_session_destroy(volatile struct ipc_client_state *ics)
 }
 
 xrt_result_t
+ipc_handle_session_request_file_picker(volatile struct ipc_client_state *ics,
+                                       const struct ipc_file_picker_info *info,
+                                       uint64_t *out_request_id)
+{
+	IPC_TRACE_MARKER();
+
+	if (out_request_id != NULL) {
+		*out_request_id = 0;
+	}
+
+	// XR_EXT_workspace_file_dialog Tier 1: app-side xrRequestFilePickerEXT.
+	// The runtime allocates a monotonic request_id, stores (request_id ->
+	// requesting slot, info) on the multi-compositor, and emits a
+	// FILE_PICKER_REQUEST event into the workspace input drain so the
+	// controller can spawn its picker exe. Any workspace client may call
+	// this — no PID auth (the OXR layer's recursion guard already rejects
+	// calls from the active workspace controller's own session).
+
+#if defined(XRT_HAVE_D3D11_SERVICE_COMPOSITOR)
+	struct ipc_server *s = ics->server;
+	if (s->xsysc == NULL || ics->xc == NULL || info == NULL || out_request_id == NULL) {
+		return XRT_ERROR_IPC_FAILURE;
+	}
+	int slot = comp_d3d11_service_workspace_find_slot_by_xc(s->xsysc, (struct xrt_compositor *)ics->xc);
+	if (slot < 0) {
+		// Caller isn't a workspace participant (standalone in-process
+		// compositor) — there's no controller to forward to. Surface
+		// as IPC failure so the OXR layer can return the fallback
+		// result code to the app.
+		return XRT_ERROR_IPC_FAILURE;
+	}
+	return comp_d3d11_service_workspace_post_file_picker_request(s->xsysc, slot, info, out_request_id);
+#else
+	(void)ics;
+	(void)info;
+	return XRT_ERROR_IPC_FAILURE;
+#endif
+}
+
+xrt_result_t
 ipc_handle_session_set_modal_state(volatile struct ipc_client_state *ics, bool is_open)
 {
 	IPC_TRACE_MARKER();
@@ -3215,6 +3255,71 @@ ipc_handle_workspace_set_chrome_layout(volatile struct ipc_client_state *_ics,
 	(void)s;
 	(void)client_id;
 	(void)layout;
+	return XRT_ERROR_IPC_FAILURE;
+#endif
+}
+
+xrt_result_t
+ipc_handle_workspace_get_file_picker_request(volatile struct ipc_client_state *_ics,
+                                             uint64_t request_id,
+                                             uint32_t *out_found,
+                                             uint32_t *out_client_id,
+                                             struct ipc_file_picker_info *out_info)
+{
+	struct ipc_server *s = _ics->server;
+
+	if (out_found != NULL) *out_found = 0;
+	if (out_client_id != NULL) *out_client_id = 0;
+	if (out_info != NULL) memset(out_info, 0, sizeof(*out_info));
+
+#if defined(XRT_HAVE_D3D11_SERVICE_COMPOSITOR)
+	if (s->xsysc == NULL) {
+		return XRT_ERROR_IPC_FAILURE;
+	}
+
+	// Auth: only the workspace controller may read the full picker info.
+	unsigned long expected_pid = get_orchestrator_workspace_pid();
+	unsigned long caller_pid = (unsigned long)_ics->client_state.pid;
+	if (expected_pid != 0 && caller_pid != expected_pid) {
+		return XRT_ERROR_NOT_AUTHORIZED;
+	}
+
+	return comp_d3d11_service_workspace_get_file_picker_request(s->xsysc, request_id,
+	                                                            out_found, out_client_id, out_info);
+#else
+	(void)s;
+	(void)request_id;
+	return XRT_ERROR_IPC_FAILURE;
+#endif
+}
+
+xrt_result_t
+ipc_handle_workspace_file_dialog_result(volatile struct ipc_client_state *_ics,
+                                        uint64_t request_id,
+                                        uint32_t result_code,
+                                        const struct ipc_file_picker_result_path *path)
+{
+	struct ipc_server *s = _ics->server;
+#if defined(XRT_HAVE_D3D11_SERVICE_COMPOSITOR)
+	if (s->xsysc == NULL) {
+		return XRT_ERROR_IPC_FAILURE;
+	}
+
+	// Auth: only the workspace controller may post a picker result. Without
+	// this, a malicious workspace client could complete another client's
+	// pending picker with an arbitrary path.
+	unsigned long expected_pid = get_orchestrator_workspace_pid();
+	unsigned long caller_pid = (unsigned long)_ics->client_state.pid;
+	if (expected_pid != 0 && caller_pid != expected_pid) {
+		return XRT_ERROR_NOT_AUTHORIZED;
+	}
+
+	return comp_d3d11_service_workspace_file_picker_result(s->xsysc, request_id, result_code, path);
+#else
+	(void)s;
+	(void)request_id;
+	(void)result_code;
+	(void)path;
 	return XRT_ERROR_IPC_FAILURE;
 #endif
 }

--- a/src/xrt/ipc/shared/ipc_protocol.h
+++ b/src/xrt/ipc/shared/ipc_protocol.h
@@ -343,6 +343,56 @@ struct ipc_launcher_app
 };
 
 /*!
+ * XR_EXT_workspace_file_dialog wire format. Flat IPC translation of
+ * XrFilePickerInfoEXT — no OpenXR-type dependency in IPC headers, no
+ * pointer chasing (the proto generator copies by value).
+ *
+ * Wire-side budgets are tighter than the public XR_MAX_FILE_PICKER_*_EXT
+ * limits so the whole struct fits inside a single IPC_BUF_SIZE
+ * (1024 byte) RPC message. The OXR translation truncates user-supplied
+ * paths/titles that exceed the wire budget and returns
+ * XR_ERROR_PATH_FORMAT_INVALID to the caller. Apps that need long-path
+ * support fall back to Tier 0.
+ *
+ * Field meanings match the public extension; see
+ * `docs/specs/extensions/XR_EXT_workspace_file_dialog.md`.
+ *
+ * @ingroup ipc
+ */
+#define IPC_FILE_PICKER_PATH_MAX     512   //!< Wire-format max; tighter than XR_MAX_FILE_PICKER_PATH_LENGTH_EXT.
+#define IPC_FILE_PICKER_TITLE_MAX    128   //!< Wire-format title size.
+#define IPC_FILE_PICKER_FILTER_MAX   64    //!< Wire-format filter description / extensions size.
+#define IPC_FILE_PICKER_FILTERS_MAX  4     //!< Wire-format filter rows.
+
+struct ipc_file_picker_filter
+{
+	char description[IPC_FILE_PICKER_FILTER_MAX];
+	char extensions[IPC_FILE_PICKER_FILTER_MAX];
+};
+
+struct ipc_file_picker_info
+{
+	uint32_t mode;                                            //!< XrFilePickerModeEXT cast to uint32_t
+	uint32_t filter_count;
+	uint64_t flags;                                           //!< XrFilePickerFlagsEXT
+	char     title[IPC_FILE_PICKER_TITLE_MAX];
+	char     default_path[IPC_FILE_PICKER_PATH_MAX];
+	struct ipc_file_picker_filter filters[IPC_FILE_PICKER_FILTERS_MAX];
+};
+
+/*!
+ * Wrapper struct so the proto generator (which only marshals named
+ * struct types) can carry the picked path as a single argument to
+ * `workspace_file_dialog_result`.
+ *
+ * @ingroup ipc
+ */
+struct ipc_file_picker_result_path
+{
+	char path[IPC_FILE_PICKER_PATH_MAX];
+};
+
+/*!
  * Phase 2.D: workspace input event wire format. Tagged union with
  * event_type as the discriminator. Mirrors the public XrWorkspaceInputEventEXT
  * but uses plain C types (no XR enum dependency in IPC headers). The state
@@ -371,6 +421,7 @@ enum ipc_workspace_input_event_type
 	IPC_WORKSPACE_INPUT_EVENT_WINDOW_POSE_CHANGED = 7, //!< spec_version 8: runtime-driven pose/size change
 	IPC_WORKSPACE_INPUT_EVENT_MODAL_OPEN          = 8, //!< spec_version 10: client opened a Win32 modal popup
 	IPC_WORKSPACE_INPUT_EVENT_MODAL_CLOSE         = 9, //!< spec_version 10: client's Win32 modal popup closed
+	IPC_WORKSPACE_INPUT_EVENT_FILE_PICKER_REQUEST = 10, //!< spec_version 11: client called xrRequestFilePickerEXT
 };
 
 struct ipc_workspace_input_event
@@ -457,6 +508,16 @@ struct ipc_workspace_input_event
 		{
 			uint32_t client_id;
 		} modal;
+		struct                      //!< spec_version 11: spatial file-picker request
+		{
+			// Payload is intentionally minimal so the event batch stays
+			// under IPC_BUF_SIZE. The controller fetches the full
+			// XrFilePickerInfoEXT-equivalent via
+			// `workspace_get_file_picker_request(request_id)`.
+			uint32_t client_id;
+			uint32_t _pad;
+			uint64_t request_id;
+		} file_picker_request;
 	} u;
 };
 

--- a/src/xrt/ipc/shared/ipc_protocol.h
+++ b/src/xrt/ipc/shared/ipc_protocol.h
@@ -359,7 +359,7 @@ struct ipc_launcher_app
  *
  * @ingroup ipc
  */
-#define IPC_FILE_PICKER_PATH_MAX     512   //!< Wire-format max; tighter than XR_MAX_FILE_PICKER_PATH_LENGTH_EXT.
+#define IPC_FILE_PICKER_PATH_MAX     256   //!< Matches XR_MAX_FILE_PICKER_PATH_LENGTH_EXT. Sized so the encompassing IPC msg fits IPC_BUF_SIZE.
 #define IPC_FILE_PICKER_TITLE_MAX    128   //!< Wire-format title size.
 #define IPC_FILE_PICKER_FILTER_MAX   64    //!< Wire-format filter description / extensions size.
 #define IPC_FILE_PICKER_FILTERS_MAX  4     //!< Wire-format filter rows.

--- a/src/xrt/ipc/shared/proto.json
+++ b/src/xrt/ipc/shared/proto.json
@@ -258,6 +258,25 @@
 		]
 	},
 
+	"workspace_get_file_picker_request": {
+		"in": [
+			{"name": "request_id", "type": "uint64_t"}
+		],
+		"out": [
+			{"name": "found", "type": "uint32_t"},
+			{"name": "client_id", "type": "uint32_t"},
+			{"name": "info", "type": "struct ipc_file_picker_info"}
+		]
+	},
+
+	"workspace_file_dialog_result": {
+		"in": [
+			{"name": "request_id", "type": "uint64_t"},
+			{"name": "result_code", "type": "uint32_t"},
+			{"name": "path", "type": "struct ipc_file_picker_result_path"}
+		]
+	},
+
 	"system_devices_get_roles": {
 		"out": [
 			{"name": "system_roles", "type": "struct xrt_system_roles"}
@@ -308,6 +327,15 @@
 	"session_set_modal_state": {
 		"in": [
 			{"name": "is_open", "type": "bool"}
+		]
+	},
+
+	"session_request_file_picker": {
+		"in": [
+			{"name": "info", "type": "struct ipc_file_picker_info"}
+		],
+		"out": [
+			{"name": "request_id", "type": "uint64_t"}
 		]
 	},
 

--- a/src/xrt/state_trackers/oxr/CMakeLists.txt
+++ b/src/xrt/state_trackers/oxr/CMakeLists.txt
@@ -49,6 +49,7 @@ add_library(
 	oxr_workspace.c
 	oxr_workspace_modal_win32.c
 	oxr_app_launcher.c
+	oxr_workspace_file_dialog.c
 	oxr_xdev.c
 	${CMAKE_CURRENT_BINARY_DIR}/oxr_bindings/b_oxr_generated_bindings.c
 	${CMAKE_CURRENT_BINARY_DIR}/oxr_bindings/b_oxr_generated_bindings.h

--- a/src/xrt/state_trackers/oxr/oxr_api_funcs.h
+++ b/src/xrt/state_trackers/oxr/oxr_api_funcs.h
@@ -919,6 +919,14 @@ XRAPI_ATTR XrResult XRAPI_CALL
 oxr_xrSetLauncherRunningTileMaskEXT(XrSession session, uint64_t mask);
 #endif
 
+#ifdef OXR_HAVE_EXT_workspace_file_dialog
+//! OpenXR API function @ep{xrRequestFilePickerEXT}
+XRAPI_ATTR XrResult XRAPI_CALL
+oxr_xrRequestFilePickerEXT(XrSession session,
+                           const XrFilePickerInfoEXT *info,
+                           XrAsyncRequestIdEXT *requestId);
+#endif
+
 // xrSetSharedTextureOutputRectEXT — canvas sub-rect, part of window binding extensions
 #if defined(OXR_HAVE_EXT_win32_window_binding) || defined(OXR_HAVE_EXT_cocoa_window_binding)
 //! OpenXR API function @ep{xrSetSharedTextureOutputRectEXT}

--- a/src/xrt/state_trackers/oxr/oxr_api_funcs.h
+++ b/src/xrt/state_trackers/oxr/oxr_api_funcs.h
@@ -925,6 +925,18 @@ XRAPI_ATTR XrResult XRAPI_CALL
 oxr_xrRequestFilePickerEXT(XrSession session,
                            const XrFilePickerInfoEXT *info,
                            XrAsyncRequestIdEXT *requestId);
+//! OpenXR API function @ep{xrGetFilePickerRequestEXT}
+XRAPI_ATTR XrResult XRAPI_CALL
+oxr_xrGetFilePickerRequestEXT(XrSession session,
+                              XrAsyncRequestIdEXT requestId,
+                              uint32_t *outClientId,
+                              XrFilePickerInfoEXT *outInfo);
+//! OpenXR API function @ep{xrCompleteFilePickerEXT}
+XRAPI_ATTR XrResult XRAPI_CALL
+oxr_xrCompleteFilePickerEXT(XrSession session,
+                            XrAsyncRequestIdEXT requestId,
+                            XrFilePickerResultEXT result,
+                            const char *path);
 #endif
 
 // xrSetSharedTextureOutputRectEXT — canvas sub-rect, part of window binding extensions

--- a/src/xrt/state_trackers/oxr/oxr_api_negotiate.c
+++ b/src/xrt/state_trackers/oxr/oxr_api_negotiate.c
@@ -476,6 +476,8 @@ handle_non_null(struct oxr_instance *inst, struct oxr_logger *log, const char *n
 
 #ifdef OXR_HAVE_EXT_workspace_file_dialog
 	ENTRY_IF_EXT(xrRequestFilePickerEXT, EXT_workspace_file_dialog);
+	ENTRY_IF_EXT(xrGetFilePickerRequestEXT, EXT_workspace_file_dialog);
+	ENTRY_IF_EXT(xrCompleteFilePickerEXT, EXT_workspace_file_dialog);
 #endif
 
 	// xrSetSharedTextureOutputRectEXT — canvas sub-rect, part of window binding extensions

--- a/src/xrt/state_trackers/oxr/oxr_api_negotiate.c
+++ b/src/xrt/state_trackers/oxr/oxr_api_negotiate.c
@@ -474,6 +474,10 @@ handle_non_null(struct oxr_instance *inst, struct oxr_logger *log, const char *n
 	ENTRY_IF_EXT(xrSetLauncherRunningTileMaskEXT, EXT_app_launcher);
 #endif
 
+#ifdef OXR_HAVE_EXT_workspace_file_dialog
+	ENTRY_IF_EXT(xrRequestFilePickerEXT, EXT_workspace_file_dialog);
+#endif
+
 	// xrSetSharedTextureOutputRectEXT — canvas sub-rect, part of window binding extensions
 #ifdef OXR_HAVE_EXT_win32_window_binding
 	ENTRY_IF_EXT(xrSetSharedTextureOutputRectEXT, EXT_win32_window_binding);

--- a/src/xrt/state_trackers/oxr/oxr_event.c
+++ b/src/xrt/state_trackers/oxr/oxr_event.c
@@ -144,6 +144,12 @@ is_session_link_to_event(struct oxr_event *event, XrSession session)
 		XrEventDataHardwareDisplayStateChangedEXT *changed = (XrEventDataHardwareDisplayStateChangedEXT *)type;
 		return changed->session == session;
 	}
+#ifdef OXR_HAVE_EXT_workspace_file_dialog
+	case XR_TYPE_EVENT_DATA_FILE_PICKER_COMPLETE_EXT: {
+		XrEventDataFilePickerCompleteEXT *complete = (XrEventDataFilePickerCompleteEXT *)type;
+		return complete->session == session;
+	}
+#endif
 	default: return false;
 	}
 }
@@ -430,6 +436,44 @@ oxr_event_push_XrEventDataHardwareDisplayStateChanged(struct oxr_logger *log,
 
 	return XR_SUCCESS;
 }
+
+#ifdef OXR_HAVE_EXT_workspace_file_dialog
+XrResult
+oxr_event_push_XrEventDataFilePickerComplete(struct oxr_logger *log,
+                                              struct oxr_session *sess,
+                                              XrAsyncRequestIdEXT requestId,
+                                              XrFilePickerResultEXT result,
+                                              const char *path)
+{
+	struct oxr_instance *inst = sess->sys->inst;
+	XrEventDataFilePickerCompleteEXT *complete;
+	struct oxr_event *event = NULL;
+
+	ALLOC(log, inst, &event, &complete);
+
+	complete->type = XR_TYPE_EVENT_DATA_FILE_PICKER_COMPLETE_EXT;
+	complete->next = NULL;
+	complete->session = oxr_session_to_openxr(sess);
+	complete->requestId = requestId;
+	complete->result = result;
+	// path[] was already zero-initialised by ALLOC (U_CALLOC_WITH_CAST).
+	if (result == XR_FILE_PICKER_RESULT_SUCCESS_EXT && path != NULL && path[0] != '\0') {
+		size_t len = strnlen(path, XR_MAX_FILE_PICKER_PATH_LENGTH_EXT - 1);
+		memcpy(complete->path, path, len);
+		complete->path[len] = '\0';
+	}
+	event->result = XR_SUCCESS;
+
+	U_LOG_I("OXR EVENT: File picker complete (requestId=%llu, result=%d)",
+	        (unsigned long long)requestId, (int)result);
+
+	lock(inst);
+	push(inst, event);
+	unlock(inst);
+
+	return XR_SUCCESS;
+}
+#endif // OXR_HAVE_EXT_workspace_file_dialog
 
 XrResult
 oxr_event_remove_session_events(struct oxr_logger *log, struct oxr_session *sess)

--- a/src/xrt/state_trackers/oxr/oxr_extension_support.h
+++ b/src/xrt/state_trackers/oxr/oxr_extension_support.h
@@ -586,6 +586,18 @@
 
 
 /*
+ * XR_EXT_workspace_file_dialog
+ */
+#if defined(XR_EXT_workspace_file_dialog) && defined(XR_USE_PLATFORM_WIN32)
+#define OXR_HAVE_EXT_workspace_file_dialog
+#define OXR_EXTENSION_SUPPORT_EXT_workspace_file_dialog(_) \
+    _(EXT_workspace_file_dialog, EXT_WORKSPACE_FILE_DIALOG)
+#else
+#define OXR_EXTENSION_SUPPORT_EXT_workspace_file_dialog(_)
+#endif
+
+
+/*
  * XR_BD_controller_interaction
  */
 #if defined(XR_BD_controller_interaction) && defined(XRT_FEATURE_OPENXR_INTERACTION_BYTEDANCE)
@@ -1063,6 +1075,7 @@
     OXR_EXTENSION_SUPPORT_EXT_display_info(_) \
     OXR_EXTENSION_SUPPORT_EXT_spatial_workspace(_) \
     OXR_EXTENSION_SUPPORT_EXT_app_launcher(_) \
+    OXR_EXTENSION_SUPPORT_EXT_workspace_file_dialog(_) \
     OXR_EXTENSION_SUPPORT_BD_controller_interaction(_) \
     OXR_EXTENSION_SUPPORT_FB_body_tracking(_) \
     OXR_EXTENSION_SUPPORT_FB_composition_layer_alpha_blend(_) \

--- a/src/xrt/state_trackers/oxr/oxr_objects.h
+++ b/src/xrt/state_trackers/oxr/oxr_objects.h
@@ -1149,6 +1149,26 @@ oxr_event_push_XrEventDataHardwareDisplayStateChanged(struct oxr_logger *log,
                                                        struct oxr_session *sess,
                                                        XrBool32 hardwareDisplay3D);
 
+#ifdef OXR_HAVE_EXT_workspace_file_dialog
+/*!
+ * Push an `XrEventDataFilePickerCompleteEXT` onto the instance event queue.
+ *
+ * Caller passes the originating session (used by `is_session_link_to_event`
+ * to route the event back to the requester on xrPollEvent), the
+ * monotonic request ID the runtime returned from `xrRequestFilePickerEXT`,
+ * the completion outcome, and the picked path (UTF-8, NUL-terminated).
+ *
+ * `path` may be NULL or empty for non-SUCCESS outcomes; in those cases
+ * the embedded buffer is zero-filled.
+ */
+XrResult
+oxr_event_push_XrEventDataFilePickerComplete(struct oxr_logger *log,
+                                              struct oxr_session *sess,
+                                              XrAsyncRequestIdEXT requestId,
+                                              XrFilePickerResultEXT result,
+                                              const char *path);
+#endif // OXR_HAVE_EXT_workspace_file_dialog
+
 #ifdef OXR_HAVE_FB_display_refresh_rate
 XrResult
 oxr_event_push_XrEventDataDisplayRefreshRateChangedFB(struct oxr_logger *log,

--- a/src/xrt/state_trackers/oxr/oxr_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_session.c
@@ -980,6 +980,15 @@ skip_macos_pump:
 			    xse.hardware_display_state_change.hardware_display_3d ? XR_TRUE : XR_FALSE);
 #endif // OXR_HAVE_EXT_display_info
 			break;
+		case XRT_SESSION_EVENT_FILE_PICKER_COMPLETE:
+#ifdef OXR_HAVE_EXT_workspace_file_dialog
+			oxr_event_push_XrEventDataFilePickerComplete(
+			    log, sess,
+			    (XrAsyncRequestIdEXT)xse.file_picker_complete.request_id,
+			    (XrFilePickerResultEXT)xse.file_picker_complete.result,
+			    xse.file_picker_complete.path);
+#endif // OXR_HAVE_EXT_workspace_file_dialog
+			break;
 		case XRT_SESSION_EVENT_EXIT_REQUEST:
 			// Runtime-initiated session exit (e.g. own window was closed).
 			// Drive the state machine to STOPPING so the app calls xrEndSession.

--- a/src/xrt/state_trackers/oxr/oxr_workspace_file_dialog.c
+++ b/src/xrt/state_trackers/oxr/oxr_workspace_file_dialog.c
@@ -26,12 +26,24 @@
 #include "oxr_api_funcs.h"
 #include "oxr_api_verify.h"
 
+#include "shared/ipc_protocol.h"
+
 #include <openxr/XR_EXT_workspace_file_dialog.h>
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <string.h>
 
 #ifdef OXR_HAVE_EXT_workspace_file_dialog
+
+// Forward declaration of the IPC client bridge — implementation lives in
+// ipc/client/ipc_client_compositor.c; we forward-declare here so the state
+// tracker doesn't have to pull the full ipc_client include path.
+struct xrt_compositor;
+xrt_result_t
+comp_ipc_client_compositor_session_request_file_picker(struct xrt_compositor *xc,
+                                                       const struct ipc_file_picker_info *info,
+                                                       uint64_t *out_request_id);
 
 static bool
 session_is_ipc_client(struct oxr_session *sess)
@@ -45,6 +57,58 @@ session_is_ipc_client(struct oxr_session *sess)
 		return false;
 	}
 	return true;
+}
+
+/*!
+ * Translate the public XrFilePickerInfoEXT to the wire-format
+ * ipc_file_picker_info. The wire format is intentionally tighter than the
+ * public ABI so the IPC payload fits inside IPC_BUF_SIZE — caller-supplied
+ * strings longer than the wire budget are rejected with
+ * XR_ERROR_PATH_FORMAT_INVALID so the picker never sees a truncated path.
+ */
+static XrResult
+translate_info(struct oxr_logger *log,
+               const XrFilePickerInfoEXT *in,
+               struct ipc_file_picker_info *out)
+{
+	memset(out, 0, sizeof(*out));
+	out->mode = (uint32_t)in->mode;
+	out->flags = (uint64_t)in->flags;
+
+	size_t title_len = strnlen(in->title, XR_MAX_FILE_PICKER_TITLE_LENGTH_EXT);
+	if (title_len >= sizeof(out->title)) {
+		return oxr_error(log, XR_ERROR_PATH_FORMAT_INVALID,
+		                 "(info->title) length %zu exceeds wire budget %zu",
+		                 title_len, sizeof(out->title) - 1);
+	}
+	memcpy(out->title, in->title, title_len);
+
+	size_t path_len = strnlen(in->defaultPath, XR_MAX_FILE_PICKER_PATH_LENGTH_EXT);
+	if (path_len >= sizeof(out->default_path)) {
+		return oxr_error(log, XR_ERROR_PATH_FORMAT_INVALID,
+		                 "(info->defaultPath) length %zu exceeds wire budget %zu",
+		                 path_len, sizeof(out->default_path) - 1);
+	}
+	memcpy(out->default_path, in->defaultPath, path_len);
+
+	if (in->filterCount > IPC_FILE_PICKER_FILTERS_MAX) {
+		return oxr_error(log, XR_ERROR_VALIDATION_FAILURE,
+		                 "(info->filterCount) %u exceeds wire budget %u",
+		                 in->filterCount, IPC_FILE_PICKER_FILTERS_MAX);
+	}
+	out->filter_count = in->filterCount;
+	for (uint32_t i = 0; i < in->filterCount; i++) {
+		size_t d = strnlen(in->filters[i].description, XR_MAX_FILE_PICKER_FILTER_LENGTH_EXT);
+		size_t e = strnlen(in->filters[i].extensions, XR_MAX_FILE_PICKER_FILTER_LENGTH_EXT);
+		if (d >= sizeof(out->filters[i].description) ||
+		    e >= sizeof(out->filters[i].extensions)) {
+			return oxr_error(log, XR_ERROR_PATH_FORMAT_INVALID,
+			                 "(info->filters[%u]) field exceeds wire budget", i);
+		}
+		memcpy(out->filters[i].description, in->filters[i].description, d);
+		memcpy(out->filters[i].extensions, in->filters[i].extensions, e);
+	}
+	return XR_SUCCESS;
 }
 
 XRAPI_ATTR XrResult XRAPI_CALL
@@ -115,21 +179,33 @@ oxr_xrRequestFilePickerEXT(XrSession session,
 		                 "xrRequestFilePickerEXT is not callable from a workspace controller session");
 	}
 
-	// PR C boundary: input is validated and we are in a position where the
-	// IPC dispatch SHOULD happen. The IPC RPC + capability lookup + Tier 0
-	// vs Tier 1 routing lands in PR B (workspace_request_file_dialog).
-	// Until then, any caller gets the documented success-class fallback
-	// signal so apps can be written and tested against the final ABI; once
-	// PR B lands, sessions whose controller advertises
-	// `SupportsFileDialog = 1` will instead receive a real request id and a
-	// later completion event.
-	static bool s_logged_stub = false;
-	if (!s_logged_stub) {
-		s_logged_stub = true;
-		U_LOG_W("xrRequestFilePickerEXT: returning XR_FILE_PICKER_FALLBACK_TIER0_EXT "
-		        "(IPC dispatch not yet implemented — see PR B for #228)");
+	// Translate to the wire format. Length-validation rejects user paths
+	// that wouldn't survive the IPC budget — the app can fall back to
+	// Tier 0 (flat OS dialog) if it needs long-path support.
+	struct ipc_file_picker_info ipc_info;
+	XrResult tr = translate_info(&log, info, &ipc_info);
+	if (tr != XR_SUCCESS) {
+		return tr;
 	}
-	return XR_FILE_PICKER_FALLBACK_TIER0_EXT;
+
+	// Dispatch through the IPC bridge. The runtime allocates a monotonic
+	// request_id, queues a FILE_PICKER_REQUEST event for the controller's
+	// drain channel, and returns. If the bridge fails (no workspace
+	// controller online, controller has not advertised file-dialog
+	// support, table full, …) we surface XR_FILE_PICKER_FALLBACK_TIER0_EXT
+	// so the app falls through to a flat OS dialog — Tier 0's CBT hook
+	// will handle z-order / focus on its own.
+	uint64_t allocated_id = 0;
+	xrt_result_t xret = comp_ipc_client_compositor_session_request_file_picker(
+	    &sess->xcn->base, &ipc_info, &allocated_id);
+	if (xret != XRT_SUCCESS || allocated_id == 0) {
+		U_LOG_I("xrRequestFilePickerEXT: bridge=%d, allocated_id=%llu — falling back to Tier 0",
+		        (int)xret, (unsigned long long)allocated_id);
+		return XR_FILE_PICKER_FALLBACK_TIER0_EXT;
+	}
+
+	*requestId = (XrAsyncRequestIdEXT)allocated_id;
+	return XR_SUCCESS;
 }
 
 #endif // OXR_HAVE_EXT_workspace_file_dialog

--- a/src/xrt/state_trackers/oxr/oxr_workspace_file_dialog.c
+++ b/src/xrt/state_trackers/oxr/oxr_workspace_file_dialog.c
@@ -1,0 +1,135 @@
+// Copyright 2026, DisplayXR
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  XR_EXT_workspace_file_dialog API entry points (Tier 1 spatial picker).
+ * @author DisplayXR
+ * @ingroup oxr_api
+ *
+ * Async request shape: the app calls xrRequestFilePickerEXT and later
+ * receives an XrEventDataFilePickerCompleteEXT via xrPollEvent. This TU
+ * owns input validation and the runtime-side fallback decision; the IPC
+ * dispatch + completion event push are wired in a separate PR alongside
+ * the new workspace_request_file_dialog / workspace_file_dialog_result
+ * RPCs.
+ *
+ * Pattern mirrors oxr_app_launcher.c (IPC-bridge forward declarations,
+ * session_is_ipc_client gate, xrt_result_t translation).
+ */
+
+#include "oxr_objects.h"
+#include "oxr_logger.h"
+
+#include "util/u_logging.h"
+#include "util/u_trace_marker.h"
+
+#include "oxr_api_funcs.h"
+#include "oxr_api_verify.h"
+
+#include <openxr/XR_EXT_workspace_file_dialog.h>
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef OXR_HAVE_EXT_workspace_file_dialog
+
+static bool
+session_is_ipc_client(struct oxr_session *sess)
+{
+	if (sess == NULL || sess->xcn == NULL || sess->sys == NULL || sess->sys->xsysc == NULL) {
+		return false;
+	}
+	if (sess->is_d3d11_native_compositor || sess->is_d3d12_native_compositor ||
+	    sess->is_metal_native_compositor || sess->is_gl_native_compositor ||
+	    sess->is_vk_native_compositor) {
+		return false;
+	}
+	return true;
+}
+
+XRAPI_ATTR XrResult XRAPI_CALL
+oxr_xrRequestFilePickerEXT(XrSession session,
+                           const XrFilePickerInfoEXT *info,
+                           XrAsyncRequestIdEXT *requestId)
+{
+	OXR_TRACE_MARKER();
+
+	struct oxr_session *sess = NULL;
+	struct oxr_logger log;
+	OXR_VERIFY_SESSION_AND_INIT_LOG(&log, session, sess, "xrRequestFilePickerEXT");
+	OXR_VERIFY_SESSION_NOT_LOST(&log, sess);
+	OXR_VERIFY_EXTENSION(&log, sess->sys->inst, EXT_workspace_file_dialog);
+
+	if (info == NULL) {
+		return oxr_error(&log, XR_ERROR_VALIDATION_FAILURE, "(info == NULL)");
+	}
+	if (info->type != XR_TYPE_FILE_PICKER_INFO_EXT) {
+		return oxr_error(&log, XR_ERROR_VALIDATION_FAILURE,
+		                 "(info->type) must be XR_TYPE_FILE_PICKER_INFO_EXT, got %d",
+		                 (int)info->type);
+	}
+	if (info->next != NULL) {
+		return oxr_error(&log, XR_ERROR_VALIDATION_FAILURE,
+		                 "(info->next) must be NULL in spec_version 1");
+	}
+	if (requestId == NULL) {
+		return oxr_error(&log, XR_ERROR_VALIDATION_FAILURE, "(requestId == NULL)");
+	}
+
+	switch (info->mode) {
+	case XR_FILE_PICKER_MODE_OPEN_EXT:
+	case XR_FILE_PICKER_MODE_SAVE_EXT:
+	case XR_FILE_PICKER_MODE_FOLDER_EXT: break;
+	default:
+		return oxr_error(&log, XR_ERROR_VALIDATION_FAILURE,
+		                 "(info->mode) invalid: %d", (int)info->mode);
+	}
+
+	if (info->filterCount > XR_MAX_FILE_PICKER_FILTERS_EXT) {
+		return oxr_error(&log, XR_ERROR_VALIDATION_FAILURE,
+		                 "(info->filterCount) %u > XR_MAX_FILE_PICKER_FILTERS_EXT (%u)",
+		                 info->filterCount, XR_MAX_FILE_PICKER_FILTERS_EXT);
+	}
+
+	if ((info->flags & XR_FILE_PICKER_FLAG_MULTI_SELECT_BIT_EXT) != 0) {
+		// Reserved bit; spec_version 1 picker UIs do not support multi-select.
+		return oxr_error(&log, XR_ERROR_FEATURE_UNSUPPORTED,
+		                 "MULTI_SELECT_BIT_EXT reserved for spec_version 2");
+	}
+
+	*requestId = XR_NULL_ASYNC_REQUEST_ID_EXT;
+
+	// Standalone (non-workspace) session: the extension is workspace-scoped.
+	// Apps in this state should call GetOpenFileName themselves; there's no
+	// Tier 0 hook installed either, so we don't promise fallback semantics.
+	if (!session_is_ipc_client(sess)) {
+		return oxr_error(&log, XR_ERROR_FEATURE_UNSUPPORTED,
+		                 "xrRequestFilePickerEXT requires a workspace (IPC-mode) session");
+	}
+
+	// Workspace controller calling its own picker would be a recursion
+	// (the picker IS a workspace client). Reject so we never spawn a picker
+	// from within the picker process or the shell itself.
+	if (sess->is_active_workspace_controller) {
+		return oxr_error(&log, XR_ERROR_VALIDATION_FAILURE,
+		                 "xrRequestFilePickerEXT is not callable from a workspace controller session");
+	}
+
+	// PR C boundary: input is validated and we are in a position where the
+	// IPC dispatch SHOULD happen. The IPC RPC + capability lookup + Tier 0
+	// vs Tier 1 routing lands in PR B (workspace_request_file_dialog).
+	// Until then, any caller gets the documented success-class fallback
+	// signal so apps can be written and tested against the final ABI; once
+	// PR B lands, sessions whose controller advertises
+	// `SupportsFileDialog = 1` will instead receive a real request id and a
+	// later completion event.
+	static bool s_logged_stub = false;
+	if (!s_logged_stub) {
+		s_logged_stub = true;
+		U_LOG_W("xrRequestFilePickerEXT: returning XR_FILE_PICKER_FALLBACK_TIER0_EXT "
+		        "(IPC dispatch not yet implemented — see PR B for #228)");
+	}
+	return XR_FILE_PICKER_FALLBACK_TIER0_EXT;
+}
+
+#endif // OXR_HAVE_EXT_workspace_file_dialog

--- a/src/xrt/state_trackers/oxr/oxr_workspace_file_dialog.c
+++ b/src/xrt/state_trackers/oxr/oxr_workspace_file_dialog.c
@@ -36,14 +36,26 @@
 
 #ifdef OXR_HAVE_EXT_workspace_file_dialog
 
-// Forward declaration of the IPC client bridge — implementation lives in
+// Forward declarations of the IPC client bridges — implementations live in
 // ipc/client/ipc_client_compositor.c; we forward-declare here so the state
 // tracker doesn't have to pull the full ipc_client include path.
 struct xrt_compositor;
+struct ipc_file_picker_result_path;
 xrt_result_t
 comp_ipc_client_compositor_session_request_file_picker(struct xrt_compositor *xc,
                                                        const struct ipc_file_picker_info *info,
                                                        uint64_t *out_request_id);
+xrt_result_t
+comp_ipc_client_compositor_workspace_get_file_picker_request(struct xrt_compositor *xc,
+                                                             uint64_t request_id,
+                                                             uint32_t *out_found,
+                                                             uint32_t *out_client_id,
+                                                             struct ipc_file_picker_info *out_info);
+xrt_result_t
+comp_ipc_client_compositor_workspace_file_dialog_result(struct xrt_compositor *xc,
+                                                        uint64_t request_id,
+                                                        uint32_t result_code,
+                                                        const struct ipc_file_picker_result_path *path);
 
 static bool
 session_is_ipc_client(struct oxr_session *sess)
@@ -205,6 +217,129 @@ oxr_xrRequestFilePickerEXT(XrSession session,
 	}
 
 	*requestId = (XrAsyncRequestIdEXT)allocated_id;
+	return XR_SUCCESS;
+}
+
+/*
+ * Controller-side entrypoints (paired with the runtime-only
+ * workspace_get_file_picker_request / workspace_file_dialog_result IPCs).
+ * Restricted to the active workspace controller — non-controller callers
+ * receive XR_ERROR_FEATURE_UNSUPPORTED.
+ */
+
+XRAPI_ATTR XrResult XRAPI_CALL
+oxr_xrGetFilePickerRequestEXT(XrSession session,
+                              XrAsyncRequestIdEXT requestId,
+                              uint32_t *outClientId,
+                              XrFilePickerInfoEXT *outInfo)
+{
+	OXR_TRACE_MARKER();
+
+	struct oxr_session *sess = NULL;
+	struct oxr_logger log;
+	OXR_VERIFY_SESSION_AND_INIT_LOG(&log, session, sess, "xrGetFilePickerRequestEXT");
+	OXR_VERIFY_SESSION_NOT_LOST(&log, sess);
+	OXR_VERIFY_EXTENSION(&log, sess->sys->inst, EXT_workspace_file_dialog);
+
+	if (outClientId == NULL || outInfo == NULL) {
+		return oxr_error(&log, XR_ERROR_VALIDATION_FAILURE, "(outClientId / outInfo NULL)");
+	}
+	if (requestId == XR_NULL_ASYNC_REQUEST_ID_EXT) {
+		return oxr_error(&log, XR_ERROR_VALIDATION_FAILURE, "(requestId == 0)");
+	}
+	*outClientId = 0;
+	memset(outInfo, 0, sizeof(*outInfo));
+
+	if (!session_is_ipc_client(sess)) {
+		return oxr_error(&log, XR_ERROR_FEATURE_UNSUPPORTED,
+		                 "xrGetFilePickerRequestEXT requires an IPC-mode session");
+	}
+	if (!sess->is_active_workspace_controller) {
+		return oxr_error(&log, XR_ERROR_FEATURE_UNSUPPORTED,
+		                 "xrGetFilePickerRequestEXT requires the active workspace controller session");
+	}
+
+	uint32_t found = 0;
+	uint32_t client_id = 0;
+	struct ipc_file_picker_info ipc_info;
+	memset(&ipc_info, 0, sizeof(ipc_info));
+	xrt_result_t xret = comp_ipc_client_compositor_workspace_get_file_picker_request(
+	    &sess->xcn->base, (uint64_t)requestId, &found, &client_id, &ipc_info);
+	if (xret != XRT_SUCCESS) {
+		return oxr_error(&log, XR_ERROR_RUNTIME_FAILURE, "workspace_get_file_picker_request: xrt_result=%d",
+		                 (int)xret);
+	}
+	if (!found) {
+		return oxr_error(&log, XR_ERROR_VALIDATION_FAILURE,
+		                 "xrGetFilePickerRequestEXT: no pending request for requestId=%llu",
+		                 (unsigned long long)requestId);
+	}
+
+	*outClientId = client_id;
+	outInfo->type = XR_TYPE_FILE_PICKER_INFO_EXT;
+	outInfo->next = NULL;
+	outInfo->mode = (XrFilePickerModeEXT)ipc_info.mode;
+	outInfo->flags = (XrFilePickerFlagsEXT)ipc_info.flags;
+	// All char fields fit by construction — wire budgets ≤ public budgets.
+	memcpy(outInfo->title, ipc_info.title,
+	       sizeof(ipc_info.title) < sizeof(outInfo->title) ? sizeof(ipc_info.title) : sizeof(outInfo->title) - 1);
+	memcpy(outInfo->defaultPath, ipc_info.default_path,
+	       sizeof(ipc_info.default_path) < sizeof(outInfo->defaultPath) ? sizeof(ipc_info.default_path)
+	                                                                    : sizeof(outInfo->defaultPath) - 1);
+	outInfo->filterCount = ipc_info.filter_count;
+	for (uint32_t i = 0; i < ipc_info.filter_count && i < XR_MAX_FILE_PICKER_FILTERS_EXT; i++) {
+		memcpy(outInfo->filters[i].description, ipc_info.filters[i].description,
+		       sizeof(ipc_info.filters[i].description));
+		memcpy(outInfo->filters[i].extensions, ipc_info.filters[i].extensions,
+		       sizeof(ipc_info.filters[i].extensions));
+	}
+	return XR_SUCCESS;
+}
+
+XRAPI_ATTR XrResult XRAPI_CALL
+oxr_xrCompleteFilePickerEXT(XrSession session,
+                            XrAsyncRequestIdEXT requestId,
+                            XrFilePickerResultEXT result,
+                            const char *path)
+{
+	OXR_TRACE_MARKER();
+
+	struct oxr_session *sess = NULL;
+	struct oxr_logger log;
+	OXR_VERIFY_SESSION_AND_INIT_LOG(&log, session, sess, "xrCompleteFilePickerEXT");
+	OXR_VERIFY_SESSION_NOT_LOST(&log, sess);
+	OXR_VERIFY_EXTENSION(&log, sess->sys->inst, EXT_workspace_file_dialog);
+
+	if (requestId == XR_NULL_ASYNC_REQUEST_ID_EXT) {
+		return oxr_error(&log, XR_ERROR_VALIDATION_FAILURE, "(requestId == 0)");
+	}
+	if (!session_is_ipc_client(sess)) {
+		return oxr_error(&log, XR_ERROR_FEATURE_UNSUPPORTED,
+		                 "xrCompleteFilePickerEXT requires an IPC-mode session");
+	}
+	if (!sess->is_active_workspace_controller) {
+		return oxr_error(&log, XR_ERROR_FEATURE_UNSUPPORTED,
+		                 "xrCompleteFilePickerEXT requires the active workspace controller session");
+	}
+
+	struct ipc_file_picker_result_path wire_path;
+	memset(&wire_path, 0, sizeof(wire_path));
+	if (result == XR_FILE_PICKER_RESULT_SUCCESS_EXT && path != NULL && path[0] != '\0') {
+		size_t len = strnlen(path, XR_MAX_FILE_PICKER_PATH_LENGTH_EXT);
+		if (len >= sizeof(wire_path.path)) {
+			return oxr_error(&log, XR_ERROR_PATH_FORMAT_INVALID,
+			                 "(path) length %zu exceeds wire budget %zu", len,
+			                 sizeof(wire_path.path) - 1);
+		}
+		memcpy(wire_path.path, path, len);
+	}
+
+	xrt_result_t xret = comp_ipc_client_compositor_workspace_file_dialog_result(
+	    &sess->xcn->base, (uint64_t)requestId, (uint32_t)result, &wire_path);
+	if (xret != XRT_SUCCESS) {
+		return oxr_error(&log, XR_ERROR_RUNTIME_FAILURE, "workspace_file_dialog_result: xrt_result=%d",
+		                 (int)xret);
+	}
 	return XR_SUCCESS;
 }
 

--- a/src/xrt/targets/service/main.c
+++ b/src/xrt/targets/service/main.c
@@ -133,6 +133,12 @@ WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdS
 	// controller we spawned may transition the runtime into workspace mode.
 	ipc_server_set_workspace_pid_provider(service_orchestrator_get_workspace_pid);
 
+	// Same plumbing for the file-dialog capability bit so the IPC server can
+	// short-circuit `session_request_file_picker` when the active controller
+	// did not opt in to Tier 1 — apps then fall back to a flat OS dialog.
+	ipc_server_set_workspace_supports_file_dialog_provider(
+	    service_orchestrator_get_workspace_supports_file_dialog);
+
 	u_trace_marker_init();
 	u_metrics_init();
 

--- a/src/xrt/targets/service/service_orchestrator.c
+++ b/src/xrt/targets/service/service_orchestrator.c
@@ -1061,6 +1061,13 @@ service_orchestrator_get_workspace_pid(void)
 	return 0;
 }
 
+bool
+service_orchestrator_get_workspace_supports_file_dialog(void)
+{
+	return s_workspace_available &&
+	       (s_workspace_active.capabilities & WORKSPACE_CAPABILITY_FILE_DIALOG) != 0;
+}
+
 void
 service_orchestrator_apply_config(const struct service_config *cfg)
 {
@@ -1202,6 +1209,12 @@ unsigned long
 service_orchestrator_get_workspace_pid(void)
 {
 	return 0;
+}
+
+bool
+service_orchestrator_get_workspace_supports_file_dialog(void)
+{
+	return false;
 }
 
 #endif // XRT_OS_WINDOWS

--- a/src/xrt/targets/service/service_orchestrator.h
+++ b/src/xrt/targets/service/service_orchestrator.h
@@ -118,6 +118,18 @@ service_orchestrator_dispatch_controller_action(const char *action_name);
 unsigned long
 service_orchestrator_get_workspace_pid(void);
 
+/*!
+ * Whether the active workspace controller advertises Tier 1 file-dialog
+ * support (registry value `SupportsFileDialog = REG_DWORD 1` under its
+ * `HKLM\Software\DisplayXR\WorkspaceControllers\<id>` key). Used by the
+ * IPC server to gate `session_request_file_picker` dispatch so apps
+ * fall back to a flat OS dialog when the controller has no picker.
+ *
+ * Returns false on non-Windows or when no controller is registered.
+ */
+bool
+service_orchestrator_get_workspace_supports_file_dialog(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/xrt/targets/service/service_workspace_registry.c
+++ b/src/xrt/targets/service/service_workspace_registry.c
@@ -26,6 +26,21 @@ file_exists(const char *path)
 	return attrs != INVALID_FILE_ATTRIBUTES && !(attrs & FILE_ATTRIBUTE_DIRECTORY);
 }
 
+//! Read a REG_DWORD value. Returns 0 on miss or wrong type.
+static uint32_t
+read_reg_dword(HKEY key, const char *value_name)
+{
+	DWORD type = 0;
+	DWORD value = 0;
+	DWORD size = sizeof(value);
+	LSTATUS rc = RegQueryValueExA(key, value_name, NULL, &type,
+	                              (LPBYTE)&value, &size);
+	if (rc != ERROR_SUCCESS || type != REG_DWORD) {
+		return 0;
+	}
+	return (uint32_t)value;
+}
+
 //! Read a REG_SZ value into a fixed-size buffer. Returns false on miss
 //! or oversize. On false, the buffer is zeroed.
 static bool
@@ -146,6 +161,10 @@ populate_from_subkey(const char *id, HKEY subkey,
 	read_reg_string(subkey, "Version", entry->version, sizeof(entry->version));
 	read_reg_string(subkey, "UninstallString", entry->uninstall_string,
 	                sizeof(entry->uninstall_string));
+
+	if (read_reg_dword(subkey, "SupportsFileDialog") != 0) {
+		entry->capabilities |= WORKSPACE_CAPABILITY_FILE_DIALOG;
+	}
 
 	populate_actions(subkey, entry);
 

--- a/src/xrt/targets/service/service_workspace_registry.h
+++ b/src/xrt/targets/service/service_workspace_registry.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <stdbool.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -51,6 +52,33 @@ struct workspace_controller_action
 #define WORKSPACE_REGISTRY_MAX_ACTIONS 16
 
 /*!
+ * Optional capability bits a controller may advertise.
+ *
+ * Each bit corresponds to a separate `REG_DWORD` value name under the
+ * controller's `HKLM\Software\DisplayXR\WorkspaceControllers\<id>` key.
+ * A value of `1` (any non-zero) enables the bit; missing values default
+ * to 0. The runtime tests these bits when deciding whether to dispatch
+ * a feature to the controller or fall back.
+ *
+ * Forward-compatible: unknown registry values are ignored; controllers
+ * never need to declare bits they don't implement.
+ */
+enum workspace_controller_capability
+{
+	/*!
+	 * Controller hosts a spatial file picker
+	 * (XR_EXT_workspace_file_dialog Tier 1).
+	 *
+	 * Registry value: `SupportsFileDialog = REG_DWORD 1`.
+	 *
+	 * Without this bit set, `xrRequestFilePickerEXT` returns
+	 * `XR_FILE_PICKER_FALLBACK_TIER0_EXT` and the app is expected to
+	 * fall back to a flat OS dialog (Tier 0 handles z-order / focus).
+	 */
+	WORKSPACE_CAPABILITY_FILE_DIALOG = 1u << 0,
+};
+
+/*!
  * Registered workspace controller. Populated from a subkey of
  * `HKLM\Software\DisplayXR\WorkspaceControllers\<id>`. Workspace apps
  * (the DisplayXR shell, third-party verticals, etc.) write these keys
@@ -64,6 +92,10 @@ struct workspace_controller_entry
 	char vendor[64];                   //!< Optional publisher.
 	char version[32];                  //!< Optional free-form version.
 	char uninstall_string[MAX_PATH];   //!< Used by runtime uninstaller for cascade.
+
+	//! Bitwise OR of `workspace_controller_capability` flags.
+	//! Zero means the controller publishes no optional capabilities.
+	uint32_t capabilities;
 
 	//! Optional published tray menu actions. `n_actions == 0` means
 	//! the tray falls back to its hardcoded Enable/Auto/Disable

--- a/test_apps/common/input_handler.cpp
+++ b/test_apps/common/input_handler.cpp
@@ -231,6 +231,12 @@ bool UpdateInputState(InputState& state, UINT msg, WPARAM wParam, LPARAM lParam)
             // consumes the flag after xrEndFrame.
             state.captureAtlasRequested = true;
             break;
+        case 'B':
+            // #228 smoke test: ask the runtime for a Tier 1 spatial file
+            // picker. Main loop consumes the flag, calls
+            // xrRequestFilePickerEXT, polls events for the completion.
+            state.filePickerRequestRequested = true;
+            break;
         case '0':
             state.absoluteRenderingModeRequested = 0; // 2D mode
             break;

--- a/test_apps/common/input_handler.h
+++ b/test_apps/common/input_handler.h
@@ -104,6 +104,12 @@ struct InputState {
     // See u_capture_intent.h and issue #210.
     bool captureAtlasRequested = false;
 
+    // 'B' key: smoke-test xrRequestFilePickerEXT (#228 Tier 1 spatial picker).
+    // Main loop sees the flag, resolves the PFN, makes the call, polls events
+    // for completion, and logs both. Falls through silently when the extension
+    // is not enabled / not available.
+    bool filePickerRequestRequested = false;
+
     // --- Gaussian-splat demo extensions (additive; unused by cube_* apps) ---
 
     // Smooth display-pose transition (double-click focus). When active,

--- a/test_apps/common/xr_session_common.cpp
+++ b/test_apps/common/xr_session_common.cpp
@@ -379,6 +379,14 @@ bool PollEvents(XrSessionManager& xr) {
             xr.currentModeIndex = modeEvent->currentModeIndex;
             break;
         }
+        case (XrStructureType)XR_TYPE_EVENT_DATA_FILE_PICKER_COMPLETE_EXT: {
+            auto* pickEvent = (XrEventDataFilePickerCompleteEXT*)&event;
+            LOG_INFO("[#228] File picker complete: requestId=%llu result=%d path=\"%s\"",
+                (unsigned long long)pickEvent->requestId,
+                (int)pickEvent->result,
+                pickEvent->path);
+            break;
+        }
         default:
             LOG_DEBUG("Received event type: %d", event.type);
             break;

--- a/test_apps/common/xr_session_common.h
+++ b/test_apps/common/xr_session_common.h
@@ -27,6 +27,7 @@
 #include <openxr/openxr_platform.h>
 #include <openxr/XR_EXT_win32_window_binding.h>
 #include <openxr/XR_EXT_display_info.h>
+#include <openxr/XR_EXT_workspace_file_dialog.h>
 #include <DirectXMath.h>
 #include <vector>
 #include <string>
@@ -81,6 +82,10 @@ struct XrSessionManager {
     // Extension support (used by ext app, ignored by non-ext app)
     bool hasWin32WindowBindingExt = false;
     bool hasDisplayInfoExt = false;
+    bool hasFileDialogExt = false;
+    // PFN resolved when XR_EXT_workspace_file_dialog is enabled. nullptr if
+    // the runtime didn't expose the extension. #228 Tier 1.
+    PFN_xrRequestFilePickerEXT pfnRequestFilePickerEXT = nullptr;
 
     // Display info from XR_EXT_display_info (static display properties)
     float recommendedViewScaleX = 1.0f;

--- a/test_apps/cube_handle_d3d11_win/main.cpp
+++ b/test_apps/cube_handle_d3d11_win/main.cpp
@@ -319,6 +319,30 @@ static void RenderOneFrame(RenderState& rs) {
         }
     }
 
+    // #228 Tier 1 smoke test: 'B' fires xrRequestFilePickerEXT and prints
+    // the immediate return code. The completion event (success/cancel +
+    // path) lands later through PollEvents -> XR_TYPE_EVENT_DATA_FILE_PICKER_COMPLETE_EXT.
+    if (g_inputState.filePickerRequestRequested) {
+        g_inputState.filePickerRequestRequested = false;
+        if (xr.pfnRequestFilePickerEXT && xr.session != XR_NULL_HANDLE) {
+            XrFilePickerInfoEXT info = {XR_TYPE_FILE_PICKER_INFO_EXT};
+            info.next = nullptr;
+            info.mode = XR_FILE_PICKER_MODE_OPEN_EXT;
+            info.flags = XR_FILE_PICKER_FLAG_NONE_EXT;
+            strncpy_s(info.title, "Smoke test (#228)", _TRUNCATE);
+            strncpy_s(info.defaultPath, "C:\\", _TRUNCATE);
+            info.filterCount = 1;
+            strncpy_s(info.filters[0].description, "Images", _TRUNCATE);
+            strncpy_s(info.filters[0].extensions, "*.png;*.jpg", _TRUNCATE);
+            XrAsyncRequestIdEXT rid = XR_NULL_ASYNC_REQUEST_ID_EXT;
+            XrResult fr = xr.pfnRequestFilePickerEXT(xr.session, &info, &rid);
+            LOG_INFO("[#228] xrRequestFilePickerEXT -> rc=0x%x requestId=%llu",
+                (unsigned)fr, (unsigned long long)rid);
+        } else {
+            LOG_INFO("[#228] xrRequestFilePickerEXT not available (ext missing or PFN NULL)");
+        }
+    }
+
     // Handle eye tracking mode toggle (T key)
     if (g_inputState.eyeTrackingModeToggleRequested) {
         g_inputState.eyeTrackingModeToggleRequested = false;

--- a/test_apps/cube_handle_d3d11_win/main.cpp
+++ b/test_apps/cube_handle_d3d11_win/main.cpp
@@ -321,11 +321,27 @@ static void RenderOneFrame(RenderState& rs) {
 
     // #228 Tier 1 smoke test: 'B' fires xrRequestFilePickerEXT and prints
     // the immediate return code. The completion event (success/cancel +
-    // path) lands later through PollEvents -> XR_TYPE_EVENT_DATA_FILE_PICKER_COMPLETE_EXT.
+    // path) lands later through PollEvents → XR_TYPE_EVENT_DATA_FILE_PICKER_COMPLETE_EXT.
     //
-    // Temporary auto-fire for headless smoke tests: when env var
-    // DISPLAYXR_AUTOFIRE_FILE_PICKER=1 is set, fire one request ~300
-    // frames after the session is running so a keypress isn't required.
+    // ------------------------------------------------------------------
+    // CI / headless smoke-test hook for #228.
+    // ------------------------------------------------------------------
+    // Setting `DISPLAYXR_AUTOFIRE_FILE_PICKER=1` in this app's
+    // environment causes ONE xrRequestFilePickerEXT call to fire
+    // automatically ~300 frames after the session enters running
+    // state (≈5 s at 60 Hz), without any keypress. The flag is reset
+    // after the first fire — there is no per-frame call cost.
+    //
+    // Why this exists: PostMessage(WM_KEYDOWN, 'B') from an external
+    // PowerShell test driver against the cube's hidden-under-workspace
+    // HWND has been flaky in practice (the keypress can arrive at the
+    // exact instant the IPC pipe transitions to broken on some runs,
+    // racing a session-lost teardown). The auto-fire path bypasses
+    // Win32 input entirely so headless CI can verify the end-to-end
+    // OpenXR contract regardless of input plumbing.
+    //
+    // Off-by-default, gated on an env var so a normal user double-
+    // clicking the cube never gets a spurious picker request.
     {
         static int s_autofire_frames = 0;
         static bool s_autofire_done = false;

--- a/test_apps/cube_handle_d3d11_win/main.cpp
+++ b/test_apps/cube_handle_d3d11_win/main.cpp
@@ -322,6 +322,25 @@ static void RenderOneFrame(RenderState& rs) {
     // #228 Tier 1 smoke test: 'B' fires xrRequestFilePickerEXT and prints
     // the immediate return code. The completion event (success/cancel +
     // path) lands later through PollEvents -> XR_TYPE_EVENT_DATA_FILE_PICKER_COMPLETE_EXT.
+    //
+    // Temporary auto-fire for headless smoke tests: when env var
+    // DISPLAYXR_AUTOFIRE_FILE_PICKER=1 is set, fire one request ~300
+    // frames after the session is running so a keypress isn't required.
+    {
+        static int s_autofire_frames = 0;
+        static bool s_autofire_done = false;
+        if (!s_autofire_done && xr.sessionRunning) {
+            s_autofire_frames++;
+            if (s_autofire_frames > 300) {
+                const char *autofire = getenv("DISPLAYXR_AUTOFIRE_FILE_PICKER");
+                if (autofire && autofire[0] == '1') {
+                    LOG_INFO("[#228] AUTO-FIRE: setting filePickerRequestRequested");
+                    g_inputState.filePickerRequestRequested = true;
+                }
+                s_autofire_done = true;
+            }
+        }
+    }
     if (g_inputState.filePickerRequestRequested) {
         g_inputState.filePickerRequestRequested = false;
         if (xr.pfnRequestFilePickerEXT && xr.session != XR_NULL_HANDLE) {

--- a/test_apps/cube_handle_d3d11_win/xr_session.cpp
+++ b/test_apps/cube_handle_d3d11_win/xr_session.cpp
@@ -81,11 +81,15 @@ bool InitializeOpenXR(XrSessionManager& xr) {
         if (strcmp(ext.extensionName, XR_EXT_DISPLAY_INFO_EXTENSION_NAME) == 0) {
             xr.hasDisplayInfoExt = true;
         }
+        if (strcmp(ext.extensionName, XR_EXT_WORKSPACE_FILE_DIALOG_EXTENSION_NAME) == 0) {
+            xr.hasFileDialogExt = true;
+        }
     }
 
     LOG_INFO("XR_KHR_D3D11_enable: %s", hasD3D11 ? "AVAILABLE" : "NOT FOUND");
     LOG_INFO("XR_EXT_win32_window_binding: %s", xr.hasWin32WindowBindingExt ? "AVAILABLE" : "NOT FOUND");
     LOG_INFO("XR_EXT_display_info: %s", xr.hasDisplayInfoExt ? "AVAILABLE" : "NOT FOUND");
+    LOG_INFO("XR_EXT_workspace_file_dialog: %s", xr.hasFileDialogExt ? "AVAILABLE" : "NOT FOUND");
 
     if (!hasD3D11) {
         LOG_ERROR("XR_KHR_D3D11_enable extension not available - cannot continue");
@@ -105,6 +109,9 @@ bool InitializeOpenXR(XrSessionManager& xr) {
     }
     if (xr.hasDisplayInfoExt) {
         enabledExtensions.push_back(XR_EXT_DISPLAY_INFO_EXTENSION_NAME);
+    }
+    if (xr.hasFileDialogExt) {
+        enabledExtensions.push_back(XR_EXT_WORKSPACE_FILE_DIALOG_EXTENSION_NAME);
     }
 
     LOG_INFO("Enabling %zu extensions", enabledExtensions.size());
@@ -198,6 +205,13 @@ bool InitializeOpenXR(XrSessionManager& xr) {
             (PFN_xrVoidFunction*)&xr.pfnRequestDisplayRenderingModeEXT);
         xrGetInstanceProcAddr(xr.instance, "xrEnumerateDisplayRenderingModesEXT",
             (PFN_xrVoidFunction*)&xr.pfnEnumerateDisplayRenderingModesEXT);
+    }
+
+    // #228 Tier 1 spatial file picker — resolve the app-side entrypoint.
+    if (xr.hasFileDialogExt) {
+        xrGetInstanceProcAddr(xr.instance, "xrRequestFilePickerEXT",
+            (PFN_xrVoidFunction*)&xr.pfnRequestFilePickerEXT);
+        LOG_INFO("xrRequestFilePickerEXT: %s", xr.pfnRequestFilePickerEXT ? "resolved" : "NULL");
     }
 
     // Get view configuration views


### PR DESCRIPTION
Implements the runtime half of #228 — the Tier 1 spatial file picker as an
async OpenXR extension. End-to-end verified locally against the matching
stub in [`displayxr-shell-pvt`](https://github.com/DisplayXR/displayxr-shell-pvt/pull/new/feature/file-dialog-stub-tier1).

## Summary

- New `XR_EXT_workspace_file_dialog` extension (v1, provisional).
  - App-side: `xrRequestFilePickerEXT(session, info, &requestId)` returns
    immediately; completion arrives via `xrPollEvent` as
    `XrEventDataFilePickerCompleteEXT`. No blocking calls inside the
    runtime — single-threaded render loops stay healthy.
  - Controller-side: `xrGetFilePickerRequestEXT` / `xrCompleteFilePickerEXT`,
    PID-authed against the active workspace controller. Surfaces as
    `XR_WORKSPACE_INPUT_EVENT_FILE_PICKER_REQUEST_EXT = 10` in the
    existing `xrEnumerateWorkspaceInputEventsEXT` drain (`XR_EXT_spatial_workspace`
    bumped to spec_version 11).
  - Fallback: `XR_FILE_PICKER_FALLBACK_TIER0_EXT` whenever no workspace
    is active or the IPC bridge fails. Apps fall back to a flat OS
    dialog; the Tier 0 hook from #227 handles z-order / focus.

- Three new IPC RPCs (`session_request_file_picker`,
  `workspace_get_file_picker_request`, `workspace_file_dialog_result`)
  plus a new `IPC_WORKSPACE_INPUT_EVENT_FILE_PICKER_REQUEST` event
  variant. Wire payloads tightened to fit `IPC_BUF_SIZE = 1024`
  (path budget = 256 = Windows `MAX_PATH`).

- Pending-request table on the multi-compositor (bounded to 8
  concurrent). Late results survive requester teardown (logged, dropped).

- Workspace-controller registration grows an optional `SupportsFileDialog`
  REG_DWORD capability flag, surfaced as
  `WORKSPACE_CAPABILITY_FILE_DIALOG` on `workspace_controller_entry`.
  (Capability-aware dispatch lands as a fast-follow on this branch.)

- Test apps: `cube_handle_d3d11_win` gets a 'B' keypress smoke probe.

## Test plan

End-to-end verified locally (`v1.3.4 + 6 commits` runtime, dev shell from
`displayxr-shell-pvt#???`):

```
[2026-05-18 23:14:00.977] [#228] xrRequestFilePickerEXT -> rc=0x0 requestId=1
[2026-05-18 23:14:06.823] [#228] File picker complete: requestId=1 result=0
                                  path="C:\stub_picked_file.txt"
```

- [ ] Windows CI (build-windows.yml)
- [ ] macOS CI (build-macos.yml — guarded by `XR_USE_PLATFORM_WIN32`, sentinel-only)
- [ ] Capability-aware dispatch (fast-follow on this branch)

## Out of scope

- Real picker UI — separate shell-pvt PR. Today's shell stub returns
  a hardcoded path so the wire is exercised.
- macOS / Linux — Tier 1 picker is Windows-only by design.
- Multi-select — `XR_FILE_PICKER_FLAG_MULTI_SELECT_BIT_EXT` is
  reserved but unimplemented in v1.

Refs #228. Builds on #227 (Tier 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)