### PR TITLE
macOS CI: build + publish DisplayXR-Installer.pkg alongside Windows .exe (#277)

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: release
-description: Create a tagged release of the displayxr-runtime repo, monitor the Windows CI build, and publish the GitHub Release with the installer asset attached. Syntax /release <version-spec>, where version-spec is vX.Y.Z or patch/minor/major.
+description: Create a tagged release of the displayxr-runtime repo, monitor the Windows + macOS CI builds, and publish the GitHub Release with the Windows installer + macOS .pkg attached. Syntax /release <version-spec>, where version-spec is vX.Y.Z or patch/minor/major.
 allowed-tools: Read, Grep, Glob, Bash, Agent, Edit, Write
 ---
 
 # Release Skill
 
-Creates a tagged release of the **displayxr-runtime** repo, monitors the Windows CI build, attaches the installer artifact to the GitHub Release, and reports.
+Creates a tagged release of the **displayxr-runtime** repo, monitors the Windows + macOS CI builds, and publishes the GitHub Release with both platform installers attached (`DisplayXRSetup-*.exe` and `DisplayXR-Installer.pkg`) plus the test-apps bundle.
 
 ## Scope
 
@@ -79,7 +79,9 @@ Execute the DisplayXR runtime release workflow for [VERSION] (tag: [FULL_TAG]).
 
 ## Configuration
 - Source repo: DisplayXR/displayxr-runtime (this is the public repo — there is no separate "publish" mirror)
-- Workflow to monitor: .github/workflows/build-windows.yml (the artifact producer)
+- Workflows to monitor (both produce artifacts the release attaches):
+  - `.github/workflows/build-windows.yml` — produces `DisplayXRSetup-*.exe` (artifact `DisplayXR-Installer`) + `TestApps-*` bundle
+  - `.github/workflows/build-macos.yml` — produces `DisplayXR-Installer.pkg` (artifact `DisplayXR-Installer-macOS`) (post-#277)
 - publish-extensions.yml fires automatically on every push to main; it does not need monitoring as part of a tagged release (header sync is independent of tags)
 - Shell, demos, displayxr-extensions are out of scope; each has its own flow
 
@@ -126,32 +128,49 @@ The runtime repo's `main` is protected. If `git push origin main` fails with "Ch
 
 ---
 
-## PHASE 3: MONITOR BUILD
+## PHASE 3: MONITOR BUILDS (Windows + macOS)
 
-### Step 3.1: Wait for build to register
+### Step 3.1: Wait for builds to register
 `sleep 15`
 
-### Step 3.2: Find the build run
+### Step 3.2: Find both build runs
 ```bash
 gh run list --workflow build-windows.yml --limit 10 --json databaseId,status,headSha,event
+gh run list --workflow build-macos.yml   --limit 10 --json databaseId,status,headSha,event
 ```
-Find the run with `headSha == $RELEASE_SHA` and event=push. Retry up to 6 times with 10s waits.
+For each workflow, find the run with `headSha == $RELEASE_SHA` and `event=push`. Retry up to 6 times with 10s waits per workflow. Store `WIN_RUN_ID` and `MAC_RUN_ID`.
 
-### Step 3.3: Watch build
-`gh run watch $RUN_ID --interval 30 --exit-status` (timeout 1800000ms — Windows CI can take up to 30 min with test apps).
+### Step 3.3: Watch both runs (in parallel)
+Use a background-poll pattern so both watches run concurrently — total wall time is `max(Windows, macOS)`, not sum.
 
-### Step 3.4: Check result
-- All required jobs succeed → Phase 4
-- Critical job (Runtime, Build) fails → Phase 6 (Rollback)
-- Pre-existing-broken jobs (e.g. demo jobs that reference paths moved to standalone repos) fail but artifact still produced → continue to Phase 4 with a flag in the final report
+```bash
+# Background Windows watch
+gh run watch $WIN_RUN_ID --interval 30 --exit-status > /tmp/win.log 2>&1 &
+WIN_PID=$!
+# Background macOS watch
+gh run watch $MAC_RUN_ID --interval 30 --exit-status > /tmp/mac.log 2>&1 &
+MAC_PID=$!
+
+wait $WIN_PID; WIN_RC=$?
+wait $MAC_PID; MAC_RC=$?
+```
+
+Windows CI can take up to 30 min with test apps; macOS is faster (~10-15 min including the installer build). Timeout each at 1800000 ms.
+
+### Step 3.4: Check both results
+- Both runs all-required-jobs succeed → Phase 4
+- Critical Windows job (`Runtime`, `Build`) fails OR macOS `Build` / `BuildInstaller` fails → Phase 6 (Rollback)
+- Pre-existing-broken jobs (e.g. demo jobs that reference paths moved to standalone repos) fail but the artifact-producing job still succeeded → continue to Phase 4 with a flag in the final report
+- macOS `BuildInstaller` infrastructure-fails (e.g. brew flake) but Windows is green and the run is rerunnable → STOP and ask the user whether to rerun macOS or release Windows-only (latter is degraded; flag clearly)
 
 ---
 
 ## PHASE 4: CREATE GITHUB RELEASE
 
-The build run produces two artifacts the release should attach:
-- **Installer** — `DisplayXR-Installer` artifact (contains `DisplayXRSetup-X.Y.Z.BUILD.exe`).
-- **Test apps bundle** — `TestApps-<run_number>` artifact (~17 MB folder containing all cube test apps). Forced on every tag push by the `DetectChanges` job (`ref_type == 'tag'`). Builders, OEM integrators, and field testers use this to validate the runtime against the public extension contracts without rebuilding from source.
+The build runs produce three artifacts the release should attach:
+- **Windows installer** — `DisplayXR-Installer` artifact from the Windows run (contains `DisplayXRSetup-X.Y.Z.BUILD.exe`).
+- **macOS installer** — `DisplayXR-Installer-macOS` artifact from the macOS run (contains `DisplayXR-Installer.pkg`). Post-#277.
+- **Test apps bundle** — `TestApps-<run_number>` artifact from the Windows run (~17 MB folder containing all cube test apps). Forced on every tag push by the `DetectChanges` job (`ref_type == 'tag'`). Builders, OEM integrators, and field testers use this to validate the runtime against the public extension contracts without rebuilding from source.
 
 Check whether the release already exists:
 
@@ -160,17 +179,33 @@ gh release view [FULL_TAG] --repo DisplayXR/displayxr-runtime 2>/dev/null
 ```
 
 ### Step 4.1: Download artifacts (always runs)
-Regardless of whether the release exists, download both artifacts so we can verify or attach them:
+Regardless of whether the release exists, download all artifacts from both runs so we can verify or attach them:
 
 ```bash
-# Installer artifact (matches DisplayXR-Installer + DisplayXR)
-gh run download $RUN_ID --repo DisplayXR/displayxr-runtime --pattern "DisplayXR*" --dir _release_assets/
+# Windows: DisplayXR* matches DisplayXR-Installer + DisplayXR (folder bundle)
+gh run download $WIN_RUN_ID --repo DisplayXR/displayxr-runtime --pattern "DisplayXR*" --dir _release_assets/
 
-# Test apps bundle — separate pattern because TestApps-* doesn't match DisplayXR*
-gh run download $RUN_ID --repo DisplayXR/displayxr-runtime --pattern "TestApps-*" --dir _release_assets/
+# Windows: TestApps-* is a separate pattern (doesn't match DisplayXR*)
+gh run download $WIN_RUN_ID --repo DisplayXR/displayxr-runtime --pattern "TestApps-*" --dir _release_assets/
+
+# macOS: DisplayXR-Installer-macOS contains DisplayXR-Installer.pkg (post-#277)
+gh run download $MAC_RUN_ID --repo DisplayXR/displayxr-runtime --pattern "DisplayXR-Installer-macOS" --dir _release_assets/
 
 INSTALLER=$(find _release_assets/ -name "DisplayXRSetup-*.exe" | head -1)
-[ -z "$INSTALLER" ] && STOP: "Could not find DisplayXRSetup-*.exe in build artifacts."
+[ -z "$INSTALLER" ] && STOP: "Could not find DisplayXRSetup-*.exe in Windows build artifacts."
+
+PKG_INSTALLER=$(find _release_assets/ -name "DisplayXR-Installer.pkg" | head -1)
+if [ -z "$PKG_INSTALLER" ]; then
+  echo "WARN: no DisplayXR-Installer.pkg in macOS run — macOS install asset will not be attached."
+  echo "Check macOS BuildInstaller job logs. Don't STOP — Windows release still ships."
+fi
+# Rename the .pkg to include the version so the asset filename matches the convention
+# (DisplayXR-Installer-X.Y.Z.pkg, parallel to DisplayXRSetup-X.Y.Z.BUILD.exe).
+if [ -n "$PKG_INSTALLER" ]; then
+  VERSIONED_PKG="_release_assets/DisplayXR-Installer-[VERSION].pkg"  # [VERSION] without leading v
+  cp "$PKG_INSTALLER" "$VERSIONED_PKG"
+  PKG_INSTALLER="$VERSIONED_PKG"
+fi
 
 # Zip the TestApps folder into a single asset. Pattern: DisplayXR-TestApps-<version>.zip.
 TESTAPPS_DIR=$(find _release_assets/ -maxdepth 2 -type d -name "TestApps-*" | head -1)
@@ -184,18 +219,21 @@ else
 fi
 ```
 
-The TestApps bundle is a soft requirement: if `DetectChanges` mis-detected and didn't produce it, log a warning and continue with installer-only. Don't STOP the release.
+The TestApps bundle and the macOS .pkg are both **soft requirements**: log a warning if missing and continue with the assets that are available. Only the Windows installer is hard-required (its absence STOPs the release).
 
 ### Step 4.2a: If release already exists
-The workflow auto-created it (rare path — currently `build-windows.yml` does not auto-create a release, so this branch is unusual). Upload any missing assets:
+The workflow auto-created it (rare path — currently neither `build-windows.yml` nor `build-macos.yml` auto-creates a release, so this branch is unusual). Upload any missing assets:
 
 ```bash
-gh release upload [FULL_TAG] --repo DisplayXR/displayxr-runtime --clobber "$INSTALLER" ${TESTAPPS_ZIP:+"$TESTAPPS_ZIP"}
+gh release upload [FULL_TAG] --repo DisplayXR/displayxr-runtime --clobber \
+  "$INSTALLER" \
+  ${PKG_INSTALLER:+"$PKG_INSTALLER"} \
+  ${TESTAPPS_ZIP:+"$TESTAPPS_ZIP"}
 ```
 Then go to Phase 5.
 
 ### Step 4.2b: If release does NOT exist
-Create it with both assets:
+Create it with all available assets:
 
 ```bash
 # Generate release notes
@@ -206,7 +244,9 @@ gh release create [FULL_TAG] \
   --repo DisplayXR/displayxr-runtime \
   --title "DisplayXR Runtime [FULL_TAG]" \
   --notes "<grouped notes here>" \
-  "$INSTALLER" ${TESTAPPS_ZIP:+"$TESTAPPS_ZIP"}
+  "$INSTALLER" \
+  ${PKG_INSTALLER:+"$PKG_INSTALLER"} \
+  ${TESTAPPS_ZIP:+"$TESTAPPS_ZIP"}
 ```
 
 ---
@@ -219,7 +259,8 @@ gh release view [FULL_TAG] --repo DisplayXR/displayxr-runtime --json tagName,nam
 
 Verify:
 - Tag matches [FULL_TAG]
-- Asset list contains `DisplayXRSetup-*.exe` with non-zero size
+- Asset list contains `DisplayXRSetup-*.exe` with non-zero size (Windows installer, hard requirement)
+- Asset list contains `DisplayXR-Installer-*.pkg` with non-zero size (macOS installer, post-#277; warn but don't fail if the macOS run skipped it — flag in final report so the user can investigate)
 - Asset list contains `DisplayXR-TestApps-*.zip` with non-zero size (warn but don't fail if `DetectChanges` skipped the test-app build — flag in final report so the user can investigate)
 
 ### Step 5.1: Cleanup staging dir

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -1,12 +1,24 @@
 name: Build macOS
 
 # Verifies that the runtime + sim_display driver compile cleanly on
-# macOS. The historical workflow also built every test app + the macOS
-# installer + the 3DGS demo (which now lives in displayxr-demo-
-# gaussiansplat); those add a lot of surface area for breakage. Keep
-# this one minimal — building the runtime is the contract that matters
-# here. Test apps and installer can be added back later as separate
-# jobs once the build itself is reliable in CI again.
+# macOS, and (post-#277) also builds + publishes
+# `DisplayXR-Installer.pkg` so /release can attach it to GitHub Releases
+# alongside the Windows `DisplayXRSetup-*.exe`. Two jobs:
+#
+#   - `Build` (kept minimal, intentionally) — fast compile check using
+#     RelWithDebInfo + SERVICE/HYBRID flags. The historical workflow
+#     also built every test app + the macOS installer + the 3DGS demo;
+#     those add a lot of surface area for breakage. The compile check
+#     is the stable contract this repo depends on for branch
+#     protection. Test app builds beyond what the installer needs stay
+#     out of scope — they were trimmed for a reason.
+#
+#   - `BuildInstaller` (new) — builds the runtime + sim-display plug-in
+#     + at least one VK test app + the .pkg via
+#     `scripts/build_macos.sh --installer`, asserts the payload
+#     contains the plug-in registration (#274 regression guard), and
+#     uploads the .pkg as a workflow artifact. Gated on `Build` so
+#     compile failures fail fast.
 
 on:
   push:
@@ -84,3 +96,97 @@ jobs:
       - name: Build
         if: needs.DetectChanges.outputs.docs_only != 'true'
         run: cmake --build build
+
+  BuildInstaller:
+    # Sequential after Build so a compile failure fails fast and we
+    # don't waste a second macos-14 runner on broken code. Both jobs
+    # use macos-14; the duplicated configure/build is the cost of
+    # keeping `Build` as a stable RelWithDebInfo+SERVICE+HYBRID compile
+    # check while `BuildInstaller` exercises the Debug + plug-in path
+    # that ships in the .pkg.
+    needs: [DetectChanges, Build]
+    runs-on: macos-14
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Doc-only PR — skipping installer build
+        if: needs.DetectChanges.outputs.docs_only == 'true'
+        run: echo "Skipping; doc-only PRs don't change build inputs."
+
+      - name: Install dependencies
+        if: needs.DetectChanges.outputs.docs_only != 'true'
+        run: |
+          brew install cmake ninja eigen
+          brew install glslang molten-vk vulkan-headers vulkan-loader
+          BREW_PREFIX=$(brew --prefix)
+          echo "VULKAN_SDK=$BREW_PREFIX" >> $GITHUB_ENV
+
+      - name: Derive installer version
+        if: needs.DetectChanges.outputs.docs_only != 'true'
+        id: version
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            # `v1.2.3` → `1.2.3` for productbuild's --version arg
+            VERSION="${GITHUB_REF#refs/tags/v}"
+          else
+            # Untagged builds get a sha-suffixed dev string so the
+            # manifest's `version` field is at least traceable to the
+            # commit that produced the .pkg.
+            VERSION="0.0.0-dev.${GITHUB_SHA::8}"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Building installer with VERSION=$VERSION"
+
+      - name: Build runtime + test app + installer
+        if: needs.DetectChanges.outputs.docs_only != 'true'
+        env:
+          DISPLAYXR_VERSION: ${{ steps.version.outputs.version }}
+        run: ./scripts/build_macos.sh --installer
+
+      - name: Assert .pkg payload includes plug-in + manifest (#274 regression guard)
+        if: needs.DetectChanges.outputs.docs_only != 'true'
+        run: |
+          set -euo pipefail
+          PKG="_package/DisplayXR-Installer.pkg"
+          if [ ! -f "$PKG" ]; then
+            echo "::error::$PKG missing — installer build did not produce expected artifact."
+            exit 1
+          fi
+          EXPAND_DIR=$(mktemp -d)
+          pkgutil --expand "$PKG" "$EXPAND_DIR/expand"
+          PAYLOAD="$EXPAND_DIR/expand/runtime.pkg/Payload"
+          if [ ! -f "$PAYLOAD" ]; then
+            echo "::error::runtime.pkg/Payload not found inside .pkg"
+            exit 1
+          fi
+          # List the cpio.gz payload contents without extracting (faster
+          # and avoids any permission/symlink surprises on the runner).
+          gunzip -c "$PAYLOAD" | cpio -i -t > "$EXPAND_DIR/files" 2>/dev/null
+
+          MISSING=0
+          if ! grep -q 'DisplayProcessors/200-sim-display.json' "$EXPAND_DIR/files"; then
+            echo "::error::200-sim-display.json missing from .pkg payload — vendor plug-in discovery would not find sim-display on a clean install (#274)."
+            MISSING=1
+          fi
+          if ! grep -q 'lib/displayxr/plugins/DisplayXR-SimDisplay.dylib' "$EXPAND_DIR/files"; then
+            echo "::error::DisplayXR-SimDisplay.dylib missing from .pkg payload — runtime would have no display processor on a clean install (#274)."
+            MISSING=1
+          fi
+          if [ "$MISSING" -ne 0 ]; then
+            echo "Payload listing:"
+            cat "$EXPAND_DIR/files"
+            exit 1
+          fi
+          echo "PASS: .pkg payload contains plug-in + manifest."
+
+      - name: Upload installer
+        uses: actions/upload-artifact@v4
+        if: needs.DetectChanges.outputs.docs_only != 'true' && (github.event_name == 'pull_request' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
+        with:
+          retention-days: 3
+          name: DisplayXR-Installer-macOS
+          if-no-files-found: error
+          path: _package/DisplayXR-Installer.pkg

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,7 +164,7 @@ scripts/format-project.sh   # Format all
 
 ### Releasing the Runtime
 
-This repo IS the public runtime — there is no private→public mirror flow. A release is just a `vX.Y.Z` tag here, a Windows CI build, and a GitHub Release with the installer attached.
+This repo IS the public runtime — there is no private→public mirror flow. A release is just a `vX.Y.Z` tag here, parallel Windows + macOS CI builds, and a GitHub Release with both installers attached (`DisplayXRSetup-*.exe` and `DisplayXR-Installer-*.pkg`) plus the test-apps bundle. macOS publishing post-#277.
 
 ```bash
 # /release skill handles version bump, tagging, build monitoring, GH release create.
@@ -325,19 +325,21 @@ Full reference: [`docs/getting-started/building.md` § Local Dev Iteration](docs
 
 **macOS** (`.github/workflows/build-macos.yml`):
 - Vulkan SDK via MoltenVK, bundles libvulkan + OpenXR loader
-- Artifact: `DisplayXR-macOS`
+- Two jobs: `Build` (compile check) + `BuildInstaller` (full runtime + sim-display plug-in + .pkg, post-#277)
+- Artifacts: `DisplayXR-Installer-macOS` (contains `DisplayXR-Installer.pkg`)
+- BuildInstaller asserts the .pkg payload includes `DisplayProcessors/200-sim-display.json` + `lib/displayxr/plugins/DisplayXR-SimDisplay.dylib` (#274 regression guard)
 
 ## Claude Code Skills
 
 ### /release - Tagged Runtime Release
-Creates a tagged runtime release here, monitors `build-windows.yml`, and attaches the installer to the GitHub Release. See `.claude/skills/release/SKILL.md`.
+Creates a tagged runtime release here, monitors `build-windows.yml` + `build-macos.yml` in parallel, and attaches both installers (`DisplayXRSetup-*.exe` and `DisplayXR-Installer-*.pkg`) plus the test-apps bundle to the GitHub Release. See `.claude/skills/release/SKILL.md`.
 ```
 /release v1.2.1    # explicit version
 /release patch     # auto-bump from latest v[0-9]+.[0-9]+.[0-9]+
 /release minor
 /release major
 ```
-Updates `CMakeLists.txt` `VERSION`, creates the tag, monitors the Windows CI build, downloads the `DisplayXRSetup-*.exe` artifact, creates the GitHub Release with grouped notes. Only releases this repo — shell, demos, extensions each have their own flows (see "Releasing the Runtime" above).
+Updates `CMakeLists.txt` `VERSION`, creates the tag, watches Windows + macOS CI concurrently (wall time = `max(Windows, macOS)`), downloads each platform's installer artifact, creates the GitHub Release with grouped notes. macOS .pkg is a soft requirement — its absence warns but doesn't STOP the release. Only releases this repo — shell, demos, extensions each have their own flows (see "Releasing the Runtime" above).
 
 ### /ask-gemini - Code Analysis with Gemini
 Ask Gemini to analyze code and produce a read-only report. See `~/.claude/skills/ask-gemini/SKILL.md`.


### PR DESCRIPTION
## Summary

Closes #277. Follow-up to #267 / #274 — the macOS .pkg installer was working end-to-end locally but CI didn't build it and GitHub Releases shipped Windows-only artifacts. This wires the .pkg into the same release pipeline the Windows installer rides.

### Changes

- **`.github/workflows/build-macos.yml`** — adds a `BuildInstaller` job sequential after the existing `Build` compile check. Derives the installer VERSION from the `v*` tag (or `0.0.0-dev.<sha8>` for untagged builds), runs `scripts/build_macos.sh --installer`, asserts the .pkg payload contains the sim-display plug-in + manifest (#274 regression guard via `pkgutil --expand` + `cpio -t`), uploads `DisplayXR-Installer.pkg` as the `DisplayXR-Installer-macOS` artifact (3-day retention, mirrors the Windows pattern). `Build` stays unchanged as the stable RelWithDebInfo+SERVICE+HYBRID compile check.
- **`.claude/skills/release/SKILL.md`** — Phase 3 watches Windows + macOS in parallel via background `gh run watch` (wall time = `max(Windows, macOS)`). Phase 4 downloads the macOS `.pkg` alongside the Windows `.exe` + test-apps bundle, renames it to `DisplayXR-Installer-X.Y.Z.pkg` to parallel the `.exe` naming, attaches both to the release. macOS .pkg is a soft requirement — warns but doesn't STOP if the macOS run skipped it. Only `DisplayXRSetup-*.exe` stays hard-required.
- **`CLAUDE.md`** — release section + GitHub Actions table + `/release` skill description updated.

### Test plan

- [x] Workflow YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"` clean)
- [x] The same `pkgutil --expand` + `cpio -t` assertion that the CI step will run passes locally against the existing `_package/DisplayXR-Installer.pkg` from #274's e2e
- [ ] CI: PR triggers `BuildInstaller` job; .pkg artifact uploaded, assertion green
- [ ] Windows CI unaffected — `.github/workflows/build-windows.yml` not touched
- [ ] On a future `v*` tag push, the .pkg artifact downloads cleanly via the `/release` skill's updated Phase 4

### Out of scope (separable)

- **Code-signing + notarization** of the .pkg. macOS Gatekeeper will currently warn on unsigned `.pkg` installs; users right-click → Open to bypass. Tracked as the "optional Step 3" in issue #277 — needs Apple Developer ID + secrets wiring; will land in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)