### PR TITLE
fix(d3d11_service): guard DP consumers under render_mutex (#363)

### DIFF
--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -11259,6 +11259,16 @@ comp_d3d11_service_get_predicted_eye_positions(struct xrt_system_compositor *xsy
 
 	struct d3d11_service_system *sys = d3d11_service_system_from_xrt(xsysc);
 
+	// #363: hold render_mutex across the DP pointer read AND the call into the
+	// DP. compositor_destroy holds render_mutex through its entire teardown
+	// (unregister -> null active_compositor -> fini_client_render_resources,
+	// which frees render.display_processor). Without this lock an IPC client
+	// thread could latch `dp` here, the teardown thread frees it, and the call
+	// below derefs freed memory — the use-after-free seen on last-client
+	// (total->0) churn. render_mutex is recursive, so callers that already
+	// hold it (multi_compositor_render, capture_frame) are unaffected.
+	std::lock_guard<std::recursive_mutex> render_lock(sys->render_mutex);
+
 	// Caching now lives inside the DP itself (vendor-internal, populated
 	// by SR's EyePairStream listener). This is just a thin pass-through.
 	// Get display processor for eye position prediction.
@@ -11437,6 +11447,12 @@ comp_d3d11_service_get_display_dimensions(struct xrt_system_compositor *xsysc,
 
 	struct d3d11_service_system *sys = d3d11_service_system_from_xrt(xsysc);
 
+	// #363: hold render_mutex across the DP pointer read AND the call into the
+	// DP, to serialize with compositor_destroy's full teardown (which frees
+	// render.display_processor). Same read-then-use-after-unlock UAF as
+	// get_predicted_eye_positions. render_mutex is recursive.
+	std::lock_guard<std::recursive_mutex> render_lock(sys->render_mutex);
+
 	// Try to get display dimensions from display processor.
 	// In workspace mode, use multi-comp's DP; in normal mode, use active compositor's DP.
 	struct xrt_display_processor_d3d11 *dp = nullptr;
@@ -11479,6 +11495,12 @@ comp_d3d11_service_get_window_metrics(struct xrt_system_compositor *xsysc,
 	}
 
 	struct d3d11_service_system *sys = d3d11_service_system_from_xrt(xsysc);
+
+	// #363: hold render_mutex across the DP pointer read AND every call into
+	// the DP below, to serialize with compositor_destroy's full teardown
+	// (which frees render.display_processor). Same read-then-use-after-unlock
+	// UAF as get_predicted_eye_positions. render_mutex is recursive.
+	std::lock_guard<std::recursive_mutex> render_lock(sys->render_mutex);
 
 	// In workspace mode, use multi-comp's window and DP.
 	// In normal mode, use the active compositor's.


### PR DESCRIPTION
## Summary

Fixes #363 — `displayxr-service.exe` use-after-free on the last-client (`total → 0`) disconnect during rapid app launch/exit churn.

**Root cause:** the three DP-consumer functions in `comp_d3d11_service.cpp` read the display-processor pointer (`active_compositor->render.display_processor` / `multi_comp->display_processor`) under the short-lived `active_compositor_mutex`, **release it**, then call into that DP. Meanwhile `compositor_destroy` holds `render_mutex` through its *entire* teardown — `multi_compositor_unregister_client` → null `active_compositor` → `fini_client_render_resources`, which frees `render.display_processor`. The two paths share **no lock covering the DP's lifetime**, so an IPC client thread (`ipc_try_get_sr_view_poses` → `get_predicted_eye_positions`, the exact crash breadcrumb) could latch a `dp`, the teardown thread frees it, and the IPC thread then derefs freed memory.

**Fix:** take `sys->render_mutex` (recursive) across the full DP read-and-use in all three consumers — `comp_d3d11_service_get_predicted_eye_positions`, `comp_d3d11_service_get_display_dimensions`, `comp_d3d11_service_get_window_metrics` — so they serialize with `compositor_destroy`'s teardown. Because the mutex is recursive, in-render callers that already hold it (`multi_compositor_render`, `capture_frame`) are unaffected. Lock order `render_mutex → active_compositor_mutex` matches `compositor_destroy`, so no deadlock.

## Testing

Built locally (`build_windows.bat build`, clean) and deployed to `C:\Program Files\DisplayXR\Runtime`. Soak-tested on a real Leia SR display:

- **150-tick pool churn:** 3 clients continuously polling eye-positions while the oldest tears down each tick, full `total → 0` drain every 12 ticks. Same service PID throughout, **0 crashes, 0 dumps**. Log confirms `compositor_destroy` (DP free under `render_mutex`) interleaved with `get_predicted_eye_positions` / `ipc_try_get_sr_view_poses` and 17× force-kill `client_loop ... disconnecting client` events — the #363 breadcrumb — with no FATAL/access-violation.

Note: #363 could not be reproduced on demand even pre-fix, so this is correctness-by-construction + a hard crash-free churn, not a before/after repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)