### PR TITLE
docs(cmakelists): note VERSION is patched by CI from latest tag (#355 follow-up)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,13 @@
 # SPDX-License-Identifier: BSL-1.0
 
 cmake_minimum_required(VERSION 3.22)
+# VERSION below is patched at build time by CI from the latest vX.Y.Z tag —
+# see .github/workflows/build-windows.yml ("Sync CMake VERSION from latest
+# vX.Y.Z tag" step) and build-macos.yml ("steps.version"). The /release skill
+# no longer touches this value; what's committed here is a historical
+# placeholder and may be stale on `main` between releases. Installer artifact
+# names and the runtime's reported version always come from the tag, not from
+# this line. Local-dev builds embed whatever was last committed.
 project(
 	XRT
 	VERSION 1.6.0


### PR DESCRIPTION
One-line follow-up to #355 (which was superseded by [`4e4c93757`](https://github.com/DisplayXR/displayxr-runtime/commit/4e4c93757) + [`40fb5cc67`](https://github.com/DisplayXR/displayxr-runtime/commit/40fb5cc67) — moving CMakeLists VERSION ownership from the source tree to the CI tag-patching step).

After that rework, the committed `VERSION x.y.z` value on `main` drifts between releases by design (CI rewrites it at build time from the latest `vX.Y.Z` tag; `/release` no longer touches it). Without a marker, a future reader seeing a stale value (e.g. \`VERSION 1.6.0\` two releases later) might \`git blame\` it and wonder why the bump was skipped.

Adds a 7-line block comment above \`project()\` pointing at the two workflow steps that own this (build-windows.yml \"Sync CMake VERSION from latest vX.Y.Z tag\" + build-macos.yml \"steps.version\") and explicitly calling out that the committed value is a historical placeholder. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)