### PR TITLE
feat(#447): cube_handle_metal_macos — reference XR_EXT_mcp_tools adoption + e2e test

### DIFF
--- a/test_apps/cube_handle_metal_macos/displayxr/cube_handle_metal_macos.displayxr.json
+++ b/test_apps/cube_handle_metal_macos/displayxr/cube_handle_metal_macos.displayxr.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": 1,
+  "name": "Cube Metal (Handle)",
+  "id": "cube-metal",
+  "type": "3d",
+  "category": "test",
+  "display_mode": "auto",
+  "description": "Reference spinning cube demonstrating XR_EXT_cocoa_window_binding on Metal; also the reference XR_EXT_mcp_tools adopter (agent tools: set_spin, get_status)."
+}

--- a/test_apps/cube_handle_metal_macos/main.mm
+++ b/test_apps/cube_handle_metal_macos/main.mm
@@ -45,6 +45,7 @@
 #include "hud_renderer_macos.h"
 #include <openxr/XR_EXT_display_info.h>
 #include <openxr/XR_EXT_atlas_capture.h>
+#include <openxr/XR_EXT_mcp_tools.h>
 
 // ============================================================================
 // Logging
@@ -62,6 +63,27 @@
             return false;                                                      \
         }                                                                      \
     } while (0)
+
+// ============================================================================
+// XR_EXT_mcp_tools — reference adoption (#447)
+//
+// This is the canonical in-tree example of an app exposing its own MCP
+// tools to agents: declare an appId matching the manifest `id` (the
+// agent-visible tool prefix, e.g. cube-metal__set_spin through the
+// workspace aggregator), register tools after session create, and
+// answer XrEventDataMCPToolCallEXT from the normal event pump. Inert
+// when the MCP capability is disabled. Spec:
+// docs/specs/extensions/XR_EXT_mcp_tools.md.
+// ============================================================================
+
+static bool g_hasMcpToolsExt = false;
+static PFN_xrSetMCPAppInfoEXT g_pfnSetMCPAppInfo = nullptr;
+static PFN_xrRegisterMCPToolEXT g_pfnRegisterMCPTool = nullptr;
+static PFN_xrGetMCPToolCallArgsEXT g_pfnGetMCPToolCallArgs = nullptr;
+static PFN_xrSubmitMCPToolResultEXT g_pfnSubmitMCPToolResult = nullptr;
+
+//! Cube spin speed in rad/s — historically hardcoded 0.5; now agent-settable.
+static float g_spinSpeed = 0.5f;
 
 // ============================================================================
 // Math (column-major 4x4 matrices)
@@ -1171,6 +1193,8 @@ static bool InitializeOpenXR(AppXrSession &app)
             app.hasDisplayInfoExt = true;
         if (strcmp(e.extensionName, XR_EXT_ATLAS_CAPTURE_EXTENSION_NAME) == 0)
             app.hasAtlasCaptureExt = true;
+        if (strcmp(e.extensionName, XR_EXT_MCP_TOOLS_EXTENSION_NAME) == 0)
+            g_hasMcpToolsExt = true;
     }
 
     if (!hasMetalEnable) {
@@ -1193,6 +1217,9 @@ static bool InitializeOpenXR(AppXrSession &app)
     }
     if (app.hasAtlasCaptureExt) {
         enabledExts.push_back(XR_EXT_ATLAS_CAPTURE_EXTENSION_NAME);
+    }
+    if (g_hasMcpToolsExt) {
+        enabledExts.push_back(XR_EXT_MCP_TOOLS_EXTENSION_NAME);
     }
 
     XrInstanceCreateInfo createInfo = {XR_TYPE_INSTANCE_CREATE_INFO};
@@ -1331,6 +1358,48 @@ static bool CreateSession(AppXrSession &app, MetalRenderer &r)
 
     XR_CHECK(xrCreateSession(app.instance, &sessionInfo, &app.session));
     LOG_INFO("Session created%s", app.hasCocoaWindowBinding ? " (with external window)" : "");
