### PR TITLE
Android: OpenXR runtime broker ContentProvider (resolves XR_ERROR_RUNTIME_UNAVAILABLE)

### DIFF
--- a/src/xrt/targets/openxr_android/src/main/AndroidManifest.xml
+++ b/src/xrt/targets/openxr_android/src/main/AndroidManifest.xml
@@ -84,6 +84,21 @@
                 <action android:name="org.khronos.openxr.OpenXRRuntimeService" />
             </intent-filter>
         </service>
+
+        <!--
+            Khronos OpenXR loader runtime-broker ContentProvider.
+            The loader's Android discovery path queries this authority
+            on first xrCreateInstance to find out which runtime .so to
+            dlopen — without it the loader fails with
+            XR_ERROR_RUNTIME_UNAVAILABLE even when the RuntimeService
+            above is installed (the loader doesn't fall back to the
+            service-intent discovery on its own — broker is the
+            primary mechanism on Android-12+).
+        -->
+        <provider
+            android:name="org.freedesktop.monado.openxr_runtime.OpenXRRuntimeBroker"
+            android:authorities="org.khronos.openxr.runtime_broker"
+            android:exported="true" />
     </application>
 
 </manifest>

--- a/src/xrt/targets/openxr_android/src/main/java/org/freedesktop/monado/openxr_runtime/OpenXRRuntimeBroker.kt
+++ b/src/xrt/targets/openxr_android/src/main/java/org/freedesktop/monado/openxr_runtime/OpenXRRuntimeBroker.kt
@@ -1,0 +1,121 @@
+// Copyright 2026, Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+package org.freedesktop.monado.openxr_runtime
+
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.database.Cursor
+import android.database.MatrixCursor
+import android.net.Uri
+import android.util.Log
+
+/**
+ * Runtime broker ContentProvider.
+ *
+ * The Khronos OpenXR loader (`openxr_loader_for_android`) discovers
+ * the active runtime by querying a ContentProvider at one of two
+ * authorities:
+ *   - `org.khronos.openxr.runtime_broker`        — installable
+ *     broker, per-user. THIS class.
+ *   - `org.khronos.openxr.system_runtime_broker` — system-installed
+ *     broker. Reserved for OS images that pre-select a vendor
+ *     runtime; we can't ship one because we're not a system app.
+ *
+ * URI shape the loader queries:
+ *   content://<authority>/openxr/<MAJOR>/abi/<ABI>/runtimes/active
+ *
+ * The loader fills MAJOR (e.g. "1") and ABI (e.g. "arm64-v8a") at
+ * query time. We always return one row pointing at our own runtime
+ * `.so` regardless of which ABI is asked for — Android Package
+ * Manager already filtered installs to compatible ABIs by the time
+ * this APK is on-device.
+ *
+ * No active-runtime selection logic (SharedPreferences, system
+ * setting, etc.) because the DisplayXR runtime APK is the only thing
+ * this broker advertises. If multiple OpenXR runtimes coexist on a
+ * device, a vendor / OEM is expected to ship a separate broker APK
+ * that knows the local selection rules and shadows this one.
+ *
+ * Function-remapping ("has_functions=1") path is unused — the
+ * runtime exports the standard `xrNegotiateLoaderRuntimeInterface`
+ * entry point, no custom symbol mapping needed.
+ */
+class OpenXRRuntimeBroker : ContentProvider() {
+
+    override fun onCreate(): Boolean = true
+
+    override fun query(
+        uri: Uri,
+        projection: Array<String>?,
+        selection: String?,
+        selectionArgs: Array<String>?,
+        sortOrder: String?,
+    ): Cursor? {
+        val segs = uri.pathSegments
+        // Active-runtime query:
+        //   /openxr/<MAJOR>/abi/<ABI>/runtimes/active
+        if (segs.size != 6 ||
+            segs[0] != "openxr" ||
+            segs[2] != "abi" ||
+            segs[4] != "runtimes" ||
+            segs[5] != "active"
+        ) {
+            Log.w(TAG, "Unrecognized broker URI: $uri")
+            return null
+        }
+        val major = segs[1].toIntOrNull() ?: return null
+        if (major != 1) {
+            // Only OpenXR 1.x is supported by this runtime. Returning
+            // null here lets the loader fall back to the system
+            // authority cleanly.
+            Log.i(TAG, "OpenXR major=$major not supported by DisplayXR (only 1.x)")
+            return null
+        }
+
+        val ctx = context ?: return null
+        val info = ctx.applicationInfo
+
+        val cursor = MatrixCursor(COLUMNS)
+        cursor.addRow(
+            arrayOf(
+                ctx.packageName,
+                // ABI-specific dir: /data/app/<pkg>-<hash>/lib/<ABI>/.
+                // applicationInfo.nativeLibraryDir already returns the
+                // ABI-suffixed path matched at install time. The loader
+                // appends the so_filename and dlopens, so this is the
+                // path we want regardless of which ABI the loader
+                // requested (Android filtered at install).
+                info.nativeLibraryDir,
+                // CMake sets PREFIX "" on the runtime target, so the
+                // file on disk is `openxr_displayxr.so` (not the
+                // Android-default `libopenxr_displayxr.so`). Match
+                // exactly what shipped in the APK's jniLibs/.
+                "openxr_displayxr.so",
+                // No custom function mappings.
+                0,
+            ),
+        )
+        Log.i(TAG, "Active runtime resolved: ${ctx.packageName}/openxr_displayxr.so in ${info.nativeLibraryDir}")
+        return cursor
+    }
+
+    override fun getType(uri: Uri): String? = null
+
+    override fun insert(uri: Uri, values: ContentValues?): Uri? = null
+
+    override fun delete(uri: Uri, selection: String?, selectionArgs: Array<String>?): Int = 0
+
+    override fun update(
+        uri: Uri,
+        values: ContentValues?,
+        selection: String?,
+        selectionArgs: Array<String>?,
+    ): Int = 0
+
+    companion object {
+        private const val TAG = "DisplayXR-Broker"
+
+        private val COLUMNS =
+            arrayOf("package_name", "native_lib_dir", "so_filename", "has_functions")
+    }
+}


