### PR TITLE
feat(#302): add FULLSCREEN_TOGGLED workspace input event (spec_version 15)

### DIFF
--- a/src/external/openxr_includes/openxr/XR_EXT_spatial_workspace.h
+++ b/src/external/openxr_includes/openxr/XR_EXT_spatial_workspace.h
@@ -25,7 +25,7 @@ extern "C" {
 #endif
 
 #define XR_EXT_spatial_workspace 1
-#define XR_EXT_spatial_workspace_SPEC_VERSION 14
+#define XR_EXT_spatial_workspace_SPEC_VERSION 15
 #define XR_EXT_SPATIAL_WORKSPACE_EXTENSION_NAME "XR_EXT_spatial_workspace"
 
 // Provisional XrStructureType values. The 1000999100..107 range is reserved for
@@ -343,6 +343,7 @@ typedef enum XrWorkspaceInputEventTypeEXT {
     XR_WORKSPACE_INPUT_EVENT_MODAL_OPEN_EXT      = 8, // spec_version 10: client opened a Win32 modal popup (refcounted, fires on 0→1 only)
     XR_WORKSPACE_INPUT_EVENT_MODAL_CLOSE_EXT     = 9, // spec_version 10: client's last Win32 modal popup closed (refcounted, fires on 1→0 only)
     XR_WORKSPACE_INPUT_EVENT_FILE_PICKER_REQUEST_EXT = 10, // spec_version 11: a workspace client called xrRequestFilePickerEXT — fetch full info via xrGetFilePickerRequestEXT, deliver result via xrCompleteFilePickerEXT
+    XR_WORKSPACE_INPUT_EVENT_FULLSCREEN_TOGGLED_EXT  = 11, // spec_version 15: a workspace client's fullscreen/maximize state transitioned (runtime-driven, e.g. double-click title bar or F11)
     XR_WORKSPACE_INPUT_EVENT_TYPE_MAX_ENUM_EXT  = 0x7FFFFFFF
 } XrWorkspaceInputEventTypeEXT;
 
@@ -462,6 +463,16 @@ typedef struct XrWorkspaceInputEventEXT {
             XrWorkspaceClientId     clientId;
             uint64_t                requestId;
         } filePickerRequest;
+        struct {  // spec_version 15: a client's fullscreen/maximize state
+            // transitioned. Runtime-driven (double-click title bar, F11,
+            // xrRequestWorkspaceClientFullscreenEXT). The workspace
+            // controller typically wants to focus the toggled client when
+            // it enters fullscreen — focus policy lives in the controller
+            // (ADR-018), so the runtime emits the event and the controller
+            // calls xrSetWorkspaceFocusedClientEXT in response.
+            XrWorkspaceClientId     clientId;
+            XrBool32                isFullscreen;  // XR_TRUE on enter, XR_FALSE on restore
+        } fullscreenToggled;
     };
 } XrWorkspaceInputEventEXT;
 

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -927,6 +927,11 @@ struct d3d11_multi_client_slot
 
 	//! True when maximized (fills display, toggle restores pre_max state).
 	bool maximized;
+	//! spec_version 15: last-emitted snapshot for the FULLSCREEN_TOGGLED drain.
+	//! Per-slot delta-vs-shadow: drain compares `maximized` to this and emits
+	//! IPC_WORKSPACE_INPUT_EVENT_FULLSCREEN_TOGGLED on every transition so the
+	//! workspace controller can update focus / chrome / layout in response.
+	bool maximized_last_emitted;
 	struct xrt_pose pre_max_pose;
 	float pre_max_width_m;
 	float pre_max_height_m;
@@ -4816,6 +4821,8 @@ multi_compositor_register_client(struct d3d11_service_system *sys, struct d3d11_
 			mc->clients[i].chrome_swapchain_id = 0;
 			mc->clients[i].chrome_layout_valid = false;
 			mc->clients[i].chrome_region_count = 0;
+			mc->clients[i].maximized = false;
+			mc->clients[i].maximized_last_emitted = false;
 
 			// Count active clients to determine grid position
 			int active_count = 0;
@@ -5142,6 +5149,7 @@ multi_compositor_add_capture_client(struct d3d11_service_system *sys, HWND hwnd,
 			mc->clients[i].active = true;
 			mc->clients[i].minimized = false;
 			mc->clients[i].maximized = false;
+			mc->clients[i].maximized_last_emitted = false;
 			mc->clients[i].hwnd_resize_pending = false;
 			mc->clients[i].frame_rate_cap_hz = 0.0f;
 
@@ -14075,6 +14083,31 @@ comp_d3d11_service_workspace_drain_input_events(struct xrt_system_compositor *xs
 				(void)AllowSetForegroundWindow(app_pid);
 			}
 		}
+	}
+
+	// spec_version 15: FULLSCREEN_TOGGLED on per-slot maximized transition.
+	// Runtime-driven (double-click title bar, F11, xrRequestWorkspaceClientFullscreenEXT).
+	// The workspace controller typically wants to focus the toggled client when
+	// it enters fullscreen — focus policy lives in the controller (ADR-018), so
+	// the runtime emits the event and the controller calls
+	// xrSetWorkspaceFocusedClientEXT in response. Includes capture clients (they
+	// can be maximized too); client_id uses the same `1000 + slot` slot-based id
+	// the pointer / focus_changed events use.
+	for (int s = 0; s < D3D11_MULTI_MAX_CLIENTS &&
+	     out_batch->count < IPC_WORKSPACE_INPUT_EVENT_BATCH_MAX; s++) {
+		struct d3d11_multi_client_slot *cs = &mc->clients[s];
+		if (!cs->active) continue;
+		if (cs->maximized == cs->maximized_last_emitted) continue;
+
+		struct ipc_workspace_input_event *ev = &out_batch->events[out_batch->count];
+		memset(ev, 0, sizeof(*ev));
+		ev->event_type = IPC_WORKSPACE_INPUT_EVENT_FULLSCREEN_TOGGLED;
+		ev->timestamp_ms = (uint32_t)GetTickCount();
+		ev->u.fullscreen_toggled.client_id = 1000u + (uint32_t)s;
+		ev->u.fullscreen_toggled.is_fullscreen = cs->maximized ? 1u : 0u;
+		out_batch->count++;
+
+		cs->maximized_last_emitted = cs->maximized;
 	}
 
 	// FRAME_TICK: one per displayed frame since the last drain, capped at

