### PR TITLE
feat(runtime): probe_displays() per-display vendor DP claims (Phase 1, #69)

### DIFF
--- a/src/xrt/drivers/sim_display/sim_display_plugin.c
+++ b/src/xrt/drivers/sim_display/sim_display_plugin.c
@@ -122,6 +122,47 @@ sim_display_plugin_get_display_info(struct xrt_plugin_instance *inst,
 }
 
 
+static uint32_t
+sim_display_plugin_probe_displays(struct xrt_plugin_instance *inst,
+                                  const struct xrt_display_descriptor *displays,
+                                  uint32_t display_count,
+                                  struct xrt_display_claim *out_claims,
+                                  uint32_t max_claims)
+{
+	(void)inst;
+
+	/*
+	 * sim_display is the vendor-neutral fallback (#69 / ADR-015): claim
+	 * EVERY descriptor at FALLBACK confidence so it backstops any monitor no
+	 * vendor plug-in recognized. A real vendor's EDID(50)/VERIFIED(100) claim
+	 * always outranks these, and a (future) per-display override can still
+	 * force sim onto a specific monitor.
+	 */
+	uint32_t n = 0;
+	for (uint32_t i = 0; i < display_count && n < max_claims; i++) {
+		struct xrt_display_claim *c = &out_claims[n++];
+		c->monitor_id = displays[i].monitor_id;
+		c->confidence = (uint32_t)XRT_DISPLAY_CLAIM_FALLBACK;
+
+		/* Mirror the #ifdef gating of the DP factory fields below — sim
+		 * ships a factory for every API the platform supports. */
+		c->supported_apis = 0;
+#if defined(XRT_HAVE_VULKAN) || !defined(_WIN32)
+		c->supported_apis |= XRT_DP_API_BIT_VK;
+#endif
+#if defined(_WIN32)
+		c->supported_apis |= XRT_DP_API_BIT_D3D11 | XRT_DP_API_BIT_D3D12;
+#endif
+		c->supported_apis |= XRT_DP_API_BIT_GL;
+#if defined(__APPLE__)
+		c->supported_apis |= XRT_DP_API_BIT_METAL;
+#endif
+		c->serial[0] = '\0';
+	}
+	return n;
+}
+
+
 /*
  *
  * Vtable.
@@ -178,6 +219,8 @@ static struct xrt_plugin_iface g_sim_display_iface = {
     .get_display_info = sim_display_plugin_get_display_info,
 
     .set_pose_source = sim_display_plugin_set_pose_source,
+
+    .probe_displays = sim_display_plugin_probe_displays,
 };
 
 

--- a/src/xrt/include/xrt/xrt_compositor.h
+++ b/src/xrt/include/xrt/xrt_compositor.h
@@ -2404,6 +2404,64 @@ xrt_comp_native_destroy(struct xrt_compositor_native **xcn_ptr)
  *
  */
 
+//! Max monitors in a @ref xrt_dp_factory_registry (mirrors OS_DISPLAY_EDID_MAX_MONITORS).
+#define XRT_DP_REGISTRY_MAX_ENTRIES 16
+
+/*!
+ * One resolved monitor→DP mapping in the @ref xrt_dp_factory_registry
+ * (issue #69 / ADR-015). Built at system init from the winning vendor
+ * claim for that monitor. Factory + owning-iface pointers are `void *` so
+ * this core header need not include `xrt/xrt_plugin.h`; the loader /
+ * target-instance TUs (which do include it) cast back.
+ */
+struct xrt_dp_registry_entry
+{
+	//! Runtime-assigned monitor id (see xrt_display_descriptor::monitor_id).
+	uint64_t monitor_id;
+
+	//! Winning claim confidence (enum xrt_display_claim_confidence).
+	uint32_t confidence;
+
+	//! Monitor geometry (for Phase 3 monitor↔window mapping).
+	int32_t screen_left;
+	int32_t screen_top;
+	uint32_t pixel_width;
+	uint32_t pixel_height;
+
+	//! Discovery id of the plug-in that won this monitor (iface->id).
+	char plugin_id[64];
+
+	//! Vendor serial from the winning claim ("" if n/a).
+	char serial[64];
+
+	//! Per-API factory pointers from the winning plug-in (NULL = API
+	//! unsupported on this monitor). Same casts as the scalar dp_factory_*.
+	void *dp_factory_vk;
+	void *dp_factory_d3d11;
+	void *dp_factory_d3d12;
+	void *dp_factory_gl;
+	void *dp_factory_metal;
+
+	//! Owning plug-in iface + instance (const struct xrt_plugin_iface * /
+	//! struct xrt_plugin_instance *), for a future per-display lifecycle.
+	const void *owning_iface;
+	void *owning_instance;
+};
+
+/*!
+ * Per-monitor resolved DP factory registry (issue #69 / ADR-015). Built by
+ * the plug-in loader from vendor `probe_displays()` claims. `entry_count ==
+ * 0` means "no per-display routing resolved — use the scalar dp_factory_*
+ * fields" (the single-display / off-Windows path). Phase 1 populates this
+ * in parallel with the scalar fields; Phase 3 migrates the compositors to
+ * consume it.
+ */
+struct xrt_dp_factory_registry
+{
+	uint32_t entry_count;
+	struct xrt_dp_registry_entry entries[XRT_DP_REGISTRY_MAX_ENTRIES];
+};
+
 /*!
  * Capabilities and information about the system compositor (and its wrapped native compositor, if any),
  * and device together.
@@ -2571,6 +2629,15 @@ struct xrt_system_compositor_info
 	void (*refresh_display_processors)(struct xrt_system_compositor_info *info);
 
 	/*! @} */
+
+	/*!
+	 * Per-monitor resolved DP factory registry (issue #69 / ADR-015), built
+	 * from vendor `probe_displays()` claims. `entry_count == 0` means "use
+	 * the scalar dp_factory_* above" (single-display / off-Windows). In
+	 * Phase 1 this is populated alongside — and the scalars re-derived from —
+	 * the primary entry, so existing compositors are unaffected.
+	 */
+	struct xrt_dp_factory_registry dp_registry;
 };
 
 struct xrt_system_compositor;

