### PR TITLE
fix(#375): workspace_minimal compile fix + capture-client workspace API gaps

### DIFF
--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -12698,6 +12698,28 @@ comp_d3d11_service_set_focused_slot(struct xrt_system_compositor *xsysc, int slo
 	}
 }
 
+extern "C" int
+comp_d3d11_service_get_focused_slot(struct xrt_system_compositor *xsysc)
+{
+	// Read-side counterpart of the setter above. The compositor's
+	// focused_slot is the workspace focus source of truth — every focus
+	// mutation path updates it (both xrSetWorkspaceFocusedClientEXT id
+	// forms incl. capture clients, the clear path, click-to-focus, and
+	// visibility-hide of the focused slot) — so the IPC layer's
+	// get_focused_client derives its answer from here rather than from
+	// active_client_index (which capture clients never touch).
+	if (xsysc == nullptr) {
+		return -1;
+	}
+	struct d3d11_service_system *sys = d3d11_service_system_from_xrt(xsysc);
+	struct d3d11_multi_compositor *mc = sys->multi_comp;
+	if (!sys->workspace_mode || mc == nullptr) {
+		return -1;
+	}
+	std::lock_guard<std::recursive_mutex> lock(sys->render_mutex);
+	return mc->focused_slot;
+}
+
 extern "C" void
 comp_d3d11_service_set_client_modal_state(struct xrt_system_compositor *xsysc, int slot, bool is_open)
 {
@@ -13204,6 +13226,96 @@ comp_d3d11_service_get_capture_client_window_pose(struct xrt_system_compositor *
 	if (out_width_m) *out_width_m = mc->clients[slot_index].window_width_m;
 	if (out_height_m) *out_height_m = mc->clients[slot_index].window_height_m;
 
+	return true;
+}
+
+bool
+comp_d3d11_service_set_capture_client_visibility(struct xrt_system_compositor *xsysc,
+                                                  int slot_index,
+                                                  bool visible)
+{
+	if (xsysc == nullptr) {
+		return false;
+	}
+
+	struct d3d11_service_system *sys = d3d11_service_system_from_xrt(xsysc);
+	if (!sys->workspace_mode || sys->multi_comp == nullptr) {
+		return false;
+	}
+
+	struct d3d11_multi_compositor *mc = sys->multi_comp;
+	if (slot_index < 0 || slot_index >= D3D11_MULTI_MAX_CLIENTS) {
+		return false;
+	}
+
+	std::lock_guard<std::recursive_mutex> lock(sys->render_mutex);
+
+	if (!mc->clients[slot_index].active) {
+		return false;
+	}
+
+	// Same semantics as the by-xc setter above (#307 slice B): `minimized`
+	// is purely the composite gate; the controller owns the user-minimize
+	// vs maximize-hide distinction. Slot-addressed and type-agnostic, like
+	// set_capture_client_window_pose.
+	mc->clients[slot_index].minimized = !visible;
+	U_LOG_W("Workspace: set_visibility slot %d visible=%d (slot-addressed)", slot_index, visible);
+
+	if (!visible && slot_index == mc->focused_slot) {
+		// ADR-018: hiding the focused client clears focus for forwarding
+		// safety; the controller picks the successor.
+		mc->focused_slot = -1;
+		multi_compositor_update_input_forward(mc);
+	}
+	return true;
+}
+
+bool
+comp_d3d11_service_get_capture_client_info(struct xrt_system_compositor *xsysc,
+                                            int slot_index,
+                                            char *out_name,
+                                            size_t name_cap,
+                                            uint32_t *out_pid,
+                                            bool *out_visible,
+                                            bool *out_focused)
+{
+	if (xsysc == nullptr) {
+		return false;
+	}
+
+	struct d3d11_service_system *sys = d3d11_service_system_from_xrt(xsysc);
+	if (!sys->workspace_mode || sys->multi_comp == nullptr) {
+		return false;
+	}
+
+	struct d3d11_multi_compositor *mc = sys->multi_comp;
+	if (slot_index < 0 || slot_index >= D3D11_MULTI_MAX_CLIENTS) {
+		return false;
+	}
+
+	std::lock_guard<std::recursive_mutex> lock(sys->render_mutex);
+
+	struct d3d11_multi_client_slot *slot = &mc->clients[slot_index];
+	if (!slot->active || slot->client_type != CLIENT_TYPE_CAPTURE) {
+		return false;
+	}
+
+	if (out_name != nullptr && name_cap > 0) {
+		snprintf(out_name, name_cap, "%s", slot->app_name);
+	}
+	if (out_pid != nullptr) {
+		DWORD pid = 0;
+		if (slot->app_hwnd != nullptr && IsWindow(slot->app_hwnd)) {
+			GetWindowThreadProcessId(slot->app_hwnd, &pid);
+		}
+		*out_pid = (uint32_t)pid;
+	}
+	if (out_visible != nullptr) {
+		*out_visible = !slot->minimized;
+	}
+	if (out_focused != nullptr) {
+		*out_focused = (slot_index == mc->focused_slot);
+	}
 	return true;
 }
 

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.h
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.h
@@ -302,6 +302,50 @@ comp_d3d11_service_get_capture_client_window_pose(struct xrt_system_compositor *
                                                     float *out_height_m);
 
 /*!
+ * Set visibility (minimize/un-minimize) for a client by slot index.
+ *
+ * Slot-addressed counterpart of comp_d3d11_service_set_client_visibility —
+ * same semantics (`minimized` composite gate + focus-clear on hiding the
+ * focused slot), but addressed by slot so the IPC layer's 1000+slot id form
+ * (capture clients have no canonical id) can route here. Type-agnostic,
+ * like comp_d3d11_service_set_capture_client_window_pose.
+ *
+ * @param xsysc       The system compositor.
+ * @param slot_index   Slot index.
+ * @param visible      false = minimized (hidden from composite), true = shown.
+ * @return true on success.
+ *
+ * @ingroup comp_d3d11_service
+ */
+bool
+comp_d3d11_service_set_capture_client_visibility(struct xrt_system_compositor *xsysc,
+                                                  int slot_index,
+                                                  bool visible);
+
+/*!
+ * Introspect a CAPTURE client slot for xrGetWorkspaceClientInfoEXT.
+ *
+ * Capture clients have no IPC client_state to read, but enumerate hands out
+ * their 1000+slot ids, so the controller must be able to introspect them.
+ * Fills the captured window's title (`app_name`), owning process id (via
+ * GetWindowThreadProcessId on the captured HWND), workspace visibility
+ * (!minimized) and focus (slot == focused_slot).
+ *
+ * @return true on success; false if the slot is inactive or not a capture
+ *         client (OpenXR clients resolve through the canonical-id path).
+ *
+ * @ingroup comp_d3d11_service
+ */
+bool
+comp_d3d11_service_get_capture_client_info(struct xrt_system_compositor *xsysc,
+                                            int slot_index,
+                                            char *out_name,
+                                            size_t name_cap,
+                                            uint32_t *out_pid,
+                                            bool *out_visible,
+                                            bool *out_focused);
+
+/*!
  * Eagerly create the workspace compositor window (for empty workspace startup).
  * Called after workspace_activate when no clients are connected yet, so the
  * window exists to receive Ctrl+O app launch requests.
@@ -631,6 +675,17 @@ comp_d3d11_service_set_client_style_by_slot(struct xrt_system_compositor *xsysc,
  */
 void
 comp_d3d11_service_set_focused_slot(struct xrt_system_compositor *xsysc, int slot);
+
+/*!
+ * Read the compositor's `focused_slot` (-1 = none / workspace not active).
+ * This is the workspace focus source of truth — every focus mutation path
+ * updates it (both set_focused id forms incl. capture clients, the clear
+ * path, click-to-focus, visibility-hide) — so xrGetWorkspaceFocusedClientEXT
+ * derives its answer from here rather than from the IPC active_client_index
+ * (which capture clients never touch).
+ */
+int
+comp_d3d11_service_get_focused_slot(struct xrt_system_compositor *xsysc);
 
 /*!
  * spec_version 10: mark slot @p slot as having a Win32 modal popup open

--- a/src/xrt/ipc/server/ipc_server_handler.c
+++ b/src/xrt/ipc/server/ipc_server_handler.c
@@ -29,6 +29,7 @@
 #endif
 
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 
 #if defined(XRT_HAVE_D3D11_SERVICE_COMPOSITOR)
@@ -2651,6 +2652,15 @@ ipc_handle_workspace_set_window_visibility(volatile struct ipc_client_state *_ic
 
 	IPC_INFO(s, "Workspace: set_visibility client_id=%u visible=%d", client_id, visible);
 
+	// Pure capture clients stay slot-addressed after normalize (they have no
+	// canonical id) — route them straight to the slot setter, mirroring
+	// set_window_pose's 1000+slot branch.
+	if (client_id >= 1000u) {
+		int slot = (int)(client_id - 1000u);
+		bool capture_ok = comp_d3d11_service_set_capture_client_visibility(s->xsysc, slot, visible);
+		return capture_ok ? XRT_SUCCESS : XRT_ERROR_IPC_FAILURE;
+	}
+
 	os_mutex_lock(&s->global_state.lock);
 
 	volatile struct ipc_client_state *target_ics = NULL;
@@ -2913,21 +2923,26 @@ ipc_handle_workspace_get_focused_client(volatile struct ipc_client_state *_ics, 
 	}
 	*out_client_id = 0;
 
+#if defined(XRT_HAVE_D3D11_SERVICE_COMPOSITOR)
+	// The compositor's focused_slot is the workspace focus source of truth —
+	// BOTH set_focused id forms update it (incl. capture clients, which have
+	// no IPC session and never touch active_client_index), as do the clear
+	// path, click-to-focus, and visibility-hide of the focused slot. Deriving
+	// the answer from active_client_index instead broke the set→get roundtrip
+	// for capture clients (set updated focused_slot only; the index stayed
+	// stale). Return the unified 1000+slot form (matches enumerate + events).
+	if (s->xsysc != NULL) {
+		int slot = comp_d3d11_service_get_focused_slot(s->xsysc);
+		*out_client_id = (slot >= 0) ? (1000u + (uint32_t)slot) : 0;
+		return XRT_SUCCESS;
+	}
+#endif
+
 	os_mutex_lock(&s->global_state.lock);
 	int idx = s->global_state.active_client_index;
 	if (idx >= 0 && idx < IPC_MAX_CLIENTS) {
 		volatile struct ipc_client_state *ics = &s->threads[idx].ics;
-#if defined(XRT_HAVE_D3D11_SERVICE_COMPOSITOR)
-		// #304 id-unification: return the 1000+slot workspace id (matches
-		// enumerate + events), resolved from the active client's slot.
-		int slot = (s->xsysc != NULL && ics->xc != NULL)
-		    ? comp_d3d11_service_workspace_find_slot_by_xc(
-		          s->xsysc, (struct xrt_compositor *)ics->xc)
-		    : -1;
-		*out_client_id = (slot >= 0) ? (1000u + (uint32_t)slot) : 0;
-#else
 		*out_client_id = ics->client_state.id;
-#endif
 	}
 	os_mutex_unlock(&s->global_state.lock);
 
@@ -3229,6 +3244,35 @@ ipc_handle_workspace_get_client_info(volatile struct ipc_client_state *_ics,
 		return XRT_ERROR_IPC_FAILURE;
 	}
 	client_id = ipc_workspace_normalize_client_id(s, client_id); // #304: accept 1000+slot
+
+#if defined(XRT_HAVE_D3D11_SERVICE_COMPOSITOR)
+	// Pure capture clients stay slot-addressed after normalize (no IPC
+	// client_state to read). Enumerate hands out these 1000+slot ids, so the
+	// controller must be able to introspect them — fill from the compositor
+	// slot instead (captured window title, owning pid, workspace
+	// minimize/focus state).
+	if (client_id >= 1000u && s->xsysc != NULL) {
+		int slot = (int)(client_id - 1000u);
+		char cap_name[XRT_MAX_APPLICATION_NAME_SIZE] = {0};
+		uint32_t cap_pid = 0;
+		bool ws_visible = false, ws_focused = false;
+		if (!comp_d3d11_service_get_capture_client_info(s->xsysc, slot, cap_name,
+		                                                sizeof(cap_name), &cap_pid,
+		                                                &ws_visible, &ws_focused)) {
+			return XRT_ERROR_IPC_FAILURE;
+		}
+		memset(out_state, 0, sizeof(*out_state));
+		out_state->id = client_id;
+		out_state->pid = (pid_t)cap_pid;
+		out_state->session_active = true;
+		out_state->session_visible = ws_visible;
+		out_state->session_focused = ws_focused;
+		snprintf(out_state->info.application_name, sizeof(out_state->info.application_name),
+		         "%s", cap_name);
+		return XRT_SUCCESS;
+	}
+#endif
+
 	xrt_result_t xret = ipc_server_get_client_app_state(s, client_id, out_state);
 	if (xret != XRT_SUCCESS) {
 		return xret;

--- a/test_apps/workspace_minimal_d3d11_win/main.cpp
+++ b/test_apps/workspace_minimal_d3d11_win/main.cpp
@@ -4,13 +4,12 @@
 // workspace_minimal_d3d11_win
 //
 // Minimal validation client for XR_EXT_spatial_workspace (Phase 2.A + 2.C
-// + 2.D + 2.F + 2.I-prequel, spec_version 9) and XR_EXT_app_launcher
-// (Phase 2.B). Creates an instance + session, resolves all 29 extension
-// PFNs, and walks through:
+// + 2.D + 2.F + 2.I-prequel). Creates an instance + session, resolves all
+// 24 extension PFNs, and walks through:
 //   activate -> get-state ->
 //     add capture client ->
 //     set/get/set client window pose + visibility ->
-//     hit-test (center + off-screen) ->
+//     set cursor depth (spec_version 22) ->
 //     set/get focused client (Phase 2.D) ->
 //     enumerate input events (count-query) (Phase 2.D) ->
 //     enable/disable pointer capture (Phase 2.D) ->
@@ -21,7 +20,6 @@
 //     enumerate workspace clients + get client info (Phase 2.I-prequel) ->
 //     capture workspace frame (Phase 2.I-prequel) ->
 //     remove capture client ->
-//     clear / add / set-visible / set-running-mask / poll / hide launcher ->
 //   deactivate.
 //
 // Two valid run paths:
@@ -46,7 +44,6 @@
 #include <openxr/openxr.h>
 #include <openxr/openxr_platform.h>
 #include <openxr/XR_EXT_spatial_workspace.h>
-#include <openxr/XR_EXT_app_launcher.h>
 
 #include <cstdio>
 #include <cstdlib>
@@ -99,14 +96,9 @@ run_workspace_test()
 	}
 
 	bool workspace_listed = false;
-	bool launcher_listed = false;
 	for (const auto &p : props) {
 		if (std::strcmp(p.extensionName, XR_EXT_SPATIAL_WORKSPACE_EXTENSION_NAME) == 0) {
 			workspace_listed = true;
-			std::printf("[enumerate                                ] found %s v%u\n", p.extensionName,
-			            p.extensionVersion);
-		} else if (std::strcmp(p.extensionName, XR_EXT_APP_LAUNCHER_EXTENSION_NAME) == 0) {
-			launcher_listed = true;
 			std::printf("[enumerate                                ] found %s v%u\n", p.extensionName,
 			            p.extensionVersion);
 		}
@@ -115,16 +107,11 @@ run_workspace_test()
 		std::printf("FAIL: runtime did not advertise %s\n", XR_EXT_SPATIAL_WORKSPACE_EXTENSION_NAME);
 		return XR_ERROR_RUNTIME_FAILURE;
 	}
-	if (!launcher_listed) {
-		std::printf("FAIL: runtime did not advertise %s\n", XR_EXT_APP_LAUNCHER_EXTENSION_NAME);
-		return XR_ERROR_RUNTIME_FAILURE;
-	}
 
-	// 2. Create instance with workspace + launcher extensions and D3D11 binding.
+	// 2. Create instance with the workspace extension and D3D11 binding.
 	const char *enabled_exts[] = {
 	    XR_KHR_D3D11_ENABLE_EXTENSION_NAME,
 	    XR_EXT_SPATIAL_WORKSPACE_EXTENSION_NAME,
-	    XR_EXT_APP_LAUNCHER_EXTENSION_NAME,
 	};
 	XrInstanceCreateInfo instInfo = {XR_TYPE_INSTANCE_CREATE_INFO};
 	instInfo.applicationInfo.apiVersion = XR_CURRENT_API_VERSION;
@@ -143,11 +130,6 @@ run_workspace_test()
 	PFN_xrGetSpatialWorkspaceStateEXT pfnGetState = nullptr;
 	PFN_xrAddWorkspaceCaptureClientEXT pfnAddCapture = nullptr;
 	PFN_xrRemoveWorkspaceCaptureClientEXT pfnRemoveCapture = nullptr;
-	PFN_xrClearLauncherAppsEXT pfnClearLauncher = nullptr;
-	PFN_xrAddLauncherAppEXT pfnAddLauncherApp = nullptr;
-	PFN_xrSetLauncherVisibleEXT pfnSetLauncherVisible = nullptr;
-	PFN_xrPollLauncherClickEXT pfnPollLauncherClick = nullptr;
-	PFN_xrSetLauncherRunningTileMaskEXT pfnSetRunningTileMask = nullptr;
 	PFN_xrSetWorkspaceClientWindowPoseEXT pfnSetClientPose = nullptr;
 	PFN_xrGetWorkspaceClientWindowPoseEXT pfnGetClientPose = nullptr;
 	PFN_xrSetWorkspaceClientVisibilityEXT pfnSetClientVisibility = nullptr;
@@ -181,12 +163,6 @@ run_workspace_test()
 	    {"xrGetSpatialWorkspaceStateEXT", reinterpret_cast<PFN_xrVoidFunction *>(&pfnGetState)},
 	    {"xrAddWorkspaceCaptureClientEXT", reinterpret_cast<PFN_xrVoidFunction *>(&pfnAddCapture)},
 	    {"xrRemoveWorkspaceCaptureClientEXT", reinterpret_cast<PFN_xrVoidFunction *>(&pfnRemoveCapture)},
-	    {"xrClearLauncherAppsEXT", reinterpret_cast<PFN_xrVoidFunction *>(&pfnClearLauncher)},
-	    {"xrAddLauncherAppEXT", reinterpret_cast<PFN_xrVoidFunction *>(&pfnAddLauncherApp)},
-	    {"xrSetLauncherVisibleEXT", reinterpret_cast<PFN_xrVoidFunction *>(&pfnSetLauncherVisible)},
-	    {"xrPollLauncherClickEXT", reinterpret_cast<PFN_xrVoidFunction *>(&pfnPollLauncherClick)},
-	    {"xrSetLauncherRunningTileMaskEXT",
-	     reinterpret_cast<PFN_xrVoidFunction *>(&pfnSetRunningTileMask)},
 	    {"xrSetWorkspaceClientWindowPoseEXT", reinterpret_cast<PFN_xrVoidFunction *>(&pfnSetClientPose)},
 	    {"xrGetWorkspaceClientWindowPoseEXT", reinterpret_cast<PFN_xrVoidFunction *>(&pfnGetClientPose)},
 	    {"xrSetWorkspaceClientVisibilityEXT",
@@ -715,32 +691,6 @@ run_workspace_test()
 	std::printf("[xrRemoveWorkspaceCaptureClientEXT(post-exit)] %s (best-effort; "
 	            "exit above already removed the slot)\n", xr_result_str(rmr));
 
-	// Launcher smoke: clear, push 3 synthetic tiles, set visible, set running
-	// mask, poll once (expect "no click" since no human is interacting),
-	// hide, clear, then proceed to deactivate.
-	CHECK_XR(pfnClearLauncher(session), "xrClearLauncherAppsEXT");
-	for (int i = 0; i < 3; ++i) {
-		XrLauncherAppInfoEXT info = {XR_TYPE_LAUNCHER_APP_INFO_EXT};
-		std::snprintf(info.name, sizeof(info.name), "TestApp%d", i);
-		info.iconPath[0] = '\0'; // No icon — runtime renders a placeholder.
-		info.appIndex = i;
-		CHECK_XR(pfnAddLauncherApp(session, &info), "xrAddLauncherAppEXT");
-	}
-	CHECK_XR(pfnSetLauncherVisible(session, XR_TRUE), "xrSetLauncherVisibleEXT(TRUE)");
-	CHECK_XR(pfnSetRunningTileMask(session, 0x3 /* tiles 0+1 running */),
-	         "xrSetLauncherRunningTileMaskEXT");
-
-	int32_t clicked_index = 0;
-	CHECK_XR(pfnPollLauncherClick(session, &clicked_index), "xrPollLauncherClickEXT");
-	if (clicked_index != XR_LAUNCHER_INVALID_APPINDEX_EXT) {
-		std::printf("INFO: launcher click pending index=%d (unexpected — no human input expected)\n",
-		            (int)clicked_index);
-	} else {
-		std::printf("INFO: launcher poll = no pending click (expected)\n");
-	}
-
-	CHECK_XR(pfnSetLauncherVisible(session, XR_FALSE), "xrSetLauncherVisibleEXT(FALSE)");
-	CHECK_XR(pfnClearLauncher(session), "xrClearLauncherAppsEXT");
 	CHECK_XR(pfnDeactivate(session), "xrDeactivateSpatialWorkspaceEXT");
 
 	xrDestroySession(session);

