### PR TITLE
chore(#298): bump orchestrator pins to runtime v1.4.3 + mcp v0.3.2

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://json.schemastore.org/displayxr-versions.json",
-  "runtime":     "v1.4.2",
+  "runtime":     "v1.4.3",
   "shell":       "v1.2.5",
   "leia_plugin": "v1.0.2",
-  "mcp_tools":   "v0.3.1",
+  "mcp_tools":   "v0.3.2",
   "demos": {
     "gaussiansplat": "v1.3.1"
   }


### PR DESCRIPTION
## Summary

Bump the dev-orchestrator pins in `versions.json` (consumed by `scripts/setup-displayxr.{bat,sh}`):

- `runtime`: v1.4.2 → v1.4.3
- `mcp_tools`: v0.3.1 → v0.3.2

## Why

Aligns the orchestrator with [`displayxr-installer/versions.json@a992488`](https://github.com/DisplayXR/displayxr-installer/commit/a992488) so dev contributors running `setup-displayxr.bat` and end users running the meta-bundle land on the same component pins. Picks up the Windows `xrDestroyInstance` hang fix (#298).

## Test plan

- [ ] CI green (doc-only-like change; sentinel jobs should short-circuit).
- [ ] Manual: `scripts\setup-displayxr.bat --with mcp` on Windows installs the new pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)