### PR TITLE
refactor: push eye-pos polling inside Leia DP via SR EyePairStream listener

### DIFF
--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -647,23 +647,13 @@ struct d3d11_service_system
 	//! within ~200 ms of the user's V keypress. Zero = no flip has landed yet.
 	std::atomic<int64_t> last_flip_landed_ns{0};
 
-	//! Phase 5c — per-frame cache of predicted eye positions (#248).
-	//! The render thread already calls `xrt_display_processor_d3d11_get_predicted_eye_positions`
-	//! once per frame from `multi_compositor_render`; cache the result so
-	//! per-frame callers (workspace_raycast_hit_test on every cursor hover,
-	//! IPC client eye-pos queries, chrome rendering, capture) reuse the
-	//! cached value instead of re-querying the DP. Each DP call indirects
-	//! into the SR SDK which throws `std::runtime_error` internally as
-	//! control flow (~5×/frame at 60Hz when uncached, ~1×/frame cached) —
-	//! caching cuts ~80% of those throws and the corresponding unwind cost.
-	//! TTL is generous (200 ms) so the cache stays useful even during
-	//! brief render-thread pauses (suspended workspace, post-dismiss
-	//! cleanup); eye position doesn't change meaningfully at sub-200 ms.
-	std::mutex                cached_eye_pos_mutex;
-	struct xrt_vec3           cached_eye_left{0, 0, 0};
-	struct xrt_vec3           cached_eye_right{0, 0, 0};
-	bool                      cached_eye_valid{false};
-	int64_t                   cached_eye_pos_ns{0};
+	// Note: a service-level eye-pos cache previously lived here as a
+	// throw-rate mitigation (#248). It moved into the Leia DP itself,
+	// which now subscribes to the SR SDK's EyePairStream and maintains
+	// the snapshot as a vendor-internal concern (separation of concerns:
+	// the compositor must not own eye-tracking caching). All consumers
+	// here call the DP via `xrt_display_processor_d3d11_get_predicted_eye_positions`
+	// which is now a cheap snapshot read.
 
 	//! Phase 2.C spec_version 8: auto-reset Win32 event signaled whenever an
 	//! async workspace state change occurs that the controller might want to
@@ -7791,7 +7781,9 @@ after_key_shortcuts:
 	// Sync tile layout (2D/3D mode may have changed)
 	sync_tile_layout(sys);
 
-	// Get eye positions from DP
+	// Get eye positions from DP — now a cheap snapshot read (the Leia DP
+	// subscribes to SR's EyePairStream listener and maintains the cache
+	// internally, see leia_sr_d3d11.cpp). No SDK call from here.
 	struct xrt_eye_positions eye_pos = {};
 	if (mc->display_processor != nullptr) {
 		xrt_display_processor_d3d11_get_predicted_eye_positions(mc->display_processor, &eye_pos);
@@ -7801,24 +7793,6 @@ after_key_shortcuts:
 		eye_pos.eyes[0] = {-0.032f, 0.0f, 0.6f};
 		eye_pos.eyes[1] = { 0.032f, 0.0f, 0.6f};
 		eye_pos.valid = true;
-	}
-
-	// Populate the per-frame eye-pos cache (#248). All other in-process
-	// callers (workspace_raycast_hit_test, IPC client eye-pos queries,
-	// capture, chrome) read from this cache via
-	// comp_d3d11_service_get_predicted_eye_positions instead of re-calling
-	// into the DP — cuts the SR SDK's per-call std::runtime_error throws
-	// from ~5/frame to ~1/frame.
-	{
-		std::lock_guard<std::mutex> lock(sys->cached_eye_pos_mutex);
-		sys->cached_eye_left.x  = eye_pos.eyes[0].x;
-		sys->cached_eye_left.y  = eye_pos.eyes[0].y;
-		sys->cached_eye_left.z  = eye_pos.eyes[0].z;
-		sys->cached_eye_right.x = eye_pos.eyes[1].x;
-		sys->cached_eye_right.y = eye_pos.eyes[1].y;
-		sys->cached_eye_right.z = eye_pos.eyes[1].z;
-		sys->cached_eye_valid = true;
-		sys->cached_eye_pos_ns = (int64_t)os_monotonic_get_ns();
 	}
 
 
