### PR TITLE
feat(abi): plug-in ABI major v2 — struct_size on DP vtables + loader reject + #342 re-scan (ADR-020 / v1.6.0)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 cmake_minimum_required(VERSION 3.22)
 project(
 	XRT
-	VERSION 1.5.2
+	VERSION 1.6.0
 	LANGUAGES C CXX
 	DESCRIPTION "DisplayXR Runtime (based on Monado/XRT)"
 	)

--- a/docs/adr/ADR-020-plugin-abi-compatibility-policy.md
+++ b/docs/adr/ADR-020-plugin-abi-compatibility-policy.md
@@ -1,5 +1,5 @@
 ---
-status: Proposed
+status: Accepted
 date: 2026-05-27
 ---
 # ADR-020: Plug-in ABI Compatibility Policy (versioning, `struct_size` negotiation, drift guards)
@@ -61,14 +61,19 @@ versioned contract governed by these rules:
 
 ### 1. `struct_size` + append-only on the DP vtable
 
-`struct xrt_display_processor` (and each `xrt_display_processor_<api>` factory's
-returned vtable) gains a `uint32_t struct_size` as its **first field**, set by
-the plug-in factory to `sizeof` at the plug-in's compile time. The runtime
-treats any vtable slot whose offset is `>= struct_size` as **absent** (NULL /
-unsupported), exactly as it already does for the optional `xrt_plugin_iface`
-methods. New methods are **only ever appended at the end** — never inserted or
-reordered. This makes additive evolution forward- *and* backward-compatible
-**within a major version**, which is what enables independent updates:
+`struct xrt_display_processor` (and each `xrt_display_processor_<api>` —
+`_d3d11`, `_d3d12`, `_gl`, `_metal` — factory's returned vtable) gains an 8-byte
+header (`uint32_t struct_size; uint32_t reserved_0;`) as its **first fields**,
+set by the plug-in factory to `sizeof` at the plug-in's compile time. The
+8-byte header (mirroring `xrt_plugin_display_info`) makes the first vtable slot
+land at offset 8 on both 64-bit and 32-bit/Android, so the compile-time asserts
+anchor at a base offset rather than brittle absolute math. The runtime treats
+any vtable slot whose bytes fall at/past `struct_size` as **absent** (NULL /
+unsupported) via the `XRT_DP_HAS_SLOT` coverage check on every optional-method
+wrapper, exactly as it already does for the optional `xrt_plugin_iface` methods.
+New methods are **only ever appended at the end** — never inserted or reordered.
+This makes additive evolution forward- *and* backward-compatible **within a
+major version**, which is what enables independent updates:
 
 | scenario | behavior |
 |---|---|
@@ -144,8 +149,15 @@ becomes a check). This catches "bumped one, forgot the other."
 
 ## Status / rollout
 
