### PR TITLE
docs(#441): post-landing sync — ADR-022, ABI-v3 history, spec closeout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,6 +208,9 @@ After a rebuild, copy runtime binaries into `C:\Program Files\DisplayXR\Runtime`
 
 Both use registry discovery on Windows (so they pick up whatever plug-in is installed — Leia SR or sim-display), `XRT_PLUGIN_SEARCH_PATH` on POSIX.
 
+### Simulating eye tracking without hardware
+sim_display honestly advertises **no** eye tracking (per-mode `has_tracking=false`, `supportedModes=0`) — `SIM_DISPLAY_FAKE_TRACKING=1` re-enables MANUAL_BIT + tracked 3D modes, and `SIM_DISPLAY_FAKE_TRACKING_PERIOD_MS=N` square-waves `is_tracking` to exercise tracking-loss edges + `XrEventDataEyeTrackingStateChangedEXT` (look for `OXR EVENT: Eye tracking state changed` WARN lines). Works in-process and via `XRT_FORCE_MODE=ipc`. Contract: `docs/specs/vendor/eye-tracking-modes.md`; design: ADR-022.
+
 ### Windows test apps
 `scripts\build_windows.bat test-apps` builds apps and generates run scripts in `_package/` that set `XR_RUNTIME_JSON` to the dev build.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -66,6 +66,7 @@ Integrate your 3D display hardware into DisplayXR.
 - **[`xrt_plugin_iface` reference](reference/xrt_plugin_iface.md)** — per-method contract for the plug-in vtable
 - **[Plug-in discovery spec](specs/runtime/plugin-discovery.md)** — registry / JSON manifest formats, env-var overrides
 - **[ADR-019: Vendor Plug-in / Aux Boundary](adr/ADR-019-vendor-plugin-aux-boundary.md)** — why the runtime DLL holds zero vendor identifiers
+- **[ADR-022: Per-Mode Capability Flags + Frozen Enumerated App Structs](adr/ADR-022-per-mode-capability-flags-frozen-enum-structs.md)** — `mode_flags` bits (no more rendering-mode ABI breaks) + `XrDisplayRenderingModeInfoEXT` frozen at v13 (all future per-mode fields chain)
 - **[Display Processor Interface](specs/vendor/display-processor-interface.md)** — the DP vtable you'll implement
 - **[Eye Tracking Modes](specs/vendor/eye-tracking-modes.md)** — MANAGED vs MANUAL contract
 - **[ADR-003: Vendor Abstraction](adr/ADR-003-vendor-abstraction-via-display-processor-vtable.md)** — why vendor code is isolated

--- a/docs/adr/ADR-022-per-mode-capability-flags-frozen-enum-structs.md
+++ b/docs/adr/ADR-022-per-mode-capability-flags-frozen-enum-structs.md
@@ -1,0 +1,88 @@
+---
+status: Accepted
+date: 2026-06-06
+---
+# ADR-022: Per-Mode Capability Flags + Frozen Enumerated App Structs
+
+## Context
+
+#441 added per-rendering-mode tracking capability (`has_tracking`) so a vendor
+can expose e.g. a "2D tracked" mode alongside tracked 3D modes and untracked
+export modes (SBS, anaglyph), and so sim_display can honestly advertise that it
+has no tracker at all. That one feature forced two structural questions whose
+answers will outlive it:
+
+1. **Vendor side** — `struct xrt_rendering_mode` is embedded **by value** as an
+   array in `xrt_device`, which the plug-in's `create_device` builds. Any field
+   addition changes the element stride → a plug-in ABI break (ADR-020 major
+   bump, coordinated vendor release). Per-mode capabilities will keep arriving
+   (low-latency, HDR-weave, requires-canvas, …). Does every one cost an ABI
+   break?
+
+2. **App side** — `xrEnumerateDisplayRenderingModesEXT` fills an app-allocated
+   array of `XrDisplayRenderingModeInfoEXT` using the **runtime's compiled
+   struct stride**. The v12 (tile fields) and v13 (`isActive`/`isRequestable`)
+   revisions plain-appended fields — which only worked because every consumer
+   in the org rebuilt in lockstep. An app binary compiled against an older
+   header (engine plug-ins, shipped demos, any third-party app now that the
+   repo is public) would have the runtime write past each element it allocated:
+   silent memory corruption, with **no version handshake on the app ABI to
+   reject the mismatch cleanly** (unlike the plug-in side, where the loader
+   rejects ABI-mismatched DLLs at `xrCreateInstance`).
+
+## Decision
+
+**1. Vendor side: capability bits, not fields — v3 is the last rendering-mode
+layout break.**
+
+`xrt_rendering_mode` gained, in the vendor-provided MUST-set section:
+
+```c
+uint32_t mode_flags;   // bit 0 = XRT_RENDERING_MODE_FLAG_HAS_TRACKING
+uint32_t reserved[3];  // MUST be zeroed by the driver
+```
+
+paid for with the `XRT_PLUGIN_API_VERSION_CURRENT` 2 → 3 bump. Every future
+per-mode boolean is a **new bit** in `mode_flags`; small future per-mode values
+draw from `reserved[]`. Zero-init = all capabilities off = the safe default,
+so older-style drivers that calloc and don't know a new bit are automatically
+conservative. No further stride changes — no ABI v4 for per-mode capabilities.
+
+**2. App side: `XrDisplayRenderingModeInfoEXT` is frozen at its v13 layout.
+All future per-mode fields chain.**
+
+New per-mode data reaches apps via structs chained to each array element's
+`next` — starting with `XrDisplayRenderingModeTrackingInfoEXT { hasTracking }`
+(header v14). The app opts in per the standard OpenXR input convention by
+pre-setting each element's `type` (and chaining); the runtime **only walks the
+chain of elements carrying the correct input type**, because v13-and-earlier
+binaries leave `type`/`next` uninitialized and walking garbage pointers would
+crash them. Non-opted-in callers get the exact v13 fill (`next = NULL`'d).
+
+This is the canonical Khronos pattern for extending enumerated output structs
+(cf. `XrViewConfigurationView` + chained per-view extension structs, and our
+own `XrEyeTrackingModeCapabilitiesEXT` chaining to `XrSystemProperties`).
+
+## Consequences
+
+- Adding a per-mode capability is now: define a bit (vendor side) + define a
+  chained struct or extend an existing one (app side) + header minor bump.
+  No plug-in ABI break, no app-binary risk, no coordinated release.
+- The v12/v13-style plain append is **prohibited** on
+  `XrDisplayRenderingModeInfoEXT`. Reviewers should treat any field added to
+  that struct as a correctness bug, not a style preference — the failure mode
+  is silent memory corruption in binaries we don't control.
+- The opt-in type handshake means chained data is invisible to apps that don't
+  ask for it — acceptable: capability discovery is inherently opt-in.
+- ABI v3 was a hard break for vendor plug-ins (each tracks its rebuild in its
+  own repo per ADR-019); the versions.json ABI gate held the runtime bump
+  until a matched pair existed, as designed (ADR-020).
+
+## References
+
+- #441 (umbrella), runtime PRs #443 / #446 / #451; vendor rebuilds tracked in
+  the respective plug-in repos
+- `docs/roadmap/per-mode-tracking-capability-plan.md` (implementation plan)
+- `docs/specs/extensions/XR_EXT_display_info.md` §7c (v14 API surface)
+- `docs/specs/vendor/eye-tracking-modes.md` (capability layering + contract)
+- ADR-020 (plug-in ABI policy this builds on)

--- a/docs/roadmap/per-mode-tracking-capability-plan.md
+++ b/docs/roadmap/per-mode-tracking-capability-plan.md
@@ -1,7 +1,7 @@
 # Per-Mode Tracking Capability + Tracking-State Event — Implementation Plan
 
-**Status:** DRAFT (2026-06-05)
-**Scope:** runtime, sim_display plug-in (in-tree), Leia SR plug-in (`displayxr-leia-plugin`), extension header v14, IPC.
+**Status:** ✅ COMPLETE (2026-06-06) — all 5 phases shipped as runtime **v1.13.0** + vendor plug-in ABI-v3 rebuild + bundle **v0.13.0**; #441 closed. Architectural decisions promoted to **ADR-022** (flags-word vendor ABI + frozen-at-v13 app struct / chaining policy).
+**Scope:** runtime, sim_display plug-in (in-tree), vendor plug-ins (own repos), extension header v14, IPC.
 **Breaking:** plug-in ABI v2 → v3 (coordinated release). Zero app-binary breakage by design.
 
 ## Goal

--- a/docs/specs/runtime/plugin-discovery.md
+++ b/docs/specs/runtime/plugin-discovery.md
@@ -404,11 +404,19 @@ manifest + binary, leaves the runtime alone.
 ## 6. Version negotiation
 
 `XRT_PLUGIN_API_VERSION_CURRENT` is defined in `xrt/xrt_plugin.h`. As of
-runtime v1.6.0 the current major is `XRT_PLUGIN_API_VERSION_2`
-(ADR-020). v1 → v2 is the one-time break that introduced the
-`struct_size` header on the display-processor vtables; ABI-v1 plug-ins
-(≤ leia v1.0.5) are rejected by the loader and must be rebuilt against
-v2 headers.
+runtime v1.13.0 the current major is `XRT_PLUGIN_API_VERSION_3`
+(ADR-020, ADR-022). History:
+
+- v1 → v2 (runtime v1.6.0): the one-time break that introduced the
+  `struct_size` header on the display-processor vtables; ABI-v1
+  plug-ins are rejected by the loader and must rebuild against v2
+  headers.
+- v2 → v3 (runtime v1.13.0, #441): `xrt_rendering_mode` gained
+  `mode_flags` (bit 0 = `XRT_RENDERING_MODE_FLAG_HAS_TRACKING`) +
+  `reserved[3]` — an element-stride change in the `xrt_device`-embedded
+  array, so ABI-v2 plug-ins are rejected. The flags word + reserved
+  padding make v3 the intended **last** rendering-mode layout break
+  (ADR-022): future per-mode capabilities are new bits, not new fields.
 
 Both the runtime and the plug-in pass their own version through
 `xrtPluginNegotiate`. The runtime enforces a strict major match — a

--- a/docs/specs/vendor/eye-tracking-modes.md
+++ b/docs/specs/vendor/eye-tracking-modes.md
@@ -220,11 +220,11 @@ Ideally vendors support **both** modes (bits = 3), giving developers the choice.
 
 ## Acceptance Criteria
 
-- [ ] Vendor integration guide updated with MANAGED/MANUAL transition contract
-- [ ] `XR_EXT_display_info.h` comments updated to document auto-switch behavior per mode
-- [ ] Vendor display processors pass eye tracking mode to the SDK wrapper when `xrRequestEyeTrackingModeEXT` is called
+- [x] Vendor integration guide updated with MANAGED/MANUAL transition contract (`docs/guides/vendor-plugin-onboarding.md`)
+- [x] `XR_EXT_display_info.h` comments updated to document auto-switch behavior per mode (v6 + v14 doc blocks)
+- [ ] Vendor display processors pass eye tracking mode to the SDK wrapper when `xrRequestEyeTrackingModeEXT` is called (vendor-side; tracked per plug-in repo)
 - [ ] Event propagation path exists for vendor-initiated 2D/3D switches (MANAGED mode auto-transitions fire `XrEventDataRenderingModeChangedEXT` + `XrEventDataHardwareDisplayStateChangedEXT`)
-- [ ] sim_display honest: `supported_eye_tracking_modes = 0`, all modes untracked; `SIM_DISPLAY_FAKE_TRACKING=1` dev toggle re-enables MANUAL_BIT + tracked modes (+ `SIM_DISPLAY_FAKE_TRACKING_PERIOD_MS` square wave) for hardware-free testing (#441)
-- [ ] Per-mode `has_tracking` plumbed plugin → `xrt_rendering_mode.mode_flags` → chained `XrDisplayRenderingModeTrackingInfoEXT` (#441)
-- [ ] `XrEventDataEyeTrackingStateChangedEXT` queued on every derived-isTracking edge (#441)
-- [ ] `is_tracking` transported over IPC; fake-TRUE fallback removed (#441 Phase 2)
+- [x] sim_display honest: `supported_eye_tracking_modes = 0`, all modes untracked; `SIM_DISPLAY_FAKE_TRACKING=1` dev toggle re-enables MANUAL_BIT + tracked modes (+ `SIM_DISPLAY_FAKE_TRACKING_PERIOD_MS` square wave) for hardware-free testing (#441, runtime v1.13.0)
+- [x] Per-mode `has_tracking` plumbed plugin → `xrt_rendering_mode.mode_flags` → chained `XrDisplayRenderingModeTrackingInfoEXT` (#441, ABI v3 / header v14 — see ADR-022)
+- [x] `XrEventDataEyeTrackingStateChangedEXT` queued on every derived-isTracking edge (#441; validated against real view-zone edges on 3D-display hardware)
+- [x] `is_tracking` transported over IPC; fake-TRUE fallback removed (#441 Phase 2, PR #446)

--- a/src/xrt/include/xrt/xrt_plugin.h
+++ b/src/xrt/include/xrt/xrt_plugin.h
@@ -106,8 +106,12 @@ struct xrt_plugin_display_info
 
 	/*! Eye-tracking mode bits supported by this display, as
 	 *  understood by `XR_EXT_display_info`. Bit 0 = MANAGED, bit 1 =
-	 *  MANUAL. Leia is MANAGED-only (bit 0); sim_display is
-	 *  MANUAL-only (bit 1). */
+	 *  MANUAL; 0 = no eye tracking at all. A typical hardware DP is
+	 *  MANAGED-only (bit 0); sim_display declares 0 — its positions
+	 *  are nominal, not tracked (`SIM_DISPLAY_FAKE_TRACKING=1`
+	 *  re-enables MANUAL for hardware-free testing). Consistency rule
+	 *  (#441): non-zero iff at least one rendering mode sets
+	 *  XRT_RENDERING_MODE_FLAG_HAS_TRACKING in `mode_flags`. */
 	uint32_t supported_eye_tracking_modes;
 
 	/*! Default eye-tracking mode for sessions that don't override.


### PR DESCRIPTION
## Summary

Post-landing doc sweep now that #441 shipped (runtime v1.13.0, bundle v0.13.0):

- **NEW [ADR-022](docs/adr/ADR-022-per-mode-capability-flags-frozen-enum-structs.md)** — promotes the two load-bearing decisions out of spec prose:
  1. per-mode capabilities are `mode_flags` **bits** (+ `reserved[]`) → ABI v3 is the intended *last* rendering-mode layout break
  2. `XrDisplayRenderingModeInfoEXT` is **frozen at its v13 layout** — all future per-mode fields chain via `next`; a plain field append is a correctness bug (silent memory corruption in app binaries we don't control)
- `plugin-discovery.md` §6: was stale at "current major is v2" — now documents the v2→v3 history
- `xrt_plugin.h` doc comment: no longer claims the simulator is MANUAL-only (it declares `0` since #441); documents the 0 = no-tracking value + consistency rule. Vendor-neutral wording per the repo rule.
- `eye-tracking-modes.md`: acceptance criteria checked off for everything verifiably shipped; the two vendor-side items remain open and point at the plug-in repos
- Plan doc: DRAFT → ✅ COMPLETE with shipped versions
- `CLAUDE.md`: "Simulating eye tracking without hardware" note (`SIM_DISPLAY_FAKE_TRACKING` / `_PERIOD_MS`, expected event log line)
- ADR-022 indexed in `docs/README.md`

Only non-doc file is the `xrt_plugin.h` comment (no code change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)