### PR TITLE
feat(#406): real-view + shared-IOSurface binding for cube_texture_metal_macos + Metal 2D rect surround

### DIFF
--- a/docs/guides/displayxr-app-rules.md
+++ b/docs/guides/displayxr-app-rules.md
@@ -583,11 +583,15 @@ The three spec-vs-code discrepancies found during research have been resolved:
    dims and *skips* on mismatch, it never rejects). `XR_EXT_win32_window_binding.md` §3.6 was
    updated to match the shipped runtime + this contract. See INV-5.4.
 
-2. **macOS `cube_texture_metal_macos` divergence — TRACKED.** The macOS sample uses the
-   offscreen/IOSurface mode (not real-view + shared-surface) and omits the surround API. Porting
-   it is tracked in [#406](https://github.com/DisplayXR/displayxr-runtime/issues/406). Until then,
-   the "real handle + shared surface + surround" model in §5 is **Windows-accurate**; macOS is the
-   exception.
+2. **macOS `cube_texture_metal_macos` divergence — RESOLVED
+   ([#406](https://github.com/DisplayXR/displayxr-runtime/issues/406)).** The macOS sample now
+   binds real-view + shared-IOSurface (Texture mode) and registers the 2D surround via
+   `xrSetSharedTextureSurround2DEXT`, so the "real handle + shared surface + surround" model in
+   §5 is accurate on both platforms. One deliberate platform delta: the **Metal surround is
+   window-clamped per [#464](https://github.com/DisplayXR/displayxr-runtime/issues/464)** — the
+   app registers a *window-sized* surround IOSurface (re-registered on resize) and the runtime
+   fills only the window rect minus the canvas. INV-5.4/5.7's "worst-case size" wording remains
+   **Windows-accurate** until the #464 D3D11/D3D12 retrofit lands.
 
 3. **Stale `XR_EXT_display_info.md` examples — RESOLVED, plus a full v13 spec refresh.** The
    view-count hardcoding (`XrView views[2]` / `for (eye<2)`) was fixed to the `XRT_MAX_VIEWS`(8)-wide

--- a/docs/specs/extensions/XR_EXT_cocoa_window_binding.md
+++ b/docs/specs/extensions/XR_EXT_cocoa_window_binding.md
@@ -97,7 +97,7 @@ typedef struct XrCocoaWindowBindingCreateInfoEXT {
 | Mode | `viewHandle` | `sharedIOSurface` | App class | Behavior |
 |------|:-:|:-:|---|---|
 | **Handle** | NSView* | NULL | `_handle` | Runtime renders directly into the app's view |
-| **Texture** | NSView* | IOSurfaceRef | `_texture` | Runtime composites into the shared IOSurface at the canvas sub-rect declared via `xrSetSharedTextureOutputRectEXT` (see [`XR_EXT_win32_window_binding` §3.5](XR_EXT_win32_window_binding.md#35-xrsetsharedtextureoutputrectext) for the read-back contract). The NSView is still required for screen-space position tracking and phase alignment. The app blits the IOSurface's canvas sub-rect into its view. |
+| **Texture** | NSView* | IOSurfaceRef | `_texture` | Runtime composites into the shared IOSurface at the canvas sub-rect declared via `xrSetSharedTextureOutputRectEXT` (see [`XR_EXT_win32_window_binding` §3.5](XR_EXT_win32_window_binding.md#35-xrsetsharedtextureoutputrectext) for the read-back contract). The NSView is still required for screen-space position tracking and phase alignment. The app blits the IOSurface's canvas sub-rect into its view — or the full window region when a 2D surround is registered (see §xrSetSharedTextureSurround2DEXT). |
 | **Offscreen** | NULL | NULL | — | `readbackCallback` receives composited pixels. No view, no phase alignment. |
 
 > **Important for `_texture` apps:** You **must** provide a valid `viewHandle` even though the runtime renders into the shared IOSurface, not the view. Without it, the display processor cannot compute correct interlacing alignment (see [XR_EXT_win32_window_binding §2.4](XR_EXT_win32_window_binding.md#24-the-phase-alignment-problem)). Additionally, call `xrSetSharedTextureOutputRectEXT` to tell the runtime where within the view the 3D canvas appears.
@@ -119,16 +119,17 @@ Sets the canvas sub-rect within the NSView where 3D content appears. Coordinates
 
 ### xrSetSharedTextureSurround2DEXT (Spec v6)
 
-Registers a full-view 2D shared texture (`IOSurfaceRef`) whose pixels outside the canvas sub-rect are blitted into the target swapchain each frame. The Metal-side mechanism differs from D3D11/D3D12 (`IOSurfaceRef` instead of an NT `HANDLE`, no `IDXGIKeyedMutex` — IOSurface use_count + Metal fence instead) but the function signature, lifecycle, and semantics are otherwise identical to the Win32 form. See [`XR_EXT_win32_window_binding` §3.6](XR_EXT_win32_window_binding.md#36-xrsetsharedtexturesurround2dext) for the full API reference.
+Registers a **window-sized** 2D shared texture (`IOSurfaceRef`) whose pixels outside the canvas sub-rect are blitted into the target swapchain each frame. The function signature, lifecycle, and core semantics match the Win32 form — see [`XR_EXT_win32_window_binding` §3.6](XR_EXT_win32_window_binding.md#36-xrsetsharedtexturesurround2dext) for the full API reference — with the sizing/synchronization deltas below.
 
 **Cocoa-specific deltas:**
 
 - `sharedTextureHandle` is an `IOSurfaceRef` cast to `void*` (matching how the multiview `sharedIOSurface` field is handled in `XrCocoaWindowBindingCreateInfoEXT`).
-- Synchronization uses Metal fences and the IOSurface use-count protocol rather than `IDXGIKeyedMutex`. The runtime increments use-count on register, drops it on clear / replace.
-- Pixel format must be `MTLPixelFormatRGBA8Unorm` or `MTLPixelFormatRGBA8Unorm_sRGB`.
-- Texture dimensions must match the NSView's `convertRectToBacking:` size in physical pixels (i.e. post-Retina scale).
+- Synchronization: the runtime retains the `IOSurfaceRef` (`CFRetain`) for the registration's lifetime and releases it on clear / replace / session teardown. IOSurface is cache-coherent between the app's CPU writes (under `IOSurfaceLock*`) and the runtime's GPU reads, so no keyed-mutex/fence handshake is required in-process. A use-count + Mach-port protocol is the cross-process follow-up.
+- Pixel format must **match the multiview shared IOSurface's format** (`'BGRA'` → `MTLPixelFormatBGRA8Unorm` in practice) — the strip blit is a region copy and requires strict format equality. A mismatch is logged once and the blit is skipped.
+- **Texture dimensions must match the NSView's `convertRectToBacking:` size** in physical pixels (post-Retina scale) — i.e. the **window rect**, not the worst-case shared-IOSurface size. Re-register on window resize (the surround is window-sized, so resize means a new IOSurface + a new `xrSetSharedTextureSurround2DEXT` call; the previous registration is released atomically on replace).
+- **Window-clamped fill ([#464](https://github.com/DisplayXR/displayxr-runtime/issues/464)):** the runtime fills only the registered window rect minus the canvas (window-anchored at the top-left of the worst-case shared surface), never the full worst-case extent. This deliberately diverges from the current Win32/D3D11 implementation (which still enforces the worst-case-dims contract and over-fills); #464 retrofits D3D11/D3D12 to this model.
 
-The Vulkan-via-MoltenVK and native-Metal compositor paths both honor the surround texture — the surround blit pass lives in `compositor/metal/` and `compositor/vk_native/` mirroring the Win32 paths.
+The native-Metal compositor path honors the surround texture — the surround blit pass lives in `compositor/metal/` (`metal_blit_surround_strips`). The Vulkan-via-MoltenVK path (`compositor/vk_native/`) is a follow-up.
 
 ---
 
@@ -244,3 +245,4 @@ The Cocoa binding tracks `XR_EXT_win32_window_binding` for forward-compatibility
 | 3 | 2026-01-10 | David Fattal | Added sharedIOSurface for zero-copy Metal texture sharing. Fixed type value collision (1000999003 → 1000999004). |
 | 4 | 2026-04-24 | David Fattal | Read-back contract clarified: runtime writes the canvas region at `(x, y)` (not origin) in the shared IOSurface, matching `xrSetSharedTextureOutputRectEXT` args. Apps must sample at `uvOffset + uv * uvScale`. See ADR-010. |
 | 6 | 2026-05-28 | David Fattal | Added `xrSetSharedTextureSurround2DEXT` (parity with `XR_EXT_win32_window_binding` v6). Lets `_texture` apps register a full-view 2D IOSurface whose pixels outside the canvas sub-rect are blitted into the target swapchain each frame. Enables apps on fixed-3D-zone displays to fill the surround region with full-resolution 2D content. |
+| 6 (erratum) | 2026-06-06 | David Fattal | Surround deltas corrected to match the shipped Metal implementation (#406): pixel format must match the multiview shared IOSurface (not "must be RGBA8Unorm"); dims are confirmed window-sized with re-register-on-resize; fill is window-clamped per #464 (window rect minus canvas, never the worst-case extent); sync is CFRetain + coherent IOSurface (no fence/use-count in-process). No version bump — text aligned to behavior, no ABI change. |

--- a/scripts/build_macos.sh
+++ b/scripts/build_macos.sh
@@ -379,7 +379,7 @@ export XR_RUNTIME_JSON="$DIR/openxr_displayxr.json"
 export DYLD_LIBRARY_PATH="$DIR/lib:${DYLD_LIBRARY_PATH:-}"
 export XRT_PLUGIN_SEARCH_PATH="$DIR/lib/displayxr/plugins"
 export SIM_DISPLAY_OUTPUT="${SIM_DISPLAY_OUTPUT:-anaglyph}"
-echo "Starting cube_texture_metal_macos (Metal, IOSurface shared texture) with $SIM_DISPLAY_OUTPUT output..."
+echo "Starting cube_texture_metal_macos (Metal, real view + shared IOSurface + 2D surround) with $SIM_DISPLAY_OUTPUT output..."
 exec "$DIR/bin/cube_texture_metal_macos" "$@"
 SCRIPT
 chmod +x "$PKG_DIR/run_cube_texture_metal.sh"

--- a/src/external/openxr_includes/openxr/XR_EXT_cocoa_window_binding.h
+++ b/src/external/openxr_includes/openxr/XR_EXT_cocoa_window_binding.h
@@ -148,14 +148,21 @@ XRAPI_ATTR XrResult XRAPI_CALL xrSetSharedTextureOutputRectEXT(
 // ---- 2D Surround Texture (Spec v6) ----
 
 /*!
- * @brief Register a full-view 2D IOSurface whose pixels OUTSIDE the canvas
+ * @brief Register a window-sized 2D IOSurface whose pixels OUTSIDE the canvas
  *        sub-rect are blitted into the target swapchain each frame.
  *
- * macOS counterpart to the Win32 version. Signature, lifecycle, and semantics
- * are identical except: sharedTextureHandle is an IOSurfaceRef (cast to void*),
- * synchronization uses Metal fences + IOSurface use-count rather than
- * IDXGIKeyedMutex, and pixel format must be MTLPixelFormatRGBA8Unorm or
- * MTLPixelFormatRGBA8Unorm_sRGB.
+ * macOS counterpart to the Win32 version. Signature and lifecycle are
+ * identical except: sharedTextureHandle is an IOSurfaceRef (cast to void*),
+ * the runtime holds a CFRetain on it for the registration's lifetime (the
+ * IOSurface is cache-coherent between app CPU writes and runtime GPU reads,
+ * so no fence/keyed-mutex handshake is needed in-process), and the pixel
+ * format must match the multiview shared IOSurface's format.
+ *
+ * The fill is window-clamped (#464): the runtime blits only the registered
+ * window rect minus the canvas, anchored top-left in the worst-case shared
+ * surface — never the full worst-case extent. Re-register on window resize
+ * (the surround is window-sized; replacing a registration atomically
+ * releases the previous one).
  *
  * See XR_EXT_win32_window_binding.h for the full semantic description.
  *
@@ -164,14 +171,18 @@ XRAPI_ATTR XrResult XRAPI_CALL xrSetSharedTextureOutputRectEXT(
  * @param sharedTextureHandle IOSurfaceRef for the 2D surround texture, or NULL
  *                            to clear.
  * @param width               Texture width in physical (post-Retina) pixels.
- *                            Must equal the NSView backing-store width.
+ *                            Must equal the IOSurface's own width (== the
+ *                            NSView backing-store width at registration time).
  * @param height              Texture height in physical pixels. Must equal
- *                            the NSView backing-store height.
+ *                            the IOSurface's own height (== the NSView
+ *                            backing-store height at registration time).
  *
  * @return XR_SUCCESS on success.
  *         XR_ERROR_FUNCTION_UNSUPPORTED if the extension is not enabled.
  *         XR_ERROR_VALIDATION_FAILURE if the dimensions do not match the
- *         current NSView backing size.
+ *         IOSurface's own dimensions. (A later window resize never errors:
+ *         the frame-time blit clamps to the registered rect until the app
+ *         re-registers.)
  *         XR_ERROR_HANDLE_INVALID if the IOSurface cannot be referenced.
  */
 #ifndef PFN_xrSetSharedTextureSurround2DEXT_DEFINED

--- a/src/xrt/auxiliary/util/u_canvas.h
+++ b/src/xrt/auxiliary/util/u_canvas.h
@@ -51,17 +51,23 @@ struct u_canvas_rect
  * "what fills the rest." See docs/specs/extensions/XR_EXT_win32_window_binding.md §3.6.
  *
  * The handle is a D3D11/D3D12 NT HANDLE on Windows, an IOSurfaceRef cast
- * to void* on macOS. The compositor opens it lazily on first use and
- * releases on clear / replace / session teardown. Dimensions MUST equal
- * the HWND/NSView client-area dimensions — the runtime does a 1:1 blit
- * with scissor-rects around the canvas hole, no scaling.
+ * to void* on macOS. The compositor opens it on registration and releases
+ * on clear / replace / session teardown. The runtime does a 1:1 blit with
+ * scissor-rects around the canvas hole, no scaling.
+ *
+ * Dimensions contract (#464): the target model is WINDOW-sized — dims equal
+ * the HWND/NSView client-area backing dimensions, the fill is clamped to
+ * the window rect, and the app re-registers on resize. The Metal compositor
+ * implements this; D3D11/D3D12 currently still enforce the legacy
+ * worst-case contract (dims == shared-texture dims, display-extent
+ * over-fill) pending the #464 retrofit.
  */
 struct u_surround_2d_handle
 {
 	bool valid;             //!< True if a surround texture has been registered
 	void *shared_handle;    //!< NT HANDLE (Win) / IOSurfaceRef (Mac), or NULL
-	uint32_t w;             //!< Texture width in pixels (== HWND client width)
-	uint32_t h;             //!< Texture height in pixels (== HWND client height)
+	uint32_t w;             //!< Texture width in pixels (window rect on Metal; see #464 note)
+	uint32_t h;             //!< Texture height in pixels (window rect on Metal; see #464 note)
 };
 
 /*!

--- a/src/xrt/compositor/metal/comp_metal_compositor.h
+++ b/src/xrt/compositor/metal/comp_metal_compositor.h
@@ -104,12 +104,20 @@ comp_metal_compositor_set_output_rect(struct xrt_compositor *xc,
                                        uint32_t w, uint32_t h);
 
 /*!
- * Register a full-view 2D IOSurface for the surround region (Spec v6).
+ * Register a window-sized 2D IOSurface for the surround region (Spec v6).
  *
  * Pass shared_handle == NULL to clear. The handle is an IOSurfaceRef cast
- * to void*; synchronization uses Metal fences + IOSurface use-count rather
- * than a KeyedMutex. See comp_d3d11_compositor_set_surround_2d for the
- * cross-platform semantics.
+ * to void*. The registered dims must equal the IOSurface's own dims and
+ * track the window backing size (#464 window-clamped model — the app
+ * re-registers on window resize); the per-frame strip blit fills only the
+ * window rect minus the canvas, never the whole worst-case shared surface.
+ * The surface's pixel format must match the multiview shared IOSurface.
+ *
+ * Lifetime is held by CFRetain; the IOSurface is cache-coherent between
+ * app CPU writes and compositor GPU reads, so no fence / use-count
+ * protocol is needed in-process. See comp_d3d11_compositor_set_surround_2d
+ * for the cross-platform semantics (D3D11 still enforces the pre-#464
+ * worst-case dims contract).
  */
 void
 comp_metal_compositor_set_surround_2d(struct xrt_compositor *xc,

--- a/src/xrt/compositor/metal/comp_metal_compositor.m
+++ b/src/xrt/compositor/metal/comp_metal_compositor.m
@@ -230,6 +230,12 @@ struct comp_metal_compositor
 	//! 2D surround IOSurface handle (Spec v6).
 	struct u_surround_2d_handle surround_2d;
 
+	//! Retained IOSurfaceRef backing the 2D surround (NULL when unregistered).
+	IOSurfaceRef surround_iosurface;
+
+	//! Metal texture wrapping surround_iosurface (MRR — explicit release).
+	id<MTLTexture> surround_texture;
+
 	//! Thread safety.
 	struct os_mutex mutex;
 
@@ -256,6 +262,20 @@ static inline struct comp_metal_swapchain *
 metal_swapchain(struct xrt_swapchain *xsc)
 {
 	return (struct comp_metal_swapchain *)xsc;
+}
+
+// Release the 2D surround resources (texture wrap + retained IOSurface).
+// Single choke point for clear / replace / destroy — keeps the MRR
+// retain/release pairing auditable.
+static void
+metal_release_surround(struct comp_metal_compositor *c)
+{
+	[c->surround_texture release];
+	c->surround_texture = nil;
+	if (c->surround_iosurface != NULL) {
+		CFRelease(c->surround_iosurface);
+		c->surround_iosurface = NULL;
+	}
 }
 
 /*
@@ -1434,6 +1454,130 @@ metal_compositor_dispatch_capture(struct comp_metal_compositor *c,
 	u_capture_intent_complete(&c->capture_intent, &c->mcp_capture, ok);
 }
 
+// Blit non-canvas pixels of the surround IOSurface into the dst texture
+// (the shared IOSurface for _texture apps). Called after the DP has weaved
+// into dst's canvas sub-rect.
+//
+// Strip layout (same as d3d11_blit_surround_strips):
+//
+//   +---------------------------------+
+//   |              TOP                |   (0, 0) -> (fw, cy)
+//   +------+--------------------+-----+
+//   | LEFT |   <canvas-region>  | RGT |   LEFT  (0, cy) -> (cx, cy+ch)
+//   |      |    (untouched —    |     |   RIGHT (cx+cw, cy) -> (fw, cy+ch)
+//   |      |     DP wrote here) |     |
+//   +------+--------------------+-----+
+//   |             BOTTOM              |   (0, cy+ch) -> (fw, fh)
+//   +---------------------------------+
+//
+// WINDOW-CLAMPED fill (#464): the fill extent (fw, fh) is the registered
+// surround dims — the window backing rect — clamped to dst, anchored at
+// (0,0) in the worst-case-sized dst. This deliberately diverges from the
+// current D3D11 strips (which require surround.dims == dst.dims and fill
+// the whole worst-case surface); D3D11 is retrofitted separately in #464.
+// Src coords == dst coords (1:1, both window-anchored top-left).
+//
+// Skips any zero-area strip. Strict pixel-format equality between surround
+// and dst is required for copyFromTexture — logs once and skips on mismatch.
+static void
+metal_blit_surround_strips(struct comp_metal_compositor *c,
+                           id<MTLCommandBuffer> cmd_buf,
+                           id<MTLTexture> dst,
+                           uint32_t dst_w,
+                           uint32_t dst_h,
+                           int32_t cx,
+                           int32_t cy,
+                           uint32_t cw,
+                           uint32_t ch)
+{
+	if (!c->surround_2d.valid || c->surround_texture == nil || dst == nil) {
+		return;
+	}
+
+	if (c->surround_texture.pixelFormat != dst.pixelFormat) {
+		static bool fmt_logged = false;
+		if (!fmt_logged) {
+			U_LOG_W("Metal surround 2D: format mismatch — surround=%lu, target=%lu. "
+			        "Surround blit skipped; the surround IOSurface must use the same "
+			        "pixel format as the multiview shared IOSurface.",
+			        (unsigned long)c->surround_texture.pixelFormat,
+			        (unsigned long)dst.pixelFormat);
+			fmt_logged = true;
+		}
+		return;
+	}
+
+	// Window-clamped fill extent (#464): surround dims ARE the window rect.
+	uint32_t fw = (c->surround_2d.w < dst_w) ? c->surround_2d.w : dst_w;
+	uint32_t fh = (c->surround_2d.h < dst_h) ? c->surround_2d.h : dst_h;
+	if (fw == 0 || fh == 0) {
+		return;
+	}
+
+	// Clamp canvas to the fill extent in case the app submitted a
+	// degenerate rect (or a one-frame resize race left canvas and surround
+	// dims briefly inconsistent — harmless, just clamp).
+	uint32_t cx_u = (cx < 0) ? 0u : (uint32_t)cx;
+	uint32_t cy_u = (cy < 0) ? 0u : (uint32_t)cy;
+	if (cx_u > fw) cx_u = fw;
+	if (cy_u > fh) cy_u = fh;
+	uint32_t cright = (cx_u + cw > fw) ? fw : cx_u + cw;
+	uint32_t cbottom = (cy_u + ch > fh) ? fh : cy_u + ch;
+
+	id<MTLBlitCommandEncoder> blit = [cmd_buf blitCommandEncoder];
+
+	// Top strip: full fill width, y in [0, cy_u).
+	if (cy_u > 0) {
+		[blit copyFromTexture:c->surround_texture
+		          sourceSlice:0
+		          sourceLevel:0
+		         sourceOrigin:MTLOriginMake(0, 0, 0)
+		           sourceSize:MTLSizeMake(fw, cy_u, 1)
+		            toTexture:dst
+		     destinationSlice:0
+		     destinationLevel:0
+		    destinationOrigin:MTLOriginMake(0, 0, 0)];
+	}
+	// Bottom strip: full fill width, y in [cbottom, fh).
+	if (cbottom < fh) {
+		[blit copyFromTexture:c->surround_texture
+		          sourceSlice:0
+		          sourceLevel:0
+		         sourceOrigin:MTLOriginMake(0, cbottom, 0)
+		           sourceSize:MTLSizeMake(fw, fh - cbottom, 1)
+		            toTexture:dst
+		     destinationSlice:0
+		     destinationLevel:0
+		    destinationOrigin:MTLOriginMake(0, cbottom, 0)];
+	}
+	// Left strip: x in [0, cx_u), y in [cy_u, cbottom).
+	if (cx_u > 0 && cbottom > cy_u) {
+		[blit copyFromTexture:c->surround_texture
+		          sourceSlice:0
+		          sourceLevel:0
+		         sourceOrigin:MTLOriginMake(0, cy_u, 0)
+		           sourceSize:MTLSizeMake(cx_u, cbottom - cy_u, 1)
+		            toTexture:dst
+		     destinationSlice:0
+		     destinationLevel:0
+		    destinationOrigin:MTLOriginMake(0, cy_u, 0)];
+	}
+	// Right strip: x in [cright, fw), y in [cy_u, cbottom).
+	if (cright < fw && cbottom > cy_u) {
+		[blit copyFromTexture:c->surround_texture
+		          sourceSlice:0
+		          sourceLevel:0
+		         sourceOrigin:MTLOriginMake(cright, cy_u, 0)
+		           sourceSize:MTLSizeMake(fw - cright, cbottom - cy_u, 1)
+		            toTexture:dst
+		     destinationSlice:0
+		     destinationLevel:0
+		    destinationOrigin:MTLOriginMake(cright, cy_u, 0)];
+	}
+
+	[blit endEncoding];
+}
+
 static xrt_result_t
 metal_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sync_handle)
 {
@@ -2070,6 +2214,87 @@ metal_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 		[blit_encoder endEncoding];
 	}
 
+	// Spec v6 surround blit: fill non-canvas pixels of the output from the
+	// app-supplied 2D surround IOSurface (no-op if
+	// xrSetSharedTextureSurround2DEXT was never called). Window-clamped
+	// fill per #464. One call site covers both the DP path and the no-DP
+	// fallback — they converge on output_texture. (In fallback mode the
+	// canvas region holds the full-target stretched atlas — consistent
+	// with the fallback's existing canvas-ignorance.)
+	metal_blit_surround_strips(c, cmd_buf, output_texture,
+	                           (uint32_t)output_texture.width,
+	                           (uint32_t)output_texture.height,
+	                           c->canvas.valid ? c->canvas.x : 0,
+	                           c->canvas.valid ? c->canvas.y : 0,
+	                           c->canvas.valid ? c->canvas.w : (uint32_t)output_texture.width,
+	                           c->canvas.valid ? c->canvas.h : (uint32_t)output_texture.height);
+
+	// Surround composite capture probe — env-gated (DISPLAYXR_SURROUND_CAPTURE=1)
+	// file-trigger dump of the post-surround output. The atlas trigger above
+	// reads the pre-DP atlas, which the surround pass never touches, so
+	// validating the surround needs this dedicated probe (mirrors
+	// d3d11_maybe_capture_surround_target). Trigger: /tmp/dxr_surround_trigger
+	// → /tmp/dxr_surround.png. Default-off, zero per-frame cost when unset.
+	{
+		static int surround_cap_enabled = -1;
+		if (surround_cap_enabled < 0) {
+			const char *e = getenv("DISPLAYXR_SURROUND_CAPTURE");
+			surround_cap_enabled = (e != NULL && e[0] != '\0' && e[0] != '0') ? 1 : 0;
+		}
+		struct stat surround_cap_st;
+		if (surround_cap_enabled && output_texture != nil &&
+		    stat("/tmp/dxr_surround_trigger", &surround_cap_st) == 0) {
+			unlink("/tmp/dxr_surround_trigger");
+			uint32_t cw = (uint32_t)output_texture.width;
+			uint32_t ch = (uint32_t)output_texture.height;
+			size_t pitch = (size_t)cw * 4;
+			size_t bytes = pitch * ch;
+			id<MTLBuffer> stg = [c->device newBufferWithLength:bytes
+			                                           options:MTLResourceStorageModeShared];
+			if (stg != nil) {
+				// Flush pending encodings (incl. the surround strips)
+				// so the readback observes the final composite.
+				[cmd_buf commit];
+				[cmd_buf waitUntilCompleted];
+
+				id<MTLCommandBuffer> bcb = [c->command_queue commandBuffer];
+				id<MTLBlitCommandEncoder> bl = [bcb blitCommandEncoder];
+				[bl copyFromTexture:output_texture
+				          sourceSlice:0
+				          sourceLevel:0
+				         sourceOrigin:MTLOriginMake(0, 0, 0)
+				           sourceSize:MTLSizeMake(cw, ch, 1)
+				             toBuffer:stg
+				    destinationOffset:0
+				 destinationBytesPerRow:pitch
+				destinationBytesPerImage:bytes];
+				[bl endEncoding];
+				[bcb commit];
+				[bcb waitUntilCompleted];
+
+				uint8_t *src = (uint8_t *)stg.contents;
+				uint8_t *out = malloc(bytes);
+				if (out != NULL) {
+					for (size_t i = 0; i < bytes; i += 4) {
+						out[i + 0] = src[i + 2];
+						out[i + 1] = src[i + 1];
+						out[i + 2] = src[i + 0];
+						out[i + 3] = src[i + 3];
+					}
+					stbi_write_png("/tmp/dxr_surround.png", (int)cw, (int)ch, 4, out,
+					               (int)pitch);
+					free(out);
+					U_LOG_W("Surround composite capture written -> /tmp/dxr_surround.png");
+				}
+				[stg release];
+
+				// The committed cmd_buf is dead — the HUD/present
+				// remainder of this frame needs a fresh one.
+				cmd_buf = [c->command_queue commandBuffer];
+			}
+		}
+	}
+
 	// HUD overlay (post-weave, before present)
 	if (c->owns_window) {
 		metal_compositor_render_hud(c, dt, cmd_buf, output_texture);
@@ -2080,7 +2305,12 @@ metal_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 	// just whatever the AppKit background draws — i.e. solid grey).
 	// Only relevant when both a shared IOSurface AND an external view are
 	// present (the editor preview / Unity standalone path).
-	if (c->shared_texture != nil && c->metal_layer != nil && !c->owns_window) {
+	//
+	// Skipped once the app declares a canvas rect: a _texture app owns
+	// presentation (it blits the IOSurface into its view itself, per the
+	// Cocoa binding spec's Texture mode) — mirroring here would fight the
+	// app over the layer's nextDrawable.
+	if (c->shared_texture != nil && c->metal_layer != nil && !c->owns_window && !c->canvas.valid) {
 		id<CAMetalDrawable> mirror = [c->metal_layer nextDrawable];
 		if (mirror != nil) {
 			id<MTLBlitCommandEncoder> blit = [cmd_buf blitCommandEncoder];
@@ -2169,6 +2399,7 @@ metal_compositor_destroy(struct xrt_compositor *xc)
 		CFRelease(c->shared_iosurface);
 		c->shared_iosurface = NULL;
 	}
+	metal_release_surround(c);
 
 	// 5. Release HUD resources
 	u_hud_destroy(&c->hud);
@@ -2628,21 +2859,68 @@ comp_metal_compositor_set_surround_2d(struct xrt_compositor *xc,
                                        uint32_t w, uint32_t h)
 {
 	struct comp_metal_compositor *c = metal_comp(xc);
+
+	// Release previous registration first (no-op on first call). Covers
+	// both the NULL-handle clear path and replace-on-resize.
+	metal_release_surround(c);
+
 	if (shared_handle == NULL) {
-		// Phase F-late TODO: release IOSurface use-count + Metal texture cache.
 		c->surround_2d = (struct u_surround_2d_handle){0};
 		U_LOG_I("Metal surround 2D cleared");
 		return;
 	}
+
+	// The handle is an in-process IOSurfaceRef — same convention as the
+	// multiview sharedIOSurface field. CFRetain guarantees lifetime; the
+	// IOSurface is cache-coherent between the app's CPU writes (under
+	// IOSurfaceLock) and our GPU reads, so no fence/use-count protocol is
+	// needed in-process. Cross-process (Mach-port lookup + use-count) is
+	// the follow-up when an out-of-process consumer shows up.
+	IOSurfaceRef surface = (IOSurfaceRef)shared_handle;
+	CFRetain(surface);
+	c->surround_iosurface = surface;
+
+	// Registered dims must be self-consistent with the surface. Per #464
+	// the surround is WINDOW-sized (the app re-registers on resize) — it
+	// is deliberately NOT required to match the worst-case shared
+	// IOSurface; the strip blit clamps its fill extent to these dims.
+	size_t sw = IOSurfaceGetWidth(surface);
+	size_t sh = IOSurfaceGetHeight(surface);
+	if (sw != w || sh != h) {
+		U_LOG_E("Metal surround 2D: registration dims (%ux%u) do not match "
+		        "IOSurface dims (%zux%zu)",
+		        w, h, sw, sh);
+		metal_release_surround(c);
+		c->surround_2d = (struct u_surround_2d_handle){0};
+		return;
+	}
+
+	uint32_t fourcc = IOSurfaceGetPixelFormat(surface);
+	MTLPixelFormat format = iosurface_fourcc_to_metal_format(fourcc);
+	MTLTextureDescriptor *desc =
+	    [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:format
+	                                                       width:sw
+	                                                      height:sh
+	                                                   mipmapped:NO];
+	desc.usage = MTLTextureUsageShaderRead;
+	desc.storageMode = MTLStorageModeShared;
+	c->surround_texture = [c->device newTextureWithDescriptor:desc
+	                                                 iosurface:surface
+	                                                     plane:0];
+	if (c->surround_texture == nil) {
+		U_LOG_E("Metal surround 2D: failed to wrap IOSurface (%zux%zu, fourcc=0x%08x)",
+		        sw, sh, fourcc);
+		metal_release_surround(c);
+		c->surround_2d = (struct u_surround_2d_handle){0};
+		return;
+	}
+
 	c->surround_2d.valid = true;
 	c->surround_2d.shared_handle = shared_handle;
 	c->surround_2d.w = w;
 	c->surround_2d.h = h;
-	// Phase F-late TODO: IOSurfaceIncrementUseCount + MTLDevice
-	// newTextureWithDescriptor:iosurface:plane: + cache Metal texture
-	// for the per-frame surround blit pass.
-	U_LOG_I("Metal surround 2D registered: handle=%p %ux%u (open + blit pending Phase F-late)",
-	        shared_handle, w, h);
+	U_LOG_I("Metal surround 2D registered: handle=%p %ux%u format=%lu",
+	        shared_handle, w, h, (unsigned long)format);
 }
 
 bool

--- a/test_apps/cube_texture_metal_macos/main.mm
+++ b/test_apps/cube_texture_metal_macos/main.mm
@@ -2,20 +2,29 @@
 // SPDX-License-Identifier: BSL-1.0
 /*!
  * @file
- * @brief  Metal OpenXR spinning cube with IOSurface shared texture
+ * @brief  Metal OpenXR spinning cube — texture mode (real view + shared IOSurface)
  *
- * Demonstrates XR_EXT_cocoa_window_binding with IOSurface shared texture:
- * the app creates an IOSurface and passes it to the runtime via the cocoa
- * window binding (viewHandle=NULL, sharedIOSurface=surface). The runtime
- * renders the composited output into the IOSurface. The app then blits
- * the IOSurface content into its own window with UI drawn around it.
+ * Demonstrates XR_EXT_cocoa_window_binding in Texture mode, matching the
+ * Windows texture apps (real HWND + shared HANDLE): the app passes BOTH its
+ * real NSView (viewHandle — used by the display processor for screen-space
+ * position tracking / phase alignment) AND a shared IOSurface
+ * (sharedIOSurface — the runtime weaves into its canvas sub-rect, declared
+ * via xrSetSharedTextureOutputRectEXT). The app owns presentation: it blits
+ * the IOSurface back into its own CAMetalLayer.
  *
- * Key difference from cube_handle_metal_macos: the app's CAMetalLayer is NOT
- * passed to the runtime. Instead, the IOSurface acts as a shared render
- * target, and the app composites the result into its own rendering pipeline.
+ * The app also registers a window-sized 2D surround IOSurface via
+ * xrSetSharedTextureSurround2DEXT (spec v6; window-clamped per #464) — the
+ * runtime strip-blits its non-canvas pixels into the shared IOSurface each
+ * frame, and the app presents the full window region (3D canvas + 2D
+ * surround).
+ *
+ * Key difference from cube_handle_metal_macos: the runtime does not present
+ * to the app's CAMetalLayer. The IOSurface acts as a shared render target,
+ * and the app composites the result into its own rendering pipeline.
  *
  * Features:
- * - IOSurface shared texture (zero-copy Metal texture sharing)
+ * - Real-view + shared-IOSurface binding (zero-copy Metal texture sharing)
+ * - 2D surround (checkerboard pattern) around a center-50% 3D canvas
  * - App-owned window with toolbar and status bar UI
  * - Mouse drag camera rotation, scroll zoom, WASD movement
  * - Metal rendering (no Vulkan/MoltenVK dependency)
@@ -776,6 +785,16 @@ static id<MTLTexture> g_ioSurfaceReadTexture = nil;
 static uint32_t g_ioSurfaceWidth = 1920;
 static uint32_t g_ioSurfaceHeight = 1080;
 
+// 2D surround IOSurface (spec v6 xrSetSharedTextureSurround2DEXT, Cocoa
+// form). Window-sized per #464 — reallocated + re-registered on window
+// resize, CPU-filled with a static checkerboard+gradient pattern. The
+// runtime strip-blits its non-canvas pixels into the shared IOSurface
+// each frame.
+static IOSurfaceRef g_surroundIOSurface = NULL;
+static uint32_t g_surroundWidth = 0;
+static uint32_t g_surroundHeight = 0;
+static bool g_surroundRegistered = false;
+
 // Input state
 struct InputState {
     float yaw = 0.0f, pitch = 0.0f;
@@ -809,7 +828,7 @@ static const float HUD_WIDTH_FRACTION = 0.20f;
 static double g_avgFrameTime = 0.0;
 static float g_hudUpdateTimer = 0.0f;
 static uint32_t g_windowW = 1512, g_windowH = 823;  // Full window backing pixels
-static uint32_t g_canvasW = 1512, g_canvasH = 823;  // Canvas (Metal view) backing pixels
+static uint32_t g_canvasW = 1512, g_canvasH = 823;  // Logical canvas backing pixels (center 50%)
 static uint32_t g_renderW = 0, g_renderH = 0;
 
 // Cached HUD section strings, refreshed at HUD throttle rate (~2 Hz).
@@ -837,7 +856,7 @@ static void SignalHandler(int)
 @implementation ToolbarView
 - (instancetype)initWithFrame:(NSRect)frame {
     self = [super initWithFrame:frame];
-    if (self) { _toolbarText = @"IOSurface Shared Texture"; [self setWantsLayer:YES]; }
+    if (self) { _toolbarText = @"Real View + Shared IOSurface + 2D Surround"; [self setWantsLayer:YES]; }
     return self;
 }
 - (BOOL)isOpaque { return YES; }
@@ -957,37 +976,26 @@ static bool CreateMacOSWindow(uint32_t width, uint32_t height, id<MTLDevice> dev
                                                  backing:NSBackingStoreBuffered
                                                    defer:NO];
 
-        [g_window setTitle:@"Metal Cube — Metal Native Compositor (IOSurface Shared)"];
+        [g_window setTitle:@"Metal Cube — Metal Native Compositor (Real View + Shared IOSurface)"];
         [g_window setAcceptsMouseMovedEvents:YES];
         [g_window setReleasedWhenClosed:NO];
 
         g_windowDelegate = [[AppWindowDelegate alloc] init];
         [g_window setDelegate:g_windowDelegate];
 
-        // Create a container view that holds toolbar + Metal view + status bar
+        // Create a container view that holds Metal view + toolbar + status bar.
+        // Layer-backed so the toolbar/status-bar overlays reliably composite
+        // ABOVE the full-window CAMetalLayer sibling.
         NSView *container = [[NSView alloc] initWithFrame:frame];
+        [container setWantsLayer:YES];
 
-        // Toolbar (top)
-        NSRect toolbarFrame = NSMakeRect(0, height - TOOLBAR_HEIGHT, width, TOOLBAR_HEIGHT);
-        g_toolbarView = [[ToolbarView alloc] initWithFrame:toolbarFrame];
-        g_toolbarView.autoresizingMask = NSViewWidthSizable | NSViewMinYMargin;
-        [container addSubview:g_toolbarView];
-
-        // Status bar (bottom)
-        NSRect statusFrame = NSMakeRect(0, 0, width, STATUSBAR_HEIGHT);
-        g_statusBarView = [[StatusBarView alloc] initWithFrame:statusFrame];
-        g_statusBarView.autoresizingMask = NSViewWidthSizable | NSViewMaxYMargin;
-        [container addSubview:g_statusBarView];
-
-        // Metal view (canvas — center 50% of window to clearly show canvas ≠ window)
-        float canvasW = width * 0.5f;
-        float canvasH = height * 0.5f;
-        float canvasX = width * 0.25f;
-        float canvasY = height * 0.25f;
-        NSRect metalFrame = NSMakeRect(canvasX, canvasY, canvasW, canvasH);
-        g_metalView = [[AppMetalView alloc] initWithFrame:metalFrame];
+        // Metal view — FULL content area (added first = bottom of z-order).
+        // The 3D canvas is a logical center sub-rect inside it (see
+        // ComputeCanvasRectPx), matching the Windows texture apps where the
+        // canvas is a sub-rect of the one full-window client area.
+        g_metalView = [[AppMetalView alloc] initWithFrame:[container bounds]];
         [g_metalView setWantsLayer:YES];
-        g_metalView.autoresizingMask = 0;  // No autoresize — repositioned each frame
+        g_metalView.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
 
         // Set Retina scale
         CAMetalLayer *metalLayer = (CAMetalLayer *)[g_metalView layer];
@@ -998,6 +1006,20 @@ static bool CreateMacOSWindow(uint32_t width, uint32_t height, id<MTLDevice> dev
         }
 
         [container addSubview:g_metalView];
+
+        // Toolbar (top, overlays the metal view)
+        NSRect toolbarFrame = NSMakeRect(0, height - TOOLBAR_HEIGHT, width, TOOLBAR_HEIGHT);
+        g_toolbarView = [[ToolbarView alloc] initWithFrame:toolbarFrame];
+        g_toolbarView.autoresizingMask = NSViewWidthSizable | NSViewMinYMargin;
+        [g_toolbarView setWantsLayer:YES];
+        [container addSubview:g_toolbarView];
+
+        // Status bar (bottom, overlays the metal view)
+        NSRect statusFrame = NSMakeRect(0, 0, width, STATUSBAR_HEIGHT);
+        g_statusBarView = [[StatusBarView alloc] initWithFrame:statusFrame];
+        g_statusBarView.autoresizingMask = NSViewWidthSizable | NSViewMaxYMargin;
+        [g_statusBarView setWantsLayer:YES];
+        [container addSubview:g_statusBarView];
 
         // HUD now lives as an XR_EXT_window_space_layer composed by the
         // runtime, not as an NSView subview.
@@ -1069,6 +1091,142 @@ static bool CreateIOSurface(uint32_t width, uint32_t height, id<MTLDevice> devic
 }
 
 // ============================================================================
+// Logical canvas rect (center 50% of the window, in backing pixels)
+// ============================================================================
+
+// The 3D canvas is a logical sub-rect of the full-window Metal view —
+// center 50%, like the Windows texture apps. Coordinates are TOP-DOWN
+// (client-area convention per XR_EXT_win32_window_binding §3.5, matching
+// Metal texture space). The pre-#406 code passed AppKit's bottom-up
+// `frame.origin.y * scale` as canvas y — it round-tripped only because the
+// same value was used for both the runtime write and the app read AND the
+// rect is centered; standardize on top-down deliberately.
+// Clamped to the shared IOSurface dims (window may exceed the worst-case
+// atlas on huge displays).
+static void ComputeCanvasRectPx(int32_t *cx, int32_t *cy, uint32_t *cw, uint32_t *ch)
+{
+    uint32_t winW = 0, winH = 0;
+    if (g_window != nil) {
+        CGFloat bs = [g_window backingScaleFactor];
+        NSSize sz = [[g_window contentView] bounds].size;
+        winW = (uint32_t)(sz.width * bs);
+        winH = (uint32_t)(sz.height * bs);
+    }
+    if (winW > g_ioSurfaceWidth) winW = g_ioSurfaceWidth;
+    if (winH > g_ioSurfaceHeight) winH = g_ioSurfaceHeight;
+
+    *cx = (int32_t)(winW / 4);
+    *cy = (int32_t)(winH / 4);
+    *cw = winW / 2;
+    *ch = winH / 2;
+}
+
+// Window content-area backing pixels, clamped to the shared IOSurface dims
+// (the region of the IOSurface the app actually presents).
+static void WindowBackingPx(uint32_t *w, uint32_t *h)
+{
+    *w = 0;
+    *h = 0;
+    if (g_window != nil) {
+        CGFloat bs = [g_window backingScaleFactor];
+        NSSize sz = [[g_window contentView] bounds].size;
+        *w = (uint32_t)(sz.width * bs);
+        *h = (uint32_t)(sz.height * bs);
+    }
+    if (*w > g_ioSurfaceWidth) *w = g_ioSurfaceWidth;
+    if (*h > g_ioSurfaceHeight) *h = g_ioSurfaceHeight;
+}
+
+// ============================================================================
+// 2D surround IOSurface (window-sized, #464)
+// ============================================================================
+
+// Fill the surround with a static checkerboard + vertical gradient, with a
+// bright border ring just outside the canvas rect so the canvas/surround
+// boundary is visually unmistakable (same intent as the Windows app's
+// RenderSurroundPattern pixel shader). Pixels inside the canvas rect are
+// skipped — the runtime never reads them (the DP owns that region).
+// CPU fill is deliberate: no per-frame redraw is required on macOS (no
+// keyed-mutex handshake; the IOSurface is coherent), and a static pattern
+// keeps captures byte-stable. A Metal-pass + shared-event version is the
+// production-shaped follow-up.
+static void FillSurroundPattern(int32_t canvasX, int32_t canvasY,
+                                uint32_t canvasW, uint32_t canvasH)
+{
+    if (g_surroundIOSurface == NULL) return;
+
+    IOSurfaceLock(g_surroundIOSurface, 0, NULL);
+    uint8_t *base = (uint8_t *)IOSurfaceGetBaseAddress(g_surroundIOSurface);
+    size_t stride = IOSurfaceGetBytesPerRow(g_surroundIOSurface);
+    uint32_t w = g_surroundWidth;
+    uint32_t h = g_surroundHeight;
+
+    const uint32_t cell = 64;        // checker cell in pixels
+    const uint32_t ring = 6;         // border ring thickness around canvas
+    int64_t cL = canvasX, cT = canvasY;
+    int64_t cR = canvasX + (int64_t)canvasW, cB = canvasY + (int64_t)canvasH;
+
+    for (uint32_t y = 0; y < h; y++) {
+        uint8_t *row = base + (size_t)y * stride;
+        for (uint32_t x = 0; x < w; x++) {
+            bool insideCanvas = ((int64_t)x >= cL && (int64_t)x < cR &&
+                                 (int64_t)y >= cT && (int64_t)y < cB);
+            if (insideCanvas) continue; // DP-owned, never read
+
+            uint8_t *px = row + (size_t)x * 4;
+            bool inRing = ((int64_t)x >= cL - (int64_t)ring && (int64_t)x < cR + (int64_t)ring &&
+                           (int64_t)y >= cT - (int64_t)ring && (int64_t)y < cB + (int64_t)ring);
+            if (inRing) {
+                // Bright amber ring at the canvas boundary
+                px[0] = 0;   px[1] = 170; px[2] = 255; px[3] = 255; // BGRA
+                continue;
+            }
+            bool check = (((x / cell) + (y / cell)) & 1) != 0;
+            float grad = (h > 1) ? (float)y / (float)(h - 1) : 0.0f;
+            uint8_t lo = (uint8_t)(40.0f + 50.0f * grad);
+            uint8_t hi = (uint8_t)(90.0f + 90.0f * grad);
+            uint8_t v = check ? hi : lo;
+            // Teal-tinted checker (BGRA byte order)
+            px[0] = v;                       // B
+            px[1] = (uint8_t)(v * 3 / 4);    // G
+            px[2] = (uint8_t)(v / 2);        // R
+            px[3] = 255;                     // A
+        }
+    }
+
+    IOSurfaceUnlock(g_surroundIOSurface, 0, NULL);
+}
+
+// (Re)create the surround IOSurface at the current window backing size.
+// Same pixel format as the multiview shared IOSurface ('BGRA') — the
+// runtime's strip blit requires strict format equality.
+static bool CreateSurroundIOSurface(uint32_t width, uint32_t height)
+{
+    if (g_surroundIOSurface != NULL) {
+        CFRelease(g_surroundIOSurface);
+        g_surroundIOSurface = NULL;
+    }
+    if (width == 0 || height == 0) return false;
+
+    NSDictionary *props = @{
+        (id)kIOSurfaceWidth:       @(width),
+        (id)kIOSurfaceHeight:      @(height),
+        (id)kIOSurfaceBytesPerElement: @(4),
+        (id)kIOSurfacePixelFormat: @((uint32_t)'BGRA'),
+    };
+    g_surroundIOSurface = IOSurfaceCreate((CFDictionaryRef)props);
+    if (g_surroundIOSurface == NULL) {
+        LOG_ERROR("Failed to create surround IOSurface (%ux%u)", width, height);
+        return false;
+    }
+    g_surroundWidth = width;
+    g_surroundHeight = height;
+    LOG_INFO("Created surround IOSurface: %ux%u, BGRA8, id=%u",
+             width, height, IOSurfaceGetID(g_surroundIOSurface));
+    return true;
+}
+
+// ============================================================================
 // Blit IOSurface to drawable (app's Metal rendering)
 // ============================================================================
 
@@ -1086,40 +1244,47 @@ static void BlitIOSurfaceToDrawable(MetalRenderer &r, CAMetalLayer *metalLayer)
     id<MTLCommandBuffer> cmdBuf = [r.commandQueue commandBuffer];
     id<MTLRenderCommandEncoder> enc = [cmdBuf renderCommandEncoderWithDescriptor:rpd];
 
-    // Blit the canvas portion of the IOSurface, letterboxed into the drawable
+    // Position-true 1:1 readback of the shared IOSurface — the drawable IS
+    // the full window now (parity with cube_texture_d3d11_win main.cpp):
+    //  - surround active:   blit the whole window region (canvas 3D weave +
+    //                       runtime-blitted 2D surround strips).
+    //  - surround inactive: blit ONLY the canvas sub-rect, at its position;
+    //                       the rest of the drawable keeps the clear color.
     if (g_ioSurfaceReadTexture != nil) {
+        // Derive the window pixel dims from the drawable itself — always
+        // self-consistent, even mid-resize while the compositor adjusts
+        // the layer's drawableSize.
         float drawW = (float)drawable.texture.width;
         float drawH = (float)drawable.texture.height;
+        float ioW = (float)g_ioSurfaceWidth;
+        float ioH = (float)g_ioSurfaceHeight;
 
-        // UV scale + offset: compositor writes the canvas region at
-        // (canvasX, canvasY) inside the IOSurface per ADR-010. Sample at
-        // uv_offset + uv * uv_scale.
-        float uvScaleX = (g_ioSurfaceWidth > 0) ? (float)g_canvasW / (float)g_ioSurfaceWidth : 1.0f;
-        float uvScaleY = (g_ioSurfaceHeight > 0) ? (float)g_canvasH / (float)g_ioSurfaceHeight : 1.0f;
-        float uvOffsetX = 0.0f, uvOffsetY = 0.0f;
-        if (g_metalView != nil && g_window != nil) {
-            CGFloat bs = [g_window backingScaleFactor];
-            NSRect mf = [g_metalView frame];
-            float canvasXpx = (float)(mf.origin.x * bs);
-            float canvasYpx = (float)(mf.origin.y * bs);
-            if (g_ioSurfaceWidth > 0) uvOffsetX = canvasXpx / (float)g_ioSurfaceWidth;
-            if (g_ioSurfaceHeight > 0) uvOffsetY = canvasYpx / (float)g_ioSurfaceHeight;
-        }
-
-        // Letterbox using canvas aspect ratio (not IOSurface aspect)
-        float canvasAspect = (g_canvasH > 0) ? (float)g_canvasW / (float)g_canvasH : 1.0f;
-        float drawAspect = drawW / drawH;
         float vpX, vpY, vpW, vpH;
-        if (canvasAspect > drawAspect) {
-            vpW = drawW;
-            vpH = drawW / canvasAspect;
-            vpX = 0;
-            vpY = (drawH - vpH) / 2.0f;
+        float uvOffsetX, uvOffsetY, uvScaleX, uvScaleY;
+        if (g_surroundRegistered) {
+            // Full window region, clamped to the worst-case IOSurface.
+            vpW = (drawW < ioW) ? drawW : ioW;
+            vpH = (drawH < ioH) ? drawH : ioH;
+            vpX = 0.0f;
+            vpY = 0.0f;
+            uvOffsetX = 0.0f;
+            uvOffsetY = 0.0f;
+            uvScaleX = (ioW > 0) ? vpW / ioW : 1.0f;
+            uvScaleY = (ioH > 0) ? vpH / ioH : 1.0f;
         } else {
-            vpH = drawH;
-            vpW = drawH * canvasAspect;
-            vpX = (drawW - vpW) / 2.0f;
-            vpY = 0;
+            // Canvas sub-rect at its position (top-down coords; MTLViewport
+            // origin is top-left, so the canvas y drops straight in).
+            int32_t cx, cy;
+            uint32_t cw, ch;
+            ComputeCanvasRectPx(&cx, &cy, &cw, &ch);
+            vpX = (float)cx;
+            vpY = (float)cy;
+            vpW = (float)cw;
+            vpH = (float)ch;
+            uvOffsetX = (ioW > 0) ? (float)cx / ioW : 0.0f;
+            uvOffsetY = (ioH > 0) ? (float)cy / ioH : 0.0f;
+            uvScaleX = (ioW > 0) ? (float)cw / ioW : 1.0f;
+            uvScaleY = (ioH > 0) ? (float)ch / ioH : 1.0f;
         }
 
         // Pass UV scale + offset to blit shader
@@ -1264,22 +1429,19 @@ static void PumpMacOSEvents()
             }
         }
 
-        // Update pixel sizes and reposition canvas at center 25%-75%
+        // Update pixel sizes. The Metal view autoresizes to fill the window;
+        // the canvas is a LOGICAL center-50% sub-rect (ComputeCanvasRectPx),
+        // no view repositioning needed.
         if (g_metalView != nil && g_window != nil) {
             CGFloat backingScale = [g_window backingScaleFactor];
-            // Full window content area
             NSSize winSize = [[g_window contentView] bounds].size;
             g_windowW = (uint32_t)(winSize.width * backingScale);
             g_windowH = (uint32_t)(winSize.height * backingScale);
-            // Reposition Metal view to center 50% of content area
-            float cw = winSize.width * 0.5f;
-            float ch = winSize.height * 0.5f;
-            float cx = winSize.width * 0.25f;
-            float cy = winSize.height * 0.25f;
-            [g_metalView setFrame:NSMakeRect(cx, cy, cw, ch)];
-            // Canvas = Metal view backing pixels
-            g_canvasW = (uint32_t)(cw * backingScale);
-            g_canvasH = (uint32_t)(ch * backingScale);
+            int32_t cx, cy;
+            uint32_t cw, ch;
+            ComputeCanvasRectPx(&cx, &cy, &cw, &ch);
+            g_canvasW = cw;
+            g_canvasH = ch;
         }
     }
 }
@@ -1368,6 +1530,7 @@ struct AppXrSession {
     PFN_xrRequestDisplayRenderingModeEXT pfnRequestDisplayRenderingModeEXT;
     PFN_xrEnumerateDisplayRenderingModesEXT pfnEnumerateDisplayRenderingModesEXT;
     PFN_xrSetSharedTextureOutputRectEXT pfnSetSharedTextureOutputRectEXT;
+    PFN_xrSetSharedTextureSurround2DEXT pfnSetSharedTextureSurround2DEXT;
     // Enumerated rendering mode info. currentModeIndex is initialized to mode 1
     // as a fallback for runtimes that don't expose isActive; v13+ runtimes
     // replace it via the enumerate step (initial-mode-sync, #234/#239).
@@ -1488,6 +1651,9 @@ static bool InitializeOpenXR(AppXrSession &app)
                 (PFN_xrVoidFunction*)&app.pfnEnumerateDisplayRenderingModesEXT);
             xrGetInstanceProcAddr(app.instance, "xrSetSharedTextureOutputRectEXT",
                 (PFN_xrVoidFunction*)&app.pfnSetSharedTextureOutputRectEXT);
+            // NULL-tolerant: pre-v6 runtimes don't export the surround call.
+            xrGetInstanceProcAddr(app.instance, "xrSetSharedTextureSurround2DEXT",
+                (PFN_xrVoidFunction*)&app.pfnSetSharedTextureSurround2DEXT);
         }
     }
 
@@ -1527,28 +1693,31 @@ static bool GetMetalGraphicsRequirements(AppXrSession &app)
 
 static bool CreateSession(AppXrSession &app, MetalRenderer &r)
 {
-    LOG_INFO("Creating OpenXR session with IOSurface shared texture...");
+    LOG_INFO("Creating OpenXR session (texture mode: real view + shared IOSurface)...");
 
     XrGraphicsBindingMetalKHR metalBinding = {XR_TYPE_GRAPHICS_BINDING_METAL_KHR};
     metalBinding.commandQueue = (__bridge void *)r.commandQueue;
 
-    // Chain the cocoa window binding extension:
-    // viewHandle=NULL (offscreen), sharedIOSurface=our IOSurface
+    // Chain the cocoa window binding extension — Texture mode:
+    // real NSView (for DP screen-space position tracking / phase alignment)
+    // + shared IOSurface (the runtime composites into its canvas sub-rect).
+    // Parity with the Windows texture apps (real HWND + shared HANDLE).
     XrCocoaWindowBindingCreateInfoEXT cocoaBinding = {};
     cocoaBinding.type = XR_TYPE_COCOA_WINDOW_BINDING_CREATE_INFO_EXT;
     cocoaBinding.next = nullptr;
-    cocoaBinding.viewHandle = NULL;  // Offscreen — no NSView passed to runtime
+    cocoaBinding.viewHandle = (__bridge void *)g_metalView;
     cocoaBinding.sharedIOSurface = (void *)g_ioSurface;
 
     metalBinding.next = &cocoaBinding;
-    LOG_INFO("Chaining XR_EXT_cocoa_window_binding: viewHandle=NULL, sharedIOSurface=%p", (void *)g_ioSurface);
+    LOG_INFO("Chaining XR_EXT_cocoa_window_binding: viewHandle=%p, sharedIOSurface=%p",
+             (__bridge void *)g_metalView, (void *)g_ioSurface);
 
     XrSessionCreateInfo sessionInfo = {XR_TYPE_SESSION_CREATE_INFO};
     sessionInfo.next = &metalBinding;
     sessionInfo.systemId = app.systemId;
 
     XR_CHECK(xrCreateSession(app.instance, &sessionInfo, &app.session));
-    LOG_INFO("Session created (IOSurface shared texture mode)");
+    LOG_INFO("Session created (texture mode: real view + shared IOSurface)");
 
     // Enumerate available rendering modes and store names
     app.renderingModeCount = 0;
@@ -1779,12 +1948,10 @@ int main(int argc, char **argv)
         }
     }
     if (ioW == 0 || ioH == 0) {
-        // Fallback: display dims or canvas backing
+        // Fallback: display dims or window backing
         ioW = app.displayPixelWidth > 0 ? app.displayPixelWidth : (uint32_t)backing.size.width;
         ioH = app.displayPixelHeight > 0 ? app.displayPixelHeight : (uint32_t)backing.size.height;
     }
-    app.canvasPixelWidth = (uint32_t)backing.size.width;
-    app.canvasPixelHeight = (uint32_t)backing.size.height;
     LOG_INFO("IOSurface dimensions (worst-case atlas): %ux%u", ioW, ioH);
 
     // Create the shared IOSurface
@@ -1793,7 +1960,17 @@ int main(int argc, char **argv)
         return 1;
     }
 
-    // Create session with IOSurface (viewHandle=NULL)
+    // Canvas = logical center-50% sub-rect of the window (clamped to the
+    // now-known IOSurface dims). The Metal view itself fills the window.
+    {
+        int32_t cx0, cy0;
+        uint32_t cw0, ch0;
+        ComputeCanvasRectPx(&cx0, &cy0, &cw0, &ch0);
+        app.canvasPixelWidth = cw0;
+        app.canvasPixelHeight = ch0;
+    }
+
+    // Create session with real view + shared IOSurface (texture mode)
     if (!CreateSession(app, renderer)) {
         LOG_ERROR("Failed to create session");
         return 1;
@@ -1801,14 +1978,35 @@ int main(int argc, char **argv)
 
     // Tell the compositor where the canvas is within the window client area
     if (app.pfnSetSharedTextureOutputRectEXT) {
-        CGFloat backingScale = g_window ? [g_window backingScaleFactor] : 2.0;
-        NSRect mf = [g_metalView frame];
-        int32_t canvasX = (int32_t)(mf.origin.x * backingScale);
-        int32_t canvasY = (int32_t)(mf.origin.y * backingScale);
+        int32_t canvasX, canvasY;
+        uint32_t canvasW, canvasH;
+        ComputeCanvasRectPx(&canvasX, &canvasY, &canvasW, &canvasH);
         app.pfnSetSharedTextureOutputRectEXT(app.session, canvasX, canvasY,
-                                              app.canvasPixelWidth, app.canvasPixelHeight);
+                                              canvasW, canvasH);
         LOG_INFO("Set shared texture output rect: x=%d, y=%d, w=%u, h=%u",
-                 canvasX, canvasY, app.canvasPixelWidth, app.canvasPixelHeight);
+                 canvasX, canvasY, canvasW, canvasH);
+    }
+
+    // Register the 2D surround (spec v6) — window-sized per #464. The
+    // runtime strip-blits its non-canvas pixels into the shared IOSurface
+    // each frame; the app then presents the full window region.
+    if (app.pfnSetSharedTextureSurround2DEXT) {
+        uint32_t winPxW, winPxH;
+        WindowBackingPx(&winPxW, &winPxH);
+        if (CreateSurroundIOSurface(winPxW, winPxH)) {
+            int32_t cx0, cy0;
+            uint32_t cw0, ch0;
+            ComputeCanvasRectPx(&cx0, &cy0, &cw0, &ch0);
+            FillSurroundPattern(cx0, cy0, cw0, ch0);
+            XrResult sres = app.pfnSetSharedTextureSurround2DEXT(
+                app.session, (void *)g_surroundIOSurface, winPxW, winPxH);
+            g_surroundRegistered = XR_SUCCEEDED(sres);
+            LOG_INFO("Surround 2D %s: %ux%u (XrResult=%d)",
+                     g_surroundRegistered ? "registered" : "REGISTRATION FAILED",
+                     winPxW, winPxH, (int)sres);
+        }
+    } else {
+        LOG_INFO("xrSetSharedTextureSurround2DEXT unavailable — no 2D surround");
     }
 
     if (!CreateSpaces(app)) {
@@ -1869,16 +2067,32 @@ int main(int argc, char **argv)
 
         PumpMacOSEvents();
 
-        // Update canvas rect and recreate IOSurface if canvas size changed
+        // Update canvas rect (logical center-50%) for Kooima/weaver alignment,
+        // and re-register the window-sized surround on window resize (#464:
+        // the surround tracks the window rect, not the worst-case surface).
         if (g_metalView != nil && g_window != nil) {
-            CGFloat bs = [g_window backingScaleFactor];
-            NSRect mf = [g_metalView frame];
+            int32_t cx, cy;
+            uint32_t cw, ch;
+            ComputeCanvasRectPx(&cx, &cy, &cw, &ch);
 
-            // Update canvas position for Kooima/weaver alignment
             if (app.pfnSetSharedTextureOutputRectEXT) {
-                app.pfnSetSharedTextureOutputRectEXT(app.session,
-                    (int32_t)(mf.origin.x * bs), (int32_t)(mf.origin.y * bs),
-                    g_canvasW, g_canvasH);
+                app.pfnSetSharedTextureOutputRectEXT(app.session, cx, cy, cw, ch);
+            }
+
+            if (g_surroundRegistered && app.pfnSetSharedTextureSurround2DEXT) {
+                uint32_t winPxW, winPxH;
+                WindowBackingPx(&winPxW, &winPxH);
+                if (winPxW != g_surroundWidth || winPxH != g_surroundHeight) {
+                    if (CreateSurroundIOSurface(winPxW, winPxH)) {
+                        FillSurroundPattern(cx, cy, cw, ch);
+                        XrResult sres = app.pfnSetSharedTextureSurround2DEXT(
+                            app.session, (void *)g_surroundIOSurface, winPxW, winPxH);
+                        g_surroundRegistered = XR_SUCCEEDED(sres);
+                    } else {
+                        app.pfnSetSharedTextureSurround2DEXT(app.session, NULL, 0, 0);
+                        g_surroundRegistered = false;
+                    }
+                }
             }
         }
 
@@ -2035,11 +2249,25 @@ int main(int argc, char **argv)
 
                 // Canvas-relative Kooima: physical size + eye offset both anchored
                 // on the canvas region within the window (not the window itself).
+                // The Metal view fills the window now, so derive the canvas rect
+                // logically (top-down backing px) and convert to AppKit's
+                // bottom-up point space for the screen conversion.
                 float eyeOffsetX = 0.0f, eyeOffsetY = 0.0f;
                 if (g_window != nil && g_metalView != nil) {
                     NSScreen *screen_ns = [g_window screen] ?: [NSScreen mainScreen];
                     NSRect screenFrame = [screen_ns frame];
-                    NSRect canvasInWindow = [g_metalView convertRect:[g_metalView bounds] toView:nil];
+                    int32_t ccx, ccy;
+                    uint32_t ccw, cch;
+                    ComputeCanvasRectPx(&ccx, &ccy, &ccw, &cch);
+                    CGFloat cbs = [g_window backingScaleFactor];
+                    NSView *content = [g_window contentView];
+                    NSSize winPts = [content bounds].size;
+                    NSRect canvasInContent = NSMakeRect(
+                        (CGFloat)ccx / cbs,
+                        winPts.height - (CGFloat)(ccy + (int32_t)cch) / cbs, // top-down -> bottom-up
+                        (CGFloat)ccw / cbs,
+                        (CGFloat)cch / cbs);
+                    NSRect canvasInWindow = [content convertRect:canvasInContent toView:nil];
                     NSRect canvasInScreen = [g_window convertRectToScreen:canvasInWindow];
                     float canvasCenterX = (canvasInScreen.origin.x - screenFrame.origin.x) + canvasInScreen.size.width / 2.0f;
                     float canvasCenterY = (canvasInScreen.origin.y - screenFrame.origin.y) + canvasInScreen.size.height / 2.0f;
@@ -2280,7 +2508,7 @@ int main(int argc, char **argv)
                 const char *kooimaMode = g_input.cameraMode
                     ? "Camera-Centric [C=Toggle]" : "Display-Centric [C=Toggle]";
                 snprintf(buf, sizeof(buf),
-                    "XR_EXT_cocoa_window_binding: ACTIVE (Metal IOSurface)\nMode: %s (%s)%s\nKooima: %s",
+                    "XR_EXT_cocoa_window_binding: ACTIVE (Real View + IOSurface)\nMode: %s (%s)%s\nKooima: %s",
                     outputModeName, display3D ? "3D" : "2D", lockSuffix, kooimaMode);
                 g_hudModeText = utf8ToW(buf);
 
@@ -2350,6 +2578,13 @@ int main(int argc, char **argv)
 
     LOG_INFO("Shutting down...");
 
+    // Clear the surround registration before tearing the session down
+    // (documented lifecycle: clear with NULL, then destroy).
+    if (g_surroundRegistered && app.pfnSetSharedTextureSurround2DEXT && app.session) {
+        app.pfnSetSharedTextureSurround2DEXT(app.session, NULL, 0, 0);
+        g_surroundRegistered = false;
+    }
+
     if (hudReady) {
         CleanupHudRenderer(hudRenderer);
     }
@@ -2367,11 +2602,15 @@ int main(int argc, char **argv)
     if (app.instance)
         xrDestroyInstance(app.instance);
 
-    // Release IOSurface
+    // Release IOSurfaces
     g_ioSurfaceReadTexture = nil;
     if (g_ioSurface != NULL) {
         CFRelease(g_ioSurface);
         g_ioSurface = NULL;
+    }
+    if (g_surroundIOSurface != NULL) {
+        CFRelease(g_surroundIOSurface);
+        g_surroundIOSurface = NULL;
     }
 
     LOG_INFO("Clean shutdown complete");


### PR DESCRIPTION
Closes #406. Implements the Metal surround **window-clamped from the start** per the #464 design constraint (issue comment on #406).

## What changed

### Divergence 1 — binding model (app)
`cube_texture_metal_macos` now passes its **real NSView + shared IOSurface** (Texture mode), parity with `cube_texture_d3d11_win`'s real HWND + shared HANDLE. The Metal view fills the window; the 3D canvas is a **logical center-50% sub-rect** in top-down client-area coords (the old bottom-up origin only round-tripped because the rect was centered). Presentation is conditional like the Windows app: full window region when the surround is registered, canvas-sub-rect-at-position otherwise.

### Divergence 2 — Metal 2D rect surround (compositor)
- `comp_metal_compositor_set_surround_2d` is now real (was a "Phase F-late" stub): CFRetain + MTLTexture wrap + dims validation; `metal_release_surround` choke point for clear/replace/destroy. CFRetain-only sync (coherent IOSurface, in-process); use-count/Mach-port is the cross-process follow-up.
- New `metal_blit_surround_strips` — the 4-strip rect copy mirroring `d3d11_blit_surround_strips`, but **window-clamped (#464)**: the fill extent is the registered window-sized dims anchored top-left, never the worst-case surface. This deliberately diverges from D3D11's `surround.dims == dst.dims` over-fill, which #464 retrofits separately. Single call site covers both the DP path and the no-DP fallback.
- **Mirror gate:** the IOSurface→layer mirror (editor-preview/Unity path) is skipped once the app declares a canvas rect — texture apps own presentation; sessions that never set a canvas keep the mirror.
- New capture probe: `DISPLAYXR_SURROUND_CAPTURE=1` + `touch /tmp/dxr_surround_trigger` → `/tmp/dxr_surround.png` (post-surround composite; mirrors `d3d11_maybe_capture_surround_target`).

**Guardrail respected:** rect strip-copy only — no alpha-mask composite (that's #439; this rect surround is the baseline it generalizes).

### Spec/doc erratum (work item 4) — spec stays v6
- `XR_EXT_cocoa_window_binding.md` surround deltas corrected: pixel format must **match the multiview shared IOSurface** (not "must be RGBA8Unorm"); window-sized dims confirmed + made explicit (re-register on resize); **window-clamped fill per #464** documented, incl. the deliberate divergence from the current Win32/D3D11 contract; sync language aligned to CFRetain/coherent. Revision-history erratum row added, **no version bump** (text aligned to behavior, no ABI change — same precedent as the Win32 §3.6 correction).
- Extension header doc comment aligned (auto-syncs to `displayxr-extensions` on merge).
- `u_canvas.h`: dims-contract note (#464 target model; D3D11/D3D12 legacy contract called out as pending retrofit).
- `displayxr-app-rules.md` §12.2 macOS divergence → **RESOLVED**, with the #464 platform delta noted (INV-5.4/5.7 "worst-case size" wording stays Windows-accurate until the retrofit).
- Win32 spec + D3D11 strips deliberately untouched (#464's scope).

## Validation
- `./scripts/build_macos.sh` green.
- Run log: `viewHandle=0x…` (non-NULL), `Surround 2D registered: 3024x1646` (window backing) vs worst-case IOSurface `3024x1964` — window-sized registration. No "Headless mode" line.
- `/tmp/dxr_surround.png`: anaglyph-weaved 3D canvas in the center sub-rect, amber boundary ring, checkerboard+gradient surround filling the window complement, and the beyond-window band **untouched** — the window-clamped fill, visible.
- Y-convention proof: temporary `cy = winH/8` capture put the canvas at the window **top** — top-down plumbing confirmed end-to-end (canvas → DP weave → strips), then reverted.
- `/tmp/dxr_atlas.png` unchanged from baseline (projection path untouched).
- `python3 scripts/check_displayxr_app.py test_apps/cube_texture_metal_macos` — 0 errors (2 pre-existing warnings: INV-4.6 sRGB, INV-9.1 manifest — no macOS test app ships a manifest yet, out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)