### PR TITLE
macOS .pkg installer: ship sim_display plug-in + system-wide loader root (#274)

### DIFF
--- a/installer/macos/build_installer.sh
+++ b/installer/macos/build_installer.sh
@@ -28,13 +28,75 @@ RUNTIME_ROOT="$WORK_DIR/payload-runtime/Library/Application Support/DisplayXR"
 mkdir -p "$RUNTIME_ROOT/lib"
 mkdir -p "$RUNTIME_ROOT/share/vulkan/icd.d"
 
-cp "$ARTIFACT_DIR"/lib/libopenxr_displayxr* "$RUNTIME_ROOT/lib/"
+# Find and copy the runtime dylib. Issue #256 / ADR-019 promoted this
+# from MODULE to SHARED + PREFIX="", so the produced file is
+# `openxr_displayxr.dylib` (no `lib` prefix). Match the legacy
+# `libopenxr_displayxr*` shape too for transition safety, same as
+# scripts/build_macos.sh.
+RUNTIME_LIB=$(find "$ARTIFACT_DIR/lib" -maxdepth 1 \
+  \( -name "openxr_displayxr.dylib" -o -name "openxr_displayxr.so" -o -name "libopenxr_displayxr*" \) \
+  -type f | head -1)
+if [ -z "$RUNTIME_LIB" ] || [ ! -f "$RUNTIME_LIB" ]; then
+    echo "Error: runtime dylib not found in $ARTIFACT_DIR/lib/" >&2
+    exit 1
+fi
+RUNTIME_BASENAME=$(basename "$RUNTIME_LIB")
+cp "$RUNTIME_LIB" "$RUNTIME_ROOT/lib/"
 cp "$ARTIFACT_DIR/lib/libvulkan.1.dylib" "$RUNTIME_ROOT/lib/"
 cp "$ARTIFACT_DIR/lib/libMoltenVK.dylib" "$RUNTIME_ROOT/lib/"
 cp "$ARTIFACT_DIR/share/vulkan/icd.d/MoltenVK_icd.json" "$RUNTIME_ROOT/share/vulkan/icd.d/"
 
-# Detect the runtime library filename
-RUNTIME_BASENAME=$(basename "$ARTIFACT_DIR"/lib/libopenxr_displayxr*)
+# Ship the vendor plug-in dylib + JSON manifest (#267, #274). The
+# runtime no longer link-includes drv_sim_display in production
+# builds; without these the installed runtime has no display
+# processor and xrCreateInstance fails. Manifest must land at the
+# DisplayProcessors/ discovery root (NOT inside lib/...); the dylib
+# can live anywhere binary_path points at.
+INSTALL_PREFIX="/Library/Application Support/DisplayXR"
+PLUGIN_PAYLOAD_DIR="$RUNTIME_ROOT/lib/displayxr/plugins"
+MANIFEST_PAYLOAD_DIR="$RUNTIME_ROOT/DisplayProcessors"
+PLUGIN_SRC="$ARTIFACT_DIR/lib/displayxr/plugins/DisplayXR-SimDisplay.dylib"
+if [ ! -f "$PLUGIN_SRC" ]; then
+    echo "Error: sim-display plug-in not found at $PLUGIN_SRC" >&2
+    echo "Re-run scripts/build_macos.sh first." >&2
+    exit 1
+fi
+mkdir -p "$PLUGIN_PAYLOAD_DIR" "$MANIFEST_PAYLOAD_DIR"
+cp "$PLUGIN_SRC" "$PLUGIN_PAYLOAD_DIR/"
+
+# Fix up the plug-in's LC_RPATH so @rpath/openxr_displayxr.dylib
+# resolves to the installed runtime, not the build-tree absolute path
+# CMake bakes in for dev iteration. Layout at install time:
+#   $INSTALL_PREFIX/lib/openxr_displayxr.dylib                 <- runtime
+#   $INSTALL_PREFIX/lib/displayxr/plugins/PLUGIN.dylib         <- plug-in
+# From the plug-in's @loader_path (.../lib/displayxr/plugins/), the
+# runtime is at @loader_path/../.. (.../lib/).
+PAYLOAD_PLUGIN="$PLUGIN_PAYLOAD_DIR/DisplayXR-SimDisplay.dylib"
+chmod u+w "$PAYLOAD_PLUGIN"
+# Drop every existing rpath that points into a build/_package tree;
+# keep only system rpaths (Homebrew cjson etc. — install_name_tool is
+# a no-op on those). We can't enumerate negatively, so just delete the
+# known dev-iteration rpaths if present and let any survivor warn.
+for r in $(otool -l "$PAYLOAD_PLUGIN" 2>/dev/null \
+           | awk '/LC_RPATH/{f=1} f && /path /{print $2; f=0}' \
+           | grep -E '^/.*displayxr-runtime/.*build|@loader_path' || true); do
+    install_name_tool -delete_rpath "$r" "$PAYLOAD_PLUGIN" 2>/dev/null || true
+done
+install_name_tool -add_rpath "@loader_path/../.." "$PAYLOAD_PLUGIN"
+
+cat > "$MANIFEST_PAYLOAD_DIR/200-sim-display.json" <<EOF
+{
+    "file_format_version": "1.0",
+    "plugin": {
+        "id":           "sim-display",
+        "display_name": "DisplayXR Sim Display",
+        "vendor":       "DisplayXR",
+        "version":      "$VERSION",
+        "binary_path":  "$INSTALL_PREFIX/lib/displayxr/plugins/DisplayXR-SimDisplay.dylib",
+        "probe_order":  200
+    }
+}
+EOF
 
 # Generate manifest with absolute library_path for installed location
 cat > "$RUNTIME_ROOT/openxr_displayxr.json" <<EOF

--- a/installer/macos/create_app_bundle.sh
+++ b/installer/macos/create_app_bundle.sh
@@ -69,8 +69,20 @@ LAUNCHER
 chmod +x "$APP_BUNDLE/Contents/MacOS/$BUNDLE_DISPLAY_NAME"
 
 # --- Resources: binary and libraries ---
+# Match the same set of runtime-dylib name shapes that build_installer.sh
+# accepts (issue #256/ADR-019 moved this from MODULE → SHARED + PREFIX="",
+# producing `openxr_displayxr.dylib` instead of the historical
+# `libopenxr_displayxr.*`).
+RUNTIME_LIB=$(find "$ARTIFACT_DIR/lib" -maxdepth 1 \
+  \( -name "openxr_displayxr.dylib" -o -name "openxr_displayxr.so" -o -name "libopenxr_displayxr*" \) \
+  -type f | head -1)
+if [ -z "$RUNTIME_LIB" ] || [ ! -f "$RUNTIME_LIB" ]; then
+    echo "Error: runtime dylib not found in $ARTIFACT_DIR/lib/" >&2
+    exit 1
+fi
+RUNTIME_BASENAME=$(basename "$RUNTIME_LIB")
 cp "$ARTIFACT_DIR/bin/$BINARY_NAME" "$APP_BUNDLE/Contents/Resources/"
-cp "$ARTIFACT_DIR"/lib/libopenxr_displayxr* "$APP_BUNDLE/Contents/Resources/lib/"
+cp "$RUNTIME_LIB" "$APP_BUNDLE/Contents/Resources/lib/"
 cp "$ARTIFACT_DIR"/lib/libopenxr_loader* "$APP_BUNDLE/Contents/Resources/lib/"
 cp "$ARTIFACT_DIR/lib/libvulkan.1.dylib" "$APP_BUNDLE/Contents/Resources/lib/"
 cp "$ARTIFACT_DIR/lib/libMoltenVK.dylib" "$APP_BUNDLE/Contents/Resources/lib/"
@@ -81,7 +93,7 @@ cat > "$APP_BUNDLE/Contents/Resources/openxr_displayxr.json" <<EOF
     "file_format_version": "1.0.0",
     "runtime": {
         "name": "DisplayXR Runtime",
-        "library_path": "lib/$(basename "$ARTIFACT_DIR"/lib/libopenxr_displayxr*)"
+        "library_path": "lib/$RUNTIME_BASENAME"
     }
 }
 EOF

