### PR TITLE
fix(workspace): app-HWND resize on set_pose (#320 regression) + LMB capture leak

### DIFF
--- a/src/xrt/compositor/d3d11/comp_d3d11_window.cpp
+++ b/src/xrt/compositor/d3d11/comp_d3d11_window.cpp
@@ -828,14 +828,6 @@ wnd_proc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 					w->mouse_press_in_content = false;
 				}
 
-				// Phase 2.G followup #1: when xrEnableWorkspacePointerCaptureEXT
-				// is active for a button, that button's events bypass the
-				// in-rect / dragging gate so a controller-driven drag (move,
-				// resize) keeps receiving the up event even when the cursor
-				// has been pulled outside the content rect. Without this gate
-				// `buttons_held` is already false at WM_*BUTTONUP and
-				// `mouse_press_in_content` was just cleared, so the up
-				// vanishes whenever the press wasn't in content.
 				LONG cap_en = InterlockedCompareExchange(
 				    &w->workspace_pointer_capture_enabled, 0, 0);
 				LONG cap_btn = InterlockedCompareExchange(
@@ -850,15 +842,40 @@ wnd_proc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 				case WM_MBUTTONUP:   evt_button = 3; break;
 				default: break;
 				}
+
+				// The controller enables pointer capture ONLY for its own
+				// window-management drags (title-bar move, edge resize — see
+				// displayxr-shell's enable_pointer_capture call sites) and
+				// disables it on release. The captured button's DOWN/UP still
+				// forward (capture_active): the grip press lands inside the
+				// window's forward rect and is eagerly forwarded before the
+				// controller engages capture, so the app must still receive the
+				// matching UP or it sits with a stuck button (which then turns
+				// later hover-moves into a phantom drag and snaps the content at
+				// drag end). What must be swallowed are the MOVES in between —
+				// they carry no evt_button, so the old capture_active gate missed
+				// them and they leaked into the app via in_rect the moment the
+				// cursor crossed into content, mirroring the controller's drag.
 				bool capture_active =
 				    (cap_en != 0) && evt_button != 0 &&
 				    cap_btn == (LONG)evt_button;
+				uint32_t cap_mk = 0;
+				switch (cap_btn) {
+				case 1: cap_mk = MK_LBUTTON; break;
+				case 2: cap_mk = MK_RBUTTON; break;
+				case 3: cap_mk = MK_MBUTTON; break;
+				default: break;
+				}
+				bool capture_move_suppress =
+				    (cap_en != 0) && cap_mk != 0 && message == WM_MOUSEMOVE &&
+				    (((uint32_t)wParam & cap_mk) != 0);
 
-				// Forward if inside rect, or if dragging from an in-content press,
-				// or if pointer capture is held for this button.
+				// Forward if inside rect, dragging from an in-content press, or
+				// the captured button's up/down — but never a captured drag's
+				// moves.
 				bool buttons_held = (wParam & (MK_LBUTTON | MK_RBUTTON | MK_MBUTTON)) != 0;
 				bool dragging = buttons_held && w->mouse_press_in_content;
