### PR TITLE
ci(#290): attach release artifacts from workflows; trim /release skill

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -38,13 +38,20 @@ version-spec:
   ├─ Pre-flight (clean tree, on main, tag not taken)
   ├─ Bump CMakeLists.txt VERSION
   ├─ Commit "Release vX.Y.Z" → push main → tag → push tag
-  ├─ Monitor build-windows.yml run for this commit
-  ├─ Download installer artifact from the build run
-  ├─ gh release create with the installer attached + grouped notes
+  │
+  │  (CI takes over here — both workflows attach their own artifacts
+  │   to the v* tag's release via softprops/action-gh-release@v2;
+  │   first job to complete creates the release, others append.)
+  │
+  ├─ Monitor build-windows.yml + build-macos.yml for this commit
+  ├─ gh release edit --title --notes (curated Highlights paragraph
+  │   layered on top of the empty body the action created)
   └─ Report
 ```
 
-CMakeLists.txt VERSION is always bumped to the new semver.
+CMakeLists.txt VERSION is always bumped to the new semver. The skill
+no longer downloads or re-uploads any artifacts — that moved into the
+workflows themselves per #290.
 
 ## CRITICAL: Launch Subagent
 
@@ -159,95 +166,65 @@ Windows CI can take up to 30 min with test apps; macOS is faster (~10-15 min inc
 
 ### Step 3.4: Check both results
 - Both runs all-required-jobs succeed → Phase 4
-- Critical Windows job (`Runtime`, `Build`) fails OR macOS `Build` / `BuildInstaller` fails → Phase 6 (Rollback)
+- Critical Windows job (`Runtime`, `Build`) fails AND macOS `Build` / `BuildInstaller` also fails → Phase 6 (Rollback) — no release was created
 - Pre-existing-broken jobs (e.g. demo jobs that reference paths moved to standalone repos) fail but the artifact-producing job still succeeded → continue to Phase 4 with a flag in the final report
-- macOS `BuildInstaller` infrastructure-fails (e.g. brew flake) but Windows is green and the run is rerunnable → STOP and ask the user whether to rerun macOS or release Windows-only (latter is degraded; flag clearly)
+- One side fails but the other succeeded → the release exists (the green side's `softprops/action-gh-release` step ran) but is missing assets. STOP and ask the user whether to rerun the failed workflow or ship degraded; flag clearly. The release tag can be left in place while the rerun happens.
 
 ---
 
-## PHASE 4: CREATE GITHUB RELEASE
+## PHASE 4: WRITE CURATED RELEASE NOTES
 
-The build runs produce three artifacts the release should attach:
-- **Windows installer** — `DisplayXR-Installer` artifact from the Windows run (contains `DisplayXRSetup-X.Y.Z.BUILD.exe`).
-- **macOS installer** — `DisplayXR-Installer-macOS` artifact from the macOS run (contains `DisplayXR-Installer.pkg`). Post-#277.
-- **Test apps bundle** — `TestApps-<run_number>` artifact from the Windows run (~17 MB folder containing all cube test apps). Forced on every tag push by the `DetectChanges` job (`ref_type == 'tag'`). Builders, OEM integrators, and field testers use this to validate the runtime against the public extension contracts without rebuilding from source.
+Since the CI workflows now attach artifacts to the release directly via
+`softprops/action-gh-release@v2` (per #290), the release exists by the
+time CI completes and already has the Windows installer, macOS .pkg,
+and test-apps zip attached. The skill's job is now just to write the
+curated Highlights paragraph on top of the auto-created (empty-body)
+release.
 
-Check whether the release already exists:
-
+### Step 4.1: Confirm the release exists
 ```bash
-gh release view [FULL_TAG] --repo DisplayXR/displayxr-runtime 2>/dev/null
+gh release view [FULL_TAG] --repo DisplayXR/displayxr-runtime --json tagName,assets --jq '{tag: .tagName, assets: [.assets[].name]}'
 ```
+If the release does NOT exist at this point, both CI workflows
+catastrophically failed before reaching their attach steps. Go to
+Phase 6.
 
-### Step 4.1: Download artifacts (always runs)
-Regardless of whether the release exists, download all artifacts from both runs so we can verify or attach them:
-
-```bash
-# Windows: DisplayXR* matches DisplayXR-Installer + DisplayXR (folder bundle)
-gh run download $WIN_RUN_ID --repo DisplayXR/displayxr-runtime --pattern "DisplayXR*" --dir _release_assets/
-
-# Windows: TestApps-* is a separate pattern (doesn't match DisplayXR*)
-gh run download $WIN_RUN_ID --repo DisplayXR/displayxr-runtime --pattern "TestApps-*" --dir _release_assets/
-
-# macOS: DisplayXR-Installer-macOS contains DisplayXR-Installer.pkg (post-#277)
-gh run download $MAC_RUN_ID --repo DisplayXR/displayxr-runtime --pattern "DisplayXR-Installer-macOS" --dir _release_assets/
-
-INSTALLER=$(find _release_assets/ -name "DisplayXRSetup-*.exe" | head -1)
-[ -z "$INSTALLER" ] && STOP: "Could not find DisplayXRSetup-*.exe in Windows build artifacts."
-
-PKG_INSTALLER=$(find _release_assets/ -name "DisplayXR-Installer.pkg" | head -1)
-if [ -z "$PKG_INSTALLER" ]; then
-  echo "WARN: no DisplayXR-Installer.pkg in macOS run — macOS install asset will not be attached."
-  echo "Check macOS BuildInstaller job logs. Don't STOP — Windows release still ships."
-fi
-# Rename the .pkg to include the version so the asset filename matches the convention
-# (DisplayXR-Installer-X.Y.Z.pkg, parallel to DisplayXRSetup-X.Y.Z.BUILD.exe).
-if [ -n "$PKG_INSTALLER" ]; then
-  VERSIONED_PKG="_release_assets/DisplayXR-Installer-[VERSION].pkg"  # [VERSION] without leading v
-  cp "$PKG_INSTALLER" "$VERSIONED_PKG"
-  PKG_INSTALLER="$VERSIONED_PKG"
-fi
-
-# Zip the TestApps folder into a single asset. Pattern: DisplayXR-TestApps-<version>.zip.
-TESTAPPS_DIR=$(find _release_assets/ -maxdepth 2 -type d -name "TestApps-*" | head -1)
-TESTAPPS_ZIP=""
-if [ -n "$TESTAPPS_DIR" ]; then
-  TESTAPPS_ZIP="_release_assets/DisplayXR-TestApps-[VERSION].zip"  # [VERSION] without leading v
-  (cd "$TESTAPPS_DIR" && zip -rq "../../$TESTAPPS_ZIP" .)
-  ls -lh "$TESTAPPS_ZIP"
-else
-  echo "WARN: no TestApps-* artifact in run — test apps will not be attached. Check DetectChanges output."
-fi
-```
-
-The TestApps bundle and the macOS .pkg are both **soft requirements**: log a warning if missing and continue with the assets that are available. Only the Windows installer is hard-required (its absence STOPs the release).
-
-### Step 4.2a: If release already exists
-The workflow auto-created it (rare path — currently neither `build-windows.yml` nor `build-macos.yml` auto-creates a release, so this branch is unusual). Upload any missing assets:
+### Step 4.2: Generate + write release notes
+Group commits from `git log $PREV_TAG..[FULL_TAG] --oneline --no-merges`
+by prefix (see "Notes template" below). Write a 1-3 line Highlights
+paragraph at the top describing what's notable for users.
 
 ```bash
-gh release upload [FULL_TAG] --repo DisplayXR/displayxr-runtime --clobber \
-  "$INSTALLER" \
-  ${PKG_INSTALLER:+"$PKG_INSTALLER"} \
-  ${TESTAPPS_ZIP:+"$TESTAPPS_ZIP"}
-```
-Then go to Phase 5.
+NOTES=$(cat <<'NOTES_EOF'
+## Highlights
+<manually written 1-3 line summary>
 
-### Step 4.2b: If release does NOT exist
-Create it with all available assets:
+## Features
+<auto-grouped feat: commits>
 
-```bash
-# Generate release notes
-NOTES=$(git log "$PREV_TAG".."[FULL_TAG]" --oneline --no-merges)
-# Group commits by prefix (Feature, Fix, CI, Docs, etc.) — see PHASE 5 notes template
+## Fixes
+<auto-grouped fix: commits>
 
-gh release create [FULL_TAG] \
+## Docs
+<auto-grouped docs: commits>
+
+## CI / Build
+<auto-grouped ci: / build: / cmake: commits>
+
+## Other
+<everything else>
+NOTES_EOF
+)
+
+gh release edit [FULL_TAG] \
   --repo DisplayXR/displayxr-runtime \
   --title "DisplayXR Runtime [FULL_TAG]" \
