### PR TITLE
feat(#444): XR_EXT_mcp_tools — app-defined MCP tools + displayxr-mcp v0.4.0 re-pin

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,7 @@ Vendor display drivers ship as **plug-in DLLs** from their own repos (ADR-019). 
 - `XR_EXT_cocoa_window_binding` — app passes NSWindow to runtime
 - `XR_EXT_display_info` — display dimensions, eye-tracking modes
 - `XR_EXT_android_surface_binding` — Android surface binding
+- `XR_EXT_mcp_tools` — app registers its own MCP tools (agent control surface); event-queue dispatch via `XrEventDataMCPToolCallEXT`
 
 Specs: `docs/specs/extensions/`. Eye-tracking MANAGED vs MANUAL contract: `docs/specs/vendor/eye-tracking-modes.md`.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,7 +125,7 @@ find_package(cJSON MODULE)
 include(FetchContent)
 FetchContent_Declare(displayxr_mcp
     GIT_REPOSITORY https://github.com/DisplayXR/displayxr-mcp.git
-    GIT_TAG v0.3.2)
+    GIT_TAG v0.4.0)
 # Build the stdio↔socket adapter alongside the lib so the Phase A test
 # scripts under tests/mcp/ can find a binary at a known path during dev
 # (build/_deps/displayxr_mcp-build/displayxr-mcp). Production

--- a/docs/specs/extensions/XR_EXT_mcp_tools.md
+++ b/docs/specs/extensions/XR_EXT_mcp_tools.md
@@ -1,0 +1,138 @@
+# XR_EXT_mcp_tools
+
+| Field | Value |
+|---|---|
+| **Name** | `XR_EXT_mcp_tools` |
+| **Spec version** | 1 |
+| **Status** | Implemented (runtime ≥ v1.13, framework ≥ displayxr-mcp v0.4.0) |
+| **Header** | [`XR_EXT_mcp_tools.h`](../../../src/external/openxr_includes/openxr/XR_EXT_mcp_tools.h) (auto-synced to `displayxr-extensions`) |
+| **Design** | [Per-app MCP tools & workspace aggregator](../../roadmap/per-app-mcp-tools.md) |
+| **Depends on** | Nothing at the API level. Functionally inert unless the MCP capability is enabled (`HKLM\Software\DisplayXR\Capabilities\MCP\Enabled` / `DISPLAYXR_MCP`). |
+
+## 1. Overview
+
+The runtime hosts an MCP (Model Context Protocol) server inside every
+app process (`\\.\pipe\displayxr-mcp-<pid>` /
+`/tmp/displayxr-mcp-<pid>.sock`). Until this extension, that server
+exposed only what the *platform* knows — Phase A introspection. This
+extension lets the **app** add its own tools — `play_pause`,
+`load_model`, `run_animation` — so agents can operate the app, not just
+its window:
+
+```
+agent → displayxr-mcp adapter → per-PID MCP server → [trampoline]
+      → XrEventDataMCPToolCallEXT → app's xrPollEvent loop
+      → xrSubmitMCPToolResultEXT → JSON-RPC response → agent
+```
+
+Through the workspace aggregator (`displayxr-mcp --target workspace`)
+the tools appear namespaced as `<app-id>__<tool>`, where `<app-id>` is
+the manifest `id` declared via `xrSetMCPAppInfoEXT`.
+
+Apps never link the MCP framework; the coupling is wire-protocol-only
+(same contract as every other DisplayXR extension, so the Unity/Unreal
+plugins can bind it).
+
+## 2. API
+
+Five functions, one event. Full signatures + parameter docs in the
+header; semantics summary:
+
+| Function | Semantics |
+|---|---|
+| `xrSetMCPAppInfoEXT(session, info)` | Declare the app's stable id (`^[a-z0-9][a-z0-9-]{0,31}$`, = manifest `id` §3.4). Becomes the aggregator's tool-name prefix. Call before registering tools; changing it later notifies agents but churns their tool names — treat as immutable. |
+| `xrRegisterMCPToolEXT(session, tool)` | Register `{name, description, inputSchemaJson}`. Strings are copied. Bare name: `^[a-z0-9][a-z0-9_-]{0,62}$`, no `__`. Duplicate → `XR_ERROR_NAME_DUPLICATED`; budget (32/process) → `XR_ERROR_LIMIT_REACHED`. Late registration is first-class: connected agents get `tools/list_changed`. |
+| `xrUnregisterMCPToolEXT(session, name)` | Remove a tool; in-flight calls on it fail to the agent. |
+| `xrGetMCPToolCallArgsEXT(session, callId, cap, count, buf)` | Two-call idiom fetch of a pending call's JSON arguments (`argsSize` in the event is the required capacity). |
+| `xrSubmitMCPToolResultEXT(session, callId, success, resultJson)` | Answer a call. `success=XR_FALSE` → agent receives a tool error. Late submits on a timed-out call return `XR_SUCCESS` and are dropped. |
+
+**Event** `XrEventDataMCPToolCallEXT` `{session, callId, toolName[64],
+argsSize}` — delivered through the session's normal `xrPollEvent`
+stream when an agent invokes a registered tool.
+
+## 3. Dispatch contract
+
+- **The MCP transport thread never calls app code.** The runtime-side
+  trampoline parks the JSON-RPC request, pushes the event, and waits.
+  Tool execution happens on the app's frame loop, where its state is
+  naturally consistent — no locking discipline is imposed on apps.
+- **Timeout:** a call unanswered after **5 s** fails to the agent
+  (JSON-RPC tool error). Handle apps pump frames while unfocused, so a
+  healthy app always drains its queue; the timeout exists for hung or
+  modal-blocked apps.
+- **Concurrency:** up to 16 calls may be pending per process; beyond
+  that, agents receive errors immediately.
+- **Session scope:** tools live on the `XrSession`. Session destroy
+  unregisters everything and fails pending calls. (Phase A's
+  session-free diagnostics cover the no-session case.)
+- **Results:** `resultJson` should be a JSON object. Unparseable JSON
+  is wrapped as `{"raw": "<string>"}` rather than dropped.
+
+## 4. Gating & errors
+
+All functions return `XR_ERROR_FEATURE_UNSUPPORTED` when the MCP
+capability is off (the per-process server was never started). Apps
+should treat this as "no agent surface available" and continue —
+registering tools must never be load-bearing for normal operation.
+
+The extension is always advertised by the runtime; the gate is
+evaluated per call so an app binary behaves identically on machines
+with and without the MCP Tools package installed.
+
+## 5. Manifest pairing & linting
+
+An app that registers MCP tools MUST declare the same id in its
+`.displayxr.json` manifest (`id` field, [manifest spec §3.4]
+(../runtime/displayxr-app-manifest.md)) that it passes to
+`xrSetMCPAppInfoEXT` — agents discover the id pre-launch from the
+manifest and at runtime from the MCP `_meta`. `scripts/check_displayxr_app.py`
+lints the pairing (manifest `id` present + charset; code/manifest match
+is checked when the source registers tools).
+
+## 6. Description quality (normative-ish)
+
+`description` is **agent-facing documentation**, not a label. The
+agent decides *whether and how* to call your tool based solely on the
+name, description, and schema. Write it like you'd write API docs:
+what it does, what the arguments mean, units, side effects,
+preconditions ("requires a model to be loaded — call load_model
+first").
+
+## 7. Example
+
+```c
+// Once, after session create:
+XrMCPAppInfoEXT app_info = {.type = XR_TYPE_MCP_APP_INFO_EXT, .appId = "mediaplayer"};
+xrSetMCPAppInfoEXT(session, &app_info);
+
+XrMCPToolInfoEXT tool = {
+    .type = XR_TYPE_MCP_TOOL_INFO_EXT,
+    .name = "play_pause",
+    .description = "Toggle playback of the currently open media file. "
+                   "No-op (success=false) when no file is open.",
+    .inputSchemaJson = "{\"type\":\"object\"}",
+};
+xrRegisterMCPToolEXT(session, &tool);
+
+// In the frame loop's event pump:
+case XR_TYPE_EVENT_DATA_MCP_TOOL_CALL_EXT: {
+    const XrEventDataMCPToolCallEXT *call = (const XrEventDataMCPToolCallEXT *)&event;
+    if (strcmp(call->toolName, "play_pause") == 0) {
+        bool ok = media_toggle_play();
+        xrSubmitMCPToolResultEXT(session, call->callId, ok ? XR_TRUE : XR_FALSE,
+                                 ok ? "{\"playing\":true}" : "{\"error\":\"no file open\"}");
+    }
+    break;
+}
+```
+
+## 8. Relationship to the aggregator
+
+Nothing in this extension knows about namespacing — apps register
+**bare** names. The `<app-id>__<tool>` prefixing, sticky instance
+suffixes, group-based exposure, and `workspace__list_apps` all live in
+the `displayxr-mcp` adapter's `--target workspace` mode
+([mcp-spec §10](https://github.com/DisplayXR/displayxr-mcp/blob/main/docs/mcp-spec.md)).
+App-registered tools carry `_meta {"displayxr/group": "app"}` and are
+exposed by default; Phase A introspection stays `diagnostic` (hidden
+unless `--expose-diagnostics`).

--- a/scripts/check_displayxr_app.py
+++ b/scripts/check_displayxr_app.py
@@ -51,7 +51,11 @@ RULES = {
     "INV-7.2": "xrCaptureAtlasEXT pathPrefix takes NO extension; the runtime appends _atlas.png.",
     "INV-9.1": "Ship a <exe>.displayxr.json (schema_version=1, name 1-64, type 2d|3d) or the app won't appear in the workspace launcher.",
     "INV-9.2": "2D icon is 512x512 (`icon`); 3D icon is 1024x512 (`icon_3d`, requires `icon`); layout in {sbs-lr,sbs-rl,tb,bt}.",
+    "INV-10.1": "Apps registering MCP tools (XR_EXT_mcp_tools) declare a manifest `id` (^[a-z0-9][a-z0-9-]{0,31}$) matching the xrSetMCPAppInfoEXT appId.",
 }
+
+# Manifest `id` / XrMCPAppInfoEXT appId slug (manifest spec §3.4).
+APP_ID_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,31}$")
 
 ERROR, WARN, INFO = "ERROR", "WARN", "INFO"
 
@@ -243,6 +247,69 @@ def validate_manifest(mpath: Path, root: Path, findings: list):
                                     f"Re-export {key} at {want[0]}x{want[1]} (PNG)."))
 
 
