### PR TITLE
docs(macos): correct stale MoltenVK 'Vulkan compositor fails' claim

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ First run downloads deps (vcpkg, OpenXR loader). Requires VS 2022 (C++ workload)
 # brew install cmake ninja eigen vulkan-sdk
 ./scripts/build_macos.sh
 ```
-Builds runtime, OpenXR loader, test apps. The Vulkan compositor fails at runtime with `VK_ERROR_EXTENSION_NOT_PRESENT` (MoltenVK limitation, not a build issue).
+Builds runtime, OpenXR loader, test apps. The macOS Vulkan native compositor runs via MoltenVK over a CAMetalLayer-backed surface (`cube_handle_vk_macos`); an earlier `VK_ERROR_EXTENSION_NOT_PRESENT` failure was a MoltenVK-era issue since resolved. The one dev gotcha is the two-`libvulkan` loader-image conflict (dev build vs installed runtime) — see `docs/getting-started/building.md` and pin `XR_RUNTIME_JSON` / share one loader image.
 
 ### Standard CMake
 ```bash

--- a/docs/getting-started/building.md
+++ b/docs/getting-started/building.md
@@ -20,7 +20,7 @@ brew install cmake ninja eigen vulkan-sdk
 ./scripts/build_macos.sh
 ```
 
-Builds the runtime, OpenXR loader, and test apps. The Vulkan compositor will fail at runtime with `VK_ERROR_EXTENSION_NOT_PRESENT` (MoltenVK limitation, not a build issue).
+Builds the runtime, OpenXR loader, and test apps. The macOS Vulkan native compositor runs via MoltenVK over a CAMetalLayer-backed surface (see `cube_handle_vk_macos`); an earlier `VK_ERROR_EXTENSION_NOT_PRESENT` runtime failure was a MoltenVK-era issue that has since been resolved. The remaining macOS-Vulkan dev gotcha is a two-`libvulkan` loader-image conflict (the dev build's image vs the installed runtime's) — share one loader image / pin `XR_RUNTIME_JSON` to avoid it.
 
 ### Windows (recommended)
 ```bat


### PR DESCRIPTION
The macOS `vk_native` Vulkan path (CAMetalLayer/MoltenVK) is actively maintained and working — `cube_handle_vk_macos` runs, and #392 (transparent present / alpha-weave) landed 2026-06-02.

The `VK_ERROR_EXTENSION_NOT_PRESENT` / "MoltenVK limitation" note in `CLAUDE.md` + `docs/getting-started/building.md` was **stale** (last touched 2026-02-15). This replaces it with the accurate status and the one real remaining macOS-Vulkan dev gotcha: the two-`libvulkan` loader-image conflict (dev build vs installed runtime).

Docs-only — CI doc-only short-circuit applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)