### PR TITLE
feat(mcp): POSIX capability gate + wire macOS .pkg in components.sh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,7 +144,7 @@ This repo IS the public runtime (no private→public mirror). A release is a `vX
 |---|---|---|
 | Shell | `displayxr-shell-pvt` → `displayxr-shell-releases` | `/dxr-release` or `git tag` → `publish-shell-releases.yml` builds + cross-publishes + dispatches `versions-bump`. Auth via `displayxr-publish-bot` GitHub App (`.secrets/displayxr-publish-bot.pem` backup; see `.secrets/NOTE.md`). |
 | Leia SR plug-in | `displayxr-leia-plugin` | `/dxr-release` → builds DLL + installer + dispatches `versions-bump` with ABI gate (ADR-020). |
-| MCP framework | `displayxr-mcp` | `/dxr-release` → matrix build + adapter installer + dispatches `versions-bump`. |
+| MCP framework | `displayxr-mcp` | `/dxr-release` → matrix build + dual-platform installers (`DisplayXRMCPSetup-*.exe` NSIS + `DisplayXRMCP-*.pkg` productbuild) + dispatches `versions-bump`. |
 | Extension headers | `displayxr-extensions` | Auto-syncs from `src/external/openxr_includes/` on every push to main. No tag. |
 | Standalone demos | `displayxr-demo-*` | `/dxr-release` → builds installer + dispatches `versions-bump`. |
 | Meta-installer bundle | `displayxr-installer` | `/installer-release` or `workflow_dispatch` (NOT auto-fired). Chains every component installer. |

--- a/docs/specs/runtime/versions-json-autobump.md
+++ b/docs/specs/runtime/versions-json-autobump.md
@@ -130,7 +130,13 @@ rebuild.
 
 ### `displayxr-mcp`
 
-Same snippet, with `field: "mcp_tools"`.
+Same snippet, with `field: "mcp_tools"`. `mcp_tools` is a dual-platform
+field — `build.yml` builds both `DisplayXRMCPSetup-*.exe` (NSIS) and
+`DisplayXRMCP-*.pkg` (productbuild) and attaches both to the same GitHub
+Release. `components.sh` carries the macOS glob + install marker
+(`/Library/Application Support/DisplayXR/Capabilities/MCP/Enabled`, the
+POSIX mirror of the Windows REG_DWORD), so `setup-displayxr.sh --with
+mcp` works on a clean Mac.
 
 ### `displayxr-demo-*`
 

--- a/scripts/lib/components.sh
+++ b/scripts/lib/components.sh
@@ -50,12 +50,14 @@ COMPONENT_INSTALL_MARKER_MACOS_leia_plugin=""
 COMPONENT_INSTALL_MARKER_WINDOWS_leia_plugin="HKLM\\Software\\DisplayXR\\DisplayProcessors\\leia-sr"
 
 # --- mcp_tools ---
-# displayxr-mcp ships a Windows installer today; macOS artifact is a future
-# component. Empty macOS glob → warn+skip.
+# displayxr-mcp ships a Windows installer (NSIS) and a macOS .pkg
+# (productbuild). On macOS the postinstall flips the capability bit at
+# /Library/Application Support/DisplayXR/Capabilities/MCP/Enabled —
+# that's also the marker setup-displayxr.sh checks for installer success.
 COMPONENT_REPO_mcp_tools="DisplayXR/displayxr-mcp"
-COMPONENT_PKG_MACOS_mcp_tools=""
+COMPONENT_PKG_MACOS_mcp_tools="DisplayXRMCP-*.pkg"
 COMPONENT_EXE_WINDOWS_mcp_tools="DisplayXRMCPSetup-*.exe"
-COMPONENT_INSTALL_MARKER_MACOS_mcp_tools=""
+COMPONENT_INSTALL_MARKER_MACOS_mcp_tools="/Library/Application Support/DisplayXR/Capabilities/MCP/Enabled"
 COMPONENT_INSTALL_MARKER_WINDOWS_mcp_tools="HKLM\\Software\\DisplayXR\\Capabilities\\MCP"
 
 # --- gauss_demo ---

--- a/src/xrt/state_trackers/oxr/oxr_instance.c
+++ b/src/xrt/state_trackers/oxr/oxr_instance.c
@@ -612,12 +612,14 @@ oxr_instance_create(struct oxr_logger *log,
 
 	*out_instance = inst;
 
-	// Opt-in AI introspection surface — Phase A. Gate is registry-first,
-	// env-var-overrides: install the MCP Tools package (writes
-	// HKLM\Software\DisplayXR\Capabilities\MCP\Enabled=1) and the MCP
-	// server starts in every handle-app process. DISPLAYXR_MCP=1/0 in
-	// the environment wins as an explicit override (CI, dev iteration,
-	// quick disable). No registry + no env var ⇒ zero runtime cost.
+	// Opt-in AI introspection surface — Phase A. Gate is installer-first,
+	// env-var-overrides: install the MCP Tools package (writes the
+	// capability marker — REG_DWORD Enabled=1 on Windows, a one-byte
+	// file under /Library/Application Support/DisplayXR/Capabilities/MCP/
+	// on macOS) and the MCP server starts in every handle-app process.
+	// DISPLAYXR_MCP=1/0 in the environment wins as an explicit override
+	// (CI, dev iteration, quick disable). No marker + no env var ⇒
+	// zero runtime cost. See oxr_mcp_capability_enabled().
 	oxr_mcp_tools_register_all();
 	if (mcp_check_env_or(oxr_mcp_capability_enabled())) {
 		mcp_server_start();

--- a/src/xrt/state_trackers/oxr/oxr_mcp_tools.c
+++ b/src/xrt/state_trackers/oxr/oxr_mcp_tools.c
@@ -30,6 +30,9 @@
 
 #ifdef _WIN32
 #include <windows.h>
+#else
+#include <fcntl.h>
+#include <unistd.h>
 #endif
 
 #include "os/os_time.h"
@@ -839,10 +842,19 @@ oxr_mcp_log_sink(const char *file,
 	mcp_log_ring_append(xlate_log_level(level), fmt, args);
 }
 
-// Reads HKLM\Software\DisplayXR\Capabilities\MCP\Enabled (DWORD) under
-// the 64-bit registry view. The MCP installer (DisplayXRMCPSetup-*.exe)
-// from displayxr-mcp writes this key. Non-Windows builds always return
-// false — there's no Capabilities key on POSIX; rely on the env var.
+// Reads the MCP capability marker written by the displayxr-mcp installer.
+//
+//   Windows: HKLM\Software\DisplayXR\Capabilities\MCP\Enabled (REG_DWORD == 1),
+//            64-bit registry view. Written by DisplayXRMCPSetup-*.exe.
+//   macOS:   /Library/Application Support/DisplayXR/Capabilities/MCP/Enabled,
+//            first byte == '1'. Written (as root:wheel 0644) by the
+//            postinstall script in DisplayXRMCP-*.pkg. See
+//            displayxr-mcp/installer/macos/scripts/postinstall.
+//
+// Returns true iff the marker is present AND set to enabled. The
+// DISPLAYXR_MCP env var still wins as a force-enable / force-disable
+// override via mcp_check_env_or() — see the call site in
+// oxr_instance.c.
 bool
 oxr_mcp_capability_enabled(void)
 {
@@ -864,7 +876,18 @@ oxr_mcp_capability_enabled(void)
 	RegCloseKey(key);
 	return rc == ERROR_SUCCESS && value_type == REG_DWORD && value == 1;
 #else
-	return false;
+	// POSIX mirror — file-existence + first-byte check. Equivalent
+	// semantics to the Win32 REG_DWORD == 1 above.
+	static const char path[] =
+	    "/Library/Application Support/DisplayXR/Capabilities/MCP/Enabled";
+	int fd = open(path, O_RDONLY);
+	if (fd < 0) {
+		return false;
+	}
+	char b = 0;
+	ssize_t n = read(fd, &b, 1);
+	close(fd);
+	return n == 1 && b == '1';
 #endif
 }
 

--- a/src/xrt/state_trackers/oxr/oxr_mcp_tools.h
+++ b/src/xrt/state_trackers/oxr/oxr_mcp_tools.h
@@ -77,9 +77,14 @@ void
 oxr_mcp_tools_set_capture_handler(oxr_mcp_capture_fn fn, void *userdata);
 
 /*!
- * Read the @c HKLM\Software\DisplayXR\Capabilities\MCP\Enabled DWORD on
- * Windows. Returns @c true iff the key exists and the value is 1. On
- * non-Windows platforms (no installer infrastructure) returns @c false.
+ * Read the MCP capability marker written by the displayxr-mcp installer.
+ * Returns @c true iff the marker is present AND set to enabled.
+ *
+ *   Windows: @c HKLM\Software\DisplayXR\Capabilities\MCP\Enabled
+ *            (REG_DWORD == 1), 64-bit registry view.
+ *   macOS:   @c /Library/Application Support/DisplayXR/Capabilities/MCP/Enabled
+ *            (first byte == @c '1', written root:wheel 0644 by the
+ *            postinstall script in DisplayXRMCP-*.pkg).
  *
  * Combine with @ref mcp_check_env_or so the @c DISPLAYXR_MCP env var
  * still wins as an explicit override:
@@ -88,7 +93,7 @@ oxr_mcp_tools_set_capture_handler(oxr_mcp_capture_fn fn, void *userdata);
  *       mcp_server_start();
  *   }
  *
- * Caller-side helper rather than framework-side because the registry
+ * Caller-side helper rather than framework-side because the marker
  * path is DisplayXR-specific; the framework stays consumer-agnostic.
  */
 bool


### PR DESCRIPTION
## Summary

Lights up the macOS half of the MCP capability gate so installing
displayxr-mcp's .pkg auto-enables MCP in the runtime — same UX Windows
has had since the NSIS installer landed.

## Why

`versions.json` is the tested-together bundle manifest. The implicit
invariant is "every field architecturally supported on macOS should
ship a .pkg, and the runtime should consume it without manual env
var twiddling". `mcp_tools` was the only field violating this:
- The adapter source is fully cross-platform, but no .pkg existed.
- `oxr_mcp_capability_enabled()` hardcoded `return false` on
  non-Windows, so even with the adapter present, users had to set
  `DISPLAYXR_MCP=1` manually.

Companion PR `DisplayXR/displayxr-mcp#8` ships the macOS .pkg. This PR
wires the runtime to consume it.

