### PR TITLE
feat(#283): Windows dev orchestrator (setup-displayxr.bat) + README quick-install promotion

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,15 +44,38 @@ Every graphics API gets its own native compositor — no Vulkan intermediary, no
 
 ## Quick Start
 
-### Install (Windows)
+### One-command dev install
 
-DisplayXR ships as three small, independent installers. Install in this order:
+```bash
+# macOS
+git clone https://github.com/DisplayXR/displayxr-runtime
+cd displayxr-runtime
+./scripts/setup-displayxr.sh                  # runtime + sim-display
+./scripts/setup-displayxr.sh --with mcp       # also DisplayXR MCP Tools when published
+```
 
-1. **DisplayXR Runtime** — `DisplayXRSetup-*.exe` from [displayxr-runtime releases](https://github.com/DisplayXR/displayxr-runtime/releases). Required.
-2. **DisplayXR Shell** — `DisplayXRShellSetup-*.exe` from [displayxr-shell-releases](https://github.com/DisplayXR/displayxr-shell-releases/releases). Optional, adds the spatial-workspace UX. Hard-requires the runtime ([workspace controller contract](docs/specs/runtime/workspace-controller-registration.md)).
-3. **DisplayXR MCP Tools** — `DisplayXRMCPSetup-*.exe` from [displayxr-mcp releases](https://github.com/DisplayXR/displayxr-mcp/releases). Optional, enables AI-agent / voice control.
+```bat
+:: Windows — run from an ELEVATED command prompt
+git clone https://github.com/DisplayXR/displayxr-runtime
+cd displayxr-runtime
+scripts\setup-displayxr.bat                   :: runtime + Shell + Leia plug-in
+scripts\setup-displayxr.bat --with mcp        :: also DisplayXR MCP Tools
+```
 
-The website's [Get Started](https://displayxr.org/getting-started) page walks through this end-to-end with verification steps.
+Downloads each component's installer from its GitHub Releases page (versions pinned in [`versions.json`](versions.json)), runs it silently, verifies the install. See [`docs/getting-started/full-stack-install.md`](docs/getting-started/full-stack-install.md) for `--with-demos`, `--dry-run`, `--uninstall`, and the per-component platform availability matrix.
+
+### Manual install
+
+For full control, install each component directly from its release page. Order: runtime → Shell → Leia plug-in → MCP Tools.
+
+| Component | Windows | macOS |
+|---|---|---|
+| **DisplayXR Runtime** (required) | [`DisplayXRSetup-*.exe`](https://github.com/DisplayXR/displayxr-runtime/releases) | [`DisplayXR-Installer-*.pkg`](https://github.com/DisplayXR/displayxr-runtime/releases) |
+| **DisplayXR Shell** (optional, spatial workspace UX) | [`DisplayXRShellSetup-*.exe`](https://github.com/DisplayXR/displayxr-shell-releases/releases) | — (deferred) |
+| **Leia SR plug-in** (Leia hardware only) | [`DisplayXRLeiaSRSetup-*.exe`](https://github.com/DisplayXR/displayxr-leia-plugin/releases) | — (vendor SDK is Windows-only) |
+| **MCP Tools** (optional, AI-agent / voice control) | [`DisplayXRMCPSetup-*.exe`](https://github.com/DisplayXR/displayxr-mcp/releases) | — (future) |
+
+The website's [Get Started](https://displayxr.org/getting-started) page walks through the manual flow end-to-end with verification steps.
 
 ### Build from source
 
@@ -67,10 +90,6 @@ brew install cmake ninja eigen vulkan-sdk && ./scripts/build_macos.sh --installe
 # Install: sudo installer -pkg _package/DisplayXR-Installer-*.pkg -target /
 # (Gatekeeper warns on double-click — the .pkg is unsigned today; sudo installer
 #  from terminal bypasses Gatekeeper. Notarization tracked in issues #280/#281.)
-
-# Or all-in-one (macOS) — download + install the pinned release matrix
-./scripts/setup-displayxr.sh
-# See docs/getting-started/full-stack-install.md for flags (#283).
 
 # Run a dev build without installing
 XR_RUNTIME_JSON=./build/Release/openxr_displayxr-dev.json ./your_openxr_app

--- a/docs/getting-started/full-stack-install.md
+++ b/docs/getting-started/full-stack-install.md
@@ -1,9 +1,10 @@
-# Full-stack DisplayXR install (macOS)
+# Full-stack DisplayXR install
 
-`scripts/setup-displayxr.sh` is a one-command orchestrator that downloads
-each DisplayXR component's release asset from GitHub Releases and installs
-it. It exists so contributors don't need to chase ~5 separate installer
-links to get a working dev box.
+`scripts/setup-displayxr.sh` (macOS) and `scripts/setup-displayxr.bat`
+(Windows) are one-command orchestrators that download each DisplayXR
+component's release installer from GitHub Releases and run it. They
+exist so contributors don't need to chase ~5 separate installer links
+to get a working dev box.
 
 > Tracking issue: [#283](https://github.com/DisplayXR/displayxr-runtime/issues/283).
 > Companion [#284](https://github.com/DisplayXR/displayxr-runtime/issues/284)
@@ -13,6 +14,7 @@ links to get a working dev box.
 ## Quick start
 
 ```bash
+# macOS
 git clone https://github.com/DisplayXR/displayxr-runtime
 cd displayxr-runtime
 ./scripts/setup-displayxr.sh
@@ -22,15 +24,27 @@ That installs the runtime + bundled `sim-display` plug-in into
 `/Library/Application Support/DisplayXR/` and registers it as the active
 OpenXR runtime at `/etc/xdg/openxr/1/active_runtime.json`.
 
+```bat
+:: Windows — run from an ELEVATED command prompt
+git clone https://github.com/DisplayXR/displayxr-runtime
+cd displayxr-runtime
+scripts\setup-displayxr.bat
+```
+
+That installs the runtime, the DisplayXR Shell, and the Leia SR plug-in
+into `C:\Program Files\DisplayXR\Runtime\` and registers each at
+`HKLM\Software\DisplayXR\…`. The runtime also becomes the active
+OpenXR runtime via `HKLM\Software\Khronos\OpenXR\1\ActiveRuntime`.
+
 ## Flags
 
 | Flag | Effect |
 |---|---|
-| _(none)_ | Install runtime only. |
-| `--with mcp` | Also install DisplayXR MCP Tools (when a macOS asset is available — warn+skip otherwise). |
+| _(none)_ | macOS: runtime only. Windows: runtime + Shell + Leia plug-in. |
+| `--with mcp` | Also install DisplayXR MCP Tools (macOS: warn-and-skip until a `.pkg` is published). |
 | `--with-demos` | Clone each `DisplayXR/displayxr-demo-*` repo into `./demos/<name>/`. Does not build them. |
 | `--dry-run` | Print every download / install command without running it. |
-| `--uninstall` | Chain the runtime's bundled uninstaller at `/Library/Application Support/DisplayXR/uninstall.sh`. |
+| `--uninstall` | macOS: chain `/Library/Application Support/DisplayXR/uninstall.sh`. Windows: silent-uninstall every `Publisher=DisplayXR` component. |
 | `-h`, `--help` | Show usage. |
 
 `--with` and `--with-demos` combine freely. `--dry-run` works with all
@@ -38,31 +52,33 @@ other flags.
 
 ## Prerequisites
 
-- macOS 13+ (the runtime targets the macOS 13 SDK; the `.pkg` itself
-  enforces a min-OS check).
-- [GitHub CLI](https://cli.github.com/) (`brew install gh`) authenticated
-  via `gh auth login`. Same requirement as `scripts/build_windows.bat`.
-- `sudo` (one prompt up front; orchestrator keeps the timestamp alive so
-  per-component installs don't re-prompt).
+### macOS
+
+- macOS 13+ (the runtime targets the macOS 13 SDK; the `.pkg` itself enforces a min-OS check).
+- [GitHub CLI](https://cli.github.com/) (`brew install gh`) authenticated via `gh auth login`.
+- `sudo` (one prompt up front; the orchestrator keeps the timestamp alive so per-component installs don't re-prompt).
+
+### Windows
+
+- Windows 10 21H2+ or Windows 11.
+- [GitHub CLI](https://cli.github.com/) (`winget install --id GitHub.cli`) authenticated via `gh auth login`. Same requirement as `scripts\build_windows.bat`.
+- **Elevated command prompt** — right-click cmd.exe and choose "Run as administrator". The NSIS installers all write to HKLM + Program Files; non-elevated runs fail with a clearer error than individual installers report.
+- PowerShell (preinstalled). The `.bat` shells out for JSON parsing and the publisher-scan uninstall path.
 
 ## Platform availability matrix
 
-What this orchestrator can actually install today depends on which
-component repos ship a macOS asset:
+What this orchestrator can actually install depends on which component
+repos ship an asset for your platform:
 
-| Component   | Repo                                  | macOS today | Windows today |
-|-------------|---------------------------------------|-------------|---------------|
-| runtime     | `displayxr-runtime`                   | yes (post v1.3.6) | yes |
-| shell       | `displayxr-shell-releases`            | — (deferred)      | yes |
-| leia_plugin | `displayxr-leia-plugin`               | — (vendor SDK is Windows-only) | yes |
-| mcp_tools   | `displayxr-mcp`                       | — (future)        | yes |
+| Component   | Repo                                  | macOS today                        | Windows today                            |
+|-------------|---------------------------------------|------------------------------------|------------------------------------------|
+| runtime     | `displayxr-runtime`                   | yes (`DisplayXR-Installer-*.pkg`)  | yes (`DisplayXRSetup-*.exe`)             |
+| shell       | `displayxr-shell-releases`            | — (macOS port deferred, M6)        | yes (`DisplayXRShellSetup-*.exe`)        |
+| leia_plugin | `displayxr-leia-plugin`               | — (vendor SDK is Windows-only)     | yes (`DisplayXRLeiaSRSetup-*.exe`)       |
+| mcp_tools   | `displayxr-mcp`                       | — (future)                         | yes (`DisplayXRMCPSetup-*.exe`)          |
 
-Empty cells warn-and-skip cleanly: the orchestrator does not abort when a
-component lacks a macOS asset for the pinned tag. (This also covers the
-pre-v1.3.6 transition window where the runtime release itself has no
-`.pkg` attached — that work landed in
-[PR #279](https://github.com/DisplayXR/displayxr-runtime/pull/279) and
-the first release after it is where the macOS asset first appears.)
+Empty cells warn-and-skip cleanly: the orchestrator does not abort when
+a component lacks an asset for the pinned tag.
 
 ## `versions.json`
 
@@ -70,9 +86,9 @@ Top-level pin file. Bump a value here to roll the dev box forward:
 
 ```json
 {
-  "runtime":     "v1.3.5",
+  "runtime":     "v1.4.0",
   "shell":       "v1.2.5",
-  "leia_plugin": "sr-sdk-v1.35.0.2011",
+  "leia_plugin": "v1.0.1",
   "mcp_tools":   "v0.3.1",
   "demos": {
     "gaussiansplat": "v1.3.1"
@@ -81,37 +97,47 @@ Top-level pin file. Bump a value here to roll the dev box forward:
 ```
 
 Each value must be a tag that exists in the corresponding repo's GitHub
-Releases — the orchestrator validates with `gh release view <tag>` before
-attempting any download.
+Releases — both orchestrators validate with `gh release view <tag>`
+before attempting any download.
 
 Repo URLs and asset name globs live alongside in
-[`scripts/lib/components.sh`](../../scripts/lib/components.sh). The same
-file is intended to be sourced by future scripts in `displayxr-installer`
-(#284) so both the dev orchestrator and the user meta-installer agree on
-what each component is.
+[`scripts/lib/components.sh`](../../scripts/lib/components.sh) (sourced
+by the macOS script; mirrored inline at the top of the Windows `.bat`
+because batch can't source bash). The same table is intended to be
+re-used by future scripts in `displayxr-installer` (#284) so all
+consumers agree on what each component is.
 
 ## Manual fallback
 
-If you can't (or don't want to) use the orchestrator, the equivalent
-manual flow is:
+The orchestrators do exactly this, plus pin validation, sudo / elevation
+priming, smoke verification, and graceful handling of missing-asset edge
+cases.
+
+### macOS
 
 ```bash
-# 1. Runtime + sim-display plug-in
-gh release download v1.3.5 \
+gh release download v1.4.0 \
     --repo DisplayXR/displayxr-runtime \
     --pattern 'DisplayXR-Installer-*.pkg' \
     --dir /tmp/dxr
 sudo installer -pkg /tmp/dxr/DisplayXR-Installer-*.pkg -target /
-
-# 2. (Optional) Demo
-gh repo clone DisplayXR/displayxr-demo-gaussiansplat demos/displayxr-demo-gaussiansplat
 ```
 
-The orchestrator does exactly this, plus pin validation, sudo timestamp
-caching, smoke verification, and graceful handling of missing-asset
-edge cases.
+### Windows
+
+```bat
+:: From an elevated cmd
+gh release download v1.4.0 --repo DisplayXR/displayxr-runtime --pattern "DisplayXRSetup-*.exe" --dir %TEMP%\dxr
+%TEMP%\dxr\DisplayXRSetup-*.exe /S
+gh release download v1.2.5 --repo DisplayXR/displayxr-shell-releases --pattern "DisplayXRShellSetup-*.exe" --dir %TEMP%\dxr
+%TEMP%\dxr\DisplayXRShellSetup-*.exe /S
+gh release download v1.0.1 --repo DisplayXR/displayxr-leia-plugin --pattern "DisplayXRLeiaSRSetup-*.exe" --dir %TEMP%\dxr
+%TEMP%\dxr\DisplayXRLeiaSRSetup-*.exe /S
+```
 
 ## Verifying the install
+
+### macOS
 
 After a successful run you should see:
 
@@ -125,8 +151,7 @@ After a successful run you should see:
 /etc/xdg/openxr/1/active_runtime.json -> /Library/Application Support/DisplayXR/openxr_displayxr.json
 ```
 
-To run a test app against the system install, point any of the existing
-run scripts at the system runtime manifest:
+To run a test app against the system install:
 
 ```bash
 XR_RUNTIME_JSON="/Library/Application Support/DisplayXR/openxr_displayxr.json" \
@@ -135,26 +160,65 @@ XR_RUNTIME_JSON="/Library/Application Support/DisplayXR/openxr_displayxr.json" \
 
 The log should contain `active plug-in: id=sim-display`.
 
+### Windows
+
+Registry markers each component writes:
+
+```
+HKLM\Software\DisplayXR\Runtime\InstallPath              = C:\Program Files\DisplayXR\Runtime
+HKLM\Software\DisplayXR\WorkspaceControllers\shell       (Shell)
+HKLM\Software\DisplayXR\DisplayProcessors\leia-sr        (Leia plug-in)
+HKLM\Software\DisplayXR\Capabilities\MCP\Enabled = 1     (MCP Tools)
+HKLM\Software\Khronos\OpenXR\1\ActiveRuntime             (active runtime symlink-equivalent)
+```
+
+To launch the spatial workspace shell:
+
+```bat
+"C:\Program Files\DisplayXR\Runtime\displayxr-shell.exe" path\to\app.exe
+```
+
+The shell auto-starts the service, sets `XR_RUNTIME_JSON`, and launches
+the app inside a spatial window.
+
 ## Uninstalling
+
+### macOS
 
 ```bash
 ./scripts/setup-displayxr.sh --uninstall
 ```
 
-This chains `/Library/Application Support/DisplayXR/uninstall.sh` (which
-ships inside the `.pkg`) so the uninstall logic stays a single source of
-truth. Cloned demo directories under `./demos/` are left in place — they
-may carry local changes and the orchestrator refuses to blindly `rm -rf`
-them.
+Chains `/Library/Application Support/DisplayXR/uninstall.sh` (which
+ships inside the `.pkg`) so the uninstall logic stays a single source
+of truth.
+
+### Windows
+
+```bat
+:: From an elevated cmd
+scripts\setup-displayxr.bat --uninstall
+```
+
+Scans `HKLM\…\Uninstall\*` for entries with `Publisher=DisplayXR` and
+runs each one's `QuietUninstallString` (falling back to
+`UninstallString /S`). This covers runtime, Shell, Leia plug-in, and
+MCP Tools in one pass regardless of which were installed.
+
+Cloned demo directories under `./demos/` are left in place on both
+platforms — they may carry local changes and the orchestrator refuses
+to blindly remove them.
 
 ## Follow-ups
 
-- Windows `setup-displayxr.bat` — separate PR. Blocks on the Leia
-  plug-in cutting its first user-facing installer release.
-- `--from-source` flag — issue #283's power-user path. Defers until the
-  binary path is in steady state.
-- Code signing / notarization for the downloaded `.pkg` — tracked as
-  issues [#280](https://github.com/DisplayXR/displayxr-runtime/issues/280)
-  and [#281](https://github.com/DisplayXR/displayxr-runtime/issues/281).
+- `--from-source` flag — issue #283's power-user path (clone each repo
+  + build from source). Defers until the binary path is in steady
+  state.
+- Code signing / notarization for the downloaded `.pkg` and `.exe`
+  installers — tracked as issues
+  [#280](https://github.com/DisplayXR/displayxr-runtime/issues/280) and
+  [#281](https://github.com/DisplayXR/displayxr-runtime/issues/281).
+- Bundling MCP Tools on macOS — blocked on upstream `displayxr-mcp`
+  shipping a `.pkg`.
 - End-user meta-installer (single download for non-developers) —
   [#284](https://github.com/DisplayXR/displayxr-runtime/issues/284).

--- a/scripts/lib/components.sh
+++ b/scripts/lib/components.sh
@@ -6,18 +6,21 @@
 # repo list and asset name patterns stay in lockstep with versions.json's
 # tag pins.
 #
-# Each component is described by four parallel arrays keyed by component
-# name:
-#   COMPONENT_REPO[<name>]         GitHub repo (owner/name)
-#   COMPONENT_PKG_MACOS[<name>]    macOS asset glob, or "" if no macOS asset today
-#   COMPONENT_EXE_WINDOWS[<name>]  Windows asset glob, or "" if no Windows asset today
-#   COMPONENT_INSTALL_MARKER[<name>]  Absolute path that must exist after a
-#                                     successful install on this platform.
-#                                     Empty = no marker (skip post-install check).
+# Each component is described by parallel variables keyed by component name:
+#   COMPONENT_REPO_<name>                     GitHub repo (owner/name)
+#   COMPONENT_PKG_MACOS_<name>                macOS asset glob, or "" if no macOS asset today
+#   COMPONENT_EXE_WINDOWS_<name>              Windows asset glob, or "" if no Windows asset today
+#   COMPONENT_INSTALL_MARKER_MACOS_<name>     Absolute file path that must exist after a
+#                                             successful install on macOS. Empty = skip check.
+#   COMPONENT_INSTALL_MARKER_WINDOWS_<name>   Registry key whose existence proves a
+#                                             successful install on Windows. Empty = skip check.
 #
 # A blank platform glob means "warn-and-skip on this platform" — used today
-# for shell/leia/mcp on macOS, and as a forward-compat hook for the Windows
-# orchestrator follow-up.
+# for shell/leia/mcp on macOS.
+#
+# `scripts/setup-displayxr.bat` mirrors these tables inline at the top of the
+# file (Windows batch can't source bash). Keep both in sync when bumping
+# components or release contracts.
 
 # Bash 3.x ships on macOS; associative arrays need 4.x. Use parallel key-prefix
 # vars instead so the file works under /bin/bash without forcing a brew bash.
@@ -27,6 +30,7 @@ COMPONENT_REPO_runtime="DisplayXR/displayxr-runtime"
 COMPONENT_PKG_MACOS_runtime="DisplayXR-Installer-*.pkg"
 COMPONENT_EXE_WINDOWS_runtime="DisplayXRSetup-*.exe"
 COMPONENT_INSTALL_MARKER_MACOS_runtime="/Library/Application Support/DisplayXR/DisplayProcessors/200-sim-display.json"
+COMPONENT_INSTALL_MARKER_WINDOWS_runtime="HKLM\\Software\\DisplayXR\\Runtime"
 
 # --- shell ---
 # macOS shell port deferred per CLAUDE.md M6. Empty macOS glob → warn+skip.
@@ -34,6 +38,7 @@ COMPONENT_REPO_shell="DisplayXR/displayxr-shell-releases"
 COMPONENT_PKG_MACOS_shell=""
 COMPONENT_EXE_WINDOWS_shell="DisplayXRShellSetup-*.exe"
 COMPONENT_INSTALL_MARKER_MACOS_shell=""
+COMPONENT_INSTALL_MARKER_WINDOWS_shell="HKLM\\Software\\DisplayXR\\WorkspaceControllers\\shell"
 
 # --- leia_plugin ---
 # Leia SR display processor is Windows-only by design (vendor SDK is
@@ -42,6 +47,7 @@ COMPONENT_REPO_leia_plugin="DisplayXR/displayxr-leia-plugin"
 COMPONENT_PKG_MACOS_leia_plugin=""
 COMPONENT_EXE_WINDOWS_leia_plugin="DisplayXRLeiaSRSetup-*.exe"
 COMPONENT_INSTALL_MARKER_MACOS_leia_plugin=""
+COMPONENT_INSTALL_MARKER_WINDOWS_leia_plugin="HKLM\\Software\\DisplayXR\\DisplayProcessors\\leia-sr"
 
 # --- mcp_tools ---
 # displayxr-mcp ships a Windows installer today; macOS artifact is a future
@@ -50,6 +56,7 @@ COMPONENT_REPO_mcp_tools="DisplayXR/displayxr-mcp"
 COMPONENT_PKG_MACOS_mcp_tools=""
 COMPONENT_EXE_WINDOWS_mcp_tools="DisplayXRMCPSetup-*.exe"
 COMPONENT_INSTALL_MARKER_MACOS_mcp_tools=""
+COMPONENT_INSTALL_MARKER_WINDOWS_mcp_tools="HKLM\\Software\\DisplayXR\\Capabilities\\MCP"
 
 # Helper: look up a per-component field for the current platform.
 #   $1 = component name (runtime, shell, leia_plugin, mcp_tools)

--- a/scripts/setup-displayxr.bat
+++ b/scripts/setup-displayxr.bat
@@ -192,7 +192,7 @@ REM Nested keys use dot notation, e.g. "demos.gaussiansplat".
 :read_pin
 set "_RP_KEY=%~1"
 set "_RP_VAR=%~2"
-for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "$d=Get-Content -Raw '%VERSIONS_JSON%' ^| ConvertFrom-Json; $v=$d; foreach ($p in '%_RP_KEY%'.Split('.')) { $v = $v.$p }; Write-Output $v"`) do set "%_RP_VAR%=%%i"
+for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "$d = ConvertFrom-Json (Get-Content -Raw '%VERSIONS_JSON%'); $v=$d; foreach ($p in '%_RP_KEY%'.Split('.')) { $v = $v.$p }; Write-Output $v"`) do set "%_RP_VAR%=%%i"
 if not defined %_RP_VAR% (
     echo ERROR: versions.json has no pin for '%_RP_KEY%' 1>&2
     set "EXITCODE=1"
@@ -235,8 +235,8 @@ if errorlevel 1 (
 REM Confirm the Windows asset is attached.
 set "_IC_FOUND="
 for /f "usebackq delims=" %%i in (`gh release view "%_IC_TAG%" --repo "%_IC_REPO%" --json assets --jq ".assets[].name"`) do (
-    echo %%i | findstr /r /c:"^DisplayXR.*\.exe$" >nul
-    if !errorlevel! EQU 0 set "_IC_FOUND=1"
+    set "_IC_LINE=%%i"
+    if /i "!_IC_LINE:~-4!"==".exe" set "_IC_FOUND=1"
 )
 if not defined _IC_FOUND (
     echo WARN: %_IC_NAME% @ %_IC_TAG%: no Windows .exe asset attached to this release. 1>&2
@@ -324,11 +324,14 @@ REM registry. Uses Publisher=DisplayXR as the discovery key (set by each
 REM component's NSIS installer); QuietUninstallString runs silently with /S.
 :do_uninstall
 echo ==^> Discovering installed DisplayXR components...
+REM Match by DisplayName prefix as well — the Leia SR plug-in's installer
+REM sets Publisher='Leia Inc.', not 'DisplayXR', but every DisplayXR-shipped
+REM installer uses 'DisplayXR <component>' as the DisplayName.
 if "%DRY_RUN%"=="1" (
-    powershell -NoProfile -Command "Get-ItemProperty 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*','HKLM:\Software\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*' -ErrorAction SilentlyContinue | Where-Object { $_.Publisher -eq 'DisplayXR' } | ForEach-Object { Write-Host ('  (dry-run) would uninstall: ' + $_.DisplayName + ' (' + $_.DisplayVersion + ')') }"
+    powershell -NoProfile -Command "Get-ItemProperty 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*','HKLM:\Software\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*' -ErrorAction SilentlyContinue | Where-Object { $_.Publisher -eq 'DisplayXR' -or $_.DisplayName -like 'DisplayXR *' } | ForEach-Object { Write-Host ('  (dry-run) would uninstall: ' + $_.DisplayName + ' (' + $_.DisplayVersion + ')') }"
     exit /b 0
 )
-powershell -NoProfile -Command "$comps = Get-ItemProperty 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*','HKLM:\Software\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*' -ErrorAction SilentlyContinue | Where-Object { $_.Publisher -eq 'DisplayXR' }; if (-not $comps) { Write-Host 'WARN: No DisplayXR-published components are installed.'; exit 0 }; foreach ($c in $comps) { Write-Host ('==> Uninstalling ' + $c.DisplayName + ' (' + $c.DisplayVersion + ')'); $u = if ($c.QuietUninstallString) { $c.QuietUninstallString } else { $c.UninstallString + ' /S' }; cmd /c $u; if ($LASTEXITCODE -ne 0) { Write-Host ('WARN: uninstaller for ' + $c.DisplayName + ' exited ' + $LASTEXITCODE) } else { Write-Host (' OK  ' + $c.DisplayName + ' uninstalled.') } }"
+powershell -NoProfile -Command "$comps = Get-ItemProperty 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*','HKLM:\Software\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*' -ErrorAction SilentlyContinue | Where-Object { $_.Publisher -eq 'DisplayXR' -or $_.DisplayName -like 'DisplayXR *' }; if (-not $comps) { Write-Host 'WARN: No DisplayXR-published components are installed.'; exit 0 }; foreach ($c in $comps) { Write-Host ('==> Uninstalling ' + $c.DisplayName + ' (' + $c.DisplayVersion + ')'); $u = if ($c.QuietUninstallString) { $c.QuietUninstallString } else { $c.UninstallString + ' /S' }; cmd /c $u; if ($LASTEXITCODE -ne 0) { Write-Host ('WARN: uninstaller for ' + $c.DisplayName + ' exited ' + $LASTEXITCODE) } else { Write-Host (' OK  ' + $c.DisplayName + ' uninstalled.') } }"
 if exist "%REPO_ROOT%\demos" (
     echo WARN: %REPO_ROOT%\demos\ is present. Leaving it in place — remove 1>&2
     echo       manually if intended ^(it may contain local changes^). 1>&2

--- a/scripts/setup-displayxr.bat
+++ b/scripts/setup-displayxr.bat
@@ -1,0 +1,336 @@
+@echo off
+REM DisplayXR dev orchestrator (#283) - Windows.
+REM
+REM One command takes a fresh contributor from `git clone` to a working
+REM DisplayXR dev box: downloads each component's release installer from
+REM the canonical GitHub Releases page (tags pinned in versions.json),
+REM runs each NSIS installer silently (/S), verifies registry markers.
+REM
+REM Mirror of scripts/setup-displayxr.sh (#283 macOS). Same flag surface,
+REM same default-install semantics, same warn-and-skip pattern for
+REM components whose pinned release has no Windows asset attached.
+REM
+REM Usage:
+REM   scripts\setup-displayxr.bat                   :: runtime + shell + leia
+REM   scripts\setup-displayxr.bat --with mcp        :: also DisplayXR MCP Tools
+REM   scripts\setup-displayxr.bat --with-demos      :: also clone demos\
+REM   scripts\setup-displayxr.bat --dry-run         :: print plan, install nothing
+REM   scripts\setup-displayxr.bat --uninstall       :: uninstall every DisplayXR-published component
+REM   scripts\setup-displayxr.bat --help
+REM
+REM Must be run from an ELEVATED command prompt (Right-click cmd.exe ->
+REM Run as administrator). The NSIS installers all write to HKLM and
+REM Program Files; non-elevated runs fail with a clearer error than
+REM individual installers report.
+
+setlocal EnableDelayedExpansion
+
+set "SCRIPT_DIR=%~dp0"
+set "REPO_ROOT=%SCRIPT_DIR%.."
+set "VERSIONS_JSON=%REPO_ROOT%\versions.json"
+
+REM --- Component table (mirrors scripts\lib\components.sh; keep in sync). ---
+set "COMPONENT_REPO_runtime=DisplayXR/displayxr-runtime"
+set "COMPONENT_EXE_runtime=DisplayXRSetup-*.exe"
+set "COMPONENT_MARKER_runtime=HKLM\Software\DisplayXR\Runtime"
+
+set "COMPONENT_REPO_shell=DisplayXR/displayxr-shell-releases"
+set "COMPONENT_EXE_shell=DisplayXRShellSetup-*.exe"
+set "COMPONENT_MARKER_shell=HKLM\Software\DisplayXR\WorkspaceControllers\shell"
+
+set "COMPONENT_REPO_leia_plugin=DisplayXR/displayxr-leia-plugin"
+set "COMPONENT_EXE_leia_plugin=DisplayXRLeiaSRSetup-*.exe"
+set "COMPONENT_MARKER_leia_plugin=HKLM\Software\DisplayXR\DisplayProcessors\leia-sr"
+
+set "COMPONENT_REPO_mcp_tools=DisplayXR/displayxr-mcp"
+set "COMPONENT_EXE_mcp_tools=DisplayXRMCPSetup-*.exe"
+set "COMPONENT_MARKER_mcp_tools=HKLM\Software\DisplayXR\Capabilities\MCP"
+
+REM --- Default flag state ---
+set "WITH_MCP=0"
+set "WITH_DEMOS=0"
+set "DRY_RUN=0"
+set "ACTION=install"
+set "EXITCODE=0"
+
+REM --- Arg parse ---
+:argloop
+if "%~1"=="" goto :argdone
+if /i "%~1"=="-h"           goto :show_help
+if /i "%~1"=="--help"       goto :show_help
+if /i "%~1"=="--dry-run"    set "DRY_RUN=1" & shift & goto :argloop
+if /i "%~1"=="--uninstall"  set "ACTION=uninstall" & shift & goto :argloop
+if /i "%~1"=="--with-demos" set "WITH_DEMOS=1" & shift & goto :argloop
+if /i "%~1"=="--with" goto :arg_with
+echo ERROR: Unknown flag: %~1 1>&2
+call :usage 1>&2
+exit /b 2
+
+:arg_with
+shift
+if "%~1"=="" echo ERROR: --with requires an argument (currently: mcp) 1>&2 & exit /b 2
+if /i "%~1"=="mcp" set "WITH_MCP=1" & shift & goto :argloop
+echo ERROR: Unknown --with target: %~1 (supported: mcp) 1>&2
+exit /b 2
+
+:argdone
+
+REM --- Preflight ---
+where gh >nul 2>&1
+if errorlevel 1 (
+    set "PATH=C:\Program Files\GitHub CLI;%PATH%"
+    where gh >nul 2>&1
+    if !errorlevel! NEQ 0 (
+        echo ERROR: GitHub CLI ^(gh^) not found. 1>&2
+        echo Install with: winget install --id GitHub.cli 1>&2
+        exit /b 1
+    )
+)
+
+gh auth status >nul 2>&1
+if errorlevel 1 (
+    echo ERROR: GitHub CLI is not authenticated. 1>&2
+    echo Run: gh auth login 1>&2
+    exit /b 1
+)
+
+if "%DRY_RUN%"=="0" if "%ACTION%"=="install" (
+    net session >nul 2>&1
+    if !errorlevel! NEQ 0 (
+        echo ERROR: This script must be run from an elevated command prompt. 1>&2
+        echo        Right-click cmd.exe and choose "Run as administrator", 1>&2
+        echo        then re-run from this directory. 1>&2
+        exit /b 1
+    )
+)
+
+if not exist "%VERSIONS_JSON%" (
+    echo ERROR: versions.json not found at %VERSIONS_JSON% 1>&2
+    exit /b 1
+)
+
+REM --- Uninstall path ---
+if "%ACTION%"=="uninstall" goto :do_uninstall
+
+REM --- Read pins from versions.json ---
+call :read_pin runtime RUNTIME_TAG
+call :read_pin shell SHELL_TAG
+call :read_pin leia_plugin LEIA_TAG
+call :read_pin mcp_tools MCP_TAG
+
+REM --- Staging dir ---
+set "STAGING=%TEMP%\dxr-setup-%RANDOM%%RANDOM%"
+if "%DRY_RUN%"=="0" mkdir "%STAGING%" 2>nul
+
+REM --- Per-component install loop (runtime, shell, leia always; mcp opt-in) ---
+call :install_component runtime "%RUNTIME_TAG%"
+call :install_component shell "%SHELL_TAG%"
+call :install_component leia_plugin "%LEIA_TAG%"
+if "%WITH_MCP%"=="1" call :install_component mcp_tools "%MCP_TAG%"
+
+REM --- --with-demos ---
+if "%WITH_DEMOS%"=="1" call :clone_demos
+
+REM --- Smoke verification ---
+if "%DRY_RUN%"=="0" if "%EXITCODE%"=="0" (
+    echo.
+    echo ==^> Smoke verification
+    reg query "HKLM\Software\DisplayXR\Runtime" /v InstallPath >nul 2>&1
+    if !errorlevel! NEQ 0 (
+        echo WARN: HKLM\Software\DisplayXR\Runtime\InstallPath missing. 1>&2
+        echo       ^(Only meaningful if the runtime install actually ran.^) 1>&2
+    ) else (
+        echo  OK  Runtime registered.
+        reg query "HKLM\Software\Khronos\OpenXR\1" /v ActiveRuntime >nul 2>&1
+        if !errorlevel! NEQ 0 (
+            echo WARN: HKLM\Software\Khronos\OpenXR\1\ActiveRuntime missing. 1>&2
+        ) else (
+            echo  OK  Active OpenXR runtime registered.
+            echo.
+            echo  OK  DisplayXR dev box is ready.
+        )
+    )
+)
+
+REM --- Cleanup ---
+if "%DRY_RUN%"=="0" if exist "%STAGING%" rmdir /s /q "%STAGING%"
+
+exit /b %EXITCODE%
+
+REM ============================================================================
+REM Subroutines
+REM ============================================================================
+
+:show_help
+echo DisplayXR dev orchestrator ^(#283, Windows^)
+echo.
+echo Usage: scripts\setup-displayxr.bat [flags]
+echo.
+echo   --with mcp        Also install DisplayXR MCP Tools.
+echo   --with-demos      Clone each DisplayXR/displayxr-demo-* repo into
+echo                     .\demos\^<name^>\ ^(does not build them; see each
+echo                     demo's README for build steps^).
+echo   --dry-run         Print everything that would be downloaded and
+echo                     installed; perform no privileged operations.
+echo   --uninstall       Silent-uninstall every DisplayXR-published component
+echo                     ^(scans HKLM\...\Uninstall\* for Publisher=DisplayXR^).
+echo   -h, --help        Show this message.
+echo.
+echo Pins live in versions.json. Bump that file to upgrade the dev box.
+echo.
+echo Must run from an ELEVATED command prompt. The NSIS installers all
+echo write to HKLM and Program Files.
+exit /b 0
+
+:usage
+echo Usage: scripts\setup-displayxr.bat [--with mcp] [--with-demos] [--dry-run] [--uninstall] [-h^|--help]
+exit /b 0
+
+REM Read a pinned tag from versions.json into the named env var.
+REM   call :read_pin <key> <var-name>
+REM Nested keys use dot notation, e.g. "demos.gaussiansplat".
+:read_pin
+set "_RP_KEY=%~1"
+set "_RP_VAR=%~2"
+for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "$d=Get-Content -Raw '%VERSIONS_JSON%' ^| ConvertFrom-Json; $v=$d; foreach ($p in '%_RP_KEY%'.Split('.')) { $v = $v.$p }; Write-Output $v"`) do set "%_RP_VAR%=%%i"
+if not defined %_RP_VAR% (
+    echo ERROR: versions.json has no pin for '%_RP_KEY%' 1>&2
+    set "EXITCODE=1"
+)
+exit /b 0
+
+REM Install one component.
+REM   call :install_component <name> <tag>
+:install_component
+set "_IC_NAME=%~1"
+set "_IC_TAG=%~2"
+call set "_IC_REPO=%%COMPONENT_REPO_%_IC_NAME%%%"
+call set "_IC_GLOB=%%COMPONENT_EXE_%_IC_NAME%%%"
+call set "_IC_MARKER=%%COMPONENT_MARKER_%_IC_NAME%%%"
+
+if "%_IC_TAG%"=="" (
+    echo WARN: skipping %_IC_NAME% — no pin in versions.json 1>&2
+    exit /b 0
+)
+
+echo.
+echo ==^> %_IC_NAME% @ %_IC_TAG%  ^(repo: %_IC_REPO%^)
+
+if "%_IC_GLOB%"=="" (
+    echo WARN: %_IC_NAME%: no Windows asset is published for this component today. 1>&2
+    echo       Skipping. 1>&2
+    exit /b 0
+)
+
+REM Validate the pin exists in the source repo's releases.
+gh release view "%_IC_TAG%" --repo "%_IC_REPO%" >nul 2>&1
+if errorlevel 1 (
+    echo ERROR: versions.json pins %_IC_NAME% to '%_IC_TAG%', but 1>&2
+    echo   gh release view %_IC_TAG% --repo %_IC_REPO% 1>&2
+    echo failed. Bump the pin in versions.json, or verify the repo is accessible. 1>&2
+    set "EXITCODE=1"
+    exit /b 1
+)
+
+REM Confirm the Windows asset is attached.
+set "_IC_FOUND="
+for /f "usebackq delims=" %%i in (`gh release view "%_IC_TAG%" --repo "%_IC_REPO%" --json assets --jq ".assets[].name"`) do (
+    echo %%i | findstr /r /c:"^DisplayXR.*\.exe$" >nul
+    if !errorlevel! EQU 0 set "_IC_FOUND=1"
+)
+if not defined _IC_FOUND (
+    echo WARN: %_IC_NAME% @ %_IC_TAG%: no Windows .exe asset attached to this release. 1>&2
+    echo       Pin a newer tag in versions.json once one is available. 1>&2
+    exit /b 0
+)
+
+REM Download into staging.
+set "_IC_SUBDIR=%STAGING%\%_IC_NAME%"
+if "%DRY_RUN%"=="0" (
+    mkdir "%_IC_SUBDIR%" 2>nul
+    gh release download "%_IC_TAG%" --repo "%_IC_REPO%" --pattern "%_IC_GLOB%" --dir "%_IC_SUBDIR%"
+    if !errorlevel! NEQ 0 (
+        echo ERROR: %_IC_NAME%: gh release download failed 1>&2
+        set "EXITCODE=1"
+        exit /b 1
+    )
+)
+
+REM Find the .exe (NSIS installer's filename includes the build number).
+set "_IC_EXE="
+if "%DRY_RUN%"=="0" (
+    for %%f in ("%_IC_SUBDIR%\*.exe") do set "_IC_EXE=%%f"
+    if not defined _IC_EXE (
+        echo ERROR: %_IC_NAME%: download succeeded but no .exe landed in %_IC_SUBDIR% 1>&2
+        set "EXITCODE=1"
+        exit /b 1
+    )
+) else (
+    set "_IC_EXE=%_IC_SUBDIR%\%_IC_GLOB%"
+)
+
+if "%DRY_RUN%"=="1" (
+    echo   ^(dry-run^) would run: "%_IC_EXE%" /S
+    exit /b 0
+)
+
+echo ==^> Installing %_IC_EXE%
+start /wait "" "%_IC_EXE%" /S
+if errorlevel 1 (
+    echo ERROR: %_IC_NAME%: installer returned non-zero exit code 1>&2
+    set "EXITCODE=1"
+    exit /b 1
+)
+
+REM Post-install marker check.
+if not "%_IC_MARKER%"=="" (
+    reg query "%_IC_MARKER%" >nul 2>&1
+    if !errorlevel! NEQ 0 (
+        echo ERROR: %_IC_NAME%: post-install registry marker missing: %_IC_MARKER% 1>&2
+        echo       Installer ran but did not register itself. 1>&2
+        set "EXITCODE=1"
+        exit /b 1
+    )
+)
+
+echo  OK  %_IC_NAME% installed.
+exit /b 0
+
+REM Discover and clone all DisplayXR/displayxr-demo-* repos into demos\<name>\.
+:clone_demos
+echo.
+echo ==^> Discovering DisplayXR demo repos...
+set "DEMOS_DIR=%REPO_ROOT%\demos"
+if "%DRY_RUN%"=="0" mkdir "%DEMOS_DIR%" 2>nul
+for /f "usebackq delims=" %%i in (`gh repo list DisplayXR --limit 50 --json name --jq ".[].name | select(startswith(\"displayxr-demo-\"))"`) do (
+    set "_CD_NAME=%%i"
+    set "_CD_TARGET=%DEMOS_DIR%\%%i"
+    if exist "!_CD_TARGET!\.git" (
+        echo   %%i already cloned at !_CD_TARGET! — skipping.
+    ) else (
+        if "%DRY_RUN%"=="1" (
+            echo   ^(dry-run^) would run: gh repo clone DisplayXR/%%i !_CD_TARGET!
+        ) else (
+            echo ==^> Cloning DisplayXR/%%i
+            gh repo clone "DisplayXR/%%i" "!_CD_TARGET!"
+            echo     See !_CD_TARGET!\README.md for build instructions.
+        )
+    )
+)
+exit /b 0
+
+REM Uninstall every DisplayXR-published component via the Apps & Features
+REM registry. Uses Publisher=DisplayXR as the discovery key (set by each
+REM component's NSIS installer); QuietUninstallString runs silently with /S.
+:do_uninstall
+echo ==^> Discovering installed DisplayXR components...
+if "%DRY_RUN%"=="1" (
+    powershell -NoProfile -Command "Get-ItemProperty 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*','HKLM:\Software\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*' -ErrorAction SilentlyContinue | Where-Object { $_.Publisher -eq 'DisplayXR' } | ForEach-Object { Write-Host ('  (dry-run) would uninstall: ' + $_.DisplayName + ' (' + $_.DisplayVersion + ')') }"
+    exit /b 0
+)
+powershell -NoProfile -Command "$comps = Get-ItemProperty 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*','HKLM:\Software\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*' -ErrorAction SilentlyContinue | Where-Object { $_.Publisher -eq 'DisplayXR' }; if (-not $comps) { Write-Host 'WARN: No DisplayXR-published components are installed.'; exit 0 }; foreach ($c in $comps) { Write-Host ('==> Uninstalling ' + $c.DisplayName + ' (' + $c.DisplayVersion + ')'); $u = if ($c.QuietUninstallString) { $c.QuietUninstallString } else { $c.UninstallString + ' /S' }; cmd /c $u; if ($LASTEXITCODE -ne 0) { Write-Host ('WARN: uninstaller for ' + $c.DisplayName + ' exited ' + $LASTEXITCODE) } else { Write-Host (' OK  ' + $c.DisplayName + ' uninstalled.') } }"
+if exist "%REPO_ROOT%\demos" (
+    echo WARN: %REPO_ROOT%\demos\ is present. Leaving it in place — remove 1>&2
+    echo       manually if intended ^(it may contain local changes^). 1>&2
+)
+exit /b 0

--- a/scripts/setup-displayxr.bat
+++ b/scripts/setup-displayxr.bat
@@ -94,7 +94,11 @@ if errorlevel 1 (
     exit /b 1
 )
 
-if "%DRY_RUN%"=="0" if "%ACTION%"=="install" (
+REM Elevation is required for both install (NSIS installers write HKLM +
+REM Program Files) and uninstall (the QuietUninstallString cmds remove
+REM the same). Skip the check only on --dry-run, which does no
+REM privileged work.
+if "%DRY_RUN%"=="0" (
     net session >nul 2>&1
     if !errorlevel! NEQ 0 (
         echo ERROR: This script must be run from an elevated command prompt. 1>&2

--- a/versions.json
+++ b/versions.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/displayxr-versions.json",
   "runtime":     "v1.4.0",
   "shell":       "v1.2.5",
-  "leia_plugin": "sr-sdk-v1.35.0.2011",
+  "leia_plugin": "v1.0.1",
   "mcp_tools":   "v0.3.1",
   "demos": {
     "gaussiansplat": "v1.3.1"

--- a/versions.json
+++ b/versions.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json.schemastore.org/displayxr-versions.json",
-  "runtime":     "v1.4.0",
+  "runtime":     "v1.4.1",
   "shell":       "v1.2.5",
-  "leia_plugin": "v1.0.1",
+  "leia_plugin": "v1.0.2",
   "mcp_tools":   "v0.3.1",
   "demos": {
     "gaussiansplat": "v1.3.1"


### PR DESCRIPTION
## Summary

Mirrors `scripts/setup-displayxr.sh` on Windows via `scripts/setup-displayxr.bat`. Same flag surface (`--with mcp`, `--with-demos`, `--dry-run`, `--uninstall`, `--help`), same warn-and-skip semantics when a pinned tag has no asset for the platform.

Default install set on Windows is **runtime + Shell + Leia plug-in** (all three have shipping `.exe` installers as of today). MCP Tools stays opt-in via `--with mcp`. macOS default remains runtime-only (Shell + Leia have no macOS port; Leia is Windows-only by design).

Closes the Windows half of #283.

## Pin bumps

| Component | From | To |
|---|---|---|
| `runtime` | `v1.4.0` | `v1.4.1` (first release with the macOS .pkg + the `DisplayXRSetup-1.4.1.929.exe` Windows installer) |
| `leia_plugin` | `sr-sdk-v1.35.0.2011` (CI build dependency, not a user installer) | `v1.0.2` (latest user-facing release: `DisplayXRLeiaSRSetup-1.0.2.12.exe`) |

`displayxr-leia-plugin` v1.0.0 (2026-05-22) was the first user-facing Leia plug-in release; v1.0.2 (2026-05-23) is the latest. All ship `DisplayXRLeiaSRSetup-*.exe`.

## Files

- **`scripts/setup-displayxr.bat`** (new, ~340 lines) — Windows orchestrator. PowerShell shell-out for `versions.json` parsing; `gh release download` + `start /wait "" "installer.exe" /S` per component; registry-key verification (`HKLM\Software\DisplayXR\...`).
- **`scripts/lib/components.sh`** — gains `COMPONENT_INSTALL_MARKER_WINDOWS_*` (registry key paths) parallel to existing `MACOS` markers. The `.bat` mirrors the table inline at its top because batch can't source bash; a header note in `components.sh` flags this.
- **`versions.json`** — pinned at runtime `v1.4.1`, leia_plugin `v1.0.2`.
- **`README.md`** — "Quick Start" now leads with parallel macOS + Windows one-liners. The manual 4-installer flow is demoted to a "Manual install" subsection below, restructured as a per-component / per-platform table that also covers the Leia plug-in (which the prior "3 installers" listing omitted).
- **`docs/getting-started/full-stack-install.md`** — extends to cover both platforms: per-OS prereqs, per-OS verification, per-OS uninstall flow, and flips every "Windows today" cell in the availability matrix.

## Platform availability matrix (post-PR)

| Component   | macOS                              | Windows                                |
|-------------|------------------------------------|----------------------------------------|
| runtime     | yes (`DisplayXR-Installer-*.pkg`)  | yes (`DisplayXRSetup-*.exe`)           |
| shell       | — (macOS port deferred, M6)        | yes (`DisplayXRShellSetup-*.exe`)      |
| leia_plugin | — (vendor SDK is Windows-only)     | yes (`DisplayXRLeiaSRSetup-*.exe`)     |
| mcp_tools   | — (future)                         | yes (`DisplayXRMCPSetup-*.exe`)        |

## Windows uninstall design

`--uninstall` scans `HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\*` (plus the WOW6432Node mirror) for entries with `Publisher=DisplayXR` **or DisplayName prefixed `DisplayXR ` (catches Leia plug-in, which sets Publisher='Leia Inc.')**, then runs each one's `QuietUninstallString` (falling back to `UninstallString /S`). One pass covers runtime, Shell, Leia plug-in, and MCP Tools regardless of exact registry subkey names or publisher field.

## Bugs surfaced during E2E test (fixed in this PR)

Running the script against the real v1.4.1 / v1.2.5 / v1.0.2 / v0.3.1 stack — i.e. an actual repo path with spaces + the real release asset list — surfaced four pitfalls the prior cmd-correctness review couldn't have caught. Full transcripts in [comment #4525971499](https://github.com/DisplayXR/displayxr-runtime/pull/291#issuecomment-4525971499). One-line summaries:

1. **`read_pin`**: `Get-Content -Raw 'PATH WITH SPACES' | ConvertFrom-Json` inside `for /f usebackq` breaks PowerShell parsing. Switched to function-call form.
2. **asset-attached check**: `echo X | findstr ...$` injects a trailing space, breaking the `$` anchor. Switched to a `:~-4` substring check.
3. **uninstall filter**: `Publisher -eq 'DisplayXR'` misses the Leia plug-in. Also match `DisplayName -like 'DisplayXR *'`.
4. **elevation preflight**: was gated on `ACTION=install` only; `--uninstall` runs `QuietUninstallString` commands that hit HKLM + Program Files too. Gate now fires for both real install and real uninstall, still no-ops on `--dry-run`.

## Cross-repo

- **`DisplayXR/displayxr-mcp#3`** — the MCP installer's uninstaller left an empty `Capabilities` parent key behind, preventing the runtime uninstaller's existing `DeleteRegKey /ifempty HKLM "Software\DisplayXR"` cleanup. PR adds `DeleteRegKey /ifempty` on the parent keys. Lands separately on the next MCP release; cosmetic until then (`reg query HKLM\Software\DisplayXR` returns success-with-empty-subkey instead of "key not found" — every functional registry trace is gone).

## Test plan

- [x] **bash side unbroken** — `./scripts/setup-displayxr.sh --dry-run` still shows runtime download cleanly.
- [x] `python3 -m json.tool versions.json` clean.
- [x] `bash -n` clean on `.sh` and `components.sh`.
- [x] All goto / call targets in `.bat` resolve to defined labels.
- [x] All `if errorlevel` checks inside parenthesized blocks use `!errorlevel!` (delayed expansion).
- [x] **E2E install verification on Windows** — ran all five steps (dry-runs, elevated install, registry / dir / log verification, `--with mcp`, full `--uninstall` round-trip → reinstall). Surfaced + fixed the four bugs above. Transcript: [comment #4525971499](https://github.com/DisplayXR/displayxr-runtime/pull/291#issuecomment-4525971499).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
