### PR TITLE
feat(#439): Phase 2 — active zone mask supersedes the canvas output rect

### DIFF
--- a/docs/roadmap/unified-2d-3d-phase2-impl.md
+++ b/docs/roadmap/unified-2d-3d-phase2-impl.md
@@ -4,7 +4,7 @@
 **Spec:** [`unified-2d-3d-compositing.md`](unified-2d-3d-compositing.md) §6 (Phase 2), §9 Q5 (full-window first, bbox under profiling). Epic #439.
 **Builds on:** Phase 1 (`XR_EXT_local_3d_zone` oxr layer + D3D11 consumer, merged in PR #469; window-clamped per #464).
 
-> **STATUS: ready to execute.** Windows-only — D3D11 compositor + Leia validation; no oxr, no DP-interface, no macOS-verifiable code.
+> **STATUS: implemented + hardware-validated (2026-06-06).** `d3d11_effective_canvas()` applied at all 8 sites; §5 matrix green on Leia hardware — no-mask leg statistically identical to a Phase-1 `main` build (DP weave geometry byte-identical, pixel diff within the same-runtime noise envelope, beyond-window region diff 0), mask-active weave flips to `canvas=(0,0,win)` with window-derived view dims, Tier-2 islands beyond the old canvas show real weave on-glass (Phase 1 showed stale 2D there), destroy snaps geometry back, drag-resize tracks the client rect per frame, `selftest` passes. Note: the window-spanning 3D is upscaled from the app's canvas-sized swapchain (app didn't re-render; expected — view dims are the runtime side only). Windows-only — D3D11 compositor + Leia validation; no oxr, no DP-interface, no macOS-verifiable code.
 
 ---
 
@@ -99,9 +99,9 @@ Reuse the Phase-1 harness (`cube_texture_d3d11_win` 'Z' cycle + `DISPLAYXR_SURRO
 
 ## 6. Done-when
 
-- [ ] Active mask ⇒ weave region, view dims, Kooima metrics, and composite region are all the client-window rect (one effective-canvas authority, all 8 sites).
-- [ ] No-mask path byte-identical to Phase 1 (capture diff 0).
-- [ ] Tier-2 island beyond the old canvas shows real weave (capture + on-glass).
-- [ ] Mask destroy restores output-rect behavior (capture matches pre-mask frame).
-- [ ] Comment fixes (:144) + extension-header note (output rect superseded while a mask is active).
+- [x] Active mask ⇒ weave region, view dims, Kooima metrics, and composite region are all the client-window rect (one effective-canvas authority, all 8 sites). DP log: `canvas=(320,180 640x360)` → `canvas=(0,0 1280x720)`, `view=320x180` → `640x360` on submit; reverse on destroy.
+- [x] No-mask path byte-identical to Phase 1 (the helper returns `c->canvas` verbatim with no mask; capture A/B vs a Phase-1 `main` build: weave geometry identical, beyond-window diff 0, window-region diff within the same-runtime capture noise — strict diff-0 is unattainable across runs because the app's surround + cube animate).
+- [x] Tier-2 island beyond the old canvas shows real weave (capture: island region 100% changed vs noise-level on Phase 1; interlace eyeballed good on-glass). Re-baselined golden: Tier-2 single rect now crops a window-spanning weave (82% changed inside the rect vs the Phase-0/1 canvas-fit output) — intended end-state semantics per §2.
+- [x] Mask destroy restores output-rect behavior (capture matches pre-mask frame within noise; geometry snap-back logged).
+- [x] Comment fixes (:144) + extension-header note (output rect superseded while a mask is active).
 - [ ] Epic #439 Phase-2 checkbox ticked; this doc's STATUS updated.

--- a/src/external/openxr_includes/openxr/XR_EXT_local_3d_zone.h
+++ b/src/external/openxr_includes/openxr/XR_EXT_local_3d_zone.h
@@ -141,7 +141,15 @@ XRAPI_ATTR XrResult XRAPI_CALL xrAcquireLocal3DZoneRenderTargetEXT(
 
 //! Stage the mask's current state for the next frame submission. The mask,
 //! the 2D layer, and the 3D layers are consumed as one coherent xrEndFrame
-//! set (atomic per frame — spec §9 Q3).
+//! set (atomic per frame — spec §9 Q3). The mask stays active across frames
+//! (sticky, last-submit-wins) until re-submit or destroy.
+//!
+//! While a submitted mask is active, the canvas output rect
+//! (xrSetSharedTextureOutputRectEXT) is SUPERSEDED, not an error: the weave
+//! region, view dimensions, and projection metrics span the full client
+//! window, and the mask is the sole 2D/3D region selector over that
+//! window-spanning 3D scene. Destroying the mask restores the rect-derived
+//! behavior on the next frame. (#439 Phase 2.)
 XRAPI_ATTR XrResult XRAPI_CALL xrSubmitLocal3DZoneEXT(
     XrLocal3DZoneMaskEXT mask);
 

--- a/src/xrt/compositor/d3d11/comp_d3d11_compositor.cpp
+++ b/src/xrt/compositor/d3d11/comp_d3d11_compositor.cpp
@@ -142,8 +142,10 @@ struct comp_d3d11_compositor
 	bool has_shared_texture;
 
 	//! Canvas output rect for shared-texture apps.
-	//! When valid, the hidden weaver window is positioned to match this
-	//! sub-rect instead of the full client rect.
+	//! When valid, it flows to the DP as the weave sub-rect via the
+	//! process_atlas canvas params (#85) and drives view dims + Kooima
+	//! metrics. Superseded by an active zone mask (#439 Phase 2) — read
+	//! through d3d11_effective_canvas() on every frame-path site.
 	struct u_canvas_rect canvas;
 
 	//! 2D surround texture handle (Spec v6).
@@ -303,9 +305,42 @@ d3d11_maybe_capture_surround_target(struct comp_d3d11_compositor *c,
 // near the bottom of the file alongside the comp_d3d11_compositor_zone_mask_*
 // entry points, called from the layer-commit paths + destroy above them.
 static bool
-d3d11_composite_zone_mask(struct comp_d3d11_compositor *c, ID3D11Texture2D *dst, uint32_t dst_w, uint32_t dst_h);
+d3d11_composite_zone_mask(struct comp_d3d11_compositor *c,
+                          ID3D11Texture2D *dst,
+                          uint32_t dst_w,
+                          uint32_t dst_h,
+                          const struct u_canvas_rect *eff_canvas);
 static void
 d3d11_release_zone_state(struct comp_d3d11_compositor *c);
+
+// #439 Phase 2: an active zone mask supersedes the canvas output rect —
+// the weave region, view dims, Kooima metrics, and composite region all
+// become the client-window rect (top-left anchored per #464). With no mask
+// this returns c->canvas verbatim, so the no-mask path is unchanged.
+// Returning a *valid* window rect (not just "invalid") matters on the
+// shared-texture path: the texture is display-sized worst-case, so an
+// invalid canvas there would fall back to display dims — the window rect
+// keeps the #464 clamp. Callers in the frame path hold c->mutex, which
+// zone_mask_submit/destroy also take, so the mask cannot flip mid-frame.
+static struct u_canvas_rect
+d3d11_effective_canvas(struct comp_d3d11_compositor *c)
+{
+	if (c->active_zone_mask == nullptr) {
+		return c->canvas;
+	}
+	struct u_canvas_rect win = {};
+	HWND wnd = c->hwnd != nullptr ? c->hwnd : c->app_hwnd;
+	RECT r;
+	if (wnd != nullptr && GetClientRect(wnd, &r) && r.right > 0 && r.bottom > 0) {
+		win.valid = true;
+		win.x = 0;
+		win.y = 0;
+		win.w = (uint32_t)r.right;
+		win.h = (uint32_t)r.bottom;
+		return win;
+	}
+	return win; // invalid → existing full-target fallbacks
+}
 
 /*
  *
@@ -1337,6 +1372,14 @@ d3d11_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 	}
 #endif
 
+	// #439 Phase 2: the one canvas authority for this frame. While a zone
+	// mask is active this is the client-window rect (the mask supersedes
+	// the output rect); otherwise it is c->canvas unchanged. Computed once
+	// under c->mutex (held for this whole function) so the weave region,
+	// view dims, and composite all see the same rect even if submit/destroy
+	// race the frame.
+	const struct u_canvas_rect eff_canvas = d3d11_effective_canvas(c);
+
 	// Get target (window) dimensions for mono viewport sizing.
 	// In shared texture mode (no target), use canvas dims if available —
 	// the DP weaves at canvas resolution, not full shared texture size.
@@ -1344,9 +1387,9 @@ d3d11_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 	uint32_t tgt_height = c->settings.preferred.height;
 	if (c->target != nullptr) {
 		comp_d3d11_target_get_dimensions(c->target, &tgt_width, &tgt_height);
-	} else if (c->canvas.valid && c->canvas.w > 0 && c->canvas.h > 0) {
-		tgt_width = c->canvas.w;
-		tgt_height = c->canvas.h;
+	} else if (eff_canvas.valid && eff_canvas.w > 0 && eff_canvas.h > 0) {
+		tgt_width = eff_canvas.w;
+		tgt_height = eff_canvas.h;
 	}
 
 	// Sync renderer view dims from active mode — set_tile_layout derives
@@ -1361,8 +1404,8 @@ d3d11_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 			if (mode->view_width_pixels > 0) {
 				uint32_t new_vw = mode->view_width_pixels;
 				uint32_t new_vh = mode->view_height_pixels;
-				if (c->canvas.valid) {
-					u_tiling_compute_canvas_view(mode, c->canvas.w, c->canvas.h,
+				if (eff_canvas.valid) {
+					u_tiling_compute_canvas_view(mode, eff_canvas.w, eff_canvas.h,
 					                             &new_vw, &new_vh);
 				} else if (!c->owns_window && tgt_width > 0 && tgt_height > 0) {
 					// Handle app: window may differ from display size,
@@ -1604,10 +1647,10 @@ d3d11_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 			xrt_display_processor_d3d11_process_atlas(
 			    c->display_processor, c->context, atlas_srv, view_width, view_height,
 			    tile_columns, tile_rows, DXGI_FORMAT_R8G8B8A8_UNORM, dp_target_w, dp_target_h,
-			    c->canvas.valid ? c->canvas.x : 0,
-			    c->canvas.valid ? c->canvas.y : 0,
-			    c->canvas.valid ? c->canvas.w : 0,
-			    c->canvas.valid ? c->canvas.h : 0);
+			    eff_canvas.valid ? eff_canvas.x : 0,
+			    eff_canvas.valid ? eff_canvas.y : 0,
+			    eff_canvas.valid ? eff_canvas.w : 0,
+			    eff_canvas.valid ? eff_canvas.h : 0);
 
 			// Spec v6 surround blit: fill non-canvas pixels of the shared
 			// texture from the app-supplied 2D surround texture (no-op if
@@ -1619,18 +1662,19 @@ d3d11_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 			// #439 Phase 0: DISPLAYXR_SURROUND_SHADER routes this through the
 			// general masked-composite shader instead of the strip copy
 			// (pixel-identical); falls back to the strips if it can't run.
-			bool surround_done = d3d11_composite_zone_mask(c, c->shared_texture, dp_target_w, dp_target_h);
+			bool surround_done =
+			    d3d11_composite_zone_mask(c, c->shared_texture, dp_target_w, dp_target_h, &eff_canvas);
 			if (!surround_done && d3d11_surround_shader_enabled()) {
 				surround_done = d3d11_composite_surround_shader(
-				    c, c->shared_texture, dp_target_w, dp_target_h, c->canvas.valid ? c->canvas.x : 0,
-				    c->canvas.valid ? c->canvas.y : 0, c->canvas.valid ? c->canvas.w : dp_target_w,
-				    c->canvas.valid ? c->canvas.h : dp_target_h);
+				    c, c->shared_texture, dp_target_w, dp_target_h, eff_canvas.valid ? eff_canvas.x : 0,
+				    eff_canvas.valid ? eff_canvas.y : 0, eff_canvas.valid ? eff_canvas.w : dp_target_w,
+				    eff_canvas.valid ? eff_canvas.h : dp_target_h);
 			}
 			if (!surround_done) {
 				d3d11_blit_surround_strips(
-				    c, c->shared_texture, dp_target_w, dp_target_h, c->canvas.valid ? c->canvas.x : 0,
-				    c->canvas.valid ? c->canvas.y : 0, c->canvas.valid ? c->canvas.w : dp_target_w,
-				    c->canvas.valid ? c->canvas.h : dp_target_h);
+				    c, c->shared_texture, dp_target_w, dp_target_h, eff_canvas.valid ? eff_canvas.x : 0,
+				    eff_canvas.valid ? eff_canvas.y : 0, eff_canvas.valid ? eff_canvas.w : dp_target_w,
+				    eff_canvas.valid ? eff_canvas.h : dp_target_h);
 			}
 
 			// #439 Phase 0 A/B validation probe (no-op unless
@@ -1689,10 +1733,10 @@ d3d11_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 		xrt_display_processor_d3d11_process_atlas(
 		    c->display_processor, c->context, atlas_srv, view_width, view_height,
 		    tile_columns, tile_rows, DXGI_FORMAT_R8G8B8A8_UNORM, target_width, target_height,
-		    c->canvas.valid ? c->canvas.x : 0,
-		    c->canvas.valid ? c->canvas.y : 0,
-		    c->canvas.valid ? c->canvas.w : 0,
-		    c->canvas.valid ? c->canvas.h : 0);
+		    eff_canvas.valid ? eff_canvas.x : 0,
+		    eff_canvas.valid ? eff_canvas.y : 0,
+		    eff_canvas.valid ? eff_canvas.w : 0,
+		    eff_canvas.valid ? eff_canvas.h : 0);
 
 		// Spec v6 surround blit: fill non-canvas pixels of the DXGI back
 		// buffer from the app-supplied 2D surround texture. The downstream
@@ -1704,18 +1748,19 @@ d3d11_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 		// the rect-derived region selection entirely (see the offscreen path).
 		// #439 Phase 0: DISPLAYXR_SURROUND_SHADER routes through the general
 		// masked-composite shader (pixel-identical); strip-copy fallback.
-		bool surround_done = d3d11_composite_zone_mask(c, back_buffer_for_surround, target_width, target_height);
+		bool surround_done =
+		    d3d11_composite_zone_mask(c, back_buffer_for_surround, target_width, target_height, &eff_canvas);
 		if (!surround_done && d3d11_surround_shader_enabled()) {
 			surround_done = d3d11_composite_surround_shader(
-			    c, back_buffer_for_surround, target_width, target_height, c->canvas.valid ? c->canvas.x : 0,
-			    c->canvas.valid ? c->canvas.y : 0, c->canvas.valid ? c->canvas.w : target_width,
-			    c->canvas.valid ? c->canvas.h : target_height);
+			    c, back_buffer_for_surround, target_width, target_height, eff_canvas.valid ? eff_canvas.x : 0,
+			    eff_canvas.valid ? eff_canvas.y : 0, eff_canvas.valid ? eff_canvas.w : target_width,
+			    eff_canvas.valid ? eff_canvas.h : target_height);
 		}
 		if (!surround_done) {
 			d3d11_blit_surround_strips(c, back_buffer_for_surround, target_width, target_height,
-			                           c->canvas.valid ? c->canvas.x : 0, c->canvas.valid ? c->canvas.y : 0,
-			                           c->canvas.valid ? c->canvas.w : target_width,
-			                           c->canvas.valid ? c->canvas.h : target_height);
+			                           eff_canvas.valid ? eff_canvas.x : 0, eff_canvas.valid ? eff_canvas.y : 0,
+			                           eff_canvas.valid ? eff_canvas.w : target_width,
+			                           eff_canvas.valid ? eff_canvas.h : target_height);
 		}
 
 		// #439 Phase 0 A/B validation probe (no-op unless
@@ -2789,8 +2834,17 @@ d3d11_ensure_srv_scratch(struct comp_d3d11_compositor *c,
 //
 // #464 window clamping: all inputs are window-sized; the pass writes only the
 // window region at the top-left anchor of the (worst-case-allocated) dst.
+//
+// #439 Phase 2: eff_canvas is the caller's per-frame effective canvas
+// (d3d11_effective_canvas under c->mutex) — the window rect while the mask
+// is active, so the composite region and the weave region share one
+// authority.
 static bool
-d3d11_composite_zone_mask(struct comp_d3d11_compositor *c, ID3D11Texture2D *dst, uint32_t dst_w, uint32_t dst_h)
+d3d11_composite_zone_mask(struct comp_d3d11_compositor *c,
+                          ID3D11Texture2D *dst,
+                          uint32_t dst_w,
+                          uint32_t dst_h,
+                          const struct u_canvas_rect *eff_canvas)
 {
 	struct comp_d3d11_zone_mask *mask = c->active_zone_mask;
 	if (mask == nullptr || !mask->submitted || dst == nullptr || c->renderer == nullptr) {
@@ -2876,12 +2930,13 @@ d3d11_composite_zone_mask(struct comp_d3d11_compositor *c, ID3D11Texture2D *dst,
 	// the lerp reads this copy — impl doc §3 step 2).
 	c->context->CopySubresourceRegion(c->weave_scratch, 0, 0, 0, 0, dst, 0, &sbox);
 
-	// Canvas rect clamped to the window region (the shader ignores it on the
-	// mask path; kept coherent for the CB anyway).
-	int32_t cx = c->canvas.valid ? c->canvas.x : 0;
-	int32_t cy = c->canvas.valid ? c->canvas.y : 0;
-	uint32_t cw = c->canvas.valid ? c->canvas.w : region_w;
-	uint32_t ch = c->canvas.valid ? c->canvas.h : region_h;
+	// Effective canvas rect clamped to the window region (the shader ignores
+	// it on the mask path; kept coherent for the CB anyway). #439 Phase 2:
+	// this is the window rect while the mask is active.
+	int32_t cx = eff_canvas->valid ? eff_canvas->x : 0;
+	int32_t cy = eff_canvas->valid ? eff_canvas->y : 0;
+	uint32_t cw = eff_canvas->valid ? eff_canvas->w : region_w;
+	uint32_t ch = eff_canvas->valid ? eff_canvas->h : region_h;
 	uint32_t cx_u = (cx < 0) ? 0u : (uint32_t)cx;
 	uint32_t cy_u = (cy < 0) ? 0u : (uint32_t)cy;
 	if (cx_u > region_w)
@@ -3259,7 +3314,13 @@ comp_d3d11_compositor_get_window_metrics(struct xrt_compositor *xc,
 
 	out_metrics->valid = true;
 
-	u_canvas_apply_to_metrics(out_metrics, &c->canvas);
+	// #439 Phase 2: the effective canvas, not c->canvas — while a zone mask
+	// is active this is the window rect, so the apply is a no-op by
+	// construction and the Kooima/adaptive-FOV metrics follow the
+	// window-spanning weave region. (Unlocked read, same as the rest of this
+	// function — the pointer check in d3d11_effective_canvas is benign.)
+	const struct u_canvas_rect eff_canvas = d3d11_effective_canvas(c);
+	u_canvas_apply_to_metrics(out_metrics, &eff_canvas);
 
 	return true;
 }


### PR DESCRIPTION
## Summary

Phase 2 of epic #439 (design: `docs/roadmap/unified-2d-3d-phase2-impl.md`, spec §6 / §9 Q5): while a submitted `XR_EXT_local_3d_zone` mask is active, the **effective canvas is the client-window rect** `{0,0,win_w,win_h}` (top-left anchored per #464), superseding `xrSetSharedTextureOutputRectEXT`. This makes the weave cover every pixel the mask can select — in Phase 1, an M=1 (3D) island beyond the canvas rect lerped toward never-weaved stale pixels and showed 2D.

- One helper, `d3d11_effective_canvas()`, applied at **all 8 canvas read sites** in `comp_d3d11_compositor.cpp`: target-dims fallback, mode-aware view-dim sync, `process_atlas` canvas params (shared-texture + DXGI paths), surround-composite args (both paths), the zone-composite region (threaded as a param), and the Kooima metrics in `get_window_metrics`.
- Computed **once per frame under `c->mutex`** (`layer_commit` holds it; `zone_mask_submit`/`destroy` take it) — extends the Phase-1 §9-Q3 atomicity to the weave region.
- No mask ⇒ the helper returns `c->canvas` verbatim — the no-mask path is unchanged by construction.
- Comment fix at the canvas field (stale hidden-weaver-window note, removed with #85) + `xrSubmitLocal3DZoneEXT` header note (supersede rule + sticky submit; auto-syncs to `displayxr-extensions` on merge).
- No oxr / DP-interface / IPC changes. Windows D3D11 only.

## Validation (Leia hardware, §5 matrix — all green)

| Case | Result |
|---|---|
| No mask vs Phase-1 `main` build | Weave geometry byte-identical (`canvas=(320,180 640x360)`); beyond-window region diff **0**; window region within the same-runtime capture noise envelope (the app's surround + cube animate, so strict cross-run diff-0 is unattainable — A-vs-A self-noise max 26 in the 2D region, A-vs-B max 26) |
| Mask active | DP log flips to `canvas=(0,0 1280x720)`, view dims `320x180 → 640x360` (window-derived) |
| Tier-2 islands beyond old canvas | Real weave (region 100% changed vs noise-level on Phase 1); **interlace eyeballed correct on-glass** |
| Tier-2 single rect == canvas | Re-baselined: now a window-spanning weave cropped to the rect (82% changed vs the Phase-0/1 canvas-fit golden) — intended §2 semantics |
| Submit→destroy→submit cycling | Geometry snaps back, post-destroy capture matches pre-mask within noise, no crash |
| Drag-resize while mask active | Weave tracks `GetClientRect` per frame (`canvas=(0,0 2508x1510)` after resize), composite coherent |
| `displayxr-cli selftest` | PASS |

Note (expected): window-spanning 3D is upscaled from the app's canvas-sized swapchain — the test app doesn't re-render at window dims; view-dim re-sync is runtime-side.

Epic #439 Phase-2 checkbox to be ticked on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)