### PR TITLE
chore: bump full-stack version pins (leia v1.0.3, gauss v1.4.1)

### DIFF
--- a/docs/getting-started/full-stack-install.md
+++ b/docs/getting-started/full-stack-install.md
@@ -86,12 +86,12 @@ Top-level pin file. Bump a value here to roll the dev box forward:
 
 ```json
 {
-  "runtime":     "v1.4.0",
+  "runtime":     "v1.4.3",
   "shell":       "v1.2.5",
-  "leia_plugin": "v1.0.1",
-  "mcp_tools":   "v0.3.1",
+  "leia_plugin": "v1.0.3",
+  "mcp_tools":   "v0.3.2",
   "demos": {
-    "gaussiansplat": "v1.3.1"
+    "gaussiansplat": "v1.4.1"
   }
 }
 ```
@@ -116,7 +116,7 @@ cases.
 ### macOS
 
 ```bash
-gh release download v1.4.0 \
+gh release download v1.4.3 \
     --repo DisplayXR/displayxr-runtime \
     --pattern 'DisplayXR-Installer-*.pkg' \
     --dir /tmp/dxr
@@ -127,11 +127,11 @@ sudo installer -pkg /tmp/dxr/DisplayXR-Installer-*.pkg -target /
 
 ```bat
 :: From an elevated cmd
-gh release download v1.4.0 --repo DisplayXR/displayxr-runtime --pattern "DisplayXRSetup-*.exe" --dir %TEMP%\dxr
+gh release download v1.4.3 --repo DisplayXR/displayxr-runtime --pattern "DisplayXRSetup-*.exe" --dir %TEMP%\dxr
 %TEMP%\dxr\DisplayXRSetup-*.exe /S
 gh release download v1.2.5 --repo DisplayXR/displayxr-shell-releases --pattern "DisplayXRShellSetup-*.exe" --dir %TEMP%\dxr
 %TEMP%\dxr\DisplayXRShellSetup-*.exe /S
-gh release download v1.0.1 --repo DisplayXR/displayxr-leia-plugin --pattern "DisplayXRLeiaSRSetup-*.exe" --dir %TEMP%\dxr
+gh release download v1.0.3 --repo DisplayXR/displayxr-leia-plugin --pattern "DisplayXRLeiaSRSetup-*.exe" --dir %TEMP%\dxr
 %TEMP%\dxr\DisplayXRLeiaSRSetup-*.exe /S
 ```
 

--- a/scripts/lib/components.sh
+++ b/scripts/lib/components.sh
@@ -60,9 +60,9 @@ COMPONENT_INSTALL_MARKER_WINDOWS_mcp_tools="HKLM\\Software\\DisplayXR\\Capabilit
 
 # --- gauss_demo ---
 # Gaussian-splat viewer demo. macOS .pkg first shipped in
-# displayxr-demo-gaussiansplat v1.4.0 (2026-05-24, #311). Windows installer
-# is built locally today; CI for the .exe is tracked at the demo repo's
-# issue #14. Note: the macOS install marker has a space in the path —
+# displayxr-demo-gaussiansplat v1.4.0 (2026-05-24, #311). Both installers
+# (macOS .pkg + Windows .exe) are now built + attached by CI on a v* tag
+# (demo #14). Note: the macOS install marker has a space in the path —
 # consumers must quote when testing existence.
 COMPONENT_REPO_gauss_demo="DisplayXR/displayxr-demo-gaussiansplat"
 COMPONENT_PKG_MACOS_gauss_demo="DisplayXRGaussianSplat-*.pkg"

--- a/versions.json
+++ b/versions.json
@@ -2,9 +2,9 @@
   "$schema": "https://json.schemastore.org/displayxr-versions.json",
   "runtime":     "v1.4.3",
   "shell":       "v1.2.5",
-  "leia_plugin": "v1.0.2",
+  "leia_plugin": "v1.0.3",
   "mcp_tools":   "v0.3.2",
   "demos": {
-    "gaussiansplat": "v1.3.1"
+    "gaussiansplat": "v1.4.1"
   }
 }


### PR DESCRIPTION
Rolls `versions.json` (the full-stack orchestrator pin file) + its mirror in `docs/getting-started/full-stack-install.md` to current released versions:

- `leia_plugin` v1.0.2 → **v1.0.3** (SR VK weaver delay-load fix; #314)
- `demos.gaussiansplat` v1.3.1 → **v1.4.1** (drops the bundled Leia SR DLL; first CI-built + auto-attached Windows installer — demo #14). Release verified with both `DisplayXRGaussianSplat-1.4.1.pkg` + `DisplayXRGaussianSplatSetup-1.4.1.exe`.
- Re-sync the doc's `versions.json` block + manual-fallback download commands to the real pins (runtime v1.4.3, shell v1.2.5, mcp v0.3.2).
- `components.sh`: note the gauss Windows installer is now CI-built.

All pinned tags exist as published releases.