### PR TITLE
Release v1.5.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 cmake_minimum_required(VERSION 3.22)
 project(
 	XRT
-	VERSION 1.4.3
+	VERSION 1.5.0
 	LANGUAGES C CXX
 	DESCRIPTION "DisplayXR Runtime (based on Monado/XRT)"
 	)

--- a/versions.json
+++ b/versions.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/displayxr-versions.json",
-  "runtime":     "v1.4.3",
+  "runtime":     "v1.5.0",
   "shell":       "v1.2.5",
   "leia_plugin": "v1.0.3",
   "mcp_tools":   "v0.3.2",


### PR DESCRIPTION
Version bump for the v1.5.0 runtime release. Carries the ADR-018 controller-migration cluster and XR_EXT_spatial_workspace spec_version 19. Tag is pushed immediately after merge.