### PR TITLE
xrSetSharedTextureSurround2DEXT (v6 KeyedMutex) + xrSetSharedTextureSurround2DFenceEXT (v7 D3D12 fence) — spec + runtime + test apps

### DIFF
--- a/docs/roadmap/surround-2d-rollout.md
+++ b/docs/roadmap/surround-2d-rollout.md
@@ -1,0 +1,114 @@
+# Surround 2D Rollout — `xrSetSharedTextureSurround2DEXT`
+
+**Status:** design + spec draft (2026-05-28). Pre-implementation.
+**Branch:** `feature/surround-2d-spec`.
+**Spec:** [`XR_EXT_win32_window_binding` §3.6](../specs/extensions/XR_EXT_win32_window_binding.md#36-xrsetsharedtexturesurround2dext), [`XR_EXT_cocoa_window_binding` §4](../specs/extensions/XR_EXT_cocoa_window_binding.md). Both bumped to spec version 6.
+**Related:** [#224 local-3d-zones](../roadmap/local-3d-zones.md) (deliberately *not* the same path — see §6).
+
+## TL;DR
+
+A `_texture` app on a display with a fixed hardware 3D zone needs to fill the area *around* the canvas sub-rect with full-resolution 2D content. Today, those non-canvas pixels of the target swapchain are undefined — the runtime only writes the canvas region. Spec v6 adds one new function, `xrSetSharedTextureSurround2DEXT`, that registers a full-window 2D shared texture; the compositor blits its non-canvas pixels into the target swapchain each frame. No new layer types, no new display-processor methods, no per-pixel mask. Builds on the canvas sub-rect plumbing that just landed for #85.
+
+End goal: ship the capability through Unity's plugin so Unity editors and runtime applications can render a 3D viewport in a fixed zone with crisp 2D toolbars / chrome around it.
+
+## Phases
+
+### Phase A — Spec + headers (this PR)
+
+- [x] Bump `XR_EXT_win32_window_binding_SPEC_VERSION` 5 → 6 in `src/external/openxr_includes/openxr/XR_EXT_win32_window_binding.h`.
+- [x] Add `PFN_xrSetSharedTextureSurround2DEXT` typedef + `xrSetSharedTextureSurround2DEXT` prototype to the Win32 header.
+- [x] Mirror on Cocoa header (`XR_EXT_cocoa_window_binding.h` v5 → v6) with IOSurface lifecycle deltas.
+- [x] Add §3.6 to the Win32 spec doc with parameters, valid usage, pipeline integration, fallback, and a worked example.
+- [x] Add a parity section in the Cocoa spec doc that points back to Win32 §3.6 and lists the Metal/IOSurface deltas.
+- [x] Extend §3.2 *Three Modes* "Texture" row prose with a forward link to §3.6 for the "fill the area around the canvas" question.
+
+### Phase B — Runtime state-tracker + compositor plumbing
+
+- [ ] Add a new extension entry to `src/xrt/state_trackers/oxr/oxr_extension_support.h` (no new bool — the existing `XR_EXT_win32_window_binding` / `XR_EXT_cocoa_window_binding` bools cover v6 since it's an additive function, not a separate extension).
+- [ ] Implement `oxr_xrSetSharedTextureSurround2DEXT` in `src/xrt/state_trackers/oxr/oxr_session.c` next to `oxr_xrSetSharedTextureOutputRectEXT`:
+  - Validate session has a window binding.
+  - Validate `width × height == HWND client area`.
+  - Open the shared handle (D3D11 `OpenSharedResource1` / D3D12 `OpenSharedHandle`).
+  - Stash the opened texture + KeyedMutex on the per-session compositor state.
+  - On NULL handle: release the previous texture + KeyedMutex.
+- [ ] Wire the function pointer into the dispatch table (`oxr_xr_to_str.c` / `xrGetInstanceProcAddr`).
+
+### Phase C — D3D11 compositor surround blit
+
+- [ ] In `src/xrt/compositor/d3d11/comp_d3d11_compositor.cpp` (or wherever the per-frame `process_atlas` is dispatched), add a surround-blit pass after the DP's weave finishes:
+  1. `AcquireSync(0)` on the surround texture's KeyedMutex.
+  2. Bind two SRVs on the surround texture (UNORM + UNORM_SRGB, parallel to the shell-mode `atlas_holds_srgb_bytes` pattern in [`compositor-pipeline.md`](../architecture/compositor-pipeline.md#color-space-handling-d3d11-service-compositor-shell-mode)).
+  3. Run a fullscreen blit shader against the target swapchain with a scissor-rect strategy:
+     - Path A: four scissor-rects (top/bottom/left/right strips around the canvas) → four `CopySubresourceRegion` or quad draws.
+     - Path B: one fullscreen pass with a "skip if inside canvas rect" branch in the pixel shader.
+     Path A is simpler and cache-friendlier when the canvas is large. Default to A; revisit if vendor weavers care about overwrite ordering with the DP's output.
+  4. `ReleaseSync(0)`.
+- [ ] Honor the existing color-space contract: target swapchain stays UNORM; the runtime selects the SRV that matches the surround texture's format so the bytes written to the target are always linear (or SRGB-encoded, depending on the target's setup — match what the DP already does for the canvas region).
+
+### Phase D — D3D12 compositor surround blit
+
+- [ ] Mirror Phase C in `src/xrt/compositor/d3d12/`. Same scissor-rect strategy. D3D12 uses `ID3D12Resource::CreateSharedHandle` + `ID3D12Device::OpenSharedHandle` and exposes the keyed mutex via DXGI.
+- [ ] Verify against the d3d12 native compositor's existing canvas sub-rect handling (already done for #85 — the surround blit is its natural complement).
+
+### Phase E — Test-app updates
+
+- [ ] **`test_apps/cube_texture_d3d11_win/`**:
+  - In `xr_session.cpp`, after the existing `xrGetInstanceProcAddr("xrSetSharedTextureOutputRectEXT", ...)` line, add the analogous proc-address lookup for `xrSetSharedTextureSurround2DEXT` and stash the PFN.
+  - In `main.cpp` (or wherever the shared multiview texture is created), allocate a *second* D3D11 shared texture at HWND client dimensions with `D3D11_RESOURCE_MISC_SHARED_NTHANDLE | D3D11_RESOURCE_MISC_SHARED_KEYEDMUTEX`, `DXGI_FORMAT_R8G8B8A8_UNORM_SRGB`.
+  - Per frame: render a deliberately-2D pattern into it — a colored gradient with crisp text overlay reading e.g. "FULL-RES 2D — `<window_w>×<window_h>`", a checkerboard at panel-pixel scale, and a thin border around the canvas hole. Acquire/release the KeyedMutex on key 0.
+  - Set the canvas rect to a centered ~60% sub-rect (simulating the fixed hardware 3D zone). The cube still weaves inside the canvas; the surround shows the 2D pattern.
+  - Bump the build version comment and add a HUD line indicating the surround texture is active.
+- [ ] **`test_apps/cube_texture_d3d12_win/`**: same pattern, D3D12 idioms.
+- [ ] (Optional, Phase F-late) `test_apps/cube_texture_metal_macos/`: mirror with IOSurface, gated on Metal compositor surround-blit support landing first.
+
+### Phase F — Local validation
+
+- [ ] Build runtime + test apps locally on Windows (`scripts\build_windows.bat all`), run `cube_texture_d3d11_win` against the Leia SR plugin or sim_display. Expected visual: 3D cube weaves inside the centered canvas; outside, the 2D pattern is crisp at full panel res; no ghosting, no leakage across the boundary.
+- [ ] Capture a compositor screenshot via `%TEMP%\workspace_screenshot_trigger` (path documented in `CLAUDE.md` § Capturing Compositor Screenshots) to inline-verify pixel-perfect canvas/surround boundary.
+- [ ] Run the MinGW compile-check on macOS (`./scripts/build-mingw-check.sh aux_util displayxr_mcp`) to catch any obvious Win32 platform-guard regressions before pushing.
+
+### Phase G — Unity plugin integration
+
+Lives in [`DisplayXR/displayxr-unity`](https://github.com/DisplayXR/displayxr-unity), not this repo. Tracked separately, but the surface shape is fixed by spec v6 above.
+
+The Unity plugin's existing C# binding for `xrSetSharedTextureOutputRectEXT` is in `native~/` (the native bridge module). The Unity-side surface looks like:
+
+```csharp
+// Existing today (sets the canvas sub-rect):
+DisplayXR.SetCanvasRect(int x, int y, int width, int height);
+
+// New (registers a Unity RenderTexture as the 2D surround source):
+DisplayXR.SetSurround2D(RenderTexture surround);   // pass null to clear
+```
+
+C# → native plumbing:
+
+1. Unity creates a `RenderTexture` at the panel's HWND client size, `RenderTextureFormat.ARGB32`, sRGB-aware. Unity's `RenderTexture` already wraps a D3D11/D3D12 shared resource; the plugin extracts the underlying `ID3D11Texture2D*` via `GetNativeTexturePtr()` and calls `IDXGIResource1::CreateSharedHandle` to get an NT HANDLE.
+2. Plugin calls `pfnSetSharedTextureSurround2DEXT(session, handle, width, height)`.
+3. Per frame, Unity renders its 2D UI camera (UGUI canvas, UI Toolkit document, whatever the app uses) to that `RenderTexture` instead of to the back buffer. The plugin's per-frame hook acquires the keyed mutex around Unity's render submission, then releases.
+4. The runtime's compositor blits the surround pixels around the weaved canvas region into the target swapchain.
+
+Discovery: `displayxr-unity` already reflects on `xrGetInstanceProcAddr` at plugin init; bumping its `XR_EXT_win32_window_binding` requested-version to 6 + adding the new PFN lookup is mechanical.
+
+Migration path for existing Unity apps:
+- Apps that already use the texture path (canvas sub-rect) get the new surround capability by adding one C# call.
+- Apps that don't set a canvas rect (full-window canvas — the default) are unaffected; the surround region is empty and the new call is a no-op even if invoked.
+
+### Phase H — Documentation closeout
+
+- [ ] Add a row to the `XR_EXT_win32_window_binding` spec version history when this lands.
+- [ ] Update `docs/specs/runtime/swapchain-model.md` § Canvas Concept with a one-paragraph addition explaining the surround texture as the "fill the rest" partner to the canvas sub-rect.
+- [ ] Update `docs/getting-started/app-classes.md` Texture-row description: "good for apps that want to render 3D content as part of a larger 2D UI" → tighten with the surround texture mechanism.
+
+## What's intentionally *not* in this design
+
+- **Per-pixel masking** ([#224](../roadmap/local-3d-zones.md)): the surround texture is rectangular complement of the canvas sub-rect. There's no per-pixel "this region is 2D" mask. When per-zone hardware lands and apps want to publish dynamic 2D/3D masks, that's `XR_EXT_local_3d_zone` from the #224 spec, layered alongside this — not replacing it.
+- **Multi-canvas / picture-in-picture**: §9.2 of the Win32 spec already reserves this as a future additive direction. Out of scope here.
+- **Cursor handling over the canvas boundary**: the Windows hardware cursor sits above the swapchain. If it crosses the canvas boundary, it visually transitions between weaved and 2D regions. Same constraint as #224. Vendor-side fix or accept-the-artifact; not blocking.
+- **Apps that aren't `_texture`**: handle apps render directly into the HWND's swap chain and already own all pixels (including the surround region by default). They don't need this extension. If a handle app wants the runtime to weave into a sub-rect, it would first need to opt into texture-mode by providing a `sharedTextureHandle` at session creation.
+
+## Why this over the alternatives we discussed
+
+- **Post-weave 2D overlay layer (new `XR_COMPOSITION_LAYER_PANEL_NATIVE_BIT`)**: more OpenXR-idiomatic, works for handle apps too, but introduces a new layer type. The texture-app idiom already plumbs the canvas rect; adding a sibling "surround texture" call is the smallest API surface that does the job. Reconsider if/when handle apps need the capability.
+- **Inverse mask (#224 software variant)**: same DP-vtable plumbing as #224, but the mask is degenerate (constant per session = hardware zone). Not worth the per-frame mask-publish cost for a static rect.
+- **Texture-app trick using one buffer**: implicit — relies on "outside canvas is whatever the app left there." Doesn't work because the target swapchain is runtime-owned, not app-owned. The surround texture is the explicit form of this.

--- a/docs/roadmap/surround-2d-rollout.md
+++ b/docs/roadmap/surround-2d-rollout.md
@@ -1,8 +1,8 @@
 # Surround 2D Rollout — `xrSetSharedTextureSurround2DEXT`
 
-**Status:** design + spec draft (2026-05-28). Pre-implementation.
+**Status:** D3D11 shipping; D3D12 fence path shipping (post spec-v7 bump on 2026-05-28).
 **Branch:** `feature/surround-2d-spec`.
-**Spec:** [`XR_EXT_win32_window_binding` §3.6](../specs/extensions/XR_EXT_win32_window_binding.md#36-xrsetsharedtexturesurround2dext), [`XR_EXT_cocoa_window_binding` §4](../specs/extensions/XR_EXT_cocoa_window_binding.md). Both bumped to spec version 6.
+**Spec:** Win32 [§3.6](../specs/extensions/XR_EXT_win32_window_binding.md#36-xrsetsharedtexturesurround2dext) (D3D11 keyed-mutex, v6) + [§3.7](../specs/extensions/XR_EXT_win32_window_binding.md#37-xrsetsharedtexturesurround2dfenceext) (D3D12 fence, v7); Cocoa [§4](../specs/extensions/XR_EXT_cocoa_window_binding.md) (IOSurface, v6). Win32 at spec version 7; Cocoa at 6.
 **Related:** [#224 local-3d-zones](../roadmap/local-3d-zones.md) (deliberately *not* the same path — see §6).
 
 ## TL;DR
@@ -52,18 +52,19 @@ End goal: ship the capability through Unity's plugin so Unity editors and runtim
 
 ### Phase E — Test-app updates
 
-- [ ] **`test_apps/cube_texture_d3d11_win/`**:
-  - In `xr_session.cpp`, after the existing `xrGetInstanceProcAddr("xrSetSharedTextureOutputRectEXT", ...)` line, add the analogous proc-address lookup for `xrSetSharedTextureSurround2DEXT` and stash the PFN.
-  - In `main.cpp` (or wherever the shared multiview texture is created), allocate a *second* D3D11 shared texture at HWND client dimensions with `D3D11_RESOURCE_MISC_SHARED_NTHANDLE | D3D11_RESOURCE_MISC_SHARED_KEYEDMUTEX`, `DXGI_FORMAT_R8G8B8A8_UNORM_SRGB`.
-  - Per frame: render a deliberately-2D pattern into it — a colored gradient with crisp text overlay reading e.g. "FULL-RES 2D — `<window_w>×<window_h>`", a checkerboard at panel-pixel scale, and a thin border around the canvas hole. Acquire/release the KeyedMutex on key 0.
-  - Set the canvas rect to a centered ~60% sub-rect (simulating the fixed hardware 3D zone). The cube still weaves inside the canvas; the surround shows the 2D pattern.
-  - Bump the build version comment and add a HUD line indicating the surround texture is active.
-- [ ] **`test_apps/cube_texture_d3d12_win/`**: same pattern, D3D12 idioms.
+- [x] **`test_apps/cube_texture_d3d11_win/`** (commit pending on `feature/surround-2d-spec`):
+  - `xr_session.cpp` resolves `xrSetSharedTextureSurround2DEXT` next to `xrSetSharedTextureOutputRectEXT` and stashes it on `XrSessionManager::pfnSetSharedTextureSurround2DEXT` (lives in `test_apps/common/xr_session_common.h`).
+  - `main.cpp` allocates a second D3D11 NT-shared + keyed-mutex texture at the shared multiview texture's worst-case atlas dims (which the compositor requires for dim + format match — `DXGI_FORMAT_B8G8R8A8_UNORM`, not the spec's R8G8B8A8, because the compositor's `CopySubresourceRegion` enforces exact format equality with `c->shared_texture`). NT handle is obtained via `IDXGIResource1::CreateSharedHandle`.
+  - Per frame the app acquires keyed mutex key 0, renders a procedural pattern (gradient + 24-pixel checkerboard + red 4-pixel border just outside the canvas + slow diagonal sweep so motion is visible) over the current `(winW × winH)` region, releases key 0. Inside-canvas pixels are written black — never sampled.
+  - Canvas stays at the existing center-50% rect set in `BlitSharedTextureToBackBuffer` / `WM_SIZE`. The DP still weaves inside it; the surround fills the rest.
+  - `BlitSharedTextureToBackBuffer` gained a surround-aware branch: when registered, viewport widens to the full window and UV samples the `(0..winW, 0..winH)` region of the shared texture (so the strip pixels written by the compositor are visible); when surround is inactive, it falls back to the legacy canvas-only blit.
+  - HUD `modeText` adds a "Surround 2D: ACTIVE (spec v6)" / "inactive" line.
+- [x] **`test_apps/cube_texture_d3d12_win/`** (commit pending on `feature/surround-2d-spec`): same shape with D3D12 idioms. Surround texture is `D3D12_HEAP_FLAG_SHARED` + `D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET`; NT handle from `ID3D12Device::CreateSharedHandle`. **Uses the spec-v7 fence path** (`xrSetSharedTextureSurround2DFenceEXT`) — the v6 keyed-mutex contract does *not* work on D3D12-native shared resources because `IDXGIKeyedMutex` is `E_NOINTERFACE` on common drivers (verified 2026-05-28 on RTX 3080 / Win11 26200). Test app allocates a paired `ID3D12Fence` with `D3D12_FENCE_FLAG_SHARED`, exports it via `CreateSharedHandle`. Per frame: record surround pattern → `ExecuteCommandLists` → `commandQueue->Signal(fence, ++value)` → `xrSetSharedTextureSurround2DFenceEXT(...)` to push the new await value. Runtime compositor queue-waits on the fence before the strip blit. Same procedural shader + 12-DWORD root-constants param block as the D3D11 app.
 - [ ] (Optional, Phase F-late) `test_apps/cube_texture_metal_macos/`: mirror with IOSurface, gated on Metal compositor surround-blit support landing first.
 
 ### Phase F — Local validation
 
-- [ ] Build runtime + test apps locally on Windows (`scripts\build_windows.bat all`), run `cube_texture_d3d11_win` against the Leia SR plugin or sim_display. Expected visual: 3D cube weaves inside the centered canvas; outside, the 2D pattern is crisp at full panel res; no ghosting, no leakage across the boundary.
+- [x] Build runtime + test apps locally on Windows (`scripts\build_windows.bat all`), run `cube_texture_d3d11_win` against the Leia SR plugin. **Confirmed 2026-05-28**: cube weaves inside the centered canvas; checkerboard + gradient + red 4-pixel border fill the surround at full panel res; boundary is pixel-crisp with no leakage. App log shows `Created surround D3D11 texture: 3840x2160 format=87` and `Registered surround 2D texture with runtime (3840x2160)`.
 - [ ] Capture a compositor screenshot via `%TEMP%\workspace_screenshot_trigger` (path documented in `CLAUDE.md` § Capturing Compositor Screenshots) to inline-verify pixel-perfect canvas/surround boundary.
 - [ ] Run the MinGW compile-check on macOS (`./scripts/build-mingw-check.sh aux_util displayxr_mcp`) to catch any obvious Win32 platform-guard regressions before pushing.
 

--- a/docs/roadmap/surround-2d-rollout.md
+++ b/docs/roadmap/surround-2d-rollout.md
@@ -67,6 +67,26 @@ End goal: ship the capability through Unity's plugin so Unity editors and runtim
 - [ ] Capture a compositor screenshot via `%TEMP%\workspace_screenshot_trigger` (path documented in `CLAUDE.md` § Capturing Compositor Screenshots) to inline-verify pixel-perfect canvas/surround boundary.
 - [ ] Run the MinGW compile-check on macOS (`./scripts/build-mingw-check.sh aux_util displayxr_mcp`) to catch any obvious Win32 platform-guard regressions before pushing.
 
+#### Local Windows handoff (Phase C/D validation only — pre Phase E)
+
+Branch: `feature/surround-2d-spec` (PR [#361](https://github.com/DisplayXR/displayxr-runtime/pull/361)). Current head should include the MSVC `HANDLE`-shadow fix (`0db22fd7` or later).
+
+What you can validate locally today (Phase C/D):
+
+```bat
+git fetch origin feature/surround-2d-spec
+git checkout feature/surround-2d-spec
+scripts\build_windows.bat build
+```
+
+- ✅ **Compile-clean MSVC build of `comp_d3d11.lib` and `comp_d3d12.lib`** is the canonical Phase C/D check. The first Windows CI run on this branch failed on a `HANDLE h` local that shadowed the `uint32_t h` (height) parameter — clang let it slide, MSVC didn't. Anything similar would surface here.
+- ✅ **Runtime loads + an existing `_handle` app runs unchanged** (e.g. `_package\run_cube_handle_d3d11_win.bat`). The new surround code path is dormant unless `xrSetSharedTextureSurround2DEXT` is called — handle apps don't call it, so they exercise the unchanged code paths and prove no regression.
+- ⚠️ **The new path is NOT exercised end-to-end yet.** None of the shipping test apps call `xrSetSharedTextureSurround2DEXT`. That's Phase E — `cube_texture_d3d11_win` / `cube_texture_d3d12_win` need updates to (a) allocate a second NT-shared + keyed-mutex D3D11/D3D12 texture at HWND client dims, (b) `xrGetInstanceProcAddr` the new PFN, (c) call it, (d) render a 2D pattern into it each frame.
+
+If you want to smoke-test the entry point before Phase E lands, the minimal addition to `test_apps/cube_texture_d3d11_win/xr_session.cpp` is one `xrGetInstanceProcAddr` lookup + one call with `nullptr` to confirm the runtime accepts the registration cycle without crashing. Watch the log for `D3D11 surround 2D cleared` / `D3D11 surround 2D registered: handle=... WxH format=...`.
+
+Phase E is the natural next step — it's where the visual validation actually becomes meaningful.
+
 ### Phase G — Unity plugin integration
 
 Lives in [`DisplayXR/displayxr-unity`](https://github.com/DisplayXR/displayxr-unity), not this repo. Tracked separately, but the surface shape is fixed by spec v6 above.

--- a/docs/specs/extensions/XR_EXT_cocoa_window_binding.md
+++ b/docs/specs/extensions/XR_EXT_cocoa_window_binding.md
@@ -3,7 +3,7 @@
 | Property | Value |
 |----------|-------|
 | Extension Name | `XR_EXT_cocoa_window_binding` |
-| Spec Version | 5 |
+| Spec Version | 6 |
 | Type Values | `XR_TYPE_COCOA_WINDOW_BINDING_CREATE_INFO_EXT` (1000999004), `XR_TYPE_COMPOSITION_LAYER_WINDOW_SPACE_EXT` (1000999002) |
 | Author | Leia Inc. |
 | Platform | macOS (Cocoa / AppKit). |
@@ -116,6 +116,19 @@ Shared with `XR_EXT_win32_window_binding`. See that extension's spec for the ful
 ### xrSetSharedTextureOutputRectEXT
 
 Sets the canvas sub-rect within the NSView where 3D content appears. Coordinates are relative to the view bounds. See [`XR_EXT_win32_window_binding` §3.5](XR_EXT_win32_window_binding.md) for the full API reference — the function signature and semantics are identical across platforms.
+
+### xrSetSharedTextureSurround2DEXT (Spec v6)
+
+Registers a full-view 2D shared texture (`IOSurfaceRef`) whose pixels outside the canvas sub-rect are blitted into the target swapchain each frame. The Metal-side mechanism differs from D3D11/D3D12 (`IOSurfaceRef` instead of an NT `HANDLE`, no `IDXGIKeyedMutex` — IOSurface use_count + Metal fence instead) but the function signature, lifecycle, and semantics are otherwise identical to the Win32 form. See [`XR_EXT_win32_window_binding` §3.6](XR_EXT_win32_window_binding.md#36-xrsetsharedtexturesurround2dext) for the full API reference.
+
+**Cocoa-specific deltas:**
+
+- `sharedTextureHandle` is an `IOSurfaceRef` cast to `void*` (matching how the multiview `sharedIOSurface` field is handled in `XrCocoaWindowBindingCreateInfoEXT`).
+- Synchronization uses Metal fences and the IOSurface use-count protocol rather than `IDXGIKeyedMutex`. The runtime increments use-count on register, drops it on clear / replace.
+- Pixel format must be `MTLPixelFormatRGBA8Unorm` or `MTLPixelFormatRGBA8Unorm_sRGB`.
+- Texture dimensions must match the NSView's `convertRectToBacking:` size in physical pixels (i.e. post-Retina scale).
+
+The Vulkan-via-MoltenVK and native-Metal compositor paths both honor the surround texture — the surround blit pass lives in `compositor/metal/` and `compositor/vk_native/` mirroring the Win32 paths.
 
 ---
 
@@ -230,3 +243,4 @@ The Cocoa binding tracks `XR_EXT_win32_window_binding` for forward-compatibility
 | 2 | 2025-09-20 | David Fattal | Added readbackCallback for offscreen mode |
 | 3 | 2026-01-10 | David Fattal | Added sharedIOSurface for zero-copy Metal texture sharing. Fixed type value collision (1000999003 → 1000999004). |
 | 4 | 2026-04-24 | David Fattal | Read-back contract clarified: runtime writes the canvas region at `(x, y)` (not origin) in the shared IOSurface, matching `xrSetSharedTextureOutputRectEXT` args. Apps must sample at `uvOffset + uv * uvScale`. See ADR-010. |
+| 6 | 2026-05-28 | David Fattal | Added `xrSetSharedTextureSurround2DEXT` (parity with `XR_EXT_win32_window_binding` v6). Lets `_texture` apps register a full-view 2D IOSurface whose pixels outside the canvas sub-rect are blitted into the target swapchain each frame. Enables apps on fixed-3D-zone displays to fill the surround region with full-resolution 2D content. |

--- a/docs/specs/extensions/XR_EXT_win32_window_binding.md
+++ b/docs/specs/extensions/XR_EXT_win32_window_binding.md
@@ -3,7 +3,7 @@
 | Property | Value |
 |----------|-------|
 | Extension Name | `XR_EXT_win32_window_binding` |
-| Spec Version | 3 |
+| Spec Version | 6 |
 | Type Values | `XR_TYPE_WIN32_WINDOW_BINDING_CREATE_INFO_EXT` (1000999001), `XR_TYPE_COMPOSITION_LAYER_WINDOW_SPACE_EXT` (1000999002) |
 | Author | Leia Inc. |
 | Platform | Windows (Win32). Linux/Android reserved for future use. |
@@ -136,6 +136,7 @@ The two concepts are inseparable: window-space layers only make sense when there
 | 1 | Initial: `windowHandle`, `readbackCallback`, `sharedTextureHandle`. |
 | 4 | `transparentBackgroundEnabled` — runtime configures DComp / DXGI for per-pixel desktop transparency. |
 | 5 | `chromaKeyColor` — optional app-supplied chroma-key override. `0` = runtime DP picks its own default. |
+| 6 | `xrSetSharedTextureSurround2DEXT` — register a full-window 2D shared texture for the non-canvas region. Enables apps with a fixed 3D zone (sub-rect canvas) to deliver full-resolution 2D content for the surrounding area. See [§3.6](#36-xrsetsharedtexturesurround2dext). |
 
 ### 3.2 XrWin32WindowBindingCreateInfoEXT
 
@@ -176,6 +177,8 @@ typedef struct XrWin32WindowBindingCreateInfoEXT {
 | **Offscreen** | NULL | NULL | — | `readbackCallback` receives composited pixels. No window, no phase alignment. |
 
 > **Important for `_texture` apps:** You **must** provide a valid `windowHandle` even though the runtime renders into the shared texture, not the window. Without the HWND, the display processor cannot compute correct interlacing alignment (see [§2.4](#24-the-phase-alignment-problem)). Additionally, call `xrSetSharedTextureOutputRectEXT` (see [§3.5](#35-xrsetsharedtextureoutputrectext)) to tell the runtime where within the window the 3D canvas appears.
+>
+> **Filling the area around the canvas:** Pixels of the target swapchain *outside* the canvas sub-rect are undefined by default — the runtime only writes the canvas region. To fill the surrounding window area with full-resolution 2D content (UI, toolbars, chrome), register a second shared texture via `xrSetSharedTextureSurround2DEXT` (see [§3.6](#36-xrsetsharedtexturesurround2dext)). This is the canonical path for apps on displays with a fixed hardware 3D zone, where the canvas is constrained to a specific sub-rect and the rest of the window needs ordinary 2D pixels.
 
 **Fallback when absent:**
 
@@ -339,6 +342,107 @@ sampled  = texture.Sample(smp, uvOffset + uv * uvScale)
 The contract is symmetric: the app sends `(x, y, w, h)`; the runtime writes `(w × h)` at `(x, y)`; the app reads `(w × h)` from `(x, y)`.
 
 This is required because vendor weavers (e.g. Leia SR) compute lenticular phase from the viewport's screen-space position. Writing at `(x, y)` keeps the on-display pixel position of the weaved output stable regardless of the shared texture's dimensions (which are typically worst-case display-sized and may differ from the HWND client area), and the symmetric read-back reproduces the same HWND coords. Apps that sample from origin will render in the wrong place and exhibit crosstalk on lenticular displays.
+
+### 3.6 xrSetSharedTextureSurround2DEXT
+
+For `_texture` apps whose 3D canvas is a sub-rect of the window — typically constrained by a display with a fixed hardware 3D zone (e.g. a centered viewport on a panel where the surrounding pixels are 2D-native) — this function registers a **full-window 2D shared texture** whose pixels outside the canvas sub-rect are blitted into the target swapchain each frame.
+
+The 3D canvas (set via `xrSetSharedTextureOutputRectEXT`) is still weaved by the display processor and overwrites whatever the surround texture contains in that sub-rect. The surround texture exclusively provides the *non*-canvas pixels.
+
+```c
+typedef XrResult (XRAPI_PTR *PFN_xrSetSharedTextureSurround2DEXT)(
+    XrSession session,
+    void*     sharedTextureHandle,
+    uint32_t  width,
+    uint32_t  height);
+```
+
+**Parameters:**
+
+| Parameter | Description |
+|-----------|-------------|
+| `session` | The session. Must have been created with `XrWin32WindowBindingCreateInfoEXT`. |
+| `sharedTextureHandle` | Shared D3D11/D3D12 NT `HANDLE` for the 2D surround texture, or `NULL` to clear. |
+| `width` | Texture width in pixels. Must equal the HWND client-area width. |
+| `height` | Texture height in pixels. Must equal the HWND client-area height. |
+
+**Returns:**
+
+| Result | Meaning |
+|---|---|
+| `XR_SUCCESS` | Texture registered (or cleared if `sharedTextureHandle == NULL`). |
+| `XR_ERROR_FUNCTION_UNSUPPORTED` | Extension not enabled or runtime build predates spec v6. |
+| `XR_ERROR_VALIDATION_FAILURE` | `width × height` does not match the current HWND client-area dimensions. |
+| `XR_ERROR_HANDLE_INVALID` | Runtime could not `OpenSharedResource` on the handle. |
+
+**Valid Usage:**
+- Session must have been created with `XrWin32WindowBindingCreateInfoEXT` (or `XrCocoaWindowBindingCreateInfoEXT` on macOS).
+- The handle must be a D3D11 or D3D12 NT handle (`CreateSharedHandle` flow). DXGI legacy shared handles are not supported.
+- The texture's pixel format must be `DXGI_FORMAT_R8G8B8A8_UNORM` or `DXGI_FORMAT_R8G8B8A8_UNORM_SRGB`. The runtime opens both UNORM and UNORM_SRGB SRVs on the underlying resource and selects at sample time based on the texture's actual format, matching the color-space handling pattern documented in [`compositor-pipeline.md`](../../architecture/compositor-pipeline.md#color-space-handling-d3d11-service-compositor-shell-mode).
+- The texture must include `D3D11_RESOURCE_MISC_SHARED_NTHANDLE | D3D11_RESOURCE_MISC_SHARED_KEYEDMUTEX` (D3D12: `D3D12_HEAP_FLAG_SHARED | D3D12_HEAP_FLAG_SHARED_CROSS_ADAPTER` as appropriate) so the runtime can synchronize via `IDXGIKeyedMutex`.
+- The synchronization key is **0**: app `AcquireSync(0)` before writing, `ReleaseSync(0)` when done; runtime `AcquireSync(0)` before sampling, `ReleaseSync(0)` after submitting the frame. Symmetric to the multiview shared texture.
+- Call with `sharedTextureHandle = NULL` to disable the surround blit. Non-canvas pixels of the target swapchain then fall back to undefined (the spec v5 behavior).
+- On window resize (`WM_SIZE` triggers a new HWND client size), the app allocates a new shared texture at the new size and calls this function again. Calling with stale dimensions returns `XR_ERROR_VALIDATION_FAILURE`.
+
+**Loaded at runtime via:**
+
+```c
+PFN_xrSetSharedTextureSurround2DEXT pfnSetSurround2D = NULL;
+xrGetInstanceProcAddr(instance, "xrSetSharedTextureSurround2DEXT",
+    (PFN_xrVoidFunction*)&pfnSetSurround2D);
+```
+
+**Pipeline integration:**
+
+Per frame, after the display processor's `process_atlas()` writes the weaved output into the canvas sub-rect of the target swapchain, the compositor runs a **surround blit pass**:
+
+```
+for each pixel (px, py) in the target swapchain:
+    if (px, py) is INSIDE the canvas rect from xrSetSharedTextureOutputRectEXT:
+        leave the DP's weaved output as-is
+    else:
+        sample surround_texture at (px, py)  // 1:1 mapping
+        write to target swapchain at (px, py)
+```
+
+The 1:1 mapping is enforced by the size-equality requirement — surround texture dimensions must equal the HWND client area, which equals the target swapchain dimensions. No scaling, no UV math, no filtering.
+
+The compositor scissor-rects the blit to the four non-canvas regions (top strip / bottom strip / left strip / right strip), or equivalently runs a shader-blit with a "skip the canvas rect" branch. Implementation choice is per-graphics-API.
+
+**Example (Unity editor with fixed-zone display):**
+
+```c
+// At session start, after creating the multiview shared texture and HWND:
+
+// 1. Tell the runtime where the 3D canvas is (set by hardware constraint).
+xrSetSharedTextureOutputRectEXT(session, zoneX, zoneY, zoneW, zoneH);
+
+// 2. Allocate a full-window 2D shared texture for the surround UI.
+//    Unity renders its 2D viewport chrome (toolbars, panels, status bar)
+//    into this texture each frame via a RenderTexture / RenderTarget.
+HANDLE surroundHandle = CreateD3D11SharedKeyedMutexTexture(
+    windowClientWidth, windowClientHeight, DXGI_FORMAT_R8G8B8A8_UNORM_SRGB);
+
+// 3. Register it with the runtime.
+pfnSetSurround2D(session, surroundHandle, windowClientWidth, windowClientHeight);
+
+// Per frame: Unity writes 2D UI into the surround texture (acquire/release key 0),
+// the runtime samples it after weave, blits non-canvas pixels into the target swapchain.
+```
+
+**Read-back contract:**
+
+There is no read-back. The surround texture is **input only** — the runtime reads it, the app writes it, the data never round-trips. (Contrast with the multiview shared texture, where the runtime writes the canvas region and the app reads it back to present.) Apps must blit the runtime-produced output to their window themselves; the surround texture is unrelated to that read-back.
+
+**Interaction with `xrSetSharedTextureOutputRectEXT`:**
+
+The two functions are independent and can be called in any order. The canvas rect is queried each frame at submit time, so changing it between frames is supported. If the canvas rect is changed mid-session, the surround blit boundary changes correspondingly on the next frame — no need to re-register the surround texture.
+
+If `xrSetSharedTextureOutputRectEXT` is never called, the canvas defaults to the full window, and the surround region is empty. Registering a surround texture in that case is legal but has no effect.
+
+**Fallback when not called:**
+
+If the app never calls this function, the runtime preserves the spec v5 behavior: non-canvas pixels of the target swapchain are undefined. Apps with `canvas == window` (most handle apps) are unaffected and need not call this function.
 
 ---
 

--- a/docs/specs/extensions/XR_EXT_win32_window_binding.md
+++ b/docs/specs/extensions/XR_EXT_win32_window_binding.md
@@ -137,6 +137,7 @@ The two concepts are inseparable: window-space layers only make sense when there
 | 4 | `transparentBackgroundEnabled` — runtime configures DComp / DXGI for per-pixel desktop transparency. |
 | 5 | `chromaKeyColor` — optional app-supplied chroma-key override. `0` = runtime DP picks its own default. |
 | 6 | `xrSetSharedTextureSurround2DEXT` — register a full-window 2D shared texture for the non-canvas region. Enables apps with a fixed 3D zone (sub-rect canvas) to deliver full-resolution 2D content for the surrounding area. See [§3.6](#36-xrsetsharedtexturesurround2dext). |
+| 7 | `xrSetSharedTextureSurround2DFenceEXT` — D3D12 variant of §3.6 that uses `ID3D12Fence` for producer→consumer sync. D3D12-native shared resources do not reliably expose `IDXGIKeyedMutex`, so the spec-v6 API does not work for D3D12 apps. See [§3.7](#37-xrsetsharedtexturesurround2dfenceext). |
 
 ### 3.2 XrWin32WindowBindingCreateInfoEXT
 
@@ -443,6 +444,112 @@ If `xrSetSharedTextureOutputRectEXT` is never called, the canvas defaults to the
 **Fallback when not called:**
 
 If the app never calls this function, the runtime preserves the spec v5 behavior: non-canvas pixels of the target swapchain are undefined. Apps with `canvas == window` (most handle apps) are unaffected and need not call this function.
+
+### 3.7 xrSetSharedTextureSurround2DFenceEXT
+
+D3D12-only variant of [§3.6](#36-xrsetsharedtexturesurround2dext) that uses an `ID3D12Fence` (shared NT handle) for producer→consumer synchronization instead of `IDXGIKeyedMutex`.
+
+**Motivation.** D3D12-native shared resources — those created via `D3D12_HEAP_FLAG_SHARED` + `ID3D12Device::CreateSharedHandle` — do not reliably expose `IDXGIKeyedMutex` when re-opened via `ID3D12Device::OpenSharedHandle`. `QueryInterface(__uuidof(IDXGIKeyedMutex))` returns `E_NOINTERFACE` on common Windows/driver combinations (verified on NVIDIA RTX, default Windows 11 drivers, 2026-05). Spec v6's keyed-mutex contract therefore fails for D3D12 apps that allocate the surround texture on their own D3D12 device.
+
+`ID3D12Fence` is the canonical D3D12 cross-process sync primitive, is shareable via `CreateSharedHandle`, and integrates cleanly with `ID3D12CommandQueue::Wait` / `Signal`. No keyed-mutex semantics are needed: the runtime only reads from the surround texture, so a producer-signal + consumer-wait pair is sufficient.
+
+```c
+typedef XrResult (XRAPI_PTR *PFN_xrSetSharedTextureSurround2DFenceEXT)(
+    XrSession session,
+    void*     sharedTextureHandle,
+    uint32_t  width,
+    uint32_t  height,
+    void*     sharedFenceHandle,
+    uint64_t  awaitFenceValue);
+```
+
+**Parameters:**
+
+| Parameter | Description |
+|-----------|-------------|
+| `session` | The session. Must have been created with `XrWin32WindowBindingCreateInfoEXT`. |
+| `sharedTextureHandle` | Shared D3D12 texture NT `HANDLE`, or `NULL` to clear. |
+| `width` | Texture width in pixels. Must equal the dst-swapchain width seen by the strip blit. |
+| `height` | Texture height in pixels. |
+| `sharedFenceHandle` | Shared `ID3D12Fence` NT `HANDLE`. Ignored when `sharedTextureHandle == NULL`. |
+| `awaitFenceValue` | Fence value the runtime should wait on before reading the surround texture this frame. Must monotonically increase across calls. |
+
+**Returns:**
+
+| Result | Meaning |
+|---|---|
+| `XR_SUCCESS` | Registered (or cleared if `sharedTextureHandle == NULL`). |
+| `XR_ERROR_FUNCTION_UNSUPPORTED` | Runtime predates spec v7 or current compositor is not D3D12 native. |
+| `XR_ERROR_HANDLE_INVALID` | Either handle could not be opened. |
+| `XR_ERROR_VALIDATION_FAILURE` | Dimension mismatch with the opened texture. |
+
+**Valid usage:**
+- Session must have been created with `XrWin32WindowBindingCreateInfoEXT` and the graphics binding must be D3D12.
+- The texture must be created with `D3D12_HEAP_FLAG_SHARED` + a render-target-capable resource flag; NT handle is obtained via `ID3D12Device::CreateSharedHandle`.
+- The fence must be created with `D3D12_FENCE_FLAG_SHARED`; NT handle is obtained via the same `CreateSharedHandle` call.
+- Texture format must match the dst the strip blit writes into (for `_texture` apps this is the multiview shared texture's format; `DXGI_FORMAT_B8G8R8A8_UNORM` is the canonical choice).
+- `awaitFenceValue` must be strictly greater than the previous frame's value once steady state begins. The first call may use any value (the fence's `GetCompletedValue()` starts at 0, so the runtime's queue wait returns immediately for the seed call).
+- The app must `ID3D12CommandQueue::Signal(fence, awaitFenceValue)` **after** the frame's surround render submission and **before** the matching `xrEndFrame`, so the runtime's wait can resolve.
+- Mutually exclusive with [§3.6](#36-xrsetsharedtexturesurround2dext) on the same session — calling one clears the other's registration.
+
+**Pipeline integration:**
+
+Per frame:
+```
+app:                                  runtime (at xrEndFrame):
+  Reset() + Record(surround render)
+  ExecuteCommandLists(cmdList)
+  commandQueue->Signal(fence, N)
+  xrSetSharedTextureSurround2DFenceEXT(
+      session, texH, w, h, fenceH, N)
+                                      commandQueue->Wait(fence, N)
+                                      Record(strip blit) into c->cmd_list
+                                      ExecuteCommandLists(c->cmd_list)
+                                      // blit waits for app's Signal(fence,N)
+                                      // before reading surround texture
+```
+
+The runtime caches `(textureHandle, fenceHandle)` by pointer equality on first call. Subsequent calls with the same handles only update `awaitFenceValue` (no re-open, no extra `OpenSharedHandle` cost). Passing different handle values triggers a re-registration cycle and clears the cached opens.
+
+**Worked example (D3D12 app with 60% canvas + animated 2D surround):**
+
+```c
+// At session start:
+PFN_xrSetSharedTextureSurround2DFenceEXT pfnSetSurround2DFence = NULL;
+xrGetInstanceProcAddr(instance, "xrSetSharedTextureSurround2DFenceEXT",
+    (PFN_xrVoidFunction*)&pfnSetSurround2DFence);
+
+ID3D12Resource* surroundTex = NULL;
+device->CreateCommittedResource(&heapProps, D3D12_HEAP_FLAG_SHARED, &texDesc,
+    D3D12_RESOURCE_STATE_COMMON, NULL, IID_PPV_ARGS(&surroundTex));
+HANDLE surroundTexH;
+device->CreateSharedHandle(surroundTex, NULL, GENERIC_ALL, NULL, &surroundTexH);
+
+ID3D12Fence* surroundFence = NULL;
+device->CreateFence(0, D3D12_FENCE_FLAG_SHARED, IID_PPV_ARGS(&surroundFence));
+HANDLE surroundFenceH;
+device->CreateSharedHandle(surroundFence, NULL, GENERIC_ALL, NULL, &surroundFenceH);
+
+uint64_t fenceValue = 0;
+pfnSetSurround2DFence(session, surroundTexH, w, h, surroundFenceH, fenceValue);
+                                                 // seed: await=0, GetCompletedValue()==0,
+                                                 // first wait returns immediately
+xrSetSharedTextureOutputRectEXT(session, cx, cy, cw, ch);  // canvas 60%
+
+// Per frame:
+//   1. Record surround pattern into cmdList (RENDER_TARGET barrier, draw, COMMON barrier)
+//   2. cmdList->Close(); commandQueue->ExecuteCommandLists(1, &cmdList);
+//   3. fenceValue++; commandQueue->Signal(surroundFence, fenceValue);
+//   4. pfnSetSurround2DFence(session, surroundTexH, w, h, surroundFenceH, fenceValue);
+//   5. xrEndFrame(...);   // runtime queue-waits for surroundFence >= fenceValue,
+                              // then runs the strip blit
+```
+
+**Read-back contract:** identical to §3.6 — the surround texture is input only.
+
+**Interaction with the canvas rect:** identical to §3.6.
+
+**Fallback when not called:** identical to §3.6.
 
 ---
 

--- a/src/external/openxr_includes/openxr/XR_EXT_cocoa_window_binding.h
+++ b/src/external/openxr_includes/openxr/XR_EXT_cocoa_window_binding.h
@@ -35,7 +35,7 @@ extern "C" {
 #endif
 
 #define XR_EXT_cocoa_window_binding 1
-#define XR_EXT_cocoa_window_binding_SPEC_VERSION 5
+#define XR_EXT_cocoa_window_binding_SPEC_VERSION 6
 #define XR_EXT_COCOA_WINDOW_BINDING_EXTENSION_NAME "XR_EXT_cocoa_window_binding"
 
 // Use a value in the vendor extension range (1000000000+)
@@ -141,6 +141,52 @@ XRAPI_ATTR XrResult XRAPI_CALL xrSetSharedTextureOutputRectEXT(
     XrSession                           session,
     int32_t                             x,
     int32_t                             y,
+    uint32_t                            width,
+    uint32_t                            height);
+#endif
+
+// ---- 2D Surround Texture (Spec v6) ----
+
+/*!
+ * @brief Register a full-view 2D IOSurface whose pixels OUTSIDE the canvas
+ *        sub-rect are blitted into the target swapchain each frame.
+ *
+ * macOS counterpart to the Win32 version. Signature, lifecycle, and semantics
+ * are identical except: sharedTextureHandle is an IOSurfaceRef (cast to void*),
+ * synchronization uses Metal fences + IOSurface use-count rather than
+ * IDXGIKeyedMutex, and pixel format must be MTLPixelFormatRGBA8Unorm or
+ * MTLPixelFormatRGBA8Unorm_sRGB.
+ *
+ * See XR_EXT_win32_window_binding.h for the full semantic description.
+ *
+ * @param session             The session (must have been created with a
+ *                            window binding).
+ * @param sharedTextureHandle IOSurfaceRef for the 2D surround texture, or NULL
+ *                            to clear.
+ * @param width               Texture width in physical (post-Retina) pixels.
+ *                            Must equal the NSView backing-store width.
+ * @param height              Texture height in physical pixels. Must equal
+ *                            the NSView backing-store height.
+ *
+ * @return XR_SUCCESS on success.
+ *         XR_ERROR_FUNCTION_UNSUPPORTED if the extension is not enabled.
+ *         XR_ERROR_VALIDATION_FAILURE if the dimensions do not match the
+ *         current NSView backing size.
+ *         XR_ERROR_HANDLE_INVALID if the IOSurface cannot be referenced.
+ */
+#ifndef PFN_xrSetSharedTextureSurround2DEXT_DEFINED
+#define PFN_xrSetSharedTextureSurround2DEXT_DEFINED
+typedef XrResult (XRAPI_PTR *PFN_xrSetSharedTextureSurround2DEXT)(
+    XrSession session,
+    void*     sharedTextureHandle,
+    uint32_t  width,
+    uint32_t  height);
+#endif
+
+#ifndef XR_NO_PROTOTYPES
+XRAPI_ATTR XrResult XRAPI_CALL xrSetSharedTextureSurround2DEXT(
+    XrSession                           session,
+    void*                               sharedTextureHandle,
     uint32_t                            width,
     uint32_t                            height);
 #endif

--- a/src/external/openxr_includes/openxr/XR_EXT_win32_window_binding.h
+++ b/src/external/openxr_includes/openxr/XR_EXT_win32_window_binding.h
@@ -30,7 +30,7 @@ extern "C" {
 #endif
 
 #define XR_EXT_win32_window_binding 1
-#define XR_EXT_win32_window_binding_SPEC_VERSION 5
+#define XR_EXT_win32_window_binding_SPEC_VERSION 6
 #define XR_EXT_WIN32_WINDOW_BINDING_EXTENSION_NAME "XR_EXT_win32_window_binding"
 
 // Use a value in the vendor extension range (1000000000+)
@@ -167,6 +167,70 @@ XRAPI_ATTR XrResult XRAPI_CALL xrSetSharedTextureOutputRectEXT(
     XrSession                           session,
     int32_t                             x,
     int32_t                             y,
+    uint32_t                            width,
+    uint32_t                            height);
+#endif
+
+// ---- 2D Surround Texture (Spec v6) ----
+
+/*!
+ * @brief Register a full-window 2D shared texture whose pixels OUTSIDE the
+ *        canvas sub-rect are blitted into the target swapchain each frame.
+ *
+ * Pairs with xrSetSharedTextureOutputRectEXT for _texture apps that want to
+ * fill the non-3D part of their window with full-resolution 2D content (UI,
+ * chrome, toolbars, status bars). The runtime samples this texture each frame
+ * and copies the pixels OUTSIDE the active canvas rect into the corresponding
+ * region of the target swapchain. Pixels INSIDE the canvas rect are ignored —
+ * that region is owned by the display processor's weaved output.
+ *
+ * The texture must be a D3D11 or D3D12 shared texture (NT HANDLE), sized to
+ * match the target swapchain dimensions (HWND client area in physical pixels).
+ * The runtime opens the handle once and re-uses it across frames; the app
+ * writes into the texture asynchronously and the runtime samples at frame
+ * submit time. Synchronization follows the same IDXGIKeyedMutex pattern as
+ * the multiview shared texture registered via XrWin32WindowBindingCreateInfoEXT
+ * (key 0 = "app done writing, runtime may read").
+ *
+ * Lifecycle:
+ * - Call with a non-NULL handle to register or replace the surround texture.
+ * - Call with NULL handle to clear — runtime falls back to undefined non-canvas
+ *   pixels (the spec v5 behavior).
+ * - If the window is resized, the app must allocate a new shared texture at
+ *   the new size and call this function again.
+ *
+ * Texture format: DXGI_FORMAT_R8G8B8A8_UNORM or DXGI_FORMAT_R8G8B8A8_UNORM_SRGB.
+ * The runtime selects the matching SRV at sample time so linearization is
+ * correct regardless of which format the app chose.
+ *
+ * @param session             The session (must have been created with a
+ *                            window binding).
+ * @param sharedTextureHandle Shared D3D11/D3D12 texture HANDLE for the 2D
+ *                            surround content, or NULL to clear.
+ * @param width               Texture width in pixels. Must equal the HWND
+ *                            client-area width.
+ * @param height              Texture height in pixels. Must equal the HWND
+ *                            client-area height.
+ *
+ * @return XR_SUCCESS on success.
+ *         XR_ERROR_FUNCTION_UNSUPPORTED if the extension is not enabled.
+ *         XR_ERROR_VALIDATION_FAILURE if the dimensions do not match the
+ *         current HWND client area.
+ *         XR_ERROR_HANDLE_INVALID if the shared handle cannot be opened.
+ */
+#ifndef PFN_xrSetSharedTextureSurround2DEXT_DEFINED
+#define PFN_xrSetSharedTextureSurround2DEXT_DEFINED
+typedef XrResult (XRAPI_PTR *PFN_xrSetSharedTextureSurround2DEXT)(
+    XrSession session,
+    void*     sharedTextureHandle,
+    uint32_t  width,
+    uint32_t  height);
+#endif
+
+#ifndef XR_NO_PROTOTYPES
+XRAPI_ATTR XrResult XRAPI_CALL xrSetSharedTextureSurround2DEXT(
+    XrSession                           session,
+    void*                               sharedTextureHandle,
     uint32_t                            width,
     uint32_t                            height);
 #endif

--- a/src/external/openxr_includes/openxr/XR_EXT_win32_window_binding.h
+++ b/src/external/openxr_includes/openxr/XR_EXT_win32_window_binding.h
@@ -30,7 +30,7 @@ extern "C" {
 #endif
 
 #define XR_EXT_win32_window_binding 1
-#define XR_EXT_win32_window_binding_SPEC_VERSION 6
+#define XR_EXT_win32_window_binding_SPEC_VERSION 7
 #define XR_EXT_WIN32_WINDOW_BINDING_EXTENSION_NAME "XR_EXT_win32_window_binding"
 
 // Use a value in the vendor extension range (1000000000+)
@@ -233,6 +233,86 @@ XRAPI_ATTR XrResult XRAPI_CALL xrSetSharedTextureSurround2DEXT(
     void*                               sharedTextureHandle,
     uint32_t                            width,
     uint32_t                            height);
+#endif
+
+// ---- 2D Surround Texture with Fence Sync (Spec v7) ----
+
+/*!
+ * @brief D3D12 variant of xrSetSharedTextureSurround2DEXT that uses an
+ *        ID3D12Fence for producer→consumer synchronization instead of
+ *        IDXGIKeyedMutex.
+ *
+ * Rationale: D3D12-native shared resources (those created via
+ * D3D12_HEAP_FLAG_SHARED + ID3D12Device::CreateSharedHandle) do not reliably
+ * expose IDXGIKeyedMutex when re-opened via OpenSharedHandle — QueryInterface
+ * returns E_NOINTERFACE on common Windows/driver combinations. ID3D12Fence is
+ * the canonical D3D12 cross-process sync primitive and is shareable via
+ * CreateSharedHandle.
+ *
+ * Semantics:
+ *   1. App allocates the surround texture as a D3D12 SHARED resource (no
+ *      KeyedMutex needed) and a shared ID3D12Fence. Exports NT handles for
+ *      both via ID3D12Device::CreateSharedHandle.
+ *   2. Each frame, after recording surround content into the texture and
+ *      calling ExecuteCommandLists, the app calls
+ *      ID3D12CommandQueue::Signal(fence, value).
+ *   3. App calls this function with the same handles + the value it just
+ *      signaled.
+ *   4. The runtime caches both handles on first call (opened via
+ *      ID3D12Device::OpenSharedHandle for the texture and OpenSharedFence
+ *      for the fence). On subsequent calls with the same handle values, it
+ *      reuses the cached opens and just updates the await value.
+ *   5. At submit time the runtime issues ID3D12CommandQueue::Wait(fence,
+ *      awaitFenceValue) on its own queue before the strip blit reads from
+ *      the surround texture. Read-only access, so no signal-back is needed.
+ *   6. Per-frame fenceValue MUST monotonically increase. The first call may
+ *      use any value; subsequent calls must use strictly greater values, or
+ *      the runtime may block forever on the queue wait.
+ *   7. Call with NULL sharedTextureHandle to clear (the fence handle is
+ *      ignored in the clear case).
+ *
+ * The D3D11 keyed-mutex path (xrSetSharedTextureSurround2DEXT) and the D3D12
+ * fence path are mutually exclusive per session. The runtime tracks which one
+ * the app used and rejects the other for the same session.
+ *
+ * @param session             The session.
+ * @param sharedTextureHandle Shared D3D12 texture NT HANDLE, or NULL to clear.
+ * @param width               Texture width in pixels.
+ * @param height              Texture height in pixels.
+ * @param sharedFenceHandle   Shared ID3D12Fence NT HANDLE. May be NULL only
+ *                            when sharedTextureHandle is NULL (clear case).
+ * @param awaitFenceValue     Fence value the runtime should wait on before
+ *                            reading the surround texture this frame. Must
+ *                            be strictly greater than the previous frame's
+ *                            value once steady-state begins.
+ *
+ * @return XR_SUCCESS on success.
+ *         XR_ERROR_FUNCTION_UNSUPPORTED if the runtime predates spec v7 or
+ *           the active compositor does not support fence-based surround
+ *           (currently D3D12 only).
+ *         XR_ERROR_HANDLE_INVALID if either handle cannot be opened.
+ *         XR_ERROR_VALIDATION_FAILURE on dimension mismatch or non-monotonic
+ *           awaitFenceValue.
+ */
+#ifndef PFN_xrSetSharedTextureSurround2DFenceEXT_DEFINED
+#define PFN_xrSetSharedTextureSurround2DFenceEXT_DEFINED
+typedef XrResult (XRAPI_PTR *PFN_xrSetSharedTextureSurround2DFenceEXT)(
+    XrSession session,
+    void*     sharedTextureHandle,
+    uint32_t  width,
+    uint32_t  height,
+    void*     sharedFenceHandle,
+    uint64_t  awaitFenceValue);
+#endif
+
+#ifndef XR_NO_PROTOTYPES
+XRAPI_ATTR XrResult XRAPI_CALL xrSetSharedTextureSurround2DFenceEXT(
+    XrSession                           session,
+    void*                               sharedTextureHandle,
+    uint32_t                            width,
+    uint32_t                            height,
+    void*                               sharedFenceHandle,
+    uint64_t                            awaitFenceValue);
 #endif
 
 #ifdef __cplusplus

--- a/src/xrt/auxiliary/util/u_canvas.h
+++ b/src/xrt/auxiliary/util/u_canvas.h
@@ -42,6 +42,29 @@ struct u_canvas_rect
 };
 
 /*!
+ * 2D surround shared texture — full-window mono buffer whose pixels OUTSIDE
+ * the canvas sub-rect are blitted into the target swapchain each frame.
+ *
+ * Set via xrSetSharedTextureSurround2DEXT (spec v6 addition to
+ * XR_EXT_win32_window_binding / XR_EXT_cocoa_window_binding). Pairs with
+ * struct u_canvas_rect — the canvas is "where 3D goes," the surround is
+ * "what fills the rest." See docs/specs/extensions/XR_EXT_win32_window_binding.md §3.6.
+ *
+ * The handle is a D3D11/D3D12 NT HANDLE on Windows, an IOSurfaceRef cast
+ * to void* on macOS. The compositor opens it lazily on first use and
+ * releases on clear / replace / session teardown. Dimensions MUST equal
+ * the HWND/NSView client-area dimensions — the runtime does a 1:1 blit
+ * with scissor-rects around the canvas hole, no scaling.
+ */
+struct u_surround_2d_handle
+{
+	bool valid;             //!< True if a surround texture has been registered
+	void *shared_handle;    //!< NT HANDLE (Win) / IOSurfaceRef (Mac), or NULL
+	uint32_t w;             //!< Texture width in pixels (== HWND client width)
+	uint32_t h;             //!< Texture height in pixels (== HWND client height)
+};
+
+/*!
  * Apply canvas output rect to window metrics.
  *
  * When a shared-texture app has set an output rect, the "window" fields in

--- a/src/xrt/compositor/d3d11/comp_d3d11_compositor.cpp
+++ b/src/xrt/compositor/d3d11/comp_d3d11_compositor.cpp
@@ -139,6 +139,12 @@ struct comp_d3d11_compositor
 	//! sub-rect instead of the full client rect.
 	struct u_canvas_rect canvas;
 
+	//! 2D surround texture handle (Spec v6).
+	//! When valid, the compositor blits non-canvas pixels from this texture
+	//! into the target swapchain each frame. See comp_d3d11_compositor.h for
+	//! the full contract.
+	struct u_surround_2d_handle surround_2d;
+
 	//! Generic D3D11 display processor (vendor-agnostic weaving).
 	struct xrt_display_processor_d3d11 *display_processor;
 
@@ -1935,6 +1941,30 @@ comp_d3d11_compositor_set_output_rect(struct xrt_compositor *xc,
 	c->canvas.y = y;
 	c->canvas.w = w;
 	c->canvas.h = h;
+}
+
+extern "C" void
+comp_d3d11_compositor_set_surround_2d(struct xrt_compositor *xc,
+                                       void *shared_handle,
+                                       uint32_t w, uint32_t h)
+{
+	struct comp_d3d11_compositor *c = d3d11_comp(xc);
+	if (shared_handle == nullptr) {
+		// Clear — falls back to undefined non-canvas pixels.
+		// Phase C TODO: release the opened ID3D11Texture2D + KeyedMutex here.
+		c->surround_2d = {};
+		U_LOG_IFL_I(U_LOGGING_INFO, "D3D11 surround 2D cleared");
+		return;
+	}
+	c->surround_2d.valid = true;
+	c->surround_2d.shared_handle = shared_handle;
+	c->surround_2d.w = w;
+	c->surround_2d.h = h;
+	// Phase C TODO: ID3D11Device::OpenSharedResource1 here, cache the
+	// ID3D11Texture2D* + IDXGIKeyedMutex* + UNORM/SRGB SRVs on the
+	// compositor for the per-frame surround blit pass to consume.
+	U_LOG_IFL_I(U_LOGGING_INFO, "D3D11 surround 2D registered: handle=%p %ux%u (open + blit pending Phase C)",
+	            shared_handle, w, h);
 }
 
 extern "C" bool

--- a/src/xrt/compositor/d3d11/comp_d3d11_compositor.cpp
+++ b/src/xrt/compositor/d3d11/comp_d3d11_compositor.cpp
@@ -2148,8 +2148,11 @@ comp_d3d11_compositor_set_surround_2d(struct xrt_compositor *xc,
 		return;
 	}
 
-	HANDLE h = static_cast<HANDLE>(shared_handle);
-	hr = device1->OpenSharedResource1(h, __uuidof(ID3D11Texture2D),
+	// Name the local 'nt_handle' (not 'h') to avoid shadowing the
+	// formal parameter 'h' (the height) — MSVC's stricter parameter
+	// scoping flagged this; clang/gcc let it slide.
+	HANDLE nt_handle = static_cast<HANDLE>(shared_handle);
+	hr = device1->OpenSharedResource1(nt_handle, __uuidof(ID3D11Texture2D),
 	                                   reinterpret_cast<void **>(&c->surround_texture));
 	device1->Release();
 	device1 = nullptr;

--- a/src/xrt/compositor/d3d11/comp_d3d11_compositor.cpp
+++ b/src/xrt/compositor/d3d11/comp_d3d11_compositor.cpp
@@ -34,6 +34,10 @@
 
 #include "xrt/xrt_display_processor_d3d11.h"
 
+// D3D11.1 for ID3D11Device1::OpenSharedResource1 (NT-handle path required for
+// IDXGIKeyedMutex sync — used by xrSetSharedTextureSurround2DEXT, spec v6).
+#include <d3d11_1.h>
+
 #include "util/u_hud.h"
 #include <displayxr_mcp/mcp_capture.h>
 
@@ -145,6 +149,15 @@ struct comp_d3d11_compositor
 	//! the full contract.
 	struct u_surround_2d_handle surround_2d;
 
+	//! Opened surround texture (lazily allocated via OpenSharedResource1
+	//! the first time surround_2d.shared_handle is non-NULL). NULL when no
+	//! surround is registered, or when the open failed.
+	ID3D11Texture2D *surround_texture;
+	//! IDXGIKeyedMutex on surround_texture for cross-process sync (key 0
+	//! protocol: app writes between Acquire(0)/Release(0), runtime samples
+	//! between Acquire(0)/Release(0)).
+	IDXGIKeyedMutex *surround_mutex;
+
 	//! Generic D3D11 display processor (vendor-agnostic weaving).
 	struct xrt_display_processor_d3d11 *display_processor;
 
@@ -232,6 +245,17 @@ d3d11_comp(struct xrt_compositor *xc)
 {
 	return reinterpret_cast<struct comp_d3d11_compositor *>(xc);
 }
+
+// Spec v6 surround-2D helpers. Defined near the bottom of the file
+// alongside comp_d3d11_compositor_set_surround_2d, forward-declared here
+// because they're called from d3d11_compositor_layer_commit and
+// d3d11_compositor_destroy (both defined above the definitions).
+static void d3d11_release_surround(struct comp_d3d11_compositor *c);
+static void d3d11_blit_surround_strips(struct comp_d3d11_compositor *c,
+                                        ID3D11Texture2D *dst,
+                                        uint32_t dst_w, uint32_t dst_h,
+                                        int32_t cx, int32_t cy,
+                                        uint32_t cw, uint32_t ch);
 
 /*
  *
@@ -1325,6 +1349,16 @@ d3d11_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 			    c->canvas.valid ? c->canvas.w : 0,
 			    c->canvas.valid ? c->canvas.h : 0);
 
+			// Spec v6 surround blit: fill non-canvas pixels of the shared
+			// texture from the app-supplied 2D surround texture (no-op if
+			// xrSetSharedTextureSurround2DEXT was never called).
+			d3d11_blit_surround_strips(
+			    c, c->shared_texture, dp_target_w, dp_target_h,
+			    c->canvas.valid ? c->canvas.x : 0,
+			    c->canvas.valid ? c->canvas.y : 0,
+			    c->canvas.valid ? c->canvas.w : dp_target_w,
+			    c->canvas.valid ? c->canvas.h : dp_target_h);
+
 			weaving_done = true;
 		}
 
@@ -1375,6 +1409,20 @@ d3d11_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 		    c->canvas.valid ? c->canvas.y : 0,
 		    c->canvas.valid ? c->canvas.w : 0,
 		    c->canvas.valid ? c->canvas.h : 0);
+
+		// Spec v6 surround blit: fill non-canvas pixels of the DXGI back
+		// buffer from the app-supplied 2D surround texture. The downstream
+		// CopyResource/CopySubresourceRegion (line ~1500) propagates the
+		// composite into c->shared_texture for _texture-mode read-back.
+		ID3D11Texture2D *back_buffer_for_surround = static_cast<ID3D11Texture2D *>(
+		    comp_d3d11_target_get_back_buffer(c->target));
+		d3d11_blit_surround_strips(
+		    c, back_buffer_for_surround, target_width, target_height,
+		    c->canvas.valid ? c->canvas.x : 0,
+		    c->canvas.valid ? c->canvas.y : 0,
+		    c->canvas.valid ? c->canvas.w : target_width,
+		    c->canvas.valid ? c->canvas.h : target_height);
+
 		weaving_done = true;
 	}
 
@@ -1467,6 +1515,10 @@ d3d11_compositor_destroy(struct xrt_compositor *xc)
 		c->shared_texture->Release();
 		c->shared_texture = nullptr;
 	}
+
+	// Spec v6: release the 2D surround texture + keyed mutex if registered.
+	d3d11_release_surround(c);
+	c->surround_2d = {};
 
 	// Destroy HUD
 	if (c->hud_texture != nullptr) {
@@ -1943,28 +1995,203 @@ comp_d3d11_compositor_set_output_rect(struct xrt_compositor *xc,
 	c->canvas.h = h;
 }
 
+// Release any cached surround resources. Idempotent; safe on a freshly
+// zeroed compositor. Used by set_surround_2d (re-register / clear) and
+// the destroy path.
+static void
+d3d11_release_surround(struct comp_d3d11_compositor *c)
+{
+	if (c->surround_mutex != nullptr) {
+		c->surround_mutex->Release();
+		c->surround_mutex = nullptr;
+	}
+	if (c->surround_texture != nullptr) {
+		c->surround_texture->Release();
+		c->surround_texture = nullptr;
+	}
+}
+
+// Blit non-canvas pixels of the surround texture into the dst texture
+// (typically c->shared_texture for _texture apps). Called after the DP
+// has weaved into dst's canvas sub-rect. Acquires the surround
+// KeyedMutex on key 0 around the copies.
+//
+// Strip layout:
+//
+//   +---------------------------------+
+//   |              TOP                |   (0, 0) -> (W, cy)
+//   +------+--------------------+-----+
+//   | LEFT |   <canvas-region>  | RGT |   LEFT  (0, cy) -> (cx, cy+ch)
+//   |      |    (untouched —    |     |   RIGHT (cx+cw, cy) -> (W, cy+ch)
+//   |      |     DP wrote here) |     |
+//   +------+--------------------+-----+
+//   |             BOTTOM              |   (0, cy+ch) -> (W, H)
+//   +---------------------------------+
+//
+// Skips any zero-area strip (canvas flush against an edge). Format
+// match between surround and dst is required for CopySubresourceRegion
+// to succeed — logs a warning and skips the blit on mismatch.
+static void
+d3d11_blit_surround_strips(struct comp_d3d11_compositor *c,
+                            ID3D11Texture2D *dst,
+                            uint32_t dst_w, uint32_t dst_h,
+                            int32_t cx, int32_t cy,
+                            uint32_t cw, uint32_t ch)
+{
+	if (!c->surround_2d.valid || c->surround_texture == nullptr || c->surround_mutex == nullptr) {
+		return;
+	}
+	if (dst == nullptr) {
+		return;
+	}
+
+	// Dimensional contract — surround texture must match the dst the DP
+	// wrote into. The OutputRect canvas may live inside this rect.
+	if (c->surround_2d.w != dst_w || c->surround_2d.h != dst_h) {
+		static bool dims_logged = false;
+		if (!dims_logged) {
+			U_LOG_W("D3D11 surround 2D: dim mismatch — surround %ux%u, target %ux%u. "
+			        "Surround blit skipped. Re-register surround on window resize.",
+			        c->surround_2d.w, c->surround_2d.h, dst_w, dst_h);
+			dims_logged = true;
+		}
+		return;
+	}
+
+	// Format compatibility for CopySubresourceRegion — require equality
+	// for v6. Cross-format (UNORM <-> UNORM_SRGB) would need a shader
+	// blit; deferred to a follow-up if a real workload asks.
+	D3D11_TEXTURE2D_DESC src_desc, dst_desc;
+	c->surround_texture->GetDesc(&src_desc);
+	dst->GetDesc(&dst_desc);
+	if (src_desc.Format != dst_desc.Format) {
+		static bool fmt_logged = false;
+		if (!fmt_logged) {
+			U_LOG_W("D3D11 surround 2D: format mismatch — surround=%u, target=%u. "
+			        "Surround blit skipped. v6 requires matching DXGI formats; "
+			        "cross-format SRGB<->UNORM blit not yet supported.",
+			        src_desc.Format, dst_desc.Format);
+			fmt_logged = true;
+		}
+		return;
+	}
+
+	// Acquire surround for read. Short timeout — if the app's writer is
+	// stuck, we'd rather skip a frame than block presentation.
+	HRESULT hr = c->surround_mutex->AcquireSync(0, 16);
+	if (FAILED(hr)) {
+		// WAIT_TIMEOUT or WAIT_ABANDONED — skip this frame's surround.
+		// Pixels stay as whatever the last successful blit left.
+		return;
+	}
+
+	// Clamp canvas to dst bounds in case the app submitted a degenerate rect.
+	uint32_t cx_u = (cx < 0) ? 0u : (uint32_t)cx;
+	uint32_t cy_u = (cy < 0) ? 0u : (uint32_t)cy;
+	if (cx_u > dst_w) cx_u = dst_w;
+	if (cy_u > dst_h) cy_u = dst_h;
+	uint32_t cright  = (cx_u + cw > dst_w) ? dst_w : cx_u + cw;
+	uint32_t cbottom = (cy_u + ch > dst_h) ? dst_h : cy_u + ch;
+
+	// Top strip: full width, y in [0, cy_u).
+	if (cy_u > 0) {
+		D3D11_BOX box = {0, 0, 0, dst_w, cy_u, 1};
+		c->context->CopySubresourceRegion(dst, 0, 0, 0, 0, c->surround_texture, 0, &box);
+	}
+	// Bottom strip: full width, y in [cbottom, dst_h).
+	if (cbottom < dst_h) {
+		D3D11_BOX box = {0, cbottom, 0, dst_w, dst_h, 1};
+		c->context->CopySubresourceRegion(dst, 0, 0, cbottom, 0, c->surround_texture, 0, &box);
+	}
+	// Left strip: x in [0, cx_u), y in [cy_u, cbottom).
+	if (cx_u > 0 && cbottom > cy_u) {
+		D3D11_BOX box = {0, cy_u, 0, cx_u, cbottom, 1};
+		c->context->CopySubresourceRegion(dst, 0, 0, cy_u, 0, c->surround_texture, 0, &box);
+	}
+	// Right strip: x in [cright, dst_w), y in [cy_u, cbottom).
+	if (cright < dst_w && cbottom > cy_u) {
+		D3D11_BOX box = {cright, cy_u, 0, dst_w, cbottom, 1};
+		c->context->CopySubresourceRegion(dst, 0, cright, cy_u, 0, c->surround_texture, 0, &box);
+	}
+
+	c->surround_mutex->ReleaseSync(0);
+}
+
 extern "C" void
 comp_d3d11_compositor_set_surround_2d(struct xrt_compositor *xc,
                                        void *shared_handle,
                                        uint32_t w, uint32_t h)
 {
 	struct comp_d3d11_compositor *c = d3d11_comp(xc);
+
+	// Release previous registration (no-op on first call). This also covers
+	// the NULL-handle clear path — caller passes NULL, we release and zero
+	// the struct.
+	d3d11_release_surround(c);
+
 	if (shared_handle == nullptr) {
-		// Clear — falls back to undefined non-canvas pixels.
-		// Phase C TODO: release the opened ID3D11Texture2D + KeyedMutex here.
 		c->surround_2d = {};
 		U_LOG_IFL_I(U_LOGGING_INFO, "D3D11 surround 2D cleared");
 		return;
 	}
+
+	// Open the NT shared handle. The OpenSharedResource1 path (vs legacy
+	// OpenSharedResource) is required by spec v6 because we need
+	// IDXGIKeyedMutex on the resource. Cast to ID3D11Device1 — D3D11 native
+	// compositor always creates a D3D11.1+ device.
+	ID3D11Device1 *device1 = nullptr;
+	HRESULT hr = c->device->QueryInterface(__uuidof(ID3D11Device1),
+	                                        reinterpret_cast<void **>(&device1));
+	if (FAILED(hr) || device1 == nullptr) {
+		U_LOG_E("D3D11 surround 2D: device does not implement ID3D11Device1 (hr=0x%08x)", hr);
+		c->surround_2d = {};
+		return;
+	}
+
+	HANDLE h = static_cast<HANDLE>(shared_handle);
+	hr = device1->OpenSharedResource1(h, __uuidof(ID3D11Texture2D),
+	                                   reinterpret_cast<void **>(&c->surround_texture));
+	device1->Release();
+	device1 = nullptr;
+	if (FAILED(hr) || c->surround_texture == nullptr) {
+		U_LOG_E("D3D11 surround 2D: OpenSharedResource1 failed for handle=%p (hr=0x%08x). "
+		        "Ensure the texture was created with D3D11_RESOURCE_MISC_SHARED_NTHANDLE | "
+		        "D3D11_RESOURCE_MISC_SHARED_KEYEDMUTEX.", shared_handle, hr);
+		c->surround_2d = {};
+		c->surround_texture = nullptr;
+		return;
+	}
+
+	// Validate dims against the app's promise (the spec requires it equal
+	// the HWND client area, but we can only check that the registration
+	// dims match the texture's own dims here — the HWND match is enforced
+	// at frame time when we compare against c->shared_texture's dims).
+	D3D11_TEXTURE2D_DESC sd;
+	c->surround_texture->GetDesc(&sd);
+	if (sd.Width != w || sd.Height != h) {
+		U_LOG_E("D3D11 surround 2D: registration dims (%ux%u) do not match opened "
+		        "texture dims (%ux%u)", w, h, sd.Width, sd.Height);
+		d3d11_release_surround(c);
+		c->surround_2d = {};
+		return;
+	}
+
+	hr = c->surround_texture->QueryInterface(__uuidof(IDXGIKeyedMutex),
+	                                          reinterpret_cast<void **>(&c->surround_mutex));
+	if (FAILED(hr) || c->surround_mutex == nullptr) {
+		U_LOG_E("D3D11 surround 2D: opened texture has no IDXGIKeyedMutex "
+		        "(hr=0x%08x). Required for cross-process sync.", hr);
+		d3d11_release_surround(c);
+		c->surround_2d = {};
+		return;
+	}
+
 	c->surround_2d.valid = true;
 	c->surround_2d.shared_handle = shared_handle;
 	c->surround_2d.w = w;
 	c->surround_2d.h = h;
-	// Phase C TODO: ID3D11Device::OpenSharedResource1 here, cache the
-	// ID3D11Texture2D* + IDXGIKeyedMutex* + UNORM/SRGB SRVs on the
-	// compositor for the per-frame surround blit pass to consume.
-	U_LOG_IFL_I(U_LOGGING_INFO, "D3D11 surround 2D registered: handle=%p %ux%u (open + blit pending Phase C)",
-	            shared_handle, w, h);
+	U_LOG_IFL_I(U_LOGGING_INFO, "D3D11 surround 2D registered: handle=%p %ux%u format=%u",
+	            shared_handle, w, h, sd.Format);
 }
 
 extern "C" bool

--- a/src/xrt/compositor/d3d11/comp_d3d11_compositor.h
+++ b/src/xrt/compositor/d3d11/comp_d3d11_compositor.h
@@ -84,6 +84,32 @@ comp_d3d11_compositor_set_output_rect(struct xrt_compositor *xc,
                                        uint32_t w, uint32_t h);
 
 /*!
+ * Register a full-window 2D shared texture for the surround region (Spec v6).
+ *
+ * Pairs with comp_d3d11_compositor_set_output_rect: the canvas rect tells
+ * the runtime where to weave 3D content, this call tells it where to find
+ * 2D pixels for the rest of the target swapchain. The compositor blits
+ * non-canvas pixels from this texture into the target each frame.
+ *
+ * Pass shared_handle == NULL to clear the surround (falls back to undefined
+ * non-canvas pixels — the pre-v6 behavior).
+ *
+ * Texture format: DXGI_FORMAT_R8G8B8A8_UNORM or *_UNORM_SRGB. Synchronization
+ * uses IDXGIKeyedMutex on key 0. Dimensions must equal the HWND client area.
+ *
+ * @param xc            The compositor.
+ * @param shared_handle D3D11 shared NT HANDLE, or NULL to clear.
+ * @param w             Texture width in pixels.
+ * @param h             Texture height in pixels.
+ *
+ * @ingroup comp_d3d11
+ */
+void
+comp_d3d11_compositor_set_surround_2d(struct xrt_compositor *xc,
+                                       void *shared_handle,
+                                       uint32_t w, uint32_t h);
+
+/*!
  * Get the predicted eye positions from the display processor.
  *
  * @param xc The compositor.

--- a/src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp
+++ b/src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp
@@ -181,8 +181,17 @@ struct comp_d3d12_compositor
 	ID3D12Resource *surround_texture;
 	//! IDXGIKeyedMutex on surround_texture for cross-process sync (key 0
 	//! protocol: app writes between Acquire(0)/Release(0), runtime samples
-	//! between Acquire(0)/Release(0)).
+	//! between Acquire(0)/Release(0)). NULL in the spec-v7 fence path.
 	IDXGIKeyedMutex *surround_mutex;
+
+	//! Spec v7 fence-sync state. Mutually exclusive with surround_mutex:
+	//! when surround_fence is non-NULL we use commandQueue->Wait(fence, value)
+	//! instead of AcquireSync(0). The handles below mirror what the app
+	//! registered so subsequent calls with the same handles skip re-opens.
+	ID3D12Fence *surround_fence;
+	void *surround_fence_cached_handle;
+	void *surround_texture_cached_handle;
+	uint64_t surround_await_fence_value;
 
 	//! Lazily allocated intermediate resource for cropping atlas to content dims.
 	ID3D12Resource *dp_input_resource;
@@ -2379,7 +2388,8 @@ comp_d3d12_compositor_set_output_rect(struct xrt_compositor *xc,
 
 // Release any cached surround resources. Idempotent; safe on a freshly
 // zeroed compositor. Used by set_surround_2d (re-register / clear) and
-// the destroy path.
+// the destroy path. Releases both keyed-mutex (spec v6) and fence (spec
+// v7) state regardless of which path the app was using.
 static void
 d3d12_release_surround(struct comp_d3d12_compositor *c)
 {
@@ -2387,6 +2397,13 @@ d3d12_release_surround(struct comp_d3d12_compositor *c)
 		c->surround_mutex->Release();
 		c->surround_mutex = nullptr;
 	}
+	if (c->surround_fence != nullptr) {
+		c->surround_fence->Release();
+		c->surround_fence = nullptr;
+	}
+	c->surround_fence_cached_handle = nullptr;
+	c->surround_texture_cached_handle = nullptr;
+	c->surround_await_fence_value = 0;
 	if (c->surround_texture != nullptr) {
 		c->surround_texture->Release();
 		c->surround_texture = nullptr;
@@ -2453,7 +2470,11 @@ d3d12_blit_surround_strips(struct comp_d3d12_compositor *c,
                             int32_t cx, int32_t cy,
                             uint32_t cw, uint32_t ch)
 {
-	if (!c->surround_2d.valid || c->surround_texture == nullptr || c->surround_mutex == nullptr) {
+	if (!c->surround_2d.valid || c->surround_texture == nullptr) {
+		return;
+	}
+	const bool use_fence = (c->surround_fence != nullptr);
+	if (!use_fence && c->surround_mutex == nullptr) {
 		return;
 	}
 	if (dst == nullptr) {
@@ -2485,10 +2506,29 @@ d3d12_blit_surround_strips(struct comp_d3d12_compositor *c,
 		return;
 	}
 
-	HRESULT hr = c->surround_mutex->AcquireSync(0, 16);
-	if (FAILED(hr)) {
-		// Timeout / abandoned — skip this frame.
-		return;
+	if (use_fence) {
+		// Spec v7: queue a wait on our command queue. The wait gates the
+		// next ExecuteCommandLists (the caller's submission of c->cmd_list
+		// happens later) on the app's Signal(fence, await_value). Read-only
+		// access — no Release counterpart is needed.
+		HRESULT hr = c->command_queue->Wait(c->surround_fence, c->surround_await_fence_value);
+		if (FAILED(hr)) {
+			static bool wait_logged = false;
+			if (!wait_logged) {
+				U_LOG_W("D3D12 surround 2D: queue->Wait(fence=%p, value=%llu) failed (hr=0x%08x). "
+				        "Surround blit skipped.",
+				        c->surround_fence,
+				        (unsigned long long)c->surround_await_fence_value, hr);
+				wait_logged = true;
+			}
+			return;
+		}
+	} else {
+		HRESULT hr = c->surround_mutex->AcquireSync(0, 16);
+		if (FAILED(hr)) {
+			// Timeout / abandoned — skip this frame.
+			return;
+		}
 	}
 
 	// Clamp canvas to dst bounds in case the app submitted a degenerate rect.
@@ -2561,7 +2601,11 @@ d3d12_blit_surround_strips(struct comp_d3d12_compositor *c,
 	}
 	c->cmd_list->ResourceBarrier(num_exit, exit);
 
-	c->surround_mutex->ReleaseSync(0);
+	if (!use_fence) {
+		c->surround_mutex->ReleaseSync(0);
+	}
+	// Fence path: read-only, no signal-back. The app guarantees the
+	// texture is stable until it bumps the fence on the next frame.
 }
 
 extern "C" void
@@ -2628,8 +2672,111 @@ comp_d3d12_compositor_set_surround_2d(struct xrt_compositor *xc,
 	c->surround_2d.shared_handle = shared_handle;
 	c->surround_2d.w = w;
 	c->surround_2d.h = h;
+	c->surround_texture_cached_handle = shared_handle;
 	U_LOG_IFL_I(U_LOGGING_INFO, "D3D12 surround 2D registered: handle=%p %llux%u format=%u",
 	            shared_handle,
 	            (unsigned long long)sd.Width, (unsigned)sd.Height,
 	            (unsigned)sd.Format);
+}
+
+extern "C" void
+comp_d3d12_compositor_set_surround_2d_fence(struct xrt_compositor *xc,
+                                              void *shared_texture_handle,
+                                              uint32_t w, uint32_t h,
+                                              void *shared_fence_handle,
+                                              uint64_t await_fence_value)
+{
+	if (xc == nullptr) return;
+	struct comp_d3d12_compositor *c = d3d12_comp(xc);
+
+	// NULL handle = clear (matches the spec v6 fn).
+	if (shared_texture_handle == nullptr) {
+		d3d12_release_surround(c);
+		c->surround_2d = {};
+		U_LOG_IFL_I(U_LOGGING_INFO, "D3D12 surround 2D (fence path) cleared");
+		return;
+	}
+
+	if (shared_fence_handle == nullptr) {
+		U_LOG_E("D3D12 surround 2D (fence path): shared_fence_handle is NULL "
+		        "but shared_texture_handle is non-NULL — fence handle is required.");
+		return;
+	}
+
+	// Hot path: same handles as last registration. Just update the await
+	// fence value. This is the steady-state per-frame call.
+	if (c->surround_texture != nullptr &&
+	    c->surround_texture_cached_handle == shared_texture_handle &&
+	    c->surround_fence != nullptr &&
+	    c->surround_fence_cached_handle == shared_fence_handle) {
+
+		// Spec v7 §3.7: awaitFenceValue must be strictly monotonic in
+		// steady-state. The very first non-zero value is accepted from any
+		// prior state. We log + ignore (don't queue a backwards wait) but
+		// don't return XR_ERROR_VALIDATION_FAILURE from the deeper layer —
+		// the state tracker doesn't surface compositor errors today.
+		if (await_fence_value < c->surround_await_fence_value) {
+			static bool nonmono_logged = false;
+			if (!nonmono_logged) {
+				U_LOG_W("D3D12 surround 2D (fence path): non-monotonic await value "
+				        "%llu < cached %llu — ignoring this frame.",
+				        (unsigned long long)await_fence_value,
+				        (unsigned long long)c->surround_await_fence_value);
+				nonmono_logged = true;
+			}
+			return;
+		}
+		c->surround_await_fence_value = await_fence_value;
+		return;
+	}
+
+	// Cold path: first registration, or handles changed. Reopen both and
+	// re-validate. Clears any prior spec-v6 keyed-mutex registration too.
+	d3d12_release_surround(c);
+	c->surround_2d = {};
+
+	HANDLE tex_nt = static_cast<HANDLE>(shared_texture_handle);
+	HRESULT hr = c->device->OpenSharedHandle(tex_nt, __uuidof(ID3D12Resource),
+	                                          reinterpret_cast<void **>(&c->surround_texture));
+	if (FAILED(hr) || c->surround_texture == nullptr) {
+		U_LOG_E("D3D12 surround 2D (fence path): OpenSharedHandle(texture=%p) failed "
+		        "(hr=0x%08x).", shared_texture_handle, hr);
+		c->surround_texture = nullptr;
+		return;
+	}
+
+	D3D12_RESOURCE_DESC sd = c->surround_texture->GetDesc();
+	if (sd.Width != w || sd.Height != h) {
+		U_LOG_E("D3D12 surround 2D (fence path): registration dims (%ux%u) do not "
+		        "match opened texture dims (%llux%u)",
+		        w, h, (unsigned long long)sd.Width, (unsigned)sd.Height);
+		d3d12_release_surround(c);
+		return;
+	}
+
+	HANDLE fence_nt = static_cast<HANDLE>(shared_fence_handle);
+	hr = c->device->OpenSharedHandle(fence_nt, __uuidof(ID3D12Fence),
+	                                  reinterpret_cast<void **>(&c->surround_fence));
+	if (FAILED(hr) || c->surround_fence == nullptr) {
+		U_LOG_E("D3D12 surround 2D (fence path): OpenSharedHandle(fence=%p) failed "
+		        "(hr=0x%08x). Ensure the fence was created with shared NT handle.",
+		        shared_fence_handle, hr);
+		d3d12_release_surround(c);
+		return;
+	}
+
+	c->surround_2d.valid = true;
+	c->surround_2d.shared_handle = shared_texture_handle;
+	c->surround_2d.w = w;
+	c->surround_2d.h = h;
+	c->surround_texture_cached_handle = shared_texture_handle;
+	c->surround_fence_cached_handle = shared_fence_handle;
+	c->surround_await_fence_value = await_fence_value;
+	U_LOG_IFL_I(U_LOGGING_INFO,
+	            "D3D12 surround 2D (fence path) registered: tex=%p fence=%p %llux%u "
+	            "format=%u initial_await=%llu",
+	            shared_texture_handle, shared_fence_handle,
+	            (unsigned long long)sd.Width, (unsigned)sd.Height,
+	            (unsigned)sd.Format,
+	            (unsigned long long)await_fence_value);
 }

--- a/src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp
+++ b/src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp
@@ -170,6 +170,11 @@ struct comp_d3d12_compositor
 	//! Canvas output rect for shared-texture apps.
 	struct u_canvas_rect canvas;
 
+	//! 2D surround texture handle (Spec v6). Phase C/D: open via
+	//! ID3D12Device::OpenSharedHandle on first use, cache resource +
+	//! KeyedMutex for the per-frame surround blit pass.
+	struct u_surround_2d_handle surround_2d;
+
 	//! Lazily allocated intermediate resource for cropping atlas to content dims.
 	ID3D12Resource *dp_input_resource;
 
@@ -2317,4 +2322,26 @@ comp_d3d12_compositor_set_output_rect(struct xrt_compositor *xc,
 	struct comp_d3d12_compositor *c = d3d12_comp(xc);
 	struct u_canvas_rect rect = {true, x, y, w, h};
 	c->canvas = rect;
+}
+
+extern "C" void
+comp_d3d12_compositor_set_surround_2d(struct xrt_compositor *xc,
+                                       void *shared_handle,
+                                       uint32_t w, uint32_t h)
+{
+	if (xc == nullptr) return;
+	struct comp_d3d12_compositor *c = d3d12_comp(xc);
+	if (shared_handle == nullptr) {
+		// Phase D TODO: release the opened ID3D12Resource + KeyedMutex here.
+		c->surround_2d = {};
+		U_LOG_IFL_I(U_LOGGING_INFO, "D3D12 surround 2D cleared");
+		return;
+	}
+	c->surround_2d.valid = true;
+	c->surround_2d.shared_handle = shared_handle;
+	c->surround_2d.w = w;
+	c->surround_2d.h = h;
+	// Phase D TODO: ID3D12Device::OpenSharedHandle + cache for blit.
+	U_LOG_IFL_I(U_LOGGING_INFO, "D3D12 surround 2D registered: handle=%p %ux%u (open + blit pending Phase D)",
+	            shared_handle, w, h);
 }

--- a/src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp
+++ b/src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp
@@ -2586,8 +2586,11 @@ comp_d3d12_compositor_set_surround_2d(struct xrt_compositor *xc,
 	// like D3D11). Spec v6 requires the source texture be created with
 	// D3D11_RESOURCE_MISC_SHARED_NTHANDLE | _SHARED_KEYEDMUTEX (or D3D12
 	// equivalents) so the IDXGIKeyedMutex QueryInterface succeeds below.
-	HANDLE h = static_cast<HANDLE>(shared_handle);
-	HRESULT hr = c->device->OpenSharedHandle(h, __uuidof(ID3D12Resource),
+	// Name the local 'nt_handle' (not 'h') to avoid shadowing the
+	// formal parameter 'h' (the height) — MSVC's stricter parameter
+	// scoping flagged this; clang/gcc let it slide.
+	HANDLE nt_handle = static_cast<HANDLE>(shared_handle);
+	HRESULT hr = c->device->OpenSharedHandle(nt_handle, __uuidof(ID3D12Resource),
 	                                          reinterpret_cast<void **>(&c->surround_texture));
 	if (FAILED(hr) || c->surround_texture == nullptr) {
 		U_LOG_E("D3D12 surround 2D: OpenSharedHandle failed for handle=%p (hr=0x%08x). "

--- a/src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp
+++ b/src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp
@@ -170,10 +170,19 @@ struct comp_d3d12_compositor
 	//! Canvas output rect for shared-texture apps.
 	struct u_canvas_rect canvas;
 
-	//! 2D surround texture handle (Spec v6). Phase C/D: open via
-	//! ID3D12Device::OpenSharedHandle on first use, cache resource +
-	//! KeyedMutex for the per-frame surround blit pass.
+	//! 2D surround texture handle (Spec v6).
 	struct u_surround_2d_handle surround_2d;
+
+	//! Opened surround resource (ID3D12Device::OpenSharedHandle on first
+	//! valid set_surround_2d). NULL when no surround is registered or open
+	//! failed. State after open is D3D12_RESOURCE_STATE_COMMON; we
+	//! transition COMMON <-> COPY_SOURCE around the per-frame strip blit
+	//! and leave it in COMMON at the boundaries.
+	ID3D12Resource *surround_texture;
+	//! IDXGIKeyedMutex on surround_texture for cross-process sync (key 0
+	//! protocol: app writes between Acquire(0)/Release(0), runtime samples
+	//! between Acquire(0)/Release(0)).
+	IDXGIKeyedMutex *surround_mutex;
 
 	//! Lazily allocated intermediate resource for cropping atlas to content dims.
 	ID3D12Resource *dp_input_resource;
@@ -222,6 +231,20 @@ d3d12_comp(struct xrt_compositor *xc)
 {
 	return reinterpret_cast<struct comp_d3d12_compositor *>(xc);
 }
+
+// Spec v6 surround-2D helpers. Defined near the bottom of the file
+// alongside comp_d3d12_compositor_set_surround_2d; forward-declared here
+// because they're called from d3d12_compositor_layer_commit and
+// d3d12_compositor_destroy (defined above the definitions). Matches the
+// file's existing helper-before-use pattern for d3d12_crop_atlas_for_dp.
+static void d3d12_release_surround(struct comp_d3d12_compositor *c);
+static void d3d12_blit_surround_strips(struct comp_d3d12_compositor *c,
+                                        ID3D12Resource *dst,
+                                        D3D12_RESOURCE_STATES dst_pre_state,
+                                        D3D12_RESOURCE_STATES dst_post_state,
+                                        uint32_t dst_w, uint32_t dst_h,
+                                        int32_t cx, int32_t cy,
+                                        uint32_t cw, uint32_t ch);
 
 /*!
  * Wait for GPU to finish all submitted work.
@@ -1445,6 +1468,18 @@ d3d12_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 			barriers[1].Transition.StateAfter = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
 			c->cmd_list->ResourceBarrier(2, barriers);
 
+			// Spec v6 surround blit: fill non-canvas pixels of the shared
+			// texture from the app-supplied 2D surround texture. dst is in
+			// COMMON (just transitioned above); leave it in COMMON after.
+			d3d12_blit_surround_strips(
+			    c, c->shared_texture,
+			    D3D12_RESOURCE_STATE_COMMON, D3D12_RESOURCE_STATE_COMMON,
+			    dp_target_w, dp_target_h,
+			    c->canvas.valid ? c->canvas.x : 0,
+			    c->canvas.valid ? c->canvas.y : 0,
+			    c->canvas.valid ? c->canvas.w : dp_target_w,
+			    c->canvas.valid ? c->canvas.h : dp_target_h);
+
 		} else if (atlas_resource != nullptr) {
 			// No DP: raw copy atlas to shared texture (2D mode fallback)
 			D3D12_RESOURCE_BARRIER barriers[2] = {};
@@ -1618,6 +1653,20 @@ d3d12_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 			    c->canvas.valid ? c->canvas.w : 0,
 			    c->canvas.valid ? c->canvas.h : 0);
 
+			// Spec v6 surround blit: fill non-canvas pixels of the back
+			// buffer from the app-supplied 2D surround texture. Back
+			// buffer is still in RENDER_TARGET from the DP; leave it
+			// in RENDER_TARGET so HUD's existing RT→COPY_DEST transition
+			// (below) proceeds unchanged.
+			d3d12_blit_surround_strips(
+			    c, back_buffer,
+			    D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_RENDER_TARGET,
+			    tgt_width, tgt_height,
+			    c->canvas.valid ? c->canvas.x : 0,
+			    c->canvas.valid ? c->canvas.y : 0,
+			    c->canvas.valid ? c->canvas.w : tgt_width,
+			    c->canvas.valid ? c->canvas.h : tgt_height);
+
 			// Transition atlas back: COMMON → PIXEL_SHADER_RESOURCE
 			atlas_barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_COMMON;
 			atlas_barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
@@ -1788,6 +1837,10 @@ d3d12_compositor_destroy(struct xrt_compositor *xc)
 		c->shared_texture_rtv_heap->Release();
 		c->shared_texture_rtv_heap = nullptr;
 	}
+
+	// Spec v6: release the 2D surround texture + keyed mutex if registered.
+	d3d12_release_surround(c);
+	c->surround_2d = {};
 
 	if (c->shared_texture != nullptr) {
 		c->shared_texture->Release();
@@ -2324,6 +2377,193 @@ comp_d3d12_compositor_set_output_rect(struct xrt_compositor *xc,
 	c->canvas = rect;
 }
 
+// Release any cached surround resources. Idempotent; safe on a freshly
+// zeroed compositor. Used by set_surround_2d (re-register / clear) and
+// the destroy path.
+static void
+d3d12_release_surround(struct comp_d3d12_compositor *c)
+{
+	if (c->surround_mutex != nullptr) {
+		c->surround_mutex->Release();
+		c->surround_mutex = nullptr;
+	}
+	if (c->surround_texture != nullptr) {
+		c->surround_texture->Release();
+		c->surround_texture = nullptr;
+	}
+}
+
+// Record a CopyTextureRegion for one strip from surround->dst.
+// Skips zero-area strips. Caller has already verified format match,
+// surround_texture is in COPY_SOURCE state, and dst is in COPY_DEST state.
+static void
+d3d12_record_surround_strip(ID3D12GraphicsCommandList *cmd_list,
+                             ID3D12Resource *dst, ID3D12Resource *src,
+                             uint32_t dst_x, uint32_t dst_y,
+                             uint32_t src_x, uint32_t src_y,
+                             uint32_t w, uint32_t h)
+{
+	if (w == 0 || h == 0) return;
+
+	D3D12_TEXTURE_COPY_LOCATION dst_loc = {};
+	dst_loc.pResource = dst;
+	dst_loc.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
+	dst_loc.SubresourceIndex = 0;
+
+	D3D12_TEXTURE_COPY_LOCATION src_loc = {};
+	src_loc.pResource = src;
+	src_loc.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
+	src_loc.SubresourceIndex = 0;
+
+	D3D12_BOX src_box = {};
+	src_box.left = src_x;
+	src_box.top = src_y;
+	src_box.front = 0;
+	src_box.right = src_x + w;
+	src_box.bottom = src_y + h;
+	src_box.back = 1;
+
+	cmd_list->CopyTextureRegion(&dst_loc, dst_x, dst_y, 0, &src_loc, &src_box);
+}
+
+// Blit non-canvas pixels of the surround texture into the dst resource.
+// Records barriers + 4× CopyTextureRegion + barriers into c->cmd_list,
+// bracketed by AcquireSync(0)/ReleaseSync(0) on the surround keyed mutex.
+//
+// Caller-supplied dst_pre_state/dst_post_state lets us drop the helper
+// into either the shared-texture path (COMMON before, COMMON after) or
+// the window-DP path (RENDER_TARGET before, RENDER_TARGET after — HUD's
+// existing transition handles the move to COPY_DEST).
+//
+// Surround texture is assumed to be in COMMON state at entry — that's
+// the cross-process-shared invariant: both sides leave it in COMMON
+// before ReleaseSync, so the next AcquireSync sees it ready for
+// transition.
+//
+// Strip layout matches the D3D11 helper. Skips any zero-area strip
+// (canvas flush against an edge). Format mismatch logs once and skips
+// the entire blit (no barriers / no mutex AcquireSync) — caller's
+// command list is unaffected.
+static void
+d3d12_blit_surround_strips(struct comp_d3d12_compositor *c,
+                            ID3D12Resource *dst,
+                            D3D12_RESOURCE_STATES dst_pre_state,
+                            D3D12_RESOURCE_STATES dst_post_state,
+                            uint32_t dst_w, uint32_t dst_h,
+                            int32_t cx, int32_t cy,
+                            uint32_t cw, uint32_t ch)
+{
+	if (!c->surround_2d.valid || c->surround_texture == nullptr || c->surround_mutex == nullptr) {
+		return;
+	}
+	if (dst == nullptr) {
+		return;
+	}
+
+	if (c->surround_2d.w != dst_w || c->surround_2d.h != dst_h) {
+		static bool dims_logged = false;
+		if (!dims_logged) {
+			U_LOG_W("D3D12 surround 2D: dim mismatch — surround %ux%u, target %ux%u. "
+			        "Surround blit skipped. Re-register surround on window resize.",
+			        c->surround_2d.w, c->surround_2d.h, dst_w, dst_h);
+			dims_logged = true;
+		}
+		return;
+	}
+
+	D3D12_RESOURCE_DESC src_desc = c->surround_texture->GetDesc();
+	D3D12_RESOURCE_DESC dst_desc = dst->GetDesc();
+	if (src_desc.Format != dst_desc.Format) {
+		static bool fmt_logged = false;
+		if (!fmt_logged) {
+			U_LOG_W("D3D12 surround 2D: format mismatch — surround=%u, target=%u. "
+			        "Surround blit skipped. v6 requires matching DXGI formats; "
+			        "cross-format SRGB<->UNORM blit not yet supported.",
+			        (unsigned)src_desc.Format, (unsigned)dst_desc.Format);
+			fmt_logged = true;
+		}
+		return;
+	}
+
+	HRESULT hr = c->surround_mutex->AcquireSync(0, 16);
+	if (FAILED(hr)) {
+		// Timeout / abandoned — skip this frame.
+		return;
+	}
+
+	// Clamp canvas to dst bounds in case the app submitted a degenerate rect.
+	uint32_t cx_u = (cx < 0) ? 0u : (uint32_t)cx;
+	uint32_t cy_u = (cy < 0) ? 0u : (uint32_t)cy;
+	if (cx_u > dst_w) cx_u = dst_w;
+	if (cy_u > dst_h) cy_u = dst_h;
+	uint32_t cright  = (cx_u + cw > dst_w) ? dst_w : cx_u + cw;
+	uint32_t cbottom = (cy_u + ch > dst_h) ? dst_h : cy_u + ch;
+
+	// Enter copy state.
+	D3D12_RESOURCE_BARRIER enter[2] = {};
+	enter[0].Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+	enter[0].Transition.pResource = dst;
+	enter[0].Transition.StateBefore = dst_pre_state;
+	enter[0].Transition.StateAfter = D3D12_RESOURCE_STATE_COPY_DEST;
+	enter[0].Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+
+	enter[1].Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+	enter[1].Transition.pResource = c->surround_texture;
+	enter[1].Transition.StateBefore = D3D12_RESOURCE_STATE_COMMON;
+	enter[1].Transition.StateAfter = D3D12_RESOURCE_STATE_COPY_SOURCE;
+	enter[1].Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+
+	// If pre-state already equals COPY_DEST, skip the dst transition by
+	// collapsing the surround barrier into slot 0.
+	uint32_t num_enter = (dst_pre_state == D3D12_RESOURCE_STATE_COPY_DEST) ? 1 : 2;
+	if (num_enter == 1) {
+		enter[0] = enter[1];
+	}
+	c->cmd_list->ResourceBarrier(num_enter, enter);
+
+	// Strips. Source and dest coords match (1:1 blit by spec).
+	// Top strip: y in [0, cy_u).
+	d3d12_record_surround_strip(c->cmd_list, dst, c->surround_texture,
+	                             0, 0, 0, 0, dst_w, cy_u);
+	// Bottom strip: y in [cbottom, dst_h).
+	if (cbottom < dst_h) {
+		d3d12_record_surround_strip(c->cmd_list, dst, c->surround_texture,
+		                             0, cbottom, 0, cbottom, dst_w, dst_h - cbottom);
+	}
+	// Left strip: x in [0, cx_u), y in [cy_u, cbottom).
+	if (cx_u > 0 && cbottom > cy_u) {
+		d3d12_record_surround_strip(c->cmd_list, dst, c->surround_texture,
+		                             0, cy_u, 0, cy_u, cx_u, cbottom - cy_u);
+	}
+	// Right strip: x in [cright, dst_w), y in [cy_u, cbottom).
+	if (cright < dst_w && cbottom > cy_u) {
+		d3d12_record_surround_strip(c->cmd_list, dst, c->surround_texture,
+		                             cright, cy_u, cright, cy_u, dst_w - cright, cbottom - cy_u);
+	}
+
+	// Exit copy state.
+	D3D12_RESOURCE_BARRIER exit[2] = {};
+	exit[0].Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+	exit[0].Transition.pResource = dst;
+	exit[0].Transition.StateBefore = D3D12_RESOURCE_STATE_COPY_DEST;
+	exit[0].Transition.StateAfter = dst_post_state;
+	exit[0].Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+
+	exit[1].Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+	exit[1].Transition.pResource = c->surround_texture;
+	exit[1].Transition.StateBefore = D3D12_RESOURCE_STATE_COPY_SOURCE;
+	exit[1].Transition.StateAfter = D3D12_RESOURCE_STATE_COMMON;
+	exit[1].Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+
+	uint32_t num_exit = (dst_post_state == D3D12_RESOURCE_STATE_COPY_DEST) ? 1 : 2;
+	if (num_exit == 1) {
+		exit[0] = exit[1];
+	}
+	c->cmd_list->ResourceBarrier(num_exit, exit);
+
+	c->surround_mutex->ReleaseSync(0);
+}
+
 extern "C" void
 comp_d3d12_compositor_set_surround_2d(struct xrt_compositor *xc,
                                        void *shared_handle,
@@ -2331,17 +2571,62 @@ comp_d3d12_compositor_set_surround_2d(struct xrt_compositor *xc,
 {
 	if (xc == nullptr) return;
 	struct comp_d3d12_compositor *c = d3d12_comp(xc);
+
+	// Release previous registration (no-op on first call). Also covers
+	// the NULL-handle clear path.
+	d3d12_release_surround(c);
+
 	if (shared_handle == nullptr) {
-		// Phase D TODO: release the opened ID3D12Resource + KeyedMutex here.
 		c->surround_2d = {};
 		U_LOG_IFL_I(U_LOGGING_INFO, "D3D12 surround 2D cleared");
 		return;
 	}
+
+	// D3D12::OpenSharedHandle handles NT handles natively (no "1" suffix
+	// like D3D11). Spec v6 requires the source texture be created with
+	// D3D11_RESOURCE_MISC_SHARED_NTHANDLE | _SHARED_KEYEDMUTEX (or D3D12
+	// equivalents) so the IDXGIKeyedMutex QueryInterface succeeds below.
+	HANDLE h = static_cast<HANDLE>(shared_handle);
+	HRESULT hr = c->device->OpenSharedHandle(h, __uuidof(ID3D12Resource),
+	                                          reinterpret_cast<void **>(&c->surround_texture));
+	if (FAILED(hr) || c->surround_texture == nullptr) {
+		U_LOG_E("D3D12 surround 2D: OpenSharedHandle failed for handle=%p (hr=0x%08x). "
+		        "Ensure the texture was created with NT-handle + keyed-mutex sharing.",
+		        shared_handle, hr);
+		c->surround_2d = {};
+		c->surround_texture = nullptr;
+		return;
+	}
+
+	// Validate dims against the app's promise. The HWND-equality check
+	// happens at frame time when we compare against c->shared_texture's
+	// (or back buffer's) dims.
+	D3D12_RESOURCE_DESC sd = c->surround_texture->GetDesc();
+	if (sd.Width != w || sd.Height != h) {
+		U_LOG_E("D3D12 surround 2D: registration dims (%ux%u) do not match opened "
+		        "texture dims (%llux%u)", w, h,
+		        (unsigned long long)sd.Width, (unsigned)sd.Height);
+		d3d12_release_surround(c);
+		c->surround_2d = {};
+		return;
+	}
+
+	hr = c->surround_texture->QueryInterface(__uuidof(IDXGIKeyedMutex),
+	                                          reinterpret_cast<void **>(&c->surround_mutex));
+	if (FAILED(hr) || c->surround_mutex == nullptr) {
+		U_LOG_E("D3D12 surround 2D: opened texture has no IDXGIKeyedMutex "
+		        "(hr=0x%08x). Required for cross-process sync.", hr);
+		d3d12_release_surround(c);
+		c->surround_2d = {};
+		return;
+	}
+
 	c->surround_2d.valid = true;
 	c->surround_2d.shared_handle = shared_handle;
 	c->surround_2d.w = w;
 	c->surround_2d.h = h;
-	// Phase D TODO: ID3D12Device::OpenSharedHandle + cache for blit.
-	U_LOG_IFL_I(U_LOGGING_INFO, "D3D12 surround 2D registered: handle=%p %ux%u (open + blit pending Phase D)",
-	            shared_handle, w, h);
+	U_LOG_IFL_I(U_LOGGING_INFO, "D3D12 surround 2D registered: handle=%p %llux%u format=%u",
+	            shared_handle,
+	            (unsigned long long)sd.Width, (unsigned)sd.Height,
+	            (unsigned)sd.Format);
 }

--- a/src/xrt/compositor/d3d12/comp_d3d12_compositor.h
+++ b/src/xrt/compositor/d3d12/comp_d3d12_compositor.h
@@ -178,6 +178,30 @@ comp_d3d12_compositor_set_surround_2d(struct xrt_compositor *xc,
                                        void *shared_handle,
                                        uint32_t w, uint32_t h);
 
+/*!
+ * Register a full-window 2D shared texture for the surround region using
+ * ID3D12Fence-based producer→consumer sync (Spec v7). Pair this with an
+ * app-side `commandQueue->Signal(fence, await_fence_value)` after the
+ * surround render submission each frame; the compositor will
+ * `commandQueue->Wait(fence, await_fence_value)` on its own queue before
+ * the strip blit.
+ *
+ * Called every frame to update await_fence_value. Texture + fence handles
+ * are opened once and cached by handle equality. Pass shared_handle == NULL
+ * to clear (fence handle ignored).
+ *
+ * Mutually exclusive with comp_d3d12_compositor_set_surround_2d on the same
+ * compositor — calling one clears the other's registration.
+ *
+ * @ingroup comp_d3d12
+ */
+void
+comp_d3d12_compositor_set_surround_2d_fence(struct xrt_compositor *xc,
+                                              void *shared_texture_handle,
+                                              uint32_t w, uint32_t h,
+                                              void *shared_fence_handle,
+                                              uint64_t await_fence_value);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/xrt/compositor/d3d12/comp_d3d12_compositor.h
+++ b/src/xrt/compositor/d3d12/comp_d3d12_compositor.h
@@ -163,6 +163,21 @@ comp_d3d12_compositor_set_output_rect(struct xrt_compositor *xc,
                                        int32_t x, int32_t y,
                                        uint32_t w, uint32_t h);
 
+/*!
+ * Register a full-window 2D shared texture for the surround region (Spec v6).
+ *
+ * Pass shared_handle == NULL to clear. See
+ * comp_d3d11_compositor_set_surround_2d for the full contract — D3D12 form
+ * is symmetric (NT HANDLE via ID3D12Device::OpenSharedHandle, KeyedMutex
+ * on key 0).
+ *
+ * @ingroup comp_d3d12
+ */
+void
+comp_d3d12_compositor_set_surround_2d(struct xrt_compositor *xc,
+                                       void *shared_handle,
+                                       uint32_t w, uint32_t h);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/xrt/compositor/gl/comp_gl_compositor.cpp
+++ b/src/xrt/compositor/gl/comp_gl_compositor.cpp
@@ -308,6 +308,9 @@ struct comp_gl_compositor
 	//! Canvas output rect for shared-texture apps.
 	struct u_canvas_rect canvas;
 
+	//! 2D surround texture handle (Spec v6).
+	struct u_surround_2d_handle surround_2d;
+
 	//! MCP capture_frame request box (serviced at end of layer_commit).
 	struct mcp_capture_request mcp_capture;
 
@@ -2050,6 +2053,27 @@ comp_gl_compositor_set_output_rect(struct xrt_compositor *xc,
 	c->canvas.y = y;
 	c->canvas.w = w;
 	c->canvas.h = h;
+}
+
+void
+comp_gl_compositor_set_surround_2d(struct xrt_compositor *xc,
+                                    void *shared_handle,
+                                    uint32_t w, uint32_t h)
+{
+	struct comp_gl_compositor *c = gl_comp(xc);
+	if (shared_handle == nullptr) {
+		c->surround_2d = {};
+		U_LOG_I("GL surround 2D cleared");
+		return;
+	}
+	c->surround_2d.valid = true;
+	c->surround_2d.shared_handle = shared_handle;
+	c->surround_2d.w = w;
+	c->surround_2d.h = h;
+	// Phase (post-Phase-C) TODO: WGL_NV_DX_interop2 share / EGL image
+	// import for the per-frame surround blit pass.
+	U_LOG_I("GL surround 2D registered: handle=%p %ux%u (open + blit pending)",
+	        shared_handle, w, h);
 }
 
 bool

--- a/src/xrt/compositor/gl/comp_gl_compositor.h
+++ b/src/xrt/compositor/gl/comp_gl_compositor.h
@@ -96,6 +96,20 @@ comp_gl_compositor_set_output_rect(struct xrt_compositor *xc,
                                     uint32_t w, uint32_t h);
 
 /*!
+ * Register a full-window 2D shared texture for the surround region (Spec v6).
+ *
+ * On Windows the handle is an NT HANDLE bridged via WGL_NV_DX_interop2;
+ * on POSIX, an EGL image / dma-buf fd. Pass shared_handle == NULL to clear.
+ * See comp_d3d11_compositor_set_surround_2d for the cross-platform semantics.
+ *
+ * @ingroup comp_gl
+ */
+void
+comp_gl_compositor_set_surround_2d(struct xrt_compositor *xc,
+                                    void *shared_handle,
+                                    uint32_t w, uint32_t h);
+
+/*!
  * Request display mode switch (2D/3D) via the GL display processor.
  *
  * @param xc        GL compositor base.

--- a/src/xrt/compositor/metal/comp_metal_compositor.h
+++ b/src/xrt/compositor/metal/comp_metal_compositor.h
@@ -104,6 +104,19 @@ comp_metal_compositor_set_output_rect(struct xrt_compositor *xc,
                                        uint32_t w, uint32_t h);
 
 /*!
+ * Register a full-view 2D IOSurface for the surround region (Spec v6).
+ *
+ * Pass shared_handle == NULL to clear. The handle is an IOSurfaceRef cast
+ * to void*; synchronization uses Metal fences + IOSurface use-count rather
+ * than a KeyedMutex. See comp_d3d11_compositor_set_surround_2d for the
+ * cross-platform semantics.
+ */
+void
+comp_metal_compositor_set_surround_2d(struct xrt_compositor *xc,
+                                       void *shared_handle,
+                                       uint32_t w, uint32_t h);
+
+/*!
  * Request a display mode switch (2D/3D).
  * Returns false if not supported.
  */

--- a/src/xrt/compositor/metal/comp_metal_compositor.m
+++ b/src/xrt/compositor/metal/comp_metal_compositor.m
@@ -227,6 +227,9 @@ struct comp_metal_compositor
 	//! Canvas output rect for shared-texture apps.
 	struct u_canvas_rect canvas;
 
+	//! 2D surround IOSurface handle (Spec v6).
+	struct u_surround_2d_handle surround_2d;
+
 	//! Thread safety.
 	struct os_mutex mutex;
 
@@ -2573,6 +2576,29 @@ comp_metal_compositor_set_output_rect(struct xrt_compositor *xc,
 {
 	struct comp_metal_compositor *c = metal_comp(xc);
 	c->canvas = (struct u_canvas_rect){.valid = true, .x = x, .y = y, .w = w, .h = h};
+}
+
+void
+comp_metal_compositor_set_surround_2d(struct xrt_compositor *xc,
+                                       void *shared_handle,
+                                       uint32_t w, uint32_t h)
+{
+	struct comp_metal_compositor *c = metal_comp(xc);
+	if (shared_handle == NULL) {
+		// Phase F-late TODO: release IOSurface use-count + Metal texture cache.
+		c->surround_2d = (struct u_surround_2d_handle){0};
+		U_LOG_I("Metal surround 2D cleared");
+		return;
+	}
+	c->surround_2d.valid = true;
+	c->surround_2d.shared_handle = shared_handle;
+	c->surround_2d.w = w;
+	c->surround_2d.h = h;
+	// Phase F-late TODO: IOSurfaceIncrementUseCount + MTLDevice
+	// newTextureWithDescriptor:iosurface:plane: + cache Metal texture
+	// for the per-frame surround blit pass.
+	U_LOG_I("Metal surround 2D registered: handle=%p %ux%u (open + blit pending Phase F-late)",
+	        shared_handle, w, h);
 }
 
 bool

--- a/src/xrt/compositor/vk_native/comp_vk_native_compositor.c
+++ b/src/xrt/compositor/vk_native/comp_vk_native_compositor.c
@@ -203,6 +203,9 @@ struct comp_vk_native_compositor
 	//! Canvas output rect for shared-texture apps.
 	struct u_canvas_rect canvas;
 
+	//! 2D surround texture handle (Spec v6).
+	struct u_surround_2d_handle surround_2d;
+
 	//! Alpha-blend pipeline for window-space (HUD) layers rendered per-tile
 	//! INTO the atlas pre-weave (matches d3d11/d3d12/metal/gl). Lazy-init
 	//! with the atlas format on first window-space submission. The DP weaver
@@ -3308,6 +3311,29 @@ comp_vk_native_compositor_set_output_rect(struct xrt_compositor *xc,
 	if (xc == NULL) return;
 	struct comp_vk_native_compositor *c = vk_comp(xc);
 	c->canvas = (struct u_canvas_rect){.valid = true, .x = x, .y = y, .w = w, .h = h};
+}
+
+void
+comp_vk_native_compositor_set_surround_2d(struct xrt_compositor *xc,
+                                           void *shared_handle,
+                                           uint32_t w, uint32_t h)
+{
+	if (xc == NULL) return;
+	struct comp_vk_native_compositor *c = vk_comp(xc);
+	if (shared_handle == NULL) {
+		c->surround_2d = (struct u_surround_2d_handle){0};
+		U_LOG_I("VK surround 2D cleared");
+		return;
+	}
+	c->surround_2d.valid = true;
+	c->surround_2d.shared_handle = shared_handle;
+	c->surround_2d.w = w;
+	c->surround_2d.h = h;
+	// Phase (post-Phase-C) TODO: VK_KHR_external_memory_win32 import on
+	// Windows / VK_KHR_external_memory_fd on POSIX; create a VkImage view
+	// for the per-frame surround blit pass.
+	U_LOG_I("VK surround 2D registered: handle=%p %ux%u (open + blit pending)",
+	        shared_handle, w, h);
 }
 
 struct vk_bundle *

--- a/src/xrt/compositor/vk_native/comp_vk_native_compositor.h
+++ b/src/xrt/compositor/vk_native/comp_vk_native_compositor.h
@@ -162,6 +162,21 @@ comp_vk_native_compositor_set_output_rect(struct xrt_compositor *xc,
                                            uint32_t w, uint32_t h);
 
 /*!
+ * Register a full-window 2D shared texture for the surround region (Spec v6).
+ *
+ * On Windows the handle is an NT HANDLE imported via VK_KHR_external_memory_win32;
+ * on POSIX, an fd via VK_KHR_external_memory_fd. Pass shared_handle == NULL to
+ * clear. See comp_d3d11_compositor_set_surround_2d for the cross-platform
+ * semantics.
+ *
+ * @ingroup comp_vk_native
+ */
+void
+comp_vk_native_compositor_set_surround_2d(struct xrt_compositor *xc,
+                                           void *shared_handle,
+                                           uint32_t w, uint32_t h);
+
+/*!
  * Get the vk_bundle from a VK native compositor (for sub-modules).
  *
  * @ingroup comp_vk_native

--- a/src/xrt/state_trackers/oxr/oxr_api_funcs.h
+++ b/src/xrt/state_trackers/oxr/oxr_api_funcs.h
@@ -963,6 +963,18 @@ XRAPI_ATTR XrResult XRAPI_CALL
 oxr_xrSetSharedTextureSurround2DEXT(XrSession session,
                                      void *sharedTextureHandle,
                                      uint32_t width, uint32_t height);
+
+//! OpenXR API function @ep{xrSetSharedTextureSurround2DFenceEXT}
+//! Spec v7 addition: D3D12 variant of surround registration using an
+//! ID3D12Fence (shared NT handle) for producer→consumer sync, since
+//! IDXGIKeyedMutex is not reliably available on D3D12-native shared
+//! resources. Called per-frame to update the await fence value.
+XRAPI_ATTR XrResult XRAPI_CALL
+oxr_xrSetSharedTextureSurround2DFenceEXT(XrSession session,
+                                          void *sharedTextureHandle,
+                                          uint32_t width, uint32_t height,
+                                          void *sharedFenceHandle,
+                                          uint64_t awaitFenceValue);
 #endif
 
 /*!

--- a/src/xrt/state_trackers/oxr/oxr_api_funcs.h
+++ b/src/xrt/state_trackers/oxr/oxr_api_funcs.h
@@ -955,6 +955,14 @@ XRAPI_ATTR XrResult XRAPI_CALL
 oxr_xrSetSharedTextureOutputRectEXT(XrSession session,
                                      int32_t x, int32_t y,
                                      uint32_t width, uint32_t height);
+
+//! OpenXR API function @ep{xrSetSharedTextureSurround2DEXT}
+//! Spec v6 addition: registers a full-window 2D shared texture whose pixels
+//! outside the canvas sub-rect are blitted into the target swapchain.
+XRAPI_ATTR XrResult XRAPI_CALL
+oxr_xrSetSharedTextureSurround2DEXT(XrSession session,
+                                     void *sharedTextureHandle,
+                                     uint32_t width, uint32_t height);
 #endif
 
 /*!

--- a/src/xrt/state_trackers/oxr/oxr_api_negotiate.c
+++ b/src/xrt/state_trackers/oxr/oxr_api_negotiate.c
@@ -483,6 +483,7 @@ handle_non_null(struct oxr_instance *inst, struct oxr_logger *log, const char *n
 #ifdef OXR_HAVE_EXT_win32_window_binding
 	ENTRY_IF_EXT(xrSetSharedTextureOutputRectEXT, EXT_win32_window_binding);
 	ENTRY_IF_EXT(xrSetSharedTextureSurround2DEXT, EXT_win32_window_binding);
+	ENTRY_IF_EXT(xrSetSharedTextureSurround2DFenceEXT, EXT_win32_window_binding);
 #endif
 #ifdef OXR_HAVE_EXT_cocoa_window_binding
 	ENTRY_IF_EXT(xrSetSharedTextureOutputRectEXT, EXT_cocoa_window_binding);

--- a/src/xrt/state_trackers/oxr/oxr_api_negotiate.c
+++ b/src/xrt/state_trackers/oxr/oxr_api_negotiate.c
@@ -482,9 +482,11 @@ handle_non_null(struct oxr_instance *inst, struct oxr_logger *log, const char *n
 	// xrSetSharedTextureOutputRectEXT — canvas sub-rect, part of window binding extensions
 #ifdef OXR_HAVE_EXT_win32_window_binding
 	ENTRY_IF_EXT(xrSetSharedTextureOutputRectEXT, EXT_win32_window_binding);
+	ENTRY_IF_EXT(xrSetSharedTextureSurround2DEXT, EXT_win32_window_binding);
 #endif
 #ifdef OXR_HAVE_EXT_cocoa_window_binding
 	ENTRY_IF_EXT(xrSetSharedTextureOutputRectEXT, EXT_cocoa_window_binding);
+	ENTRY_IF_EXT(xrSetSharedTextureSurround2DEXT, EXT_cocoa_window_binding);
 #endif
 
 #ifdef OXR_HAVE_KHR_locate_spaces

--- a/src/xrt/state_trackers/oxr/oxr_api_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_api_session.c
@@ -1566,4 +1566,54 @@ oxr_xrSetSharedTextureOutputRectEXT(XrSession session,
 	                 "Output rect not supported for this compositor");
 }
 
+XRAPI_ATTR XrResult XRAPI_CALL
+oxr_xrSetSharedTextureSurround2DEXT(XrSession session,
+                                     void *sharedTextureHandle,
+                                     uint32_t width, uint32_t height)
+{
+	OXR_TRACE_MARKER();
+
+	struct oxr_session *sess;
+	struct oxr_logger log;
+	OXR_VERIFY_SESSION_AND_INIT_LOG(&log, session, sess, "xrSetSharedTextureSurround2DEXT");
+
+#ifdef XRT_HAVE_D3D11_NATIVE_COMPOSITOR
+	if (sess->is_d3d11_native_compositor && sess->xcn != NULL) {
+		comp_d3d11_compositor_set_surround_2d(&sess->xcn->base, sharedTextureHandle, width, height);
+		return XR_SUCCESS;
+	}
+#endif
+
+#ifdef XRT_HAVE_METAL_NATIVE_COMPOSITOR
+	if (sess->is_metal_native_compositor && sess->xcn != NULL) {
+		comp_metal_compositor_set_surround_2d(&sess->xcn->base, sharedTextureHandle, width, height);
+		return XR_SUCCESS;
+	}
+#endif
+
+#ifdef XRT_HAVE_GL_NATIVE_COMPOSITOR
+	if (sess->is_gl_native_compositor && sess->xcn != NULL) {
+		comp_gl_compositor_set_surround_2d(&sess->xcn->base, sharedTextureHandle, width, height);
+		return XR_SUCCESS;
+	}
+#endif
+
+#ifdef XRT_HAVE_VK_NATIVE_COMPOSITOR
+	if (sess->is_vk_native_compositor && sess->xcn != NULL) {
+		comp_vk_native_compositor_set_surround_2d(&sess->xcn->base, sharedTextureHandle, width, height);
+		return XR_SUCCESS;
+	}
+#endif
+
+#ifdef XRT_HAVE_D3D12_NATIVE_COMPOSITOR
+	if (sess->is_d3d12_native_compositor && sess->xcn != NULL) {
+		comp_d3d12_compositor_set_surround_2d(&sess->xcn->base, sharedTextureHandle, width, height);
+		return XR_SUCCESS;
+	}
+#endif
+
+	return oxr_error(&log, XR_ERROR_FEATURE_UNSUPPORTED,
+	                 "Surround 2D not supported for this compositor");
+}
+
 #endif // OXR_HAVE_EXT_display_info

--- a/src/xrt/state_trackers/oxr/oxr_api_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_api_session.c
@@ -1616,4 +1616,33 @@ oxr_xrSetSharedTextureSurround2DEXT(XrSession session,
 	                 "Surround 2D not supported for this compositor");
 }
 
+XRAPI_ATTR XrResult XRAPI_CALL
+oxr_xrSetSharedTextureSurround2DFenceEXT(XrSession session,
+                                          void *sharedTextureHandle,
+                                          uint32_t width, uint32_t height,
+                                          void *sharedFenceHandle,
+                                          uint64_t awaitFenceValue)
+{
+	OXR_TRACE_MARKER();
+
+	struct oxr_session *sess;
+	struct oxr_logger log;
+	OXR_VERIFY_SESSION_AND_INIT_LOG(&log, session, sess, "xrSetSharedTextureSurround2DFenceEXT");
+
+#ifdef XRT_HAVE_D3D12_NATIVE_COMPOSITOR
+	if (sess->is_d3d12_native_compositor && sess->xcn != NULL) {
+		comp_d3d12_compositor_set_surround_2d_fence(&sess->xcn->base,
+		                                              sharedTextureHandle, width, height,
+		                                              sharedFenceHandle, awaitFenceValue);
+		return XR_SUCCESS;
+	}
+#endif
+
+	// Fence-based surround is D3D12-only by design — D3D11 has KeyedMutex,
+	// Metal has IOSurface lock primitives. Apps on other backends should call
+	// xrSetSharedTextureSurround2DEXT instead.
+	return oxr_error(&log, XR_ERROR_FEATURE_UNSUPPORTED,
+	                 "Surround 2D fence path only supported on D3D12 native compositor");
+}
+
 #endif // OXR_HAVE_EXT_display_info

--- a/test_apps/common/xr_session_common.h
+++ b/test_apps/common/xr_session_common.h
@@ -117,6 +117,12 @@ struct XrSessionManager {
     // Canvas sub-rect (XR_EXT_win32_window_binding / XR_EXT_cocoa_window_binding)
     PFN_xrSetSharedTextureOutputRectEXT pfnSetSharedTextureOutputRectEXT = nullptr;
 
+    // Full-window 2D surround texture (XR_EXT_win32_window_binding spec v6 §3.6)
+    PFN_xrSetSharedTextureSurround2DEXT pfnSetSharedTextureSurround2DEXT = nullptr;
+
+    // Full-window 2D surround texture, fence sync (spec v7 §3.7) — D3D12 only
+    PFN_xrSetSharedTextureSurround2DFenceEXT pfnSetSharedTextureSurround2DFenceEXT = nullptr;
+
     // Environment blend modes advertised by the runtime. Populated at session
     // create time via xrEnumerateEnvironmentBlendModes. Used to pick the
     // correct mode for xrEndFrame: ALPHA_BLEND when transparent_bg is desired

--- a/test_apps/cube_texture_d3d11_win/main.cpp
+++ b/test_apps/cube_texture_d3d11_win/main.cpp
@@ -74,11 +74,26 @@ static uint32_t g_sharedHeight = 0;
 static uint32_t g_canvasW = 0;
 static uint32_t g_canvasH = 0;
 
+// Surround 2D texture (spec v6 §3.6 of XR_EXT_win32_window_binding). Holds
+// the app's full-window 2D content; the runtime blits non-canvas pixels of
+// this into the shared swapchain each frame around the weaved canvas.
+// Must match the shared multiview texture's dims + format because the
+// compositor strip-blit uses CopySubresourceRegion (no format conversion).
+static ComPtr<ID3D11Texture2D> g_surroundTexture;
+static ComPtr<ID3D11RenderTargetView> g_surroundRTV;
+static ComPtr<IDXGIKeyedMutex> g_surroundMutex;
+static HANDLE g_surroundHandle = nullptr;
+static bool g_surroundRegistered = false;
+
 // Blit shader resources
 static ComPtr<ID3D11VertexShader> g_blitVS;
 static ComPtr<ID3D11PixelShader> g_blitPS;
 static ComPtr<ID3D11SamplerState> g_blitSampler;
 static ComPtr<ID3D11Buffer> g_blitParamsCB;
+
+// Surround pattern shader resources
+static ComPtr<ID3D11PixelShader> g_surroundPS;
+static ComPtr<ID3D11Buffer> g_surroundParamsCB;
 
 struct RenderState;
 static RenderState* g_renderState = nullptr;
@@ -220,6 +235,186 @@ float4 main(float4 pos : SV_Position, float2 uv : TEXCOORD0) : SV_Target {
 }
 )";
 
+// Surround pattern pixel shader. Draws a checkerboard + soft gradient over
+// the window region, with a bright border just outside the canvas hole so
+// the canvas/surround boundary is visually unmistakable. Pixels inside the
+// canvas are written black — the compositor blit doesn't read them (DP's
+// weaved output stays in the canvas region of the shared texture), so this
+// just keeps the texture tidy in case anyone samples it.
+static const char* g_surroundPSSource = R"(
+cbuffer SurroundParams : register(b0) {
+    float2 windowSize;     // current window client area
+    float2 _pad0;
+    int4   canvas;         // (x, y, w, h) in window pixels
+    float  time;           // seconds, for subtle motion
+    float3 _pad1;
+};
+float4 main(float4 pos : SV_Position, float2 uv : TEXCOORD0) : SV_Target {
+    float2 p = pos.xy;
+    if (p.x >= windowSize.x || p.y >= windowSize.y) {
+        return float4(0, 0, 0, 1);
+    }
+    float bx0 = (float)canvas.x;
+    float by0 = (float)canvas.y;
+    float bx1 = (float)(canvas.x + canvas.z);
+    float by1 = (float)(canvas.y + canvas.w);
+    float dx = max(bx0 - p.x, p.x - bx1);
+    float dy = max(by0 - p.y, p.y - by1);
+    float d  = max(dx, dy);   // negative inside canvas, positive outside
+    if (d <= 0) {
+        return float4(0, 0, 0, 1);
+    }
+    if (d <= 4.0) {
+        return float4(1.0, 0.25, 0.25, 1.0);
+    }
+    int2 cell = int2(p / 24.0);
+    bool light = ((cell.x + cell.y) & 1) == 0;
+    float3 base = light ? float3(0.82, 0.84, 0.92) : float3(0.50, 0.55, 0.80);
+    float2 g = saturate(p / windowSize);
+    base.r += g.x * 0.18;
+    base.g += g.y * 0.10;
+    base.b += (1.0 - g.x) * 0.10;
+    // Diagonal sweep so motion is visible at a glance.
+    float sweep = frac((p.x + p.y) / 256.0 - time * 0.10);
+    base += (smoothstep(0.45, 0.5, sweep) - smoothstep(0.5, 0.55, sweep)) * 0.10;
+    return float4(saturate(base), 1.0);
+}
+)";
+
+static bool CreateSurroundShaderResources(ID3D11Device* device) {
+    ComPtr<ID3DBlob> psBlob, errBlob;
+    HRESULT hr = D3DCompile(g_surroundPSSource, strlen(g_surroundPSSource), "surroundPS",
+        nullptr, nullptr, "main", "ps_5_0", 0, 0, &psBlob, &errBlob);
+    if (FAILED(hr)) {
+        LOG_ERROR("Surround PS compile failed: %s", errBlob ? (char*)errBlob->GetBufferPointer() : "unknown");
+        return false;
+    }
+    hr = device->CreatePixelShader(psBlob->GetBufferPointer(), psBlob->GetBufferSize(), nullptr, &g_surroundPS);
+    if (FAILED(hr)) return false;
+
+    D3D11_BUFFER_DESC cbd = {};
+    cbd.ByteWidth = 48;  // 3 × float4 = 48 bytes
+    cbd.Usage = D3D11_USAGE_DYNAMIC;
+    cbd.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
+    cbd.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
+    hr = device->CreateBuffer(&cbd, nullptr, &g_surroundParamsCB);
+    return SUCCEEDED(hr);
+}
+
+// Allocate the NT-shared keyed-mutex surround texture sized to match the
+// multiview shared texture (spec v6 compositor enforces dim + format
+// equality between the surround source and the dst it blits into).
+// Returns the NT HANDLE that the runtime opens via OpenSharedResource1.
+static bool CreateSurroundTexture(ID3D11Device* device,
+                                   uint32_t width, uint32_t height,
+                                   DXGI_FORMAT format) {
+    D3D11_TEXTURE2D_DESC desc = {};
+    desc.Width = width;
+    desc.Height = height;
+    desc.MipLevels = 1;
+    desc.ArraySize = 1;
+    desc.Format = format;
+    desc.SampleDesc.Count = 1;
+    desc.Usage = D3D11_USAGE_DEFAULT;
+    desc.BindFlags = D3D11_BIND_RENDER_TARGET;
+    desc.MiscFlags = D3D11_RESOURCE_MISC_SHARED_NTHANDLE
+                   | D3D11_RESOURCE_MISC_SHARED_KEYEDMUTEX;
+    HRESULT hr = device->CreateTexture2D(&desc, nullptr, &g_surroundTexture);
+    if (FAILED(hr)) {
+        LOG_ERROR("Surround texture create failed: 0x%08x", hr);
+        return false;
+    }
+
+    hr = device->CreateRenderTargetView(g_surroundTexture.Get(), nullptr, &g_surroundRTV);
+    if (FAILED(hr)) {
+        LOG_ERROR("Surround RTV create failed: 0x%08x", hr);
+        return false;
+    }
+
+    ComPtr<IDXGIResource1> dxgiRes1;
+    hr = g_surroundTexture.As(&dxgiRes1);
+    if (FAILED(hr) || !dxgiRes1) {
+        LOG_ERROR("Surround texture has no IDXGIResource1: 0x%08x", hr);
+        return false;
+    }
+    hr = dxgiRes1->CreateSharedHandle(nullptr,
+        DXGI_SHARED_RESOURCE_READ | DXGI_SHARED_RESOURCE_WRITE,
+        nullptr, &g_surroundHandle);
+    if (FAILED(hr) || !g_surroundHandle) {
+        LOG_ERROR("Surround texture CreateSharedHandle failed: 0x%08x", hr);
+        return false;
+    }
+
+    hr = g_surroundTexture.As(&g_surroundMutex);
+    if (FAILED(hr) || !g_surroundMutex) {
+        LOG_ERROR("Surround texture has no IDXGIKeyedMutex: 0x%08x", hr);
+        return false;
+    }
+
+    LOG_INFO("Created surround D3D11 texture: %ux%u format=%u handle=%p",
+        width, height, (unsigned)format, g_surroundHandle);
+    return true;
+}
+
+// Render the surround pattern into the surround texture. Holds the keyed
+// mutex on key 0 while writing — runtime samples on the same key during
+// xrEndFrame's submit-layers path. Renders only the current window-pixel
+// region (0..winW, 0..winH); area outside is never sampled.
+static void RenderSurroundPattern(D3D11Renderer& renderer,
+                                   uint32_t winW, uint32_t winH,
+                                   int32_t canvasX, int32_t canvasY,
+                                   uint32_t canvasW, uint32_t canvasH,
+                                   float timeSeconds) {
+    if (!g_surroundRTV || !g_surroundPS || !g_surroundParamsCB || !g_surroundMutex) return;
+
+    HRESULT hr = g_surroundMutex->AcquireSync(0, 16);
+    if (FAILED(hr)) {
+        return;  // Skip this frame; runtime's previous-frame copy remains.
+    }
+
+    D3D11_MAPPED_SUBRESOURCE mapped;
+    if (SUCCEEDED(renderer.context->Map(g_surroundParamsCB.Get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped))) {
+        struct Params {
+            float windowSize[2];
+            float _pad0[2];
+            int32_t canvas[4];
+            float time;
+            float _pad1[3];
+        } p = {};
+        p.windowSize[0] = (float)winW;
+        p.windowSize[1] = (float)winH;
+        p.canvas[0] = canvasX;
+        p.canvas[1] = canvasY;
+        p.canvas[2] = (int32_t)canvasW;
+        p.canvas[3] = (int32_t)canvasH;
+        p.time = timeSeconds;
+        memcpy(mapped.pData, &p, sizeof(p));
+        renderer.context->Unmap(g_surroundParamsCB.Get(), 0);
+    }
+
+    ID3D11RenderTargetView* rtv = g_surroundRTV.Get();
+    renderer.context->OMSetRenderTargets(1, &rtv, nullptr);
+
+    D3D11_VIEWPORT vp = {};
+    vp.Width = (FLOAT)winW;
+    vp.Height = (FLOAT)winH;
+    vp.MaxDepth = 1.0f;
+    renderer.context->RSSetViewports(1, &vp);
+
+    renderer.context->VSSetShader(g_blitVS.Get(), nullptr, 0);
+    renderer.context->PSSetShader(g_surroundPS.Get(), nullptr, 0);
+    ID3D11Buffer* cb = g_surroundParamsCB.Get();
+    renderer.context->PSSetConstantBuffers(0, 1, &cb);
+    renderer.context->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+    renderer.context->IASetInputLayout(nullptr);
+    renderer.context->Draw(3, 0);
+
+    ID3D11RenderTargetView* nullRTV = nullptr;
+    renderer.context->OMSetRenderTargets(1, &nullRTV, nullptr);
+
+    g_surroundMutex->ReleaseSync(0);
+}
+
 static bool CreateBlitResources(ID3D11Device* device) {
     // Compile vertex shader
     ComPtr<ID3DBlob> vsBlob, psBlob, errBlob;
@@ -259,7 +454,14 @@ static bool CreateBlitResources(ID3D11Device* device) {
     return SUCCEEDED(hr);
 }
 
-// Blit shared texture to back buffer with aspect-ratio letterboxing
+// Blit shared texture to back buffer with aspect-ratio letterboxing.
+// Two sub-modes:
+//  - surround inactive: blit ONLY the canvas sub-rect of the shared texture
+//    into the matching back-buffer sub-rect (legacy behavior). Non-canvas
+//    back-buffer pixels stay as the clear color.
+//  - surround active: blit the whole window region of the shared texture.
+//    Compositor has filled the strips around the canvas with the app's 2D
+//    pattern (spec v6), so a full-window blit lets the user see them.
 static void BlitSharedTextureToBackBuffer(D3D11Renderer& renderer, ID3D11RenderTargetView* backBufferRTV,
                                            uint32_t winW, uint32_t winH, XrSessionManager& xr) {
     if (!g_sharedSRV) return;
@@ -267,32 +469,48 @@ static void BlitSharedTextureToBackBuffer(D3D11Renderer& renderer, ID3D11RenderT
     renderer.context->OMSetRenderTargets(1, &backBufferRTV, nullptr);
 
     // Canvas = center 50% of window (25%-75% region) to demonstrate canvas ≠ window
+    float canvasX = (FLOAT)winW * 0.25f;
+    float canvasY = (FLOAT)winH * 0.25f;
+    float canvasW = (FLOAT)winW * 0.5f;
+    float canvasH = (FLOAT)winH * 0.5f;
+
+    // Tell the runtime where the canvas lives. Always do this — even when the
+    // surround texture covers the rest of the window, the canvas rect drives
+    // both the DP weave region and the compositor's surround-strip layout.
+    if (xr.pfnSetSharedTextureOutputRectEXT && xr.session != XR_NULL_HANDLE) {
+        xr.pfnSetSharedTextureOutputRectEXT(xr.session,
+            (int32_t)canvasX, (int32_t)canvasY,
+            (uint32_t)canvasW, (uint32_t)canvasH);
+    }
+
+    // Pick the viewport + UV range based on whether surround is active.
     D3D11_VIEWPORT vp = {};
-    vp.Width = (FLOAT)winW * 0.5f;
-    vp.Height = (FLOAT)winH * 0.5f;
-    vp.TopLeftX = (FLOAT)winW * 0.25f;
-    vp.TopLeftY = (FLOAT)winH * 0.25f;
+    float uvParams[4];  // (scaleX, scaleY, offsetX, offsetY)
+    if (g_surroundRegistered) {
+        // Full window — read back canvas weave + surround strips.
+        vp.TopLeftX = 0.0f;
+        vp.TopLeftY = 0.0f;
+        vp.Width = (FLOAT)winW;
+        vp.Height = (FLOAT)winH;
+        uvParams[0] = (float)winW / (float)g_sharedWidth;
+        uvParams[1] = (float)winH / (float)g_sharedHeight;
+        uvParams[2] = 0.0f;
+        uvParams[3] = 0.0f;
+    } else {
+        // Canvas-only — non-canvas back-buffer pixels stay at the clear color.
+        vp.TopLeftX = canvasX;
+        vp.TopLeftY = canvasY;
+        vp.Width = canvasW;
+        vp.Height = canvasH;
+        uvParams[0] = canvasW / (float)g_sharedWidth;
+        uvParams[1] = canvasH / (float)g_sharedHeight;
+        uvParams[2] = canvasX / (float)g_sharedWidth;
+        uvParams[3] = canvasY / (float)g_sharedHeight;
+    }
     vp.MaxDepth = 1.0f;
     renderer.context->RSSetViewports(1, &vp);
 
-    // Tell the runtime where the shared texture is displayed within our window
-    // so the SR weaver hidden window aligns correctly for interlacing
-    if (xr.pfnSetSharedTextureOutputRectEXT && xr.session != XR_NULL_HANDLE) {
-        xr.pfnSetSharedTextureOutputRectEXT(xr.session,
-            (int32_t)vp.TopLeftX, (int32_t)vp.TopLeftY,
-            (uint32_t)vp.Width, (uint32_t)vp.Height);
-    }
-
-    // Update UV scale + offset: content is at (canvasX, canvasY) in the shared
-    // texture per ADR-010 — compositor writes the weaved canvas region at that
-    // offset. Sample at uvOffset + uv * uvScale.
     if (g_blitParamsCB && g_sharedWidth > 0 && g_sharedHeight > 0) {
-        float uvParams[4] = {
-            (float)g_canvasW / (float)g_sharedWidth,
-            (float)g_canvasH / (float)g_sharedHeight,
-            vp.TopLeftX / (float)g_sharedWidth,
-            vp.TopLeftY / (float)g_sharedHeight,
-        };
         D3D11_MAPPED_SUBRESOURCE mapped;
         if (SUCCEEDED(renderer.context->Map(g_blitParamsCB.Get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped))) {
             memcpy(mapped.pData, uvParams, sizeof(uvParams));
@@ -401,6 +619,20 @@ static void RenderOneFrame(RenderState& rs) {
     if (g_windowWidth > 0 && g_windowHeight > 0) {
         g_canvasW = g_windowWidth / 2;
         g_canvasH = g_windowHeight / 2;
+    }
+
+    // Spec v6 §3.6: refresh the surround texture each frame. Done before
+    // xrBeginFrame so the runtime sees up-to-date pixels when it reads the
+    // surround at submit time. The keyed-mutex acquire-write-release inside
+    // RenderSurroundPattern handshakes with the compositor's read pass.
+    if (g_surroundRegistered && rs.perfStats) {
+        static auto surroundStartTime = std::chrono::steady_clock::now();
+        float t = std::chrono::duration<float>(std::chrono::steady_clock::now() - surroundStartTime).count();
+        int32_t cx = (int32_t)(g_windowWidth * 0.25f);
+        int32_t cy = (int32_t)(g_windowHeight * 0.25f);
+        uint32_t cw = g_windowWidth / 2;
+        uint32_t ch = g_windowHeight / 2;
+        RenderSurroundPattern(renderer, g_windowWidth, g_windowHeight, cx, cy, cw, ch, t);
     }
 
     if (xr.sessionRunning) {
@@ -539,6 +771,9 @@ static void RenderOneFrame(RenderState& rs) {
                             sessionText += L"\nSession: ";
                             sessionText += FormatSessionState((int)xr.sessionState);
                             std::wstring modeText = L"Shared Texture D3D11 (offscreen)";
+                            modeText += g_surroundRegistered ?
+                                L"\nSurround 2D: ACTIVE (spec v6)" :
+                                L"\nSurround 2D: inactive";
                             modeText += g_inputState.cameraMode ?
                                 L"\nKooima: Camera-Centric [C=Toggle]" :
                                 L"\nKooima: Display-Centric [C=Toggle]";
@@ -907,6 +1142,23 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         return 1;
     }
 
+    // Spec v6 §3.6: full-window 2D surround texture. Sized + formatted to
+    // match the multiview shared texture so the compositor strip-blit
+    // (CopySubresourceRegion, no format conversion) succeeds. We resolve the
+    // PFN after CreateInstance in InitializeOpenXR, so it's known here.
+    bool surroundSetupOk = false;
+    if (xr.pfnSetSharedTextureSurround2DEXT) {
+        surroundSetupOk = CreateSurroundShaderResources(renderer.device.Get()) &&
+                          CreateSurroundTexture(renderer.device.Get(),
+                                                g_sharedWidth, g_sharedHeight,
+                                                DXGI_FORMAT_B8G8R8A8_UNORM);
+        if (!surroundSetupOk) {
+            LOG_WARN("Surround 2D setup failed — continuing without surround (canvas-only blit)");
+        }
+    } else {
+        LOG_WARN("Runtime does not expose xrSetSharedTextureSurround2DEXT (pre-spec-v6) — surround disabled");
+    }
+
     // HUD renderer
     HudRenderer hudRenderer = {};
     bool hudOk = InitializeHudRenderer(hudRenderer, HUD_PIXEL_WIDTH, HUD_PIXEL_HEIGHT);
@@ -919,6 +1171,19 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         CleanupOpenXR(xr);
         ShutdownLogging();
         return 1;
+    }
+
+    // Register the surround texture with the runtime. NULL pfn or handle =
+    // we skip and the blit stays on the canvas-only path.
+    if (surroundSetupOk && xr.pfnSetSharedTextureSurround2DEXT && g_surroundHandle) {
+        XrResult sres = xr.pfnSetSharedTextureSurround2DEXT(xr.session, g_surroundHandle,
+            g_sharedWidth, g_sharedHeight);
+        if (XR_SUCCEEDED(sres)) {
+            g_surroundRegistered = true;
+            LOG_INFO("Registered surround 2D texture with runtime (%ux%u)", g_sharedWidth, g_sharedHeight);
+        } else {
+            LogXrResult("xrSetSharedTextureSurround2DEXT", sres);
+        }
     }
 
     if (!CreateSpaces(xr)) {
@@ -1028,6 +1293,22 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
     rs.appSwapchain.Reset();
     rs.depthDSV.Reset();
     rs.depthTexture.Reset();
+
+    // Clear the runtime's surround registration first so the compositor
+    // releases its opened texture before we drop our refs.
+    if (g_surroundRegistered && xr.pfnSetSharedTextureSurround2DEXT && xr.session != XR_NULL_HANDLE) {
+        xr.pfnSetSharedTextureSurround2DEXT(xr.session, nullptr, 0, 0);
+        g_surroundRegistered = false;
+    }
+    if (g_surroundHandle) {
+        CloseHandle(g_surroundHandle);
+        g_surroundHandle = nullptr;
+    }
+    g_surroundMutex.Reset();
+    g_surroundRTV.Reset();
+    g_surroundTexture.Reset();
+    g_surroundPS.Reset();
+    g_surroundParamsCB.Reset();
 
     depthDSV.Reset();
     depthTexture.Reset();

--- a/test_apps/cube_texture_d3d11_win/xr_session.cpp
+++ b/test_apps/cube_texture_d3d11_win/xr_session.cpp
@@ -160,6 +160,8 @@ bool InitializeOpenXR(XrSessionManager& xr) {
             (PFN_xrVoidFunction*)&xr.pfnEnumerateDisplayRenderingModesEXT);
         xrGetInstanceProcAddr(xr.instance, "xrSetSharedTextureOutputRectEXT",
             (PFN_xrVoidFunction*)&xr.pfnSetSharedTextureOutputRectEXT);
+        xrGetInstanceProcAddr(xr.instance, "xrSetSharedTextureSurround2DEXT",
+            (PFN_xrVoidFunction*)&xr.pfnSetSharedTextureSurround2DEXT);
     }
 
     // Get view configuration views

--- a/test_apps/cube_texture_d3d12_win/main.cpp
+++ b/test_apps/cube_texture_d3d12_win/main.cpp
@@ -73,6 +73,21 @@ static uint32_t g_sharedHeight = 0;
 static uint32_t g_canvasW = 0;
 static uint32_t g_canvasH = 0;
 
+// Surround 2D texture (spec v7 §3.7). Same dims + format as g_sharedTexture
+// because the D3D12 compositor strip-blit uses CopyTextureRegion and
+// enforces format equality. Uses an ID3D12Fence (shared NT handle) for
+// producer→consumer sync since IDXGIKeyedMutex is not reliably available
+// on D3D12-native shared resources (E_NOINTERFACE on common drivers).
+static ComPtr<ID3D12Resource> g_surroundTexture;
+static HANDLE g_surroundHandle = nullptr;
+static ComPtr<ID3D12Fence> g_surroundFence;
+static HANDLE g_surroundFenceHandle = nullptr;
+static uint64_t g_surroundFenceValue = 0;  // app-side monotonic counter
+static ComPtr<ID3D12DescriptorHeap> g_surroundRtvHeap;
+static ComPtr<ID3D12RootSignature> g_surroundRootSig;
+static ComPtr<ID3D12PipelineState> g_surroundPSO;
+static bool g_surroundRegistered = false;
+
 // App-side DXGI swapchain for window presentation
 static const UINT APP_BACK_BUFFER_COUNT = 2;
 static ComPtr<IDXGISwapChain3> g_appSwapchain;
@@ -325,6 +340,251 @@ static bool CreateBlitPipeline(ID3D12Device* device) {
     return true;
 }
 
+// ---- Surround 2D pipeline (spec v6 §3.6) ----
+
+// Identical procedural pattern to cube_texture_d3d11_win: gradient +
+// checkerboard everywhere outside the canvas, red highlight on the canvas
+// border, slow diagonal sweep. Inside the canvas it writes black — the
+// compositor copy doesn't read those pixels (the canvas region is the DP's
+// weave), so the value is cosmetic only.
+static const char* g_surroundPSSource = R"(
+cbuffer SurroundParams : register(b0) {
+    float2 windowSize;
+    float2 _pad0;
+    int4   canvas;
+    float  time;
+    float3 _pad1;
+};
+float4 main(float4 pos : SV_Position, float2 uv : TEXCOORD0) : SV_Target {
+    float2 p = pos.xy;
+    if (p.x >= windowSize.x || p.y >= windowSize.y) {
+        return float4(0, 0, 0, 1);
+    }
+    float bx0 = (float)canvas.x;
+    float by0 = (float)canvas.y;
+    float bx1 = (float)(canvas.x + canvas.z);
+    float by1 = (float)(canvas.y + canvas.w);
+    float dx = max(bx0 - p.x, p.x - bx1);
+    float dy = max(by0 - p.y, p.y - by1);
+    float d  = max(dx, dy);
+    if (d <= 0) {
+        return float4(0, 0, 0, 1);
+    }
+    if (d <= 4.0) {
+        return float4(1.0, 0.25, 0.25, 1.0);
+    }
+    int2 cell = int2(p / 24.0);
+    bool light = ((cell.x + cell.y) & 1) == 0;
+    float3 base = light ? float3(0.82, 0.84, 0.92) : float3(0.50, 0.55, 0.80);
+    float2 g = saturate(p / windowSize);
+    base.r += g.x * 0.18;
+    base.g += g.y * 0.10;
+    base.b += (1.0 - g.x) * 0.10;
+    float sweep = frac((p.x + p.y) / 256.0 - time * 0.10);
+    base += (smoothstep(0.45, 0.5, sweep) - smoothstep(0.5, 0.55, sweep)) * 0.10;
+    return float4(saturate(base), 1.0);
+}
+)";
+
+static bool CreateSurroundPipeline(ID3D12Device* device) {
+    // Root signature: one root-constants param (12 × uint32 = 48 bytes).
+    D3D12_ROOT_PARAMETER param = {};
+    param.ParameterType = D3D12_ROOT_PARAMETER_TYPE_32BIT_CONSTANTS;
+    param.Constants.ShaderRegister = 0;
+    param.Constants.RegisterSpace = 0;
+    param.Constants.Num32BitValues = 12;
+    param.ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
+
+    D3D12_ROOT_SIGNATURE_DESC rsDesc = {};
+    rsDesc.NumParameters = 1;
+    rsDesc.pParameters = &param;
+    rsDesc.Flags = D3D12_ROOT_SIGNATURE_FLAG_NONE;
+
+    ComPtr<ID3DBlob> serialized, error;
+    HRESULT hr = D3D12SerializeRootSignature(&rsDesc, D3D_ROOT_SIGNATURE_VERSION_1,
+        &serialized, &error);
+    if (FAILED(hr)) {
+        LOG_ERROR("Surround root signature serialize failed: %s",
+            error ? (char*)error->GetBufferPointer() : "unknown");
+        return false;
+    }
+    hr = device->CreateRootSignature(0, serialized->GetBufferPointer(),
+        serialized->GetBufferSize(), IID_PPV_ARGS(&g_surroundRootSig));
+    if (FAILED(hr)) return false;
+
+    // Reuse the blit fullscreen-triangle VS.
+    ComPtr<ID3DBlob> vsBlob, psBlob, errBlob;
+    hr = D3DCompile(g_blitVSSource, strlen(g_blitVSSource), "blitVS",
+        nullptr, nullptr, "main", "vs_5_0", 0, 0, &vsBlob, &errBlob);
+    if (FAILED(hr)) {
+        LOG_ERROR("Surround VS compile failed: %s",
+            errBlob ? (char*)errBlob->GetBufferPointer() : "unknown");
+        return false;
+    }
+    hr = D3DCompile(g_surroundPSSource, strlen(g_surroundPSSource), "surroundPS",
+        nullptr, nullptr, "main", "ps_5_0", 0, 0, &psBlob, &errBlob);
+    if (FAILED(hr)) {
+        LOG_ERROR("Surround PS compile failed: %s",
+            errBlob ? (char*)errBlob->GetBufferPointer() : "unknown");
+        return false;
+    }
+
+    D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
+    psoDesc.pRootSignature = g_surroundRootSig.Get();
+    psoDesc.VS = {vsBlob->GetBufferPointer(), vsBlob->GetBufferSize()};
+    psoDesc.PS = {psBlob->GetBufferPointer(), psBlob->GetBufferSize()};
+    psoDesc.BlendState.RenderTarget[0].RenderTargetWriteMask = D3D12_COLOR_WRITE_ENABLE_ALL;
+    psoDesc.SampleMask = UINT_MAX;
+    psoDesc.RasterizerState.FillMode = D3D12_FILL_MODE_SOLID;
+    psoDesc.RasterizerState.CullMode = D3D12_CULL_MODE_NONE;
+    psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+    psoDesc.NumRenderTargets = 1;
+    psoDesc.RTVFormats[0] = DXGI_FORMAT_B8G8R8A8_UNORM;
+    psoDesc.SampleDesc.Count = 1;
+
+    hr = device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&g_surroundPSO));
+    if (FAILED(hr)) {
+        LOG_ERROR("Surround PSO creation failed: 0x%08X", hr);
+        return false;
+    }
+
+    // One RTV for the surround texture.
+    D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
+    rtvHeapDesc.NumDescriptors = 1;
+    rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+    rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+    hr = device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&g_surroundRtvHeap));
+    return SUCCEEDED(hr);
+}
+
+// Creates the surround texture (D3D12_HEAP_FLAG_SHARED, no KeyedMutex needed)
+// AND a paired shared ID3D12Fence (D3D12_FENCE_FLAG_SHARED). Both NT handles
+// are exported via ID3D12Device::CreateSharedHandle. The fence drives the
+// runtime's `commandQueue->Wait` before its strip-blit each frame.
+static bool CreateSurroundTextureD3D12(ID3D12Device* device,
+                                        uint32_t width, uint32_t height,
+                                        DXGI_FORMAT format) {
+    D3D12_HEAP_PROPERTIES heapProps = {};
+    heapProps.Type = D3D12_HEAP_TYPE_DEFAULT;
+
+    D3D12_RESOURCE_DESC texDesc = {};
+    texDesc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
+    texDesc.Width = width;
+    texDesc.Height = height;
+    texDesc.DepthOrArraySize = 1;
+    texDesc.MipLevels = 1;
+    texDesc.Format = format;
+    texDesc.SampleDesc.Count = 1;
+    texDesc.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
+    texDesc.Flags = D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET;
+
+    HRESULT hr = device->CreateCommittedResource(
+        &heapProps, D3D12_HEAP_FLAG_SHARED, &texDesc,
+        D3D12_RESOURCE_STATE_COMMON, nullptr, IID_PPV_ARGS(&g_surroundTexture));
+    if (FAILED(hr)) {
+        LOG_ERROR("Surround texture create failed: 0x%08x", hr);
+        return false;
+    }
+
+    hr = device->CreateSharedHandle(g_surroundTexture.Get(), nullptr, GENERIC_ALL,
+        nullptr, &g_surroundHandle);
+    if (FAILED(hr)) {
+        LOG_ERROR("Surround texture CreateSharedHandle failed: 0x%08x", hr);
+        g_surroundTexture.Reset();
+        return false;
+    }
+
+    hr = device->CreateFence(0,
+        D3D12_FENCE_FLAG_SHARED,
+        IID_PPV_ARGS(&g_surroundFence));
+    if (FAILED(hr)) {
+        LOG_ERROR("Surround fence create failed: 0x%08x", hr);
+        CloseHandle(g_surroundHandle);
+        g_surroundHandle = nullptr;
+        g_surroundTexture.Reset();
+        return false;
+    }
+
+    hr = device->CreateSharedHandle(g_surroundFence.Get(), nullptr, GENERIC_ALL,
+        nullptr, &g_surroundFenceHandle);
+    if (FAILED(hr)) {
+        LOG_ERROR("Surround fence CreateSharedHandle failed: 0x%08x", hr);
+        g_surroundFence.Reset();
+        CloseHandle(g_surroundHandle);
+        g_surroundHandle = nullptr;
+        g_surroundTexture.Reset();
+        return false;
+    }
+
+    D3D12_RENDER_TARGET_VIEW_DESC rtvDesc = {};
+    rtvDesc.Format = format;
+    rtvDesc.ViewDimension = D3D12_RTV_DIMENSION_TEXTURE2D;
+    device->CreateRenderTargetView(g_surroundTexture.Get(), &rtvDesc,
+        g_surroundRtvHeap->GetCPUDescriptorHandleForHeapStart());
+
+    LOG_INFO("Created surround D3D12 texture: %ux%u format=%u tex_handle=%p fence_handle=%p",
+        width, height, (unsigned)format, g_surroundHandle, g_surroundFenceHandle);
+    return true;
+}
+
+// Record (into an already-Reset cmd list) the surround render pass: barrier
+// COMMON→RENDER_TARGET, fullscreen triangle, barrier back. Caller acquires
+// the keyed mutex on key 0 before this and releases after ExecuteCommandLists.
+static void RecordSurroundPattern(ID3D12GraphicsCommandList* cmdList,
+                                    uint32_t winW, uint32_t winH,
+                                    int32_t canvasX, int32_t canvasY,
+                                    uint32_t canvasW, uint32_t canvasH,
+                                    float timeSeconds) {
+    D3D12_RESOURCE_BARRIER barrier = {};
+    barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+    barrier.Transition.pResource = g_surroundTexture.Get();
+    barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_COMMON;
+    barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_RENDER_TARGET;
+    barrier.Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+    cmdList->ResourceBarrier(1, &barrier);
+
+    D3D12_CPU_DESCRIPTOR_HANDLE rtv = g_surroundRtvHeap->GetCPUDescriptorHandleForHeapStart();
+    cmdList->OMSetRenderTargets(1, &rtv, FALSE, nullptr);
+
+    D3D12_VIEWPORT vp = {};
+    vp.TopLeftX = 0.0f;
+    vp.TopLeftY = 0.0f;
+    vp.Width = (FLOAT)winW;
+    vp.Height = (FLOAT)winH;
+    vp.MaxDepth = 1.0f;
+    cmdList->RSSetViewports(1, &vp);
+
+    D3D12_RECT scissor = {0, 0, (LONG)winW, (LONG)winH};
+    cmdList->RSSetScissorRects(1, &scissor);
+
+    cmdList->SetPipelineState(g_surroundPSO.Get());
+    cmdList->SetGraphicsRootSignature(g_surroundRootSig.Get());
+
+    // Match the cbuffer SurroundParams layout (48 bytes, 12 × uint32).
+    struct ParamsLayout {
+        float windowSize[2];
+        float _pad0[2];
+        int32_t canvas[4];
+        float time;
+        float _pad1[3];
+    } params = {};
+    params.windowSize[0] = (float)winW;
+    params.windowSize[1] = (float)winH;
+    params.canvas[0] = canvasX;
+    params.canvas[1] = canvasY;
+    params.canvas[2] = (int32_t)canvasW;
+    params.canvas[3] = (int32_t)canvasH;
+    params.time = timeSeconds;
+    cmdList->SetGraphicsRoot32BitConstants(0, 12, &params, 0);
+
+    cmdList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+    cmdList->DrawInstanced(3, 1, 0, 0);
+
+    barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
+    barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_COMMON;
+    cmdList->ResourceBarrier(1, &barrier);
+}
+
 static void CreateSharedTextureSRV(ID3D12Device* device) {
     D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
     srvDesc.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
@@ -335,8 +595,14 @@ static void CreateSharedTextureSRV(ID3D12Device* device) {
         g_blitSrvHeap->GetCPUDescriptorHandleForHeapStart());
 }
 
-// Blit shared texture to back buffer with canvas letterboxing
-static void BlitSharedTextureToBackBuffer(D3D12Renderer& renderer, XrSessionManager& xr) {
+// Blit shared texture to back buffer with canvas letterboxing.
+// When the surround texture is registered, this also (1) records a per-frame
+// surround pattern render at the top of the cmd list (covered by a keyed
+// mutex on key 0) and (2) widens the blit viewport + UV range to read back
+// the full window region of the shared texture so the surround strips
+// (filled by the compositor at submit time) are visible in the window.
+static void BlitSharedTextureToBackBuffer(D3D12Renderer& renderer, XrSessionManager& xr,
+                                           float surroundTimeSeconds) {
     if (!g_sharedTexture || !g_appSwapchain) return;
 
     UINT bbIndex = g_appSwapchain->GetCurrentBackBufferIndex();
@@ -345,7 +611,37 @@ static void BlitSharedTextureToBackBuffer(D3D12Renderer& renderer, XrSessionMana
     g_blitCmdAllocator->Reset();
     g_blitCmdList->Reset(g_blitCmdAllocator.Get(), g_blitPSO.Get());
 
-    // Barriers: shared texture COMMON→SRV, back buffer PRESENT→RENDER_TARGET
+    // Canvas = center 50% of window
+    float canvasX = (FLOAT)g_windowWidth * 0.25f;
+    float canvasY = (FLOAT)g_windowHeight * 0.25f;
+    float canvasW = (FLOAT)g_windowWidth * 0.5f;
+    float canvasH = (FLOAT)g_windowHeight * 0.5f;
+
+    // Tell runtime where the canvas is. The compositor uses this to drive
+    // DP weave region + surround strip layout — call every frame.
+    if (xr.pfnSetSharedTextureOutputRectEXT && xr.session != XR_NULL_HANDLE) {
+        xr.pfnSetSharedTextureOutputRectEXT(xr.session,
+            (int32_t)canvasX, (int32_t)canvasY,
+            (uint32_t)canvasW, (uint32_t)canvasH);
+    }
+
+    // (1) Surround render — sync is fence-based (spec v7). We record the
+    // surround draw into the same cmd list as the blit; the GPU executes
+    // them in order. After ExecuteCommandLists below we Signal(fence, N)
+    // and tell the runtime to Wait(fence, N) via the OpenXR call. The
+    // runtime's own command queue will block on the next ExecuteCommandLists
+    // until our signal lands, so its strip-blit reads stable pixels.
+    bool surroundRecorded = false;
+    if (g_surroundRegistered && g_surroundFence && g_surroundPSO) {
+        RecordSurroundPattern(g_blitCmdList.Get(),
+            g_windowWidth, g_windowHeight,
+            (int32_t)canvasX, (int32_t)canvasY,
+            (uint32_t)canvasW, (uint32_t)canvasH,
+            surroundTimeSeconds);
+        surroundRecorded = true;
+    }
+
+    // (2) Blit setup — barriers, RTV, viewport.
     D3D12_RESOURCE_BARRIER barriers[2] = {};
     barriers[0].Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
     barriers[0].Transition.pResource = g_sharedTexture.Get();
@@ -361,49 +657,49 @@ static void BlitSharedTextureToBackBuffer(D3D12Renderer& renderer, XrSessionMana
 
     g_blitCmdList->ResourceBarrier(2, barriers);
 
-    // Clear back buffer to black
     D3D12_CPU_DESCRIPTOR_HANDLE rtvHandle = g_appRtvHeap->GetCPUDescriptorHandleForHeapStart();
     rtvHandle.ptr += bbIndex * g_appRtvDescriptorSize;
     float clearColor[4] = {0.0f, 0.0f, 0.0f, 1.0f};
     g_blitCmdList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
 
-    // Set render target
     g_blitCmdList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
 
-    // Canvas = center 50% of window
+    // Viewport + UV sampling: full-window when surround is active so the
+    // strip pixels become visible; canvas-only otherwise.
     D3D12_VIEWPORT vp = {};
-    vp.Width = (FLOAT)g_windowWidth * 0.5f;
-    vp.Height = (FLOAT)g_windowHeight * 0.5f;
-    vp.TopLeftX = (FLOAT)g_windowWidth * 0.25f;
-    vp.TopLeftY = (FLOAT)g_windowHeight * 0.25f;
+    float uvParams[4];
+    if (g_surroundRegistered) {
+        vp.TopLeftX = 0.0f;
+        vp.TopLeftY = 0.0f;
+        vp.Width = (FLOAT)g_windowWidth;
+        vp.Height = (FLOAT)g_windowHeight;
+        uvParams[0] = g_sharedWidth  > 0 ? (float)g_windowWidth  / (float)g_sharedWidth  : 1.0f;
+        uvParams[1] = g_sharedHeight > 0 ? (float)g_windowHeight / (float)g_sharedHeight : 1.0f;
+        uvParams[2] = 0.0f;
+        uvParams[3] = 0.0f;
+    } else {
+        vp.TopLeftX = canvasX;
+        vp.TopLeftY = canvasY;
+        vp.Width = canvasW;
+        vp.Height = canvasH;
+        uvParams[0] = g_sharedWidth  > 0 ? canvasW / (float)g_sharedWidth  : 1.0f;
+        uvParams[1] = g_sharedHeight > 0 ? canvasH / (float)g_sharedHeight : 1.0f;
+        uvParams[2] = g_sharedWidth  > 0 ? canvasX / (float)g_sharedWidth  : 0.0f;
+        uvParams[3] = g_sharedHeight > 0 ? canvasY / (float)g_sharedHeight : 0.0f;
+    }
     vp.MaxDepth = 1.0f;
     g_blitCmdList->RSSetViewports(1, &vp);
 
     D3D12_RECT scissor = {0, 0, (LONG)g_windowWidth, (LONG)g_windowHeight};
     g_blitCmdList->RSSetScissorRects(1, &scissor);
 
-    // Tell runtime where canvas is in the window (weaver alignment)
-    if (xr.pfnSetSharedTextureOutputRectEXT && xr.session != XR_NULL_HANDLE) {
-        xr.pfnSetSharedTextureOutputRectEXT(xr.session,
-            (int32_t)vp.TopLeftX, (int32_t)vp.TopLeftY,
-            (uint32_t)vp.Width, (uint32_t)vp.Height);
-    }
-
-    // Set blit pipeline
+    // The surround pass above changed the PSO. Re-set blit PSO and root sig.
+    g_blitCmdList->SetPipelineState(g_blitPSO.Get());
     g_blitCmdList->SetGraphicsRootSignature(g_blitRootSig.Get());
     ID3D12DescriptorHeap* heaps[] = {g_blitSrvHeap.Get()};
     g_blitCmdList->SetDescriptorHeaps(1, heaps);
     g_blitCmdList->SetGraphicsRootDescriptorTable(0, g_blitSrvHeap->GetGPUDescriptorHandleForHeapStart());
 
-    // UV scale + offset: content is at (canvasX, canvasY) in the shared texture
-    // per ADR-010 — compositor writes the weaved canvas region at that offset.
-    // Sample at uvOffset + uv * uvScale.
-    float uvParams[4] = {
-        g_sharedWidth > 0 ? (float)g_canvasW / (float)g_sharedWidth : 1.0f,
-        g_sharedHeight > 0 ? (float)g_canvasH / (float)g_sharedHeight : 1.0f,
-        g_sharedWidth > 0 ? vp.TopLeftX / (float)g_sharedWidth : 0.0f,
-        g_sharedHeight > 0 ? vp.TopLeftY / (float)g_sharedHeight : 0.0f,
-    };
     g_blitCmdList->SetGraphicsRoot32BitConstants(1, 4, uvParams, 0);
 
     g_blitCmdList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
@@ -420,6 +716,20 @@ static void BlitSharedTextureToBackBuffer(D3D12Renderer& renderer, XrSessionMana
 
     ID3D12CommandList* lists[] = {g_blitCmdList.Get()};
     renderer.commandQueue->ExecuteCommandLists(1, lists);
+
+    if (surroundRecorded) {
+        // Spec v7 producer signal: bump fence on our queue, then push the
+        // new await value to the runtime so its next per-frame strip-blit
+        // queue-waits on it. The OpenXR call also keeps the registration
+        // alive (clearing it would require passing NULL handle).
+        g_surroundFenceValue++;
+        renderer.commandQueue->Signal(g_surroundFence.Get(), g_surroundFenceValue);
+        if (xr.pfnSetSharedTextureSurround2DFenceEXT && xr.session != XR_NULL_HANDLE) {
+            xr.pfnSetSharedTextureSurround2DFenceEXT(xr.session,
+                g_surroundHandle, g_sharedWidth, g_sharedHeight,
+                g_surroundFenceHandle, g_surroundFenceValue);
+        }
+    }
 
     g_appSwapchain->Present(1, 0);
 
@@ -759,6 +1069,9 @@ static void RenderOneFrame(RenderState& rs) {
                             sessionText += L"\nSession: ";
                             sessionText += FormatSessionState((int)xr.sessionState);
                             std::wstring modeText = L"Shared Texture D3D12 (offscreen)";
+                            modeText += g_surroundRegistered ?
+                                L"\nSurround 2D: ACTIVE (spec v6)" :
+                                L"\nSurround 2D: inactive";
                             modeText += g_inputState.cameraMode ?
                                 L"\nKooima: Camera-Centric [C=Toggle]" :
                                 L"\nKooima: Display-Centric [C=Toggle]";
@@ -952,9 +1265,13 @@ static void RenderOneFrame(RenderState& rs) {
                 ResizeAppSwapchain(renderer);
             }
 
-            // After xrEndFrame: blit shared texture to app window
+            // After xrEndFrame: blit shared texture to app window. We also
+            // render the surround pattern inline (under keyed mutex) when
+            // surround is registered.
             if (frameState.shouldRender) {
-                BlitSharedTextureToBackBuffer(renderer, xr);
+                static auto surroundStartTime = std::chrono::steady_clock::now();
+                float t = std::chrono::duration<float>(std::chrono::steady_clock::now() - surroundStartTime).count();
+                BlitSharedTextureToBackBuffer(renderer, xr, t);
             }
         }
     } else {
@@ -1115,6 +1432,23 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
     // Create SRV for shared texture (for blit)
     CreateSharedTextureSRV(renderer.device.Get());
 
+    // Spec v7 §3.7: full-window 2D surround texture with fence-based sync
+    // (the only path that works on D3D12-native shared resources). On a
+    // pre-v7 runtime the PFN lookup returns null and surround stays off —
+    // the cube still weaves correctly via the canvas-only blit.
+    bool surroundSetupOk = false;
+    if (xr.pfnSetSharedTextureSurround2DFenceEXT) {
+        surroundSetupOk = CreateSurroundPipeline(renderer.device.Get()) &&
+                          CreateSurroundTextureD3D12(renderer.device.Get(),
+                                                     g_sharedWidth, g_sharedHeight,
+                                                     DXGI_FORMAT_B8G8R8A8_UNORM);
+        if (!surroundSetupOk) {
+            LOG_WARN("Surround 2D (fence) setup failed — continuing without surround");
+        }
+    } else {
+        LOG_WARN("Runtime does not expose xrSetSharedTextureSurround2DFenceEXT (pre-spec-v7) — surround disabled");
+    }
+
     // HUD renderer
     HudRenderer hudRenderer = {};
     bool hudOk = InitializeHudRenderer(hudRenderer, HUD_PIXEL_WIDTH, HUD_PIXEL_HEIGHT);
@@ -1127,6 +1461,23 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         CleanupOpenXR(xr);
         ShutdownLogging();
         return 1;
+    }
+
+    // Seed the runtime with handle opens + initial await value of 0. The
+    // fence's completed value is 0 at creation, so the first frame's
+    // queue->Wait(fence, 0) returns immediately; subsequent per-frame
+    // calls bump the await value.
+    if (surroundSetupOk && xr.pfnSetSharedTextureSurround2DFenceEXT && g_surroundHandle) {
+        XrResult sres = xr.pfnSetSharedTextureSurround2DFenceEXT(xr.session,
+            g_surroundHandle, g_sharedWidth, g_sharedHeight,
+            g_surroundFenceHandle, 0);
+        if (XR_SUCCEEDED(sres)) {
+            g_surroundRegistered = true;
+            LOG_INFO("Registered surround 2D (fence) with runtime (%ux%u)",
+                g_sharedWidth, g_sharedHeight);
+        } else {
+            LogXrResult("xrSetSharedTextureSurround2DFenceEXT", sres);
+        }
     }
 
     if (!CreateSpaces(xr)) {
@@ -1307,6 +1658,27 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
     g_blitPSO.Reset();
     g_blitRootSig.Reset();
     g_blitSrvHeap.Reset();
+
+    // Clear surround registration before dropping our refs so the runtime
+    // releases its opened ID3D12Resource + ID3D12Fence views of the shared
+    // handles. Fence handle argument is ignored on the clear path.
+    if (g_surroundRegistered && xr.pfnSetSharedTextureSurround2DFenceEXT && xr.session != XR_NULL_HANDLE) {
+        xr.pfnSetSharedTextureSurround2DFenceEXT(xr.session, nullptr, 0, 0, nullptr, 0);
+        g_surroundRegistered = false;
+    }
+    if (g_surroundHandle) {
+        CloseHandle(g_surroundHandle);
+        g_surroundHandle = nullptr;
+    }
+    if (g_surroundFenceHandle) {
+        CloseHandle(g_surroundFenceHandle);
+        g_surroundFenceHandle = nullptr;
+    }
+    g_surroundFence.Reset();
+    g_surroundRtvHeap.Reset();
+    g_surroundPSO.Reset();
+    g_surroundRootSig.Reset();
+    g_surroundTexture.Reset();
 
     // Cleanup shared texture
     if (g_sharedHandle) {

--- a/test_apps/cube_texture_d3d12_win/xr_session.cpp
+++ b/test_apps/cube_texture_d3d12_win/xr_session.cpp
@@ -160,6 +160,10 @@ bool InitializeOpenXR(XrSessionManager& xr) {
             (PFN_xrVoidFunction*)&xr.pfnEnumerateDisplayRenderingModesEXT);
         xrGetInstanceProcAddr(xr.instance, "xrSetSharedTextureOutputRectEXT",
             (PFN_xrVoidFunction*)&xr.pfnSetSharedTextureOutputRectEXT);
+        xrGetInstanceProcAddr(xr.instance, "xrSetSharedTextureSurround2DEXT",
+            (PFN_xrVoidFunction*)&xr.pfnSetSharedTextureSurround2DEXT);
+        xrGetInstanceProcAddr(xr.instance, "xrSetSharedTextureSurround2DFenceEXT",
+            (PFN_xrVoidFunction*)&xr.pfnSetSharedTextureSurround2DFenceEXT);
     }
 
     // Get view configuration views


### PR DESCRIPTION
## Summary

Adds `xrSetSharedTextureSurround2DEXT` (Win32 v6 / Cocoa v6) and `xrSetSharedTextureSurround2DFenceEXT` (Win32 v7) to register a full-window 2D shared texture whose pixels **outside** the canvas sub-rect are blitted into the target swapchain each frame. Pairs with the existing `xrSetSharedTextureOutputRectEXT` — canvas rect says *where* 3D content goes; the new call says *what fills the rest*.

**Target use case:** displays with a **fixed hardware 3D zone** (a sub-rect of the panel that's lenticular-weaved; the rest is 2D-native). The 3D viewport renders inside the canvas, full-resolution 2D UI / chrome fills the surround. End consumer: the [Unity plugin](https://github.com/DisplayXR/displayxr-unity) (Phase G, not in this PR).

**Visually verified end-to-end on Leia SR hardware on this branch** (`cube_texture_d3d11_win` + `cube_texture_d3d12_win`): center-50% canvas weave + checkerboard/gradient/sweep surround, pixel-crisp boundary, no leakage.

## Two API variants — why both

| API | Spec | Sync | When |
|---|---|---|---|
| `xrSetSharedTextureSurround2DEXT` | v6 | `IDXGIKeyedMutex` (key 0) | D3D11 apps |
| `xrSetSharedTextureSurround2DFenceEXT` | v7 | `ID3D12Fence` (producer Signal / consumer Wait) | **D3D12 apps** |

The v7 fence path was added after we discovered the v6 keyed-mutex contract does not work for D3D12-native shared resources: `QueryInterface(__uuidof(IDXGIKeyedMutex))` returns `E_NOINTERFACE` on common Windows/driver combinations (verified RTX 3080 / Win11 26200 on 2026-05-28). `ID3D12Fence` is the canonical D3D12 cross-process sync primitive, is shareable via `CreateSharedHandle`, and integrates with `ID3D12CommandQueue::Wait` / `Signal`. Read-only access on the runtime side means producer-signal + consumer-wait is sufficient — no bidirectional bracket needed.

The two paths are mutually exclusive per session and per compositor. The D3D12 compositor accepts either (the v7 path is the recommended one for D3D12 apps).

## Design conversation

Considered four alternatives before settling on the texture-app setter:

| | Approach | Why not |
|---|---|---|
| 1 | Post-weave overlay layer (`XR_COMPOSITION_LAYER_PANEL_NATIVE_BIT`) | OpenXR-canonical but introduces a new layer type; texture-app idiom already plumbs the canvas rect so a sibling setter is smaller surface |
| 2 | Inverse mask, software variant of #224 | Mask is degenerate (constant rect per session = hardware zone); not worth the per-frame publish cost when a static rect via setter is equivalent |
| 3 | Texture-app trick using one buffer (implicit) | "Outside canvas is whatever the app left there" doesn't work — target swap chain is runtime-owned, not app-owned. The surround texture is the explicit form of this. |
| **4** | **`xrSetSharedTextureSurround2D{,Fence}EXT` (this PR)** | **Smallest API surface, reuses canvas plumbing, generalizes the existing texture-app model** |

Full design doc: [`docs/roadmap/surround-2d-rollout.md`](https://github.com/DisplayXR/displayxr-runtime/blob/feature/surround-2d-spec/docs/roadmap/surround-2d-rollout.md).

## Relationship to #224 (local-3d-zones)

Complementary, not competing.

- **This PR:** static rectangular complement of the canvas rect, software only, works on **today's hardware** where the 3D zone is fixed.
- **#224 (XR_EXT_local_3d_zone):** per-frame per-pixel mask published via DP vtable, drives **per-zone hardware switching** when that hardware lands.

The two primitives coexist — an app could register a surround for the static surround and publish a mask for dynamic per-pixel exceptions.

## Phase status

| Phase | Status | Commit |
|---|---|---|
| A — Spec + headers (v6 win32 + cocoa) | ✅ landed | d7d9bef9 |
| B — State-tracker entry point + 5-way compositor dispatch | ✅ landed | 08ca0c8a |
| C — D3D11 real impl (OpenSharedResource1, KeyedMutex, 4-strip copy) | ✅ landed | 80925b2f |
| D — D3D12 real impl (KeyedMutex variant, 4-strip copy with barriers) | ✅ landed | 5541e74c |
| E — Test apps (`cube_texture_d3d11_win` + `cube_texture_d3d12_win`) | ✅ this PR | 684624e5 |
| F — Local validation on Leia SR hardware | ✅ this PR | 684624e5 (eyeballed) |
| **+v7** — `xrSetSharedTextureSurround2DFenceEXT` for D3D12 | ✅ this PR | 684624e5 |
| G — Unity plugin (`DisplayXR/displayxr-unity`) integration | ⏸ separate repo | — |
| H — Doc closeout in `swapchain-model.md` + `app-classes.md` | ⏸ follow-up | — |

## Key engineering decisions

- **4-strip `CopySubresourceRegion` / `CopyTextureRegion`**, not a shader-blit. Simplest path, zero shader infrastructure. Same-format requirement.
- **16 ms `AcquireSync` timeout** (D3D11 path) — one frame at 60 Hz; never blocks presentation.
- **NT handle + IDXGIKeyedMutex** for D3D11; **NT handle + ID3D12Fence** for D3D12. The two cross-API sharing patterns the platform actually supports.
- **D3D12 fence path caches `(textureHandle, fenceHandle)`** by pointer equality — first call opens, subsequent per-frame calls only update the await value. No per-frame `OpenSharedHandle` cost.
- **D3D12 helper takes pre/post resource states** as parameters — drops cleanly into both the shared-texture path (COMMON↔COMMON) and the window+DP path (RENDER_TARGET↔RENDER_TARGET).

## Test plan

- [x] Local MSVC build of `comp_d3d11.lib` + `comp_d3d12.lib` clean
- [x] `cube_texture_d3d11_win` against Leia SR plug-in: center-50% cube weave + crisp 2D surround pattern, eyeballed
- [x] `cube_texture_d3d12_win` (v7 fence path) against Leia SR plug-in: same visual, eyeballed
- [ ] CI: `Build Windows` + `Build macOS` (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)