### PR TITLE
guard(abi): compile-time tripwire on the plug-in DP-vtable ABI + ADR-020

### DIFF
--- a/docs/adr/ADR-020-plugin-abi-compatibility-policy.md
+++ b/docs/adr/ADR-020-plugin-abi-compatibility-policy.md
@@ -1,0 +1,151 @@
+---
+status: Proposed
+date: 2026-05-27
+---
+# ADR-020: Plug-in ABI Compatibility Policy (versioning, `struct_size` negotiation, drift guards)
+
+## Context
+
+ADR-019 split the vendor display drivers into separately-built plug-in DLLs
+(`DisplayXR-LeiaSR.dll`, `DisplayXR-SimDisplay.dll`) that the runtime
+(`DisplayXRClient.dll`) discovers and negotiates with at `xrCreateInstance`.
+The negotiation handshake (`xrt_plugin.h`) was designed with forward-compat in
+mind: `xrt_plugin_iface`, `xrt_plugin_host_iface`, and
+`xrt_plugin_display_info` each carry a `struct_size` field, are documented as
+**append-only**, and the consuming side "MUST NOT read past `struct_size`."
+
+But the **display-processor vtable** the plug-in factory returns —
+`struct xrt_display_processor` (and the per-API factory typedefs) — was **left
+out of that discipline**. It is an inline C vtable that the runtime calls at
+**fixed compile-time offsets**. It has no `struct_size`. It is not mentioned in
+the API-version contract. And the plug-in builds it against whatever runtime
+headers it pinned via `FetchContent` (`DXR_RUNTIME_GIT_TAG`).
+
+This bit us hard (the multi-day standalone-VK-no-weave / `xrCreateSession`-crash
+saga, fixed immediately by leia PR #16):
+
+- Runtime commit `d665014ab` (after `v1.4.1`) **inserted** `is_self_submitting`,
+  `on_pause`, `on_resume` into `xrt_display_processor` *before* `destroy`,
+  shifting `set_chroma_key` `0x48 → 0x50` and `destroy` `0x50 → 0x68`.
+- `XRT_PLUGIN_API_VERSION_CURRENT` was **not** bumped (the version contract only
+  ever covered the structs in `xrt_plugin.h`, not the DP vtable).
+- The leia plug-in pinned runtime headers at `v1.4.1` while shipping alongside
+  runtime `v1.5.2`. So the runtime's `set_chroma_key` call (slot `0x50`) landed
+  on the plug-in's `leia_dp_destroy` (which sits at `0x50` in the `v1.4.1`
+  layout): **the runtime destroyed the DP immediately after creating it** —
+  freeing `ldp`, tearing down the SR weaver. Downstream that manifested as
+  "freed/corrupt vtable", a UAF crash, and no weave.
+- It reproduced only in CI/shipping because only the CI build uses the pinned
+  tag; local/ASan builds point `DXR_RUNTIME_SOURCE_DIR` at the current runtime
+  checkout (matching ABI), which masked it for days.
+
+Two structural facts made this possible and will recur unless addressed:
+
+1. **The DP vtable is an unversioned, fixed-offset ABI** with no `struct_size`
+   negotiation. *Any* layout change (even a pure append, today) silently breaks
+   a plug-in built against older headers.
+2. **Nothing enforces that a runtime ABI change bumps the version, nor that a
+   plug-in's pinned runtime matches the runtime it is deployed with.** The
+   `KEEP IN SYNC` note in the plug-in CI is a comment, and the runtime loader
+   *logs* the negotiated `plugin_api` version but never compares it.
+
+We also want plug-ins to be **updatable independently of the runtime** (ship a
+new `DisplayXR-LeiaSR.dll` without re-cutting the runtime, and vice-versa)
+within a compatible window — lock-step pairing (e.g. a bundle-only pairing
+assert) is explicitly *not* the goal.
+
+## Decision
+
+Treat the **entire plug-in-facing ABI**, including the DP vtables, as a single
+versioned contract governed by these rules:
+
+### 1. `struct_size` + append-only on the DP vtable
+
+`struct xrt_display_processor` (and each `xrt_display_processor_<api>` factory's
+returned vtable) gains a `uint32_t struct_size` as its **first field**, set by
+the plug-in factory to `sizeof` at the plug-in's compile time. The runtime
+treats any vtable slot whose offset is `>= struct_size` as **absent** (NULL /
+unsupported), exactly as it already does for the optional `xrt_plugin_iface`
+methods. New methods are **only ever appended at the end** — never inserted or
+reordered. This makes additive evolution forward- *and* backward-compatible
+**within a major version**, which is what enables independent updates:
+
+| scenario | behavior |
+|---|---|
+| newer plug-in (extra appended method) + older runtime | runtime ignores slots beyond its own knowledge → OK |
+| newer runtime (calls a new method) + older plug-in | new slot `>= plug-in struct_size` → treated NULL → skipped → OK |
+| reorder / remove / signature change | **breaking** → major bump (below) |
+
+### 2. Major version = the compatibility boundary
+
+`XRT_PLUGIN_API_VERSION_CURRENT` is the **major** ABI version. It is bumped
+**only** on a non-additive change (reorder, remove, signature change, or adding
+a field anywhere but the end of an append-only struct). The negotiation rule is
+**same major == compatible; different major == reject**. Additive minor
+evolution within a major needs no version change (handled by `struct_size`), so
+"plug-in requires runtime min version" reduces to "plug-in and runtime must
+share the same API major." Crossing a major requires coordinated updates — and
+those are caught loudly (next two rules).
+
+### 3. The runtime loader enforces the major version
+
+`target_plugin_loader.c` must **reject** a negotiated plug-in whose
+`plugin_api_version` major differs from the runtime's (today it only logs it).
+A rejected plug-in is skipped with a loud error — the runtime falls back to the
+next plug-in / `sim_display` and **never** calls through a mismatched vtable.
+This is the deploy-time backstop that protects against plug-ins that bypass our
+CI (third parties, manual installs, stale bundles).
+
+### 4. A compile-time ABI tripwire keeps the version honest
+
+A block of `_Static_assert`s (committed in `xrt_display_processor.h` and a
+companion check for `xrt_plugin.h`) pins the offset of every DP-vtable slot, the
+struct size, and the current `XRT_PLUGIN_API_VERSION_CURRENT`. Changing the
+layout fails the build (locally **and** in CI), forcing the author to
+consciously update the asserts — adjacent to a loud comment that says: *this is
+a breaking ABI change; bump the major, follow this ADR, re-pin every plug-in.*
+Had this existed, `d665014ab` would not have compiled without a version bump.
+
+### 5. Plug-in CI asserts its pin is self-consistent
+
+Each plug-in repo's CI hard-asserts `DXR_RUNTIME_GIT_TAG` (CMake) == the
+workflow's pinned runtime checkout `ref` (the existing `KEEP IN SYNC` comment
+becomes a check). This catches "bumped one, forgot the other."
+
+### What we explicitly do NOT do
+
+- **No bundle-level pairing assert as the primary mechanism.** Verifying "the
+  leia release in this bundle was built against the runtime this bundle pins"
+  enforces *lock-step*, which is the opposite of the independent-update goal,
+  only covers the bundle (not standalone/third-party installs), and catches the
+  symptom rather than the cause. Rules 1–4 make compatible combinations *work*
+  and incompatible ones *fail loud* regardless of how they were assembled.
+
+## Consequences
+
+- Implementing rules 1–3 is a **coordinated, major-version-bumped change**:
+  runtime + every in-tree/first-party plug-in rebuild together, and the bump is
+  validated end-to-end on hardware. It must **not** gate the immediate leia
+  `v1.0.5` fix (PR #16), which is already correctly matched to runtime `v1.5.2`.
+  It lands as the next runtime minor/major (e.g. `v1.6.0`) + matching plug-ins.
+- Rule 4 (the `_Static_assert` tripwire) and rule 5 (plug-in pin self-check) are
+  **safe to land immediately** — they change no runtime behavior, only fail the
+  build on an un-versioned ABI change. They are the forward guard that prevents
+  the next `d665014ab`.
+- Once `struct_size` negotiation is in place, the runtime's existing
+  `dp_vtable_looks_sane` guard (runtime `158dfb7c2`) remains as a belt-and-
+  suspenders crash-degrader, but should rarely trigger; its "driver heap-reuse
+  collision" log wording should be updated to name ABI mismatch as the likely
+  cause.
+- The independent-update window is bounded by the major version. Documented
+  policy: a plug-in built against major *N* runs against any runtime of major
+  *N*; a runtime of major *N* runs any plug-in of major *N*. Crossing *N*
+  requires both sides to move and is rejected (not corrupted) in the meantime.
+
+## Status / rollout
+
+- **Now (this change set):** rule 4 (compile-time tripwire) + this ADR.
+- **Next runtime release (coordinated):** rules 1–3 (`struct_size` + append-only
+  + loader major-version enforcement), with the major bumped, all first-party
+  plug-ins rebuilt and re-pinned, validated on the Leia box.
+- **Plug-in repos:** rule 5 (pin self-consistency CI assert).

--- a/src/xrt/include/xrt/xrt_display_processor.h
+++ b/src/xrt/include/xrt/xrt_display_processor.h
@@ -19,6 +19,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <stddef.h> // offsetof — used by the ABI tripwire at the end of this header
 
 #ifdef __cplusplus
 extern "C" {
@@ -298,6 +299,57 @@ struct xrt_display_processor
 
 	/*! @} */
 };
+
+/*
+ * ── Plug-in ABI tripwire (ADR-020) ─────────────────────────────────────────
+ *
+ * `xrt_display_processor` is a FIXED-OFFSET vtable shared across the runtime ↔
+ * vendor-plug-in DLL boundary (ADR-019). The runtime calls these slots at the
+ * compile-time slot indices below; a plug-in built against an older copy of
+ * this header that disagrees on a single slot makes the runtime call the WRONG
+ * function — exactly what broke standalone-VK weaving (the runtime's
+ * set_chroma_key call hit leia's destroy after on_pause/on_resume were inserted
+ * mid-struct without a version bump). See ADR-020.
+ *
+ * If you change anything that trips an assert below, you are making a BREAKING
+ * ABI change. In the SAME change you MUST:
+ *   1. Bump XRT_PLUGIN_API_VERSION_CURRENT in xrt_plugin.h,
+ *   2. Update the slot indices / count here,
+ *   3. Re-pin + rebuild every vendor plug-in (e.g. leia-plugin's
+ *      DXR_RUNTIME_GIT_TAG and its CI runtime-checkout ref) and the bundle,
+ *   4. Follow the append-only + struct_size plan in ADR-020.
+ * Until struct_size negotiation (ADR-020 rule 1) lands, even APPENDING a method
+ * is breaking — old plug-ins still read fixed offsets. New methods go at the
+ * END only.
+ *
+ * Offsets are asserted as (slot index) * sizeof(void *) so the check holds on
+ * both 64-bit and 32-bit (Android) builds — the slot index is the invariant
+ * that decides which function the runtime dispatches to.
+ */
+#if defined(__cplusplus)
+#define XRT_DP_ABI_ASSERT(cond, msg) static_assert(cond, msg)
+#else
+#define XRT_DP_ABI_ASSERT(cond, msg) _Static_assert(cond, msg)
+#endif
+#define XRT_DP_ABI_MSG                                                                                                  \
+	"xrt_display_processor ABI changed — see ADR-020: bump XRT_PLUGIN_API_VERSION_CURRENT and re-pin every plug-in."
+// clang-format off
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, process_atlas)                ==  0 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, get_predicted_eye_positions)  ==  1 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, get_window_metrics)           ==  2 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, request_display_mode)         ==  3 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, get_hardware_3d_state)        ==  4 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, get_render_pass)              ==  5 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, get_display_dimensions)       ==  6 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, get_display_pixel_info)       ==  7 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, is_alpha_native)              ==  8 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, is_self_submitting)           ==  9 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, set_chroma_key)               == 10 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, on_pause)                     == 11 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, on_resume)                    == 12 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, destroy)                      == 13 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(sizeof(struct xrt_display_processor)                                 == 14 * sizeof(void *), XRT_DP_ABI_MSG);
+// clang-format on
 
 /*!
  * @copydoc xrt_display_processor::process_atlas

--- a/src/xrt/include/xrt/xrt_plugin.h
+++ b/src/xrt/include/xrt/xrt_plugin.h
@@ -123,14 +123,24 @@ struct xrt_plugin_display_info
  */
 
 /*!
- * Plug-in ABI version. Bumped only on a non-additive layout change in
- * the structs declared in this header. Pure-additive changes (new fields
- * appended at the end of a struct, covered by the struct's `struct_size`
- * field) are NOT version bumps and remain backward-compatible.
+ * Plug-in ABI version (major). Bumped on a non-additive layout change in the
+ * structs declared in this header **OR** in the display-processor vtables
+ * (`xrt_display_processor` + the per-API factory contracts in
+ * `xrt_display_processor_<api>.h`), which are part of this ABI even though they
+ * live in their own headers and are handed back by `create_dp_<api>`.
  *
- * Numbers grow forward; the runtime + each plug-in declare which they
- * implement, the runtime compares, and either side can decline cleanly
- * if the other is too old or too new.
+ * For the `struct_size`-carrying structs here, pure-additive changes (fields
+ * appended at the end, covered by `struct_size`) are NOT version bumps.
+ *
+ * For the DP vtables: until they gain `struct_size` negotiation (ADR-020 rule
+ * 1), they are read at FIXED offsets, so even an append is breaking — any
+ * layout change there is a major bump. The compile-time tripwire at the end of
+ * `xrt_display_processor.h` fails the build if that vtable changes without
+ * bumping this macro. See ADR-020 for the full policy.
+ *
+ * Compatibility rule (ADR-020 rule 2/3): same major == compatible; a different
+ * major is rejected by the loader (it must not call through a mismatched
+ * vtable). Numbers grow forward.
  */
 #define XRT_PLUGIN_API_VERSION_1 1
 


