### PR TITLE
feat(workspace): controller owns RMB rotation drag

### DIFF
--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -1174,16 +1174,6 @@ struct d3d11_multi_compositor
 	HCURSOR cursor_sizenesw; // NE-SW diagonal
 	HCURSOR cursor_sizeall;  // move/grab (title drag, right-click drag)
 
-	//! Title bar right-click drag state for window rotation.
-	struct
-	{
-		bool active;
-		int32_t slot;
-		POINT start_cursor;
-		float start_yaw;   //!< Yaw (radians) at drag start
-		float start_pitch;  //!< Pitch (radians) at drag start
-	} title_rmb_drag;
-
 	//! Momentary toast notification (e.g. "how to restore after fullscreen").
 	char toast_text[256];
 	uint64_t toast_until_ns;
@@ -7402,76 +7392,14 @@ after_key_shortcuts:
 			goto after_rmb_handling;
 		}
 
-		if (rmb_held) {
-			// Phase 2.K: when the controller has pointer capture, suppress
-			// the runtime's RMB rotation drag — the controller owns interactive
-			// motion policy.
-			bool ctrl_owns_drag = (mc->window != nullptr) &&
-			                      comp_d3d11_window_is_workspace_pointer_capture_enabled(mc->window);
-			if (!mc->title_rmb_drag.active && rmb_just_pressed && !ctrl_owns_drag) {
-				// RMB just pressed — check if on title bar to start rotation drag
-				POINT pt;
-				GetCursorPos(&pt);
-				ScreenToClient(mc->hwnd, &pt);
-				struct workspace_hit_result rmb_hit = workspace_raycast_hit_test(sys, mc, pt);
-				if (rmb_hit.slot >= 0) {
-					if (rmb_hit.slot != mc->focused_slot) {
-						mc->focused_slot = rmb_hit.slot;
-						multi_compositor_update_input_forward(mc);
-					}
-					// Phase 2.K Commit 8 tweak: only start rotation drag
-					// when RMB lands on the grip dots (matches LMB drag).
-					if (rmb_hit.in_grip_handle) {
-						// Start rotation drag
-						mc->title_rmb_drag.active = true;
-						mc->title_rmb_drag.slot = rmb_hit.slot;
-						mc->title_rmb_drag.start_cursor = pt;
-						// Extract current yaw/pitch from quaternion. Note:
-						// math_quat_to_euler_angles uses Eigen's Z-Y-X
-						// decomposition and writes the result with .x = Z
-						// (roll), .y = Y (yaw), .z = X (pitch). Reading
-						// pitch from .x (the roll slot) was a long-standing
-						// bug — on every RMB-drag start it snapped pitch
-						// to 0, so any previously-accumulated pitch
-						// vanished the moment the user pressed RMB again.
-						struct xrt_vec3 euler;
-						math_quat_to_euler_angles(&mc->clients[rmb_hit.slot].window_pose.orientation, &euler);
-						mc->title_rmb_drag.start_yaw = euler.y;
-						mc->title_rmb_drag.start_pitch = euler.z;
-					}
-				}
-			} else if (mc->title_rmb_drag.active) {
-				// RMB held — update rotation during drag
-				POINT pt;
-				GetCursorPos(&pt);
-				ScreenToClient(mc->hwnd, &pt);
-				int s = mc->title_rmb_drag.slot;
-				if (s >= 0 && s < D3D11_MULTI_MAX_CLIENTS && mc->clients[s].active) {
-					float dx = (float)(pt.x - mc->title_rmb_drag.start_cursor.x);
-					float dy = (float)(pt.y - mc->title_rmb_drag.start_cursor.y);
-					// ~1 degree per 10 pixels
-					float deg_per_px = (float)(M_PI / 180.0) / 10.0f;
-					float yaw = mc->title_rmb_drag.start_yaw + dx * deg_per_px;
-					float pitch = mc->title_rmb_drag.start_pitch + dy * deg_per_px;
-					// Clamp: yaw ±30°, pitch ±15°
-					float max_yaw = (float)(30.0 * M_PI / 180.0);
-					float max_pitch = (float)(15.0 * M_PI / 180.0);
-					if (yaw < -max_yaw) yaw = -max_yaw;
-					if (yaw > max_yaw) yaw = max_yaw;
-					if (pitch < -max_pitch) pitch = -max_pitch;
-					if (pitch > max_pitch) pitch = max_pitch;
-
-					mc->clients[s].window_pose.orientation = quat_from_yaw_pitch(yaw, pitch);
-				}
-			}
-		} else {
-			if (mc->title_rmb_drag.active) {
-				mc->title_rmb_drag.active = false;
-				mc->title_rmb_drag.slot = -1;
-				// Nudge cursor to force WM_SETCURSOR update
-				POINT p; GetCursorPos(&p); SetCursorPos(p.x, p.y);
-			}
-		}
+		// RMB rotation drag and RMB-content focus are the workspace
+		// controller's job (ADR-018 / PR 4 of the runtime→controller
+		// migration). Controllers see POINTER(R,*) events with hit_region
+		// + chrome_region_id and decide what to do: rotation drag on
+		// grip-hit (capture + per-frame xrSetWorkspaceClientWindowPoseEXT
+		// with quaternion from yaw/pitch), focus via
+		// xrSetWorkspaceFocusedClientEXT on RMB-on-tile, or context menu.
+		(void)rmb_just_pressed;
 
 	after_rmb_handling:
 		(void)0; // label target for the launcher-visible fast-path above.