--- a/test_apps/workspace_minimal_d3d11_win/main.cpp
+++ b/test_apps/workspace_minimal_d3d11_win/main.cpp
@@ -13,10 +13,8 @@
 //     set/get focused client (Phase 2.D) ->
 //     enumerate input events (count-query) (Phase 2.D) ->
 //     enable/disable pointer capture (Phase 2.D) ->
-//     create chrome swapchain + acquire/wait/clear/release one image ->
-//     set chrome layout with auto-anchor + 2 hit regions (spec_version 8) ->
+//     chrome-on-capture documented rejection (captures carry no chrome) ->
 //     acquire wakeup event handle (spec_version 8) ->
-//     destroy chrome swapchain ->
 //     enumerate workspace clients + get client info (Phase 2.I-prequel) ->
 //     capture workspace frame (Phase 2.I-prequel) ->
 //     remove capture client ->
@@ -304,12 +302,9 @@ run_workspace_test()
 	}
 	std::printf("INFO: added capture client id=%u\n", (unsigned)clientId);
 
-	// Window pose + visibility smoke (Phase 2.C). Whether the captured
-	// HWND is treated as a positionable workspace client is a runtime
-	// decision; we expect either XR_SUCCESS or a documented error code
-	// (typically XR_ERROR_VALIDATION_FAILURE if the slot isn't mapped to
-	// a positionable client). Either response proves the dispatch path
-	// reaches the IPC layer end-to-end.
+	// Window pose + visibility smoke (Phase 2.C). Capture clients are
+	// full positionable workspace clients (slot-addressed via their
+	// 1000+slot id) — pose set/get and visibility set must all succeed.
 	{
 		XrPosef testPose = {};
 		testPose.orientation.w = 1.0f; // identity
@@ -326,10 +321,13 @@ run_workspace_test()
 			            readback.position.y, readback.position.z, w, h);
 		}
 
