### PR TITLE
Phase 4 of #441: app tracking-event logging + chained-enumerate reference + INV-2.8 advisory

### DIFF
--- a/docs/guides/displayxr-app-rules.md
+++ b/docs/guides/displayxr-app-rules.md
@@ -151,6 +151,18 @@ re-implementing — see [INV-8.1](#8-app-folder-layout--what-to-include)).
   `isTracking` tells you whether poses are live or a vendor fallback — it does **not** mean the
   views are unpopulated. Ref: `XR_EXT_display_info.h:141-165`.
 
+- **INV-2.8 (advisory) — MANUAL mode: handle the tracking-state event.** If you request
+  `XR_EYE_TRACKING_MODE_MANUAL_EXT` you've told the vendor *not* to run its grace
+  period / collapse animation / auto 2D fallback — tracking loss is **your** problem. React to
+  `XrEventDataEyeTrackingStateChangedEXT` (v14, edge-triggered on every `isTracking` flip;
+  also fires on mode switches into/out of untracked modes) instead of polling
+  `XrViewEyeTrackingStateEXT.isTracking` per frame: run your own transition, then
+  `xrRequestDisplayRenderingModeEXT` a 2D mode when ready. MANAGED apps may ignore the event
+  (the vendor handles the lifecycle). Per-mode tracking capability is queryable by chaining
+  `XrDisplayRenderingModeTrackingInfoEXT` at enumerate time (opt-in handshake — pre-set each
+  element's `type` and `next`; reference: `cube_handle_d3d11_win/xr_session.cpp`). Ref:
+  `XR_EXT_display_info.h` v14 block, `docs/specs/vendor/eye-tracking-modes.md`.
+
 ---
 
 ## 3. Views — the locate-views gotcha
@@ -545,6 +557,7 @@ launcher. The bare runtime ignores manifests — discovery is the workspace laye
 - [ ] Window passed for handle/texture, NULL for hosted (INV-1.1); HWND kept even in texture mode (INV-1.2)
 - [ ] Display info queried once via `XrSystemProperties`, treated as static (INV-2.1)
 - [ ] Modes enumerated; active mode tracked via the *event*, not set locally (INV-2.4); per-mode state re-derived each frame (INV-2.6)
+- [ ] (MANUAL eye tracking) `XrEventDataEyeTrackingStateChangedEXT` handled — own transition + 2D mode request on loss (INV-2.8)
 - [ ] `xrLocateViews` into an 8-wide buffer; render/submit `eyeCount` from the active mode, not 2 (INV-3.1)
 - [ ] App swapchain sized once to worst-case atlas (INV-4.2); per-tile = window/canvas × scaleXY, never display (INV-4.3)
 - [ ] Color space: request an **sRGB swapchain** and write a correctly-encoded image (linear render + GPU sRGB-write, or display-referred bytes — not both); linear/UNORM swapchain is not color-managed; data textures always linear (INV-4.6)

--- a/scripts/check_displayxr_app.py
+++ b/scripts/check_displayxr_app.py
@@ -44,6 +44,7 @@ SOURCE_EXTS = {".c", ".cc", ".cpp", ".cxx", ".h", ".hh", ".hpp", ".m", ".mm"}
 
 # ---- rule catalog (kept in sync with docs/guides/displayxr-app-rules.md) ----
 RULES = {
+    "INV-2.8": "Apps requesting MANUAL eye tracking SHOULD handle XrEventDataEyeTrackingStateChangedEXT (tracking loss is the app's problem in MANUAL).",
     "INV-3.1": "Locate into an XRT_MAX_VIEWS (8)-wide buffer; render/submit the active mode's viewCount, never a hardcoded 2.",
     "INV-4.3": "Per-tile render size = window/canvas x scaleXY, never display size.",
     "INV-4.6": "Request an sRGB swapchain (and store a correctly-encoded image); don't double-encode.",
@@ -310,6 +311,53 @@ def check_mcp_pairing(root: Path, findings: list):
                                     "Make the code and manifest agree — agents key tool names on this slug."))
 
 
+def check_manual_tracking_event(root: Path, findings: list):
+    """INV-2.8 (advisory) — MANUAL eye tracking <-> tracking-state event.
+
+    An app that REQUESTS MANUAL mode has opted out of the vendor's grace
+    period / collapse animation / auto 2D fallback — tracking loss becomes the
+    app's problem, and the edge-triggered XrEventDataEyeTrackingStateChangedEXT
+    (#441 v14) is the intended primitive for reacting to it. Conservative
+    trigger: only fires when BOTH xrRequestEyeTrackingModeEXT is called AND the
+    XR_EYE_TRACKING_MODE_MANUAL_EXT enum appears (merely printing "MANUAL" in a
+    HUD doesn't flag), and no source references the event type.
+    """
+    requests_manual = None  # (path, line) of the first MANUAL enum use
+    calls_request = False
+    handles_event = False
+    for p in sorted(root.rglob("*")):
+        if p.suffix.lower() not in SOURCE_EXTS or not p.is_file():
+            continue
+        if any(part in EXCLUDE_DIRS for part in p.relative_to(root).parts[:-1]):
+            continue
+        try:
+            text = strip_comments(p.read_text(encoding="utf-8", errors="replace"))
+        except OSError:
+            continue
+        if "xrRequestEyeTrackingModeEXT" in text:
+            calls_request = True
+        m = re.search(r"\bXR_EYE_TRACKING_MODE_MANUAL_EXT\b", text)
+        if m and requests_manual is None:
+            requests_manual = (rel(p, root), text.count("\n", 0, m.start()) + 1)
+        if ("XR_TYPE_EVENT_DATA_EYE_TRACKING_STATE_CHANGED_EXT" in text or
+                "XrEventDataEyeTrackingStateChangedEXT" in text):
+            handles_event = True
+        # Apps built on test_apps/common delegate event polling to the shared
+        # PollEvents(XrSessionManager&), which handles the event (common/ is
+        # excluded from linting, so look for the call instead).
+        if re.search(r"\bPollEvents\s*\(", text):
+            handles_event = True
+
+    if calls_request and requests_manual and not handles_event:
+        path, line = requests_manual
+        findings.append(Finding(
+            WARN, "INV-2.8", path, line,
+            "App requests MANUAL eye tracking but never handles XrEventDataEyeTrackingStateChangedEXT.",
+            "Handle the event in your xrPollEvent loop (run your own loss transition, request a 2D "
+            "mode when ready) — in MANUAL mode the vendor does no grace period or auto-fallback for you.",
+        ))
+
+
 def scan_manifests(root: Path, findings: list):
     manifests = [p for p in root.rglob("*.displayxr.json")
                  if not any(part in EXCLUDE_DIRS for part in p.relative_to(root).parts[:-1])]
@@ -324,7 +372,9 @@ def scan_manifests(root: Path, findings: list):
 
 def print_findings(findings: list, root: Path) -> None:
     if not findings:
-        print(f"✓ check_displayxr_app: no issues in {root}")
+        # ASCII on purpose: a checkmark glyph dies with UnicodeEncodeError on
+        # cp1252 Windows consoles, turning a CLEAN lint into exit 1.
+        print(f"OK check_displayxr_app: no issues in {root}")
         return
     order = {ERROR: 0, WARN: 1, INFO: 2}
     findings.sort(key=lambda f: (order[f.level], f.rule, f.path, f.line))
@@ -357,6 +407,7 @@ def main(argv=None) -> int:
     scan_sources(root, findings)
     scan_manifests(root, findings)
     check_mcp_pairing(root, findings)
+    check_manual_tracking_event(root, findings)
     print_findings(findings, root)
 
     n_err = sum(1 for f in findings if f.level == ERROR)

--- a/test_apps/common/xr_session_common.cpp
+++ b/test_apps/common/xr_session_common.cpp
@@ -430,6 +430,20 @@ bool PollEvents(XrSessionManager& xr) {
             xr.currentModeIndex = modeEvent->currentModeIndex;
             break;
         }
+        case (XrStructureType)XR_TYPE_EVENT_DATA_EYE_TRACKING_STATE_CHANGED_EXT: {
+            // Edge-triggered tracking loss/recovery (#441 v14). The HUD state
+            // refreshes per-frame from the XrViewEyeTrackingStateEXT chain in
+            // LocateViews; this handler exists so every manual test session
+            // logs the edges, and as the reference for the MANUAL-mode
+            // pattern (react here instead of polling isTracking).
+            auto* etEvent = (XrEventDataEyeTrackingStateChangedEXT*)&event;
+            LOG_INFO("Eye tracking state changed: isTracking=%s mode=%u",
+                etEvent->isTracking == XR_TRUE ? "YES" : "NO",
+                (uint32_t)etEvent->activeMode);
+            xr.isEyeTracking = (etEvent->isTracking == XR_TRUE);
+            xr.activeEyeTrackingMode = (uint32_t)etEvent->activeMode;
+            break;
+        }
         case (XrStructureType)XR_TYPE_EVENT_DATA_FILE_PICKER_COMPLETE_EXT: {
             auto* pickEvent = (XrEventDataFilePickerCompleteEXT*)&event;
             LOG_INFO("[#228] File picker complete: requestId=%llu result=%d path=\"%s\"",

--- a/test_apps/cube_handle_d3d11_win/xr_session.cpp
+++ b/test_apps/cube_handle_d3d11_win/xr_session.cpp
@@ -302,9 +302,18 @@ bool CreateSession(XrSessionManager& xr, ID3D11Device* d3d11Device, HWND hwnd) {
         XrResult enumRes = xr.pfnEnumerateDisplayRenderingModesEXT(xr.session, 0, &modeCount, nullptr);
         if (XR_SUCCEEDED(enumRes) && modeCount > 0) {
             std::vector<XrDisplayRenderingModeInfoEXT> modes(modeCount);
+            // Per-mode tracking capability (#441 v14) — reference adoption of
+            // the chained-struct opt-in: pre-set each element's type AND chain
+            // the tracking struct on next BEFORE the fill call. The runtime
+            // only walks elements carrying the pre-set type, so v13 binaries
+            // (uninitialized type/next) are untouched.
+            std::vector<XrDisplayRenderingModeTrackingInfoEXT> trackingInfos(modeCount);
             for (uint32_t i = 0; i < modeCount; i++) {
+                trackingInfos[i].type = (XrStructureType)XR_TYPE_DISPLAY_RENDERING_MODE_TRACKING_INFO_EXT;
+                trackingInfos[i].next = nullptr;
+                trackingInfos[i].hasTracking = XR_FALSE;
                 modes[i].type = XR_TYPE_DISPLAY_RENDERING_MODE_INFO_EXT;
-                modes[i].next = nullptr;
+                modes[i].next = &trackingInfos[i];
             }
             enumRes = xr.pfnEnumerateDisplayRenderingModesEXT(xr.session, modeCount, &modeCount, modes.data());
             if (XR_SUCCEEDED(enumRes)) {
@@ -313,7 +322,7 @@ bool CreateSession(XrSessionManager& xr, ID3D11Device* d3d11Device, HWND hwnd) {
                 for (uint32_t i = 0; i < xr.renderingModeCount; i++) {
                     strncpy(xr.renderingModeNames[i], modes[i].modeName, XR_MAX_SYSTEM_NAME_SIZE - 1);
                     xr.renderingModeNames[i][XR_MAX_SYSTEM_NAME_SIZE - 1] = '\0';
-                    LOG_INFO("  [%u] %s (views=%u, tiles=%ux%u, scale=%.2fx%.2f, 3D=%d)", modes[i].modeIndex, modes[i].modeName, modes[i].viewCount, modes[i].tileColumns, modes[i].tileRows, modes[i].viewScaleX, modes[i].viewScaleY, modes[i].hardwareDisplay3D);
+                    LOG_INFO("  [%u] %s (views=%u, tiles=%ux%u, scale=%.2fx%.2f, 3D=%d, tracked=%d)", modes[i].modeIndex, modes[i].modeName, modes[i].viewCount, modes[i].tileColumns, modes[i].tileRows, modes[i].viewScaleX, modes[i].viewScaleY, modes[i].hardwareDisplay3D, trackingInfos[i].hasTracking == XR_TRUE);
                     xr.renderingModeViewCounts[i] = modes[i].viewCount;
                     xr.renderingModeTileColumns[i] = modes[i].tileColumns;
                     xr.renderingModeTileRows[i] = modes[i].tileRows;

--- a/test_apps/cube_handle_gl_macos/main.mm
+++ b/test_apps/cube_handle_gl_macos/main.mm
@@ -1466,6 +1466,16 @@ static void PollEvents(AppXrSession &app)
             app.currentModeIndex = modeEvent->currentModeIndex;
             break;
         }
+        case (XrStructureType)XR_TYPE_EVENT_DATA_EYE_TRACKING_STATE_CHANGED_EXT: {
+            // Edge-triggered tracking loss/recovery (#441 v14); HUD state
+            // also refreshes per-frame from the XrViewEyeTrackingStateEXT chain.
+            auto* etEvent = (XrEventDataEyeTrackingStateChangedEXT*)&event;
+            LOG_INFO("Eye tracking state changed: isTracking=%s mode=%u",
+                etEvent->isTracking == XR_TRUE ? "YES" : "NO",
+                (uint32_t)etEvent->activeMode);
+            app.isEyeTracking = (etEvent->isTracking == XR_TRUE);
+            break;
+        }
         default: break;
         }
         event = {XR_TYPE_EVENT_DATA_BUFFER};

--- a/test_apps/cube_handle_metal_macos/main.mm
+++ b/test_apps/cube_handle_metal_macos/main.mm
@@ -1567,6 +1567,16 @@ static void PollEvents(AppXrSession &app)
             app.currentModeIndex = modeEvent->currentModeIndex;
             break;
         }
+        case (XrStructureType)XR_TYPE_EVENT_DATA_EYE_TRACKING_STATE_CHANGED_EXT: {
+            // Edge-triggered tracking loss/recovery (#441 v14); HUD state
+            // also refreshes per-frame from the XrViewEyeTrackingStateEXT chain.
+            auto* etEvent = (XrEventDataEyeTrackingStateChangedEXT*)&event;
+            LOG_INFO("Eye tracking state changed: isTracking=%s mode=%u",
+                etEvent->isTracking == XR_TRUE ? "YES" : "NO",
+                (uint32_t)etEvent->activeMode);
+            app.isEyeTracking = (etEvent->isTracking == XR_TRUE);
+            break;
+        }
         case (XrStructureType)XR_TYPE_EVENT_DATA_MCP_TOOL_CALL_EXT: {
             // An agent invoked one of our XR_EXT_mcp_tools tools. Fetch the
             // JSON args (two-call idiom; argsSize is the required capacity),

--- a/test_apps/cube_handle_vk_macos/main.mm
+++ b/test_apps/cube_handle_vk_macos/main.mm
@@ -2467,6 +2467,16 @@ static bool PollEvents(AppXrSession& xr) {
             xr.currentModeIndex = modeEvent->currentModeIndex;
             break;
         }
+        case (XrStructureType)XR_TYPE_EVENT_DATA_EYE_TRACKING_STATE_CHANGED_EXT: {
+            // Edge-triggered tracking loss/recovery (#441 v14); HUD state
+            // also refreshes per-frame from the XrViewEyeTrackingStateEXT chain.
+            auto* etEvent = (XrEventDataEyeTrackingStateChangedEXT*)&event;
+            LOG_INFO("Eye tracking state changed: isTracking=%s mode=%u",
+                etEvent->isTracking == XR_TRUE ? "YES" : "NO",
+                (uint32_t)etEvent->activeMode);
+            xr.isEyeTracking = (etEvent->isTracking == XR_TRUE);
+            break;
+        }
         default:
             break;
         }

--- a/test_apps/cube_hosted_metal_macos/main.mm
+++ b/test_apps/cube_hosted_metal_macos/main.mm
@@ -983,6 +983,13 @@ static void PollEvents(AppXrSession &app)
             LOG_INFO("Rendering mode changed: %u -> %u", rmc->previousModeIndex, rmc->currentModeIndex);
             break;
         }
+        case (XrStructureType)XR_TYPE_EVENT_DATA_EYE_TRACKING_STATE_CHANGED_EXT: {
+            // Edge-triggered tracking loss/recovery (#441 v14) — log-only here.
+            auto *ets = (XrEventDataEyeTrackingStateChangedEXT *)&event;
+            LOG_INFO("Eye tracking state changed: isTracking=%s mode=%u",
+                ets->isTracking == XR_TRUE ? "YES" : "NO", (uint32_t)ets->activeMode);
+            break;
+        }
         default: break;
         }
         event = {XR_TYPE_EVENT_DATA_BUFFER};

--- a/test_apps/cube_texture_metal_macos/main.mm
+++ b/test_apps/cube_texture_metal_macos/main.mm
@@ -1712,6 +1712,16 @@ static void PollEvents(AppXrSession &app)
             app.currentModeIndex = modeEvent->currentModeIndex;
             break;
         }
+        case (XrStructureType)XR_TYPE_EVENT_DATA_EYE_TRACKING_STATE_CHANGED_EXT: {
+            // Edge-triggered tracking loss/recovery (#441 v14); HUD state
+            // also refreshes per-frame from the XrViewEyeTrackingStateEXT chain.
+            auto* etEvent = (XrEventDataEyeTrackingStateChangedEXT*)&event;
+            LOG_INFO("Eye tracking state changed: isTracking=%s mode=%u",
+                etEvent->isTracking == XR_TRUE ? "YES" : "NO",
+                (uint32_t)etEvent->activeMode);
+            app.isEyeTracking = (etEvent->isTracking == XR_TRUE);
+            break;
+        }
         default: break;
         }
         event = {XR_TYPE_EVENT_DATA_BUFFER};


### PR DESCRIPTION
Phase 4 of #441 (per Phases plan in `docs/roadmap/per-mode-tracking-capability-plan.md` §Phase 4). Phases 0–3 done: #443 + #446 merged (e2e green: [#446 results](https://github.com/DisplayXR/displayxr-runtime/pull/446#issuecomment-4637217252)), Leia plug-in ABI v3 in displayxr-leia-plugin#30 (SR hardware results on displayxr-leia-plugin#29).

## What

**Test apps — event logging (every manual test session gets free edge visibility):**
- `XrEventDataEyeTrackingStateChangedEXT` case added to the shared `PollEvents` (`test_apps/common/xr_session_common.cpp`, covers all `_win` apps) and to the five macOS mains that poll their own events. Logs each edge; also refreshes `isEyeTracking`/`activeEyeTrackingMode` so the existing `Tracking: YES/NO [MODE]` HUD line follows events. (The HUD line itself already existed — fed per-frame by the `XrViewEyeTrackingStateEXT` chain.)
- **Validated on SR hardware**: 21 loss/recovery edges logged app-side over ~7 min of natural movement, incl. sub-second zone-boundary flickers.

**Reference adoption of the v14 chained struct:**
- `cube_handle_d3d11_win/xr_session.cpp` chains `XrDisplayRenderingModeTrackingInfoEXT` per element at enumerate time, demonstrating the opt-in handshake (pre-set `type`, chain `next` BEFORE the fill call). Mode log gains `tracked=N`. **Verified live against the ABI-3 Leia plug-in**: `[0] 2D tracked=0`, `[1] LeiaSR tracked=1`.

**INV-2.8 advisory (rules doc + linter):**
- `docs/guides/displayxr-app-rules.md`: new INV-2.8 in §2 + checklist entry — apps requesting MANUAL eye tracking SHOULD handle the tracking-state event (in MANUAL the vendor does no grace period/auto-fallback; loss is the app's problem).
- `scripts/check_displayxr_app.py`: matching advisory WARN. Conservative trigger: `xrRequestEyeTrackingModeEXT` called AND `XR_EYE_TRACKING_MODE_MANUAL_EXT` referenced AND no event reference anywhere; delegating to common's `PollEvents` counts as handled (common/ is lint-excluded). Verified: flags a synthetic MANUAL-no-handler app, clean on all cube apps.

**Drive-by linter fix:** the ✓ in the clean-pass message raised `UnicodeEncodeError` on cp1252 Windows consoles — a fully CLEAN lint exited 1 with a traceback. Now ASCII.

**Adoption issues filed (third Phase-4 item):** displayxr-unity#145 + #449 (WebXR bridge) — both opt-in, no action required.

## Test evidence
- `scripts\build_windows.bat test-apps` clean.
- App-side event log (SR display, real tracking): `Eye tracking state changed: isTracking=YES/NO mode=0` edges as operator left/entered the view zone.
- Chained enumerate against Leia ABI v3: per-mode `tracked=` correct.
- Linter: `--list-rules` shows INV-2.8; cube apps clean (exit 0); synthetic MANUAL app flagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
