### PR TITLE
fix(#303): gate runtime V/1/2/3 mode-key poll behind workspace mode

### DIFF
--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -9893,13 +9893,19 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 		}
 	}
 
-	// Runtime-side 2D/3D toggle (V key) — polls qwerty driver each frame.
+	// Runtime-side 2D/3D toggle (V key) + 1/2/3 mode-select — polls qwerty
+	// driver each frame.
 	// Disabled when bridge is active: mode changes go through the HWND
 	// property relay above (app-initiated path). When the multi-comp is
 	// active, routes through the acked-flip path (#234); otherwise preserves
 	// the immediate-flip behavior on the per-client DP.
+	// #303: also disabled under workspace mode — the workspace controller
+	// owns these keys and drives mode via xrRequestDisplayRenderingModeEXT
+	// (ADR-018 "controller owns input"). qwerty is already suppressed at the
+	// window WM_KEYDOWN gate under workspace mode, but gate the apply site too
+	// so an activation/deactivation race can't sneak a flip through here.
 #ifdef XRT_BUILD_DRIVER_QWERTY
-	if (sys->xsysd != NULL && !bridge_live) {
+	if (sys->xsysd != NULL && !bridge_live && !sys->workspace_mode) {
 		bool force_2d = false;
 		bool toggled = qwerty_check_display_mode_toggle(
 		    sys->xsysd->xdevs, sys->xsysd->xdev_count, &force_2d);


### PR DESCRIPTION
Closes #303.

## Summary
- Adds `!sys->workspace_mode` to the per-frame qwerty mode-key poll gate in `comp_d3d11_service.cpp` (the block that applies the **V** 2D/3D toggle via `qwerty_check_display_mode_toggle` and **1/2/3** rendering-mode select via `qwerty_check_rendering_mode_change`).
- Under a workspace session the controller owns these keys (ADR-018 "controller owns input") and drives mode via `xrRequestDisplayRenderingModeEXT`. The runtime was a second consumer that bypassed the controller / acked-flip pipeline.
- qwerty is already suppressed at the window `WM_KEYDOWN` gate under workspace mode; gating the apply site too closes the activation/deactivation race where the window atomic (`workspace_mode_active`) and the service bool (`sys->workspace_mode`) briefly diverge.

Note: issue text references `sys->workspace_mode_active`, but that name only exists as the window-level atomic — the service struct field is `bool workspace_mode`. Used the correct field.

Scope: runtime-only. No spec_version bump, no shell change. Ctrl+1/2/3 layout presets were already removed (Phase 2.G); ESC/TAB/DELETE handling untouched.

## Test plan
- [x] Local build (`build_windows.bat build`), deployed to Program Files.
- [x] **Shell mode** (2 D3D11 cubes via installed shell): bare V/1/2/3 inert (runtime no longer fires); Ctrl+V still toggles via the shell controller; apps locked to shell's rendering mode. No double-flip / fighting.
- [x] **Standalone** (`run_cube_handle_d3d11_win.bat`, non-workspace): V toggles 2D/3D and 1/2/3 select modes — unchanged.
- Verified on a Leia SR display.

🤖 Generated with [Claude Code](https://claude.com/claude-code)