### PR TITLE
installer: drop system PATH modification; static-link transitive deps

### DIFF
--- a/cmake/vcpkg-overlay-triplets/x64-windows.cmake
+++ b/cmake/vcpkg-overlay-triplets/x64-windows.cmake
@@ -1,0 +1,17 @@
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE dynamic)
+
+# Force pthreads to build as a static library so DisplayXRClient.dll has no
+# runtime dependency on pthreadVCE3.dll. The PThreads4WConfig.cmake provided
+# by the port auto-detects the absence of bin/*.dll and creates an UNKNOWN
+# IMPORTED CMake target — same target name (PThreads4W::PThreads4W_CXXEXC),
+# so xrt-pthreads requires no source changes.
+#
+# Static pthreads is the only piece statically linked from vcpkg; everything
+# else (Vulkan loader, glslang, eigen) keeps its default linkage. This lets
+# the installer drop its system-PATH modification (issue: PATH was previously
+# required to resolve pthreadVCE3.dll alongside DisplayXRClient.dll).
+if(PORT STREQUAL "pthreads")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif()

--- a/installer/DisplayXRInstaller.nsi
+++ b/installer/DisplayXRInstaller.nsi
@@ -662,16 +662,26 @@ Section "DisplayXR Runtime" SecRuntime
 	; SetRegView; explicit no-op kept for clarity).
 	WriteRegStr HKLM "Software\Khronos\OpenXR\1" "ActiveRuntime" "$INSTDIR\DisplayXR_win64.json"
 
-	; PATH is intentionally not modified. DisplayXRClient.dll has no static
-	; DLL imports that live in $INSTDIR — cjson is compiled in from bundled
-	; source, SDL2 is disabled in the production build, and pthreads is
-	; statically linked via the vcpkg overlay triplet at
-	; cmake/vcpkg-overlay-triplets/x64-windows.cmake. The only DLL co-located
-	; in $INSTDIR (SimulatedRealityVulkanBeta.dll) is /DELAYLOAD'd and only
-	; reached by the Vulkan compositor path, which is loaded via LoadLibrary
-	; from the service exe's own directory (already on the default search path).
-	; The uninstaller still runs un.RemoveFromPath to clean up entries written
-	; by older installer versions.
+	; PATH is intentionally not modified. DisplayXRClient.dll's third-party
+	; transitive deps that previously *required* $INSTDIR on PATH are gone:
+	; cjson is compiled in from bundled source, SDL2 is disabled in the
+	; production build, and pthreads is statically linked via the vcpkg
+	; overlay triplet at cmake/vcpkg-overlay-triplets/x64-windows.cmake.
+	;
+	; $INSTDIR still receives other files via the wildcard at the File line
+	; above (openxr_loader.dll, the five static-imported SimulatedReality*.dll
+	; shipped by drv_leia's import-lib link, etc.), but none of those need
+	; PATH to resolve:
+	;  - SimulatedReality{Core,Displays,FaceTrackers,DirectX,OpenGL}.dll are
+	;    also installed by the Leia SR Platform (a hard prereq of drv_leia),
+	;    which adds its own dir to system PATH independently — static imports
+	;    resolve through that.
+	;  - SimulatedRealityVulkanBeta.dll is /DELAYLOAD'd and resolved by
+	;    DisplayXRClient.dll's __pfnDliNotifyHook2 (target_dll_init.c), which
+	;    LoadLibraryEx's it from this $INSTDIR at first use.
+	;
+	; The uninstaller still runs un.RemoveFromPath to clean up entries
+	; written by older installer versions.
 
 	; Enable D3D11 native compositor by default
 	; This bypasses Vulkan and avoids D3D11<->Vulkan interop issues on Intel GPUs

--- a/installer/DisplayXRInstaller.nsi
+++ b/installer/DisplayXRInstaller.nsi
@@ -662,11 +662,16 @@ Section "DisplayXR Runtime" SecRuntime
 	; SetRegView; explicit no-op kept for clarity).
 	WriteRegStr HKLM "Software\Khronos\OpenXR\1" "ActiveRuntime" "$INSTDIR\DisplayXR_win64.json"
 
