### PR TITLE
fix(installer): clear stale 32-bit Run entry to stop double service launch

### DIFF
--- a/installer/DisplayXRInstaller.nsi
+++ b/installer/DisplayXRInstaller.nsi
@@ -771,10 +771,19 @@ Section "DisplayXR Runtime" SecRuntime
 		nsExec::ExecToLog 'schtasks /delete /tn "DisplayXR Service" /f'
 		Pop $0
 
-		; Register in HKLM Run key (starts in user session with GPU/tray access)
+		; Register in HKLM Run key (starts in user session with GPU/tray access).
+		; This section runs in the 64-bit view (SetRegView 64 at section start).
 		DetailPrint "Registering DisplayXR Service for auto-start..."
 		WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Run" \
 			"DisplayXR Service" "$\"$INSTDIR\displayxr-service.exe$\""
+		; Drop any stale 32-bit (WOW6432Node) Run entry from an interim installer
+		; that wrote it before this section used SetRegView 64. Windows fires both
+		; views at logon, so a leftover 32-bit copy double-launches the service.
+		; Doing this on install (not just uninstall) fixes affected machines on a
+		; plain upgrade, without requiring a full uninstall/reinstall.
+		SetRegView 32
+		DeleteRegValue HKLM "Software\Microsoft\Windows\CurrentVersion\Run" "DisplayXR Service"
+		SetRegView 64
 
 		; Start the service immediately so it's available without relogon
 		DetailPrint "Starting DisplayXR Service..."
@@ -821,6 +830,15 @@ Section "Uninstall"
 	DetailPrint "Stopping DisplayXR Service before cascade..."
 	nsExec::ExecToLog 'taskkill /f /im displayxr-service.exe'
 	DeleteRegValue HKLM "Software\Microsoft\Windows\CurrentVersion\Run" "DisplayXR Service"
+	; Also clear the stale 32-bit (WOW6432Node) Run entry left by interim
+	; installers that wrote it before this section moved to SetRegView 64.
+	; Windows fires BOTH the 64-bit and 32-bit Run views at logon, so an
+	; orphaned 32-bit copy double-launches the service (the second instance
+	; bails on the single-instance pipe guard, but it's noise). Clean both
+	; views, then restore the 64-bit view for the rest of the section.
+	SetRegView 32
+	DeleteRegValue HKLM "Software\Microsoft\Windows\CurrentVersion\Run" "DisplayXR Service"
+	SetRegView 64
 	nsExec::ExecToLog 'schtasks /delete /tn "DisplayXR Service" /f'
 
 	; -----------------------------------------------------------------


### PR DESCRIPTION
## Problem
At logon, `displayxr-service.exe` launches **twice**. The second instance bails on the single-instance IPC-pipe guard:

```
An existing process id <pid> has the communication pipe already created.
You likely have "displayxr-service.exe" running already. This service instance cannot continue...
```

Benign (the guard does its job) but noisy, and confusing to anyone reading the boot logs.

## Root cause
The auto-start Run value `DisplayXR Service` exists in **both** registry views:
- native 64-bit `HKLM\Software\Microsoft\Windows\CurrentVersion\Run`
- 32-bit `HKLM\Software\WOW6432Node\...\Run`

Windows enumerates **both** views at logon → two launches.

The Run-key autostart landed in #68 (2026-03-23) before the install section was fully on `SetRegView 64`, so an interim installer wrote the value into NSIS's default 32-bit view (`WOW6432Node`). The uninstaller has only ever deleted the **64-bit** value (`SetRegView 64` at the Uninstall section start), so the 32-bit orphan survived every upgrade.

## Fix
Delete the value from **both** views:
- **Uninstall section** — clear the 32-bit entry alongside the existing 64-bit delete.
- **Install section** — also drop the 32-bit orphan after writing the canonical 64-bit value, so a plain **upgrade** repairs already-affected machines without requiring a full uninstall/reinstall.

The single-instance pipe guard is intentionally left in place — it's what keeps the duplicate launch harmless, and protects against any other source of a double-start.

## Notes
- No behavior change for clean machines (they only ever had the 64-bit entry).
- Already cleared the stale entry on the local dev box manually; this makes the fix durable across upgrades.

🤖 Generated with [Claude Code](https://claude.com/claude-code)