### PR TITLE
ci(versions): fan out org-changed dispatch to displayxr-website

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1224,6 +1224,7 @@ jobs:
             displayxr-runtime
             displayxr-installer
             displayxr-leia-plugin
+            displayxr-website
 
       - name: Checkout main
         uses: actions/checkout@v4
@@ -1330,3 +1331,22 @@ jobs:
           Auto-synced from displayxr-runtime/versions.json by build-windows.yml on tag push.
           [skip ci]"
           git push origin HEAD:main || (git pull --rebase origin main && git push origin HEAD:main)
+
+      # Nudge the project website to re-pull org data after a runtime release,
+      # mirroring the same step in versions-bump.yml. Non-fatal — a website
+      # hiccup must never fail the runtime's self-bump. See docs/org-sync.md
+      # in displayxr-website.
+      - name: Notify website to resync
+        if: steps.abi.outputs.rc == '0' && hashFiles('.bump-noop') == ''
+        continue-on-error: true
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          repository: DisplayXR/displayxr-website
+          event-type: org-changed
+          client-payload: |
+            {
+              "field":       "runtime",
+              "tag":         "${{ github.ref_name }}",
+              "source_repo": "DisplayXR/displayxr-runtime"
+            }

--- a/.github/workflows/versions-bump.yml
+++ b/.github/workflows/versions-bump.yml
@@ -89,11 +89,12 @@ jobs:
           private-key: ${{ secrets.DISPLAYXR_APP_PRIVATE_KEY }}
           owner: DisplayXR
           # Bumping versions.json here + mirror there; issue-opening on
-          # ABI fail in leia repo.
+          # ABI fail in leia repo; org-changed dispatch to the website.
           repositories: |
             displayxr-runtime
             displayxr-installer
             displayxr-leia-plugin
+            displayxr-website
 
       - name: Checkout main
         uses: actions/checkout@v4
@@ -229,3 +230,23 @@ jobs:
           See displayxr-runtime/docs/specs/runtime/versions-json-autobump.md.
           [skip ci]"
           git push origin HEAD:main || (git pull --rebase origin main && git push origin HEAD:main)
+
+      # Nudge the project website to re-pull org data (versions, demos, repos)
+      # so displayxr.org reflects the new release within ~1 min instead of
+      # waiting for its daily cron. The website's sync-org.yml regenerates and
+      # direct-commits to its main; it ignores the payload but we send it for
+      # log context. Non-fatal: a website hiccup must never fail a version bump.
+      - name: Notify website to resync
+        if: hashFiles('.bump-noop') == '' && (steps.inputs.outputs.field != 'leia_plugin' || steps.abi.outputs.rc == '0')
+        continue-on-error: true
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          repository: DisplayXR/displayxr-website
+          event-type: org-changed
+          client-payload: |
+            {
+              "field":       "${{ steps.inputs.outputs.field }}",
+              "tag":         "${{ steps.inputs.outputs.tag }}",
+              "source_repo": "${{ steps.inputs.outputs.src }}"
+            }

--- a/docs/specs/runtime/versions-json-autobump.md
+++ b/docs/specs/runtime/versions-json-autobump.md
@@ -154,6 +154,21 @@ demo gets its own top-level key matching the asset table in runtime's
             }
 ```
 
+## Website fan-out (low-latency org-sync)
+
+After a bump commits — in **both** `versions-bump.yml` (sibling releases)
+and `build-windows.yml`'s `BumpVersionsJsonOnTag` (runtime self-bump) — a
+final `repository_dispatch` step fires an `org-changed` event at
+`displayxr-website`. The website's `sync-org.yml` re-pulls org data
+(versions, demo cards, repo list) and direct-commits the refresh to its
+`main` (same no-review-theatre contract as this file), so `displayxr.org`
+reflects a release within ~1 min instead of waiting for its daily cron. The step is `continue-on-error: true` and runs *after*
+the push + installer mirror, so a website hiccup can never fail a real
+version bump. `displayxr-website` is added to the App token's
+`repositories:` list in both jobs. The website ignores the payload (it
+regenerates wholesale) but receives `{field, tag, source_repo}` for log
+context. Full design: `displayxr-website/docs/org-sync.md`.
+
 ## ABI gate (the one carve-out)
 
 The leia plug-in reports `XRT_PLUGIN_API_VERSION_CURRENT` from the


### PR DESCRIPTION
Phase 2 of the website org-sync system (full design: `displayxr-website/docs/org-sync.md`).

## What
After any `versions.json` bump commits, fire a `repository_dispatch` (`org-changed`) at **displayxr-website** so the site re-pulls org data (versions, demo cards, repo list) within ~1 min instead of waiting for its daily cron. The website's `sync-org.yml` regenerates and **direct-commits the refresh to its own `main`** (it does not open a PR), so this needs no org-wide "Actions may create PRs" policy.

Added to **both** bump paths:
- `versions-bump.yml` — sibling releases (shell / leia / mcp / demos)
- `build-windows.yml` → `BumpVersionsJsonOnTag` — runtime self-bump on tag

Each new step:
- uses `peter-evans/repository-dispatch@v3`, guarded by the same "did we actually bump" condition as the commit step;
- runs **after** the push + installer mirror with `continue-on-error: true`, so a website hiccup can never fail a real version bump;
- sends `{field, tag, source_repo}` for log context (the website ignores the payload and regenerates wholesale).

`displayxr-website` added to the publish-bot App token `repositories:` list in both jobs. Fan-out documented in `docs/specs/runtime/versions-json-autobump.md`.

## Prereqs
- The `displayxr-publish-bot` App must be installed on **displayxr-website** with contents write (org-wide install → already covered).
- displayxr-website's `sync-org.yml` listens for `org-changed` — already on its `main`.

## Not exercised until next release
Workflow-only; the dispatch first fires on the next component/runtime release. The website's daily cron is the backstop meanwhile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)