### PR DESCRIPTION
## Summary

Stacks on PR #268. New \`OpenXRRuntimeBroker.kt\` ContentProvider in the runtime APK that the Khronos OpenXR loader queries to find the active runtime. **Without this, \`xrCreateInstance\` fails with \`XR_ERROR_RUNTIME_UNAVAILABLE\` on any Android device that doesn't ship a vendor broker — including possibly Lume Pad.**

## The bug this fixes

Discovered while validating PR #268's runtime APK on an Android-36 emulator (after PR #269's \`<queries>\` fix made the loader's PackageManager calls work at all). With the runtime APK installed and the test app having the right \`<queries>\` block:

\`\`\`
OpenXR-Loader: getActiveRuntimeCursor: Querying URI: content://org.khronos.openxr.runtime_broker/openxr/1/abi/arm64-v8a/runtimes/active
ActivityThread: Failed to find provider info for org.khronos.openxr.runtime_broker
OpenXR-Loader: Could access neither the installable nor system runtime broker.
xrCreateInstance -> XR_ERROR_RUNTIME_UNAVAILABLE
\`\`\`

The Khronos OpenXR loader's primary Android discovery mechanism is a ContentProvider at one of two authorities:
- \`org.khronos.openxr.runtime_broker\` — installable, per-user (what this PR adds)
- \`org.khronos.openxr.system_runtime_broker\` — system-installed, requires being a system app

The \`<service android:name=\"…RuntimeService\">\` declaration in our manifest is a secondary mechanism that the loader doesn't probe directly. So without a broker, the loader has no way to find the runtime even when the APK is correctly installed.

Reference: [OpenXR-SDK-Source/specification/loader/runtime.adoc](https://github.com/KhronosGroup/OpenXR-SDK-Source/blob/main/specification/loader/runtime.adoc).

## What this PR adds

| File | Change |
|---|---|
| \`OpenXRRuntimeBroker.kt\` (new, ~110 lines) | ContentProvider implementation: responds to \`content://…/openxr/1/abi/<ABI>/runtimes/active\` with a single-row MatrixCursor containing \`package_name\`, \`native_lib_dir\`, \`so_filename\`, \`has_functions\`. |
| \`AndroidManifest.xml\` (+12 lines) | \`<provider android:authorities=\"org.khronos.openxr.runtime_broker\" android:exported=\"true\" />\` declaration. |

No active-runtime selection logic — the broker always returns the DisplayXR runtime since that's the only thing this APK ships. If multiple OpenXR runtimes coexist, a vendor / OEM is expected to ship a separate broker APK that shadows this one (broker discovery is \"first authority match wins\", with \`system_runtime_broker\` prioritized over \`runtime_broker\`).

\`so_filename\` is hardcoded to \`openxr_displayxr.so\` to match the CMake \`PREFIX \"\"\` on the runtime target (same convention as the existing \`OpenXRRuntime.SoFilename\` meta-data).

\`native_lib_dir\` is taken from \`ApplicationInfo.nativeLibraryDir\` at runtime, so the resolved path is always the correct ABI-suffixed filesystem path Android extracted at install — works across emulator + arm64 device, doesn't hardcode anything.

## Verification

On an Android-36 emulator with the runtime APK installed:

\`\`\`bash
\$ adb shell dumpsys package providers | grep -A1 OpenXRRuntimeBroker
  org.freedesktop.monado.openxr_runtime.in_process/org.freedesktop.monado.openxr_runtime.OpenXRRuntimeBroker:
    Provider{b5c2a26 org.freedesktop.monado.openxr_runtime.in_process/org.freedesktop.monado.openxr_runtime.OpenXRRuntimeBroker}
  [org.khronos.openxr.runtime_broker]:
\`\`\`

After running the test app:

\`\`\`
xrInitializeLoaderKHR -> XR_SUCCESS
OpenXR-Loader: getActiveRuntimeCursor: Querying URI: content://org.khronos.openxr.runtime_broker/openxr/1/abi/arm64-v8a/runtimes/active
DisplayXR-Broker: Active runtime resolved: org.freedesktop.monado.openxr_runtime.in_process/openxr_displayxr.so in /data/app/.../lib/arm64
OpenXR-Loader: RuntimeInterface::LoadRuntime succeeded loading runtime defined in manifest file
OXR: LOG in oxr_xrInitializeLoaderKHR: Loader forwarded call to xrInitializeLoaderKHR.
\`\`\`

\`xrCreateInstance\` now reaches the runtime's own initialization — the failure mode moves to the next bug downstream (CNSDK plug-in transitive \`.so\` deps aren't bundled into the APK — separate follow-up).

## Stacking

Best landed in this order:
1. PR #268 (rebased runtime POC) — gives this PR a base.
2. PR #269 (\`<queries>\` fix) — the broker is only reachable from a test app that has \`<queries>\` declared on Android 12+.
3. **This PR** — adds the broker.

After all three, the runtime APK is self-sufficient — no separate broker APK needed.

## Test plan

- [ ] Build runtime APK on top of PR #268 + this branch.
- [ ] \`adb shell dumpsys package providers | grep openxr.runtime_broker\` shows the provider registered.
- [ ] Install test app from PR #269 head (with \`<queries>\` fix), launch.
- [ ] Logcat shows \`DisplayXR-Broker: Active runtime resolved: …openxr_displayxr.so\` followed by \`OpenXR-Loader: RuntimeInterface::LoadRuntime succeeded\`.
- [ ] If a vendor broker is also installed at \`system_runtime_broker\`, it takes priority (test left as a TODO — needs Lume Pad).

🤖 Generated with [Claude Code](https://claude.com/claude-code)