### PR TITLE
fix(#431): windowed D3D11 handle-app DP-crop + capture (TYPELESS, dims, metadata)

### DIFF
--- a/src/xrt/auxiliary/util/CMakeLists.txt
+++ b/src/xrt/auxiliary/util/CMakeLists.txt
@@ -23,6 +23,8 @@ add_library(
 	u_bitwise.h
 	u_builders.c
 	u_builders.h
+	u_capture_dims.c
+	u_capture_dims.h
 	u_debug.c
 	u_debug.h
 	u_deque.cpp

--- a/src/xrt/auxiliary/util/u_capture_dims.c
+++ b/src/xrt/auxiliary/util/u_capture_dims.c
@@ -1,0 +1,49 @@
+// Copyright 2026, DisplayXR
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  Process-global capture-dims provider registry (see u_capture_dims.h).
+ * @ingroup aux_util
+ */
+
+#include "util/u_capture_dims.h"
+
+#include <pthread.h>
+
+// A single installed provider — matches the in-process single-compositor model
+// the rest of the capture machinery (mcp_capture) already assumes. Guarded by a
+// statically-initialized mutex so register/clear/query never tear.
+static pthread_mutex_t g_lock = PTHREAD_MUTEX_INITIALIZER;
+static u_capture_dims_fn g_fn = NULL;
+static void *g_userdata = NULL;
+
+void
+u_capture_dims_set_provider(u_capture_dims_fn fn, void *userdata)
+{
+	pthread_mutex_lock(&g_lock);
+	if (fn == NULL && g_userdata != userdata) {
+		// Clear request from a caller that no longer owns the slot — ignore.
+		pthread_mutex_unlock(&g_lock);
+		return;
+	}
+	g_fn = fn;
+	g_userdata = fn != NULL ? userdata : NULL;
+	pthread_mutex_unlock(&g_lock);
+}
+
+bool
+u_capture_dims_query(uint32_t *out_view_w,
+                     uint32_t *out_view_h,
+                     uint32_t *out_tile_cols,
+                     uint32_t *out_tile_rows)
+{
+	pthread_mutex_lock(&g_lock);
+	u_capture_dims_fn fn = g_fn;
+	void *ud = g_userdata;
+	pthread_mutex_unlock(&g_lock);
+
+	if (fn == NULL) {
+		return false;
+	}
+	return fn(ud, out_view_w, out_view_h, out_tile_cols, out_tile_rows);
+}

--- a/src/xrt/auxiliary/util/u_capture_dims.h
+++ b/src/xrt/auxiliary/util/u_capture_dims.h
@@ -1,0 +1,67 @@
+// Copyright 2026, DisplayXR
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  Process-global provider for the in-process compositor's CURRENT
+ *         window-scaled capture dimensions.
+ *
+ * The static @c xrt_system_compositor_info carries the NOMINAL atlas / view
+ * dims (display-sized). When an app window differs from the display, the
+ * in-process compositor renders — and captures — at window-scaled dims that
+ * live only inside the compositor's renderer. xrCaptureAtlasEXT runs in the
+ * state tracker (a layer above the compositor) and cannot reach those dims, so
+ * it would report the nominal dims, disagreeing with the captured PNG (#431).
+ *
+ * This tiny registry bridges the gap without a compositor↔state-tracker edge:
+ * it lives in aux_util (below both). The active in-process native compositor
+ * registers a pull-callback at creation; the state tracker queries it when
+ * filling @c XrAtlasCaptureResultEXT. Compositors that don't register (or a
+ * not-yet-sized renderer) leave the query returning false, so the caller falls
+ * back to the nominal dims.
+ *
+ * @ingroup aux_util
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*!
+ * Returns the compositor's current window-scaled per-view dims + tile layout —
+ * what the next capture will actually write. @p userdata is the value passed to
+ * @ref u_capture_dims_set_provider. Returns true and fills the out-params on
+ * success; false leaves them untouched.
+ */
+typedef bool (*u_capture_dims_fn)(void *userdata,
+                                  uint32_t *out_view_w,
+                                  uint32_t *out_view_h,
+                                  uint32_t *out_tile_cols,
+                                  uint32_t *out_tile_rows);
+
+/*!
+ * Register (@p fn != NULL) or clear the provider. On clear, pass the same
+ * @p userdata that was registered — the slot is only released if it still
+ * belongs to that caller, so a torn-down compositor never clobbers a provider a
+ * newer compositor installed.
+ */
+void
+u_capture_dims_set_provider(u_capture_dims_fn fn, void *userdata);
+
+/*!
+ * Query the registered provider. Returns false (out-params untouched) if no
+ * provider is installed or the provider declined.
+ */
+bool
+u_capture_dims_query(uint32_t *out_view_w,
+                     uint32_t *out_view_h,
+                     uint32_t *out_tile_cols,
+                     uint32_t *out_tile_rows);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/xrt/compositor/d3d11/comp_d3d11_compositor.cpp
+++ b/src/xrt/compositor/d3d11/comp_d3d11_compositor.cpp
@@ -49,9 +49,11 @@
 #include "stb_image_write.h"
 
 #include "math/m_api.h"
+#include "d3d/d3d_dxgi_formats.h"
 #include "util/u_tiling.h"
 #include "util/u_canvas.h"
 #include "util/u_capture_intent.h"
+#include "util/u_capture_dims.h"
 #include "util/u_image_capture.h"
 
 #ifdef XRT_BUILD_DRIVER_QWERTY
@@ -872,7 +874,19 @@ d3d11_crop_atlas_for_dp(struct comp_d3d11_compositor *c,
 			return atlas_srv; // fallback to original
 		}
 
-		hr = c->device->CreateShaderResourceView(c->dp_input_texture, nullptr, &c->dp_input_srv);
+		// Build an explicit SRV desc: a null desc is only valid over a fully
+		// typed resource, and Unity D3D11 swapchains are TYPELESS — the null
+		// path failed E_INVALIDARG every frame (#431). Select the typed UNORM
+		// sibling (NOT the _SRGB one): in-process is ADR-021 Model A
+		// passthrough, so the DP must sample the raw bytes — an _SRGB view
+		// would decode sRGB->linear on sample and re-introduce the ~2.2x
+		// too-dark half-conversion fixed by #407/#408/#409.
+		D3D11_SHADER_RESOURCE_VIEW_DESC srv_desc = {};
+		srv_desc.Format = d3d_dxgi_format_to_unorm_sample(atlas_desc.Format);
+		srv_desc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
+		srv_desc.Texture2D.MostDetailedMip = 0;
+		srv_desc.Texture2D.MipLevels = 1;
+		hr = c->device->CreateShaderResourceView(c->dp_input_texture, &srv_desc, &c->dp_input_srv);
 		if (FAILED(hr)) {
 			U_LOG_E("Failed to create DP input SRV: 0x%lx", hr);
 			c->dp_input_texture->Release();
@@ -905,11 +919,22 @@ d3d11_crop_atlas_for_dp(struct comp_d3d11_compositor *c,
 // (clamped to its actual size) and write @p path as an opaque RGBA8 PNG. The
 // source may be the renderer's composited atlas OR, in zero-copy present, the
 // app's own swapchain image — both already hold the laid-out multi-view atlas.
+//
+// When @p dst_w / @p dst_h are non-zero and differ from the read-back region,
+// the buffer is bilinear-resampled to (dst_w × dst_h) before the PNG write.
+// This is used by the zero-copy path: an app may present a multi-view atlas at
+// the mode NOMINAL dims while the runtime renders at the window-scaled dims, so
+// the readback (nominal) must be scaled down to the content dims the DP sees
+// (#431). A uniform resample is correct for an equal-sized tile grid — the tile
+// boundary at source view_w maps exactly to the target view_w. Pass 0 to write
+// the read-back region verbatim (no resample).
 static bool
 d3d11_capture_texture_to_png(struct comp_d3d11_compositor *c,
                              ID3D11Texture2D *atlas_tex,
                              uint32_t content_w,
                              uint32_t content_h,
+                             uint32_t dst_w,
+                             uint32_t dst_h,
                              const char *path)
 {
 	if (atlas_tex == nullptr || content_w == 0 || content_h == 0) {
@@ -956,7 +981,44 @@ d3d11_capture_texture_to_png(struct comp_d3d11_compositor *c,
 			memcpy(tight + (size_t)y * tight_pitch, src + (size_t)y * m.RowPitch, tight_pitch);
 		}
 		u_image_force_opaque_rgba8(tight, content_w, content_h, tight_pitch);
-		ok = stbi_write_png(path, (int)content_w, (int)content_h, 4, tight, (int)tight_pitch) != 0;
+
+		// Optional resample to (dst_w × dst_h) — see header comment (#431).
+		if (dst_w != 0 && dst_h != 0 && (dst_w != content_w || dst_h != content_h)) {
+			size_t dst_pitch = (size_t)dst_w * 4;
+			uint8_t *out = (uint8_t *)malloc(dst_pitch * dst_h);
+			if (out != nullptr) {
+				// Bilinear, RGBA8. Sample centers map source<->dst so the
+				// outer edges align (no half-texel shift across the grid).
+				float sx = (dst_w > 1) ? (float)(content_w - 1) / (float)(dst_w - 1) : 0.0f;
+				float sy = (dst_h > 1) ? (float)(content_h - 1) / (float)(dst_h - 1) : 0.0f;
+				for (uint32_t dy = 0; dy < dst_h; dy++) {
+					float fy = dy * sy;
+					uint32_t y0 = (uint32_t)fy;
+					uint32_t y1 = (y0 + 1 < content_h) ? y0 + 1 : y0;
+					float wy = fy - (float)y0;
+					for (uint32_t dx = 0; dx < dst_w; dx++) {
+						float fx = dx * sx;
+						uint32_t x0 = (uint32_t)fx;
+						uint32_t x1 = (x0 + 1 < content_w) ? x0 + 1 : x0;
+						float wx = fx - (float)x0;
+						const uint8_t *p00 = tight + (size_t)y0 * tight_pitch + (size_t)x0 * 4;
+						const uint8_t *p01 = tight + (size_t)y0 * tight_pitch + (size_t)x1 * 4;
+						const uint8_t *p10 = tight + (size_t)y1 * tight_pitch + (size_t)x0 * 4;
+						const uint8_t *p11 = tight + (size_t)y1 * tight_pitch + (size_t)x1 * 4;
+						uint8_t *d = out + (size_t)dy * dst_pitch + (size_t)dx * 4;
+						for (int ch = 0; ch < 4; ch++) {
+							float top = p00[ch] * (1.0f - wx) + p01[ch] * wx;
+							float bot = p10[ch] * (1.0f - wx) + p11[ch] * wx;
+							d[ch] = (uint8_t)(top * (1.0f - wy) + bot * wy + 0.5f);
+						}
+					}
+				}
+				ok = stbi_write_png(path, (int)dst_w, (int)dst_h, 4, out, (int)dst_pitch) != 0;
+				free(out);
+			}
+		} else {
+			ok = stbi_write_png(path, (int)content_w, (int)content_h, 4, tight, (int)tight_pitch) != 0;
+		}
 		free(tight);
 	}
 
@@ -985,6 +1047,33 @@ d3d11_compositor_content_dims(struct comp_d3d11_compositor *c, uint32_t *out_w, 
 	return true;
 }
 
+// u_capture_dims provider: report the renderer's CURRENT window-scaled per-view
+// dims + tile layout so xrCaptureAtlasEXT can fill XrAtlasCaptureResultEXT with
+// what the capture actually writes, not the nominal system info (#431).
+static bool
+d3d11_compositor_capture_dims_provider(void *userdata,
+                                       uint32_t *out_view_w,
+                                       uint32_t *out_view_h,
+                                       uint32_t *out_tile_cols,
+                                       uint32_t *out_tile_rows)
+{
+	struct comp_d3d11_compositor *c = static_cast<struct comp_d3d11_compositor *>(userdata);
+	if (c == nullptr || c->renderer == nullptr) {
+		return false;
+	}
+	uint32_t vw = 0, vh = 0, cols = 1, rows = 1;
+	comp_d3d11_renderer_get_view_dimensions(c->renderer, &vw, &vh);
+	comp_d3d11_renderer_get_tile_layout(c->renderer, &cols, &rows);
+	if (vw == 0 || vh == 0) {
+		return false;
+	}
+	*out_view_w = vw;
+	*out_view_h = vh;
+	*out_tile_cols = cols;
+	*out_tile_rows = rows;
+	return true;
+}
+
 // Capture from the renderer's composited atlas (non-zero-copy frames).
 static bool
 d3d11_compositor_capture_atlas_to_png(struct comp_d3d11_compositor *c, const char *path)
@@ -995,7 +1084,7 @@ d3d11_compositor_capture_atlas_to_png(struct comp_d3d11_compositor *c, const cha
 	if (atlas_tex == nullptr || !d3d11_compositor_content_dims(c, &content_w, &content_h)) {
 		return false;
 	}
-	return d3d11_capture_texture_to_png(c, atlas_tex, content_w, content_h, path);
+	return d3d11_capture_texture_to_png(c, atlas_tex, content_w, content_h, 0, 0, path);
 }
 
 // Service a pending MCP capture_frame request — thin wrapper around
@@ -1039,19 +1128,34 @@ d3d11_compositor_dispatch_capture_zerocopy(struct comp_d3d11_compositor *c, void
 	srv->GetResource(&resource);
 	ID3D11Texture2D *zc_tex = static_cast<ID3D11Texture2D *>(resource);
 
-	// Capture the whole swapchain texture: zero-copy is only eligible when the
-	// app's swapchain matches the active mode's atlas dimensions exactly
-	// (u_tiling_can_zero_copy), so the entire texture IS the multi-view atlas.
-	// Do NOT use the renderer's view/tile dims here — for a legacy app those are
-	// the 2D/3D compromise size (e.g. 1200×1080), which is smaller than the
-	// app's real per-view render (e.g. 1920×1080) and would crop the atlas
-	// (issue #425, the Unity stretched/cropped-PNG case).
+	// Read back the whole swapchain texture: zero-copy is only eligible when the
+	// app's swapchain laid-out rects tile it exactly (u_tiling_can_zero_copy), so
+	// the entire texture IS the multi-view atlas.
+	//
+	// For an EXTENSION app, the swapchain may be presented at the mode NOMINAL
+	// dims (e.g. a Unity backend composes a double-wide 3840×1080 atlas) while the
+	// runtime renders at the window-scaled content dims (e.g. 2400×1080) — so we
+	// resample the readback down to the renderer's current content dims, matching
+	// the PNG D3D12 produces for the same window (#431). A plain crop would slice
+	// the larger tiles; a uniform resample preserves the equal-sized tile grid.
+	//
+	// For a LEGACY app, the renderer view dims are the 2D/3D compromise size
+	// (smaller than the app's real per-view render), so resampling to them would
+	// needlessly downscale — keep the verbatim full-swapchain dump (#425).
 	bool ok = false;
 	if (zc_tex != nullptr) {
 		D3D11_TEXTURE2D_DESC zdesc;
 		zc_tex->GetDesc(&zdesc);
+		uint32_t dst_w = 0, dst_h = 0;
+		if (!c->legacy_app_tile_scaling) {
+			uint32_t content_w = 0, content_h = 0;
+			if (d3d11_compositor_content_dims(c, &content_w, &content_h)) {
+				dst_w = content_w;
+				dst_h = content_h;
+			}
+		}
 		ok = d3d11_capture_texture_to_png(c, zc_tex, zdesc.Width, zdesc.Height,
-		                                  c->capture_intent.path);
+		                                  dst_w, dst_h, c->capture_intent.path);
 	}
 	if (resource != nullptr) {
 		resource->Release();
@@ -1593,6 +1697,7 @@ d3d11_compositor_destroy(struct xrt_compositor *xc)
 
 	U_LOG_I("Destroying D3D11 compositor");
 
+	u_capture_dims_set_provider(NULL, c);
 	mcp_capture_uninstall();
 	mcp_capture_fini(&c->mcp_capture);
 
@@ -1987,6 +2092,9 @@ comp_d3d11_compositor_create(struct xrt_device *xdev,
 		d3d11_compositor_destroy(&c->base.base);
 		return xret;
 	}
+
+	// Expose current window-scaled capture dims to xrCaptureAtlasEXT (#431).
+	u_capture_dims_set_provider(d3d11_compositor_capture_dims_provider, c);
 
 #ifdef XRT_FEATURE_DEBUG_GUI
 	// Create debug GUI (controlled by XRT_DEBUG_GUI env var)

--- a/src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp
+++ b/src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp
@@ -33,6 +33,7 @@
 #include "util/u_tiling.h"
 #include "util/u_canvas.h"
 #include "util/u_capture_intent.h"
+#include "util/u_capture_dims.h"
 #include "util/u_image_capture.h"
 #include "util/u_hud.h"
 #include <displayxr_mcp/mcp_capture.h>
@@ -945,6 +946,33 @@ d3d12_crop_atlas_for_dp(struct comp_d3d12_compositor *c,
  *
  */
 
+// u_capture_dims provider: report the renderer's CURRENT window-scaled per-view
+// dims + tile layout so xrCaptureAtlasEXT can fill XrAtlasCaptureResultEXT with
+// what the capture actually writes, not the nominal system info (#431).
+static bool
+d3d12_compositor_capture_dims_provider(void *userdata,
+                                       uint32_t *out_view_w,
+                                       uint32_t *out_view_h,
+                                       uint32_t *out_tile_cols,
+                                       uint32_t *out_tile_rows)
+{
+	struct comp_d3d12_compositor *c = static_cast<struct comp_d3d12_compositor *>(userdata);
+	if (c == nullptr || c->renderer == nullptr) {
+		return false;
+	}
+	uint32_t vw = 0, vh = 0, cols = 1, rows = 1;
+	comp_d3d12_renderer_get_view_dimensions(c->renderer, &vw, &vh);
+	comp_d3d12_renderer_get_tile_layout(c->renderer, &cols, &rows);
+	if (vw == 0 || vh == 0) {
+		return false;
+	}
+	*out_view_w = vw;
+	*out_view_h = vh;
+	*out_tile_cols = cols;
+	*out_tile_rows = rows;
+	return true;
+}
+
 // Copy the content region of the renderer's atlas (tile_columns × view_width
 // by tile_rows × view_height — what the app actually wrote, same region the
 // compositor crops and sends to the DP) into a READBACK heap buffer, then
@@ -1825,6 +1853,7 @@ d3d12_compositor_destroy(struct xrt_compositor *xc)
 	U_LOG_I("Destroying D3D12 compositor");
 
 	// Uninstall MCP capture hook before the GPU resources go away.
+	u_capture_dims_set_provider(NULL, c);
 	mcp_capture_uninstall();
 	mcp_capture_fini(&c->mcp_capture);
 
@@ -2226,6 +2255,9 @@ comp_d3d12_compositor_create(struct xrt_device *xdev,
 		d3d12_compositor_destroy(&c->base.base);
 		return xret;
 	}
+
+	// Expose current window-scaled capture dims to xrCaptureAtlasEXT (#431).
+	u_capture_dims_set_provider(d3d12_compositor_capture_dims_provider, c);
 
 	// Initialize layer accumulator
 	memset(&c->layer_accum, 0, sizeof(c->layer_accum));

--- a/src/xrt/state_trackers/oxr/oxr_capture.c
+++ b/src/xrt/state_trackers/oxr/oxr_capture.c
@@ -35,6 +35,7 @@
 
 #include "util/u_logging.h"
 #include "util/u_trace_marker.h"
+#include "util/u_capture_dims.h"
 
 #include "os/os_time.h"
 
@@ -153,14 +154,35 @@ capture_inprocess(struct oxr_logger *log,
 		result->type = XR_TYPE_ATLAS_CAPTURE_RESULT_EXT;
 		result->next = NULL;
 		result->timestampNs = (uint64_t)os_monotonic_get_ns();
-		result->atlasWidth = sci->atlas_width_pixels;
-		result->atlasHeight = sci->atlas_height_pixels;
-		// Per-view recommended dims approximate the captured eye-tile size.
-		result->eyeWidth = sci->views[0].recommended.width_pixels;
-		result->eyeHeight = sci->views[0].recommended.height_pixels;
-		// Tile layout from the active rendering mode (resolved above). Eye
-		// poses are still not surfaced on the in-process path — eye-pose
-		// plumbing stops at the display processor; the IPC path returns them.
+
+		// Prefer the compositor's CURRENT window-scaled dims — what the capture
+		// actually writes — over the static nominal system-compositor info,
+		// which disagrees with the PNG whenever the window differs from the
+		// display (#431). Falls back to nominal dims if no provider is
+		// registered (gl/vk/metal) or the renderer isn't sized yet.
+		uint32_t qvw = 0, qvh = 0, qcols = 0, qrows = 0;
+		if (u_capture_dims_query(&qvw, &qvh, &qcols, &qrows) && qvw > 0 && qvh > 0) {
+			if (qcols > 0) {
+				cols = qcols;
+			}
+			if (qrows > 0) {
+				rows = qrows;
+			}
+			result->eyeWidth = qvw;
+			result->eyeHeight = qvh;
+			result->atlasWidth = cols * qvw;
+			result->atlasHeight = rows * qvh;
+		} else {
+			result->atlasWidth = sci->atlas_width_pixels;
+			result->atlasHeight = sci->atlas_height_pixels;
+			// Per-view recommended dims approximate the captured eye-tile size.
+			result->eyeWidth = sci->views[0].recommended.width_pixels;
+			result->eyeHeight = sci->views[0].recommended.height_pixels;
+		}
+		// Tile layout from the active rendering mode (resolved above), unless
+		// the provider supplied a current layout. Eye poses are still not
+		// surfaced on the in-process path — eye-pose plumbing stops at the
+		// display processor; the IPC path returns them.
 		result->tileColumns = cols;
 		result->tileRows = rows;
 		result->displayWidthM = sci->display_width_m;


### PR DESCRIPTION
Fixes #431. Three independent in-process **D3D11** bugs that broke windowed handle apps (repro: Unity windowed D3D11 at 2400×2160 on the 4K Leia panel). D3D12 was already correct end-to-end; this brings D3D11 to parity. None touch the ADR-021 Model-B / service color path — in-process D3D11 is **Model A passthrough**.

### Item 1 — TYPELESS DP-crop SRV
`d3d11_crop_atlas_for_dp` built the DP-input SRV with a null desc, which fails `E_INVALIDARG (0x80070057)` every frame on a TYPELESS source (Unity D3D11 swapchains), silently falling back to the uncropped input. Now builds an explicit SRV desc using the typed **UNORM** sibling via `d3d_dxgi_format_to_unorm_sample()` — **not** `_SRGB`: in-process is passthrough, and an sRGB view would re-introduce the ~2.2× too-dark half-conversion fixed by #407/#408/#409. Mirrors the D3D12 / service compositor pattern.

### Item 2 — zero-copy capture ignored window scaling
The zero-copy capture wrote the app swapchain verbatim, so a backend that composes a double-wide atlas at the mode nominal dims (3840×1080) produced a 3840×1080 PNG with window-aspect content stretched into display-aspect tiles. Now bilinear-resamples the readback to the renderer's window-scaled content dims (2400×1080) before the PNG write, gated on `!legacy_app_tile_scaling` so the #425 legacy full-swapchain dump is preserved.

### Item 3 — capture-result metadata was static
`XrAtlasCaptureResultEXT` was filled from static `xrt_system_compositor_info` (nominal dims), disagreeing with the PNG whenever the window ≠ display. Adds a tiny aux-layer provider registry (`u_capture_dims`) so the in-process D3D11/D3D12 compositors expose their current window-scaled view dims + tile layout; the result struct is filled from it, falling back to nominal dims when unregistered (gl/vk/metal unchanged).

## Verification
On the Unity D3D11 repro (`DisplayXR-test.exe`, windowed 2400×2160), against the deployed runtime:
- **Item 1:** zero `0x80070057` SRV errors across the run (was *every frame* in the original session log); captured atlas correctly exposed — no sRGB double-decode darkening.
- **Item 2:** D3D11 windowed capture PNG = **2400×1080**, correct aspect — **exact parity with the D3D12 reference (also 2400×1080)**.
- **Item 3:** provider returns 1200×1080 × 2×1 = 2400×1080, matching the captured PNG (full result-struct readback needs an app-driven `xrCaptureAtlasEXT` call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)