### PR TITLE
feat(test-apps): adopt display3d_view superset + ZDP-anchored clip [#396 W1]

### DIFF
--- a/test_apps/common/display3d_view.c
+++ b/test_apps/common/display3d_view.c
@@ -10,6 +10,7 @@
 #include "display3d_view.h"
 #include <math.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -263,8 +264,8 @@ display3d_compute_view(const XrVector3f *processed_eye,
                        const Display3DScreen *screen,
                        const Display3DTunables *tunables,
                        const XrPosef *display_pose,
-                       float near_z,
-                       float far_z,
+                       float near_offset,
+                       float far_offset,
                        Display3DView *out)
 {
 	Display3DTunables t = tunables ? *tunables : display3d_default_tunables();
@@ -296,6 +297,30 @@ display3d_compute_view(const XrVector3f *processed_eye,
 	eye_world.y += disp_pos.y;
 	eye_world.z += disp_pos.z;
 	out->eye_world = eye_world;
+
+	// ZDP-relative clip planes: near/far placed at fixed *absolute* offsets in
+	// front of / behind this eye's perpendicular distance to the display/
+	// convergence plane (ZDP). eye_scaled.z is that per-eye distance (==
+	// out->eye_display.z) in the same kooima-scaled units as the offsets, so
+	// the planes are per-eye and the offsets are expressed in virtual-display-
+	// height (vH) units by the caller. near = ez - near_offset, far = ez +
+	// far_offset. far_offset = 0 => far sits at the ZDP (foreground-only, e.g.
+	// transparent mode). Offsets are absolute (vH multiples), NOT fractions of
+	// ez — large scenes no longer scale the band with ez.
+	float ez = eye_scaled.z;
+	float near_z = ez - near_offset;
+	float far_z = ez + far_offset;
+	if (near_z < 1.0e-4f)
+		near_z = 1.0e-4f;
+	// Guarantee a valid frustum (far strictly past near) even when ez is tiny
+	// and far_offset is 0 (transparent mode at near-degenerate eye distance).
+	if (far_z < near_z + 1.0e-4f)
+		far_z = near_z + 1.0e-4f;
+	// Expose the resolved view-space planes so the caller can drive the
+	// renderer's explicit geometric near/far culls (this splat rasterizer does
+	// not clip against the projection matrix planes — see GsRenderer::renderEye).
+	out->near_z = near_z;
+	out->far_z = far_z;
 
 	// Build view matrix + projection + FOV
 	build_view_matrix(out->view_matrix, disp_ori, eye_world);
@@ -474,6 +499,27 @@ display3d_unproject_ndc_to_ray(float ndc_x,
 	out_origin_world->z = -(V[8] * tx + V[9] * ty + V[10] * tz);
 }
 
+// ── The single Vulkan-render Y-mirror ───────────────────────────────────────
+// This is the ONE place the +Y-up world frame is mirrored into the Vulkan
+// render frame (Y-down NDC). It pairs with the NDC view-row flip that
+// GsRenderer::updateUniforms applies. The render path passes vulkan_flip_y=1
+// here; the pick path passes 0 to stay in the clean world frame. No other
+// code (app, pick, geometry) negates Y — so the render and pick frames can
+// only ever differ by this one flag, never by hand-rolled sign juggling.
+static XrVector3f
+flip_vec_y(XrVector3f v, int flip)
+{
+	if (flip) v.y = -v.y;
+	return v;
+}
+
+static XrPosef
+flip_pose_y(XrPosef p, int flip)
+{
+	if (flip) p.position.y = -p.position.y;
+	return p;
+}
+
 void
 display3d_compute_views(const XrVector3f *raw_eyes,
                                uint32_t count,
@@ -481,26 +527,162 @@ display3d_compute_views(const XrVector3f *raw_eyes,
                                const Display3DScreen *screen,
                                const Display3DTunables *tunables,
                                const XrPosef *display_pose,
-                               float near_z,
-                               float far_z,
+                               float near_offset,
+                               float far_offset,
+                               int vulkan_flip_y,
                                Display3DView *out_views)
 {
 	Display3DTunables t = tunables ? *tunables : display3d_default_tunables();
 
+	if (count == 0)
+		return;
+
+	// Mirror inputs into the render frame (vulkan_flip_y) — single source of
+	// truth for the render-vs-pick frame relationship. Callers always supply
+	// clean +Y-up world-space inputs.
+	XrVector3f stack_eyes[8];
+	XrVector3f *eyes = (count <= 8) ? stack_eyes : (XrVector3f *)malloc(count * sizeof(XrVector3f));
+	for (uint32_t i = 0; i < count; i++)
+		eyes[i] = flip_vec_y(raw_eyes[i], vulkan_flip_y);
+	XrVector3f nom_local;
+	const XrVector3f *nom = nominal_viewer;
+	if (nominal_viewer) { nom_local = flip_vec_y(*nominal_viewer, vulkan_flip_y); nom = &nom_local; }
+	XrPosef pose_local;
+	const XrPosef *pose = display_pose;
+	if (display_pose) { pose_local = flip_pose_y(*display_pose, vulkan_flip_y); pose = &pose_local; }
+
 	// Apply IPD and parallax factors (N-view path)
 	XrVector3f stack_processed[8];
 	XrVector3f *processed = (count <= 8) ? stack_processed : (XrVector3f *)malloc(count * sizeof(XrVector3f));
-	display3d_apply_eye_factors_n(raw_eyes, count, nominal_viewer,
+	display3d_apply_eye_factors_n(eyes, count, nom,
 	                              t.ipd_factor, t.parallax_factor,
 	                              processed);
 
 	// Compute each view via single-eye primitive
 	for (uint32_t i = 0; i < count; i++) {
 		display3d_compute_view(&processed[i], screen, &t,
-		                       display_pose, near_z, far_z,
+		                       pose, near_offset, far_offset,
 		                       &out_views[i]);
 	}
 
-	if (count > 8)
+	if (count > 8) {
 		free(processed);
+		free(eyes);
+	}
+}
+
+void
+display3d_compute_center_view(const XrVector3f *raw_eyes,
+                              uint32_t count,
+                              const XrVector3f *nominal_viewer,
+                              const Display3DScreen *screen,
+                              const Display3DTunables *tunables,
+                              const XrPosef *display_pose,
+                              float near_offset,
+                              float far_offset,
+                              int vulkan_flip_y,
+                              Display3DView *out_view)
+{
+	Display3DTunables t = tunables ? *tunables : display3d_default_tunables();
+	if (count == 0)
+		return;
+
+	// Cyclopean eye = centroid of the raw eyes. (Averaging then mirroring Y is
+	// identical to mirroring each then averaging — the flip is linear.)
+	XrVector3f c = {0, 0, 0};
+	for (uint32_t i = 0; i < count; i++) {
+		c.x += raw_eyes[i].x; c.y += raw_eyes[i].y; c.z += raw_eyes[i].z;
+	}
+	float inv = 1.0f / (float)count;
+	c.x *= inv; c.y *= inv; c.z *= inv;
+	c = flip_vec_y(c, vulkan_flip_y);
+
+	XrVector3f nom_local;
+	const XrVector3f *nom = nominal_viewer;
+	if (nominal_viewer) { nom_local = flip_vec_y(*nominal_viewer, vulkan_flip_y); nom = &nom_local; }
+	XrPosef pose_local;
+	const XrPosef *pose = display_pose;
+	if (display_pose) { pose_local = flip_pose_y(*display_pose, vulkan_flip_y); pose = &pose_local; }
+
+	// Run the SAME eye-factor pipeline as compute_views on the single centroid.
+	// For a single eye the IPD term is a no-op, leaving the parallax-lerped
+	// center — exactly the average of the per-eye processed positions.
+	XrVector3f processed;
+	display3d_apply_eye_factors_n(&c, 1, nom, t.ipd_factor, t.parallax_factor, &processed);
+	display3d_compute_view(&processed, screen, &t, pose, near_offset, far_offset, out_view);
+}
+
+// Column-major 4x4 * vec4.
+static void
+mat4_mul_vec4_cm(const float *m, const float *v, float *out)
+{
+	for (int r = 0; r < 4; r++)
+		out[r] = m[0 * 4 + r] * v[0] + m[1 * 4 + r] * v[1] +
+		         m[2 * 4 + r] * v[2] + m[3 * 4 + r] * v[3];
+}
+
+int
+display3d_selftest(void)
+{
+	int fails = 0;
+
+	Display3DScreen screen = {0.30f, 0.20f};
+	Display3DTunables t = display3d_default_tunables();
+	t.virtual_display_height = 0.20f;
+	XrPosef pose;
+	pose.orientation = (XrQuaternionf){0, 0, 0, 1};
+	pose.position = (XrVector3f){0, 0, 0};
+	XrVector3f eye = {0, 0, 0.6f};
+
+	// Picking (clean) frame view. Offsets are absolute (vH units); the round-
+	// trip/orientation checks below only need a valid frustum.
+	Display3DView v;
+	display3d_compute_center_view(&eye, 1, NULL, &screen, &t, &pose,
+	                              t.virtual_display_height,
+	                              1000.0f * t.virtual_display_height,
+	                              /*vulkan_flip_y=*/0, &v);
+
+	// (a) Round-trip: project a world point, then unproject its NDC; the ray
+	//     must pass through the original point.
+	XrVector3f pts[3] = {{0.0f, 0.0f, -0.30f},
+	                     {0.05f, 0.04f, -0.50f},
+	                     {-0.06f, 0.03f, -0.80f}};
+	for (int i = 0; i < 3; i++) {
+		float w[4] = {pts[i].x, pts[i].y, pts[i].z, 1.0f};
+		float vc[4], cl[4];
+		mat4_mul_vec4_cm(v.view_matrix, w, vc);
+		mat4_mul_vec4_cm(v.projection_matrix, vc, cl);
+		if (fabsf(cl[3]) < 1e-6f) { fails++; continue; }
+		float ndcx = cl[0] / cl[3], ndcy = cl[1] / cl[3];
+		XrVector3f ro, rd;
+		display3d_unproject_ndc_to_ray(ndcx, ndcy, v.view_matrix, v.projection_matrix, &ro, &rd);
+		float dx = pts[i].x - ro.x, dy = pts[i].y - ro.y, dz = pts[i].z - ro.z;
+		float tt = dx * rd.x + dy * rd.y + dz * rd.z;
+		float ex = dx - tt * rd.x, ey = dy - tt * rd.y, ez = dz - tt * rd.z;
+		float perp = sqrtf(ex * ex + ey * ey + ez * ez);
+		if (perp > 1e-3f) {
+			fails++;
+			fprintf(stderr, "[display3d_selftest] round-trip perp=%.5f for point (%.2f,%.2f,%.2f)\n",
+			        perp, pts[i].x, pts[i].y, pts[i].z);
+		}
+	}
+
+	// (b) Orientation: +NDC.y must map to higher world Y, +NDC.x to higher world X.
+	XrVector3f roU, rdU, roD, rdD, roR, rdR, roL, rdL;
+	display3d_unproject_ndc_to_ray(0.0f, 0.5f, v.view_matrix, v.projection_matrix, &roU, &rdU);
+	display3d_unproject_ndc_to_ray(0.0f, -0.5f, v.view_matrix, v.projection_matrix, &roD, &rdD);
+	if (!((roU.y + rdU.y) > (roD.y + rdD.y))) {
+		fails++;
+		fprintf(stderr, "[display3d_selftest] +NDC.y did not map to higher world Y (%.3f <= %.3f)\n",
+		        roU.y + rdU.y, roD.y + rdD.y);
+	}
+	display3d_unproject_ndc_to_ray(0.5f, 0.0f, v.view_matrix, v.projection_matrix, &roR, &rdR);
+	display3d_unproject_ndc_to_ray(-0.5f, 0.0f, v.view_matrix, v.projection_matrix, &roL, &rdL);
+	if (!((roR.x + rdR.x) > (roL.x + rdL.x))) {
+		fails++;
+		fprintf(stderr, "[display3d_selftest] +NDC.x did not map to higher world X (%.3f <= %.3f)\n",
+		        roR.x + rdR.x, roL.x + rdL.x);
+	}
+
+	return fails;
 }

--- a/test_apps/common/display3d_view.h
+++ b/test_apps/common/display3d_view.h
@@ -46,6 +46,8 @@ typedef struct Display3DView {
 	XrVector3f eye_display;      //!< Modified eye position in display space (after all factors)
 	XrVector3f eye_world;        //!< Eye position in world space (after display pose transform)
 	XrQuaternionf orientation;   //!< Display/camera orientation (same for both eyes)
+	float near_z;                //!< Resolved view-space near plane = ez - near_offset (clamped)
+	float far_z;                 //!< Resolved view-space far plane  = ez + far_offset (clamped)
 } Display3DView;
 
 // --- Functions ---
@@ -69,8 +71,21 @@ typedef struct Display3DView {
  * @param screen         Physical screen dimensions
  * @param tunables       View factors (or NULL for defaults: all 1.0)
  * @param display_pose   Display pose in world space (or NULL for identity)
- * @param near_z         Near clip plane distance
- * @param far_z          Far clip plane distance
+ * @param near_offset    Pop-out clip as an ABSOLUTE offset (in virtual-display-
+ *                       height / kooima-scaled units) in front of the per-eye
+ *                       eye->display (ZDP) distance: near = ez - near_offset.
+ * @param far_offset     Recede clip as an absolute offset: far = ez + far_offset.
+ *                       far_offset = 0 => far at the ZDP (foreground only).
+ *                       Offsets are absolute (vH multiples), NOT fractions of ez.
+ * @param vulkan_flip_y  Single source of truth for the render-vs-pick frame.
+ *                       Pass 1 from the RENDER path: the eyes, nominal viewer,
+ *                       and display pose are Y-mirrored internally so the
+ *                       off-axis Kooima frustum matches the NDC view-row flip
+ *                       that GsRenderer::updateUniforms applies for Vulkan's
+ *                       Y-down clip space. Pass 0 to stay in the clean +Y-up
+ *                       world frame (used for picking). Callers ALWAYS pass
+ *                       clean +Y-up world-space inputs and never negate Y
+ *                       themselves — this flag owns the entire mirror.
  * @param out_views      Output array of N views
  */
 void
@@ -80,9 +95,53 @@ display3d_compute_views(const XrVector3f *raw_eyes,
                                const Display3DScreen *screen,
                                const Display3DTunables *tunables,
                                const XrPosef *display_pose,
-                               float near_z,
-                               float far_z,
+                               float near_offset,
+                               float far_offset,
+                               int vulkan_flip_y,
                                Display3DView *out_views);
+
+/*!
+ * Compute a single cyclopean (center-eye) view from N raw eyes — the average
+ * eye position run through the same IPD/parallax/Kooima pipeline as
+ * display3d_compute_views. This is the canonical view for CPU picking: it
+ * shares the exact eye-factor math (no hand-rolled inverse of
+ * eye_display = processed * es), so the pick ray can never drift from the
+ * render rig. Pass vulkan_flip_y = 0 for a clean world-frame ray.
+ *
+ * @param raw_eyes       Array of N raw eye positions in DISPLAY space
+ * @param count          Number of views (must be >= 1)
+ * @param nominal_viewer Nominal viewer in DISPLAY space (or NULL for {0,0,0.5})
+ * @param screen         Physical screen dimensions
+ * @param tunables       View factors (or NULL for defaults)
+ * @param display_pose   Display pose in world space (or NULL for identity)
+ * @param near_offset    See display3d_compute_views.
+ * @param far_offset     See display3d_compute_views.
+ * @param vulkan_flip_y  See display3d_compute_views (pass 0 for picking).
+ * @param out_view       Output center view
+ */
+void
+display3d_compute_center_view(const XrVector3f *raw_eyes,
+                              uint32_t count,
+                              const XrVector3f *nominal_viewer,
+                              const Display3DScreen *screen,
+                              const Display3DTunables *tunables,
+                              const XrPosef *display_pose,
+                              float near_offset,
+                              float far_offset,
+                              int vulkan_flip_y,
+                              Display3DView *out_view);
+
+/*!
+ * Self-test of the view/unproject math (the render-vs-pick drift guard).
+ * Builds a synthetic rig and asserts, for the picking (clean) frame:
+ *   (a) round-trip: unproject(project(P)) yields a ray through P;
+ *   (b) orientation: +NDC.y maps to higher world Y, +NDC.x to higher world X.
+ * Returns the number of failed checks (0 = all pass). On failure it writes a
+ * diagnostic to stderr. Call once at startup; a non-zero return means the
+ * projection/unproject/orientation conventions have drifted.
+ */
+int
+display3d_selftest(void);
 
 /*!
  * Compute Kooima FOV angles only (no matrices). Useful for runtime-side
@@ -164,8 +223,10 @@ display3d_apply_eye_factors_n(const XrVector3f *raw_eyes,
  * @param screen         Physical screen dimensions
  * @param tunables       View factors (perspective_factor, virtual_display_height)
  * @param display_pose   Display pose in world space (or NULL for identity)
- * @param near_z         Near clip plane distance
- * @param far_z          Far clip plane distance
+ * @param near_offset    Pop-out clip as an absolute offset (vH/kooima-scaled
+ *                       units): near = ez - near_offset.
+ * @param far_offset     Recede clip as an absolute offset: far = ez + far_offset;
+ *                       0 => far at the ZDP (foreground only).
  * @param out            Output view for this eye
  */
 void
@@ -173,8 +234,8 @@ display3d_compute_view(const XrVector3f *processed_eye,
                        const Display3DScreen *screen,
                        const Display3DTunables *tunables,
                        const XrPosef *display_pose,
-                       float near_z,
-                       float far_z,
+                       float near_offset,
+                       float far_offset,
                        Display3DView *out);
 
 /*!

--- a/test_apps/common/projection_depth.h
+++ b/test_apps/common/projection_depth.h
@@ -1,0 +1,32 @@
+// Copyright 2025-2026, Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  GL->[0,1] clip-depth conversion for display3d projections.
+ *
+ * display3d_compute_projection() emits an OpenGL-convention projection matrix
+ * (clip-space z in [-1,1]). D3D11/D3D12/Vulkan/Metal rasterizers clip at [0,1],
+ * so the depth row must be remapped (z' = 0.5*z + 0.5*w) before the matrix is
+ * handed to those APIs — otherwise everything nearer than the mid-range
+ * crossover is wrongly near-clipped. This is harmless with a tiny near plane
+ * (old test apps passed 0.01) but is exposed once the ZDP-anchored near
+ * (near = ez - vH) sits close to the content (#396 W1).
+ *
+ * Apply ONLY to the 3D display3d output (per-view projection_matrix), never to
+ * runtime/mono projections (xr.projMatrices), which already carry the correct
+ * convention. The Metal test apps have a local equivalent
+ * (convert_projection_gl_to_metal) for the same reason.
+ *
+ * In-place on a column-major float[16] (the layout display3d emits).
+ */
+
+#pragma once
+
+static inline void
+convert_projection_gl_to_zero_to_one(float m[16])
+{
+	m[2]  = 0.5f * m[2]  + 0.5f * m[3];
+	m[6]  = 0.5f * m[6]  + 0.5f * m[7];
+	m[10] = 0.5f * m[10] + 0.5f * m[11];
+	m[14] = 0.5f * m[14] + 0.5f * m[15];
+}

--- a/test_apps/cube_handle_d3d11_win/main.cpp
+++ b/test_apps/cube_handle_d3d11_win/main.cpp
@@ -21,6 +21,7 @@
 #include "hud_renderer.h"
 #include "xr_session.h"
 #include "display3d_view.h"
+#include "projection_depth.h"
 #include "camera3d_view.h"
 #include "atlas_capture.h"
 
@@ -532,6 +533,11 @@ static void RenderOneFrame(RenderState& rs) {
                                 rawEyes.data(), eyeCount, &nominalViewer,
                                 &screen, &tunables, &cameraPose,
                                 tunables.virtual_display_height, 1000.0f * tunables.virtual_display_height, /*vulkan_flip_y=*/0, stereoViews.data());
+                            // display3d emits a GL ([-1,1] clip-z) projection; D3D clips [0,1].
+                            // Remap depth on the 3D per-view projections (not the mono/legacy
+                            // xr.projMatrices path). [#396 W1]
+                            for (uint32_t _v = 0; _v < eyeCount; _v++)
+                                convert_projection_gl_to_zero_to_one(stereoViews[_v].projection_matrix);
                         }
                     }
 

--- a/test_apps/cube_handle_d3d11_win/main.cpp
+++ b/test_apps/cube_handle_d3d11_win/main.cpp
@@ -531,7 +531,7 @@ static void RenderOneFrame(RenderState& rs) {
                             display3d_compute_views(
                                 rawEyes.data(), eyeCount, &nominalViewer,
                                 &screen, &tunables, &cameraPose,
-                                0.01f, 100.0f, stereoViews.data());
+                                tunables.virtual_display_height, 1000.0f * tunables.virtual_display_height, /*vulkan_flip_y=*/0, stereoViews.data());
                         }
                     }
 

--- a/test_apps/cube_handle_d3d12_win/main.cpp
+++ b/test_apps/cube_handle_d3d12_win/main.cpp
@@ -19,6 +19,7 @@
 #include "hud_renderer.h"
 #include "text_overlay.h"
 #include "display3d_view.h"
+#include "projection_depth.h"
 #include "atlas_capture.h"
 
 #include <atomic>
@@ -437,6 +438,11 @@ static void RenderThreadFunc(
                                 rawEyes.data(), eyeCount, &nominalViewer,
                                 &screen, &tunables, &displayPose,
                                 tunables.virtual_display_height, 1000.0f * tunables.virtual_display_height, /*vulkan_flip_y=*/0, stereoViews.data());
+                            // display3d emits a GL ([-1,1] clip-z) projection; D3D clips [0,1].
+                            // Remap depth on the 3D per-view projections (not the mono/legacy
+                            // xr.projMatrices path). [#396 W1]
+                            for (uint32_t _v = 0; _v < eyeCount; _v++)
+                                convert_projection_gl_to_zero_to_one(stereoViews[_v].projection_matrix);
                         }
 
                         rendered = true;

