### PR TITLE
Per-mode tracking capability + tracking-state event (Phase 0+1 of #441)

### DIFF
--- a/docs/guides/vendor-plugin-onboarding.md
+++ b/docs/guides/vendor-plugin-onboarding.md
@@ -196,7 +196,24 @@ If it doesn't, document the SDK as a hard prereq in your installer's pre-install
 - bit 0 (`0x1`) — `MANAGED` (vendor SDK predicts eye positions; the runtime queries them per frame)
 - bit 1 (`0x2`) — `MANUAL` (the app submits eye positions via `XR_EXT_display_info`)
 
-Declare both bits if your SDK supports both modes; declare just one if not. A typical hardware DP is `MANAGED`-only; sim-display is `MANUAL`-only. The `default_eye_tracking_mode` field picks which mode the runtime uses for sessions that don't explicitly opt in.
+Declare both bits if your SDK supports both modes; declare just one if not. A typical hardware DP is `MANAGED`-only. Declare `0` if your display has no eye tracker at all — sim-display does this (its positions are nominal, not tracked). The `default_eye_tracking_mode` field picks which mode the runtime uses for sessions that don't explicitly opt in.
+
+### Per-mode tracking capability (`mode_flags`, ABI v3 / #441)
+
+Every `xrt_rendering_mode` your `create_device` device exposes carries a `mode_flags`
+bitmask in the **vendor-provided (MUST set)** section:
+
+- `XRT_RENDERING_MODE_FLAG_HAS_TRACKING` (`1u << 0`) — set on each mode that consumes live
+  eye tracking (typically your 3D modes; optionally a "2D tracked" mode where content is
+  flat but the viewer remains tracked).
+- Zero-init = untracked = the safe default; `reserved[]` MUST stay zeroed.
+
+The runtime forces the app-visible `isTracking` to false whenever the active mode is
+untracked, and surfaces the flag to apps via the chained
+`XrDisplayRenderingModeTrackingInfoEXT` (header v14). **Consistency rule:**
+`supported_eye_tracking_modes != 0` ⇔ at least one mode sets `HAS_TRACKING` — the runtime
+logs a one-shot WARN at init if violated. Full contract:
+`docs/specs/vendor/eye-tracking-modes.md`.
 
 ### Per-API DP factories
 

--- a/docs/reference/xrt_plugin_iface.md
+++ b/docs/reference/xrt_plugin_iface.md
@@ -140,7 +140,7 @@ Fields to populate:
 | `display_pixel_width`, `display_pixel_height` | pixels (uint32) | Native panel resolution |
 | `recommended_view_scale_x`, `recommended_view_scale_y` | float, 1.0 = native | Vendor-recommended per-view scaling. <1.0 means downscale. |
 | `display_screen_left`, `display_screen_top` | virtual-screen coords (int32) | Display top-left in Windows-style virtual-screen pixels. Used to position workspace windows. Both 0 = "no preference / display origin == desktop origin" (sim-display picks this). |
-| `supported_eye_tracking_modes` | bitmask | bit 0 = MANAGED, bit 1 = MANUAL. A typical hardware DP is MANAGED-only; the reference simulator (sim_display) is MANUAL-only. |
+| `supported_eye_tracking_modes` | bitmask | bit 0 = MANAGED, bit 1 = MANUAL, `0` = no eye tracking. A typical hardware DP is MANAGED-only; the reference simulator (sim_display) declares `0` — its positions are nominal, not tracked (`SIM_DISPLAY_FAKE_TRACKING=1` dev toggle re-enables MANUAL for testing). Must be non-zero iff at least one `xrt_rendering_mode` sets `XRT_RENDERING_MODE_FLAG_HAS_TRACKING` in `mode_flags` (ABI v3, #441). |
 | `default_eye_tracking_mode` | enum | 0 = MANAGED, 1 = MANUAL. |
 
 **Returns:**

--- a/docs/roadmap/per-mode-tracking-capability-plan.md
+++ b/docs/roadmap/per-mode-tracking-capability-plan.md
@@ -45,6 +45,7 @@ typedef struct XrDisplayRenderingModeTrackingInfoEXT {
 typedef struct XrEventDataEyeTrackingStateChangedEXT {
     XrStructureType       type;
     const void* XR_MAY_ALIAS next;
+    XrSession             session;
     XrBool32              isTracking;  //!< New state
     XrEyeTrackingModeEXT  activeMode;  //!< Session's MANAGED/MANUAL preference at edge time
 } XrEventDataEyeTrackingStateChangedEXT;

--- a/docs/roadmap/per-mode-tracking-capability-plan.md
+++ b/docs/roadmap/per-mode-tracking-capability-plan.md
@@ -1,0 +1,147 @@
+# Per-Mode Tracking Capability + Tracking-State Event — Implementation Plan
+
+**Status:** DRAFT (2026-06-05)
+**Scope:** runtime, sim_display plug-in (in-tree), Leia SR plug-in (`displayxr-leia-plugin`), extension header v14, IPC.
+**Breaking:** plug-in ABI v2 → v3 (coordinated release). Zero app-binary breakage by design.
+
+## Goal
+
+1. Every display rendering mode carries its own **`has_tracking`** capability — e.g. Leia can
+   expose a "2D tracked" mode alongside the default 3D mode; sim_display honestly reports
+   no tracking on all modes.
+2. **`is_tracking`** (per-frame, DP-reported) reaches apps truthfully on every path —
+   including IPC, where it is currently faked to TRUE.
+3. New **`XrEventDataEyeTrackingStateChangedEXT`** event so MANUAL-mode apps get edge-triggered
+   tracking-loss/recovery notification instead of polling `XrViewEyeTrackingStateEXT`.
+4. MANAGED/MANUAL contract unchanged (already specified in
+   `docs/specs/vendor/eye-tracking-modes.md`); this plan implements the missing plumbing.
+
+## Design decisions (locked)
+
+| Decision | Choice |
+|---|---|
+| Capability layering | Per-mode `has_tracking` = "does this rendering mode consume live tracking". System-level `supported_eye_tracking_modes` (MANAGED/MANUAL bits) = "which control contracts the vendor offers". Consistency rule: `supportedModes != 0` ⇔ at least one mode has `has_tracking = true`. |
+| `isTracking` computation | `active_mode.has_tracking && eye_pos.valid && eye_pos.is_tracking`. Replaces the contradictory fallback heuristic at `oxr_session.c:1747-1764`. |
+| sim_display | All 5 modes `has_tracking = false`; `supported_eye_tracking_modes = 0`. Dev-only env toggle `SIM_DISPLAY_FAKE_TRACKING=1` re-enables MANUAL_BIT + `has_tracking=true` (+ optional `SIM_DISPLAY_FAKE_TRACKING_PERIOD_MS=N` to square-wave `is_tracking` for event testing). Env var, not registry — this is a dev override, not a product feature. |
+| `xrRequestEyeTrackingModeEXT` | Stays a **session preference** validated against system `supportedModes` only. Latent (no error) while the active rendering mode is untracked. No ordering race with workspace mode switches. |
+| `activeMode` in untracked modes | Keeps reporting the session's MANAGED/MANUAL preference. No new "NONE" enum value. |
+| App-facing per-mode capability | **Chained struct**, NOT a field append. `oxr_xrEnumerateDisplayRenderingModesEXT` writes with the runtime's compiled stride (`oxr_api_session.c:1497`), so appending to `XrDisplayRenderingModeInfoEXT` (the v12/v13 precedent) corrupts memory in app binaries compiled against older headers (Unity plug-in, shipped demos) — and unlike the plug-in side there is no version gate to reject them cleanly. Chaining is zero-break AND the canonical Khronos pattern (cf. `XrSystemProperties` capability chaining, which `XrEyeTrackingModeCapabilitiesEXT` already uses). **Policy: `XrDisplayRenderingModeInfoEXT` is frozen at its v13 layout; all future per-mode fields chain.** |
+| Plug-in ABI | `uint32_t mode_flags` (bit 0 = `XRT_RENDERING_MODE_FLAG_HAS_TRACKING`) + `uint32_t reserved[3]` added to the vendor-provided section of `struct xrt_rendering_mode` (`xrt_device.h:249`). The array is embedded in `xrt_device`, which the plug-in creates (`plugin->create_device`), so element stride changes → `XRT_PLUGIN_API_VERSION_CURRENT` 2 → 3. Loader rejects mismatched plug-ins; versions.json ABI gate coordinates the release. A flags word + reserved padding (zero-init = all off = untracked = safe) means future per-mode capabilities are new bits, not new fields — **this is intended to be the last rendering-mode ABI break**. |
+| MANAGED auto-switch × workspace authority | Vendor-initiated MANAGED transitions are **hardware display state** changes: they fire `XrEventDataHardwareDisplayStateChangedEXT` (and the new tracking event), and flow through the existing DP→runtime event path. They are NOT rendering-mode requests, so the workspace-controller authority gate (#233/#234) is untouched. Under a workspace, the vendor SHOULD still honor the 2D/3D weave decision globally (it owns the panel); the shell observes the event like any session. |
+
+## New API surface (extension header v14)
+
+```c
+// Chained (input) to each XrDisplayRenderingModeInfoEXT element's next by apps that opt in.
+#define XR_TYPE_DISPLAY_RENDERING_MODE_TRACKING_INFO_EXT ((XrStructureType)1000999012)
+typedef struct XrDisplayRenderingModeTrackingInfoEXT {
+    XrStructureType    type;
+    void* XR_MAY_ALIAS next;
+    XrBool32           hasTracking;  //!< Mode consumes live eye tracking
+} XrDisplayRenderingModeTrackingInfoEXT;
+
+// Queued on every is_tracking edge (and on transitions into/out of untracked modes).
+#define XR_TYPE_EVENT_DATA_EYE_TRACKING_STATE_CHANGED_EXT ((XrStructureType)1000999013)
+typedef struct XrEventDataEyeTrackingStateChangedEXT {
+    XrStructureType       type;
+    const void* XR_MAY_ALIAS next;
+    XrBool32              isTracking;  //!< New state
+    XrEyeTrackingModeEXT  activeMode;  //!< Session's MANAGED/MANUAL preference at edge time
+} XrEventDataEyeTrackingStateChangedEXT;
+```
+
+`XrEyeTrackingModeCapabilitiesEXT`, `XrViewEyeTrackingStateEXT`, and
+`xrRequestEyeTrackingModeEXT` are unchanged.
+
+## Phases
+
+### Phase 0 — Spec & docs (doc-only, direct to main)
+- `docs/specs/vendor/eye-tracking-modes.md`: add per-mode `has_tracking` section, layering +
+  consistency rules, the new event, the workspace-authority resolution above, and the
+  vendor decision table row for "2D tracked" modes.
+- `docs/specs/extensions/XR_EXT_display_info.md`: v14 additions (chained struct + event),
+  explicit note on why chaining (binary compat) — sets precedent for future per-mode fields.
+- `docs/guides/vendor-plugin-onboarding.md` + `docs/reference/xrt_plugin_iface.md`:
+  `has_tracking` is in the "driver MUST set" block (no `struct_size` clamp on
+  `xrt_rendering_mode`; zero-init = untracked = safe default).
+
+### Phase 1 — Runtime core + ABI v3 (PR 1)
+1. `xrt_device.h`: `uint32_t mode_flags` (`XRT_RENDERING_MODE_FLAG_HAS_TRACKING = 1u << 0`) +
+   `uint32_t reserved[3]` in the vendor-provided section of `xrt_rendering_mode`.
+2. `xrt_plugin.h`: `XRT_PLUGIN_API_VERSION_3`, bump `XRT_PLUGIN_API_VERSION_CURRENT`.
+3. `XR_EXT_display_info.h` → v14: the two structs above (auto-syncs to
+   `displayxr-extensions` via `publish-extensions.yml`).
+4. `sim_display_device.c`: `has_tracking = false` on all modes; `sim_display_plugin.c`:
+   `supported_eye_tracking_modes = 0` by default; `SIM_DISPLAY_FAKE_TRACKING` env toggle
+   (advertise MANUAL_BIT, `has_tracking = true` on 3D modes, square-wave `is_tracking` in
+   `sim_dp_get_predicted_eye_positions` when `..._PERIOD_MS` set).
+5. `oxr_api_session.c` enumerate: walk each element's input `next` chain
+   (`OXR_GET_OUTPUT_FROM_CHAIN` pattern) and fill `hasTracking`. Stop nulling `next`
+   unconditionally.
+6. `oxr_session.c`: replace the isTracking fallback block (`:1747-1764`) with
+   `active_mode.has_tracking && eye_pos.valid && eye_pos.is_tracking`. Requires plumbing the
+   head device's active mode's `has_tracking` to the session (read via
+   `GET_XDEV_BY_ROLE(... head)->rendering_modes[active_rendering_mode_index]`).
+7. Event: `sess->last_is_tracking` edge detection at the end of the `xrLocateViews` path;
+   enqueue via the `oxr_event.c` pattern (`oxr_event.c:398`). Also fires on mode switches
+   that flip effective tracking (handled naturally since isTracking recomputes per locate).
+8. `cli_query.c` (`displayxr-cli info`): print `has_tracking` per rendering mode.
+9. Consistency warning at init (`target_instance.c`): `supportedModes != 0` but no tracked
+   mode (or inverse) → one-shot `U_LOG_W`.
+
+Verify: `ctest`, `./scripts/build-mingw-check.sh`, `displayxr-cli selftest` (CI gate
+exercises plug-in discovery + new ABI), cube_handle_d3d11 with `SIM_DISPLAY_FAKE_TRACKING=1`
+observing the event + isTracking edges.
+
+### Phase 2 — IPC transport (PR 2)
+- Carry `xrt_eye_positions` (positions + `valid` + `is_tracking` + timestamp) to IPC clients:
+  extend the IPC view-pose sync (proto.json — renames cascade per the proto codegen rules)
+  or the shared-memory frame state, whichever carries view poses today.
+- Wire `client_*_compositor` `get_predicted_eye_positions` so
+  `oxr_session_get_predicted_eye_positions` (`oxr_session.c:158`) succeeds for IPC sessions;
+  delete the IPC fake-TRUE fallback.
+- Verify: `displayxr-service.exe` + `XRT_FORCE_MODE=ipc` + cube_handle_d3d11 (NOT cube_ipc),
+  with `SIM_DISPLAY_FAKE_TRACKING=1` — IPC app must see the same isTracking edges + events
+  as in-process.
+
+### Phase 3 — Leia plug-in (`displayxr-leia-plugin`)
+- Sync new runtime headers; report ABI 3.
+- Set `has_tracking = true` on the 3D mode(s); decide whether to add the "2D tracked" mode
+  now or later (the capability plumbing supports it either way).
+- `is_tracking` from the SR SDK is already wired through `get_predicted_eye_positions`;
+  audit it against the MANAGED grace-period recommendation in the spec (SHOULD stay true
+  during collapse animation, flip false on actual 2D fallback).
+
+### Phase 4 — Apps, linter, polish (PR 3, runtime)
+- cube test apps: HUD line for `isTracking`/`activeMode` + log the new event (gives every
+  manual test session free visibility).
+- `docs/guides/displayxr-app-rules.md` + `scripts/check_displayxr_app.py`: advisory rule —
+  apps requesting MANUAL mode SHOULD handle `XrEventDataEyeTrackingStateChangedEXT`.
+- WebXR bridge + Unity plug-in: no changes required (chained struct is opt-in); file
+  tracking issues to adopt the new event when convenient.
+
+### Phase 5 — Coordinated release
+1. Land PRs 1-3 on runtime `main`; land Leia plug-in PR (built against the v3 headers).
+2. `/release minor` (runtime) — versions.json self-bump runs; the **leia ABI gate**
+   (`scripts/check_plugin_abi.py`) will detect the old plug-in's ABI 2 ≠ 3, skip its bump,
+   and auto-open the tracking issue on `displayxr-leia-plugin`. Expected, by design.
+3. `/dxr-release leia-plugin vX.Y.Z` — built with ABI 3; versions-bump now passes the gate.
+4. `/installer-release` — ship the matched runtime + plug-in pair in one bundle so end
+   users can't land in the mixed state.
+
+Mixed-state behavior (by construction): new runtime + old Leia plug-in → loader rejects ABI 2
+→ sim_display fallback (priority -20) — degraded to sim, no crash, `selftest` flags it.
+Old runtime + new plug-in → equally rejected. The bundle release closes the window.
+
+## App-compat matrix
+
+| App | Impact |
+|---|---|
+| Existing binaries (cube, gauss, Unity, WebXR) | Zero change in struct layout; on Leia, isTracking behavior identical. On sim, isTracking becomes honestly FALSE (was inconsistent TRUE/FALSE) — only test code asserting TRUE would notice. |
+| IPC/service-mode apps | isTracking becomes truthful (was always TRUE). Behavior *improvement*; apps that ignored it see no difference. |
+| New apps | Opt into per-mode `hasTracking` via chaining; subscribe to the tracking event for MANUAL mode. |
+
+## Out of scope
+- Per-mode MANAGED/MANUAL capability (system-level stays sufficient).
+- "NONE" eye-tracking-mode enum value.
+- Leia "2D tracked" product mode itself (enabled by, not part of, this work).

--- a/docs/specs/extensions/XR_EXT_display_info.md
+++ b/docs/specs/extensions/XR_EXT_display_info.md
@@ -1844,6 +1844,7 @@ that carries the chain; elements without it are filled exactly as in v13.
 typedef struct XrEventDataEyeTrackingStateChangedEXT {
     XrStructureType          type;       // XR_TYPE_EVENT_DATA_EYE_TRACKING_STATE_CHANGED_EXT
     const void* XR_MAY_ALIAS next;
+    XrSession                session;
     XrBool32                 isTracking; // new state
     XrEyeTrackingModeEXT     activeMode; // session's MANAGED/MANUAL preference at edge time
 } XrEventDataEyeTrackingStateChangedEXT;

--- a/docs/specs/extensions/XR_EXT_display_info.md
+++ b/docs/specs/extensions/XR_EXT_display_info.md
@@ -1812,8 +1812,12 @@ typedef struct XrDisplayRenderingModeTrackingInfoEXT {
 
 The application chains one instance to the `next` pointer of **each**
 `XrDisplayRenderingModeInfoEXT` element it wants the capability for, before calling
-`xrEnumerateDisplayRenderingModesEXT`. The runtime fills `hasTracking` for every element
-that carries the chain; elements without it are filled exactly as in v13.
+`xrEnumerateDisplayRenderingModesEXT`, **and pre-sets each element's `type` to
+`XR_TYPE_DISPLAY_RENDERING_MODE_INFO_EXT`** (standard OpenXR input convention). The
+type value is the opt-in handshake: v13-and-earlier binaries leave `type`/`next`
+uninitialized (the runtime always overwrote them), so the runtime only walks the chain of
+elements carrying the correct input type — and keeps nulling `next` for everyone else,
+exactly as in v13. The runtime fills `hasTracking` for every chained element.
 
 > **Why a chained struct, not a field append — layout-freeze policy.** The runtime's
 > enumerate fill writes array elements with its own compiled struct stride. Appending

--- a/docs/specs/extensions/XR_EXT_display_info.md
+++ b/docs/specs/extensions/XR_EXT_display_info.md
@@ -637,7 +637,7 @@ No known IP claims.
 ### Name Strings
 
 - Extension name: `XR_EXT_display_info`
-- Spec version: 13
+- Spec version: 14
 - Extension name define: `XR_EXT_DISPLAY_INFO_EXTENSION_NAME`
 
 ### Overview
@@ -738,7 +738,10 @@ typedef enum XrDisplayModeEXT {
 
 ### New Functions
 
-This extension's current (v13) function set:
+This extension's current (v14) function set (v14 adds no functions — only the chained
+`XrDisplayRenderingModeTrackingInfoEXT` struct and the
+`XrEventDataEyeTrackingStateChangedEXT` event; see
+[Per-Mode Tracking Capability + Tracking-State Event (v14)](#7c-per-mode-tracking-capability--tracking-state-event-v14)):
 
 | Function | Added | Purpose |
 |---|---|---|
@@ -1777,8 +1780,97 @@ See `docs/specs/vendor/eye-tracking-modes.md` for the full MANAGED/MANUAL contra
 |--------|-------------------|---------------|---------------------|
 | Hardware DP (typical) | `MANAGED_BIT` | `MANAGED` | Eye-distance heuristic (collapsed = not tracking) |
 | Hardware DP (future) | `MANAGED_BIT \| MANUAL_BIT` | `MANAGED` | SDK native flag |
-| Sim display | `MANUAL_BIT` | `MANUAL` | Always `XR_TRUE` (simulated) |
+| Sim display | `0` (NONE) — no real tracker (v14; was `MANUAL_BIT`) | undefined | Always `XR_FALSE` (dev toggle `SIM_DISPLAY_FAKE_TRACKING=1` re-enables `MANUAL_BIT` for hardware-free testing) |
 | No-tracker display | `0` (NONE) | undefined | Always `XR_FALSE` |
+
+---
+
+## 7c. Per-Mode Tracking Capability + Tracking-State Event (v14)
+
+### Motivation
+
+Tracking capability is not uniform across a display's rendering modes. A vendor may offer
+a **"2D tracked"** mode (content presented in 2D while the viewer remains eye-tracked, e.g.
+for head-coupled UI) alongside the default tracked 3D mode and fully untracked export modes
+(side-by-side, anaglyph). v13 and earlier could only express tracking capability
+system-wide via `XrEyeTrackingModeCapabilitiesEXT.supportedModes`.
+
+Separately, MANUAL-mode apps had to poll `XrViewEyeTrackingStateEXT.isTracking` every
+`xrLocateViews` to detect tracking loss; an edge-triggered event is the right primitive.
+
+### `XrDisplayRenderingModeTrackingInfoEXT` — chained per enumerated mode
+
+```c
+#define XR_TYPE_DISPLAY_RENDERING_MODE_TRACKING_INFO_EXT ((XrStructureType)1000999012)
+
+typedef struct XrDisplayRenderingModeTrackingInfoEXT {
+    XrStructureType    type;        // XR_TYPE_DISPLAY_RENDERING_MODE_TRACKING_INFO_EXT
+    void* XR_MAY_ALIAS next;
+    XrBool32           hasTracking; // mode consumes live eye tracking
+} XrDisplayRenderingModeTrackingInfoEXT;
+```
+
+The application chains one instance to the `next` pointer of **each**
+`XrDisplayRenderingModeInfoEXT` element it wants the capability for, before calling
+`xrEnumerateDisplayRenderingModesEXT`. The runtime fills `hasTracking` for every element
+that carries the chain; elements without it are filled exactly as in v13.
+
+> **Why a chained struct, not a field append — layout-freeze policy.** The runtime's
+> enumerate fill writes array elements with its own compiled struct stride. Appending
+> fields to `XrDisplayRenderingModeInfoEXT` (as v12/v13 did) silently corrupts memory in
+> application binaries compiled against an older header — there is no version handshake on
+> the app ABI to reject them cleanly. **`XrDisplayRenderingModeInfoEXT` is therefore frozen
+> at its v13 layout; all future per-mode fields MUST be added as chained structs.** This is
+> the canonical OpenXR pattern for extending enumerated output structs.
+
+**Semantics:**
+
+- `hasTracking == XR_FALSE` on the active mode forces
+  `XrViewEyeTrackingStateEXT.isTracking = XR_FALSE`, regardless of tracker state. The
+  runtime derives: `isTracking = activeMode.hasTracking && dp.is_tracking`.
+- `xrLocateViews` still ALWAYS returns fully populated views in every mode — in untracked
+  modes positions derive from the nominal viewer (or whatever the vendor chooses).
+- Consistency rule: `XrEyeTrackingModeCapabilitiesEXT.supportedModes != 0` ⇔ at least one
+  rendering mode reports `hasTracking == XR_TRUE`.
+- `xrRequestEyeTrackingModeEXT` remains a session-level preference validated against
+  `supportedModes` only; requesting MANAGED/MANUAL while an untracked mode is active is
+  valid and latent.
+
+### `XrEventDataEyeTrackingStateChangedEXT` — tracking-state edge event
+
+```c
+#define XR_TYPE_EVENT_DATA_EYE_TRACKING_STATE_CHANGED_EXT ((XrStructureType)1000999013)
+
+typedef struct XrEventDataEyeTrackingStateChangedEXT {
+    XrStructureType          type;       // XR_TYPE_EVENT_DATA_EYE_TRACKING_STATE_CHANGED_EXT
+    const void* XR_MAY_ALIAS next;
+    XrBool32                 isTracking; // new state
+    XrEyeTrackingModeEXT     activeMode; // session's MANAGED/MANUAL preference at edge time
+} XrEventDataEyeTrackingStateChangedEXT;
+```
+
+Queued on **every edge of the derived `isTracking` value** — DP-reported tracking
+loss/recovery AND rendering-mode switches into/out of untracked modes. This is the primary
+tracking-loss notification for MANUAL mode (detect `isTracking == XR_FALSE`, run your own
+transition, request a 2D mode when ready); it also fires in MANAGED mode, where apps may
+ignore it entirely. Edge detection runs in the runtime's `xrLocateViews` path, so apps that
+never locate views receive no events.
+
+### Backward Compatibility
+
+- v13-and-earlier binaries: `XrDisplayRenderingModeInfoEXT` layout unchanged; apps that
+  don't chain see exactly v13 behavior. The new event type is never delivered to apps that
+  don't recognize it any differently than other unhandled events (apps skip unknown
+  `xrPollEvent` results by design).
+- sim_display behavior change: `isTracking` is now honestly `XR_FALSE` (previously
+  inconsistently `XR_TRUE`/`XR_FALSE` depending on code path). Only test code asserting
+  `XR_TRUE` on sim would notice; use `SIM_DISPLAY_FAKE_TRACKING=1` there.
+
+### Vendor requirements
+
+Vendors set `XRT_RENDERING_MODE_FLAG_HAS_TRACKING` in `xrt_rendering_mode.mode_flags` for
+each tracked mode (plug-in ABI v3 — see `docs/specs/vendor/eye-tracking-modes.md` and
+`docs/guides/vendor-plugin-onboarding.md`). Zero-init = untracked = safe default.
 
 ---
 

--- a/docs/specs/vendor/eye-tracking-modes.md
+++ b/docs/specs/vendor/eye-tracking-modes.md
@@ -1,8 +1,8 @@
 ---
 status: Active
 owner: David Fattal
-updated: 2026-03-15
-issues: [81]
+updated: 2026-06-05
+issues: [81, 441]
 code-paths: [src/external/openxr_includes/openxr/XR_EXT_display_info.h, src/xrt/state_trackers/oxr/]
 ---
 
@@ -10,7 +10,11 @@ code-paths: [src/external/openxr_includes/openxr/XR_EXT_display_info.h, src/xrt/
 
 ## Summary
 
-Formalize the contract between MANAGED and MANUAL eye tracking modes with respect to vendor-controlled 2D/3D display transitions on tracking loss. Strategy: **MANAGED = vendor SDK controls grace period, animations, auto 2D/3D switching; MANUAL = developer controls everything, SDK just reports isTracking immediately**. No new API needed -- this clarifies existing semantics and specifies vendor integration requirements.
+Formalize the contract between MANAGED and MANUAL eye tracking modes with respect to vendor-controlled 2D/3D display transitions on tracking loss. Strategy: **MANAGED = vendor SDK controls grace period, animations, auto 2D/3D switching; MANUAL = developer controls everything, SDK just reports isTracking immediately**.
+
+Extended (#441, header v14) with **per-rendering-mode tracking capability** (`has_tracking`) and an
+edge-triggered **`XrEventDataEyeTrackingStateChangedEXT`** event. Implementation plan:
+`docs/roadmap/per-mode-tracking-capability-plan.md`.
 
 ## Background
 
@@ -30,6 +34,50 @@ And the rendering mode API (v7/v8) provides:
 **The gap:** There is no specification of how these two systems interact during tracking loss/recovery transitions.
 
 ## Contract
+
+### Capability layering: per-mode `has_tracking` × system-level control contract (v14, #441)
+
+Tracking capability is expressed at **two layers**, which answer different questions:
+
+1. **Per rendering mode — `has_tracking`** (`xrt_rendering_mode.mode_flags` bit
+   `XRT_RENDERING_MODE_FLAG_HAS_TRACKING`; surfaced to apps via the chained
+   `XrDisplayRenderingModeTrackingInfoEXT`): *does this rendering mode consume live eye
+   tracking?* A vendor can expose e.g. a "2D tracked" mode (content presented 2D, viewer
+   still eye-tracked) alongside the default tracked 3D mode and untracked export modes
+   (SBS, anaglyph). sim_display sets `has_tracking = false` on **all** modes — it reports
+   nominal positions, not tracking.
+2. **Per system — `supported_eye_tracking_modes`** (MANAGED/MANUAL bits,
+   `xrt_plugin_display_info`): *which control contracts does the vendor offer when tracking
+   is in play?* Unchanged by v14.
+
+**Consistency rule:** `supported_eye_tracking_modes != 0` ⇔ at least one rendering mode has
+`has_tracking = true`. The runtime logs a one-shot WARN at init if a plug-in violates this.
+
+**isTracking derivation:** the runtime computes the per-frame app-visible flag as
+
+```
+isTracking = active_mode.has_tracking && eye_positions.valid && eye_positions.is_tracking
+```
+
+so `XrViewEyeTrackingStateEXT.isTracking` is forcibly `XR_FALSE` whenever the active
+rendering mode is untracked, regardless of what the DP reports.
+
+**`xrRequestEyeTrackingModeEXT` is a session preference**, validated against the
+system-level `supported_eye_tracking_modes` only. It does NOT error based on the current
+rendering mode; the preference is simply latent while an untracked mode is active. This
+avoids ordering races with workspace-driven mode switches. `XrViewEyeTrackingStateEXT.activeMode`
+keeps reporting the session's MANAGED/MANUAL preference even while `isTracking == XR_FALSE`
+in an untracked mode — there is no "NONE" enum value.
+
+### Tracking-state change event (v14, #441)
+
+`XrEventDataEyeTrackingStateChangedEXT { isTracking, activeMode }` is queued on every edge
+of the derived `isTracking` value — including edges caused by rendering-mode switches into
+or out of untracked modes, not just DP-reported tracking loss/recovery. This is the primary
+notification primitive for MANUAL mode (replaces per-frame polling of
+`XrViewEyeTrackingStateEXT`); it fires in MANAGED mode too, where apps may use it to drive
+optional UI. Edge detection happens in the runtime's `xrLocateViews` path, so an app that
+never locates views receives no events (it also has no use for them).
 
 ### Tracking loss and eye position reporting
 
@@ -130,6 +178,13 @@ bool vendor_sdk_get_current_hardware_3d_state(struct vendor_sdk *sdk, bool *out_
 
 The compositor (or display processor) checks for state changes each frame and pushes `XrEventDataHardwareDisplayStateChangedEXT` + `XrEventDataRenderingModeChangedEXT` when the hardware state flips.
 
+**Workspace authority (#233/#234 interaction):** vendor-initiated MANAGED transitions are
+**hardware display state** changes, NOT rendering-mode requests. They flow through the
+DP→runtime event path above and do not pass through (or get blocked by) the
+workspace-controller mode-authority gate in `oxr_xrRequestDisplayRenderingModeEXT`. Under a
+workspace, the vendor still owns the panel's 2D/3D weave decision globally; the shell
+observes the resulting events like any other session.
+
 ### Capability advertisement
 
 Vendor sets capability bits in `xrt_system_compositor_info`:
@@ -139,7 +194,14 @@ Vendor sets capability bits in `xrt_system_compositor_info`:
 | SDK has grace period + animation + auto-switch | `3` (MANAGED \| MANUAL) | `0` (MANAGED) |
 | SDK has managed filtering only, no auto-switch control | `1` (MANAGED only) | `0` (MANAGED) |
 | SDK provides manual only (no filtering available) | `2` (MANUAL only) | `1` (MANUAL) |
-| No eye tracking | `0` | N/A |
+| No eye tracking (incl. sim_display) | `0` | N/A |
+
+Additionally (v14), the vendor sets `XRT_RENDERING_MODE_FLAG_HAS_TRACKING` in
+`xrt_rendering_mode.mode_flags` on every rendering mode that consumes live tracking
+(typically the 3D modes; optionally a "2D tracked" mode). `mode_flags` lives in the
+vendor-provided MUST-set section — zero-init means untracked, which is the safe default.
+Per the consistency rule, advertise `supported_eye_tracking_modes != 0` iff at least one
+mode carries the flag.
 
 Ideally vendors support **both** modes (bits = 3), giving developers the choice.
 
@@ -147,9 +209,14 @@ Ideally vendors support **both** modes (bits = 3), giving developers the choice.
 
 ## Non-goals
 
-- No new OpenXR extension functions or structs -- existing API is sufficient
-- No changes to `XrDisplayRenderingModeInfoEXT` -- eye tracking behavior is orthogonal to rendering mode definition
-- No per-rendering-mode tracking behavior (keeps it simple; if needed later, can be added as a separate feature)
+- No per-rendering-mode MANAGED/MANUAL capability — the control contract stays system-level
+- No "NONE" value added to `XrEyeTrackingModeEXT`
+- No layout change to `XrDisplayRenderingModeInfoEXT` — it is **frozen at its v13 layout**;
+  per-mode tracking capability (and all future per-mode fields) chain via `next`
+  (see `docs/specs/extensions/XR_EXT_display_info.md`)
+
+> Historical note: this spec originally declared per-rendering-mode tracking behavior a
+> non-goal ("can be added as a separate feature"). #441 / header v14 is that feature.
 
 ## Acceptance Criteria
 
@@ -157,4 +224,7 @@ Ideally vendors support **both** modes (bits = 3), giving developers the choice.
 - [ ] `XR_EXT_display_info.h` comments updated to document auto-switch behavior per mode
 - [ ] Vendor display processors pass eye tracking mode to the SDK wrapper when `xrRequestEyeTrackingModeEXT` is called
 - [ ] Event propagation path exists for vendor-initiated 2D/3D switches (MANAGED mode auto-transitions fire `XrEventDataRenderingModeChangedEXT` + `XrEventDataHardwareDisplayStateChangedEXT`)
-- [ ] sim_display updated: MANUAL mode returns immediate `isTracking` transitions, MANAGED mode simulates grace period (optional, for testing)
+- [ ] sim_display honest: `supported_eye_tracking_modes = 0`, all modes untracked; `SIM_DISPLAY_FAKE_TRACKING=1` dev toggle re-enables MANUAL_BIT + tracked modes (+ `SIM_DISPLAY_FAKE_TRACKING_PERIOD_MS` square wave) for hardware-free testing (#441)
+- [ ] Per-mode `has_tracking` plumbed plugin → `xrt_rendering_mode.mode_flags` → chained `XrDisplayRenderingModeTrackingInfoEXT` (#441)
+- [ ] `XrEventDataEyeTrackingStateChangedEXT` queued on every derived-isTracking edge (#441)
+- [ ] `is_tracking` transported over IPC; fake-TRUE fallback removed (#441 Phase 2)

--- a/src/external/openxr_includes/openxr/XR_EXT_display_info.h
+++ b/src/external/openxr_includes/openxr/XR_EXT_display_info.h
@@ -22,7 +22,7 @@ extern "C" {
 #endif
 
 #define XR_EXT_display_info 1
-#define XR_EXT_display_info_SPEC_VERSION 13
+#define XR_EXT_display_info_SPEC_VERSION 14
 #define XR_EXT_DISPLAY_INFO_EXTENSION_NAME "XR_EXT_display_info"
 
 // Reuse the type value from the deleted XR_EXT_dynamic_render_resolution
@@ -325,6 +325,61 @@ typedef struct XrEventDataHardwareDisplayStateChangedEXT {
 } XrEventDataHardwareDisplayStateChangedEXT;
 
 // xrSetSharedTextureOutputRectEXT moved to XR_EXT_win32_window_binding.h / XR_EXT_cocoa_window_binding.h (v12)
+
+// ---- v14: Per-Mode Tracking Capability + Tracking-State Event (#441) ----
+
+#define XR_TYPE_DISPLAY_RENDERING_MODE_TRACKING_INFO_EXT  ((XrStructureType)1000999012)
+#define XR_TYPE_EVENT_DATA_EYE_TRACKING_STATE_CHANGED_EXT ((XrStructureType)1000999013)
+
+/*!
+ * @brief Per-mode tracking capability — chained by the APP to each
+ * XrDisplayRenderingModeInfoEXT element's next before calling
+ * xrEnumerateDisplayRenderingModesEXT.
+ *
+ * hasTracking tells whether the rendering mode consumes live eye tracking
+ * (e.g., a tracked 3D mode or a "2D tracked" mode) or is fully untracked
+ * (e.g., SBS/anaglyph export modes; every sim_display mode). When the ACTIVE
+ * mode has hasTracking == XR_FALSE, XrViewEyeTrackingStateEXT.isTracking is
+ * always XR_FALSE — regardless of tracker state. xrLocateViews still returns
+ * fully populated views in every mode.
+ *
+ * LAYOUT-FREEZE POLICY: XrDisplayRenderingModeInfoEXT is frozen at its v13
+ * layout. The runtime's enumerate fill writes array elements with its own
+ * compiled stride, so appending fields (as v12/v13 did) silently corrupts app
+ * binaries compiled against older headers. All future per-mode fields MUST be
+ * added as chained structs like this one.
+ *
+ * @extends XrDisplayRenderingModeInfoEXT
+ */
+typedef struct XrDisplayRenderingModeTrackingInfoEXT {
+    XrStructureType             type;        //!< Must be XR_TYPE_DISPLAY_RENDERING_MODE_TRACKING_INFO_EXT
+    void* XR_MAY_ALIAS          next;
+    XrBool32                    hasTracking; //!< Mode consumes live eye tracking
+} XrDisplayRenderingModeTrackingInfoEXT;
+
+/*!
+ * @brief Event fired on every edge of the derived isTracking value.
+ *
+ * The runtime derives isTracking as
+ *   activeMode.hasTracking && dp.is_tracking
+ * and queues this event whenever the value changes — on DP-reported tracking
+ * loss/recovery AND on rendering-mode switches into/out of untracked modes.
+ *
+ * This is the primary tracking-loss notification for MANUAL eye-tracking mode
+ * (detect isTracking == XR_FALSE, run your own transition, request a 2D mode
+ * when ready). It also fires in MANAGED mode, where apps may ignore it.
+ * Edge detection runs in the runtime's xrLocateViews path, so a session that
+ * never locates views receives no events.
+ *
+ * @extends XrEventDataBaseHeader
+ */
+typedef struct XrEventDataEyeTrackingStateChangedEXT {
+    XrStructureType             type;       //!< Must be XR_TYPE_EVENT_DATA_EYE_TRACKING_STATE_CHANGED_EXT
+    const void* XR_MAY_ALIAS    next;
+    XrSession                   session;
+    XrBool32                    isTracking; //!< New state
+    XrEyeTrackingModeEXT        activeMode; //!< Session's MANAGED/MANUAL preference at edge time
+} XrEventDataEyeTrackingStateChangedEXT;
 
 #ifdef __cplusplus
 }

--- a/src/external/openxr_includes/openxr/XR_EXT_display_info.h
+++ b/src/external/openxr_includes/openxr/XR_EXT_display_info.h
@@ -336,6 +336,13 @@ typedef struct XrEventDataHardwareDisplayStateChangedEXT {
  * XrDisplayRenderingModeInfoEXT element's next before calling
  * xrEnumerateDisplayRenderingModesEXT.
  *
+ * OPT-IN HANDSHAKE: to use the chain, the app MUST pre-set each array
+ * element's type to XR_TYPE_DISPLAY_RENDERING_MODE_INFO_EXT (standard OpenXR
+ * input convention) and set next to this struct (or a chain containing it).
+ * The runtime only walks elements carrying that type — v13-and-earlier
+ * binaries leave type/next uninitialized, and the runtime keeps overwriting
+ * next with NULL for them, exactly as before.
+ *
  * hasTracking tells whether the rendering mode consumes live eye tracking
  * (e.g., a tracked 3D mode or a "2D tracked" mode) or is fully untracked
  * (e.g., SBS/anaglyph export modes; every sim_display mode). When the ACTIVE

--- a/src/xrt/drivers/sim_display/sim_display_device.c
+++ b/src/xrt/drivers/sim_display/sim_display_device.c
@@ -112,6 +112,43 @@ sim_display_get_view_count(void)
 	return (uint32_t)xrt_atomic_s32_load(&g_sim_display_view_count);
 }
 
+bool
+sim_display_fake_tracking_enabled(void)
+{
+	// Dev-only override (#441) — product gates live in the registry, but
+	// this is a test harness knob, so an env var is the right shape.
+	static int cached = -1;
+	if (cached < 0) {
+		const char *e = getenv("SIM_DISPLAY_FAKE_TRACKING");
+		cached = (e != NULL && e[0] != '\0' && e[0] != '0') ? 1 : 0;
+	}
+	return cached == 1;
+}
+
+bool
+sim_display_fake_tracking_is_tracking(void)
+{
+	if (!sim_display_fake_tracking_enabled()) {
+		return false; // Honest: sim_display never really tracks.
+	}
+
+	static int64_t period_ms = -1;
+	if (period_ms < 0) {
+		const char *e = getenv("SIM_DISPLAY_FAKE_TRACKING_PERIOD_MS");
+		period_ms = (e != NULL) ? atol(e) : 0;
+		if (period_ms < 0) {
+			period_ms = 0;
+		}
+	}
+	if (period_ms == 0) {
+		return true; // Toggle on, no period: always tracking.
+	}
+
+	// Square wave: tracking for one period, lost for the next.
+	int64_t now_ms = (int64_t)(os_monotonic_get_ns() / 1000000);
+	return ((now_ms / period_ms) % 2) == 0;
+}
+
 void
 sim_display_set_view_count(uint32_t count)
 {
@@ -634,6 +671,18 @@ sim_display_hmd_create(void)
 	hmd->base.rendering_modes[4].hardware_display_3d = true;
 	hmd->base.rendering_modes[4].tile_columns = 2;
 	hmd->base.rendering_modes[4].tile_rows = 2;
+
+	// Per-mode tracking capability (#441): sim_display has no real eye
+	// tracker, so every mode stays untracked (mode_flags/reserved are
+	// zero from the calloc'd device). Under the dev-only
+	// SIM_DISPLAY_FAKE_TRACKING toggle the 3D modes claim HAS_TRACKING so
+	// the MANUAL path + tracking-state event are exercisable without
+	// hardware (matches the MANUAL_BIT the plug-in then advertises).
+	if (sim_display_fake_tracking_enabled()) {
+		for (uint32_t m = 1; m < hmd->base.rendering_mode_count; m++) {
+			hmd->base.rendering_modes[m].mode_flags |= XRT_RENDERING_MODE_FLAG_HAS_TRACKING;
+		}
+	}
 
 	// view_count = max across all rendering modes
 	{

--- a/src/xrt/drivers/sim_display/sim_display_interface.h
+++ b/src/xrt/drivers/sim_display/sim_display_interface.h
@@ -92,6 +92,35 @@ uint32_t
 sim_display_get_view_count(void);
 
 /*!
+ * Dev-only fake-tracking toggle (#441): `SIM_DISPLAY_FAKE_TRACKING=1`.
+ *
+ * sim_display has no real eye tracker — by default it advertises
+ * `supported_eye_tracking_modes = 0`, leaves every rendering mode untracked
+ * (`mode_flags = 0`), and its DPs report `is_tracking = false`. This toggle
+ * re-enables MANUAL_BIT + tracked 3D modes so the MANUAL code path and
+ * XrEventDataEyeTrackingStateChangedEXT can be exercised without hardware.
+ *
+ * @return True iff the env toggle is set (cached on first call).
+ * @ingroup drv_sim_display
+ */
+bool
+sim_display_fake_tracking_enabled(void);
+
+/*!
+ * The simulated per-frame tracking state (#441).
+ *
+ * False when the fake-tracking toggle is off (honest: sim never tracks).
+ * When on: true, or a square wave if `SIM_DISPLAY_FAKE_TRACKING_PERIOD_MS=N`
+ * is also set — flips every N ms to exercise tracking-loss/recovery edges
+ * and the tracking-state-changed event.
+ *
+ * @return The simulated is_tracking value for this instant.
+ * @ingroup drv_sim_display
+ */
+bool
+sim_display_fake_tracking_is_tracking(void);
+
+/*!
  * Set the view count for the active rendering mode.
  *
  * Thread-safe (atomic). Called when the rendering mode changes.

--- a/src/xrt/drivers/sim_display/sim_display_plugin.c
+++ b/src/xrt/drivers/sim_display/sim_display_plugin.c
@@ -113,10 +113,20 @@ sim_display_plugin_get_display_info(struct xrt_plugin_instance *inst,
 	/* No EDID screen position for the simulated display. */
 	out_info->display_screen_left = 0;
 	out_info->display_screen_top = 0;
-	/* MANUAL eye tracking only — the simulated device is always
-	 * "tracking" and eye positions come from app input. */
-	out_info->supported_eye_tracking_modes = 2u; /* MANUAL_BIT */
-	out_info->default_eye_tracking_mode = 1u;    /* MANUAL */
+	/* Honest by default (#441): sim_display has no eye tracker — its
+	 * positions are nominal, not tracked — so it advertises NO
+	 * eye-tracking capability. The dev-only SIM_DISPLAY_FAKE_TRACKING
+	 * toggle re-enables MANUAL_BIT (paired with HAS_TRACKING on the 3D
+	 * rendering modes in sim_display_device.c) so the MANUAL path and
+	 * XrEventDataEyeTrackingStateChangedEXT are testable without
+	 * hardware. */
+	if (sim_display_fake_tracking_enabled()) {
+		out_info->supported_eye_tracking_modes = 2u; /* MANUAL_BIT */
+		out_info->default_eye_tracking_mode = 1u;    /* MANUAL */
+	} else {
+		out_info->supported_eye_tracking_modes = 0u; /* no tracking */
+		out_info->default_eye_tracking_mode = 0u;    /* undefined; keep 0 */
+	}
 
 	return true;
 }

--- a/src/xrt/drivers/sim_display/sim_display_processor.c
+++ b/src/xrt/drivers/sim_display/sim_display_processor.c
@@ -528,7 +528,7 @@ sim_dp_get_predicted_eye_positions(struct xrt_display_processor *xdp, struct xrt
 	}
 	out->timestamp_ns = os_monotonic_get_ns();
 	out->valid = true;
-	out->is_tracking = false; // Nominal, not real tracking
+	out->is_tracking = sim_display_fake_tracking_is_tracking(); // false unless SIM_DISPLAY_FAKE_TRACKING (#441)
 	return true;
 }
 

--- a/src/xrt/drivers/sim_display/sim_display_processor_d3d11.cpp
+++ b/src/xrt/drivers/sim_display/sim_display_processor_d3d11.cpp
@@ -314,7 +314,7 @@ sim_dp_d3d11_get_predicted_eye_positions(struct xrt_display_processor_d3d11 *xdp
 	}
 	out->timestamp_ns = os_monotonic_get_ns();
 	out->valid = true;
-	out->is_tracking = false; // Nominal, not real tracking
+	out->is_tracking = sim_display_fake_tracking_is_tracking(); // false unless SIM_DISPLAY_FAKE_TRACKING (#441)
 	return true;
 }
 

--- a/src/xrt/drivers/sim_display/sim_display_processor_d3d12.cpp
+++ b/src/xrt/drivers/sim_display/sim_display_processor_d3d12.cpp
@@ -326,7 +326,7 @@ sim_dp_d3d12_get_predicted_eye_positions(struct xrt_display_processor_d3d12 *xdp
 	}
 	out->timestamp_ns = os_monotonic_get_ns();
 	out->valid = true;
-	out->is_tracking = false; // Nominal, not real tracking
+	out->is_tracking = sim_display_fake_tracking_is_tracking(); // false unless SIM_DISPLAY_FAKE_TRACKING (#441)
 	return true;
 }
 

--- a/src/xrt/drivers/sim_display/sim_display_processor_gl.c
+++ b/src/xrt/drivers/sim_display/sim_display_processor_gl.c
@@ -297,7 +297,7 @@ sim_dp_gl_get_predicted_eye_positions(struct xrt_display_processor_gl *xdp,
 	}
 	out->timestamp_ns = os_monotonic_get_ns();
 	out->valid = true;
-	out->is_tracking = false; // Nominal, not real tracking
+	out->is_tracking = sim_display_fake_tracking_is_tracking(); // false unless SIM_DISPLAY_FAKE_TRACKING (#441)
 	return true;
 }
 

--- a/src/xrt/drivers/sim_display/sim_display_processor_metal.m
+++ b/src/xrt/drivers/sim_display/sim_display_processor_metal.m
@@ -311,7 +311,7 @@ sim_dp_metal_get_predicted_eye_positions(struct xrt_display_processor_metal *xdp
 	}
 	out->timestamp_ns = os_monotonic_get_ns();
 	out->valid = true;
-	out->is_tracking = false; // Nominal, not real tracking
+	out->is_tracking = sim_display_fake_tracking_is_tracking(); // false unless SIM_DISPLAY_FAKE_TRACKING (#441)
 	return true;
 }
 

--- a/src/xrt/include/xrt/xrt_device.h
+++ b/src/xrt/include/xrt/xrt_device.h
@@ -242,6 +242,18 @@ struct xrt_binding_profile
 };
 
 /*!
+ * Per-rendering-mode capability bits for @ref xrt_rendering_mode::mode_flags.
+ *
+ * Future per-mode capabilities are new bits here (plus `reserved[]` words),
+ * NOT new struct fields — `xrt_rendering_mode` is embedded by value in
+ * `xrt_device`, so any stride change is a plug-in ABI break (the v2→v3
+ * lesson; see #441 and ADR-020).
+ *
+ * @ingroup xrt_iface
+ */
+#define XRT_RENDERING_MODE_FLAG_HAS_TRACKING (1u << 0) //!< Mode consumes live eye tracking
+
+/*!
  * A named rendering mode exposed by a device.
  *
  * @ingroup xrt_iface
@@ -257,6 +269,8 @@ struct xrt_rendering_mode
 	bool hardware_display_3d;               //!< Whether display hardware is in 3D mode
 	uint32_t tile_columns;                  //!< Tile columns in atlas layout (MUST be set by driver)
 	uint32_t tile_rows;                     //!< Tile rows in atlas layout (MUST be set by driver)
+	uint32_t mode_flags;                    //!< XRT_RENDERING_MODE_FLAG_* bits (zero = untracked; v3, #441)
+	uint32_t reserved[3];                   //!< MUST be zeroed; future capability bits/values, no ABI bump
 
 	// --- Runtime-computed (u_tiling_compute_mode fills these) ---
 	uint32_t view_width_pixels;             //!< Per-view width in pixels

--- a/src/xrt/include/xrt/xrt_plugin.h
+++ b/src/xrt/include/xrt/xrt_plugin.h
@@ -254,9 +254,18 @@ struct xrt_display_claim
  * `struct_size` header on the DP vtables and turns the loader's version *log*
  * into an enforced *reject*. ABI-v1 plug-ins (≤ leia v1.0.5) are rejected and
  * must rebuild against v2 headers.
+ *
+ * v2 → v3 history (#441): `xrt_rendering_mode` gained `mode_flags`
+ * (bit 0 = XRT_RENDERING_MODE_FLAG_HAS_TRACKING) + `reserved[3]` in its
+ * vendor-provided section. The array is embedded by value in `xrt_device`
+ * (created by the plug-in), so the element-stride change is a layout break.
+ * The flags word + reserved padding exist so future per-mode capabilities are
+ * new bits, not new fields — v3 is intended to be the last rendering-mode
+ * layout break.
  */
 #define XRT_PLUGIN_API_VERSION_1 1
 #define XRT_PLUGIN_API_VERSION_2 2
+#define XRT_PLUGIN_API_VERSION_3 3
 
 /*!
  * The version the runtime / plug-in is built against at compile time.
@@ -264,7 +273,7 @@ struct xrt_display_claim
  * `*out_plugin_api_version` are rejected by the runtime (ADR-020 rule 3) with a
  * logged error, and the loader falls back to the next plug-in / sim_display.
  */
-#define XRT_PLUGIN_API_VERSION_CURRENT XRT_PLUGIN_API_VERSION_2
+#define XRT_PLUGIN_API_VERSION_CURRENT XRT_PLUGIN_API_VERSION_3
 
 /*!
  * The single exported symbol every plug-in DLL must provide. C linkage,

--- a/src/xrt/state_trackers/oxr/oxr_api_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_api_session.c
@@ -1495,8 +1495,29 @@ oxr_xrEnumerateDisplayRenderingModesEXT(XrSession session,
 	uint32_t active_idx = (head->hmd != NULL) ? head->hmd->active_rendering_mode_index : 0;
 
 	for (uint32_t i = 0; i < count; i++) {
+		// v14 (#441): apps opt into per-element chain processing by
+		// pre-setting type on input (standard OpenXR convention). The
+		// handshake matters: v13-and-earlier binaries leave type/next
+		// uninitialized (the runtime always overwrote them), so the
+		// chain must never be walked without it.
+		bool app_chained = (modes[i].type == XR_TYPE_DISPLAY_RENDERING_MODE_INFO_EXT);
+		XrDisplayRenderingModeTrackingInfoEXT *tracking = NULL;
+		if (app_chained) {
+			tracking = OXR_GET_OUTPUT_FROM_CHAIN(&modes[i],
+			                                     XR_TYPE_DISPLAY_RENDERING_MODE_TRACKING_INFO_EXT,
+			                                     XrDisplayRenderingModeTrackingInfoEXT);
+		}
+		if (tracking != NULL) {
+			tracking->hasTracking =
+			    (head->rendering_modes[i].mode_flags & XRT_RENDERING_MODE_FLAG_HAS_TRACKING)
+			        ? XR_TRUE
+			        : XR_FALSE;
+		}
+
 		modes[i].type = XR_TYPE_DISPLAY_RENDERING_MODE_INFO_EXT;
-		modes[i].next = NULL;
+		if (!app_chained) {
+			modes[i].next = NULL; // v13 behavior for non-opted-in callers.
+		}
 		modes[i].modeIndex = head->rendering_modes[i].mode_index;
 		snprintf(modes[i].modeName, XR_MAX_SYSTEM_NAME_SIZE, "%s",
 		         head->rendering_modes[i].mode_name);

--- a/src/xrt/state_trackers/oxr/oxr_event.c
+++ b/src/xrt/state_trackers/oxr/oxr_event.c
@@ -144,6 +144,10 @@ is_session_link_to_event(struct oxr_event *event, XrSession session)
 		XrEventDataHardwareDisplayStateChangedEXT *changed = (XrEventDataHardwareDisplayStateChangedEXT *)type;
 		return changed->session == session;
 	}
+	case XR_TYPE_EVENT_DATA_EYE_TRACKING_STATE_CHANGED_EXT: {
+		XrEventDataEyeTrackingStateChangedEXT *changed = (XrEventDataEyeTrackingStateChangedEXT *)type;
+		return changed->session == session;
+	}
 #ifdef OXR_HAVE_EXT_workspace_file_dialog
 	case XR_TYPE_EVENT_DATA_FILE_PICKER_COMPLETE_EXT: {
 		XrEventDataFilePickerCompleteEXT *complete = (XrEventDataFilePickerCompleteEXT *)type;
@@ -403,6 +407,35 @@ oxr_event_push_XrEventDataRenderingModeChanged(struct oxr_logger *log,
 	event->result = XR_SUCCESS;
 
 	U_LOG_I("OXR EVENT: Rendering mode changed %u -> %u", previousModeIndex, currentModeIndex);
+
+	lock(inst);
+	push(inst, event);
+	unlock(inst);
+
+	return XR_SUCCESS;
+}
+
+XrResult
+oxr_event_push_XrEventDataEyeTrackingStateChanged(struct oxr_logger *log,
+                                                  struct oxr_session *sess,
+                                                  XrBool32 isTracking,
+                                                  XrEyeTrackingModeEXT activeMode)
+{
+	struct oxr_instance *inst = sess->sys->inst;
+	XrEventDataEyeTrackingStateChangedEXT *changed;
+	struct oxr_event *event = NULL;
+
+	ALLOC(log, inst, &event, &changed);
+
+	changed->type = XR_TYPE_EVENT_DATA_EYE_TRACKING_STATE_CHANGED_EXT;
+	changed->next = NULL;
+	changed->session = oxr_session_to_openxr(sess);
+	changed->isTracking = isTracking;
+	changed->activeMode = activeMode;
+	event->result = XR_SUCCESS;
+
+	// One-off lifecycle edge, not per-frame — WARN is the visible tier (#441).
+	U_LOG_W("OXR EVENT: Eye tracking state changed: isTracking=%d mode=%d", isTracking, (int)activeMode);
 
 	lock(inst);
 	push(inst, event);

--- a/src/xrt/state_trackers/oxr/oxr_objects.h
+++ b/src/xrt/state_trackers/oxr/oxr_objects.h
@@ -1149,6 +1149,12 @@ oxr_event_push_XrEventDataHardwareDisplayStateChanged(struct oxr_logger *log,
                                                        struct oxr_session *sess,
                                                        XrBool32 hardwareDisplay3D);
 
+XrResult
+oxr_event_push_XrEventDataEyeTrackingStateChanged(struct oxr_logger *log,
+                                                  struct oxr_session *sess,
+                                                  XrBool32 isTracking,
+                                                  XrEyeTrackingModeEXT activeMode);
+
 #ifdef OXR_HAVE_EXT_workspace_file_dialog
 /*!
  * Push an `XrEventDataFilePickerCompleteEXT` onto the instance event queue.
@@ -2050,6 +2056,11 @@ struct oxr_session
 
 	//! Active eye tracking mode (0=MANAGED, 1=MANUAL). Default: 0 (MANAGED).
 	uint32_t eye_tracking_mode;
+
+	//! Last derived isTracking value (#441): -1 = no sample yet, else 0/1.
+	//! Edge detection in the xrLocateViews path pushes
+	//! XrEventDataEyeTrackingStateChangedEXT on change.
+	int32_t last_is_tracking;
 
 	//! Cached rendering mode index for detecting compositor-driven mode changes.
 	uint32_t last_rendering_mode_index;

--- a/src/xrt/state_trackers/oxr/oxr_plugin_stub.c
+++ b/src/xrt/state_trackers/oxr/oxr_plugin_stub.c
@@ -34,10 +34,10 @@
 _Static_assert(sizeof(XRT_PLUGIN_ENTRYPOINT_NAME) == sizeof("xrtPluginNegotiate"),
                "xrt_plugin: entry-point symbol name changed; coordinate with all plug-in builds");
 
-/* Current API version is the v2 line (ADR-020 rules 1–3 landed) — bump
- * deliberately, not by accident. */
-_Static_assert(XRT_PLUGIN_API_VERSION_CURRENT == XRT_PLUGIN_API_VERSION_2,
-               "xrt_plugin: API version current/v2 drift");
+/* Current API version is the v3 line (per-mode mode_flags on
+ * xrt_rendering_mode, #441) — bump deliberately, not by accident. */
+_Static_assert(XRT_PLUGIN_API_VERSION_CURRENT == XRT_PLUGIN_API_VERSION_3,
+               "xrt_plugin: API version current/v3 drift");
 
 /*
  * Host iface layout. struct_size must be the first field so plug-ins can

--- a/src/xrt/state_trackers/oxr/oxr_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_session.c
@@ -1738,31 +1738,41 @@ oxr_session_locate_views(struct oxr_logger *log,
 
 #ifdef OXR_HAVE_EXT_display_info
 	if (sess->sys->inst->extensions.EXT_display_info) {
+		// Derived per-frame tracking state (#441):
+		//   isTracking = active_mode.has_tracking && dp.is_tracking
+		// The active rendering mode's capability gates the DP value, so
+		// untracked modes (and trackerless displays — every sim_display
+		// mode) are always FALSE. This replaces the old fallback
+		// heuristic that guessed TRUE for sim_display / IPC sessions.
+		bool mode_has_tracking = false;
+		struct xrt_device *et_head = GET_XDEV_BY_ROLE(sess->sys, head);
+		if (et_head != NULL && et_head->hmd != NULL &&
+		    et_head->hmd->active_rendering_mode_index < et_head->rendering_mode_count) {
+			uint32_t ami = et_head->hmd->active_rendering_mode_index;
+			mode_has_tracking =
+			    (et_head->rendering_modes[ami].mode_flags & XRT_RENDERING_MODE_FLAG_HAS_TRACKING) != 0;
+		}
+		bool is_tracking = mode_has_tracking && got_eye_positions && eye_pos.valid && eye_pos.is_tracking;
+
 		XrViewEyeTrackingStateEXT *ets = OXR_GET_OUTPUT_FROM_CHAIN(
 		    viewState, XR_TYPE_VIEW_EYE_TRACKING_STATE_EXT, XrViewEyeTrackingStateEXT);
 		if (ets) {
 			ets->activeMode = (XrEyeTrackingModeEXT)sess->eye_tracking_mode;
-			if (got_eye_positions && eye_pos.valid) {
-				ets->isTracking = eye_pos.is_tracking ? XR_TRUE : XR_FALSE;
-			} else {
-				// No eye tracking backend or invalid data.
-				// For sim_display (MANUAL_BIT, always "tracking"), eye positions
-				// come from nominal viewer, not the eye tracking path.
-				// Report isTracking based on whether the system has tracking
-				// and the nominal path was used successfully.
-				const struct xrt_system_compositor_info *et_info =
-				    sess->sys->xsysc ? &sess->sys->xsysc->info : NULL;
-				uint32_t supported = et_info ? et_info->supported_eye_tracking_modes : 0;
-				if (supported != 0 && !got_eye_positions) {
-					// System claims tracking support but no eye tracking
-					// backend is active (e.g., sim_display with nominal viewer).
-					// Sim display is always "tracking" its simulated viewer.
-					ets->isTracking = XR_TRUE;
-				} else {
-					ets->isTracking = XR_FALSE;
-				}
-			}
+			ets->isTracking = is_tracking ? XR_TRUE : XR_FALSE;
 		}
+
+		// Edge-triggered XrEventDataEyeTrackingStateChangedEXT (#441) —
+		// fires on DP tracking loss/recovery AND on mode switches
+		// into/out of untracked modes. last_is_tracking == -1 means "no
+		// sample yet": the first locate establishes the baseline
+		// without firing (apps read the initial state from
+		// XrViewEyeTrackingStateEXT).
+		if (sess->last_is_tracking >= 0 && (sess->last_is_tracking != 0) != is_tracking) {
+			oxr_event_push_XrEventDataEyeTrackingStateChanged(
+			    log, sess, is_tracking ? XR_TRUE : XR_FALSE,
+			    (XrEyeTrackingModeEXT)sess->eye_tracking_mode);
+		}
+		sess->last_is_tracking = is_tracking ? 1 : 0;
 	}
 #endif // OXR_HAVE_EXT_display_info
 
@@ -2075,6 +2085,9 @@ oxr_session_allocate_and_init(struct oxr_logger *log,
 	if (sys->xsysc) {
 		sess->eye_tracking_mode = sys->xsysc->info.default_eye_tracking_mode;
 	}
+	// No derived-isTracking sample yet (#441) — first xrLocateViews
+	// establishes the baseline without firing the state-changed event.
+	sess->last_is_tracking = -1;
 #endif
 
 	// Action system hashmaps.

--- a/src/xrt/targets/cli/cli_query.c
+++ b/src/xrt/targets/cli/cli_query.c
@@ -94,6 +94,15 @@ cli_query_run(struct cli_query_result *r)
 	r->head_ok = true;
 	snprintf(r->head_str, sizeof(r->head_str), "%s", head->str);
 
+	// Rendering-mode snapshot incl. per-mode tracking flags (#441).
+	r->rendering_mode_count = head->rendering_mode_count;
+	if (r->rendering_mode_count > XRT_MAX_RENDERING_MODES) {
+		r->rendering_mode_count = XRT_MAX_RENDERING_MODES;
+	}
+	for (uint32_t m = 0; m < r->rendering_mode_count; m++) {
+		r->rendering_modes[m] = head->rendering_modes[m];
+	}
+
 	const struct xrt_plugin_iface *iface = target_plugin_get_active();
 	if (iface == NULL) {
 		r->result_code = CLI_SELFTEST_NO_DP;
@@ -227,6 +236,13 @@ cli_query_print_info_text(const struct cli_query_result *r)
 	PT("eye-tracking: supported=%s (0x%x) default=%s\n",
 	   eye_modes_label(i->supported_eye_tracking_modes, et_buf, sizeof(et_buf)),
 	   i->supported_eye_tracking_modes, eye_default_label(i->default_eye_tracking_mode));
+	PT("modes:        %u\n", r->rendering_mode_count);
+	for (uint32_t m = 0; m < r->rendering_mode_count; m++) {
+		const struct xrt_rendering_mode *rm = &r->rendering_modes[m];
+		PT("  [%u] %-14s views=%u 3d=%c tracked=%c\n", rm->mode_index, rm->mode_name, rm->view_count,
+		   rm->hardware_display_3d ? 'y' : 'n',
+		   (rm->mode_flags & XRT_RENDERING_MODE_FLAG_HAS_TRACKING) ? 'y' : 'n');
+	}
 }
 
 void
@@ -262,6 +278,18 @@ cli_query_print_info_json(const struct cli_query_result *r)
 
 	if (r->head_ok) {
 		cJSON_AddStringToObject(root, "device", r->head_str);
+		cJSON *rms = cJSON_AddArrayToObject(root, "rendering_modes");
+		for (uint32_t m = 0; m < r->rendering_mode_count; m++) {
+			const struct xrt_rendering_mode *rm = &r->rendering_modes[m];
+			cJSON *o = cJSON_CreateObject();
+			cJSON_AddNumberToObject(o, "mode_index", (double)rm->mode_index);
+			cJSON_AddStringToObject(o, "name", rm->mode_name);
+			cJSON_AddNumberToObject(o, "view_count", (double)rm->view_count);
+			cJSON_AddBoolToObject(o, "hardware_display_3d", rm->hardware_display_3d);
+			cJSON_AddBoolToObject(o, "has_tracking",
+			                      (rm->mode_flags & XRT_RENDERING_MODE_FLAG_HAS_TRACKING) != 0);
+			cJSON_AddItemToArray(rms, o);
+		}
 	} else {
 		cJSON_AddNullToObject(root, "device");
 	}

--- a/src/xrt/targets/cli/cli_query.h
+++ b/src/xrt/targets/cli/cli_query.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "xrt/xrt_plugin.h"
+#include "xrt/xrt_device.h"
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -73,6 +74,11 @@ struct cli_query_result
 
 	/* Head/display device description (valid iff head_ok). */
 	char head_str[256];
+
+	/* Rendering-mode snapshot incl. per-mode tracking flags (#441;
+	 * valid iff head_ok — count 0 if the device exposes none). */
+	uint32_t rendering_mode_count;
+	struct xrt_rendering_mode rendering_modes[XRT_MAX_RENDERING_MODES];
 
 	/* Vendor-neutral display info (valid iff display_info_ok). */
 	struct xrt_plugin_display_info display_info;

--- a/src/xrt/targets/common/target_instance.c
+++ b/src/xrt/targets/common/target_instance.c
@@ -306,6 +306,32 @@ out:
 				xsysc->info.supported_eye_tracking_modes = pdi.supported_eye_tracking_modes;
 				xsysc->info.default_eye_tracking_mode = pdi.default_eye_tracking_mode;
 
+				// Consistency rule (#441): supported_eye_tracking_modes != 0
+				// ⇔ at least one rendering mode claims HAS_TRACKING. A
+				// mismatch means the plug-in's capability advertisement and
+				// its per-mode flags disagree — apps would see impossible
+				// combinations (e.g. MANAGED offered but isTracking pinned
+				// FALSE). One-shot init WARN, not fatal.
+				{
+					bool any_tracked = false;
+					for (uint32_t mi = 0; mi < head->rendering_mode_count; mi++) {
+						if (head->rendering_modes[mi].mode_flags &
+						    XRT_RENDERING_MODE_FLAG_HAS_TRACKING) {
+							any_tracked = true;
+							break;
+						}
+					}
+					if ((pdi.supported_eye_tracking_modes != 0) != any_tracked) {
+						U_LOG_W("Plug-in '%s' tracking advertisement inconsistent: "
+						        "supported_eye_tracking_modes=0x%x but %s rendering "
+						        "mode sets XRT_RENDERING_MODE_FLAG_HAS_TRACKING "
+						        "(see #441 consistency rule)",
+						        plugin->id ? plugin->id : "?",
+						        pdi.supported_eye_tracking_modes,
+						        any_tracked ? "at least one" : "no");
+					}
+				}
+
 				// Compute tiling once we have native pixel dims.
 				if (pdi.display_pixel_width > 0 && pdi.display_pixel_height > 0) {
 					for (uint32_t mi = 0; mi < head->rendering_mode_count; mi++) {


### PR DESCRIPTION
## Summary

Phases 0+1 of #441 — per-rendering-mode tracking capability, truthful `isTracking`, and the new tracking-state-changed event. Plan: `docs/roadmap/per-mode-tracking-capability-plan.md`.

### Phase 0 — specs
- `eye-tracking-modes.md`: capability layering (per-mode `has_tracking` × system MANAGED/MANUAL), isTracking derivation + consistency rules, tracking-state event, workspace-authority resolution (#233/#234)
- `XR_EXT_display_info.md` → v14 + layout-freeze policy for `XrDisplayRenderingModeInfoEXT`
- vendor onboarding + iface reference updates

### Phase 1 — runtime
- **`xrt_rendering_mode.mode_flags`** (bit 0 = `XRT_RENDERING_MODE_FLAG_HAS_TRACKING`) + `reserved[3]` → **plug-in ABI v2→v3** (embedded-array stride change; tripwire in `oxr_plugin_stub.c` bumped consciously). Flags word + padding = intended last rendering-mode layout break.
- **Header v14**: chained `XrDisplayRenderingModeTrackingInfoEXT` (opt-in via input-type handshake — the runtime never walks v13 binaries' uninitialized `next`) + `XrEventDataEyeTrackingStateChangedEXT`.
- **`xrLocateViews`**: `isTracking = active_mode.has_tracking && eye_pos.valid && eye_pos.is_tracking` — replaces the contradictory sim/IPC fallback heuristic.
- **Edge-triggered event** on every derived-isTracking change (DP loss/recovery + mode switches into/out of untracked modes); first locate establishes baseline silently.
- **sim_display honest**: `supported_eye_tracking_modes=0`, all modes untracked. `SIM_DISPLAY_FAKE_TRACKING=1` (+`_PERIOD_MS=N` square wave) re-enables MANUAL_BIT + tracked 3D modes for hardware-free testing across all 5 DP variants.
- **Diagnostics**: `displayxr-cli info` per-mode tracking table (text+JSON); one-shot init WARN on capability/per-mode inconsistency.

### Interim behavior note
Until Phase 2 (IPC transport of `is_tracking`) lands, IPC sessions report `isTracking=FALSE` (honest "unknown") instead of the previous fake TRUE.

## Verification
- macOS build green; **22/22 ctest pass**
- MinGW compile-check green (default targets; touched sim files compile clean — GL target's glad include is a pre-existing subset limitation)
- Headless `displayxr-cli selftest` **PASS** with dev plug-in negotiating **ABI v3**
- `displayxr-cli info`: default → `supported=none`, all modes `tracked=n`; `SIM_DISPLAY_FAKE_TRACKING=1` → `MANUAL (0x2)`, 3D modes `tracked=y`, 2D stays `n`; no consistency warning in either state

## Coordination
- Leia plug-in counterpart: DisplayXR/displayxr-leia-plugin#29 (ABI 3 + mode flags) — the versions.json ABI gate will hold the leia bump until it ships (by design)
- Phase 2 (IPC) + Phase 4 (test-app HUD/linter) follow as separate PRs

Closes nothing yet — tracks #441.

🤖 Generated with [Claude Code](https://claude.com/claude-code)