### PR TITLE
feat(oxr): XR_EXT_atlas_capture / xrCaptureAtlasEXT (in-process) [#396 W6]

### DIFF
--- a/src/external/openxr_includes/openxr/XR_EXT_atlas_capture.h
+++ b/src/external/openxr_includes/openxr/XR_EXT_atlas_capture.h
@@ -1,0 +1,130 @@
+// Copyright 2026, DisplayXR
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  Header for XR_EXT_atlas_capture extension
+ * @author David Fattal
+ * @ingroup external_openxr
+ *
+ * A vendor-neutral, non-privileged entry point for "snapshot the multi-view
+ * atlas the runtime composes for my session to a PNG." Replaces the per-app,
+ * per-graphics-API readbacks every DisplayXR consumer reimplements today: the
+ * app no longer touches a staging texture — the runtime does the readback with
+ * the compositor's own atlas image, at a caller-selected stage.
+ *
+ * Any session class (handle / texture / hosted / IPC) may call it. The
+ * privileged cross-client workspace capture (xrCaptureWorkspaceFrameEXT in
+ * XR_EXT_spatial_workspace) stays separate; the two share the runtime readback
+ * core. Full design: docs/roadmap/unified-atlas-capture.md (W6 of issue #396).
+ */
+#ifndef XR_EXT_ATLAS_CAPTURE_H
+#define XR_EXT_ATLAS_CAPTURE_H 1
+
+#include <openxr/openxr.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define XR_EXT_atlas_capture 1
+#define XR_EXT_atlas_capture_SPEC_VERSION 1
+#define XR_EXT_ATLAS_CAPTURE_EXTENSION_NAME "XR_EXT_atlas_capture"
+
+// Reserved 1000999xxx range, next free slot after the workspace block
+// (1000999100..110). Final values reconcile with the Khronos registry before
+// spec freeze.
+#define XR_TYPE_ATLAS_CAPTURE_INFO_EXT   ((XrStructureType)1000999120)
+#define XR_TYPE_ATLAS_CAPTURE_RESULT_EXT ((XrStructureType)1000999121)
+
+#define XR_ATLAS_CAPTURE_PATH_MAX_EXT 256
+
+/*!
+ * @brief Compositor stage at which to capture the atlas.
+ *
+ * Values match @c enum mcp_capture_mode in the runtime so no translation layer
+ * is needed:
+ *   POST_COMPOSE   — the atlas handed to the display processor (projection +
+ *                    window-space + quad layers), end of frame.
+ *   PROJECTION_ONLY — the atlas with only projection-class layers, captured at
+ *                    the projection-done boundary.
+ */
+typedef enum XrAtlasCaptureStageEXT {
+    XR_ATLAS_CAPTURE_STAGE_POST_COMPOSE_EXT    = 0,
+    XR_ATLAS_CAPTURE_STAGE_PROJECTION_ONLY_EXT = 1,
+    XR_ATLAS_CAPTURE_STAGE_MAX_ENUM_EXT        = 0x7FFFFFFF
+} XrAtlasCaptureStageEXT;
+
+/*!
+ * @brief Request struct for xrCaptureAtlasEXT.
+ *
+ * The runtime appends a format-specific suffix (e.g. "_atlas.png") to
+ * @c pathPrefix. The prefix is an in-struct char array (not a separately
+ * allocated string) so the same struct can cross the IPC schema unchanged.
+ */
+typedef struct XrAtlasCaptureInfoEXT {
+    XrStructureType          type;   //!< Must be XR_TYPE_ATLAS_CAPTURE_INFO_EXT
+    const void* XR_MAY_ALIAS next;
+    XrAtlasCaptureStageEXT   stage;  //!< Capture stage (post-compose / projection-only)
+    char                     pathPrefix[XR_ATLAS_CAPTURE_PATH_MAX_EXT];
+} XrAtlasCaptureInfoEXT;
+
+/*!
+ * @brief Result returned by xrCaptureAtlasEXT.
+ *
+ * Same metadata block as XrWorkspaceCaptureResultEXT minus @c viewsWritten.
+ * For in-process sessions @c eyeLeftM / @c eyeRightM (and @c tileColumns /
+ * @c tileRows) may be zero — eye-pose plumbing currently stops at the display
+ * processor and is only surfaced on the IPC/workspace path.
+ */
+typedef struct XrAtlasCaptureResultEXT {
+    XrStructureType    type;   //!< Must be XR_TYPE_ATLAS_CAPTURE_RESULT_EXT
+    void* XR_MAY_ALIAS next;
+    uint64_t           timestampNs;
+    uint32_t           atlasWidth;
+    uint32_t           atlasHeight;
+    uint32_t           eyeWidth;
+    uint32_t           eyeHeight;
+    uint32_t           tileColumns;
+    uint32_t           tileRows;
+    float              displayWidthM;
+    float              displayHeightM;
+    float              eyeLeftM[3];
+    float              eyeRightM[3];
+} XrAtlasCaptureResultEXT;
+
+/*!
+ * @brief Capture the multi-view atlas the runtime composes for this session.
+ *
+ * The runtime reads the compositor's own atlas at @c info->stage and writes it
+ * to a PNG named after @c info->pathPrefix (the runtime appends "_atlas.png").
+ * If @c result is non-NULL it is filled with metadata describing the capture.
+ *
+ * Timing: the call is non-blocking and latches the request; the readback runs
+ * at the next composed frame (the caller's next xrEndFrame), so the PNG exists
+ * shortly after this call returns rather than on return. XR_SUCCESS means the
+ * capture was accepted, not that the file is already on disk. (A future async
+ * variant may expose explicit completion; see docs/roadmap/3d-capture.md.)
+ *
+ * @param session A valid session of any class.
+ * @param info    The capture request (stage + path prefix).
+ * @param result  Output: capture metadata. May be NULL to capture the PNG only.
+ */
+typedef XrResult (XRAPI_PTR *PFN_xrCaptureAtlasEXT)(
+    XrSession                    session,
+    const XrAtlasCaptureInfoEXT *info,
+    XrAtlasCaptureResultEXT     *result);
+
+#ifndef XR_NO_PROTOTYPES
+#ifdef XR_EXTENSION_PROTOTYPES
+XRAPI_ATTR XrResult XRAPI_CALL xrCaptureAtlasEXT(
+    XrSession                    session,
+    const XrAtlasCaptureInfoEXT *info,
+    XrAtlasCaptureResultEXT     *result);
+#endif /* XR_EXTENSION_PROTOTYPES */
+#endif /* !XR_NO_PROTOTYPES */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // XR_EXT_ATLAS_CAPTURE_H

--- a/src/xrt/include/xrt/xrt_openxr_includes.h
+++ b/src/xrt/include/xrt/xrt_openxr_includes.h
@@ -76,3 +76,4 @@ typedef __eglMustCastToProperFunctionPointerType (*PFNEGLGETPROCADDRESSPROC)(con
 #include "openxr/XR_EXT_display_info.h"
 #include "openxr/XR_EXT_spatial_workspace.h"
 #include "openxr/XR_EXT_workspace_file_dialog.h"
+#include "openxr/XR_EXT_atlas_capture.h"

--- a/src/xrt/state_trackers/oxr/CMakeLists.txt
+++ b/src/xrt/state_trackers/oxr/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(
 	oxr_api_verify.h
 	oxr_api_xdev.c
 	oxr_binding.c
+	oxr_capture.c
 	oxr_chain.h
 	oxr_dpad.c
 	oxr_event.c

--- a/src/xrt/state_trackers/oxr/oxr_api_funcs.h
+++ b/src/xrt/state_trackers/oxr/oxr_api_funcs.h
@@ -923,6 +923,12 @@ oxr_xrSetWorkspaceClientStyleEXT(XrSession session,
                                  const XrWorkspaceClientStyleEXT *style);
 #endif
 
+#ifdef OXR_HAVE_EXT_atlas_capture
+//! OpenXR API function @ep{xrCaptureAtlasEXT}
+XRAPI_ATTR XrResult XRAPI_CALL
+oxr_xrCaptureAtlasEXT(XrSession session, const XrAtlasCaptureInfoEXT *info, XrAtlasCaptureResultEXT *result);
+#endif
+
 #ifdef OXR_HAVE_EXT_workspace_file_dialog
 //! OpenXR API function @ep{xrRequestFilePickerEXT}
 XRAPI_ATTR XrResult XRAPI_CALL

--- a/src/xrt/state_trackers/oxr/oxr_api_negotiate.c
+++ b/src/xrt/state_trackers/oxr/oxr_api_negotiate.c
@@ -473,6 +473,10 @@ handle_non_null(struct oxr_instance *inst, struct oxr_logger *log, const char *n
 	ENTRY_IF_EXT(xrSetWorkspaceInputGrabEXT, EXT_spatial_workspace);
 #endif
 
+#ifdef OXR_HAVE_EXT_atlas_capture
+	ENTRY_IF_EXT(xrCaptureAtlasEXT, EXT_atlas_capture);
+#endif
+
 #ifdef OXR_HAVE_EXT_workspace_file_dialog
 	ENTRY_IF_EXT(xrRequestFilePickerEXT, EXT_workspace_file_dialog);
 	ENTRY_IF_EXT(xrGetFilePickerRequestEXT, EXT_workspace_file_dialog);

--- a/src/xrt/state_trackers/oxr/oxr_capture.c
+++ b/src/xrt/state_trackers/oxr/oxr_capture.c
@@ -1,0 +1,137 @@
+// Copyright 2026, DisplayXR
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  XR_EXT_atlas_capture API entry point.
+ * @author David Fattal
+ * @ingroup oxr_api
+ *
+ * Phase 1 (in-process). xrCaptureAtlasEXT lets any session snapshot the
+ * multi-view atlas the runtime composes for it, at a caller-selected stage,
+ * without the app doing its own GPU readback. For an in-process native
+ * compositor the entry point drives the same blocking capture bridge the MCP
+ * @c capture_frame tool and the dev trigger files already use
+ * (@ref oxr_mcp_tools_submit_capture → the compositor's @c u_capture_intent).
+ * IPC-session routing (sharing the workspace capture bridge) and the workspace
+ * PROJECTION_ONLY flag are a Phase-2 follow-up; see
+ * docs/roadmap/unified-atlas-capture.md (W6 of issue #396).
+ */
+
+#include "oxr_objects.h"
+#include "oxr_logger.h"
+#include "oxr_mcp_tools.h"
+
+#include "util/u_logging.h"
+#include "util/u_trace_marker.h"
+
+#include "os/os_time.h"
+
+#include "oxr_api_funcs.h"
+#include "oxr_api_verify.h"
+
+#include <openxr/XR_EXT_atlas_capture.h>
+
+// enum mcp_capture_mode values; XrAtlasCaptureStageEXT is defined to match.
+#include <displayxr_mcp/mcp_capture.h>
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#ifdef OXR_HAVE_EXT_atlas_capture
+
+static bool
+session_is_inprocess_native(struct oxr_session *sess)
+{
+	if (sess == NULL || sess->xcn == NULL) {
+		return false;
+	}
+	return sess->is_d3d11_native_compositor || sess->is_d3d12_native_compositor ||
+	       sess->is_metal_native_compositor || sess->is_gl_native_compositor ||
+	       sess->is_vk_native_compositor;
+}
+
+XRAPI_ATTR XrResult XRAPI_CALL
+oxr_xrCaptureAtlasEXT(XrSession session, const XrAtlasCaptureInfoEXT *info, XrAtlasCaptureResultEXT *result)
+{
+	OXR_TRACE_MARKER();
+
+	struct oxr_session *sess = NULL;
+	struct oxr_logger log;
+	OXR_VERIFY_SESSION_AND_INIT_LOG(&log, session, sess, "xrCaptureAtlasEXT");
+	OXR_VERIFY_SESSION_NOT_LOST(&log, sess);
+	OXR_VERIFY_EXTENSION(&log, sess->sys->inst, EXT_atlas_capture);
+	OXR_VERIFY_ARG_TYPE_AND_NOT_NULL(&log, info, XR_TYPE_ATLAS_CAPTURE_INFO_EXT);
+	// result is optional: NULL captures the PNG only.
+
+	if (info->stage != XR_ATLAS_CAPTURE_STAGE_POST_COMPOSE_EXT &&
+	    info->stage != XR_ATLAS_CAPTURE_STAGE_PROJECTION_ONLY_EXT) {
+		return oxr_error(&log, XR_ERROR_VALIDATION_FAILURE,
+		                 "xrCaptureAtlasEXT: info->stage %d is not a valid XrAtlasCaptureStageEXT",
+		                 (int)info->stage);
+	}
+
+	if (info->pathPrefix[0] == '\0') {
+		return oxr_error(&log, XR_ERROR_VALIDATION_FAILURE, "xrCaptureAtlasEXT: info->pathPrefix is empty");
+	}
+
+	// Phase 1: only in-process native compositors are supported. IPC sessions
+	// (workspace/WebXR) route through the workspace capture bridge in Phase 2.
+	if (!session_is_inprocess_native(sess)) {
+		return oxr_error(&log, XR_ERROR_FEATURE_UNSUPPORTED,
+		                 "xrCaptureAtlasEXT currently supports in-process sessions only");
+	}
+
+	// Build the output path. The runtime appends "_atlas.png" — same suffix
+	// convention as the workspace capture path.
+	char path[XR_ATLAS_CAPTURE_PATH_MAX_EXT + 16];
+	int n = snprintf(path, sizeof(path), "%.*s_atlas.png", (int)(XR_ATLAS_CAPTURE_PATH_MAX_EXT - 1),
+	                 info->pathPrefix);
+	if (n <= 0 || (size_t)n >= sizeof(path)) {
+		return oxr_error(&log, XR_ERROR_VALIDATION_FAILURE, "xrCaptureAtlasEXT: path prefix too long");
+	}
+
+	// Stage values are defined to match enum mcp_capture_mode (no translation).
+	uint32_t mode = (info->stage == XR_ATLAS_CAPTURE_STAGE_PROJECTION_ONLY_EXT)
+	                    ? (uint32_t)MCP_CAPTURE_MODE_PROJECTION_ONLY
+	                    : (uint32_t)MCP_CAPTURE_MODE_POST_COMPOSE;
+
+	// Latch the capture intent onto the in-process compositor (non-blocking).
+	// The readback + PNG encode happen at the next layer_commit poll — i.e. the
+	// app's next xrEndFrame. We cannot block here: this runs on the app's
+	// xrEndFrame thread, which is the same thread that drives the in-process
+	// compositor's poll, so blocking would deadlock. The PNG therefore exists
+	// shortly after the next composed frame, not when this call returns.
+	if (!oxr_mcp_tools_submit_capture(path, mode)) {
+		return oxr_error(&log, XR_ERROR_RUNTIME_FAILURE,
+		                 "xrCaptureAtlasEXT: no in-process compositor capture handler is installed");
+	}
+
+	if (result != NULL) {
+		const struct xrt_system_compositor_info *sci = &sess->sys->xsysc->info;
+		result->type = XR_TYPE_ATLAS_CAPTURE_RESULT_EXT;
+		result->next = NULL;
+		result->timestampNs = (uint64_t)os_monotonic_get_ns();
+		result->atlasWidth = sci->atlas_width_pixels;
+		result->atlasHeight = sci->atlas_height_pixels;
+		// Per-view recommended dims approximate the captured eye-tile size.
+		result->eyeWidth = sci->views[0].recommended.width_pixels;
+		result->eyeHeight = sci->views[0].recommended.height_pixels;
+		// Tile layout and eye poses are not surfaced to oxr on the in-process
+		// path (the compositor knows them, but there is no accessor today and
+		// eye-pose plumbing stops at the display processor). Left zero for
+		// Phase 1; populated on the IPC/workspace path. See the W6 design doc.
+		result->tileColumns = 0;
+		result->tileRows = 0;
+		result->displayWidthM = sci->display_width_m;
+		result->displayHeightM = sci->display_height_m;
+		result->eyeLeftM[0] = result->eyeLeftM[1] = result->eyeLeftM[2] = 0.0f;
+		result->eyeRightM[0] = result->eyeRightM[1] = result->eyeRightM[2] = 0.0f;
+	}
+
+	return XR_SUCCESS;
+}
+
+#endif // OXR_HAVE_EXT_atlas_capture

--- a/src/xrt/state_trackers/oxr/oxr_extension_support.h
+++ b/src/xrt/state_trackers/oxr/oxr_extension_support.h
@@ -574,6 +574,18 @@
 
 
 /*
+ * XR_EXT_atlas_capture
+ */
+#if defined(XR_EXT_atlas_capture)
+#define OXR_HAVE_EXT_atlas_capture
+#define OXR_EXTENSION_SUPPORT_EXT_atlas_capture(_) \
+    _(EXT_atlas_capture, EXT_ATLAS_CAPTURE)
+#else
+#define OXR_EXTENSION_SUPPORT_EXT_atlas_capture(_)
+#endif
+
+
+/*
  * XR_EXT_workspace_file_dialog
  */
 #if defined(XR_EXT_workspace_file_dialog) && defined(XR_USE_PLATFORM_WIN32)
@@ -1062,6 +1074,7 @@
     OXR_EXTENSION_SUPPORT_EXT_macos_gl_binding(_) \
     OXR_EXTENSION_SUPPORT_EXT_display_info(_) \
     OXR_EXTENSION_SUPPORT_EXT_spatial_workspace(_) \
+    OXR_EXTENSION_SUPPORT_EXT_atlas_capture(_) \
     OXR_EXTENSION_SUPPORT_EXT_workspace_file_dialog(_) \
     OXR_EXTENSION_SUPPORT_BD_controller_interaction(_) \
     OXR_EXTENSION_SUPPORT_FB_body_tracking(_) \

--- a/src/xrt/state_trackers/oxr/oxr_mcp_tools.c
+++ b/src/xrt/state_trackers/oxr/oxr_mcp_tools.c
@@ -672,6 +672,35 @@ oxr_mcp_tools_set_capture_handler(oxr_mcp_capture_fn fn, void *userdata)
 	pthread_mutex_unlock(&g_capture_lock);
 }
 
+bool
+oxr_mcp_tools_submit_capture(const char *path, uint32_t mode)
+{
+	if (path == NULL) {
+		return false;
+	}
+
+	// Latch directly onto the installed compositor request (the same one the
+	// trigger files and the MCP tool feed). We deliberately do NOT call the
+	// blocking handler: this runs on the app's xrEndFrame thread, which also
+	// drives the in-process compositor's layer_commit poll, so blocking here
+	// would deadlock. mcp_capture_get_installed() is the library's sanctioned
+	// "submit directly to the compositor handler" accessor.
+	struct mcp_capture_request *req = mcp_capture_get_installed();
+	if (req == NULL) {
+		return false;
+	}
+
+	pthread_mutex_lock(&req->lock);
+	strncpy(req->path, path, MCP_CAPTURE_PATH_MAX - 1);
+	req->path[MCP_CAPTURE_PATH_MAX - 1] = '\0';
+	req->mode = mode;
+	req->pending = true;
+	req->done = false;
+	req->success = false;
+	pthread_mutex_unlock(&req->lock);
+	return true;
+}
+
 static cJSON *
 tool_capture_frame(const cJSON *params, void *userdata)
 {

--- a/src/xrt/state_trackers/oxr/oxr_mcp_tools.h
+++ b/src/xrt/state_trackers/oxr/oxr_mcp_tools.h
@@ -77,6 +77,23 @@ void
 oxr_mcp_tools_set_capture_handler(oxr_mcp_capture_fn fn, void *userdata);
 
 /*!
+ * Latch a capture request on the installed in-process compositor handler and
+ * return immediately — does NOT block. The compositor consumes the latch at
+ * its next layer_commit poll (the next xrEndFrame), does the GPU readback, and
+ * writes the PNG to @p path. This is the non-blocking sibling of the MCP
+ * @c capture_frame tool's blocking handler: it must NOT block here because
+ * @ref oxr_xrCaptureAtlasEXT runs on the app's own xrEndFrame thread, which is
+ * also the thread that drives the in-process compositor's layer_commit —
+ * blocking it would deadlock the very poll we are waiting on.
+ *
+ * @p mode is an @ref mcp_capture_mode value. Returns @c false if no in-process
+ * compositor handler is installed (e.g. an IPC/service session). The PNG
+ * exists shortly after the next composed frame, not when this call returns.
+ */
+bool
+oxr_mcp_tools_submit_capture(const char *path, uint32_t mode);
+
+/*!
  * Read the MCP capability marker written by the displayxr-mcp installer.
  * Returns @c true iff the marker is present AND set to enabled.
  *

--- a/test_apps/common/xr_session_common.h
+++ b/test_apps/common/xr_session_common.h
@@ -28,6 +28,7 @@
 #include <openxr/XR_EXT_win32_window_binding.h>
 #include <openxr/XR_EXT_display_info.h>
 #include <openxr/XR_EXT_workspace_file_dialog.h>
+#include <openxr/XR_EXT_atlas_capture.h>
 #include <DirectXMath.h>
 #include <vector>
 #include <string>
@@ -86,6 +87,11 @@ struct XrSessionManager {
     // PFN resolved when XR_EXT_workspace_file_dialog is enabled. nullptr if
     // the runtime didn't expose the extension. #228 Tier 1.
     PFN_xrRequestFilePickerEXT pfnRequestFilePickerEXT = nullptr;
+
+    // XR_EXT_atlas_capture (W6 of #396): the runtime owns the atlas readback,
+    // so the app drops its per-API CaptureAtlasRegion* glue for one call.
+    bool hasAtlasCaptureExt = false;
+    PFN_xrCaptureAtlasEXT pfnCaptureAtlasEXT = nullptr;
 
     // Display info from XR_EXT_display_info (static display properties)
     float recommendedViewScaleX = 1.0f;

--- a/test_apps/cube_handle_d3d11_win/main.cpp
+++ b/test_apps/cube_handle_d3d11_win/main.cpp
@@ -772,19 +772,46 @@ static void RenderOneFrame(RenderState& rs) {
                         if (g_inputState.captureAtlasRequested) {
                             g_inputState.captureAtlasRequested = false;
                             if (!monoMode && (tileColumns > 1 || tileRows > 1)) {
-                                uint32_t atlasW = tileColumns * renderW;
-                                uint32_t atlasH = tileRows * renderH;
-                                if (atlasW <= xr.swapchain.width && atlasH <= xr.swapchain.height) {
-                                    std::string outPath = dxr_capture::MakeCapturePath(
-                                        APP_NAME, tileColumns, tileRows);
-                                    bool ok = dxr_capture::CaptureAtlasRegionD3D11(
-                                        renderer.device.Get(), renderer.context.Get(),
-                                        swapchainTexture,
-                                        0, 0, atlasW, atlasH, outPath);
-                                    if (ok) {
-                                        LOG_INFO("Captured atlas %ux%u -> %s",
-                                                 atlasW, atlasH, outPath.c_str());
+                                std::string outPath = dxr_capture::MakeCapturePath(
+                                    APP_NAME, tileColumns, tileRows);
+                                if (xr.pfnCaptureAtlasEXT && xr.session != XR_NULL_HANDLE) {
+                                    // XR_EXT_atlas_capture (W6 of #396): the runtime owns
+                                    // the readback — no app-side staging texture. The latch
+                                    // is consumed by this iteration's xrEndFrame below, so it
+                                    // captures the current frame. Pass a prefix without our
+                                    // ".png"; the runtime appends "_atlas.png".
+                                    std::string prefix = outPath;
+                                    if (prefix.size() > 4 &&
+                                        prefix.compare(prefix.size() - 4, 4, ".png") == 0) {
+                                        prefix.resize(prefix.size() - 4);
+                                    }
+                                    XrAtlasCaptureInfoEXT info = {XR_TYPE_ATLAS_CAPTURE_INFO_EXT};
+                                    info.next = nullptr;
+                                    info.stage = XR_ATLAS_CAPTURE_STAGE_PROJECTION_ONLY_EXT;
+                                    strncpy_s(info.pathPrefix, prefix.c_str(), _TRUNCATE);
+                                    XrResult cr = xr.pfnCaptureAtlasEXT(xr.session, &info, nullptr);
+                                    if (XR_SUCCEEDED(cr)) {
+                                        LOG_INFO("Atlas capture requested -> %s_atlas.png",
+                                                 prefix.c_str());
                                         dxr_capture::PostFlashRequest(rs.hwnd);
+                                    } else {
+                                        LOG_WARN("xrCaptureAtlasEXT failed: 0x%x", (unsigned)cr);
+                                    }
+                                } else {
+                                    // Fallback: legacy app-side readback when the runtime
+                                    // does not expose XR_EXT_atlas_capture.
+                                    uint32_t atlasW = tileColumns * renderW;
+                                    uint32_t atlasH = tileRows * renderH;
+                                    if (atlasW <= xr.swapchain.width && atlasH <= xr.swapchain.height) {
+                                        bool ok = dxr_capture::CaptureAtlasRegionD3D11(
+                                            renderer.device.Get(), renderer.context.Get(),
+                                            swapchainTexture,
+                                            0, 0, atlasW, atlasH, outPath);
+                                        if (ok) {
+                                            LOG_INFO("Captured atlas %ux%u -> %s",
+                                                     atlasW, atlasH, outPath.c_str());
+                                            dxr_capture::PostFlashRequest(rs.hwnd);
+                                        }
                                     }
                                 }
                             } else {

--- a/test_apps/cube_handle_d3d11_win/xr_session.cpp
+++ b/test_apps/cube_handle_d3d11_win/xr_session.cpp
@@ -84,12 +84,16 @@ bool InitializeOpenXR(XrSessionManager& xr) {
         if (strcmp(ext.extensionName, XR_EXT_WORKSPACE_FILE_DIALOG_EXTENSION_NAME) == 0) {
             xr.hasFileDialogExt = true;
         }
+        if (strcmp(ext.extensionName, XR_EXT_ATLAS_CAPTURE_EXTENSION_NAME) == 0) {
+            xr.hasAtlasCaptureExt = true;
+        }
     }
 
     LOG_INFO("XR_KHR_D3D11_enable: %s", hasD3D11 ? "AVAILABLE" : "NOT FOUND");
     LOG_INFO("XR_EXT_win32_window_binding: %s", xr.hasWin32WindowBindingExt ? "AVAILABLE" : "NOT FOUND");
     LOG_INFO("XR_EXT_display_info: %s", xr.hasDisplayInfoExt ? "AVAILABLE" : "NOT FOUND");
     LOG_INFO("XR_EXT_workspace_file_dialog: %s", xr.hasFileDialogExt ? "AVAILABLE" : "NOT FOUND");
+    LOG_INFO("XR_EXT_atlas_capture: %s", xr.hasAtlasCaptureExt ? "AVAILABLE" : "NOT FOUND");
 
     if (!hasD3D11) {
         LOG_ERROR("XR_KHR_D3D11_enable extension not available - cannot continue");
@@ -112,6 +116,9 @@ bool InitializeOpenXR(XrSessionManager& xr) {
     }
     if (xr.hasFileDialogExt) {
         enabledExtensions.push_back(XR_EXT_WORKSPACE_FILE_DIALOG_EXTENSION_NAME);
+    }
+    if (xr.hasAtlasCaptureExt) {
+        enabledExtensions.push_back(XR_EXT_ATLAS_CAPTURE_EXTENSION_NAME);
     }
 
     LOG_INFO("Enabling %zu extensions", enabledExtensions.size());
@@ -212,6 +219,13 @@ bool InitializeOpenXR(XrSessionManager& xr) {
         xrGetInstanceProcAddr(xr.instance, "xrRequestFilePickerEXT",
             (PFN_xrVoidFunction*)&xr.pfnRequestFilePickerEXT);
         LOG_INFO("xrRequestFilePickerEXT: %s", xr.pfnRequestFilePickerEXT ? "resolved" : "NULL");
+    }
+
+    // XR_EXT_atlas_capture (W6 of #396): resolve the runtime-owned capture entry.
+    if (xr.hasAtlasCaptureExt) {
+        xrGetInstanceProcAddr(xr.instance, "xrCaptureAtlasEXT",
+            (PFN_xrVoidFunction*)&xr.pfnCaptureAtlasEXT);
+        LOG_INFO("xrCaptureAtlasEXT: %s", xr.pfnCaptureAtlasEXT ? "resolved" : "NULL");
     }
 
     // Get view configuration views


### PR DESCRIPTION
## Summary

W6 (Phase 1) of epic #396: one official runtime entry point for "snapshot the multi-view atlas to a PNG", replacing the per-app, per-graphics-API readbacks every consumer reimplements. New vendor-neutral extension **`XR_EXT_atlas_capture`** / `xrCaptureAtlasEXT`, wired to the **in-process** native compositors. The runtime already owned the readback (`u_capture_intent` + the per-API `*_capture_atlas_to_png`); this exposes it as a public, non-privileged, all-graphics-API call.

Design doc: `docs/roadmap/unified-atlas-capture.md`.

## What's in this PR (Phase 1 — in-process)

- **New header** `XR_EXT_atlas_capture.h` (`xrCaptureAtlasEXT` + `XrAtlasCaptureInfoEXT`/`ResultEXT` + `XrAtlasCaptureStageEXT` whose values match `enum mcp_capture_mode`). Auto-syncs to `displayxr-extensions` on merge.
- **Registration** mirrors `EXT_spatial_workspace` exactly: `oxr_extension_support.h` (block + `GENERATE` list), `oxr_api_negotiate.c`, `oxr_api_funcs.h`.
- **`oxr_capture.c`**: `oxr_xrCaptureAtlasEXT` validates, gates to in-process native sessions (IPC returns `FEATURE_UNSUPPORTED` for now), latches the capture onto the compositor's existing intent, fills result metadata from `xrt_system_compositor_info`.
- **`oxr_mcp_tools_submit_capture()`**: a **non-blocking** latch via `mcp_capture_get_installed()`. It must not block — the call runs on the app's `xrEndFrame` thread, which is the same thread that drives the in-process compositor's `layer_commit` poll, so a blocking handler (as the MCP tool uses, from its own thread) would deadlock. The readback runs at the next `layer_commit`.
- **Proof consumer** `cube_handle_d3d11_win`: enables + resolves the PFN, replaces the D3D11 `CaptureAtlasRegion` glue with one `xrCaptureAtlasEXT` call (`PROJECTION_ONLY`), keeps the flash overlay + `I`-key, and keeps the legacy readback as a fallback when the runtime lacks the extension.

## Verification (local, D3D11 native)

- Build: runtime + all test apps compile; deployed to Program Files, loaded via registry under the elevated harness.
- `I`-key writes a valid **1280×360 2×1 atlas** PNG — the runtime's readback, correct inter-view disparity, **no deadlock**.
- **Stage flag correct**: `POST_COMPOSE` includes the window-space HUD layer (panel on both tiles); `PROJECTION_ONLY` excludes it.
- **Size correct**: window 1280×720 × scale 0.5 = 640×360/tile → 2×1 = 1280×360 (the content region, not the worst-case 3840×2160 allocation).

## Deferred to Phase 2 (follow-up PR)

- IPC-session routing (reuse `comp_ipc_client_compositor_workspace_capture_frame`) + the `XR_EXT_spatial_workspace` `PROJECTION_ONLY` flag bump + service-side honoring.
- In-process eye-pose / tile-layout metadata (currently 0; see W6 design doc open question).
- Broader consumer migration (other test apps, both demos, Unity, Unreal) + `atlas_capture_*` deletions.

## Notes

- No local `clang-format` available; style matched by hand — CI format gate not pre-checked.
- Minor: the runtime forces a `_atlas.png` suffix, so the app's `NextCaptureNum` (scans `<stem>-<N>_<cols>x<rows>.png`) doesn't see captures and re-captures overwrite at index `-1`. Ties to the design doc's "Result path ownership" open question; harmless for a debug capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)