### PR TITLE
Android: emulator pre-bring-up procedure + gap analysis

### DIFF
--- a/docs/getting-started/android-bringup-checklist.md
+++ b/docs/getting-started/android-bringup-checklist.md
@@ -14,6 +14,7 @@ A→B→C→D test plan for the first hardware install of the Android POC. Each 
 Companion docs:
 - [`android-build-guide.md`](android-build-guide.md) — prerequisites, CNSDK setup, build commands.
 - [`android-bringup-logcat.md`](android-bringup-logcat.md) — pre-written `adb logcat` filters per test + expected line sequences + failure-shortcut table.
+- [`android-emulator-setup.md`](android-emulator-setup.md) — half-bringup on the Android emulator before Lume Pad arrives (catches build/install/loader-discovery bugs; can't render).
 - [`displayxr-leia-plugin/docs/cnsdk-android-calibration.md`](https://github.com/DisplayXR/displayxr-leia-plugin/blob/main/docs/cnsdk-android-calibration.md) — face axes / view mapping / UV flip calibration (Test B).
 
 ## What to test

--- a/docs/getting-started/android-emulator-setup.md
+++ b/docs/getting-started/android-emulator-setup.md
@@ -1,0 +1,200 @@
+# Android emulator pre-bring-up
+
+How far the Android emulator gets you on the way to a real Lume Pad
+bring-up. Short version: **build + install + most of the OpenXR loader
+discovery surface — but xrCreateInstance fails at the broker step.**
+Useful for catching half the bring-up bugs early; not a full
+replacement for hardware.
+
+## What works on the emulator
+
+| Step | Works | Notes |
+|---|---|---|
+| Build runtime + plug-in + test app APKs | ✅ | All gradle + cmake paths the bring-up checklist documents. |
+| `adb install` of arm64-v8a APKs | ✅ | Android-36 emulator's `cpu.abilist` includes `arm64-v8a` (binary translation via libnativebridge); no x86_64 rebuild required. |
+| Test app launches as a NativeActivity | ✅ | `am start -n com.displayxr.cube_handle_vk_android/android.app.NativeActivity`. |
+| `xrInitializeLoaderKHR` succeeds | ✅ | Khronos loader picks up the JavaVM + Activity refs. |
+| Vulkan 1.0+ available | ✅ | `pm list features` reports `vulkan.level=1`, `vulkan.version=4206592` (0x402080 = 1.0.131). |
+
+## What doesn't work on the emulator
+
+`xrCreateInstance` fails with `XR_ERROR_RUNTIME_UNAVAILABLE`. Logcat:
+
+```
+OpenXR-Loader: Error: RuntimeManifestFile::FindManifestFiles -
+    failed to determine active runtime file path for this environment
+OpenXR-Loader: Error: RuntimeInterface::LoadRuntimes - unknown error
+OpenXR-Loader: Error: xrCreateInstance failed
+cube_handle_vk_android: xrCreateInstance -> XR_ERROR_RUNTIME_UNAVAILABLE
+```
+
+The Khronos OpenXR loader on Android uses a **runtime broker** model:
+the test app queries PackageManager for an installed
+ContentProvider at the authority `org.khronos.openxr.runtime_broker`
+(or `org.khronos.openxr.system_runtime_broker`), and that broker
+tells the loader which `.so` to dlopen. The DisplayXR runtime APK
+ships only the runtime `.so` + `RuntimeService` — not the broker
+ContentProvider — so even with the APK installed, the loader has no
+way to discover it.
+
+Two related issues fall out of this:
+
+1. **`<queries>` element**: Android 12+ blocks cross-package
+   PackageManager queries by default. Fixed in PR #269 — the test
+   app's manifest now declares `<queries><intent>... OpenXRRuntimeService ...</intent></queries>`.
+   Without this, the loader's PackageManager query returns empty on
+   any Android-12+ device, emulator or Lume Pad.
+
+2. **Active runtime broker**: real hardware (Lume Pad) presumably
+   ships a vendor broker APK pointing at the installed runtime,
+   OR a system-level setting that the loader consults. On the
+   stock Android emulator neither exists, so the runtime is
+   invisible to the loader.
+
+### What to do about the broker on the emulator
+
+Three options if you really need to exercise `xrCreateInstance` →
+`xrCreateSession` on the emulator:
+
+| Option | Effort | Caveats |
+|---|---|---|
+| **Install Khronos's sample broker APK** | Medium — build from <https://github.com/KhronosGroup/OpenXR-SDK-Source/tree/main/specification/sources/scripts/openxr-android-broker> | Sample isn't published as an APK; need to build it yourself. |
+| **Add a broker ContentProvider to the runtime APK** | Small (~50 lines Kotlin) | Probably the right long-term answer for the runtime — a broker is needed on any Android device where the runtime is the only one installed. Tracked as a follow-up. |
+| **Set the active runtime via Settings provider** | OS-dependent | Lume Pad may expose this; stock emulator doesn't. |
+
+For first-light bring-up on Lume Pad, **skip the emulator** and go
+straight to hardware — Lume Pad's preinstalled OS likely handles the
+broker. If you hit `XR_ERROR_RUNTIME_UNAVAILABLE` on the Lume Pad too,
+swap to one of the three options above (likely option 2 — bake the
+broker into the runtime APK).
+
+## Step-by-step emulator workflow
+
+This walks the full happy path. Stop at any step that errors.
+
+### 0. One-time AVD setup
+
+```bash
+# In Android Studio: Tools > Device Manager > Create Device > Phone >
+# any device > Next > pick a recent x86_64 system image (Android 13+ is
+# fine — Android 12+ has all the package-visibility hardening you want
+# to catch).
+#
+# Or via cmdline:
+ANDROID_SDK=$LOCALAPPDATA/Android/Sdk
+$ANDROID_SDK/cmdline-tools/latest/bin/sdkmanager.bat \
+    "system-images;android-36;google_apis_playstore;x86_64"
+$ANDROID_SDK/cmdline-tools/latest/bin/avdmanager.bat create avd \
+    -n DisplayXR_Emulator -k "system-images;android-36;google_apis_playstore;x86_64"
+```
+
+### 1. Start emulator + wait for boot
+
+```bash
+ANDROID_SDK=$LOCALAPPDATA/Android/Sdk
+"$ANDROID_SDK/emulator/emulator.exe" -avd DisplayXR_Emulator \
+    -no-snapshot-save -no-audio -gpu swiftshader_indirect -no-boot-anim &
+
+ADB="$ANDROID_SDK/platform-tools/adb.exe"
+until [ "$("$ADB" shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" = "1" ]; do
+    sleep 5
+done
+
+# Confirm Vulkan support is present
+"$ADB" shell pm list features | grep vulkan
+```
+
+### 2. Build the three APKs
+
+See [`android-build-guide.md`](android-build-guide.md) for the
+build steps. The condensed version:
+
+```bash
+# Plug-in .so (arm64-v8a)
+cd /c/displayxr-leia-plugin && scripts/build-android.sh
+
+# Drop into runtime APK's jniLibs/<ABI>/
+mkdir -p /c/openxr-3d-display/src/xrt/targets/openxr_android/src/main/jniLibs/arm64-v8a
+cp build-android/src/drv_leia_android/libdxrp050_leia_cnsdk.so \
+   /c/openxr-3d-display/src/xrt/targets/openxr_android/src/main/jniLibs/arm64-v8a/
+
+# Runtime + test app
+cd /c/openxr-3d-display
+./gradlew.bat :src:xrt:targets:openxr_android:assembleInProcessDebug --rerun-tasks
+./gradlew.bat :test_apps:cube_handle_vk_android:assembleDebug
+```
+
+The `--rerun-tasks` flag on the runtime build is load-bearing the first
+time — gradle's incremental builder can miss a newly-created
+`jniLibs/<ABI>/` directory and ship the runtime APK without the
+plug-in `.so`. Always sanity-check `unzip -l <runtime.apk> | grep '.so$'`
+shows both `openxr_displayxr.so` and `libdxrp050_leia_cnsdk.so`.
+
+### 3. Install on emulator
+
+```bash
+ADB="$LOCALAPPDATA/Android/Sdk/platform-tools/adb.exe"
+"$ADB" install -r src/xrt/targets/openxr_android/build/outputs/apk/inProcess/debug/openxr_android-inProcess-debug.apk
+"$ADB" install -r test_apps/cube_handle_vk_android/build/outputs/apk/debug/cube_handle_vk_android-debug.apk
+```
+
+### 4. Run + observe
+
+```bash
+# Clear log buffer + start the test app
+"$ADB" logcat -c
+"$ADB" shell am start -n com.displayxr.cube_handle_vk_android/android.app.NativeActivity
+
+# Capture logcat (filter strings from android-bringup-logcat.md)
+"$ADB" logcat -v threadtime -s cube_handle_vk_android:V OpenXR-Loader:V \
+    target_plugin_loader:V leia_cnsdk:V
+```
+
+**Expected log on the emulator (without a broker):**
+
+```
+xrInitializeLoaderKHR -> XR_SUCCESS
+OpenXR-Loader: Entering loader trampoline (xrCreateInstance)
+OpenXR-Loader: Error: RuntimeManifestFile::FindManifestFiles - failed to determine active runtime file path
+xrCreateInstance -> XR_ERROR_RUNTIME_UNAVAILABLE
+```
+
+If you see this exact sequence, the emulator confirms:
+- Build pipeline produced a valid APK that installs.
+- Manifest's `<queries>` block lets the loader's PackageManager calls run (no platform-level visibility errors).
+- Vulkan is available.
+
+The error at `xrCreateInstance` is the **expected emulator stopping
+point** — the next step requires a broker.
+
+## What this catches before Lume Pad
+
+Half-dozen bug classes you can hit and fix without leaving the host:
+
+| Bug class | Caught? | Example |
+|---|---|---|
+| APK build failures | ✅ | The `.so`-name / manifest-name mismatch fixed in PR #268. |
+| `jniLibs/` plumbing | ✅ | Plug-in `.so` not bundled into the runtime APK (gradle incremental cache bug). |
+| Android-12+ `<queries>` regressions | ✅ | PR #269's manifest fix. |
+| OpenXR loader binding (instance create entry point) | ✅ | `xrInitializeLoaderKHR` succeeds. |
+| Native-lib JNI plumbing (NativeActivity, ALooper, etc.) | ✅ | Test app boots into android_main without crashing. |
+| Vulkan-extension availability mismatches | Partial | Emulator's Vulkan 1.0.131 is older than Lume Pad's; some extension queries we'd want to make won't exercise. |
+| CNSDK init | ❌ | Needs Leia hardware (no lenticular optics, no face-tracking camera). |
+| Display weave correctness | ❌ | Same — needs hardware. |
+| Face-axis / view-mapping / UV-flip calibration | ❌ | Same. |
+| Active-runtime broker resolution | ❌ | Needs a broker installed (deferred). |
+
+## Tear-down
+
+```bash
+"$ADB" shell am force-stop com.displayxr.cube_handle_vk_android
+"$ADB" uninstall com.displayxr.cube_handle_vk_android
+"$ADB" uninstall org.freedesktop.monado.openxr_runtime.in_process
+"$ADB" emu kill
+```
+
+## Related docs
+
+- [`android-build-guide.md`](android-build-guide.md) — full prerequisites + build commands.
+- [`android-bringup-checklist.md`](android-bringup-checklist.md) — the post-emulator hardware test plan.
+- [`android-bringup-logcat.md`](android-bringup-logcat.md) — pre-written logcat filters per test.


### PR DESCRIPTION
## Summary

Stacks on PR #329 (CI workflow). New `docs/getting-started/android-emulator-setup.md` walking through how to drive the runtime + plug-in + test app on an Android emulator before the Lume Pad arrives — and documenting what the emulator can't catch.

**Validated end-to-end on a stock Android-36 Google APIs emulator (x86_64).**

## Findings

### What works on emulator
- Build pipeline (runtime APK + plug-in `.so` + test app APK) — full happy path runs.
- `adb install` of arm64-v8a APKs onto x86_64 emulator — `cpu.abilist` includes arm64-v8a via libnativebridge translation. No x86_64 rebuild needed.
- Test app launches into NativeActivity.
- `xrInitializeLoaderKHR` succeeds.
- Vulkan 1.0+ available (`pm list features` reports vulkan.compute, vulkan.level=1).

### What doesn't (and why)

`xrCreateInstance` fails with `XR_ERROR_RUNTIME_UNAVAILABLE`. Two distinct issues compounded:

1. **Android-12+ package visibility** blocks the OpenXR loader's PackageManager scan unless the test app declares `<queries>`. Fixed as a one-commit follow-up on PR #269 (`263b40826` — applies to Lume Pad too).
2. **No runtime broker installed.** The Khronos OpenXR loader on Android uses a broker-ContentProvider model: an installed app exposes `org.khronos.openxr.runtime_broker` authority and tells the loader which `.so` to dlopen. The DisplayXR runtime APK ships only the runtime `.so` + `RuntimeService` — no broker — so the loader has no way to discover it.

Lume Pad's preinstalled OS likely handles the broker. Stock emulator doesn't. Three workarounds documented in the doc:
| Option | Effort | Caveats |
|---|---|---|
| Install Khronos's sample broker APK | Medium (build from OpenXR-SDK-Source) | Sample isn't published as an APK; build yourself |
| Add a broker ContentProvider to the runtime APK | Small (~50 lines Kotlin) | Probably the right long-term answer |
| Set active runtime via Settings provider | OS-dependent | Lume Pad may expose this; stock emulator doesn't |

## Why this is worth the doc

| Bug class | Caught by emulator |
|---|---|
| APK build / `.so`-name / manifest mismatch | ✅ (this is how I caught the `lib` prefix bug from earlier) |
| `jniLibs/` plumbing | ✅ |
| Android-12+ `<queries>` regressions | ✅ |
| OpenXR loader binding | ✅ |
| Native-lib JNI plumbing | ✅ |
| Vulkan extension queries | Partial |
| CNSDK init / display weave / calibration | ❌ — need hardware |
| Active-runtime broker resolution | ❌ — need broker or hardware |

Net: emulator catches the entire build-pipeline + Android-platform stack of bugs. The remaining bugs all need Leia hardware to surface. That's enough to make the doc worth landing.

Docs-only — CI sentinel fires in ~30s.

## Test plan

- [ ] DocsOnly CI sentinel reports `Build Android: Runtime: success` in ~30s.
- [ ] Each command in the doc copy-pastes cleanly.
- [ ] The companion-docs cross-links at the top of `android-bringup-checklist.md` now include `android-emulator-setup.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)