-				if (in_rect || dragging || capture_active) {
+				if (!capture_move_suppress && (in_rect || dragging || capture_active)) {
 					// Remap to app-window client coords.
 					// Scale if target HWND is a different size than the
 					// virtual rect (e.g., captured 2D windows).

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -958,10 +958,9 @@ struct d3d11_multi_client_slot
 	//! since slot registration. Until then, multi_compositor_render skips
 	//! drawing this slot entirely — the per-client atlas is uninitialized and
 	//! `content_view_w/_h` are zero, so any draw shows undefined-memory black
-	//! at fallback dims. The entry animation start time is reset on the
-	//! false→true transition so the slot's grow-in animation plays once
-	//! content is actually available (mirrors the capture-client pattern of
-	//! gating on `capture_srv` non-null at the same render-loop site).
+	//! at fallback dims (mirrors the capture-client pattern of gating on
+	//! `capture_srv` non-null at the same render-loop site). The entry grow-in
+	//! animation is controller-owned now (#306); the runtime only gates drawing.
 	bool has_first_frame_committed;
 
 	//! Monotonic time the first projection-layer commit landed for this
@@ -6442,9 +6441,6 @@ quat_is_identity(const struct xrt_quat *q)
 
 // ANIM_DURATION_NS defined earlier (forward declaration section).
 
-//! Animation duration for initial window entry (400ms).
-#define ANIM_ENTRY_DURATION_NS (400ULL * 1000000ULL)
-
 /*!
  * Ease-out cubic: fast start, smooth deceleration.
  * t in [0,1] → result in [0,1].
@@ -7510,9 +7506,10 @@ after_key_shortcuts:
 	(void)display_w_m;
 	(void)display_h_m;
 
-	// Tick per-slot animations (for static layout transitions + entry animations).
-	// Phase 2.G: layout-preset state machine moved to the workspace controller,
-	// so this no longer needs to skip when a "dynamic" layout is active.
+	// Tick per-slot animations. The entry grow-in moved to the controller
+	// (#306); what remains here is the maximize/restore ease (toggle_fullscreen,
+	// moves to the controller in #307). Phase 2.G: layout-preset state machine
+	// already moved to the controller, so this no longer skips on "dynamic".
 	{
 		uint64_t anim_now = os_monotonic_get_ns();
 		bool focused_rect_changed = false;
@@ -11228,14 +11225,11 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 
 		// Store content dims on multi-comp slot for multi_compositor_render.
 		// Also flip `has_first_frame_committed` on the false→true transition
-		// and reset the entry animation's start time so the slot's grow-in
-		// animation plays once Chrome (or any IPC client) has actually
-		// submitted content. Without this, the multi-comp would draw the
-		// slot at intermediate animation sizes with uninitialized atlas
-		// content for the 2-3s while Chrome's WebGL is initializing —
-		// visible as a narrow black rectangle that jumps to full size when
-		// the first frame lands. Mirrors the capture-client `capture_srv`
-		// readiness gate.
+		// so the slot starts compositing only once Chrome (or any IPC client)
+		// has actually submitted content. Without this, the multi-comp would
+		// draw the slot with uninitialized atlas content for the 2-3s while
+		// Chrome's WebGL is initializing — visible as a black rectangle.
+		// Mirrors the capture-client `capture_srv` readiness gate.
 		if (sys->workspace_mode && sys->multi_comp != nullptr) {
 			for (int s = 0; s < D3D11_MULTI_MAX_CLIENTS; s++) {
 				if (sys->multi_comp->clients[s].active &&
@@ -13361,11 +13355,11 @@ comp_d3d11_service_set_client_window_pose(struct xrt_system_compositor *xsysc,
 	// starts compositing it from here (gated with first-frame-committed).
 	mc->clients[slot].placed = true;
 
-	// Cancel any in-flight slot animation (e.g. entry animation from
-	// register_client). Without this, slot_animate_tick keeps interpolating
-	// from the animation's original start→target every frame and overwrites
-	// the pose we just snapped, so the controller's set_pose appears to do
-	// nothing for ~300ms after a fresh connect.
+	// Cancel any in-flight slot animation (e.g. an in-progress maximize/restore
+	// ease). Without this, slot_animate_tick keeps interpolating from the
+	// animation's original start→target every frame and overwrites the pose we
+	// just snapped, so the controller's set_pose appears to do nothing until
+	// the animation completes.
 	mc->clients[slot].anim.active = false;
 
 	// Recompute pixel rect from pose
@@ -15037,6 +15031,25 @@ comp_d3d11_service_set_capture_client_window_pose(struct xrt_system_compositor *
 	    &mc->clients[slot_index].window_rect_y,
 	    &mc->clients[slot_index].window_rect_w,
 	    &mc->clients[slot_index].window_rect_h);
+
+	// #320 regression fix: OpenXR clients are posed through this slot-addressed
+	// (1000+slot) path too. The canonical-id setter resizes the app HWND on
+	// every pose change — and that resize is what delivers WM_SIZE to the app
+	// so it updates its window dims (Kooima physical screen size + render
+	// resolution). Without it the app keeps rendering at its launch size,
+	// scaled into a moved/resized tile, and its window-relative projection goes
+	// stale. Restore that for non-capture clients (also cancel any in-flight
+	// maximize/restore ease the controller is overriding, and refresh the
+	// focused slot's input-forward rect so clicks track the moved/resized
+	// tile). Capture clients resize their source HWND on their own edge-drag
+	// schedule, so leave them untouched here.
+	if (mc->clients[slot_index].client_type != CLIENT_TYPE_CAPTURE) {
+		mc->clients[slot_index].anim.active = false;
+		mc->clients[slot_index].hwnd_resize_pending = true;
+		if (slot_index == mc->focused_slot) {
+			multi_compositor_update_input_forward(mc);
+		}
+	}
 
 	return true;
 }


### PR DESCRIPTION
## Summary
- **Restore app-HWND resize on controller `set_pose` (#320 regression).** #320's id-unification routed OpenXR clients through the slot-addressed setter `comp_d3d11_service_set_capture_client_window_pose`, which dropped `hwnd_resize_pending` — so the deferred `SWP_ASYNCWINDOWPOS` HWND-resize loop never ran for OpenXR apps and their window dims (the app-side Kooima physical screen size) froze at launch. Restored `hwnd_resize_pending` + in-flight-anim cancel + focused input-forward refresh for non-capture clients. The app then gets `WM_SIZE` on every workspace resize and recomputes its off-axis projection.
- **Stop LMB drag leaking to the app during a controller window-management drag.** While the controller holds pointer-capture (title-bar move / edge resize), held-LMB `WM_MOUSEMOVE` was still forwarded to the app via the `in_rect` gate (move events carry no button id, so the `capture_active` check missed them) — causing a phantom drag and a stuck button. Now suppress move-forwarding for the captured button while pointer-capture is held; keep forwarding its down/up so the eagerly-forwarded grip press is released.
- **Drop dead `ANIM_ENTRY_DURATION_NS`** and correct stale comments that still described a runtime-owned grow-in (entry animation is controller-owned now, #306).

## Test plan
- [x] Built locally (`build_windows.bat build`), deployed to Program Files, tested on the Leia SR display with 2-4 cubes via the installed shell.
- [x] Edge-resize: app re-renders at the new size (HUD Window/Render updates), window-relative Kooima stays correct; no LMB leak / phantom drag / stuck button.
- [x] Click-to-focus + in-content click-drag still reach the app; title-bar move no longer leaks.

Pairs with the shell entry grow-in (#306) in `displayxr-shell-pvt` `feat/306-entry-animation` — independent (no `spec_version` bump, no shared ABI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)