### PR TITLE
fix(#453): ABI-gate issue-create must not fail the by-design skip path

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -995,15 +995,34 @@ jobs:
           **To unblock:** rebuild the leia plug-in against runtime \`${{ github.ref_name }}\` (bump \`DXR_RUNTIME_GIT_TAG\` in this repo's \`CMakeLists.txt\`), tag a new release. The leia release's \`versions-bump\` dispatch will then bump leia first; the next runtime tag (or a manual workflow_dispatch on \`versions-bump.yml\` with \`field=runtime\`) will catch up the runtime field.
           EOF
           )
+          # Surface the by-design skip BEFORE any fallible gh call so the
+          # annotation always lands even if issue/label plumbing fails (#453).
+          echo "::warning::Skipped versions.json[runtime] bump — ABI mismatch; opening tracking issue in displayxr-leia-plugin."
+
+          # Ensure the labels exist (idempotent; --force updates in place).
+          # Best-effort: label problems must never fail the gate (#453 —
+          # 'abi-mismatch' missing on the target repo hard-failed the
+          # v1.13.0 run AFTER the issue was already created).
+          gh label create abi-mismatch --repo DisplayXR/displayxr-leia-plugin \
+            --description "Plug-in ABI does not match the runtime's XRT_PLUGIN_API_VERSION_CURRENT" \
+            --color B60205 --force || true
+          gh label create automated --repo DisplayXR/displayxr-leia-plugin \
+            --description "Opened by a DisplayXR workflow" \
+            --color 0E8A16 --force || true
+
           EXISTING=$(gh issue list --repo DisplayXR/displayxr-leia-plugin \
                        --state open --search "$TITLE in:title" --json number --jq '.[0].number // empty')
           if [ -n "$EXISTING" ]; then
             gh issue comment "$EXISTING" --repo DisplayXR/displayxr-leia-plugin --body "$BODY"
           else
-            gh issue create --repo DisplayXR/displayxr-leia-plugin \
-              --title "$TITLE" --body "$BODY" --label "abi-mismatch,automated"
+            # Create WITHOUT --label (gh creates the issue and only then
+            # attaches labels, so a label failure used to abort the job with
+            # the issue already open — #453). Attach labels best-effort after.
+            NEW_URL=$(gh issue create --repo DisplayXR/displayxr-leia-plugin \
+              --title "$TITLE" --body "$BODY")
+            gh issue edit "$NEW_URL" --repo DisplayXR/displayxr-leia-plugin \
+              --add-label "abi-mismatch" --add-label "automated" || true
           fi
-          echo "::warning::Skipped versions.json[runtime] bump — opened tracking issue in displayxr-leia-plugin."
 
       - name: Bump versions.json[runtime]
         if: steps.abi.outputs.rc == '0'

--- a/.github/workflows/versions-bump.yml
+++ b/.github/workflows/versions-bump.yml
@@ -127,16 +127,33 @@ jobs:
           **To unblock:** rebuild against the current runtime headers (bump \`DXR_RUNTIME_GIT_TAG\` in \`CMakeLists.txt\` to the current runtime \`versions.json[runtime]\`), tag a new release. The next tag's auto-dispatch will retry the bump.
           EOF
           )
+          # Surface the by-design skip BEFORE any fallible gh call so the
+          # annotation always lands even if issue/label plumbing fails (#453).
+          echo "::warning::Skipped versions.json bump — ABI mismatch; opening tracking issue in displayxr-leia-plugin."
+
+          # Ensure the labels exist (idempotent; --force updates in place).
+          # Best-effort: label problems must never fail the gate (#453).
+          gh label create abi-mismatch --repo DisplayXR/displayxr-leia-plugin \
+            --description "Plug-in ABI does not match the runtime's XRT_PLUGIN_API_VERSION_CURRENT" \
+            --color B60205 --force || true
+          gh label create automated --repo DisplayXR/displayxr-leia-plugin \
+            --description "Opened by a DisplayXR workflow" \
+            --color 0E8A16 --force || true
+
           # If an open issue with this title already exists, comment instead of duplicating.
           EXISTING=$(gh issue list --repo DisplayXR/displayxr-leia-plugin \
                        --state open --search "$TITLE in:title" --json number --jq '.[0].number // empty')
           if [ -n "$EXISTING" ]; then
             gh issue comment "$EXISTING" --repo DisplayXR/displayxr-leia-plugin --body "$BODY"
           else
-            gh issue create --repo DisplayXR/displayxr-leia-plugin \
-              --title "$TITLE" --body "$BODY" --label "abi-mismatch,automated"
+            # Create WITHOUT --label (gh creates the issue and only then
+            # attaches labels, so a label failure used to abort the job with
+            # the issue already open — #453). Attach labels best-effort after.
+            NEW_URL=$(gh issue create --repo DisplayXR/displayxr-leia-plugin \
+              --title "$TITLE" --body "$BODY")
+            gh issue edit "$NEW_URL" --repo DisplayXR/displayxr-leia-plugin \
+              --add-label "abi-mismatch" --add-label "automated" || true
           fi
-          echo "::warning::Skipped versions.json bump — opened tracking issue in displayxr-leia-plugin."
           exit 0
 
       - name: Apply bump


### PR DESCRIPTION
## Summary

Fixes #453 — observed on the v1.13.0 tag run: the ABI gate worked exactly as designed (detected leia v1.3.0 ≠ runtime ABI v3, skipped the bump, opened leia-plugin#31) but the job still went red because `gh issue create --label "abi-mismatch,automated"` attaches labels *after* creating the issue, and `abi-mismatch` didn't exist on the target repo. The `::warning::` skip annotation after it never ran either.

Both gate sites (`build-windows.yml` tag path and `versions-bump.yml` dispatch path) now:

1. **Emit the skip `::warning::` first**, before any fallible `gh` call — the by-design outcome is always surfaced in annotations
2. **Ensure both labels exist idempotently** (`gh label create --force || true`) so they self-heal on any repo
3. **Create the issue without `--label`, then attach via `gh issue edit … || true`** — avoids the create-succeeded-but-label-failed half-state that aborted the job with the issue already open, and guarantees label problems can never fail the gate again

## Verification
- YAML parses (both workflows); extracted bash block passes `bash -n`
- Logic-only change to the failure-path step; the happy path (`rc == 0` → bump) is untouched
- Real-world validation comes free on the next ABI-mismatch tag (the gate fires rarely and by design)

🤖 Generated with [Claude Code](https://claude.com/claude-code)