### PR TITLE
feat(#457): port XR_EXT_mcp_tools reference tools to the Windows cube test apps

### DIFF
--- a/test_apps/common/d3d11_renderer.cpp
+++ b/test_apps/common/d3d11_renderer.cpp
@@ -608,9 +608,9 @@ void CleanupD3D11(D3D11Renderer& renderer) {
     renderer.dxgiFactory.Reset();
 }
 
-void UpdateScene(D3D11Renderer& renderer, float deltaTime) {
-    // Rotate cube
-    renderer.cubeRotation += deltaTime * 0.5f; // Half rotation per second
+void UpdateScene(D3D11Renderer& renderer, float deltaTime, float spinSpeed) {
+    // Rotate cube — spinSpeed is agent-settable via cube-d3d11__set_spin (#457)
+    renderer.cubeRotation += deltaTime * spinSpeed;
     if (renderer.cubeRotation > XM_2PI) {
         renderer.cubeRotation -= XM_2PI;
     }

--- a/test_apps/common/d3d11_renderer.h
+++ b/test_apps/common/d3d11_renderer.h
@@ -77,8 +77,10 @@ bool CreateResources(D3D11Renderer& renderer);
 // Clean up D3D11 resources
 void CleanupD3D11(D3D11Renderer& renderer);
 
-// Update scene state (cube rotation, etc.)
-void UpdateScene(D3D11Renderer& renderer, float deltaTime);
+// Update scene state (cube rotation, etc.). spinSpeed is in rad/s — the
+// handle apps pass xr.spinSpeed (agent-settable via the set_spin MCP tool,
+// #457); other callers keep the historical 0.5 default.
+void UpdateScene(D3D11Renderer& renderer, float deltaTime, float spinSpeed = 0.5f);
 
 // Render the scene to a render target view
 // viewMatrix and projMatrix come from OpenXR views (already includes player locomotion

--- a/test_apps/common/xr_session_common.cpp
+++ b/test_apps/common/xr_session_common.cpp
@@ -10,6 +10,7 @@
 #include "logging.h"
 #include <cstring>
 #include <cmath>
+#include <cstdio>
 #include <cstdlib>
 // #include <chrono>  // [Commented out — was only used for convergence plane logging throttle]
 
@@ -450,6 +451,50 @@ bool PollEvents(XrSessionManager& xr) {
                 (unsigned long long)pickEvent->requestId,
                 (int)pickEvent->result,
                 pickEvent->path);
+            break;
+        }
+        case (XrStructureType)XR_TYPE_EVENT_DATA_MCP_TOOL_CALL_EXT: {
+            // An agent invoked one of our XR_EXT_mcp_tools tools (#457). Fetch
+            // the JSON args (two-call idiom; argsSize is the required
+            // capacity), act on app state — we're on the main loop, so no
+            // locking — and answer. An unanswered call fails to the agent
+            // after ~5 s. Only apps that registered tools in their
+            // CreateSession ever receive this event.
+            auto* call = (XrEventDataMCPToolCallEXT*)&event;
+            char args[512] = {0};
+            uint32_t needed = 0;
+            if (xr.pfnGetMCPToolCallArgsEXT != nullptr) {
+                xr.pfnGetMCPToolCallArgsEXT(xr.session, call->callId, sizeof(args), &needed, args);
+            }
+            char result[256];
+            XrBool32 ok = XR_TRUE;
+            if (strcmp(call->toolName, "set_spin") == 0) {
+                // Test apps stay dependency-free: hand-scan the one expected
+                // numeric key instead of pulling in a JSON parser.
+                const char* key = strstr(args, "\"speed_rad_per_sec\"");
+                const char* colon = key != nullptr ? strchr(key, ':') : nullptr;
+                if (colon != nullptr) {
+                    float speed = strtof(colon + 1, nullptr);
+                    if (speed < 0.f) speed = 0.f;
+                    if (speed > 10.f) speed = 10.f;
+                    xr.spinSpeed = speed;
+                    snprintf(result, sizeof(result), "{\"spin_speed_rad_per_sec\":%.3f}", xr.spinSpeed);
+                } else {
+                    ok = XR_FALSE;
+                    snprintf(result, sizeof(result), "{\"error\":\"missing speed_rad_per_sec\"}");
+                }
+            } else if (strcmp(call->toolName, "get_status") == 0) {
+                snprintf(result, sizeof(result),
+                    "{\"spin_speed_rad_per_sec\":%.3f,\"session_running\":%s,"
+                    "\"rendering_mode_index\":%u}",
+                    xr.spinSpeed, xr.sessionRunning ? "true" : "false", xr.currentModeIndex);
+            } else {
+                ok = XR_FALSE;
+                snprintf(result, sizeof(result), "{\"error\":\"unhandled tool\"}");
+            }
+            if (xr.pfnSubmitMCPToolResultEXT != nullptr) {
+                xr.pfnSubmitMCPToolResultEXT(xr.session, call->callId, ok, result);
+            }
             break;
         }
         default:

--- a/test_apps/common/xr_session_common.h
+++ b/test_apps/common/xr_session_common.h
@@ -29,6 +29,7 @@
 #include <openxr/XR_EXT_display_info.h>
 #include <openxr/XR_EXT_workspace_file_dialog.h>
 #include <openxr/XR_EXT_atlas_capture.h>
+#include <openxr/XR_EXT_mcp_tools.h>
 #include <DirectXMath.h>
 #include <vector>
 #include <string>
@@ -92,6 +93,22 @@ struct XrSessionManager {
     // so the app drops its per-API CaptureAtlasRegion* glue for one call.
     bool hasAtlasCaptureExt = false;
     PFN_xrCaptureAtlasEXT pfnCaptureAtlasEXT = nullptr;
+
+    // XR_EXT_mcp_tools (#457): reference adoption — the app registers its own
+    // agent tools (set_spin/get_status). Each app's xr_session.cpp detects the
+    // extension, resolves these PFNs after xrCreateSession, and declares its
+    // per-app appId (matching the manifest `id`, INV-10.1); the shared
+    // PollEvents answers XrEventDataMCPToolCallEXT. Inert when the extension /
+    // MCP capability is absent.
+    bool hasMcpToolsExt = false;
+    PFN_xrSetMCPAppInfoEXT pfnSetMCPAppInfoEXT = nullptr;
+    PFN_xrRegisterMCPToolEXT pfnRegisterMCPToolEXT = nullptr;
+    PFN_xrGetMCPToolCallArgsEXT pfnGetMCPToolCallArgsEXT = nullptr;
+    PFN_xrSubmitMCPToolResultEXT pfnSubmitMCPToolResultEXT = nullptr;
+
+    //! Cube spin speed in rad/s — historically hardcoded 0.5; now agent-settable
+    //! via the set_spin MCP tool. Apps pass it to their renderer's UpdateScene.
+    float spinSpeed = 0.5f;
 
     // Display info from XR_EXT_display_info (static display properties)
     float recommendedViewScaleX = 1.0f;

--- a/test_apps/cube_handle_d3d11_win/displayxr/cube_handle_d3d11_win.displayxr.json
+++ b/test_apps/cube_handle_d3d11_win/displayxr/cube_handle_d3d11_win.displayxr.json
@@ -1,10 +1,11 @@
 {
   "schema_version": 1,
   "name": "Cube D3D11 (Handle)",
+  "id": "cube-d3d11",
   "type": "3d",
   "category": "test",
   "display_mode": "auto",
-  "description": "Reference spinning cube demonstrating XR_EXT_win32_window_binding on Direct3D 11.",
+  "description": "Reference spinning cube demonstrating XR_EXT_win32_window_binding on Direct3D 11; XR_EXT_mcp_tools adopter (agent tools: set_spin, get_status).",
   "icon": "icon.png",
   "icon_3d": "icon_sbs.png",
   "icon_3d_layout": "sbs-lr"

--- a/test_apps/cube_handle_d3d11_win/main.cpp
+++ b/test_apps/cube_handle_d3d11_win/main.cpp
@@ -392,8 +392,8 @@ static void RenderOneFrame(RenderState& rs) {
         }
     }
 
-    // Update scene (cube rotation)
-    UpdateScene(renderer, rs.perfStats->deltaTime);
+    // Update scene (cube rotation) — speed agent-settable via cube-d3d11__set_spin (#457)
+    UpdateScene(renderer, rs.perfStats->deltaTime, xr.spinSpeed);
 
     // Poll OpenXR events
     PollEvents(xr);

--- a/test_apps/cube_handle_d3d11_win/xr_session.cpp
+++ b/test_apps/cube_handle_d3d11_win/xr_session.cpp
@@ -87,6 +87,9 @@ bool InitializeOpenXR(XrSessionManager& xr) {
         if (strcmp(ext.extensionName, XR_EXT_ATLAS_CAPTURE_EXTENSION_NAME) == 0) {
             xr.hasAtlasCaptureExt = true;
         }
+        if (strcmp(ext.extensionName, XR_EXT_MCP_TOOLS_EXTENSION_NAME) == 0) {
+            xr.hasMcpToolsExt = true;
+        }
     }
 
     LOG_INFO("XR_KHR_D3D11_enable: %s", hasD3D11 ? "AVAILABLE" : "NOT FOUND");
@@ -94,6 +97,7 @@ bool InitializeOpenXR(XrSessionManager& xr) {
     LOG_INFO("XR_EXT_display_info: %s", xr.hasDisplayInfoExt ? "AVAILABLE" : "NOT FOUND");
     LOG_INFO("XR_EXT_workspace_file_dialog: %s", xr.hasFileDialogExt ? "AVAILABLE" : "NOT FOUND");
     LOG_INFO("XR_EXT_atlas_capture: %s", xr.hasAtlasCaptureExt ? "AVAILABLE" : "NOT FOUND");
+    LOG_INFO("XR_EXT_mcp_tools: %s", xr.hasMcpToolsExt ? "AVAILABLE" : "NOT FOUND");
 
     if (!hasD3D11) {
         LOG_ERROR("XR_KHR_D3D11_enable extension not available - cannot continue");
@@ -119,6 +123,9 @@ bool InitializeOpenXR(XrSessionManager& xr) {
     }
     if (xr.hasAtlasCaptureExt) {
         enabledExtensions.push_back(XR_EXT_ATLAS_CAPTURE_EXTENSION_NAME);
+    }
+    if (xr.hasMcpToolsExt) {
+        enabledExtensions.push_back(XR_EXT_MCP_TOOLS_EXTENSION_NAME);
     }
 
     LOG_INFO("Enabling %zu extensions", enabledExtensions.size());
@@ -295,6 +302,48 @@ bool CreateSession(XrSessionManager& xr, ID3D11Device* d3d11Device, HWND hwnd) {
     LOG_INFO("Calling xrCreateSession...");
     XR_CHECK_LOG(xrCreateSession(xr.instance, &sessionInfo, &xr.session));
     LOG_INFO("Session created: 0x%p", (void*)xr.session);
+
+    // XR_EXT_mcp_tools (#457): declare identity + register agent tools. The
+    // appId MUST match `id` in displayxr/cube_handle_d3d11_win.displayxr.json
+    // (INV-10.1). Failure is non-fatal by design — the MCP capability gate
+    // may simply be off on this machine.
+    if (xr.hasMcpToolsExt) {
+        xrGetInstanceProcAddr(xr.instance, "xrSetMCPAppInfoEXT",
+            (PFN_xrVoidFunction*)&xr.pfnSetMCPAppInfoEXT);
+        xrGetInstanceProcAddr(xr.instance, "xrRegisterMCPToolEXT",
+            (PFN_xrVoidFunction*)&xr.pfnRegisterMCPToolEXT);
+        xrGetInstanceProcAddr(xr.instance, "xrGetMCPToolCallArgsEXT",
+            (PFN_xrVoidFunction*)&xr.pfnGetMCPToolCallArgsEXT);
+        xrGetInstanceProcAddr(xr.instance, "xrSubmitMCPToolResultEXT",
+            (PFN_xrVoidFunction*)&xr.pfnSubmitMCPToolResultEXT);
+        if (xr.pfnSetMCPAppInfoEXT && xr.pfnRegisterMCPToolEXT && xr.pfnSubmitMCPToolResultEXT) {
+            XrMCPAppInfoEXT mcpAppInfo = {XR_TYPE_MCP_APP_INFO_EXT};
+            strncpy(mcpAppInfo.appId, "cube-d3d11", sizeof(mcpAppInfo.appId) - 1);
+            XrResult ar = xr.pfnSetMCPAppInfoEXT(xr.session, &mcpAppInfo);
+
+            XrMCPToolInfoEXT setSpin = {XR_TYPE_MCP_TOOL_INFO_EXT};
+            setSpin.name = "set_spin";
+            setSpin.description =
+                "Set the cube's spin speed. Takes effect immediately; the change is "
+                "visually verifiable via capture_frame. Returns the applied speed.";
+            setSpin.inputSchemaJson =
+                "{\"type\":\"object\",\"properties\":{\"speed_rad_per_sec\":{\"type\":\"number\","
+                "\"minimum\":0,\"maximum\":10,\"description\":\"Spin speed in radians/second; "
+                "0 freezes the cube. Default at launch is 0.5.\"}},"
+                "\"required\":[\"speed_rad_per_sec\"]}";
+            XrResult tr1 = xr.pfnRegisterMCPToolEXT(xr.session, &setSpin);
+
+            XrMCPToolInfoEXT getStatus = {XR_TYPE_MCP_TOOL_INFO_EXT};
+            getStatus.name = "get_status";
+            getStatus.description =
+                "Read the cube app's live state: spin speed (rad/s), whether the XR "
+                "session is running, and the active rendering-mode index.";
+            getStatus.inputSchemaJson = "{\"type\":\"object\"}";
+            XrResult tr2 = xr.pfnRegisterMCPToolEXT(xr.session, &getStatus);
+
+            LOG_INFO("XR_EXT_mcp_tools: appId=%d set_spin=%d get_status=%d", ar, tr1, tr2);
+        }
+    }
 
     // Enumerate available rendering modes and store names
     if (xr.pfnEnumerateDisplayRenderingModesEXT && xr.session != XR_NULL_HANDLE) {

--- a/test_apps/cube_handle_d3d12_win/d3d12_renderer.cpp
+++ b/test_apps/cube_handle_d3d12_win/d3d12_renderer.cpp
@@ -817,8 +817,9 @@ bool CreateSwapchainRTVs(D3D12Renderer& renderer,
     return true;
 }
 
-void UpdateScene(D3D12Renderer& renderer, float deltaTime) {
-    renderer.cubeRotation += deltaTime * 0.5f;
+void UpdateScene(D3D12Renderer& renderer, float deltaTime, float spinSpeed) {
+    // spinSpeed is agent-settable via cube-d3d12__set_spin (#457)
+    renderer.cubeRotation += deltaTime * spinSpeed;
     if (renderer.cubeRotation > XM_2PI) {
         renderer.cubeRotation -= XM_2PI;
     }

--- a/test_apps/cube_handle_d3d12_win/d3d12_renderer.h
+++ b/test_apps/cube_handle_d3d12_win/d3d12_renderer.h
@@ -89,8 +89,9 @@ bool CreateSwapchainRTVs(D3D12Renderer& renderer,
     uint32_t width, uint32_t height,
     DXGI_FORMAT format);
 
-// Update scene state
-void UpdateScene(D3D12Renderer& renderer, float deltaTime);
+// Update scene state. spinSpeed (rad/s) is agent-settable via the
+// set_spin MCP tool (#457).
+void UpdateScene(D3D12Renderer& renderer, float deltaTime, float spinSpeed = 0.5f);
 
 // Render the scene to a swapchain image
 void RenderScene(

--- a/test_apps/cube_handle_d3d12_win/displayxr/cube_handle_d3d12_win.displayxr.json
+++ b/test_apps/cube_handle_d3d12_win/displayxr/cube_handle_d3d12_win.displayxr.json
@@ -1,10 +1,11 @@
 {
   "schema_version": 1,
   "name": "Cube D3D12 (Handle)",
+  "id": "cube-d3d12",
   "type": "3d",
   "category": "test",
   "display_mode": "auto",
-  "description": "Reference spinning cube demonstrating XR_EXT_win32_window_binding on Direct3D 12.",
+  "description": "Reference spinning cube demonstrating XR_EXT_win32_window_binding on Direct3D 12; XR_EXT_mcp_tools adopter (agent tools: set_spin, get_status).",
   "icon": "icon.png",
   "icon_3d": "icon_sbs.png",
   "icon_3d_layout": "sbs-lr"

--- a/test_apps/cube_handle_d3d12_win/main.cpp
+++ b/test_apps/cube_handle_d3d12_win/main.cpp
@@ -310,7 +310,8 @@ static void RenderThreadFunc(
             }
         }
 
-        UpdateScene(*renderer, perfStats.deltaTime);
+        // Cube spin speed is agent-settable via cube-d3d12__set_spin (#457)
+        UpdateScene(*renderer, perfStats.deltaTime, xr->spinSpeed);
         PollEvents(*xr);
 
         if (xr->sessionRunning) {

--- a/test_apps/cube_handle_d3d12_win/xr_session.cpp
+++ b/test_apps/cube_handle_d3d12_win/xr_session.cpp
@@ -81,11 +81,15 @@ bool InitializeOpenXR(XrSessionManager& xr) {
         if (strcmp(ext.extensionName, XR_EXT_ATLAS_CAPTURE_EXTENSION_NAME) == 0) {
             xr.hasAtlasCaptureExt = true;
         }
+        if (strcmp(ext.extensionName, XR_EXT_MCP_TOOLS_EXTENSION_NAME) == 0) {
+            xr.hasMcpToolsExt = true;
+        }
     }
 
     LOG_INFO("XR_KHR_D3D12_enable: %s", hasD3D12 ? "AVAILABLE" : "NOT FOUND");
     LOG_INFO("XR_EXT_win32_window_binding: %s", xr.hasWin32WindowBindingExt ? "AVAILABLE" : "NOT FOUND");
     LOG_INFO("XR_EXT_display_info: %s", xr.hasDisplayInfoExt ? "AVAILABLE" : "NOT FOUND");
+    LOG_INFO("XR_EXT_mcp_tools: %s", xr.hasMcpToolsExt ? "AVAILABLE" : "NOT FOUND");
 
     if (!hasD3D12) {
         LOG_ERROR("XR_KHR_D3D12_enable extension not available - cannot continue");
@@ -102,6 +106,9 @@ bool InitializeOpenXR(XrSessionManager& xr) {
     }
     if (xr.hasAtlasCaptureExt) {
         enabledExtensions.push_back(XR_EXT_ATLAS_CAPTURE_EXTENSION_NAME);
+    }
+    if (xr.hasMcpToolsExt) {
+        enabledExtensions.push_back(XR_EXT_MCP_TOOLS_EXTENSION_NAME);
     }
 
     LOG_INFO("Enabling %zu extensions", enabledExtensions.size());
@@ -255,6 +262,48 @@ bool CreateSession(XrSessionManager& xr, ID3D12Device* device, ID3D12CommandQueu
     LOG_INFO("Calling xrCreateSession...");
     XR_CHECK_LOG(xrCreateSession(xr.instance, &sessionInfo, &xr.session));
     LOG_INFO("Session created: 0x%p", (void*)xr.session);
+
+    // XR_EXT_mcp_tools (#457): declare identity + register agent tools. The
+    // appId MUST match `id` in displayxr/cube_handle_d3d12_win.displayxr.json
+    // (INV-10.1). Failure is non-fatal by design — the MCP capability gate
+    // may simply be off on this machine.
+    if (xr.hasMcpToolsExt) {
+        xrGetInstanceProcAddr(xr.instance, "xrSetMCPAppInfoEXT",
+            (PFN_xrVoidFunction*)&xr.pfnSetMCPAppInfoEXT);
+        xrGetInstanceProcAddr(xr.instance, "xrRegisterMCPToolEXT",
+            (PFN_xrVoidFunction*)&xr.pfnRegisterMCPToolEXT);
+        xrGetInstanceProcAddr(xr.instance, "xrGetMCPToolCallArgsEXT",
+            (PFN_xrVoidFunction*)&xr.pfnGetMCPToolCallArgsEXT);
+        xrGetInstanceProcAddr(xr.instance, "xrSubmitMCPToolResultEXT",
+            (PFN_xrVoidFunction*)&xr.pfnSubmitMCPToolResultEXT);
+        if (xr.pfnSetMCPAppInfoEXT && xr.pfnRegisterMCPToolEXT && xr.pfnSubmitMCPToolResultEXT) {
+            XrMCPAppInfoEXT mcpAppInfo = {XR_TYPE_MCP_APP_INFO_EXT};
+            strncpy(mcpAppInfo.appId, "cube-d3d12", sizeof(mcpAppInfo.appId) - 1);
+            XrResult ar = xr.pfnSetMCPAppInfoEXT(xr.session, &mcpAppInfo);
+
+            XrMCPToolInfoEXT setSpin = {XR_TYPE_MCP_TOOL_INFO_EXT};
+            setSpin.name = "set_spin";
+            setSpin.description =
+                "Set the cube's spin speed. Takes effect immediately; the change is "
+                "visually verifiable via capture_frame. Returns the applied speed.";
+            setSpin.inputSchemaJson =
+                "{\"type\":\"object\",\"properties\":{\"speed_rad_per_sec\":{\"type\":\"number\","
+                "\"minimum\":0,\"maximum\":10,\"description\":\"Spin speed in radians/second; "
+                "0 freezes the cube. Default at launch is 0.5.\"}},"
+                "\"required\":[\"speed_rad_per_sec\"]}";
+            XrResult tr1 = xr.pfnRegisterMCPToolEXT(xr.session, &setSpin);
+
+            XrMCPToolInfoEXT getStatus = {XR_TYPE_MCP_TOOL_INFO_EXT};
+            getStatus.name = "get_status";
+            getStatus.description =
+                "Read the cube app's live state: spin speed (rad/s), whether the XR "
+                "session is running, and the active rendering-mode index.";
+            getStatus.inputSchemaJson = "{\"type\":\"object\"}";
+            XrResult tr2 = xr.pfnRegisterMCPToolEXT(xr.session, &getStatus);
+
+            LOG_INFO("XR_EXT_mcp_tools: appId=%d set_spin=%d get_status=%d", ar, tr1, tr2);
+        }
+    }
 
     // Enumerate available rendering modes and store names
     if (xr.pfnEnumerateDisplayRenderingModesEXT && xr.session != XR_NULL_HANDLE) {

--- a/test_apps/cube_handle_gl_win/displayxr/cube_handle_gl_win.displayxr.json
+++ b/test_apps/cube_handle_gl_win/displayxr/cube_handle_gl_win.displayxr.json
@@ -1,10 +1,11 @@
 {
   "schema_version": 1,
   "name": "Cube OpenGL (Handle)",
+  "id": "cube-gl",
   "type": "3d",
   "category": "test",
   "display_mode": "auto",
-  "description": "Reference spinning cube demonstrating XR_EXT_win32_window_binding on OpenGL.",
+  "description": "Reference spinning cube demonstrating XR_EXT_win32_window_binding on OpenGL; XR_EXT_mcp_tools adopter (agent tools: set_spin, get_status).",
   "icon": "icon.png",
   "icon_3d": "icon_sbs.png",
   "icon_3d_layout": "sbs-lr"

--- a/test_apps/cube_handle_gl_win/gl_renderer.cpp
+++ b/test_apps/cube_handle_gl_win/gl_renderer.cpp
@@ -318,8 +318,9 @@ bool CreateSwapchainFBOs(GLRenderer& renderer,
     return true;
 }
 
-void UpdateScene(GLRenderer& renderer, float deltaTime) {
-    renderer.cubeRotation += deltaTime * 0.5f;
+void UpdateScene(GLRenderer& renderer, float deltaTime, float spinSpeed) {
+    // spinSpeed is agent-settable via cube-gl__set_spin (#457)
+    renderer.cubeRotation += deltaTime * spinSpeed;
     if (renderer.cubeRotation > XM_2PI) {
         renderer.cubeRotation -= XM_2PI;
     }

--- a/test_apps/cube_handle_gl_win/gl_renderer.h
+++ b/test_apps/cube_handle_gl_win/gl_renderer.h
@@ -47,8 +47,9 @@ bool CreateSwapchainFBOs(GLRenderer& renderer,
     const GLuint* images, uint32_t count,
     uint32_t width, uint32_t height);
 
-// Update scene
-void UpdateScene(GLRenderer& renderer, float deltaTime);
+// Update scene. spinSpeed (rad/s) is agent-settable via the set_spin
+// MCP tool (#457).
+void UpdateScene(GLRenderer& renderer, float deltaTime, float spinSpeed = 0.5f);
 
 // Render to a specific FBO with viewport offset (SBS layout)
 void RenderScene(

--- a/test_apps/cube_handle_gl_win/main.cpp
+++ b/test_apps/cube_handle_gl_win/main.cpp
@@ -379,7 +379,8 @@ static void RenderThreadFunc(
             }
         }
 
-        UpdateScene(*renderer, perfStats.deltaTime);
+        // Cube spin speed is agent-settable via cube-gl__set_spin (#457)
+        UpdateScene(*renderer, perfStats.deltaTime, xr->spinSpeed);
         PollEvents(*xr);
 
         if (xr->sessionRunning) {

--- a/test_apps/cube_handle_gl_win/xr_session.cpp
+++ b/test_apps/cube_handle_gl_win/xr_session.cpp
@@ -84,11 +84,15 @@ bool InitializeOpenXR(XrSessionManager& xr) {
         if (strcmp(ext.extensionName, XR_EXT_ATLAS_CAPTURE_EXTENSION_NAME) == 0) {
             xr.hasAtlasCaptureExt = true;
         }
+        if (strcmp(ext.extensionName, XR_EXT_MCP_TOOLS_EXTENSION_NAME) == 0) {
+            xr.hasMcpToolsExt = true;
+        }
     }
 
     LOG_INFO("XR_KHR_opengl_enable: %s", hasOpenGL ? "AVAILABLE" : "NOT FOUND");
     LOG_INFO("XR_EXT_win32_window_binding: %s", xr.hasWin32WindowBindingExt ? "AVAILABLE" : "NOT FOUND");
     LOG_INFO("XR_EXT_display_info: %s", xr.hasDisplayInfoExt ? "AVAILABLE" : "NOT FOUND");
+    LOG_INFO("XR_EXT_mcp_tools: %s", xr.hasMcpToolsExt ? "AVAILABLE" : "NOT FOUND");
 
     if (!hasOpenGL) {
         LOG_ERROR("XR_KHR_opengl_enable extension not available");
@@ -105,6 +109,9 @@ bool InitializeOpenXR(XrSessionManager& xr) {
     }
     if (xr.hasAtlasCaptureExt) {
         enabledExtensions.push_back(XR_EXT_ATLAS_CAPTURE_EXTENSION_NAME);
+    }
+    if (xr.hasMcpToolsExt) {
+        enabledExtensions.push_back(XR_EXT_MCP_TOOLS_EXTENSION_NAME);
     }
 
     XrInstanceCreateInfo createInfo = {XR_TYPE_INSTANCE_CREATE_INFO};
@@ -232,6 +239,48 @@ bool CreateSession(XrSessionManager& xr, HDC hDC, HGLRC hGLRC, HWND hwnd) {
 
     XR_CHECK_LOG(xrCreateSession(xr.instance, &sessionInfo, &xr.session));
     LOG_INFO("Session created: 0x%p", (void*)xr.session);
+
+    // XR_EXT_mcp_tools (#457): declare identity + register agent tools. The
+    // appId MUST match `id` in displayxr/cube_handle_gl_win.displayxr.json
+    // (INV-10.1). Failure is non-fatal by design — the MCP capability gate
+    // may simply be off on this machine.
+    if (xr.hasMcpToolsExt) {
+        xrGetInstanceProcAddr(xr.instance, "xrSetMCPAppInfoEXT",
+            (PFN_xrVoidFunction*)&xr.pfnSetMCPAppInfoEXT);
+        xrGetInstanceProcAddr(xr.instance, "xrRegisterMCPToolEXT",
+            (PFN_xrVoidFunction*)&xr.pfnRegisterMCPToolEXT);
+        xrGetInstanceProcAddr(xr.instance, "xrGetMCPToolCallArgsEXT",
+            (PFN_xrVoidFunction*)&xr.pfnGetMCPToolCallArgsEXT);
+        xrGetInstanceProcAddr(xr.instance, "xrSubmitMCPToolResultEXT",
+            (PFN_xrVoidFunction*)&xr.pfnSubmitMCPToolResultEXT);
+        if (xr.pfnSetMCPAppInfoEXT && xr.pfnRegisterMCPToolEXT && xr.pfnSubmitMCPToolResultEXT) {
+            XrMCPAppInfoEXT mcpAppInfo = {XR_TYPE_MCP_APP_INFO_EXT};
+            strncpy(mcpAppInfo.appId, "cube-gl", sizeof(mcpAppInfo.appId) - 1);
+            XrResult ar = xr.pfnSetMCPAppInfoEXT(xr.session, &mcpAppInfo);
+
+            XrMCPToolInfoEXT setSpin = {XR_TYPE_MCP_TOOL_INFO_EXT};
+            setSpin.name = "set_spin";
+            setSpin.description =
+                "Set the cube's spin speed. Takes effect immediately; the change is "
+                "visually verifiable via capture_frame. Returns the applied speed.";
+            setSpin.inputSchemaJson =
+                "{\"type\":\"object\",\"properties\":{\"speed_rad_per_sec\":{\"type\":\"number\","
+                "\"minimum\":0,\"maximum\":10,\"description\":\"Spin speed in radians/second; "
+                "0 freezes the cube. Default at launch is 0.5.\"}},"
+                "\"required\":[\"speed_rad_per_sec\"]}";
+            XrResult tr1 = xr.pfnRegisterMCPToolEXT(xr.session, &setSpin);
+
+            XrMCPToolInfoEXT getStatus = {XR_TYPE_MCP_TOOL_INFO_EXT};
+            getStatus.name = "get_status";
+            getStatus.description =
+                "Read the cube app's live state: spin speed (rad/s), whether the XR "
+                "session is running, and the active rendering-mode index.";
+            getStatus.inputSchemaJson = "{\"type\":\"object\"}";
+            XrResult tr2 = xr.pfnRegisterMCPToolEXT(xr.session, &getStatus);
+
+            LOG_INFO("XR_EXT_mcp_tools: appId=%d set_spin=%d get_status=%d", ar, tr1, tr2);
+        }
+    }
 
     // Enumerate available rendering modes and store names
     if (xr.pfnEnumerateDisplayRenderingModesEXT && xr.session != XR_NULL_HANDLE) {

--- a/test_apps/cube_handle_vk_win/displayxr/cube_handle_vk_win.displayxr.json
+++ b/test_apps/cube_handle_vk_win/displayxr/cube_handle_vk_win.displayxr.json
@@ -1,10 +1,11 @@
 {
   "schema_version": 1,
   "name": "Cube Vulkan (Handle)",
+  "id": "cube-vk",
   "type": "3d",
   "category": "test",
   "display_mode": "auto",
-  "description": "Reference spinning cube demonstrating XR_EXT_win32_window_binding on Vulkan.",
+  "description": "Reference spinning cube demonstrating XR_EXT_win32_window_binding on Vulkan; XR_EXT_mcp_tools adopter (agent tools: set_spin, get_status).",
   "icon": "icon.png",
   "icon_3d": "icon_sbs.png",
   "icon_3d_layout": "sbs-lr"

--- a/test_apps/cube_handle_vk_win/main.cpp
+++ b/test_apps/cube_handle_vk_win/main.cpp
@@ -314,7 +314,8 @@ static void RenderThreadFunc(
             }
         }
 
-        UpdateScene(*renderer, perfStats.deltaTime);
+        // Cube spin speed is agent-settable via cube-vk__set_spin (#457)
+        UpdateScene(*renderer, perfStats.deltaTime, xr->spinSpeed);
         PollEvents(*xr);
 
         if (xr->sessionRunning) {

--- a/test_apps/cube_handle_vk_win/vk_renderer.cpp
+++ b/test_apps/cube_handle_vk_win/vk_renderer.cpp
@@ -1218,8 +1218,9 @@ bool CreateSwapchainFramebuffers(VkRenderer& renderer, int eye,
     return true;
 }
 
-void UpdateScene(VkRenderer& renderer, float deltaTime) {
-    renderer.cubeRotation += deltaTime * 0.5f;
+void UpdateScene(VkRenderer& renderer, float deltaTime, float spinSpeed) {
+    // spinSpeed is agent-settable via cube-vk__set_spin (#457)
+    renderer.cubeRotation += deltaTime * spinSpeed;
     if (renderer.cubeRotation > XM_2PI) {
         renderer.cubeRotation -= XM_2PI;
     }

--- a/test_apps/cube_handle_vk_win/vk_renderer.h
+++ b/test_apps/cube_handle_vk_win/vk_renderer.h
@@ -89,8 +89,9 @@ bool CreateSwapchainFramebuffers(VkRenderer& renderer, int eye,
     const VkImage* images, uint32_t count,
     uint32_t width, uint32_t height, VkFormat colorFormat);
 
-// Update scene
-void UpdateScene(VkRenderer& renderer, float deltaTime);
+// Update scene. spinSpeed (rad/s) is agent-settable via the set_spin
+// MCP tool (#457).
+void UpdateScene(VkRenderer& renderer, float deltaTime, float spinSpeed = 0.5f);
 
 // Per-eye render parameters for single-pass SBS rendering
 struct EyeRenderParams {

--- a/test_apps/cube_handle_vk_win/xr_session.cpp
+++ b/test_apps/cube_handle_vk_win/xr_session.cpp
@@ -53,11 +53,15 @@ bool InitializeOpenXR(XrSessionManager& xr) {
         if (strcmp(ext.extensionName, XR_EXT_ATLAS_CAPTURE_EXTENSION_NAME) == 0) {
             xr.hasAtlasCaptureExt = true;
         }
+        if (strcmp(ext.extensionName, XR_EXT_MCP_TOOLS_EXTENSION_NAME) == 0) {
+            xr.hasMcpToolsExt = true;
+        }
     }
 
     LOG_INFO("XR_KHR_vulkan_enable: %s", hasVulkan ? "AVAILABLE" : "NOT FOUND");
     LOG_INFO("XR_EXT_win32_window_binding: %s", xr.hasWin32WindowBindingExt ? "AVAILABLE" : "NOT FOUND");
     LOG_INFO("XR_EXT_display_info: %s", xr.hasDisplayInfoExt ? "AVAILABLE" : "NOT FOUND");
+    LOG_INFO("XR_EXT_mcp_tools: %s", xr.hasMcpToolsExt ? "AVAILABLE" : "NOT FOUND");
 
     if (!hasVulkan) {
         LOG_ERROR("XR_KHR_vulkan_enable extension not available");
@@ -74,6 +78,9 @@ bool InitializeOpenXR(XrSessionManager& xr) {
     }
     if (xr.hasAtlasCaptureExt) {
         enabledExtensions.push_back(XR_EXT_ATLAS_CAPTURE_EXTENSION_NAME);
+    }
+    if (xr.hasMcpToolsExt) {
+        enabledExtensions.push_back(XR_EXT_MCP_TOOLS_EXTENSION_NAME);
     }
 
     XrInstanceCreateInfo createInfo = {XR_TYPE_INSTANCE_CREATE_INFO};
@@ -440,6 +447,48 @@ bool CreateSession(XrSessionManager& xr, VkInstance vkInstance, VkPhysicalDevice
 
     XR_CHECK_LOG(xrCreateSession(xr.instance, &sessionInfo, &xr.session));
     LOG_INFO("Session created: 0x%p", (void*)xr.session);
+
+    // XR_EXT_mcp_tools (#457): declare identity + register agent tools. The
+    // appId MUST match `id` in displayxr/cube_handle_vk_win.displayxr.json
+    // (INV-10.1). Failure is non-fatal by design — the MCP capability gate
+    // may simply be off on this machine.
+    if (xr.hasMcpToolsExt) {
+        xrGetInstanceProcAddr(xr.instance, "xrSetMCPAppInfoEXT",
+            (PFN_xrVoidFunction*)&xr.pfnSetMCPAppInfoEXT);
+        xrGetInstanceProcAddr(xr.instance, "xrRegisterMCPToolEXT",
+            (PFN_xrVoidFunction*)&xr.pfnRegisterMCPToolEXT);
+        xrGetInstanceProcAddr(xr.instance, "xrGetMCPToolCallArgsEXT",
+            (PFN_xrVoidFunction*)&xr.pfnGetMCPToolCallArgsEXT);
+        xrGetInstanceProcAddr(xr.instance, "xrSubmitMCPToolResultEXT",
+            (PFN_xrVoidFunction*)&xr.pfnSubmitMCPToolResultEXT);
+        if (xr.pfnSetMCPAppInfoEXT && xr.pfnRegisterMCPToolEXT && xr.pfnSubmitMCPToolResultEXT) {
+            XrMCPAppInfoEXT mcpAppInfo = {XR_TYPE_MCP_APP_INFO_EXT};
+            strncpy(mcpAppInfo.appId, "cube-vk", sizeof(mcpAppInfo.appId) - 1);
+            XrResult ar = xr.pfnSetMCPAppInfoEXT(xr.session, &mcpAppInfo);
+
+            XrMCPToolInfoEXT setSpin = {XR_TYPE_MCP_TOOL_INFO_EXT};
+            setSpin.name = "set_spin";
+            setSpin.description =
+                "Set the cube's spin speed. Takes effect immediately; the change is "
+                "visually verifiable via capture_frame. Returns the applied speed.";
+            setSpin.inputSchemaJson =
+                "{\"type\":\"object\",\"properties\":{\"speed_rad_per_sec\":{\"type\":\"number\","
+                "\"minimum\":0,\"maximum\":10,\"description\":\"Spin speed in radians/second; "
+                "0 freezes the cube. Default at launch is 0.5.\"}},"
+                "\"required\":[\"speed_rad_per_sec\"]}";
+            XrResult tr1 = xr.pfnRegisterMCPToolEXT(xr.session, &setSpin);
+
+            XrMCPToolInfoEXT getStatus = {XR_TYPE_MCP_TOOL_INFO_EXT};
+            getStatus.name = "get_status";
+            getStatus.description =
+                "Read the cube app's live state: spin speed (rad/s), whether the XR "
+                "session is running, and the active rendering-mode index.";
+            getStatus.inputSchemaJson = "{\"type\":\"object\"}";
+            XrResult tr2 = xr.pfnRegisterMCPToolEXT(xr.session, &getStatus);
+
+            LOG_INFO("XR_EXT_mcp_tools: appId=%d set_spin=%d get_status=%d", ar, tr1, tr2);
+        }
+    }
 
     // Enumerate available rendering modes and store names
     if (xr.pfnEnumerateDisplayRenderingModesEXT && xr.session != XR_NULL_HANDLE) {


### PR DESCRIPTION
Closes #457. P2c of the per-app MCP tools rollout (docs/roadmap/per-app-mcp-tools.md): propagate the metal-cube reference adoption (#447, PR #448) to the Windows cube test-app fleet.

## What changed

The Windows cubes share an event pump (`test_apps/common/xr_session_common.cpp`), unlike the metal cube's monolithic `main.mm`, so the five template pieces land where they idiomatically belong:

**Shared (`test_apps/common/`)**
- `xr_session_common.h` — `#include <openxr/XR_EXT_mcp_tools.h>`; `XrSessionManager` gains `hasMcpToolsExt`, the four PFNs, and agent-settable `spinSpeed` (default 0.5, the historical hardcoded constant).
- `xr_session_common.cpp` — one `XR_TYPE_EVENT_DATA_MCP_TOOL_CALL_EXT` case in the shared `PollEvents`: two-call args fetch, dependency-free hand-parse of `speed_rad_per_sec` (strstr/strchr/strtof, clamped 0..10 — no JSON lib), and every call answered via `xrSubmitMCPToolResultEXT` (`success=XR_FALSE` + `{"error":...}` for bad args / unhandled tools). `get_status` reports `spin_speed_rad_per_sec`, `session_running`, `rendering_mode_index` (the same trio the apps already track via `xr.sessionRunning` / `xr.currentModeIndex`).
- `d3d11_renderer.{h,cpp}` — `UpdateScene` gains a `spinSpeed` param, defaulted to `0.5f` so the hosted/texture/legacy callers of the shared D3D11 renderer are untouched.

**Per app** (each: extension detect + enable in `xr_session.cpp::InitializeOpenXR`, PFN resolve + `xrSetMCPAppInfoEXT` + `set_spin`/`get_status` registration after `xrCreateSession` in `CreateSession`, manifest `id` + description, spin-speed plumb-through):

| App | appId | registration | spin update |
|---|---|---|---|
| `cube_handle_d3d11_win` | `cube-d3d11` | `xr_session.cpp` | `common/d3d11_renderer.cpp` `UpdateScene` ← `main.cpp` passes `xr.spinSpeed` |
| `cube_handle_d3d12_win` | `cube-d3d12` | `xr_session.cpp` | `d3d12_renderer.cpp` `UpdateScene` ← `main.cpp` passes `xr->spinSpeed` |
| `cube_handle_gl_win` | `cube-gl` | `xr_session.cpp` | `gl_renderer.cpp` `UpdateScene` ← `main.cpp` passes `xr->spinSpeed` |
| `cube_handle_vk_win` | `cube-vk` | `xr_session.cpp` | `vk_renderer.cpp` `UpdateScene` ← `main.cpp` passes `xr->spinSpeed` |

Tool descriptions/schemas are verbatim from the metal cube (they are agent-facing docs). appIds contain no underscores (`__` is the MCP namespace separator); bare tool names are exactly `set_spin` and `get_status`. The whole block is inert when the extension / MCP capability is absent — registration is gated on `hasMcpToolsExt` + resolved PFNs, and the runtime evaluates the capability gate per call, so the binaries behave identically on machines without the MCP Tools package.

## Lint

`python3 scripts/check_displayxr_app.py` on all four apps:

```
cube_handle_d3d11_win  OK — no issues
cube_handle_d3d12_win  OK — no issues
cube_handle_gl_win     OK — no issues
cube_handle_vk_win     0 error(s), 1 warning(s)  (INV-3.1 literal-2 eye loop — pre-exists on main, unrelated)
```

INV-10.1 (manifest `id` ↔ `xrSetMCPAppInfoEXT` appId pairing) engages and passes for all four.

## Validation

- CI compiles all four test apps on `test_apps/` changes — that is the merge gate for this PR.
- Live d3d11 tool-call transcript to be captured on a Leia machine (this branch was authored on macOS; no Windows build possible locally).
- VK live check blocked by #456 (NVIDIA + sim-display).

🤖 Generated with [Claude Code](https://claude.com/claude-code)