--- a/src/xrt/include/xrt/xrt_plugin.h
+++ b/src/xrt/include/xrt/xrt_plugin.h
@@ -118,6 +118,110 @@ struct xrt_plugin_display_info
 
 /*
  *
+ * Per-display vendor claims (issue #69 / ADR-015).
+ *
+ */
+
+/*!
+ * Vendor-neutral descriptor for one connected monitor, handed to the
+ * plug-in's `xrt_plugin_iface::probe_displays`. Built by the runtime from
+ * the vendor-neutral EDID enumerator (`os_display_edid`). The plug-in
+ * echoes back `monitor_id` for the monitors it claims.
+ *
+ * Forward-compat: the runtime sets `struct_size` to its own
+ * `sizeof(struct xrt_display_descriptor)` before the call; plug-ins MUST
+ * NOT read past that offset. Field additions append at the end with no
+ * API version bump.
+ */
+struct xrt_display_descriptor
+{
+	/*! `sizeof(struct xrt_display_descriptor)` at the runtime's compile
+	 *  time. The plug-in clamps its reads to this offset. */
+	uint32_t struct_size;
+
+	/*! Reserved for alignment. Must be 0. */
+	uint32_t reserved_0;
+
+	/*! Runtime-assigned monitor identifier, stable for this boot.
+	 *  Derived from stable EDID identity (manufacturer/product/screen
+	 *  position), not the transient HMONITOR. The plug-in echoes it back
+	 *  in the matching @ref xrt_display_claim. */
+	uint64_t monitor_id;
+
+	/*! EDID bytes 8-9 (raw, as stored in EDID) — mirrors
+	 *  `os_display_edid_monitor::manufacturer_id`. */
+	uint16_t edid_manufacturer;
+
+	/*! EDID bytes 10-11 (raw, as stored in EDID) — mirrors
+	 *  `os_display_edid_monitor::product_id`. */
+	uint16_t edid_product;
+
+	/*! Monitor width/height in pixels (current mode). */
+	uint32_t pixel_width;
+	uint32_t pixel_height;
+
+	/*! Current refresh rate in milli-Hz (e.g. 60000 = 60 Hz). Integer
+	 *  so no float crosses the ABI. */
+	uint32_t refresh_mhz;
+
+	/*! Monitor top-left in virtual-screen coordinates. */
+	int32_t screen_left;
+	int32_t screen_top;
+
+	/*! Bit 0 = primary monitor. Other bits reserved (must be 0). */
+	uint32_t flags;
+};
+
+/*!
+ * How sure a plug-in is that a monitor is its hardware. The runtime
+ * resolves competing claims for the same monitor by highest confidence
+ * (ties broken by registration ProbeOrder).
+ */
+enum xrt_display_claim_confidence
+{
+	XRT_DISPLAY_CLAIM_FALLBACK = 10,  //!< sim_display: "anything unclaimed".
+	XRT_DISPLAY_CLAIM_EDID = 50,      //!< matched my EDID table.
+	XRT_DISPLAY_CLAIM_VERIFIED = 100, //!< EDID + SDK/service/serial handshake.
+};
+
+/*!
+ * Per-API bits for @ref xrt_display_claim::supported_apis. A set bit means
+ * the plug-in's matching `create_dp_<api>` factory works for that monitor.
+ * @{
+ */
+#define XRT_DP_API_BIT_VK (1u << 0)
+#define XRT_DP_API_BIT_D3D11 (1u << 1)
+#define XRT_DP_API_BIT_D3D12 (1u << 2)
+#define XRT_DP_API_BIT_GL (1u << 3)
+#define XRT_DP_API_BIT_METAL (1u << 4)
+/*! @} */
+
+/*!
+ * One monitor a plug-in claims, returned from
+ * `xrt_plugin_iface::probe_displays`. Fixed layout (no `struct_size`): the
+ * plug-in fills a runtime-provided array and returns a count, so growth is
+ * via @ref xrt_display_descriptor (input) rather than this output struct.
+ */
+struct xrt_display_claim
+{
+	/*! Echoes the @ref xrt_display_descriptor::monitor_id being claimed. */
+	uint64_t monitor_id;
+
+	/*! @ref xrt_display_claim_confidence. */
+	uint32_t confidence;
+
+	/*! Bitmask of @ref XRT_DP_API_BIT_ values — which `create_dp_<api>`
+	 *  factories work for this monitor. */
+	uint32_t supported_apis;
+
+	/*! Vendor device serial (e.g. Leia FPC) tying this monitor to a
+	 *  specific camera/calibration unit; empty string if not applicable. */
+	char serial[64];
+};
+
+
+/*
+ *
  * API versioning.
  *
  */
@@ -428,6 +532,33 @@ struct xrt_plugin_iface
 	void (*set_pose_source)(struct xrt_plugin_instance *inst,
 	                        struct xrt_device *xdev,
 	                        struct xrt_device *source);
+
+	/*!
+	 * Report which of the supplied monitors this plug-in claims as its
+	 * hardware (issue #69 / ADR-015). Turns the binary, system-level
+	 * `probe()` into a per-monitor claim list so the runtime can route
+	 * monitor→DP for mixed-vendor / force-sim-on-one-monitor setups.
+	 *
+	 * The runtime passes `display_count` vendor-neutral descriptors (built
+	 * from `os_display_edid`) and a `max_claims`-sized output array. The
+	 * plug-in writes one @ref xrt_display_claim per monitor it recognizes
+	 * (using its own proprietary detection — EDID table match, USB
+	 * handshake, etc.) and returns the number written (<= `max_claims`).
+	 * Monitors the plug-in does not recognize are simply omitted.
+	 *
+	 * Each descriptor carries `struct_size`; the plug-in MUST NOT read past
+	 * that offset. Cheap — called once at system init, not per-frame.
+	 *
+	 * Optional. NULL (or a plug-in whose `struct_size` predates this field)
+	 * means "no per-display claims": the runtime falls back to treating a
+	 * successful binary `probe()` as a single `XRT_DISPLAY_CLAIM_EDID` claim
+	 * on the primary monitor (back-compat for single-display plug-ins).
+	 */
+	uint32_t (*probe_displays)(struct xrt_plugin_instance *inst,
+	                           const struct xrt_display_descriptor *displays,
+	                           uint32_t display_count,
+	                           struct xrt_display_claim *out_claims,
+	                           uint32_t max_claims);
 };
 
 