-		XrResult vr = pfnSetClientVisibility(session, clientId, XR_FALSE);
-		std::printf("[xrSetWorkspaceClientVisibilityEXT(FALSE)   ] %s\n", xr_result_str(vr));
-		vr = pfnSetClientVisibility(session, clientId, XR_TRUE);
-		std::printf("[xrSetWorkspaceClientVisibilityEXT(TRUE)    ] %s\n", xr_result_str(vr));
+		// Visibility round-trip: capture clients are slot-addressed in the
+		// runtime (no canonical IPC id), and the visibility handler routes
+		// 1000+slot ids to the by-slot setter — both calls must succeed.
+		CHECK_XR(pfnSetClientVisibility(session, clientId, XR_FALSE),
+		         "xrSetWorkspaceClientVisibilityEXT(FALSE)");
+		CHECK_XR(pfnSetClientVisibility(session, clientId, XR_TRUE),
+		         "xrSetWorkspaceClientVisibilityEXT(TRUE)");
 
 		// Cursor-depth smoke (spec_version 22): the runtime raycast +
 		// xrWorkspaceHitTestEXT were removed; the controller now owns the
@@ -352,6 +350,7 @@ run_workspace_test()
 		if (focused != clientId) {
 			std::printf("FAIL: focused-client roundtrip mismatch (got %u, set %u)\n",
 			            (unsigned)focused, (unsigned)clientId);
+			return XR_ERROR_RUNTIME_FAILURE;
 		}
 
 		// Drain count-query (capacity=0): expect zero events because no