+
+    // XR_EXT_mcp_tools: declare identity + register agent tools. The appId
+    // MUST match `id` in displayxr/cube_handle_metal_macos.displayxr.json
+    // (INV-10.1). Failure is non-fatal by design — the MCP capability gate
+    // may simply be off on this machine.
+    if (g_hasMcpToolsExt) {
+        xrGetInstanceProcAddr(app.instance, "xrSetMCPAppInfoEXT",
+                              (PFN_xrVoidFunction *)&g_pfnSetMCPAppInfo);
+        xrGetInstanceProcAddr(app.instance, "xrRegisterMCPToolEXT",
+                              (PFN_xrVoidFunction *)&g_pfnRegisterMCPTool);
+        xrGetInstanceProcAddr(app.instance, "xrGetMCPToolCallArgsEXT",
+                              (PFN_xrVoidFunction *)&g_pfnGetMCPToolCallArgs);
+        xrGetInstanceProcAddr(app.instance, "xrSubmitMCPToolResultEXT",
+                              (PFN_xrVoidFunction *)&g_pfnSubmitMCPToolResult);
+        if (g_pfnSetMCPAppInfo && g_pfnRegisterMCPTool && g_pfnSubmitMCPToolResult) {
+            XrMCPAppInfoEXT mcpAppInfo = {XR_TYPE_MCP_APP_INFO_EXT};
+            strncpy(mcpAppInfo.appId, "cube-metal", sizeof(mcpAppInfo.appId) - 1);
+            XrResult ar = g_pfnSetMCPAppInfo(app.session, &mcpAppInfo);
+
+            XrMCPToolInfoEXT setSpin = {XR_TYPE_MCP_TOOL_INFO_EXT};
+            setSpin.name = "set_spin";
+            setSpin.description =
+                "Set the cube's spin speed. Takes effect immediately; the change is "
+                "visually verifiable via capture_frame. Returns the applied speed.";
+            setSpin.inputSchemaJson =
+                "{\"type\":\"object\",\"properties\":{\"speed_rad_per_sec\":{\"type\":\"number\","
+                "\"minimum\":0,\"maximum\":10,\"description\":\"Spin speed in radians/second; "
+                "0 freezes the cube. Default at launch is 0.5.\"}},"
+                "\"required\":[\"speed_rad_per_sec\"]}";
+            XrResult tr1 = g_pfnRegisterMCPTool(app.session, &setSpin);
+
+            XrMCPToolInfoEXT getStatus = {XR_TYPE_MCP_TOOL_INFO_EXT};
+            getStatus.name = "get_status";
+            getStatus.description =
+                "Read the cube app's live state: spin speed (rad/s), whether the XR "
+                "session is running, and the active rendering-mode index.";
+            getStatus.inputSchemaJson = "{\"type\":\"object\"}";
+            XrResult tr2 = g_pfnRegisterMCPTool(app.session, &getStatus);
+
+            LOG_INFO("XR_EXT_mcp_tools: appId=%d set_spin=%d get_status=%d", ar, tr1, tr2);
+        }
+    }
 
     // Enumerate available rendering modes and store names
     app.renderingModeCount = 0;
@@ -1498,6 +1567,48 @@ static void PollEvents(AppXrSession &app)
             app.currentModeIndex = modeEvent->currentModeIndex;
             break;
         }