--- a/test_apps/cube_handle_d3d12_win/main.cpp
+++ b/test_apps/cube_handle_d3d12_win/main.cpp
@@ -436,7 +436,7 @@ static void RenderThreadFunc(
                             display3d_compute_views(
                                 rawEyes.data(), eyeCount, &nominalViewer,
                                 &screen, &tunables, &displayPose,
-                                0.01f, 100.0f, stereoViews.data());
+                                tunables.virtual_display_height, 1000.0f * tunables.virtual_display_height, /*vulkan_flip_y=*/0, stereoViews.data());
                         }
 
                         rendered = true;

--- a/test_apps/cube_handle_gl_macos/main.mm
+++ b/test_apps/cube_handle_gl_macos/main.mm
@@ -1809,7 +1809,7 @@ int main(int argc, char **argv)
                     display3d_compute_views(
                         rawEyePos.data(), eyeCount, &nominalViewer,
                         &screen, &tunables, &cameraPose,
-                        0.01f, 100.0f, d3dViews.data());
+                        tunables.virtual_display_height, 1000.0f * tunables.virtual_display_height, /*vulkan_flip_y=*/0, d3dViews.data());
                 }
 
                 // display3d/camera3d already produce OpenGL-convention z[-1,1] — no conversion needed

--- a/test_apps/cube_handle_gl_win/main.cpp
+++ b/test_apps/cube_handle_gl_win/main.cpp
@@ -516,7 +516,7 @@ static void RenderThreadFunc(
                             display3d_compute_views(
                                 rawEyes.data(), eyeCount, &nominalViewer,
                                 &screen, &tunables, &displayPose,
-                                0.01f, 100.0f, stereoViews.data());
+                                tunables.virtual_display_height, 1000.0f * tunables.virtual_display_height, /*vulkan_flip_y=*/0, stereoViews.data());
                         }
 
                         rendered = true;

