### PR TITLE
android: bump sharedTargetSdk 31 -> 34

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ ext {
     ndk_version = '26.3.11579264'
     // If you update this, must also update .gitlab-ci/config.yml
     sharedCompileSdk = 35
-    sharedTargetSdk = 31
+    sharedTargetSdk = 34
     sharedMinSdk = 29
 
     // If you are building on Windows, you will need to explicitly set eigenCMakeDir in your


### PR DESCRIPTION
Static cleanup from the Android POC pre-hardware pass (deferred item #4). **Stacked on the pollOnce PR.**

Lifts the shared `targetSdkVersion` (consumed by every Android module: runtime, ipc, android_common, and the `cube_handle_vk_android` test app) from API 31 to 34. `compileSdk` was already 35.

targetSdk 31 was sideload-only; Play submission requires 34. The POC is a single full-screen `NativeActivity` per app — none of the API 33/34 behaviour gates (foreground-service types, implicit-intent restrictions, runtime-registered receiver export flags) apply, so this is config-only.

**Validation:** merged manifest confirmed `targetSdkVersion="34"`; `:test_apps:cube_handle_vk_android:assembleDebug` builds + packages clean. Recommend a full `scripts/android-smoketest.sh` emulator pass (install + launch + sentinel) on the integration branch before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)