-- **Now (this change set):** rule 4 (compile-time tripwire) + this ADR.
-- **Next runtime release (coordinated):** rules 1–3 (`struct_size` + append-only
-  + loader major-version enforcement), with the major bumped, all first-party
-  plug-ins rebuilt and re-pinned, validated on the Leia box.
-- **Plug-in repos:** rule 5 (pin self-consistency CI assert).
+- **Landed in the v1.5.x line:** rule 4 (compile-time tripwire) + this ADR
+  (runtime PR #348).
+- **Done (runtime v1.6.0, ABI major 2):** rules 1–3 — `struct_size` + append-only
+  on `xrt_display_processor` *and* the per-API vtables (`_d3d11`, `_d3d12`,
+  `_gl`, `_metal`), plus loader major-version enforcement in all three
+  `target_plugin_loader.c` `try_load_one` variants (Windows registry, POSIX/JSON,
+  Android). `XRT_PLUGIN_API_VERSION_CURRENT` bumped `1 → 2`; the tripwire asserts
+  rewritten to the `XRT_DP_BASE_OFF`-anchored, struct_size-aware scheme; all
+  first-party plug-ins (in-tree sim_display, and leia v1.0.6 out-of-tree) set
+  `struct_size` and re-pin to v1.6.0.
+- **Plug-in repos:** rule 5 (pin self-consistency CI assert) — leia v1.0.6's CI
+  asserts `DXR_RUNTIME_GIT_TAG` == the workflow's runtime checkout `ref`.

--- a/docs/specs/runtime/plugin-discovery.md
+++ b/docs/specs/runtime/plugin-discovery.md
@@ -348,27 +348,36 @@ manifest + binary, leaves the runtime alone.
 
 ## 6. Version negotiation
 
-`XRT_PLUGIN_API_VERSION_CURRENT` is defined in `xrt/xrt_plugin.h`. v1
-is the only released line.
+`XRT_PLUGIN_API_VERSION_CURRENT` is defined in `xrt/xrt_plugin.h`. As of
+runtime v1.6.0 the current major is `XRT_PLUGIN_API_VERSION_2`
+(ADR-020). v1 → v2 is the one-time break that introduced the
+`struct_size` header on the display-processor vtables; ABI-v1 plug-ins
+(≤ leia v1.0.5) are rejected by the loader and must be rebuilt against
+v2 headers.
 
 Both the runtime and the plug-in pass their own version through
-`xrtPluginNegotiate`. Either side can decline (return
-`XRT_ERROR_PROBER_NOT_SUPPORTED`) on a mismatch. The runtime logs the
-mismatch and skips to the next plug-in in the probe order.
+`xrtPluginNegotiate`. The runtime enforces a strict major match — a
+plug-in reporting any version other than the runtime's
+`XRT_PLUGIN_API_VERSION_CURRENT` is rejected at the loader (`ABI major
+mismatch — plugin_api=%u, runtime expects %u`) and discovery falls back
+to the next plug-in / `sim_display`. ADR-020 rule 3.
 
-**Forward-compat for vtable additions:** new methods on
-`xrt_plugin_iface` and new fields on `xrt_plugin_display_info` MUST be
-appended at the end. Plug-ins built against an older header report
-`struct_size = sizeof(struct xrt_plugin_iface)` at their compile time;
-the runtime guards each new vtable call on
+**Forward-compat for vtable additions within a major:** new methods on
+`xrt_plugin_iface`, the DP vtables (`xrt_display_processor`,
+`xrt_display_processor_<api>`), and new fields on
+`xrt_plugin_display_info` MUST be appended at the end. Plug-ins built
+against an older header report `struct_size = sizeof(struct …)` at
+their compile time; the runtime guards each new vtable call on
+`XRT_DP_HAS_SLOT(xdp, <new field>)` (DP vtables) or
 `iface->struct_size > offsetof(struct xrt_plugin_iface, <new field>)`
-before dereferencing. See `oxr_plugin_stub.c` for the structural
-asserts that enforce the append-only rule at compile time.
+(plug-in iface / display info) before dereferencing. See
+`oxr_plugin_stub.c` for the structural asserts that enforce the
+append-only rule at compile time.
 
-Versioned struct bumps (`XRT_PLUGIN_API_VERSION_2`) are reserved for
-non-additive changes (reordering, renaming, signature changes on
-existing fields). v1 commits to the field order documented in the
-header.
+Versioned struct bumps (the next would be `XRT_PLUGIN_API_VERSION_3`)
+are reserved for non-additive changes (reordering, renaming, signature
+changes on existing fields). v2 commits to the field order documented
+in the header.
 
 ---
 

--- a/src/xrt/compositor/d3d11/comp_d3d11_window.cpp
+++ b/src/xrt/compositor/d3d11/comp_d3d11_window.cpp
@@ -995,10 +995,14 @@ wnd_proc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 		ofn.lpstrTitle = "Launch App in Workspace";
 		ofn.Flags = OFN_FILEMUSTEXIST | OFN_PATHMUSTEXIST;
 		if (GetOpenFileNameA(&ofn)) {
-			// Set workspace session env var and ensure XR_RUNTIME_JSON points to
-			// the dev build runtime (matching the running service).
+			// Set workspace session env var.
 			SetEnvironmentVariableA("DISPLAYXR_WORKSPACE_SESSION", "1");
-			if (getenv("XR_RUNTIME_JSON") == NULL) {
+			// #345 (ADR-020): only auto-resolve the sibling dev manifest onto
+			// child apps under an explicit dev opt-in (DISPLAYXR_DEV=1) and only
+			// when the launcher itself hasn't already chosen a runtime. In a
+			// normal install there is no build/Release/ tree; forcing a stale
+			// XR_RUNTIME_JSON there made child apps load the wrong runtime.
+			if (getenv("DISPLAYXR_DEV") != NULL && getenv("XR_RUNTIME_JSON") == NULL) {
 				// Use dev build manifest (has absolute path to DLL).
 				// Service is at _package/bin/, dev manifest is at build/Release/.
 				char module_dir[MAX_PATH] = {0};

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -10566,6 +10566,15 @@ system_create_native_compositor(struct xrt_system_compositor *xsysc,
 {
 	struct d3d11_service_system *sys = d3d11_service_system_from_xrt(xsysc);
 
+	// #342 / ADR-020: re-derive dp_factory_* from the plug-in loader before
+	// any per-client DP-factory read in this function (and downstream
+	// `multi_compositor_ensure_output` calls). Picks up a vendor plug-in
+	// registered after the service started without requiring a service
+	// restart. NULL on builds without the loader hook.
+	if (sys->base.info.refresh_display_processors != NULL) {
+		sys->base.info.refresh_display_processors(&sys->base.info);
+	}
+
 	// Create per-client native compositor
 	struct d3d11_service_compositor *c = new d3d11_service_compositor();
 	std::memset(&c->base, 0, sizeof(c->base));

--- a/src/xrt/compositor/multi/comp_multi_compositor.c
+++ b/src/xrt/compositor/multi/comp_multi_compositor.c
@@ -1904,6 +1904,14 @@ multi_compositor_create(struct multi_system_compositor *msc,
 {
 	COMP_TRACE_MARKER();
 
+	// #342 / ADR-020: re-derive dp_factory_* from the plug-in loader before
+	// this client's session_render reads them. Picks up a vendor plug-in
+	// registered after the service started (mid-install case) without
+	// requiring a service restart. NULL on builds without the loader hook.
+	if (msc->base.info.refresh_display_processors != NULL) {
+		msc->base.info.refresh_display_processors(&msc->base.info);
+	}
+
 	struct multi_compositor *mc = U_TYPED_CALLOC(struct multi_compositor);
 
 	mc->base.base.get_swapchain_create_properties = multi_compositor_get_swapchain_create_properties;

--- a/src/xrt/compositor/vk_native/comp_vk_native_compositor.c
+++ b/src/xrt/compositor/vk_native/comp_vk_native_compositor.c
@@ -2923,7 +2923,8 @@ comp_vk_native_compositor_create(struct xrt_device *xdev,
 	// pointer may itself be garbage; leak the corrupt object on this path.
 	if (c->display_processor != NULL && !dp_vtable_looks_sane(c->display_processor)) {
 		U_LOG_E("VK display processor vtable corrupt after target creation — "
-		        "disabling DP (output will not be woven). Likely a driver "
+		        "disabling DP (output will not be woven). Likely a plug-in built "
+		        "against a different runtime ABI major (ADR-020), or a driver "
 		        "heap-reuse collision.");
 		c->display_processor = NULL;
 	}

--- a/src/xrt/drivers/sim_display/sim_display_processor.c
+++ b/src/xrt/drivers/sim_display/sim_display_processor.c
@@ -611,6 +611,9 @@ sim_display_processor_create(enum sim_display_output_mode mode,
 		return XRT_ERROR_ALLOCATION;
 	}
 
+	// ADR-020 rule 1: advertise the vtable size so the runtime knows which
+	// slots this plug-in actually built (calloc already zeroed reserved_0).
+	sdp->base.struct_size = (uint32_t)sizeof(struct xrt_display_processor);
 	sdp->base.destroy = sim_dp_destroy;
 	sdp->base.get_render_pass = sim_dp_get_render_pass;
 	sdp->base.get_predicted_eye_positions = sim_dp_get_predicted_eye_positions;

--- a/src/xrt/drivers/sim_display/sim_display_processor_d3d11.cpp
+++ b/src/xrt/drivers/sim_display/sim_display_processor_d3d11.cpp
@@ -418,6 +418,8 @@ sim_display_processor_d3d11_create(enum sim_display_output_mode mode,
 		return XRT_ERROR_ALLOCATION;
 	}
 
+	// ADR-020 rule 1: advertise the vtable size (calloc zeroed reserved_0).
+	sdp->base.struct_size = static_cast<uint32_t>(sizeof(struct xrt_display_processor_d3d11));
 	sdp->base.destroy = sim_dp_d3d11_destroy;
 	sdp->base.process_atlas = sim_dp_d3d11_process_atlas;
 	sdp->base.get_predicted_eye_positions = sim_dp_d3d11_get_predicted_eye_positions;

--- a/src/xrt/drivers/sim_display/sim_display_processor_d3d12.cpp
+++ b/src/xrt/drivers/sim_display/sim_display_processor_d3d12.cpp
@@ -494,6 +494,8 @@ sim_display_processor_d3d12_create(enum sim_display_output_mode mode,
 		return XRT_ERROR_ALLOCATION;
 	}
 
+	// ADR-020 rule 1: advertise the vtable size (calloc zeroed reserved_0).
+	sdp->base.struct_size = static_cast<uint32_t>(sizeof(struct xrt_display_processor_d3d12));
 	sdp->base.destroy = sim_dp_d3d12_destroy;
 	sdp->base.process_atlas = sim_dp_d3d12_process_atlas;
 	sdp->base.get_predicted_eye_positions = sim_dp_d3d12_get_predicted_eye_positions;

--- a/src/xrt/drivers/sim_display/sim_display_processor_gl.c
+++ b/src/xrt/drivers/sim_display/sim_display_processor_gl.c
@@ -424,6 +424,8 @@ sim_display_processor_gl_create(enum sim_display_output_mode mode,
 		return XRT_ERROR_ALLOCATION;
 	}
 
+	// ADR-020 rule 1: advertise the vtable size (calloc zeroed reserved_0).
+	sdp->base.struct_size = (uint32_t)sizeof(struct xrt_display_processor_gl);
 	sdp->base.destroy = sim_dp_gl_destroy;
 	sdp->base.process_atlas = sim_dp_gl_process_atlas;
 	sdp->base.get_predicted_eye_positions = sim_dp_gl_get_predicted_eye_positions;

--- a/src/xrt/drivers/sim_display/sim_display_processor_metal.m
+++ b/src/xrt/drivers/sim_display/sim_display_processor_metal.m
@@ -444,6 +444,8 @@ sim_display_processor_metal_create(enum sim_display_output_mode mode,
 		return XRT_ERROR_ALLOCATION;
 	}
 
+	// ADR-020 rule 1: advertise the vtable size (calloc zeroed reserved_0).
+	sdp->base.struct_size = (uint32_t)sizeof(struct xrt_display_processor_metal);
 	sdp->base.destroy = sim_dp_metal_destroy;
 	sdp->base.process_atlas = sim_dp_metal_process_atlas;
 	sdp->base.get_predicted_eye_positions = sim_dp_metal_get_predicted_eye_positions;

--- a/src/xrt/include/xrt/xrt_compositor.h
+++ b/src/xrt/include/xrt/xrt_compositor.h
@@ -2558,6 +2558,18 @@ struct xrt_system_compositor_info
 	//! Signature: xrt_dp_factory_gl_fn_t (see xrt_display_processor_gl.h).
 	void *dp_factory_gl;
 
+	/*!
+	 * Optional callback: re-derive the dp_factory_* pointers above from the
+	 * runtime's plug-in loader. Long-lived service-mode compositors invoke
+	 * this once at per-client compositor create, so a vendor plug-in
+	 * installed AFTER the service started (#342) is picked up on the first
+	 * app launch without a service restart. NULL on the in-process / handle
+	 * path — those create a fresh instance per app launch and never need it.
+	 * The callee may swap in a strictly-better (lower ProbeOrder) plug-in
+	 * and leak the old DLL; see ADR-020 and `target_plugin_loader.c`.
+	 */
+	void (*refresh_display_processors)(struct xrt_system_compositor_info *info);
+
 	/*! @} */
 };
 

--- a/src/xrt/include/xrt/xrt_display_processor.h
+++ b/src/xrt/include/xrt/xrt_display_processor.h
@@ -70,6 +70,20 @@ struct xrt_window_metrics;
 struct xrt_display_processor
 {
 	/*!
+	 * `sizeof(struct xrt_display_processor)` as known at the *plug-in's*
+	 * compile time. Set by the plug-in factory before handing the vtable
+	 * back. The runtime treats any vtable slot whose bytes fall at or past
+	 * this offset as absent (NULL / unsupported) — see @ref XRT_DP_HAS_SLOT
+	 * and ADR-020 rule 1. Together with @ref reserved_0 this is an 8-byte
+	 * header (mirroring @ref xrt_plugin_display_info) so @ref process_atlas
+	 * lands at offset 8 on both 64-bit and 32-bit/Android targets.
+	 */
+	uint32_t struct_size;
+
+	/*! Reserved for alignment / future flags. Must be 0. */
+	uint32_t reserved_0;
+
+	/*!
 	 * @name Interface Methods
 	 * @{
 	 */
@@ -303,53 +317,93 @@ struct xrt_display_processor
 /*
  * ── Plug-in ABI tripwire (ADR-020) ─────────────────────────────────────────
  *
- * `xrt_display_processor` is a FIXED-OFFSET vtable shared across the runtime ↔
- * vendor-plug-in DLL boundary (ADR-019). The runtime calls these slots at the
- * compile-time slot indices below; a plug-in built against an older copy of
- * this header that disagrees on a single slot makes the runtime call the WRONG
- * function — exactly what broke standalone-VK weaving (the runtime's
- * set_chroma_key call hit leia's destroy after on_pause/on_resume were inserted
- * mid-struct without a version bump). See ADR-020.
+ * `xrt_display_processor` is a vtable shared across the runtime ↔ vendor-plug-in
+ * DLL boundary (ADR-019). As of ABI major v2 it carries a `struct_size` header
+ * (see the struct above): the plug-in reports how many slots it built, and the
+ * runtime treats any slot at/past that offset as absent (NULL) via
+ * @ref XRT_DP_HAS_SLOT. That makes *appending* a new method at the END
+ * backward- and forward-compatible WITHIN a major — no version bump needed.
+ *
+ * What is STILL breaking (and trips an assert below): reordering an existing
+ * slot, removing one, changing a signature, or inserting anywhere but the end.
+ * That is exactly what broke standalone-VK weaving — on_pause/on_resume were
+ * inserted mid-struct (before destroy) without a version bump, so the runtime's
+ * set_chroma_key call hit a plug-in's destroy. See ADR-020.
  *
  * If you change anything that trips an assert below, you are making a BREAKING
  * ABI change. In the SAME change you MUST:
- *   1. Bump XRT_PLUGIN_API_VERSION_CURRENT in xrt_plugin.h,
+ *   1. Bump XRT_PLUGIN_API_VERSION_CURRENT in xrt_plugin.h (major),
  *   2. Update the slot indices / count here,
  *   3. Re-pin + rebuild every vendor plug-in (e.g. leia-plugin's
- *      DXR_RUNTIME_GIT_TAG and its CI runtime-checkout ref) and the bundle,
- *   4. Follow the append-only + struct_size plan in ADR-020.
- * Until struct_size negotiation (ADR-020 rule 1) lands, even APPENDING a method
- * is breaking — old plug-ins still read fixed offsets. New methods go at the
- * END only.
+ *      DXR_RUNTIME_GIT_TAG and its CI runtime-checkout ref) and the bundle.
+ * To add a method WITHOUT a major bump: append it at the very END (after the
+ * last slot below), add its assert, bump the size assert, and gate its wrapper
+ * on @ref XRT_DP_HAS_SLOT — old plug-ins (smaller struct_size) see it as absent.
  *
- * Offsets are asserted as (slot index) * sizeof(void *) so the check holds on
- * both 64-bit and 32-bit (Android) builds — the slot index is the invariant
- * that decides which function the runtime dispatches to.
+ * Offsets are anchored at XRT_DP_BASE_OFF (the offset of the first slot, after
+ * the 8-byte struct_size header) plus (slot index) * sizeof(void *), so the
+ * check holds on both 64-bit and 32-bit (Android) builds.
  */
+// Guarded so the per-API xrt_display_processor_<api>.h headers can define the
+// same helpers regardless of include order (no MSVC C4005 redefinition).
+#ifndef XRT_DP_ABI_ASSERT
 #if defined(__cplusplus)
 #define XRT_DP_ABI_ASSERT(cond, msg) static_assert(cond, msg)
 #else
 #define XRT_DP_ABI_ASSERT(cond, msg) _Static_assert(cond, msg)
 #endif
+#endif
+#ifndef XRT_DP_ABI_MSG
 #define XRT_DP_ABI_MSG                                                                                                  \
 	"xrt_display_processor ABI changed — see ADR-020: bump XRT_PLUGIN_API_VERSION_CURRENT and re-pin every plug-in."
+#endif
+
+/*!
+ * Offset of the first vtable slot (`process_atlas`), i.e. the size of the
+ * struct_size header. Asserted == 8 below so it holds identically on 64-bit
+ * (8 = one pointer slot) and 32-bit/Android (8 = two pointer slots).
+ */
+#define XRT_DP_BASE_OFF offsetof(struct xrt_display_processor, process_atlas)
+
 // clang-format off
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, process_atlas)                ==  0 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, get_predicted_eye_positions)  ==  1 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, get_window_metrics)           ==  2 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, request_display_mode)         ==  3 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, get_hardware_3d_state)        ==  4 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, get_render_pass)              ==  5 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, get_display_dimensions)       ==  6 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, get_display_pixel_info)       ==  7 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, is_alpha_native)              ==  8 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, is_self_submitting)           ==  9 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, set_chroma_key)               == 10 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, on_pause)                     == 11 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, on_resume)                    == 12 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, destroy)                      == 13 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(sizeof(struct xrt_display_processor)                                 == 14 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(XRT_DP_BASE_OFF == 8, XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, process_atlas)                == XRT_DP_BASE_OFF +  0 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, get_predicted_eye_positions)  == XRT_DP_BASE_OFF +  1 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, get_window_metrics)           == XRT_DP_BASE_OFF +  2 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, request_display_mode)         == XRT_DP_BASE_OFF +  3 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, get_hardware_3d_state)        == XRT_DP_BASE_OFF +  4 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, get_render_pass)              == XRT_DP_BASE_OFF +  5 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, get_display_dimensions)       == XRT_DP_BASE_OFF +  6 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, get_display_pixel_info)       == XRT_DP_BASE_OFF +  7 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, is_alpha_native)              == XRT_DP_BASE_OFF +  8 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, is_self_submitting)           == XRT_DP_BASE_OFF +  9 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, set_chroma_key)               == XRT_DP_BASE_OFF + 10 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, on_pause)                     == XRT_DP_BASE_OFF + 11 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, on_resume)                    == XRT_DP_BASE_OFF + 12 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, destroy)                      == XRT_DP_BASE_OFF + 13 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(sizeof(struct xrt_display_processor)                                 == XRT_DP_BASE_OFF + 14 * sizeof(void *), XRT_DP_ABI_MSG);
 // clang-format on