-	; Add install directory to system PATH
-	; This is needed so OpenXR apps can find DisplayXRClient.dll's dependencies
-	; (vulkan-1.dll, SDL2.dll, etc.) when loading the runtime
-	Push $INSTDIR
-	Call AddToPath
+	; PATH is intentionally not modified. DisplayXRClient.dll has no static
+	; DLL imports that live in $INSTDIR — cjson is compiled in from bundled
+	; source, SDL2 is disabled in the production build, and pthreads is
+	; statically linked via the vcpkg overlay triplet at
+	; cmake/vcpkg-overlay-triplets/x64-windows.cmake. The only DLL co-located
+	; in $INSTDIR (SimulatedRealityVulkanBeta.dll) is /DELAYLOAD'd and only
+	; reached by the Vulkan compositor path, which is loaded via LoadLibrary
+	; from the service exe's own directory (already on the default search path).
+	; The uninstaller still runs un.RemoveFromPath to clean up entries written
+	; by older installer versions.
 
 	; Enable D3D11 native compositor by default
 	; This bypasses Vulkan and avoids D3D11<->Vulkan interop issues on Intel GPUs

--- a/src/external/CMakeLists.txt
+++ b/src/external/CMakeLists.txt
@@ -24,6 +24,16 @@ target_include_directories(
 add_library(xrt-external-cjson INTERFACE)
 if(XRT_HAVE_SYSTEM_CJSON)
 	target_link_libraries(xrt-external-cjson INTERFACE cJSON::cJSON)
+elseif(TARGET displayxr_mcp_vendored_cjson)
+	# Reuse the static cJSON lib already compiled by the displayxr_mcp
+	# FetchContent module. Linking the same static lib from both aux_util
+	# and displayxr_mcp::mcp gives the linker a single definition of every
+	# cJSON_* symbol, where compiling cJSON.c into u_json.c (via the
+	# bundled-source path below) would collide with the MCP copy.
+	target_link_libraries(
+		xrt-external-cjson INTERFACE displayxr_mcp_vendored_cjson
+		)
+	target_compile_definitions(xrt-external-cjson INTERFACE XRT_HAVE_LINKED_CJSON)
 else()
 	target_include_directories(
 		xrt-external-cjson SYSTEM INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/cjson

--- a/src/xrt/auxiliary/util/u_json.c
+++ b/src/xrt/auxiliary/util/u_json.c
@@ -9,7 +9,7 @@
  */
 
 #include "util/u_json.h"
-#ifndef XRT_HAVE_SYSTEM_CJSON
+#if !defined(XRT_HAVE_SYSTEM_CJSON) && !defined(XRT_HAVE_LINKED_CJSON)
 #if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_WARNINGS)
 #define _CRT_SECURE_NO_WARNINGS
 #endif
@@ -20,11 +20,13 @@
 #include <assert.h>
 #include <stdio.h>
 
-#ifndef XRT_HAVE_SYSTEM_CJSON
+#if !defined(XRT_HAVE_SYSTEM_CJSON) && !defined(XRT_HAVE_LINKED_CJSON)
 #if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_WARNINGS)
 #define _CRT_SECURE_NO_WARNINGS
 #endif
-// This includes the c file completely.
+// This includes the c file completely. Skipped when cJSON comes from an
+// external static lib (system cJSON, or the MCP module's vendored copy
+// linked via xrt-external-cjson — XRT_HAVE_LINKED_CJSON gate).
 #include "cjson/cJSON.c"
 #endif
 

--- a/src/xrt/targets/openxr/CMakeLists.txt
+++ b/src/xrt/targets/openxr/CMakeLists.txt
@@ -20,6 +20,10 @@ add_library(${RUNTIME_TARGET} MODULE target.c libopenxr.def)
 if(WIN32)
 	set_target_properties(${RUNTIME_TARGET} PROPERTIES OUTPUT_NAME "DisplayXRClient")
 
+	# DllMain + delay-load notification hook: resolves /DELAYLOAD'd DLLs
+	# from the runtime's install dir without requiring $INSTDIR on PATH.
+	target_sources(${RUNTIME_TARGET} PRIVATE target_dll_init.c)
+
 	# Delay-load Vulkan and SR Vulkan DLLs so the runtime can load on systems
 	# where these are absent. The D3D11 native compositor path never calls into
 	# Vulkan weaver functions, so the delay-loaded DLLs are never triggered.

--- a/src/xrt/targets/openxr/target_dll_init.c
+++ b/src/xrt/targets/openxr/target_dll_init.c
@@ -1,0 +1,73 @@
+// Copyright 2026, Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief DllMain + delay-load hook for DisplayXRClient.dll on Windows.
+ *
+ * Resolves /DELAYLOAD'd dependencies (SimulatedRealityVulkanBeta.dll) from
+ * the runtime's own install directory without requiring $INSTDIR to be on
+ * the system PATH. We're loaded into the host app's process and must not
+ * mutate process-wide DLL search behavior (no SetDefaultDllDirectories) —
+ * the delay-load notification hook is the surgical option.
+ */
+
+#ifdef _WIN32
+
+#include <windows.h>
+#include <delayimp.h>
+#include <stdio.h>
+#include <wchar.h>
+
+static wchar_t g_runtime_dir[MAX_PATH] = {0};
+
+static FARPROC WINAPI
+displayxr_dli_hook(unsigned dli_notify, PDelayLoadInfo pdli)
+{
+	if (dli_notify != dliNotePreLoadLibrary || g_runtime_dir[0] == L'\0' || pdli == NULL ||
+	    pdli->szDll == NULL) {
+		return NULL;
+	}
+
+	wchar_t dll_wide[MAX_PATH];
+	int converted = MultiByteToWideChar(CP_ACP, 0, pdli->szDll, -1, dll_wide, MAX_PATH);
+	if (converted <= 0) {
+		return NULL;
+	}
+
+	wchar_t full_path[MAX_PATH];
+	int written = swprintf_s(full_path, MAX_PATH, L"%s\\%s", g_runtime_dir, dll_wide);
+	if (written <= 0) {
+		return NULL;
+	}
+
+	// LOAD_WITH_ALTERED_SEARCH_PATH so any transitive imports of the
+	// loaded DLL are resolved against its own directory (i.e. our install
+	// dir), not the host app's exe directory.
+	HMODULE h = LoadLibraryExW(full_path, NULL, LOAD_WITH_ALTERED_SEARCH_PATH);
+	return (FARPROC)h;
+}
+
+// MSVC delay-load runtime picks this up by name. Falls back to the default
+// resolver when the hook returns NULL. Note: modern delayimp.h declares
+// this with `const` qualification — definition must match.
+const PfnDliHook __pfnDliNotifyHook2 = displayxr_dli_hook;
+
+BOOL APIENTRY
+DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)
+{
+	(void)lpReserved;
+	if (ul_reason_for_call == DLL_PROCESS_ATTACH) {
+		DisableThreadLibraryCalls(hModule);
+		if (GetModuleFileNameW(hModule, g_runtime_dir, MAX_PATH) > 0) {
+			wchar_t *last_slash = wcsrchr(g_runtime_dir, L'\\');
+			if (last_slash != NULL) {
+				*last_slash = L'\0';
+			} else {
+				g_runtime_dir[0] = L'\0';
+			}
+		}
+	}
+	return TRUE;
+}
+
+#endif // _WIN32

--- a/test_apps/cube_handle_vk_win/CMakeLists.txt
+++ b/test_apps/cube_handle_vk_win/CMakeLists.txt
@@ -128,10 +128,12 @@ if(TEXTURE_FILES)
     )
 endif()
 