+        case (XrStructureType)XR_TYPE_EVENT_DATA_MCP_TOOL_CALL_EXT: {
+            // An agent invoked one of our XR_EXT_mcp_tools tools. Fetch the
+            // JSON args (two-call idiom; argsSize is the required capacity),
+            // act on app state — we're on the main loop, so no locking —
+            // and answer. An unanswered call fails to the agent after ~5 s.
+            auto *call = (XrEventDataMCPToolCallEXT *)&event;
+            char args[512] = {0};
+            uint32_t needed = 0;
+            if (g_pfnGetMCPToolCallArgs != nullptr) {
+                g_pfnGetMCPToolCallArgs(app.session, call->callId, sizeof(args), &needed, args);
+            }
+            char result[256];
+            XrBool32 ok = XR_TRUE;
+            if (strcmp(call->toolName, "set_spin") == 0) {
+                // Test apps stay dependency-free: hand-scan the one expected
+                // numeric key instead of pulling in a JSON parser.
+                const char *key = strstr(args, "\"speed_rad_per_sec\"");
+                const char *colon = key != nullptr ? strchr(key, ':') : nullptr;
+                if (colon != nullptr) {
+                    float speed = strtof(colon + 1, nullptr);
+                    if (speed < 0.f) speed = 0.f;
+                    if (speed > 10.f) speed = 10.f;
+                    g_spinSpeed = speed;
+                    snprintf(result, sizeof(result), "{\"spin_speed_rad_per_sec\":%.3f}", g_spinSpeed);
+                } else {
+                    ok = XR_FALSE;
+                    snprintf(result, sizeof(result), "{\"error\":\"missing speed_rad_per_sec\"}");
+                }
+            } else if (strcmp(call->toolName, "get_status") == 0) {
+                snprintf(result, sizeof(result),
+                         "{\"spin_speed_rad_per_sec\":%.3f,\"session_running\":%s,"
+                         "\"rendering_mode_index\":%u}",
+                         g_spinSpeed, app.sessionRunning ? "true" : "false", app.currentModeIndex);
+            } else {
+                ok = XR_FALSE;
+                snprintf(result, sizeof(result), "{\"error\":\"unhandled tool\"}");
+            }
+            if (g_pfnSubmitMCPToolResult != nullptr) {
+                g_pfnSubmitMCPToolResult(app.session, call->callId, ok, result);
+            }
+            break;
+        }
         default: break;
         }
         event = {XR_TYPE_EVENT_DATA_BUFFER};
@@ -1637,7 +1748,7 @@ int main(int argc, char **argv)
         }
 
         // Update animation
-        renderer.cubeRotation += dt * 0.5f;
+        renderer.cubeRotation += dt * g_spinSpeed; // agent-settable via cube-metal__set_spin
 
         // Wait frame
         XrFrameWaitInfo waitInfo = {XR_TYPE_FRAME_WAIT_INFO};

