### PR TITLE
fix(vk_native/macos): transparent present — clear atlas + weave to alpha=0 (#392)

### DIFF
--- a/src/xrt/compositor/vk_native/comp_vk_native_compositor.c
+++ b/src/xrt/compositor/vk_native/comp_vk_native_compositor.c
@@ -2981,6 +2981,11 @@ comp_vk_native_compositor_create(struct xrt_device *xdev,
 		return xret;
 	}
 
+	// Clear the atlas transparent (alpha=0) instead of opaque black when a
+	// transparent background was requested, so app alpha<1 regions survive
+	// to the present (issue #392). Mirrors the DP weave-clear plumbing above.
+	comp_vk_native_renderer_set_transparent(c->renderer, transparent_background);
+
 	// Set tile layout from active rendering mode
 	if (c->xdev != NULL && c->xdev->hmd != NULL) {
 		uint32_t idx = c->xdev->hmd->active_rendering_mode_index;

--- a/src/xrt/compositor/vk_native/comp_vk_native_compositor.c
+++ b/src/xrt/compositor/vk_native/comp_vk_native_compositor.c
@@ -2760,7 +2760,7 @@ comp_vk_native_compositor_create(struct xrt_device *xdev,
 	if (hwnd != NULL) {
 		// hwnd is an NSView* from cocoa_window_binding
 		xrt_result_t xret = comp_vk_native_window_macos_setup_external(
-		    hwnd, &c->macos_window);
+		    hwnd, transparent_background, &c->macos_window);
 		if (xret != XRT_SUCCESS) {
 			U_LOG_E("Failed to set up external view for VK native");
 			free(c);
@@ -2780,7 +2780,7 @@ comp_vk_native_compositor_create(struct xrt_device *xdev,
 		}
 		U_LOG_I("Creating self-owned macOS window (%ux%u)", win_w, win_h);
 		xrt_result_t xret = comp_vk_native_window_macos_create(
-		    win_w, win_h, &c->macos_window);
+		    win_w, win_h, transparent_background, &c->macos_window);
 		if (xret != XRT_SUCCESS) {
 			U_LOG_E("Failed to create self-owned macOS window");
 			free(c);

--- a/src/xrt/compositor/vk_native/comp_vk_native_renderer.c
+++ b/src/xrt/compositor/vk_native/comp_vk_native_renderer.c
@@ -71,6 +71,10 @@ struct comp_vk_native_renderer
 
 	//! Format of the atlas texture.
 	VkFormat format;
+
+	//! When true, clear the atlas to alpha=0 (transparent) instead of
+	//! opaque black, so app alpha<1 regions survive to the present (issue #392).
+	bool transparent_background;
 };
 
 static void
@@ -330,8 +334,9 @@ comp_vk_native_renderer_draw(struct comp_vk_native_renderer *r,
 	                   VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
 	                   VK_PIPELINE_STAGE_TRANSFER_BIT);
 
-	// Clear atlas texture to black
-	VkClearColorValue clear_color = {{0.0f, 0.0f, 0.0f, 1.0f}};
+	// Clear atlas texture to black. Use alpha=0 in transparent-background mode
+	// so atlas regions not overwritten by a tile blit stay see-through (issue #392).
+	VkClearColorValue clear_color = {{0.0f, 0.0f, 0.0f, r->transparent_background ? 0.0f : 1.0f}};
 	VkImageSubresourceRange range = {
 	    .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
 	    .baseMipLevel = 0,
@@ -688,4 +693,10 @@ uint64_t
 comp_vk_native_renderer_get_cmd_pool(struct comp_vk_native_renderer *r)
 {
 	return (uint64_t)(uintptr_t)r->cmd_pool;
+}
+
+void
+comp_vk_native_renderer_set_transparent(struct comp_vk_native_renderer *r, bool transparent_background)
+{
+	r->transparent_background = transparent_background;
 }

--- a/src/xrt/compositor/vk_native/comp_vk_native_renderer.h
+++ b/src/xrt/compositor/vk_native/comp_vk_native_renderer.h
@@ -238,6 +238,19 @@ comp_vk_native_renderer_set_tile_layout(struct comp_vk_native_renderer *renderer
 uint64_t
 comp_vk_native_renderer_get_cmd_pool(struct comp_vk_native_renderer *renderer);
 
+/*!
+ * Set whether the atlas should be cleared transparent (alpha=0) instead of
+ * opaque black. Used for the transparent-background present path (issue #392).
+ *
+ * @param renderer The renderer.
+ * @param transparent_background True to clear the atlas to alpha=0.
+ *
+ * @ingroup comp_vk_native
+ */
+void
+comp_vk_native_renderer_set_transparent(struct comp_vk_native_renderer *renderer,
+                                         bool transparent_background);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/xrt/compositor/vk_native/comp_vk_native_target.cpp
+++ b/src/xrt/compositor/vk_native/comp_vk_native_target.cpp
@@ -214,15 +214,33 @@ create_swapchain(struct comp_vk_native_target *target)
 	// visible without spamming per-frame.
 	VkCompositeAlphaFlagBitsKHR composite_alpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
 	if (target->transparent_background) {
+		U_LOG_I("VK target: transparent_background requested, supportedCompositeAlpha=0x%x",
+		        (unsigned)caps.supportedCompositeAlpha);
 		if (caps.supportedCompositeAlpha & VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR) {
 			composite_alpha = VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR;
 			U_LOG_I("VK target: transparent_background using PRE_MULTIPLIED");
+#if defined(XRT_OS_MACOS)
+		} else if (caps.supportedCompositeAlpha & VK_COMPOSITE_ALPHA_POST_MULTIPLIED_BIT_KHR) {
+			// MoltenVK does not expose PRE_MULTIPLIED, but it honors
+			// POST_MULTIPLIED by forcing CAMetalLayer.opaque = NO. It does
+			// not premultiply/un-premultiply — Core Animation always
+			// composites premultiplied bytes, and our content is already
+			// premultiplied (renderer emits alpha = 1 - T premultiplied), so
+			// the present is correct. This is more reliable than INHERIT,
+			// which depends on the app's CAMetalLayer.opaque state surviving
+			// AppKit's layer-backed-view sync. macOS-only on purpose: on
+			// Win32 ICDs POST_MULTIPLIED would mean straight alpha and break
+			// the (premultiplied) content — Windows uses the DComp bridge or
+			// PRE_MULTIPLIED instead.
+			composite_alpha = VK_COMPOSITE_ALPHA_POST_MULTIPLIED_BIT_KHR;
+			U_LOG_I("VK target: transparent_background using POST_MULTIPLIED (macOS/MoltenVK)");
+#endif
 		} else if (caps.supportedCompositeAlpha & VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR) {
 			composite_alpha = VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR;
 			U_LOG_I("VK target: transparent_background using INHERIT (PRE_MULTIPLIED unavailable)");
 		} else {
-			U_LOG_W("VK target: transparent_background requested but neither PRE_MULTIPLIED nor "
-			        "INHERIT compositeAlpha is supported (caps=0x%x); falling back to OPAQUE — "
+			U_LOG_W("VK target: transparent_background requested but no transparent "
+			        "compositeAlpha is supported (caps=0x%x); falling back to OPAQUE — "
 			        "alpha will be dropped at WSI present",
 			        (unsigned)caps.supportedCompositeAlpha);
 		}

--- a/src/xrt/compositor/vk_native/comp_vk_native_window_macos.h
+++ b/src/xrt/compositor/vk_native/comp_vk_native_window_macos.h
@@ -28,8 +28,11 @@ struct comp_vk_native_window_macos;
 /*!
  * Create a self-owned NSWindow with a CAMetalLayer-backed view.
  *
- * @param width   Requested window width in points.
- * @param height  Requested window height in points.
+ * @param width                 Requested window width in points.
+ * @param height                Requested window height in points.
+ * @param transparent_background When true, the NSWindow + CAMetalLayer are
+ *                              configured non-opaque (clear background) so the
+ *                              desktop shows through alpha < 1 regions.
  * @param out_win Pointer to receive the created window handle.
  *
  * @return XRT_SUCCESS on success, error code otherwise.
@@ -37,6 +40,7 @@ struct comp_vk_native_window_macos;
 xrt_result_t
 comp_vk_native_window_macos_create(uint32_t width,
                                     uint32_t height,
+                                    bool transparent_background,
                                     struct comp_vk_native_window_macos **out_win);
 
 /*!
@@ -46,12 +50,18 @@ comp_vk_native_window_macos_create(uint32_t width,
  * Otherwise, a CAMetalLayer is added as a sublayer.
  *
  * @param ns_view  The app's NSView (as void*).
+ * @param transparent_background When true, force the CAMetalLayer non-opaque
+ *                              so the desktop shows through alpha < 1 regions.
+ *                              Enforced runtime-side (not relying on the app's
+ *                              layer.opaque, which AppKit may reset on a
+ *                              layer-backed view) right before VkSurface creation.
  * @param out_win  Pointer to receive the window handle.
  *
  * @return XRT_SUCCESS on success, error code otherwise.
  */
 xrt_result_t
 comp_vk_native_window_macos_setup_external(void *ns_view,
+                                            bool transparent_background,
                                             struct comp_vk_native_window_macos **out_win);
 
 /*!

--- a/src/xrt/compositor/vk_native/comp_vk_native_window_macos.m
+++ b/src/xrt/compositor/vk_native/comp_vk_native_window_macos.m
@@ -70,6 +70,7 @@ static void
 create_window_on_main_thread(struct comp_vk_native_window_macos *win,
                               uint32_t width,
                               uint32_t height,
+                              bool transparent_background,
                               bool *out_success)
 {
 	ensure_ns_app();
@@ -103,6 +104,15 @@ create_window_on_main_thread(struct comp_vk_native_window_macos *win,
 	win->metal_layer.pixelFormat = MTLPixelFormatBGRA8Unorm;
 	win->metal_layer.framebufferOnly = NO;
 
+	if (transparent_background) {
+		// Non-opaque window + layer so the desktop shows through alpha < 1
+		// regions of the composited output. Mirrors comp_metal_compositor.m.
+		[win->window setOpaque:NO];
+		[win->window setBackgroundColor:[NSColor clearColor]];
+		win->metal_layer.opaque = NO;
+		U_LOG_I("VK native macOS: transparent background — NSWindow + CAMetalLayer set isOpaque=NO");
+	}
+
 	CGFloat scale = win->window.backingScaleFactor;
 	win->metal_layer.contentsScale = scale;
 	win->metal_layer.drawableSize = CGSizeMake(width * scale, height * scale);
@@ -126,6 +136,7 @@ create_window_on_main_thread(struct comp_vk_native_window_macos *win,
 xrt_result_t
 comp_vk_native_window_macos_create(uint32_t width,
                                     uint32_t height,
+                                    bool transparent_background,
                                     struct comp_vk_native_window_macos **out_win)
 {
 	struct comp_vk_native_window_macos *win = U_TYPED_CALLOC(struct comp_vk_native_window_macos);
@@ -135,10 +146,10 @@ comp_vk_native_window_macos_create(uint32_t width,
 
 	__block bool success = false;
 	if ([NSThread isMainThread]) {
-		create_window_on_main_thread(win, width, height, &success);
+		create_window_on_main_thread(win, width, height, transparent_background, &success);
 	} else {
 		dispatch_sync(dispatch_get_main_queue(), ^{
-			create_window_on_main_thread(win, width, height, &success);
+			create_window_on_main_thread(win, width, height, transparent_background, &success);
 		});
 	}
 
@@ -154,6 +165,7 @@ comp_vk_native_window_macos_create(uint32_t width,
 
 xrt_result_t
 comp_vk_native_window_macos_setup_external(void *ns_view,
+                                            bool transparent_background,
                                             struct comp_vk_native_window_macos **out_win)
 {
 	if (ns_view == NULL) {
@@ -193,6 +205,21 @@ comp_vk_native_window_macos_setup_external(void *ns_view,
 			scale = [NSScreen mainScreen].backingScaleFactor;
 		}
 		win->metal_layer.contentsScale = scale;
+
+		if (transparent_background) {
+			// Enforce non-opaque on the app's layer + window right before
+			// VkSurface creation. A layer-backed NSView lets AppKit sync the
+			// backing layer's `opaque` to the view's state, so an opaque=NO set
+			// by the app at makeBackingLayer time may have been reverted by now.
+			// Setting it here (and on the host window) guarantees the desktop
+			// shows through alpha < 1 regions for the INHERIT compositeAlpha path.
+			win->metal_layer.opaque = NO;
+			if (view.window != nil) {
+				[view.window setOpaque:NO];
+				[view.window setBackgroundColor:[NSColor clearColor]];
+			}
+			U_LOG_I("VK native macOS (external view): transparent background — CAMetalLayer set isOpaque=NO");
+		}
 	};
 
 	if ([NSThread isMainThread]) {

--- a/src/xrt/drivers/sim_display/shaders/anaglyph.frag
+++ b/src/xrt/drivers/sim_display/shaders/anaglyph.frag
@@ -29,6 +29,7 @@ void main()
 	vec4 right = texture(atlas_tex, right_uv);
 
 	// Red-cyan anaglyph: red channel from left eye,
-	// green+blue channels from right eye.
-	out_color = vec4(left.r, right.g, right.b, 1.0);
+	// green+blue channels from right eye. Preserve alpha (max of both eyes)
+	// so transparent-background regions survive the anaglyph mix (issue #392).
+	out_color = vec4(left.r, right.g, right.b, max(left.a, right.a));
 }

--- a/src/xrt/drivers/sim_display/sim_display_processor.c
+++ b/src/xrt/drivers/sim_display/sim_display_processor.c
@@ -59,6 +59,10 @@ struct sim_display_processor
 	float nominal_x_m;
 	float nominal_y_m;
 	float nominal_z_m;
+
+	//! When true, the app requested a transparent background — clear the
+	//! weave target to alpha=0 so alpha<1 regions stay see-through.
+	bool transparent_bg;
 };
 
 static inline struct sim_display_processor *
@@ -147,8 +151,10 @@ sim_dp_process_atlas(struct xrt_display_processor *xdp,
 
 	vk->vkUpdateDescriptorSets(vk->device, 1, &write, 0, NULL);
 
-	// Begin render pass
-	VkClearValue clear_value = {.color = {{0.0f, 0.0f, 0.0f, 1.0f}}};
+	// Begin render pass. Clear to alpha=0 when a transparent background was
+	// requested so any region the weave doesn't fully overwrite stays
+	// see-through instead of opaque black (issue #392).
+	VkClearValue clear_value = {.color = {{0.0f, 0.0f, 0.0f, sdp->transparent_bg ? 0.0f : 1.0f}}};
 	VkRenderPassBeginInfo rp_begin = {
 	    .sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO,
 	    .renderPass = sdp->render_pass,
@@ -583,10 +589,11 @@ sim_dp_set_chroma_key(struct xrt_display_processor *xdp,
                       uint32_t key_color,
                       bool transparent_bg_enabled)
 {
-	(void)xdp;
 	(void)key_color;
-	(void)transparent_bg_enabled;
-	// Alpha-native — no chroma-key fill/strip required.
+	// Alpha-native — no chroma-key fill/strip required. We do honor the
+	// transparent-background bit so the weave render-pass clears the target
+	// to alpha=0 instead of opaque black (issue #392).
+	sim_display_processor(xdp)->transparent_bg = transparent_bg_enabled;
 }
 
 

--- a/test_apps/cube_handle_vk_macos/main.mm
+++ b/test_apps/cube_handle_vk_macos/main.mm
@@ -1379,8 +1379,16 @@ static void RenderScene(VkRenderer& renderer, uint32_t imageIndex,
     beginInfo.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
     vkBeginCommandBuffer(cmd, &beginInfo);
 
+    // Transparent-background mode (DISPLAYXR_TRANSPARENT_BG=1) clears RGBA(0,0,0,0)
+    // so the desktop shows through everywhere the cube isn't drawn. Pairs with
+    // XrCocoaWindowBindingCreateInfoEXT.transparentBackgroundEnabled = XR_TRUE.
+    static const bool transparent_bg = []() {
+        const char *e = getenv("DISPLAYXR_TRANSPARENT_BG");
+        return e != nullptr && *e != '\0' && *e != '0';
+    }();
     VkClearValue clearValues[2] = {};
-    clearValues[0].color = {{0.05f, 0.05f, 0.1f, 1.0f}};
+    clearValues[0].color = transparent_bg ? VkClearColorValue{{0.0f, 0.0f, 0.0f, 0.0f}}
+                                          : VkClearColorValue{{0.05f, 0.05f, 0.1f, 1.0f}};
     clearValues[1].depthStencil = {1.0f, 0};
 
     VkRenderPassBeginInfo rpBegin = {};
@@ -2213,6 +2221,22 @@ static bool CreateSession(AppXrSession& xr, VkInstance vkInstance, VkPhysicalDev
     macosBinding.type = XR_TYPE_COCOA_WINDOW_BINDING_CREATE_INFO_EXT;
     macosBinding.next = nullptr;
     macosBinding.viewHandle = (__bridge void *)g_metalView;
+
+    // Optional transparent-background mode (spec v5). Pairs with the
+    // RGBA(0,0,0,0) clear above so alpha<1 regions show the desktop.
+    {
+        const char *e = getenv("DISPLAYXR_TRANSPARENT_BG");
+        if (e != nullptr && *e != '\0' && *e != '0') {
+            macosBinding.transparentBackgroundEnabled = XR_TRUE;
+            // Make our app-owned NSWindow non-opaque too — the runtime configures
+            // the CAMetalLayer it presents into, but the NSWindow alpha is ours.
+            if (g_window != nil) {
+                [g_window setOpaque:NO];
+                [g_window setBackgroundColor:[NSColor clearColor]];
+            }
+            LOG_INFO("Transparent background ENABLED (DISPLAYXR_TRANSPARENT_BG=1)");
+        }
+    }
 
     // Chain: sessionInfo -> vkBinding -> macosBinding
     if (xr.hasCocoaWindowBinding) {


### PR DESCRIPTION
## Summary

Completes the macOS **VK-native** (MoltenVK + `sim_display`) transparent-background present path, fixing #392 — apps that request `transparentBackgroundEnabled = XR_TRUE` were rendering **opaque black** instead of letting the desktop show through alpha&nbsp;<&nbsp;1 regions.

The earlier WIP (`5b9a16db2`) already fixed the *present* side (prefer `POST_MULTIPLIED`, force `CAMetalLayer.opaque = NO`), but the result stayed opaque: alpha was being forced to `1` by hardcoded clears **upstream** of the present. This mirrors the proven Metal fix `e94d07292`.

## Root cause

The VK-native pipeline is otherwise alpha-clean (blit-based atlas fill + present copy all 4 channels; weave `colorWriteMask` includes A; 5 of 6 weave shaders preserve alpha). The opaque result came from three hardcoded `alpha = 1.0` writes:

1. **Weave render-pass clear** (`sim_display_processor.c`) — the decisive one; it clears the target framebuffer the swapchain presents.
2. **Atlas clear** (`comp_vk_native_renderer.c`) — forces alpha=1 in regions not overwritten by a tile blit.
3. **Anaglyph shader** (`anaglyph.frag`) — hardcoded `1.0` alpha (the one weave shader that hand-builds its output `vec4`).

The transparent flag already reached the DP via `set_chroma_key(...)`, but `sim_dp_set_chroma_key` `(void)`'d it.

## Changes

- **`sim_display_processor.c`** — honor + store the transparent-background bit; weave clears the target to alpha=0 in transparent mode.
- **`comp_vk_native_renderer.{c,h}`** — add `transparent_background` + setter; atlas clears to alpha=0 in transparent mode.
- **`comp_vk_native_compositor.c`** — wire the renderer setter from the create-time flag (after renderer creation; the DP `set_chroma_key` path runs before the renderer exists).
- **`shaders/anaglyph.frag`** — `alpha = max(left.a, right.a)` instead of hardcoded `1.0` (parity with Metal fix #3). The other five shaders already preserve alpha via `texture()` / `mix()`.
- **`test_apps/cube_handle_vk_macos`** — add the `DISPLAYXR_TRANSPARENT_BG=1` opt-in (cocoa-binding flag + `RGBA(0,0,0,0)` clear + non-opaque `NSWindow`), mirroring `cube_handle_metal_macos`, so the path is verifiable in-repo without the external gauss demo.

All runtime changes are transparent-gated — they no-op in the default opaque case. Windows (Leia DComp bridge) is untouched.

## Verification

Verified end-to-end on macOS (Apple M1 Pro, MoltenVK) with `cube_handle_vk_macos`:

```bash
DISPLAYXR_TRANSPARENT_BG=1 SIM_DISPLAY_OUTPUT=passthrough \
  _package/DisplayXR-macOS/run_cube_handle_vk.sh
```

Desktop shows through alpha&nbsp;<&nbsp;1 regions instead of opaque black. ✅

Closes #392

🤖 Generated with [Claude Code](https://claude.com/claude-code)