### PR TITLE
chore(versions): register mediaplayer_demo (displayxr-demo-mediaplayer)

### DIFF
--- a/.claude/skills/dxr-release/SKILL.md
+++ b/.claude/skills/dxr-release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dxr-release
-description: Tag-and-publish a release for any DisplayXR sibling component (shell, leia-plugin, mcp, gauss & modelviewer demos) FROM the displayxr-runtime hub. Takes an explicit component + version — clones the target repo to a temp dir, tags HEAD, watches the repo's CI, watches the dispatched versions-bump.yml on displayxr-runtime, reports the bump + installer-mirror outcome. NOT for displayxr-runtime itself (use /release) and NOT for the bundle (use /installer-release).
+description: Tag-and-publish a release for any DisplayXR sibling component (shell, leia-plugin, mcp, gauss & modelviewer & mediaplayer demos) FROM the displayxr-runtime hub. Takes an explicit component + version — clones the target repo to a temp dir, tags HEAD, watches the repo's CI, watches the dispatched versions-bump.yml on displayxr-runtime, reports the bump + installer-mirror outcome. NOT for displayxr-runtime itself (use /release) and NOT for the bundle (use /installer-release).
 ---
 
 # dxr-release — component release driven from the runtime hub
@@ -28,7 +28,7 @@ Spec: [`docs/specs/runtime/versions-json-autobump.md`](../../docs/specs/runtime/
 ```
 /dxr-release <component> <version-spec>
 
-  <component>     shell | leia-plugin (leia) | mcp | gauss (demo-gaussiansplat) | modelviewer (demo-modelviewer)
+  <component>     shell | leia-plugin (leia) | mcp | gauss (demo-gaussiansplat) | modelviewer (demo-modelviewer) | mediaplayer (demo-mediaplayer)
   <version-spec>  vX.Y.Z  |  patch  |  minor  |  major
 ```
 
@@ -52,6 +52,7 @@ from cwd — that's the old cwd-detecting behavior this skill replaced.
 | `mcp` | `DisplayXR/displayxr-mcp` | `mcp_tools` | `build.yml` | same repo |
 | `gauss` / `demo-gaussiansplat` | `DisplayXR/displayxr-demo-gaussiansplat` | `gauss_demo` | `build-windows.yml` | same repo |
 | `modelviewer` / `demo-modelviewer` | `DisplayXR/displayxr-demo-modelviewer` | `modelviewer_demo` | `build-windows.yml` | same repo |
+| `mediaplayer` / `demo-mediaplayer` | `DisplayXR/displayxr-demo-mediaplayer` | `mediaplayer_demo` | `build-windows.yml` | same repo |
 
 `runtime` → tell the user to use `/release` (in-repo). `installer` →
 tell them to use `/installer-release`.
@@ -84,9 +85,10 @@ case "$COMPONENT" in
   mcp)                           REPO=DisplayXR/displayxr-mcp;                FIELD=mcp_tools;   WORKFLOW=build.yml;                   REL_REPO=DisplayXR/displayxr-mcp ;;
   gauss|demo-gaussiansplat)      REPO=DisplayXR/displayxr-demo-gaussiansplat; FIELD=gauss_demo; WORKFLOW=build-windows.yml;           REL_REPO=DisplayXR/displayxr-demo-gaussiansplat ;;
   modelviewer|demo-modelviewer)  REPO=DisplayXR/displayxr-demo-modelviewer;   FIELD=modelviewer_demo; WORKFLOW=build-windows.yml;      REL_REPO=DisplayXR/displayxr-demo-modelviewer ;;
+  mediaplayer|demo-mediaplayer)  REPO=DisplayXR/displayxr-demo-mediaplayer;   FIELD=mediaplayer_demo; WORKFLOW=build-windows.yml;      REL_REPO=DisplayXR/displayxr-demo-mediaplayer ;;
   runtime)                       echo "Use /release (in-repo) for the runtime."; exit 1 ;;
   installer)                     echo "Use /installer-release for the bundle.";  exit 1 ;;