@@ -466,13 +465,15 @@ run_workspace_test()
 
 		// Phase 2.C controller-owned chrome smoke (spec_version 7 + 8).
 		//
-		// Mints a chrome swapchain bound to the captured client, walks the
-		// standard acquire / wait / render-into-image[index] / release
-		// loop once (clearing image to a recognizable magenta), pushes a
-		// chrome layout with two UV-space hit regions and the new
-		// auto-anchor flags (spec_version 8), acquires a wakeup event
-		// handle, then destroys. Validates dispatch reaches the runtime
-		// for every chrome path without requiring a real controller.
+		// Chrome decorates OPENXR clients only — capture clients are
+		// rejected by design ("captures aren't decorated with chrome",
+		// ipc_handle_workspace_register_chrome_swapchain; the controller
+		// draws its own chrome around captured windows). This smoke's only
+		// addressable client IS a capture client (the controller's own
+		// session is never slotted), so assert the documented rejection
+		// here; the full create / acquire / layout / destroy walk needs a
+		// slotted OpenXR app client under a real controller and lives
+		// outside this single-process smoke.
 		{
 			constexpr int64_t  kSrgbFormat   = 29; // DXGI_FORMAT_R8G8B8A8_UNORM_SRGB
 			constexpr uint32_t kChromeWidth  = 256;
@@ -486,90 +487,24 @@ run_workspace_test()
 			chromeCi.sampleCount = 1;
 			chromeCi.mipCount = 1;
 			XrSwapchain chromeSwapchain = XR_NULL_HANDLE;
-			CHECK_XR(pfnCreateChromeSwapchain(session, clientId, &chromeCi, &chromeSwapchain),
-			         "xrCreateWorkspaceClientChromeSwapchainEXT");
-
-			// Enumerate images via the standard core entry point —
-			// chrome swapchains behave like normal XrSwapchains once
-			// created. Single-image loop (mipCount=1, sampleCount=1).
-			uint32_t imgCount = 0;
-			CHECK_XR(xrEnumerateSwapchainImages(chromeSwapchain, 0, &imgCount, nullptr),
-			         "xrEnumerateSwapchainImages(chrome,count)");
-			std::vector<XrSwapchainImageD3D11KHR> images(
-			    imgCount, {XR_TYPE_SWAPCHAIN_IMAGE_D3D11_KHR});
-			CHECK_XR(xrEnumerateSwapchainImages(
-			             chromeSwapchain, imgCount, &imgCount,
-			             reinterpret_cast<XrSwapchainImageBaseHeader *>(images.data())),
-			         "xrEnumerateSwapchainImages(chrome,fill)");
-			std::printf("[xrEnumerateSwapchainImages(chrome)         ] count=%u\n",
-			            (unsigned)imgCount);
-
-			XrSwapchainImageAcquireInfo acqInfo = {XR_TYPE_SWAPCHAIN_IMAGE_ACQUIRE_INFO};
-			uint32_t idx = 0xFFFFFFFFu;
-			CHECK_XR(xrAcquireSwapchainImage(chromeSwapchain, &acqInfo, &idx),
-			         "xrAcquireSwapchainImage(chrome)");
-
-			XrSwapchainImageWaitInfo waitInfo = {XR_TYPE_SWAPCHAIN_IMAGE_WAIT_INFO};
-			waitInfo.timeout = XR_INFINITE_DURATION;
-			CHECK_XR(xrWaitSwapchainImage(chromeSwapchain, &waitInfo),
-			         "xrWaitSwapchainImage(chrome)");
-
-			// Render: ClearRTV the acquired image to magenta. Best-effort
-			// — failure to create the RTV doesn't fail the smoke; the
-			// acquire/release loop itself is what's being validated.
-			if (idx < images.size() && images[idx].texture != nullptr) {
-				ComPtr<ID3D11RenderTargetView> rtv;
-				D3D11_RENDER_TARGET_VIEW_DESC rtvd = {};
-				rtvd.Format = DXGI_FORMAT_R8G8B8A8_UNORM_SRGB;
-				rtvd.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE2D;
-				rtvd.Texture2D.MipSlice = 0;
-				HRESULT rh = device->CreateRenderTargetView(
-				    images[idx].texture, &rtvd, rtv.GetAddressOf());
-				if (SUCCEEDED(rh)) {
-					const float magenta[4] = {0.85f, 0.10f, 0.85f, 0.85f};
-					context->ClearRenderTargetView(rtv.Get(), magenta);
-					context->Flush();
-					std::printf("[Phase 2.C chrome ClearRTV(magenta)         ] OK\n");
-				} else {
-					std::printf("INFO: CreateRenderTargetView(chrome img %u) hr=0x%08lx — paint skipped\n",
-					            (unsigned)idx, (unsigned long)rh);
-				}
+			XrResult ccr = pfnCreateChromeSwapchain(session, clientId, &chromeCi, &chromeSwapchain);
+			std::printf("[xrCreateWorkspaceClientChromeSwapchainEXT  ] %s "
+			            "(expect RUNTIME_FAILURE: capture clients carry no chrome)\n",
+			            xr_result_str(ccr));
+			if (ccr == XR_SUCCESS) {
+				// Chrome-on-capture gained support since this was written —
+				// don't leak the handle, and flag the stale expectation.
+				std::printf("INFO: chrome-on-capture unexpectedly supported — update this "
+				            "smoke to walk the full chrome loop.\n");
+				CHECK_XR(pfnDestroyChromeSwapchain(chromeSwapchain),
+				         "xrDestroyWorkspaceClientChromeSwapchainEXT");
+			} else if (ccr != XR_ERROR_RUNTIME_FAILURE) {
+				std::printf("FAIL: expected RUNTIME_FAILURE for chrome on a capture client\n");
+				return ccr;
 			}
 
-			XrSwapchainImageReleaseInfo relInfo = {XR_TYPE_SWAPCHAIN_IMAGE_RELEASE_INFO};
-			CHECK_XR(xrReleaseSwapchainImage(chromeSwapchain, &relInfo),
-			         "xrReleaseSwapchainImage(chrome)");
-
-			// Layout with two hit regions + spec_version 8 auto-anchor.
-			// Region IDs are controller-defined opaque uint32_t — the
-			// runtime echoes them back as `chromeRegionId` on POINTER
-			// events. We use 1=drag, 2=close as a self-documenting smoke.
-			XrWorkspaceChromeHitRegionEXT regions[2] = {};
-			regions[0].id = 1;
-			regions[0].bounds.offset = {0.0f, 0.0f};
-			regions[0].bounds.extent = {0.5f, 1.0f};
-			regions[1].id = 2;
-			regions[1].bounds.offset = {0.5f, 0.0f};
-			regions[1].bounds.extent = {0.5f, 1.0f};
-
-			XrWorkspaceChromeLayoutEXT layout = {XR_TYPE_WORKSPACE_CHROME_LAYOUT_EXT};
-			layout.poseInClient.orientation.w = 1.0f;
-			// With anchorToWindowTopEdge = XR_TRUE (spec_version 8), this
-			// y is interpreted as an offset ABOVE the window's top edge.
-			// 12 mm sits a generous gap above any reasonable window.
-			layout.poseInClient.position.y = 0.012f;
-			layout.sizeMeters = {0.20f, 0.012f};
-			layout.followsWindowOrient = XR_FALSE;
-			layout.hitRegionCount = 2;
-			layout.hitRegions = regions;
-			layout.depthBiasMeters = 0.0f; // runtime default (1 mm)
-			layout.anchorToWindowTopEdge = XR_TRUE;
-			layout.widthAsFractionOfWindow = 0.75f; // 75% of current win_w
-			CHECK_XR(pfnSetChromeLayout(session, clientId, &layout),
-			         "xrSetWorkspaceClientChromeLayoutEXT");
-			std::printf("[Phase 2.C chrome layout (auto-anchor, 2 regions)] OK\n");
-
-			// Wakeup event handle (spec_version 8). Validate the handle
+			// Wakeup event handle (spec_version 8) — session-level, not
+			// chrome-bound, so it stays exercised. Validate the handle
 			// is non-NULL and well-formed (zero-timeout wait should
 			// succeed with WAIT_TIMEOUT or WAIT_OBJECT_0 — both prove
 			// the kernel object is reachable). We don't rely on a signal
@@ -589,9 +524,6 @@ run_workspace_test()
 				            wstr);
 				CloseHandle(reinterpret_cast<HANDLE>(wakeup));
 			}
