### PR TITLE
fix(#413): generalize vk_native window-space layers beyond 2-view modes

### DIFF
--- a/src/xrt/compositor/gl/comp_gl_compositor.cpp
+++ b/src/xrt/compositor/gl/comp_gl_compositor.cpp
@@ -1496,9 +1496,15 @@ gl_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t
 				           c->view_width, c->view_height);
 			}
 
-			// Per-eye disparity offset
+			// Per-view disparity, graded across the view sweep (#413):
+			// first view = -half, last = +half. Degenerates to the classic
+			// -/+ pair for 2-view modes; a single view gets no shift.
 			float half_disp = ws->disparity / 2.0f;
-			float eye_shift = (eye == 0) ? -half_disp : half_disp;
+			float eye_shift = 0.0f;
+			if (effective_views > 1) {
+				float t = (float)eye / (float)(effective_views - 1);
+				eye_shift = -half_disp + ws->disparity * t;
+			}
 
 			// Window-space fractional coords → NDC [-1, 1]
 			float ndc_x = (ws->x + eye_shift) * 2.0f - 1.0f;

--- a/src/xrt/compositor/metal/comp_metal_compositor.m
+++ b/src/xrt/compositor/metal/comp_metal_compositor.m
@@ -1845,9 +1845,15 @@ metal_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 				uint32_t tile_x = eye % c->tile_columns;
 				uint32_t tile_y = eye / c->tile_columns;
 
-				// Per-eye horizontal disparity (eye 0 shifts left).
+				// Per-view disparity, graded across the view sweep (#413):
+				// first view = -half, last = +half. Degenerates to the
+				// classic -/+ pair for 2-view modes; one view = no shift.
 				float half_disp = ws->disparity / 2.0f;
-				float eye_shift = (eye == 0) ? -half_disp : half_disp;
+				float eye_shift = 0.0f;
+				if (mode_views_ws > 1) {
+					float t = (float)eye / (float)(mode_views_ws - 1);
+					eye_shift = -half_disp + ws->disparity * t;
+				}
 
 				// Per-eye sub-rect within the atlas, in atlas pixels. The
 				// projection_pipeline shader expects viewport=(0,0,1,1) and

--- a/src/xrt/compositor/vk_native/comp_vk_native_compositor.c
+++ b/src/xrt/compositor/vk_native/comp_vk_native_compositor.c
@@ -1079,27 +1079,68 @@ vk_compositor_render_window_space_into_atlas(struct comp_vk_native_compositor *c
 		    VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
 		    0, 0, NULL, 0, NULL, 1, &src_to_sample);
 
-		// Per-tile pass with disparity shift in tile-fraction → atlas px.
+		// Per-view pass with disparity shift in tile-fraction → atlas px.
+		// Mirrors the metal/GL compositors (#413): a 2D (non-3D) mode gets
+		// ONE stamp over the full content region (tile grid × view dims);
+		// 3D modes stamp every tile. The previous code looped the tile grid
+		// unconditionally and hardcoded the 2-view disparity pair
+		// (tile_index == 0 ? -half : +half), which mis-shifts every layout
+		// other than 2 views.
+		uint32_t effective_views = c->hardware_display_3d ? (tile_columns * tile_rows) : 1;
 		float half_disp = ws->disparity / 2.0f;