--- a/test_apps/cube_handle_metal_macos/main.mm
+++ b/test_apps/cube_handle_metal_macos/main.mm
@@ -1820,7 +1820,7 @@ int main(int argc, char **argv)
                     display3d_compute_views(
                         rawEyePos.data(), eyeCount, &nominalViewer,
                         &screen, &tunables, &cameraPose,
-                        0.01f, 100.0f, d3dViews.data());
+                        tunables.virtual_display_height, 1000.0f * tunables.virtual_display_height, /*vulkan_flip_y=*/0, d3dViews.data());
                 }
 
                 // Convert projection matrices from OpenGL z[-1,1] to Metal z[0,1]

--- a/test_apps/cube_handle_vk_macos/main.mm
+++ b/test_apps/cube_handle_vk_macos/main.mm
@@ -3107,7 +3107,7 @@ int main() {
                                 display3d_compute_views(
                                     rawEyePos.data(), eyeCount, &nominalViewer,
                                     &screen, &tunables, &cameraPose,
-                                    0.01f, 100.0f, d3dViews.data());
+                                    tunables.virtual_display_height, 1000.0f * tunables.virtual_display_height, /*vulkan_flip_y=*/0, d3dViews.data());
                             }
                         }
 

--- a/test_apps/cube_handle_vk_macos/main.mm
+++ b/test_apps/cube_handle_vk_macos/main.mm
@@ -43,6 +43,7 @@
 
 #include "view_params.h"
 #include "display3d_view.h"