-
-			CHECK_XR(pfnDestroyChromeSwapchain(chromeSwapchain),
-			         "xrDestroyWorkspaceClientChromeSwapchainEXT");
 		}
 
 		// Phase 2.C spec_version 9: per-client visual style smoke. Push a
@@ -621,10 +553,14 @@ run_workspace_test()
 		}
 
 		// Phase 2.I-prequel: client enumeration smoke.
-		// Count-query first, then enumerate. The smoke session is itself an
-		// OpenXR client connection so enumerate should return at least 1 id
-		// (this session). xrGetWorkspaceClientInfoEXT against the first id
-		// should succeed and return a non-empty name.
+		// Enumerate walks IPC-connected OpenXR clients with bound slots.
+		// Neither of this smoke's connections qualifies: the controller's
+		// own session is never slotted, and capture clients aren't IPC
+		// clients (they're deliberately excluded — the shell's per-tick
+		// chrome-creation walk would otherwise spam rejected creates; the
+		// controller already holds the 1000+slot id from add). So expect
+		// count == 0 here; a non-zero count (some other OpenXR app is
+		// connected) exercises the fill + info path below.
 		uint32_t client_count = 0;
 		CHECK_XR(pfnEnumClients(session, 0, &client_count, nullptr),
 		         "xrEnumerateWorkspaceClientsEXT(count)");