-		for (uint32_t row = 0; row < tile_rows; row++) {
-			for (uint32_t col = 0; col < tile_columns; col++) {
-				uint32_t tile_index = row * tile_columns + col;
-				float eye_shift = (tile_index == 0) ? -half_disp : half_disp;
+		for (uint32_t eye = 0; eye < effective_views; eye++) {
+			uint32_t tile_x = eye % tile_columns;
+			uint32_t tile_y = eye / tile_columns;
 
-				int32_t dx = (int32_t)((ws->x + eye_shift) * (float)view_w)
-				             + (int32_t)(col * view_w);
-				int32_t dy = (int32_t)(ws->y * (float)view_h)
-				             + (int32_t)(row * view_h);
-				int32_t dw_i = (int32_t)(ws->width * (float)view_w);
-				int32_t dh_i = (int32_t)(ws->height * (float)view_h);
-				if (dw_i <= 0 || dh_i <= 0) {
-					continue;
-				}
+			float tile_origin_x = c->hardware_display_3d ? (float)(tile_x * view_w) : 0.0f;
+			float tile_origin_y = c->hardware_display_3d ? (float)(tile_y * view_h) : 0.0f;
+			float tile_w = c->hardware_display_3d ? (float)view_w
+			                                      : (float)(tile_columns * view_w);
+			float tile_h = c->hardware_display_3d ? (float)view_h
+			                                      : (float)(tile_rows * view_h);
 
-				vk_hud_blend_draw_no_layout(&c->window_space_blend, vk, cmd,
-				    c->atlas_ws_fb, atlas_w, atlas_h,
-				    src_image, dx, dy, (uint32_t)dw_i, (uint32_t)dh_i);
+			// Per-view horizontal disparity, graded across the view sweep
+			// (view index = baseline order, same as the projection views):
+			// first view = -half, last = +half. Degenerates to the classic
+			// -/+ pair for 2-view modes and to 0 for a single view.
+			float eye_shift = 0.0f;
+			if (effective_views > 1) {
+				float t = (float)eye / (float)(effective_views - 1);
+				eye_shift = -half_disp + ws->disparity * t;
 			}
+
+			int32_t dx = (int32_t)(tile_origin_x + (ws->x + eye_shift) * tile_w);
+			int32_t dy = (int32_t)(tile_origin_y + ws->y * tile_h);
+			int32_t dw_i = (int32_t)(ws->width * tile_w);
+			int32_t dh_i = (int32_t)(ws->height * tile_h);
+			if (dw_i <= 0 || dh_i <= 0) {
+				continue;
+			}
+
+			// One-shot per-geometry diagnostic (#413): logs the resolved
+			// per-view placement whenever the mode/layout/dims change, so a
+			// missing-HUD report can be pinned to placement vs crop without
+			// a custom build. Not per-frame (see debug-logging conventions).
+			{
+				static uint32_t logged_key = 0;
+				uint32_t key = (tile_columns << 28) ^ (tile_rows << 24) ^
+				               (effective_views << 20) ^ (view_w << 8) ^ view_h ^
+				               ((uint32_t)c->hardware_display_3d << 31);
+				if (key != logged_key && eye == 0) {
+					logged_key = key;
+					U_LOG_W("[VK native] window-space placement: 3d=%d tiles=%ux%u "
+					        "views=%u view=%ux%u atlas=%ux%u first stamp dst=(%d,%d "
+					        "%dx%d) ws=(%.3f,%.3f %.3fx%.3f disp=%.3f)",
+					        (int)c->hardware_display_3d, tile_columns, tile_rows,
+					        effective_views, view_w, view_h, atlas_w, atlas_h,
+					        dx, dy, dw_i, dh_i,
+					        ws->x, ws->y, ws->width, ws->height, ws->disparity);
+				}
+			}
+
+			vk_hud_blend_draw_no_layout(&c->window_space_blend, vk, cmd,
+			    c->atlas_ws_fb, atlas_w, atlas_h,
+			    src_image, dx, dy, (uint32_t)dw_i, (uint32_t)dh_i);
 		}
 
 		// Source back to COLOR_ATTACHMENT_OPTIMAL so the app can rerender.

--- a/src/xrt/drivers/sim_display/sim_display_plugin.c
+++ b/src/xrt/drivers/sim_display/sim_display_plugin.c
@@ -21,6 +21,14 @@
  * @ingroup drv_sim_display
  */
 
+// xrt_config_have.h supplies the XRT_HAVE_* feature macros used by the
+// vtable gating below. Without it, `#if defined(XRT_HAVE_VULKAN)` was
+// silently false in this TU, so the Windows plug-in never wired
+// create_dp_vk (or the VK bit in probe_displays claims) even though the
+// VK display processor was compiled in — every VK app under sim-display
+// on Windows ran DP-less in permanent 2D (#456).
+#include "xrt/xrt_config_have.h"
+
 #include "xrt/xrt_plugin.h"
 #include "xrt/xrt_results.h"
 


### PR DESCRIPTION
## What

`vk_compositor_render_window_space_into_atlas()` looped the tile grid unconditionally and hardcoded the 2-view disparity pair (`tile_index == 0 ? -half : +half`) — the smoking gun from #413. This ports the metal/GL structure:

- **2D (non-3D) modes** draw ONE stamp over the full content region (tile grid × view dims) instead of per-tile stamps;
- **3D modes** stamp every tile at tile-local coordinates;
- the **per-view disparity shift is graded across the view sweep** (first view = −half … last = +half), correct for 1×2 and 2×2 layouts; 2-view modes degenerate to the previous ∓ pair. (Deviation from the issue's "per-column" suggestion: view index is baseline order — same as the projection views — so grading by view index also handles the 1×2 Cropped-SBS layout, where per-column would zero the shift.)
- metal + GL get the same graded shift (their 2D/all-tiles handling was already correct; they kept the `eye==0` pair).
- Adds the diagnostic the issue asked for: a **one-shot-per-layout** `U_LOG_W` placement line (`[VK native] window-space placement: …`) — fires on mode/layout change only, per the debug-logging conventions.

## Validation (Windows / RTX 3080, sim-display, `cube_handle_vk_win` HUD)

Post-compose atlas captures across all 5 sim modes, before/after, including a mediaplayer-style bottom-center bar with non-zero disparity:

| Mode | Layout | After |
|---|---|---|
| 2D | 1×1 | single full-canvas stamp ✅ |
| Anaglyph | 2×1 | both tiles ✅ |
| Cropped SBS | 1×2 | both rows ✅ |
| Squeezed SBS | 2×1 | both tiles ✅ |
| Quad | 2×2 | all 4 tiles incl. bottom row ✅ |

Leia 2-view regression smoke on the live panel (3D + V-toggle 2D): HUD single/sharp/stable, user-verified. `ctest -C Release`: 25/25.

## Caveat — macOS

The reported visibility symptoms (2D invisible, Quad bottom row missing) did **not** reproduce on Windows vk_native at HEAD, even with mediaplayer-like HUD geometry. If they persist on macOS/MoltenVK after this fix, the new placement diagnostic pins placement-vs-crop from a stock build — re-run the mediaplayer repro and grab the `window-space placement` lines.

Stacked on #465 (its sim-display VK factory fix is what makes the Windows sim validation rig possible at all).

🤖 Generated with [Claude Code](https://claude.com/claude-code)