--- a/tests/mcp/test_app_tools.sh
+++ b/tests/mcp/test_app_tools.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# Copyright 2026, DisplayXR / Leia Inc.
+# SPDX-License-Identifier: BSL-1.0
+#
+# XR_EXT_mcp_tools e2e (#447) — the full app-defined-tool round-trip.
+#
+# Launches cube_handle_metal_macos (the reference XR_EXT_mcp_tools
+# adopter) with DISPLAYXR_MCP=1 and verifies, via the displayxr-mcp
+# stdio adapter on the per-PID endpoint:
+#
+#   1. tools/list contains the app tools (set_spin, get_status) tagged
+#      _meta {"displayxr/group":"app"} and the result-level
+#      _meta {"displayxr/appId":"cube-metal"}.
+#   2. tools/call set_spin round-trips through the OpenXR event queue
+#      (trampoline -> XrEventDataMCPToolCallEXT -> app frame loop ->
+#      xrSubmitMCPToolResultEXT) and the new value reads back through
+#      get_status.
+#   3. A bad call (missing required arg) surfaces as a JSON-RPC error,
+#      not a hang.
+#
+# Unlike test_handshake.sh this needs a *session* (tools register after
+# xrCreateSession), so the sim-display plug-in must be discoverable —
+# we point XRT_PLUGIN_SEARCH_PATH at the dev package tree.
+#
+# Exit 0 = pass, nonzero = fail.
+
+set -u
+set -o pipefail
+
+if [[ "$(uname)" != "Darwin" ]]; then
+	echo "skip: mac-only test" >&2
+	exit 0
+fi
+
+cd "$(dirname "$0")/../.."
+ROOT="$(pwd)"
+
+ADAPTER="$ROOT/build/_deps/displayxr_mcp-build/displayxr-mcp"
+APP="$ROOT/test_apps/cube_handle_metal_macos/build/cube_handle_metal_macos"
+RUNTIME_JSON="$ROOT/build/openxr_displayxr-dev.json"
+PLUGINS="$ROOT/_package/DisplayXR-macOS/lib/displayxr/plugins"
+
+for f in "$ADAPTER" "$APP" "$RUNTIME_JSON" "$PLUGINS"; do
+	if [[ ! -e "$f" ]]; then
+		echo "FAIL: missing $f — run ./scripts/build_macos.sh first" >&2
+		exit 1
+	fi
+done
+
+export DISPLAYXR_MCP=1
+export XR_RUNTIME_JSON="$RUNTIME_JSON"
+export XRT_PLUGIN_SEARCH_PATH="$PLUGINS"
+
+"$APP" >/tmp/mcp_app_tools_app.log 2>&1 &
+APP_PID=$!
+
+cleanup() {
+	kill "$APP_PID" 2>/dev/null || true
+	wait "$APP_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# Wait for the MCP socket, then for tool registration (post-session).
+SOCK="/tmp/displayxr-mcp-${APP_PID}.sock"
+for _ in $(seq 1 50); do
+	[[ -S "$SOCK" ]] && break
+	sleep 0.1
+done
+if [[ ! -S "$SOCK" ]]; then
+	echo "FAIL: socket $SOCK never appeared (app log:)" >&2
+	cat /tmp/mcp_app_tools_app.log >&2 || true
+	exit 1
+fi
+for _ in $(seq 1 50); do
+	grep -q "XR_EXT_mcp_tools: appId=0" /tmp/mcp_app_tools_app.log && break
+	sleep 0.1
+done
+# get_status asserts session_running — wait for the session to begin.
+for _ in $(seq 1 100); do
+	grep -q "Session started" /tmp/mcp_app_tools_app.log && break
+	sleep 0.1
+done
+
+python3 - "$ADAPTER" "$APP_PID" <<'PY'
+import json, subprocess, sys
+
+adapter, pid = sys.argv[1], sys.argv[2]
+
+def frame(obj):
+    body = json.dumps(obj).encode()
+    return b"Content-Length: %d\r\n\r\n" % len(body) + body
+
+proc = subprocess.Popen(
+    [adapter, "--pid", pid],
+    stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+)
+
+def read_frame(p):
+    hdr = b""
+    while b"\r\n\r\n" not in hdr and b"\n\n" not in hdr:
+        c = p.stdout.read(1)
+        if not c:
+            raise RuntimeError("EOF reading header; stderr=%s" % p.stderr.read().decode("utf-8", "replace"))
+        hdr += c
+    clen = None
+    for line in hdr.splitlines():
+        if line.lower().startswith(b"content-length:"):
+            clen = int(line.split(b":", 1)[1].strip())
+    if clen is None:
+        raise RuntimeError("no Content-Length in %r" % hdr)
+    return json.loads(p.stdout.read(clen))
+
+def request(p, rid, method, params=None):
+    msg = {"jsonrpc": "2.0", "id": rid, "method": method}
+    if params is not None:
+        msg["params"] = params
+    p.stdin.write(frame(msg))
+    p.stdin.flush()
+    # Skip interleaved notifications (tools/list_changed is expected —
+    # the app registers tools while agents may already be connected).
+    while True:
+        r = read_frame(p)
+        if r.get("id") == rid:
+            return r
+
+try:
+    r = request(proc, 1, "initialize", {"protocolVersion": "2024-11-05", "capabilities": {}, "clientInfo": {"name": "test", "version": "0"}})
+    assert r["result"]["capabilities"]["tools"]["listChanged"] is True, r
+    assert r["result"]["serverInfo"].get("appId") == "cube-metal", r
+
+    # 1. App tools present, tagged, and namespaceable.
+    r = request(proc, 2, "tools/list")
+    tools = {t["name"]: t for t in r["result"]["tools"]}
+    assert r["result"].get("_meta", {}).get("displayxr/appId") == "cube-metal", r
+    for name in ("set_spin", "get_status"):
+        assert name in tools, sorted(tools)
+        assert tools[name]["_meta"]["displayxr/group"] == "app", tools[name]
+    assert tools["capture_frame"]["_meta"]["displayxr/group"] == "capture", tools["capture_frame"]
+
+    # 2. set_spin round-trips the event queue; get_status reads it back.
+    r = request(proc, 3, "tools/call", {"name": "set_spin", "arguments": {"speed_rad_per_sec": 2.25}})
+    structured = r["result"]["structured"]
+    assert abs(structured["spin_speed_rad_per_sec"] - 2.25) < 1e-3, r
+
+    r = request(proc, 4, "tools/call", {"name": "get_status", "arguments": {}})
+    structured = r["result"]["structured"]
+    assert abs(structured["spin_speed_rad_per_sec"] - 2.25) < 1e-3, r
+    assert structured["session_running"] is True, r
+
+    # 3. Bad call errors cleanly (app answers success=false -> tool error).
+    r = request(proc, 5, "tools/call", {"name": "set_spin", "arguments": {}})
+    assert "error" in r, r
+
+    print("PASS")
+finally:
+    try:
+        proc.stdin.close()
+    except Exception:
+        pass
+    proc.wait(timeout=3)
+PY
+RC=$?
+
+if [[ $RC -eq 0 ]]; then
+	echo "test_app_tools.sh: OK"
+else
+	echo "test_app_tools.sh: FAIL (rc=$RC)" >&2
+	echo "--- app log ---" >&2
+	cat /tmp/mcp_app_tools_app.log >&2 || true
+fi
+exit $RC

--- a/tests/mcp/test_handshake.sh
+++ b/tests/mcp/test_handshake.sh
@@ -34,6 +34,10 @@ done
 
 export DISPLAYXR_MCP=1
 export XR_RUNTIME_JSON="$RUNTIME_JSON"
+# Hermetic plug-in discovery: don't depend on an installed plug-in under
+# ~/Library/Application Support — use the dev package tree (sim-display).
+PLUGINS="$ROOT/_package/DisplayXR-macOS/lib/displayxr/plugins"
+[[ -d "$PLUGINS" ]] && export XRT_PLUGIN_SEARCH_PATH="$PLUGINS"
 
 # Launch the handle app detached.
 "$APP" >/tmp/mcp_handshake_app.log 2>&1 &


### PR DESCRIPTION
Closes #447. P2a of [per-app MCP tools](https://github.com/DisplayXR/displayxr-runtime/blob/main/docs/roadmap/per-app-mcp-tools.md) — the canonical in-tree example apps (and the mediaplayer demo) will copy from.

## What

- **Reference adoption** in `cube_handle_metal_macos`: `appId="cube-metal"` + two tools wired to real app state — `set_spin` (the spin speed was hardcoded `0.5f`; now agent-settable, clamped 0–10 rad/s) and `get_status`. Calls answered from the normal `xrPollEvent` pump; entire block inert when the MCP capability is off.
- **First manifest with the new `id` field** (`displayxr/cube_handle_metal_macos.displayxr.json`) — exercises INV-10.1 end to end (positive: lints clean; negative: mismatch fixture errors).
- **`tests/mcp/test_app_tools.sh`** — automated e2e of the full extension round-trip: `_meta` group/appId assertions, `set_spin` through the OpenXR event queue, readback via `get_status`, JSON-RPC error on a missing-arg call. The extension now has a regression test on every macOS dev box.
- Drive-by: `test_handshake.sh` made hermetic (was silently depending on an installed plug-in under `~/Library/Application Support`).

## Validation

Both MCP test scripts pass locally (`test_app_tools.sh` OK, `test_handshake.sh` OK); `check_displayxr_app.py` clean on the new rule. The `set_spin` choice makes agent actions visually verifiable via `capture_frame` — the act→capture→verify loop from the design doc, with zero new apps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)