### PR TITLE
android(test app): MainActivity wrapper requests CAMERA at onCreate

### DIFF
--- a/docs/getting-started/android-bringup-checklist.md
+++ b/docs/getting-started/android-bringup-checklist.md
@@ -39,15 +39,12 @@ If A passes you can stop. B confirms the CNSDK convention assumptions. C is only
 
 The test app's `AndroidManifest.xml` declares `android.permission.CAMERA` (CNSDK front-camera face tracking) and `android.permission.WAKE_LOCK` (keep screen on during XR sessions). On Android 6+ `CAMERA` is a "dangerous" permission that requires either a user dialog OR an `adb pm grant`.
 
-The test app is a thin `NativeActivity` with no Java/Kotlin wrapper to surface the runtime permission dialog. Two options for day-1:
+The test app's `MainActivity` is a thin Kotlin wrapper around `NativeActivity` whose only job is to call `requestPermissions(CAMERA)` from `onCreate`. Day-1 path on Lume Pad: launch the app, tap **Allow** when the system permission dialog appears. The wrapper hands off to `NativeActivity` immediately, so the native init / `xrCreateInstance` runs in parallel — by the time CNSDK's face tracker opens the camera at session start, the grant is in place.
+
+For non-interactive bring-up (CI, scripted soak tests, no human at the device), pre-grant via adb:
 
 ```bash
-# Option 1: pre-grant via adb (works on emulator + device-with-developer-mode)
 adb shell pm grant com.displayxr.cube_handle_vk_android android.permission.CAMERA
-
-# Option 2: tap "Allow" on the system permission dialog the first time
-# face tracking tries to open the camera (CNSDK throws the dialog itself
-# on first leia_core_enable_face_tracking call — confirm at A1).
 ```
 
 **Missing CAMERA on Lume Pad symptom:** session reaches FOCUSED, app renders, but `xrLocateViews` always returns the default centered eye position regardless of head motion. No crash, no log error from CNSDK — just silently no face tracking. Check `adb shell dumpsys package com.displayxr.cube_handle_vk_android | grep CAMERA` to confirm grant.

