### PR TITLE
fix(orchestrator): modelviewer ships a macOS .pkg — stop skipping it on macOS

### DIFF
--- a/scripts/lib/components.sh
+++ b/scripts/lib/components.sh
@@ -91,13 +91,13 @@ COMPONENT_INSTALL_MARKER_WINDOWS_gauss_demo="HKLM\\Software\\DisplayXR\\Demos\\G
 DEMO_COMPONENTS="gauss_demo modelviewer_demo mediaplayer_demo"
 
 # --- modelviewer_demo ---
-# glTF 2.0 PBR model viewer demo (displayxr-demo-modelviewer). Windows-only
-# today — the macOS app is not yet ported, so the macOS glob/marker are empty
-# → warn+skip on macOS. First release v0.1.0 (2026-06-01).
+# glTF 2.0 PBR model viewer demo (displayxr-demo-modelviewer). Dual-platform:
+# its build-macos.yml + Windows CI both attach installers on every v* tag
+# (macOS .pkg since v0.3.0; the macOS app installs to "3D Model Viewer.app").
 COMPONENT_REPO_modelviewer_demo="DisplayXR/displayxr-demo-modelviewer"
-COMPONENT_PKG_MACOS_modelviewer_demo=""
+COMPONENT_PKG_MACOS_modelviewer_demo="DisplayXRModelViewer-*.pkg"
 COMPONENT_EXE_WINDOWS_modelviewer_demo="DisplayXRModelViewerSetup-*.exe"
-COMPONENT_INSTALL_MARKER_MACOS_modelviewer_demo=""
+COMPONENT_INSTALL_MARKER_MACOS_modelviewer_demo="/Applications/3D Model Viewer.app"
 COMPONENT_INSTALL_MARKER_WINDOWS_modelviewer_demo="HKLM\\Software\\DisplayXR\\Demos\\ModelViewer"
 
 # --- mediaplayer_demo ---


### PR DESCRIPTION
Follow-up to #339. While prepping a real `--with-demos` run on macOS, found that `components.sh` marked `modelviewer_demo` as macOS-unavailable (empty `COMPONENT_PKG_MACOS` / `INSTALL_MARKER_MACOS`) — a stale leftover from when modelviewer was Windows-only.

In reality the demo's `build-macos.yml` has attached `DisplayXRModelViewer-*.pkg` to **every release since v0.3.0** (verified v0.3.0→v0.7.0; the pkg installs `/Applications/3D Model Viewer.app`). So `--with-demos` was wrongly warn-skipping an installable demo on macOS.

Populates the macOS glob + install marker from the real v0.7.0 artifact.

**Verified** via `./scripts/setup-displayxr.sh --with-demos --dry-run` (macOS): all three demos now route to install — `gauss_demo @ v1.6.0`, `modelviewer_demo @ v0.7.0` (was skip), `mediaplayer_demo @ v1.0.0`. `mediaplayer_demo`'s entry was already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)