-  *)                             echo "Unknown component '$COMPONENT'. One of: shell, leia-plugin, mcp, gauss."; exit 1 ;;
+  *)                             echo "Unknown component '$COMPONENT'. One of: shell, leia-plugin, mcp, gauss, modelviewer, mediaplayer."; exit 1 ;;
 esac
 echo "repo=$REPO field=$FIELD workflow=$WORKFLOW"
 ```

--- a/scripts/lib/components.sh
+++ b/scripts/lib/components.sh
@@ -82,6 +82,18 @@ COMPONENT_EXE_WINDOWS_modelviewer_demo="DisplayXRModelViewerSetup-*.exe"
 COMPONENT_INSTALL_MARKER_MACOS_modelviewer_demo=""
 COMPONENT_INSTALL_MARKER_WINDOWS_modelviewer_demo="HKLM\\Software\\DisplayXR\\Demos\\ModelViewer"
 
+# --- mediaplayer_demo ---
+# Stereo media player demo (displayxr-demo-mediaplayer). Plays SBS image/video
+# on the 3D display via the OpenXR extension wire protocol — no vendor SR SDK.
+# Both installers (macOS .pkg + Windows .exe) are built + attached by CI on a
+# v* tag. First release v1.0.0. Note: the macOS install marker has a space in
+# the path — consumers must quote when testing existence.
+COMPONENT_REPO_mediaplayer_demo="DisplayXR/displayxr-demo-mediaplayer"
+COMPONENT_PKG_MACOS_mediaplayer_demo="DisplayXRMediaPlayer-*.pkg"
+COMPONENT_EXE_WINDOWS_mediaplayer_demo="DisplayXRMediaPlayerSetup-*.exe"
+COMPONENT_INSTALL_MARKER_MACOS_mediaplayer_demo="/Applications/Stereo Media Player.app"
+COMPONENT_INSTALL_MARKER_WINDOWS_mediaplayer_demo="HKLM\\Software\\DisplayXR\\Demos\\MediaPlayer"
+
 # Helper: look up a per-component field for the current platform.
 #   $1 = component name (runtime, shell, leia_plugin, mcp_tools)
 #   $2 = field (REPO, PKG_MACOS, EXE_WINDOWS, INSTALL_MARKER_MACOS)

--- a/scripts/setup-displayxr.bat
+++ b/scripts/setup-displayxr.bat
@@ -54,6 +54,10 @@ set "COMPONENT_REPO_modelviewer_demo=DisplayXR/displayxr-demo-modelviewer"
 set "COMPONENT_EXE_modelviewer_demo=DisplayXRModelViewerSetup-*.exe"
 set "COMPONENT_MARKER_modelviewer_demo=HKLM\Software\DisplayXR\Demos\ModelViewer"
 
+set "COMPONENT_REPO_mediaplayer_demo=DisplayXR/displayxr-demo-mediaplayer"
+set "COMPONENT_EXE_mediaplayer_demo=DisplayXRMediaPlayerSetup-*.exe"
+set "COMPONENT_MARKER_mediaplayer_demo=HKLM\Software\DisplayXR\Demos\MediaPlayer"
+
 REM --- Default flag state ---
 set "WITH_MCP=0"
 set "WITH_DEMOS=0"

--- a/versions.json
+++ b/versions.json
@@ -5,5 +5,6 @@
   "leia_plugin": "v1.2.1",
   "mcp_tools":   "v0.3.4",
   "gauss_demo":  "v1.6.0",
-  "modelviewer_demo": "v0.7.0"
+  "modelviewer_demo": "v0.7.0",
+  "mediaplayer_demo": "v0.0.0"
 }


### PR DESCRIPTION
## What

Registers the **stereo media player demo** (`DisplayXR/displayxr-demo-mediaplayer`) in the hub so its imminent **v1.0.0** release can auto-bump and join the dev-orchestrator / meta-installer matrix.

The demo (M0–M6 complete; one Vulkan codebase across Windows/Linux/macOS, FFmpeg decode, subtle-3D ImGui UI) couples to the runtime via the **OpenXR extension wire protocol only** — no vendor SR SDK. This PR is pure distribution metadata.

## Why now (the blocker)

The demo's `build-windows.yml` dispatches a `versions-bump` event on its `v*` tag with `field: "mediaplayer_demo"`. `versions-bump.yml`'s apply step **hard-fails on an unknown field** (`if leaf not in cur: sys.exit("versions.json has no field")`). So the field must pre-exist here **before** the demo cuts `v1.0.0`, or the bump errors out and the demo never joins the bundle.

## Changes

- **`versions.json`** — add `"mediaplayer_demo": "v0.0.0"` (placeholder; the demo's tag bump rewrites it to `v1.0.0`).
- **`scripts/lib/components.sh`** — `mediaplayer_demo` asset table (macOS `DisplayXRMediaPlayer-*.pkg`, Windows `DisplayXRMediaPlayerSetup-*.exe`; markers `/Applications/Stereo Media Player.app`, `HKLM\Software\DisplayXR\Demos\MediaPlayer`), mirroring `gauss_demo`.
- **`scripts/setup-displayxr.bat`** — matching Windows per-component block.
- **`.claude/skills/dxr-release/SKILL.md`** — add the `mediaplayer` / `demo-mediaplayer` row to the component→config map + `case` resolver (so `/dxr-release mediaplayer <ver>` works).

## Verification

- `python3 -c 'json.load(open("versions.json"))'` → valid; keys now include `mediaplayer_demo`.
- Sourced `components.sh`; `component_field mediaplayer_demo {REPO,PKG_MACOS,EXE_WINDOWS,INSTALL_MARKER_*}` all resolve correctly.
- Markers cross-checked against the demo's NSIS (`HKLM\Software\DisplayXR\Demos\MediaPlayer`) and macOS bundle name (`Stereo Media Player.app`).

## Follow-up (separate, in displayxr-installer)

Adding the demo's `.pkg` to the **bundle composition** (`build-bundle.sh` `extract_*` / `process_component`, like `gauss_demo`) is a separate displayxr-installer change. The `versions.json` mirror into displayxr-installer on the next bump already pins the demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)