### PR TITLE
fix(build): gate sim-display plug-in on XRT_FEATURE_OPENXR (restores main CI)

### DIFF
--- a/src/xrt/drivers/CMakeLists.txt
+++ b/src/xrt/drivers/CMakeLists.txt
@@ -152,14 +152,24 @@ list(APPEND ENABLED_DRIVERS drv_sim_display)
 # v1 ships this alongside the runtime — discovery + load wiring lands
 # in the next sequencing step.
 #
-# Gated on the runtime DLL target existing: the plug-in links against
+# Gated on the runtime DLL being built: the plug-in links against
 # $<TARGET_LINKER_FILE:${RUNTIME_TARGET}> and add_dependencies()es it, so it
 # cannot be configured when the runtime is not built — e.g. the MinGW-w64
 # compile-check, which sets XRT_FEATURE_OPENXR=OFF and so never creates the
 # openxr_displayxr target. Skipping the plug-in there avoids a generate-time
 # "target openxr_displayxr does not exist" error; real Windows/macOS builds
 # always have the runtime target so the plug-in builds as before.
-if(TARGET ${RUNTIME_TARGET})
+#
+# We gate on XRT_FEATURE_OPENXR (the option that controls whether the runtime
+# target gets created — see src/xrt/targets/CMakeLists.txt) rather than
+# if(TARGET ${RUNTIME_TARGET}): RUNTIME_TARGET is only the target *name*
+# string (set in the root CMakeLists), and the target itself is created later
+# in targets/openxr/, which add_subdirectory()s AFTER drivers/. So at this
+# point in configure the target does not exist yet and if(TARGET ...) is
+# always false — which silently dropped the plug-in from every build, not
+# just the MinGW one (the $<TARGET_LINKER_FILE> generator expression still
+# resolves because it's evaluated at generate time, when the target exists).
+if(XRT_FEATURE_OPENXR)
 add_library(drv_sim_display_plugin SHARED ${SIM_DISPLAY_SOURCES} sim_display/sim_display_plugin.c)
 target_compile_definitions(drv_sim_display_plugin PRIVATE XRT_USING_RUNTIME_DLL)
 target_link_libraries(
@@ -246,7 +256,7 @@ elseif(NOT ANDROID)
 		LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/displayxr/plugins COMPONENT Runtime
 		)
 endif()
-endif() # TARGET ${RUNTIME_TARGET} — DisplayXR-SimDisplay plug-in block
+endif() # XRT_FEATURE_OPENXR — DisplayXR-SimDisplay plug-in block
 
 set(ENABLED_DRIVERS ${ENABLED_HEADSET_DRIVERS} ${ENABLED_DRIVERS})
 if(ENABLED_DRIVERS)


### PR DESCRIPTION
## Problem — main CI is red on both platforms

`build-windows.yml` and `build-macos.yml` have failed on every push to `main` since **5d7d68dcd** (the commit after the v1.5.0 release; both were green at the v1.5.0 tag `4c172c25d`):

```
DisplayXR-SimDisplay.dll missing — sim-display plug-in did not build.   (Windows)
sim-display plug-in not found … DisplayXR-SimDisplay.dylib              (macOS, #274 guard)
```

`5d7d68dcd` gated the `drv_sim_display_plugin` block on `if(TARGET ${RUNTIME_TARGET})` to skip it in the MinGW compile-check (`XRT_FEATURE_OPENXR=OFF`, where the runtime target is never created). But `RUNTIME_TARGET` is only the target **name** string (set in the root `CMakeLists.txt`); the target itself is created in `targets/openxr/`, which is `add_subdirectory()`'d **after** `drivers/` (`src/xrt/CMakeLists.txt`). So at configure time inside `drivers/` the target doesn't exist yet → `if(TARGET …)` is **always false** → the plug-in is dropped from *every* build, not just MinGW. The `$<TARGET_LINKER_FILE>` generator expression still resolved (generate-time), which masked the breakage at configure time, and only the MinGW check was verified.

## Fix

Gate on `XRT_FEATURE_OPENXR` — the option that actually controls whether the runtime target is created (`src/xrt/targets/CMakeLists.txt`: `if(XRT_FEATURE_OPENXR) add_subdirectory(openxr)`). It's a configure-time variable available in every subdirectory regardless of processing order, capturing the original intent without the ordering trap:

- real Windows/macOS builds (`XRT_FEATURE_OPENXR=ON`) → plug-in builds (as before 5d7d68dcd);
- MinGW cross-check (`XRT_FEATURE_OPENXR=OFF`) → plug-in skipped cleanly (no "target does not exist").

## Verification

Local Windows build produces `_package/bin/plugins/DisplayXR-SimDisplay.dll` again. CI on this PR (clean configure) is the authoritative check — the Windows `Runtime` job's "Assert … DisplayXR-SimDisplay.dll" and the macOS `BuildInstaller` payload assertion should both pass.

Unblocks #334 (and any other PR), which currently inherit this red from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)