### PR TITLE
chore: drop stale /DELAYLOAD:SimulatedRealityVulkanBeta.dll from runtime

### DIFF
--- a/src/xrt/compositor/d3d11/comp_d3d11_window.cpp
+++ b/src/xrt/compositor/d3d11/comp_d3d11_window.cpp
@@ -189,6 +189,15 @@ struct comp_d3d11_window
 	//! Set on button-down inside rect, cleared on button-up.
 	bool mouse_press_in_content;
 
+	//! The HWND the most recent button-DOWN was forwarded to, or NULL if it
+	//! was not forwarded (cursor outside the focused window's rect — i.e. a
+	//! click on an unfocused window). Captured at WndProc time, BEFORE the
+	//! workspace controller's async xrSetWorkspaceFocusedClientEXT can update
+	//! the forward target. The render-loop click handler reads this to decide
+	//! whether to synthesize a DOWN to the hit window for drag-in-one-click:
+	//! it must NOT rely on focused_slot, which the controller mutates async.
+	volatile HWND last_pointer_down_target;
+
 	//! Workspace display processor for ESC/close 2D mode switch (opaque, can be NULL).
 	volatile void *workspace_dp;
 
@@ -723,6 +732,11 @@ wnd_proc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 				}
 				workspace_public_ring_push(w, WORKSPACE_PUBLIC_EVENT_POINTER,
 				                           cx, cy, button, is_down, mods, 0.0f);
+				// Default: this DOWN was not forwarded. The forward site
+				// below overwrites with the actual target HWND if it is.
+				if (is_down) {
+					w->last_pointer_down_target = NULL;
+				}
 			}
 		}
 
@@ -868,6 +882,15 @@ wnd_proc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 					}
 					// PostMessage: works for classic Win32 apps (test apps)
 					PostMessage(fwd, message, wParam, MAKELPARAM(app_x, app_y));
+
+					// Record where a button-DOWN was actually forwarded so
+					// the render-loop click handler can tell whether the hit
+					// window already received this DOWN (no synth needed) or
+					// not (synth a DOWN for drag-in-one-click). Independent of
+					// the controller's async focus update.
+					if (is_button_down) {
+						w->last_pointer_down_target = fwd;
+					}
 
 					// For mouse buttons: also inject via SendInput so apps
 					// using Raw Input (RIDEV_INPUTSINK) see the event in
@@ -1419,6 +1442,16 @@ comp_d3d11_window_set_input_forward(struct comp_d3d11_window *window,
 	} else {
 		U_LOG_W("D3D11 window: input forwarding disabled");
 	}
+}
+
+void *
+comp_d3d11_window_get_last_pointer_down_target(struct comp_d3d11_window *window)
+{
+	if (window == NULL) {
+		return NULL;
+	}
+	return (void *)InterlockedCompareExchangePointer(
+	    (volatile PVOID *)&window->last_pointer_down_target, NULL, NULL);
 }
 
 void