--- a/src/xrt/ipc/client/ipc_client_compositor.c
+++ b/src/xrt/ipc/client/ipc_client_compositor.c
@@ -659,6 +659,10 @@ comp_ipc_client_compositor_workspace_enumerate_input_events(struct xrt_composito
 			out->filePickerRequest.clientId = (XrWorkspaceClientId)src->u.file_picker_request.client_id;
 			out->filePickerRequest.requestId = src->u.file_picker_request.request_id;
 			break;
+		case IPC_WORKSPACE_INPUT_EVENT_FULLSCREEN_TOGGLED:
+			out->fullscreenToggled.clientId = (XrWorkspaceClientId)src->u.fullscreen_toggled.client_id;
+			out->fullscreenToggled.isFullscreen = src->u.fullscreen_toggled.is_fullscreen ? XR_TRUE : XR_FALSE;
+			break;
 		default:
 			break;
 		}

--- a/src/xrt/ipc/shared/ipc_protocol.h
+++ b/src/xrt/ipc/shared/ipc_protocol.h
@@ -422,6 +422,7 @@ enum ipc_workspace_input_event_type
 	IPC_WORKSPACE_INPUT_EVENT_MODAL_OPEN          = 8, //!< spec_version 10: client opened a Win32 modal popup
 	IPC_WORKSPACE_INPUT_EVENT_MODAL_CLOSE         = 9, //!< spec_version 10: client's Win32 modal popup closed
 	IPC_WORKSPACE_INPUT_EVENT_FILE_PICKER_REQUEST = 10, //!< spec_version 11: client called xrRequestFilePickerEXT
+	IPC_WORKSPACE_INPUT_EVENT_FULLSCREEN_TOGGLED  = 11, //!< spec_version 15: client's fullscreen/maximize state transitioned
 };
 
 struct ipc_workspace_input_event
@@ -518,6 +519,11 @@ struct ipc_workspace_input_event
 			uint32_t _pad;
 			uint64_t request_id;
 		} file_picker_request;
+		struct                      //!< spec_version 15: fullscreen/maximize state transition
+		{
+			uint32_t client_id;
+			uint32_t is_fullscreen;     //!< XrBool32 semantics (1 = entered, 0 = restored)
+		} fullscreen_toggled;
 	} u;
 };
 


### PR DESCRIPTION
## Summary

PR **A of 3** for issue #302 (ADR-018 focus-policy migration). Purely additive — adds the new event the shell will subscribe to in PR B; PR C removes the runtime's focus-policy writes.

- Bumps `XR_EXT_spatial_workspace_SPEC_VERSION` 14 → 15.
- Adds `XR_WORKSPACE_INPUT_EVENT_FULLSCREEN_TOGGLED_EXT = 11` with a `clientId` + `isFullscreen` payload on the public event union, plus the matching `IPC_WORKSPACE_INPUT_EVENT_FULLSCREEN_TOGGLED = 11` on the IPC protocol.
- Emits the event per-slot using the same delta-vs-shadow pattern as MODAL_OPEN / FOCUS_CHANGED / WINDOW_POSE_CHANGED. New `maximized_last_emitted` shadow on each `d3d11_multi_client_slot`; transitions emit `client_id = 1000 + slot` (same scheme pointer + focus_changed events use) and `is_fullscreen = current maximized`.
- Keeps the existing `mc->focused_slot = slot` write inside `toggle_fullscreen()` — that's removed in **PR C** once the shell PR (B) is deployed and owns focus end-to-end.

Continuation of the per-client frame-rate-cap landings in #301 (runtime) and DisplayXR/displayxr-shell-pvt#22 (shell), which set up the `shell_focus_policy` module that PR B will wire to TAB / LMB / this new event.

## Test plan

- [x] `scripts\build_windows.bat build` — clean, 118 targets.
- [x] Standalone `cube_handle_d3d11_win` ran for 6 s with no errors in `%LOCALAPPDATA%\DisplayXR\` log.
- [x] Shell mode with the new runtime + previously-installed shell binary — focus, double-click-maximize, and 2-cube layout all behave unchanged (old shell sees the new event kind, falls into the `default:` switch arm, and ignores it — exactly what we want pre-PR-B).
- [ ] CI: Windows + macOS (run on push).

## Coordinated rollout

Merge order is **A → publish-extensions auto-sync → B (shell) → C (runtime focus removal)**, per `feedback_coupled_extension_pr_merge_order`. Order chosen so the shell is upgraded to own focus **before** the runtime stops deciding focus — avoids any "TAB does nothing / LMB doesn't focus" gap on dev machines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)