### PR TITLE
fix(comp/vk): guard against corrupt display-processor vtable (graceful degrade)

### DIFF
--- a/src/xrt/compositor/vk_native/comp_vk_native_compositor.c
+++ b/src/xrt/compositor/vk_native/comp_vk_native_compositor.c
@@ -2596,6 +2596,52 @@ vk_compositor_destroy(struct xrt_compositor *xc)
 	free(c);
 }
 
+/*!
+ * Sanity-check a display-processor's C vtable before the compositor trusts it.
+ *
+ * The DP is a plug-in-owned struct of function pointers. On Windows we have
+ * observed (standalone VK + Leia SR) the DP's small heap block being reused by
+ * the GPU driver's Vulkan shader compiler during pipeline creation, leaving the
+ * vtable holding garbage (non-code) pointers — a subsequent call through it is a
+ * hard ACCESS_VIOLATION. This validates that the load-bearing slots point into
+ * committed, executable pages; NULL is left alone (it's a valid "unsupported"
+ * sentinel that every xrt_display_processor_* wrapper already tolerates).
+ *
+ * Returns true if the vtable looks usable. On non-Windows this is a no-op
+ * (returns true) — the failure mode is Windows-driver-specific.
+ */
+static bool
+dp_vtable_looks_sane(struct xrt_display_processor *dp)
+{
+	if (dp == NULL) {
+		return false;
+	}
+#ifdef XRT_OS_WINDOWS
+	// Load-bearing slots the compositor calls. process_atlas + destroy are
+	// mandatory; the rest are optional (may legitimately be NULL).
+	void *fns[] = {
+	    (void *)dp->process_atlas,        (void *)dp->destroy,
+	    (void *)dp->get_display_pixel_info, (void *)dp->get_render_pass,
+	    (void *)dp->get_display_dimensions, (void *)dp->set_chroma_key,
+	};
+	if (dp->process_atlas == NULL || dp->destroy == NULL) {
+		return false; // mandatory slots
+	}
+	const DWORD exec = PAGE_EXECUTE | PAGE_EXECUTE_READ | PAGE_EXECUTE_READWRITE | PAGE_EXECUTE_WRITECOPY;
+	for (size_t i = 0; i < sizeof(fns) / sizeof(fns[0]); i++) {
+		if (fns[i] == NULL) {
+			continue; // valid "unsupported" sentinel
+		}
+		MEMORY_BASIC_INFORMATION mbi;
+		if (VirtualQuery(fns[i], &mbi, sizeof(mbi)) == 0 || mbi.State != MEM_COMMIT ||
+		    (mbi.Protect & exec) == 0) {
+			return false;
+		}
+	}
+#endif
+	return true;
+}
+
 /*
  *
  * Exported functions
@@ -2866,6 +2912,20 @@ comp_vk_native_compositor_create(struct xrt_device *xdev,
 	} else {
 		c->target = NULL;
 		U_LOG_I("No VK target — offscreen shared texture mode");
+	}
+
+	// Guard: target/swapchain creation above can trigger GPU-driver Vulkan
+	// shader-compiler heap churn that, on some configs (Windows + Leia SR),
+	// reuses the display-processor's heap block and corrupts its vtable. A
+	// call through a garbage vtable slot (e.g. get_display_pixel_info just
+	// below) is a hard crash. Validate here and degrade to passthrough
+	// (no weaving) instead of crashing. Do NOT call the DP's destroy — that
+	// pointer may itself be garbage; leak the corrupt object on this path.
+	if (c->display_processor != NULL && !dp_vtable_looks_sane(c->display_processor)) {
+		U_LOG_E("VK display processor vtable corrupt after target creation — "
+		        "disabling DP (output will not be woven). Likely a driver "
+		        "heap-reuse collision.");
+		c->display_processor = NULL;
 	}
 
 	// Determine view dimensions


### PR DESCRIPTION
## Problem
Standalone VK + Leia SR crashes (`0xC0000005`) in `comp_vk_native_compositor_create` during `xrCreateSession`: target/swapchain creation triggers GPU-driver Vulkan shader-compiler heap churn that, on some configs, reuses the plug-in display-processor's heap block and corrupts its C vtable. The next call through it (`get_display_pixel_info`, vtable offset `0x38`) jumps to a garbage pointer.

See the companion root-cause + fix in `DisplayXR/displayxr-leia-plugin#9` (allocation-ordering change that reduces the chance of the corruption occurring). AddressSanitizer found **no overflow/UAF in our code** — the collision is with the non-instrumented NVIDIA Vulkan driver heap.

## Fix
Add `dp_vtable_looks_sane()`: on Windows, `VirtualQuery` the load-bearing vtable slots and require committed **executable** pages (`NULL` stays a valid "unsupported" sentinel that the `xrt_display_processor_*` wrappers already tolerate). After target creation — where the corruption manifests — if the vtable is corrupt, **log and disable the DP** (passthrough, no weave) instead of crashing. The corrupt object is intentionally **leaked** on this rare path (its `destroy` pointer may be garbage too).

Codegen-independent safety net: turns a hard AV into a logged graceful degrade regardless of driver heap behavior. No-op on non-Windows. Verified the healthy DP still passes the guard and weaves correctly.

## Validation
⚠️ The crash only reproduces in the shipping CI codegen (local builds mask it). The guard itself is exercised on the happy path (healthy DP passes); the degrade path is reasoned-through. Real-world validation alongside leia v1.0.4 on Leia hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)