### PR TITLE
fix(installer/macos): register active_runtime in loader datadir too (#385)

### DIFF
--- a/installer/macos/scripts/runtime/postinstall
+++ b/installer/macos/scripts/runtime/postinstall
@@ -1,10 +1,30 @@
 #!/bin/bash
-# Post-install: register DisplayXR as the active OpenXR runtime (system-wide)
+# Post-install: register DisplayXR as the active OpenXR runtime (system-wide).
+#
+# The active_runtime.json must be written everywhere the macOS OpenXR loader
+# looks, otherwise default discovery (apps launched without XR_RUNTIME_JSON)
+# won't find the freshly-installed runtime:
+#   - /etc/xdg/openxr/1            XDG_CONFIG_DIRS default
+#   - /usr/local/share/openxr/1    the loader's datadir (<prefix>/share/openxr/N
+#                                   for prefix=/usr/local — the Khronos SDK
+#                                   loaders bundled with the demo .apps read
+#                                   here; mirrors MANIFEST_RELATIVE_DIR in
+#                                   src/xrt/targets/openxr/CMakeLists.txt)
+# Registering only /etc/xdg left default discovery resolving a stale symlink in
+# the datadir (left by a prior `make install`), or failing outright (#385).
+#
+# `ln -sfn` overwrites any pre-existing file/symlink at the target, so this also
+# self-heals a stale datadir symlink from an earlier dev `make install`.
 INSTALL_DIR="/Library/Application Support/DisplayXR"
 MANIFEST="$INSTALL_DIR/openxr_displayxr.json"
 
-# System-wide OpenXR runtime registration (same mechanism as active_runtime.cmake)
-mkdir -p /etc/xdg/openxr/1
-ln -sf "$MANIFEST" /etc/xdg/openxr/1/active_runtime.json
+register_active_runtime() {
+    local dir="$1"
+    mkdir -p "$dir"
+    ln -sfn "$MANIFEST" "$dir/active_runtime.json"
+}
+
+register_active_runtime /etc/xdg/openxr/1
+register_active_runtime /usr/local/share/openxr/1
 
 exit 0

--- a/installer/macos/uninstall.sh
+++ b/installer/macos/uninstall.sh
@@ -14,7 +14,16 @@ echo "Removing DisplayXR runtime..."
 sudo rm -rf "/Library/Application Support/DisplayXR"
 
 echo "Removing OpenXR runtime registration..."
-sudo rm -f /etc/xdg/openxr/1/active_runtime.json
+# The postinstall registers active_runtime.json in both the XDG config dir and
+# the loader datadir (#385). Remove each only when it points at our install, so
+# a third-party runtime registered there isn't clobbered. (readlink returns the
+# stored link text even after the target dir above is deleted.)
+for rt in /etc/xdg/openxr/1/active_runtime.json /usr/local/share/openxr/1/active_runtime.json; do
+    target="$(readlink "$rt" 2>/dev/null || true)"
+    case "$target" in
+        "/Library/Application Support/DisplayXR/"*) sudo rm -f "$rt" ;;
+    esac
+done
 
 echo "Removing test app..."
 rm -rf "/Applications/DisplayXRCube.app"


### PR DESCRIPTION
Fixes #385.

The macOS `.pkg` postinstall registered the active OpenXR runtime only at `/etc/xdg/openxr/1/active_runtime.json`, but the Khronos SDK loaders bundled with the demo `.app`s (install prefix `/usr/local`) resolve `active_runtime.json` from their datadir `/usr/local/share/openxr/1/` (mirrors `MANIFEST_RELATIVE_DIR = share/openxr/N` in `src/xrt/targets/openxr/CMakeLists.txt`). So after install, default discovery (apps launched without `XR_RUNTIME_JSON`) didn't find the runtime — it resolved a stale datadir symlink from a prior `make install` (older runtime → sim-display `negotiate -17`) or failed outright (`Failed to find default runtime`).

## Changes (installer-only)
- **postinstall**: register `active_runtime.json` in **both** `/etc/xdg/openxr/1` and `/usr/local/share/openxr/1`, via `ln -sfn` so a stale datadir symlink from an earlier dev `make install` is overwritten (self-heal).
- **uninstall.sh**: also remove the datadir registration, guarded to delete each link only when it points at our install (won't clobber a third-party runtime).

Left the upstream `active_runtime.cmake` dev-install path untouched (avoids perturbing Linux).

## Verification
- `bash -n` clean on both scripts; sandbox-tested the `ln -sfn` stale-link overwrite.
- On a Mac: re-pointing the datadir link at the installed runtime restored default discovery (`active plug-in 1.9.0, plugin_api=2`, session up). Found while porting the model viewer demo to macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)