### PR TITLE
feat(compositor): route DP factory selection through the registry (#387, #69 Phase 3a)

### DIFF
--- a/src/xrt/auxiliary/util/u_multi_display.h
+++ b/src/xrt/auxiliary/util/u_multi_display.h
@@ -28,6 +28,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <stddef.h> // NULL
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/xrt/auxiliary/util/u_multi_display.h
+++ b/src/xrt/auxiliary/util/u_multi_display.h
@@ -1,0 +1,159 @@
+// Copyright 2025, Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  Header-only multi-display slice geometry for cross-monitor weaving.
+ * @author David Fattal
+ * @ingroup aux_util
+ *
+ * A window's client area maps 1:1 to ONE multiview atlas content region. When
+ * that window spans several physical monitors, each monitor's display processor
+ * must weave only the sub-region of the atlas that lands on it, and needs the
+ * slice's monitor-relative screen position as its lenticular-phase input.
+ *
+ * This file splits a window rect against a list of monitor rects into
+ * per-monitor slices. Pure integer geometry, no OS headers — testable headless
+ * on any platform (this is issue #69 Phase 3b's highest-risk math, proven here
+ * before a second display is ever attached; no compositor wiring yet).
+ *
+ * DENSITY ASSUMPTION (Phase 3a): uniform effective pixel density across all
+ * monitors. One window-client pixel == one screen pixel == one atlas pixel
+ * everywhere, so this is a pure rect clip and `backbuffer_offset` equals the
+ * atlas offset. Per-monitor DPI / fractional scaling is Phase 3b — at which
+ * point `backbuffer_offset_*` diverges from the atlas offset (it is kept as a
+ * separate field here precisely so that change needs no ABI break).
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*! Max slices a single window split can produce. */
+#define U_MD_MAX_SLICES 8
+
+/*!
+ * A half-open screen-space rectangle covering [left,right) x [top,bottom).
+ * Signed because monitors legitimately sit at negative virtual-desktop
+ * coordinates (a monitor placed left of / above the primary). Translate a
+ * Win32 RECT directly into these fields at the call site.
+ */
+struct u_md_rect
+{
+	int32_t left;   //!< Inclusive left edge, screen-space pixels.
+	int32_t top;    //!< Inclusive top edge, screen-space pixels.
+	int32_t right;  //!< Exclusive right edge, screen-space pixels.
+	int32_t bottom; //!< Exclusive bottom edge, screen-space pixels.
+};
+
+/*!
+ * One per-monitor slice of the window/atlas.
+ */
+struct u_md_slice
+{
+	int32_t atlas_x;  //!< Slice origin X relative to window/atlas (>= 0).
+	int32_t atlas_y;  //!< Slice origin Y relative to window/atlas (>= 0).
+	uint32_t atlas_w; //!< Slice width in atlas pixels (> 0).
+	uint32_t atlas_h; //!< Slice height in atlas pixels (> 0).
+
+	int32_t canvas_offset_x; //!< Slice top-left X within this monitor's panel.
+	int32_t canvas_offset_y; //!< Slice top-left Y within this monitor's panel.
+	                         //!< Monitor-relative screen pos = DP phase input.
+
+	int32_t backbuffer_offset_x; //!< Where the slice lands in the window backbuffer.
+	int32_t backbuffer_offset_y; //!< 3a: == atlas_x/atlas_y (1:1). 3b: diverges.
+
+	int32_t monitor_index; //!< Index into the caller's monitor_rects[].
+};
+
+/*! @private */
+static inline int32_t
+u_md_max32(int32_t a, int32_t b)
+{
+	return a > b ? a : b;
+}
+
+/*! @private */
+static inline int32_t
+u_md_min32(int32_t a, int32_t b)
+{
+	return a < b ? a : b;
+}
+
+/*!
+ * Split a window rect into per-monitor atlas slices.
+ *
+ * For each monitor, intersect (window ∩ monitor) in half-open screen space; if
+ * non-empty, emit one slice. Window pixels that fall on no monitor are silently
+ * dropped (a partially-off-screen window weaves only its on-screen portion).
+ *
+ * Half-open edges mean a monitor seam is counted exactly once: a window flush
+ * to the shared edge emits a slice on the left monitor only, never both.
+ *
+ * On `out_capacity` overflow, extra intersections are silently dropped — the
+ * return count communicates how many were written.
+ *
+ * @param window         Window client area in screen-space pixels.
+ * @param monitor_rects  Array of monitor rects in screen-space pixels.
+ * @param monitor_count  Number of monitors (0 → no slices).
+ * @param[out] out_slices  Caller buffer for emitted slices.
+ * @param out_capacity   Size of out_slices (typically @ref U_MD_MAX_SLICES).
+ * @return Number of slices written. 0 if the window is off all monitors, the
+ *         monitor list is empty, or the window has zero area.
+ */
+static inline uint32_t
+u_multi_display_compute_slices(struct u_md_rect window,
+                               const struct u_md_rect *monitor_rects,
+                               uint32_t monitor_count,
+                               struct u_md_slice *out_slices,
+                               uint32_t out_capacity)
+{
+	// Degenerate window → nothing to weave.
+	if (window.right <= window.left || window.bottom <= window.top) {
+		return 0;
+	}
+	if (monitor_rects == NULL || monitor_count == 0 || out_slices == NULL || out_capacity == 0) {
+		return 0;
+	}
+
+	uint32_t n = 0;
+	for (uint32_t i = 0; i < monitor_count; i++) {
+		const struct u_md_rect m = monitor_rects[i];
+
+		int32_t l = u_md_max32(window.left, m.left);
+		int32_t t = u_md_max32(window.top, m.top);
+		int32_t r = u_md_min32(window.right, m.right);
+		int32_t b = u_md_min32(window.bottom, m.bottom);
+
+		// Empty intersection (half-open) → skip; also kills seam double-count.
+		if (r <= l || b <= t) {
+			continue;
+		}
+
+		// Out of room → silently drop the rest (return count signals it).
+		if (n >= out_capacity) {
+			break;
+		}
+
+		struct u_md_slice *s = &out_slices[n++];
+		s->atlas_x = l - window.left;
+		s->atlas_y = t - window.top;
+		s->atlas_w = (uint32_t)(r - l);
+		s->atlas_h = (uint32_t)(b - t);
+		s->canvas_offset_x = l - m.left;
+		s->canvas_offset_y = t - m.top;
+		s->backbuffer_offset_x = s->atlas_x; // 3a: 1:1 with atlas (uniform density)
+		s->backbuffer_offset_y = s->atlas_y; // 3a: 1:1 with atlas (uniform density)
+		s->monitor_index = (int32_t)i;
+	}
+
+	return n;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -29,6 +29,7 @@
 #include "os/os_time.h"
 
 #include "util/comp_layer_accum.h"
+#include "util/comp_dp_factory.h"
 
 #include "comp_d3d11_window.h"
 
@@ -2858,8 +2859,9 @@ init_client_render_resources(struct d3d11_service_system *sys,
 	// creating a SECOND DP instance causes the SR SDK to recalibrate its
 	// weaver, producing a multi-second stretched-left-eye artifact. The
 	// per-client DP is only needed for standalone (non-workspace) rendering.
-	if (sys->base.info.dp_factory_d3d11 != NULL && !sys->workspace_mode) {
-		auto factory = (xrt_dp_factory_d3d11_fn_t)sys->base.info.dp_factory_d3d11;
+	void *dp_fac = comp_dp_factory_for_window(&sys->base.info, COMP_DP_PRIMARY_MONITOR, COMP_DP_API_D3D11);
+	if (dp_fac != NULL && !sys->workspace_mode) {
+		auto factory = (xrt_dp_factory_d3d11_fn_t)dp_fac;
 		xrt_result_t dp_ret = factory(sys->device.get(), sys->context.get(), res->hwnd, &res->display_processor);
 		if (dp_ret != XRT_SUCCESS) {
 			U_LOG_W("D3D11 display processor factory failed (error %d), continuing without",
@@ -5601,8 +5603,9 @@ multi_compositor_ensure_output(struct d3d11_service_system *sys)
 	}
 
 	// Create display processor via factory
-	if (sys->base.info.dp_factory_d3d11 != NULL) {
-		auto factory = (xrt_dp_factory_d3d11_fn_t)sys->base.info.dp_factory_d3d11;
+	void *dp_fac = comp_dp_factory_for_window(&sys->base.info, COMP_DP_PRIMARY_MONITOR, COMP_DP_API_D3D11);
+	if (dp_fac != NULL) {
+		auto factory = (xrt_dp_factory_d3d11_fn_t)dp_fac;
 		xrt_result_t dp_ret = factory(
 		    sys->device.get(), sys->context.get(), mc->hwnd, &mc->display_processor);
 
@@ -5902,8 +5905,10 @@ multi_compositor_render(struct d3d11_service_system *sys)
 							    bb.get(), nullptr, res->back_buffer_rtv.put());
 						}
 
-						if (sys->base.info.dp_factory_d3d11 != NULL) {
-							auto factory = (xrt_dp_factory_d3d11_fn_t)sys->base.info.dp_factory_d3d11;
+						void *dp_fac_dismiss = comp_dp_factory_for_window(
+						    &sys->base.info, COMP_DP_PRIMARY_MONITOR, COMP_DP_API_D3D11);
+						if (dp_fac_dismiss != NULL) {
+							auto factory = (xrt_dp_factory_d3d11_fn_t)dp_fac_dismiss;
 							factory(sys->device.get(), sys->context.get(),
 							        app_hwnd, &res->display_processor);
 							// Phase 6.1 (#140): don't call request_display_mode
@@ -9586,8 +9591,9 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 			U_LOG_E("Hot-switch: swap chain failed (hr=0x%08X)", hr);
 		}
 
-		if (sys->base.info.dp_factory_d3d11 != NULL) {
-			auto factory = (xrt_dp_factory_d3d11_fn_t)sys->base.info.dp_factory_d3d11;
+		void *dp_fac_hs = comp_dp_factory_for_window(&sys->base.info, COMP_DP_PRIMARY_MONITOR, COMP_DP_API_D3D11);
+		if (dp_fac_hs != NULL) {
+			auto factory = (xrt_dp_factory_d3d11_fn_t)dp_fac_hs;
 			factory(sys->device.get(), sys->context.get(),
 			        c->app_hwnd, &c->render.display_processor);
 			if (c->render.display_processor != nullptr) {
@@ -10457,7 +10463,7 @@ comp_d3d11_service_create_system(struct xrt_device *xdev,
 	// Query display dimensions from display processor (if factory is available).
 	// Create a temporary display processor with NULL window to query pixel info,
 	// then destroy it. Per-client display processors are created later with real windows.
-	if (sys->base.info.dp_factory_d3d11 != NULL) {
+	if (comp_dp_factory_for_window(&sys->base.info, COMP_DP_PRIMARY_MONITOR, COMP_DP_API_D3D11) != NULL) {
 	}
 
 	// Create layer shaders and resources for UI layer rendering
@@ -13047,8 +13053,9 @@ comp_d3d11_service_ensure_workspace_window(struct xrt_system_compositor *xsysc)
 		}
 
 		// Recreate display processor via factory (window + swap chain still alive)
-		if (mc->display_processor == nullptr && sys->base.info.dp_factory_d3d11 != NULL) {
-			auto factory = (xrt_dp_factory_d3d11_fn_t)sys->base.info.dp_factory_d3d11;
+		void *dp_fac_resume = comp_dp_factory_for_window(&sys->base.info, COMP_DP_PRIMARY_MONITOR, COMP_DP_API_D3D11);
+		if (mc->display_processor == nullptr && dp_fac_resume != NULL) {
+			auto factory = (xrt_dp_factory_d3d11_fn_t)dp_fac_resume;
 			xrt_result_t dp_ret = factory(
 			    sys->device.get(), sys->context.get(), mc->hwnd, &mc->display_processor);
 

--- a/src/xrt/compositor/util/comp_dp_factory.h
+++ b/src/xrt/compositor/util/comp_dp_factory.h
@@ -32,6 +32,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <stddef.h> // NULL
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/xrt/compositor/util/comp_dp_factory.h
+++ b/src/xrt/compositor/util/comp_dp_factory.h
@@ -1,0 +1,147 @@
+// Copyright 2025, Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  Header-only accessor that selects a vendor DP factory from the
+ *         per-monitor @ref xrt_dp_factory_registry, with a scalar safety net.
+ * @author David Fattal
+ * @ingroup comp_util
+ *
+ * Phase 3a of multi-display vendor DP routing (issue #69 / ADR-015). The
+ * registry (`xrt_system_compositor_info::dp_registry`) is populated at system
+ * init but, before this accessor, was consumed by nothing — every compositor
+ * read the scalar `dp_factory_*` fields directly. This routes the live
+ * single-display render *through* the registry so any resolution bug surfaces
+ * immediately, while keeping the scalar as the safety-net fallback:
+ *
+ *   - `entry_count == 0`            → return the scalar verbatim (zero-risk).
+ *   - entry found for the monitor   → return its per-API factory, but if that
+ *                                      is NULL fall back to the scalar.
+ *   - registry pointer != scalar    → log once (drift detector). On a single
+ *                                      display the primary entry equals the
+ *                                      scalar, so this stays silent.
+ *
+ * The factory pointers are `void *` (cast back to `xrt_dp_factory_<api>_fn_t`
+ * at the call site, exactly as the scalar fields were).
+ */
+
+#pragma once
+
+#include "xrt/xrt_compositor.h"
+#include "util/u_logging.h"
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*!
+ * Graphics API selector for @ref comp_dp_factory_for_window — picks which
+ * `dp_factory_<api>` field (scalar and registry-entry) to read.
+ */
+enum comp_dp_api
+{
+	COMP_DP_API_VK,
+	COMP_DP_API_D3D11,
+	COMP_DP_API_D3D12,
+	COMP_DP_API_GL,
+	COMP_DP_API_METAL,
+};
+
+/*!
+ * Sentinel monitor id meaning "don't care — use the primary entry". Phase 3a
+ * call sites pass this (single display → one entry); Phase 3b passes the real
+ * per-window monitor id once split-weave routing exists.
+ */
+#define COMP_DP_PRIMARY_MONITOR ((uint64_t)UINT64_MAX)
+
+/*! @private Read the scalar `dp_factory_<api>` for @p api. */
+static inline void *
+comp_dp_scalar_for_api(const struct xrt_system_compositor_info *info, enum comp_dp_api api)
+{
+	switch (api) {
+	case COMP_DP_API_VK: return info->dp_factory_vk;
+	case COMP_DP_API_D3D11: return info->dp_factory_d3d11;
+	case COMP_DP_API_D3D12: return info->dp_factory_d3d12;
+	case COMP_DP_API_GL: return info->dp_factory_gl;
+	case COMP_DP_API_METAL: return info->dp_factory_metal;
+	default: return NULL;
+	}
+}
+
+/*! @private Read the per-entry `dp_factory_<api>` for @p api. */
+static inline void *
+comp_dp_entry_for_api(const struct xrt_dp_registry_entry *e, enum comp_dp_api api)
+{
+	switch (api) {
+	case COMP_DP_API_VK: return e->dp_factory_vk;
+	case COMP_DP_API_D3D11: return e->dp_factory_d3d11;
+	case COMP_DP_API_D3D12: return e->dp_factory_d3d12;
+	case COMP_DP_API_GL: return e->dp_factory_gl;
+	case COMP_DP_API_METAL: return e->dp_factory_metal;
+	default: return NULL;
+	}
+}
+
+/*!
+ * Select the vendor DP factory for the window on @p monitor_id and graphics
+ * @p api, routing through the registry with a scalar fallback (see file doc).
+ *
+ * @param info        System compositor info (holds both the scalar fields and
+ *                    the per-monitor registry). Must be non-NULL.
+ * @param monitor_id  Monitor to route for, or @ref COMP_DP_PRIMARY_MONITOR for
+ *                    the primary entry (Phase 3a always passes the sentinel).
+ * @param api         Which graphics-API factory to select.
+ * @return Factory pointer (cast to the matching `xrt_dp_factory_<api>_fn_t`),
+ *         or NULL if neither the registry nor the scalar provides one.
+ */
+static inline void *
+comp_dp_factory_for_window(const struct xrt_system_compositor_info *info,
+                           uint64_t monitor_id,
+                           enum comp_dp_api api)
+{
+	if (info == NULL) {
+		return NULL;
+	}
+
+	void *scalar = comp_dp_scalar_for_api(info, api);
+
+	// No per-display routing resolved → the scalar is authoritative.
+	if (info->dp_registry.entry_count == 0) {
+		return scalar;
+	}
+
+	// Pick the entry: an exact monitor match, else the primary (entries[0]).
+	const struct xrt_dp_registry_entry *chosen_entry = &info->dp_registry.entries[0];
+	if (monitor_id != COMP_DP_PRIMARY_MONITOR) {
+		for (uint32_t i = 0; i < info->dp_registry.entry_count; i++) {
+			if (info->dp_registry.entries[i].monitor_id == monitor_id) {
+				chosen_entry = &info->dp_registry.entries[i];
+				break;
+			}
+		}
+	}
+
+	void *chosen = comp_dp_entry_for_api(chosen_entry, api);
+
+	// Drift detector: on a single display the registry primary equals the
+	// scalar, so this must stay silent. Warn once if they ever diverge.
+	if (chosen != scalar) {
+		static bool warned = false;
+		if (!warned) {
+			warned = true;
+			U_LOG_W("comp_dp_factory: registry factory %p != scalar %p (api=%d, "
+			        "monitor=0x%016llx) — falling back to scalar; investigate registry resolution",
+			        chosen, scalar, (int)api, (unsigned long long)monitor_id);
+		}
+	}
+
+	// Registry-chosen factory wins when present; scalar is the safety net.
+	return (chosen != NULL) ? chosen : scalar;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/xrt/state_trackers/oxr/oxr_session_gfx_gl_macos.m
+++ b/src/xrt/state_trackers/oxr/oxr_session_gfx_gl_macos.m
@@ -17,6 +17,7 @@
 
 #include "util/u_misc.h"
 #include "util/u_logging.h"
+#include "util/comp_dp_factory.h"
 
 #include "xrt/xrt_instance.h"
 #include "xrt/xrt_config_have.h"
@@ -62,7 +63,9 @@ oxr_session_populate_gl_macos(struct oxr_logger *log,
 	    window_handle,        // NSView from cocoa_window_binding (or NULL for shared texture)
 	    next->cglContext,     // App's CGLContextObj for texture sharing
 	    NULL,                 // gl_display (not used on macOS)
-	    (sys->xsysc != NULL) ? sys->xsysc->info.dp_factory_gl : NULL,
+	    (sys->xsysc != NULL)
+	        ? comp_dp_factory_for_window(&sys->xsysc->info, COMP_DP_PRIMARY_MONITOR, COMP_DP_API_GL)
+	        : NULL,
 	    shared_iosurface,     // IOSurfaceRef for shared texture mode (or NULL for windowed)
 	    /*transparent_background*/ false,  // GL transparent present path is deferred (PR #3b §3b)
 	    /*chroma_key_color*/ 0,

--- a/src/xrt/state_trackers/oxr/oxr_session_gfx_gl_native.c
+++ b/src/xrt/state_trackers/oxr/oxr_session_gfx_gl_native.c
@@ -17,6 +17,7 @@
 #include "util/u_misc.h"
 #include "util/u_logging.h"
 #include "util/u_debug.h"
+#include "util/comp_dp_factory.h"
 
 #include "xrt/xrt_instance.h"
 #include "xrt/xrt_config_have.h"
@@ -86,7 +87,9 @@ oxr_session_populate_gl_native(struct oxr_logger *log,
 	struct xrt_compositor_native *xcn = NULL;
 
 	// Get GL display processor factory and display top-left from system compositor info
-	void *dp_factory_gl = (sys->xsysc != NULL) ? sys->xsysc->info.dp_factory_gl : NULL;
+	void *dp_factory_gl = (sys->xsysc != NULL)
+	    ? comp_dp_factory_for_window(&sys->xsysc->info, COMP_DP_PRIMARY_MONITOR, COMP_DP_API_GL)
+	    : NULL;
 	int32_t display_screen_left = (sys->xsysc != NULL) ? sys->xsysc->info.display_screen_left : 0;
 	int32_t display_screen_top = (sys->xsysc != NULL) ? sys->xsysc->info.display_screen_top : 0;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ set(tests
     tests_worker
     tests_pose
     tests_vec3_angle
+    tests_u_multi_display
 	)
 if(XRT_HAVE_D3D11)
 	list(APPEND tests tests_aux_d3d_d3d11 tests_comp_client_d3d11)

--- a/tests/tests_u_multi_display.cpp
+++ b/tests/tests_u_multi_display.cpp
@@ -1,0 +1,171 @@
+// Copyright 2025, Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief Multi-display slice geometry tests (issue #69 Phase 3a.2).
+ * @author David Fattal
+ */
+
+#include "util/u_multi_display.h"
+
+#include "catch_amalgamated.hpp"
+
+// Monitor fixtures (screen-space, half-open):
+//   A: primary 1920x1080 at origin
+//   B: 1920x1080 directly right of A (side-by-side, seam at x=1920)
+//   C: 640x1040 right of A but offset upward (different size + negative top)
+static const u_md_rect A{0, 0, 1920, 1080};
+static const u_md_rect B{1920, 0, 3840, 1080};
+static const u_md_rect C{1920, -200, 2560, 840};
+
+TEST_CASE("u_multi_display_compute_slices")
+{
+	u_md_slice out[U_MD_MAX_SLICES];
+
+	SECTION("window fully on one monitor -> 1 slice == whole window")
+	{
+		u_md_rect win{100, 100, 500, 400}; // 400 x 300
+		u_md_rect mons[] = {A};
+		uint32_t n = u_multi_display_compute_slices(win, mons, 1, out, U_MD_MAX_SLICES);
+		REQUIRE(n == 1);
+		CHECK(out[0].atlas_x == 0);
+		CHECK(out[0].atlas_y == 0);
+		CHECK(out[0].atlas_w == 400);
+		CHECK(out[0].atlas_h == 300);
+		CHECK(out[0].canvas_offset_x == 100);
+		CHECK(out[0].canvas_offset_y == 100);
+		CHECK(out[0].backbuffer_offset_x == 0);
+		CHECK(out[0].backbuffer_offset_y == 0);
+		CHECK(out[0].monitor_index == 0);
+	}
+
+	SECTION("window spanning two side-by-side monitors")
+	{
+		u_md_rect win{1820, 200, 2020, 500}; // 200 x 300, straddles seam at x=1920
+		u_md_rect mons[] = {A, B};
+		uint32_t n = u_multi_display_compute_slices(win, mons, 2, out, U_MD_MAX_SLICES);
+		REQUIRE(n == 2);
+
+		// Monitor A: x in [1820,1920) -> 100 wide at atlas origin.
+		CHECK(out[0].monitor_index == 0);
+		CHECK(out[0].atlas_x == 0);
+		CHECK(out[0].atlas_y == 0);
+		CHECK(out[0].atlas_w == 100);
+		CHECK(out[0].atlas_h == 300);
+		CHECK(out[0].canvas_offset_x == 1820); // 1820 - 0
+		CHECK(out[0].canvas_offset_y == 200);
+		CHECK(out[0].backbuffer_offset_x == 0);
+		CHECK(out[0].backbuffer_offset_y == 0);
+
+		// Monitor B: x in [1920,2020) -> 100 wide, atlas offset 100.
+		CHECK(out[1].monitor_index == 1);
+		CHECK(out[1].atlas_x == 100);
+		CHECK(out[1].atlas_y == 0);
+		CHECK(out[1].atlas_w == 100);
+		CHECK(out[1].atlas_h == 300);
+		CHECK(out[1].canvas_offset_x == 0); // 1920 - 1920
+		CHECK(out[1].canvas_offset_y == 200);
+		CHECK(out[1].backbuffer_offset_x == 100);
+		CHECK(out[1].backbuffer_offset_y == 0);
+	}
+
+	SECTION("spanning monitors of different size/origin (negative coords)")
+	{
+		u_md_rect win{1800, -100, 2200, 600}; // 400 x 700
+		u_md_rect mons[] = {A, C};
+		uint32_t n = u_multi_display_compute_slices(win, mons, 2, out, U_MD_MAX_SLICES);
+		REQUIRE(n == 2);
+
+		// A ∩ win: l=1800 t=0 r=1920 b=600 -> 120 x 600 @ screen (1800,0)
+		CHECK(out[0].monitor_index == 0);
+		CHECK(out[0].atlas_x == 0);   // 1800 - 1800
+		CHECK(out[0].atlas_y == 100); // 0 - (-100)
+		CHECK(out[0].atlas_w == 120);
+		CHECK(out[0].atlas_h == 600);
+		CHECK(out[0].canvas_offset_x == 1800);
+		CHECK(out[0].canvas_offset_y == 0);
+		CHECK(out[0].backbuffer_offset_x == 0);
+		CHECK(out[0].backbuffer_offset_y == 100);
+
+		// C ∩ win: l=1920 t=-100 r=2200 b=600 -> 280 x 700 @ screen (1920,-100)
+		CHECK(out[1].monitor_index == 1);
+		CHECK(out[1].atlas_x == 120); // 1920 - 1800
+		CHECK(out[1].atlas_y == 0);   // -100 - (-100)
+		CHECK(out[1].atlas_w == 280);
+		CHECK(out[1].atlas_h == 700);
+		CHECK(out[1].canvas_offset_x == 0);   // 1920 - 1920
+		CHECK(out[1].canvas_offset_y == 100); // -100 - (-200)
+		CHECK(out[1].backbuffer_offset_x == 120);
+		CHECK(out[1].backbuffer_offset_y == 0);
+	}
+
+	SECTION("window partly off all monitors (partial coverage)")
+	{
+		u_md_rect win{-50, 1000, 50, 1200}; // 100 x 200, off-left + below-bottom
+		u_md_rect mons[] = {A};
+		uint32_t n = u_multi_display_compute_slices(win, mons, 1, out, U_MD_MAX_SLICES);
+		REQUIRE(n == 1);
+		// A ∩ win: l=0 t=1000 r=50 b=1080 -> 50 x 80 @ screen (0,1000)
+		CHECK(out[0].atlas_x == 50); // 0 - (-50)
+		CHECK(out[0].atlas_y == 0);  // 1000 - 1000
+		CHECK(out[0].atlas_w == 50);
+		CHECK(out[0].atlas_h == 80);
+		CHECK(out[0].canvas_offset_x == 0);
+		CHECK(out[0].canvas_offset_y == 1000);
+		CHECK(out[0].backbuffer_offset_x == 50);
+		CHECK(out[0].backbuffer_offset_y == 0);
+		// Only 50*80=4000 of 100*200=20000 px covered; the rest is off-screen.
+	}
+
+	SECTION("empty / zero monitor list -> 0 slices")
+	{
+		u_md_rect win{0, 0, 100, 100};
+		CHECK(u_multi_display_compute_slices(win, nullptr, 0, out, U_MD_MAX_SLICES) == 0);
+		u_md_rect mons[] = {A};
+		CHECK(u_multi_display_compute_slices(win, mons, 0, out, U_MD_MAX_SLICES) == 0);
+	}
+
+	SECTION("window fully off-screen -> 0 slices")
+	{
+		u_md_rect win{5000, 5000, 5100, 5100};
+		u_md_rect mons[] = {A, B};
+		CHECK(u_multi_display_compute_slices(win, mons, 2, out, U_MD_MAX_SLICES) == 0);
+	}
+
+	SECTION("zero-area window -> 0 slices")
+	{
+		u_md_rect mons[] = {A};
+		CHECK(u_multi_display_compute_slices(u_md_rect{10, 10, 10, 200}, mons, 1, out, U_MD_MAX_SLICES) == 0);
+		CHECK(u_multi_display_compute_slices(u_md_rect{10, 10, 200, 10}, mons, 1, out, U_MD_MAX_SLICES) == 0);
+	}
+
+	SECTION("exact-edge adjacency -> no double-count")
+	{
+		u_md_rect mons[] = {A, B};
+
+		// Window exactly == A; B starts at the exclusive right edge -> A only.
+		uint32_t n = u_multi_display_compute_slices(u_md_rect{0, 0, 1920, 1080}, mons, 2, out, U_MD_MAX_SLICES);
+		REQUIRE(n == 1);
+		CHECK(out[0].monitor_index == 0);
+		CHECK(out[0].atlas_w == 1920);
+		CHECK(out[0].atlas_h == 1080);
+
+		// Window exactly == B -> B only.
+		n = u_multi_display_compute_slices(u_md_rect{1920, 0, 3840, 1080}, mons, 2, out, U_MD_MAX_SLICES);
+		REQUIRE(n == 1);
+		CHECK(out[0].monitor_index == 1);
+		CHECK(out[0].atlas_x == 0);
+		CHECK(out[0].canvas_offset_x == 0);
+	}
+
+	SECTION("capacity clamp -> only the first out_capacity slices written")
+	{
+		// Window covers A, B, and C; capacity 2 -> only the first two written.
+		u_md_rect win{1800, 0, 3000, 800};
+		u_md_rect mons[] = {A, B, C};
+		uint32_t n = u_multi_display_compute_slices(win, mons, 3, out, 2);
+		CHECK(n == 2);
+		CHECK(out[0].monitor_index == 0);
+		CHECK(out[1].monitor_index == 1);
+	}
+}


### PR DESCRIPTION
## Summary

Phase 3a of multi-display vendor DP routing (#387, part of #69 / ADR-015). The `xrt_dp_factory_registry` shipped in v1.9.0 was **populated but consumed by nothing** — every compositor still selected its DP factory from the scalar `dp_factory_*`. This routes the live single-display render *through* the registry so any resolution bug surfaces under the existing cube/selftest gates, while keeping the scalar as the safety-net fallback.

**No ABI change. No behavior change on a single display** — that is the entire point. On this box the registry's primary entry equals the scalar, so the path is byte-identical.

### 3a.1 — registry accessor on the live path
- New header-only `src/xrt/compositor/util/comp_dp_factory.h`: `comp_dp_factory_for_window(info, monitor_id, api)`.
  - `entry_count == 0` → return the scalar verbatim (zero-risk path).
  - else the matching (or primary) entry's per-API factory, falling back to the scalar when NULL.
  - once-only `U_LOG_W` drift detector if the registry pointer ever diverges from the scalar (silent on a single display).
- Migrated the **8** factory-selection read sites: 6 in `comp_d3d11_service.cpp` + `oxr_session_gfx_gl_native.c` + `oxr_session_gfx_gl_macos.m`.
- **Left alone (intentionally):** the `= NULL` placeholders in the other `oxr_session_gfx_*_native` TUs (routing them would *create* a DP where there is none = behavior change), the write sites (`target_instance.c`, `target_plugin_loader.c`), and `cli_cmd_displays.c`.

### 3a.2 — pure slice-geometry helper (no compositor wiring)
- New header-only `src/xrt/auxiliary/util/u_multi_display.h`: `u_multi_display_compute_slices()` splits a window rect against monitor rects into per-monitor atlas slices (pure half-open integer clip; documented uniform-density assumption for 3b — `backbuffer_offset` kept as a separate field so 3b's DPI divergence needs no ABI break).
- `tests/tests_u_multi_display.cpp`: headless Catch2 cases — single monitor, side-by-side span, different size/origin (negative coords), partial off-screen, exact-edge adjacency (no double-count), capacity clamp, degenerate inputs.

## Verification (single Leia box)
- Build clean; `ctest` 25/25 incl. new `tests_u_multi_display`.
- `displayxr-cli selftest` exit 0, leia-sr ABI v2; `displays --claims` unchanged (one entry, EDID, vk|d3d11|d3d12|gl).
- **GL in-process path** (`cube_handle_gl`): DP created via the accessor-selected leia GL factory; **drift `U_LOG_W` silent**. Behavior byte-identical to a baseline (main) run — both reach the same pre-existing cube-teardown segfault, confirming no regression.
- **D3D11 service / multi-compositor path** (shell + `cube_handle_d3d11`): `leia_dp_factory_d3d11` DP created via factory; **drift `U_LOG_W` silent**; cube renders correctly (visually confirmed on the live display).

## Out of scope (3b / deferred)
Split-weave dispatch, per-display DP lifecycle, HWND/phase ownership, hot-swap, atlas-sizing-over-engaged-set, the placeholder TUs — all need a 2nd 3D display + the Leia Tier 2/3 weaver spike.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
