### PR TITLE
feat(#305): move scroll-resize / Shift+Scroll-Z / [ ] Z-step to the controller

### DIFF
--- a/src/xrt/compositor/d3d11/comp_d3d11_window.cpp
+++ b/src/xrt/compositor/d3d11/comp_d3d11_window.cpp
@@ -346,6 +346,10 @@ is_workspace_reserved_key(WPARAM vk, bool shift)
 	// controller ignores ESC, so it's a harmless no-op rather than killing the
 	// app. (The runtime itself holds no maximize state — ADR-018.)
 	case VK_ESCAPE: return true;
+	// #305: [ and ] step the focused window's Z-depth — a workspace control
+	// owned by the controller. Reserve them so they don't also reach the app.
+	case VK_OEM_4:  return true;    // [ = window Z back
+	case VK_OEM_6:  return true;    // ] = window Z forward
 	default:        return false;
 	}
 }
@@ -699,15 +703,11 @@ wnd_proc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 			int32_t cx = GET_X_LPARAM(lParam);
 			int32_t cy = GET_Y_LPARAM(lParam);
 			uint32_t mods = workspace_compute_modifiers();
-			if (message == WM_MOUSEWHEEL) {
-				int16_t delta_int = GET_WHEEL_DELTA_WPARAM(wParam);
-				float delta = (float)delta_int / (float)WHEEL_DELTA;
-				// WM_MOUSEWHEEL coords are screen-space; convert to client.
-				POINT clip = {cx, cy};
-				ScreenToClient(hWnd, &clip);
-				workspace_public_ring_push(w, WORKSPACE_PUBLIC_EVENT_SCROLL,
-				                           clip.x, clip.y, 0, 0, mods, delta);
-			} else if (message == WM_MOUSEMOVE) {
+			// #305: SCROLL is emitted later in the wheel-routing block so that
+			// only workspace (non-app-forwarded) scrolls reach the controller —
+			// a plain scroll over app content is forwarded to the app and must
+			// NOT also drive a controller resize.
+			if (message == WM_MOUSEMOVE) {
 				// Gate motion on pointer capture so idle hover doesn't
 				// flood the public ring. wParam carries the held-button
 				// state (MK_LBUTTON / MK_RBUTTON / MK_MBUTTON) — pack
@@ -722,7 +722,7 @@ wnd_proc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 					workspace_public_ring_push(w, WORKSPACE_PUBLIC_EVENT_MOTION,
 					                           cx, cy, mask, 0, mods, 0.0f);
 				}
-			} else {
+			} else if (message != WM_MOUSEWHEEL) {
 				uint32_t button = 0;
 				uint32_t is_down = 0;
 				switch (message) {
@@ -760,10 +760,13 @@ wnd_proc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 		if (fwd != NULL) {
 			// Workspace mode wheel routing:
 			//   cursor over app content + no modifier → forward to app (e.g. 3DGS zoom)
-			//   cursor outside app content            → workspace resize (no modifier needed)
-			//   Ctrl + scroll                         → workspace resize (force, even over app)
-			//   Shift + scroll                        → window Z-depth
-			// Capture clients don't take wheel input, so always consume their delta.
+			//   cursor outside app content            → workspace scroll (emitted to controller)
+			//   Ctrl / Shift + scroll                 → workspace scroll (emitted to controller)
+			// Capture clients don't take wheel input, so always treat as workspace.
+			// #305: the runtime no longer interprets workspace scrolls — it emits
+			// SCROLL_EXT and the controller owns resize/Z policy. Emission happens
+			// only on this (non-forwarded) path so a plain scroll over app content
+			// goes to the app alone, never also resizing.
 			if (message == WM_MOUSEWHEEL) {
 				bool ctrl  = (GetAsyncKeyState(VK_CONTROL) & 0x8000) != 0;
 				bool shift = (GetAsyncKeyState(VK_SHIFT) & 0x8000) != 0;
@@ -788,7 +791,14 @@ wnd_proc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 					PostMessage(fwd, message, wParam, lParam);
 				} else {
 					short delta = GET_WHEEL_DELTA_WPARAM(wParam);
+					// Launcher grid still drains this (#308 will move it out).
 					InterlockedExchangeAdd(&w->scroll_accum, (LONG)delta);
+					// Controller-bound scroll: resize / Z-depth policy lives
+					// in the workspace controller (ADR-018, #305).
+					workspace_public_ring_push(w, WORKSPACE_PUBLIC_EVENT_SCROLL,
+					                           pt.x, pt.y, 0, 0,
+					                           workspace_compute_modifiers(),
+					                           (float)delta / (float)WHEEL_DELTA);
 				}
 				return 0;
 			}

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -7135,87 +7135,12 @@ after_key_shortcuts:
 		(void)0; // label target for the launcher-visible fast-path above.
 	}
 
-	// Scroll wheel (workspace consumes only when modifier held; plain scroll is
-	// forwarded to the focused app by the WndProc):
-	//   Shift+Scroll → Z-depth
-	//   Ctrl+Scroll  → resize
-	if (mc->window != nullptr && mc->focused_slot >= 0) {
-		int32_t scroll = comp_d3d11_window_consume_scroll(mc->window);
-		if (scroll != 0) {
-			int s = mc->focused_slot;
-			if (s >= 0 && s < D3D11_MULTI_MAX_CLIENTS && mc->clients[s].active) {
-				bool shift_held = (GetAsyncKeyState(VK_SHIFT) & 0x8000) != 0;
-				if (shift_held) {
-					// Shift+Scroll: move window in Z (~2mm per notch)
-					float dz = (float)scroll / (120.0f * 500.0f); // ~0.002m per notch
-					float new_z = mc->clients[s].window_pose.position.z + dz;
-					if (new_z < -0.05f) new_z = -0.05f;
-					if (new_z >  0.05f) new_z =  0.05f;
-					mc->clients[s].window_pose.position.z = new_z;
-
-					slot_pose_to_pixel_rect(sys, &mc->clients[s],
-					                        &mc->clients[s].window_rect_x,
-					                        &mc->clients[s].window_rect_y,
-					                        &mc->clients[s].window_rect_w,
-					                        &mc->clients[s].window_rect_h);
-					U_LOG_I("Multi-comp: Shift+Scroll Z depth slot %d → Z=%.3fm", s, new_z);
-				} else {
-				// Plain scroll: resize (~5% per notch)
-				float factor = 1.0f + (float)scroll / (120.0f * 20.0f); // 5% per notch
-				if (factor < 0.5f) factor = 0.5f;
-				if (factor > 2.0f) factor = 2.0f;
-
-				float new_w = mc->clients[s].window_width_m * factor;
-				float new_h = mc->clients[s].window_height_m * factor;
-
-				// Clamp width to fit title bar buttons; height to 2cm; max 80% of display.
-				float max_w = sys->base.info.display_width_m * 0.8f;
-				float max_h = sys->base.info.display_height_m * 0.8f;
-				if (max_w <= 0.0f) max_w = 0.560f;
-				if (max_h <= 0.0f) max_h = 0.315f;
-
-				if (new_w < UI_MIN_WIN_W_M) new_w = UI_MIN_WIN_W_M;
-				if (new_h < UI_MIN_WIN_H_M) new_h = UI_MIN_WIN_H_M;
-				if (new_w > max_w) new_w = max_w;
-				if (new_h > max_h) new_h = max_h;
-
-				mc->clients[s].window_width_m = new_w;
-				mc->clients[s].window_height_m = new_h;
-
-				slot_pose_to_pixel_rect(sys, &mc->clients[s],
-				                        &mc->clients[s].window_rect_x,
-				                        &mc->clients[s].window_rect_y,
-				                        &mc->clients[s].window_rect_w,
-				                        &mc->clients[s].window_rect_h);
-
-				mc->clients[s].hwnd_resize_pending = true;
-				multi_compositor_update_input_forward(mc);
-				} // end else (plain scroll resize)
-			}
-		}
-	}
-
-	// [ / ] keys: step Z depth ±5mm for focused window.
-	if (mc->focused_slot >= 0 && mc->focused_slot < D3D11_MULTI_MAX_CLIENTS &&
-	    mc->clients[mc->focused_slot].active) {
-		float z_step = 0.0f;
-		if (GetAsyncKeyState(VK_OEM_4) & 1) z_step = -0.005f;  // [ = back
-		if (GetAsyncKeyState(VK_OEM_6) & 1) z_step =  0.005f;  // ] = forward
-		if (z_step != 0.0f) {
-			int s = mc->focused_slot;
-			float new_z = mc->clients[s].window_pose.position.z + z_step;
-			if (new_z < -0.05f) new_z = -0.05f;
-			if (new_z >  0.05f) new_z =  0.05f;
-			mc->clients[s].window_pose.position.z = new_z;
-
-			slot_pose_to_pixel_rect(sys, &mc->clients[s],
-			                        &mc->clients[s].window_rect_x,
-			                        &mc->clients[s].window_rect_y,
-			                        &mc->clients[s].window_rect_w,
-			                        &mc->clients[s].window_rect_h);
-			U_LOG_I("Multi-comp: [/] Z depth slot %d → Z=%.3fm", s, new_z);
-		}
-	}
+	// #305: scroll-to-resize, Shift+Scroll Z-depth, and [ / ] Z-step are now
+	// owned by the workspace controller (ADR-018 — controller owns interactive
+	// policy). The runtime emits SCROLL_EXT / KEY_EXT on the public event
+	// surface; the controller drives size/Z via xrSetWorkspaceClientWindowPoseEXT.
+	// (The launcher grid still consumes scroll via comp_d3d11_window_consume_scroll
+	// above — that path stays until the launcher itself moves out per #308.)
 
 	// Handle swap chain resize
 	if (mc->hwnd != nullptr && mc->swap_chain) {


### PR DESCRIPTION
## Summary

Closes #305. The last interactive policy in the runtime's wheel/key path moves to the workspace controller (ADR-018 — runtime owns mechanism, controller owns interactive policy). Follows #303 (V/1/2/3 keys), #306 (entry animation), #307 (maximize/minimize/ESC).

- `comp_d3d11_service.cpp`: deleted the scroll-consume resize/Z block and the `[` / `]` `GetAsyncKeyState` Z-step poll. The runtime no longer interprets these.
- `comp_d3d11_window.cpp`:
  - `SCROLL_EXT` is now emitted **only** for workspace (non-app-forwarded) scrolls — a plain scroll over app content is forwarded to the app alone and never also drives a controller resize.
  - Reserved `VK_OEM_4` / `VK_OEM_6` (`[` / `]`) in `is_workspace_reserved_key` so they no longer reach the focused app (consistent with TAB/DELETE/ESC). They still flow to the controller as KEY events.

The launcher grid's `scroll_accum` consumer is intentionally left intact — it moves out with the launcher itself in #308.

**No spec bump / no header change.** `SCROLL_EXT` (`scroll.deltaY/cursorX/cursorY/modifiers`) and `KEY_EXT` already exist at the published `XR_EXT_spatial_workspace` spec_version 17, and the pose API expresses Z via `XrPosef.position.z`. So this PR is not coupled to the shell PR through publish-extensions.

## Paired PR

Shell side: `DisplayXR/displayxr-shell-pvt` PR `feat/305-scroll-z-resize` (consumes the events and drives size/Z via `xrSetWorkspaceClientWindowPoseEXT`). Merge this runtime PR first.

## Test plan

- [x] Local build (`build_windows.bat build`), deployed runtime + shell to Program Files, tested on the Leia SR display.
- [x] Scroll over chrome / empty space resizes the focused window (~5%/notch).
- [x] Shift+Scroll moves the focused window in Z (~2mm/notch), clamped ±50mm.
- [x] `[` / `]` step Z ±5mm and no longer reach the app.
- [x] Plain scroll over app content forwards to the app (does not resize).
- [x] Standalone cube (no workspace) unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)