### PR TITLE
feat(capture): per-session xrCaptureAtlasEXT over IPC + numbering fix [#396 W6 2]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,6 +216,22 @@ Both use registry discovery on Windows (so they pick up whatever plug-in is inst
 | cube_handle_gl_win | `_package\run_cube_handle_gl_win.bat` |
 | cube_handle_vk_win | `_package\run_cube_handle_vk_win.bat` |
 
+**Forcing the IPC/service path (easiest way to exercise IPC without the shell).**
+By default `handle`/`hosted` apps run **in-process** (local compositor, app- or
+runtime-owned window) — a running `displayxr-service.exe` does *not* by itself
+make an app an IPC client. To put **any** existing app on the IPC path, start the
+service and launch the app with `XRT_FORCE_MODE=ipc` (read by the runtime DLL;
+this is exactly what `webxr_bridge` sets via `force_ipc_mode_env()`):
+```cmd
+_package\bin\displayxr-service.exe                            REM D3D11 service compositor
+set XRT_FORCE_MODE=ipc && test_apps\cube_handle_d3d11_win\build\cube_handle_d3d11_win.exe
+```
+The app then creates a `client_d3d11_compositor` (`server-creates-swapchain`
+model), `is_service_mode` flips true, and `is_*_native_compositor` stays false —
+so e.g. `xrCaptureAtlasEXT` routes through the IPC branch, not the in-process
+one. (`XRT_FORCE_MODE=ipc` must be set process-level via the env, not the run
+script, since the DLL has its own static-CRT environment block.)
+
 ### macOS test apps
 Copy binaries to `_package/DisplayXR-macOS/bin/`. Generated `run_*.sh` set `XRT_PLUGIN_SEARCH_PATH=$DIR/lib/displayxr/plugins` so the dev tree's `DisplayXR-SimDisplay.dylib` (+ `200-sim-display.json`) is discovered without touching `~/Library/Application Support/`.
 

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -10688,21 +10688,63 @@ comp_d3d11_service_capture_frame(struct xrt_system_compositor *xsysc,
 	memset(out_result, 0, sizeof(*out_result));
 
 	struct d3d11_service_system *sys = d3d11_service_system_from_xrt(xsysc);
-	struct d3d11_multi_compositor *mc = sys ? sys->multi_comp : nullptr;
-	if (mc == nullptr || !mc->combined_atlas || sys->device == nullptr || sys->context == nullptr) {
-		U_LOG_W("capture_frame: no combined atlas / device / context available");
+	if (sys == nullptr || sys->device == nullptr || sys->context == nullptr) {
+		U_LOG_W("capture_frame: no service system / device / context available");
 		return false;
 	}
+	struct d3d11_multi_compositor *mc = sys->multi_comp;
 
 	std::lock_guard<std::recursive_mutex> lock(sys->render_mutex);
 
-	// Re-check under lock.
-	if (!mc->combined_atlas) {
+	// Select the source atlas by requested stage. We hold a com_ptr ref so the
+	// texture survives even if its owning compositor tears down (render_mutex
+	// already serializes against teardown; the ref is belt-and-suspenders).
+	//
+	//   PROJECTION_ONLY -> the active client's own per-session projection atlas
+	//     (render.atlas_texture). Window-space/HUD is composited only into
+	//     combined_atlas, so this buffer is projection-only by construction, and
+	//     it exists for a single (non-workspace) IPC client where combined_atlas
+	//     does not. This is what makes xrCaptureAtlasEXT work over IPC. (Captures
+	//     the active client; under multi-client workspace that is the focused
+	//     client, not necessarily an arbitrary caller — a known limitation.)
+	//   ATLAS (post-compose) -> the multi-compositor's combined atlas (the
+	//     workspace whole-composite). Null for a single non-workspace client, so
+	//     post-compose over IPC reports unsupported for those.
+	wil::com_ptr<ID3D11Texture2D> src_tex;
+	uint32_t want_flag = 0;
+	if (flags & IPC_CAPTURE_FLAG_PROJECTION_ONLY) {
+		std::lock_guard<std::mutex> alock(sys->active_compositor_mutex);
+		struct d3d11_service_compositor *ac = sys->active_compositor;
+		if (ac != nullptr) {
+			// Prefer the content-sized crop atlas — the actual DP input, tightly
+			// packed to (tile_columns·view_w)×(tile_rows·view_h) — so the PNG
+			// matches the in-process capture's content region instead of the
+			// full atlas with per-tile black padding. Fall back to the full
+			// per-client atlas when no crop was needed (content == atlas).
+			if (ac->render.crop_texture) {
+				src_tex = ac->render.crop_texture;
+			} else if (ac->render.atlas_texture) {
+				src_tex = ac->render.atlas_texture;
+			}
+			if (src_tex) {
+				want_flag = IPC_CAPTURE_FLAG_PROJECTION_ONLY;
+			}
+		}
+	} else if (flags & IPC_CAPTURE_FLAG_ATLAS) {
+		if (mc != nullptr && mc->combined_atlas) {
+			src_tex = mc->combined_atlas;
+			want_flag = IPC_CAPTURE_FLAG_ATLAS;
+		}
+	}
+	if (!src_tex) {
+		U_LOG_W("capture_frame: no source atlas for flags=0x%x (projection-only needs an "
+		        "active client; post-compose needs workspace mode)",
+		        flags);
 		return false;
 	}
 
 	D3D11_TEXTURE2D_DESC desc;
-	mc->combined_atlas->GetDesc(&desc);
+	src_tex->GetDesc(&desc);
 	const uint32_t atlas_w = desc.Width;
 	const uint32_t atlas_h = desc.Height;
 	const uint32_t tile_columns = sys->tile_columns > 0 ? sys->tile_columns : 1;
@@ -10715,8 +10757,17 @@ comp_d3d11_service_capture_frame(struct xrt_system_compositor *xsysc,
 	resolve_active_view_dims(sys, atlas_w, atlas_h, &eye_w_res, &eye_h_res);
 	const uint32_t eye_w = eye_w_res;
 	const uint32_t eye_h = eye_h_res;
-	const uint32_t used_w = eye_w * tile_columns;
-	const uint32_t used_h = eye_h * tile_rows;
+	uint32_t used_w = eye_w * tile_columns;
+	uint32_t used_h = eye_h * tile_rows;
+	// Clamp to the source texture: the per-client projection atlas can be smaller
+	// than the display-derived view grid, and over-reading the staging copy would
+	// read past its rows.
+	if (used_w > atlas_w) {
+		used_w = atlas_w;
+	}
+	if (used_h > atlas_h) {
+		used_h = atlas_h;
+	}
 
 	// Create CPU-readable staging texture and copy atlas into it.
 	D3D11_TEXTURE2D_DESC sd = desc;
@@ -10730,7 +10781,7 @@ comp_d3d11_service_capture_frame(struct xrt_system_compositor *xsysc,
 		U_LOG_W("capture_frame: CreateTexture2D(staging) failed 0x%08lx", hr);
 		return false;
 	}
-	sys->context->CopyResource(staging.get(), mc->combined_atlas.get());
+	sys->context->CopyResource(staging.get(), src_tex.get());
 
 	D3D11_MAPPED_SUBRESOURCE m;
 	hr = sys->context->Map(staging.get(), 0, D3D11_MAP_READ, 0, &m);
@@ -10741,7 +10792,7 @@ comp_d3d11_service_capture_frame(struct xrt_system_compositor *xsysc,
 
 	uint32_t views_written = 0;
 
-	if (flags & IPC_CAPTURE_FLAG_ATLAS) {
+	if (want_flag != 0) {
 		// Tightly-pack the active top-left region (used_w × used_h) into a
 		// contiguous RGBA8 buffer. Drops the black padding outside the tile
 		// grid and also handles staging RowPitch > used_w*4.
@@ -10756,7 +10807,7 @@ comp_d3d11_service_capture_frame(struct xrt_system_compositor *xsysc,
 		snprintf(path, sizeof(path), "%s_atlas.png", path_prefix);
 		if (stbi_write_png(path, (int)used_w, (int)used_h, 4,
 		                   buf.data(), (int)(used_w * 4u)) != 0) {
-			views_written |= IPC_CAPTURE_FLAG_ATLAS;
+			views_written |= want_flag;
 		} else {
 			U_LOG_W("capture_frame: stbi_write_png failed for %s", path);
 		}

--- a/src/xrt/ipc/shared/ipc_protocol.h
+++ b/src/xrt/ipc/shared/ipc_protocol.h
@@ -513,6 +513,11 @@ struct ipc_workspace_input_event_batch
  * @ingroup ipc
  */
 #define IPC_CAPTURE_FLAG_ATLAS (1u << 0)
+// Stage selector (W6 of #396): capture the projection-only atlas (no window-space
+// / chrome) instead of the post-compose ATLAS. The service-side projection-only
+// readback lands in a follow-up (Phase 2b); until then the service writes nothing
+// for this bit and the caller sees it absent from views_written.
+#define IPC_CAPTURE_FLAG_PROJECTION_ONLY (1u << 1)
 #define IPC_CAPTURE_FLAG_ALL (IPC_CAPTURE_FLAG_ATLAS)
 
 #define IPC_CAPTURE_PATH_MAX 256

--- a/src/xrt/state_trackers/oxr/oxr_capture.c
+++ b/src/xrt/state_trackers/oxr/oxr_capture.c
@@ -6,15 +6,27 @@
  * @author David Fattal
  * @ingroup oxr_api
  *
- * Phase 1 (in-process). xrCaptureAtlasEXT lets any session snapshot the
- * multi-view atlas the runtime composes for it, at a caller-selected stage,
- * without the app doing its own GPU readback. For an in-process native
- * compositor the entry point drives the same blocking capture bridge the MCP
- * @c capture_frame tool and the dev trigger files already use
- * (@ref oxr_mcp_tools_submit_capture → the compositor's @c u_capture_intent).
- * IPC-session routing (sharing the workspace capture bridge) and the workspace
- * PROJECTION_ONLY flag are a Phase-2 follow-up; see
- * docs/roadmap/unified-atlas-capture.md (W6 of issue #396).
+ * xrCaptureAtlasEXT lets any session snapshot the multi-view atlas the runtime
+ * composes for it, at a caller-selected stage, without the app doing its own
+ * GPU readback.
+ *
+ * - **In-process** native compositors (d3d11/d3d12/gl/vk/metal): the entry
+ *   point LATCHES the capture onto the compositor's existing
+ *   @c u_capture_intent (via @ref oxr_mcp_tools_submit_capture, the same bridge
+ *   the MCP @c capture_frame tool and the dev trigger files use). It must be
+ *   non-blocking — the call runs on the app's xrEndFrame thread, which also
+ *   drives the in-process compositor's layer_commit poll, so blocking would
+ *   deadlock. The readback happens at the next layer_commit.
+ * - **IPC / service-mode** sessions: routed over the existing capture IPC
+ *   bridge; the service compositor owns the readback. PROJECTION_ONLY captures
+ *   the calling session's own per-client projection atlas (the service reads the
+ *   active client's content-sized crop atlas), so it is per-session correct and
+ *   works for a single (non-workspace) IPC client. POST_COMPOSE maps to the
+ *   multi-compositor's combined (whole-workspace) atlas, which only exists in
+ *   workspace mode — so POST_COMPOSE over IPC is reported UNSUPPORTED for a
+ *   single non-workspace client.
+ *
+ * Full design: docs/roadmap/unified-atlas-capture.md (W6 of issue #396).
  */
 
 #include "oxr_objects.h"
@@ -29,6 +41,12 @@
 #include "oxr_api_funcs.h"
 #include "oxr_api_verify.h"
 
+#include "xrt/xrt_results.h"
+
+// IPC_CAPTURE_FLAG_* stage selectors for the IPC capture bridge. The CMake
+// include path (state_trackers/oxr/../../ipc) lets us write "shared/...".
+#include "shared/ipc_protocol.h"
+
 #include <openxr/XR_EXT_atlas_capture.h>
 
 // enum mcp_capture_mode values; XrAtlasCaptureStageEXT is defined to match.
@@ -42,6 +60,27 @@
 
 #ifdef OXR_HAVE_EXT_atlas_capture
 
+// Forward decl of the IPC-bridge wrapper (defined in ipc_client_compositor.c).
+// st_oxr does not pull the ipc_client include path; the runtime DLL links it so
+// the symbol resolves at link time. Same pattern as oxr_workspace.c.
+struct xrt_compositor;
+xrt_result_t
+comp_ipc_client_compositor_workspace_capture_frame(struct xrt_compositor *xc,
+                                                    const char *path_prefix,
+                                                    uint32_t flags,
+                                                    uint64_t *out_timestamp_ns,
+                                                    uint32_t *out_atlas_w,
+                                                    uint32_t *out_atlas_h,
+                                                    uint32_t *out_eye_w,
+                                                    uint32_t *out_eye_h,
+                                                    uint32_t *out_views_written,
+                                                    uint32_t *out_tile_columns,
+                                                    uint32_t *out_tile_rows,
+                                                    float *out_display_w_m,
+                                                    float *out_display_h_m,
+                                                    float out_eye_left_m[3],
+                                                    float out_eye_right_m[3]);
+
 static bool
 session_is_inprocess_native(struct oxr_session *sess)
 {
@@ -51,6 +90,122 @@ session_is_inprocess_native(struct oxr_session *sess)
 	return sess->is_d3d11_native_compositor || sess->is_d3d12_native_compositor ||
 	       sess->is_metal_native_compositor || sess->is_gl_native_compositor ||
 	       sess->is_vk_native_compositor;
+}
+
+static bool
+session_is_ipc(struct oxr_session *sess)
+{
+	// IPC sessions hold a native-compositor handle (the IPC client compositor)
+	// but none of the in-process native-compositor flags are set.
+	return sess != NULL && sess->xcn != NULL && sess->sys != NULL && sess->sys->xsysc != NULL &&
+	       !session_is_inprocess_native(sess);
+}
+
+//! In-process path: latch onto the compositor's capture intent (non-blocking).
+static XrResult
+capture_inprocess(struct oxr_logger *log,
+                  struct oxr_session *sess,
+                  const XrAtlasCaptureInfoEXT *info,
+                  XrAtlasCaptureResultEXT *result)
+{
+	// The runtime appends "_atlas.png" — same suffix convention as the
+	// workspace capture path.
+	char path[XR_ATLAS_CAPTURE_PATH_MAX_EXT + 16];
+	int n = snprintf(path, sizeof(path), "%.*s_atlas.png", (int)(XR_ATLAS_CAPTURE_PATH_MAX_EXT - 1),
+	                 info->pathPrefix);
+	if (n <= 0 || (size_t)n >= sizeof(path)) {
+		return oxr_error(log, XR_ERROR_VALIDATION_FAILURE, "xrCaptureAtlasEXT: path prefix too long");
+	}
+
+	// Stage values are defined to match enum mcp_capture_mode (no translation).
+	uint32_t mode = (info->stage == XR_ATLAS_CAPTURE_STAGE_PROJECTION_ONLY_EXT)
+	                    ? (uint32_t)MCP_CAPTURE_MODE_PROJECTION_ONLY
+	                    : (uint32_t)MCP_CAPTURE_MODE_POST_COMPOSE;
+
+	if (!oxr_mcp_tools_submit_capture(path, mode)) {
+		return oxr_error(log, XR_ERROR_RUNTIME_FAILURE,
+		                 "xrCaptureAtlasEXT: no in-process compositor capture handler is installed");
+	}
+
+	if (result != NULL) {
+		const struct xrt_system_compositor_info *sci = &sess->sys->xsysc->info;
+		result->type = XR_TYPE_ATLAS_CAPTURE_RESULT_EXT;
+		result->next = NULL;
+		result->timestampNs = (uint64_t)os_monotonic_get_ns();
+		result->atlasWidth = sci->atlas_width_pixels;
+		result->atlasHeight = sci->atlas_height_pixels;
+		// Per-view recommended dims approximate the captured eye-tile size.
+		result->eyeWidth = sci->views[0].recommended.width_pixels;
+		result->eyeHeight = sci->views[0].recommended.height_pixels;
+		// Tile layout and eye poses are not surfaced to oxr on the in-process
+		// path (no accessor; eye-pose plumbing stops at the display processor).
+		// Left zero; the IPC path below returns them. See the W6 design doc.
+		result->tileColumns = 0;
+		result->tileRows = 0;
+		result->displayWidthM = sci->display_width_m;
+		result->displayHeightM = sci->display_height_m;
+		result->eyeLeftM[0] = result->eyeLeftM[1] = result->eyeLeftM[2] = 0.0f;
+		result->eyeRightM[0] = result->eyeRightM[1] = result->eyeRightM[2] = 0.0f;
+	}
+	return XR_SUCCESS;
+}
+
+//! IPC path: route over the existing workspace-capture bridge. The service
+//! compositor owns the readback (and full metadata, including eye poses).
+static XrResult
+capture_ipc(struct oxr_logger *log,
+            struct oxr_session *sess,
+            const XrAtlasCaptureInfoEXT *info,
+            XrAtlasCaptureResultEXT *result)
+{
+	// Map the stage to the IPC stage-selector flag. The service writes the
+	// matching bit into views_written iff it actually captured that stage.
+	uint32_t want_flag = (info->stage == XR_ATLAS_CAPTURE_STAGE_PROJECTION_ONLY_EXT)
+	                         ? IPC_CAPTURE_FLAG_PROJECTION_ONLY
+	                         : IPC_CAPTURE_FLAG_ATLAS;
+
+	uint64_t ts_ns = 0;
+	uint32_t aw = 0, ah = 0, ew = 0, eh = 0, vw = 0, tc = 0, tr = 0;
+	float dw_m = 0.0f, dh_m = 0.0f;
+	float eye_l[3] = {0}, eye_r[3] = {0};
+	xrt_result_t xret = comp_ipc_client_compositor_workspace_capture_frame(
+	    &sess->xcn->base, info->pathPrefix, want_flag, &ts_ns, &aw, &ah, &ew, &eh, &vw, &tc, &tr, &dw_m,
+	    &dh_m, eye_l, eye_r);
+	if (xret != XRT_SUCCESS) {
+		return oxr_error(log, XR_ERROR_RUNTIME_FAILURE,
+		                 "xrCaptureAtlasEXT: IPC capture failed (xrt_result=%d)", (int)xret);
+	}
+
+	// The service reports which stage it actually wrote. If the requested stage
+	// wasn't written, it isn't available on this session: POST_COMPOSE needs the
+	// multi-compositor's combined atlas (workspace mode), absent for a single
+	// non-workspace IPC client.
+	if ((vw & want_flag) == 0) {
+		return oxr_error(log, XR_ERROR_FEATURE_UNSUPPORTED,
+		                 "xrCaptureAtlasEXT: the requested capture stage is not available for this "
+		                 "IPC session (post-compose requires workspace mode)");
+	}
+
+	if (result != NULL) {
+		result->type = XR_TYPE_ATLAS_CAPTURE_RESULT_EXT;
+		result->next = NULL;
+		result->timestampNs = ts_ns;
+		result->atlasWidth = aw;
+		result->atlasHeight = ah;
+		result->eyeWidth = ew;
+		result->eyeHeight = eh;
+		result->tileColumns = tc;
+		result->tileRows = tr;
+		result->displayWidthM = dw_m;
+		result->displayHeightM = dh_m;
+		result->eyeLeftM[0] = eye_l[0];
+		result->eyeLeftM[1] = eye_l[1];
+		result->eyeLeftM[2] = eye_l[2];
+		result->eyeRightM[0] = eye_r[0];
+		result->eyeRightM[1] = eye_r[1];
+		result->eyeRightM[2] = eye_r[2];
+	}
+	return XR_SUCCESS;
 }
 
 XRAPI_ATTR XrResult XRAPI_CALL
@@ -77,61 +232,15 @@ oxr_xrCaptureAtlasEXT(XrSession session, const XrAtlasCaptureInfoEXT *info, XrAt
 		return oxr_error(&log, XR_ERROR_VALIDATION_FAILURE, "xrCaptureAtlasEXT: info->pathPrefix is empty");
 	}
 
-	// Phase 1: only in-process native compositors are supported. IPC sessions
-	// (workspace/WebXR) route through the workspace capture bridge in Phase 2.
-	if (!session_is_inprocess_native(sess)) {
-		return oxr_error(&log, XR_ERROR_FEATURE_UNSUPPORTED,
-		                 "xrCaptureAtlasEXT currently supports in-process sessions only");
+	if (session_is_inprocess_native(sess)) {
+		return capture_inprocess(&log, sess, info, result);
+	}
+	if (session_is_ipc(sess)) {
+		return capture_ipc(&log, sess, info, result);
 	}
 
-	// Build the output path. The runtime appends "_atlas.png" — same suffix
-	// convention as the workspace capture path.
-	char path[XR_ATLAS_CAPTURE_PATH_MAX_EXT + 16];
-	int n = snprintf(path, sizeof(path), "%.*s_atlas.png", (int)(XR_ATLAS_CAPTURE_PATH_MAX_EXT - 1),
-	                 info->pathPrefix);
-	if (n <= 0 || (size_t)n >= sizeof(path)) {
-		return oxr_error(&log, XR_ERROR_VALIDATION_FAILURE, "xrCaptureAtlasEXT: path prefix too long");
-	}
-
-	// Stage values are defined to match enum mcp_capture_mode (no translation).
-	uint32_t mode = (info->stage == XR_ATLAS_CAPTURE_STAGE_PROJECTION_ONLY_EXT)
-	                    ? (uint32_t)MCP_CAPTURE_MODE_PROJECTION_ONLY
-	                    : (uint32_t)MCP_CAPTURE_MODE_POST_COMPOSE;
-
-	// Latch the capture intent onto the in-process compositor (non-blocking).
-	// The readback + PNG encode happen at the next layer_commit poll — i.e. the
-	// app's next xrEndFrame. We cannot block here: this runs on the app's
-	// xrEndFrame thread, which is the same thread that drives the in-process
-	// compositor's poll, so blocking would deadlock. The PNG therefore exists
-	// shortly after the next composed frame, not when this call returns.
-	if (!oxr_mcp_tools_submit_capture(path, mode)) {
-		return oxr_error(&log, XR_ERROR_RUNTIME_FAILURE,
-		                 "xrCaptureAtlasEXT: no in-process compositor capture handler is installed");
-	}
-
-	if (result != NULL) {
-		const struct xrt_system_compositor_info *sci = &sess->sys->xsysc->info;
-		result->type = XR_TYPE_ATLAS_CAPTURE_RESULT_EXT;
-		result->next = NULL;
-		result->timestampNs = (uint64_t)os_monotonic_get_ns();
-		result->atlasWidth = sci->atlas_width_pixels;
-		result->atlasHeight = sci->atlas_height_pixels;
-		// Per-view recommended dims approximate the captured eye-tile size.
-		result->eyeWidth = sci->views[0].recommended.width_pixels;
-		result->eyeHeight = sci->views[0].recommended.height_pixels;
-		// Tile layout and eye poses are not surfaced to oxr on the in-process
-		// path (the compositor knows them, but there is no accessor today and
-		// eye-pose plumbing stops at the display processor). Left zero for
-		// Phase 1; populated on the IPC/workspace path. See the W6 design doc.
-		result->tileColumns = 0;
-		result->tileRows = 0;
-		result->displayWidthM = sci->display_width_m;
-		result->displayHeightM = sci->display_height_m;
-		result->eyeLeftM[0] = result->eyeLeftM[1] = result->eyeLeftM[2] = 0.0f;
-		result->eyeRightM[0] = result->eyeRightM[1] = result->eyeRightM[2] = 0.0f;
-	}
-
-	return XR_SUCCESS;
+	return oxr_error(&log, XR_ERROR_FEATURE_UNSUPPORTED,
+	                 "xrCaptureAtlasEXT: session has no capture-capable compositor");
 }
 
 #endif // OXR_HAVE_EXT_atlas_capture

--- a/test_apps/common/atlas_capture.cpp
+++ b/test_apps/common/atlas_capture.cpp
@@ -45,14 +45,14 @@ std::string PicturesDirectory() {
     return out;
 }
 
-int NextCaptureNum(const std::string& dir,
-                   const std::string& stem,
-                   uint32_t cols, uint32_t rows) {
+// Scan `dir` for files named "<stem>-<N><suffix>" with an all-digit <N> and
+// return max(N)+1 (1 if none). Shared by the legacy and the xrCaptureAtlasEXT
+// naming, which differ only in the trailing suffix.
+static int NextCaptureNumSuffix(const std::string& dir,
+                                const std::string& stem,
+                                const std::string& suffix) {
     if (dir.empty()) return 1;
-    char suffixBuf[64];
-    snprintf(suffixBuf, sizeof(suffixBuf), "_%ux%u.png", cols, rows);
     std::string prefix = stem + "-";
-    std::string suffix = suffixBuf;
     int maxNum = 0;
     std::string pattern = dir + "\\" + prefix + "*" + suffix;
     WIN32_FIND_DATAA fd;
@@ -81,6 +81,14 @@ int NextCaptureNum(const std::string& dir,
     return maxNum + 1;
 }
 
+int NextCaptureNum(const std::string& dir,
+                   const std::string& stem,
+                   uint32_t cols, uint32_t rows) {
+    char suffixBuf[64];
+    snprintf(suffixBuf, sizeof(suffixBuf), "_%ux%u.png", cols, rows);
+    return NextCaptureNumSuffix(dir, stem, suffixBuf);
+}
+
 std::string MakeCapturePath(const std::string& stem,
                             uint32_t cols, uint32_t rows) {
     std::string dir = PicturesDirectory();
@@ -88,6 +96,20 @@ std::string MakeCapturePath(const std::string& stem,
     char tail[256];
     snprintf(tail, sizeof(tail), "%s-%d_%ux%u.png",
              stem.c_str(), n, cols, rows);
+    return dir.empty() ? std::string(tail) : (dir + "\\" + tail);
+}
+
+std::string MakeCaptureAtlasPrefix(const std::string& stem,
+                                   uint32_t cols, uint32_t rows) {
+    std::string dir = PicturesDirectory();
+    // xrCaptureAtlasEXT appends "_atlas.png"; number against that final name so
+    // repeats accumulate rather than overwrite (the legacy "_CxR.png" name space
+    // is scanned separately, so the two never clobber each other's count).
+    char atlasSuffix[80];
+    snprintf(atlasSuffix, sizeof(atlasSuffix), "_%ux%u_atlas.png", cols, rows);
+    int n = NextCaptureNumSuffix(dir, stem, atlasSuffix);
+    char tail[256];
+    snprintf(tail, sizeof(tail), "%s-%d_%ux%u", stem.c_str(), n, cols, rows);
     return dir.empty() ? std::string(tail) : (dir + "\\" + tail);
 }
 

--- a/test_apps/common/atlas_capture.h
+++ b/test_apps/common/atlas_capture.h
@@ -94,6 +94,15 @@ std::string MakeCapturePath(const std::string& stem,
                             uint32_t cols,
                             uint32_t rows);
 
+// Path PREFIX (no extension) for xrCaptureAtlasEXT, which appends "_atlas.png".
+// Numbers against existing "<stem>-<N>_<cols>x<rows>_atlas.png" files (the
+// runtime-produced names) so repeat captures accumulate instead of overwriting.
+// Returns "<dir>/<stem>-<N>_<cols>x<rows>" (no "_atlas", no ".png"). The legacy
+// readback path keeps MakeCapturePath; the two name spaces don't collide.
+std::string MakeCaptureAtlasPrefix(const std::string& stem,
+                                   uint32_t cols,
+                                   uint32_t rows);
+
 // ---------------------------------------------------------------------------
 // Visual feedback — brief white flash overlay (~250 ms fade).
 // ---------------------------------------------------------------------------

--- a/test_apps/cube_handle_d3d11_win/main.cpp
+++ b/test_apps/cube_handle_d3d11_win/main.cpp
@@ -772,19 +772,14 @@ static void RenderOneFrame(RenderState& rs) {
                         if (g_inputState.captureAtlasRequested) {
                             g_inputState.captureAtlasRequested = false;
                             if (!monoMode && (tileColumns > 1 || tileRows > 1)) {
-                                std::string outPath = dxr_capture::MakeCapturePath(
-                                    APP_NAME, tileColumns, tileRows);
                                 if (xr.pfnCaptureAtlasEXT && xr.session != XR_NULL_HANDLE) {
                                     // XR_EXT_atlas_capture (W6 of #396): the runtime owns
                                     // the readback — no app-side staging texture. The latch
                                     // is consumed by this iteration's xrEndFrame below, so it
-                                    // captures the current frame. Pass a prefix without our
-                                    // ".png"; the runtime appends "_atlas.png".
-                                    std::string prefix = outPath;
-                                    if (prefix.size() > 4 &&
-                                        prefix.compare(prefix.size() - 4, 4, ".png") == 0) {
-                                        prefix.resize(prefix.size() - 4);
-                                    }
+                                    // captures the current frame. The prefix has no ".png";
+                                    // the runtime appends "_atlas.png".
+                                    std::string prefix = dxr_capture::MakeCaptureAtlasPrefix(
+                                        APP_NAME, tileColumns, tileRows);
                                     XrAtlasCaptureInfoEXT info = {XR_TYPE_ATLAS_CAPTURE_INFO_EXT};
                                     info.next = nullptr;
                                     info.stage = XR_ATLAS_CAPTURE_STAGE_PROJECTION_ONLY_EXT;
@@ -800,6 +795,8 @@ static void RenderOneFrame(RenderState& rs) {
                                 } else {
                                     // Fallback: legacy app-side readback when the runtime
                                     // does not expose XR_EXT_atlas_capture.
+                                    std::string outPath = dxr_capture::MakeCapturePath(
+                                        APP_NAME, tileColumns, tileRows);
                                     uint32_t atlasW = tileColumns * renderW;
                                     uint32_t atlasH = tileRows * renderH;
                                     if (atlasW <= xr.swapchain.width && atlasH <= xr.swapchain.height) {


### PR DESCRIPTION
## Summary

W6 Phase 2 of #396: extend `xrCaptureAtlasEXT` (Phase 1 / #397 was in-process only) to **IPC / service-mode** sessions, capturing the **calling session's own atlas** rather than the whole-workspace composite — plus a capture-file numbering fix and a docs note.

The original "Phase 2a (routing) then 2b (service)" split collapsed after a live IPC test: the workspace-capture bridge reads the multi-compositor's `combined_atlas`, which is null for a single (non-workspace) IPC client and is the *whole workspace* (wrong buffer) under the shell. So per-session capture needed real service-side work, folded in here.

## oxr (`oxr_capture.c`)
- Split into `capture_inprocess()` (Phase-1 non-blocking latch, unchanged) and `capture_ipc()`. IPC sessions route over the existing `comp_ipc_client_compositor_workspace_capture_frame`. Stage→flag: `PROJECTION_ONLY`→`IPC_CAPTURE_FLAG_PROJECTION_ONLY` (new), `POST_COMPOSE`→`IPC_CAPTURE_FLAG_ATLAS`. A `views_written` check turns an unwritten stage into `XR_ERROR_FEATURE_UNSUPPORTED`. Full result metadata (eye poses, tile layout) comes back from the service.

## service (`comp_d3d11_service.cpp`) — per-session capture
- **PROJECTION_ONLY** → the **active client's own content-sized crop atlas** (`render.crop_texture`, the real DP input; falls back to `render.atlas_texture`). Window-space/HUD is composited only into `combined_atlas`, so this buffer is projection-only by construction, and it exists for a single non-workspace client where `combined_atlas` is null. `used_w/h` clamped to the source → tight PNG.
- **POST_COMPOSE/ATLAS** → unchanged `combined_atlas` (whole-workspace; the shell's `xrCaptureWorkspaceFrameEXT`); null for a single client → unsupported over IPC.
- No signature change: the source is selected from the requested flag + the service's own `active_compositor` (a known-valid `d3d11_service_compositor`), avoiding a blind cast of the caller's xc.

## numbering (`atlas_capture.{h,cpp}` + `cube_handle_d3d11_win`)
- The runtime forces `_atlas.png`, which `NextCaptureNum` (scans `<stem>-*_CxR.png`) never matched → index stuck at `-1`, repeats overwrote. New `MakeCaptureAtlasPrefix()` numbers against the runtime-produced `<stem>-<N>_CxR_atlas.png` names (shared scan); the legacy `CaptureAtlasRegion` fallback keeps `MakeCapturePath`.

## docs (`CLAUDE.md`)
- Document `XRT_FORCE_MODE=ipc` + a running `displayxr-service.exe` as the easiest way to put any app on the IPC path (hosted/handle are in-process; a running service alone does **not** make an app an IPC client).

## Verification (local, D3D11)
- In-process: three `I`-presses now write `-1/-2/-3` (was overwriting `-1`).
- **IPC** (`XRT_FORCE_MODE=ipc` + service): PROJECTION_ONLY writes a tight **1280×360** two-view atlas captured by the **service** from the client's crop atlas (`flags=0x2 written=0x2`), content + disparity matching the in-process capture.
- POST_COMPOSE over a single IPC client correctly reports unsupported (no `combined_atlas`).

## Notes / follow-ups
- Under multi-client workspace, PROJECTION_ONLY captures the **active/focused** client (the service's `active_compositor`), not an arbitrary caller — fine for the single-client IPC case (forced-ipc / WebXR bridge); per-arbitrary-caller selection would need caller→slot mapping. Documented in-code.
- No local `clang-format`; style matched by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)