--- a/src/xrt/compositor/d3d11/comp_d3d11_window.h
+++ b/src/xrt/compositor/d3d11/comp_d3d11_window.h
@@ -252,6 +252,17 @@ comp_d3d11_window_set_input_forward(struct comp_d3d11_window *window,
                                      bool is_capture);
 
 /*!
+ * Return the HWND the most recent button-DOWN was forwarded to, or NULL if it
+ * was not forwarded (a click on an unfocused window, where the cursor is
+ * outside the focused window's rect). Captured at WndProc time, before the
+ * workspace controller's async focus change can move the forward target — the
+ * render-loop click handler uses it to decide whether to synthesize a DOWN to
+ * the hit window for drag-in-one-click.
+ */
+void *
+comp_d3d11_window_get_last_pointer_down_target(struct comp_d3d11_window *window);
+
+/*!
  * Mark workspace mode as active/inactive on the window. While active, ESC on the
  * compositor window is swallowed instead of posting WM_CLOSE — an empty workspace
  * (no focused app) would otherwise take the service down with its own window.

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -4868,9 +4868,10 @@ multi_compositor_register_client(struct d3d11_service_system *sys, struct d3d11_
 			mc->clients[i].hwnd_resize_pending = true;
 
 			mc->client_count++;
-			if (mc->focused_slot < 0) {
-				mc->focused_slot = i;
-			}
+			// ADR-018: the runtime no longer auto-focuses the first
+			// client. The workspace controller owns focus — it sees the
+			// new client in xrEnumerateWorkspaceClientsEXT and calls
+			// xrSetWorkspaceFocusedClientEXT (shell auto-focus-first path).
 			U_LOG_W("Multi-comp: registered client in slot %d (total=%u)", i, mc->client_count);
 			U_LOG_W("  window: pose=(%.3f,%.3f,%.3f) size=%.3fx%.3fm rect=(%d,%d %dx%d px)",
 			        mc->clients[i].window_pose.position.x,
@@ -4936,13 +4937,12 @@ multi_compositor_unregister_client(struct d3d11_service_system *sys, struct d3d1
 			mc->clients[i].compositor = nullptr;
 			mc->client_count--;
 			if (mc->focused_slot == i) {
+				// ADR-018: the disconnecting client held focus. Clear it so
+				// keyboard forwarding never targets a freed slot, but DON'T
+				// pick the successor — that's the controller's call. The
+				// shell's client-list diff sees the disconnect and auto-
+				// focuses a survivor on its next tick.
 				mc->focused_slot = -1;
-				for (int j = 0; j < D3D11_MULTI_MAX_CLIENTS; j++) {
-					if (mc->clients[j].active && !mc->clients[j].minimized) {
-						mc->focused_slot = j;
-						break;
-					}
-				}
 				multi_compositor_update_input_forward(mc);
 			}
 			// Cancel any active drag on this slot
@@ -5262,9 +5262,8 @@ multi_compositor_add_capture_client(struct d3d11_service_system *sys, HWND hwnd,
 
 			mc->client_count++;
 			mc->capture_client_count++;
-			if (mc->focused_slot < 0) {
-				mc->focused_slot = i;
-			}
+			// ADR-018: no runtime auto-focus on register (see the IPC-client
+			// register path). The controller focuses via the workspace API.
 
 			U_LOG_W("Multi-comp: added capture client in slot %d HWND=%p '%s' "
 			         "(%ux%u px, %.3fx%.3f m, total=%u, captures=%u)",
@@ -5319,13 +5318,9 @@ multi_compositor_remove_capture_client(struct d3d11_service_system *sys, int slo
 	mc->capture_client_count--;
 
 	if (mc->focused_slot == slot_index) {
+		// ADR-018: clear focus for forwarding safety; controller picks the
+		// successor (shell auto-focus-next path on its client-list diff).
 		mc->focused_slot = -1;
-		for (int j = 0; j < D3D11_MULTI_MAX_CLIENTS; j++) {
-			if (mc->clients[j].active && !mc->clients[j].minimized) {
-				mc->focused_slot = j;
-				break;
-			}
-		}
 		multi_compositor_update_input_forward(mc);
 	}
 	if (mc->drag.active && mc->drag.slot == slot_index) {
@@ -6603,7 +6598,11 @@ toggle_fullscreen(struct d3d11_service_system *sys,
 		U_LOG_W("Multi-comp: fullscreen slot %d", slot);
 	}
 
-	mc->focused_slot = slot;
+	// ADR-018: the runtime no longer focuses the toggled client. PR A
+	// added the FULLSCREEN_TOGGLED workspace event (emitted from the
+	// drain on the maximized transition); the controller reacts by
+	// calling xrSetWorkspaceFocusedClientEXT. Input forwarding is
+	// re-applied here against the current (controller-set) focus.
 	multi_compositor_update_input_forward(mc);
 
 	// Update window layer's ESC-suppression flag
@@ -6961,27 +6960,11 @@ multi_compositor_render(struct d3d11_service_system *sys)
 		goto after_key_shortcuts;
 	}
 
-	// Bare TAB: cycle focus forward. Never unfocuses when windows exist.
-	// SHIFT+TAB is no longer reserved here — it falls through to wnd_proc's
-	// forward-to-app path so apps can use it (e.g. HUD toggle in cube tests).
-	// Ignore ALT+TAB (system task switcher).
-	if ((GetAsyncKeyState(VK_TAB) & 1) &&
-	    !(GetAsyncKeyState(VK_MENU) & 0x8000) &&
-	    !(GetAsyncKeyState(VK_SHIFT) & 0x8000)) {
-		if (mc->client_count > 0) {
-			int n = D3D11_MULTI_MAX_CLIENTS;
-			int base = (mc->focused_slot >= 0) ? mc->focused_slot : -1;
-			for (int i = 1; i <= n; i++) {
-				int idx = (base + i) % n;
-				if (mc->clients[idx].active && !mc->clients[idx].minimized) {
-					mc->focused_slot = idx;
-					break;
-				}
-			}
-			U_LOG_W("Multi-comp: TAB → focused slot %d", mc->focused_slot);
-			multi_compositor_update_input_forward(mc);
-		}
-	}
+	// ADR-018: the runtime no longer consumes TAB to cycle focus. TAB is
+	// already emitted on the workspace input-event queue (comp_d3d11_window
+	// pushes WORKSPACE_PUBLIC_EVENT_KEY before any suppression), so the
+	// controller drains it and applies its own focus-cycle policy. ALT+TAB
+	// (system task switcher) and SHIFT+TAB (app HUD toggles) are unaffected.
 
 	// DELETE: close focused client
 	if (GetAsyncKeyState(VK_DELETE) & 1) {
@@ -7188,14 +7171,10 @@ after_key_shortcuts:
 				mc->clients[hit_slot].minimized = true;
 				U_LOG_W("Multi-comp: minimize slot %d", hit_slot);
 				if (hit_slot == mc->focused_slot) {
-					// Advance focus to next visible window
+					// ADR-018: minimizing the focused window clears focus
+					// for forwarding safety; the controller picks the
+					// successor (shell auto-focus-next path).
 					mc->focused_slot = -1;
-					for (int i = 0; i < D3D11_MULTI_MAX_CLIENTS; i++) {
-						if (mc->clients[i].active && !mc->clients[i].minimized) {
-							mc->focused_slot = i;
-							break;
-						}
-					}
 					multi_compositor_update_input_forward(mc);
 				}
 			} else if (in_title_bar && hit_slot >= 0) {
@@ -7208,17 +7187,14 @@ after_key_shortcuts:
 
 				if (is_double_click) {
 					toggle_fullscreen(sys, mc, hit_slot);
-				} else {
-					// Single click on title bar — focus the window. Drag
-					// is the workspace controller's job (ADR-018 / PR 2 of
-					// the runtime→controller migration). The controller
-					// observes the POINTER event, calls
-					// xrEnableWorkspacePointerCaptureEXT, snapshots pose
-					// via xrGetWorkspaceClientWindowPoseEXT, and drives
-					// per-frame xrSetWorkspaceClientWindowPoseEXT.
-					mc->focused_slot = hit_slot;
-					multi_compositor_update_input_forward(mc);
 				}
+				// ADR-018: single-click title-bar focus is the controller's
+				// call now (it was the last runtime self-focus on the title
+				// bar; drag already moved in an earlier slice). The runtime
+				// emits the POINTER event and the shell calls
+				// xrSetWorkspaceFocusedClientEXT. Double-click → maximize
+				// stays here (fullscreen state machine is runtime-owned; PR A
+				// added the FULLSCREEN_TOGGLED event the controller focuses on).
 			} else {
 				// Content area click or taskbar click
 				if (hit_slot < 0) {
@@ -7244,9 +7220,11 @@ after_key_shortcuts:
 							float ind_left_m = -disp_w_tb / 2.0f + 0.002f + ind_idx * (pill_w_m + gap_m);
 							float ind_right_m = ind_left_m + pill_w_m;
 							if (cursor_x_m >= ind_left_m && cursor_x_m < ind_right_m) {
+								// ADR-018: un-minimize only; focus is the
+								// controller's call. The restored window's
+								// visibility change is observable to the
+								// shell, which focuses it per its policy.
 								mc->clients[i].minimized = false;
-								mc->focused_slot = i;
-								multi_compositor_update_input_forward(mc);
 								U_LOG_W("Multi-comp: taskbar → un-minimize slot %d", i);
 								break;
 							}
@@ -7267,13 +7245,33 @@ after_key_shortcuts:
 					// DOWN to the NEW target after the focus change so
 					// the app sees a full DOWN/MOVE/UP and the click+drag
 					// works in a single motion.
+					// ADR-018: the runtime no longer self-focuses on a
+					// content click — the controller owns focus and reacts
+					// to the POINTER event with xrSetWorkspaceFocusedClientEXT.
+					// We still compute focus_changed (clicked slot != current
+					// focus) to drive the synthetic-DOWN click routing below:
+					// that is input forwarding (translating a spatial click
+					// into a Win32 click on the target HWND), which is
+					// plumbing the runtime legitimately owns, not focus policy.
+					// The synthetic DOWN is posted directly to hit_slot's
+					// HWND, so drag-in-one-click + 2D-capture child-control
+					// routing keep working; the controller updates the input-
+					// forward target for the follow-up MOVE/UP when it focuses.
 					const bool focus_changed = (hit_slot != mc->focused_slot);
-					if (focus_changed) {
-						mc->focused_slot = hit_slot;
-						U_LOG_W("Multi-comp: click → focused slot %d%s", mc->focused_slot,
-						        mc->focused_slot < 0 ? " (unfocused)" : "");
-						multi_compositor_update_input_forward(mc);
-					}
+
+					// Drag-in-one-click signal. focus_changed is no longer a
+					// reliable "did the hit window receive this DOWN?" proxy:
+					// the controller sets focus asynchronously (ADR-018), so by
+					// the time this render-frame handler runs focused_slot may
+					// already point at the hit slot even though the WndProc
+					// forwarded the original DOWN elsewhere (or nowhere). Ask
+					// the window what it ACTUALLY forwarded the DOWN to,
+					// captured at WndProc time — independent of focus timing.
+					HWND last_down_tgt =
+					    (HWND)comp_d3d11_window_get_last_pointer_down_target(mc->window);
+					const bool down_reached_hit =
+					    (last_down_tgt != NULL &&
+					     last_down_tgt == mc->clients[hit_slot].app_hwnd);
 
 					// For capture clients, synthesize a click to route to the correct
 					// child control. When focus DIDN'T change (single click on the
@@ -7324,13 +7322,15 @@ after_key_shortcuts:
 						if (!focus_changed) {
 							PostMessage(click_target, WM_LBUTTONUP, 0, lp);
 						}
-					} else if (focus_changed &&
+					} else if (!down_reached_hit &&
 					           mc->clients[hit_slot].app_hwnd != nullptr &&
 					           !mc->clients[hit_slot].modal_open) {
-						// IPC app: focus changed mid-click. WndProc had
-						// already forwarded the initial DOWN to the OLD
-						// fwd target (or nowhere if none); the NEW target
-						// is missing it. Inject one — but use the SAME
+						// IPC app: the WndProc did NOT forward this DOWN to
+						// the hit window (the click landed on an unfocused
+						// window, so the cursor was outside the focused
+						// window's forward rect — or there was no focus).
+						// The hit window is missing its DOWN, so a drag can't
+						// start in one click. Inject one — using the SAME
 						// coord transform the WndProc applies to MOVE/UP
 						// (app-relative inside the inset content rect,
 						// scaled if app HWND ≠ rect dims) so the app
@@ -13493,13 +13493,9 @@ comp_d3d11_service_set_client_visibility(struct xrt_system_compositor *xsysc,
 	U_LOG_W("Workspace: set_visibility slot %d visible=%d", slot, visible);
 
 	if (!visible && slot == mc->focused_slot) {
+		// ADR-018: hiding the focused client clears focus for forwarding
+		// safety; the controller picks the successor (shell auto-focus-next).
 		mc->focused_slot = -1;
-		for (int i = 0; i < D3D11_MULTI_MAX_CLIENTS; i++) {
-			if (mc->clients[i].active && !mc->clients[i].minimized) {
-				mc->focused_slot = i;
-				break;
-			}
-		}
 		multi_compositor_update_input_forward(mc);
 	}
 	return true;
@@ -14265,6 +14261,36 @@ comp_d3d11_service_workspace_find_slot_by_xc(struct xrt_system_compositor *xsysc
 	struct d3d11_service_compositor *c = d3d11_service_compositor_from_xrt(xc);
 	std::lock_guard<std::recursive_mutex> lock(sys->render_mutex);
 	return multi_comp_find_slot(mc, c);
+}
+
+extern "C" bool
+comp_d3d11_service_workspace_get_client_state(struct xrt_system_compositor *xsysc,
+                                              struct xrt_compositor *xc,
+                                              bool *out_visible,
+                                              bool *out_focused)
+{
+	if (xsysc == nullptr || xc == nullptr) {
+		return false;
+	}
+	struct d3d11_service_system *sys = d3d11_service_system_from_xrt(xsysc);
+	struct d3d11_multi_compositor *mc = sys->multi_comp;
+	if (mc == nullptr) {
+		return false;
+	}
+	struct d3d11_service_compositor *c = d3d11_service_compositor_from_xrt(xc);
+	std::lock_guard<std::recursive_mutex> lock(sys->render_mutex);
+	int slot = multi_comp_find_slot(mc, c);
+	if (slot < 0) {
+		return false;
+	}
+	// WORKSPACE visibility = not minimized. Distinct from IPC session_visible.
+	if (out_visible != nullptr) {
+		*out_visible = !mc->clients[slot].minimized;
+	}
+	if (out_focused != nullptr) {
+		*out_focused = (slot == mc->focused_slot);
+	}
+	return true;
 }
 
 // IPC-facing wrappers (signatures from comp_d3d11_service.h). Resolve

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.h
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.h
@@ -531,6 +531,21 @@ int
 comp_d3d11_service_workspace_find_slot_by_xc(struct xrt_system_compositor *xsysc, struct xrt_compositor *xc);
 
 /*!
+ * Report the WORKSPACE visibility + focus state of the slot bound to @p xc.
+ * out_visible is !minimized (the compositor's workspace-minimize flag), NOT
+ * the IPC session-visible state. out_focused is (slot == focused_slot). Used
+ * by ipc_handle_workspace_get_client_info so the controller's
+ * XrWorkspaceClientInfoEXT.isVisible / isFocused reflect workspace state — the
+ * shell's auto-focus must skip minimized windows, which session_visible does
+ * not capture. Returns false on miss (unknown xc); outputs untouched then.
+ */
+bool
+comp_d3d11_service_workspace_get_client_state(struct xrt_system_compositor *xsysc,
+                                              struct xrt_compositor *xc,
+                                              bool *out_visible,
+                                              bool *out_focused);
+
+/*!
  * Phase 2.C: register a controller-minted swapchain as the chrome image for
  * a workspace slot. The runtime keeps a strong ref to @p chrome_xsc and
  * composites its first image every render at the pose previously set via

--- a/src/xrt/ipc/server/ipc_server_handler.c
+++ b/src/xrt/ipc/server/ipc_server_handler.c
@@ -2848,6 +2848,45 @@ ipc_handle_workspace_set_focused_client(volatile struct ipc_client_state *_ics, 
 		return XRT_SUCCESS;
 	}
 
+	// The workspace controller may pass EITHER form of client id:
+	//   - the canonical IPC client id (xrEnumerateWorkspaceClientsEXT form,
+	//     always < 1000 for OpenXR clients), or
+	//   - the legacy "1000 + slot" form that POINTER / POINTER_MOTION /
+	//     HOVER / FOCUS_CHANGED events report as hit_client_id.
+	// Click-to-focus (LMB/RMB), TAB cycle, and the FULLSCREEN_TOGGLED event
+	// all hand the controller the pointer hit id (1000 + slot), so accept
+	// that form here. We can't route it through ipc_server_set_active_client
+	// (which looks up by canonical id and would fail for 1000+slot); instead
+	// map it straight to the compositor slot for the glow + key forwarding,
+	// and resolve the slot's occupying IPC client to keep the active-client
+	// index — which drives session-focus events — in sync. Capture clients
+	// have no IPC session, so focused_slot alone is the whole story.
+#if defined(XRT_HAVE_D3D11_SERVICE_COMPOSITOR)
+	if (client_id >= 1000u && s->xsysc != NULL) {
+		int slot = (int)(client_id - 1000u);
+		uint32_t canonical_id = 0;
+		os_mutex_lock(&s->global_state.lock);
+		for (uint32_t i = 0; i < IPC_MAX_CLIENTS; i++) {
+			volatile struct ipc_client_state *ics = &s->threads[i].ics;
+			if (ics->server_thread_index < 0 || ics->xc == NULL) {
+				continue;
+			}
+			if (comp_d3d11_service_workspace_find_slot_by_xc(
+			        s->xsysc, (struct xrt_compositor *)ics->xc) == slot) {
+				canonical_id = ics->client_state.id;
+				break;
+			}
+		}
+		os_mutex_unlock(&s->global_state.lock);
+		if (canonical_id != 0) {
+			(void)ipc_server_set_active_client(s, canonical_id);
+		}
+		comp_d3d11_service_set_focused_slot(s->xsysc, slot);
+		return XRT_SUCCESS;
+	}
+#endif
+
+	// Canonical IPC client id path (xrEnumerateWorkspaceClientsEXT form).
 	xrt_result_t xret = ipc_server_set_active_client(s, client_id);
 
 #if defined(XRT_HAVE_D3D11_SERVICE_COMPOSITOR)
@@ -2857,27 +2896,22 @@ ipc_handle_workspace_set_focused_client(volatile struct ipc_client_state *_ics, 
 	// index in mc->clients[]. Map via find_slot_by_xc — same lookup
 	// the chrome layout setter uses.
 	if (xret == XRT_SUCCESS && s->xsysc != NULL) {
-		// Capture clients (id >= 1000) map straight to slot.
-		if (client_id >= 1000u) {
-			comp_d3d11_service_set_focused_slot(s->xsysc, (int)(client_id - 1000u));
-		} else {
-			os_mutex_lock(&s->global_state.lock);
-			volatile struct ipc_client_state *target_ics = NULL;
-			for (uint32_t i = 0; i < IPC_MAX_CLIENTS; i++) {
-				volatile struct ipc_client_state *ics = &s->threads[i].ics;
-				if (ics->client_state.id == client_id && ics->server_thread_index >= 0) {
-					target_ics = ics;
-					break;
-				}
+		os_mutex_lock(&s->global_state.lock);
+		volatile struct ipc_client_state *target_ics = NULL;
+		for (uint32_t i = 0; i < IPC_MAX_CLIENTS; i++) {
+			volatile struct ipc_client_state *ics = &s->threads[i].ics;
+			if (ics->client_state.id == client_id && ics->server_thread_index >= 0) {
+				target_ics = ics;
+				break;
 			}
-			int mc_slot = -1;
-			if (target_ics != NULL && target_ics->xc != NULL) {
-				mc_slot = comp_d3d11_service_workspace_find_slot_by_xc(
-				    s->xsysc, (struct xrt_compositor *)target_ics->xc);
-			}
-			os_mutex_unlock(&s->global_state.lock);
-			comp_d3d11_service_set_focused_slot(s->xsysc, mc_slot);
 		}
+		int mc_slot = -1;
+		if (target_ics != NULL && target_ics->xc != NULL) {
+			mc_slot = comp_d3d11_service_workspace_find_slot_by_xc(
+			    s->xsysc, (struct xrt_compositor *)target_ics->xc);
+		}
+		os_mutex_unlock(&s->global_state.lock);
+		comp_d3d11_service_set_focused_slot(s->xsysc, mc_slot);
 	}
 #endif
 
@@ -2936,12 +2970,32 @@ ipc_handle_workspace_set_client_frame_rate_cap(volatile struct ipc_client_state 
 
 	os_mutex_lock(&s->global_state.lock);
 
+	// Accept both client-id forms (see ipc_handle_workspace_set_focused_client):
+	// the canonical IPC id (< 1000) from xrEnumerateWorkspaceClientsEXT, and the
+	// "1000 + slot" form the controller carries from POINTER / FOCUS_CHANGED
+	// events. The shell's focus-policy caps the previously/newly focused client
+	// using whatever id form it last saw, so both must resolve to the same xc.
 	volatile struct ipc_client_state *target_ics = NULL;
-	for (uint32_t i = 0; i < IPC_MAX_CLIENTS; i++) {
-		volatile struct ipc_client_state *ics = &s->threads[i].ics;
-		if (ics->client_state.id == client_id && ics->server_thread_index >= 0) {
-			target_ics = ics;
-			break;
+	if (client_id >= 1000u) {
+		int slot = (int)(client_id - 1000u);
+		for (uint32_t i = 0; i < IPC_MAX_CLIENTS; i++) {
+			volatile struct ipc_client_state *ics = &s->threads[i].ics;
+			if (ics->server_thread_index < 0 || ics->xc == NULL) {
+				continue;
+			}
+			if (comp_d3d11_service_workspace_find_slot_by_xc(
+			        s->xsysc, (struct xrt_compositor *)ics->xc) == slot) {
+				target_ics = ics;
+				break;
+			}
+		}
+	} else {
+		for (uint32_t i = 0; i < IPC_MAX_CLIENTS; i++) {
+			volatile struct ipc_client_state *ics = &s->threads[i].ics;
+			if (ics->client_state.id == client_id && ics->server_thread_index >= 0) {
+				target_ics = ics;
+				break;
+			}
 		}
 	}
 
@@ -3169,7 +3223,32 @@ ipc_handle_workspace_get_client_info(volatile struct ipc_client_state *_ics,
 	if (out_state == NULL) {
 		return XRT_ERROR_IPC_FAILURE;
 	}
-	return ipc_server_get_client_app_state(s, client_id, out_state);
+	xrt_result_t xret = ipc_server_get_client_app_state(s, client_id, out_state);
+	if (xret != XRT_SUCCESS) {
+		return xret;
+	}
+
+#if defined(XRT_HAVE_D3D11_SERVICE_COMPOSITOR)
+	// Override session_visible / session_focused with the WORKSPACE state
+	// (the compositor's minimized flag + focused_slot). The IPC session
+	// flags describe xrSession lifecycle, not workspace minimize/focus —
+	// the controller's auto-focus must skip minimized windows, which the
+	// session flags do not capture. Resolve client_id → xc → slot state.
+	if (s->xsysc != NULL) {
+		struct xrt_compositor *target_xc = NULL;
+		if (ipc_server_get_client_xc(s, client_id, &target_xc) == XRT_SUCCESS &&
+		    target_xc != NULL) {
+			bool ws_visible = false, ws_focused = false;
+			if (comp_d3d11_service_workspace_get_client_state(
+			        s->xsysc, target_xc, &ws_visible, &ws_focused)) {
+				out_state->session_visible = ws_visible;
+				out_state->session_focused = ws_focused;
+			}
+		}
+	}
+#endif
+
+	return XRT_SUCCESS;
 }
 
 xrt_result_t

--- a/src/xrt/targets/openxr/target_dll_init.c
+++ b/src/xrt/targets/openxr/target_dll_init.c
@@ -4,11 +4,12 @@
  * @file
  * @brief DllMain + delay-load hook for DisplayXRClient.dll on Windows.
  *
- * Resolves /DELAYLOAD'd dependencies (SimulatedRealityVulkanBeta.dll) from
- * the runtime's own install directory without requiring $INSTDIR to be on
- * the system PATH. We're loaded into the host app's process and must not
- * mutate process-wide DLL search behavior (no SetDefaultDllDirectories) —
- * the delay-load notification hook is the surgical option.
+ * Resolves /DELAYLOAD'd dependencies (e.g. vulkan-1.dll) from the runtime's
+ * own install directory without requiring $INSTDIR to be on the system PATH.
+ * We're loaded into the host app's process and must not mutate process-wide
+ * DLL search behavior (no SetDefaultDllDirectories) — the delay-load
+ * notification hook is the surgical option. (Vendor SR weaver DLLs are not
+ * delay-loaded by the runtime; the Leia plug-in loads its own.)
  */
 
 #ifdef _WIN32