-  --notes "<grouped notes here>" \
-  "$INSTALLER" \
-  ${PKG_INSTALLER:+"$PKG_INSTALLER"} \
-  ${TESTAPPS_ZIP:+"$TESTAPPS_ZIP"}
+  --notes "$NOTES"
 ```
+
+`gh release edit --notes` overwrites whatever body the action created
+(`softprops/action-gh-release@v2` with no `body`/`body_path` defaults
+to an empty body, so there's nothing to merge — just overwrite).
 
 ---
 
@@ -260,15 +237,12 @@ gh release view [FULL_TAG] --repo DisplayXR/displayxr-runtime --json tagName,nam
 Verify:
 - Tag matches [FULL_TAG]
 - Asset list contains `DisplayXRSetup-*.exe` with non-zero size (Windows installer, hard requirement)
-- Asset list contains `DisplayXR-Installer-*.pkg` with non-zero size (macOS installer, post-#277; warn but don't fail if the macOS run skipped it — flag in final report so the user can investigate)
-- Asset list contains `DisplayXR-TestApps-*.zip` with non-zero size (warn but don't fail if `DetectChanges` skipped the test-app build — flag in final report so the user can investigate)
+- Asset list contains `DisplayXR-Installer-*.pkg` with non-zero size (macOS installer; warn but don't fail if the macOS run skipped it — flag in final report)
+- Asset list contains `DisplayXR-TestApps-*.zip` with non-zero size (warn but don't fail if the BundleTestApps job skipped it — flag in final report)
+- Title is `DisplayXR Runtime [FULL_TAG]`
+- Body starts with `## Highlights`
 