--- a/installer/macos/uninstall.sh
+++ b/installer/macos/uninstall.sh
@@ -5,6 +5,12 @@ set -e
 echo "=== DisplayXR Uninstaller ==="
 
 echo "Removing DisplayXR runtime..."
+# This recursive delete covers the runtime dylib, the
+# DisplayXR-SimDisplay.dylib plug-in under lib/displayxr/plugins/,
+# and the 200-sim-display.json manifest under DisplayProcessors/
+# (issue #274). Per-user manifests at ~/Library/Application
+# Support/DisplayXR/DisplayProcessors/ are intentionally left alone —
+# those are user-owned dev-iteration state.
 sudo rm -rf "/Library/Application Support/DisplayXR"
 
 echo "Removing OpenXR runtime registration..."
@@ -14,7 +20,12 @@ echo "Removing test app..."
 rm -rf "/Applications/DisplayXRCube.app"
 
 echo "Forgetting installer receipts..."
-sudo pkgutil --forget com.displayxr.displayxr.runtime 2>/dev/null || true
-sudo pkgutil --forget com.displayxr.displayxr.testapp 2>/dev/null || true
+# Identifiers must match the --identifier values in build_installer.sh
+# (com.displayxr.runtime, com.displayxr.testapp). Earlier revisions of
+# this script had `com.displayxr.displayxr.*` here — a double-prefix
+# typo that silently swallowed via `|| true`, leaving orphan receipts
+# in `pkgutil --pkgs` after every uninstall (#274).
+sudo pkgutil --forget com.displayxr.runtime 2>/dev/null || true
+sudo pkgutil --forget com.displayxr.testapp 2>/dev/null || true
 
 echo "=== DisplayXR uninstalled ==="

