### PR TITLE
feat(workspace): xrUpdateWorkspaceClientChromeLayerPoseEXT (spec_version 12)

### DIFF
--- a/src/external/openxr_includes/openxr/XR_EXT_spatial_workspace.h
+++ b/src/external/openxr_includes/openxr/XR_EXT_spatial_workspace.h
@@ -25,7 +25,7 @@ extern "C" {
 #endif
 
 #define XR_EXT_spatial_workspace 1
-#define XR_EXT_spatial_workspace_SPEC_VERSION 11
+#define XR_EXT_spatial_workspace_SPEC_VERSION 12
 #define XR_EXT_SPATIAL_WORKSPACE_EXTENSION_NAME "XR_EXT_spatial_workspace"
 
 // Provisional XrStructureType values. The 1000999100..105 range is reserved for
@@ -775,6 +775,32 @@ typedef XrResult (XRAPI_PTR *PFN_xrSetWorkspaceClientChromeLayoutEXT)(
     XrWorkspaceClientId                clientId,
     const XrWorkspaceChromeLayoutEXT  *layout);
 
+/*!
+ * @brief Per-frame pose update for a client's chrome quad (spec_version 12).
+ *
+ * @c xrSetWorkspaceClientChromeLayoutEXT is the cached-layout fast path: call
+ * it once on connect and whenever the chrome's *size*, hit regions, depth bias,
+ * or anchor flags change. It is documented as "per-frame IPC is not needed."
+ *
+ * This call is the pose-only complement, intended for fast-moving chrome: a
+ * cursor sprite whose Z depth tracks the per-frame hit-test, a focus-ring
+ * animation, a tooltip that follows the user's gaze, etc. Carries only the
+ * 3-vec + quaternion (~32 bytes on the wire) and overwrites the @c poseInClient
+ * field of the previously-cached layout. All other fields stay as last set.
+ *
+ * If no layout has been set for @p clientId yet, the call still records the
+ * pose; once the controller pushes a layout, the recorded pose is used as the
+ * starting value.
+ *
+ * @return XR_SUCCESS on success,
+ *         XR_ERROR_HANDLE_INVALID if @p clientId is unknown,
+ *         XR_ERROR_FEATURE_UNSUPPORTED if @p session is not the active workspace.
+ */
+typedef XrResult (XRAPI_PTR *PFN_xrUpdateWorkspaceClientChromeLayerPoseEXT)(
+    XrSession            session,
+    XrWorkspaceClientId  clientId,
+    const XrPosef       *poseInClient);
+
 // ---- Event-driven wakeup (spec_version 8) ----
 
 /*!
@@ -1003,6 +1029,11 @@ XRAPI_ATTR XrResult XRAPI_CALL xrSetWorkspaceClientChromeLayoutEXT(
     XrSession                          session,
     XrWorkspaceClientId                clientId,
     const XrWorkspaceChromeLayoutEXT  *layout);
+
+XRAPI_ATTR XrResult XRAPI_CALL xrUpdateWorkspaceClientChromeLayerPoseEXT(
+    XrSession            session,
+    XrWorkspaceClientId  clientId,
+    const XrPosef       *poseInClient);
 
 XRAPI_ATTR XrResult XRAPI_CALL xrAcquireWorkspaceWakeupEventEXT(
     XrSession  session,

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -14481,6 +14481,30 @@ comp_d3d11_service_workspace_set_chrome_layout_by_slot(struct xrt_system_composi
 	return XRT_SUCCESS;
 }
 
+extern "C" xrt_result_t
+comp_d3d11_service_workspace_update_chrome_layer_pose_by_slot(struct xrt_system_compositor *xsysc,
+                                                              int slot,
+                                                              const struct xrt_pose *pose_in_client)
+{
+	if (xsysc == nullptr || pose_in_client == nullptr) {
+		return XRT_ERROR_IPC_FAILURE;
+	}
+	struct d3d11_service_system *sys = d3d11_service_system_from_xrt(xsysc);
+	struct d3d11_multi_compositor *mc = sys->multi_comp;
+	if (mc == nullptr || slot < 0 || slot >= D3D11_MULTI_MAX_CLIENTS) {
+		return XRT_ERROR_IPC_FAILURE;
+	}
+
+	std::lock_guard<std::recursive_mutex> lock(sys->render_mutex);
+	mc->clients[slot].chrome_pose_in_client = *pose_in_client;
+	// Note: chrome_layout_valid is NOT toggled here. A pose-only update on a
+	// slot whose layout hasn't been pushed yet just stages the pose for the
+	// controller's eventual set_chrome_layout_by_slot to inherit. If a
+	// layout has already been pushed (the common case for cursor + animated
+	// chrome), the flag is already true and stays that way.
+	return XRT_SUCCESS;
+}
+
 // Phase 2.C spec_version 9: shared body for both IPC and capture client style
 // pushes. Copies fields; does NOT validate (state tracker already validated).
 static void

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.h
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.h
@@ -561,6 +561,21 @@ comp_d3d11_service_workspace_set_chrome_layout_by_slot(struct xrt_system_composi
                                                        const struct ipc_workspace_chrome_layout *layout);
 
 /*!
+ * spec_version 12: per-frame pose-only update for a previously-laid-out chrome
+ * layer. Cheaper than set_chrome_layout (one ~32-byte XrPosef, no region
+ * array). Used for fast-moving chrome — cursor sprite, focus-ring animation,
+ * gaze-tracked tooltips. Overwrites only chrome_pose_in_client; all other
+ * cached layout fields stay as last set.
+ *
+ * Idempotent if the slot has no chrome layout yet — the pose is recorded and
+ * the controller's next set_chrome_layout_by_slot inherits it.
+ */
+xrt_result_t
+comp_d3d11_service_workspace_update_chrome_layer_pose_by_slot(struct xrt_system_compositor *xsysc,
+                                                              int slot,
+                                                              const struct xrt_pose *pose_in_client);
+
+/*!
  * Phase 2.C spec_version 8: lazy-create + return the workspace wakeup
  * event handle (Win32 HANDLE on Windows). The IPC handler then DuplicateHandle's
  * it into the controller process so the controller can wait on it instead

--- a/src/xrt/ipc/client/ipc_client_compositor.c
+++ b/src/xrt/ipc/client/ipc_client_compositor.c
@@ -896,6 +896,21 @@ comp_ipc_client_compositor_workspace_set_chrome_layout(struct xrt_compositor *xc
 }
 
 xrt_result_t
+comp_ipc_client_compositor_workspace_update_chrome_layer_pose(struct xrt_compositor *xc,
+                                                              uint32_t client_id,
+                                                              const struct xrt_pose *pose_in_client)
+{
+	if (xc == NULL || pose_in_client == NULL) {
+		return XRT_ERROR_IPC_FAILURE;
+	}
+	struct ipc_client_compositor *icc = ipc_client_compositor(xc);
+	if (icc == NULL || icc->ipc_c == NULL) {
+		return XRT_ERROR_IPC_FAILURE;
+	}
+	return ipc_call_workspace_update_chrome_layer_pose(icc->ipc_c, client_id, pose_in_client);
+}
+
+xrt_result_t
 comp_ipc_client_compositor_workspace_acquire_wakeup_event(struct xrt_compositor *xc,
                                                           xrt_graphics_sync_handle_t *out_handle)
 {

--- a/src/xrt/ipc/server/ipc_server_handler.c
+++ b/src/xrt/ipc/server/ipc_server_handler.c
@@ -3283,6 +3283,51 @@ ipc_handle_workspace_set_chrome_layout(volatile struct ipc_client_state *_ics,
 }
 
 xrt_result_t
+ipc_handle_workspace_update_chrome_layer_pose(volatile struct ipc_client_state *_ics,
+                                              uint32_t client_id,
+                                              const struct xrt_pose *pose_in_client)
+{
+	struct ipc_server *s = _ics->server;
+#if defined(XRT_HAVE_D3D11_SERVICE_COMPOSITOR)
+	if (s->xsysc == NULL || pose_in_client == NULL) {
+		return XRT_ERROR_IPC_FAILURE;
+	}
+
+	if (client_id >= 1000u) {
+		IPC_WARN(s, "Workspace: update_chrome_layer_pose - capture clients (id=%u) not supported", client_id);
+		return XRT_ERROR_IPC_FAILURE;
+	}
+
+	os_mutex_lock(&s->global_state.lock);
+	volatile struct ipc_client_state *target_ics = NULL;
+	for (uint32_t i = 0; i < IPC_MAX_CLIENTS; i++) {
+		volatile struct ipc_client_state *ics = &s->threads[i].ics;
+		if (ics->client_state.id == client_id && ics->server_thread_index >= 0) {
+			target_ics = ics;
+			break;
+		}
+	}
+	if (target_ics == NULL || target_ics->xc == NULL) {
+		os_mutex_unlock(&s->global_state.lock);
+		// Per-frame call — quieter log than set_chrome_layout (which warns).
+		return XRT_ERROR_IPC_FAILURE;
+	}
+	int slot = comp_d3d11_service_workspace_find_slot_by_xc(s->xsysc, (struct xrt_compositor *)target_ics->xc);
+	os_mutex_unlock(&s->global_state.lock);
+	if (slot < 0) {
+		return XRT_ERROR_IPC_FAILURE;
+	}
+
+	return comp_d3d11_service_workspace_update_chrome_layer_pose_by_slot(s->xsysc, slot, pose_in_client);
+#else
+	(void)s;
+	(void)client_id;
+	(void)pose_in_client;
+	return XRT_ERROR_IPC_FAILURE;
+#endif
+}
+
+xrt_result_t
 ipc_handle_workspace_get_file_picker_request(volatile struct ipc_client_state *_ics,
                                              uint64_t request_id,
                                              uint32_t *out_found,

--- a/src/xrt/ipc/shared/proto.json
+++ b/src/xrt/ipc/shared/proto.json
@@ -247,6 +247,13 @@
 		]
 	},
 
+	"workspace_update_chrome_layer_pose": {
+		"in": [
+			{"name": "client_id", "type": "uint32_t"},
+			{"name": "pose_in_client", "type": "struct xrt_pose"}
+		]
+	},
+
 	"workspace_acquire_wakeup_event": {
 		"out_handles": {"type": "xrt_graphics_sync_handle_t"}
 	},

--- a/src/xrt/state_trackers/oxr/oxr_api_funcs.h
+++ b/src/xrt/state_trackers/oxr/oxr_api_funcs.h
@@ -891,6 +891,11 @@ XRAPI_ATTR XrResult XRAPI_CALL
 oxr_xrSetWorkspaceClientChromeLayoutEXT(XrSession session,
                                         XrWorkspaceClientId clientId,
                                         const XrWorkspaceChromeLayoutEXT *layout);
+//! OpenXR API function @ep{xrUpdateWorkspaceClientChromeLayerPoseEXT} (spec_version 12)
+XRAPI_ATTR XrResult XRAPI_CALL
+oxr_xrUpdateWorkspaceClientChromeLayerPoseEXT(XrSession session,
+                                              XrWorkspaceClientId clientId,
+                                              const XrPosef *poseInClient);
 //! OpenXR API function @ep{xrAcquireWorkspaceWakeupEventEXT}
 XRAPI_ATTR XrResult XRAPI_CALL
 oxr_xrAcquireWorkspaceWakeupEventEXT(XrSession session, uint64_t *outNativeHandle);

--- a/src/xrt/state_trackers/oxr/oxr_api_negotiate.c
+++ b/src/xrt/state_trackers/oxr/oxr_api_negotiate.c
@@ -462,6 +462,7 @@ handle_non_null(struct oxr_instance *inst, struct oxr_logger *log, const char *n
 	ENTRY_IF_EXT(xrCreateWorkspaceClientChromeSwapchainEXT, EXT_spatial_workspace);
 	ENTRY_IF_EXT(xrDestroyWorkspaceClientChromeSwapchainEXT, EXT_spatial_workspace);
 	ENTRY_IF_EXT(xrSetWorkspaceClientChromeLayoutEXT, EXT_spatial_workspace);
+	ENTRY_IF_EXT(xrUpdateWorkspaceClientChromeLayerPoseEXT, EXT_spatial_workspace);
 	ENTRY_IF_EXT(xrAcquireWorkspaceWakeupEventEXT, EXT_spatial_workspace);
 	ENTRY_IF_EXT(xrSetWorkspaceClientStyleEXT, EXT_spatial_workspace);
 #endif

--- a/src/xrt/state_trackers/oxr/oxr_workspace.c
+++ b/src/xrt/state_trackers/oxr/oxr_workspace.c
@@ -149,6 +149,10 @@ comp_ipc_client_compositor_workspace_set_chrome_layout(struct xrt_compositor *xc
                                                        uint32_t client_id,
                                                        const struct ipc_workspace_chrome_layout *layout);
 xrt_result_t
+comp_ipc_client_compositor_workspace_update_chrome_layer_pose(struct xrt_compositor *xc,
+                                                              uint32_t client_id,
+                                                              const struct xrt_pose *pose_in_client);
+xrt_result_t
 comp_ipc_client_compositor_workspace_acquire_wakeup_event(struct xrt_compositor *xc,
                                                           xrt_graphics_sync_handle_t *out_handle);
 // Phase 2.C spec_version 9: per-client visual style.
@@ -1108,6 +1112,39 @@ oxr_xrSetWorkspaceClientChromeLayoutEXT(XrSession session,
 	xrt_result_t xret = comp_ipc_client_compositor_workspace_set_chrome_layout(
 	    &sess->xcn->base, (uint32_t)clientId, &ipc_layout);
 	return xret_to_xr_result(&log, xret, "workspace_set_chrome_layout");
+}
+
+XRAPI_ATTR XrResult XRAPI_CALL
+oxr_xrUpdateWorkspaceClientChromeLayerPoseEXT(XrSession session,
+                                              XrWorkspaceClientId clientId,
+                                              const XrPosef *poseInClient)
+{
+	OXR_TRACE_MARKER();
+
+	struct oxr_session *sess = NULL;
+	struct oxr_logger log;
+	OXR_VERIFY_SESSION_AND_INIT_LOG(&log, session, sess, "xrUpdateWorkspaceClientChromeLayerPoseEXT");
+	OXR_VERIFY_SESSION_NOT_LOST(&log, sess);
+	OXR_VERIFY_EXTENSION(&log, sess->sys->inst, EXT_spatial_workspace);
+	OXR_VERIFY_ARG_NOT_NULL(&log, poseInClient);
+
+	if (clientId == XR_NULL_WORKSPACE_CLIENT_ID) {
+		return oxr_error(&log, XR_ERROR_VALIDATION_FAILURE,
+		                 "xrUpdateWorkspaceClientChromeLayerPoseEXT: clientId must not be "
+		                 "XR_NULL_WORKSPACE_CLIENT_ID");
+	}
+
+	if (!session_is_ipc_client(sess)) {
+		return oxr_error(&log, XR_ERROR_FEATURE_UNSUPPORTED,
+		                 "xrUpdateWorkspaceClientChromeLayerPoseEXT requires an IPC-mode session");
+	}
+
+	struct xrt_pose xpose;
+	xr_pose_to_xrt_pose(poseInClient, &xpose);
+
+	xrt_result_t xret = comp_ipc_client_compositor_workspace_update_chrome_layer_pose(
+	    &sess->xcn->base, (uint32_t)clientId, &xpose);
+	return xret_to_xr_result(&log, xret, "workspace_update_chrome_layer_pose");
 }
 
 XRAPI_ATTR XrResult XRAPI_CALL


### PR DESCRIPTION
## Summary

PR 5 of the [workspace policy migration](../blob/main/.claude/plans/workspace-runtime-contract-review-streamed-quilt.md). **Additive surface, no behavior change — landable independently** (no lockstep hold).

Adds \`xrUpdateWorkspaceClientChromeLayerPoseEXT(session, clientId, poseInClient)\` — a per-frame pose-only complement to the cached \`xrSetWorkspaceClientChromeLayoutEXT\`. Bumps \`XR_EXT_spatial_workspace_SPEC_VERSION\` 11 → 12.

## Why

\`xrSetWorkspaceClientChromeLayoutEXT\` is the cached-layout fast path; its header explicitly says "per-frame IPC is not needed." Cursor migration (PR 6) needs to push a new chrome pose every frame because cursor hit-Z varies per frame, which would violate that contract. This RPC is the right shape:

- Pose-only (~32-byte wire payload)
- Doesn't touch hit regions, size, anchor flags, depth bias — they stay cached
- Generalizes beyond cursor: any fast-moving controller-rendered chrome (focus-ring animations, gaze-tracked tooltips, multi-cursor) uses the same call

Auto-syncs to \`DisplayXR/displayxr-extensions\` on push to main; the public extension header reaches third-party controllers without manual mirroring.

## Surface (+181 LOC, 9 files)

| File | What |
|---|---|
| \`XR_EXT_spatial_workspace.h\` | \`SPEC_VERSION\` 11→12, PFN typedef + fn decl with docstring |
| \`proto.json\` | New IPC message \`workspace_update_chrome_layer_pose(client_id, pose_in_client)\` |
| \`ipc_client_compositor.c\` | \`comp_ipc_client_compositor_workspace_update_chrome_layer_pose\` thin wrapper |
| \`ipc_server_handler.c\` | \`ipc_handle_workspace_update_chrome_layer_pose\` — same client_id→slot resolution as \`set_chrome_layout\`, quieter warn log (per-frame call) |
| \`comp_d3d11_service.{h,cpp}\` | \`comp_d3d11_service_workspace_update_chrome_layer_pose_by_slot\` — takes \`render_mutex\`, updates \`clients[slot].chrome_pose_in_client\`. Does **NOT** toggle \`chrome_layout_valid\` (pose-only updates on slots without a layout pre-stage the pose for the controller's eventual \`set_chrome_layout_by_slot\` to inherit) |
| \`oxr_workspace.c\` | OXR entry point with validation matching \`xrSetWorkspaceClientWindowPoseEXT\`. Uses \`xr_pose_to_xrt_pose\` field-wise helper per existing convention. |
| \`oxr_api_funcs.h\` | Prototype decl |
| \`oxr_api_negotiate.c\` | \`ENTRY_IF_EXT\` dispatch entry |

Codegen regenerates \`ipc_protocol_generated.h\`, \`ipc_client_generated.{c,h}\`, \`ipc_server_generated.{c,h}\` from \`proto.json\` without manual edits.

## Test plan

- [x] Local build clean (codegen regenerated correctly, service + client DLL relinked).
- [ ] Smoke: existing shell still works with no regressions (existing chrome behavior is untouched — this PR only adds a new entry point).
- [ ] Unit / integration test (deferred to PR 6): a workspace controller creates a chrome swapchain, calls \`xrSetWorkspaceClientChromeLayoutEXT\` once, then \`xrUpdateWorkspaceClientChromeLayerPoseEXT\` at 60 Hz for 5 s — verify reported pose tracks the updates and no IPC errors.

## Migration progress

| PR | Migrates | Status |
|---|---|---|
| #254 | (verification) | open |
| #255 | A — title drag | open, hold for lockstep |
| #257 | B — edge resize | open, hold for lockstep |
| #258 | C — RMB rotation | open, hold for lockstep |
| **this** | **(new chrome pose RPC, spec 11→12)** | **open, mergeable independently** |
| _next_ | D — cursor (depends on this) | — |

🤖 Generated with [Claude Code](https://claude.com/claude-code)