### PR TITLE
fix(#456): sim-display plug-in never wired its VK display processor on Windows

### DIFF
--- a/src/xrt/drivers/sim_display/sim_display_plugin.c
+++ b/src/xrt/drivers/sim_display/sim_display_plugin.c
@@ -21,6 +21,14 @@
  * @ingroup drv_sim_display
  */
 
+// xrt_config_have.h supplies the XRT_HAVE_* feature macros used by the
+// vtable gating below. Without it, `#if defined(XRT_HAVE_VULKAN)` was
+// silently false in this TU, so the Windows plug-in never wired
+// create_dp_vk (or the VK bit in probe_displays claims) even though the
+// VK display processor was compiled in — every VK app under sim-display
+// on Windows ran DP-less in permanent 2D (#456).
+#include "xrt/xrt_config_have.h"
+
 #include "xrt/xrt_plugin.h"
 #include "xrt/xrt_results.h"
 


### PR DESCRIPTION
## Root cause

`sim_display_plugin.c` gates `.create_dp_vk` (and the VK bit in `probe_displays` claims) on `#if defined(XRT_HAVE_VULKAN) || !defined(_WIN32)` — but the TU never included the generated `xrt/xrt_config_have.h`, so the macro was undefined and the gate has been **dead on Windows since the original plug-in extraction** (`ceec0f0c5`, Step 4a).

CMake *did* compile the VK display processor into the DLL (its gate is the CMake-level `XRT_HAVE_VULKAN`) — it was just unreachable: `fill_dp_factories_from_plugin` saw `create_dp_vk == NULL`, the VK native compositor logged `No VK display processor factory provided`, and every Vulkan app under sim-display on Windows silently ran DP-less in permanent 2D. This is what blocked the hardware-free VK validation path in #456.

## Fix

Include the config header so the existing preprocessor gates see the real feature set. One include + comment; no logic changes.

## Validation (Windows / RTX 3080, sim-display registered, leia-sr key removed)

- Before: `plugin loader: active plug-in: id=sim-display` at instance create, then `No VK display processor factory provided` → 1×1 2D, no weave.
- After: `Created sim display processor (all 6 pipelines)` + `VK display processor created via factory`; all 5 sim modes (2D / Anaglyph / Cropped SBS / Squeezed SBS / Quad) weave correctly — verified with post-compose atlas captures via the `%TEMP%\displayxr_atlas_trigger` rig.
- Leia regression smoke: leia-sr key restored, `cube_handle_vk_win` → leia VK DP created, 2-view weave + eye tracking valid, user-verified on the live panel.
- `ctest -C Release`: 25/25 pass.

## Note on the crash half of #456

The `nvoglv64.dll+0xd9f124` hard crash did **not** reproduce on this NVIDIA host — neither before the fix (DP-less path), after the fix (live sim VK DP), nor with a deliberately planted stray `vulkan-1.dll` in the Runtime dir. Since the reporting machine's build had the same dead gate, the crash happened *before any sim DP code could run* and is environmental to that machine. Diagnosis kit posted on #456.

Stacked PR with the #413 fix follows on top of this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)