+
+/*!
+ * True when the vtable @p xdp actually carries the slot @p field — i.e. the
+ * plug-in that built it reported a `struct_size` large enough to include that
+ * field's bytes. The runtime treats appended-but-unknown-to-this-plug-in slots
+ * as absent (ADR-020 rule 1). Optional-method wrappers below gate on this in
+ * addition to the per-pointer NULL check, so a runtime built against a newer
+ * header never reads a slot an older plug-in never allocated.
+ *
+ * Evaluates @p xdp once would require a statement-expr; the macro instead
+ * tolerates re-evaluation — callers always pass a plain local pointer.
+ *
+ * The body is type-generic (it only needs `field` and `struct_size` members),
+ * so the per-API `xrt_display_processor_<api>.h` headers reuse the same macro;
+ * the `#ifndef` guard lets whichever header is included first define it.
+ */
+#ifndef XRT_DP_HAS_SLOT
+#define XRT_DP_HAS_SLOT(xdp, field)                                                                                    \
+	((xdp) != NULL && ((const char *)&(xdp)->field + sizeof((xdp)->field)) <=                                       \
+	                      ((const char *)(xdp) + (xdp)->struct_size))
+#endif
 
 /*!
  * @copydoc xrt_display_processor::process_atlas
@@ -378,6 +432,8 @@ xrt_display_processor_process_atlas(struct xrt_display_processor *xdp,
                                     uint32_t canvas_width,
                                     uint32_t canvas_height)
 {
+	// Mandatory slot (offset XRT_DP_BASE_OFF): every plug-in's struct_size
+	// covers it, so no XRT_DP_HAS_SLOT gate — see ADR-020.
 	xdp->process_atlas(xdp, cmd_buffer, atlas_image, atlas_view,
 	                   view_width, view_height,
 	                   tile_columns, tile_rows,
@@ -398,7 +454,7 @@ static inline bool
 xrt_display_processor_get_predicted_eye_positions(struct xrt_display_processor *xdp,
                                                   struct xrt_eye_positions *out_eye_pos)
 {
-	if (xdp == NULL || xdp->get_predicted_eye_positions == NULL) {
+	if (!XRT_DP_HAS_SLOT(xdp, get_predicted_eye_positions) || xdp->get_predicted_eye_positions == NULL) {
 		return false;
 	}
 	return xdp->get_predicted_eye_positions(xdp, out_eye_pos);
@@ -413,7 +469,7 @@ static inline bool
 xrt_display_processor_get_window_metrics(struct xrt_display_processor *xdp,
                                          struct xrt_window_metrics *out_metrics)
 {
-	if (xdp == NULL || xdp->get_window_metrics == NULL) {
+	if (!XRT_DP_HAS_SLOT(xdp, get_window_metrics) || xdp->get_window_metrics == NULL) {
 		return false;
 	}
 	return xdp->get_window_metrics(xdp, out_metrics);
@@ -427,7 +483,7 @@ xrt_display_processor_get_window_metrics(struct xrt_display_processor *xdp,
 static inline bool
 xrt_display_processor_request_display_mode(struct xrt_display_processor *xdp, bool enable_3d)
 {
-	if (xdp == NULL || xdp->request_display_mode == NULL) {
+	if (!XRT_DP_HAS_SLOT(xdp, request_display_mode) || xdp->request_display_mode == NULL) {
 		return false;
 	}
 	return xdp->request_display_mode(xdp, enable_3d);
@@ -442,7 +498,7 @@ static inline bool
 xrt_display_processor_get_hardware_3d_state(struct xrt_display_processor *xdp,
                                             bool *out_is_3d)
 {
-	if (xdp == NULL || xdp->get_hardware_3d_state == NULL) {
+	if (!XRT_DP_HAS_SLOT(xdp, get_hardware_3d_state) || xdp->get_hardware_3d_state == NULL) {
 		return false;
 	}
 	return xdp->get_hardware_3d_state(xdp, out_is_3d);
@@ -456,7 +512,7 @@ xrt_display_processor_get_hardware_3d_state(struct xrt_display_processor *xdp,
 static inline VkRenderPass
 xrt_display_processor_get_render_pass(struct xrt_display_processor *xdp)
 {
-	if (xdp == NULL || xdp->get_render_pass == NULL) {
+	if (!XRT_DP_HAS_SLOT(xdp, get_render_pass) || xdp->get_render_pass == NULL) {
 		return (VkRenderPass)0;
 	}
 	return xdp->get_render_pass(xdp);
@@ -472,7 +528,7 @@ xrt_display_processor_get_display_dimensions(struct xrt_display_processor *xdp,
                                              float *out_width_m,
                                              float *out_height_m)
 {
-	if (xdp == NULL || xdp->get_display_dimensions == NULL) {
+	if (!XRT_DP_HAS_SLOT(xdp, get_display_dimensions) || xdp->get_display_dimensions == NULL) {
 		return false;
 	}
 	return xdp->get_display_dimensions(xdp, out_width_m, out_height_m);
@@ -490,7 +546,7 @@ xrt_display_processor_get_display_pixel_info(struct xrt_display_processor *xdp,
                                              int32_t *out_screen_left,
                                              int32_t *out_screen_top)
 {
-	if (xdp == NULL || xdp->get_display_pixel_info == NULL) {
+	if (!XRT_DP_HAS_SLOT(xdp, get_display_pixel_info) || xdp->get_display_pixel_info == NULL) {
 		return false;
 	}
 	return xdp->get_display_pixel_info(xdp, out_pixel_width, out_pixel_height, out_screen_left, out_screen_top);
@@ -504,7 +560,7 @@ xrt_display_processor_get_display_pixel_info(struct xrt_display_processor *xdp,
 static inline bool
 xrt_display_processor_is_alpha_native(struct xrt_display_processor *xdp)
 {
-	if (xdp == NULL || xdp->is_alpha_native == NULL) {
+	if (!XRT_DP_HAS_SLOT(xdp, is_alpha_native) || xdp->is_alpha_native == NULL) {
 		return false;
 	}
 	return xdp->is_alpha_native(xdp);
@@ -518,7 +574,7 @@ xrt_display_processor_is_alpha_native(struct xrt_display_processor *xdp)
 static inline bool
 xrt_display_processor_is_self_submitting(struct xrt_display_processor *xdp)
 {
-	if (xdp == NULL || xdp->is_self_submitting == NULL) {
+	if (!XRT_DP_HAS_SLOT(xdp, is_self_submitting) || xdp->is_self_submitting == NULL) {
 		return false;
 	}
 	return xdp->is_self_submitting(xdp);
@@ -534,7 +590,7 @@ xrt_display_processor_set_chroma_key(struct xrt_display_processor *xdp,
                                      uint32_t key_color,
                                      bool transparent_bg_enabled)
 {
-	if (xdp == NULL || xdp->set_chroma_key == NULL) {
+	if (!XRT_DP_HAS_SLOT(xdp, set_chroma_key) || xdp->set_chroma_key == NULL) {
 		return;
 	}
 	xdp->set_chroma_key(xdp, key_color, transparent_bg_enabled);
@@ -548,7 +604,7 @@ xrt_display_processor_set_chroma_key(struct xrt_display_processor *xdp,
 static inline void
 xrt_display_processor_on_pause(struct xrt_display_processor *xdp)
 {
-	if (xdp == NULL || xdp->on_pause == NULL) {
+	if (!XRT_DP_HAS_SLOT(xdp, on_pause) || xdp->on_pause == NULL) {
 		return;
 	}
 	xdp->on_pause(xdp);
@@ -562,7 +618,7 @@ xrt_display_processor_on_pause(struct xrt_display_processor *xdp)
 static inline void
 xrt_display_processor_on_resume(struct xrt_display_processor *xdp)
 {
-	if (xdp == NULL || xdp->on_resume == NULL) {
+	if (!XRT_DP_HAS_SLOT(xdp, on_resume) || xdp->on_resume == NULL) {
 		return;
 	}
 	xdp->on_resume(xdp);
@@ -607,6 +663,7 @@ xrt_display_processor_destroy(struct xrt_display_processor **xdp_ptr)
 		return;
 	}
 
+	// Mandatory slot: covered by every plug-in's struct_size, so un-gated.
 	xdp->destroy(xdp);
 	*xdp_ptr = NULL;
 }

--- a/src/xrt/include/xrt/xrt_display_processor_d3d11.h
+++ b/src/xrt/include/xrt/xrt_display_processor_d3d11.h
@@ -23,6 +23,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <stddef.h> // offsetof — used by the ABI tripwire at the end of this header
 
 #ifdef __cplusplus
 extern "C" {
@@ -46,6 +47,17 @@ struct xrt_window_metrics;
  */
 struct xrt_display_processor_d3d11
 {
+	/*!
+	 * `sizeof(struct xrt_display_processor_d3d11)` at the plug-in's compile
+	 * time. Set by the plug-in factory; the runtime treats any slot at/past
+	 * this offset as absent (NULL). 8-byte header (with @ref reserved_0) so
+	 * @ref process_atlas lands at offset 8 on 64- and 32-bit. See ADR-020.
+	 */
+	uint32_t struct_size;
+
+	/*! Reserved for alignment / future flags. Must be 0. */
+	uint32_t reserved_0;
+
 	/*!
 	 * Process an atlas texture into the final display output.
 	 *
@@ -161,6 +173,50 @@ struct xrt_display_processor_d3d11
 	void (*destroy)(struct xrt_display_processor_d3d11 *xdp);
 };
 
+/*
+ * ── Plug-in ABI tripwire (ADR-020) ─────────────────────────────────────────
+ *
+ * The per-API DP vtable is part of the same versioned plug-in ABI as the base
+ * @ref xrt_display_processor (the compositor calls it directly; the plug-in
+ * factory fills it). As of ABI major v2 it carries the same 8-byte struct_size
+ * header, so appending a method at the END is compatible within a major; any
+ * other layout change is breaking and must bump XRT_PLUGIN_API_VERSION_CURRENT
+ * (xrt_plugin.h) + re-pin every plug-in. The asserts pin each slot at
+ * base-offset + index*sizeof(void *) so they hold on 64- and 32-bit.
+ */
+#ifndef XRT_DP_ABI_ASSERT
+#if defined(__cplusplus)
+#define XRT_DP_ABI_ASSERT(cond, msg) static_assert(cond, msg)
+#else
+#define XRT_DP_ABI_ASSERT(cond, msg) _Static_assert(cond, msg)
+#endif
+#endif
+#ifndef XRT_DP_ABI_MSG
+#define XRT_DP_ABI_MSG                                                                                                  \
+	"xrt_display_processor ABI changed — see ADR-020: bump XRT_PLUGIN_API_VERSION_CURRENT and re-pin every plug-in."
+#endif
+#ifndef XRT_DP_HAS_SLOT
+#define XRT_DP_HAS_SLOT(xdp, field)                                                                                    \
+	((xdp) != NULL && ((const char *)&(xdp)->field + sizeof((xdp)->field)) <=                                       \
+	                      ((const char *)(xdp) + (xdp)->struct_size))
+#endif
+
+#define XRT_DP_D3D11_BASE_OFF offsetof(struct xrt_display_processor_d3d11, process_atlas)
+// clang-format off
+XRT_DP_ABI_ASSERT(XRT_DP_D3D11_BASE_OFF == 8, XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, process_atlas)               == XRT_DP_D3D11_BASE_OFF + 0 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, get_predicted_eye_positions) == XRT_DP_D3D11_BASE_OFF + 1 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, get_window_metrics)          == XRT_DP_D3D11_BASE_OFF + 2 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, request_display_mode)        == XRT_DP_D3D11_BASE_OFF + 3 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, get_hardware_3d_state)       == XRT_DP_D3D11_BASE_OFF + 4 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, get_display_dimensions)      == XRT_DP_D3D11_BASE_OFF + 5 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, get_display_pixel_info)      == XRT_DP_D3D11_BASE_OFF + 6 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, is_alpha_native)             == XRT_DP_D3D11_BASE_OFF + 7 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, set_chroma_key)              == XRT_DP_D3D11_BASE_OFF + 8 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, destroy)                     == XRT_DP_D3D11_BASE_OFF + 9 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(sizeof(struct xrt_display_processor_d3d11)                                == XRT_DP_D3D11_BASE_OFF + 10 * sizeof(void *), XRT_DP_ABI_MSG);
+// clang-format on
+
 /*!
  * @copydoc xrt_display_processor_d3d11::process_atlas
  *
@@ -198,7 +254,7 @@ static inline bool
 xrt_display_processor_d3d11_get_predicted_eye_positions(struct xrt_display_processor_d3d11 *xdp,
                                                         struct xrt_eye_positions *out_eye_pos)
 {
-	if (xdp == NULL || xdp->get_predicted_eye_positions == NULL) {
+	if (!XRT_DP_HAS_SLOT(xdp, get_predicted_eye_positions) || xdp->get_predicted_eye_positions == NULL) {
 		return false;
 	}
 	return xdp->get_predicted_eye_positions(xdp, out_eye_pos);
@@ -213,7 +269,7 @@ static inline bool
 xrt_display_processor_d3d11_get_window_metrics(struct xrt_display_processor_d3d11 *xdp,
                                                struct xrt_window_metrics *out_metrics)
 {
-	if (xdp == NULL || xdp->get_window_metrics == NULL) {
+	if (!XRT_DP_HAS_SLOT(xdp, get_window_metrics) || xdp->get_window_metrics == NULL) {
 		return false;
 	}
 	return xdp->get_window_metrics(xdp, out_metrics);
@@ -227,7 +283,7 @@ xrt_display_processor_d3d11_get_window_metrics(struct xrt_display_processor_d3d1
 static inline bool
 xrt_display_processor_d3d11_request_display_mode(struct xrt_display_processor_d3d11 *xdp, bool enable_3d)
 {
-	if (xdp == NULL || xdp->request_display_mode == NULL) {
+	if (!XRT_DP_HAS_SLOT(xdp, request_display_mode) || xdp->request_display_mode == NULL) {
 		return false;
 	}
 	return xdp->request_display_mode(xdp, enable_3d);
@@ -242,7 +298,7 @@ static inline bool
 xrt_display_processor_d3d11_get_hardware_3d_state(struct xrt_display_processor_d3d11 *xdp,
                                                   bool *out_is_3d)
 {
-	if (xdp == NULL || xdp->get_hardware_3d_state == NULL) {
+	if (!XRT_DP_HAS_SLOT(xdp, get_hardware_3d_state) || xdp->get_hardware_3d_state == NULL) {
 		return false;
 	}
 	return xdp->get_hardware_3d_state(xdp, out_is_3d);
@@ -258,7 +314,7 @@ xrt_display_processor_d3d11_get_display_dimensions(struct xrt_display_processor_
                                                    float *out_width_m,
                                                    float *out_height_m)
 {
-	if (xdp == NULL || xdp->get_display_dimensions == NULL) {
+	if (!XRT_DP_HAS_SLOT(xdp, get_display_dimensions) || xdp->get_display_dimensions == NULL) {
 		return false;
 	}
 	return xdp->get_display_dimensions(xdp, out_width_m, out_height_m);
@@ -276,7 +332,7 @@ xrt_display_processor_d3d11_get_display_pixel_info(struct xrt_display_processor_
                                                    int32_t *out_screen_left,
                                                    int32_t *out_screen_top)
 {
-	if (xdp == NULL || xdp->get_display_pixel_info == NULL) {
+	if (!XRT_DP_HAS_SLOT(xdp, get_display_pixel_info) || xdp->get_display_pixel_info == NULL) {
 		return false;
 	}
 	return xdp->get_display_pixel_info(xdp, out_pixel_width, out_pixel_height, out_screen_left, out_screen_top);
@@ -290,7 +346,7 @@ xrt_display_processor_d3d11_get_display_pixel_info(struct xrt_display_processor_
 static inline bool
 xrt_display_processor_d3d11_is_alpha_native(struct xrt_display_processor_d3d11 *xdp)
 {
-	if (xdp == NULL || xdp->is_alpha_native == NULL) {
+	if (!XRT_DP_HAS_SLOT(xdp, is_alpha_native) || xdp->is_alpha_native == NULL) {
 		return false;
 	}
 	return xdp->is_alpha_native(xdp);
@@ -306,7 +362,7 @@ xrt_display_processor_d3d11_set_chroma_key(struct xrt_display_processor_d3d11 *x
                                             uint32_t key_color,
                                             bool transparent_bg_enabled)
 {
-	if (xdp == NULL || xdp->set_chroma_key == NULL) {
+	if (!XRT_DP_HAS_SLOT(xdp, set_chroma_key) || xdp->set_chroma_key == NULL) {
 		return;
 	}
 	xdp->set_chroma_key(xdp, key_color, transparent_bg_enabled);

--- a/src/xrt/include/xrt/xrt_display_processor_d3d12.h
+++ b/src/xrt/include/xrt/xrt_display_processor_d3d12.h
@@ -23,6 +23,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <stddef.h> // offsetof — used by the ABI tripwire at the end of this header
 
 #ifdef __cplusplus
 extern "C" {
@@ -46,6 +47,17 @@ struct xrt_window_metrics;
  */
 struct xrt_display_processor_d3d12
 {
+	/*!
+	 * `sizeof(struct xrt_display_processor_d3d12)` at the plug-in's compile
+	 * time. Set by the plug-in factory; the runtime treats any slot at/past
+	 * this offset as absent (NULL). 8-byte header (with @ref reserved_0) so
+	 * @ref process_atlas lands at offset 8 on 64- and 32-bit. See ADR-020.
+	 */
+	uint32_t struct_size;
+
+	/*! Reserved for alignment / future flags. Must be 0. */
+	uint32_t reserved_0;
+
 	/*!
 	 * Process an atlas texture into the final display output.
 	 *
@@ -173,6 +185,50 @@ struct xrt_display_processor_d3d12
 	void (*destroy)(struct xrt_display_processor_d3d12 *xdp);
 };
 
+/*
+ * ── Plug-in ABI tripwire (ADR-020) ─────────────────────────────────────────
+ *
+ * Per-API DP vtable; part of the same versioned plug-in ABI as the base
+ * @ref xrt_display_processor. As of ABI major v2 it carries the 8-byte
+ * struct_size header, so appending a method at the END is compatible within a
+ * major; any other layout change is breaking and must bump
+ * XRT_PLUGIN_API_VERSION_CURRENT (xrt_plugin.h) + re-pin every plug-in. Note
+ * D3D12 has an extra `set_output_format` slot (index 1) the other APIs omit.
+ */
+#ifndef XRT_DP_ABI_ASSERT
+#if defined(__cplusplus)
+#define XRT_DP_ABI_ASSERT(cond, msg) static_assert(cond, msg)
+#else
+#define XRT_DP_ABI_ASSERT(cond, msg) _Static_assert(cond, msg)
+#endif
+#endif
+#ifndef XRT_DP_ABI_MSG
+#define XRT_DP_ABI_MSG                                                                                                  \
+	"xrt_display_processor ABI changed — see ADR-020: bump XRT_PLUGIN_API_VERSION_CURRENT and re-pin every plug-in."
+#endif
+#ifndef XRT_DP_HAS_SLOT
+#define XRT_DP_HAS_SLOT(xdp, field)                                                                                    \
+	((xdp) != NULL && ((const char *)&(xdp)->field + sizeof((xdp)->field)) <=                                       \
+	                      ((const char *)(xdp) + (xdp)->struct_size))
+#endif
+
+#define XRT_DP_D3D12_BASE_OFF offsetof(struct xrt_display_processor_d3d12, process_atlas)
+// clang-format off
+XRT_DP_ABI_ASSERT(XRT_DP_D3D12_BASE_OFF == 8, XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d12, process_atlas)               == XRT_DP_D3D12_BASE_OFF +  0 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d12, set_output_format)           == XRT_DP_D3D12_BASE_OFF +  1 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d12, get_predicted_eye_positions) == XRT_DP_D3D12_BASE_OFF +  2 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d12, get_window_metrics)          == XRT_DP_D3D12_BASE_OFF +  3 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d12, request_display_mode)        == XRT_DP_D3D12_BASE_OFF +  4 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d12, get_hardware_3d_state)       == XRT_DP_D3D12_BASE_OFF +  5 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d12, get_display_dimensions)      == XRT_DP_D3D12_BASE_OFF +  6 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d12, get_display_pixel_info)      == XRT_DP_D3D12_BASE_OFF +  7 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d12, is_alpha_native)             == XRT_DP_D3D12_BASE_OFF +  8 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d12, set_chroma_key)              == XRT_DP_D3D12_BASE_OFF +  9 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d12, destroy)                     == XRT_DP_D3D12_BASE_OFF + 10 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(sizeof(struct xrt_display_processor_d3d12)                                == XRT_DP_D3D12_BASE_OFF + 11 * sizeof(void *), XRT_DP_ABI_MSG);
+// clang-format on
+
 /*!
  * @copydoc xrt_display_processor_d3d12::process_atlas
  *
@@ -214,7 +270,7 @@ xrt_display_processor_d3d12_process_atlas(struct xrt_display_processor_d3d12 *xd
 static inline void
 xrt_display_processor_d3d12_set_output_format(struct xrt_display_processor_d3d12 *xdp, uint32_t format)
 {
-	if (xdp != NULL && xdp->set_output_format != NULL) {
+	if (XRT_DP_HAS_SLOT(xdp, set_output_format) && xdp->set_output_format != NULL) {
 		xdp->set_output_format(xdp, format);
 	}
 }
@@ -228,7 +284,7 @@ static inline bool
 xrt_display_processor_d3d12_get_predicted_eye_positions(struct xrt_display_processor_d3d12 *xdp,
                                                         struct xrt_eye_positions *out_eye_pos)
 {
-	if (xdp == NULL || xdp->get_predicted_eye_positions == NULL) {
+	if (!XRT_DP_HAS_SLOT(xdp, get_predicted_eye_positions) || xdp->get_predicted_eye_positions == NULL) {
 		return false;
 	}
 	return xdp->get_predicted_eye_positions(xdp, out_eye_pos);
@@ -243,7 +299,7 @@ static inline bool
 xrt_display_processor_d3d12_get_window_metrics(struct xrt_display_processor_d3d12 *xdp,
                                                struct xrt_window_metrics *out_metrics)
 {
-	if (xdp == NULL || xdp->get_window_metrics == NULL) {
+	if (!XRT_DP_HAS_SLOT(xdp, get_window_metrics) || xdp->get_window_metrics == NULL) {
 		return false;
 	}
 	return xdp->get_window_metrics(xdp, out_metrics);
@@ -257,7 +313,7 @@ xrt_display_processor_d3d12_get_window_metrics(struct xrt_display_processor_d3d1
 static inline bool
 xrt_display_processor_d3d12_request_display_mode(struct xrt_display_processor_d3d12 *xdp, bool enable_3d)
 {
-	if (xdp == NULL || xdp->request_display_mode == NULL) {
+	if (!XRT_DP_HAS_SLOT(xdp, request_display_mode) || xdp->request_display_mode == NULL) {
 		return false;
 	}
 	return xdp->request_display_mode(xdp, enable_3d);
@@ -272,7 +328,7 @@ static inline bool
 xrt_display_processor_d3d12_get_hardware_3d_state(struct xrt_display_processor_d3d12 *xdp,
                                                   bool *out_is_3d)
 {
-	if (xdp == NULL || xdp->get_hardware_3d_state == NULL) {
+	if (!XRT_DP_HAS_SLOT(xdp, get_hardware_3d_state) || xdp->get_hardware_3d_state == NULL) {
 		return false;
 	}
 	return xdp->get_hardware_3d_state(xdp, out_is_3d);
@@ -288,7 +344,7 @@ xrt_display_processor_d3d12_get_display_dimensions(struct xrt_display_processor_
                                                    float *out_width_m,
                                                    float *out_height_m)
 {
-	if (xdp == NULL || xdp->get_display_dimensions == NULL) {
+	if (!XRT_DP_HAS_SLOT(xdp, get_display_dimensions) || xdp->get_display_dimensions == NULL) {
 		return false;
 	}
 	return xdp->get_display_dimensions(xdp, out_width_m, out_height_m);
@@ -306,7 +362,7 @@ xrt_display_processor_d3d12_get_display_pixel_info(struct xrt_display_processor_
                                                    int32_t *out_screen_left,
                                                    int32_t *out_screen_top)
 {
-	if (xdp == NULL || xdp->get_display_pixel_info == NULL) {
+	if (!XRT_DP_HAS_SLOT(xdp, get_display_pixel_info) || xdp->get_display_pixel_info == NULL) {
 		return false;
 	}
 	return xdp->get_display_pixel_info(xdp, out_pixel_width, out_pixel_height, out_screen_left, out_screen_top);
@@ -320,7 +376,7 @@ xrt_display_processor_d3d12_get_display_pixel_info(struct xrt_display_processor_
 static inline bool
 xrt_display_processor_d3d12_is_alpha_native(struct xrt_display_processor_d3d12 *xdp)
 {
-	if (xdp == NULL || xdp->is_alpha_native == NULL) {
+	if (!XRT_DP_HAS_SLOT(xdp, is_alpha_native) || xdp->is_alpha_native == NULL) {
 		return false;
 	}
 	return xdp->is_alpha_native(xdp);
@@ -336,7 +392,7 @@ xrt_display_processor_d3d12_set_chroma_key(struct xrt_display_processor_d3d12 *x
                                             uint32_t key_color,
                                             bool transparent_bg_enabled)
 {
-	if (xdp == NULL || xdp->set_chroma_key == NULL) {
+	if (!XRT_DP_HAS_SLOT(xdp, set_chroma_key) || xdp->set_chroma_key == NULL) {
 		return;
 	}
 	xdp->set_chroma_key(xdp, key_color, transparent_bg_enabled);

--- a/src/xrt/include/xrt/xrt_display_processor_gl.h
+++ b/src/xrt/include/xrt/xrt_display_processor_gl.h
@@ -23,6 +23,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <stddef.h> // offsetof — used by the ABI tripwire at the end of this header
 
 #ifdef __cplusplus
 extern "C" {
@@ -46,6 +47,17 @@ struct xrt_window_metrics;
  */
 struct xrt_display_processor_gl
 {
+	/*!
+	 * `sizeof(struct xrt_display_processor_gl)` at the plug-in's compile
+	 * time. Set by the plug-in factory; the runtime treats any slot at/past
+	 * this offset as absent (NULL). 8-byte header (with @ref reserved_0) so
+	 * @ref process_atlas lands at offset 8 on 64- and 32-bit. See ADR-020.
+	 */
+	uint32_t struct_size;
+
+	/*! Reserved for alignment / future flags. Must be 0. */
+	uint32_t reserved_0;
+
 	/*!
 	 * Process an atlas texture into the final display output.
 	 *
@@ -155,6 +167,48 @@ struct xrt_display_processor_gl
 	void (*destroy)(struct xrt_display_processor_gl *xdp);
 };
 
+/*
+ * ── Plug-in ABI tripwire (ADR-020) ─────────────────────────────────────────
+ *
+ * Per-API DP vtable; part of the same versioned plug-in ABI as the base
+ * @ref xrt_display_processor. As of ABI major v2 it carries the 8-byte
+ * struct_size header, so appending a method at the END is compatible within a
+ * major; any other layout change is breaking and must bump
+ * XRT_PLUGIN_API_VERSION_CURRENT (xrt_plugin.h) + re-pin every plug-in.
+ */
+#ifndef XRT_DP_ABI_ASSERT
+#if defined(__cplusplus)
+#define XRT_DP_ABI_ASSERT(cond, msg) static_assert(cond, msg)
+#else
+#define XRT_DP_ABI_ASSERT(cond, msg) _Static_assert(cond, msg)
+#endif
+#endif
+#ifndef XRT_DP_ABI_MSG
+#define XRT_DP_ABI_MSG                                                                                                  \
+	"xrt_display_processor ABI changed — see ADR-020: bump XRT_PLUGIN_API_VERSION_CURRENT and re-pin every plug-in."
+#endif
+#ifndef XRT_DP_HAS_SLOT
+#define XRT_DP_HAS_SLOT(xdp, field)                                                                                    \
+	((xdp) != NULL && ((const char *)&(xdp)->field + sizeof((xdp)->field)) <=                                       \
+	                      ((const char *)(xdp) + (xdp)->struct_size))
+#endif
+
+#define XRT_DP_GL_BASE_OFF offsetof(struct xrt_display_processor_gl, process_atlas)
+// clang-format off
+XRT_DP_ABI_ASSERT(XRT_DP_GL_BASE_OFF == 8, XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_gl, process_atlas)               == XRT_DP_GL_BASE_OFF + 0 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_gl, get_predicted_eye_positions) == XRT_DP_GL_BASE_OFF + 1 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_gl, get_window_metrics)          == XRT_DP_GL_BASE_OFF + 2 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_gl, request_display_mode)        == XRT_DP_GL_BASE_OFF + 3 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_gl, get_hardware_3d_state)       == XRT_DP_GL_BASE_OFF + 4 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_gl, get_display_dimensions)      == XRT_DP_GL_BASE_OFF + 5 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_gl, get_display_pixel_info)      == XRT_DP_GL_BASE_OFF + 6 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_gl, is_alpha_native)             == XRT_DP_GL_BASE_OFF + 7 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_gl, set_chroma_key)              == XRT_DP_GL_BASE_OFF + 8 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_gl, destroy)                     == XRT_DP_GL_BASE_OFF + 9 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(sizeof(struct xrt_display_processor_gl)                                == XRT_DP_GL_BASE_OFF + 10 * sizeof(void *), XRT_DP_ABI_MSG);
+// clang-format on
+
 /*!
  * @copydoc xrt_display_processor_gl::process_atlas
  *
@@ -191,7 +245,7 @@ static inline bool
 xrt_display_processor_gl_get_predicted_eye_positions(struct xrt_display_processor_gl *xdp,
                                                      struct xrt_eye_positions *out_eye_pos)
 {
-	if (xdp == NULL || xdp->get_predicted_eye_positions == NULL) {
+	if (!XRT_DP_HAS_SLOT(xdp, get_predicted_eye_positions) || xdp->get_predicted_eye_positions == NULL) {
 		return false;
 	}
 	return xdp->get_predicted_eye_positions(xdp, out_eye_pos);
@@ -206,7 +260,7 @@ static inline bool
 xrt_display_processor_gl_get_window_metrics(struct xrt_display_processor_gl *xdp,
                                             struct xrt_window_metrics *out_metrics)
 {
-	if (xdp == NULL || xdp->get_window_metrics == NULL) {
+	if (!XRT_DP_HAS_SLOT(xdp, get_window_metrics) || xdp->get_window_metrics == NULL) {
 		return false;
 	}
 	return xdp->get_window_metrics(xdp, out_metrics);
@@ -220,7 +274,7 @@ xrt_display_processor_gl_get_window_metrics(struct xrt_display_processor_gl *xdp
 static inline bool
 xrt_display_processor_gl_request_display_mode(struct xrt_display_processor_gl *xdp, bool enable_3d)
 {
-	if (xdp == NULL || xdp->request_display_mode == NULL) {
+	if (!XRT_DP_HAS_SLOT(xdp, request_display_mode) || xdp->request_display_mode == NULL) {
 		return false;
 	}
 	return xdp->request_display_mode(xdp, enable_3d);
@@ -235,7 +289,7 @@ static inline bool
 xrt_display_processor_gl_get_hardware_3d_state(struct xrt_display_processor_gl *xdp,
                                                bool *out_is_3d)
 {
-	if (xdp == NULL || xdp->get_hardware_3d_state == NULL) {
+	if (!XRT_DP_HAS_SLOT(xdp, get_hardware_3d_state) || xdp->get_hardware_3d_state == NULL) {
 		return false;
 	}
 	return xdp->get_hardware_3d_state(xdp, out_is_3d);
@@ -251,7 +305,7 @@ xrt_display_processor_gl_get_display_dimensions(struct xrt_display_processor_gl 
                                                 float *out_width_m,
                                                 float *out_height_m)
 {
-	if (xdp == NULL || xdp->get_display_dimensions == NULL) {
+	if (!XRT_DP_HAS_SLOT(xdp, get_display_dimensions) || xdp->get_display_dimensions == NULL) {
 		return false;
 	}
 	return xdp->get_display_dimensions(xdp, out_width_m, out_height_m);
@@ -269,7 +323,7 @@ xrt_display_processor_gl_get_display_pixel_info(struct xrt_display_processor_gl 
                                                 int32_t *out_screen_left,
                                                 int32_t *out_screen_top)
 {
-	if (xdp == NULL || xdp->get_display_pixel_info == NULL) {
+	if (!XRT_DP_HAS_SLOT(xdp, get_display_pixel_info) || xdp->get_display_pixel_info == NULL) {
 		return false;
 	}
 	return xdp->get_display_pixel_info(xdp, out_pixel_width, out_pixel_height, out_screen_left, out_screen_top);
@@ -283,7 +337,7 @@ xrt_display_processor_gl_get_display_pixel_info(struct xrt_display_processor_gl 
 static inline bool
 xrt_display_processor_gl_is_alpha_native(struct xrt_display_processor_gl *xdp)
 {
-	if (xdp == NULL || xdp->is_alpha_native == NULL) {
+	if (!XRT_DP_HAS_SLOT(xdp, is_alpha_native) || xdp->is_alpha_native == NULL) {
 		return false;
 	}
 	return xdp->is_alpha_native(xdp);
@@ -299,7 +353,7 @@ xrt_display_processor_gl_set_chroma_key(struct xrt_display_processor_gl *xdp,
                                          uint32_t key_color,
                                          bool transparent_bg_enabled)
 {
-	if (xdp == NULL || xdp->set_chroma_key == NULL) {
+	if (!XRT_DP_HAS_SLOT(xdp, set_chroma_key) || xdp->set_chroma_key == NULL) {
 		return;
 	}
 	xdp->set_chroma_key(xdp, key_color, transparent_bg_enabled);

--- a/src/xrt/include/xrt/xrt_display_processor_metal.h
+++ b/src/xrt/include/xrt/xrt_display_processor_metal.h
@@ -23,6 +23,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <stddef.h> // offsetof — used by the ABI tripwire at the end of this header
 
 #ifdef __cplusplus
 extern "C" {
@@ -46,6 +47,17 @@ struct xrt_window_metrics;
  */
 struct xrt_display_processor_metal
 {
+	/*!
+	 * `sizeof(struct xrt_display_processor_metal)` at the plug-in's compile
+	 * time. Set by the plug-in factory; the runtime treats any slot at/past
+	 * this offset as absent (NULL). 8-byte header (with @ref reserved_0) so
+	 * @ref process_atlas lands at offset 8 on 64- and 32-bit. See ADR-020.
+	 */
+	uint32_t struct_size;
+
+	/*! Reserved for alignment / future flags. Must be 0. */
+	uint32_t reserved_0;
+
 	/*!
 	 * Process an atlas texture into the final display output.
 	 *
@@ -155,6 +167,48 @@ struct xrt_display_processor_metal
 	void (*destroy)(struct xrt_display_processor_metal *xdp);
 };
 
+/*
+ * ── Plug-in ABI tripwire (ADR-020) ─────────────────────────────────────────
+ *
+ * Per-API DP vtable; part of the same versioned plug-in ABI as the base
+ * @ref xrt_display_processor. As of ABI major v2 it carries the 8-byte
+ * struct_size header, so appending a method at the END is compatible within a
+ * major; any other layout change is breaking and must bump
+ * XRT_PLUGIN_API_VERSION_CURRENT (xrt_plugin.h) + re-pin every plug-in.
+ */
+#ifndef XRT_DP_ABI_ASSERT
+#if defined(__cplusplus)
+#define XRT_DP_ABI_ASSERT(cond, msg) static_assert(cond, msg)
+#else
+#define XRT_DP_ABI_ASSERT(cond, msg) _Static_assert(cond, msg)
+#endif
+#endif
+#ifndef XRT_DP_ABI_MSG
+#define XRT_DP_ABI_MSG                                                                                                  \
+	"xrt_display_processor ABI changed — see ADR-020: bump XRT_PLUGIN_API_VERSION_CURRENT and re-pin every plug-in."
+#endif
+#ifndef XRT_DP_HAS_SLOT
+#define XRT_DP_HAS_SLOT(xdp, field)                                                                                    \
+	((xdp) != NULL && ((const char *)&(xdp)->field + sizeof((xdp)->field)) <=                                       \
+	                      ((const char *)(xdp) + (xdp)->struct_size))
+#endif
+
+#define XRT_DP_METAL_BASE_OFF offsetof(struct xrt_display_processor_metal, process_atlas)
+// clang-format off
+XRT_DP_ABI_ASSERT(XRT_DP_METAL_BASE_OFF == 8, XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_metal, process_atlas)               == XRT_DP_METAL_BASE_OFF + 0 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_metal, get_predicted_eye_positions) == XRT_DP_METAL_BASE_OFF + 1 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_metal, get_window_metrics)          == XRT_DP_METAL_BASE_OFF + 2 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_metal, request_display_mode)        == XRT_DP_METAL_BASE_OFF + 3 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_metal, get_hardware_3d_state)       == XRT_DP_METAL_BASE_OFF + 4 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_metal, get_display_dimensions)      == XRT_DP_METAL_BASE_OFF + 5 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_metal, get_display_pixel_info)      == XRT_DP_METAL_BASE_OFF + 6 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_metal, is_alpha_native)             == XRT_DP_METAL_BASE_OFF + 7 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_metal, set_chroma_key)              == XRT_DP_METAL_BASE_OFF + 8 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_metal, destroy)                     == XRT_DP_METAL_BASE_OFF + 9 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(sizeof(struct xrt_display_processor_metal)                                == XRT_DP_METAL_BASE_OFF + 10 * sizeof(void *), XRT_DP_ABI_MSG);
+// clang-format on
+
 /*!
  * @copydoc xrt_display_processor_metal::process_atlas
  *
@@ -193,7 +247,7 @@ static inline bool
 xrt_display_processor_metal_get_predicted_eye_positions(struct xrt_display_processor_metal *xdp,
                                                         struct xrt_eye_positions *out_eye_pos)
 {
-	if (xdp == NULL || xdp->get_predicted_eye_positions == NULL) {
+	if (!XRT_DP_HAS_SLOT(xdp, get_predicted_eye_positions) || xdp->get_predicted_eye_positions == NULL) {
 		return false;
 	}
 	return xdp->get_predicted_eye_positions(xdp, out_eye_pos);
@@ -208,7 +262,7 @@ static inline bool
 xrt_display_processor_metal_get_window_metrics(struct xrt_display_processor_metal *xdp,
                                                struct xrt_window_metrics *out_metrics)
 {
-	if (xdp == NULL || xdp->get_window_metrics == NULL) {
+	if (!XRT_DP_HAS_SLOT(xdp, get_window_metrics) || xdp->get_window_metrics == NULL) {
 		return false;
 	}
 	return xdp->get_window_metrics(xdp, out_metrics);
@@ -222,7 +276,7 @@ xrt_display_processor_metal_get_window_metrics(struct xrt_display_processor_meta
 static inline bool
 xrt_display_processor_metal_request_display_mode(struct xrt_display_processor_metal *xdp, bool enable_3d)
 {
-	if (xdp == NULL || xdp->request_display_mode == NULL) {
+	if (!XRT_DP_HAS_SLOT(xdp, request_display_mode) || xdp->request_display_mode == NULL) {
 		return false;
 	}
 	return xdp->request_display_mode(xdp, enable_3d);
@@ -237,7 +291,7 @@ static inline bool
 xrt_display_processor_metal_get_hardware_3d_state(struct xrt_display_processor_metal *xdp,
                                                   bool *out_is_3d)
 {
-	if (xdp == NULL || xdp->get_hardware_3d_state == NULL) {
+	if (!XRT_DP_HAS_SLOT(xdp, get_hardware_3d_state) || xdp->get_hardware_3d_state == NULL) {
 		return false;
 	}
 	return xdp->get_hardware_3d_state(xdp, out_is_3d);
@@ -253,7 +307,7 @@ xrt_display_processor_metal_get_display_dimensions(struct xrt_display_processor_
                                                    float *out_width_m,
                                                    float *out_height_m)
 {
-	if (xdp == NULL || xdp->get_display_dimensions == NULL) {
+	if (!XRT_DP_HAS_SLOT(xdp, get_display_dimensions) || xdp->get_display_dimensions == NULL) {
 		return false;
 	}
 	return xdp->get_display_dimensions(xdp, out_width_m, out_height_m);
@@ -271,7 +325,7 @@ xrt_display_processor_metal_get_display_pixel_info(struct xrt_display_processor_
                                                    int32_t *out_screen_left,
                                                    int32_t *out_screen_top)
 {
-	if (xdp == NULL || xdp->get_display_pixel_info == NULL) {
+	if (!XRT_DP_HAS_SLOT(xdp, get_display_pixel_info) || xdp->get_display_pixel_info == NULL) {
 		return false;
 	}
 	return xdp->get_display_pixel_info(xdp, out_pixel_width, out_pixel_height, out_screen_left, out_screen_top);
@@ -285,7 +339,7 @@ xrt_display_processor_metal_get_display_pixel_info(struct xrt_display_processor_
 static inline bool
 xrt_display_processor_metal_is_alpha_native(struct xrt_display_processor_metal *xdp)
 {
-	if (xdp == NULL || xdp->is_alpha_native == NULL) {
+	if (!XRT_DP_HAS_SLOT(xdp, is_alpha_native) || xdp->is_alpha_native == NULL) {
 		return false;
 	}
 	return xdp->is_alpha_native(xdp);
@@ -301,7 +355,7 @@ xrt_display_processor_metal_set_chroma_key(struct xrt_display_processor_metal *x
                                             uint32_t key_color,
                                             bool transparent_bg_enabled)
 {
-	if (xdp == NULL || xdp->set_chroma_key == NULL) {
+	if (!XRT_DP_HAS_SLOT(xdp, set_chroma_key) || xdp->set_chroma_key == NULL) {
 		return;
 	}
 	xdp->set_chroma_key(xdp, key_color, transparent_bg_enabled);

--- a/src/xrt/include/xrt/xrt_plugin.h
+++ b/src/xrt/include/xrt/xrt_plugin.h
@@ -125,32 +125,42 @@ struct xrt_plugin_display_info
 /*!
  * Plug-in ABI version (major). Bumped on a non-additive layout change in the
  * structs declared in this header **OR** in the display-processor vtables
- * (`xrt_display_processor` + the per-API factory contracts in
+ * (`xrt_display_processor` + the per-API vtables/factory contracts in
  * `xrt_display_processor_<api>.h`), which are part of this ABI even though they
  * live in their own headers and are handed back by `create_dp_<api>`.
  *
- * For the `struct_size`-carrying structs here, pure-additive changes (fields
- * appended at the end, covered by `struct_size`) are NOT version bumps.
- *
- * For the DP vtables: until they gain `struct_size` negotiation (ADR-020 rule
- * 1), they are read at FIXED offsets, so even an append is breaking — any
- * layout change there is a major bump. The compile-time tripwire at the end of
- * `xrt_display_processor.h` fails the build if that vtable changes without
- * bumping this macro. See ADR-020 for the full policy.
+ * As of major **v2** (ADR-020 rules 1–3), the DP vtables ALSO carry a
+ * `struct_size` header — exactly like the structs in this file. So a
+ * pure-additive change to a DP vtable (a method appended at the END, covered by
+ * `struct_size`) is NOT a version bump: a newer runtime treats slots past an
+ * older plug-in's `struct_size` as absent, and an older runtime ignores slots
+ * it doesn't know about. Reordering, removing, or signature-changing a slot —
+ * or inserting anywhere but the end — IS a major bump. The compile-time
+ * tripwires at the end of each `xrt_display_processor*.h` fail the build if a
+ * vtable's layout changes without updating the asserts, forcing a conscious
+ * version bump. See ADR-020 for the full policy.
  *
  * Compatibility rule (ADR-020 rule 2/3): same major == compatible; a different
- * major is rejected by the loader (it must not call through a mismatched
- * vtable). Numbers grow forward.
+ * major is **rejected by the loader** (`target_plugin_loader.c`) — it must not
+ * call through a mismatched vtable. Numbers grow forward.
+ *
+ * v1 → v2 history: v1 DP vtables had no `struct_size` and were read at fixed
+ * offsets, so any layout change silently broke older plug-ins (the
+ * standalone-VK weave regression). v2 is the one-time break that introduces the
+ * `struct_size` header on the DP vtables and turns the loader's version *log*
+ * into an enforced *reject*. ABI-v1 plug-ins (≤ leia v1.0.5) are rejected and
+ * must rebuild against v2 headers.
  */
 #define XRT_PLUGIN_API_VERSION_1 1
