### PR TITLE
fix(#433): MCP log sink tee + cube sub-rect knobs; fix(#431): don't crop zero-copy atlases for the DP

### DIFF
--- a/src/xrt/auxiliary/util/u_file_logging.c
+++ b/src/xrt/auxiliary/util/u_file_logging.c
@@ -259,6 +259,17 @@ u_file_logging_write_raw(const char *msg)
 }
 
 void
+u_file_logging_write_va(const char *func, enum u_logging_level level, const char *format, va_list args)
+{
+	u_file_logging_init();
+	if (g_log_file == NULL || format == NULL) {
+		return;
+	}
+
+	file_logging_sink(NULL, 0, func, level, format, args, NULL);
+}
+
+void
 u_file_logging_shutdown(void)
 {
 	if (g_log_file != NULL) {
@@ -283,6 +294,16 @@ void
 u_file_logging_write_raw(const char *msg)
 {
 	(void)msg;
+	// File logging only implemented on Windows
+}
+
+void
+u_file_logging_write_va(const char *func, enum u_logging_level level, const char *format, va_list args)
+{
+	(void)func;
+	(void)level;
+	(void)format;
+	(void)args;
 	// File logging only implemented on Windows
 }
 

--- a/src/xrt/auxiliary/util/u_file_logging.h
+++ b/src/xrt/auxiliary/util/u_file_logging.h
@@ -10,6 +10,9 @@
 #pragma once
 
 #include "xrt/xrt_api.h"
+#include "util/u_logging.h"
+
+#include <stdarg.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -33,6 +36,16 @@ u_file_logging_init(void);
  */
 XRT_API_FUNC void
 u_file_logging_write_raw(const char *msg);
+
+/*!
+ * Write a formatted message (va_list form) to the log file with the standard
+ * timestamp/level/function prefix. Used by the MCP log sink to tee U_LOG_*
+ * messages into the per-process file log while also appending them to the MCP
+ * ring (issue #433 — the ring-only sink truncated the file log at instance
+ * creation). Safe to call before init or after shutdown (will be a no-op).
+ */
+XRT_API_FUNC void
+u_file_logging_write_va(const char *func, enum u_logging_level level, const char *format, va_list args);
 
 /*!
  * Close the log file and clean up resources.

--- a/src/xrt/compositor/d3d11/comp_d3d11_compositor.cpp
+++ b/src/xrt/compositor/d3d11/comp_d3d11_compositor.cpp
@@ -1527,10 +1527,19 @@ d3d11_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 			uint32_t tile_columns, tile_rows;
 			comp_d3d11_renderer_get_tile_layout(c->renderer, &tile_columns, &tile_rows);
 
-			// Crop atlas to content dimensions before passing to DP
+			// Crop the renderer's atlas to content dims before passing to the
+			// DP (the renderer allocates a worst-case atlas; content sits
+			// top-left at the content stride). Do NOT crop a zero-copy atlas:
+			// the app's swapchain is already a complete, correctly-strided
+			// multi-view atlas (the DP derives tile stride from atlas_width /
+			// tile_columns), so a top-left crop to the window-scaled width
+			// would slice the tiles and weave them misaligned — big disparity
+			// (#431 follow-up: the crop must not touch the zero-copy path).
 			uint32_t content_w = tile_columns * view_width;
 			uint32_t content_h = tile_rows * view_height;
-			atlas_srv = d3d11_crop_atlas_for_dp(c, atlas_srv, content_w, content_h);
+			if (!zero_copy) {
+				atlas_srv = d3d11_crop_atlas_for_dp(c, atlas_srv, content_w, content_h);
+			}
 
 			// Weave directly into the shared texture at the canvas sub-rect.
 			// The SR weaver handles backbuffer > HWND correctly as long as the
@@ -1598,10 +1607,16 @@ d3d11_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 		uint32_t tile_columns, tile_rows;
 		comp_d3d11_renderer_get_tile_layout(c->renderer, &tile_columns, &tile_rows);
 
-		// Crop atlas to content dimensions before passing to DP
+		// Crop the renderer's atlas to content dims before passing to the DP;
+		// never crop a zero-copy atlas — the app's swapchain is already a
+		// complete, correctly-strided multi-view atlas, and a top-left crop to
+		// the window-scaled width would slice the tiles and weave them
+		// misaligned (big disparity). See the offscreen path above (#431).
 		uint32_t content_w = tile_columns * view_width;
 		uint32_t content_h = tile_rows * view_height;
-		atlas_srv = d3d11_crop_atlas_for_dp(c, atlas_srv, content_w, content_h);
+		if (!zero_copy) {
+			atlas_srv = d3d11_crop_atlas_for_dp(c, atlas_srv, content_w, content_h);
+		}
 
 		uint32_t target_width, target_height;
 		comp_d3d11_target_get_dimensions(c->target, &target_width, &target_height);

--- a/src/xrt/state_trackers/oxr/oxr_mcp_tools.c
+++ b/src/xrt/state_trackers/oxr/oxr_mcp_tools.c
@@ -27,6 +27,7 @@
 #include <displayxr_mcp/mcp_log_ring.h>
 
 #include "util/u_logging.h"
+#include "util/u_file_logging.h"
 
 #ifdef _WIN32
 #include <windows.h>
@@ -866,8 +867,16 @@ oxr_mcp_log_sink(const char *file,
 {
 	(void)file;
 	(void)line;
-	(void)func;
 	(void)data;
+
+	// Tee into the per-process file log first (#433): replacing the file
+	// sink with a ring-only sink made DisplayXR_<exe>.*.log stop growing at
+	// xrCreateInstance, hiding every compositor diagnostic from field debugging.
+	va_list args_copy;
+	va_copy(args_copy, args);
+	u_file_logging_write_va(func, level, fmt, args_copy);
+	va_end(args_copy);
+
 	mcp_log_ring_append(xlate_log_level(level), fmt, args);
 }
 
@@ -1162,9 +1171,9 @@ oxr_mcp_tools_register_all(void)
 	// Only hijack the global log sink when MCP is actually enabled; otherwise
 	// leave whatever sink the runtime had already installed (typically
 	// `file_logging_sink` so per-process .log files keep growing past
-	// xrCreateInstance). Without this gate the MCP ring sink silently swallows
-	// every U_LOG_* call once the OXR instance is created, even with MCP off,
-	// breaking standalone diagnostics like [CLIENT_FRAME_NS].
+	// xrCreateInstance). The MCP sink tees into the file log before appending
+	// to the ring (#433), so even with MCP on the per-process .log stays
+	// complete for field debugging.
 	if (mcp_check_env_or(oxr_mcp_capability_enabled())) {
 		u_log_set_sink(oxr_mcp_log_sink, NULL);
 	}

--- a/test_apps/common/xr_session_common.cpp
+++ b/test_apps/common/xr_session_common.cpp
@@ -621,7 +621,22 @@ bool EndFrame(XrSessionManager& xr, XrTime displayTime, const XrCompositionLayer
     endInfo.layerCount = 1;
     endInfo.layers = layers;
 
-    return XR_SUCCEEDED(xrEndFrame(xr.session, &endInfo));
+    XrResult result = xrEndFrame(xr.session, &endInfo);
+    if (XR_FAILED(result)) {
+        // A rejected frame leaves the compositor presenting the previous
+        // atlas — make that loud (throttled) instead of silent (#433).
+        static int endFrameFailLog = 0;
+        if (endFrameFailLog < 10 || endFrameFailLog % 300 == 0) {
+            LOG_WARN("[Frame] xrEndFrame FAILED: %d (view[0] rect=(%d,%d %dx%d))",
+                     result,
+                     viewCount > 0 ? views[0].subImage.imageRect.offset.x : 0,
+                     viewCount > 0 ? views[0].subImage.imageRect.offset.y : 0,
+                     viewCount > 0 ? views[0].subImage.imageRect.extent.width : 0,
+                     viewCount > 0 ? views[0].subImage.imageRect.extent.height : 0);
+        }
+        endFrameFailLog++;
+    }
+    return XR_SUCCEEDED(result);
 }
 
 bool CreateHudSwapchain(XrSessionManager& xr, uint32_t width, uint32_t height) {
@@ -750,7 +765,22 @@ bool EndFrameWithWindowSpaceHud(
     endInfo.layerCount = xr.hasHudSwapchain ? 2 : 1;
     endInfo.layers = layers;
 
-    return XR_SUCCEEDED(xrEndFrame(xr.session, &endInfo));
+    XrResult result = xrEndFrame(xr.session, &endInfo);
+    if (XR_FAILED(result)) {
+        // A rejected frame leaves the compositor presenting the previous
+        // atlas — make that loud (throttled) instead of silent (#433).
+        static int endFrameFailLog = 0;
+        if (endFrameFailLog < 10 || endFrameFailLog % 300 == 0) {
+            LOG_WARN("[Frame] xrEndFrame (HUD) FAILED: %d (view[0] rect=(%d,%d %dx%d))",
+                     result,
+                     viewCount > 0 ? projViews[0].subImage.imageRect.offset.x : 0,
+                     viewCount > 0 ? projViews[0].subImage.imageRect.offset.y : 0,
+                     viewCount > 0 ? projViews[0].subImage.imageRect.extent.width : 0,
+                     viewCount > 0 ? projViews[0].subImage.imageRect.extent.height : 0);
+        }
+        endFrameFailLog++;
+    }
+    return XR_SUCCEEDED(result);
 }
 
 // [Commented out — will be reused for 3D-positioned HUD later]

--- a/test_apps/cube_texture_d3d12_win/main.cpp
+++ b/test_apps/cube_texture_d3d12_win/main.cpp
@@ -36,6 +36,8 @@
 
 #include <chrono>
 #include <cmath>
+#include <cstdlib>
+#include <cstring>
 #include <string>
 #include <sstream>
 #include <vector>
@@ -821,6 +823,11 @@ struct RenderState {
     bool hudOk;
     std::vector<XrSwapchainImageD3D12KHR>* swapchainImages;
     int rtvBaseIndex;
+    // #433 DXR_TEST_PER_VIEW_SC: optional second swapchain so view 1 submits
+    // from its own swapchain (Unity submission shape). XR_NULL_HANDLE when off.
+    XrSwapchain swapchain2;
+    std::vector<XrSwapchainImageD3D12KHR>* swapchain2Images;
+    int rtv2BaseIndex;
     std::vector<XrSwapchainImageD3D12KHR>* hudSwapchainImages;
     ID3D12Resource* hudUploadBuffer;
     uint8_t* hudUploadMapped;
@@ -929,6 +936,37 @@ static void RenderOneFrame(RenderState& rs) {
                         renderH = (uint32_t)(g_canvasH * xr.recommendedViewScaleY);
                         if (renderW > maxTileW) renderW = maxTileW;
                         if (renderH > maxTileH) renderH = maxTileH;
+                    }
+
+                    // #433 regression knobs: a runtime must treat any in-bounds
+                    // sub-rect as a plain UV window, so the composited result
+                    // must be pixel-identical with these set.
+                    //   DXR_TEST_RECT_DELTA=<int>   extent = computed + N px
+                    //                               (render viewport follows —
+                    //                               mirrors Unity's floor()-
+                    //                               rounded renderViewportScale)
+                    //   DXR_TEST_RECT_ANCHOR=bottom rect anchored to the bottom
+                    //                               of the swapchain instead of
+                    //                               the top (Unity-style)
+                    static const int testRectDelta = []() {
+                        const char* e = getenv("DXR_TEST_RECT_DELTA");
+                        return e != nullptr ? atoi(e) : 0;
+                    }();
+                    static const bool testRectBottomAnchor = []() {
+                        const char* e = getenv("DXR_TEST_RECT_ANCHOR");
+                        return e != nullptr && _stricmp(e, "bottom") == 0;
+                    }();
+                    if (testRectDelta != 0) {
+                        int w = (int)renderW + testRectDelta;
+                        int h = (int)renderH + testRectDelta;
+                        renderW = (uint32_t)(w < 16 ? 16 : w);
+                        renderH = (uint32_t)(h < 16 ? 16 : h);
+                        static bool deltaLogged = false;
+                        if (!deltaLogged) {
+                            LOG_WARN("[#433] DXR_TEST_RECT_DELTA=%d -> submitting %ux%u rects",
+                                     testRectDelta, renderW, renderH);
+                            deltaLogged = true;
+                        }
                     }
 
                     // Kooima projection using canvas dims
@@ -1205,14 +1243,48 @@ static void RenderOneFrame(RenderState& rs) {
                     // Render scene into OpenXR swapchain atlas
                     uint32_t imageIndex;
                     if (AcquireSwapchainImage(xr, imageIndex)) {
-                        ID3D12Resource* swapchainTexture = (*rs.swapchainImages)[imageIndex].texture;
-                        int rtvIdx = rs.rtvBaseIndex + (int)imageIndex;
+                        // #433: DXR_TEST_PER_VIEW_SC — Unity submission shape:
+                        // each view in its OWN swapchain, identical rects.
+                        uint32_t imageIndex2 = 0;
+                        bool sc2Acquired = false;
+                        if (rs.swapchain2 != XR_NULL_HANDLE && !monoMode) {
+                            XrSwapchainImageAcquireInfo ai = {XR_TYPE_SWAPCHAIN_IMAGE_ACQUIRE_INFO};
+                            if (XR_SUCCEEDED(xrAcquireSwapchainImage(rs.swapchain2, &ai, &imageIndex2))) {
+                                XrSwapchainImageWaitInfo wi = {XR_TYPE_SWAPCHAIN_IMAGE_WAIT_INFO};
+                                wi.timeout = XR_INFINITE_DURATION;
+                                sc2Acquired = XR_SUCCEEDED(xrWaitSwapchainImage(rs.swapchain2, &wi));
+                                if (!sc2Acquired) {
+                                    XrSwapchainImageReleaseInfo ri = {XR_TYPE_SWAPCHAIN_IMAGE_RELEASE_INFO};
+                                    xrReleaseSwapchainImage(rs.swapchain2, &ri);
+                                }
+                            }
+                        }
 
                         for (int eye = 0; eye < eyeCount; eye++) {
-                            uint32_t tileX = monoMode ? 0 : (eye % tileColumns);
-                            uint32_t tileY = monoMode ? 0 : (eye / tileColumns);
+                            const bool useSc2 = sc2Acquired && eye == 1;
+                            uint32_t tileX = (monoMode || useSc2) ? 0 : (eye % tileColumns);
+                            uint32_t tileY = (monoMode || useSc2) ? 0 : (eye / tileColumns);
                             uint32_t vpX = tileX * renderW;
                             uint32_t vpY = tileY * renderH;
+                            if (testRectBottomAnchor) {
+                                // #433: bottom-anchored rect, Unity-style — the
+                                // render viewport moves with the submitted rect.
+                                vpY = xr.swapchain.height - (tileY + 1) * renderH;
+                                static bool anchorLogged = false;
+                                if (!anchorLogged) {
+                                    LOG_WARN("[#433] DXR_TEST_RECT_ANCHOR=bottom -> view0 rect=(%u,%u %ux%u) in %ux%u swapchain",
+                                             vpX, vpY, renderW, renderH,
+                                             xr.swapchain.width, xr.swapchain.height);
+                                    anchorLogged = true;
+                                }
+                            }
+
+                            ID3D12Resource* swapchainTexture = useSc2
+                                ? (*rs.swapchain2Images)[imageIndex2].texture
+                                : (*rs.swapchainImages)[imageIndex].texture;
+                            int rtvIdx = useSc2
+                                ? rs.rtv2BaseIndex + (int)imageIndex2
+                                : rs.rtvBaseIndex + (int)imageIndex;
 
                             int vi = eye < (int)viewCount ? eye : 0;
                             XMMATRIX viewMatrix, projMatrix;
@@ -1231,10 +1303,11 @@ static void RenderOneFrame(RenderState& rs) {
                                 vpX, vpY, renderW, renderH,
                                 viewMatrix, projMatrix,
                                 useAppProjection ? 1.0f : g_inputState.viewParams.scaleFactor,
-                                eye == 0);
+                                eye == 0 || useSc2);
 
                             projectionViews[eye].type = XR_TYPE_COMPOSITION_LAYER_PROJECTION_VIEW;
-                            projectionViews[eye].subImage.swapchain = xr.swapchain.swapchain;
+                            projectionViews[eye].subImage.swapchain = useSc2
+                                ? rs.swapchain2 : xr.swapchain.swapchain;
                             projectionViews[eye].subImage.imageRect.offset = {
                                 (int32_t)vpX, (int32_t)vpY
                             };
@@ -1248,6 +1321,10 @@ static void RenderOneFrame(RenderState& rs) {
                                 (monoMode ? monoFov : rawViews[vi].fov);
                         }
 
+                        if (sc2Acquired) {
+                            XrSwapchainImageReleaseInfo ri = {XR_TYPE_SWAPCHAIN_IMAGE_RELEASE_INFO};
+                            xrReleaseSwapchainImage(rs.swapchain2, &ri);
+                        }
                         ReleaseSwapchainImage(xr);
                     }
                 }
@@ -1502,7 +1579,45 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         return 1;
     }
 
-    // Enumerate D3D12 swapchain images
+    // #433 DXR_TEST_PER_VIEW_SC: create a second, identical swapchain so view 1
+    // can submit from its own swapchain — mirrors Unity's per-view-swapchain
+    // submission shape. The runtime must composite this identically to the
+    // single-swapchain tiling. Created BEFORE the RTV pass because
+    // CreateSwapchainRTVs (re)creates the RTV heap sized to its texture count —
+    // both swapchains' images must go into ONE combined call.
+    XrSwapchain swapchain2 = XR_NULL_HANDLE;
+    std::vector<XrSwapchainImageD3D12KHR> swapchain2Images;
+    int rtv2BaseIndex = 0;
+    {
+        const char* e = getenv("DXR_TEST_PER_VIEW_SC");
+        if (e != nullptr && *e != '\0' && *e != '0') {
+            XrSwapchainCreateInfo sci = {XR_TYPE_SWAPCHAIN_CREATE_INFO};
+            sci.usageFlags = XR_SWAPCHAIN_USAGE_COLOR_ATTACHMENT_BIT | XR_SWAPCHAIN_USAGE_SAMPLED_BIT;
+            sci.format = xr.swapchain.format;
+            sci.sampleCount = 1;
+            sci.width = xr.swapchain.width;
+            sci.height = xr.swapchain.height;
+            sci.faceCount = 1;
+            sci.arraySize = 1;
+            sci.mipCount = 1;
+            XrResult r = xrCreateSwapchain(xr.session, &sci, &swapchain2);
+            if (XR_SUCCEEDED(r)) {
+                uint32_t count2 = 0;
+                xrEnumerateSwapchainImages(swapchain2, 0, &count2, nullptr);
+                swapchain2Images.resize(count2, {XR_TYPE_SWAPCHAIN_IMAGE_D3D12_KHR});
+                xrEnumerateSwapchainImages(swapchain2, count2, &count2,
+                    (XrSwapchainImageBaseHeader*)swapchain2Images.data());
+                LOG_WARN("[#433] DXR_TEST_PER_VIEW_SC=1 -> view 1 submits from its own %ux%u swapchain (%u images)",
+                         xr.swapchain.width, xr.swapchain.height, count2);
+            } else {
+                LOG_WARN("[#433] DXR_TEST_PER_VIEW_SC: xrCreateSwapchain failed (%d), knob disabled", r);
+                swapchain2 = XR_NULL_HANDLE;
+            }
+        }
+    }
+
+    // Enumerate D3D12 swapchain images and create RTVs (one combined heap for
+    // both swapchains — see the #433 note above).
     std::vector<XrSwapchainImageD3D12KHR> swapchainImages;
     int rtvBaseIndex = 0;
     {
@@ -1515,9 +1630,13 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         for (uint32_t i = 0; i < count; i++) {
             textures[i] = swapchainImages[i].texture;
         }
+        rtv2BaseIndex = (int)count;
+        for (const auto& img : swapchain2Images) {
+            textures.push_back(img.texture);
+        }
 
         rtvBaseIndex = (int)renderer.rtvCount;
-        if (!CreateSwapchainRTVs(renderer, textures.data(), count,
+        if (!CreateSwapchainRTVs(renderer, textures.data(), (uint32_t)textures.size(),
             xr.swapchain.width, xr.swapchain.height,
             (DXGI_FORMAT)xr.swapchain.format)) {
             LOG_ERROR("Failed to create RTVs");
@@ -1605,6 +1724,9 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
     rs.hudOk = hudOk;
     rs.swapchainImages = &swapchainImages;
     rs.rtvBaseIndex = rtvBaseIndex;
+    rs.swapchain2 = swapchain2;
+    rs.swapchain2Images = &swapchain2Images;
+    rs.rtv2BaseIndex = rtv2BaseIndex;
     rs.hudSwapchainImages = &hudSwapImages;
     rs.hudUploadBuffer = hudUploadBuffer.Get();
     rs.hudUploadMapped = hudUploadMapped;
@@ -1699,6 +1821,10 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
     g_appSwapchain.Reset();
 
     g_xr = nullptr;
+    if (swapchain2 != XR_NULL_HANDLE) {
+        xrDestroySwapchain(swapchain2);
+        swapchain2 = XR_NULL_HANDLE;
+    }
     CleanupOpenXR(xr);
     if (hudOk) CleanupHudRenderer(hudRenderer);
     CleanupD3D12(renderer);


### PR DESCRIPTION
Two commits:

### `fix(#433)` — MCP log sink tee + cube sub-rect regression knobs
Tees the MCP log sink to the per-process file log and adds cube sub-rect regression knobs. (Branch's primary work.)

### `fix(#431)` — don't crop zero-copy atlases for the DP (big-disparity regression)
Follow-up to the merged #431 PR (903cfffa5). That commit made `d3d11_crop_atlas_for_dp` succeed on TYPELESS zero-copy swapchains, but the crop is a top-left `CopySubresourceRegion` to the window-scaled content width — and a zero-copy app atlas has its tiles at the app/nominal stride (e.g. Unity's 1920/tile), not the content stride (1200/tile). The DP derives tile stride from `atlas_width / tile_columns`, so the cropped atlas weaved misaligned tiles → **big disparity on the live display**.

Fix: guard both DP-crop call sites with `!zero_copy`. A zero-copy swapchain is already a complete, correctly-strided multi-view atlas, so it reaches the DP uncropped (the pre-903cfffa5 fallback, now explicit and correct). The crop still applies to the renderer's own worst-case atlas. This also moots #431's original every-frame `E_INVALIDARG` SRV failure for zero-copy. Capture resample (item 2) and result metadata (item 3) are unaffected.

**Verified** on the Unity D3D11 windowed repro (in-process D3D11 native compositor, `is_service_mode=false`):
- Live Leia weave correct again (user-confirmed); the disparity is gone.
- Capture PNG 2400×1080 (matches D3D12 reference).
- `XrAtlasCaptureResultEXT` reports `atlas=2400x1080 eye=1200x1080 tiles=2x1` (window-scaled, not nominal) — verified live through the Unity plugin's `xrCaptureAtlasEXT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)