### PR TITLE
docs(#264): vendor plug-in onboarding guide + xrt_plugin_iface reference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -402,7 +402,8 @@ See `docs/README.md` for a complete index. Key docs by task:
 |---|---|
 | Understand layer boundaries (what goes where) | `docs/architecture/separation-of-concerns.md` |
 | Build a workspace app (shell-style controller) | `docs/specs/runtime/workspace-controller-registration.md` |
-| Add a new display vendor | `docs/guides/vendor-integration.md` § 1.2 ("Plug-in distribution model") then `docs/specs/runtime/plugin-discovery.md` |
+| Add a new display vendor | `docs/guides/vendor-plugin-onboarding.md` (post-#263 model — fork the Leia plug-in repo) then `docs/reference/xrt_plugin_iface.md` + `docs/specs/runtime/plugin-discovery.md` |
+| Understand the `xrt_plugin_iface` callbacks | `docs/reference/xrt_plugin_iface.md` |
 | Understand multiview tiling / atlas layout | `docs/specs/runtime/multiview-tiling.md` |
 | Understand extension API (display_info, window bindings) | `docs/specs/extensions/XR_EXT_display_info.md` |
 | Know why an architectural decision was made | `docs/adr/` (16 ADRs) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -59,14 +59,18 @@ Contribute to the DisplayXR runtime — compositors, state tracker, auxiliary co
 
 Integrate your 3D display hardware into DisplayXR.
 
-- **[Vendor Integration Guide](guides/vendor-integration.md)** — comprehensive walkthrough
-- **[Writing a Driver](guides/writing-driver.md)** — driver framework basics
+- **[Vendor Plug-in Onboarding](guides/vendor-plugin-onboarding.md)** — zero-to-shipping guide for a new vendor's external plug-in repo (post-#263 model)
+- **[`xrt_plugin_iface` reference](reference/xrt_plugin_iface.md)** — per-method contract for the plug-in vtable
+- **[Plug-in discovery spec](specs/runtime/plugin-discovery.md)** — registry / JSON manifest formats, env-var overrides
+- **[ADR-019: Vendor Plug-in / Aux Boundary](adr/ADR-019-vendor-plugin-aux-boundary.md)** — why the runtime DLL holds zero vendor identifiers
 - **[Display Processor Interface](specs/vendor/display-processor-interface.md)** — the DP vtable you'll implement
 - **[Eye Tracking Modes](specs/vendor/eye-tracking-modes.md)** — MANAGED vs MANUAL contract
 - **[ADR-003: Vendor Abstraction](adr/ADR-003-vendor-abstraction-via-display-processor-vtable.md)** — why vendor code is isolated
 - **[ADR-007: Compositor Never Weaves](adr/ADR-007-compositor-never-weaves.md)** — compositor / DP boundary
 - **[ADR-015: Multi-Display Routing](adr/ADR-015-displayxr-owns-multi-display-vendor-routing.md)** — how multiple vendors coexist
 - **[Separation of Concerns](architecture/separation-of-concerns.md)** — what goes where
+- [Legacy: in-tree integration model](guides/vendor-integration.md) — historical reference for pre-#263 vendors who forked the runtime
+- [Writing a Driver](guides/writing-driver.md) — driver framework basics
 
 ### Integrated vendors (`vendors/`)
 

--- a/docs/guides/vendor-plugin-onboarding.md
+++ b/docs/guides/vendor-plugin-onboarding.md
@@ -1,0 +1,255 @@
+# Vendor Plug-in Onboarding
+
+This guide walks a new 3D-display vendor from zero to a shipping DisplayXR-compatible plug-in. After ADR-019 / #263 (May 2026), every vendor integration is an **external project**: you don't touch this repo, you ship a plug-in DLL from your own repo and an installer that registers it with the runtime at install time.
+
+If you're maintaining a vendor integration that was historically in-tree (the way `drv_leia` was before #263), see the [legacy `vendor-integration.md`](vendor-integration.md) — kept for historical context. Everything below assumes the post-#263 model.
+
+> **Canonical examples**
+> - [`DisplayXR/displayxr-leia-plugin`](https://github.com/DisplayXR/displayxr-leia-plugin) — full vendor integration with SR SDK; the recommended starting point. Fork the repo, swap `drv_leia/` for `drv_<your-vendor>/`, point the installer at your `<id>`.
+> - `src/xrt/drivers/sim_display/sim_display_plugin.c` (in this repo) — vendor-neutral software-only plug-in. Smaller, no vendor SDK, useful as a minimal-shape reference.
+
+## 1. What you ship
+
+Two artifacts make a complete vendor integration:
+
+1. **A plug-in DLL** (Windows `.dll` / macOS `.dylib` / Linux `.so`) named `DisplayXR-<YourVendor>.dll`, implementing [`xrt_plugin_iface`](../reference/xrt_plugin_iface.md) and exporting exactly one C symbol: `xrtPluginNegotiate`.
+2. **An installer** that drops the DLL at a well-known path and registers it under `HKLM\Software\DisplayXR\DisplayProcessors\<your-id>` (Windows; POSIX uses a JSON manifest — see §4).
+
+The runtime DLL has zero vendor identifiers in its own link line (`dumpbin /imports DisplayXRClient.dll` returns nothing matching vendor SDK names — there's a CI tripwire that fails any change which regresses this). All vendor SDK static imports live in **your** plug-in DLL.
+
+## 2. What you consume from the runtime
+
+Your plug-in build links against the runtime's public ABI surface. None of this needs to be vendored — the runtime tree provides headers + import lib via CMake `FetchContent`.
+
+### Headers (public C ABI — every plug-in needs these)
+
+| Header | Purpose |
+|---|---|
+| `xrt/xrt_plugin.h` | The iface contract — `xrt_plugin_iface`, `xrtPluginNegotiate`, `xrt_plugin_display_info`. Versioned via `XRT_PLUGIN_API_VERSION_CURRENT`. |
+| `xrt/xrt_api.h` | `XRT_API_FUNC` decoration — expands to `__declspec(dllimport)` when `XRT_USING_RUNTIME_DLL` is defined in the plug-in build. |
+| `xrt/xrt_device.h` | Abstract device interface (you return one of these from `create_device`). |
+| `xrt/xrt_display_processor.h` + per-API headers (`xrt_display_processor_d3d11.h`, etc.) | DP vtable contract per graphics API. |
+| `xrt/xrt_results.h` | `xrt_result_t` + the standard error codes. |
+| `aux/util/u_logging.h`, `aux/util/u_var.h`, `aux/util/u_metrics.h`, … | Aux utilities (see "DLL surface" below). |
+
+### Runtime DLL import library — `DisplayXRClient.lib`
+
+Link against this to resolve `XRT_API_FUNC`-decorated symbols at load time. The runtime's exported aux surface (per [ADR-019](../adr/ADR-019-vendor-plugin-aux-boundary.md)):
+
+- `u_log_*` — per-process file logger (`%LOCALAPPDATA%\DisplayXR\` on Windows)
+- `u_var_*` — debug variable tracking
+- `u_metrics_*` — frame timing
+- `u_trace_marker_*` — Perfetto tracing
+- `u_limited_unique_id_get` — process-wide unique IDs
+- `u_pa_factory_create` — pacing factory
+
+Define `XRT_USING_RUNTIME_DLL` in your plug-in's compile flags so `XRT_API_FUNC` expands correctly. See `installer/CMakeLists.txt` in the Leia plug-in repo for the canonical setup:
+
+```cmake
+target_compile_definitions(DisplayXR-LeiaSR PRIVATE XRT_USING_RUNTIME_DLL)
+target_link_libraries(DisplayXR-LeiaSR PRIVATE
+    $<TARGET_LINKER_FILE:${RUNTIME_TARGET}>   # DisplayXRClient.lib
+    xrt-interfaces aux_util aux_os aux_math aux_vk drv_includes
+)
+```
+
+The non-exported static aux helpers (`xrt-interfaces`, `aux_util`, etc.) are pulled in by the linker on a per-`.obj` basis — only the bits your plug-in actually references end up in your DLL.
+
+### Shared third-party DLLs from the runtime install dir
+
+The runtime installer ships several DLLs in `C:\Program Files\DisplayXR\Runtime\` that are **not** transitive dependencies of `DisplayXRClient.dll` itself — they're a shared surface for downstream consumers:
+
+- `openxr_loader.dll`
+- `pthreadVC3.dll`
+- `cjson.dll`
+
+If your plug-in dynamically imports any of these, they resolve through standard exe-directory DLL search from `$RuntimeInstall\` (your plug-in's installer drops `DisplayXR-<You>.dll` into `$RuntimeInstall\Plugins\<your-id>\`, two directory levels into the same install tree).
+
+**Do NOT re-ship these DLLs in your plug-in installer** — bundling duplicates risks version skew across the install tree. The runtime owns their lifecycle.
+
+## 3. Building from the template
+
+The fastest path:
+
+```bash
+gh repo fork DisplayXR/displayxr-leia-plugin --clone=true --remote=true displayxr-vendor-XXX-plugin
+cd displayxr-vendor-XXX-plugin
+```
+
+Then:
+
+1. **Rename `src/drv_leia/` → `src/drv_<vendor>/`** and replace its contents with your SDK glue: device init, hardware probe, weaver per-API, eye tracking listener.
+2. **Rewrite `src/drv_<vendor>/<vendor>_plugin.c`** against `xrt_plugin_iface` — see the [iface reference](../reference/xrt_plugin_iface.md) for which callbacks are required vs optional and what each one must produce.
+3. **Update `CMakeLists.txt`** — rename the `add_library(DisplayXR-LeiaSR SHARED …)` target to `DisplayXR-<YourVendor>`. The `XRT_USING_RUNTIME_DLL` + linker settings stay the same.
+4. **Update `installer/DisplayXR<YourVendor>Installer.nsi`** — change the registry `<id>` from `leia-sr` to your own, the install dir from `LeiaSR` to your vendor name, and the `DisplayName` / `Vendor` strings.
+5. **Update `scripts/build-windows.bat`** — point the SR SDK download URL at your vendor's SDK release artifact. Replace the `LEIASR_SDKROOT` env-var with `<VENDOR>_SDKROOT`.
+
+The runtime `FetchContent` setup at the top of the plug-in repo's `CMakeLists.txt` does NOT need editing — your plug-in still consumes the same runtime ABI.
+
+## 4. Discovery contract
+
+At `xrCreateInstance` time the runtime walks the registered plug-ins, sorts them by `ProbeOrder` (lower runs first), `LoadLibraryExW`s each, resolves `xrtPluginNegotiate`, calls it, then calls the returned `iface->probe()`. The first plug-in whose `probe()` returns `XRT_SUCCESS` claims the system; the rest are skipped silently.
+
+### Windows: registry-based
+
+Your installer writes these values under `HKLM\Software\DisplayXR\DisplayProcessors\<your-id>`:
+
+| Value | Type | Purpose |
+|---|---|---|
+| `Binary` | `REG_SZ` | Absolute path to your plug-in DLL |
+| `DisplayName` | `REG_SZ` | Human-readable name, logged at probe |
+| `Vendor` | `REG_SZ` | Your company name |
+| `Version` | `REG_SZ` | Plug-in version (e.g. `1.0.0`) |
+| `ProbeOrder` | `REG_DWORD` | Discovery priority — see below |
+| `UninstallString` | `REG_SZ` | Quoted full path to your `Uninstall.exe`; the runtime's cascade-uninstaller invokes this with `/S` when the runtime is uninstalled |
+
+`<your-id>` is a short kebab-case identifier matching `iface->id` (the string the plug-in returns from `xrtPluginNegotiate`). The Leia plug-in uses `leia-sr`; sim-display uses `sim-display`.
+
+### POSIX: JSON manifest-based
+
+The runtime reads manifests from:
+- macOS: `~/Library/Application Support/DisplayXR/DisplayProcessors/`
+- Linux: `${XDG_DATA_HOME:-~/.local/share}/DisplayXR/DisplayProcessors/`
+
+Plus any directory in `XRT_PLUGIN_SEARCH_PATH`. Each `*.json` manifest:
+
+```json
+{
+    "id": "your-id",
+    "display_name": "Your Vendor Display",
+    "vendor": "Your Company",
+    "version": "1.0.0",
+    "probe_order": 50,
+    "binary": "/absolute/path/to/DisplayXR-YourVendor.dylib"
+}
+```
+
+The full discovery contract — registry layout, JSON schema, env-var overrides, fallback search order — is documented in [`docs/specs/runtime/plugin-discovery.md`](../specs/runtime/plugin-discovery.md).
+
+### `ProbeOrder` convention
+
+| Range | Meaning | Examples |
+|---|---|---|
+| 1–99 | Vendor with hardware probe — claims the system when its hardware is present, declines cleanly otherwise | Leia SR = 50 |
+| 100–199 | Reserved | — |
+| 200–254 | Vendor-neutral fallback that always claims if reached | sim-display = 200 |
+
+Pick a value in 1–99 if your `probe()` consults a vendor SDK to detect connected hardware and returns `XRT_ERROR_PROBER_NOT_SUPPORTED` cleanly when absent. Pick something close to 200 if your plug-in is meant to handle "any machine, no specific hardware" cases (rare for vendor plug-ins).
+
+## 5. Installer contract
+
+The vendor plug-in installer is independent of the runtime installer — it has its own version cadence, its own release flow, its own NSIS script (Windows) or `.pkg` builder (macOS).
+
+### Hard prereq: the runtime must already be installed
+
+Your installer's first action should be:
+
+```nsis
+ReadRegStr $0 HKLM "Software\DisplayXR\Runtime" "InstallPath"
+${If} $0 == ""
+    MessageBox MB_OK|MB_ICONSTOP "DisplayXR Runtime is required. Install it first from https://github.com/DisplayXR/displayxr-runtime/releases then retry."
+    Abort
+${EndIf}
+```
+
+This prevents "I installed the plug-in but nothing happens" support tickets — without the runtime, `DisplayXRClient.dll` doesn't exist and your plug-in's import fails at load time.
+
+### Install dir convention
+
+`$RuntimeInstall\Plugins\<YourVendorId>\` — e.g. `C:\Program Files\DisplayXR\Plugins\LeiaSR\`.
+
+Drop the following into that directory:
+- Your plug-in DLL (`DisplayXR-<YourVendor>.dll`)
+- Any vendor SDK runtime DLLs you license to redistribute (e.g. the Leia plug-in bundles `SimulatedRealityVulkanBeta.dll` because it's not in the SR Platform install set; everything else comes from the SR Platform installer separately)
+- An `Uninstall.exe` (NSIS generates this automatically)
+
+Do **not** drop anything into `$RuntimeInstall\` (the parent). That's runtime-owned.
+
+### `UninstallString` for cascade-uninstall
+
+The runtime's uninstaller has a **cascade-uninstall** pass: it walks `HKLM\Software\DisplayXR\DisplayProcessors\*`, reads each entry's `UninstallString`, and runs it silently before uninstalling its own files. This is how the runtime cleans up vendor plug-ins when the user uninstalls the runtime.
+
+Your installer **must** register `UninstallString` correctly:
+
+```nsis
+WriteRegStr HKLM "Software\DisplayXR\DisplayProcessors\<your-id>" \
+    "UninstallString" "$\"$INSTDIR\Uninstall.exe$\""
+```
+
+The quoted form (with embedded double-quotes) is the convention the runtime's cascade-uninstaller expects.
+
+### Reference installer
+
+[`displayxr-leia-plugin/installer/DisplayXRLeiaSRInstaller.nsi`](https://github.com/DisplayXR/displayxr-leia-plugin/blob/main/installer/DisplayXRLeiaSRInstaller.nsi) is the canonical reference. Lift it wholesale; rename `LeiaSR` → your vendor name, change the registry `<id>`, and you're 90% there.
+
+## 6. Vendor-specific concerns
+
+### SDK redistribution
+
+If your vendor SDK's license allows redistribution, bundle the runtime DLLs in your installer. The end-user's experience is one installer click.
+
+If it doesn't, document the SDK as a hard prereq in your installer's pre-install check (similar to how the Leia plug-in's installer requires the SR Platform installer to be run first, separately).
+
+### Eye-tracking mode
+
+`xrt_plugin_display_info.supported_eye_tracking_modes` is a bitmask:
+- bit 0 (`0x1`) — `MANAGED` (vendor SDK predicts eye positions; the runtime queries them per frame)
+- bit 1 (`0x2`) — `MANUAL` (the app submits eye positions via `XR_EXT_display_info`)
+
+Declare both bits if your SDK supports both modes; declare just one if not. Leia is `MANAGED`-only; sim-display is `MANUAL`-only. The `default_eye_tracking_mode` field picks which mode the runtime uses for sessions that don't explicitly opt in.
+
+### Per-API DP factories
+
+Only fill in the `create_dp_<api>` factories your SDK actually supports. NULL means "this graphics API isn't supported on this platform by this plug-in." The runtime gracefully falls back to the sim-display DP for any API your plug-in doesn't cover, so a vendor with only D3D11 + D3D12 weavers can still ship a useful plug-in — Vulkan / OpenGL / Metal apps just transparently use sim-display while DX apps use your weaver.
+
+### Plug-in lifetime + threading
+
+- `xrtPluginNegotiate` is called exactly once per process, at first `xrCreateInstance`.
+- `probe()` is called on the `xrCreateInstance` hot path — keep it sub-millisecond. If your hardware probe takes longer, cache the result statically.
+- `create_device`, `get_display_info`, and `set_pose_source` are called on the runtime's main thread.
+- The DP factories (`create_dp_<api>`) are called on the compositor's session-create thread.
+- `destroy()` is called on the runtime's main thread at instance teardown.
+
+## 7. Testing your plug-in
+
+### Smoke tests: cube apps in this repo
+
+The runtime ships standalone cube apps under `test_apps/`. Install your plug-in (via your installer), then launch any of:
+
+```
+test_apps\cube_handle_d3d11_win\build\cube_handle_d3d11_win.exe
+test_apps\cube_handle_d3d12_win\build\cube_handle_d3d12_win.exe
+test_apps\cube_handle_gl_win\build\cube_handle_gl_win.exe
+test_apps\cube_handle_vk_win\build\cube_handle_vk_win.exe
+```
+
+The cube renders through your weaver per API. The per-process runtime log (`%LOCALAPPDATA%\DisplayXR\DisplayXR_<exe>.<pid>_<ts>.log`) shows which plug-in claimed the system:
+
+```
+[try_load_one] plugin loader: active plug-in: id=<your-id> name='<your-name>' …
+```
+
+If your plug-in's `probe()` is declining when it shouldn't, set `XRT_PLUGIN_DEBUG=1` to log probe outcomes per registered plug-in.
+
+### Full workspace test: DisplayXR Shell
+
+Install the DisplayXR Shell ([`displayxr-shell-releases`](https://github.com/DisplayXR/displayxr-shell-releases)), then launch a cube via the shell:
+
+```
+"C:\Program Files\DisplayXR\Runtime\displayxr-shell.exe" path\to\cube.exe
+```
+
+The shell drives the runtime through the OpenXR workspace extensions, so cube-in-shell exercises a more complete path than standalone cube.
+
+### Optional: link to the vendor list
+
+Add a short `docs/vendors/<your-vendor>.md` to the runtime repo via PR — a one-page summary of your plug-in (link to your repo, supported APIs, eye-tracking mode, installer link). The runtime maintainers will review + merge as a docs-only change.
+
+## Related
+
+- [Plug-in iface reference](../reference/xrt_plugin_iface.md) — per-method contract for `xrt_plugin_iface`
+- [Plug-in discovery spec](../specs/runtime/plugin-discovery.md) — registry / JSON manifest formats, env var overrides
+- [ADR-019](../adr/ADR-019-vendor-plugin-aux-boundary.md) — why the runtime DLL holds zero vendor identifiers and how the aux import-library boundary works
+- [`XR_EXT_display_info` spec](../specs/extensions/XR_EXT_display_info.md) — display info + eye-tracking mode contract
+- [Eye tracking modes spec](../specs/vendor/eye-tracking-modes.md) — MANAGED vs MANUAL contract
+- [Legacy in-tree integration model](vendor-integration.md) — historical reference for the pre-#263 in-tree integration shape

--- a/docs/reference/xrt_plugin_iface.md
+++ b/docs/reference/xrt_plugin_iface.md
@@ -1,0 +1,218 @@
+# `xrt_plugin_iface` Reference
+
+Per-method reference for the vendor plug-in vtable returned from `xrtPluginNegotiate`. For the higher-level onboarding flow (how to package, install, register), see [`vendor-plugin-onboarding.md`](../guides/vendor-plugin-onboarding.md). The C ABI is declared in [`src/xrt/include/xrt/xrt_plugin.h`](../../src/xrt/include/xrt/xrt_plugin.h).
+
+## Lifecycle
+
+```
+runtime startup
+  └── walks HKLM\Software\DisplayXR\DisplayProcessors\*
+       (Windows; POSIX uses JSON manifests — see plugin-discovery.md)
+       sorted by ProbeOrder, ascending
+       │
+       └── for each registered plug-in:
+            LoadLibraryExW(plugin.dll)
+            GetProcAddress("xrtPluginNegotiate")
+            ├── xrtPluginNegotiate(rt_ver, host, &iface, &plugin_ver)
+            │     returns XRT_SUCCESS + iface
+            │     OR XRT_ERROR_PROBER_NOT_SUPPORTED + skip
+            │
+            ├── iface->probe(&instance)
+            │     returns XRT_SUCCESS + instance handle → claim the system
+            │     OR XRT_ERROR_PROBER_NOT_SUPPORTED + skip (try next plug-in)
+            │
+            ├── iface->create_device(instance, &xdev)
+            │
+            ├── iface->get_display_info(instance, xdev, &info)
+            │
+            ├── iface->set_pose_source(instance, xdev, qwerty_xdev)
+            │     [optional binding for WASD/mouse pose source]
+            │
+            ├── iface->create_dp_<api>(...)   per app session, per graphics API
+            │
+            └── iface->destroy(instance)       runtime shutdown
+```
+
+Once a plug-in's `probe()` succeeds, the runtime stops scanning — subsequent plug-ins are not loaded. The first plug-in to claim the system wins.
+
+## Entry point
+
+### `xrtPluginNegotiate`
+
+```c
+XRT_PLUGIN_EXPORT xrt_result_t
+xrtPluginNegotiate(uint32_t runtime_api_version,
+                   const struct xrt_plugin_host_iface *host,
+                   struct xrt_plugin_iface **out_iface,
+                   uint32_t *out_plugin_api_version);
+```
+
+The single C-ABI symbol your plug-in DLL must export. Called once per process at first `xrCreateInstance`.
+
+| Param | Contract |
+|---|---|
+| `runtime_api_version` | The `XRT_PLUGIN_API_VERSION_*` the runtime speaks. Compare against `XRT_PLUGIN_API_VERSION_CURRENT` from your headers; return `XRT_ERROR_PROBER_NOT_SUPPORTED` if you can't handle the runtime's version. |
+| `host` | Read-only callback table from the runtime. v1 has only the struct-size header + reserved slots; future host-supplied callbacks land in the reserved space. Lifetime: valid for the duration of this call AND for the plug-in's lifetime. **Don't dereference past `host->struct_size`.** |
+| `out_iface` | You return your vtable here. Storage is plug-in-owned; the runtime treats it as a read-only borrow until `destroy()`. Must remain valid until `destroy()` returns. Set `(*out_iface)->struct_size = sizeof(struct xrt_plugin_iface)` at YOUR compile time so the runtime can forward-version-detect. |
+| `out_plugin_api_version` | The `XRT_PLUGIN_API_VERSION_*` you implement. Runtime compares; mismatch → plug-in skipped with a logged warning. |
+
+**Returns:**
+- `XRT_SUCCESS` → runtime proceeds to call `(*out_iface)->probe()`
+- `XRT_ERROR_PROBER_NOT_SUPPORTED` → clean decline (e.g. version mismatch), runtime logs an info line and skips
+- Other `XRT_ERROR_*` → hard failure, runtime logs a warning and skips
+
+## Required vtable methods
+
+### `probe`
+
+```c
+xrt_result_t (*probe)(struct xrt_plugin_instance **out_inst);
+```
+
+"Do you want to claim the current system?"
+
+Called on the `xrCreateInstance` hot path for every registered plug-in until one succeeds — **sub-millisecond budget**. May consult the vendor SDK to check for connected hardware (e.g. EDID lookup, device enumeration), but if your check is expensive, cache the result statically on first call.
+
+**Returns:**
+- `XRT_SUCCESS` + populate `*out_inst` → you claim the system. The runtime owns the lifetime of the returned handle and frees it via `destroy()`.
+- `XRT_ERROR_PROBER_NOT_SUPPORTED` → clean decline ("no device of this type on this system"). Runtime logs an info line and tries the next plug-in.
+- Other `XRT_ERROR_*` → hard probe failure. Logged at warning level. Runtime skips this plug-in.
+
+The plug-in defines the concrete layout of `xrt_plugin_instance`; the runtime treats it as an opaque `void *` keyed off this call's out-param and passes it back to every subsequent vtable call.
+
+### `create_device`
+
+```c
+xrt_result_t (*create_device)(struct xrt_plugin_instance *inst,
+                              struct xrt_device **out_dev);
+```
+
+Construct the plug-in's `xrt_device` — the head / HMD-equivalent device for the runtime's prober + system-builder. Called only after a successful `probe()`.
+
+Ownership of `*out_dev` is transferred to the runtime, which destroys the device via the usual `xrt_device::destroy` vtable method (not through this iface's `destroy`).
+
+### Per-API DP factories
+
+```c
+xrt_dp_factory_vk_fn_t    create_dp_vk;
+xrt_dp_factory_d3d11_fn_t create_dp_d3d11;
+xrt_dp_factory_d3d12_fn_t create_dp_d3d12;
+xrt_dp_factory_gl_fn_t    create_dp_gl;
+xrt_dp_factory_metal_fn_t create_dp_metal;
+```
+
+Construct the per-graphics-API display processor. Called per app session, per graphics API.
+
+`NULL` means your plug-in doesn't support that graphics API on this platform — the runtime gracefully falls back to the sim-display DP for that API. **At least one** of the five must be non-NULL — a plug-in whose probe succeeds but offers no DP factory is rejected (it'd have nothing the compositor can drive).
+
+Each factory's signature is owned by `xrt_display_processor_<api>.h` and is unchanged from the pre-plug-in shape — see those headers for the exact contracts. The plug-in iface just hands one back per supported API.
+
+### `destroy`
+
+```c
+void (*destroy)(struct xrt_plugin_instance *inst);
+```
+
+Free `inst` and all plug-in-owned resources hanging off it. Called by the runtime at instance teardown, or after a negotiated plug-in is superseded by a later registration.
+
+After `destroy()` returns, the runtime stops dereferencing both `inst` and the vtable; you can safely tear down DLL-static state here too.
+
+## Optional vtable methods
+
+### `get_display_info`
+
+```c
+bool (*get_display_info)(struct xrt_plugin_instance *inst,
+                         struct xrt_device *xdev,
+                         struct xrt_plugin_display_info *out_info);
+```
+
+Fill in vendor-neutral physical-display info. Lets the runtime populate `xrt_system_compositor_info` without calling any vendor-specific symbol directly — the headline ADR-019 goal.
+
+**Forward-compat:** the runtime sets `out_info->struct_size` to its own `sizeof(struct xrt_plugin_display_info)` before the call; the plug-in **must not** write past that offset. Field additions append at the end with no API version bump.
+
+Fields to populate:
+
+| Field | Units / type | Notes |
+|---|---|---|
+| `display_width_m`, `display_height_m` | meters (float) | Physical panel dimensions |
+| `nominal_viewer_x_m`, `nominal_viewer_y_m`, `nominal_viewer_z_m` | meters (float) | Default viewer position relative to display center. Drives Kooima projection defaults when the app has no head tracking. |
+| `display_pixel_width`, `display_pixel_height` | pixels (uint32) | Native panel resolution |
+| `recommended_view_scale_x`, `recommended_view_scale_y` | float, 1.0 = native | Vendor-recommended per-view scaling. <1.0 means downscale. |
+| `display_screen_left`, `display_screen_top` | virtual-screen coords (int32) | Display top-left in Windows-style virtual-screen pixels. Used to position workspace windows. Both 0 = "no preference / display origin == desktop origin" (sim-display picks this). |
+| `supported_eye_tracking_modes` | bitmask | bit 0 = MANAGED, bit 1 = MANUAL. Leia is MANAGED-only; sim_display is MANUAL-only. |
+| `default_eye_tracking_mode` | enum | 0 = MANAGED, 1 = MANUAL. |
+
+**Returns:**
+- `true` → struct populated, runtime uses your values
+- `false` → plug-in couldn't produce info (e.g. vendor SDK declined). Runtime keeps the defaults already in `xsysc->info`.
+
+**NULL is allowed.** A NULL pointer is treated as if the call returned `false`. Required to be non-NULL for plug-ins that ship a `create_device` implementation, otherwise the runtime has no source of display dimensions and falls back to OpenXR defaults.
+
+### `set_pose_source`
+
+```c
+void (*set_pose_source)(struct xrt_plugin_instance *inst,
+                        struct xrt_device *xdev,
+                        struct xrt_device *source);
+```
+
+Bind an external pose source to the device returned by `create_device`. Used to wire the qwerty HMD (WASD/mouse camera controls) into your vendor device.
+
+Each vendor's driver owns a private cast from `xrt_device *` back to its container struct; this iface method lets the runtime invoke that vendor-private binding without the runtime DLL knowing the vendor's struct layout.
+
+Passing `source = NULL` clears the binding (the device falls back to its static pose).
+
+**NULL is allowed.** NULL means your plug-in doesn't support external pose binding — the caller skips silently. If you support it, the canonical pattern (lifted from `drv_leia` / `drv_sim_display`):
+
+```c
+static void
+my_plugin_set_pose_source(struct xrt_plugin_instance *inst,
+                          struct xrt_device *xdev,
+                          struct xrt_device *source)
+{
+    if (xdev == NULL) return;
+    struct my_device *m = container_of(xdev, struct my_device, base);
+    m->external_pose_source = source;
+}
+```
+
+## Forward-compatibility rules
+
+The iface is designed to evolve without breaking older plug-ins:
+
+1. **New fields are only appended at the end.** Reordering or redefining an existing field bumps `XRT_PLUGIN_API_VERSION_CURRENT`.
+2. **`struct_size` is the read-clamp.** The runtime sets `host->struct_size` to its own `sizeof(struct xrt_plugin_host_iface)`; plug-ins must not dereference past that. Plug-ins set `iface->struct_size` to their own compile-time size; the runtime must not dereference past that. Either side can detect a "newer than I know about" peer and clamp cleanly.
+3. **Pure-additive struct changes do NOT bump the API version.** Only non-additive layout changes do.
+4. **Optional methods are NULL-safe.** Adding a new optional method is a pure-additive change; old plug-ins return NULL for the new slot, the runtime handles NULL.
+
+## Aux surface — separate from the iface
+
+Logging, debug-variable tracking, frame metrics, Perfetto tracing, and unique-ID generation are **not** plumbed through this iface. Plug-ins reach them by linking the runtime DLL's import library (`DisplayXRClient.lib`) and getting `__declspec(dllimport)`'d symbols. See [ADR-019](../adr/ADR-019-vendor-plugin-aux-boundary.md) for the rationale.
+
+In practice your plug-in's CMakeLists looks like:
+
+```cmake
+target_compile_definitions(DisplayXR-MyVendor PRIVATE XRT_USING_RUNTIME_DLL)
+target_link_libraries(DisplayXR-MyVendor PRIVATE
+    $<TARGET_LINKER_FILE:${RUNTIME_TARGET}>    # DisplayXRClient.lib
+    xrt-interfaces aux_util aux_os aux_math    # for non-exported helpers
+)
+```
+
+And in any plug-in TU:
+
+```c
+#include "aux/util/u_logging.h"
+
+void my_plugin_init(void) {
+    U_LOG_W("plug-in version 1.0.0 init");  // resolves to DisplayXRClient.dll
+}
+```
+
+## Related
+
+- [Vendor plug-in onboarding](../guides/vendor-plugin-onboarding.md) — high-level guide for building + shipping a plug-in
+- [Plug-in discovery spec](../specs/runtime/plugin-discovery.md) — registry / manifest formats, env-var overrides
+- [ADR-019](../adr/ADR-019-vendor-plugin-aux-boundary.md) — vendor / aux boundary rationale
+- [`xrt_plugin.h`](../../src/xrt/include/xrt/xrt_plugin.h) — the C ABI header itself


### PR DESCRIPTION
## Summary

Phase B of the #263 driver extraction work. Adds the vendor-onboarding documentation that describes the contract a new display vendor follows post-#263 — ship a plug-in DLL from your own repo, register at install time, never touch this repo.

Closes #264.

## What's new

- **`docs/guides/vendor-plugin-onboarding.md`** — zero-to-shipping guide for an external vendor plug-in repo. Walks through:
  1. What you ship (plug-in DLL + installer)
  2. What you consume from the runtime (`DisplayXRClient.lib` + headers; the shared-DLL-surface note from #264's comment about not re-shipping `cjson.dll` / `pthreadVC3.dll` / `openxr_loader.dll`)
  3. Building from the template (fork `displayxr-leia-plugin`, swap `drv_<vendor>/`)
  4. Discovery contract (registry on Windows + JSON manifests on POSIX, `ProbeOrder` convention)
  5. Installer contract (`UninstallString` for cascade-uninstall, install dir convention)
  6. Vendor-specific concerns (SDK redistribution, eye-tracking modes, per-API DP factories, lifecycle/threading)
  7. Testing flow (cube apps for smoke tests, shell for full workspace)

- **`docs/reference/xrt_plugin_iface.md`** — per-method contract for the vtable returned by `xrtPluginNegotiate`. Required vs optional methods flagged inline; forward-compat rules (`struct_size` clamping, append-only field additions) called out; the lifecycle ASCII diagram up top gives the call order at a glance.

## Index updates

- `docs/README.md` — "For Display Vendors" section leads with the new onboarding doc + iface reference + plug-in-discovery spec. The old `vendor-integration.md` is now flagged as the legacy reference (it already had the legacy banner from PR #285).
- `CLAUDE.md` — Documentation table: "Add a new display vendor" row updated to point at the post-#263 docs; new row for the iface reference.

## Out of scope

- A `displayxr-vendor-plugin-template` repo (mentioned in #264's "Out of scope" section) — for now the canonical fork target is `displayxr-leia-plugin` itself. A purpose-built template repo can land later as a separate cleanup.
- Updating `docs/architecture/in-process-vs-service.md`, `docs/architecture/project-structure.md`, and `docs/vendors/leia/README.md` to drop their `XRT_HAVE_LEIA_SR` / `target_builder_leia.c` references — those mentions are now historically inaccurate but non-load-bearing. They can be fixed alongside future doc passes.

## Test plan

- [x] `docs/guides/vendor-plugin-onboarding.md` walks a hypothetical new vendor from zero through the install + discovery flow with concrete code/registry examples
- [x] References to canonical examples (`DisplayXR/displayxr-leia-plugin` post-#263, `src/xrt/drivers/sim_display/sim_display_plugin.c` in-tree) link cleanly
- [x] `vendor-integration.md` banner (added in PR #285) points readers here
- [x] `docs/README.md` index mentions both new docs in the "For Display Vendors" section
- [x] `CLAUDE.md` Documentation table updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)