### PR TITLE
build(test-apps): adopt displayxr::math Layer 1 window/canvas resolve [#396]

### DIFF
--- a/test_apps/common/CMakeLists.txt
+++ b/test_apps/common/CMakeLists.txt
@@ -21,7 +21,7 @@ set(DISPLAYXR_COMMON_BUILD_TESTS OFF CACHE BOOL "" FORCE)
 FetchContent_Declare(
     displayxr_common
     GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
-    GIT_TAG v0.1.1
+    GIT_TAG v0.2.0
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(displayxr_common)

--- a/test_apps/cube_handle_d3d11_win/main.cpp
+++ b/test_apps/cube_handle_d3d11_win/main.cpp
@@ -443,36 +443,41 @@ static void RenderOneFrame(RenderState& rs) {
                     std::vector<Display3DView> stereoViews(eyeCount);
                     bool useAppProjection = (xr.hasDisplayInfoExt && xr.displayWidthM > 0.0f);
                     if (useAppProjection) {
-                        // Window-relative Kooima: use actual window physical dims as screen,
-                        // offset eyes to be relative to window center (not display center)
-                        float pxSizeX = xr.displayWidthM / (float)xr.swapchain.width;
-                        float pxSizeY = xr.displayHeightM / (float)xr.swapchain.height;
-                        float winW_m = (float)g_windowWidth * pxSizeX;
-                        float winH_m = (float)g_windowHeight * pxSizeY;
-
-                        // Compute window center offset from display center (meters)
-                        float eyeOffsetX = 0.0f, eyeOffsetY = 0.0f;
+                        // Window-relative Kooima: the window's placement on the
+                        // display + raw eyes -> Kooima screen dims + window-relative
+                        // eyes, via the shared displayxr::math helper (#396 Layer 1).
+                        // The platform rect-fetch (ClientToScreen/MonitorInfo) stays
+                        // here; the px-size / screen / offset / Y-flip math is in the lib.
+                        Display3DWindowPlacement place;
+                        place.display_width_m   = xr.displayWidthM;
+                        place.display_height_m  = xr.displayHeightM;
+                        place.display_width_px  = (float)xr.swapchain.width;   // fallback
+                        place.display_height_px = (float)xr.swapchain.height;
+                        place.rect_width_px     = (float)g_windowWidth;
+                        place.rect_height_px    = (float)g_windowHeight;
+                        place.rect_center_x_px  = place.display_width_px * 0.5f;  // fallback: centered
+                        place.rect_center_y_px  = place.display_height_px * 0.5f;
                         {
                             POINT clientOrigin = {0, 0};
                             ClientToScreen(rs.hwnd, &clientOrigin);
                             HMONITOR hMon = MonitorFromWindow(rs.hwnd, MONITOR_DEFAULTTONEAREST);
                             MONITORINFO mi = {sizeof(mi)};
                             if (GetMonitorInfo(hMon, &mi)) {
-                                float winCenterX = (float)(clientOrigin.x - mi.rcMonitor.left) + g_windowWidth / 2.0f;
-                                float winCenterY = (float)(clientOrigin.y - mi.rcMonitor.top) + g_windowHeight / 2.0f;
-                                float dispW = (float)(mi.rcMonitor.right - mi.rcMonitor.left);
-                                float dispH = (float)(mi.rcMonitor.bottom - mi.rcMonitor.top);
-                                eyeOffsetX = (winCenterX - dispW / 2.0f) * pxSizeX;
-                                eyeOffsetY = -((winCenterY - dispH / 2.0f) * pxSizeY); // Y flip: screen Y-down, eye Y-up
+                                place.display_width_px  = (float)(mi.rcMonitor.right - mi.rcMonitor.left);
+                                place.display_height_px = (float)(mi.rcMonitor.bottom - mi.rcMonitor.top);
+                                place.rect_center_x_px  = (float)(clientOrigin.x - mi.rcMonitor.left) + g_windowWidth / 2.0f;
+                                place.rect_center_y_px  = (float)(clientOrigin.y - mi.rcMonitor.top) + g_windowHeight / 2.0f;
                             }
                         }
 
-                        // Build per-view eye positions (shifted to window center)
+                        // Gather raw (unshifted) per-view eyes, then resolve to screen
+                        // dims + window-relative eyes (in place).
                         std::vector<XrVector3f> rawEyes(eyeCount);
                         for (int v = 0; v < eyeCount; v++) {
-                            XrVector3f pos = (v < (int)viewCount) ? rawViews[v].pose.position : rawViews[0].pose.position;
-                            rawEyes[v] = {pos.x - eyeOffsetX, pos.y - eyeOffsetY, pos.z};
+                            rawEyes[v] = (v < (int)viewCount) ? rawViews[v].pose.position : rawViews[0].pose.position;
                         }
+                        Display3DScreen screen;
+                        display3d_resolve_window_rect(&place, rawEyes.data(), (uint32_t)eyeCount, &screen, rawEyes.data());
 
                         // For mono: average all views to center eye
                         if (monoMode) {
@@ -498,7 +503,6 @@ static void RenderOneFrame(RenderState& rs) {
                         cameraPose.position = {g_inputState.cameraPosX, g_inputState.cameraPosY, g_inputState.cameraPosZ};
 
                         XrVector3f nominalViewer = {xr.nominalViewerX, xr.nominalViewerY, xr.nominalViewerZ};
-                        Display3DScreen screen = {winW_m, winH_m};
 
                         if (g_inputState.cameraMode) {
                             // Camera-centric path

--- a/test_apps/cube_texture_d3d11_win/main.cpp
+++ b/test_apps/cube_texture_d3d11_win/main.cpp
@@ -677,36 +677,42 @@ static void RenderOneFrame(RenderState& rs) {
                     std::vector<Display3DView> stereoViews(eyeCount);
                     bool useAppProjection = (xr.hasDisplayInfoExt && xr.displayWidthM > 0.0f);
                     if (useAppProjection) {
-                        float pxSizeX = xr.displayWidthM / (float)xr.displayPixelWidth;
-                        float pxSizeY = xr.displayHeightM / (float)xr.displayPixelHeight;
-                        float canvasW_m = (float)g_canvasW * pxSizeX;
-                        float canvasH_m = (float)g_canvasH * pxSizeY;
-
-                        // Canvas-relative Kooima: physical size + eye offset both anchored
-                        // on the canvas region within the window (not the window itself).
+                        // Canvas-relative Kooima: the CANVAS sub-rect's placement on the
+                        // display + raw eyes -> Kooima screen dims + canvas-relative eyes,
+                        // via the shared displayxr::math helper (#396 Layer 1). Same call
+                        // as a handle app — just the canvas sub-rect instead of the full
+                        // window (no app-class branching in the lib). Platform rect-fetch
+                        // (incl. the canvas's offset within the window) stays here.
                         float canvas_off_x = (float)g_windowWidth  / 4.0f;
                         float canvas_off_y = (float)g_windowHeight / 4.0f;
-                        float eyeOffsetX = 0.0f, eyeOffsetY = 0.0f;
+                        Display3DWindowPlacement place;
+                        place.display_width_m   = xr.displayWidthM;
+                        place.display_height_m  = xr.displayHeightM;
+                        place.display_width_px  = (float)xr.displayPixelWidth;   // fallback
+                        place.display_height_px = (float)xr.displayPixelHeight;
+                        place.rect_width_px     = (float)g_canvasW;
+                        place.rect_height_px    = (float)g_canvasH;
+                        place.rect_center_x_px  = place.display_width_px * 0.5f;  // fallback: centered
+                        place.rect_center_y_px  = place.display_height_px * 0.5f;
                         {
                             POINT clientOrigin = {0, 0};
                             ClientToScreen(rs.hwnd, &clientOrigin);
                             HMONITOR hMon = MonitorFromWindow(rs.hwnd, MONITOR_DEFAULTTONEAREST);
                             MONITORINFO mi = {sizeof(mi)};
                             if (GetMonitorInfo(hMon, &mi)) {
-                                float canvasCenterX = (float)(clientOrigin.x - mi.rcMonitor.left) + canvas_off_x + g_canvasW / 2.0f;
-                                float canvasCenterY = (float)(clientOrigin.y - mi.rcMonitor.top)  + canvas_off_y + g_canvasH / 2.0f;
-                                float dispW = (float)(mi.rcMonitor.right - mi.rcMonitor.left);
-                                float dispH = (float)(mi.rcMonitor.bottom - mi.rcMonitor.top);
-                                eyeOffsetX =  (canvasCenterX - dispW / 2.0f) * pxSizeX;
-                                eyeOffsetY = -((canvasCenterY - dispH / 2.0f) * pxSizeY);
+                                place.display_width_px  = (float)(mi.rcMonitor.right - mi.rcMonitor.left);
+                                place.display_height_px = (float)(mi.rcMonitor.bottom - mi.rcMonitor.top);
+                                place.rect_center_x_px  = (float)(clientOrigin.x - mi.rcMonitor.left) + canvas_off_x + g_canvasW / 2.0f;
+                                place.rect_center_y_px  = (float)(clientOrigin.y - mi.rcMonitor.top)  + canvas_off_y + g_canvasH / 2.0f;
                             }
                         }
 
                         std::vector<XrVector3f> rawEyes(modeViewCount);
                         for (uint32_t v = 0; v < modeViewCount; v++) {
-                            XrVector3f pos = (v < viewCount) ? rawViews[v].pose.position : rawViews[0].pose.position;
-                            rawEyes[v] = {pos.x - eyeOffsetX, pos.y - eyeOffsetY, pos.z};
+                            rawEyes[v] = (v < viewCount) ? rawViews[v].pose.position : rawViews[0].pose.position;
                         }
+                        Display3DScreen screen;
+                        display3d_resolve_window_rect(&place, rawEyes.data(), modeViewCount, &screen, rawEyes.data());
                         if (monoMode && modeViewCount >= 2) {
                             XrVector3f center = {0, 0, 0};
                             for (uint32_t v = 0; v < modeViewCount; v++) {
@@ -729,7 +735,6 @@ static void RenderOneFrame(RenderState& rs) {
                         cameraPose.position = {g_inputState.cameraPosX, g_inputState.cameraPosY, g_inputState.cameraPosZ};
 
                         XrVector3f nominalViewer = {xr.nominalViewerX, xr.nominalViewerY, xr.nominalViewerZ};
-                        Display3DScreen screen = {canvasW_m, canvasH_m};
 
                         if (g_inputState.cameraMode) {
                             Camera3DTunables camTunables;


### PR DESCRIPTION
Moves the duplicated window-relative/canvas Kooima input-prep (px-size, screen dims, rect-center offset + Y-flip) out of the test apps into the shared `display3d_resolve_window_rect` (displayxr::math **v0.2.0**). Apps keep only the platform rect-fetch + a `Display3DWindowPlacement` — window rect for handle, **canvas sub-rect for texture**, same call. Bumps the pin v0.1.1→v0.2.0. d3d11 handle+texture migrated as the proof; **verified on the Leia display** (handle window-relative move-tracking + texture canvas sub-rect 3D both correct). Remaining apps + engines adopt Layer 1 next.