### PR TITLE
macOS: enforce vendor plug-in separation (POSIX loader + installer + link gate)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -239,10 +239,12 @@ For the full interface catalog including display processor vtables (5 API varian
 Vendor display drivers now ship as **plug-in DLLs** (ADR-019 / issue
 #256). `DisplayXR-LeiaSR.dll` (built from `drivers/leia/` + the
 `xrtPluginNegotiate` entry point in `leia_plugin.c`) loads at
-`xrCreateInstance` time via the registry-driven discovery in
-`target_plugin_loader.c`. The runtime DLL itself has zero SR
-identifiers in its link line — see ADR-019 §2.1 and the CI assertion
-in `.github/workflows/build-windows.yml`.
+`xrCreateInstance` time via the registry-driven discovery on Windows
+(or the JSON-manifest discovery on POSIX, as of issue #267 — macOS
+also enforces vendor separation now via `DisplayXR-SimDisplay.dylib`)
+in `target_plugin_loader.c`. The runtime DLL itself has zero SR or
+`sim_display_*` identifiers in its link line — see ADR-019 §2.1 and
+the CI assertion in `.github/workflows/build-windows.yml`.
 
 - `XRT_HAVE_LEIA_SR` CMake option (auto-enabled if SDK found) now
   drives the plug-in DLL build, not a static link of `drv_leia` into
@@ -305,9 +307,10 @@ Full reference: [`docs/getting-started/building.md` § Local Dev Iteration](docs
   DLL build; the runtime DLL no longer static-links drv_leia)
 - `XRT_HAVE_LEIA_SR_VULKAN` / `XRT_HAVE_LEIA_SR_D3D11` — API-specific weavers
 - `XRT_PLUGIN_BUILD_INPROC_FALLBACK` (default OFF) — developer flag
-  that also static-links drv_leia into the runtime DLL for in-proc
-  debugging. Production builds leave this off and route everything
-  through the plug-in DLL.
+  that also static-links `drv_leia` and `drv_sim_display` into the
+  runtime DLL for in-proc debugging. Production builds leave this off
+  and route everything through the plug-in DLL/dylib (`DisplayXR-LeiaSR`,
+  `DisplayXR-SimDisplay`) discovered at `xrCreateInstance` time.
 - `XRT_FEATURE_SERVICE` — Out-of-process service mode
 - `BUILD_TESTING` — Test suite
 
@@ -341,7 +344,7 @@ Ask Gemini to analyze code and produce a read-only report. See `~/.claude/skills
 
 ## macOS Test App Local Builds
 
-Copy binaries to `_package/DisplayXR-macOS/bin/`. Run scripts exec from `$DIR/bin/`.
+Copy binaries to `_package/DisplayXR-macOS/bin/`. Run scripts exec from `$DIR/bin/`. As of issue #267, every generated `run_*.sh` also sets `XRT_PLUGIN_SEARCH_PATH=$DIR/lib/displayxr/plugins` so the dev tree's `DisplayXR-SimDisplay.dylib` (alongside its `200-sim-display.json` manifest) is discovered by the runtime's plug-in loader without touching `~/Library/Application Support/`.
 
 | Test App | Build Output | Package Binary | Run Script |
 |----------|-------------|---------------|------------|

--- a/docs/specs/runtime/plugin-discovery.md
+++ b/docs/specs/runtime/plugin-discovery.md
@@ -3,10 +3,14 @@
 **Audience:** Vendor integrators shipping a display-processor plug-in DLL,
 and runtime engineers maintaining the discovery path.
 
-**Status:** v1. Windows shipping; Linux + macOS spec finalized but loader
-implementation pending Mac access (target_plugin_loader.c's non-Windows
-branch returns NULL today and the runtime falls back to the in-tree
-static drv_sim_display path).
+**Status:** v1. Windows shipping. macOS shipping as of issue #267 —
+runtime dylib has zero `sim_display_*` symbols in its link line, the
+`DisplayXR-SimDisplay.dylib` plug-in is discovered via the JSON
+manifest path described in §3, and `scripts/build_macos.sh` packages
++ wires up the plug-in for dev runs via `XRT_PLUGIN_SEARCH_PATH`.
+Linux uses the same loader code (POSIX branch in
+`target_plugin_loader.c`), but is untested end-to-end because no
+graphics-stack-complete Linux build target ships today.
 
 This document is the **runtime ↔ plug-in discovery contract**. The
 C-ABI side — the negotiation entry point, the `xrt_plugin_iface` vtable,
@@ -129,11 +133,13 @@ plug-in: sim-display".
 
 ## 3. POSIX: JSON-manifest discovery
 
-> **Implementation status:** spec finalized; `target_plugin_loader.c`'s
-> non-Windows branch returns NULL today. macOS/Linux loader work is
-> tracked separately from the Step 9 docs commit that landed this
-> spec; the runtime falls back to the in-tree static
-> `drv_sim_display` path until the loader is wired in.
+> **Implementation status:** shipping on macOS (issue #267). Linux uses
+> the same code path but is untested end-to-end. The `XRT_PLUGIN_SEARCH_PATH`
+> env var (colon-separated directory list) overrides the default
+> search roots — used by `scripts/build_macos.sh`-generated
+> `run_*.sh` scripts to point at the dev tree's
+> `_package/DisplayXR-macOS/lib/displayxr/plugins/` without polluting
+> `~/Library/Application Support/`.
 
 **Discovery root (macOS):**
 `~/Library/Application Support/DisplayXR/DisplayProcessors/`

--- a/scripts/build_macos.sh
+++ b/scripts/build_macos.sh
@@ -165,10 +165,51 @@ mkdir -p "$PKG_DIR/lib"
 mkdir -p "$PKG_DIR/share/vulkan/icd.d"
 mkdir -p "$PKG_DIR/bin"
 
-# Find and copy runtime
-RUNTIME_LIB=$(find "$BUILD_DIR/src/xrt/targets/openxr" -name "libopenxr_displayxr*" -type f | head -1)
+# Find and copy runtime.
+# The runtime is a SHARED dylib with PREFIX="" (issue #256 / ADR-019):
+# CMake produces `openxr_displayxr.dylib`, not `libopenxr_displayxr.*`.
+# Match both the new dylib name and legacy `.so`/`lib*` shapes in case an
+# in-flight build leaves one of those behind during transition.
+RUNTIME_LIB=$(find "$BUILD_DIR/src/xrt/targets/openxr" -maxdepth 1 \
+  \( -name "openxr_displayxr.dylib" -o -name "openxr_displayxr.so" -o -name "libopenxr_displayxr*" \) \
+  -type f | head -1)
+if [ -z "$RUNTIME_LIB" ] || [ ! -f "$RUNTIME_LIB" ]; then
+  echo "ERROR: runtime dylib not found in $BUILD_DIR/src/xrt/targets/openxr/" >&2
+  exit 1
+fi
 RUNTIME_BASENAME=$(basename "$RUNTIME_LIB")
 cp "$RUNTIME_LIB" "$PKG_DIR/lib/"
+
+# Ship the vendor plug-in dylibs (issue #267 / ADR-019). The runtime
+# dylib no longer link-includes drv_sim_display; everything routes
+# through DisplayXR-SimDisplay.dylib, discovered via the JSON manifest
+# placed alongside it. Run scripts point XRT_PLUGIN_SEARCH_PATH at this
+# dir so dev iteration doesn't require touching
+# ~/Library/Application Support/.
+mkdir -p "$PKG_DIR/lib/displayxr/plugins"
+SIMDISPLAY_PLUGIN=$(find "$BUILD_DIR/src/xrt/drivers" -name "DisplayXR-SimDisplay.dylib" -type f | head -1)
+if [ -n "$SIMDISPLAY_PLUGIN" ] && [ -f "$SIMDISPLAY_PLUGIN" ]; then
+  cp "$SIMDISPLAY_PLUGIN" "$PKG_DIR/lib/displayxr/plugins/"
+  cat > "$PKG_DIR/lib/displayxr/plugins/200-sim-display.json" <<EOF
+{
+    "file_format_version": "1.0",
+    "plugin": {
+        "id":           "sim-display",
+        "display_name": "DisplayXR Sim Display",
+        "vendor":       "DisplayXR",
+        "version":      "dev",
+        "binary_path":  "$PKG_DIR/lib/displayxr/plugins/DisplayXR-SimDisplay.dylib",
+        "probe_order":  200
+    }
+}
+EOF
+  # Plug-in resolves aux symbols from the runtime dylib next to it via
+  # the @loader_path-relative rpath baked in at link time. Add an rpath
+  # to be safe for the dev tree layout (../.. from plugins/ → lib/).
+  install_name_tool -add_rpath @loader_path/../.. "$PKG_DIR/lib/displayxr/plugins/DisplayXR-SimDisplay.dylib" 2>/dev/null || true
+else
+  echo "Warning: DisplayXR-SimDisplay.dylib not found in build tree — runtime will have no display processor!"
+fi
 
 # Copy test app binaries
 cp "$ROOT/test_apps/cube_handle_vk_macos/build/cube_handle_vk_macos" "$PKG_DIR/bin/"
@@ -242,6 +283,7 @@ cat > "$PKG_DIR/run_cube_handle_vk.sh" <<'SCRIPT'
 DIR="$(cd "$(dirname "$0")" && pwd)"
 export XR_RUNTIME_JSON="$DIR/openxr_displayxr.json"
 export DYLD_LIBRARY_PATH="$DIR/lib:${DYLD_LIBRARY_PATH:-}"
+export XRT_PLUGIN_SEARCH_PATH="$DIR/lib/displayxr/plugins"
 export VK_ICD_FILENAMES="$DIR/share/vulkan/icd.d/MoltenVK_icd.json"
 export VK_DRIVER_FILES="$DIR/share/vulkan/icd.d/MoltenVK_icd.json"
 export SIM_DISPLAY_OUTPUT="${SIM_DISPLAY_OUTPUT:-anaglyph}"
@@ -256,6 +298,7 @@ cat > "$PKG_DIR/run_cube_handle_metal.sh" <<'SCRIPT'
 DIR="$(cd "$(dirname "$0")" && pwd)"
 export XR_RUNTIME_JSON="$DIR/openxr_displayxr.json"
 export DYLD_LIBRARY_PATH="$DIR/lib:${DYLD_LIBRARY_PATH:-}"
+export XRT_PLUGIN_SEARCH_PATH="$DIR/lib/displayxr/plugins"
 export SIM_DISPLAY_OUTPUT="${SIM_DISPLAY_OUTPUT:-anaglyph}"
 echo "Starting cube_handle_metal_macos (Metal, window handle) with $SIM_DISPLAY_OUTPUT output..."
 exec "$DIR/bin/cube_handle_metal_macos" "$@"
@@ -268,6 +311,7 @@ cat > "$PKG_DIR/run_cube_handle_gl.sh" <<'SCRIPT'
 DIR="$(cd "$(dirname "$0")" && pwd)"
 export XR_RUNTIME_JSON="$DIR/openxr_displayxr.json"
 export DYLD_LIBRARY_PATH="$DIR/lib:${DYLD_LIBRARY_PATH:-}"
+export XRT_PLUGIN_SEARCH_PATH="$DIR/lib/displayxr/plugins"
 export SIM_DISPLAY_OUTPUT="${SIM_DISPLAY_OUTPUT:-anaglyph}"
 echo "Starting cube_handle_gl_macos (OpenGL, window handle) with $SIM_DISPLAY_OUTPUT output..."
 exec "$DIR/bin/cube_handle_gl_macos" "$@"
@@ -280,6 +324,7 @@ cat > "$PKG_DIR/run_cube_texture_metal.sh" <<'SCRIPT'
 DIR="$(cd "$(dirname "$0")" && pwd)"
 export XR_RUNTIME_JSON="$DIR/openxr_displayxr.json"
 export DYLD_LIBRARY_PATH="$DIR/lib:${DYLD_LIBRARY_PATH:-}"
+export XRT_PLUGIN_SEARCH_PATH="$DIR/lib/displayxr/plugins"
 export SIM_DISPLAY_OUTPUT="${SIM_DISPLAY_OUTPUT:-anaglyph}"
 echo "Starting cube_texture_metal_macos (Metal, IOSurface shared texture) with $SIM_DISPLAY_OUTPUT output..."
 exec "$DIR/bin/cube_texture_metal_macos" "$@"
@@ -292,6 +337,7 @@ cat > "$PKG_DIR/run_cube_hosted_metal.sh" <<'SCRIPT'
 DIR="$(cd "$(dirname "$0")" && pwd)"
 export XR_RUNTIME_JSON="$DIR/openxr_displayxr.json"
 export DYLD_LIBRARY_PATH="$DIR/lib:${DYLD_LIBRARY_PATH:-}"
+export XRT_PLUGIN_SEARCH_PATH="$DIR/lib/displayxr/plugins"
 export SIM_DISPLAY_OUTPUT="${SIM_DISPLAY_OUTPUT:-anaglyph}"
 echo "Starting cube_hosted_metal_macos (Metal, hosted) with $SIM_DISPLAY_OUTPUT output..."
 exec "$DIR/bin/cube_hosted_metal_macos" "$@"
@@ -304,6 +350,7 @@ cat > "$PKG_DIR/run_cube_hosted_legacy_metal.sh" <<'SCRIPT'
 DIR="$(cd "$(dirname "$0")" && pwd)"
 export XR_RUNTIME_JSON="$DIR/openxr_displayxr.json"
 export DYLD_LIBRARY_PATH="$DIR/lib:${DYLD_LIBRARY_PATH:-}"
+export XRT_PLUGIN_SEARCH_PATH="$DIR/lib/displayxr/plugins"
 export SIM_DISPLAY_OUTPUT="${SIM_DISPLAY_OUTPUT:-anaglyph}"
 echo "Starting cube_hosted_legacy_metal_macos (Metal, legacy hosted) with $SIM_DISPLAY_OUTPUT output..."
 exec "$DIR/bin/cube_hosted_legacy_metal_macos" "$@"
@@ -316,6 +363,7 @@ cat > "$PKG_DIR/run_cube_hosted_legacy_gl.sh" <<'SCRIPT'
 DIR="$(cd "$(dirname "$0")" && pwd)"
 export XR_RUNTIME_JSON="$DIR/openxr_displayxr.json"
 export DYLD_LIBRARY_PATH="$DIR/lib:${DYLD_LIBRARY_PATH:-}"
+export XRT_PLUGIN_SEARCH_PATH="$DIR/lib/displayxr/plugins"
 export SIM_DISPLAY_OUTPUT="${SIM_DISPLAY_OUTPUT:-anaglyph}"
 echo "Starting cube_hosted_legacy_gl_macos (OpenGL, legacy hosted) with $SIM_DISPLAY_OUTPUT output..."
 exec "$DIR/bin/cube_hosted_legacy_gl_macos" "$@"
@@ -328,6 +376,7 @@ cat > "$PKG_DIR/run_cube_hosted_legacy_vk.sh" <<'SCRIPT'
 DIR="$(cd "$(dirname "$0")" && pwd)"
 export XR_RUNTIME_JSON="$DIR/openxr_displayxr.json"
 export DYLD_LIBRARY_PATH="$DIR/lib:${DYLD_LIBRARY_PATH:-}"
+export XRT_PLUGIN_SEARCH_PATH="$DIR/lib/displayxr/plugins"
 export VK_ICD_FILENAMES="$DIR/share/vulkan/icd.d/MoltenVK_icd.json"
 export VK_DRIVER_FILES="$DIR/share/vulkan/icd.d/MoltenVK_icd.json"
 export SIM_DISPLAY_OUTPUT="${SIM_DISPLAY_OUTPUT:-anaglyph}"

--- a/src/xrt/drivers/CMakeLists.txt
+++ b/src/xrt/drivers/CMakeLists.txt
@@ -381,6 +381,14 @@ if(XRT_HAVE_LEIA_SR AND LEIA_SOURCES)
 		VISIBILITY_INLINES_HIDDEN ON
 		)
 
+	if(APPLE)
+		target_link_options(drv_leia_plugin PRIVATE
+			"LINKER:-exported_symbol,_xrtPluginNegotiate")
+	elseif(NOT WIN32 AND NOT ANDROID)
+		target_link_options(drv_leia_plugin PRIVATE
+			"LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/plugin_exports.version")
+	endif()
+
 	if(WIN32)
 		install(
 			TARGETS drv_leia_plugin
@@ -547,8 +555,10 @@ endif()
 # Honor the ADR-019 invariant that every plug-in DLL exports exactly
 # one symbol: xrtPluginNegotiate. The XRT_PLUGIN_EXPORT decoration in
 # sim_display_plugin.c does the heavy lifting on Windows (dllexport).
-# On Linux / macOS we apply visibility=hidden defaults below so any
-# accidentally-non-static symbols stay private.
+# On Linux / macOS the visibility=hidden defaults only hide the
+# plug-in's own TUs; static archives pulled in from aux_util / aux_os
+# / aux_math carry their original (default-visible) symbols into the
+# plug-in dylib unless we explicitly filter at the link step.
 set_target_properties(drv_sim_display_plugin PROPERTIES
 	OUTPUT_NAME "DisplayXR-SimDisplay"
 	PREFIX ""
@@ -556,6 +566,18 @@ set_target_properties(drv_sim_display_plugin PROPERTIES
 	CXX_VISIBILITY_PRESET hidden
 	VISIBILITY_INLINES_HIDDEN ON
 	)
+
+# Single-symbol export filter for the plug-in dylib. Mirrors the
+# runtime's exported_symbols.list-driven Mach-O filter and Linux's
+# version-script approach. xrtPluginNegotiate is the only ABI symbol
+# the discovery loader resolves via dlsym.
+if(APPLE)
+	target_link_options(drv_sim_display_plugin PRIVATE
+		"LINKER:-exported_symbol,_xrtPluginNegotiate")
+elseif(NOT WIN32 AND NOT ANDROID)
+	target_link_options(drv_sim_display_plugin PRIVATE
+		"LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/plugin_exports.version")
+endif()
 
 # Install the plug-in DLL next to the runtime DLL. The plan defines
 # $INSTDIR\plugins\ as the home, but the runtime DLL's transitive

--- a/src/xrt/drivers/plugin_exports.version
+++ b/src/xrt/drivers/plugin_exports.version
@@ -1,0 +1,16 @@
+/*
+ * Single-symbol export filter for vendor plug-in dylibs on Linux/BSD.
+ * Mirrors the Mach-O `-exported_symbol _xrtPluginNegotiate` filter on
+ * macOS and the implicit dllexport-only contract on Windows.
+ *
+ * Every DisplayXR plug-in dylib MUST export exactly one symbol:
+ * `xrtPluginNegotiate`. The runtime's discovery loader resolves it via
+ * dlsym; all other symbols (including aux helpers pulled in from
+ * static archives) stay local.
+ */
+{
+	global:
+		xrtPluginNegotiate;
+	local:
+		*;
+};

--- a/src/xrt/targets/common/CMakeLists.txt
+++ b/src/xrt/targets/common/CMakeLists.txt
@@ -14,6 +14,13 @@ add_library(
 target_link_libraries(target_lists PRIVATE xrt-interfaces aux_util aux_util_sink drv_includes)
 target_include_directories(target_lists PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
+# target_plugin_loader.c uses dlopen/dlsym on non-Windows for the
+# manifest-driven discovery path. CMAKE_DL_LIBS is empty on Windows /
+# macOS (libSystem already provides dlopen) and `-ldl` on Linux.
+if(NOT WIN32)
+	target_link_libraries(target_lists PRIVATE ${CMAKE_DL_LIBS})
+endif()
+
 ###
 # Builders
 #
@@ -34,9 +41,18 @@ if(XRT_HAVE_LEIA_SR AND XRT_PLUGIN_BUILD_INPROC_FALLBACK)
 	target_link_libraries(target_lists PRIVATE drv_leia)
 endif()
 
-# Sim display builder (always available, guards itself via env var)
+# Sim display builder (always available — picks up the plug-in iface via
+# target_plugin_loader). The static drv_sim_display archive is now linked
+# only when XRT_PLUGIN_BUILD_INPROC_FALLBACK=ON (developer fallback),
+# mirroring the drv_leia gating above. Production builds resolve all
+# sim_display work — device creation, display-info, DP factories — through
+# the plug-in iface; the runtime DLL holds zero sim_display identifiers in
+# its link line (ADR-019/plan goal §2.1).
 target_sources(target_lists PRIVATE target_builder_sim_display.c)
-target_link_libraries(target_lists PRIVATE drv_sim_display)
+target_link_libraries(target_lists PRIVATE drv_sim_display_includes)
+if(XRT_PLUGIN_BUILD_INPROC_FALLBACK)
+	target_link_libraries(target_lists PRIVATE drv_sim_display)
+endif()
 if(XRT_BUILD_DRIVER_QWERTY)
 	# sim_display builder uses qwerty_device.h for pose delegation config
 	target_link_libraries(target_lists PRIVATE drv_qwerty drv_qwerty_includes)

--- a/src/xrt/targets/common/target_builder_sim_display.c
+++ b/src/xrt/targets/common/target_builder_sim_display.c
@@ -7,18 +7,22 @@
  * @ingroup drv_sim_display
  */
 
+#include "xrt/xrt_config_build.h"
 #include "xrt/xrt_config_drivers.h"
 
 #include "util/u_misc.h"
 #include "util/u_debug.h"
 #include "util/u_builders.h"
+#include "util/u_logging.h"
 #include "util/u_system_helpers.h"
 
 #include "target_builder_interface.h"
 #include "target_builder_qwerty_input.h"
 #include "target_plugin_loader.h"
 
+#ifdef XRT_PLUGIN_BUILD_INPROC_FALLBACK
 #include "sim_display/sim_display_interface.h"
+#endif
 
 #ifdef XRT_BUILD_DRIVER_QWERTY
 #include "qwerty/qwerty_device.h"
@@ -75,10 +79,11 @@ sim_display_open_system_impl(struct xrt_builder *xb,
                              struct u_builder_roles_helper *ubrh)
 {
 	/*
-	 * Prefer the sim_display plug-in DLL when present. The loader caches
-	 * the negotiated iface across calls; failure → NULL, which falls
-	 * through to the statically-linked sim_display_hmd_create() — same
-	 * device shape, just an in-process construction. Issue #256.
+	 * Device creation always routes through the plug-in iface (issue #256
+	 * / ADR-019). The runtime DLL no longer link-includes drv_sim_display
+	 * in production builds; the static fallback only compiles in when
+	 * XRT_PLUGIN_BUILD_INPROC_FALLBACK is on (developer convenience for
+	 * running without the plug-in dylib registered).
 	 */
 	struct xrt_device *head = NULL;
 	const struct xrt_plugin_iface *plugin = target_plugin_get_active();
@@ -87,10 +92,13 @@ sim_display_open_system_impl(struct xrt_builder *xb,
 			head = NULL;
 		}
 	}
+#ifdef XRT_PLUGIN_BUILD_INPROC_FALLBACK
 	if (head == NULL) {
 		head = sim_display_hmd_create();
 	}
+#endif
 	if (head == NULL) {
+		U_LOG_E("sim_display builder: no plug-in created a device and no static fallback compiled in.");
 		return XRT_ERROR_DEVICE_CREATION_FAILED;
 	}
 
@@ -136,6 +144,7 @@ sim_display_open_system_impl(struct xrt_builder *xb,
 				nominal_z_m = pdi.nominal_viewer_z_m;
 			}
 		}
+#ifdef XRT_PLUGIN_BUILD_INPROC_FALLBACK
 		if (screen_height_m == 0.0f) {
 			struct sim_display_info info;
 			if (sim_display_get_display_info(head, &info)) {
@@ -143,6 +152,7 @@ sim_display_open_system_impl(struct xrt_builder *xb,
 				nominal_z_m = info.nominal_z_m;
 			}
 		}
+#endif
 		if (screen_height_m > 0.0f) {
 			qd->sys->screen_height_m = screen_height_m;
 		}
@@ -152,16 +162,19 @@ sim_display_open_system_impl(struct xrt_builder *xb,
 
 		// Bind the qwerty HMD as the head's external pose source.
 		// Iface-routed (plug-in owns the vendor-private cast);
-		// falls back to the in-tree sim_display call when no
-		// iface is active (in-proc fallback build, or a developer
-		// configuration with no plug-ins).
+		// falls back to the in-tree sim_display call only when the
+		// developer in-proc fallback is compiled in (no plug-in dylib
+		// available for the running build).
 		if (plugin != NULL &&
 		    plugin->struct_size > offsetof(struct xrt_plugin_iface, set_pose_source) &&
 		    plugin->set_pose_source != NULL) {
 			plugin->set_pose_source(target_plugin_get_active_instance(), head, qwerty_hmd);
-		} else {
+		}
+#ifdef XRT_PLUGIN_BUILD_INPROC_FALLBACK
+		else {
 			sim_display_hmd_set_pose_source(head, qwerty_hmd);
 		}
+#endif
 	}
 #endif
 

--- a/src/xrt/targets/common/target_instance.c
+++ b/src/xrt/targets/common/target_instance.c
@@ -50,8 +50,12 @@
 #endif
 #endif
 
-// sim_display display info for XR_EXT_display_info fallback
+// sim_display display info for XR_EXT_display_info fallback — only
+// compiled in the developer in-proc fallback build (ADR-019 / issue
+// #256). Production builds route everything through the plug-in iface.
+#ifdef XRT_PLUGIN_BUILD_INPROC_FALLBACK
 #include "sim_display/sim_display_interface.h"
+#endif
 
 #include "target_plugin_loader.h"
 
@@ -394,10 +398,25 @@ out:
 		}
 #endif /* XRT_HAVE_LEIA_SR && XRT_PLUGIN_BUILD_INPROC_FALLBACK */
 
-		// sim_display fallback: populate display info and factory if not already set by SR SDK
+		/* Consumed by the gated fallback blocks (Leia in-proc + sim_display
+		 * in-proc). When neither fallback compiles in (production builds),
+		 * silence -Wunused-but-set-variable. */
+		(void)plugin_filled_display_info;
+
+		// sim_display fallback. Production builds (ADR-019/issue #256)
+		// populate everything through the plug-in iface above and skip
+		// this block entirely — the runtime DLL no longer link-includes
+		// drv_sim_display, so its symbols aren't available.
+		//
+		// XRT_PLUGIN_BUILD_INPROC_FALLBACK keeps the static path
+		// compiled in for developer iteration without a registered
+		// plug-in dylib. Even in the fallback build, the iface path
+		// runs first; this block only fires when no plug-in loaded
+		// AND the static archive is on the link line.
+#ifdef XRT_PLUGIN_BUILD_INPROC_FALLBACK
 		{
 			struct sim_display_info sd_info;
-			if (xsysc->info.display_width_m == 0.0f &&
+			if (!plugin_filled_display_info && xsysc->info.display_width_m == 0.0f &&
 			    sim_display_get_display_info(head, &sd_info)) {
 				xsysc->info.display_width_m = sd_info.display_width_m;
 				xsysc->info.display_height_m = sd_info.display_height_m;
@@ -434,7 +453,7 @@ out:
 				// Sim display: manual eye tracking only (simulated device, always "tracking")
 				xsysc->info.supported_eye_tracking_modes = 2; // MANUAL_BIT
 				xsysc->info.default_eye_tracking_mode = 1;    // MANUAL
-				U_LOG_W("XR_EXT_display_info (sim_display): display=%.3fx%.3f m, "
+				U_LOG_W("XR_EXT_display_info (sim_display in-proc fallback): display=%.3fx%.3f m, "
 				        "nominal=(0, %.3f, %.3f) m, scale=%.2fx%.2f, atlas=%ux%u, pixels=%ux%u",
 				        sd_info.display_width_m, sd_info.display_height_m,
 				        sd_info.nominal_y_m, sd_info.nominal_z_m,
@@ -444,47 +463,30 @@ out:
 				        xsysc->info.atlas_height_pixels,
 				        sd_info.display_pixel_width, sd_info.display_pixel_height);
 
-				// Set sim_display factories (only if Leia SR didn't already set them).
-				//
-				// Prefer the sim_display plug-in DLL's factories when it loaded
-				// successfully (issue #256 / ADR-019); otherwise fall back to
-				// the in-tree statically-linked sim_display_dp_factory_*. NULL
-				// from the iface (per-API not supported on this platform) also
-				// falls through to the static path.
-				const struct xrt_plugin_iface *sd_plugin = target_plugin_get_active();
 				if (xsysc->info.dp_factory_vk == NULL) {
-					xsysc->info.dp_factory_vk = (void *)((sd_plugin && sd_plugin->create_dp_vk)
-					                                         ? sd_plugin->create_dp_vk
-					                                         : sim_display_dp_factory_vk);
+					xsysc->info.dp_factory_vk = (void *)sim_display_dp_factory_vk;
 				}
 #ifdef XRT_OS_WINDOWS
 				if (xsysc->info.dp_factory_d3d11 == NULL) {
-					xsysc->info.dp_factory_d3d11 = (void *)((sd_plugin && sd_plugin->create_dp_d3d11)
-					                                            ? sd_plugin->create_dp_d3d11
-					                                            : sim_display_dp_factory_d3d11);
+					xsysc->info.dp_factory_d3d11 = (void *)sim_display_dp_factory_d3d11;
 				}
 #endif
 #if defined(XRT_OS_WINDOWS) && defined(XRT_HAVE_D3D12)
 				if (xsysc->info.dp_factory_d3d12 == NULL) {
-					xsysc->info.dp_factory_d3d12 = (void *)((sd_plugin && sd_plugin->create_dp_d3d12)
-					                                            ? sd_plugin->create_dp_d3d12
-					                                            : sim_display_dp_factory_d3d12);
+					xsysc->info.dp_factory_d3d12 = (void *)sim_display_dp_factory_d3d12;
 				}
 #endif
 #ifdef __APPLE__
 				if (xsysc->info.dp_factory_metal == NULL) {
-					xsysc->info.dp_factory_metal = (void *)((sd_plugin && sd_plugin->create_dp_metal)
-					                                            ? sd_plugin->create_dp_metal
-					                                            : sim_display_dp_factory_metal);
+					xsysc->info.dp_factory_metal = (void *)sim_display_dp_factory_metal;
 				}
 #endif
 				if (xsysc->info.dp_factory_gl == NULL) {
-					xsysc->info.dp_factory_gl = (void *)((sd_plugin && sd_plugin->create_dp_gl)
-					                                         ? sd_plugin->create_dp_gl
-					                                         : sim_display_dp_factory_gl);
+					xsysc->info.dp_factory_gl = (void *)sim_display_dp_factory_gl;
 				}
 			}
 		}
+#endif /* XRT_PLUGIN_BUILD_INPROC_FALLBACK */
 
 		assert(out_xsysc != NULL);
 		*out_xsysc = xsysc;

--- a/src/xrt/targets/common/target_plugin_loader.c
+++ b/src/xrt/targets/common/target_plugin_loader.c
@@ -28,6 +28,7 @@
 
 #include "util/u_logging.h"
 
+#include <errno.h>
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
@@ -323,17 +324,367 @@ discover_active_plugin(struct xrt_plugin_instance **out_inst)
 
 #else /* !XRT_OS_WINDOWS */
 
+#include "util/u_json.h"
+
+#include <dirent.h>
+#include <dlfcn.h>
+#include <limits.h>
+#include <stdio.h>
+#include <sys/stat.h>
+
+/*
+ * Same upper bound as the Windows path — admits a vendor plug-in plus
+ * the sim_display fallback with plenty of headroom.
+ */
+#define MAX_PLUGIN_ENTRIES 16
+
+/*
+ * Discovery contract: see docs/specs/runtime/plugin-discovery.md §3.
+ *
+ * Each plug-in publishes a JSON manifest with the filename convention
+ * `<probe_order>-<id>.json` (three-digit zero-padded ProbeOrder prefix
+ * gives lexicographic ordering — `050-leia-sr.json` runs before
+ * `200-sim-display.json` without parsing the JSON to sort).
+ *
+ * Roots searched, in priority order:
+ *   1. $XRT_PLUGIN_SEARCH_PATH — dev override, single colon-separated list
+ *   2. macOS: ~/Library/Application Support/DisplayXR/DisplayProcessors/
+ *      Linux: $XDG_DATA_HOME/DisplayXR/DisplayProcessors/
+ *             (defaults to ~/.local/share/DisplayXR/DisplayProcessors/)
+ *   3. Linux only: /usr/local/share/displayxr/DisplayProcessors/
+ *                  /usr/share/displayxr/DisplayProcessors/
+ *
+ * Per-user shadows system entries via lexicographic sort tie-break on
+ * the absolute path (later inserts win — the loop inserts in priority
+ * order, so per-user comes first and a duplicate `<id>` from a system
+ * root is dropped at insert time).
+ */
+
+struct plugin_entry
+{
+	char manifest_path[PATH_MAX]; /* absolute path to the JSON */
+	char manifest_file[PATH_MAX]; /* basename, used for stable sort */
+	char binary_path[PATH_MAX];   /* absolute path to the dylib/.so */
+	char id[64];                  /* manifest "plugin.id" */
+	char display_name[128];
+	char vendor[64];
+	char version[64];
+	uint32_t probe_order;
+};
+
+static int
+compare_by_filename(const void *a, const void *b)
+{
+	const struct plugin_entry *pa = (const struct plugin_entry *)a;
+	const struct plugin_entry *pb = (const struct plugin_entry *)b;
+	return strcmp(pa->manifest_file, pb->manifest_file);
+}
+
+static void
+copy_optional_str(const cJSON *root, const char *field, char *dst, size_t dst_size)
+{
+	if (dst_size == 0) {
+		return;
+	}
+	dst[0] = '\0';
+	const cJSON *node = u_json_get(root, field);
+	if (node == NULL) {
+		return;
+	}
+	(void)u_json_get_string_into_array(node, dst, dst_size);
+}
+
+static bool
+parse_manifest(const char *path, struct plugin_entry *e)
+{
+	FILE *f = fopen(path, "rb");
+	if (f == NULL) {
+		U_LOG_W("plugin loader: %s: fopen failed (errno=%d).", path, errno);
+		return false;
+	}
+	if (fseek(f, 0, SEEK_END) != 0) {
+		fclose(f);
+		return false;
+	}
+	long len = ftell(f);
+	if (len <= 0 || len > 64 * 1024) {
+		U_LOG_W("plugin loader: %s: implausible manifest size %ld.", path, len);
+		fclose(f);
+		return false;
+	}
+	if (fseek(f, 0, SEEK_SET) != 0) {
+		fclose(f);
+		return false;
+	}
+	char *buf = (char *)malloc((size_t)len + 1);
+	if (buf == NULL) {
+		fclose(f);
+		return false;
+	}
+	size_t got = fread(buf, 1, (size_t)len, f);
+	fclose(f);
+	if (got != (size_t)len) {
+		free(buf);
+		return false;
+	}
+	buf[len] = '\0';
+
+	cJSON *root = cJSON_Parse(buf);
+	free(buf);
+	if (root == NULL) {
+		U_LOG_W("plugin loader: %s: JSON parse failed.", path);
+		return false;
+	}
+
+	char fmt[16] = {0};
+	const cJSON *fmt_node = u_json_get(root, "file_format_version");
+	if (fmt_node != NULL) {
+		(void)u_json_get_string_into_array(fmt_node, fmt, sizeof(fmt));
+	}
+	if (strcmp(fmt, "1.0") != 0) {
+		U_LOG_W("plugin loader: %s: unsupported file_format_version='%s'.", path, fmt);
+		cJSON_Delete(root);
+		return false;
+	}
+
+	const cJSON *plugin = u_json_get(root, "plugin");
+	if (plugin == NULL) {
+		U_LOG_W("plugin loader: %s: missing 'plugin' object.", path);
+		cJSON_Delete(root);
+		return false;
+	}
+
+	copy_optional_str(plugin, "id", e->id, sizeof(e->id));
+	copy_optional_str(plugin, "display_name", e->display_name, sizeof(e->display_name));
+	copy_optional_str(plugin, "vendor", e->vendor, sizeof(e->vendor));
+	copy_optional_str(plugin, "version", e->version, sizeof(e->version));
+	copy_optional_str(plugin, "binary_path", e->binary_path, sizeof(e->binary_path));
+
+	int probe_order = 100;
+	const cJSON *po = u_json_get(plugin, "probe_order");
+	if (po != NULL) {
+		(void)u_json_get_int(po, &probe_order);
+	}
+	e->probe_order = (uint32_t)probe_order;
+
+	cJSON_Delete(root);
+
+	if (e->id[0] == '\0' || e->binary_path[0] == '\0') {
+		U_LOG_W("plugin loader: %s: required fields 'plugin.id' or 'plugin.binary_path' missing.", path);
+		return false;
+	}
+	return true;
+}
+
+static bool
+already_have_id(const struct plugin_entry *entries, int n, const char *id)
+{
+	for (int i = 0; i < n; i++) {
+		if (strcmp(entries[i].id, id) == 0) {
+			return true;
+		}
+	}
+	return false;
+}
+
+static int
+enumerate_dir(const char *root, struct plugin_entry *entries, int start, int max)
+{
+	DIR *d = opendir(root);
+	if (d == NULL) {
+		return start;
+	}
+
+	int count = start;
+	struct dirent *de;
+	while ((de = readdir(d)) != NULL) {
+		if (count >= max) {
+			U_LOG_W("plugin loader: more than %d entries — truncating.", max);
+			break;
+		}
+		const char *name = de->d_name;
+		size_t n = strlen(name);
+		if (n < 6 || strcmp(name + n - 5, ".json") != 0) {
+			continue;
+		}
+
+		struct plugin_entry e;
+		memset(&e, 0, sizeof(e));
+		snprintf(e.manifest_path, sizeof(e.manifest_path), "%s/%s", root, name);
+		snprintf(e.manifest_file, sizeof(e.manifest_file), "%s", name);
+
+		if (!parse_manifest(e.manifest_path, &e)) {
+			continue;
+		}
+		/* Per-user shadows system: roots are walked in priority order,
+		 * so the first occurrence of an `<id>` wins. */
+		if (already_have_id(entries, count, e.id)) {
+			U_LOG_I("plugin loader:   %s: shadowed by earlier manifest for id='%s'.", e.manifest_path,
+			        e.id);
+			continue;
+		}
+		entries[count++] = e;
+	}
+	closedir(d);
+	return count;
+}
+
+static void
+append_roots(char roots[][PATH_MAX], int max_roots, int *n_roots, const char *path)
+{
+	if (path == NULL || *path == '\0' || *n_roots >= max_roots) {
+		return;
+	}
+	struct stat st;
+	if (stat(path, &st) != 0 || !S_ISDIR(st.st_mode)) {
+		return;
+	}
+	snprintf(roots[(*n_roots)++], PATH_MAX, "%s", path);
+}
+
+static const struct xrt_plugin_iface *
+try_load_one(const struct plugin_entry *e, struct xrt_plugin_instance **out_inst)
+{
+	*out_inst = NULL;
+
+	/* RTLD_LOCAL keeps the plug-in's symbols private; aux symbols
+	 * resolve via the dependent runtime dylib that ld already linked
+	 * into our process. */
+	void *handle = dlopen(e->binary_path, RTLD_NOW | RTLD_LOCAL);
+	if (handle == NULL) {
+		U_LOG_W("plugin loader:   %s: dlopen(%s) failed: %s.", e->id, e->binary_path, dlerror());
+		return NULL;
+	}
+
+	dlerror();
+	xrt_plugin_negotiate_fn_t negotiate =
+	    (xrt_plugin_negotiate_fn_t)dlsym(handle, XRT_PLUGIN_ENTRYPOINT_NAME);
+	const char *err = dlerror();
+	if (negotiate == NULL || err != NULL) {
+		U_LOG_W("plugin loader:   %s: missing entry point '%s' (%s) — skipping.", e->id,
+		        XRT_PLUGIN_ENTRYPOINT_NAME, err ? err : "null");
+		dlclose(handle);
+		return NULL;
+	}
+
+	struct xrt_plugin_host_iface host = {0};
+	host.struct_size = (uint32_t)sizeof(struct xrt_plugin_host_iface);
+	host.host_api_version = XRT_PLUGIN_API_VERSION_CURRENT;
+
+	struct xrt_plugin_iface *iface = NULL;
+	uint32_t plugin_version = 0;
+	xrt_result_t xret = negotiate(XRT_PLUGIN_API_VERSION_CURRENT, &host, &iface, &plugin_version);
+	if (xret != XRT_SUCCESS || iface == NULL) {
+		U_LOG_W("plugin loader:   %s: negotiate returned %d (iface=%p) — skipping.", e->id, (int)xret,
+		        (void *)iface);
+		dlclose(handle);
+		return NULL;
+	}
+
+	if (iface->probe != NULL) {
+		xret = iface->probe(out_inst);
+		if (xret == XRT_ERROR_PROBER_NOT_SUPPORTED) {
+			U_LOG_I("plugin loader:   %s: probe declined (no matching device).", e->id);
+			dlclose(handle);
+			return NULL;
+		}
+		if (xret != XRT_SUCCESS) {
+			U_LOG_W("plugin loader:   %s: probe returned %d — skipping.", e->id, (int)xret);
+			dlclose(handle);
+			return NULL;
+		}
+	}
+
+	U_LOG_W(
+	    "plugin loader: active plug-in: id=%s name='%s' vendor='%s' version='%s' "
+	    "plugin_api=%u probe_order=%u path=%s",
+	    iface->id ? iface->id : e->id, iface->display_name ? iface->display_name : e->display_name,
+	    iface->vendor ? iface->vendor : e->vendor, e->version, plugin_version, e->probe_order, e->binary_path);
+
+	/* dlopen handle intentionally leaked: the iface's function pointers
+	 * remain reachable into the dylib for the process's lifetime. */
+	return iface;
+}
+
 static const struct xrt_plugin_iface *
 discover_active_plugin(struct xrt_plugin_instance **out_inst)
 {
 	*out_inst = NULL;
-	/*
-	 * Plug-in DLL discovery ships on Windows first. macOS adopts a
-	 * `~/Library/Application Support/DisplayXR/DisplayProcessors/`
-	 * JSON-manifest discovery shape; Linux mirrors that under
-	 * `$XDG_DATA_HOME/DisplayXR/DisplayProcessors/`. Both land with
-	 * the cross-platform port.
-	 */
+
+	char roots[8][PATH_MAX];
+	int n_roots = 0;
+
+	const char *override = getenv("XRT_PLUGIN_SEARCH_PATH");
+	if (override != NULL && *override != '\0') {
+		/* Colon-separated list, like PATH. */
+		const char *p = override;
+		while (*p && n_roots < (int)(sizeof(roots) / sizeof(roots[0]))) {
+			const char *colon = strchr(p, ':');
+			size_t len = colon ? (size_t)(colon - p) : strlen(p);
+			if (len > 0 && len < PATH_MAX) {
+				char buf[PATH_MAX];
+				memcpy(buf, p, len);
+				buf[len] = '\0';
+				append_roots(roots, (int)(sizeof(roots) / sizeof(roots[0])), &n_roots, buf);
+			}
+			if (!colon) {
+				break;
+			}
+			p = colon + 1;
+		}
+	}
+
+	const char *home = getenv("HOME");
+	char user_root[PATH_MAX];
+#ifdef __APPLE__
+	if (home != NULL && *home != '\0') {
+		snprintf(user_root, sizeof(user_root),
+		         "%s/Library/Application Support/DisplayXR/DisplayProcessors", home);
+		append_roots(roots, (int)(sizeof(roots) / sizeof(roots[0])), &n_roots, user_root);
+	}
+#else
+	const char *xdg = getenv("XDG_DATA_HOME");
+	if (xdg != NULL && *xdg != '\0') {
+		snprintf(user_root, sizeof(user_root), "%s/DisplayXR/DisplayProcessors", xdg);
+		append_roots(roots, (int)(sizeof(roots) / sizeof(roots[0])), &n_roots, user_root);
+	} else if (home != NULL && *home != '\0') {
+		snprintf(user_root, sizeof(user_root), "%s/.local/share/DisplayXR/DisplayProcessors", home);
+		append_roots(roots, (int)(sizeof(roots) / sizeof(roots[0])), &n_roots, user_root);
+	}
+	append_roots(roots, (int)(sizeof(roots) / sizeof(roots[0])), &n_roots,
+	             "/usr/local/share/displayxr/DisplayProcessors");
+	append_roots(roots, (int)(sizeof(roots) / sizeof(roots[0])), &n_roots,
+	             "/usr/share/displayxr/DisplayProcessors");
+#endif
+
+	if (n_roots == 0) {
+		U_LOG_I("plugin loader: no discovery roots present — no plug-ins to try.");
+		return NULL;
+	}
+
+	struct plugin_entry entries[MAX_PLUGIN_ENTRIES];
+	int n = 0;
+	for (int r = 0; r < n_roots; r++) {
+		n = enumerate_dir(roots[r], entries, n, MAX_PLUGIN_ENTRIES);
+	}
+	if (n == 0) {
+		U_LOG_I("plugin loader: %d root(s) searched, no JSON manifests found.", n_roots);
+		return NULL;
+	}
+
+	qsort(entries, (size_t)n, sizeof(entries[0]), compare_by_filename);
+
+	U_LOG_I("plugin loader: %d registered plug-in(s); attempting in filename order.", n);
+	for (int i = 0; i < n; i++) {
+		U_LOG_I("plugin loader:   [%d/%d] %s (ProbeOrder=%u, %s)", i + 1, n, entries[i].id,
+		        entries[i].probe_order, entries[i].binary_path);
+		const struct xrt_plugin_iface *iface = try_load_one(&entries[i], out_inst);
+		if (iface != NULL) {
+			return iface;
+		}
+	}
+
+	U_LOG_W("plugin loader: no registered plug-in claimed the system — falling back to static drivers.");
 	return NULL;
 }
 

--- a/src/xrt/targets/common/target_plugin_loader.h
+++ b/src/xrt/targets/common/target_plugin_loader.h
@@ -5,15 +5,18 @@
  * @brief  Runtime-side loader for vendor plug-in DLLs.
  *
  * Implements the consumer side of the ABI defined in
- * `xrt/xrt_plugin.h`. On first call, the loader enumerates
- * `HKLM\Software\DisplayXR\DisplayProcessors\*` (Windows) — the
- * registry schema documented in
- * `docs/roadmap/vendor-plugin-architecture.md` §4.1 — sorts the
- * registered plug-ins by their `ProbeOrder` value (ascending; missing
- * = 100), and tries each in turn: `LoadLibraryExW` → `GetProcAddress`
- * → `xrtPluginNegotiate` → `iface->probe()`. The first plug-in whose
- * probe returns `XRT_SUCCESS` wins and is cached for the process's
- * lifetime; subsequent registry entries are not attempted.
+ * `xrt/xrt_plugin.h`. On first call, the loader enumerates the
+ * platform's discovery root — `HKLM\Software\DisplayXR\DisplayProcessors\*`
+ * on Windows, JSON manifests under
+ * `~/Library/Application Support/DisplayXR/DisplayProcessors/` on macOS,
+ * or `${XDG_DATA_HOME:-~/.local/share}/DisplayXR/DisplayProcessors/`
+ * plus system roots on Linux — sorts the registered plug-ins by their
+ * `ProbeOrder` value (ascending; missing = 100), and tries each in
+ * turn: load the DLL/dylib → resolve `xrtPluginNegotiate` →
+ * `iface->probe()`. The first plug-in whose probe returns
+ * `XRT_SUCCESS` wins and is cached for the process's lifetime;
+ * subsequent entries are not attempted. The discovery contract lives
+ * at `docs/specs/runtime/plugin-discovery.md`.
  *
  * The loader is intentionally per-process and one-shot. Multi-vendor
  * heterogeneous setups (multiple active plug-ins concurrently) are a
@@ -45,11 +48,9 @@ extern "C" {
  * fall back to the statically-linked driver symbols.
  *
  * Reasons the loader returns NULL:
- *   - Non-Windows platform (v1 limitation; the manifest-driven Linux
- *     and macOS discovery lands with the cross-platform port).
- *   - `HKLM\Software\DisplayXR\DisplayProcessors` absent or empty
- *     (typical for developer builds that haven't run the installer or
- *     written the registry entry by hand).
+ *   - Discovery root is absent or empty (no Windows registry key, no
+ *     JSON manifests in any POSIX root — typical for developer builds
+ *     that haven't run an installer or set `XRT_PLUGIN_SEARCH_PATH`).
  *   - Every registered plug-in failed to load, declined at
  *     `xrtPluginNegotiate`, or returned non-`XRT_SUCCESS` from
  *     `iface->probe()`.

--- a/src/xrt/targets/openxr/exported_symbols.list
+++ b/src/xrt/targets/openxr/exported_symbols.list
@@ -13,8 +13,10 @@
 # --- Khronos OpenXR loader interface ---
 _xrNegotiateLoaderRuntimeInterface
 
-# --- sim_display in-process driver hook (legacy, kept for compatibility) ---
-_sim_display_set_output_mode
+# (Removed: _sim_display_set_output_mode — that symbol lives in the
+#  DisplayXR-SimDisplay.dylib plug-in since ADR-019 / issue #256. The
+#  runtime DLL no longer link-includes drv_sim_display in production
+#  builds, so the symbol isn't available to export here.)
 
 # --- u_logging.h ---
 _u_log


### PR DESCRIPTION
## Summary

Closes #267. Implements the POSIX side of `docs/specs/runtime/plugin-discovery.md` §3 and gates the static `drv_sim_display` link behind `XRT_PLUGIN_BUILD_INPROC_FALLBACK`, so macOS now matches Windows on ADR-019 §2.1: the runtime dylib has zero `sim_display_*` symbols in its link line.

- **Step 1 — POSIX manifest loader.** `target_plugin_loader.c`'s non-Windows branch walks `$XRT_PLUGIN_SEARCH_PATH` (dev override) plus `~/Library/Application Support/DisplayXR/DisplayProcessors/` on macOS (XDG roots on Linux), parses each `<probe_order>-<id>.json` manifest via aux's cJSON, then `dlopen` + `dlsym("xrtPluginNegotiate")` + probe.
- **Step 2 — `build_macos.sh` packaging.** Ships `DisplayXR-SimDisplay.dylib` + auto-generated `200-sim-display.json` into `_package/DisplayXR-macOS/lib/displayxr/plugins/`. Every `run_*.sh` exports `XRT_PLUGIN_SEARCH_PATH` so dev iteration doesn't pollute `~/Library/Application Support/`. Also fixed a stale `find` pattern that was picking up `libopenxr_displayxr.so` instead of the new `openxr_displayxr.dylib`.
- **Step 3 — gate static `drv_sim_display`.** Mirrors the existing `drv_leia` gating. Static fallback calls in `target_builder_sim_display.c` + `target_instance.c` are now `#ifdef XRT_PLUGIN_BUILD_INPROC_FALLBACK`. Plug-in dylibs/sos also gain a single-symbol linker filter (`-exported_symbol` on macOS, `--version-script` on Linux) so aux helpers stay local.

## Test plan

- [x] `nm -gU openxr_displayxr.dylib` returns zero `sim_display_*` / `leia_*` symbols
- [x] `nm -gU DisplayXR-SimDisplay.dylib` exports only `_xrtPluginNegotiate`
- [x] Dev path e2e: `cube_handle_metal_macos` via the generated `run_cube_handle_metal.sh` logs `active plug-in: id=sim-display` (from `_package/.../lib/displayxr/plugins/`) and `XR_EXT_display_info (iface=sim-display)`
- [x] Install path e2e: plug-in + manifest at `~/Library/Application Support/DisplayXR/DisplayProcessors/`, `XRT_PLUGIN_SEARCH_PATH` unset — same outcome; manifest `version="install-test"` in the log confirms the install manifest was the one parsed
- [x] No `(sim_display in-proc fallback)` or `falling back to static drivers` log lines fire
- [ ] Windows CI (`build-windows.yml`): runtime DLL still passes the existing `dumpbin /imports … findstr SimulatedReality` assertion; plug-in DLL still exports `xrtPluginNegotiate`. Loader's `XRT_OS_WINDOWS` branch is untouched.
- [ ] macOS CI (`build-macos.yml`): full clean build green.

## Notes

- Caveat for a future macOS installer: the plug-in dylib's `LC_RPATH` carries the build-dir absolute path. A real `installer/macos/build_installer.sh` will need `install_name_tool` fixup to retarget `@rpath/openxr_displayxr.dylib` at install time. Separate from the loader contract this PR lands.
- `_sim_display_set_output_mode` removed from `exported_symbols.list` (macOS-only entry) — the symbol now lives inside `DisplayXR-SimDisplay.dylib` and no test app actually called it via `dlsym`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)