### PR TITLE
macos: retarget bundled Vulkan to @rpath + ad-hoc re-sign + versioned .pkg filename

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -2,7 +2,7 @@ name: Build macOS
 
 # Verifies that the runtime + sim_display driver compile cleanly on
 # macOS, and (post-#277) also builds + publishes
-# `DisplayXR-Installer.pkg` so /release can attach it to GitHub Releases
+# `DisplayXR-Installer-${VERSION}.pkg` so /release can attach it to GitHub Releases
 # alongside the Windows `DisplayXRSetup-*.exe`. Two jobs:
 #
 #   - `Build` (kept minimal, intentionally) — fast compile check using
@@ -148,13 +148,20 @@ jobs:
 
       - name: Assert .pkg payload includes plug-in + manifest (#274 regression guard)
         if: needs.DetectChanges.outputs.docs_only != 'true'
+        env:
+          DISPLAYXR_VERSION: ${{ steps.version.outputs.version }}
         run: |
           set -euo pipefail
-          PKG="_package/DisplayXR-Installer.pkg"
-          if [ ! -f "$PKG" ]; then
-            echo "::error::$PKG missing — installer build did not produce expected artifact."
+          # Filename is versioned post-PR #279
+          # (DisplayXR-Installer-${VERSION}.pkg). Match by glob to stay
+          # robust if the naming scheme evolves further.
+          PKG=$(find _package -maxdepth 1 -name "DisplayXR-Installer*.pkg" -type f | head -1)
+          if [ -z "$PKG" ] || [ ! -f "$PKG" ]; then
+            echo "::error::DisplayXR-Installer*.pkg missing from _package/ — installer build did not produce expected artifact."
+            ls -la _package/ || true
             exit 1
           fi
+          echo "Found installer: $PKG"
           EXPAND_DIR=$(mktemp -d)
           pkgutil --expand "$PKG" "$EXPAND_DIR/expand"
           PAYLOAD="$EXPAND_DIR/expand/runtime.pkg/Payload"
@@ -189,4 +196,7 @@ jobs:
           retention-days: 3
           name: DisplayXR-Installer-macOS
           if-no-files-found: error
-          path: _package/DisplayXR-Installer.pkg
+          # Glob — filename is `DisplayXR-Installer-${VERSION}.pkg`
+          # post-PR #279 (versioned filename, parallel to Windows'
+          # DisplayXRSetup-X.Y.Z.NNN.exe).
+          path: _package/DisplayXR-Installer-*.pkg

--- a/installer/macos/build_installer.sh
+++ b/installer/macos/build_installer.sh
@@ -7,8 +7,12 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 ARTIFACT_DIR="${1:?Usage: $0 <artifact-dir> [output.pkg]}"
-OUTPUT_PKG="${2:-DisplayXR-Installer.pkg}"
 VERSION="${DISPLAYXR_VERSION:-1.0.0}"
+# Default to a versioned filename so the artifact carries its version
+# in its name (mirrors Windows' DisplayXRSetup-X.Y.Z.NNN.exe). The
+# explicit $2 form is still honored for callers that want a fixed
+# output path.
+OUTPUT_PKG="${2:-DisplayXR-Installer-$VERSION.pkg}"
 
 if [ ! -d "$ARTIFACT_DIR" ]; then
     echo "Error: artifact directory '$ARTIFACT_DIR' not found"
@@ -46,6 +50,37 @@ cp "$ARTIFACT_DIR/lib/libvulkan.1.dylib" "$RUNTIME_ROOT/lib/"
 cp "$ARTIFACT_DIR/lib/libMoltenVK.dylib" "$RUNTIME_ROOT/lib/"
 cp "$ARTIFACT_DIR/share/vulkan/icd.d/MoltenVK_icd.json" "$RUNTIME_ROOT/share/vulkan/icd.d/"
 
+# Defensive Vulkan rpath fixup. `scripts/build_macos.sh` already runs
+# the equivalent install_name_tool steps against the artifact dir, but
+# repeat here to be robust against external callers that hand us an
+# artifact dir built by something else (or by an older script). All
+# operations are idempotent — install_name_tool -change is a no-op
+# when the source path isn't present; install_name_tool -id always
+# writes (cheap).
+#
+# Each install_name_tool invocation invalidates the dylib's code
+# signature; on modern macOS, loading an invalidly-signed dylib via
+# dlopen results in immediate SIGKILL ("Code Signature Invalid").
+# Re-sign ad-hoc after every modification — `codesign --force --sign -`
+# is a no-op-equivalent for already-correctly-signed dylibs.
+chmod u+w "$RUNTIME_ROOT/lib/libvulkan.1.dylib"
+install_name_tool -id @rpath/libvulkan.1.dylib "$RUNTIME_ROOT/lib/libvulkan.1.dylib" 2>/dev/null || true
+codesign --force --sign - "$RUNTIME_ROOT/lib/libvulkan.1.dylib" 2>/dev/null || true
+
+chmod u+w "$RUNTIME_ROOT/lib/libMoltenVK.dylib"
+install_name_tool -id @rpath/libMoltenVK.dylib "$RUNTIME_ROOT/lib/libMoltenVK.dylib" 2>/dev/null || true
+codesign --force --sign - "$RUNTIME_ROOT/lib/libMoltenVK.dylib" 2>/dev/null || true
+
+chmod u+w "$RUNTIME_ROOT/lib/$RUNTIME_BASENAME"
+install_name_tool -change /opt/homebrew/opt/vulkan-loader/lib/libvulkan.1.dylib \
+                          @rpath/libvulkan.1.dylib \
+                          "$RUNTIME_ROOT/lib/$RUNTIME_BASENAME" 2>/dev/null || true
+# Runtime needs @loader_path so it can resolve @rpath/libvulkan.1.dylib
+# from its own directory. Idempotent: install_name_tool warns + exits 0
+# if the rpath is already there.
+install_name_tool -add_rpath @loader_path "$RUNTIME_ROOT/lib/$RUNTIME_BASENAME" 2>/dev/null || true
+codesign --force --sign - "$RUNTIME_ROOT/lib/$RUNTIME_BASENAME" 2>/dev/null || true
+
 # Ship the vendor plug-in dylib + JSON manifest (#267, #274). The
 # runtime no longer link-includes drv_sim_display in production
 # builds; without these the installed runtime has no display
@@ -82,7 +117,17 @@ for r in $(otool -l "$PAYLOAD_PLUGIN" 2>/dev/null \
            | grep -E '^/.*displayxr-runtime/.*build|@loader_path' || true); do
     install_name_tool -delete_rpath "$r" "$PAYLOAD_PLUGIN" 2>/dev/null || true
 done
-install_name_tool -add_rpath "@loader_path/../.." "$PAYLOAD_PLUGIN"
+install_name_tool -add_rpath "@loader_path/../.." "$PAYLOAD_PLUGIN" 2>/dev/null || true
+
+# Defensive Vulkan -change on the embedded plug-in (same idempotent
+# fixup applied to the runtime above). @loader_path/../.. above doubles
+# as the rpath that resolves @rpath/libvulkan.1.dylib to
+# .../lib/libvulkan.1.dylib at the install location.
+install_name_tool -change /opt/homebrew/opt/vulkan-loader/lib/libvulkan.1.dylib \
+                          @rpath/libvulkan.1.dylib \
+                          "$PAYLOAD_PLUGIN" 2>/dev/null || true
+# Re-sign after all install_name_tool ops to avoid SIGKILL at dlopen.
+codesign --force --sign - "$PAYLOAD_PLUGIN" 2>/dev/null || true
 
 cat > "$MANIFEST_PAYLOAD_DIR/200-sim-display.json" <<EOF
 {

--- a/scripts/build_macos.sh
+++ b/scripts/build_macos.sh
@@ -242,6 +242,45 @@ for lib in libvulkan.1.dylib libMoltenVK.dylib; do
   fi
 done
 
+# Rewrite the bundled Vulkan/MoltenVK install_names to @rpath. As shipped
+# by Homebrew, both carry hardcoded LC_ID_DYLIB of
+# `/opt/homebrew/opt/{vulkan-loader,molten-vk}/lib/...`, which means
+# anything linking them inherits the absolute Homebrew path as a direct
+# dependency — so the .pkg runtime would only load on machines that
+# happen to have Homebrew installed at that exact prefix. Retarget to
+# @rpath so dyld finds the bundled copy next to the runtime.
+#
+# Every install_name_tool invocation invalidates the dylib's code
+# signature; on modern macOS the loader SIGKILLs processes that try
+# to load a dylib with an invalidated signature. Re-sign ad-hoc with
+# `codesign --force --sign -` after each modification.
+chmod u+w "$PKG_DIR/lib/libvulkan.1.dylib" 2>/dev/null || true
+install_name_tool -id @rpath/libvulkan.1.dylib "$PKG_DIR/lib/libvulkan.1.dylib" 2>/dev/null || true
+codesign --force --sign - "$PKG_DIR/lib/libvulkan.1.dylib" 2>/dev/null || true
+
+chmod u+w "$PKG_DIR/lib/libMoltenVK.dylib" 2>/dev/null || true
+install_name_tool -id @rpath/libMoltenVK.dylib "$PKG_DIR/lib/libMoltenVK.dylib" 2>/dev/null || true
+codesign --force --sign - "$PKG_DIR/lib/libMoltenVK.dylib" 2>/dev/null || true
+
+# Retarget the runtime + sim-display plug-in's Vulkan dependency from
+# the Homebrew absolute path to @rpath/libvulkan.1.dylib. The @rpath
+# entries below give dyld the right hint:
+#   runtime  → @loader_path        (libvulkan.1.dylib lives next to it)
+#   plug-in  → @loader_path/../..  (libvulkan.1.dylib is two levels up)
+chmod u+w "$PKG_DIR/lib/$RUNTIME_BASENAME" 2>/dev/null || true
+install_name_tool -change /opt/homebrew/opt/vulkan-loader/lib/libvulkan.1.dylib \
+                          @rpath/libvulkan.1.dylib \
+                          "$PKG_DIR/lib/$RUNTIME_BASENAME" 2>/dev/null || true
+codesign --force --sign - "$PKG_DIR/lib/$RUNTIME_BASENAME" 2>/dev/null || true
+
+if [ -f "$PKG_DIR/lib/displayxr/plugins/DisplayXR-SimDisplay.dylib" ]; then
+  chmod u+w "$PKG_DIR/lib/displayxr/plugins/DisplayXR-SimDisplay.dylib"
+  install_name_tool -change /opt/homebrew/opt/vulkan-loader/lib/libvulkan.1.dylib \
+                            @rpath/libvulkan.1.dylib \
+                            "$PKG_DIR/lib/displayxr/plugins/DisplayXR-SimDisplay.dylib" 2>/dev/null || true
+  codesign --force --sign - "$PKG_DIR/lib/displayxr/plugins/DisplayXR-SimDisplay.dylib" 2>/dev/null || true
+fi
+
 # Fix rpaths
 install_name_tool -add_rpath @loader_path "$PKG_DIR/lib/$RUNTIME_BASENAME" 2>/dev/null || true
 install_name_tool -add_rpath @executable_path/../lib "$PKG_DIR/bin/cube_handle_vk_macos" 2>/dev/null || true
@@ -253,6 +292,20 @@ install_name_tool -add_rpath @executable_path/../lib "$PKG_DIR/bin/cube_hosted_l
 install_name_tool -add_rpath @executable_path/../lib "$PKG_DIR/bin/cube_hosted_legacy_gl_macos" 2>/dev/null || true
 install_name_tool -add_rpath @executable_path/../lib "$PKG_DIR/bin/cube_hosted_legacy_vk_macos" 2>/dev/null || true
 install_name_tool -add_rpath @loader_path "$PKG_DIR"/lib/libopenxr_loader*.dylib 2>/dev/null || true
+
+# Re-sign every artifact we touched with install_name_tool. The
+# add_rpath calls above invalidate signatures the same way -id and
+# -change do; without re-signing, modern macOS SIGKILLs the process
+# at dlopen with "Code Signature Invalid" before any of our logging
+# gets a chance to fire.
+codesign --force --sign - "$PKG_DIR/lib/$RUNTIME_BASENAME" 2>/dev/null || true
+codesign --force --sign - "$PKG_DIR"/lib/libopenxr_loader*.dylib 2>/dev/null || true
+for app in cube_handle_vk_macos cube_handle_metal_macos cube_handle_gl_macos \
+           cube_texture_metal_macos cube_hosted_metal_macos \
+           cube_hosted_legacy_metal_macos cube_hosted_legacy_gl_macos \
+           cube_hosted_legacy_vk_macos; do
+  [ -f "$PKG_DIR/bin/$app" ] && codesign --force --sign - "$PKG_DIR/bin/$app" 2>/dev/null || true
+done
 
 # Create MoltenVK ICD manifest
 cat > "$PKG_DIR/share/vulkan/icd.d/MoltenVK_icd.json" <<EOF
@@ -386,17 +439,31 @@ SCRIPT
 chmod +x "$PKG_DIR/run_cube_hosted_legacy_vk.sh"
 
 
-# Step 5: Build .pkg installer (optional)
+# Step 5: Build .pkg installer (optional). Versioned filename mirrors
+# Windows' `DisplayXRSetup-X.Y.Z.NNN.exe`; DISPLAYXR_VERSION is also
+# baked into the .pkg's internal version + the sim-display manifest,
+# so it's the single source of truth across the artifact.
+#
+# Falls back to a sha-suffixed dev string for local builds with no
+# explicit version set — matches build-macos.yml's BuildInstaller job.
 if [ "$BUILD_INSTALLER" = "ON" ]; then
-  echo "=== Building .pkg installer ==="
-  "$ROOT/installer/macos/build_installer.sh" "$PKG_DIR" "$ROOT/_package/DisplayXR-Installer.pkg"
+  if [ -z "${DISPLAYXR_VERSION:-}" ]; then
+    GIT_SHA=$(git -C "$ROOT" rev-parse --short=8 HEAD 2>/dev/null || echo "local")
+    INSTALLER_VERSION="0.0.0-dev.$GIT_SHA"
+  else
+    INSTALLER_VERSION="$DISPLAYXR_VERSION"
+  fi
+  INSTALLER_PKG="$ROOT/_package/DisplayXR-Installer-$INSTALLER_VERSION.pkg"
+  echo "=== Building .pkg installer (VERSION=$INSTALLER_VERSION) ==="
+  DISPLAYXR_VERSION="$INSTALLER_VERSION" \
+    "$ROOT/installer/macos/build_installer.sh" "$PKG_DIR" "$INSTALLER_PKG"
 fi
 
 echo ""
 echo "=== Build complete! ==="
 echo ""
 if [ "$BUILD_INSTALLER" = "ON" ]; then
-  echo "Installer: $ROOT/_package/DisplayXR-Installer.pkg"
+  echo "Installer: $INSTALLER_PKG"
   echo ""
 fi
 echo "Artifacts in _package/:"


### PR DESCRIPTION
## Summary

Three related installer-fitness fixes surfaced during the clean-install e2e dry run of PR #275/#278's .pkg.

### 1. Bundled Vulkan/MoltenVK install_names → @rpath

`otool -L` on the .pkg payload runtime + plug-in revealed `/opt/homebrew/opt/vulkan-loader/lib/libvulkan.1.dylib` baked in as a direct dependency. The .pkg already bundles a copy of libvulkan.1.dylib at `/Library/Application Support/DisplayXR/lib/libvulkan.1.dylib`, but the runtime never sees it because the dependency is absolute, not @rpath-resolved. On any user macOS without Homebrew installed at that exact prefix, dyld can't find libvulkan and the runtime fails to load. Same problem for libMoltenVK.

Fix: `install_name_tool -id @rpath/...` on the bundled libs + `install_name_tool -change /opt/homebrew/.../libvulkan.1.dylib @rpath/libvulkan.1.dylib` on the runtime and the embedded plug-in. The existing `@loader_path` / `@loader_path/../..` rpaths give dyld the right resolution.

### 2. Ad-hoc re-sign after every install_name_tool op

Discovered while testing fix #1: modern macOS SIGKILLs any process trying to `dlopen` a dylib whose code signature was invalidated by `install_name_tool`. The crash report from a stalled test app showed:

```
"signal":"SIGKILL (Code Signature Invalid)"
"termination":{"namespace":"CODESIGNING","indicator":"Invalid Page"}
LoaderXrEnumerateInstanceExtensionProperties → dlopen → ... → dyld bails
```

Every `install_name_tool` invocation invalidates the signature. Add `codesign --force --sign - <dylib>` after every modification. Locally-built dylibs (runtime, plug-in) re-sign cleanly because the original signature is already ad-hoc; Homebrew libs (libvulkan, libMoltenVK) need the explicit re-sign to be loadable.

### 3. Versioned .pkg filename

`installer/macos/build_installer.sh` now defaults `OUTPUT_PKG` to `DisplayXR-Installer-${VERSION}.pkg` (parallel to Windows' `DisplayXRSetup-X.Y.Z.NNN.exe`). `scripts/build_macos.sh` passes a sha-suffixed dev string when `DISPLAYXR_VERSION` is unset, so the filename version, internal pkg version, and sim-display manifest version all line up.

## Test plan

- [x] All four bundled dylibs (runtime, plug-in, libvulkan, libMoltenVK) report `valid on disk` via `codesign -vv` — both in `_package/.../lib/` and after `pkgutil --expand` of the freshly-built .pkg
- [x] `otool -L` on runtime + plug-in shows only `@rpath/libvulkan.1.dylib` — no `/opt/homebrew/` paths anywhere in their dep graphs
- [x] `run_cube_handle_metal.sh` against the dev tree loads the plug-in cleanly (`active plug-in: id=sim-display`). Before this PR, the same script hung after window creation, killed by dyld for code-signature violation
- [x] `_package/DisplayXR-Installer-${VERSION}.pkg` filename observed
- [ ] CI: PR triggers `BuildInstaller`, .pkg artifact uploaded, payload assertion still green
- [ ] Resume clean-install e2e on this branch (the next step after this lands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)