+#include "projection_depth.h"
 #include "camera3d_view.h"
 #include "atlas_capture.h"
 #include "xr_window_space_hud.h"
@@ -3108,6 +3109,11 @@ int main() {
                                     rawEyePos.data(), eyeCount, &nominalViewer,
                                     &screen, &tunables, &cameraPose,
                                     tunables.virtual_display_height, 1000.0f * tunables.virtual_display_height, /*vulkan_flip_y=*/0, d3dViews.data());
+                                // display3d emits a GL ([-1,1] clip-z) projection; Vulkan clips [0,1].
+                                // Remap depth on the 3D per-view projections (not the mono/legacy
+                                // xr.projMatrices path). [#396 W1]
+                                for (uint32_t _v = 0; _v < eyeCount; _v++)
+                                    convert_projection_gl_to_zero_to_one(d3dViews[_v].projection_matrix);
                             }
                         }
 

--- a/test_apps/cube_handle_vk_win/main.cpp
+++ b/test_apps/cube_handle_vk_win/main.cpp
@@ -17,6 +17,7 @@
 #include "xr_session.h"
 #include "vk_renderer.h"
 #include "display3d_view.h"
+#include "projection_depth.h"
 #include "camera3d_view.h"
 
 #include "hud_renderer.h"
@@ -476,6 +477,11 @@ static void RenderThreadFunc(
                                     rawEyes.data(), eyeCount, &nominalViewer,
                                     &screen, &tunables, &cameraPose,
                                     tunables.virtual_display_height, 1000.0f * tunables.virtual_display_height, /*vulkan_flip_y=*/0, stereoViews.data());