+#define XRT_PLUGIN_API_VERSION_2 2
 
 /*!
  * The version the runtime / plug-in is built against at compile time.
  * Plug-in DLLs returning a different value from `xrtPluginNegotiate`'s
- * `*out_plugin_api_version` are skipped by the runtime with a logged
- * mismatch warning.
+ * `*out_plugin_api_version` are rejected by the runtime (ADR-020 rule 3) with a
+ * logged error, and the loader falls back to the next plug-in / sim_display.
  */
-#define XRT_PLUGIN_API_VERSION_CURRENT XRT_PLUGIN_API_VERSION_1
+#define XRT_PLUGIN_API_VERSION_CURRENT XRT_PLUGIN_API_VERSION_2
 
 /*!
  * The single exported symbol every plug-in DLL must provide. C linkage,
@@ -432,13 +442,17 @@ struct xrt_plugin_iface
  * @ref XRT_PLUGIN_ENTRYPOINT_NAME (`"xrtPluginNegotiate"`). Exported with
  * C linkage; no name mangling.
  *
- * @param      runtime_api_version       The @ref XRT_PLUGIN_API_VERSION_1
- *                                       (or newer) the runtime speaks.
- *                                       Plug-ins compare this against the
- *                                       version they implement and may
- *                                       return `XRT_ERROR_PROBER_NOT_SUPPORTED`
- *                                       to bail cleanly if the runtime
- *                                       is too old or too new.
+ * @param      runtime_api_version       The @ref XRT_PLUGIN_API_VERSION_CURRENT
+ *                                       (currently @ref XRT_PLUGIN_API_VERSION_2)
+ *                                       the runtime speaks. Plug-ins compare
+ *                                       this against the version they implement
+ *                                       and may return
+ *                                       `XRT_ERROR_PROBER_NOT_SUPPORTED` to
+ *                                       bail cleanly if the runtime is too old
+ *                                       or too new. The runtime also enforces
+ *                                       the major match by rejecting any plug-in
+ *                                       whose @p out_plugin_api_version differs
+ *                                       (ADR-020 rule 3).
  * @param      host                      Pointer to the host's iface.
  *                                       `host->struct_size` tells the
  *                                       plug-in how much of the struct
@@ -453,8 +467,10 @@ struct xrt_plugin_iface
  *                                       so the runtime can detect
  *                                       forward-version fields and clamp
  *                                       its reads.
- * @param[out] out_plugin_api_version    The @ref XRT_PLUGIN_API_VERSION_1
- *                                       the plug-in implements.
+ * @param[out] out_plugin_api_version    The @ref XRT_PLUGIN_API_VERSION_CURRENT
+ *                                       (i.e. the major) the plug-in implements.
+ *                                       Must equal the runtime's major or the
+ *                                       loader rejects the plug-in.
  *
  * @return `XRT_SUCCESS` on negotiation success — the runtime proceeds to
  *         call `(*out_iface)->probe()`. `XRT_ERROR_PROBER_NOT_SUPPORTED`

--- a/src/xrt/state_trackers/oxr/oxr_plugin_stub.c
+++ b/src/xrt/state_trackers/oxr/oxr_plugin_stub.c
@@ -34,9 +34,10 @@
 _Static_assert(sizeof(XRT_PLUGIN_ENTRYPOINT_NAME) == sizeof("xrtPluginNegotiate"),
                "xrt_plugin: entry-point symbol name changed; coordinate with all plug-in builds");
 
-/* Current API version is the v1 line — bump deliberately, not by accident. */
-_Static_assert(XRT_PLUGIN_API_VERSION_CURRENT == XRT_PLUGIN_API_VERSION_1,
-               "xrt_plugin: API version current/v1 drift");
+/* Current API version is the v2 line (ADR-020 rules 1–3 landed) — bump
+ * deliberately, not by accident. */
+_Static_assert(XRT_PLUGIN_API_VERSION_CURRENT == XRT_PLUGIN_API_VERSION_2,
+               "xrt_plugin: API version current/v2 drift");
 
 /*
  * Host iface layout. struct_size must be the first field so plug-ins can

--- a/src/xrt/targets/common/target_instance.c
+++ b/src/xrt/targets/common/target_instance.c
@@ -81,6 +81,54 @@ null_compositor_create_system_with_dims(struct xrt_device *xdev,
  *
  */
 
