### PR TITLE
chore(#283): bump runtime pin to v1.4.2

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/displayxr-versions.json",
-  "runtime":     "v1.4.1",
+  "runtime":     "v1.4.2",
   "shell":       "v1.2.5",
   "leia_plugin": "v1.0.2",
   "mcp_tools":   "v0.3.1",


### PR DESCRIPTION
## Summary
Bumps `versions.json` runtime pin from `v1.4.1` → `v1.4.2`.

v1.4.2 ships both `DisplayXRSetup-1.4.2.940.exe` and `DisplayXR-Installer-1.4.2.pkg` (verified via `gh release view`). No installer-behavior change between v1.4.1 and v1.4.2:
- 625713211 — `fix(ci): expose GH_TOKEN env to BuildInstaller for release attach` (CI plumbing only)
- 87c20443c — `Release v1.4.2` (version bump tag)

The orchestrator e2e transcripts on #291 stay valid against v1.4.2; the NSIS `/S` install path and registry layout are unchanged.

## Test plan
- [x] `gh release view v1.4.2 --repo DisplayXR/displayxr-runtime` confirms both `.exe` and `.pkg` assets attached.
- [ ] Re-run `scripts\setup-displayxr.bat --dry-run` post-merge — output should show `runtime @ v1.4.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)