--- a/src/xrt/targets/common/target_plugin_loader.c
+++ b/src/xrt/targets/common/target_plugin_loader.c
@@ -351,8 +351,9 @@ discover_active_plugin(struct xrt_plugin_instance **out_inst)
  *   2. macOS: ~/Library/Application Support/DisplayXR/DisplayProcessors/
  *      Linux: $XDG_DATA_HOME/DisplayXR/DisplayProcessors/
  *             (defaults to ~/.local/share/DisplayXR/DisplayProcessors/)
- *   3. Linux only: /usr/local/share/displayxr/DisplayProcessors/
- *                  /usr/share/displayxr/DisplayProcessors/
+ *   3. macOS: /Library/Application Support/DisplayXR/DisplayProcessors/
+ *      Linux: /usr/local/share/displayxr/DisplayProcessors/
+ *             /usr/share/displayxr/DisplayProcessors/
  *
  * Per-user shadows system entries via lexicographic sort tie-break on
  * the absolute path (later inserts win — the loop inserts in priority
@@ -642,6 +643,13 @@ discover_active_plugin(struct xrt_plugin_instance **out_inst)
 		         "%s/Library/Application Support/DisplayXR/DisplayProcessors", home);
 		append_roots(roots, (int)(sizeof(roots) / sizeof(roots[0])), &n_roots, user_root);
 	}
