### PR TITLE
chore(#298): bump displayxr-mcp pin to v0.3.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,7 +118,7 @@ find_package(cJSON MODULE)
 include(FetchContent)
 FetchContent_Declare(displayxr_mcp
     GIT_REPOSITORY https://github.com/DisplayXR/displayxr-mcp.git
-    GIT_TAG v0.3.1)
+    GIT_TAG v0.3.2)
 # Build the stdio↔socket adapter alongside the lib so the Phase A test
 # scripts under tests/mcp/ can find a binary at a known path during dev
 # (build/_deps/displayxr_mcp-build/displayxr-mcp). Production


### PR DESCRIPTION
## Summary

- Bumps `FetchContent_Declare(displayxr_mcp GIT_TAG)` from `v0.3.1` to `v0.3.2`.
- v0.3.2 picks up [DisplayXR/displayxr-mcp#5](https://github.com/DisplayXR/displayxr-mcp/pull/5) — `CancelIoEx` on the Windows pipe-close path so the MCP server thread parked in synchronous `ConnectNamedPipe` actually wakes up.

## Why

Issue #298 — Unity preview Stop hangs the editor: `xrDestroyInstance` calls `mcp_server_stop()` first, which calls `pthread_join` on a server thread that's parked in synchronous `ConnectNamedPipe` on a non-`OVERLAPPED` pipe. `CloseHandle` from another thread does NOT wake a synchronous `ConnectNamedPipe` on Windows, so `pthread_join` deadlocks forever.

Verified locally by toggling `HKLM\Software\DisplayXR\Capabilities\MCP\Enabled` between `0` and `1` — hang reproduces with `1`, clean with `0`. The MCP-side fix has been merged + tagged + released as v0.3.2.

## Follow-up

- Cut runtime v1.4.3 once this lands (`/release patch`).
- Bump `mcp_tools` + `runtime` in [`displayxr-installer/versions.json`](https://github.com/DisplayXR/displayxr-installer/blob/main/versions.json).
- Revert the Unity plugin's skip-`xrDestroyInstance`-on-Windows workaround (DisplayXR/displayxr-unity#118).

## Test plan

- [ ] Windows CI green
- [ ] macOS CI green (sentinel — no MCP transport changes on POSIX)
- [ ] Manual: with `Enabled=1` and a runtime built from this branch, Unity preview Start → Stop returns within ~1 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)