### PR TITLE
cleanup: drop strstr device-name discrimination in target_instance.c

### DIFF
--- a/src/xrt/targets/common/target_instance.c
+++ b/src/xrt/targets/common/target_instance.c
@@ -158,8 +158,14 @@ t_instance_create_system(struct xrt_instance *xinst,
 		// build — production builds get the SR refresh rate through the
 		// plug-in iface (TODO: add to xrt_plugin_display_info if it
 		// becomes load-bearing for the null compositor path).
-		if (strstr(head->str, "Sim 3D Display") == NULL)
-		{
+		//
+		// Gate on the cached EDID probe rather than on a device-name
+		// substring: leia_edid_get_cached_result() reports hw_found=true
+		// only when a known Leia/Dimenco panel is connected, so the slow
+		// 5s leiasr_query_* call is skipped cleanly on sim_display and
+		// any non-Leia HMD without depending on driver-name strings.
+		struct leia_display_probe_result probe = {0};
+		if (leia_edid_get_cached_result(&probe) && probe.hw_found) {
 			uint32_t sr_rec_width = 0, sr_rec_height = 0;
 			uint32_t sr_native_width = 0, sr_native_height = 0;
 			if (leiasr_query_recommended_view_dimensions(5.0, &sr_rec_width, &sr_rec_height,
@@ -331,7 +337,14 @@ out:
 		// debugging without the plug-in DLL). Production runtime uses
 		// the iface-populated values above and never touches these
 		// vendor symbols.
-		if (!plugin_filled_display_info && strstr(head->str, "Sim 3D Display") == NULL)
+		//
+		// Gate on the cached EDID probe (non-blocking) rather than on a
+		// device-name substring: hw_found is true iff a known
+		// Leia/Dimenco panel is connected, so non-Leia setups skip the
+		// whole block cleanly without depending on driver-name strings.
+		struct leia_display_probe_result probe_edid = {0};
+		if (!plugin_filled_display_info &&
+		    leia_edid_get_cached_result(&probe_edid) && probe_edid.hw_found)
 		{
 			uint32_t di_sr_w = 0, di_sr_h = 0, di_nat_w = 0, di_nat_h = 0;
 			float di_refresh = 0.0f;
@@ -357,13 +370,11 @@ out:
 				xsysc->info.supported_eye_tracking_modes = 1; /* MANAGED_BIT */
 				xsysc->info.default_eye_tracking_mode = 0;    /* MANAGED */
 			}
-			{
-				struct leia_display_probe_result edid;
-				if (leia_edid_get_cached_result(&edid) && edid.hw_found) {
-					xsysc->info.display_screen_left = edid.screen_left;
-					xsysc->info.display_screen_top = edid.screen_top;
-				}
-			}
+
+			// Reuse the gating probe — hw_found guarantees screen
+			// coords are valid.
+			xsysc->info.display_screen_left = probe_edid.screen_left;
+			xsysc->info.display_screen_top = probe_edid.screen_top;
 
 			if (xsysc->info.display_pixel_width > 0 && xsysc->info.display_pixel_height > 0) {
 				for (uint32_t mi = 0; mi < head->rendering_mode_count; mi++) {


### PR DESCRIPTION
Follow-up to #273 (closes #265) — eliminates the final ADR-001 anti-pattern in the runtime tree.

## Background

PR #273 fixed the HIGH-severity violation in `comp_d3d11_window.cpp`. Two adjacent matches were flagged in #265's "out of scope, next cleanup target" section:

- `src/xrt/targets/common/target_instance.c:161` — `if (strstr(head->str, "Sim 3D Display") == NULL)` gating SR refresh-rate query in the null-compositor path.
- `src/xrt/targets/common/target_instance.c:334` — same check gating the entire legacy in-proc Leia display-info population block.

Both live inside `#if defined(XRT_HAVE_LEIA_SR) && defined(XRT_PLUGIN_BUILD_INPROC_FALLBACK)`, so they never compile into production builds. But substring-matching a human-readable device name to discriminate vendors is exactly the anti-pattern the plug-in architecture eliminated — leaving it in the developer-fallback path makes it a trap for the next person who decides to revive in-proc debugging.

## Fix

Replace both checks with a cached-EDID hardware-presence gate:

```c
struct leia_display_probe_result probe = {0};
if (leia_edid_get_cached_result(&probe) && probe.hw_found) { ... }
```

`hw_found` is true iff the EDID matched a known Leia/Dimenco panel. This:

1. Doesn't depend on whatever string the active driver decided to use for `xrt_device::str`.
2. Asks the right question (do we have the hardware?) instead of the discriminator question (is this not sim-display?).
3. Short-circuits the slow 5s `leiasr_query_recommended_view_dimensions` call on non-Leia setups at site 1, which the strstr was already doing as a side effect.

At site 2, the outer probe also folds in the inner `leia_edid_get_cached_result` call (was a duplicate after the gate change — `screen_left`/`screen_top` are now read from `probe_edid`).

## Verification

- ✅ `scripts\build_windows.bat all` (production, `INPROC_FALLBACK=OFF`) — green. Strictly a verification that the surrounding code path isn't broken; the changed code doesn't compile into this configuration.
- ✅ One-off `cmake -DXRT_PLUGIN_BUILD_INPROC_FALLBACK=ON` regen — `openxr_displayxr` target builds clean. Confirms the legacy block still compiles with the new gate.
- ✅ `cube_handle_d3d11_win` on Leia hardware — no regression (user-verified).
- ✅ `grep -n "strstr.*head\|Sim 3D Display" src/xrt/targets/common/target_instance.c` → zero hits.

## Test plan

- [ ] CI green (build-windows.yml, build-macos.yml).
- [x] Local production build verifies surrounding code.
- [x] Local INPROC_FALLBACK build verifies new gate compiles.
- [x] Local cube smoke test on Leia hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)