+	/* System-wide root for `.pkg`-style installs that run as root and
+	 * write to /Library/Application Support/ rather than ~. Per-user
+	 * entries above shadow system-wide entries via the already_have_id
+	 * dedup inside enumerate_dir. Mirrors the Linux system-root
+	 * convention below. Issue #274. */
+	append_roots(roots, (int)(sizeof(roots) / sizeof(roots[0])), &n_roots,
+	             "/Library/Application Support/DisplayXR/DisplayProcessors");
 #else
 	const char *xdg = getenv("XDG_DATA_HOME");
 	if (xdg != NULL && *xdg != '\0') {


### PR DESCRIPTION
## Summary

Closes #274. Follow-up to #267 / PR #272 — the loader contract was shipping on macOS but the `.pkg` installer hadn't been updated, so a user who ran the installer got a runtime with zero `sim_display_*` symbols (correct per #267) and no plug-in available (broken — `xrCreateInstance` would fail with `XRT_ERROR_DEVICE_CREATION_FAILED`).

Three fixes:

- **Loader (system-wide root).** `target_plugin_loader.c` now also walks `/Library/Application Support/DisplayXR/DisplayProcessors/` on macOS, mirroring how the Linux branch handles `/usr/local/share/...` + `/usr/share/...`. Per-user shadows system-wide via the existing `already_have_id` dedup.
- **`installer/macos/build_installer.sh`.** Ships `DisplayXR-SimDisplay.dylib` into the payload's `lib/displayxr/plugins/`, writes `200-sim-display.json` into `DisplayProcessors/` (the discovery root — the manifest's location is what matters; the dylib can live anywhere `binary_path` points at), and runs `install_name_tool` fixup on the embedded plug-in: drop the build-tree absolute `LC_RPATH` that CMake bakes in for dev iteration, add `@loader_path/../..` so `@rpath/openxr_displayxr.dylib` resolves to the installed runtime. Also fixes the same `MODULE → SHARED + PREFIX=""` `find` glob bug that #272 patched in `scripts/build_macos.sh`.
- **`installer/macos/uninstall.sh`.** The recursive `rm -rf /Library/Application Support/DisplayXR/` already covered the plug-in + manifest; comment added so that's explicit. Also fixed a pre-existing double-prefix typo in the `pkgutil --forget` identifiers (`com.displayxr.displayxr.{runtime,testapp}` → `com.displayxr.{runtime,testapp}`) that was silently orphaning receipts on every uninstall.
- **`installer/macos/create_app_bundle.sh`.** Same find-pattern fix as `build_installer.sh`.

## Test plan

- [x] `scripts/build_macos.sh --installer` builds `DisplayXR-Installer.pkg` cleanly
- [x] `pkgutil --expand` of the .pkg shows `DisplayProcessors/200-sim-display.json` and `lib/displayxr/plugins/DisplayXR-SimDisplay.dylib` in the payload
- [x] Payload plug-in's `LC_RPATH` is `@loader_path/../..` only — build-tree absolute path stripped
- [x] `sudo installer -pkg DisplayXR-Installer.pkg -target /` installs cleanly into `/Library/Application Support/DisplayXR/`
- [x] `cube_handle_metal_macos` with the dev tree hidden, no per-user state, no `XRT_PLUGIN_SEARCH_PATH` override loads the plug-in from the system-wide root and logs `active plug-in: id=sim-display ... version='1.0.0' path=/Library/Application Support/DisplayXR/lib/displayxr/plugins/DisplayXR-SimDisplay.dylib` and `XR_EXT_display_info (iface=sim-display): …`
- [x] `manifest.version='1.0.0'` (the .pkg's `$VERSION`) confirms the install manifest was the one parsed, distinct from the dev tree's `version='dev'`
- [x] `uninstall.sh` removes the install tree (including plug-in + manifest under `DisplayProcessors/`) and the corrected `pkgutil` identifiers actually forget the receipts
- [ ] Windows CI: loader change is in the `__APPLE__` branch and doesn't touch the `XRT_OS_WINDOWS` path; the existing dumpbin assertion should still pass
- [ ] macOS CI: full clean build

🤖 Generated with [Claude Code](https://claude.com/claude-code)