+/*!
+ * Copy the per-graphics-API DP factories from a plug-in iface into the system
+ * compositor info. Used both at instance create (after `get_display_info`
+ * succeeded) and from the @ref refresh_display_processors_cb callback at
+ * per-client compositor create. NULL plug-in is a no-op so the callback path
+ * survives an empty-discovery-root start.
+ */
+static void
+fill_dp_factories_from_plugin(struct xrt_system_compositor_info *info, const struct xrt_plugin_iface *plugin)
+{
+	if (info == NULL || plugin == NULL) {
+		return;
+	}
+	if (plugin->create_dp_vk != NULL) {
+		info->dp_factory_vk = (void *)plugin->create_dp_vk;
+	}
+#ifdef XRT_OS_WINDOWS
+	if (plugin->create_dp_d3d11 != NULL) {
+		info->dp_factory_d3d11 = (void *)plugin->create_dp_d3d11;
+	}
+	if (plugin->create_dp_d3d12 != NULL) {
+		info->dp_factory_d3d12 = (void *)plugin->create_dp_d3d12;
+	}
+#endif
+	if (plugin->create_dp_gl != NULL) {
+		info->dp_factory_gl = (void *)plugin->create_dp_gl;
+	}
+#ifdef __APPLE__
+	if (plugin->create_dp_metal != NULL) {
+		info->dp_factory_metal = (void *)plugin->create_dp_metal;
+	}
+#endif
+}
+
+/*!
+ * Installed on @ref xrt_system_compositor_info::refresh_display_processors so a
+ * long-lived service-mode compositor can pick up a vendor plug-in registered
+ * AFTER the service started (issue #342). Each per-client compositor-create
+ * path invokes it once, before any DP-factory read; the call is cheap when no
+ * better plug-in has appeared. See ADR-020 / `target_plugin_refresh_active`.
+ */
+static void
+refresh_display_processors_cb(struct xrt_system_compositor_info *info)
+{
+	const struct xrt_plugin_iface *plugin = target_plugin_refresh_active();
+	fill_dp_factories_from_plugin(info, plugin);
+}
+
 static xrt_result_t
 t_instance_create_system(struct xrt_instance *xinst,
                          struct xrt_system **out_xsys,
@@ -192,6 +240,16 @@ out:
 		// Tell the system about the system compositor.
 		u_system_set_system_compositor(usys, xsysc);
 
+		// Install the durable-DP-refresh callback (#342, ADR-020): long-
+		// lived service compositors invoke this at per-client compositor
+		// create so a plug-in registered AFTER the service started is
+		// picked up on the first app launch without a service restart.
+		// In-process / handle apps never call it — they create a fresh
+		// instance per launch, so their initial discovery is already
+		// post-install. Install unconditionally so the path works even
+		// when the initial `get_display_info` below failed / had no plug-in.
+		xsysc->info.refresh_display_processors = refresh_display_processors_cb;
+
 		// Vendor-neutral display-info population through the plug-in
 		// iface (issue #256 / ADR-019). Runs FIRST regardless of whether
 		// the active plug-in is leia-sr or sim-display — the
@@ -252,26 +310,10 @@ out:
 					xsysc->info.recommended_view_scale_y = min_scale_y;
 				}
 
