### PR TITLE
fix(ci): expose GH_TOKEN to macOS BuildInstaller for release attach

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -111,6 +111,14 @@ jobs:
     # that ships in the .pkg.
     needs: [DetectChanges, Build]
     runs-on: macos-14
+    # GH_TOKEN exposes the workflow's GITHUB_TOKEN to the gh CLI AND to
+    # softprops/action-gh-release (which prefers $GH_TOKEN over the
+    # action's `token:` input when set). Without this, the action falls
+    # back to a token path that hits "Bad credentials" against the
+    # Releases API even with `permissions: contents: write` set at the
+    # workflow level. Mirrors the GH_TOKEN env set in build-windows.yml.
+    env:
+      GH_TOKEN: ${{ github.token }}
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Surfaced by the [v999.0.0-test-release-flow](https://github.com/DisplayXR/displayxr-runtime/releases/tag/v999.0.0-test-release-flow) throwaway-tag test for #290:

| Workflow | Attach step result |
|---|---|
| build-windows.yml (Runtime job) | ✅ success — `DisplayXRSetup-1.4.1.935.exe` + `DisplayXR-TestApps-*.zip` attached |
| build-macos.yml (BuildInstaller job) | ❌ failure — `HttpError: Bad credentials` |

Both have identical `permissions: contents: write` at workflow level and identical `softprops/action-gh-release@v2` invocations. The diff: Windows's `Runtime` job has `env: GH_TOKEN: ${{ github.token }}` (added long ago for `gh release download sr-sdk-...` in build steps), and `softprops/action-gh-release@v2` **prefers `$GH_TOKEN` from env** over its own default token path when set. macOS `BuildInstaller` had no `GH_TOKEN` env, so the action fell through to whatever path hits \"Bad credentials.\"

## Fix

Add `env: GH_TOKEN: ${{ github.token }}` at the `BuildInstaller` job level. One-line YAML change + a comment explaining why.

## Test plan

After merge, re-run a throwaway-tag test:

1. Delete the existing failed test artifact:
   ```
   gh release delete v999.0.0-test-release-flow --repo DisplayXR/displayxr-runtime --cleanup-tag --yes
   ```
2. Re-tag main + push:
   ```
   git tag v999.0.0-test-release-flow && git push origin v999.0.0-test-release-flow
   ```
3. Verify the release now has the macOS `.pkg` attached alongside the Windows installer + test-apps zip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)