-### Step 5.1: Cleanup staging dir
-Only after the verification above passes. If verification fails, leave the dir for inspection.
-```bash
-rm -rf _release_assets/
-```
-Phase 4.2a always downloads into this dir before any upload, so the `rm -rf` is always meaningful — safe to run unconditionally.
+No local staging dir to clean up — the CI does all artifact handling.
 
 ### Notes template
 Group commits from `git log $PREV_TAG..[FULL_TAG] --oneline --no-merges` by prefix:

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -31,6 +31,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+# `contents: write` is required for softprops/action-gh-release to
+# create-or-update the GitHub Release for v* tag pushes (#290).
+permissions:
+  contents: write
+
 jobs:
   DetectChanges:
     runs-on: ubuntu-latest
@@ -200,3 +205,17 @@ jobs:
           # post-PR #279 (versioned filename, parallel to Windows'
           # DisplayXRSetup-X.Y.Z.NNN.exe).
           path: _package/DisplayXR-Installer-*.pkg
+
+      # Attach the .pkg to the v* GitHub release (#290). The action
+      # create-or-updates the release: first workflow to complete on
+      # the tag creates it; subsequent ones append their artifacts. The
+      # filename is already versioned (DisplayXR-Installer-X.Y.Z.pkg)
+      # per PR #279.
+      - name: Attach macOS installer to GitHub release on tag
+        if: needs.DetectChanges.outputs.docs_only != 'true' && startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: _package/DisplayXR-Installer-*.pkg
+          fail_on_unmatched_files: true
+          draft: false
+          prerelease: false

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -220,6 +220,20 @@ jobs:
           if-no-files-found: error
           path: _package/DisplayXRSetup-*.exe
 