--- a/test_apps/cube_handle_vk_android/build.gradle
+++ b/test_apps/cube_handle_vk_android/build.gradle
@@ -9,6 +9,7 @@
 
 plugins {
     id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
 }
 
 android {
@@ -76,6 +77,10 @@ android {
         targetCompatibility JavaVersion.VERSION_17
     }
 
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_17
+    }
+
     packagingOptions {
         jniLibs {
             // libopenxr_loader.so ships in the AAR; keep it as-is
@@ -85,6 +90,8 @@ android {
 }
 
 dependencies {
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+
     // Khronos OpenXR loader for Android — bundles libopenxr_loader.so +
     // openxr/*.h headers via prefab. The loader discovers our runtime
     // APK at runtime via the OpenXRRuntimeService intent declared in

--- a/test_apps/cube_handle_vk_android/src/main/AndroidManifest.xml
+++ b/test_apps/cube_handle_vk_android/src/main/AndroidManifest.xml
@@ -58,11 +58,18 @@
 
     <application
         android:allowBackup="false"
-        android:label="DisplayXR Cube VK"
-        android:hasCode="false">
+        android:label="DisplayXR Cube VK">
 
+        <!--
+            MainActivity is a thin Kotlin wrapper around NativeActivity
+            that requests CAMERA at onCreate so CNSDK's face tracker
+            can open the front camera at xrCreateSession. The
+            android.app.lib_name meta-data is still required so the
+            wrapper inherits the native lib load path from
+            NativeActivity.
+        -->
         <activity
-            android:name="android.app.NativeActivity"
+            android:name=".MainActivity"
             android:exported="true"
             android:configChanges="orientation|keyboardHidden|screenSize"
             android:launchMode="singleTask">

--- a/test_apps/cube_handle_vk_android/src/main/java/com/displayxr/cube_handle_vk_android/MainActivity.kt
+++ b/test_apps/cube_handle_vk_android/src/main/java/com/displayxr/cube_handle_vk_android/MainActivity.kt
@@ -1,0 +1,40 @@
+// Copyright 2026, Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+//
+// Thin NativeActivity wrapper whose only job is to surface the runtime
+// CAMERA permission dialog at first launch. CNSDK's face tracker
+// (libleiaSDK-faceTrackingInApp.so, loaded into this process by the
+// DisplayXR runtime broker) opens the front camera during
+// xrCreateSession. On Android 6+ a manifest <uses-permission> is not
+// sufficient for "dangerous" perms — the user must grant at runtime.
+// Without this prompt, the camera open silently fails and head
+// tracking permanently uses a default centered eye position.
+//
+// We delegate everything else (window setup, ANativeActivity glue,
+// android_main thread spawn) to NativeActivity by calling
+// super.onCreate first; the permission request is async and happens
+// in parallel with the native init. If the user grants in time, the
+// first xrCreateSession picks up the permission. If they deny or
+// haven't decided yet, CNSDK degrades to no-face state — same as
+// pre-wrapper behavior, but at least the dialog appeared.
+
+package com.displayxr.cube_handle_vk_android
+
+import android.Manifest
+import android.app.NativeActivity
+import android.content.pm.PackageManager
+import android.os.Bundle
+
+class MainActivity : NativeActivity() {
+
+    companion object {
+        private const val REQUEST_CAMERA = 1
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        if (checkSelfPermission(Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED) {
+            requestPermissions(arrayOf(Manifest.permission.CAMERA), REQUEST_CAMERA)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Pick-up of the deferred follow-up from #350. Adds a thin Kotlin `MainActivity` subclass of `NativeActivity` whose only job is to call `requestPermissions(CAMERA)` from `onCreate`. Stacked on top of #350 (the manifest declarations the wrapper depends on).

## Why this matters

CNSDK's face tracker (`libleiaSDK-faceTrackingInApp.so`, loaded into the app's process by the DisplayXR runtime broker) opens the front camera during `xrCreateSession`. On Android 6+ a manifest `<uses-permission>` declaration is **not sufficient** for "dangerous" perms — the user must explicitly grant at runtime. Without the grant: camera `open()` silently fails, CNSDK never reports a face, all `xrLocateViews` calls return the default centered eye position. **No crash, no log error** — just permanently no head tracking, which on Lume Pad is the entire point of the platform.

Pre-this-PR the only workaround was `adb shell pm grant ...` documented in Step 0 of the bring-up checklist (#350). That works for emulator + developer-mode device but is not a real day-1 path for hardware.

## How it works

```kotlin
class MainActivity : NativeActivity() {
    override fun onCreate(savedInstanceState: Bundle?) {
        super.onCreate(savedInstanceState)
        if (checkSelfPermission(Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED) {
            requestPermissions(arrayOf(Manifest.permission.CAMERA), REQUEST_CAMERA)
        }
    }
}
```

`super.onCreate(...)` runs the full `NativeActivity` glue (spawns the `android_main` thread, sets up the `ANativeActivity` callbacks, attaches the window) **before** we kick off `requestPermissions`. The native init / `xrCreateInstance` chain runs in parallel with the user-facing dialog. By the time CNSDK reaches its `leia_core_enable_face_tracking` call at session start, the user has already decided.

## Trade-offs

- **First-launch race:** if the user is slow to tap Allow, CNSDK may try to open the camera before the grant lands. Same end-state as current behavior (no face), and re-launching after the grant is a clean second-light. Avoiding this fully would require blocking the native main thread until the permission decision comes back — more invasive than the value it'd add.
- **No `onRequestPermissionsResult` override:** we don't need one. The native code never asks Java about the permission; it just calls into CNSDK which calls into the system camera. If the permission flips state mid-session, CNSDK's `leia_core_enable_face_tracking` either succeeds or no-ops — both are valid states.
- **Deny case:** silent no-face, identical to no-grant-at-all. Not great UX but acceptable for a POC test app; a production app would need to inform the user.

## Verification (Android-36 emulator)

```
$ adb shell pm uninstall com.displayxr.cube_handle_vk_android
$ adb install -r cube_handle_vk_android-debug.apk
$ adb shell dumpsys package com.displayxr.cube_handle_vk_android | grep CAMERA
      android.permission.CAMERA
$ adb shell am start -n com.displayxr.cube_handle_vk_android/.MainActivity
... GrantPermissionsActivity launched ...
$ adb shell pm grant com.displayxr.cube_handle_vk_android android.permission.CAMERA  # simulates "Allow"
$ adb logcat | grep cube_handle
  xrInitializeLoaderKHR -> XR_SUCCESS
  xrCreateInstance -> XR_SUCCESS
  xrCreateVulkanInstanceKHR -> XR_SUCCESS
  xrCreateVulkanDeviceKHR vk_result=-7   # known emulator wall
```

Same full sentinel chain as pre-wrapper. No regression in `NativeActivity` glue (`android_main`, `APP_CMD_INIT_WINDOW`, `xrInitializeLoaderKHR` all reached). The permission dialog launches as the `GrantPermissionsActivity` intent.

## Files

- `test_apps/cube_handle_vk_android/build.gradle` — Kotlin Android plugin, `kotlin-stdlib` dep, `kotlinOptions { jvmTarget = 17 }`.
- `test_apps/cube_handle_vk_android/src/main/java/.../MainActivity.kt` — the wrapper (~10 lines of actual code, rest is the file's why-this-exists block comment).
- `test_apps/cube_handle_vk_android/src/main/AndroidManifest.xml` — drop `android:hasCode="false"`, swap `android.app.NativeActivity` → `.MainActivity`. `android.app.lib_name` meta-data preserved (the wrapper inherits the native lib load path).
- `docs/getting-started/android-bringup-checklist.md` — Step 0 rewritten: dialog is now the default day-1 path; `adb pm grant` becomes opt-in for non-interactive bring-up.

## Test plan

- [ ] On Lume Pad first launch, system permission dialog appears within ~1s of icon tap.
- [ ] Tapping **Allow** results in `dumpsys package ... | grep CAMERA` showing `granted=true`.
- [ ] Head tracking works at session start (face-driven cube parallax visible).
- [ ] Tapping **Deny** results in no head tracking but no crash (graceful degrade — same as missing grant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)