+                                // display3d emits a GL ([-1,1] clip-z) projection; Vulkan clips [0,1].
+                                // Remap depth on the 3D per-view projections (not the mono/legacy
+                                // xr.projMatrices path). [#396 W1]
+                                for (uint32_t _v = 0; _v < eyeCount; _v++)
+                                    convert_projection_gl_to_zero_to_one(stereoViews[_v].projection_matrix);
                             }
                         }
 

--- a/test_apps/cube_handle_vk_win/main.cpp
+++ b/test_apps/cube_handle_vk_win/main.cpp
@@ -475,7 +475,7 @@ static void RenderThreadFunc(
                                 display3d_compute_views(
                                     rawEyes.data(), eyeCount, &nominalViewer,
                                     &screen, &tunables, &cameraPose,
-                                    0.01f, 100.0f, stereoViews.data());
+                                    tunables.virtual_display_height, 1000.0f * tunables.virtual_display_height, /*vulkan_flip_y=*/0, stereoViews.data());
                             }
                         }
 

--- a/test_apps/cube_texture_d3d11_win/main.cpp
+++ b/test_apps/cube_texture_d3d11_win/main.cpp
@@ -759,7 +759,7 @@ static void RenderOneFrame(RenderState& rs) {
                             display3d_compute_views(
                                 rawEyes.data(), eyeCount, &nominalViewer,
                                 &screen, &tunables, &cameraPose,
-                                0.01f, 100.0f, stereoViews.data());
+                                tunables.virtual_display_height, 1000.0f * tunables.virtual_display_height, /*vulkan_flip_y=*/0, stereoViews.data());
                         }
                     }
 