### PR DESCRIPTION
## What

Adds the immediate, **behavior-neutral** guard against the class of bug that caused the standalone-VK no-weave / `xrCreateSession` crash, plus the policy that explains the durable follow-up. No runtime logic changes.

## Why

That bug was an **unguarded ABI drift**: runtime `d665014ab` inserted `is_self_submitting`/`on_pause`/`on_resume` into `struct xrt_display_processor` (after `v1.4.1`) **without bumping `XRT_PLUGIN_API_VERSION_CURRENT`**, and the leia plug-in shipped built against the older layout. The DP vtable is a **fixed-offset ABI with no `struct_size`**, so the runtime's `set_chroma_key` call (slot `0x50`) landed on the plug-in's `destroy` (`0x50` in the old layout) and self-destructed the DP right after creation. Nothing flagged it — the version contract only ever mentioned the structs in `xrt_plugin.h`, the DP vtable was excluded, and the loader only *logs* the negotiated version.

## Changes

- **`xrt_display_processor.h`** — a block of `_Static_assert`s pinning every DP-vtable slot index + struct size. Any layout change **fails the build locally and in CI**, right next to a loud comment instructing the author to bump `XRT_PLUGIN_API_VERSION_CURRENT`, update the asserts, re-pin every plug-in, and follow ADR-020. Offsets are asserted as `index * sizeof(void *)` so the check holds on 32-bit (Android) too.
  - Verified: clean header compiles (`cl /std:c11`, exit 0); corrupting a slot index → `error C2338`, build fails.
- **`xrt_plugin.h`** — widen the API-version contract comment to state the DP vtables are part of this ABI (the documentation gap that let `d665014ab` slip).
- **`docs/adr/ADR-020`** — the full policy: `struct_size` + append-only on the DP vtable, major-version = compatibility boundary, loader rejects major mismatch, this tripwire, and plug-in-CI pin self-consistency; and why a bundle-level lock-step pairing assert is explicitly *not* the mechanism (it fights independent plug-in/runtime updates).

## Scope

This is the safe-to-land-now slice. The **coordinated `struct_size` + append-only + loader-enforcement** work (ADR-020 rules 1–3 — a major bump that rebuilds all first-party plug-ins) is a separate, hardware-validated follow-up and does **not** gate the immediate leia `v1.0.5` fix.

No auto-merge — for @dfattal review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
