### PR TITLE
fix(#265): drop hardcoded Leia EDID lookup from comp_d3d11_window.cpp

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -368,20 +368,20 @@ Copy binaries to `_package/DisplayXR-macOS/bin/`. Run scripts exec from `$DIR/bi
 
 **Shell mode — single command (recommended):**
 
-`displayxr-shell.exe` auto-starts the service, activates shell mode via IPC, launches apps with correct env vars, and monitors clients.
+`displayxr-shell.exe` auto-starts the service, activates shell mode via IPC, launches apps with correct env vars, and monitors clients. The shell ships from [`displayxr-shell-pvt`](https://github.com/DisplayXR/displayxr-shell-pvt) via its own installer (`DisplayXRShellSetup-*.exe` from [`displayxr-shell-releases`](https://github.com/DisplayXR/displayxr-shell-releases)) — install it once and it lands at `C:\Program Files\DisplayXR\Runtime\displayxr-shell.exe`. **This repo does NOT build a shell binary anymore** (the `_package\bin\displayxr-shell.exe` from old builds is stale; ignore / delete).
 
 ```
-_package\bin\displayxr-shell.exe app1.exe app2.exe
+"C:\Program Files\DisplayXR\Runtime\displayxr-shell.exe" app1.exe app2.exe
 ```
 
 Example with two cube apps:
 ```
-_package\bin\displayxr-shell.exe test_apps\cube_handle_d3d11_win\build\cube_handle_d3d11_win.exe test_apps\cube_handle_d3d11_win\build\cube_handle_d3d11_win.exe
+"C:\Program Files\DisplayXR\Runtime\displayxr-shell.exe" test_apps\cube_handle_d3d11_win\build\cube_handle_d3d11_win.exe test_apps\cube_handle_d3d11_win\build\cube_handle_d3d11_win.exe
 ```
 
 Optional per-app window pose (`--pose x,y,z,width_m,height_m` before each app path):
 ```
-_package\bin\displayxr-shell.exe --pose -0.1,0.05,0,0.14,0.08 app1.exe --pose 0.1,0.05,0,0.14,0.08 app2.exe
+"C:\Program Files\DisplayXR\Runtime\displayxr-shell.exe" --pose -0.1,0.05,0,0.14,0.08 app1.exe --pose 0.1,0.05,0,0.14,0.08 app2.exe
 ```
 
 **Shell mode — legacy multi-terminal (still works):**

--- a/docs/internal/issue-158-agent-prompt.md
+++ b/docs/internal/issue-158-agent-prompt.md
@@ -60,7 +60,7 @@ Driver side: confirm the Leia SR driver populates `view_scale_x/y` and that `u_t
 2. Stop any running service/shell and redeploy to `C:\Program Files\DisplayXR\Runtime\` (both `displayxr-service.exe` AND `DisplayXRClient.dll` per `feedback_dll_version_mismatch.md`).
 3. Launch the shell with the D3D11 cube app and press **Ctrl+Shift+C** to capture:
    ```
-   _package\bin\displayxr-shell.exe test_apps\cube_handle_d3d11_win\build\cube_handle_d3d11_win.exe
+   "C:\Program Files\DisplayXR\Runtime\displayxr-shell.exe" test_apps\cube_handle_d3d11_win\build\cube_handle_d3d11_win.exe
    ```
 4. Inspect `%USERPROFILE%\Pictures\DisplayXR\capture_*_sbs.png`:
    - Atlas should still be 3840×2160 (full swapchain)

--- a/docs/roadmap/shell-phase1-status.md
+++ b/docs/roadmap/shell-phase1-status.md
@@ -131,17 +131,17 @@ scripts\build_windows.bat test-apps   # Test apps + generates run scripts in _pa
 
 **Two apps (one command):**
 ```
-_package\bin\displayxr-shell.exe test_apps\cube_handle_d3d11_win\build\cube_handle_d3d11_win.exe test_apps\cube_handle_d3d11_win\build\cube_handle_d3d11_win.exe
+"C:\Program Files\DisplayXR\Runtime\displayxr-shell.exe" test_apps\cube_handle_d3d11_win\build\cube_handle_d3d11_win.exe test_apps\cube_handle_d3d11_win\build\cube_handle_d3d11_win.exe
 ```
 
 **Two apps with custom poses:**
 ```
-_package\bin\displayxr-shell.exe --pose -0.1,0.05,0,0.14,0.08 app1.exe --pose 0.1,0.05,0,0.14,0.08 app2.exe
+"C:\Program Files\DisplayXR\Runtime\displayxr-shell.exe" --pose -0.1,0.05,0,0.14,0.08 app1.exe --pose 0.1,0.05,0,0.14,0.08 app2.exe
 ```
 
 **Monitor only (no apps — connect to existing or auto-start service):**
 ```
-_package\bin\displayxr-shell.exe
+"C:\Program Files\DisplayXR\Runtime\displayxr-shell.exe"
 ```
 
 ### Run from generated scripts (legacy — multiple terminals)
@@ -170,7 +170,7 @@ taskkill //F //IM displayxr-shell.exe 2>&1 || true
 taskkill //F //IM cube_handle_d3d11_win.exe 2>&1 || true
 
 # Step 2: Launch shell + apps (run_in_background: true, timeout: 600000)
-cd "/c/Users/Sparks i7 3080/Documents/GitHub/openxr-3d-display" && _package/bin/displayxr-shell.exe test_apps/cube_handle_d3d11_win/build/cube_handle_d3d11_win.exe test_apps/cube_handle_d3d11_win/build/cube_handle_d3d11_win.exe 2>&1
+cd "/c/Users/Sparks i7 3080/Documents/GitHub/openxr-3d-display" && "/c/Program Files/DisplayXR/Runtime/displayxr-shell.exe" test_apps/cube_handle_d3d11_win/build/cube_handle_d3d11_win.exe test_apps/cube_handle_d3d11_win/build/cube_handle_d3d11_win.exe 2>&1
 ```
 
 **Notes:**

--- a/docs/roadmap/shell-phase2-plan.md
+++ b/docs/roadmap/shell-phase2-plan.md
@@ -119,10 +119,10 @@ scripts\build_windows.bat build
 scripts\build_windows.bat test-apps
 
 # Run (single command)
-_package\bin\displayxr-shell.exe test_apps\cube_handle_d3d11_win\build\cube_handle_d3d11_win.exe test_apps\cube_handle_d3d11_win\build\cube_handle_d3d11_win.exe
+"C:\Program Files\DisplayXR\Runtime\displayxr-shell.exe" test_apps\cube_handle_d3d11_win\build\cube_handle_d3d11_win.exe test_apps\cube_handle_d3d11_win\build\cube_handle_d3d11_win.exe
 
 # Or with custom poses
-_package\bin\displayxr-shell.exe --pose -0.1,0.05,0,0.14,0.08 app1.exe --pose 0.1,0.05,0,0.14,0.08 app2.exe
+"C:\Program Files\DisplayXR\Runtime\displayxr-shell.exe" --pose -0.1,0.05,0,0.14,0.08 app1.exe --pose 0.1,0.05,0,0.14,0.08 app2.exe
 ```
 
 **Shell controls (Phase 1, carried forward):**

--- a/docs/specs/runtime/modal-dialog-handling.md
+++ b/docs/specs/runtime/modal-dialog-handling.md
@@ -93,7 +93,7 @@ See ADR-017 §"T2 — REJECTED". Apps use Qt / wx / Imgui / raw listboxes, UAC r
 ## Verification
 
 - Local mac: `./scripts/build-mingw-check.sh` clean for the Win32 surface (the new TU compiles standalone via direct `x86_64-w64-mingw32-gcc`).
-- Windows: `_package\bin\displayxr-shell.exe` launches a `cube_handle_d3d11_win` instrumented with a `B`-key `GetOpenFileName(NULL, …)` smoke. Expected: dialog appears in front, focus returns to cube, 3D resumes.
+- Windows: `"C:\Program Files\DisplayXR\Runtime\displayxr-shell.exe"` (installed from `DisplayXRShellSetup-*.exe`) launches a `cube_handle_d3d11_win` instrumented with a `B`-key `GetOpenFileName(NULL, …)` smoke. Expected: dialog appears in front, focus returns to cube, 3D resumes.
 - `MessageBox(hWnd, "test", "test", MB_OK)` smoke: appears on top, modal disable works correctly.
 - 90s open-dialog soak: shell's compositor still presents the requester's last-good frame; no crashes.
 - Multi-app: open dialogs from two apps simultaneously. Each dims independently; closing one doesn't restore the other.

--- a/scripts/bench_shell_present.ps1
+++ b/scripts/bench_shell_present.ps1
@@ -34,8 +34,10 @@
                                  timeout / acquire totals from [MUTEX].
       5. Prints a one-line summary.
 
-    The shell binary is expected at _package\bin\displayxr-shell.exe by
-    default (matches scripts\build_windows.bat output).
+    The shell binary is expected at the installed location under
+    C:\Program Files\DisplayXR\Runtime\displayxr-shell.exe by default
+    (the shell ships from DisplayXR/displayxr-shell-releases via
+    DisplayXRShellSetup-*.exe — it's NOT built by this repo anymore).
 
 .PARAMETER Seconds
     Run duration in seconds. Default: 60.
@@ -47,8 +49,10 @@
     Filename tag (e.g. "before", "after"). Default: timestamp.
 
 .PARAMETER Shell
-    Path to displayxr-shell.exe. Default: _package\bin\displayxr-shell.exe
-    relative to the repo root.
+    Path to displayxr-shell.exe. Default:
+    C:\Program Files\DisplayXR\Runtime\displayxr-shell.exe (the installed
+    location; install DisplayXRShellSetup-*.exe from
+    DisplayXR/displayxr-shell-releases first).
 
 .PARAMETER App
     One or more app paths to pass to displayxr-shell. Default: two
@@ -71,7 +75,7 @@ param(
     [int]    $Seconds = 60,
     [string] $OutDir  = "docs\roadmap\bench",
     [string] $Tag     = (Get-Date -Format "yyyyMMdd-HHmmss"),
-    [string] $Shell   = "_package\bin\displayxr-shell.exe",
+    [string] $Shell   = "C:\Program Files\DisplayXR\Runtime\displayxr-shell.exe",
     [string[]] $App = @(
         "test_apps\cube_handle_d3d11_win\build\cube_handle_d3d11_win.exe",
         "test_apps\cube_handle_d3d11_win\build\cube_handle_d3d11_win.exe"
@@ -85,7 +89,7 @@ $repoRoot = Split-Path -Parent $PSScriptRoot
 Set-Location $repoRoot
 
 if (-not (Test-Path $Shell)) {
-    throw "displayxr-shell not found at '$Shell'. Build via 'scripts\build_windows.bat build' first."
+    throw "displayxr-shell not found at '$Shell'. Install DisplayXRShellSetup-*.exe from DisplayXR/displayxr-shell-releases (gh release download), or pass -Shell <path> explicitly."
 }
 foreach ($a in $App) {
     if (-not (Test-Path $a)) {

--- a/scripts/test/shell_launcher_smoke.sh
+++ b/scripts/test/shell_launcher_smoke.sh
@@ -17,7 +17,11 @@
 # Usage:
 #   bash scripts/test/shell_launcher_smoke.sh
 #
-# Requires a successful `scripts\build_windows.bat build` first.
+# Requires:
+#   - `scripts\build_windows.bat build` for the runtime + cube test app.
+#   - DisplayXRShellSetup-*.exe (from DisplayXR/displayxr-shell-releases)
+#     installed — the shell is NOT built by this repo, it ships from
+#     displayxr-shell-pvt via its own installer.
 
 set -u
 
@@ -27,7 +31,7 @@ cd "$REPO_ROOT"
 OUT_DIR="scripts/test/out"
 mkdir -p "$OUT_DIR"
 
-SHELL_EXE="_package\\bin\\displayxr-shell.exe"
+SHELL_EXE="C:\\Program Files\\DisplayXR\\Runtime\\displayxr-shell.exe"
 CUBE_EXE="test_apps\\cube_handle_d3d11_win\\build\\cube_handle_d3d11_win.exe"
 LOG="$OUT_DIR/shell_test.log"
 

--- a/src/xrt/compositor/d3d11/comp_d3d11_compositor.cpp
+++ b/src/xrt/compositor/d3d11/comp_d3d11_compositor.cpp
@@ -1526,6 +1526,8 @@ comp_d3d11_compositor_create(struct xrt_device *xdev,
                              void *shared_texture_handle,
                              bool transparent_background,
                              uint32_t chroma_key_color,
+                             int32_t display_screen_left,
+                             int32_t display_screen_top,
                              struct xrt_compositor_native **out_xc)
 {
 	if (d3d11_device == nullptr) {
@@ -1575,7 +1577,8 @@ comp_d3d11_compositor_create(struct xrt_device *xdev,
 			win_h = 1080;
 		}
 		U_LOG_I("No window handle provided, creating self-owned window (%ux%u)", win_w, win_h);
-		xrt_result_t xret = comp_d3d11_window_create(win_w, win_h, &c->own_window);
+		xrt_result_t xret = comp_d3d11_window_create(
+		    win_w, win_h, display_screen_left, display_screen_top, &c->own_window);
 		if (xret != XRT_SUCCESS) {
 			U_LOG_E("Failed to create self-owned window");
 			delete c;

--- a/src/xrt/compositor/d3d11/comp_d3d11_compositor.h
+++ b/src/xrt/compositor/d3d11/comp_d3d11_compositor.h
@@ -41,6 +41,9 @@ extern "C" {
  *                         a post-weave shader pass that converts pixels matching this
  *                         RGB (0x00BBGGRR / Win32 COLORREF) to alpha=0. Required when
  *                         the bound display processor strips alpha during weaving.
+ * @param display_screen_left Display top-left X in OS screen coords (from xsysc->info,
+ *                            populated by the vendor plug-in iface). 0 = primary.
+ * @param display_screen_top  Display top-left Y in OS screen coords. 0 = primary.
  * @param out_xc Pointer to receive the created compositor.
  *
  * @return XRT_SUCCESS on success, error code otherwise.
@@ -55,6 +58,8 @@ comp_d3d11_compositor_create(struct xrt_device *xdev,
                              void *shared_texture_handle,
                              bool transparent_background,
                              uint32_t chroma_key_color,
+                             int32_t display_screen_left,
+                             int32_t display_screen_top,
                              struct xrt_compositor_native **out_xc);
 
 /*!

--- a/src/xrt/compositor/d3d11/comp_d3d11_window.cpp
+++ b/src/xrt/compositor/d3d11/comp_d3d11_window.cpp
@@ -35,11 +35,6 @@
 
 #include "xrt/xrt_device.h"
 
-// EDID-based display identification for window positioning
-#ifdef XRT_HAVE_LEIA_SR
-#include "leia/leia_interface.h"
-#endif
-
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <windowsx.h> // GET_X_LPARAM, GET_Y_LPARAM
@@ -105,6 +100,11 @@ struct comp_d3d11_window
 
 	//! Requested height (set before thread start, read by window thread)
 	uint32_t requested_height;
+
+	//! Display top-left in OS screen coords (from xsysc->info, plug-in iface).
+	//! (0, 0) = primary monitor (sim_display default or unknown panel).
+	int32_t display_screen_left;
+	int32_t display_screen_top;
 
 	//! Current width (window thread writes, compositor thread reads)
 	volatile LONG current_width;
@@ -337,35 +337,6 @@ is_workspace_reserved_key(WPARAM vk, bool shift)
 	case VK_DELETE: return true;    // Close focused app
 	default:        return false;
 	}
-}
-
-/*!
- * Resolve the top-left pixel coordinate of the 3D display on this machine.
- *
- * Does a fresh EDID probe every call (no stale cache) so monitor rearrangements
- * take effect without restarting the service. Falls back to primary (0, 0) when
- * no 3D display is identified — we do NOT guess "first non-primary monitor",
- * because on a setup where the 3D display IS primary, that guess would land
- * the compositor on a 2D monitor.
- */
-static bool
-get_3d_display_top_left(int *x, int *y)
-{
-#ifdef XRT_HAVE_LEIA_SR
-	int32_t left = 0;
-	int32_t top = 0;
-	if (leia_edid_find_3d_display_rect(&left, &top, NULL, NULL)) {
-		*x = (int)left;
-		*y = (int)top;
-		U_LOG_W("3D display resolved via EDID to (%d, %d)", *x, *y);
-		return true;
-	}
-	U_LOG_W("3D display EDID probe found no known panel — defaulting to primary monitor");
-#endif
-
-	*x = 0;
-	*y = 0;
-	return false;
 }
 
 /*!
@@ -1090,16 +1061,16 @@ window_thread_func(LPVOID param)
 		}
 	}
 
-	// Position on Leia/secondary monitor if available
-	RECT rc = {0, 0, (LONG)w->requested_width, (LONG)w->requested_height};
-	int monitor_x = 0;
-	int monitor_y = 0;
-	if (get_3d_display_top_left(&monitor_x, &monitor_y)) {
-		rc.left = monitor_x;
-		rc.top = monitor_y;
-		rc.right = monitor_x + (LONG)w->requested_width;
-		rc.bottom = monitor_y + (LONG)w->requested_height;
-	}
+	// Position on the 3D display. The vendor plug-in iface publishes the
+	// display top-left through xsysc->info.display_screen_left/top; the
+	// state tracker forwards those into comp_d3d11_window_create. (0, 0)
+	// means primary monitor (sim_display default or unknown panel).
+	RECT rc = {
+	    (LONG)w->display_screen_left,
+	    (LONG)w->display_screen_top,
+	    (LONG)w->display_screen_left + (LONG)w->requested_width,
+	    (LONG)w->display_screen_top + (LONG)w->requested_height,
+	};
 
 	// Hidden windows use WS_POPUP (borderless) so client rect = window rect = exact texture size.
 	// Visible windows use WS_OVERLAPPEDWINDOW for normal window chrome.
@@ -1194,7 +1165,11 @@ window_thread_func(LPVOID param)
  */
 
 extern "C" xrt_result_t
-comp_d3d11_window_create(uint32_t width, uint32_t height, struct comp_d3d11_window **out)
+comp_d3d11_window_create(uint32_t width,
+                         uint32_t height,
+                         int32_t screen_left,
+                         int32_t screen_top,
+                         struct comp_d3d11_window **out)
 {
 	struct comp_d3d11_window *w = U_TYPED_CALLOC(struct comp_d3d11_window);
 	if (w == NULL) {
@@ -1204,12 +1179,16 @@ comp_d3d11_window_create(uint32_t width, uint32_t height, struct comp_d3d11_wind
 	w->instance = GetModuleHandle(NULL);
 	w->requested_width = width > 0 ? width : 1920;
 	w->requested_height = height > 0 ? height : 1080;
+	w->display_screen_left = screen_left;
+	w->display_screen_top = screen_top;
 	w->xsysd = NULL;
 	w->qwerty_enabled = true;  // Always enabled for DisplayXR-owned windows
 
 	U_LOG_W("D3D11 window: QWERTY input ENABLED");
 
-	U_LOG_W("D3D11 window: Creating window on dedicated thread (%ux%u)", w->requested_width, w->requested_height);
+	U_LOG_W("D3D11 window: Creating window on dedicated thread (%ux%u) at (%d, %d)",
+	        w->requested_width, w->requested_height,
+	        (int)w->display_screen_left, (int)w->display_screen_top);
 
 	// Create manual-reset event for window-ready synchronization
 	w->window_ready_event = CreateEventW(NULL, TRUE, FALSE, NULL);

--- a/src/xrt/compositor/d3d11/comp_d3d11_window.h
+++ b/src/xrt/compositor/d3d11/comp_d3d11_window.h
@@ -84,20 +84,28 @@ struct workspace_public_event_raw
  * caller does NOT need to pump messages — the compositor thread
  * continues rendering independently during modal drag/resize.
  *
- * The window is automatically positioned on the Leia display if found,
- * or on a secondary monitor, or on the primary display as fallback.
+ * The window is positioned at (@p screen_left, @p screen_top) in OS screen
+ * coordinates — the display top-left that the vendor plug-in iface published
+ * through `xrt_system_compositor_info.display_screen_left/top`. (0, 0) means
+ * the primary monitor (sim_display default, or unknown panel).
  *
  * By default, the window starts in fullscreen mode unless the environment
  * variable XRT_COMPOSITOR_START_WINDOWED=1 is set.
  *
- * @param width  Requested window width
- * @param height Requested window height
- * @param out    Pointer to receive the created window handle
+ * @param width        Requested window width
+ * @param height       Requested window height
+ * @param screen_left  Display top-left X in OS screen coords
+ * @param screen_top   Display top-left Y in OS screen coords
+ * @param out          Pointer to receive the created window handle
  *
  * @return XRT_SUCCESS on success, error code otherwise
  */
 xrt_result_t
-comp_d3d11_window_create(uint32_t width, uint32_t height, struct comp_d3d11_window **out);
+comp_d3d11_window_create(uint32_t width,
+                         uint32_t height,
+                         int32_t screen_left,
+                         int32_t screen_top,
+                         struct comp_d3d11_window **out);
 
 /*!
  * Destroy the self-owned window.

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -2716,7 +2716,11 @@ init_client_render_resources(struct d3d11_service_system *sys,
 		U_LOG_W("Using external window handle: %p", external_hwnd);
 	} else {
 		// Create our own window (IPC/WebXR path)
-		xrt_result_t wret = comp_d3d11_window_create(sys->output_width, sys->output_height, &res->window);
+		xrt_result_t wret = comp_d3d11_window_create(
+		    sys->output_width, sys->output_height,
+		    sys->base.info.display_screen_left,
+		    sys->base.info.display_screen_top,
+		    &res->window);
 		if (wret != XRT_SUCCESS || res->window == nullptr) {
 			U_LOG_E("Failed to create window for client");
 			return XRT_ERROR_VULKAN;
@@ -5370,7 +5374,11 @@ multi_compositor_ensure_output(struct d3d11_service_system *sys)
 		win_w = sys->output_width;
 		win_h = sys->output_height;
 	}
-	xrt_result_t wret = comp_d3d11_window_create(win_w, win_h, &mc->window);
+	xrt_result_t wret = comp_d3d11_window_create(
+	    win_w, win_h,
+	    sys->base.info.display_screen_left,
+	    sys->base.info.display_screen_top,
+	    &mc->window);
 	if (wret != XRT_SUCCESS || mc->window == nullptr) {
 		U_LOG_E("Multi-comp: failed to create window");
 		return XRT_ERROR_D3D11;
@@ -5667,7 +5675,11 @@ multi_compositor_ensure_output(struct d3d11_service_system *sys)
 				comp_d3d11_window_destroy(&mc->window);
 
 				// Recreate window at DP-reported size
-				wret = comp_d3d11_window_create(dp_px_w, dp_px_h, &mc->window);
+				wret = comp_d3d11_window_create(
+				    dp_px_w, dp_px_h,
+				    sys->base.info.display_screen_left,
+				    sys->base.info.display_screen_top,
+				    &mc->window);
 				if (wret != XRT_SUCCESS || mc->window == nullptr) {
 					U_LOG_E("Multi-comp: failed to recreate window at %ux%u", dp_px_w, dp_px_h);
 					return XRT_ERROR_D3D11;

--- a/src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp
+++ b/src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp
@@ -1851,6 +1851,8 @@ comp_d3d12_compositor_create(struct xrt_device *xdev,
                              void *dp_factory_d3d12,
                              bool transparent_background,
                              uint32_t chroma_key_color,
+                             int32_t display_screen_left,
+                             int32_t display_screen_top,
                              struct xrt_compositor_native **out_xc)
 {
 	if (d3d12_device == nullptr) {
@@ -1904,7 +1906,8 @@ comp_d3d12_compositor_create(struct xrt_device *xdev,
 			win_h = 1080;
 		}
 		U_LOG_I("No window handle provided, creating self-owned window (%ux%u)", win_w, win_h);
-		xrt_result_t xret = comp_d3d11_window_create(win_w, win_h, &c->own_window);
+		xrt_result_t xret = comp_d3d11_window_create(
+		    win_w, win_h, display_screen_left, display_screen_top, &c->own_window);
 		if (xret != XRT_SUCCESS) {
 			U_LOG_E("Failed to create self-owned window");
 			delete c;

--- a/src/xrt/compositor/d3d12/comp_d3d12_compositor.h
+++ b/src/xrt/compositor/d3d12/comp_d3d12_compositor.h
@@ -41,6 +41,9 @@ extern "C" {
  *                         a post-weave shader pass that converts pixels matching this
  *                         RGB (0x00BBGGRR / Win32 COLORREF) to alpha=0. Required when
  *                         the bound display processor strips alpha during weaving.
+ * @param display_screen_left Display top-left X in OS screen coords (from xsysc->info,
+ *                            populated by the vendor plug-in iface). 0 = primary.
+ * @param display_screen_top  Display top-left Y in OS screen coords. 0 = primary.
  * @param out_xc Pointer to receive the created compositor.
  *
  * @return XRT_SUCCESS on success, error code otherwise.
@@ -56,6 +59,8 @@ comp_d3d12_compositor_create(struct xrt_device *xdev,
                              void *dp_factory_d3d12,
                              bool transparent_background,
                              uint32_t chroma_key_color,
+                             int32_t display_screen_left,
+                             int32_t display_screen_top,
                              struct xrt_compositor_native **out_xc);
 
 /*!

--- a/src/xrt/compositor/gl/comp_gl_compositor.cpp
+++ b/src/xrt/compositor/gl/comp_gl_compositor.cpp
@@ -1838,7 +1838,9 @@ gl_create_window_and_context(struct comp_gl_compositor *c,
                               void *window_handle,
                               void *app_gl_context,
                               uint32_t width,
-                              uint32_t height)
+                              uint32_t height,
+                              int32_t screen_left,
+                              int32_t screen_top)
 {
 	// Register window class
 	WNDCLASSEXW wc = {0};
@@ -1857,7 +1859,8 @@ gl_create_window_and_context(struct comp_gl_compositor *c,
 		// dedicated thread with message pump, QWERTY input support.
 		uint32_t win_w = width > 0 ? width : GL_DEFAULT_WIDTH;
 		uint32_t win_h = height > 0 ? height : GL_DEFAULT_HEIGHT;
-		xrt_result_t xret = comp_d3d11_window_create(win_w, win_h, &c->own_window);
+		xrt_result_t xret = comp_d3d11_window_create(
+		    win_w, win_h, screen_left, screen_top, &c->own_window);
 		if (xret != XRT_SUCCESS) {
 			U_LOG_E("Failed to create self-owned window for GL compositor");
 			return false;
@@ -2213,6 +2216,8 @@ comp_gl_compositor_create(struct xrt_device *xdev,
                           void *shared_texture_handle,
                           bool transparent_background,
                           uint32_t chroma_key_color,
+                          int32_t display_screen_left,
+                          int32_t display_screen_top,
                           struct xrt_compositor_native **out_xcn)
 {
 	struct comp_gl_compositor *c = U_TYPED_CALLOC(struct comp_gl_compositor);
@@ -2243,7 +2248,8 @@ comp_gl_compositor_create(struct xrt_device *xdev,
 
 	// Platform-specific context/window setup
 #ifdef XRT_OS_WINDOWS
-	if (!gl_create_window_and_context(c, window_handle, gl_context, width, height)) {
+	if (!gl_create_window_and_context(c, window_handle, gl_context, width, height,
+	                                  display_screen_left, display_screen_top)) {
 		free(c);
 		return XRT_ERROR_OPENGL;
 	}

--- a/src/xrt/compositor/gl/comp_gl_compositor.h
+++ b/src/xrt/compositor/gl/comp_gl_compositor.h
@@ -40,6 +40,10 @@ struct xrt_system_compositor_info;
  * @param chroma_key_color       0x00BBGGRR. Forwarded to the display processor as the
  *                               chroma-key color used by the post-weave alpha-recovery pass.
  *                               Pass 0 to let the DP pick a default (magenta).
+ * @param display_screen_left    Display top-left X in OS screen coords (from xsysc->info,
+ *                               populated by the vendor plug-in iface). 0 = primary.
+ *                               Used only on Windows for self-owned window positioning.
+ * @param display_screen_top     Display top-left Y in OS screen coords. 0 = primary.
  * @param out_xcn                Output native compositor.
  * @return XRT_SUCCESS or error.
  *
@@ -54,6 +58,8 @@ comp_gl_compositor_create(struct xrt_device *xdev,
                           void *shared_texture_handle,
                           bool transparent_background,
                           uint32_t chroma_key_color,
+                          int32_t display_screen_left,
+                          int32_t display_screen_top,
                           struct xrt_compositor_native **out_xcn);
 
 /*!

--- a/src/xrt/compositor/multi/comp_multi_compositor.c
+++ b/src/xrt/compositor/multi/comp_multi_compositor.c
@@ -540,7 +540,11 @@ multi_compositor_begin_session(struct xrt_compositor *xc, const struct xrt_begin
 			}
 			U_LOG_W("No external HWND provided, creating self-owned window (%ux%u)", win_w, win_h);
 			struct comp_d3d11_window *own_win = NULL;
-			xrt_result_t xret = comp_d3d11_window_create(win_w, win_h, &own_win);
+			xrt_result_t xret = comp_d3d11_window_create(
+			    win_w, win_h,
+			    mc->msc->base.info.display_screen_left,
+			    mc->msc->base.info.display_screen_top,
+			    &own_win);
 			if (xret == XRT_SUCCESS && own_win != NULL) {
 				mc->session_render.own_window = own_win;
 				mc->session_render.owns_window = true;

--- a/src/xrt/compositor/vk_native/comp_vk_native_compositor.c
+++ b/src/xrt/compositor/vk_native/comp_vk_native_compositor.c
@@ -2528,6 +2528,8 @@ comp_vk_native_compositor_create(struct xrt_device *xdev,
                                  void *shared_texture_handle,
                                  bool transparent_background,
                                  uint32_t chroma_key_color,
+                                 int32_t display_screen_left,
+                                 int32_t display_screen_top,
                                  struct xrt_compositor_native **out_xc)
 {
 	if (vk_device == NULL) {
@@ -2605,7 +2607,8 @@ comp_vk_native_compositor_create(struct xrt_device *xdev,
 			win_h = 1080;
 		}
 		U_LOG_I("Creating self-owned window (%ux%u)", win_w, win_h);
-		xrt_result_t xret = comp_d3d11_window_create(win_w, win_h, &c->own_window);
+		xrt_result_t xret = comp_d3d11_window_create(
+		    win_w, win_h, display_screen_left, display_screen_top, &c->own_window);
 		if (xret != XRT_SUCCESS) {
 			U_LOG_E("Failed to create self-owned window");
 			free(c);

--- a/src/xrt/compositor/vk_native/comp_vk_native_compositor.h
+++ b/src/xrt/compositor/vk_native/comp_vk_native_compositor.h
@@ -62,6 +62,8 @@ comp_vk_native_compositor_create(struct xrt_device *xdev,
                                  void *shared_texture_handle,
                                  bool transparent_background,
                                  uint32_t chroma_key_color,
+                                 int32_t display_screen_left,
+                                 int32_t display_screen_top,
                                  struct xrt_compositor_native **out_xc);
 
 /*!

--- a/src/xrt/state_trackers/oxr/oxr_session_gfx_d3d11_native.c
+++ b/src/xrt/state_trackers/oxr/oxr_session_gfx_d3d11_native.c
@@ -136,14 +136,18 @@ oxr_session_populate_d3d11_native(struct oxr_logger *log,
 
 	// Get D3D11 display processor factory from system compositor info (set by target builder)
 	void *dp_factory_d3d11 = NULL;
+	int32_t display_screen_left = 0;
+	int32_t display_screen_top = 0;
 	if (sys->xsysc != NULL) {
 		dp_factory_d3d11 = sys->xsysc->info.dp_factory_d3d11;
+		display_screen_left = sys->xsysc->info.display_screen_left;
+		display_screen_top = sys->xsysc->info.display_screen_top;
 	}
 
 	// Create the D3D11 native compositor
 	xrt_result_t xret = comp_d3d11_compositor_create(
 	    xdev, window_handle, (void *)next->device, dp_factory_d3d11, shared_texture_handle,
-	    transparent_background, chroma_key_color, &xcn);
+	    transparent_background, chroma_key_color, display_screen_left, display_screen_top, &xcn);
 	if (xret != XRT_SUCCESS) {
 		return oxr_error(log, XR_ERROR_INITIALIZATION_FAILED,
 		                 "Failed to create D3D11 native compositor: %d", xret);

--- a/src/xrt/state_trackers/oxr/oxr_session_gfx_d3d12_native.c
+++ b/src/xrt/state_trackers/oxr/oxr_session_gfx_d3d12_native.c
@@ -99,17 +99,22 @@ oxr_session_populate_d3d12_native(struct oxr_logger *log,
 	struct xrt_device *xdev = get_role_head(sess->sys);
 	struct xrt_compositor_native *xcn = NULL;
 
-	// Get D3D12 display processor factory from system compositor info
+	// Get D3D12 display processor factory and display top-left from system compositor info
 	void *dp_factory_d3d12 = NULL;
+	int32_t display_screen_left = 0;
+	int32_t display_screen_top = 0;
 	if (sys->xsysc != NULL) {
 		dp_factory_d3d12 = sys->xsysc->info.dp_factory_d3d12;
+		display_screen_left = sys->xsysc->info.display_screen_left;
+		display_screen_top = sys->xsysc->info.display_screen_top;
 	}
 
 	// Create the D3D12 native compositor
 	xrt_result_t xret = comp_d3d12_compositor_create(
 	    xdev, window_handle, shared_texture_handle,
 	    (void *)next->device, (void *)next->queue,
-	    dp_factory_d3d12, transparent_background, chroma_key_color, &xcn);
+	    dp_factory_d3d12, transparent_background, chroma_key_color,
+	    display_screen_left, display_screen_top, &xcn);
 	if (xret != XRT_SUCCESS) {
 		return oxr_error(log, XR_ERROR_INITIALIZATION_FAILED,
 		                 "Failed to create D3D12 native compositor: %d", xret);

--- a/src/xrt/state_trackers/oxr/oxr_session_gfx_gl_macos.m
+++ b/src/xrt/state_trackers/oxr/oxr_session_gfx_gl_macos.m
@@ -66,6 +66,8 @@ oxr_session_populate_gl_macos(struct oxr_logger *log,
 	    shared_iosurface,     // IOSurfaceRef for shared texture mode (or NULL for windowed)
 	    /*transparent_background*/ false,  // GL transparent present path is deferred (PR #3b §3b)
 	    /*chroma_key_color*/ 0,
+	    /*display_screen_left*/ 0,   // macOS: NSOpenGLView positioning, no D3D11 window
+	    /*display_screen_top*/ 0,
 	    &xcn);
 	if (xret != XRT_SUCCESS) {
 		return oxr_error(log, XR_ERROR_INITIALIZATION_FAILED,

--- a/src/xrt/state_trackers/oxr/oxr_session_gfx_gl_native.c
+++ b/src/xrt/state_trackers/oxr/oxr_session_gfx_gl_native.c
@@ -85,8 +85,10 @@ oxr_session_populate_gl_native(struct oxr_logger *log,
 	struct xrt_device *xdev = get_role_head(sess->sys);
 	struct xrt_compositor_native *xcn = NULL;
 
-	// Get GL display processor factory from system compositor info
+	// Get GL display processor factory and display top-left from system compositor info
 	void *dp_factory_gl = (sys->xsysc != NULL) ? sys->xsysc->info.dp_factory_gl : NULL;
+	int32_t display_screen_left = (sys->xsysc != NULL) ? sys->xsysc->info.display_screen_left : 0;
+	int32_t display_screen_top = (sys->xsysc != NULL) ? sys->xsysc->info.display_screen_top : 0;
 
 	// Create the GL native compositor
 	xrt_result_t xret = comp_gl_compositor_create(
@@ -98,6 +100,8 @@ oxr_session_populate_gl_native(struct oxr_logger *log,
 	    shared_texture_handle,
 	    transparent_background,
 	    chroma_key_color,
+	    display_screen_left,
+	    display_screen_top,
 	    &xcn);
 	if (xret != XRT_SUCCESS) {
 		return oxr_error(log, XR_ERROR_INITIALIZATION_FAILED,

--- a/src/xrt/state_trackers/oxr/oxr_session_gfx_vk_native.c
+++ b/src/xrt/state_trackers/oxr/oxr_session_gfx_vk_native.c
@@ -255,10 +255,14 @@ oxr_session_populate_vk_native(struct oxr_logger *log,
 	struct xrt_device *xdev = get_role_head(sess->sys);
 	struct xrt_compositor_native *xcn = NULL;
 
-	// Get VK display processor factory from system compositor info
+	// Get VK display processor factory and display top-left from system compositor info
 	void *dp_factory_vk = NULL;
+	int32_t display_screen_left = 0;
+	int32_t display_screen_top = 0;
 	if (sys->xsysc != NULL) {
 		dp_factory_vk = sys->xsysc->info.dp_factory_vk;
+		display_screen_left = sys->xsysc->info.display_screen_left;
+		display_screen_top = sys->xsysc->info.display_screen_top;
 	}
 
 	// Create the VK native compositor
@@ -271,6 +275,7 @@ oxr_session_populate_vk_native(struct oxr_logger *log,
 	    next->queueIndex,
 	    dp_factory_vk, shared_texture_handle,
 	    transparent_background, chroma_key_color,
+	    display_screen_left, display_screen_top,
 	    &xcn);
 	if (xret != XRT_SUCCESS) {
 		return oxr_error(log, XR_ERROR_INITIALIZATION_FAILED,


### PR DESCRIPTION
Closes #265.

## Summary

`comp_d3d11_window.cpp` was the last HIGH-severity ADR-001 violation in the runtime after #256 landed. It called `leia_edid_find_3d_display_rect()` directly (`#ifdef XRT_HAVE_LEIA_SR`) to find the 3D panel's desktop origin so the self-owned window could land on the right monitor. This PR routes that value through the generic plug-in iface path that #256 already established and removes the vendor coupling.

## Fix surface

- **Runtime DLL**: `comp_d3d11_window.cpp` drops the `#ifdef XRT_HAVE_LEIA_SR` include of `leia/leia_interface.h`, deletes `get_3d_display_top_left()`, and reads `display_screen_left/top` from two new fields on `struct comp_d3d11_window` populated at create time. The `comp_d3d11_window_create()` signature grows two `int32_t` parameters.
- **Plumbing**: same two params added to `comp_{d3d11,d3d12,vk_native,gl}_compositor_create()`. Each corresponding state tracker (`oxr_session_gfx_*`) reads `sys->xsysc->info.display_screen_left/top` (mirroring the existing `dp_factory_*` pattern) and forwards them down.
- **Service-side compositors** (`comp_multi_compositor.c`, `comp_d3d11_service.cpp`) read the values from `*->base.info.display_screen_left/top` locally at each callsite — the `xrt_system_compositor_info` struct is already in scope, no new params needed.

## Audit

```
grep -ri "leia\|simulatedreality\|XRT_HAVE_LEIA_SR" src/xrt/compositor/d3d11/comp_d3d11_window.cpp
```
→ zero hits.

```
grep -ri "leia\|simulatedreality" src/xrt/compositor/d3d11/
```
→ only copyright lines + two descriptive comments in `comp_d3d11_compositor.cpp` referring to "Leia DP" / "Leia D3D11 display processor" behavior. No compile-time vendor coupling.

Sibling native compositors (d3d12, vk_native, gl, metal, multi, client) were already clean — confirmed by audit.

## Test plan

- [x] Local build: `scripts\build_windows.bat all` green (runtime + installer + test apps).
- [x] `cube_handle_d3d11_win` standalone on Leia hardware — window opens on the 3D panel, cube renders correctly. (User-verified.)
- [x] `displayxr-shell.exe cube_handle_d3d11_win.exe` (shell v1.2.5) — window opens on the 3D panel with correct tile placement. (User-verified.)
- [ ] CI: `build-windows.yml`, `build-macos.yml` green.
- [ ] sim_display fallback regression check: `display_screen_left/top = 0,0` puts the window at desktop origin (sim_display default). Will verify on next sim_display test session.

## Adjacent (out of scope, next cleanup target)

- `src/xrt/targets/common/target_instance.c:157, 330` — `strstr(head->str, "Sim 3D Display")` string-match discrimination. Gated behind `XRT_PLUGIN_BUILD_INPROC_FALLBACK` (developer-only), not a production hazard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)