--- a/test_apps/cube_texture_d3d11_win/main.cpp
+++ b/test_apps/cube_texture_d3d11_win/main.cpp
@@ -30,6 +30,7 @@
 #include "hud_renderer.h"
 #include "xr_session.h"
 #include "display3d_view.h"
+#include "projection_depth.h"
 #include "camera3d_view.h"
 
 #include <chrono>
@@ -760,6 +761,11 @@ static void RenderOneFrame(RenderState& rs) {
                                 rawEyes.data(), eyeCount, &nominalViewer,
                                 &screen, &tunables, &cameraPose,
                                 tunables.virtual_display_height, 1000.0f * tunables.virtual_display_height, /*vulkan_flip_y=*/0, stereoViews.data());
+                            // display3d emits a GL ([-1,1] clip-z) projection; D3D clips [0,1].
+                            // Remap depth on the 3D per-view projections (not the mono/legacy
+                            // xr.projMatrices path). [#396 W1]
+                            for (uint32_t _v = 0; _v < eyeCount; _v++)
+                                convert_projection_gl_to_zero_to_one(stereoViews[_v].projection_matrix);
                         }
                     }
 

--- a/test_apps/cube_texture_d3d12_win/main.cpp
+++ b/test_apps/cube_texture_d3d12_win/main.cpp
@@ -31,6 +31,7 @@
 #include "text_overlay.h"
 #include "xr_session.h"
 #include "display3d_view.h"
