### PR TITLE
chore(workspace): verify EDGE_RESIZE_* surfaces in POINTER events

### DIFF
--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -14198,6 +14198,18 @@ comp_d3d11_service_workspace_drain_input_events(struct xrt_system_compositor *xs
 			POINT pt = {(LONG)r->cursor_x, (LONG)r->cursor_y};
 			struct workspace_hit_result hit = workspace_raycast_hit_test(sys, mc, pt);
 			ev->u.pointer.hit_region = hit_result_to_region(hit);
+			// PR 1 (workspace controller migration): verify EDGE_RESIZE_*
+			// region values surface to the controller. One-shot — fires on
+			// the first POINTER event whose region is N/S/E/W/NE/NW/SE/SW.
+			if (ev->u.pointer.hit_region >= 10u && ev->u.pointer.hit_region <= 17u) {
+				static bool logged = false;
+				if (!logged) {
+					logged = true;
+					U_LOG_W("[ws-migrate] POINTER edge-resize emit: region=%u slot=%d edge_flags=0x%x button=%u down=%u",
+					        ev->u.pointer.hit_region, hit.slot, hit.edge_flags,
+					        ev->u.pointer.button, ev->u.pointer.is_down);
+				}
+			}
 			if (hit.slot >= 0) {
 				ev->u.pointer.hit_client_id = 1000u + (uint32_t)hit.slot;
 				if (hit.in_content) {
@@ -14239,6 +14251,19 @@ comp_d3d11_service_workspace_drain_input_events(struct xrt_system_compositor *xs
 			POINT pt = {(LONG)r->cursor_x, (LONG)r->cursor_y};
 			struct workspace_hit_result hit = workspace_raycast_hit_test(sys, mc, pt);
 			ev->u.pointer_motion.hit_region = hit_result_to_region(hit);
+			// PR 1 (workspace controller migration): see POINTER branch above.
+			// One-shot edge-resize verification on the MOTION path too —
+			// motion is what carries pose updates during a controller-owned
+			// resize drag, so we want both paths confirmed.
+			if (ev->u.pointer_motion.hit_region >= 10u && ev->u.pointer_motion.hit_region <= 17u) {
+				static bool logged = false;
+				if (!logged) {
+					logged = true;
+					U_LOG_W("[ws-migrate] MOTION edge-resize emit: region=%u slot=%d edge_flags=0x%x button_mask=0x%x",
+					        ev->u.pointer_motion.hit_region, hit.slot, hit.edge_flags,
+					        ev->u.pointer_motion.button_mask);
+				}
+			}
 			if (hit.slot >= 0) {
 				ev->u.pointer_motion.hit_client_id = 1000u + (uint32_t)hit.slot;
 				if (hit.in_content) {


### PR DESCRIPTION
## Summary

PR 1 of the [workspace policy migration plan](../blob/main/.claude/plans/) (ADR-018 follow-up). Six-PR series moves the drag / resize / rotation / cursor state machines from `comp_d3d11_service.cpp` to the workspace controller, leaving the runtime as plumbing only.

This PR is **verification only** — no behavior change. It pins the runtime's hit-region mapping (`workspace_raycast_hit_test.edge_flags` → `hit_result_to_region` → `XrWorkspaceHitRegionEXT::EDGE_RESIZE_*`) with one-shot WARN logs on first emit. Locks the contract before PRs 2–4 delete the in-runtime state machines and the controller starts driving its own resize state from these regions.

- One-shot `[ws-migrate] POINTER edge-resize emit: ...` on the first POINTER event with region ∈ {N, S, E, W, NE, NW, SE, SW}.
- Same on POINTER_MOTION (will fire later when the controller takes pointer capture during a drag).
- `static bool logged` guard — one line per path per service lifetime; zero per-frame overhead.

## Test plan

- [x] Local build (`scripts\build_windows.bat build`) — clean.
- [x] Deployed to `C:\Program Files\DisplayXR\Runtime\` and launched `displayxr-shell.exe cube_handle_d3d11_win.exe`.
- [x] Pressed LMB on the cube window's west edge — log fired:
      `[ws-migrate] POINTER edge-resize emit: region=13 slot=0 edge_flags=0x1 button=1 down=1`
      region 13 == `EDGE_RESIZE_W_EXT`; edge_flags 0x1 == `RESIZE_LEFT`. End-to-end mapping confirmed.
- [x] MOTION-side log correctly stays silent — runtime-owned resize doesn't enable pointer capture, so MOTION events aren't emitted during the drag. That path will exercise once PR 2/3 land.

## Migration context

Next PRs in the series:

| PR | Migrates | Depends |
|---|---|---|
| **1** | (verification) | — |
| 2 | Title-bar drag (`mc->title_drag`) | 1 |
| 3 | Edge resize (`mc->resize`) | 1 |
| 4 | RMB rotation (`mc->title_rmb_drag`) | 1 |
| 5 | New per-frame chrome layer pose RPC (spec 11→12) | — |
| 6 | Cursor (`mc->cursor_*`, OS + 3D sprite) | 2, 3, 5 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)