### PR TITLE
fix(orchestrator): retry transient GitHub API failures; drop fragile pre-check

### DIFF
--- a/scripts/setup-displayxr.sh
+++ b/scripts/setup-displayxr.sh
@@ -132,6 +132,28 @@ for p in k: v=v[p]
 print(v)" "$VERSIONS_JSON" "$1"
 }
 
+# Retry a gh invocation a few times with exponential backoff to ride out
+# transient GitHub API failures — secondary rate limits and broken pipes
+# that crop up mid-run when the install loop fires a burst of authenticated
+# calls + large downloads. Without this, one hiccup aborts a component even
+# though the same command succeeds when run by hand a moment later. stdout is
+# discarded (callers that need files use --dir side effects); the final
+# attempt's stderr is surfaced so a genuine failure shows its real cause
+# instead of a misleading "bump the pin".
+gh_retry() {
+    local attempt=1 max=4 delay=2 err_out rc
+    while :; do
+        err_out="$("$@" 2>&1 1>/dev/null)"; rc=$?
+        [ "$rc" -eq 0 ] && return 0
+        if [ "$attempt" -ge "$max" ]; then
+            [ -n "$err_out" ] && printf '%s\n' "$err_out" >&2
+            return "$rc"
+        fi
+        warn "  gh call failed (attempt $attempt/$max) — retrying in ${delay}s…"
+        sleep "$delay"; attempt=$((attempt + 1)); delay=$((delay * 2))
+    done
+}
+
 # --- uninstall path ---
 
 if [ "$ACTION" = "uninstall" ]; then
@@ -205,13 +227,12 @@ install_component() {
         return 0
     fi
 
-    # Validate the pin exists in the source repo's releases before downloading.
-    if ! gh release view "$tag" --repo "$repo" >/dev/null 2>&1; then
-        err "versions.json pins $name to '$tag', but"
-        err "  gh release view $tag --repo $repo"
-        err "failed. Bump the pin in versions.json, or verify the repo is accessible."
-        return 1
-    fi
+    # No separate "does the release exist" pre-check: it was a redundant,
+    # non-resilient gh call (a single transient throttle aborted the whole
+    # component with a misleading "bump the pin"). The asset probe below
+    # already tolerates transient failure, and the retried download is the
+    # real gate — a genuinely missing tag/asset surfaces there with its
+    # actual gh error.
 
     # Confirm the macOS asset exists on this release — gh download will
     # fail with a noisy stack otherwise, and we want a clean warn-and-skip
@@ -233,12 +254,17 @@ install_component() {
 
     local subdir="$STAGING/$name"
     mkdir -p "$subdir"
-    gh release download "$tag" --repo "$repo" --pattern "$glob" --dir "$subdir"
+    if ! gh_retry gh release download "$tag" --repo "$repo" --pattern "$glob" --dir "$subdir" --clobber; then
+        err "$name: 'gh release download $tag --repo $repo' failed after retries (real error above)."
+        err "       A 403 / secondary-rate-limit is transient — re-run. A 404 means the"
+        err "       tag or asset is genuinely missing — bump the pin in versions.json."
+        return 1
+    fi
 
     local pkg
     pkg="$(find "$subdir" -maxdepth 1 -name "*.pkg" -type f | head -1)"
     if [ -z "$pkg" ]; then
-        err "$name: download succeeded but no .pkg landed in $subdir"
+        err "$name: download reported success but no .pkg landed in $subdir"
         return 1
     fi
 


### PR DESCRIPTION
## Symptom
A real macOS `./scripts/setup-displayxr.sh --with-demos` aborted `modelviewer_demo` **deterministically** (twice) with:
```
ERROR versions.json pins modelviewer_demo to 'v0.7.0', but
ERROR   gh release view v0.7.0 --repo DisplayXR/displayxr-demo-modelviewer
ERROR failed. Bump the pin in versions.json, or verify the repo is accessible.
```
…yet that exact `gh release view` returns exit 0 when run by hand, the release + `.pkg` plainly exist, and there's no `GH_TOKEN` env override. gauss installed fine; one run also showed a literal `write: broken pipe` on the mediaplayer API call.

## Root cause
The install loop fires a burst of authenticated `gh` calls + large downloads (runtime 60 MB, gauss 30 MB). GitHub throttles mid-burst (secondary rate limit / dropped connection), and the **one non-resilient call** — a redundant strict `gh release view` *pre-check* — hard-aborts the component and **masks the real error** behind a misleading "bump the pin." (The rest of `install_component` already tolerates transient failure by design — see the existing broken-pipe comment on the asset probe — this pre-check predated that.)

## Fix
- **`gh_retry()`** — 4 attempts, exponential backoff (2/4/8 s), around `gh` calls; surfaces the final attempt's **real stderr** so a genuine 404 is distinguishable from a transient 403/broken-pipe.
- **Removed the redundant strict `gh release view` pre-check** — the asset probe already tolerates transient failure, and the retried download is the real gate.
- **Retry `gh release download`** (`--clobber` for clean re-attempts); on final failure print the actual gh error + whether it's transient (re-run) vs 404 (bump the pin).

## Validation
- `bash -n` clean.
- `gh_retry` unit-tested: success suppresses stdout / returns 0; flaky-then-OK returns 0 after retries; always-fail returns the real rc and prints the real stderr (`HTTP 403: secondary rate limit`).
- `--with-demos --dry-run` downloads all four components (runtime + gauss + **modelviewer** + mediaplayer) and routes each to install.

Follow-up to #339 / #426 (the `components.sh` modelviewer macOS entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)