+#include "projection_depth.h"
 #include "camera3d_view.h"
 
 #include <chrono>
@@ -1018,6 +1019,11 @@ static void RenderOneFrame(RenderState& rs) {
                                 rawEyes.data(), eyeCount, &nominalViewer,
                                 &screen, &tunables, &cameraPose,
                                 tunables.virtual_display_height, 1000.0f * tunables.virtual_display_height, /*vulkan_flip_y=*/0, stereoViews.data());
+                            // display3d emits a GL ([-1,1] clip-z) projection; D3D clips [0,1].
+                            // Remap depth on the 3D per-view projections (not the mono/legacy
+                            // xr.projMatrices path). [#396 W1]
+                            for (uint32_t _v = 0; _v < eyeCount; _v++)
+                                convert_projection_gl_to_zero_to_one(stereoViews[_v].projection_matrix);
                         }
                     }
 

--- a/test_apps/cube_texture_d3d12_win/main.cpp
+++ b/test_apps/cube_texture_d3d12_win/main.cpp
@@ -1017,7 +1017,7 @@ static void RenderOneFrame(RenderState& rs) {
                             display3d_compute_views(
                                 rawEyes.data(), eyeCount, &nominalViewer,
                                 &screen, &tunables, &cameraPose,
-                                0.01f, 100.0f, stereoViews.data());
+                                tunables.virtual_display_height, 1000.0f * tunables.virtual_display_height, /*vulkan_flip_y=*/0, stereoViews.data());
                         }
                     }
 

