### PR TITLE
android: fixed-point preload to resolve transitive .so deps

### DIFF
--- a/src/xrt/targets/common/target_plugin_loader.c
+++ b/src/xrt/targets/common/target_plugin_loader.c
@@ -709,6 +709,7 @@ target_plugin_clear_preferred(void)
 #include <dirent.h>
 #include <dlfcn.h>
 #include <limits.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/stat.h>
@@ -904,12 +905,18 @@ get_runtime_lib_dir(char *out_dir, size_t out_size)
 static void
 preload_runtime_lib_dir(const char *lib_dir)
 {
+#define MAX_PRELOAD_CANDIDATES 64
+	char *names[MAX_PRELOAD_CANDIDATES];
+	int loaded[MAX_PRELOAD_CANDIDATES] = {0};
+	char *last_err[MAX_PRELOAD_CANDIDATES] = {0};
+	int n_candidates = 0;
+
 	DIR *d = opendir(lib_dir);
 	if (d == NULL) {
 		return;
 	}
 	struct dirent *de;
-	while ((de = readdir(d)) != NULL) {
+	while ((de = readdir(d)) != NULL && n_candidates < MAX_PRELOAD_CANDIDATES) {
 		if (de->d_type != DT_REG) {
 			continue;
 		}
@@ -928,16 +935,59 @@ preload_runtime_lib_dir(const char *lib_dir)
 		    strncmp(name, "libopenxr_displayxr.so", 22) == 0) {
 			continue;
 		}
-		char path[PATH_MAX];
-		(void)snprintf(path, sizeof(path), "%s/%s", lib_dir, name);
-		void *h = dlopen(path, RTLD_LAZY | RTLD_LOCAL);
-		if (h == NULL) {
-			U_LOG_I("plugin loader: preload %s skipped: %s", name, dlerror());
-		} else {
-			U_LOG_I("plugin loader: preloaded %s", name);
+		names[n_candidates] = strdup(name);
+		if (names[n_candidates] == NULL) {
+			break;
 		}
+		n_candidates++;
 	}
 	closedir(d);
+
+	/* Fixed-point iteration: a vendor .so often has DT_NEEDED entries
+	 * pointing at sibling .so files (e.g. CNSDK's libleiaSDK depends on
+	 * libblink, which depends on libSNPE + liblicense_utils). readdir
+	 * order is filesystem-dependent and may visit a dependent before
+	 * its deps, so a single pass would fail to load it. Loop until a
+	 * full pass produces no new successful loads. Worst case O(N²)
+	 * dlopen attempts for N libs, but N is small (≤20) and dlopen of
+	 * an already-loaded soinfo is essentially free. */
+	int total_loaded = 0;
+	bool progress = true;
+	while (progress) {
+		progress = false;
+		for (int i = 0; i < n_candidates; i++) {
+			if (loaded[i]) {
+				continue;
+			}
+			char path[PATH_MAX];
+			(void)snprintf(path, sizeof(path), "%s/%s", lib_dir, names[i]);
+			void *h = dlopen(path, RTLD_LAZY | RTLD_LOCAL);
+			if (h != NULL) {
+				U_LOG_I("plugin loader: preloaded %s", names[i]);
+				loaded[i] = 1;
+				total_loaded++;
+				progress = true;
+				free(last_err[i]);
+				last_err[i] = NULL;
+			} else {
+				/* Cache for final report; another pass might succeed. */
+				const char *err = dlerror();
+				free(last_err[i]);
+				last_err[i] = err ? strdup(err) : NULL;
+			}
+		}
+	}
+
+	for (int i = 0; i < n_candidates; i++) {
+		if (!loaded[i]) {
+			U_LOG_W("plugin loader: preload %s failed after fixed-point: %s", names[i],
+			        last_err[i] ? last_err[i] : "(no dlerror)");
+		}
+		free(names[i]);
+		free(last_err[i]);
+	}
+	U_LOG_I("plugin loader: preload complete (%d/%d loaded)", total_loaded, n_candidates);
+#undef MAX_PRELOAD_CANDIDATES
 }
 
 static const struct xrt_plugin_iface *


### PR DESCRIPTION
## Summary

Regression fix on top of PR #333. The preload loop in `target_plugin_loader.c` did a single readdir pass — fine if the filesystem visited dependency-leaves first, broken if it didn't. The current CNSDK bundle's deps are: `libdxrp050 → libleiaSDK → libblink → libSNPE + liblicense_utils`. When readdir visits `libblink` before `liblicense_utils`, libblink's preload fails (its DT_NEEDED for liblicense_utils can't resolve in the namespace yet), libleiaSDK fails (needs libblink), and `libdxrp050_leia_cnsdk.so` ultimately fails to dlopen with:

```
dlopen failed: library \"libleiaSDK-faceTrackingInApp.so\" not found:
  needed by .../libdxrp050_leia_cnsdk.so in namespace clns-7.
```

This regression silently broke the validation chain on Android-36 emulator — `xrCreateInstance` returned `XR_ERROR_INITIALIZATION_FAILED` instead of the previously-validated `XR_SUCCESS`.

## Fix

Iterate the preload loop until a full pass loads nothing new. Worst case O(N²) dlopen attempts for N libs, but N is small (~16) and dlopen of an already-loaded soinfo is essentially free. After fixed-point, any libs still unloaded get logged at `WARN` with their last dlerror — useful for diagnosing genuinely broken deps vs. ordering issues.

Some SNPE DSP `.so` files always fail on non-Qualcomm hardware (libcdsprpc.so missing, or 32-bit Skel files); they're never reached at runtime on the main load path, so they're noise in the report rather than blockers.

## Verification

Android-36 x86_64 emulator (arm64 binary translation), runtime APK + leia-cnsdk plug-in (post bundle-transitive) + cube_handle_vk_android test app:

| Step | Before this PR | After this PR |
|---|---|---|
| Runtime broker resolves | ✅ | ✅ |
| Runtime dlopen | ✅ | ✅ |
| Plug-in `libdxrp050_leia_cnsdk.so` dlopen | ❌ libleiaSDK not found | ✅ |
| Plug-in negotiate + probe | ❌ | ✅ |
| `xrCreateInstance` | ❌ XR_ERROR_INITIALIZATION_FAILED | ✅ XR_SUCCESS |
| `xrCreateVulkanInstanceKHR` | — | ✅ XR_SUCCESS |
| `xrCreateVulkanDeviceKHR` | — | ❌ VK_ERROR_EXTENSION_NOT_PRESENT (expected emulator limit) |

Same emulator wall as documented in `docs/getting-started/android-emulator-setup.md`.

## Test plan

- [ ] `:src:xrt:targets:openxr_android:assembleInProcessDebug` builds clean.
- [ ] On Android-36 emulator with the bundled-transitive runtime APK + cube_handle_vk_android, logcat shows `preloaded libleiaSDK-faceTrackingInApp.so` (etc.) and `xrCreateInstance -> XR_SUCCESS`.
- [ ] On Lume Pad once it arrives, expectation is the preload list is smaller (system-supplied CNSDK?) but the same fixed-point logic still applies safely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)