--- a/src/xrt/state_trackers/oxr/oxr_plugin_stub.c
+++ b/src/xrt/state_trackers/oxr/oxr_plugin_stub.c
@@ -91,8 +91,23 @@ _Static_assert(offsetof(struct xrt_plugin_iface, get_display_info) < offsetof(st
                "xrt_plugin: set_pose_source must follow get_display_info (additive-only growth)");
 
 /*
+ * probe_displays (#69 / ADR-015) is the next additive vtable field after
+ * set_pose_source. Appended at the end, NULL-safe, struct_size-guarded —
+ * no API version bump.
+ */
+_Static_assert(offsetof(struct xrt_plugin_iface, set_pose_source) < offsetof(struct xrt_plugin_iface, probe_displays),
+               "xrt_plugin: probe_displays must follow set_pose_source (additive-only growth)");
+
+/*
  * Display-info struct's first field must be struct_size so plug-ins
  * can detect host's compile-time sizeof and clamp writes accordingly.
  */
 _Static_assert(offsetof(struct xrt_plugin_display_info, struct_size) == 0,
                "xrt_plugin: display_info.struct_size must be the first field");
+
+/*
+ * The display-descriptor the runtime hands probe_displays() is likewise
+ * struct_size-headed so plug-ins can clamp their reads for forward compat.
+ */
+_Static_assert(offsetof(struct xrt_display_descriptor, struct_size) == 0,
+               "xrt_plugin: display_descriptor.struct_size must be the first field");

--- a/src/xrt/targets/cli/cli_cmd_displays.c
+++ b/src/xrt/targets/cli/cli_cmd_displays.c
@@ -16,6 +16,9 @@
 #include "cli_common.h"
 
 #include "os/os_display_edid.h"
+#include "xrt/xrt_compositor.h"
+#include "xrt/xrt_plugin.h"
+#include "target_plugin_loader.h"
 
 #include <cjson/cJSON.h>
 
@@ -43,11 +46,119 @@ pnp_code(uint16_t mfr_raw, char out[4])
 	out[3] = '\0';
 }
 