@@ -646,6 +582,24 @@ run_workspace_test()
 				            (unsigned)ids[0], cinfo.name, (unsigned long long)cinfo.pid,
 				            (unsigned)cinfo.zOrder, (unsigned)cinfo.isFocused,
 				            (unsigned)cinfo.isVisible);
+			}
+		}
+
+		// Capture-client introspection: enumerate doesn't list captures, but
+		// xrGetWorkspaceClientInfoEXT must resolve the 1000+slot id the
+		// controller got from add — name/pid/visible/focused are filled from
+		// the compositor slot (captures have no IPC client_state).
+		{
+			XrWorkspaceClientInfoEXT cinfo = {XR_TYPE_WORKSPACE_CLIENT_INFO_EXT};
+			CHECK_XR(pfnGetClientInfo(session, clientId, &cinfo),
+			         "xrGetWorkspaceClientInfoEXT(capture)");
+			std::printf("[xrGetWorkspaceClientInfoEXT(capture id=%u)] name=\"%s\" pid=%llu "
+			            "focused=%u visible=%u\n",
+			            (unsigned)clientId, cinfo.name, (unsigned long long)cinfo.pid,
+			            (unsigned)cinfo.isFocused, (unsigned)cinfo.isVisible);
+			if (cinfo.name[0] == '\0') {
+				std::printf("FAIL: capture-client info returned an empty name\n");
+				return XR_ERROR_RUNTIME_FAILURE;
 			}
 		}
 


