### PR TITLE
Wire modelviewer_demo into versions.json + orchestrator

### DIFF
--- a/scripts/lib/components.sh
+++ b/scripts/lib/components.sh
@@ -72,6 +72,16 @@ COMPONENT_EXE_WINDOWS_gauss_demo="DisplayXRGaussianSplatSetup-*.exe"
 COMPONENT_INSTALL_MARKER_MACOS_gauss_demo="/Applications/Gaussian Splat Viewer.app"
 COMPONENT_INSTALL_MARKER_WINDOWS_gauss_demo="HKLM\\Software\\DisplayXR\\Demos\\GaussianSplat"
 
+# --- modelviewer_demo ---
+# glTF 2.0 PBR model viewer demo (displayxr-demo-modelviewer). Windows-only
+# today — the macOS app is not yet ported, so the macOS glob/marker are empty
+# → warn+skip on macOS. First release v0.1.0 (2026-06-01).
+COMPONENT_REPO_modelviewer_demo="DisplayXR/displayxr-demo-modelviewer"
+COMPONENT_PKG_MACOS_modelviewer_demo=""
+COMPONENT_EXE_WINDOWS_modelviewer_demo="DisplayXRModelViewerSetup-*.exe"
+COMPONENT_INSTALL_MARKER_MACOS_modelviewer_demo=""
+COMPONENT_INSTALL_MARKER_WINDOWS_modelviewer_demo="HKLM\\Software\\DisplayXR\\Demos\\ModelViewer"
+
 # Helper: look up a per-component field for the current platform.
 #   $1 = component name (runtime, shell, leia_plugin, mcp_tools)
 #   $2 = field (REPO, PKG_MACOS, EXE_WINDOWS, INSTALL_MARKER_MACOS)

--- a/scripts/setup-displayxr.bat
+++ b/scripts/setup-displayxr.bat
@@ -50,6 +50,10 @@ set "COMPONENT_REPO_gauss_demo=DisplayXR/displayxr-demo-gaussiansplat"
 set "COMPONENT_EXE_gauss_demo=DisplayXRGaussianSplatSetup-*.exe"
 set "COMPONENT_MARKER_gauss_demo=HKLM\Software\DisplayXR\Demos\GaussianSplat"
 
+set "COMPONENT_REPO_modelviewer_demo=DisplayXR/displayxr-demo-modelviewer"
+set "COMPONENT_EXE_modelviewer_demo=DisplayXRModelViewerSetup-*.exe"
+set "COMPONENT_MARKER_modelviewer_demo=HKLM\Software\DisplayXR\Demos\ModelViewer"
+
 REM --- Default flag state ---
 set "WITH_MCP=0"
 set "WITH_DEMOS=0"

--- a/versions.json
+++ b/versions.json
@@ -4,5 +4,6 @@
   "shell":       "v1.5.0",
   "leia_plugin": "v1.2.0",
   "mcp_tools":   "v0.3.4",
-  "gauss_demo":  "v1.4.4"
+  "gauss_demo":  "v1.4.4",
+  "modelviewer_demo": "v0.1.0"
 }


### PR DESCRIPTION
Adds displayxr-demo-modelviewer (v0.1.0) to versions.json, components.sh, and setup-displayxr.bat. Windows-only today (macOS app not ported). Bundle wiring + mirror handled in displayxr-installer.