### PR TITLE
android(test app): declare CAMERA + WAKE_LOCK permissions for Lume Pad

### DIFF
--- a/docs/getting-started/android-bringup-checklist.md
+++ b/docs/getting-started/android-bringup-checklist.md
@@ -35,6 +35,27 @@ If A passes you can stop. B confirms the CNSDK convention assumptions. C is only
 
 ---
 
+## Step 0: Grant runtime permissions (one-time per install)
+
+The test app's `AndroidManifest.xml` declares `android.permission.CAMERA` (CNSDK front-camera face tracking) and `android.permission.WAKE_LOCK` (keep screen on during XR sessions). On Android 6+ `CAMERA` is a "dangerous" permission that requires either a user dialog OR an `adb pm grant`.
+
+The test app is a thin `NativeActivity` with no Java/Kotlin wrapper to surface the runtime permission dialog. Two options for day-1:
+
+```bash
+# Option 1: pre-grant via adb (works on emulator + device-with-developer-mode)
+adb shell pm grant com.displayxr.cube_handle_vk_android android.permission.CAMERA
+
+# Option 2: tap "Allow" on the system permission dialog the first time
+# face tracking tries to open the camera (CNSDK throws the dialog itself
+# on first leia_core_enable_face_tracking call — confirm at A1).
+```
+
+**Missing CAMERA on Lume Pad symptom:** session reaches FOCUSED, app renders, but `xrLocateViews` always returns the default centered eye position regardless of head motion. No crash, no log error from CNSDK — just silently no face tracking. Check `adb shell dumpsys package com.displayxr.cube_handle_vk_android | grep CAMERA` to confirm grant.
+
+`WAKE_LOCK` is install-time (no dialog needed) and lets the runtime keep the screen on for the session.
+
+---
+
 ## Step A: First light (atlas mode)
 
 **Goal:** Verify the entire OpenXR loader → DisplayXR runtime → CNSDK DP → Lume Pad display pipeline runs end-to-end.

--- a/test_apps/cube_handle_vk_android/src/main/AndroidManifest.xml
+++ b/test_apps/cube_handle_vk_android/src/main/AndroidManifest.xml
@@ -25,6 +25,35 @@
         android:glEsVersion="0x00030002"
         android:required="false" />
 
+    <!--
+        CNSDK's face tracker uses the front-facing camera at runtime
+        (via libleiaSDK-faceTrackingInApp.so, loaded by the runtime
+        broker into this app's process). Without these declarations:
+          - CAMERA permission missing → camera open silently fails →
+            CNSDK never reports a face → all xrLocateViews calls use
+            the default centered eye position (no head tracking on
+            Lume Pad).
+          - uses-feature camera.front missing → Play Store filters
+            this app off devices that lack a front camera, AND
+            Android may not surface camera in the runtime permission
+            dialog.
+        Both required="false" so the same APK still installs on the
+        emulator (no camera hardware) — CNSDK is fine with no face.
+    -->
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-feature android:name="android.hardware.camera" android:required="false" />
+    <uses-feature android:name="android.hardware.camera.front" android:required="false" />
+
+    <!--
+        Long XR sessions don't generate user-input events; without
+        WAKE_LOCK the screen dims/sleeps and the session pauses.
+        FLAG_KEEP_SCREEN_ON would also work but requires the Activity
+        to set it programmatically — for a NativeActivity, easier to
+        request the permission and let the runtime keep the wake
+        lock for its session duration.
+    -->
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application


### PR DESCRIPTION
## Summary

Pre-Lume-Pad audit of the test app's `AndroidManifest.xml`. Adds two missing permissions that would otherwise silently degrade the day-1 experience, plus a Step 0 in `android-bringup-checklist.md` documenting how to grant them.

## What this fixes (silent failures avoided)

| Missing | Day-1 symptom | Fix |
|---|---|---|
| `android.permission.CAMERA` | CNSDK's `libleiaSDK-faceTrackingInApp.so` opens the front camera at `leia_core_enable_face_tracking`. Without CAMERA: silent open() failure, no face reported, `xrLocateViews` always returns default centered eye position. **No crash, no log error** — just no head tracking. Hours of "why isn't head tracking working" debugging. | Declared in manifest + `pm grant` documented |
| `uses-feature camera.front` | Play Store filters the app off no-camera devices, AND Android may not surface camera in runtime dialog | Declared `required="false"` so emulator (no camera) still installs |
| `android.permission.WAKE_LOCK` | Long XR sessions don't generate input → screen dims/sleeps → session pauses | Declared (install-time grant) |

## Notes on CAMERA runtime grant

CAMERA is "dangerous" on Android 6+; declaring it in the manifest isn't enough — the user must grant at runtime. The test app is a pure `NativeActivity` with no Java/Kotlin wrapper to surface the system dialog. Two workarounds documented in the bring-up checklist:

1. **Pre-grant via adb** (works on emulator + developer-mode device):
   ```bash
   adb shell pm grant com.displayxr.cube_handle_vk_android android.permission.CAMERA
   ```
2. **Wait for CNSDK's own dialog** at first `leia_core_enable_face_tracking` — depends on CNSDK behavior on Lume Pad, untested pre-hardware.

Production-quality permission handling (wrap `NativeActivity` in a Kotlin `Activity` that calls `requestPermissions()` at `onCreate`) deferred — that's a separate ~50 LOC change with its own review concerns.

## Verification

Built + installed on the Android-36 emulator:

```
$ adb shell dumpsys package com.displayxr.cube_handle_vk_android | grep -E 'CAMERA|WAKE_LOCK|INTERNET'
      android.permission.INTERNET
      android.permission.CAMERA
      android.permission.WAKE_LOCK
      android.permission.INTERNET: granted=true
      android.permission.WAKE_LOCK: granted=true
        android.permission.CAMERA: granted=false, flags=[ USER_SENSITIVE_WHEN_GRANTED|USER_SENSITIVE_WHEN_DENIED]
```

Install/launch unchanged. `xrCreateInstance -> XR_SUCCESS` still reaches the runtime as before.

## Test plan

- [ ] On Lume Pad, run the bring-up checklist Step 0 → confirm `dumpsys package | grep CAMERA` shows `granted=true` before launching the app.
- [ ] Head tracking works during session (visible face-driven parallax / cube perspective).
- [ ] If CNSDK throws its own permission dialog before Step 0's `pm grant` is run, document the timing in the bring-up doc for future installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)