--- a/src/xrt/targets/service/CMakeLists.txt
+++ b/src/xrt/targets/service/CMakeLists.txt
@@ -15,14 +15,14 @@ target_link_libraries(
 		target_instance
 	)
 
-# Delay-load Vulkan and SR Vulkan DLLs so the service can start on systems
-# where these are absent. The D3D11 service compositor path never calls into
-# Vulkan or SR Vulkan weaver functions, so the delay-loaded DLLs are never triggered.
-# This mirrors the same pattern used by the in-process runtime (DisplayXRClient.dll).
+# Delay-load Vulkan so the service can start on systems where it is absent.
+# The D3D11 service compositor path never calls into Vulkan functions, so the
+# delay-loaded DLL is never triggered. This mirrors the same pattern used by
+# the in-process runtime (DisplayXRClient.dll). (No vendor SR DLL here: the SR
+# Vulkan weaver is a Leia plug-in concern, loaded by the plug-in itself.)
 if(WIN32)
 	target_link_options(displayxr-service PRIVATE
 		"/DELAYLOAD:vulkan-1.dll"
-		"/DELAYLOAD:SimulatedRealityVulkanBeta.dll"
 	)
 	target_link_libraries(displayxr-service PRIVATE delayimp)
 


### PR DESCRIPTION
## What