+      # Attach the Windows installer to the v* GitHub release (#290).
+      # First workflow to complete on the tag creates the release;
+      # subsequent ones (macOS BuildInstaller, BundleTestApps) append
+      # their artifacts. Filename is DisplayXRSetup-X.Y.Z.BUILD.exe
+      # from the NSI's OutFile.
+      - name: Attach Windows installer to GitHub release on tag
+        if: needs.DetectChanges.outputs.docs_only != 'true' && startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: _package/DisplayXRSetup-*.exe
+          fail_on_unmatched_files: true
+          draft: false
+          prerelease: false
+
       # OneDrive upload uses RCLONE_CONFIG, which is null on fork PRs. Skip
       # the whole rclone group on forks; the artifact-upload steps above
       # already give reviewers the installer.
@@ -1041,3 +1055,25 @@ jobs:
           echo "Uploading TestApps-${{ github.run_number }}.zip to OneDrive: $destPath"
           rclone copy TestApps-${{ github.run_number }}.zip "onedrive:$destPath" --progress
           echo "Upload complete!"
+
+      # Versioned re-zip for the v* GitHub release (#290). Asset name
+      # mirrors the convention from the /release skill — DisplayXR-
+      # TestApps-X.Y.Z.zip — so older skill-cut releases and CI-cut
+      # releases use identical naming.
+      - name: Zip test apps for release (versioned)
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          cd TestApps
+          zip -r "../DisplayXR-TestApps-${VERSION}.zip" .
+          cd ..
+          ls -lh "DisplayXR-TestApps-${VERSION}.zip"
+
+      - name: Attach test apps bundle to GitHub release on tag
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: DisplayXR-TestApps-*.zip
+          fail_on_unmatched_files: true
+          draft: false
+          prerelease: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -333,7 +333,7 @@ Creates a tagged runtime release here, monitors `build-windows.yml` + `build-mac
 /release minor
 /release major
 ```