### PR DESCRIPTION
> ⚠️ **HOLD FOR LOCKSTEP MERGE** — RMB rotation and RMB-on-content focus will not work in shell mode until the matching \`displayxr-shell-pvt\` PR also lands. Do not merge alone.

## Summary

PR 4 of the [workspace policy migration](../blob/main/.claude/plans/workspace-runtime-contract-review-streamed-quilt.md) (ADR-018 follow-up). Deletes the runtime-side RMB rotation state machine + RMB-on-content focus. The controller now owns both via spec_version 11 surface.

**Controller protocol** (no API delta):
- On \`POINTER(button=R, down, hit_region == TITLE_BAR or grip CHROME region)\` → \`xrSetWorkspaceFocusedClientEXT\`, then \`xrEnableWorkspacePointerCaptureEXT(session, 2)\`, snapshot orientation, decompose Z-Y-X Eigen (yaw = euler.y, pitch = euler.z — **NOT** .x, that was a long-standing runtime bug).
- On \`POINTER_MOTION\` while captured → yaw/pitch += dx/dy × (1°/10px); clamp ±30° / ±15°; \`xrSetWorkspaceClientWindowPoseEXT\` with \`quat_from_yaw_pitch\`.
- On \`POINTER(R, up)\` → \`xrDisableWorkspacePointerCaptureEXT\`.

## Removed (net −72 LOC)

| Site | LOC | What |
|---|---|---|
| Struct field | 9 | \`mc->title_rmb_drag\` (active, slot, start_cursor, start_yaw, start_pitch) |
| RMB-on-tile focus | ~5 | Focus assignment + \`multi_compositor_update_input_forward\`. Controller now calls \`xrSetWorkspaceFocusedClientEXT\` on RMB-on-content. |
| Rotation-drag-start | ~32 | start state + \`ctrl_owns_drag\` opt-out + the Z-Y-X Eigen decomposition note (preserved in the shell-pvt PR spec so the bug doesn't reappear) |
| Per-frame rotation | ~22 | yaw/pitch accumulate + ±30°/±15° clamp + \`quat_from_yaw_pitch\` |
| Rotation-end | ~7 | state reset + cursor nudge |

## Preserved

- **Launcher RMB context-menu fast-path** (lines 7586–7600). Launcher policy — already separate.
- **\`prev_rmb_held\` + \`rmb_just_pressed\`** — still consumed by the launcher fast-path.

## Test plan

- [x] Local build clean.
- [ ] Shell-pvt matching PR ready.
- [ ] Merge both; verify RMB-drag-from-grip rotates the window with ±30°/±15° clamps and the right sensitivity, and that the Z-Y-X decomposition is correct (start a rotation, release, start again — pitch should not snap back to 0).
- [ ] Sanity: launcher RMB context menu still works.
- [ ] Sanity: focus-on-RMB-content works (now controller-driven).

## Migration progress

| PR | Migrates | Status |
|---|---|---|
| #254 | (verification) | open |
| #255 | A — title drag | open, hold for lockstep |
| #257 | B — edge resize | open, hold for lockstep |
| **this** | **C — RMB rotation** | **open, hold for lockstep** |
| _next_ | (new per-frame chrome RPC, spec 11→12) | — |
| _next_ | D — cursor | — |

🤖 Generated with [Claude Code](https://claude.com/claude-code)