Remove the runtime's last reference to the Leia SR Vulkan weaver DLL.

- Drop `/DELAYLOAD:SimulatedRealityVulkanBeta.dll` from `displayxr-service` (`src/xrt/targets/service/CMakeLists.txt`). The `/DELAYLOAD:vulkan-1.dll` stays — that one is live (lets the service/null compositor start without Vulkan present).
- De-vendor the `target_dll_init.c` header comment. The generic delay-load notification hook remains for `vulkan-1.dll` resolution from `$INSTDIR`.

## Why

Stale leftover from before the Leia weaver moved out of the runtime (#263 / ADR-019). `DisplayXRClient.dll` and `displayxr-service` no longer link any SR import lib, so the `/DELAYLOAD` directive produced no delay-import and the hook never fired for SR — a no-op that still named a vendor binary in vendor-neutral runtime build files. The Leia plug-in now loads `SimulatedRealityVulkanBeta.dll` itself (**displayxr-leia-plugin#2**), which is where that responsibility belongs (ADR-019; the vendor-plugin-architecture roadmap explicitly says this machinery moves to the plug-in).

## Risk

No functional change. No SR symbols are referenced anywhere in the runtime link line, so removing the directive changes nothing at load time. The ADR-019 CI guard (`dumpbin /imports DisplayXRClient.dll` → zero `SimulatedReality*`) continues to hold. Not built locally — relying on Windows CI for the link verification.

Part of making the SR weaver DLL a Leia-plugin-only concern (companion to displayxr-leia-plugin#2 and displayxr-demo-gaussiansplat#15). Context: #314.