--- a/test_apps/cube_texture_metal_macos/main.mm
+++ b/test_apps/cube_texture_metal_macos/main.mm
@@ -2081,7 +2081,7 @@ int main(int argc, char **argv)
                     display3d_compute_views(
                         rawEyePos.data(), eyeCount, &nominalViewer,
                         &screen, &tunables, &cameraPose,
-                        0.01f, 100.0f, d3dViews.data());
+                        tunables.virtual_display_height, 1000.0f * tunables.virtual_display_height, /*vulkan_flip_y=*/0, d3dViews.data());
                 }
 
                 for (int i = 0; i < eyeCount; i++) {


### PR DESCRIPTION
## What

Epic #396 **W1** (math-core reconciliation), first concrete unit: fold the most-advanced `display3d_view` — the gauss-demo **superset** (landed in `displayxr-demo-gaussiansplat` via its PR #26) — into this repo's `test_apps/common` copy so the two stop drifting.

## Why

`display3d_view.{c,h}` is vendored-by-copy in 6+ places (runtime test apps, both demos, kooima-projection, Unreal, Unity). The gauss copy is already the superset; this repo's `test_apps/common` was still on the **old** `near_z/far_z` API. This brings them into sync as the precursor to extracting `displayxr::math` (W2).

## Changes

**Library (`test_apps/common/display3d_view.{c,h}`)** — adopted the gauss superset verbatim (content-identical, CRLF-normalized). Over the old version it adds:
- `near_offset`/`far_offset` clip params (ZDP-anchored: `near = ez - near_offset`, `far = ez + far_offset`) replacing absolute `near_z`/`far_z` on `display3d_compute_views`;
- resolved `near_z`/`far_z` **output** fields on `Display3DView`;
- `vulkan_flip_y` — single source of truth for the render-vs-pick frame;
- `display3d_compute_center_view()` — cyclopean view for CPU picking;
- `display3d_selftest()` — project/unproject + NDC-orientation drift guard;
- `far > near + 1e-4` frustum clamp.

`camera3d_view.{c,h}` and `leia_math.h` were already byte-identical to the gauss superset → **no change**. `display3d_compute_projection` (the lower-level matrix builder) is unchanged, so `xr_session_common.cpp` is untouched.

**Call sites (10)** — all `cube_handle`/`cube_texture` apps (Win d3d11/d3d12/gl/vk + macOS gl/metal/vk) migrate from fixed hardware-clip `0.01/100` to the ZDP-anchored model:
- `near_offset = vH`, `far_offset = 1000*vH` (opaque — no effective far cull);
- `vulkan_flip_y = 0` — the new lib's clean +Y-up world frame **==** the old no-flip behavior, so each cube renderer continues to own its NDC Y convention (behavior-preserving on the frame; the clip model is the only intended behavioral change).

## Verification

- **CI** compiles Windows + macOS (this PR is the cross-platform compile gate — the 4 macOS call sites can only be built there).
- **HELD for merge** pending a Leia-display eyeball: the clip model changes from hardware-clip to ZDP-anchored, so the cube should be visually re-checked on hardware (disparity/clip correct, cube not culled) before merging. Not auto-merging.

## Follow-ups (not in this PR)
- Wire `display3d_selftest()` into a test-app startup as a standing drift guard.
- W2: stand up `displayxr-common` (`kooima-projection` rename) and seed `displayxr::math` from this reconciled core; then re-pin every consumer (incl. modelviewer + engines) by tag.

Part of #396.