@@ -10794,30 +10768,14 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 	int64_t profile_s0b = os_monotonic_get_ns(); // Phase 5a — post vendor 3d-state poll.
 
 	// Get predicted eye positions (used for UI layers and HUD).
-	// Use the per-frame cache populated by multi_compositor_render (#248)
-	// so each IPC client's per-frame layer_commit doesn't re-trigger the
-	// SR SDK's std::runtime_error throw inside getPredictedEyePositions.
-	// On a 3-client workspace this cuts ~180 SDK calls/sec to 0 from this
-	// call site (the render thread's once-per-frame call stays the only
-	// SDK invocation that hits the throw). The cache only stores L/R
-	// (eyes[0..1]); for views > 2 the renderer falls back to the
-	// interpolated baseline below.
+	// This is a cheap snapshot read — the Leia DP subscribes to SR's
+	// EyePairStream listener and maintains the cache internally (#248
+	// Tier 2). No SDK polling on the per-client commit path.
 	struct xrt_eye_positions eye_pos = {};
 	bool weaving_done = false;
-	{
-		std::lock_guard<std::mutex> lock(sys->cached_eye_pos_mutex);
-		if (sys->cached_eye_valid &&
-		    ((int64_t)os_monotonic_get_ns() - sys->cached_eye_pos_ns) <
-		        200LL * 1000LL * 1000LL) {
-			eye_pos.eyes[0].x = sys->cached_eye_left.x;
-			eye_pos.eyes[0].y = sys->cached_eye_left.y;
-			eye_pos.eyes[0].z = sys->cached_eye_left.z;
-			eye_pos.eyes[1].x = sys->cached_eye_right.x;
-			eye_pos.eyes[1].y = sys->cached_eye_right.y;
-			eye_pos.eyes[1].z = sys->cached_eye_right.z;
-			eye_pos.count = 2;
-			eye_pos.valid = true;
-		}
+	if (c->render.display_processor != nullptr) {
+		xrt_display_processor_d3d11_get_predicted_eye_positions(
+		    c->render.display_processor, &eye_pos);
 	}
 
 	int64_t profile_s0c = os_monotonic_get_ns(); // Phase 5a — post vendor eye-pos poll.
@@ -13154,24 +13112,8 @@ comp_d3d11_service_get_predicted_eye_positions(struct xrt_system_compositor *xsy
 
 	struct d3d11_service_system *sys = d3d11_service_system_from_xrt(xsysc);
 
-	// Per-frame eye-pos cache served from `multi_compositor_render` (#248).
-	// Returns the most recent eye position computed during the current
-	// render cycle (TTL 200 ms) — avoids a redundant DP call (and the
-	// SR SDK's internal std::runtime_error throw) on every cursor hover,
-	// IPC client query, chrome render, and capture. Cache miss falls
-	// through to the DP path below (cold start, workspace suspended).
-	{
-		std::lock_guard<std::mutex> lock(sys->cached_eye_pos_mutex);
-		if (sys->cached_eye_valid) {
-			int64_t age_ns = (int64_t)os_monotonic_get_ns() - sys->cached_eye_pos_ns;
-			if (age_ns < 200LL * 1000LL * 1000LL) {
-				*out_left  = sys->cached_eye_left;
-				*out_right = sys->cached_eye_right;
-				return true;
-			}
-		}
-	}
-
+	// Caching now lives inside the DP itself (vendor-internal, populated
+	// by SR's EyePairStream listener). This is just a thin pass-through.
 	// Get display processor for eye position prediction.
 	// In workspace mode, use the multi-comp's DP (per-client compositors have no DP).
 	// In normal mode, use the active compositor's DP.

--- a/src/xrt/drivers/CMakeLists.txt
+++ b/src/xrt/drivers/CMakeLists.txt
@@ -142,10 +142,14 @@ if(XRT_HAVE_LEIA_SR)
 			${SR_PATH}/third_party/OpenCV/include)
 
 		# Core SR libraries (always needed)
+		# SimulatedRealityFaceTrackers.lib added for the EyeTracker /
+		# EyePairStream listener subscription used by the DP eye-pos
+		# snapshot cache (#248 Tier 2 — eliminates per-frame SDK polling).
 		target_link_libraries(drv_leia PRIVATE
 			xrt-interfaces aux_util aux_os aux_math
 			${SR_PATH}/lib/SimulatedRealityCore.lib
 			${SR_PATH}/lib/SimulatedRealityDisplays.lib
+			${SR_PATH}/lib/SimulatedRealityFaceTrackers.lib
 			${SR_PATH}/third_party/OpenCV/lib/x64/opencv_world343.lib
 			PUBLIC drv_includes)
 

--- a/src/xrt/drivers/leia/leia_sr_d3d11.cpp
+++ b/src/xrt/drivers/leia/leia_sr_d3d11.cpp
@@ -14,6 +14,10 @@
 #include <sr/weaver/dx11weaver.h>
 #include <sr/world/display/display.h>
 #include <sr/sense/display/switchablehint.h>
+#include <sr/sense/eyetracker/eyetracker.h>
+#include <sr/sense/eyetracker/eyepair.h>
+#include <sr/sense/eyetracker/eyepairlistener.h>
+#include <sr/sense/eyetracker/eyepairstream.h>
 #include <sr/utility/exception.h>
 
 #include <d3d11.h>
@@ -22,6 +26,11 @@
 #include <sysinfoapi.h>
 
 #include <cmath>
+#include <memory>
+#include <mutex>
+
+// Forward decl — defined below so it can hold a back-pointer to leiasr_d3d11.
+class LeiaEyePairListener;
 
 /*!
  * D3D11 SR weaver instance.
@@ -32,6 +41,20 @@ struct leiasr_d3d11
 	SR::SRContext *context = nullptr;
 	SR::IDX11Weaver1 *weaver = nullptr;
 	SR::SwitchableLensHint *lens_hint = nullptr;
+
+	// Listener-driven eye-position cache (#248 Tier 2). Instead of polling
+	// the weaver per-frame (which throws std::runtime_error internally as
+	// routine control flow), we subscribe to SR::EyeTracker's EyePairStream
+	// once and let the SDK's internal thread push SR_eyePair frames into
+	// `cached_eye_pair` via the listener's accept() callback. All in-runtime
+	// eye-pos consumers then read this snapshot — zero SDK invocations from
+	// our side after subscription, zero per-frame throws.
+	SR::EyeTracker                       *eye_tracker = nullptr;  // owned by SRContext
+	std::shared_ptr<SR::EyePairStream>    eye_pair_stream;
+	std::unique_ptr<LeiaEyePairListener>  eye_listener;
+	std::mutex                            cached_eye_pair_mutex;
+	bool                                  cached_eye_pair_valid = false;
+	SR_eyePair                            cached_eye_pair = {};
 
 	// D3D11 resources (references, not owned)
 	ID3D11Device *device = nullptr;
@@ -63,6 +86,33 @@ struct leiasr_d3d11
 	// Configuration
 	bool srgb_read = false;
 	bool srgb_write = false;
+};
+
+/*!
+ * Listener that receives SR_eyePair updates from the SDK's internal
+ * eye-tracking thread and writes them into the owning leiasr_d3d11's
+ * snapshot under a mutex. No polling, no throws — the SDK calls accept()
+ * whenever a fresh frame is available. The eye_pair_stream owns a raw
+ * pointer to the listener instance, so the stream MUST be stopped (via
+ * stopListening()) before the listener is destroyed.
+ */
+class LeiaEyePairListener : public SR::EyePairListener
+{
+public:
+	explicit LeiaEyePairListener(leiasr_d3d11 *owner) : owner_(owner) {}
+
+	void accept(const SR_eyePair &frame) override
+	{
+		if (owner_ == nullptr) {
+			return;
+		}
+		std::lock_guard<std::mutex> lock(owner_->cached_eye_pair_mutex);
+		owner_->cached_eye_pair       = frame;
+		owner_->cached_eye_pair_valid = true;
+	}
+
+private:
+	leiasr_d3d11 *owner_;
 };
 
 namespace {
@@ -215,6 +265,34 @@ leiasr_d3d11_create(double max_time,
 		return XRT_ERROR_DEVICE_CREATION_FAILED;
 	}
 
+	// Subscribe to SR::EyeTracker via listener pattern (#248 Tier 2)
+	// BEFORE creating the weaver and BEFORE context->initialize(). Match
+	// the dx11_weaving SDK sample's order — context->initialize() starts
+	// all senses that were registered to the context up to that point;
+	// any sense added afterwards never starts and the listener silently
+	// never fires. Best-effort: if subscription fails (older SDK,
+	// transient init race), the get_predicted_eye_positions path falls
+	// back to a guarded weaver poll.
+	try {
+		sr->eye_tracker = SR::EyeTracker::create(*sr->context);
+		if (sr->eye_tracker != nullptr) {
+			sr->eye_listener = std::make_unique<LeiaEyePairListener>(sr);
+			sr->eye_pair_stream =
+			    sr->eye_tracker->openEyePairStream(sr->eye_listener.get());
+			U_LOG_W("SR D3D11: subscribed to EyeTracker EyePairStream "
+			        "(listener-driven, no per-frame SDK polling)");
+		} else {
+			U_LOG_W("SR D3D11: EyeTracker::create returned null — "
+			        "falling back to weaver polling for eye positions");
+		}
+	} catch (...) {
+		U_LOG_W("SR D3D11: EyeTracker subscription threw — falling back "
+		        "to weaver polling for eye positions");
+		sr->eye_pair_stream.reset();
+		sr->eye_listener.reset();
+		sr->eye_tracker = nullptr;
+	}
+
 	// Create D3D11 weaver (SR SDK installs its WndProc via SetWindowLongPtr).
 	// Set DPI awareness so the SDK sees physical pixels when it queries the
 	// HWND. See LeiaInc/LeiaSR@a8a9fb9 for the pattern.
@@ -234,7 +312,8 @@ leiasr_d3d11_create(double max_time,
 		return XRT_ERROR_DEVICE_CREATION_FAILED;
 	}
 
-	// Initialize the context after creating the weaver.
+	// Initialize the context AFTER all senses (EyeTracker above) and the
+	// weaver have been registered. initialize() starts the senses.
 	sr->context->initialize();
 
 	// Set default latency (1 frame)
@@ -255,6 +334,24 @@ leiasr_d3d11_destroy(struct leiasr_d3d11 **leiasr_ptr)
 	}
 
 	leiasr_d3d11 *sr = *leiasr_ptr;
+
+	// Stop the eye-pair stream BEFORE destroying the listener — the SDK's
+	// internal thread is calling listener->accept() concurrently and
+	// stopListening() blocks until any in-flight callback returns.
+	// Failing to do this risks a use-after-free if the SDK fires accept()
+	// after the listener has been freed.
+	if (sr->eye_pair_stream) {
+		try {
+			sr->eye_pair_stream->stopListening();
+		} catch (...) {
+			// Best-effort teardown; SDK shouldn't throw here but defend.
+		}
+		sr->eye_pair_stream.reset();
+	}
+	sr->eye_listener.reset();
+	// EyeTracker is a Sense owned by SRContext — do NOT delete manually
+	// (same contract as lens_hint below). Just drop our reference.
+	sr->eye_tracker = nullptr;
 
 	// SwitchableLensHint is managed by SRContext — do NOT delete it manually.
 	// SRContext::~SRContext() calls deleteAllSenses() which cleans it up.
@@ -380,34 +477,46 @@ leiasr_d3d11_get_predicted_eye_positions(struct leiasr_d3d11 *leiasr,
                                          float out_left_eye[3],
                                          float out_right_eye[3])
 {
-	if (leiasr == nullptr || leiasr->weaver == nullptr) {
+	if (leiasr == nullptr) {
 		return false;
 	}
 
-	// Get positions in millimeters from weaver. The SR SDK's
-	// PredictingEyeTracker::predict throws std::runtime_error as routine
-	// control flow when no eye-tracking data is available — ~5×/frame at
-	// 60Hz during normal operation. The SDK normally catches its own
-	// throws one frame up; if one ever escapes (cold-start state, init
-	// race, future SDK version), the unguarded callers above will let it
-	// unwind through capture_render_thread_func → std::thread entry →
-	// std::terminate() and silently kill the service (runtime#248).
-	// Catch here so the throw never leaves our code.
+	// Primary path: listener-driven cache (#248 Tier 2). The SDK's
+	// internal thread fills `cached_eye_pair` via LeiaEyePairListener::accept;
+	// no SDK calls from our code, no per-frame throws. SR_eyePair positions
+	// are in millimeters — convert to meters here.
+	{
+		std::lock_guard<std::mutex> lock(leiasr->cached_eye_pair_mutex);
+		if (leiasr->cached_eye_pair_valid) {
+			out_left_eye[0]  = leiasr->cached_eye_pair.left.x  / 1000.0f;
+			out_left_eye[1]  = leiasr->cached_eye_pair.left.y  / 1000.0f;
+			out_left_eye[2]  = leiasr->cached_eye_pair.left.z  / 1000.0f;
+			out_right_eye[0] = leiasr->cached_eye_pair.right.x / 1000.0f;
+			out_right_eye[1] = leiasr->cached_eye_pair.right.y / 1000.0f;
+			out_right_eye[2] = leiasr->cached_eye_pair.right.z / 1000.0f;
+			return true;
+		}
+	}
+
+	// Fallback: listener hasn't fired yet (cold-start, first few frames
+	// after subscription) or subscription failed at create. Poll the
+	// weaver, catching the SR SDK's std::runtime_error so it never leaves
+	// the DP. Once the listener warms up this path is never taken again.
+	if (leiasr->weaver == nullptr) {
+		return false;
+	}
 	float left_mm[3], right_mm[3];
 	try {
 		leiasr->weaver->getPredictedEyePositions(left_mm, right_mm);
 	} catch (...) {
 		return false;
 	}
-
-	// Convert to meters
-	out_left_eye[0] = left_mm[0] / 1000.0f;
-	out_left_eye[1] = left_mm[1] / 1000.0f;
-	out_left_eye[2] = left_mm[2] / 1000.0f;
+	out_left_eye[0]  = left_mm[0]  / 1000.0f;
+	out_left_eye[1]  = left_mm[1]  / 1000.0f;
+	out_left_eye[2]  = left_mm[2]  / 1000.0f;
 	out_right_eye[0] = right_mm[0] / 1000.0f;
 	out_right_eye[1] = right_mm[1] / 1000.0f;
 	out_right_eye[2] = right_mm[2] / 1000.0f;
-
 	return true;
 }
 


### PR DESCRIPTION
Tier 2 follow-on to #248. Eliminates per-frame SR SDK polling for predicted eye positions, fixes the separation-of-concerns leak where the compositor was driving vendor eye-tracking work, and drops the SDK's per-frame std::runtime_error rate from ~313/sec → ~0/sec in steady state.

## Problem

Before this change, six per-frame call sites in \`comp_d3d11_service.cpp\` queried \`xrt_display_processor_d3d11_get_predicted_eye_positions\`, which under the hood polled \`weaver->getPredictedEyePositions()\` — an SR SDK API that throws \`std::runtime_error\` internally as routine control flow (~2 throws per call). #248 mitigated this with a service-level cache and a try/catch at the SDK call site, dropping the rate from ~313/sec → ~117/sec and stopping the cancel crash. But:

1. The runtime was still polling the throwing API once per frame.
2. Eye-tracking caching state lived in \`d3d11_service_system\` — a compositor-layer object. The compositor should not own vendor-internal eye-tracking state (see \`[[compositor-eye-pos-layering]]\`).

## Fix

Subscribe to **SR::EyeTracker::openEyePairStream(listener)** once at session bring-up. The SDK's internal eye-tracking thread pushes \`SR_eyePair\` frames into \`LeiaEyePairListener::accept()\`, which atomically writes a snapshot in the leia driver. \`leiasr_d3d11_get_predicted_eye_positions\` now reads the snapshot — no SDK invocation, no throws. The weaver-poll path stays as a cold-start fallback (guarded by try/catch) for the first ~3s before the listener warms up; once warm the fallback is never taken.

**Init order matters**, and it's not obvious from the headers — \`SRContext::initialize()\` starts all senses registered up to that point; senses created afterwards silently never start and the listener never fires. The dx11_weaving SDK sample shows the correct order:

\`\`\`
SR::SRContext::create()
SR::EyeTracker::create(*context) + openEyePairStream(listener)  ← register sense FIRST
SR::CreateDX11Weaver(context, ...)
context->initialize()                                            ← starts the sense
\`\`\`

## Compositor cleanup

Service-level eye-pos cache (\`d3d11_service_system::cached_eye_*\`) removed. Caching is now a vendor-internal DP concern. All eye-pos callers go through the existing \`xrt_display_processor_d3d11_get_predicted_eye_positions\` vtable, which is now a cheap snapshot read inside the DP. The vendor isolation rule (\`docs/architecture/separation-of-concerns.md\`) is satisfied: the compositor knows nothing about EyeTracker / EyePairStream / SR SDK.

## Measured impact

\`procdump -e -f runtime_error\`, 2-cancel-cycle workspace session with picker open:

| Phase | Throws | Note |
|---|---|---|
| Cold start (first ~3 s) | ~155 total (60/sec) | Listener cache warming; weaver-poll fallback |
| Steady state | **0/sec** | Listener active, snapshot read only |

vs. prior:
- Original (no mitigation): 313/sec continuous
- After #248 Tier 1 cache: 117/sec continuous

## Build change

\`SimulatedRealityFaceTrackers.lib\` added to \`drv_leia\` link line. EyeTracker / EyePairStream symbols live there; SimulatedRealityCore covers Sense / SRContext.

## Test plan

- [x] Build clean on Windows MSVC
- [x] Cold-service start → repeated picker open/cancel — no crash, no .dmp
- [x] Service stays alive across shell Ctrl+Space exit
- [x] procdump confirms throw rate falls to 0/sec after ~3 s warm-up
- [x] Service log confirms \`SR D3D11: subscribed to EyeTracker EyePairStream (listener-driven, no per-frame SDK polling)\`

## Note on listener API status

LeiaSR-SDK-1.35.0.2011-win64 ships \`SR::EyeTracker\` listener usage under \`#ifdef USE_DEPRECATED_WEAVER\` in the sample apps, marking it as the "old" path in favor of \`weaver->getPredictedEyePositions()\`. The listener pattern is alive and works correctly; the deprecation is about the WEAVER variant that uses it (\`PredictingDX11Weaver\` etc.), not the listener itself. For runtime code that cannot tolerate exception-driven control flow at our call rate, the listener remains the right vendor-internal alternative. If a future SDK ships a non-throwing query API, we can swap to that.