+//! Human label for an xrt_display_claim_confidence value.
+static const char *
+confidence_label(uint32_t c)
+{
+	switch (c) {
+	case (uint32_t)XRT_DISPLAY_CLAIM_FALLBACK: return "FALLBACK";
+	case (uint32_t)XRT_DISPLAY_CLAIM_EDID: return "EDID";
+	case (uint32_t)XRT_DISPLAY_CLAIM_VERIFIED: return "VERIFIED";
+	default: return "?";
+	}
+}
+
+//! Decode a supported-API bitmask into a "vk|d3d11|gl" style string.
+static void
+apis_to_str(const struct xrt_dp_registry_entry *e, char *out, size_t cap)
+{
+	out[0] = '\0';
+	size_t len = 0;
+	const struct {
+		void *fn;
+		const char *name;
+	} apis[] = {
+	    {e->dp_factory_vk, "vk"},       {e->dp_factory_d3d11, "d3d11"}, {e->dp_factory_d3d12, "d3d12"},
+	    {e->dp_factory_gl, "gl"},       {e->dp_factory_metal, "metal"},
+	};
+	for (size_t i = 0; i < sizeof(apis) / sizeof(apis[0]); i++) {
+		if (apis[i].fn == NULL) {
+			continue;
+		}
+		int n = snprintf(out + len, cap - len, "%s%s", len > 0 ? "|" : "", apis[i].name);
+		if (n > 0 && (size_t)n < cap - len) {
+			len += (size_t)n;
+		}
+	}
+	if (out[0] == '\0') {
+		snprintf(out, cap, "(none)");
+	}
+}
+
+/*!
+ * `displays --claims`: enumerate EDID, ask the registered plug-ins which
+ * monitors they claim, and print the resolved monitor→plug-in registry
+ * (#69 / ADR-015). Loads the active plug-in(s) — same exposure as
+ * `selftest`/`info`. Plain `displays` stays vendor-blind (no plug-in load).
+ */
+static int
+cli_cmd_displays_claims(const struct os_display_edid_list *list, bool json)
+{
+	struct xrt_display_descriptor descs[XRT_DP_REGISTRY_MAX_ENTRIES];
+	uint32_t dn = target_plugin_build_descriptors(list, descs, XRT_DP_REGISTRY_MAX_ENTRIES);
+
+	struct xrt_dp_factory_registry reg = {0};
+	target_plugin_resolve_displays(descs, dn, &reg);
+
+	if (json) {
+		cJSON *root = cJSON_CreateObject();
+		cJSON_AddNumberToObject(root, "monitor_count", (double)dn);
+		cJSON_AddNumberToObject(root, "claimed_count", (double)reg.entry_count);
+		cJSON *arr = cJSON_AddArrayToObject(root, "claims");
+		for (uint32_t i = 0; i < reg.entry_count; i++) {
+			const struct xrt_dp_registry_entry *e = &reg.entries[i];
+			char idhex[19];
+			snprintf(idhex, sizeof(idhex), "0x%016llx", (unsigned long long)e->monitor_id);
+			char apis[64];
+			apis_to_str(e, apis, sizeof(apis));
+			cJSON *c = cJSON_CreateObject();
+			cJSON_AddStringToObject(c, "monitor_id", idhex);
+			cJSON_AddStringToObject(c, "plugin_id", e->plugin_id);
+			cJSON_AddStringToObject(c, "confidence", confidence_label(e->confidence));
+			cJSON_AddNumberToObject(c, "confidence_value", (double)e->confidence);
+			cJSON_AddStringToObject(c, "supported_apis", apis);
+			cJSON_AddStringToObject(c, "serial", e->serial);
+			cJSON_AddNumberToObject(c, "pixel_width", (double)e->pixel_width);
+			cJSON_AddNumberToObject(c, "pixel_height", (double)e->pixel_height);
+			cJSON_AddNumberToObject(c, "screen_left", (double)e->screen_left);
+			cJSON_AddNumberToObject(c, "screen_top", (double)e->screen_top);
+			cJSON_AddItemToArray(arr, c);
+		}
+		char *out = cJSON_Print(root);
+		if (out != NULL) {
+			printf("%s\n", out);
+			cJSON_free(out);
+		}
+		cJSON_Delete(root);
+		return 0;
+	}
+
+	P(" :: Per-display DP claims (resolved registry, #69)\n");
+	if (reg.entry_count == 0) {
+		PT("(no monitor was claimed by any registered plug-in; %u monitor(s) enumerated)\n", dn);
+		return 0;
+	}
+	for (uint32_t i = 0; i < reg.entry_count; i++) {
+		const struct xrt_dp_registry_entry *e = &reg.entries[i];
+		char apis[64];
+		apis_to_str(e, apis, sizeof(apis));
+		PT("monitor 0x%016llx  %ux%u @ (%d,%d)\n", (unsigned long long)e->monitor_id, e->pixel_width,
+		   e->pixel_height, e->screen_left, e->screen_top);
+		PT("    plug-in='%s'  confidence=%s  apis=%s%s%s\n", e->plugin_id, confidence_label(e->confidence),
+		   apis, e->serial[0] != '\0' ? "  serial=" : "", e->serial);
+	}
+	return 0;
+}
+
 int
 cli_cmd_displays(int argc, const char **argv)
 {
 	struct os_display_edid_list list = {0};
 	os_display_edid_enumerate(&list);
+
+	if (cli_has_flag(argc, argv, "--claims")) {
+		return cli_cmd_displays_claims(&list, cli_has_flag(argc, argv, "--json"));
+	}
 
 	if (cli_has_flag(argc, argv, "--json")) {
 		cJSON *root = cJSON_CreateObject();

--- a/src/xrt/targets/cli/cli_main.c
+++ b/src/xrt/targets/cli/cli_main.c
@@ -35,6 +35,7 @@ cli_print_help(int argc, const char **argv)
 	P("  runtime <...>     - Show / set DisplayXR as the active OpenXR runtime.\n");
 	P("                      'runtime status', 'runtime activate'.\n");
 	P("  displays [--json] - Enumerate connected displays via EDID (vendor-neutral).\n");
+	P("           [--claims] - Also show which plug-in claims each display (loads plug-ins).\n");
 	P("  test              - List found devices and role assignments, for prober testing.\n");
 	P("  probe             - Just probe and then exit.\n");
 

--- a/src/xrt/targets/common/CMakeLists.txt
+++ b/src/xrt/targets/common/CMakeLists.txt
@@ -62,6 +62,7 @@ if(XRT_MODULE_COMPOSITOR_MAIN OR XRT_MODULE_COMPOSITOR_NULL)
 		PRIVATE
 			xrt-interfaces
 			aux_util
+			aux_os
 			st_prober
 			target_lists
 			drv_includes
@@ -90,6 +91,7 @@ if(XRT_MODULE_COMPOSITOR_MAIN OR XRT_MODULE_COMPOSITOR_NULL)
 			PRIVATE
 				xrt-interfaces
 				aux_util
+				aux_os
 				st_prober
 				target_lists
 				drv_includes

--- a/src/xrt/targets/common/target_instance.c
+++ b/src/xrt/targets/common/target_instance.c
@@ -17,6 +17,7 @@
 
 
 #include "os/os_time.h"
+#include "os/os_display_edid.h"
 
 #include "util/u_debug.h"
 #include "util/u_system.h"
@@ -116,6 +117,30 @@ fill_dp_factories_from_plugin(struct xrt_system_compositor_info *info, const str
 }
 
 /*!
+ * Enumerate connected monitors (vendor-neutral EDID), ask the registered
+ * plug-ins which they claim, and build the per-monitor DP factory registry
+ * (issue #69 / ADR-015). The scalar `dp_factory_*` fields are left as the
+ * authoritative compositor input in Phase 1 — the registry's primary-monitor
+ * winner is the same plug-in as the active one, so they stay consistent; the
+ * registry is built in parallel for the CLI and the future Phase 3 compositor
+ * migration. No-op (empty registry) off-Windows, where the EDID enumerator
+ * returns no monitors.
+ */
+static void
+build_dp_registry(struct xrt_system_compositor_info *info)
+{
+	if (info == NULL) {
+		return;
+	}
+	struct os_display_edid_list edid = {0};
+	os_display_edid_enumerate(&edid);
+
+	struct xrt_display_descriptor descs[XRT_DP_REGISTRY_MAX_ENTRIES];
+	uint32_t dn = target_plugin_build_descriptors(&edid, descs, XRT_DP_REGISTRY_MAX_ENTRIES);
+	target_plugin_resolve_displays(descs, dn, &info->dp_registry);
+}
+
+/*!
  * Installed on @ref xrt_system_compositor_info::refresh_display_processors so a
  * long-lived service-mode compositor can pick up a vendor plug-in registered
  * AFTER the service started (issue #342). Each per-client compositor-create
@@ -127,6 +152,10 @@ refresh_display_processors_cb(struct xrt_system_compositor_info *info)
 {
 	const struct xrt_plugin_iface *plugin = target_plugin_refresh_active();
 	fill_dp_factories_from_plugin(info, plugin);
+	// Rebuild the per-monitor registry too — refresh_active invalidates the
+	// loader's source cache on a swap, so this re-resolves against the new
+	// winner (#69 / ADR-015).
+	build_dp_registry(info);
 }
 
 static xrt_result_t
@@ -329,6 +358,12 @@ out:
 				plugin_filled_display_info = true;
 			}
 		}
+
+		// Build the per-monitor DP factory registry (#69 / ADR-015) from the
+		// vendor-neutral EDID enumeration + per-plug-in probe_displays claims.
+		// Independent of the active plug-in's get_display_info above; the
+		// scalar dp_factory_* set there stays the Phase-1 compositor input.
+		build_dp_registry(&xsysc->info);
 
 		// All display-info + DP factories are sourced from the plug-in
 		// iface above (ADR-019 / #256 / #263). The runtime DLL no longer

--- a/src/xrt/targets/common/target_plugin_loader.c
+++ b/src/xrt/targets/common/target_plugin_loader.c
@@ -23,10 +23,12 @@
 #include "target_plugin_loader.h"
 
 #include "xrt/xrt_plugin.h"
+#include "xrt/xrt_compositor.h"
 #include "xrt/xrt_results.h"
 #include "xrt/xrt_config_os.h"
 
 #include "os/os_threading.h"
+#include "os/os_display_edid.h"
 #include "util/u_logging.h"
 
 #include <errno.h>
@@ -65,6 +67,37 @@ static uint32_t g_active_probe_order = 0xFFFFFFFFu;
  */
 static struct os_mutex g_refresh_mutex;
 static int g_refresh_mutex_initialized = 0;
+
+/*!
+ * Max plug-in sources consulted when building the per-display registry
+ * (issue #69 / ADR-015). One per registered plug-in — a handful in practice.
+ */
+#define TARGET_PLUGIN_MAX_SOURCES 16
+
+/*!
+ * One loaded plug-in consulted for display claims. Distinct from the single
+ * "active" plug-in (which drives create_device / get_display_info): the
+ * display registry asks EVERY registered plug-in for its claims, so the
+ * lower-confidence fallback (sim_display) and a vendor plug-in can both
+ * contribute. The active plug-in is reused as one of these sources rather
+ * than loaded twice.
+ */
+struct plugin_display_source
+{
+	const struct xrt_plugin_iface *iface;
+	struct xrt_plugin_instance *inst;
+	uint32_t probe_order; /* ascending = higher priority on a confidence tie */
+};
+
+/*!
+ * Cached display-claim source set, built lazily on the first
+ * @ref target_plugin_resolve_displays and reused for the process lifetime.
+ * `< 0` means "not collected yet"; reset to -1 when
+ * @ref target_plugin_refresh_active adopts a better plug-in so the next
+ * resolve rebuilds. Guarded by @ref g_refresh_mutex.
+ */
+static struct plugin_display_source g_display_sources[TARGET_PLUGIN_MAX_SOURCES];
+static int g_display_source_count = -1;
 
 
 /*
@@ -259,10 +292,24 @@ compare_by_probe_order(const void *a, const void *b)
  * loads intentionally leak it for the process lifetime so the iface's
  * function pointers remain callable.
  */
+/*!
+ * Load + negotiate + ABI-check + probe one registered plug-in. Returns the
+ * iface (writing the instance to *out_inst and the negotiated ABI version to
+ * *out_version) on success, NULL (and closes the DLL) on any failure. No
+ * "active plug-in" logging — callers add their own role-specific line, so
+ * this can serve both the single-winner discovery and the load-all display
+ * probe (#69). Successful loads intentionally leak the HMODULE for the
+ * process lifetime so the iface's function pointers remain callable.
+ */
 static const struct xrt_plugin_iface *
-try_load_one(const struct plugin_entry *e, struct xrt_plugin_instance **out_inst)
+load_and_probe_one(const struct plugin_entry *e,
+                   struct xrt_plugin_instance **out_inst,
+                   uint32_t *out_version)
 {
 	*out_inst = NULL;
+	if (out_version != NULL) {
+		*out_version = 0;
+	}
 
 	HMODULE dll = LoadLibraryExW(e->binary_path, NULL, LOAD_WITH_ALTERED_SEARCH_PATH);
 	if (dll == NULL) {
@@ -319,6 +366,26 @@ try_load_one(const struct plugin_entry *e, struct xrt_plugin_instance **out_inst
 			FreeLibrary(dll);
 			return NULL;
 		}
+	}
+
+	if (out_version != NULL) {
+		*out_version = plugin_version;
+	}
+	return iface;
+}
+
+/*!
+ * Try one registered plug-in as the single active winner. Thin wrapper over
+ * @ref load_and_probe_one that adds the canonical "active plug-in:" log line
+ * (parsed by diagnostics). Returns the iface on success, NULL on any failure.
+ */
+static const struct xrt_plugin_iface *
+try_load_one(const struct plugin_entry *e, struct xrt_plugin_instance **out_inst)
+{
+	uint32_t plugin_version = 0;
+	const struct xrt_plugin_iface *iface = load_and_probe_one(e, out_inst, &plugin_version);
+	if (iface == NULL) {
+		return NULL;
 	}
 
 	U_LOG_W(
@@ -477,6 +544,60 @@ discover_active_plugin(struct xrt_plugin_instance **out_inst, uint32_t max_probe
 
 	U_LOG_W("plugin loader: no registered plug-in claimed the system — falling back to static drivers.");
 	return NULL;
+}
+
+/*!
+ * Load EVERY registered plug-in and return them as display-claim sources for
+ * the per-monitor registry (#69 / ADR-015). Unlike @ref discover_active_plugin
+ * (which stops at the first winner), this consults all of them so the
+ * fallback (sim_display) and a vendor plug-in can both contribute claims. The
+ * already-active plug-in is reused — not loaded twice — and the remainder are
+ * loaded via @ref load_and_probe_one (DLL handles leaked, consistent with the
+ * single-winner path). Plug-ins whose `probe()` declines contribute nothing.
+ * Returns the source count, sorted ascending by ProbeOrder (so a confidence
+ * tie resolves to the lower-ProbeOrder plug-in).
+ *
+ * Caller must hold @ref g_refresh_mutex and have already loaded the active
+ * plug-in (so `g_active_*` are set for the reuse path).
+ */
+static int
+collect_display_sources_platform(struct plugin_display_source *out, int max)
+{
+	struct plugin_entry entries[MAX_PLUGIN_ENTRIES];
+	int n = enumerate_registry(entries, MAX_PLUGIN_ENTRIES);
+	if (n == 0) {
+		return 0;
+	}
+	qsort(entries, (size_t)n, sizeof(entries[0]), compare_by_probe_order);
+
+	const char *active_id = (g_active_iface != NULL && g_active_iface->id != NULL) ? g_active_iface->id : NULL;
+
+	int count = 0;
+	for (int i = 0; i < n && count < max; i++) {
+		// Reuse the already-loaded active plug-in rather than loading a
+		// second instance of it.
+		if (active_id != NULL && strcmp(entries[i].id, active_id) == 0) {
+			out[count].iface = g_active_iface;
+			out[count].inst = g_active_instance;
+			out[count].probe_order = g_active_probe_order;
+			count++;
+			continue;
+		}
+
+		uint32_t ver = 0;
+		struct xrt_plugin_instance *inst = NULL;
+		const struct xrt_plugin_iface *iface = load_and_probe_one(&entries[i], &inst, &ver);
+		if (iface == NULL) {
+			continue; // declined / failed → contributes no claims
+		}
+		U_LOG_I("plugin loader: display-claim source id=%s (ProbeOrder=%u)", entries[i].id,
+		        entries[i].probe_order);
+		out[count].iface = iface;
+		out[count].inst = inst;
+		out[count].probe_order = entries[i].probe_order;
+		count++;
+	}
+	return count;
 }
 
 /*
@@ -1653,6 +1774,9 @@ target_plugin_refresh_active(void)
 		        cand->id ? cand->id : "?", prev_order, g_active_probe_order);
 		g_active_iface = cand;
 		g_active_instance = new_inst;
+		// Invalidate the display-claim source cache so the next
+		// target_plugin_resolve_displays rebuilds it against the new winner.
+		g_display_source_count = -1;
 	}
 
 	const struct xrt_plugin_iface *result = g_active_iface;
@@ -1661,4 +1785,261 @@ target_plugin_refresh_active(void)
 		os_mutex_unlock(&g_refresh_mutex);
 	}
 	return result;
+}
+
+
+/*
+ *
+ * Per-display resolution (issue #69 / ADR-015).
+ *
+ */
+
+/*!
+ * Stable-for-this-boot monitor id. FNV-1a-64 over the EDID identity fields
+ * that survive a mode/refresh change — manufacturer, product, and screen
+ * position (so two identical-model panels at different positions differ).
+ * Excludes pixel dims/refresh/HMONITOR (transient). Known limitation:
+ * repositioning a monitor changes its id within a boot — acceptable for
+ * Phase 1; EDID device-instance-path keying is the Phase 2/3 hardening.
+ */
+static uint64_t
+monitor_id_from_edid(uint16_t mfr, uint16_t product, int32_t left, int32_t top)
+{
+	uint64_t h = 1469598103934665603ULL; /* FNV-1a-64 offset basis */
+	const uint64_t prime = 1099511628211ULL;
+	uint8_t bytes[12];
+	memcpy(&bytes[0], &mfr, sizeof(mfr));
+	memcpy(&bytes[2], &product, sizeof(product));
+	memcpy(&bytes[4], &left, sizeof(left));
+	memcpy(&bytes[8], &top, sizeof(top));
+	for (size_t i = 0; i < sizeof(bytes); i++) {
+		h ^= (uint64_t)bytes[i];
+		h *= prime;
+	}
+	return h;
+}
+
+uint32_t
+target_plugin_build_descriptors(const struct os_display_edid_list *list,
+                                struct xrt_display_descriptor *out,
+                                uint32_t max)
+{
+	if (list == NULL || out == NULL || max == 0) {
+		return 0;
+	}
+	uint32_t n = list->count;
+	if (n > max) {
+		n = max;
+	}
+	for (uint32_t i = 0; i < n; i++) {
+		const struct os_display_edid_monitor *m = &list->monitors[i];
+		struct xrt_display_descriptor *d = &out[i];
+		memset(d, 0, sizeof(*d));
+		d->struct_size = (uint32_t)sizeof(*d);
+		d->monitor_id = monitor_id_from_edid(m->manufacturer_id, m->product_id, m->screen_left, m->screen_top);
+		d->edid_manufacturer = m->manufacturer_id;
+		d->edid_product = m->product_id;
+		d->pixel_width = m->pixel_width;
+		d->pixel_height = m->pixel_height;
+		d->refresh_mhz = m->refresh_hz * 1000u;
+		d->screen_left = m->screen_left;
+		d->screen_top = m->screen_top;
+		d->flags = m->is_primary ? 1u : 0u;
+	}
+	return n;
+}
+
+/*!
+ * Synthesize the back-compat claim for a loaded plug-in that has no
+ * `probe_displays` but whose binary `probe()` succeeded: one
+ * @ref XRT_DISPLAY_CLAIM_EDID claim on the primary monitor (or the first
+ * descriptor if none is flagged primary). `supported_apis` is set to all
+ * bits — the actual factory set is masked against the plug-in's non-NULL
+ * factory pointers at fill time.
+ */
+static uint32_t
+synth_primary_edid_claim(const struct xrt_display_descriptor *descs,
+                         uint32_t n,
+                         struct xrt_display_claim *out,
+                         uint32_t max)
+{
+	if (n == 0 || max == 0) {
+		return 0;
+	}
+	uint32_t pick = 0;
+	for (uint32_t i = 0; i < n; i++) {
+		if (descs[i].flags & 1u) {
+			pick = i;
+			break;
+		}
+	}
+	out[0].monitor_id = descs[pick].monitor_id;
+	out[0].confidence = (uint32_t)XRT_DISPLAY_CLAIM_EDID;
+	out[0].supported_apis = 0xFFFFFFFFu;
+	out[0].serial[0] = '\0';
+	return 1;
+}
+
+/*!
+ * Get one source's claims for the supplied descriptors: call its
+ * `probe_displays()` if present (struct_size-guarded), else synthesize the
+ * back-compat primary-monitor claim.
+ */
+static uint32_t
+query_source_claims(const struct plugin_display_source *src,
+                    const struct xrt_display_descriptor *descs,
+                    uint32_t n,
+                    struct xrt_display_claim *out,
+                    uint32_t max)
+{
+	const struct xrt_plugin_iface *iface = src->iface;
+	if (iface == NULL) {
+		return 0;
+	}
+	if (iface->struct_size > offsetof(struct xrt_plugin_iface, probe_displays) &&
+	    iface->probe_displays != NULL) {
+		return iface->probe_displays(src->inst, descs, n, out, max);
+	}
+	return synth_primary_edid_claim(descs, n, out, max);
+}
+
+/*!
+ * Copy the winning source's per-API factory pointers (masked by the claim's
+ * supported_apis AND the plug-in's actually-non-NULL factory) plus identity
+ * into a registry entry. Mirrors the platform gating of
+ * `fill_dp_factories_from_plugin` in target_instance.c.
+ */
+static void
+fill_registry_entry(struct xrt_dp_registry_entry *e,
+                    const struct xrt_display_descriptor *desc,
+                    const struct plugin_display_source *src,
+                    const struct xrt_display_claim *claim)
+{
+	const struct xrt_plugin_iface *iface = src->iface;
+	memset(e, 0, sizeof(*e));
+	e->monitor_id = desc->monitor_id;
+	e->confidence = claim->confidence;
+	e->screen_left = desc->screen_left;
+	e->screen_top = desc->screen_top;
+	e->pixel_width = desc->pixel_width;
+	e->pixel_height = desc->pixel_height;
+	snprintf(e->plugin_id, sizeof(e->plugin_id), "%s", iface->id != NULL ? iface->id : "");
+	snprintf(e->serial, sizeof(e->serial), "%s", claim->serial);
+
+	if ((claim->supported_apis & XRT_DP_API_BIT_VK) && iface->create_dp_vk != NULL) {
+		e->dp_factory_vk = (void *)iface->create_dp_vk;
+	}
+#ifdef XRT_OS_WINDOWS
+	if ((claim->supported_apis & XRT_DP_API_BIT_D3D11) && iface->create_dp_d3d11 != NULL) {
+		e->dp_factory_d3d11 = (void *)iface->create_dp_d3d11;
+	}
+	if ((claim->supported_apis & XRT_DP_API_BIT_D3D12) && iface->create_dp_d3d12 != NULL) {
+		e->dp_factory_d3d12 = (void *)iface->create_dp_d3d12;
+	}
+#endif
+	if ((claim->supported_apis & XRT_DP_API_BIT_GL) && iface->create_dp_gl != NULL) {
+		e->dp_factory_gl = (void *)iface->create_dp_gl;
+	}
+#ifdef __APPLE__
+	if ((claim->supported_apis & XRT_DP_API_BIT_METAL) && iface->create_dp_metal != NULL) {
+		e->dp_factory_metal = (void *)iface->create_dp_metal;
+	}
+#endif
+	e->owning_iface = (const void *)iface;
+	e->owning_instance = src->inst;
+}
+
+/*!
+ * Build the cached display-claim source set if not already collected. Caller
+ * holds @ref g_refresh_mutex and has loaded the active plug-in.
+ */
+static void
+ensure_display_sources(void)
+{
+	if (g_display_source_count >= 0) {
+		return;
+	}
+	g_display_source_count = 0;
+#ifdef XRT_OS_WINDOWS
+	g_display_source_count = collect_display_sources_platform(g_display_sources, TARGET_PLUGIN_MAX_SOURCES);
+#else
+	// Off-Windows the EDID enumerator yields no monitors, so resolution is
+	// a no-op regardless; the single active plug-in suffices as the lone
+	// source for any caller that supplies its own descriptors.
+	if (g_active_iface != NULL) {
+		g_display_sources[0].iface = g_active_iface;
+		g_display_sources[0].inst = g_active_instance;
+		g_display_sources[0].probe_order = g_active_probe_order;
+		g_display_source_count = 1;
+	}
+#endif
+}
+
+void
+target_plugin_resolve_displays(const struct xrt_display_descriptor *descriptors,
+                               uint32_t descriptor_count,
+                               struct xrt_dp_factory_registry *out_registry)
+{
+	if (out_registry == NULL) {
+		return;
+	}
+	memset(out_registry, 0, sizeof(*out_registry));
+	if (descriptors == NULL || descriptor_count == 0) {
+		return;
+	}
+
+	// Ensure the active plug-in is loaded (and the refresh mutex initialized)
+	// before we lock — get_active() runs the one-shot discovery on first call.
+	(void)target_plugin_get_active();
+
+	if (g_refresh_mutex_initialized) {
+		os_mutex_lock(&g_refresh_mutex);
+	}
+
+	ensure_display_sources();
+
+	uint32_t dn = descriptor_count;
+	if (dn > XRT_DP_REGISTRY_MAX_ENTRIES) {
+		dn = XRT_DP_REGISTRY_MAX_ENTRIES;
+	}
+
+	// Query every source once for the full descriptor set.
+	static struct xrt_display_claim src_claims[TARGET_PLUGIN_MAX_SOURCES][XRT_DP_REGISTRY_MAX_ENTRIES];
+	uint32_t src_claim_count[TARGET_PLUGIN_MAX_SOURCES] = {0};
+	for (int s = 0; s < g_display_source_count; s++) {
+		src_claim_count[s] =
+		    query_source_claims(&g_display_sources[s], descriptors, dn, src_claims[s], XRT_DP_REGISTRY_MAX_ENTRIES);
+	}
+
+	// Resolve per monitor: highest confidence wins; ties → lower ProbeOrder.
+	// Sources are already in ascending ProbeOrder, so a strict `>` keeps the
+	// first (lowest-order) source at any given confidence.
+	for (uint32_t d = 0; d < dn; d++) {
+		const struct xrt_display_descriptor *desc = &descriptors[d];
+		const struct plugin_display_source *best_src = NULL;
+		const struct xrt_display_claim *best_claim = NULL;
+		for (int s = 0; s < g_display_source_count; s++) {
+			for (uint32_t c = 0; c < src_claim_count[s]; c++) {
+				const struct xrt_display_claim *cl = &src_claims[s][c];
+				if (cl->monitor_id != desc->monitor_id) {
+					continue;
+				}
+				if (best_claim == NULL || cl->confidence > best_claim->confidence) {
+					best_claim = cl;
+					best_src = &g_display_sources[s];
+				}
+			}
+		}
+		if (best_claim == NULL) {
+			continue; // no plug-in claimed this monitor
+		}
+		struct xrt_dp_registry_entry *e = &out_registry->entries[out_registry->entry_count++];
+		fill_registry_entry(e, desc, best_src, best_claim);
+		U_LOG_I("plugin loader: monitor 0x%016llx → plug-in '%s' (confidence=%u)",
+		        (unsigned long long)e->monitor_id, e->plugin_id, e->confidence);
+	}
+
+	if (g_refresh_mutex_initialized) {
+		os_mutex_unlock(&g_refresh_mutex);
+	}
 }

--- a/src/xrt/targets/common/target_plugin_loader.h
+++ b/src/xrt/targets/common/target_plugin_loader.h
@@ -169,6 +169,51 @@ target_plugin_get_active_instance(void);
 const struct xrt_plugin_iface *
 target_plugin_refresh_active(void);
 
+/* Forward declarations — full defs in xrt/xrt_compositor.h and
+ * os/os_display_edid.h; the .c includes those, the header stays lean. */
+struct xrt_dp_factory_registry;
+struct os_display_edid_list;
+
+/*!
+ * Map an enumerated EDID monitor list (`os_display_edid_enumerate`) into the
+ * vendor-neutral @ref xrt_display_descriptor array handed to
+ * `probe_displays()`. Assigns each monitor a stable-for-this-boot
+ * `monitor_id` (hashed from EDID manufacturer/product + screen position),
+ * converts `refresh_hz`→`refresh_mhz`, and maps `is_primary`→`flags` bit 0.
+ * Writes up to @p max descriptors and returns the count.
+ *
+ * Issue #69 / ADR-015.
+ */
+uint32_t
+target_plugin_build_descriptors(const struct os_display_edid_list *list,
+                                struct xrt_display_descriptor *out,
+                                uint32_t max);
+
+/*!
+ * Build the per-monitor DP factory registry (issue #69 / ADR-015). Loads
+ * every registered plug-in (reusing the already-active one), asks each for
+ * its `probe_displays()` claims — or, for a plug-in without `probe_displays`
+ * whose binary `probe()` succeeded, synthesizes a single
+ * @ref XRT_DISPLAY_CLAIM_EDID claim on the primary monitor (single-display
+ * back-compat) — then resolves per monitor (highest confidence wins; ties by
+ * ascending ProbeOrder) into @p out_registry. A monitor no plug-in claims
+ * gets no entry.
+ *
+ * Vendor-blind: the registry stores only `void *` factory pointers, the
+ * winning `iface->id` string, and the claim serial — no vendor symbols enter
+ * the runtime link line (ADR-019). The loaded plug-in source set is cached
+ * for the process lifetime (rebuilt when @ref target_plugin_refresh_active
+ * swaps in a better plug-in). Mutex-guarded like the refresh path.
+ *
+ * Off-Windows the EDID enumerator yields no monitors, so a 0-length
+ * descriptor list resolves to an empty registry (`entry_count == 0`),
+ * signalling callers to use the scalar `dp_factory_*` fields.
+ */
+void
+target_plugin_resolve_displays(const struct xrt_display_descriptor *descriptors,
+                               uint32_t descriptor_count,
+                               struct xrt_dp_factory_registry *out_registry);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
## Summary

Phase 1 of per-display vendor DP routing (#69 / ADR-015): turn the binary, system-level `xrt_plugin_iface::probe()` into a **per-monitor claim list**, so DisplayXR can route monitor→DP (mixed-vendor / force-sim-on-one-monitor). New iface method is **append-only + `struct_size`-guarded → no ABI major bump** (ADR-020).

This is the runtime-side ABI + plumbing only. **Phase 2** = Leia plug-in's real `probe_displays()` (separate repo). **Phase 3** (deferred) = compositor per-display routing / atlas split-weave — the 5 native compositors are deliberately untouched here.

## Changes

- **ABI** (`xrt_plugin.h`): `xrt_display_descriptor`, `xrt_display_claim`, `xrt_display_claim_confidence` (FALLBACK/EDID/VERIFIED), `XRT_DP_API_BIT_*`, and `probe_displays` appended to `xrt_plugin_iface`; matching layout `_Static_assert`s in `oxr_plugin_stub.c`.
- **Registry** (`xrt_compositor.h`): `xrt_dp_factory_registry` (monitor → per-API factories + confidence + plugin id + serial) on `xrt_system_compositor_info`.
- **Loader** (`target_plugin_loader`): load **all** registered plug-ins (reusing the active one), query each `probe_displays()` or synthesize an `EDID@primary` claim for a plug-in without it (single-display back-compat), resolve per monitor (highest confidence; ties by ProbeOrder). Cached, mutex-guarded, invalidated on the #342 refresh; FNV-1a `monitor_id`.
- **`target_instance`**: build the registry at instance-create + on refresh. Scalar `dp_factory_*` kept as the compositor input (== primary registry entry in Phase 1), so compositors are unaffected.
- **sim_display**: `probe_displays()` claims every monitor at `FALLBACK`.
- **CLI**: `displays --claims` (text + JSON) prints the resolved registry.

## ADR compliance
- **ADR-019** (vendor-blind link line): registry holds only `void*` factories + `iface->id` + serial — no vendor symbols enter the runtime DLL.
- **ADR-020** (append-only ABI): `probe_displays` appended last, NULL-safe, `struct_size`-guarded; `XRT_PLUGIN_API_VERSION_CURRENT` stays `_2`. DP vtables untouched.

## Verification (local, single-Leia-panel box)
- `selftest` exit 0; `info` unchanged.
- `displays --claims` (leia + sim): **leia-sr wins EDID(50) > sim FALLBACK(10)** — real cross-plugin resolution. APIs masked to the winner's factories.
- Removed leia reg key → confirmed back-compat synth (stale sim) **and** new sim `probe_displays` → FALLBACK on the fresh build.
- In-process cube (deployed fresh `DisplayXRClient.dll`): `xrCreateInstance`/`build_dp_registry` ran clean, leia active, **rendered fine (eyeballed)**, clean exit — no regression. Live install restored afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)