+def check_mcp_pairing(root: Path, findings: list):
+    """INV-10.1 — XR_EXT_mcp_tools <-> manifest `id` pairing.
+
+    If any source registers MCP tools, a manifest must declare a valid
+    `id`; when the appId literal is extractable from the source, it must
+    equal the manifest's. Manifests with a malformed `id` get a WARN
+    regardless (soft failure per manifest spec §6 — the launcher still
+    accepts the app, consumers fall back to the exe basename).
+    """
+    # Manifest ids.
+    manifest_ids = {}
+    for m in root.rglob("*.displayxr.json"):
+        if any(part in EXCLUDE_DIRS for part in m.relative_to(root).parts[:-1]):
+            continue
+        try:
+            data = json.loads(m.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue  # INV-9.1 already reported it.
+        app_id = data.get("id")
+        if app_id is None:
+            continue
+        if not isinstance(app_id, str) or not APP_ID_RE.match(app_id):
+            findings.append(Finding(WARN, "INV-10.1", rel(m, root), 1,
+                                    f"id {app_id!r} does not match ^[a-z0-9][a-z0-9-]{{0,31}}$ — consumers will ignore it.",
+                                    "Use a lowercase slug (letters/digits/hyphens, no underscores — '__' is the MCP namespace separator)."))
+            continue
+        manifest_ids[rel(m, root)] = app_id
+
+    # Source-side usage + declared appId literals.
+    uses_mcp_tools = False
+    declared = []  # (path, line, appId literal)
+    appid_re = re.compile(r"\.appId\s*=\s*\"([^\"]*)\"|appId\s*,\s*\"([^\"]*)\"")
+    for p in sorted(root.rglob("*")):
+        if p.suffix.lower() not in SOURCE_EXTS or not p.is_file():
+            continue
+        if any(part in EXCLUDE_DIRS for part in p.relative_to(root).parts[:-1]):
+            continue
+        try:
+            text = p.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        if "xrRegisterMCPToolEXT" in text or "xrSetMCPAppInfoEXT" in text:
+            uses_mcp_tools = True
+        for i, line in enumerate(text.splitlines(), 1):
+            m = appid_re.search(line)
+            if m:
+                declared.append((rel(p, root), i, m.group(1) or m.group(2)))
+
+    if not uses_mcp_tools:
+        return
+    if not manifest_ids:
+        findings.append(Finding(ERROR, "INV-10.1", str(root), 1,
+                                "Source registers MCP tools (XR_EXT_mcp_tools) but no manifest declares an `id`.",
+                                'Add "id": "<slug>" to the .displayxr.json — it is the agent-visible tool prefix.'))
+        return
+    for path, line, lit in declared:
+        if lit and lit not in manifest_ids.values():
+            findings.append(Finding(ERROR, "INV-10.1", path, line,
+                                    f"xrSetMCPAppInfoEXT appId {lit!r} does not match any manifest id "
+                                    f"({', '.join(sorted(set(manifest_ids.values())))}).",
+                                    "Make the code and manifest agree — agents key tool names on this slug."))
+
+
 def scan_manifests(root: Path, findings: list):
     manifests = [p for p in root.rglob("*.displayxr.json")
                  if not any(part in EXCLUDE_DIRS for part in p.relative_to(root).parts[:-1])]
@@ -289,6 +356,7 @@ def main(argv=None) -> int:
     findings: list = []
     scan_sources(root, findings)
     scan_manifests(root, findings)
+    check_mcp_pairing(root, findings)
     print_findings(findings, root)
 
     n_err = sum(1 for f in findings if f.level == ERROR)

--- a/src/external/openxr_includes/openxr/XR_EXT_mcp_tools.h
+++ b/src/external/openxr_includes/openxr/XR_EXT_mcp_tools.h
@@ -1,0 +1,227 @@
+// Copyright 2026, DisplayXR
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  Header for XR_EXT_mcp_tools extension (app-defined agent tools).
+ * @author DisplayXR
+ * @ingroup external_openxr
+ *
+ * Lets an app register its own MCP (Model Context Protocol) tools —
+ * "play_pause", "load_model", "run_animation" — on the per-process MCP
+ * server the runtime already hosts. Agents reach them via the
+ * displayxr-mcp adapter (`--target pid:N`, or namespaced as
+ * `<app-id>__<tool>` through `--target workspace`).
+ *
+ * Dispatch is event-based on purpose: the MCP transport thread never
+ * calls into app code. A tool invocation surfaces as an
+ * XrEventDataMCPToolCallEXT through xrPollEvent; the app executes the
+ * tool on its own frame loop (where its state is naturally consistent)
+ * and answers with xrSubmitMCPToolResultEXT. The runtime fails a call
+ * the app has not answered within ~5 seconds.
+ *
+ * Event payloads are fixed-size, so tool arguments use the OpenXR
+ * two-call idiom via xrGetMCPToolCallArgsEXT.
+ *
+ * All functions return XR_ERROR_FEATURE_UNSUPPORTED when the MCP
+ * capability is disabled (HKLM\Software\DisplayXR\Capabilities\MCP /
+ * DISPLAYXR_MCP) — apps should treat that as "no agent surface" and
+ * continue normally.
+ *
+ * Design: displayxr-runtime docs/roadmap/per-app-mcp-tools.md;
+ * spec: docs/specs/extensions/XR_EXT_mcp_tools.md.
+ */
+#ifndef XR_EXT_MCP_TOOLS_H
+#define XR_EXT_MCP_TOOLS_H 1
+
+#include <openxr/openxr.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define XR_EXT_mcp_tools 1
+#define XR_EXT_mcp_tools_SPEC_VERSION 1
+#define XR_EXT_MCP_TOOLS_EXTENSION_NAME "XR_EXT_mcp_tools"
+
+// Provisional XrStructureType values. The 1000999130..132 range is
+// reserved for this extension. Reconciles with the Khronos registry
+// before any spec-freeze attempt.
+#define XR_TYPE_MCP_APP_INFO_EXT            ((XrStructureType)1000999130)
+#define XR_TYPE_MCP_TOOL_INFO_EXT           ((XrStructureType)1000999131)
+#define XR_TYPE_EVENT_DATA_MCP_TOOL_CALL_EXT ((XrStructureType)1000999132)
+
+/*!
+ * @brief Maximum app-id length (the manifest `id` slug), incl. NUL.
+ *
+ * Charset is `^[a-z0-9][a-z0-9-]{0,31}$` — lowercase ASCII letters,
+ * digits, hyphens. Underscores are excluded by design: `__` is the
+ * workspace aggregator's namespace separator.
+ */
+#define XR_MAX_MCP_APP_ID_SIZE_EXT 33
+
+/*!
+ * @brief Maximum bare tool-name length, incl. NUL.
+ *
+ * Charset is `^[a-z0-9][a-z0-9_-]{0,62}$` and the name must not
+ * contain the substring `__` (reserved namespace separator).
+ */
+#define XR_MAX_MCP_TOOL_NAME_SIZE_EXT 64
+
+/*!
+ * @brief App identity declaration.
+ *
+ * `appId` MUST match the `id` field of the app's `.displayxr.json`
+ * manifest (manifest spec §3.4); `scripts/check_displayxr_app.py`
+ * lints the pairing. It becomes the agent-visible tool-name prefix.
+ */
+typedef struct XrMCPAppInfoEXT {
+    XrStructureType          type; //!< Must be XR_TYPE_MCP_APP_INFO_EXT
+    const void* XR_MAY_ALIAS next; //!< Reserved; must be NULL in spec_version 1
+    char                     appId[XR_MAX_MCP_APP_ID_SIZE_EXT]; //!< NUL-terminated slug
+} XrMCPAppInfoEXT;
+
+/*!
+ * @brief Declare the app's stable identifier. Call once per session,
+ * before registering tools. May be called again to change it (the
+ * runtime notifies connected agents), but treat the id as immutable
+ * in practice — agents key tool names on it.
+ *
+ * @return XR_SUCCESS, XR_ERROR_VALIDATION_FAILURE (bad type/charset),
+ *         XR_ERROR_FEATURE_UNSUPPORTED (MCP capability disabled),
+ *         XR_ERROR_HANDLE_INVALID.
+ */
+typedef XrResult (XRAPI_PTR *PFN_xrSetMCPAppInfoEXT)(
+    XrSession                session,
+    const XrMCPAppInfoEXT*   info);
+
+#ifndef XR_NO_PROTOTYPES
+XRAPI_ATTR XrResult XRAPI_CALL xrSetMCPAppInfoEXT(
+    XrSession                session,
+    const XrMCPAppInfoEXT*   info);
+#endif
+
+/*!
+ * @brief One tool registration.
+ *
+ * `description` is what the agent reads to decide when to call the
+ * tool — write it like API documentation, not a label.
+ * `inputSchemaJson` is a JSON Schema object describing `arguments`
+ * (NULL/empty means "no arguments": `{"type":"object"}`).
+ *
+ * The strings are copied; the struct need not outlive the call.
+ */
+typedef struct XrMCPToolInfoEXT {
+    XrStructureType          type; //!< Must be XR_TYPE_MCP_TOOL_INFO_EXT
+    const void* XR_MAY_ALIAS next; //!< Reserved; must be NULL in spec_version 1
+    const char*              name;            //!< Bare name; runtime/aggregator prefixes
+    const char*              description;     //!< Agent-facing; required
+    const char*              inputSchemaJson; //!< JSON Schema; optional
+} XrMCPToolInfoEXT;
+
+/*!
+ * @brief Register a tool on the session. Tools registered after agents
+ * connected surface immediately (the runtime broadcasts the MCP
+ * `tools/list_changed` notification). All of a session's tools are
+ * unregistered automatically when the session is destroyed; pending
+ * calls fail with an error to the agent.
+ *
+ * @return XR_SUCCESS,
+ *         XR_ERROR_NAME_DUPLICATED (name already registered),
+ *         XR_ERROR_VALIDATION_FAILURE (bad type/name/missing description),
+ *         XR_ERROR_LIMIT_REACHED (per-process tool budget exhausted),
+ *         XR_ERROR_FEATURE_UNSUPPORTED, XR_ERROR_HANDLE_INVALID.
+ */
+typedef XrResult (XRAPI_PTR *PFN_xrRegisterMCPToolEXT)(
+    XrSession                session,
+    const XrMCPToolInfoEXT*  tool);
+
+/*!
+ * @brief Unregister a tool by bare name. In-flight calls on the tool
+ * fail to the agent. XR_ERROR_VALIDATION_FAILURE if the name is not
+ * registered on this session.
+ */
+typedef XrResult (XRAPI_PTR *PFN_xrUnregisterMCPToolEXT)(
+    XrSession                session,
+    const char*              name);
+
+#ifndef XR_NO_PROTOTYPES
+XRAPI_ATTR XrResult XRAPI_CALL xrRegisterMCPToolEXT(
+    XrSession                session,
+    const XrMCPToolInfoEXT*  tool);
+XRAPI_ATTR XrResult XRAPI_CALL xrUnregisterMCPToolEXT(
+    XrSession                session,
+    const char*              name);
+#endif
+
+/*!
+ * @brief Tool invocation event, delivered via xrPollEvent.
+ *
+ * The app fetches the JSON arguments with xrGetMCPToolCallArgsEXT
+ * (`argsSize` is the required capacity incl. NUL), executes the tool,
+ * and answers with xrSubmitMCPToolResultEXT. An unanswered call fails
+ * to the agent after ~5 seconds; a result submitted after that is
+ * silently dropped (XR_SUCCESS).
+ *
+ * @extends XrEventDataBaseHeader
+ */
+typedef struct XrEventDataMCPToolCallEXT {
+    XrStructureType          type; //!< Must be XR_TYPE_EVENT_DATA_MCP_TOOL_CALL_EXT
+    const void* XR_MAY_ALIAS next;
+    XrSession                session;
+    uint64_t                 callId;   //!< Correlates xrGet…Args/xrSubmit…Result; never 0
+    char                     toolName[XR_MAX_MCP_TOOL_NAME_SIZE_EXT]; //!< NUL-terminated
+    uint32_t                 argsSize; //!< Bytes incl. NUL for xrGetMCPToolCallArgsEXT
+} XrEventDataMCPToolCallEXT;
+
+/*!
+ * @brief Fetch a pending call's JSON arguments (two-call idiom).
+ *
+ * @param capacity     Size of @p buffer in bytes; 0 to query.
+ * @param countOutput  Required size incl. NUL.
+ * @return XR_SUCCESS, XR_ERROR_SIZE_INSUFFICIENT,
+ *         XR_ERROR_VALIDATION_FAILURE (unknown/expired callId),
+ *         XR_ERROR_HANDLE_INVALID.
+ */
+typedef XrResult (XRAPI_PTR *PFN_xrGetMCPToolCallArgsEXT)(
+    XrSession                session,
+    uint64_t                 callId,
+    uint32_t                 capacity,
+    uint32_t*                countOutput,
+    char*                    buffer);
+
+/*!
+ * @brief Answer a pending tool call.
+ *
+ * @param success     XR_TRUE → @p resultJson becomes the tool result;
+ *                    XR_FALSE → the agent receives a tool error.
+ * @param resultJson  NUL-terminated JSON value (object recommended).
+ *                    NULL/empty is treated as `{}`. Copied.
+ * @return XR_SUCCESS (also for late results on an expired callId —
+ *         the result is dropped), XR_ERROR_VALIDATION_FAILURE
+ *         (callId never existed), XR_ERROR_HANDLE_INVALID.
+ */
+typedef XrResult (XRAPI_PTR *PFN_xrSubmitMCPToolResultEXT)(
+    XrSession                session,
+    uint64_t                 callId,
+    XrBool32                 success,
+    const char*              resultJson);
+
+#ifndef XR_NO_PROTOTYPES
+XRAPI_ATTR XrResult XRAPI_CALL xrGetMCPToolCallArgsEXT(
+    XrSession                session,
+    uint64_t                 callId,
+    uint32_t                 capacity,
+    uint32_t*                countOutput,
+    char*                    buffer);
+XRAPI_ATTR XrResult XRAPI_CALL xrSubmitMCPToolResultEXT(
+    XrSession                session,
+    uint64_t                 callId,
+    XrBool32                 success,
+    const char*              resultJson);
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // XR_EXT_MCP_TOOLS_H

--- a/src/xrt/include/xrt/xrt_openxr_includes.h
+++ b/src/xrt/include/xrt/xrt_openxr_includes.h
@@ -77,3 +77,4 @@ typedef __eglMustCastToProperFunctionPointerType (*PFNEGLGETPROCADDRESSPROC)(con
 #include "openxr/XR_EXT_spatial_workspace.h"
 #include "openxr/XR_EXT_workspace_file_dialog.h"
 #include "openxr/XR_EXT_atlas_capture.h"
+#include "openxr/XR_EXT_mcp_tools.h"

--- a/src/xrt/state_trackers/oxr/CMakeLists.txt
+++ b/src/xrt/state_trackers/oxr/CMakeLists.txt
@@ -34,6 +34,7 @@ add_library(
 	oxr_instance.c
 	oxr_logger.c
 	oxr_logger.h
+	oxr_mcp_app_tools.c
 	oxr_mcp_tools.c
 	oxr_mcp_tools.h
 	oxr_objects.h

--- a/src/xrt/state_trackers/oxr/oxr_api_funcs.h
+++ b/src/xrt/state_trackers/oxr/oxr_api_funcs.h
@@ -949,6 +949,25 @@ oxr_xrCompleteFilePickerEXT(XrSession session,
                             const char *path);
 #endif
 
+#ifdef OXR_HAVE_EXT_mcp_tools
+//! OpenXR API function @ep{xrSetMCPAppInfoEXT}
+XRAPI_ATTR XrResult XRAPI_CALL
+oxr_xrSetMCPAppInfoEXT(XrSession session, const XrMCPAppInfoEXT *info);
+//! OpenXR API function @ep{xrRegisterMCPToolEXT}
+XRAPI_ATTR XrResult XRAPI_CALL
+oxr_xrRegisterMCPToolEXT(XrSession session, const XrMCPToolInfoEXT *tool);
+//! OpenXR API function @ep{xrUnregisterMCPToolEXT}
+XRAPI_ATTR XrResult XRAPI_CALL
+oxr_xrUnregisterMCPToolEXT(XrSession session, const char *name);
+//! OpenXR API function @ep{xrGetMCPToolCallArgsEXT}
+XRAPI_ATTR XrResult XRAPI_CALL
+oxr_xrGetMCPToolCallArgsEXT(
+    XrSession session, uint64_t callId, uint32_t capacity, uint32_t *countOutput, char *buffer);
+//! OpenXR API function @ep{xrSubmitMCPToolResultEXT}
+XRAPI_ATTR XrResult XRAPI_CALL
+oxr_xrSubmitMCPToolResultEXT(XrSession session, uint64_t callId, XrBool32 success, const char *resultJson);
+#endif
+
 // xrSetSharedTextureOutputRectEXT — canvas sub-rect, part of window binding extensions
 #if defined(OXR_HAVE_EXT_win32_window_binding) || defined(OXR_HAVE_EXT_cocoa_window_binding)
 //! OpenXR API function @ep{xrSetSharedTextureOutputRectEXT}

--- a/src/xrt/state_trackers/oxr/oxr_api_negotiate.c
+++ b/src/xrt/state_trackers/oxr/oxr_api_negotiate.c
@@ -483,6 +483,14 @@ handle_non_null(struct oxr_instance *inst, struct oxr_logger *log, const char *n
 	ENTRY_IF_EXT(xrCompleteFilePickerEXT, EXT_workspace_file_dialog);
 #endif
 
+#ifdef OXR_HAVE_EXT_mcp_tools
+	ENTRY_IF_EXT(xrSetMCPAppInfoEXT, EXT_mcp_tools);
+	ENTRY_IF_EXT(xrRegisterMCPToolEXT, EXT_mcp_tools);
+	ENTRY_IF_EXT(xrUnregisterMCPToolEXT, EXT_mcp_tools);
+	ENTRY_IF_EXT(xrGetMCPToolCallArgsEXT, EXT_mcp_tools);
+	ENTRY_IF_EXT(xrSubmitMCPToolResultEXT, EXT_mcp_tools);
+#endif
+
 	// xrSetSharedTextureOutputRectEXT — canvas sub-rect, part of window binding extensions
 #ifdef OXR_HAVE_EXT_win32_window_binding
 	ENTRY_IF_EXT(xrSetSharedTextureOutputRectEXT, EXT_win32_window_binding);

--- a/src/xrt/state_trackers/oxr/oxr_event.c
+++ b/src/xrt/state_trackers/oxr/oxr_event.c
@@ -154,6 +154,12 @@ is_session_link_to_event(struct oxr_event *event, XrSession session)
 		return complete->session == session;
 	}
 #endif
+#ifdef OXR_HAVE_EXT_mcp_tools
+	case XR_TYPE_EVENT_DATA_MCP_TOOL_CALL_EXT: {
+		XrEventDataMCPToolCallEXT *call = (XrEventDataMCPToolCallEXT *)type;
+		return call->session == session;
+	}
+#endif
 	default: return false;
 	}
 }
@@ -507,6 +513,44 @@ oxr_event_push_XrEventDataFilePickerComplete(struct oxr_logger *log,
 	return XR_SUCCESS;
 }
 #endif // OXR_HAVE_EXT_workspace_file_dialog
+
+#ifdef OXR_HAVE_EXT_mcp_tools
+XrResult
+oxr_event_push_XrEventDataMCPToolCall(struct oxr_logger *log,
+                                      struct oxr_session *sess,
+                                      uint64_t call_id,
+                                      const char *tool_name,
+                                      uint32_t args_size)
+{
+	struct oxr_instance *inst = sess->sys->inst;
+	XrEventDataMCPToolCallEXT *call;
+	struct oxr_event *event = NULL;
+
+	ALLOC(log, inst, &event, &call);
+
+	call->type = XR_TYPE_EVENT_DATA_MCP_TOOL_CALL_EXT;
+	call->next = NULL;
+	call->session = oxr_session_to_openxr(sess);
+	call->callId = call_id;
+	// toolName[] was already zero-initialised by ALLOC.
+	if (tool_name != NULL) {
+		size_t len = strnlen(tool_name, XR_MAX_MCP_TOOL_NAME_SIZE_EXT - 1);
+		memcpy(call->toolName, tool_name, len);
+		call->toolName[len] = '\0';
+	}
+	call->argsSize = args_size;
+	event->result = XR_SUCCESS;
+
+	U_LOG_I("OXR EVENT: MCP tool call (callId=%llu, tool=%s)", (unsigned long long)call_id,
+	        tool_name != NULL ? tool_name : "(null)");
+
+	lock(inst);
+	push(inst, event);
+	unlock(inst);
+
+	return XR_SUCCESS;
+}
+#endif // OXR_HAVE_EXT_mcp_tools
 
 XrResult
 oxr_event_remove_session_events(struct oxr_logger *log, struct oxr_session *sess)

--- a/src/xrt/state_trackers/oxr/oxr_extension_support.h
+++ b/src/xrt/state_trackers/oxr/oxr_extension_support.h
@@ -598,6 +598,18 @@
 
 
 /*
+ * XR_EXT_mcp_tools
+ */
+#if defined(XR_EXT_mcp_tools)
+#define OXR_HAVE_EXT_mcp_tools
+#define OXR_EXTENSION_SUPPORT_EXT_mcp_tools(_) \
+    _(EXT_mcp_tools, EXT_MCP_TOOLS)
+#else
+#define OXR_EXTENSION_SUPPORT_EXT_mcp_tools(_)
+#endif
+
+
+/*
  * XR_BD_controller_interaction
  */
 #if defined(XR_BD_controller_interaction) && defined(XRT_FEATURE_OPENXR_INTERACTION_BYTEDANCE)
@@ -1076,6 +1088,7 @@
     OXR_EXTENSION_SUPPORT_EXT_spatial_workspace(_) \
     OXR_EXTENSION_SUPPORT_EXT_atlas_capture(_) \
     OXR_EXTENSION_SUPPORT_EXT_workspace_file_dialog(_) \
+    OXR_EXTENSION_SUPPORT_EXT_mcp_tools(_) \
     OXR_EXTENSION_SUPPORT_BD_controller_interaction(_) \
     OXR_EXTENSION_SUPPORT_FB_body_tracking(_) \
     OXR_EXTENSION_SUPPORT_FB_composition_layer_alpha_blend(_) \

--- a/src/xrt/state_trackers/oxr/oxr_mcp_app_tools.c
+++ b/src/xrt/state_trackers/oxr/oxr_mcp_app_tools.c
@@ -1,0 +1,502 @@
+// Copyright 2026, DisplayXR / Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  XR_EXT_mcp_tools — app-defined MCP tools on the per-process server.
+ * @ingroup oxr_main
+ *
+ * The runtime already hosts an MCP server inside every app process
+ * (oxr_mcp_tools.c, Phase A). This TU lets the *app* add its own tools
+ * to it ("play_pause", "load_model", …) without linking the MCP
+ * framework: registration travels over the OpenXR API boundary, and
+ * invocation rides the OpenXR event queue.
+ *
+ * Dispatch contract (design doc per-app-mcp-tools.md §4.2): the MCP
+ * transport thread never calls app code. The trampoline registered as
+ * each tool's handler parks the JSON-RPC request in a pending-call
+ * slot, pushes an XrEventDataMCPToolCallEXT, and blocks on a condvar
+ * until the app answers via xrSubmitMCPToolResultEXT — or until the
+ * 5 s timeout, after which the agent gets a tool error and a late
+ * result is silently dropped.
+ *
+ * Threading: one global lock (g_lock) guards both tables. The
+ * trampoline blocks on g_cond while holding nothing the app's API
+ * calls need for longer than table edits. Parking a request is free on
+ * the MCP side — JSON-RPC is async and the v0.4.0 server serves each
+ * client on its own thread.
+ */
+
+#include "oxr_objects.h"
+#include "oxr_logger.h"
+#include "oxr_handle.h"
+#include "oxr_api_verify.h"
+#include "oxr_mcp_tools.h"
+
+#ifdef OXR_HAVE_EXT_mcp_tools
+
+#include "displayxr_mcp/mcp_server.h"
+
+#include <cjson/cJSON.h>
+
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#define MAX_APP_TOOLS 32
+#define MAX_PENDING_CALLS 16
+#define CALL_TIMEOUT_SEC 5
+//! Abandoned (timed-out, never-answered) slots are reclaimed after this.
+#define ABANDONED_REAP_SEC 60
+
+struct app_tool
+{
+	bool used;
+	struct oxr_session *sess;
+	char name[XR_MAX_MCP_TOOL_NAME_SIZE_EXT];
+	char *description;      //!< strdup'd; freed on unregister.
+	char *schema;           //!< strdup'd or NULL.
+	struct mcp_tool tool;   //!< Registered with the framework; stable storage.
+};
+
+struct pending_call
+{
+	bool used;
+	bool completed; //!< App answered; result fields valid.
+	bool abandoned; //!< Timed out or tool/session torn down; awaiting reap.
+	uint64_t call_id;
+	struct oxr_session *sess;
+	char *args_json;   //!< Owned. Exposed via xrGetMCPToolCallArgsEXT.
+	char *result_json; //!< Owned. Set by xrSubmitMCPToolResultEXT.
+	bool success;
+	time_t abandoned_at; //!< For the reaper.
+};
+
+static pthread_mutex_t g_lock = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t g_cond = PTHREAD_COND_INITIALIZER;
+static struct app_tool g_tools[MAX_APP_TOOLS];
+static struct pending_call g_pending[MAX_PENDING_CALLS];
+static uint64_t g_next_call_id = 0;
+
+/*
+ *
+ * Helpers.
+ *
+ */
+
+static bool
+mcp_active(void)
+{
+	// Same gate expression as the server start in oxr_instance.c — if
+	// this is false the per-process MCP server was never started and
+	// the extension's functions are inert.
+	return mcp_check_env_or(oxr_mcp_capability_enabled());
+}
+
+/*!
+ * Bare tool name: ^[a-z0-9][a-z0-9_-]{0,62}$ and no "__" (the
+ * aggregator's namespace separator).
+ */
+static bool
+tool_name_valid(const char *name)
+{
+	if (name == NULL || name[0] == '\0') {
+		return false;
+	}
+	size_t len = strlen(name);
+	if (len >= XR_MAX_MCP_TOOL_NAME_SIZE_EXT) {
+		return false;
+	}
+	for (size_t i = 0; i < len; i++) {
+		char c = name[i];
+		bool alnum = (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9');
+		if (i == 0 ? !alnum : !(alnum || c == '-' || c == '_')) {
+			return false;
+		}
+	}
+	return strstr(name, "__") == NULL;
+}
+
+/*!
+ * App id: ^[a-z0-9][a-z0-9-]{0,31}$ — mirrors manifest spec §3.4 and
+ * the framework-side validation in mcp_server_set_app_id().
+ */
+static bool
+app_id_valid(const char *id)
+{
+	if (id == NULL || id[0] == '\0') {
+		return false;
+	}
+	size_t len = strlen(id);
+	if (len >= XR_MAX_MCP_APP_ID_SIZE_EXT) {
+		return false;
+	}
+	for (size_t i = 0; i < len; i++) {
+		char c = id[i];
+		bool alnum = (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9');
+		if (i == 0 ? !alnum : !(alnum || c == '-')) {
+			return false;
+		}
+	}
+	return true;
+}
+
+// Caller holds g_lock.
+static void
+pending_free_locked(struct pending_call *pc)
+{
+	free(pc->args_json);
+	free(pc->result_json);
+	memset(pc, 0, sizeof(*pc));
+}
+
+// Caller holds g_lock. Reclaim abandoned slots whose app never answered.
+static void
+pending_reap_locked(void)
+{
+	time_t now = time(NULL);
+	for (size_t i = 0; i < MAX_PENDING_CALLS; i++) {
+		struct pending_call *pc = &g_pending[i];
+		if (pc->used && pc->abandoned && now - pc->abandoned_at > ABANDONED_REAP_SEC) {
+			pending_free_locked(pc);
+		}
+	}
+}
+
+/*
+ *
+ * The trampoline — runs on an MCP server client thread.
+ *
+ */
+
+static cJSON *
+tool_trampoline(const cJSON *params, void *userdata)
+{
+	struct app_tool *tool = userdata;
+
+	pthread_mutex_lock(&g_lock);
+	pending_reap_locked();
+
+	struct pending_call *pc = NULL;
+	for (size_t i = 0; i < MAX_PENDING_CALLS; i++) {
+		if (!g_pending[i].used) {
+			pc = &g_pending[i];
+			break;
+		}
+	}
+	if (pc == NULL || !tool->used) {
+		pthread_mutex_unlock(&g_lock);
+		return NULL; // Saturated or tool raced away → JSON-RPC error.
+	}
+	pc->used = true;
+	pc->call_id = ++g_next_call_id;
+	pc->sess = tool->sess;
+	pc->args_json = params != NULL ? cJSON_PrintUnformatted(params) : NULL;
+	if (pc->args_json == NULL) {
+		pc->args_json = strdup("{}");
+	}
+	uint64_t call_id = pc->call_id;
+	uint32_t args_size = (uint32_t)strlen(pc->args_json) + 1;
+
+	struct oxr_logger log;
+	oxr_log_init(&log, "mcp_tool_call");
+	XrResult res = oxr_event_push_XrEventDataMCPToolCall(&log, tool->sess, call_id, tool->name, args_size);
+	if (res != XR_SUCCESS) {
+		pending_free_locked(pc);
+		pthread_mutex_unlock(&g_lock);
+		return NULL;
+	}
+
+	// Park until the app answers or the deadline passes. The condvar is
+	// broadcast on every submit/teardown; re-find our slot by call_id
+	// each wake (the table may have been edited around us).
+	struct timespec deadline;
+	timespec_get(&deadline, TIME_UTC);
+	deadline.tv_sec += CALL_TIMEOUT_SEC;
+
+	cJSON *out = NULL;
+	for (;;) {
+		// Re-locate; teardown may have freed the slot entirely.
+		pc = NULL;
+		for (size_t i = 0; i < MAX_PENDING_CALLS; i++) {
+			if (g_pending[i].used && g_pending[i].call_id == call_id) {
+				pc = &g_pending[i];
+				break;
+			}
+		}
+		if (pc == NULL || pc->abandoned) {
+			break; // Torn down (session destroy / unregister).
+		}
+		if (pc->completed) {
+			if (pc->success) {
+				out = pc->result_json != NULL ? cJSON_Parse(pc->result_json) : cJSON_CreateObject();
+				if (out == NULL) {
+					// App submitted unparseable JSON; surface raw.
+					out = cJSON_CreateObject();
+					cJSON_AddStringToObject(out, "raw",
+					                        pc->result_json != NULL ? pc->result_json : "");
+				}
+			}
+			pending_free_locked(pc);
+			break;
+		}
+		int rc = pthread_cond_timedwait(&g_cond, &g_lock, &deadline);
+		if (rc != 0) {
+			// Timeout: the agent gets an error now; a late submit
+			// finds `abandoned` and is dropped.
+			pc->abandoned = true;
+			pc->abandoned_at = time(NULL);
+			break;
+		}
+	}
+	pthread_mutex_unlock(&g_lock);
+	return out; // NULL → framework replies with a JSON-RPC tool error.
+}
+
+/*
+ *
+ * Session teardown — from oxr_session_destroy.
+ *
+ */
+
+void
+oxr_mcp_app_tools_session_destroy(struct oxr_session *sess)
+{
+	// Collect names first; mcp_server_unregister_tool broadcasts a
+	// list_changed per call and must not run under g_lock (it takes the
+	// framework's own locks).
+	char names[MAX_APP_TOOLS][XR_MAX_MCP_TOOL_NAME_SIZE_EXT];
+	size_t name_count = 0;
+
+	pthread_mutex_lock(&g_lock);
+	for (size_t i = 0; i < MAX_APP_TOOLS; i++) {
+		struct app_tool *t = &g_tools[i];
+		if (!t->used || t->sess != sess) {
+			continue;
+		}
+		strncpy(names[name_count], t->name, sizeof(names[0]) - 1);
+		names[name_count][sizeof(names[0]) - 1] = '\0';
+		name_count++;
+		free(t->description);
+		free(t->schema);
+		memset(t, 0, sizeof(*t));
+	}
+	// Fail the session's pending calls; parked trampolines wake and
+	// return errors to their agents.
+	for (size_t i = 0; i < MAX_PENDING_CALLS; i++) {
+		struct pending_call *pc = &g_pending[i];
+		if (pc->used && pc->sess == sess && !pc->completed) {
+			pc->abandoned = true;
+			pc->abandoned_at = time(NULL);
+		}
+	}
+	pthread_cond_broadcast(&g_cond);
+	pthread_mutex_unlock(&g_lock);
+
+	for (size_t i = 0; i < name_count; i++) {
+		mcp_server_unregister_tool(names[i]);
+	}
+}
+
+/*
+ *
+ * API functions.
+ *
+ */
+
+XRAPI_ATTR XrResult XRAPI_CALL
+oxr_xrSetMCPAppInfoEXT(XrSession session, const XrMCPAppInfoEXT *info)
+{
+	struct oxr_session *sess;
+	struct oxr_logger log;
+	OXR_VERIFY_SESSION_AND_INIT_LOG(&log, session, sess, "xrSetMCPAppInfoEXT");
+	OXR_VERIFY_ARG_TYPE_AND_NOT_NULL(&log, info, XR_TYPE_MCP_APP_INFO_EXT);
+
+	if (!mcp_active()) {
+		return oxr_error(&log, XR_ERROR_FEATURE_UNSUPPORTED,
+		                 "MCP capability is disabled (Capabilities\\MCP / DISPLAYXR_MCP)");
+	}
+	if (!app_id_valid(info->appId)) {
+		return oxr_error(&log, XR_ERROR_VALIDATION_FAILURE,
+		                 "appId must match ^[a-z0-9][a-z0-9-]{0,31}$ (manifest spec 3.4)");
+	}
+
+	mcp_server_set_app_id(info->appId);
+	return XR_SUCCESS;
+}
+
+XRAPI_ATTR XrResult XRAPI_CALL
+oxr_xrRegisterMCPToolEXT(XrSession session, const XrMCPToolInfoEXT *tool)
+{
+	struct oxr_session *sess;
+	struct oxr_logger log;
+	OXR_VERIFY_SESSION_AND_INIT_LOG(&log, session, sess, "xrRegisterMCPToolEXT");
+	OXR_VERIFY_ARG_TYPE_AND_NOT_NULL(&log, tool, XR_TYPE_MCP_TOOL_INFO_EXT);
+
+	if (!mcp_active()) {
+		return oxr_error(&log, XR_ERROR_FEATURE_UNSUPPORTED,
+		                 "MCP capability is disabled (Capabilities\\MCP / DISPLAYXR_MCP)");
+	}
+	if (!tool_name_valid(tool->name)) {
+		return oxr_error(&log, XR_ERROR_VALIDATION_FAILURE,
+		                 "tool name must match ^[a-z0-9][a-z0-9_-]{0,62}$ with no '__'");
+	}
+	if (tool->description == NULL || tool->description[0] == '\0') {
+		return oxr_error(&log, XR_ERROR_VALIDATION_FAILURE,
+		                 "description is required — it is what the agent reads");
+	}
+
+	pthread_mutex_lock(&g_lock);
+	struct app_tool *slot = NULL;
+	for (size_t i = 0; i < MAX_APP_TOOLS; i++) {
+		if (g_tools[i].used && strcmp(g_tools[i].name, tool->name) == 0) {
+			pthread_mutex_unlock(&g_lock);
+			return oxr_error(&log, XR_ERROR_NAME_DUPLICATED, "tool '%s' is already registered",
+			                 tool->name);
+		}
+		if (!g_tools[i].used && slot == NULL) {
+			slot = &g_tools[i];
+		}
+	}
+	if (slot == NULL) {
+		pthread_mutex_unlock(&g_lock);
+		return oxr_error(&log, XR_ERROR_LIMIT_REACHED, "app tool budget (%d) exhausted",
+		                 MAX_APP_TOOLS);
+	}
+
+	slot->used = true;
+	slot->sess = sess;
+	snprintf(slot->name, sizeof(slot->name), "%s", tool->name);
+	slot->description = strdup(tool->description);
+	slot->schema = (tool->inputSchemaJson != NULL && tool->inputSchemaJson[0] != '\0')
+	                   ? strdup(tool->inputSchemaJson)
+	                   : NULL;
+	slot->tool = (struct mcp_tool){
+	    .name = slot->name,
+	    .description = slot->description,
+	    .input_schema_json = slot->schema != NULL ? slot->schema : "{\"type\":\"object\"}",
+	    .fn = tool_trampoline,
+	    .userdata = slot,
+	    .group = MCP_TOOL_GROUP_APP,
+	};
+	pthread_mutex_unlock(&g_lock);
+
+	// Outside g_lock: broadcasts tools/list_changed to connected agents.
+	mcp_server_register_tool(&slot->tool);
+	return XR_SUCCESS;
+}
+
+XRAPI_ATTR XrResult XRAPI_CALL
+oxr_xrUnregisterMCPToolEXT(XrSession session, const char *name)
+{
+	struct oxr_session *sess;
+	struct oxr_logger log;
+	OXR_VERIFY_SESSION_AND_INIT_LOG(&log, session, sess, "xrUnregisterMCPToolEXT");
+
+	if (!mcp_active()) {
+		return oxr_error(&log, XR_ERROR_FEATURE_UNSUPPORTED,
+		                 "MCP capability is disabled (Capabilities\\MCP / DISPLAYXR_MCP)");
+	}
+	if (name == NULL || name[0] == '\0') {
+		return oxr_error(&log, XR_ERROR_VALIDATION_FAILURE, "name is required");
+	}
+
+	pthread_mutex_lock(&g_lock);
+	struct app_tool *found = NULL;
+	for (size_t i = 0; i < MAX_APP_TOOLS; i++) {
+		if (g_tools[i].used && g_tools[i].sess == sess && strcmp(g_tools[i].name, name) == 0) {
+			found = &g_tools[i];
+			break;
+		}
+	}
+	if (found == NULL) {
+		pthread_mutex_unlock(&g_lock);
+		return oxr_error(&log, XR_ERROR_VALIDATION_FAILURE, "tool '%s' is not registered on this session",
+		                 name);
+	}
+	free(found->description);
+	free(found->schema);
+	memset(found, 0, sizeof(*found));
+	// In-flight calls on the tool: their slots survive (keyed by
+	// call_id, not tool pointer) and fail at timeout or session end —
+	// wake them now so they fail promptly.
+	pthread_cond_broadcast(&g_cond);
+	pthread_mutex_unlock(&g_lock);
+
+	mcp_server_unregister_tool(name);
+	return XR_SUCCESS;
+}
+
+XRAPI_ATTR XrResult XRAPI_CALL
+oxr_xrGetMCPToolCallArgsEXT(
+    XrSession session, uint64_t callId, uint32_t capacity, uint32_t *countOutput, char *buffer)
+{
+	struct oxr_session *sess;
+	struct oxr_logger log;
+	OXR_VERIFY_SESSION_AND_INIT_LOG(&log, session, sess, "xrGetMCPToolCallArgsEXT");
+	OXR_VERIFY_ARG_NOT_NULL(&log, countOutput);
+
+	pthread_mutex_lock(&g_lock);
+	struct pending_call *pc = NULL;
+	for (size_t i = 0; i < MAX_PENDING_CALLS; i++) {
+		if (g_pending[i].used && g_pending[i].call_id == callId && !g_pending[i].abandoned) {
+			pc = &g_pending[i];
+			break;
+		}
+	}
+	if (pc == NULL || pc->sess != sess) {
+		pthread_mutex_unlock(&g_lock);
+		return oxr_error(&log, XR_ERROR_VALIDATION_FAILURE, "unknown or expired callId %llu",
+		                 (unsigned long long)callId);
+	}
+	uint32_t needed = (uint32_t)strlen(pc->args_json) + 1;
+	*countOutput = needed;
+	if (capacity == 0) {
+		pthread_mutex_unlock(&g_lock);
+		return XR_SUCCESS;
+	}
+	if (capacity < needed || buffer == NULL) {
+		pthread_mutex_unlock(&g_lock);
+		return oxr_error(&log, XR_ERROR_SIZE_INSUFFICIENT, "need %u bytes, got %u", needed, capacity);
+	}
+	memcpy(buffer, pc->args_json, needed);
+	pthread_mutex_unlock(&g_lock);
+	return XR_SUCCESS;
+}
+
+XRAPI_ATTR XrResult XRAPI_CALL
+oxr_xrSubmitMCPToolResultEXT(XrSession session, uint64_t callId, XrBool32 success, const char *resultJson)
+{
+	struct oxr_session *sess;
+	struct oxr_logger log;
+	OXR_VERIFY_SESSION_AND_INIT_LOG(&log, session, sess, "xrSubmitMCPToolResultEXT");
+
+	pthread_mutex_lock(&g_lock);
+	struct pending_call *pc = NULL;
+	for (size_t i = 0; i < MAX_PENDING_CALLS; i++) {
+		if (g_pending[i].used && g_pending[i].call_id == callId) {
+			pc = &g_pending[i];
+			break;
+		}
+	}
+	if (pc == NULL || pc->sess != sess) {
+		pthread_mutex_unlock(&g_lock);
+		return oxr_error(&log, XR_ERROR_VALIDATION_FAILURE, "callId %llu never existed",
+		                 (unsigned long long)callId);
+	}
+	if (pc->abandoned) {
+		// Late result after timeout/teardown: drop silently per spec.
+		pending_free_locked(pc);
+		pthread_mutex_unlock(&g_lock);
+		return XR_SUCCESS;
+	}
+	pc->result_json = strdup(resultJson != NULL && resultJson[0] != '\0' ? resultJson : "{}");
+	pc->success = success == XR_TRUE;
+	pc->completed = true;
+	pthread_cond_broadcast(&g_cond);
+	pthread_mutex_unlock(&g_lock);
+	return XR_SUCCESS;
+}
+
+#endif // OXR_HAVE_EXT_mcp_tools

--- a/src/xrt/state_trackers/oxr/oxr_mcp_tools.c
+++ b/src/xrt/state_trackers/oxr/oxr_mcp_tools.c
@@ -810,6 +810,10 @@ static const struct mcp_tool TOOL_CAPTURE_FRAME = {
         "\"enum\":[\"post-compose\",\"projection-only\"],"
         "\"description\":\"Atlas state to capture; default post-compose.\"}}}",
     .fn = tool_capture_frame,
+    // The verification primitive — exposed by default through the
+    // workspace aggregator (every other Phase A tool stays DIAGNOSTIC,
+    // the zero-init default, hidden unless --expose-diagnostics).
+    .group = MCP_TOOL_GROUP_CAPTURE,
 };
 
 static const struct mcp_tool TOOL_DIFF_PROJECTION = {

--- a/src/xrt/state_trackers/oxr/oxr_objects.h
+++ b/src/xrt/state_trackers/oxr/oxr_objects.h
@@ -1175,6 +1175,31 @@ oxr_event_push_XrEventDataFilePickerComplete(struct oxr_logger *log,
                                               const char *path);
 #endif // OXR_HAVE_EXT_workspace_file_dialog
 
+#ifdef OXR_HAVE_EXT_mcp_tools
+/*!
+ * Push an `XrEventDataMCPToolCallEXT` onto the instance event queue.
+ *
+ * Called by the MCP app-tool trampoline (oxr_mcp_app_tools.c) when an
+ * agent invokes an app-registered tool; the app fetches the args via
+ * `xrGetMCPToolCallArgsEXT(callId)` and answers with
+ * `xrSubmitMCPToolResultEXT`.
+ */
+XrResult
+oxr_event_push_XrEventDataMCPToolCall(struct oxr_logger *log,
+                                      struct oxr_session *sess,
+                                      uint64_t call_id,
+                                      const char *tool_name,
+                                      uint32_t args_size);
+
+/*!
+ * Unregister every app tool the session registered via
+ * `xrRegisterMCPToolEXT` and fail its pending tool calls. Called from
+ * session destroy. Implemented in oxr_mcp_app_tools.c.
+ */
+void
+oxr_mcp_app_tools_session_destroy(struct oxr_session *sess);
+#endif // OXR_HAVE_EXT_mcp_tools
+
 #ifdef OXR_HAVE_FB_display_refresh_rate
 XrResult
 oxr_event_push_XrEventDataDisplayRefreshRateChangedFB(struct oxr_logger *log,

--- a/src/xrt/state_trackers/oxr/oxr_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_session.c
@@ -2004,6 +2004,12 @@ oxr_session_destroy(struct oxr_logger *log, struct oxr_handle_base *hb)
 	// MCP tool handler stops reading.
 	oxr_mcp_tools_detach_session(sess);
 
+#ifdef OXR_HAVE_EXT_mcp_tools
+	// Unregister the session's app-defined tools (XR_EXT_mcp_tools) and
+	// fail their pending calls before the event queue is drained below.
+	oxr_mcp_app_tools_session_destroy(sess);
+#endif
+
 #ifdef XRT_OS_WINDOWS
 	// GH #227 Tier 0: tear down the modal-dialog hook before sess->xcn is
 	// destroyed — the hook proc dereferences sess->xcn->base via its


### PR DESCRIPTION
Closes #444. P1 of the [per-app MCP tools design](https://github.com/DisplayXR/displayxr-runtime/blob/main/docs/roadmap/per-app-mcp-tools.md); the framework half shipped as [displayxr-mcp v0.4.0](https://github.com/DisplayXR/displayxr-mcp/releases/tag/v0.4.0).

## What

- **`XR_EXT_mcp_tools` v1** — `xrSetMCPAppInfoEXT` (manifest-`id` slug, becomes the workspace aggregator's `<id>__<tool>` prefix), `xrRegisterMCPToolEXT`/`xrUnregisterMCPToolEXT` (late registration broadcasts `tools/list_changed`), two-call `xrGetMCPToolCallArgsEXT`, `xrSubmitMCPToolResultEXT`. Header in `src/external/openxr_includes/` (auto-syncs to displayxr-extensions); spec at `docs/specs/extensions/XR_EXT_mcp_tools.md`.
- **Event-queue dispatch** (`oxr_mcp_app_tools.c`) — the MCP transport thread never calls app code: a trampoline parks the JSON-RPC request, pushes `XrEventDataMCPToolCallEXT`, the app answers from its frame loop. 5 s timeout → agent error; late results silently dropped; session destroy unregisters all tools + fails pending calls.
- **Re-pin displayxr-mcp v0.3.2 → v0.4.0**; tag `capture_frame` `MCP_TOOL_GROUP_CAPTURE` (other Phase A tools stay DIAGNOSTIC via zero-init) — aggregator default exposure = app tools + capture only.
- **Linter INV-10.1** — manifest `id` charset + `xrSetMCPAppInfoEXT` appId pairing.
- All functions return `XR_ERROR_FEATURE_UNSUPPORTED` when the `Capabilities\MCP` gate is off — registering tools is never load-bearing.

## Validation (macOS, live)

- Full build green; Phase A `tools/list` verified live: `capture_frame → capture`, all else `diagnostic`, `listChanged:true`.
- E2E with a throwaway `cube_handle_metal_macos` patch (not committed): app declared `appId="cubemetal"` + registered `ping_app`; agent called `cubemetal__ping_app` through `displayxr-mcp --target workspace`; args round-tripped through the event queue → `{"pong":true,"echo":{"hello":"agent"}}`. AppId beat the exe-basename fallback; merged list exposed exactly `cubemetal__ping_app` + `cubemetal__capture_frame` (of 14 tools).

## Notes

- Heads-up: `origin/main` currently fails to build (`oxr_plugin_stub.c` asserts ABI v2 vs header v3) — the fix is on `feature/per-mode-tracking` (PR #443). This PR is independent; CI may be red until #443 lands or the tripwire fix is cherry-picked to main.
- Follow-ups tracked in #444: P1′ shell tagging (shell-pvt), P2 demo adoption, P3 manifest `mcp` block + Unity binding, Windows e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)