### PR TITLE
feat(#311): register gauss_demo in component table

### DIFF
--- a/scripts/lib/components.sh
+++ b/scripts/lib/components.sh
@@ -58,6 +58,18 @@ COMPONENT_EXE_WINDOWS_mcp_tools="DisplayXRMCPSetup-*.exe"
 COMPONENT_INSTALL_MARKER_MACOS_mcp_tools=""
 COMPONENT_INSTALL_MARKER_WINDOWS_mcp_tools="HKLM\\Software\\DisplayXR\\Capabilities\\MCP"
 
+# --- gauss_demo ---
+# Gaussian-splat viewer demo. macOS .pkg first shipped in
+# displayxr-demo-gaussiansplat v1.4.0 (2026-05-24, #311). Windows installer
+# is built locally today; CI for the .exe is tracked at the demo repo's
+# issue #14. Note: the macOS install marker has a space in the path —
+# consumers must quote when testing existence.
+COMPONENT_REPO_gauss_demo="DisplayXR/displayxr-demo-gaussiansplat"
+COMPONENT_PKG_MACOS_gauss_demo="DisplayXRGaussianSplat-*.pkg"
+COMPONENT_EXE_WINDOWS_gauss_demo="DisplayXRGaussianSplatSetup-*.exe"
+COMPONENT_INSTALL_MARKER_MACOS_gauss_demo="/Applications/Gaussian Splat Viewer.app"
+COMPONENT_INSTALL_MARKER_WINDOWS_gauss_demo="HKLM\\Software\\DisplayXR\\Demos\\GaussianSplat"
+
 # Helper: look up a per-component field for the current platform.
 #   $1 = component name (runtime, shell, leia_plugin, mcp_tools)
 #   $2 = field (REPO, PKG_MACOS, EXE_WINDOWS, INSTALL_MARKER_MACOS)

--- a/scripts/setup-displayxr.bat
+++ b/scripts/setup-displayxr.bat
@@ -46,6 +46,10 @@ set "COMPONENT_REPO_mcp_tools=DisplayXR/displayxr-mcp"
 set "COMPONENT_EXE_mcp_tools=DisplayXRMCPSetup-*.exe"
 set "COMPONENT_MARKER_mcp_tools=HKLM\Software\DisplayXR\Capabilities\MCP"
 
+set "COMPONENT_REPO_gauss_demo=DisplayXR/displayxr-demo-gaussiansplat"
+set "COMPONENT_EXE_gauss_demo=DisplayXRGaussianSplatSetup-*.exe"
+set "COMPONENT_MARKER_gauss_demo=HKLM\Software\DisplayXR\Demos\GaussianSplat"
+
 REM --- Default flag state ---
 set "WITH_MCP=0"
 set "WITH_DEMOS=0"


### PR DESCRIPTION
## Summary

- Adds the `gauss_demo` 5-var block to `scripts/lib/components.sh` (REPO, PKG_MACOS, EXE_WINDOWS, INSTALL_MARKER_MACOS, INSTALL_MARKER_WINDOWS) — mirrors the existing entries for runtime / shell / leia_plugin / mcp_tools.
- Mirrors the same data in `scripts/setup-displayxr.bat` (3 vars only; the .bat is Windows-only so it doesn't carry PKG_MACOS / INSTALL_MARKER_MACOS).
- No changes to the install loops in `setup-displayxr.{sh,bat}` — adding the demo to that loop is a separate decision (it's a demo, not a core component). This PR just makes the data available.

Closes the follow-up part of [#311](https://github.com/DisplayXR/displayxr-runtime/issues/311).

## Why

The meta-installer bundle ([`DisplayXR/displayxr-installer`](https://github.com/DisplayXR/displayxr-installer), [#284](https://github.com/DisplayXR/displayxr-runtime/issues/284)) sources this table for the per-component repo + asset-glob + install-marker triple it needs at bundle-build time. Until this entry exists, the bundle can't reach `displayxr-demo-gaussiansplat`'s releases even though the macOS `.pkg` is now published (v1.4.0, 2026-05-24).

## Values

- `COMPONENT_REPO_gauss_demo` = `DisplayXR/displayxr-demo-gaussiansplat`
- `COMPONENT_PKG_MACOS_gauss_demo` = `DisplayXRGaussianSplat-*.pkg` (first published in [v1.4.0](https://github.com/DisplayXR/displayxr-demo-gaussiansplat/releases/tag/v1.4.0))
- `COMPONENT_EXE_WINDOWS_gauss_demo` = `DisplayXRGaussianSplatSetup-*.exe` (still built locally today; CI tracked at [demo repo #14](https://github.com/DisplayXR/displayxr-demo-gaussiansplat/issues/14))
- `COMPONENT_INSTALL_MARKER_MACOS_gauss_demo` = `/Applications/Gaussian Splat Viewer.app` — path has a space; consumers must quote when testing existence (which they already do — `setup-displayxr.sh` line 233 reads `[ ! -e \"\$marker\" ]`).
- `COMPONENT_INSTALL_MARKER_WINDOWS_gauss_demo` = `HKLM\\Software\\DisplayXR\\Demos\\GaussianSplat` (matches the NSI's `InstallDirRegKey`).

## Out of scope

- `versions.json` not bumped — the existing pin (`demos.gaussiansplat = v1.3.1`) is the nested-under-demos shape that `setup-displayxr.sh --with-demos` uses for the source-clone path. Whether to lift `gauss_demo` to a top-level pin is a separate call once the meta-installer's bundle script is wired to consume it.
- `setup-displayxr.{sh,bat}` install loop unchanged — demos are opt-in via `--with-demos` (clone), not via the per-component install loop.
- No changes in `displayxr-installer` — bundle-script wiring (the `process_component gauss_demo` call) lives there and is a separate PR.

## Test plan

- [x] `grep gauss_demo scripts/lib/components.sh scripts/setup-displayxr.bat` — entries present in both, structurally parallel to existing components.
- [x] `bash -n scripts/lib/components.sh` — syntax check clean.
- [x] `bash -c 'source scripts/lib/components.sh && component_field gauss_demo PKG_MACOS'` — returns `DisplayXRGaussianSplat-*.pkg`.
- [ ] Smoke: in `displayxr-installer`, point `versions.json.gauss_demo` at `v1.4.0`, add `process_component gauss_demo` to `build-bundle.sh`, rebuild the bundle — verify the demo `.pkg` downloads and gets stitched into Distribution.xml (manual follow-up).