## What changed

| File | Change |
|---|---|
| `src/xrt/state_trackers/oxr/oxr_mcp_tools.c` | POSIX branch reads `/Library/Application Support/DisplayXR/Capabilities/MCP/Enabled` (first byte == `'1'`). Semantically identical to the Win32 `REG_DWORD == 1` check. |
| `src/xrt/state_trackers/oxr/oxr_mcp_tools.h` | Doxygen updated to document both Windows + macOS gate paths. |
| `src/xrt/state_trackers/oxr/oxr_instance.c` | Boot-call comment: "registry-first" → "installer-first" with the macOS path called out. |
| `scripts/lib/components.sh` | `COMPONENT_PKG_MACOS_mcp_tools=DisplayXRMCP-*.pkg` + `COMPONENT_INSTALL_MARKER_MACOS_mcp_tools=…/Capabilities/MCP/Enabled`. Existing `install_component()` loop in `setup-displayxr.sh` picks both up — no logic changes. |
| `docs/specs/runtime/versions-json-autobump.md` | `mcp_tools` is now a dual-platform field (both `*.exe` and `*.pkg` attach to the Release). |
| `CLAUDE.md` | Sibling release flows table: MCP framework row mentions both installers. |

## Verified

- `./scripts/build-mingw-check.sh` → passes. POSIX branch is
  `#ifdef`-guarded; MinGW defines `_WIN32` so `unistd.h` / `fcntl.h`
  never compile-in on the Windows side.
- `./scripts/build_macos.sh` → builds clean. New `<fcntl.h>` +
  `<unistd.h>` includes inside `#else` branch don't leak to Win.
- `sudo installer -pkg DisplayXRMCP-0.3.2.pkg -target /` then
  `_package/.../run_cube_handle_metal.sh` → `[mcp] server started
  (pid=27554)` in log when marker present.
- `rm -rf /Library/Application Support/DisplayXR/Capabilities/MCP` +
  re-run → MCP correctly does not boot.

## Companion PR

[`DisplayXR/displayxr-mcp#8`](https://github.com/DisplayXR/displayxr-mcp/pull/8) — adds the macOS .pkg pipeline + the missing `DispatchVersionsBump` CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)