-				// Per-API DP factories from the iface.
-				if (plugin->create_dp_vk != NULL) {
-					xsysc->info.dp_factory_vk = (void *)plugin->create_dp_vk;
-				}
-#ifdef XRT_OS_WINDOWS
-				if (plugin->create_dp_d3d11 != NULL) {
-					xsysc->info.dp_factory_d3d11 = (void *)plugin->create_dp_d3d11;
-				}
-				if (plugin->create_dp_d3d12 != NULL) {
-					xsysc->info.dp_factory_d3d12 = (void *)plugin->create_dp_d3d12;
-				}
-#endif
-				if (plugin->create_dp_gl != NULL) {
-					xsysc->info.dp_factory_gl = (void *)plugin->create_dp_gl;
-				}
-#ifdef __APPLE__
-				if (plugin->create_dp_metal != NULL) {
-					xsysc->info.dp_factory_metal = (void *)plugin->create_dp_metal;
-				}
-#endif
+				// Per-API DP factories from the iface — factored into
+				// a helper so the refresh callback below uses the same
+				// per-platform mask. See @ref fill_dp_factories_from_plugin.
+				fill_dp_factories_from_plugin(&xsysc->info, plugin);
 
 				U_LOG_W("XR_EXT_display_info (iface=%s): display=%.4f x %.4f m, "
 				        "nominal=(%.4f, %.4f, %.4f) m, scale=%.4f x %.4f, "

--- a/src/xrt/targets/common/target_plugin_loader.c
+++ b/src/xrt/targets/common/target_plugin_loader.c
@@ -26,10 +26,12 @@
 #include "xrt/xrt_results.h"
 #include "xrt/xrt_config_os.h"
 
+#include "os/os_threading.h"
 #include "util/u_logging.h"
 
 #include <errno.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -43,6 +45,26 @@
 static int g_load_attempted = 0;
 static const struct xrt_plugin_iface *g_active_iface = NULL;
 static struct xrt_plugin_instance *g_active_instance = NULL;
+
+/*!
+ * Winning ProbeOrder from the most recent successful discovery, or UINT32_MAX
+ * when no plug-in is active (first-call path or empty discovery root).
+ * @ref target_plugin_refresh_active uses it as a strict upper bound: a refresh
+ * only adopts a plug-in whose ProbeOrder is STRICTLY LESS than this — meaning
+ * we never re-probe the already-active plug-in, only ones that legitimately
+ * out-rank it.
+ */
+static uint32_t g_active_probe_order = 0xFFFFFFFFu;
+
+/*!
+ * Guards @ref target_plugin_refresh_active against concurrent IPC-client
+ * compositor creates in service mode. Initialized lazily on the
+ * (single-threaded) first call to @ref target_plugin_get_active, which always
+ * precedes any compositor-create-time refresh. Using os_mutex (not C11 atomics)
+ * per the MinGW caveat in CLAUDE.md.
+ */
+static struct os_mutex g_refresh_mutex;
+static int g_refresh_mutex_initialized = 0;
 
 
 /*
@@ -272,6 +294,19 @@ try_load_one(const struct plugin_entry *e, struct xrt_plugin_instance **out_inst
 		return NULL;
 	}
 
+	/* ADR-020 rule 3: reject a major-version mismatch before touching the
+	 * vtable. A plug-in built against a different ABI major lays its vtable
+	 * out at offsets the runtime doesn't agree on — calling through it is
+	 * exactly the corruption this guards against. Skip it (the caller falls
+	 * back to the next plug-in / sim_display); never dispatch. */
+	if (plugin_version != XRT_PLUGIN_API_VERSION_CURRENT) {
+		U_LOG_E("plugin loader:   %s: ABI major mismatch — plugin_api=%u, runtime expects %u; "
+		        "the plug-in must be rebuilt against this runtime's headers — skipping (ADR-020 rule 3).",
+		        e->id, plugin_version, (unsigned)XRT_PLUGIN_API_VERSION_CURRENT);
+		FreeLibrary(dll);
+		return NULL;
+	}
+
 	if (iface->probe != NULL) {
 		xret = iface->probe(out_inst);
 		if (xret == XRT_ERROR_PROBER_NOT_SUPPORTED) {
@@ -378,7 +413,7 @@ preload_runtime_core_dll(void)
 }
 
 static const struct xrt_plugin_iface *
-discover_active_plugin(struct xrt_plugin_instance **out_inst)
+discover_active_plugin(struct xrt_plugin_instance **out_inst, uint32_t max_probe_order)
 {
 	*out_inst = NULL;
 
@@ -396,10 +431,18 @@ discover_active_plugin(struct xrt_plugin_instance **out_inst)
 
 	U_LOG_I("plugin loader: %d registered plug-in(s); attempting in ProbeOrder ascending.", n);
 	for (int i = 0; i < n; i++) {
+		// Refresh path (#342) passes the active plug-in's ProbeOrder as
+		// max so we only re-attempt strictly-better candidates and never
+		// re-probe the already-active one. First-call path passes
+		// UINT32_MAX, so no entry is skipped.
+		if (entries[i].probe_order >= max_probe_order) {
+			continue;
+		}
 		U_LOG_I("plugin loader:   [%d/%d] %s (ProbeOrder=%u, %ls)", i + 1, n, entries[i].id,
 		        entries[i].probe_order, entries[i].binary_path);
 		const struct xrt_plugin_iface *iface = try_load_one(&entries[i], out_inst);
 		if (iface != NULL) {
+			g_active_probe_order = entries[i].probe_order;
 			return iface;
 		}
 	}
@@ -682,6 +725,19 @@ try_load_one(const struct plugin_entry *e, struct xrt_plugin_instance **out_inst
 		return NULL;
 	}
 
+	/* ADR-020 rule 3: reject a major-version mismatch before touching the
+	 * vtable. A plug-in built against a different ABI major lays its vtable
+	 * out at offsets the runtime doesn't agree on — calling through it is
+	 * exactly the corruption this guards against. Skip it (the caller falls
+	 * back to the next plug-in / sim_display); never dispatch. */
+	if (plugin_version != XRT_PLUGIN_API_VERSION_CURRENT) {
+		U_LOG_E("plugin loader:   %s: ABI major mismatch — plugin_api=%u, runtime expects %u; "
+		        "the plug-in must be rebuilt against this runtime's headers — skipping (ADR-020 rule 3).",
+		        e->id, plugin_version, (unsigned)XRT_PLUGIN_API_VERSION_CURRENT);
+		dlclose(handle);
+		return NULL;
+	}
+
 	if (iface->probe != NULL) {
 		xret = iface->probe(out_inst);
 		if (xret == XRT_ERROR_PROBER_NOT_SUPPORTED) {
@@ -708,7 +764,7 @@ try_load_one(const struct plugin_entry *e, struct xrt_plugin_instance **out_inst
 }
 
 static const struct xrt_plugin_iface *
-discover_active_plugin(struct xrt_plugin_instance **out_inst)
+discover_active_plugin(struct xrt_plugin_instance **out_inst, uint32_t max_probe_order)
 {
 	*out_inst = NULL;
 
@@ -743,10 +799,16 @@ discover_active_plugin(struct xrt_plugin_instance **out_inst)
 
 	U_LOG_I("plugin loader: %d registered plug-in(s) in %s; attempting in filename order.", n, root);
 	for (int i = 0; i < n; i++) {
+		// Refresh path (#342): only attempt strictly-better candidates.
+		// First-call path passes UINT32_MAX so no entry is skipped.
+		if (entries[i].probe_order >= max_probe_order) {
+			continue;
+		}
 		U_LOG_I("plugin loader:   [%d/%d] %s (ProbeOrder=%u, %s)", i + 1, n, entries[i].id,
 		        entries[i].probe_order, entries[i].binary_path);
 		const struct xrt_plugin_iface *iface = try_load_one(&entries[i], out_inst);
 		if (iface != NULL) {
+			g_active_probe_order = entries[i].probe_order;
 			return iface;
 		}
 	}
@@ -1015,6 +1077,19 @@ try_load_one(const struct plugin_entry *e, struct xrt_plugin_instance **out_inst
 		return NULL;
 	}
 
+	/* ADR-020 rule 3: reject a major-version mismatch before touching the
+	 * vtable. A plug-in built against a different ABI major lays its vtable
+	 * out at offsets the runtime doesn't agree on — calling through it is
+	 * exactly the corruption this guards against. Skip it (the caller falls
+	 * back to the next plug-in / sim_display); never dispatch. */
+	if (plugin_version != XRT_PLUGIN_API_VERSION_CURRENT) {
+		U_LOG_E("plugin loader:   %s: ABI major mismatch — plugin_api=%u, runtime expects %u; "
+		        "the plug-in must be rebuilt against this runtime's headers — skipping (ADR-020 rule 3).",
+		        e->id, plugin_version, (unsigned)XRT_PLUGIN_API_VERSION_CURRENT);
+		dlclose(handle);
+		return NULL;
+	}
+
 	if (iface->probe != NULL) {
 		xret = iface->probe(out_inst);
 		if (xret == XRT_ERROR_PROBER_NOT_SUPPORTED) {
@@ -1041,7 +1116,7 @@ try_load_one(const struct plugin_entry *e, struct xrt_plugin_instance **out_inst
 }
 
 static const struct xrt_plugin_iface *
-discover_active_plugin(struct xrt_plugin_instance **out_inst)
+discover_active_plugin(struct xrt_plugin_instance **out_inst, uint32_t max_probe_order)
 {
 	*out_inst = NULL;
 
@@ -1117,10 +1192,16 @@ discover_active_plugin(struct xrt_plugin_instance **out_inst)
 
 	U_LOG_I("plugin loader: %d registered plug-in(s); attempting in filename order.", n);
 	for (int i = 0; i < n; i++) {
+		// Refresh path (#342): only attempt strictly-better candidates.
+		// First-call path passes UINT32_MAX so no entry is skipped.
+		if (entries[i].probe_order >= max_probe_order) {
+			continue;
+		}
 		U_LOG_I("plugin loader:   [%d/%d] %s (ProbeOrder=%u, %s)", i + 1, n, entries[i].id,
 		        entries[i].probe_order, entries[i].binary_path);
 		const struct xrt_plugin_iface *iface = try_load_one(&entries[i], out_inst);
 		if (iface != NULL) {
+			g_active_probe_order = entries[i].probe_order;
 			return iface;
 		}
 	}
@@ -1145,7 +1226,19 @@ target_plugin_get_active(void)
 		return g_active_iface;
 	}
 	g_load_attempted = 1;
-	g_active_iface = discover_active_plugin(&g_active_instance);
+
+	// Init the refresh mutex here, while we're still single-threaded
+	// (xrCreateInstance is per the OpenXR spec). Subsequent compositor-
+	// create-time refreshes can then lock it from multiple IPC clients.
+	if (!g_refresh_mutex_initialized) {
+		if (os_mutex_init(&g_refresh_mutex) == 0) {
+			g_refresh_mutex_initialized = 1;
+		} else {
+			U_LOG_W("plugin loader: os_mutex_init failed — refresh path will skip locking.");
+		}
+	}
+
+	g_active_iface = discover_active_plugin(&g_active_instance, 0xFFFFFFFFu /* try all */);
 	return g_active_iface;
 }
 
@@ -1159,4 +1252,39 @@ target_plugin_get_active_instance(void)
 	 */
 	(void)target_plugin_get_active();
 	return g_active_instance;
+}
+
+const struct xrt_plugin_iface *
+target_plugin_refresh_active(void)
+{
+	// Force the one-shot discovery (also inits the mutex) if the caller
+	// hits this before the runtime's xrCreateInstance — defensive only;
+	// in practice instance-create always precedes session-create.
+	(void)target_plugin_get_active();
+
+	if (g_refresh_mutex_initialized) {
+		os_mutex_lock(&g_refresh_mutex);
+	}
+
+	uint32_t prev_order = g_active_probe_order;
+	struct xrt_plugin_instance *new_inst = NULL;
+	const struct xrt_plugin_iface *cand = discover_active_plugin(&new_inst, prev_order);
+	if (cand != NULL) {
+		// `g_active_probe_order` was already updated by discover to the
+		// new (lower) winner. The previous plug-in's DLL is intentionally
+		// leaked — its vtable may still be reachable from existing live
+		// DPs the compositor hasn't recreated yet.
+		U_LOG_W("plugin loader: refresh adopted better plug-in id=%s (ProbeOrder %u → %u) — "
+		        "re-scan after mid-install (#342).",
+		        cand->id ? cand->id : "?", prev_order, g_active_probe_order);
+		g_active_iface = cand;
+		g_active_instance = new_inst;
+	}
+
+	const struct xrt_plugin_iface *result = g_active_iface;
+
+	if (g_refresh_mutex_initialized) {
+		os_mutex_unlock(&g_refresh_mutex);
+	}
+	return result;
 }

--- a/src/xrt/targets/common/target_plugin_loader.h
+++ b/src/xrt/targets/common/target_plugin_loader.h
@@ -75,6 +75,32 @@ target_plugin_get_active(void);
 struct xrt_plugin_instance *
 target_plugin_get_active_instance(void);
 
+/*!
+ * Re-enumerate the platform's discovery root and, if a STRICTLY-BETTER
+ * (lower ProbeOrder) plug-in than the currently active one is now
+ * registered (or no plug-in was active before), swap it in and return
+ * its iface. Otherwise returns the unchanged current iface.
+ *
+ * Concretely: addresses issue #342 — the service starts mid-install
+ * with only `sim-display` registered (ProbeOrder 200) and bakes its
+ * factory pointers into `xrt_system_compositor_info`; the vendor
+ * plug-in (e.g. `leia-sr` at ProbeOrder 50) registers a moment later.
+ * Service-mode compositors invoke
+ * `xrt_system_compositor_info::refresh_display_processors` at
+ * per-client compositor create, which calls this and then re-derives
+ * the factory pointers, so the first app launch picks up the better
+ * plug-in without a service restart.
+ *
+ * Thread-safety: mutex-guarded internally. Idempotent — repeated calls
+ * with no new registration are cheap (re-enumerate + skip every entry
+ * whose ProbeOrder is not strictly better than the active one). The
+ * previously-active plug-in's DLL is intentionally LEAKED on swap,
+ * consistent with the load path: the runtime never destroys a vtable
+ * the compositor might still hold pointers into.
+ */
+const struct xrt_plugin_iface *
+target_plugin_refresh_active(void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
## Track B1 — runtime v1.6.0, plug-in ABI major v2

Ships ADR-020 rules 1–3 as the coordinated runtime major bump that prevents the class of bug that broke standalone-VK weaving (leia v1.4.1 headers vs runtime v1.5.2 → DP vtable offset skew → runtime's `set_chroma_key` call hit the plug-in's `destroy`).

Track A (bundle v0.5.0 with the leia v1.0.5 pin fix + `#346` version gate + `#342` finalize restart) shipped 2026-05-27 and was validated end-to-end on the Leia box (fresh install + upgrade, no reboot). With Track A out, this PR is unblocked.

### ABI v2 — `struct_size` + append-only + loader enforcement

- **`xrt_display_processor.h`**: 8-byte `struct_size`/`reserved_0` header at the top of the vtable. #348 asserts rewritten to anchor at `XRT_DP_BASE_OFF` (= `offsetof(.., process_atlas)`, asserted `== 8` on both 64- and 32-bit) plus `i*sizeof(void*)`. New `XRT_DP_HAS_SLOT(xdp, field)` macro bounds the field against the plug-in's reported `struct_size`, so appending a new method at the END of the vtable is now backward AND forward compatible within a major. All 12 optional inline wrappers gate on `HAS_SLOT` in addition to the NULL check; mandatory `process_atlas` (slot 0) + `destroy` (last) stay un-gated.
- **`xrt_display_processor_{d3d11,d3d12,gl,metal}.h`**: same 8-byte header + a per-API tripwire block (`XRT_DP_{D3D11,D3D12,GL,METAL}_BASE_OFF`) + `HAS_SLOT` gating on every optional wrapper. `d3d12` has the extra `set_output_format` slot the other APIs omit. The `XRT_DP_ABI_ASSERT` / `XRT_DP_ABI_MSG` / `XRT_DP_HAS_SLOT` macros are `#ifndef`-guarded in both base and per-API headers so any include order is safe (no MSVC C4005).
- **`xrt_plugin.h`**: `XRT_PLUGIN_API_VERSION_2 = 2`; `XRT_PLUGIN_API_VERSION_CURRENT` now points at it. The v1 → v2 break is the one-time introduction of `struct_size` on the DP vtables + the flip from loader-log to loader-reject. ABI-v1 plug-ins (≤ `leia v1.0.5`) are rejected.
- **`target_plugin_loader.c`**: rule 3 enforcement — after a successful `xrtPluginNegotiate` but **before** `iface->probe`, reject any plug-in whose reported `plugin_api_version != XRT_PLUGIN_API_VERSION_CURRENT` in all three `try_load_one` variants (Windows registry, Android, POSIX/JSON). DLL unloaded; loader falls back to the next plug-in / `sim_display`.
- **`sim_display_processor{,_d3d11,_d3d12,_gl,_metal}.{c,cpp,m}`**: every factory sets `base.struct_size = sizeof(struct xrt_display_processor[_<api>])` before assigning the vtable.
- **`oxr_plugin_stub.c`**: `_Static_assert` pin moved from `XRT_PLUGIN_API_VERSION_CURRENT == _1` to `== _2`.

### Folded #342 — durable DP re-scan at per-client compositor create

Track A's bundle finalize service-restart deterministically covers the fresh-bundle-install ordering, but a service started mid-install outside the bundle path (or a standalone service) still bakes the already-discovered factories into `xrt_system_compositor_info` forever. This change picks up a vendor plug-in registered AFTER the service started on the next app launch, **without** requiring a service restart.

Layering-clean mechanism (callback-on-syscomp-info — confirmed with @dfattal):

- **`xrt_compositor.h`**: add `void (*refresh_display_processors)(...)` fn-ptr to `xrt_system_compositor_info`.
- **`target_plugin_loader.{c,h}`**: new public `target_plugin_refresh_active()`. Tracks the winning ProbeOrder in a new static `g_active_probe_order`; `discover_active_plugin` now takes a `uint32_t max_probe_order` filter — first-call path passes `UINT32_MAX`, refresh path passes the active ProbeOrder so it only attempts **strictly-better** candidates (never re-probes the active plug-in). `os_mutex` guarded (not C11 atomics — MinGW caveat). Previous DLL intentionally leaked on swap, consistent with the existing load-path leak.
- **`target_instance.c`**: factor the `xsysc->info.dp_factory_*` assignment block into `fill_dp_factories_from_plugin()`; install `refresh_display_processors_cb` (calls `target_plugin_refresh_active` + re-derives factories) on `xsysc->info`. In-process / handle path leaves the field NULL — fresh-instance-per-launch already covers it.
- **`comp_multi_compositor.c`** (VK service) and **`comp_d3d11_service.cpp`** (D3D11 service) invoke the callback at the top of `multi_compositor_create` / `system_create_native_compositor` — once per IPC client, before any DP-factory read.

### Cleanups bundled with the bump

- **`comp_vk_native_compositor.c`**: the `dp_vtable_looks_sane` degrade-log now names "a plug-in built against a different runtime ABI major (ADR-020)" alongside the heap-collision possibility.
- **`comp_d3d11_window.cpp`** (#345, dev-only): dev-manifest auto-resolution at `WM_WORKSPACE_LAUNCH_APP` now gated on `getenv("DISPLAYXR_DEV") != NULL && getenv("XR_RUNTIME_JSON") == NULL`. End-user installs (no `build/Release/` sibling) no longer have a stale `XR_RUNTIME_JSON` forced onto child apps.
- **`docs/adr/ADR-020`**: status `Proposed → Accepted`; rules 1–3 marked Done (v1.6.0, ABI major 2); per-API DP structs called out.
- **`docs/specs/runtime/plugin-discovery.md`**: §6 rewritten for v2.
- **`CMakeLists.txt`**: `VERSION 1.5.2 → 1.6.0`.

### Validation

- Local `scripts\build_windows.bat build` → exit 0.
- All `_Static_assert`s hold (base + 4 per-API blocks) on MSVC x64.
- `DisplayXRClient.dll` (1.81 MB), `displayxr-service.exe` (1.62 MB), `DisplayXR-SimDisplay.dll` (60 KB) all relink.
- Only pre-existing warnings (`oxr_session.c:2867` C4090 + the unrelated `cmake_install.cmake:101` `\d` escape).

### Sequencing — what ships next

1. This PR → review → merge → `/release v1.6.0` cuts the tag.
2. **B2 — leia v1.0.6** (separate PR in `displayxr-leia-plugin`): `struct_size` in 4 leia factories, re-pin `DXR_RUNTIME_GIT_TAG "v1.5.2" → "v1.6.0"`, workflow `ref: 'v1.5.2' → 'v1.6.0'`, rule-5 CI pin self-check, `VERSION 1.0.5 → 1.0.6`. Mechanical (~10 min) once the v1.6.0 tag exists.
3. **B4 — bundle v0.6.0**: `versions.json` re-pin to runtime v1.6.0 + leia v1.0.6.

### Expected behavior post-merge (before B2 ships)

On the Leia box with the currently-shipped `leia v1.0.5` (ABI v1), the new loader will log:

```
plugin loader:   leia-sr: ABI major mismatch — plugin_api=1, runtime expects 2;
the plug-in must be rebuilt against this runtime's headers — skipping (ADR-020 rule 3).
```

…and fall back to `sim_display` SBS. That's the intentional Track-B cliff — `leia v1.0.6` (B2) restores the weave.

Plan: `~/.claude/plans/task-ship-the-displayxr-ticklish-quokka.md` (Track B).
Memory: `project_plugin_abi_policy_and_release`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