-# SimulatedRealityVulkanBeta.dll: shipped with the runtime
-# (`Program Files\DisplayXR\Runtime\` post-install — added to system
-# PATH by the runtime installer; dev `_package/bin/` is added to
-# PATH by `_package/run_*.bat`). Apps no longer bundle a per-app copy.
+# SimulatedRealityVulkanBeta.dll: shipped with the runtime under
+# `Program Files\DisplayXR\Runtime\` post-install. Resolved by
+# DisplayXRClient.dll's delay-load notify hook (target_dll_init.c),
+# which loads it from the runtime's own install dir at first use.
+# Dev iteration: `_package/bin/` is added to PATH by `_package/run_*.bat`.
+# Apps don't bundle a per-app copy.
 
 # DisplayXR shell manifest sidecar
 include(${CMAKE_CURRENT_SOURCE_DIR}/../common/displayxr_manifest.cmake)

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,0 +1,5 @@
+{
+    "overlay-triplets": [
+        "cmake/vcpkg-overlay-triplets"
+    ]
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -11,14 +11,12 @@
             "name": "pthreads",
             "platform": "windows"
         },
-        "cjson",
         "eigen3",
         "glslang",
         "vulkan"
     ],
     "default-features": [
-        "usb",
-        "gui"
+        "usb"
     ],
     "features": {
         "usb": {


### PR DESCRIPTION
## Summary

The runtime installer no longer modifies system PATH. `DisplayXRClient.dll`'s transitive third-party deps (cjson, SDL2, pthreads) are eliminated at the build layer instead — bundled source for cjson, vcpkg static linkage for pthreads, removed entirely for SDL2 — and the one delay-loaded DLL still co-located in \$INSTDIR (Leia SR Vulkan weaver) is resolved by a DllMain notify hook scoped to delay-loads.

## Why

The old `AddToPath` was needed so Windows could resolve `DisplayXRClient.dll`'s static imports of `pthreadVCE3.dll` / `cjson.dll` / `SDL2.dll`. PATH writes leak across installs — we observed duplicate `C:\Program Files\DisplayXR\Runtime` entries from prior versions on the same machine — and fight with other DisplayXR-adjacent installers. Dropping the PATH write is desirable on its own; eliminating the imports it was masking is the structural fix.

## What changed

- **`vcpkg.json`** — drop `cjson` from deps; drop `gui` from `default-features` (kills SDL2 from the install set; XRT_HAVE_SDL2 auto-detects off).
- **`vcpkg-configuration.json` + `cmake/vcpkg-overlay-triplets/x64-windows.cmake`** (new) — per-port `VCPKG_LIBRARY_LINKAGE` override forces vcpkg's `pthreads` port to build static. `PThreads4WConfig.cmake` auto-detects no `bin/*.dll` and switches the imported target type, so `xrt-pthreads` needs no source change.
- **`src/external/CMakeLists.txt` + `src/xrt/auxiliary/util/u_json.c`** — when the MCP module's `displayxr_mcp_vendored_cjson` static lib is in the build, route `xrt-external-cjson` through it instead of `#include "cjson/cJSON.c"` in `u_json.c`. New `XRT_HAVE_LINKED_CJSON` gate avoids duplicate-symbol collision (`aux_util.lib` vs `displayxr_mcp_vendored_cjson.lib`).
- **`src/xrt/targets/openxr/target_dll_init.c`** (new) — `DllMain` + `__pfnDliNotifyHook2`. Resolves `/DELAYLOAD`'d DLLs from the runtime's own install dir via `LoadLibraryExW + LOAD_WITH_ALTERED_SEARCH_PATH`. Strictly scoped to delay-loads — we're loaded into the host app's process, so `SetDefaultDllDirectories` would be rude.
- **`installer/DisplayXRInstaller.nsi`** — remove `Call AddToPath` in the install section. `un.RemoveFromPath` stays in the uninstaller path so upgrades from older installer versions still clean up stale entries.

## Verification

End-to-end on a Leia SR machine, fresh runtime install with `C:\Program Files\DisplayXR\Runtime` confirmed absent from system PATH:

- `dumpbin /imports DisplayXRClient.dll` — no third-party DLLs in static imports; delay-loaded list correctly shows `SimulatedRealityVulkanBeta.dll` + `vulkan-1.dll`.
- All four cube test apps (D3D11, D3D12, GL, Vulkan) launch and render correctly from a clean install.
- `displayxr-shell.exe` + two cube apps launches, lays out, and chrome renders — paired with a sibling PR in `displayxr-shell-pvt` that mirrors the static-pthreads/cjson change for the shell binary.

## Test plan

- [ ] CI green (build-windows.yml)
- [ ] Smoke: cube_handle_d3d11_win.exe via installed runtime, no PATH workaround
- [ ] Smoke: cube_handle_vk_win.exe via installed runtime (exercises the DllMain delay-load hook for SR weaver)
- [ ] Verify uninstaller still removes legacy PATH entries from installs predating this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Release notes / heads-up for downstream consumers

The runtime installer no longer modifies system PATH. Downstream apps that previously relied on `C:\Program Files\DisplayXR\Runtime` being on PATH for any reason need to make their own provisions:

- **OpenXR apps that link the Khronos loader:** bundle `openxr_loader.dll` next to your app's `.exe`. The test apps in this repo (`test_apps/cube_*/CMakeLists.txt`), `displayxr-webxr-bridge`, and the new shell installer all do this via a `POST_BUILD` `copy_if_different` of `OpenXR::openxr_loader`'s `IMPORTED_LOCATION`. Apps that previously found `openxr_loader.dll` in `$INSTDIR` via the PATH entry will need to start shipping their own copy.
- **WebXR consumers:** Chrome's renderer loads `openxr_loader.dll` from the system; this is unchanged. The native WebXR bridge (`displayxr-webxr-bridge.exe`) already co-locates its own loader via the same `POST_BUILD` pattern.
- **Workspace controllers (third-party shells):** statically-imported third-party DLLs need to be self-contained — either statically linked or bundled next to the workspace controller's exe. See the sibling `displayxr-shell-pvt` PR for the canonical pattern (`vcpkg-configuration.json` + per-port static triplet override, plus `install(FILES ... openxr_loader.dll ...)`).
