### PR TITLE
Phase 2 of #441: transport DP is_tracking to IPC clients

### DIFF
--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -10749,11 +10749,10 @@ comp_d3d11_service_is_d3d11_service(struct xrt_system_compositor *xsysc)
 }
 
 bool
-comp_d3d11_service_get_predicted_eye_positions(struct xrt_system_compositor *xsysc,
-                                                struct xrt_vec3 *out_left,
-                                                struct xrt_vec3 *out_right)
+comp_d3d11_service_get_predicted_eye_positions_full(struct xrt_system_compositor *xsysc,
+                                                     struct xrt_eye_positions *out_eyes)
 {
-	if (xsysc == NULL || out_left == NULL || out_right == NULL) {
+	if (xsysc == NULL || out_eyes == NULL) {
 		return false;
 	}
 
@@ -10787,23 +10786,8 @@ comp_d3d11_service_get_predicted_eye_positions(struct xrt_system_compositor *xsy
 	}
 
 	if (dp != nullptr) {
-		struct xrt_eye_positions eyes;
-		if (xrt_display_processor_d3d11_get_predicted_eye_positions(dp, &eyes) && eyes.valid) {
-			out_left->x = eyes.eyes[0].x;
-			out_left->y = eyes.eyes[0].y;
-			out_left->z = eyes.eyes[0].z;
-			out_right->x = eyes.eyes[1].x;
-			out_right->y = eyes.eyes[1].y;
-			out_right->z = eyes.eyes[1].z;
-
-			// Log periodically for debugging
-			static int log_counter = 0;
-			if (++log_counter >= 60) {
-				log_counter = 0;
-				U_LOG_D("IPC eye positions (from display processor): L=(%.3f,%.3f,%.3f) R=(%.3f,%.3f,%.3f)",
-				        out_left->x, out_left->y, out_left->z,
-				        out_right->x, out_right->y, out_right->z);
-			}
+		U_ZERO(out_eyes);
+		if (xrt_display_processor_d3d11_get_predicted_eye_positions(dp, out_eyes)) {
 			return true;
 		}
 	}
@@ -10816,6 +10800,38 @@ comp_d3d11_service_get_predicted_eye_positions(struct xrt_system_compositor *xsy
 	}
 
 	return false;
+}
+
+bool
+comp_d3d11_service_get_predicted_eye_positions(struct xrt_system_compositor *xsysc,
+                                                struct xrt_vec3 *out_left,
+                                                struct xrt_vec3 *out_right)
+{
+	if (out_left == NULL || out_right == NULL) {
+		return false;
+	}
+
+	struct xrt_eye_positions eyes;
+	if (!comp_d3d11_service_get_predicted_eye_positions_full(xsysc, &eyes) || !eyes.valid) {
+		return false;
+	}
+
+	out_left->x = eyes.eyes[0].x;
+	out_left->y = eyes.eyes[0].y;
+	out_left->z = eyes.eyes[0].z;
+	out_right->x = eyes.eyes[1].x;
+	out_right->y = eyes.eyes[1].y;
+	out_right->z = eyes.eyes[1].z;
+
+	// Log periodically for debugging
+	static int log_counter = 0;
+	if (++log_counter >= 60) {
+		log_counter = 0;
+		U_LOG_D("IPC eye positions (from display processor): L=(%.3f,%.3f,%.3f) R=(%.3f,%.3f,%.3f)",
+		        out_left->x, out_left->y, out_left->z,
+		        out_right->x, out_right->y, out_right->z);
+	}
+	return true;
 }
 
 bool

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.h
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.h
@@ -91,6 +91,22 @@ comp_d3d11_service_get_predicted_eye_positions(struct xrt_system_compositor *xsy
                                                 struct xrt_vec3 *out_right);
 
 /*!
+ * Get the full predicted eye-position struct from the active DP — N-view
+ * positions plus `valid` and `is_tracking` (#441 Phase 2). The left/right
+ * variant above is a thin wrapper over this.
+ *
+ * @param xsysc The system compositor (must be D3D11 service compositor).
+ * @param[out] out_eyes Full eye-position struct incl. is_tracking.
+ * @return true if the DP produced positions (out_eyes->valid may still
+ *         gate usability), false if no DP was available.
+ *
+ * @ingroup comp_d3d11_service
+ */
+bool
+comp_d3d11_service_get_predicted_eye_positions_full(struct xrt_system_compositor *xsysc,
+                                                     struct xrt_eye_positions *out_eyes);
+
+/*!
  * Get display dimensions from the D3D11 service compositor's SR weaver.
  *
  * @param xsysc The system compositor (must be D3D11 service compositor).

--- a/src/xrt/ipc/client/ipc_client_compositor.c
+++ b/src/xrt/ipc/client/ipc_client_compositor.c
@@ -218,6 +218,37 @@ comp_ipc_client_compositor_get_window_metrics(struct xrt_compositor *xc, struct 
 }
 
 /*
+ * Full DP eye-position struct incl. is_tracking, over IPC (#441 Phase 2).
+ * Same gating contract as comp_ipc_client_compositor_get_window_metrics:
+ * only safe to call when `xc` is an ipc_client_compositor (the OpenXR state
+ * tracker gates on is_service_mode && !is_*_native_compositor).
+ *
+ * Consumed ONLY for the derived isTracking value + tracking-state event —
+ * NOT for view poses, which stay server-computed. Returns false on IPC
+ * failure or when the server has no DP data (out->valid == false).
+ */
+bool
+comp_ipc_client_compositor_get_predicted_eye_positions(struct xrt_compositor *xc,
+                                                       struct xrt_eye_positions *out_eyes)
+{
+	if (xc == NULL || out_eyes == NULL) {
+		return false;
+	}
+
+	struct ipc_client_compositor *icc = ipc_client_compositor(xc);
+	if (icc == NULL || icc->ipc_c == NULL) {
+		return false;
+	}
+
+	xrt_result_t xret = ipc_call_compositor_get_predicted_eye_positions(icc->ipc_c, out_eyes);
+	if (xret != XRT_SUCCESS) {
+		return false;
+	}
+
+	return out_eyes->valid;
+}
+
+/*
  * Phase 2 — workspace_sync_fence bridges (D3D11 client compositor only).
  * Same gating contract: only safe to call when `xc` is an ipc_client_compositor.
  *

--- a/src/xrt/ipc/server/ipc_server_handler.c
+++ b/src/xrt/ipc/server/ipc_server_handler.c
@@ -1574,6 +1574,34 @@ ipc_handle_compositor_get_window_metrics(volatile struct ipc_client_state *ics,
 }
 
 xrt_result_t
+ipc_handle_compositor_get_predicted_eye_positions(volatile struct ipc_client_state *ics,
+                                                  struct xrt_eye_positions *out_eye_positions)
+{
+	IPC_TRACE_MARKER();
+
+	struct xrt_eye_positions eyes = {0};
+
+#if defined(XRT_HAVE_D3D11_SERVICE_COMPOSITOR)
+	// Full DP eye-position struct incl. is_tracking (#441 Phase 2). The
+	// client's OpenXR state tracker consumes this ONLY for the derived
+	// XrViewEyeTrackingStateEXT.isTracking value + the tracking-state
+	// event — view poses stay server-computed (ipc_try_get_sr_view_poses),
+	// so these positions never feed the client-side Kooima path.
+	if (ics->server != NULL && ics->server->xsysc != NULL &&
+	    comp_d3d11_service_is_d3d11_service(ics->server->xsysc)) {
+		(void)comp_d3d11_service_get_predicted_eye_positions_full(ics->server->xsysc, &eyes);
+	}
+#else
+	(void)ics;
+#endif
+
+	// eyes.valid == false signals "no DP / no data" to the client.
+	*out_eye_positions = eyes;
+
+	return XRT_SUCCESS;
+}
+
+xrt_result_t
 ipc_handle_compositor_predict_frame(volatile struct ipc_client_state *ics,
                                     int64_t *out_frame_id,
                                     int64_t *out_wake_up_time_ns,

--- a/src/xrt/ipc/shared/proto.json
+++ b/src/xrt/ipc/shared/proto.json
@@ -471,6 +471,12 @@
 		]
 	},
 
+	"compositor_get_predicted_eye_positions": {
+		"out": [
+			{"name": "eye_positions", "type": "struct xrt_eye_positions"}
+		]
+	},
+
 	"compositor_predict_frame": {
 		"out": [
 			{"name": "frame_id", "type": "int64_t"},

--- a/src/xrt/state_trackers/oxr/oxr_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_session.c
@@ -98,6 +98,14 @@ struct xrt_window_metrics;
 bool
 comp_ipc_client_compositor_get_window_metrics(struct xrt_compositor *xc, struct xrt_window_metrics *out_metrics);
 
+// IPC-client DP tracking state (#441 Phase 2) — same linkage pattern as
+// above. Consumed ONLY for the derived isTracking value + tracking-state
+// event; view poses stay server-computed (ipc_try_get_sr_view_poses).
+struct xrt_eye_positions;
+bool
+comp_ipc_client_compositor_get_predicted_eye_positions(struct xrt_compositor *xc,
+                                                       struct xrt_eye_positions *out_eyes);
+
 #ifdef XRT_OS_WINDOWS
 // GH #227 Tier 0: install / tear down the in-app CBT hook that re-parents
 // owned modal popups (file dialogs etc.) from the hidden app HWND onto a
@@ -1753,6 +1761,25 @@ oxr_session_locate_views(struct oxr_logger *log,
 			    (et_head->rendering_modes[ami].mode_flags & XRT_RENDERING_MODE_FLAG_HAS_TRACKING) != 0;
 		}
 		bool is_tracking = mode_has_tracking && got_eye_positions && eye_pos.valid && eye_pos.is_tracking;
+
+		// IPC sessions (#441 Phase 2): the in-process eye-position getters
+		// all miss (sess->xcn is an IPC proxy), so fetch the DP tracking
+		// state over IPC. Consumed ONLY here — feeding these positions
+		// into got_eye_positions would activate the client-side Kooima
+		// path and double-apply window math on top of the
+		// server-computed view poses (the Phase-0 multi-comp regression).
+		// Skipped when the active mode is untracked: the result would be
+		// FALSE either way, so don't pay the round-trip.
+		if (!got_eye_positions && mode_has_tracking && sess->xcn != NULL &&
+		    sess->sys->xsysc != NULL && sess->sys->xsysc->info.is_service_mode &&
+		    !sess->is_d3d11_native_compositor && !sess->is_d3d12_native_compositor &&
+		    !sess->is_gl_native_compositor && !sess->is_vk_native_compositor &&
+		    !sess->is_metal_native_compositor && sess->sys->xsysc->xmcc == NULL) {
+			struct xrt_eye_positions ipc_eyes;
+			if (comp_ipc_client_compositor_get_predicted_eye_positions(&sess->xcn->base, &ipc_eyes)) {
+				is_tracking = ipc_eyes.is_tracking;
+			}
+		}
 
 		XrViewEyeTrackingStateEXT *ets = OXR_GET_OUTPUT_FROM_CHAIN(
 		    viewState, XR_TYPE_VIEW_EYE_TRACKING_STATE_EXT, XrViewEyeTrackingStateEXT);


### PR DESCRIPTION
## Summary

Phase 2 of #441 (Phases 0+1 landed in #443).

Adds the IPC sideband so service-mode apps see truthful `isTracking` + `XrEventDataEyeTrackingStateChangedEXT`:

- **proto.json**: new `compositor_get_predicted_eye_positions` call returning the full `xrt_eye_positions` (positions, `valid`, `is_tracking`, timestamp)
- **Server**: handler → new `comp_d3d11_service_get_predicted_eye_positions_full` accessor (legacy left/right variant refactored as a thin wrapper over it; same #363 `render_mutex` use-after-free guard). `valid=false` = "no DP".
- **Client**: `comp_ipc_client_compositor_get_predicted_eye_positions` bridge (same gating + linkage contract as the window-metrics bridge)
- **oxr**: consumed ONLY in the isTracking derivation — deliberately NOT routed through `got_eye_positions`, which would activate the client-side Kooima path and double-apply window math on the server-computed view poses (the exact Phase-0 multi-comp regression). Round-trip skipped in untracked modes.

## Verification
- macOS build green (ipc client/server/shared + proto codegen emits the new call), 22/22 ctest, MinGW check green
- **Windows e2e pending**: `displayxr-service.exe` + `XRT_FORCE_MODE=ipc` + cube_handle_d3d11 with `SIM_DISPLAY_FAKE_TRACKING=1 SIM_DISPLAY_FAKE_TRACKING_PERIOD_MS=3000` — expect isTracking edges + tracking-state events at 3 s cadence in the app log. To be run on the Leia machine alongside Phase 3 (leia-plugin#29).

## Not in scope
- Headless bridge-relay sessions (WebXR) have `compositor == NULL` so they can't use this compositor call; tracking-state relay for the bridge can piggyback on `device_get_view_poses_2` later if needed.

Tracks #441.

🤖 Generated with [Claude Code](https://claude.com/claude-code)