### PR TITLE
Release v1.5.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 cmake_minimum_required(VERSION 3.22)
 project(
 	XRT
-	VERSION 1.5.0
+	VERSION 1.5.1
 	LANGUAGES C CXX
 	DESCRIPTION "DisplayXR Runtime (based on Monado/XRT)"
 	)


### PR DESCRIPTION
Version bump for the v1.5.1 runtime release. Ships #328 (service auto-start: pre-load DisplayXRClient.dll so DP plug-ins resolve regardless of cwd) and the sim-display build-gate fix that restored CI (#335).