### PR TITLE
fix(client/gl): don't toggle flip_y on window-space layers (#429)

### DIFF
--- a/src/xrt/compositor/client/comp_gl_client.c
+++ b/src/xrt/compositor/client/comp_gl_client.c
@@ -399,10 +399,17 @@ client_gl_compositor_layer_window_space(struct xrt_compositor *xc,
 
 	xscfb = to_native_swapchain(xsc);
 
-	struct xrt_layer_data d = *data;
-	d.flip_y = !d.flip_y;
-
-	return xrt_comp_layer_window_space(xcn, xdev, xscfb, &d);
+	/*
+	 * No flip_y toggle here, unlike the other layer types: the
+	 * window-space contract is that HUD pixels are uploaded top-down
+	 * (D2D/CG row order, image top at texel row 0) regardless of client
+	 * API, so the shared texture already matches the D3D11/Vulkan
+	 * convention. The in-process GL compositor bakes that assumption
+	 * into its window-space shader (ignores flip_y), and the D3D11
+	 * service honors flip_y as a V-flip — toggling it here Y-flipped GL
+	 * clients' HUDs on the IPC/workspace path (#429).
+	 */
+	return xrt_comp_layer_window_space(xcn, xdev, xscfb, data);
 }
 
 static xrt_result_t


### PR DESCRIPTION
## Summary
Fixes #429 — an OpenGL client's window-space (HUD) layer rendered Y-flipped under the workspace/shell (IPC → D3D11 service) while standalone (in-process GL) was upright.

## Root cause
`client_gl_compositor_layer_window_space` blanket-toggled `flip_y` like every other layer type. That toggle is correct for GL-rendered content (bottom-up framebuffer rows, e.g. the projection layer — which is why projection is upright on both paths), but window-space HUD pixels are CPU-uploaded **top-down** (D2D/CG row order), so the shared texture already matches the D3D11 convention and needs no flip.

The mismatch was invisible in-process because the GL native compositor bakes the top-down contract into its window-space shader (`VS_WINDOW_SPACE` UV flip + NDC geometry flip) and ignores `flip_y` entirely. The D3D11 service honors `flip_y` as a V-range flip (`comp_d3d11_service.cpp` HUD compose), so the bogus `flip_y=true` flipped an already-top-down HUD.

## Fix
Pass window-space layer data through unchanged in the GL client (one site), with a comment documenting the orientation contract.

## Testing
- `cube_handle_gl_win` standalone (in-process GL native compositor): HUD upright ✅ (unchanged — `flip_y` is ignored there)
- `cube_handle_gl_win` under the shell (IPC → D3D11 service): HUD upright ✅ (was flipped before)
- Projection layer upright on both paths (its `flip_y` toggle is untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)