### PR TITLE
docs: archive legacy vendor guide, fix post-extraction drift (#263)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ Key facts for AI context: `_handle` and `_texture` are always extension apps. `_
 - **Compositor pipeline** — see `docs/architecture/compositor-pipeline.md`
 
 For the vendor isolation rule and layer "must NOT contain" constraints, see `docs/architecture/separation-of-concerns.md`.
-For display processor vtable design (all 5 API variants), see `docs/guides/vendor-integration.md`.
+For display processor vtable design (all 5 API variants), see `docs/archive/vendor-integration-historical.md`.
 
 ## Project Overview
 
@@ -235,7 +235,7 @@ C interfaces with vtable-style polymorphism:
 - `struct xrt_instance` — Runtime instance
 - `struct xrt_prober` — Device discovery
 
-For the full interface catalog including display processor vtables (5 API variants), see `docs/guides/vendor-integration.md`.
+For the full interface catalog including display processor vtables (5 API variants), see `docs/archive/vendor-integration-historical.md`.
 
 ### Vendor Plug-in Integration
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ Open issues at [github.com/DisplayXR/displayxr-runtime/issues](https://github.co
 
 ### For Display Vendors
 
-See the [vendor integration guide](docs/guides/vendor-integration.md). All vendor-specific code lives under `src/xrt/drivers/<vendor>/` — zero compositor changes required. The runtime is purposefully decoupled from any specific vendor SDK; the LeiaSR integration is one example, and adding a new vendor follows the same pattern.
+See the [vendor plug-in onboarding guide](docs/guides/vendor-plugin-onboarding.md). Vendors ship a plug-in DLL from their own repo — the runtime discovers it at `xrCreateInstance` and never carries vendor code or SDK identifiers in its link line (ADR-019). Zero compositor changes required. The [Leia SR plug-in](https://github.com/DisplayXR/displayxr-leia-plugin) is the canonical example; new vendors follow the same pattern.
 
 ### License
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Every graphics API gets its own native compositor — no Vulkan intermediary, no
 git clone https://github.com/DisplayXR/displayxr-runtime
 cd displayxr-runtime
 ./scripts/setup-displayxr.sh                  # runtime + sim-display
-./scripts/setup-displayxr.sh --with mcp       # also DisplayXR MCP Tools when published
+./scripts/setup-displayxr.sh --with mcp       # also DisplayXR MCP Tools (AI-agent / voice control)
 ```
 
 ```bat
@@ -59,7 +59,7 @@ cd displayxr-runtime
 git clone https://github.com/DisplayXR/displayxr-runtime
 cd displayxr-runtime
 scripts\setup-displayxr.bat                   :: runtime + Shell + Leia plug-in
-scripts\setup-displayxr.bat --with mcp        :: also DisplayXR MCP Tools
+scripts\setup-displayxr.bat --with mcp        :: also DisplayXR MCP Tools (AI-agent / voice control)
 ```
 
 Downloads each component's installer from its GitHub Releases page (versions pinned in [`versions.json`](versions.json)), runs it silently, verifies the install. See [`docs/getting-started/full-stack-install.md`](docs/getting-started/full-stack-install.md) for `--with-demos`, `--dry-run`, `--uninstall`, and the per-component platform availability matrix.
@@ -80,7 +80,7 @@ The website's [Get Started](https://displayxr.org/getting-started) page walks th
 ### Build from source
 
 ```bash
-# Windows — auto-fetches vcpkg, OpenXR loader, LeiaSR SDK
+# Windows — auto-fetches vcpkg + OpenXR loader (no vendor SDK; Leia ships as a separate plug-in)
 scripts\build_windows.bat all
 # Outputs: _package/DisplayXRSetup-*.exe (installer) + _package/bin/
 
@@ -111,7 +111,7 @@ XR_RUNTIME_JSON=./build/openxr_displayxr-dev.json ./build/test_apps/cube_handle_
 |---|---|
 | **Build apps** for 3D displays | [Getting Started](docs/getting-started/overview.md) |
 | **Contribute** to DisplayXR | [Contributing Guide](docs/guides/contributing.md) |
-| **Integrate my display** hardware | [Vendor Integration Guide](docs/guides/vendor-integration.md) |
+| **Integrate my display** hardware | [Vendor Plug-in Onboarding](docs/guides/vendor-plugin-onboarding.md) |
 | See the full docs index | [Documentation Index](docs/README.md) |
 | See the project roadmap | [Roadmap](docs/roadmap/overview.md) |
 
@@ -127,7 +127,9 @@ XR_RUNTIME_JSON=./build/openxr_displayxr-dev.json ./build/test_apps/cube_handle_
 
 | Repo | Description |
 |------|-------------|
+| [displayxr-installer](https://github.com/DisplayXR/displayxr-installer) | Meta-installer — one bundle that installs runtime + Shell + plug-ins |
 | [displayxr-shell-releases](https://github.com/DisplayXR/displayxr-shell-releases) | DisplayXR Shell — spatial workspace controller (installer + bug reports) |
+| [displayxr-leia-plugin](https://github.com/DisplayXR/displayxr-leia-plugin) | Leia SR display-processor plug-in (`DisplayXRLeiaSRSetup-*.exe`) |
 | [displayxr-extensions](https://github.com/DisplayXR/displayxr-extensions) | OpenXR extension specs and headers |
 | [displayxr-mcp](https://github.com/DisplayXR/displayxr-mcp) | Embeddable MCP server framework + **DisplayXR MCP Tools** installer (end-user opt-in for agent / voice control) |
 | [displayxr-demo-gaussiansplat](https://github.com/DisplayXR/displayxr-demo-gaussiansplat) | 3D Gaussian Splatting reference demo |

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@
 | **App developer** | **OXR contributor** | **DXR core contributor** | **Vendor contributor** |
 |---|---|---|---|
 | Building apps that target DisplayXR | Working on the OpenXR state tracker / extensions | Working on compositors, IPC, shell contracts, build | Integrating a 3D-display vendor (driver + DP) |
-| → [`getting-started/`](getting-started/) | → [`architecture/`](architecture/) | → [`architecture/`](architecture/) | → [`guides/vendor-integration.md`](guides/vendor-integration.md) |
+| → [`getting-started/`](getting-started/) | → [`architecture/`](architecture/) | → [`architecture/`](architecture/) | → [`guides/vendor-plugin-onboarding.md`](guides/vendor-plugin-onboarding.md) |
 | → [`specs/extensions/`](specs/extensions/) | → [`specs/extensions/`](specs/extensions/) | → [`specs/runtime/`](specs/runtime/) | → [`specs/vendor/`](specs/vendor/) |
 | → [`reference/`](reference/) | → [`guides/implementing-extension.md`](guides/implementing-extension.md) | → [`adr/`](adr/), [`roadmap/`](roadmap/) | → [`vendors/`](vendors/) (your vendor's subfolder) |
 | | → [`adr/`](adr/) | | → [`adr/`](adr/) (003, 007, 015) |
@@ -69,7 +69,7 @@ Integrate your 3D display hardware into DisplayXR.
 - **[ADR-007: Compositor Never Weaves](adr/ADR-007-compositor-never-weaves.md)** — compositor / DP boundary
 - **[ADR-015: Multi-Display Routing](adr/ADR-015-displayxr-owns-multi-display-vendor-routing.md)** — how multiple vendors coexist
 - **[Separation of Concerns](architecture/separation-of-concerns.md)** — what goes where
-- [Legacy: in-tree integration model](guides/vendor-integration.md) — historical reference for pre-#263 vendors who forked the runtime
+- [Legacy: in-tree integration model](archive/vendor-integration-historical.md) — historical reference for pre-#263 vendors who forked the runtime
 - [Writing a Driver](guides/writing-driver.md) — driver framework basics
 
 ### Integrated vendors (`vendors/`)

--- a/docs/architecture/compositor-pipeline.md
+++ b/docs/architecture/compositor-pipeline.md
@@ -80,7 +80,7 @@ The `process_atlas()` method exists in 5 API-specific variants:
 | Metal | `xrt_display_processor_metal.h` |
 | OpenGL | `xrt_display_processor_gl.h` |
 
-See [Display Processor Interface](../specs/vendor/display-processor-interface.md) for the unified vtable design and [Vendor Integration Guide](../guides/vendor-integration.md) for implementation guidance.
+See [Display Processor Interface](../specs/vendor/display-processor-interface.md) for the unified vtable design and [Vendor Integration Guide](../guides/vendor-plugin-onboarding.md) for implementation guidance.
 
 ## Further Reading
 

--- a/docs/archive/vendor-integration-historical.md
+++ b/docs/archive/vendor-integration-historical.md
@@ -1,14 +1,21 @@
-# Vendor Integration Guide: Adding a 3D Display to the OpenXR Runtime
+# [ARCHIVED] Vendor Integration Guide: the in-tree integration model
 
-> **Legacy in-tree integration model.** Since issues #256 / #263 (ADR-019),
-> new vendor integrations ship as plug-in DLLs from their own repos and
-> never modify this tree. See [`vendor-plugin-onboarding.md`](vendor-plugin-onboarding.md)
-> for the post-#263 contract. This document is retained for vendors who
-> fork the runtime, for historical context on how the in-tree
-> `src/xrt/drivers/leia/` (now extracted to
+> **⚠️ Archived — do not use for new integrations.** This describes the
+> *pre-#263 in-tree* model, where a vendor driver lived in
+> `src/xrt/drivers/<vendor>/` and was linked into the runtime build.
+> Since ADR-019 (issues #256 / #263), vendors ship plug-in DLLs from
+> their own repos and never touch this tree.
+>
+> **For the current contract, start here instead:**
+> - [Vendor Plug-in Onboarding](../guides/vendor-plugin-onboarding.md) — the post-#263 model
+> - [Plug-in Discovery spec](../specs/runtime/plugin-discovery.md) — registry / JSON-manifest contract
+> - [ADR-019](../adr/ADR-019-vendor-plugin-aux-boundary.md) — why the extraction happened
+>
+> This file is retained only for runtime forks and for historical
+> context on how the in-tree `src/xrt/drivers/leia/` (now extracted to
 > [DisplayXR/displayxr-leia-plugin](https://github.com/DisplayXR/displayxr-leia-plugin))
-> was wired, and for the vendor-neutral `sim_display` reference still
-> shipped in-tree.
+> was wired. The vendor-neutral `sim_display` reference it cites still
+> ships in-tree.
 
 This guide tells a new 3D display vendor exactly what to implement to connect
 their hardware to this OpenXR runtime.  It covers every integration point:
@@ -1479,7 +1486,7 @@ my_vendor_sdk_weave(struct my_vendor_sdk *sdk, /* ... */)
 > **Note (ADR-019 / issues #256 + #263 + #287):** This section
 > describes the **legacy in-tree** registration shape from before the
 > driver extraction. **New vendor integrations should NOT follow this
-> section** — see [`vendor-plugin-onboarding.md`](vendor-plugin-onboarding.md)
+> section** — see [`vendor-plugin-onboarding.md`](../guides/vendor-plugin-onboarding.md)
 > for the current contract. Vendors ship a plug-in DLL from their own
 > repo with an installer that registers it under
 > `HKLM\Software\DisplayXR\DisplayProcessors\<id>` per

--- a/docs/getting-started/building.md
+++ b/docs/getting-started/building.md
@@ -28,10 +28,12 @@ scripts\build_windows.bat all
 ```
 
 The script auto-fetches everything needed: vcpkg (for cJSON +
-runtime deps), the OpenXR loader release zip, and the LeiaSR SDK
-release artifact (from this repo's `sr-sdk-v*` release). It then
-runs CMake (Ninja Multi-Config) and builds the runtime + installer
-in one go. Outputs land in `_package/`.
+runtime deps) and the OpenXR loader release zip. It then runs CMake
+(Ninja Multi-Config) and builds the runtime + installer in one go.
+Outputs land in `_package/`. No vendor SDK is fetched — the runtime
+DLL holds zero vendor identifiers (ADR-019); Leia SR ships as a
+separate plug-in (see [Vendor displays](#vendor-displays-leia-sr-etc)
+below).
 
 Available targets: `all` (default), `build` (runtime only,
 fastest iteration), `installer`, `test-apps`, `generate`. See

--- a/docs/guides/contributing.md
+++ b/docs/guides/contributing.md
@@ -53,7 +53,7 @@ Key principles:
 
 If you're integrating a new display into DisplayXR:
 
-1. Start with the [Vendor Integration Guide](vendor-integration.md) — comprehensive walkthrough
+1. Start with the [Vendor Plug-in Onboarding](vendor-plugin-onboarding.md) — comprehensive walkthrough
 2. Read [Writing a Driver](writing-driver.md) for the basics of the driver framework
 3. Review [ADR-003](../adr/ADR-003-vendor-abstraction-via-display-processor-vtable.md) and [Separation of Concerns](../architecture/separation-of-concerns.md) for the vendor isolation rules
 4. Use sim_display (`src/xrt/drivers/sim_display/`) as a reference implementation

--- a/docs/guides/vendor-plugin-onboarding.md
+++ b/docs/guides/vendor-plugin-onboarding.md
@@ -2,7 +2,7 @@
 
 This guide walks a new 3D-display vendor from zero to a shipping DisplayXR-compatible plug-in. After ADR-019 / #263 (May 2026), every vendor integration is an **external project**: you don't touch this repo, you ship a plug-in DLL from your own repo and an installer that registers it with the runtime at install time.
 
-If you're maintaining a vendor integration that was historically in-tree (the way `drv_leia` was before #263), see the [legacy `vendor-integration.md`](vendor-integration.md) — kept for historical context. Everything below assumes the post-#263 model.
+If you're maintaining a vendor integration that was historically in-tree (the way `drv_leia` was before #263), see the [legacy in-tree guide](../archive/vendor-integration-historical.md) — kept for historical context. Everything below assumes the post-#263 model.
 
 > **Canonical examples**
 > - [`DisplayXR/displayxr-leia-plugin`](https://github.com/DisplayXR/displayxr-leia-plugin) — full vendor integration with SR SDK; the recommended starting point. Fork the repo, swap `drv_leia/` for `drv_<your-vendor>/`, point the installer at your `<id>`.
@@ -252,4 +252,4 @@ Add a short `docs/vendors/<your-vendor>.md` to the runtime repo via PR — a one
 - [ADR-019](../adr/ADR-019-vendor-plugin-aux-boundary.md) — why the runtime DLL holds zero vendor identifiers and how the aux import-library boundary works
 - [`XR_EXT_display_info` spec](../specs/extensions/XR_EXT_display_info.md) — display info + eye-tracking mode contract
 - [Eye tracking modes spec](../specs/vendor/eye-tracking-modes.md) — MANAGED vs MANUAL contract
-- [Legacy in-tree integration model](vendor-integration.md) — historical reference for the pre-#263 in-tree integration shape
+- [Legacy in-tree integration model](../archive/vendor-integration-historical.md) — historical reference for the pre-#263 in-tree integration shape

--- a/docs/guides/writing-driver.md
+++ b/docs/guides/writing-driver.md
@@ -66,5 +66,5 @@ found in `src/xrt/targets`.
 
 If your driver provides a 3D display, you will also need to implement the
 **display processor** vtable for each graphics API your display supports. See
-[vendor-integration.md](vendor-integration.md) for the full display processor
+[vendor-plugin-onboarding.md](vendor-plugin-onboarding.md) for the full display processor
 contract, vtable design, and integration instructions.

--- a/docs/roadmap/local-3d-zones.md
+++ b/docs/roadmap/local-3d-zones.md
@@ -293,7 +293,7 @@ Shell becomes one more client publishing a mask; multi-app per-window 3D in shel
 ## Cross-references
 
 - DP vtable (existing): `src/xrt/include/xrt/xrt_display_processor.h:152–164` — `get_hardware_3d_state`, `request_display_mode`, `process_atlas`. The local-zone methods sit alongside these.
-- Vendor integration guide: `docs/guides/vendor-integration.md` — to be extended with the local-zone vtable methods once this spec lands.
+- Vendor integration guide: `docs/guides/vendor-plugin-onboarding.md` — to be extended with the local-zone vtable methods once this spec lands.
 - Vendor-initiated state change events (today): `comp_d3d11_service.cpp:10180–10230`, `oxr_session.c:968` — the polling/event pattern that the new local-zone path coexists with, not replaces.
 - ADR-014 (shell owns rendering mode): generalizes in the zone world — the shell becomes one mask publisher among many rather than the sole policy holder.
 - `docs/specs/extensions/XR_EXT_display_info.md`: candidate place for `localZoneCapable` + grid dimensions to surface to apps that don't take the full `XR_EXT_local_3d_zone` extension.

--- a/docs/roadmap/prfaq.md
+++ b/docs/roadmap/prfaq.md
@@ -56,7 +56,7 @@ DisplayXR ships a WebXR bridge that connects Chrome's native WebXR implementatio
 ### For 3D display vendors
 
 **Q: I make a 3D display panel. How do I integrate with DisplayXR?**
-Implement the display-processor vtable for your weaving / depth-mapping / eye-tracking integration. The vtable has five API variants (D3D11, D3D12, Metal, Vulkan, OpenGL) so your weaver runs natively in whatever graphics API the application is using. See `docs/guides/vendor-integration.md` for the full contract. Leia SR is the first integration; it's a reference, not a precedent — there is no privileged path.
+Implement the display-processor vtable for your weaving / depth-mapping / eye-tracking integration. The vtable has five API variants (D3D11, D3D12, Metal, Vulkan, OpenGL) so your weaver runs natively in whatever graphics API the application is using. See `docs/guides/vendor-plugin-onboarding.md` for the full contract. Leia SR is the first integration; it's a reference, not a precedent — there is no privileged path.
 
 **Q: Once my display is integrated, who picks DisplayXR up?**
 Two distinct downstream audiences: OEMs who ship finished products built around your display panel, and vertical integrators who build a focused experience on it. Both groups consume the runtime via standard distribution channels (your driver bundles it, an OEM bundles it, or end users install it directly). Your DP integration enables both paths simultaneously.

--- a/docs/roadmap/vendor-plugin-architecture.md
+++ b/docs/roadmap/vendor-plugin-architecture.md
@@ -13,7 +13,7 @@ for the design decisions.
 
 ## 1. Problem
 
-The "vendor-agnostic" framing in `CLAUDE.md` and `docs/guides/vendor-integration.md` is aspirational on Windows. The shipped `DisplayXRClient.dll` has these static (load-time) imports baked in:
+The "vendor-agnostic" framing in `CLAUDE.md` and `docs/archive/vendor-integration-historical.md` is aspirational on Windows. The shipped `DisplayXRClient.dll` has these static (load-time) imports baked in:
 
 ```
 SimulatedRealityCore.dll
@@ -124,7 +124,7 @@ struct xrt_plugin_iface {
 };
 ```
 
-The DP vtable returned by `create_display_processor` is unchanged — it's the existing per-API `xrt_display_processor*` contract from `docs/guides/vendor-integration.md`. The plug-in restructure adds plumbing **around** that vtable, not changes to it.
+The DP vtable returned by `create_display_processor` is unchanged — it's the existing per-API `xrt_display_processor*` contract from `docs/archive/vendor-integration-historical.md`. The plug-in restructure adds plumbing **around** that vtable, not changes to it.
 
 **Header location:** `src/xrt/include/xrt/xrt_plugin.h`. Public, stable. Goes through the same ABI-bump discipline as other extension headers (memory: [[feedback_extension_struct_abi.md]] — add `struct_size` first field, never reorder existing fields, version every public struct).
 
@@ -215,7 +215,7 @@ Recommended order. Each step lands as its own PR.
 | 6 | **Migrate `drv_leia` to plug-in shape.** | `DisplayXR-LeiaSR.dll` built. SR SDK linkage entirely contained in plug-in. Cube apps render via Leia through the plug-in path. PR #253's DllMain hook moves here. | 3-5 |
 | 7 | **Installer split.** | Runtime installer drops SR DLLs + drv_leia bits. New Leia plug-in installer (or hand off to SR Platform). Cascade uninstall verified. | 2 |
 | 8 | **CI: vendor-agnostic build + assert.** | Workflow builds without SR SDK present, asserts zero vendor imports, smoke-tests sim_display path. | 1 |
-| 9 | **macOS port + docs.** | sim_display dylib + manifest discovery. `docs/guides/vendor-integration.md` rewrite for plug-in shape. | 2-3 |
+| 9 | **macOS port + docs.** | sim_display dylib + manifest discovery. `docs/archive/vendor-integration-historical.md` rewrite for plug-in shape. | 2-3 |
 
 **Total: ~3-4 weeks** for one focused engineer. Parallelizable to ~2 calendar weeks with two.
 
@@ -246,7 +246,7 @@ Recommended order. Each step lands as its own PR.
 
 ## 9. References
 
-- `docs/guides/vendor-integration.md` — existing DP vtable contract (unchanged by this work).
+- `docs/archive/vendor-integration-historical.md` — existing DP vtable contract (unchanged by this work).
 - `docs/specs/runtime/workspace-controller-registration.md` — the registration pattern this plug-in shape mirrors.
 - `docs/adr/ADR-003-vendor-abstraction-via-display-processor-vtable.md` — vtable rationale; this work is the natural follow-up.
 - `docs/architecture/separation-of-concerns.md` — layer boundaries that today are aspirational on Windows; this work makes them real.

--- a/docs/specs/extensions/XR_EXT_display_info.md
+++ b/docs/specs/extensions/XR_EXT_display_info.md
@@ -1336,7 +1336,7 @@ installed runtime. The `XR_EXT_display_info` extension's capability reporting
 (`XrDisplayInfoEXT`, `XrEyeTrackingModeCapabilitiesEXT`) reflects only what the device
 actually supports, not the full SDK API surface.
 
-See the **Vendor Integration Guide** (`docs/guides/vendor-integration.md` §13)
+See the archived **Vendor Integration Guide** (`docs/archive/vendor-integration-historical.md` §13)
 for the complete deployment model, multi-vendor build strategy, and driver implementation
 guidelines.
 
@@ -1827,7 +1827,7 @@ A complete reference implementation is available in the [DisplayXR runtime](http
 | Metal test application (macOS) | `test_apps/cube_handle_metal_macos/` |
 | Common Kooima projection | `test_apps/common/xr_session_common.cpp` |
 
-The runtime is based on Monado (open-source OpenXR runtime) with native compositors per graphics API (D3D11, D3D12, Metal, OpenGL, Vulkan). Vendor display processing is abstracted via the `xrt_display_processor` interface — see `docs/guides/vendor-integration.md`.
+The runtime is based on Monado (open-source OpenXR runtime) with native compositors per graphics API (D3D11, D3D12, Metal, OpenGL, Vulkan). Vendor display processing is abstracted via the `xrt_display_processor` interface — see `docs/guides/vendor-plugin-onboarding.md`.
 
 ## Appendix B: Glossary
 

--- a/docs/vendors/README.md
+++ b/docs/vendors/README.md
@@ -1,6 +1,6 @@
 # Vendor Integrations
 
-DisplayXR is vendor-agnostic — any 3D-display vendor can integrate their hardware by implementing the [display processor interface](../specs/vendor/display-processor-interface.md) and following the [vendor integration guide](../guides/vendor-integration.md).
+DisplayXR is vendor-agnostic — any 3D-display vendor can integrate their hardware by implementing the [display processor interface](../specs/vendor/display-processor-interface.md) and following the [vendor plug-in onboarding guide](../guides/vendor-plugin-onboarding.md).
 
 This directory holds **vendor-specific** documentation. Generic contracts that every vendor must follow live in `specs/vendor/` and `guides/`.
 
@@ -8,14 +8,14 @@ This directory holds **vendor-specific** documentation. Generic contracts that e
 
 | Vendor | Driver | Docs | APIs supported |
 |---|---|---|---|
-| **Leia SR** | `src/xrt/drivers/leia/` | [leia/](leia/) | D3D11, D3D12, OpenGL, Vulkan |
+| **Leia SR** | plug-in ([displayxr-leia-plugin](https://github.com/DisplayXR/displayxr-leia-plugin)) | [leia/](leia/) | D3D11, D3D12, OpenGL, Vulkan |
 | **sim_display** | `src/xrt/drivers/sim_display/` | [sim_display/](sim_display/) | D3D11, D3D12, OpenGL, Metal |
 
 `sim_display` is the reference simulation vendor — it ships with the runtime and renders side-by-side / anaglyph output to a normal 2D window so contributors can develop without 3D-display hardware.
 
 ## Adding a new vendor
 
-1. Read [guides/vendor-integration.md](../guides/vendor-integration.md) — the end-to-end walkthrough.
+1. Read [guides/vendor-plugin-onboarding.md](../guides/vendor-plugin-onboarding.md) — the end-to-end walkthrough.
 2. Implement the [display processor vtable](../specs/vendor/display-processor-interface.md) for each graphics API you support.
 3. Decide your [eye-tracking mode](../specs/vendor/eye-tracking-modes.md) (MANAGED or MANUAL).
 4. Add `docs/vendors/<your-vendor>/` with a `README.md` describing your integration; link any internals docs (weaver, transparency model, etc.) from there.

--- a/docs/vendors/leia/README.md
+++ b/docs/vendors/leia/README.md
@@ -1,6 +1,6 @@
 # Leia SR Integration
 
-Leia is the first 3D-display vendor integrated into DisplayXR. This directory documents the Leia-specific implementation; the generic vendor contract lives in [`docs/specs/vendor/`](../../specs/vendor/) and [`docs/guides/vendor-integration.md`](../../guides/vendor-integration.md).
+Leia is the first 3D-display vendor integrated into DisplayXR. This directory documents the Leia-specific implementation; the generic vendor contract lives in [`docs/specs/vendor/`](../../specs/vendor/) and [`docs/guides/vendor-plugin-onboarding.md`](../../guides/vendor-plugin-onboarding.md).
 
 ## Source layout
 

--- a/docs/vendors/sim_display/README.md
+++ b/docs/vendors/sim_display/README.md
@@ -38,4 +38,4 @@ sim_display reports **MANAGED** mode and feeds a fixed eye position (no actual t
 - CI builds and headless tests
 - Reference implementation when writing a new vendor — `sim_display_processor.c` is the smallest complete DP implementation in the tree.
 
-For the generic vendor contract, see [`docs/guides/vendor-integration.md`](../../guides/vendor-integration.md) and [`docs/specs/vendor/display-processor-interface.md`](../../specs/vendor/display-processor-interface.md).
+For the generic vendor contract, see [`docs/guides/vendor-plugin-onboarding.md`](../../guides/vendor-plugin-onboarding.md) and [`docs/specs/vendor/display-processor-interface.md`](../../specs/vendor/display-processor-interface.md).


### PR DESCRIPTION
## Summary
Org-wide documentation refresh (runtime portion). Drift was low; **accretion** was the real problem — a 2,333-line legacy vendor guide had a "see the other doc" banner stapled on instead of being retired.

- Archive `docs/guides/vendor-integration.md` → `docs/archive/vendor-integration-historical.md` with a clear "do not use for new integrations" banner.
- Repoint ~20 inbound links across 16 files (the move broke every one): onboarding-style refs → `vendor-plugin-onboarding.md`; deep DP-vtable / §13 refs → the archive.
- Fix stale post-extraction claims: README "Integrate my display" link (was pointing at the archived behemoth), "auto-fetches LeiaSR SDK" build text (no Leia in the build since ADR-019), MCP "when published", CONTRIBUTING "vendor code lives in-tree" framing, in-tree Leia path in `docs/vendors/README.md`.
- Add `displayxr-leia-plugin` + `displayxr-installer` to the README Related Repos table.

Docs-only. No code or build changes.

## Test plan
- [x] `grep` confirms zero remaining references to the old `vendor-integration.md` path
- [x] Archive + onboarding + discovery-spec link targets all exist