### PR DESCRIPTION
## Summary

Two stacked fixes, surfaced in sequence:

**Commit 1 — fixes #375.** `workspace_minimal_d3d11_win` failed to compile because #308 removed the launcher extension (`XR_EXT_app_launcher.h`) but the smoke test still included it and exercised the 5 removed launcher PFNs. Removes the orphaned launcher surface; the app resolves only the live `XR_EXT_spatial_workspace` (v23) — 24 PFNs.

**Commit 2 — capture-client API gaps.** Running the now-compilable smoke against the live service (Calculator as WGC capture client) surfaced three runtime gaps that drifted in while the test was broken:

| Call | Was | Root cause | Fix |
|---|---|---|---|
| `xrSetWorkspaceClientVisibilityEXT(1000+slot)` | RUNTIME_FAILURE | normalize leaves pure-capture ids slot-addressed; handler's client_state lookup missed | new by-slot setter `comp_d3d11_service_set_capture_client_visibility` + 1000+slot branch (mirrors `set_window_pose`) |
| `xrGetWorkspaceFocusedClientEXT` after focusing a capture | stale (returned 0) | SET updates compositor `focused_slot` only; GET read `active_client_index` | GET now reads `focused_slot` (new `comp_d3d11_service_get_focused_slot`) — the focus source of truth every mutation path updates |
| `xrGetWorkspaceClientInfoEXT(1000+slot)` | IPC failure | `find_client_locked` only knows IPC clients | fill from compositor slot: window title, owning pid, workspace minimize/focus |

**By design, unchanged:** chrome-on-capture stays rejected ("captures aren't decorated with chrome") — the test now asserts the documented rejection. Enumerate also keeps excluding captures (the shell's per-tick chrome-creation walk over the enumerate list would otherwise spam rejected creates; controllers hold the capture id from `add`).

## Verification

- `build_windows.bat build` + `test-apps` — clean
- Hardware run: `displayxr-service --workspace` + Calculator capture → **RESULT: PASS** end-to-end — activate, pose set/get, visibility round-trip, cursor depth, focused set/get roundtrip (1000=1000), input drain (tick=106/2s), fullscreen toggles, chrome documented-reject, wakeup event, capture introspection (`name="Calculator"`, correct pid, focused=1 visible=1), frame capture, exit, deactivate
- Shell unaffected: it never calls `xrGetWorkspaceFocusedClientEXT`, and enumerate semantics are unchanged

Fixes #375

🤖 Generated with [Claude Code](https://claude.com/claude-code)