### PR TITLE
fix(mcp): unregister app tools from the framework registry before freeing slots

### DIFF
--- a/src/xrt/state_trackers/oxr/oxr_mcp_app_tools.c
+++ b/src/xrt/state_trackers/oxr/oxr_mcp_app_tools.c
@@ -278,9 +278,6 @@ oxr_mcp_app_tools_session_destroy(struct oxr_session *sess)
 		strncpy(names[name_count], t->name, sizeof(names[0]) - 1);
 		names[name_count][sizeof(names[0]) - 1] = '\0';
 		name_count++;
-		free(t->description);
-		free(t->schema);
-		memset(t, 0, sizeof(*t));
 	}
 	// Fail the session's pending calls; parked trampolines wake and
 	// return errors to their agents.
@@ -294,9 +291,25 @@ oxr_mcp_app_tools_session_destroy(struct oxr_session *sess)
 	pthread_cond_broadcast(&g_cond);
 	pthread_mutex_unlock(&g_lock);
 
+	// Drop the tools from the framework registry BEFORE freeing the slots:
+	// the registry stores &slot->tool, whose .name points into the slot, so
+	// the registry scan strcmp's it — zeroing the slot first reads NULL
+	// (#459).
 	for (size_t i = 0; i < name_count; i++) {
 		mcp_server_unregister_tool(names[i]);
 	}
+
+	pthread_mutex_lock(&g_lock);
+	for (size_t i = 0; i < MAX_APP_TOOLS; i++) {
+		struct app_tool *t = &g_tools[i];
+		if (!t->used || t->sess != sess) {
+			continue;
+		}
+		free(t->description);
+		free(t->schema);
+		memset(t, 0, sizeof(*t));
+	}
+	pthread_mutex_unlock(&g_lock);
 }
 
 /*
@@ -415,16 +428,24 @@ oxr_xrUnregisterMCPToolEXT(XrSession session, const char *name)
 		return oxr_error(&log, XR_ERROR_VALIDATION_FAILURE, "tool '%s' is not registered on this session",
 		                 name);
 	}
-	free(found->description);
-	free(found->schema);
-	memset(found, 0, sizeof(*found));
 	// In-flight calls on the tool: their slots survive (keyed by
 	// call_id, not tool pointer) and fail at timeout or session end —
 	// wake them now so they fail promptly.
 	pthread_cond_broadcast(&g_cond);
 	pthread_mutex_unlock(&g_lock);
 
+	// Drop the tool from the framework registry BEFORE freeing the slot:
+	// the registry stores &found->tool, whose .name points at found->name,
+	// so the registry scan strcmp's it — zeroing the slot first reads NULL
+	// (#459). `found` stays valid across the unlock: the slot is still
+	// marked used, so a concurrent register can't reuse it.
 	mcp_server_unregister_tool(name);
+
+	pthread_mutex_lock(&g_lock);
+	free(found->description);
+	free(found->schema);
+	memset(found, 0, sizeof(*found));
+	pthread_mutex_unlock(&g_lock);
 	return XR_SUCCESS;
 }
 


### PR DESCRIPTION
Closes #459.

## Bug
The framework registry (`mcp_server.c`) stores `&slot->tool`, whose `.name` points into the slot. Both unregister paths in `oxr_mcp_app_tools.c` freed/zeroed the slot **first** and only then called `mcp_server_unregister_tool()`, whose registry scan strcmp's the now-NULL name → `SIGSEGV`:

```
_platform_strcmp + 64
mcp_server_unregister_tool + 120
oxr_xrUnregisterMCPToolEXT + 720
```

Hit by the first real exerciser of `xrUnregisterMCPToolEXT` — the model viewer's late-registration adoption (displayxr-demo-modelviewer#22, animation tools unregistered when a clip-less model replaces an animated one). `oxr_mcp_app_tools_session_destroy` had the identical ordering bug, so **every clean session teardown with registered app tools crashed too** (unnoticed so far because the e2e harness kills the cube app before teardown).

## Fix
Drop the tool(s) from the framework registry first — outside `g_lock`, since `mcp_server_unregister_tool` takes the framework's own locks and broadcasts `tools/list_changed` — then free/zero the slots. Slots stay `used=true` across the unlock window, so a concurrent register can't reuse them.

## Verification
- ✅ `tests/mcp/test_app_tools.sh` → `PASS` (cube reference adopter, unchanged behavior)
- ✅ Live unregister round-trip via the model viewer (displayxr-demo-modelviewer#22 validation): register 3 animation tools → agent sees `tools/list_changed` → load clip-less model → `xrUnregisterMCPToolEXT` ×3 → tools disappear from `tools/list`, app keeps running (previously: instant segfault on the first unregister)
- ✅ Clean app shutdown with 4 tools registered (session-destroy path) — no crash report, `Application shutdown complete`

🤖 Generated with [Claude Code](https://claude.com/claude-code)