-Updates `CMakeLists.txt` `VERSION`, creates the tag, watches Windows + macOS CI concurrently (wall time = `max(Windows, macOS)`), downloads each platform's installer artifact, creates the GitHub Release with grouped notes. macOS .pkg is a soft requirement — its absence warns but doesn't STOP the release. Only releases this repo — shell, demos, extensions each have their own flows (see "Releasing the Runtime" above).
+Updates `CMakeLists.txt` `VERSION`, creates the tag, watches Windows + macOS CI concurrently (wall time = `max(Windows, macOS)`). The CI workflows themselves attach the artifacts to the GitHub Release on `v*` tag push via `softprops/action-gh-release@v2` (post-#290); the skill writes curated release notes on top via `gh release edit --notes`. macOS .pkg is a soft requirement — its absence warns but doesn't STOP the release. Only releases this repo — shell, demos, extensions each have their own flows (see "Releasing the Runtime" above).
 
 ### /ask-gemini - Code Analysis with Gemini
 Ask Gemini to analyze code and produce a read-only report. See `~/.claude/skills/ask-gemini/SKILL.md`.


### PR DESCRIPTION
## Summary

Migrates release artifact attachment from the local `/release` skill to the CI workflows themselves. The skill no longer downloads + re-uploads the Windows installer / macOS .pkg / test-apps zip — each workflow attaches its own artifact directly to the v* tag's GitHub Release via `softprops/action-gh-release@v2`.

Closes #290.

## What changes

### `build-windows.yml`

- **`Runtime` job:** new \"Attach Windows installer to GitHub release on tag\" step right after the existing `Upload installer` step. Attaches `_package/DisplayXRSetup-*.exe` (NSI's `OutFile` already produces a versioned filename — `DisplayXRSetup-X.Y.Z.BUILD.exe`).
- **`BundleTestApps` job:** new \"Zip test apps for release (versioned)\" step parses `VERSION` from `GITHUB_REF_NAME` and re-zips `TestApps/` into `DisplayXR-TestApps-${VERSION}.zip`, then \"Attach test apps bundle to GitHub release on tag\" attaches it. Asset naming matches the convention the skill used historically — release pages stay visually consistent across the old and new flow. The pre-existing `TestApps-${run_number}.zip` used for OneDrive upload is untouched.

### `build-macos.yml`

- New top-level `permissions: contents: write` block (previously had no `permissions:` line, defaulting to read-only — `softprops/action-gh-release` would have failed to create or update the release without this).
- **`BuildInstaller` job:** new \"Attach macOS installer to GitHub release on tag\" step right after `Upload installer`. Attaches `_package/DisplayXR-Installer-*.pkg` — filename already includes the version per PR #279.

All three attach steps are gated on `startsWith(github.ref, 'refs/tags/v') && docs_only != 'true'`. First workflow to complete creates the release as a side effect of `softprops/action-gh-release` finding no release yet at that tag; subsequent workflows' attach steps append to the existing release.

### `.claude/skills/release/SKILL.md`

- **Architecture diagram** updated — CI handles artifact attachment.
- **Phase 4 rewritten** — was \"download artifacts + create release with assets\"; now \"confirm release exists (CI created it), \`gh release edit --notes\` to layer in the curated Highlights paragraph.\"
- **Phase 5 simplified** — no `_release_assets/` staging dir to clean up.
- **Phase 3.4 failure-handling refined** — the release tag may exist even on partial CI failure (one workflow's attach step ran while the other failed). Rollback rules become \"both fail → rollback; one fails → ask user to rerun the failed side.\"

Net SKILL.md diff: 136 lines reorganized → much shorter Phase 4.

### `CLAUDE.md`

- `/release` skill description updated to mention CI-native artifact attachment and the `gh release edit --notes` layer.

## Net change

```
 .claude/skills/release/SKILL.md     | 136 +++++++++++++++---------------------
 .github/workflows/build-macos.yml   |  19 +++++
 .github/workflows/build-windows.yml |  36 ++++++++++
 CLAUDE.md                           |   2 +-
 4 files changed, 111 insertions(+), 82 deletions(-)
```

## Test plan

**This PR's CI** runs the non-tag path (push to feature branch, pull_request event). The new attach steps are gated on \`startsWith(github.ref, 'refs/tags/v')\`, so they're inert on a PR. CI must still pass — the existing artifact-upload + dumpbin assertion steps run unchanged.

**Post-merge throwaway-tag test** (the actual validation):

1. \`git checkout main && git pull\`
2. \`git tag v999.0.0-test-release-flow\`
3. \`git push origin v999.0.0-test-release-flow\`
4. Watch both \`build-windows.yml\` + \`build-macos.yml\` tag-push runs
5. Verify release at https://github.com/DisplayXR/displayxr-runtime/releases/tag/v999.0.0-test-release-flow has all three assets:
   - \`DisplayXRSetup-999.0.0.<BUILD>.exe\`
   - \`DisplayXR-Installer-999.0.0.pkg\`
   - \`DisplayXR-TestApps-999.0.0.zip\`
6. \`gh release delete v999.0.0-test-release-flow --cleanup-tag --yes\` to clean up

If the test passes, the next real runtime release (v1.4.2 will be the first — bundling #286, #287, this PR) gets the new flow naturally. No further skill-side migration work needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)