### PR TITLE
feat(#304): unify workspace client-id on 1000+slot across all events + APIs

### DIFF
--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -4852,6 +4852,11 @@ multi_compositor_register_client(struct d3d11_service_system *sys, struct d3d11_
 			mc->clients[i].anim.active = false;
 			mc->clients[i].announce_connected = true;
 			mc->clients[i].placed = false;
+			// #304 id-unification: the slot's permanent workspace client id is
+			// 1000 + slot, assigned here at register (NOT at chrome-create as
+			// before). Every event + API uses this one id. Chrome create/
+			// destroy no longer touches it; has-chrome gating uses chrome_xsc.
+			mc->clients[i].workspace_client_id = 1000u + (uint32_t)i;
 
 			// Compute pixel rect from the sentinel pose.
 			slot_pose_to_pixel_rect(sys, &mc->clients[i],
@@ -5209,6 +5214,9 @@ multi_compositor_add_capture_client(struct d3d11_service_system *sys, HWND hwnd,
 			mc->clients[i].window_height_m = height_m;
 			mc->clients[i].anim.active = false;
 			mc->clients[i].announce_connected = true;
+			// #304 id-unification: permanent workspace id = 1000 + slot. For
+			// capture clients this matches the id add_capture already returns.
+			mc->clients[i].workspace_client_id = 1000u + (uint32_t)i;
 			// Capture clients are controller-chosen (added via add_capture) and
 			// the controller already knows them; start them placed so the
 			// dormant 2D-capture path keeps drawing at the sentinel rather than
@@ -6993,7 +7001,10 @@ after_key_shortcuts:
 		for (int sw = 0; sw < D3D11_MULTI_MAX_CLIENTS; sw++) {
 			struct d3d11_multi_client_slot *cs = &mc->clients[sw];
 			if (!cs->active || cs->client_type == CLIENT_TYPE_CAPTURE) continue;
-			if (cs->workspace_client_id == 0) continue;
+			// #304: has-chrome gate (was the workspace_client_id==0 proxy,
+			// which is now always non-zero). Only chromed slots need the
+			// pose-change wakeup so the controller can re-anchor its pill.
+			if (cs->chrome_xsc == nullptr) continue;
 			const float kEps = 1e-5f;
 			if (fabsf(cs->window_width_m  - cs->window_w_last_emitted) > kEps ||
 			    fabsf(cs->window_height_m - cs->window_h_last_emitted) > kEps ||
@@ -13930,7 +13941,7 @@ comp_d3d11_service_workspace_drain_input_events(struct xrt_system_compositor *xs
 	     out_batch->count < IPC_WORKSPACE_INPUT_EVENT_BATCH_MAX; s++) {
 		struct d3d11_multi_client_slot *cs = &mc->clients[s];
 		if (!cs->active || cs->client_type == CLIENT_TYPE_CAPTURE) continue;
-		if (cs->workspace_client_id == 0) continue; // skip uninteresting (no chrome registered)
+		if (cs->chrome_xsc == nullptr) continue; // #304: has-chrome gate (was workspace_client_id==0 proxy)
 
 		const struct xrt_pose &p = cs->window_pose;
 		const struct xrt_pose &q = cs->window_pose_last_emitted;
@@ -13981,7 +13992,7 @@ comp_d3d11_service_workspace_drain_input_events(struct xrt_system_compositor *xs
 	     out_batch->count < IPC_WORKSPACE_INPUT_EVENT_BATCH_MAX; s++) {
 		struct d3d11_multi_client_slot *cs = &mc->clients[s];
 		if (!cs->active || cs->client_type == CLIENT_TYPE_CAPTURE) continue;
-		if (cs->workspace_client_id == 0) continue;
+		if (cs->chrome_xsc == nullptr) continue; // #304: has-chrome gate (was workspace_client_id==0 proxy)
 		if (cs->modal_open == cs->modal_open_last_emitted) continue;
 
 		struct ipc_workspace_input_event *ev = &out_batch->events[out_batch->count];
@@ -14317,12 +14328,13 @@ comp_d3d11_service_workspace_register_chrome_swapchain_by_slot(struct xrt_system
 	if (cs->chrome_xsc != nullptr) {
 		xrt_swapchain_reference(&cs->chrome_xsc, NULL);
 		cs->chrome_swapchain_id = 0;
-		cs->workspace_client_id = 0;
 	}
 
 	xrt_swapchain_reference(&cs->chrome_xsc, chrome_xsc);
 	cs->chrome_swapchain_id = swapchain_id;
-	cs->workspace_client_id = client_id;
+	// #304 id-unification: workspace_client_id is the permanent slot id set at
+	// register; chrome create/destroy no longer owns it. (client_id passed in
+	// equals 1000+slot post-unification — kept only for the log below.)
 
 	U_LOG_W("workspace: chrome swapchain registered for slot %d (client_id=%u, sc_id=%u)",
 	        slot, client_id, swapchain_id);
@@ -14352,7 +14364,8 @@ comp_d3d11_service_workspace_unregister_chrome_swapchain(struct xrt_system_compo
 			xrt_swapchain_reference(&cs->chrome_xsc, NULL);
 			cs->chrome_swapchain_id = 0;
 			cs->chrome_layout_valid = false;
-			cs->workspace_client_id = 0;
+			// #304: keep workspace_client_id (permanent slot id); only chrome
+			// state is torn down here.
 			U_LOG_W("workspace: chrome swapchain unregistered (slot=%d, id=%u)", s, swapchain_id);
 			return XRT_SUCCESS;
 		}

--- a/src/xrt/ipc/server/ipc_server_handler.c
+++ b/src/xrt/ipc/server/ipc_server_handler.c
@@ -2548,6 +2548,41 @@ ipc_handle_launcher_poll_click(volatile struct ipc_client_state *_ics,
 #endif
 }
 
+// #304 id-unification: workspace clients are addressed by the unified
+// "1000 + slot" id everywhere (enumerate / get_focused / events all use it).
+// Handlers whose bodies look a client up by the canonical IPC id call this
+// first to translate a 1000+slot id back to the canonical id. Pass-through
+// for ids that are already canonical (< 1000) or that don't resolve to a
+// live OpenXR slot (e.g. capture clients, which have no canonical id — those
+// handlers carry their own >= 1000 slot branch).
+static uint32_t
+ipc_workspace_normalize_client_id(struct ipc_server *s, uint32_t client_id)
+{
+#if defined(XRT_HAVE_D3D11_SERVICE_COMPOSITOR)
+	if (client_id >= 1000u && s != NULL && s->xsysc != NULL) {
+		int slot = (int)(client_id - 1000u);
+		os_mutex_lock(&s->global_state.lock);
+		uint32_t canon = 0;
+		for (uint32_t i = 0; i < IPC_MAX_CLIENTS; i++) {
+			volatile struct ipc_client_state *ics = &s->threads[i].ics;
+			if (ics->server_thread_index < 0 || ics->xc == NULL) {
+				continue;
+			}
+			if (comp_d3d11_service_workspace_find_slot_by_xc(
+			        s->xsysc, (struct xrt_compositor *)ics->xc) == slot) {
+				canon = ics->client_state.id;
+				break;
+			}
+		}
+		os_mutex_unlock(&s->global_state.lock);
+		if (canon != 0) {
+			return canon;
+		}
+	}
+#endif
+	return client_id;
+}
+
 xrt_result_t
 ipc_handle_workspace_set_window_pose(volatile struct ipc_client_state *_ics,
                                   uint32_t client_id,
@@ -2624,6 +2659,8 @@ ipc_handle_workspace_set_window_visibility(volatile struct ipc_client_state *_ic
 	if (s->xsysc == NULL) {
 		return XRT_ERROR_IPC_FAILURE;
 	}
+
+	client_id = ipc_workspace_normalize_client_id(s, client_id); // #304: accept 1000+slot
 
 	IPC_INFO(s, "Workspace: set_visibility client_id=%u visible=%d", client_id, visible);
 
@@ -2943,7 +2980,17 @@ ipc_handle_workspace_get_focused_client(volatile struct ipc_client_state *_ics, 
 	int idx = s->global_state.active_client_index;
 	if (idx >= 0 && idx < IPC_MAX_CLIENTS) {
 		volatile struct ipc_client_state *ics = &s->threads[idx].ics;
+#if defined(XRT_HAVE_D3D11_SERVICE_COMPOSITOR)
+		// #304 id-unification: return the 1000+slot workspace id (matches
+		// enumerate + events), resolved from the active client's slot.
+		int slot = (s->xsysc != NULL && ics->xc != NULL)
+		    ? comp_d3d11_service_workspace_find_slot_by_xc(
+		          s->xsysc, (struct xrt_compositor *)ics->xc)
+		    : -1;
+		*out_client_id = (slot >= 0) ? (1000u + (uint32_t)slot) : 0;
+#else
 		*out_client_id = ics->client_state.id;
+#endif
 	}
 	os_mutex_unlock(&s->global_state.lock);
 
@@ -3204,6 +3251,22 @@ ipc_handle_workspace_enumerate_clients(volatile struct ipc_client_state *_ics, s
 		if (ics->server_thread_index < 0) {
 			continue;
 		}
+#if defined(XRT_HAVE_D3D11_SERVICE_COMPOSITOR)
+		// #304 id-unification: return the unified 1000+slot workspace id so
+		// it matches what the events report and what set_*/chrome accept.
+		// Clients not yet bound to a compositor slot (and the controller's
+		// own session, which has no slot) are skipped — they reappear once
+		// slotted, and they can't be posed/chromed/focused before that.
+		if (s->xsysc != NULL && ics->xc != NULL) {
+			int slot = comp_d3d11_service_workspace_find_slot_by_xc(
+			    s->xsysc, (struct xrt_compositor *)ics->xc);
+			if (slot < 0) {
+				continue;
+			}
+			list->ids[count++] = 1000u + (uint32_t)slot;
+			continue;
+		}
+#endif
 		list->ids[count++] = ics->client_state.id;
 	}
 	list->id_count = count;
@@ -3228,6 +3291,7 @@ ipc_handle_workspace_get_client_info(volatile struct ipc_client_state *_ics,
 	if (out_state == NULL) {
 		return XRT_ERROR_IPC_FAILURE;
 	}
+	client_id = ipc_workspace_normalize_client_id(s, client_id); // #304: accept 1000+slot
 	xrt_result_t xret = ipc_server_get_client_app_state(s, client_id, out_state);
 	if (xret != XRT_SUCCESS) {
 		return xret;
@@ -3320,6 +3384,11 @@ ipc_handle_workspace_register_chrome_swapchain(volatile struct ipc_client_state 
 		return XRT_ERROR_IPC_FAILURE;
 	}
 
+	// #304: accept the unified 1000+slot id. Normalize translates an OpenXR
+	// client's 1000+slot back to its canonical id (so the find-by-id below
+	// works); a capture client has no canonical id so it stays >= 1000 and
+	// hits the reject below (captures aren't decorated with chrome).
+	client_id = ipc_workspace_normalize_client_id(s, client_id);
 	int slot = -1;
 	if (client_id >= 1000u) {
 		// Capture clients aren't decorated with chrome — reject for now.
@@ -3390,6 +3459,7 @@ ipc_handle_workspace_set_chrome_layout(volatile struct ipc_client_state *_ics,
 		return XRT_ERROR_IPC_FAILURE;
 	}
 
+	client_id = ipc_workspace_normalize_client_id(s, client_id); // #304: accept 1000+slot
 	int slot = -1;
 	if (client_id >= 1000u) {
 		IPC_WARN(s, "Workspace: set_chrome_layout - capture clients (id=%u) not supported", client_id);
@@ -3464,6 +3534,7 @@ ipc_handle_workspace_update_chrome_layer_pose(volatile struct ipc_client_state *
 		return XRT_ERROR_IPC_FAILURE;
 	}
 
+	client_id = ipc_workspace_normalize_client_id(s, client_id); // #304: accept 1000+slot
 	if (client_id >= 1000u) {
 		IPC_WARN(s, "Workspace: update_chrome_layer_pose - capture clients (id=%u) not supported", client_id);
 		return XRT_ERROR_IPC_FAILURE;


### PR DESCRIPTION
## Summary

Second slice of #304 (follows the merged `CLIENT_CONNECTED` + `placed` draw-gate, #319). Collapses the two colliding workspace client-id conventions onto **one opaque id**: `1000 + slot`, everywhere the controller sees.

Today: pointer/focus/fullscreen/hover events use `1000+slot`, while `enumerate`/`get_focused`/chrome use the canonical IPC id (`< 1000` for OpenXR clients). The shell straddled both, which caused three separate bugs during #302. This unifies them.

Chosen `1000+slot` (not canonical) because the per-frame event hot path lives in the compositor, which has the slot natively — no per-event slot→canonical lookup — and capture clients already use it.

### Compositor
- `workspace_client_id` is now the **permanent** slot id (`1000 + slot`), assigned at register for every client (was set only at chrome-create). HOVER / WINDOW_POSE_CHANGED / MODAL / FILE_PICKER emits now carry the unified id and are non-zero from connect.
- chrome create/destroy no longer writes/clears it; the three emit gates that used `workspace_client_id == 0` as a has-chrome proxy now test the real marker (`chrome_xsc == nullptr`).

### IPC handlers
- **Producers** emit `1000+slot`: `xrEnumerateWorkspaceClientsEXT` (resolves each IPC client's slot; skips unslotted clients + the controller's own session) and `xrGetWorkspaceFocusedClientEXT`.
- **Consumers** that looked up by canonical id (`set_visibility`, register/set/update chrome, `get_client_info`) gain a `ipc_workspace_normalize_client_id()` prefix translating `1000+slot` → canonical; capture ids (no canonical) pass through to the existing capture-reject in the chrome handlers. Handlers that already accepted `>=1000` (`set_pose`/`set_focused`/cap/`request_exit`/fullscreen/z_order/style) unchanged.
- The **system** enumerate/get_client_info channel (WebXR bridge) is left on canonical ids — untouched.

No header/spec_version change (behavior only) — **not** a coupled PR; no shell change (the shell passes enumerate ids through transparently and is now consistent).

## Test plan
- [x] `scripts\build_windows.bat build` — clean.
- [x] Shell + 4 cubes (Leia SR): chrome pills on all cubes, clean grid, TAB / click-to-focus / close-refocus / minimize-refocus, hover/cursor — all working with the unified id.
- [x] Standalone cube unaffected.
- [ ] CI: Windows + macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)