### PR TITLE
android(test app): use ALooper_pollOnce, not deprecated pollAll

### DIFF
--- a/test_apps/cube_handle_vk_android/src/main/cpp/main.cpp
+++ b/test_apps/cube_handle_vk_android/src/main/cpp/main.cpp
@@ -1384,10 +1384,15 @@ android_main(struct android_app *app)
 		// session isn't actively rendering yet — once we hit
 		// SYNCHRONIZED+, we want to spin the frame loop and only
 		// non-blocking poll Android.
+		//
+		// ALooper_pollOnce (not the NDK r26-deprecated ALooper_pollAll)
+		// dispatches one ready source per call; the enclosing while loop
+		// drains the rest, matching android_native_app_glue's own
+		// migration off pollAll.
 		const int poll_timeout_ms = g_session_running ? 0 : 250;
 		int events;
 		struct android_poll_source *source;
-		while (ALooper_pollAll(poll_timeout_ms, nullptr, &events, (void **)&source) >= 0) {
+		while (ALooper_pollOnce(poll_timeout_ms, nullptr, &events, (void **)&source) >= 0) {
 			if (source != nullptr) {
 				source->process(app, source);
 			}


### PR DESCRIPTION
Static cleanup from the Android POC pre-hardware pass (deferred item #4). **Stacked on #416.**

`ALooper_pollAll` is deprecated as of **NDK r26** — its internal callback dispatch can silently consume the event the caller was waiting on and return `ALOOPER_POLL_CALLBACK` unexpectedly. `ALooper_pollOnce` has an identical signature; the existing `while(... >= 0)` loop in `android_main` already drains every ready source per iteration, so this is a drop-in that mirrors `android_native_app_glue`'s own migration off `pollAll`.

**Validation:** `:test_apps:cube_handle_vk_android:assembleDebug` builds clean (arm64-v8a NDK 26.3). The poll loop runs pre-XR-init so it executes on the emulator smoke-test path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)