### PR TITLE
feat(#396): W7 — XR_EXT_view_rig: app-facing rig control + raw-inputs channel

### DIFF
--- a/docs/roadmap/raw-vs-render-ready-views.md
+++ b/docs/roadmap/raw-vs-render-ready-views.md
@@ -1,9 +1,10 @@
 ---
-status: Proposal
+status: Phase 1 implemented (extension surface)
 owner: David Fattal
 updated: 2026-06-06
 issues: [396]
 code-paths:
+  - src/external/openxr_includes/openxr/XR_EXT_view_rig.h
   - src/xrt/state_trackers/oxr/oxr_session.c
   - src/xrt/drivers/qwerty/qwerty_device.c
   - src/xrt/auxiliary/math/m_display3d_view.*
@@ -12,9 +13,42 @@ code-paths:
   - src/xrt/ipc/server/ipc_server_handler.c
 ---
 
-> **Status: Proposal** — design spike, no implementation yet. Promote the
-> "Proposal" section to an ADR (next free number) once accepted. Tracked as
+> **Status: Phase 1 implemented** — the `XR_EXT_view_rig` extension surface
+> ships (header, registration, per-locate rig chaining on in-process sessions,
+> raw-result channel; verify vehicle `cube_handle_d3d11_win` R-toggle). The
+> equivalence-by-construction half (type-neutral `displayxr::math` core
+> replacing the runtime's `m_*_view` ports) is a follow-up phase, as are IPC
+> plumbing, the texture-canvas sub-rect in the raw channel, and surplus-eye
+> exposure — see "Phase 1 decisions" below. Promote to an ADR (next free
+> number) once the math fold-in lands. Tracked as
 > **W7 of [#396](https://github.com/DisplayXR/displayxr-runtime/issues/396)**.
+
+## Phase 1 decisions (implementation, 2026-06-06)
+
+- **Per-locate, not sticky.** A rig drives exactly the locates that chain it.
+  Sticky state would break the raw-eye transport contract: an external-window
+  app that stops chaining must get raw display-local eyes in `XrView.pose`
+  again (its local math consumes them), not a latched rig's `eye_world`.
+- **Raw chain point**: single `XrViewDisplayRawEXT` on `XrViewState::next`
+  (as recommended).
+- **Validation**: clamp + one-shot WARN per session, never reject. Factors
+  clamp to their doc ranges; `virtualDisplayHeight` to [0.01, 1000] (math-safe
+  bounds, deliberately wider than qwerty's keyboard-UX range);
+  `convergenceDiopters` to [0, 20]; `verticalFov` to [0.01, π−0.01]. Both
+  structs chained → one-shot WARN, camera rig wins.
+- **Raw eyes**: tracked set verbatim (pre legacy-2D centering, pre surplus
+  synthesis); nominal-viewer pair with `isTracking = false` when the DP has no
+  lock. Synthesized surplus eyes stay runtime-internal (gap noted below).
+- **Boundary conversions**: `convergenceDiopters` → `inv_convergence_distance`
+  is numerically identity (qwerty's `cam_convergence` is already diopters);
+  `verticalFov` → `tanf(v/2)`.
+- **Known Phase-1 gaps** (each a follow-up): IPC-client sessions parse but
+  ignore the rig (the client-side Kooima block never runs — the server
+  computes views; raw channel returns defaults); the raw `canvasRectPx` is the
+  window client area even for texture apps (mirrors exactly what the runtime's
+  own rig math consumes today — the canvas sub-rect lives compositor-side);
+  workspace-controller rig constraints unimplemented (rig stays app visual
+  policy).
 
 # Raw vs Render-Ready Views — the rig API
 

--- a/src/external/openxr_includes/openxr/XR_EXT_view_rig.h
+++ b/src/external/openxr_includes/openxr/XR_EXT_view_rig.h
@@ -1,0 +1,130 @@
+// Copyright 2026, DisplayXR
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  Header for XR_EXT_view_rig extension
+ * @author David Fattal
+ * @ingroup external_openxr
+ *
+ * App-facing control of the runtime's view-rig math: the app chains a rig
+ * descriptor (the handful of Kooima tunables) onto xrLocateViews and consumes
+ * standard XrView{pose, fov} — render-ready, clip-independent — instead of
+ * re-implementing the view math from raw eye positions. A separate raw-result
+ * struct exposes the complete rig inputs (display-space eyes, display plane,
+ * canvas rect, sample time, tracking lock) for aware consumers that keep doing
+ * their own math (e.g. the WebXR bridge).
+ *
+ * Two rigs exist, matching the two canonical pipelines:
+ *  - display rig (display-centric): the window/canvas is a portal into the
+ *    scene; tunables = virtual display height (m2v scale), ipd factor,
+ *    parallax factor, perspective factor.
+ *  - camera rig (camera-centric): an app-defined camera whose frustum eye
+ *    tracking perturbs; tunables = ipd factor, parallax factor, convergence,
+ *    vertical FOV.
+ *
+ * Descriptors carry NO clip parameters (fov is clip-independent — near/far and
+ * depth convention stay app-side) and NO placement parameters (the runtime owns
+ * the window/canvas geometry). The rig is strictly per-locate: chain a
+ * descriptor on every xrLocateViews you want it to drive (animating
+ * convergence or virtual display height is just passing different values next
+ * frame), and a locate that chains nothing keeps the default behavior —
+ * including the raw-eye transport in XrView.pose for external-window apps.
+ *
+ * This extension adds no entry points — it is pure next-chain structs on
+ * xrLocateViews. Full design: docs/roadmap/raw-vs-render-ready-views.md
+ * (W7 of issue #396).
+ */
+#ifndef XR_EXT_VIEW_RIG_H
+#define XR_EXT_VIEW_RIG_H 1
+
+#include <openxr/openxr.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define XR_EXT_view_rig 1
+#define XR_EXT_view_rig_SPEC_VERSION 1
+#define XR_EXT_VIEW_RIG_EXTENSION_NAME "XR_EXT_view_rig"
+
+// Reserved 1000999xxx range, next free block after mcp_tools (…130-132).
+// Final values reconcile with the Khronos registry before spec freeze.
+#define XR_TYPE_DISPLAY_RIG_EXT      ((XrStructureType)1000999140)
+#define XR_TYPE_CAMERA_RIG_EXT       ((XrStructureType)1000999141)
+#define XR_TYPE_VIEW_DISPLAY_RAW_EXT ((XrStructureType)1000999142)
+
+//! Capacity of XrViewDisplayRawEXT::rawEyes (matches the runtime's max views).
+#define XR_VIEW_RIG_MAX_RAW_EYES_EXT 8
+
+// ---- Request: chain exactly ONE of these on XrViewLocateInfo::next. ----
+
+/*!
+ * @brief Display-centric rig: the window/canvas is a portal into the scene.
+ *
+ * Maps 1:1 onto the runtime's display-rig tunables. Out-of-range values are
+ * clamped (with a one-shot runtime WARN), never rejected.
+ */
+typedef struct XrDisplayRigEXT {
+    XrStructureType          type;   //!< Must be XR_TYPE_DISPLAY_RIG_EXT
+    const void* XR_MAY_ALIAS next;
+    XrPosef pose;                  //!< virtual display plane pose in the locate space
+    float   virtualDisplayHeight;  //!< app units; m2v = this / physical canvas height
+    float   ipdFactor;             //!< [0,1] multiplies view-pose spread about the center
+    float   parallaxFactor;        //!< [0,1] lerps eye centroid toward nominal viewer
+    float   perspectiveFactor;     //!< [0.1,10] scales eye XYZ (object perspective)
+} XrDisplayRigEXT;
+
+/*!
+ * @brief Camera-centric rig: an app camera whose frustum eye tracking perturbs.
+ *
+ * Maps 1:1 onto the runtime's camera-rig tunables (convergenceDiopters is the
+ * inverse convergence distance the math consumes; verticalFov converts to
+ * half-tan at the boundary). Out-of-range values are clamped (one-shot WARN),
+ * never rejected.
+ */
+typedef struct XrCameraRigEXT {
+    XrStructureType          type;   //!< Must be XR_TYPE_CAMERA_RIG_EXT
+    const void* XR_MAY_ALIAS next;
+    XrPosef pose;                  //!< camera pose in the locate space
+    float   ipdFactor;             //!< [0,1] multiplies view-pose spread about the center
+    float   parallaxFactor;        //!< [0,1] lerps eye centroid toward nominal viewer
+    float   convergenceDiopters;   //!< 1/m to the convergence plane; 0 = infinity
+    float   verticalFov;           //!< radians, full vertical angle
+} XrCameraRigEXT;
+
+// ---- Result: app chains this on XrViewState::next; runtime fills it. ----
+
+/*!
+ * @brief Raw rig inputs for the locate, filled by the runtime.
+ *
+ * The complete input set the rigs consume, untransformed: per-view eye
+ * positions verbatim in physical display space (NOT canvas-rebased — apply
+ * the canvas rect yourself, e.g. via display3d_resolve_window_rect), the
+ * display-plane pose, the effective canvas the runtime resolved for this
+ * session, the eye-sample timestamp and the physical tracker lock. Reported
+ * eyes are the tracked set only (synthesized surplus eyes for >2-view modes
+ * stay runtime-internal); when the tracker has no lock the runtime still
+ * reports nominal-viewer eyes with isTracking = XR_FALSE.
+ */
+typedef struct XrViewDisplayRawEXT {
+    XrStructureType    type;       //!< Must be XR_TYPE_VIEW_DISPLAY_RAW_EXT
+    void* XR_MAY_ALIAS next;
+    XrVector3f  rawEyes[XR_VIEW_RIG_MAX_RAW_EYES_EXT]; //!< display-space eye positions (meters,
+                                   //!< display-center origin, +X right +Y up +Z toward viewer)
+    uint32_t    eyeCountOutput;    //!< tracked eyes actually written
+    XrPosef     displayPlanePose;  //!< physical display plane in the locate space
+    XrRect2Di   canvasRectPx;      //!< effective canvas on the panel (window client
+                                   //!< area / texture sub-rect / runtime window)
+    XrExtent2Df canvasSizeMeters;  //!< physical size of that canvas
+    int64_t     sampleTimeNs;      //!< when the eyes were sampled (monotonic)
+    XrBool32    isTracking;        //!< physical tracker lock (vs nominal fallback)
+} XrViewDisplayRawEXT;
+
+// This extension defines no functions — both halves ride existing calls
+// (request structs on XrViewLocateInfo::next, result on XrViewState::next).
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // XR_EXT_VIEW_RIG_H

--- a/src/xrt/include/xrt/xrt_openxr_includes.h
+++ b/src/xrt/include/xrt/xrt_openxr_includes.h
@@ -79,3 +79,4 @@ typedef __eglMustCastToProperFunctionPointerType (*PFNEGLGETPROCADDRESSPROC)(con
 #include "openxr/XR_EXT_atlas_capture.h"
 #include "openxr/XR_EXT_mcp_tools.h"
 #include "openxr/XR_EXT_local_3d_zone.h"
+#include "openxr/XR_EXT_view_rig.h"

--- a/src/xrt/state_trackers/oxr/oxr_extension_support.h
+++ b/src/xrt/state_trackers/oxr/oxr_extension_support.h
@@ -598,6 +598,18 @@
 
 
 /*
+ * XR_EXT_view_rig
+ */
+#if defined(XR_EXT_view_rig)
+#define OXR_HAVE_EXT_view_rig
+#define OXR_EXTENSION_SUPPORT_EXT_view_rig(_) \
+    _(EXT_view_rig, EXT_VIEW_RIG)
+#else
+#define OXR_EXTENSION_SUPPORT_EXT_view_rig(_)
+#endif
+
+
+/*
  * XR_EXT_workspace_file_dialog
  */
 #if defined(XR_EXT_workspace_file_dialog) && defined(XR_USE_PLATFORM_WIN32)
@@ -1100,6 +1112,7 @@
     OXR_EXTENSION_SUPPORT_EXT_spatial_workspace(_) \
     OXR_EXTENSION_SUPPORT_EXT_atlas_capture(_) \
     OXR_EXTENSION_SUPPORT_EXT_local_3d_zone(_) \
+    OXR_EXTENSION_SUPPORT_EXT_view_rig(_) \
     OXR_EXTENSION_SUPPORT_EXT_workspace_file_dialog(_) \
     OXR_EXTENSION_SUPPORT_EXT_mcp_tools(_) \
     OXR_EXTENSION_SUPPORT_BD_controller_interaction(_) \

--- a/src/xrt/state_trackers/oxr/oxr_objects.h
+++ b/src/xrt/state_trackers/oxr/oxr_objects.h
@@ -2031,6 +2031,48 @@ struct oxr_instance
 };
 
 /*!
+ * Which rig descriptor a session chained via XR_EXT_view_rig (#396 W7).
+ */
+enum oxr_view_rig_type
+{
+	OXR_VIEW_RIG_NONE = 0,    //!< nothing chained — default behavior (qwerty/forcing)
+	OXR_VIEW_RIG_DISPLAY = 1, //!< XrDisplayRigEXT
+	OXR_VIEW_RIG_CAMERA = 2,  //!< XrCameraRigEXT
+};
+
+/*!
+ * Per-session view-rig state for XR_EXT_view_rig (#396 W7).
+ *
+ * The rig drives the view math only on locates that chain a descriptor
+ * (per-locate, not sticky — non-chained locates keep the default behavior,
+ * including the raw-eye transport contract in XrView.pose for external-window
+ * apps). This struct holds the last-parsed values and the one-shot warn latch.
+ * Values are stored post-clamp and post-boundary-conversion
+ * (convergenceDiopters → inv_convergence_distance, verticalFov → half-tan),
+ * i.e. exactly the shape the view math consumes.
+ */
+struct oxr_view_rig_state
+{
+	enum oxr_view_rig_type type;
+	struct xrt_pose pose; //!< display-plane (display rig) or camera (camera rig) pose
+
+	// Display-rig tunables.
+	float virtual_display_height;
+	float perspective_factor;
+
+	// Camera-rig tunables.
+	float inv_convergence_distance;
+	float half_tan_vfov;
+
+	// Shared tunables.
+	float ipd_factor;
+	float parallax_factor;
+
+	//! One-shot WARN latch for out-of-range descriptor clamping.
+	bool clamp_warned;
+};
+
+/*!
  * Object that client program interact with.
  *
  * Parent type/handle is @ref oxr_instance
@@ -2078,6 +2120,12 @@ struct oxr_session
 	//! a browser-side app, which renders via a separate Chrome session; treat
 	//! view poses like a handle app (display-local, no world_head_pos offset).
 	bool is_bridge_relay;
+
+	//! XR_EXT_view_rig (#396 W7): per-session rig parse state. A rig chained
+	//! on a locate drives the view math for that locate (lifting the
+	//! external-window display-centric forcing); locates that chain nothing
+	//! keep the default behavior exactly.
+	struct oxr_view_rig_state view_rig;
 
 	//! True if this session has successfully called xrActivateSpatialWorkspaceEXT
 	//! and is currently the active workspace controller (#234).

--- a/src/xrt/state_trackers/oxr/oxr_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_session.c
@@ -1094,6 +1094,90 @@ adjust_fov(const struct xrt_fov *original_fov, const struct xrt_quat *original_r
 	};
 }
 
+#ifdef OXR_HAVE_EXT_view_rig
+/*
+ * XR_EXT_view_rig (#396 W7) — descriptor validation policy: CLAMP out-of-range
+ * values (one-shot WARN per session), never reject. Per-frame error handling
+ * would be awkward for apps animating tunables.
+ */
+static float
+view_rig_clampf(float v, float lo, float hi, bool *clamped)
+{
+	if (v < lo) {
+		*clamped = true;
+		return lo;
+	}
+	if (v > hi) {
+		*clamped = true;
+		return hi;
+	}
+	return v;
+}
+
+/*
+ * Walk XrViewLocateInfo::next for a chained rig descriptor and parse it into
+ * the per-session rig state. Returns the rig type chained on THIS locate —
+ * OXR_VIEW_RIG_NONE when nothing is chained. The rig is strictly per-locate
+ * (chain it on every locate you want it to drive): a non-chained locate keeps
+ * the default behavior, including the raw-eye transport contract in
+ * XrView.pose for external-window apps.
+ * Values are stored post-clamp and post-boundary-conversion so the locate path
+ * consumes them directly: convergenceDiopters (1/m) IS the inverse convergence
+ * distance the math takes (identity conversion); full-angle verticalFov
+ * converts to half-tan.
+ */
+static enum oxr_view_rig_type
+view_rig_update_from_chain(struct oxr_session *sess, const XrViewLocateInfo *viewLocateInfo)
+{
+	const XrDisplayRigEXT *drig =
+	    OXR_GET_INPUT_FROM_CHAIN(viewLocateInfo, XR_TYPE_DISPLAY_RIG_EXT, XrDisplayRigEXT);
+	const XrCameraRigEXT *crig =
+	    OXR_GET_INPUT_FROM_CHAIN(viewLocateInfo, XR_TYPE_CAMERA_RIG_EXT, XrCameraRigEXT);
+	if (drig == NULL && crig == NULL) {
+		return OXR_VIEW_RIG_NONE;
+	}
+
+	struct oxr_view_rig_state *rig = &sess->view_rig;
+	bool clamped = false;
+
+	if (drig != NULL && crig != NULL && !rig->clamp_warned) {
+		U_LOG_W("XR_EXT_view_rig: both XrDisplayRigEXT and XrCameraRigEXT chained — "
+		        "chain exactly one; using the camera rig");
+		rig->clamp_warned = true;
+	}
+
+	if (crig != NULL) {
+		rig->type = OXR_VIEW_RIG_CAMERA;
+		rig->pose = (struct xrt_pose){
+		    {crig->pose.orientation.x, crig->pose.orientation.y, crig->pose.orientation.z,
+		     crig->pose.orientation.w},
+		    {crig->pose.position.x, crig->pose.position.y, crig->pose.position.z}};
+		rig->ipd_factor = view_rig_clampf(crig->ipdFactor, 0.0f, 1.0f, &clamped);
+		rig->parallax_factor = view_rig_clampf(crig->parallaxFactor, 0.0f, 1.0f, &clamped);
+		rig->inv_convergence_distance = view_rig_clampf(crig->convergenceDiopters, 0.0f, 20.0f, &clamped);
+		float vfov = view_rig_clampf(crig->verticalFov, 0.01f, 3.13f, &clamped);
+		rig->half_tan_vfov = tanf(vfov * 0.5f);
+	} else {
+		rig->type = OXR_VIEW_RIG_DISPLAY;
+		rig->pose = (struct xrt_pose){
+		    {drig->pose.orientation.x, drig->pose.orientation.y, drig->pose.orientation.z,
+		     drig->pose.orientation.w},
+		    {drig->pose.position.x, drig->pose.position.y, drig->pose.position.z}};
+		rig->virtual_display_height = view_rig_clampf(drig->virtualDisplayHeight, 0.01f, 1000.0f, &clamped);
+		rig->ipd_factor = view_rig_clampf(drig->ipdFactor, 0.0f, 1.0f, &clamped);
+		rig->parallax_factor = view_rig_clampf(drig->parallaxFactor, 0.0f, 1.0f, &clamped);
+		rig->perspective_factor = view_rig_clampf(drig->perspectiveFactor, 0.1f, 10.0f, &clamped);
+	}
+
+	if (clamped && !rig->clamp_warned) {
+		U_LOG_W("XR_EXT_view_rig: descriptor value(s) out of range — clamped");
+		rig->clamp_warned = true;
+	}
+
+	return rig->type;
+}
+#endif // OXR_HAVE_EXT_view_rig
+
 XrResult
 oxr_session_locate_views(struct oxr_logger *log,
                          struct oxr_session *sess,
@@ -1187,6 +1271,38 @@ oxr_session_locate_views(struct oxr_logger *log,
 	bool have_view_state = false;
 #endif
 
+	// XR_EXT_view_rig (#396 W7): parse a chained rig descriptor (per-locate)
+	// and locate the optional raw-result output struct. A chained rig drives
+	// the view math below in place of the qwerty debug state and lifts the
+	// external-window display-centric forcing — the explicit descriptor is
+	// the knowledge that guard substituted for. Locates that chain nothing
+	// keep today's behavior exactly.
+	bool rig_camera = false;
+	bool rig_display = false;
+#ifdef OXR_HAVE_EXT_view_rig
+	XrViewDisplayRawEXT *view_raw = NULL;
+	if (sess->sys->inst->extensions.EXT_view_rig) {
+		enum oxr_view_rig_type rig_type = view_rig_update_from_chain(sess, viewLocateInfo);
+		rig_camera = rig_type == OXR_VIEW_RIG_CAMERA;
+		rig_display = rig_type == OXR_VIEW_RIG_DISPLAY;
+
+		view_raw = OXR_GET_OUTPUT_FROM_CHAIN(viewState, XR_TYPE_VIEW_DISPLAY_RAW_EXT, XrViewDisplayRawEXT);
+		if (view_raw != NULL) {
+			// Defaults for frames with no eye/window data (e.g. IPC
+			// proxies, pre-tracking frames); overwritten below when
+			// the Kooima input set is resolved. Don't touch ->next.
+			U_ZERO_ARRAY(view_raw->rawEyes);
+			view_raw->eyeCountOutput = 0;
+			view_raw->displayPlanePose = (XrPosef){{0, 0, 0, 1}, {0, 0, 0}};
+			view_raw->canvasRectPx = (XrRect2Di){{0, 0}, {0, 0}};
+			view_raw->canvasSizeMeters = (XrExtent2Df){0, 0};
+			view_raw->sampleTimeNs = 0;
+			view_raw->isTracking = XR_FALSE;
+		}
+	}
+#endif
+	const bool rig_active = rig_camera || rig_display;
+
 	// Query eye tracking (vendor-neutral — returns false if no backend available).
 	// Safe to call unconditionally: oxr_session_get_predicted_eye_positions()
 	// checks xmcc != NULL before casting to multi_compositor, so IPC proxies
@@ -1238,6 +1354,16 @@ oxr_session_locate_views(struct oxr_logger *log,
 		}
 	}
 
+	// XR_EXT_view_rig: the chained rig pose IS the display-plane / camera
+	// pose — it replaces the qwerty device pose (runtime-window sessions)
+	// and the {0,1.6,0}/identity defaults (external-window sessions, where
+	// the defaults were harmless only because their eye_world output was
+	// discarded under the forcing this extension lifts).
+	if (rig_active) {
+		world_head_pos = sess->view_rig.pose.position;
+		world_head_ori = sess->view_rig.pose.orientation;
+	}
+
 	bool have_eyes = got_eye_positions && eye_pos.valid;
 
 	// Kooima FOV computation (vendor-neutral)
@@ -1275,6 +1401,26 @@ oxr_session_locate_views(struct oxr_logger *log,
 				}
 			}
 		}
+
+#ifdef OXR_HAVE_EXT_view_rig
+		// XR_EXT_view_rig raw channel: report the rig INPUT eyes verbatim
+		// in display space — tracked set when the DP provides one, else
+		// the nominal-viewer pair (isTracking=false). Captured before the
+		// legacy-2D center override and the surplus-view synthesis below:
+		// both are rig-side concepts, not raw inputs.
+		if (view_raw != NULL && have_eye_positions) {
+			uint32_t raw_count = eye_count;
+			if (raw_count > XR_VIEW_RIG_MAX_RAW_EYES_EXT) {
+				raw_count = XR_VIEW_RIG_MAX_RAW_EYES_EXT;
+			}
+			for (uint32_t ei = 0; ei < raw_count; ei++) {
+				view_raw->rawEyes[ei] = (XrVector3f){adj_eyes[ei].x, adj_eyes[ei].y, adj_eyes[ei].z};
+			}
+			view_raw->eyeCountOutput = raw_count;
+			view_raw->sampleTimeNs = have_eyes ? eye_pos.timestamp_ns : 0;
+			view_raw->isTracking = (have_eyes && eye_pos.is_tracking) ? XR_TRUE : XR_FALSE;
+		}
+#endif
 
 		// Legacy apps in 2D mode: override both eye positions to center.
 		// The compositor crops to the left view, so it must be rendered
@@ -1339,6 +1485,30 @@ oxr_session_locate_views(struct oxr_logger *log,
 				// eye_offset stays (0,0) — identity behavior
 			}
 
+#ifdef OXR_HAVE_EXT_view_rig
+			// XR_EXT_view_rig raw channel: the effective canvas + display
+			// plane — exactly the input set the rig math below consumes
+			// (window client area today; the texture-app canvas sub-rect
+			// is a follow-up, see raw-vs-render-ready-views.md).
+			if (view_raw != NULL) {
+				// Same gate as the window-relative branch above, so the
+				// rect and the meters always describe the same canvas.
+				if (have_wm && wm.valid && wm.window_width_m > 0.0f && wm.window_height_m > 0.0f) {
+					view_raw->canvasRectPx = (XrRect2Di){
+					    {wm.window_screen_left - wm.display_screen_left,
+					     wm.window_screen_top - wm.display_screen_top},
+					    {(int32_t)wm.window_pixel_width, (int32_t)wm.window_pixel_height}};
+				} else if (have_wm && wm.valid) {
+					view_raw->canvasRectPx = (XrRect2Di){
+					    {0, 0}, {(int32_t)wm.display_pixel_width, (int32_t)wm.display_pixel_height}};
+				}
+				view_raw->canvasSizeMeters = (XrExtent2Df){screen_width_m, screen_height_m};
+				view_raw->displayPlanePose = (XrPosef){
+				    {world_head_ori.x, world_head_ori.y, world_head_ori.z, world_head_ori.w},
+				    {world_head_pos.x, world_head_pos.y, world_head_pos.z}};
+			}
+#endif
+
 			if (should_log) {
 					U_LOG_I("KOOIMA GATE: have_eyes=%d screen=%.4fx%.4f have_view=%d cam=%d ext_win=%d",
 					        have_eye_positions, screen_width_m, screen_height_m,
@@ -1389,15 +1559,29 @@ oxr_session_locate_views(struct oxr_logger *log,
 				    {world_head_ori.x, world_head_ori.y, world_head_ori.z, world_head_ori.w},
 				    {world_head_pos.x, world_head_pos.y, world_head_pos.z}};
 
-				// Camera-centric path: canonical camera3d_compute_views
-				if (have_view_state && view_state.camera_mode &&
-				    !sess->has_external_window) {
-					Camera3DTunables ct = {
-					    .ipd_factor = view_state.cam_spread_factor,
-					    .parallax_factor = view_state.cam_parallax_factor,
-					    .inv_convergence_distance = view_state.cam_convergence,
-					    .half_tan_vfov = view_state.cam_half_tan_vfov,
-					};
+				// Camera-centric path: canonical camera3d_compute_views.
+				// A chained XrCameraRigEXT (#396 W7) takes it regardless of
+				// has_external_window — the explicit rig descriptor is the
+				// knowledge the external-window forcing substituted for.
+				if (rig_camera ||
+				    (have_view_state && view_state.camera_mode &&
+				     !sess->has_external_window)) {
+					Camera3DTunables ct;
+					if (rig_camera) {
+						ct = (Camera3DTunables){
+						    .ipd_factor = sess->view_rig.ipd_factor,
+						    .parallax_factor = sess->view_rig.parallax_factor,
+						    .inv_convergence_distance = sess->view_rig.inv_convergence_distance,
+						    .half_tan_vfov = sess->view_rig.half_tan_vfov,
+						};
+					} else {
+						ct = (Camera3DTunables){
+						    .ipd_factor = view_state.cam_spread_factor,
+						    .parallax_factor = view_state.cam_parallax_factor,
+						    .inv_convergence_distance = view_state.cam_convergence,
+						    .half_tan_vfov = view_state.cam_half_tan_vfov,
+						};
+					}
 					Camera3DView cam_views[XRT_MAX_VIEWS];
 					camera3d_compute_views(raw_eyes, eye_count, &nominal, &scr, &ct,
 					                       &display_pose, 0.01f, 100.0f,
@@ -1413,7 +1597,14 @@ oxr_session_locate_views(struct oxr_logger *log,
 				} else {
 					// Display-centric (Kooima) path: canonical display3d_compute_views
 					Display3DTunables dt = display3d_default_tunables();
-					if (have_view_state && !sess->has_external_window) {
+					if (rig_display) {
+						// Chained XrDisplayRigEXT (#396 W7) — lifts the
+						// identity-m2v forcing for external windows too.
+						dt.ipd_factor = sess->view_rig.ipd_factor;
+						dt.parallax_factor = sess->view_rig.parallax_factor;
+						dt.perspective_factor = sess->view_rig.perspective_factor;
+						dt.virtual_display_height = sess->view_rig.virtual_display_height;
+					} else if (have_view_state && !sess->has_external_window) {
 						dt.ipd_factor = view_state.disp_spread_factor;
 						dt.parallax_factor = view_state.disp_parallax_factor;
 						dt.perspective_factor = 1.0f;
@@ -1433,7 +1624,8 @@ oxr_session_locate_views(struct oxr_logger *log,
 					}
 					have_kooima_fov = true;
 
-					if (have_view_state && !sess->has_external_window) {
+					if (rig_display ||
+					    (have_view_state && !sess->has_external_window)) {
 						for (uint32_t ei = 0; ei < eye_count; ei++) {
 							view_eye_world[ei] = disp_views[ei].eye_world;
 						}
@@ -1480,7 +1672,7 @@ oxr_session_locate_views(struct oxr_logger *log,
 	{
 		struct xrt_fov kooima_fovs[XRT_MAX_VIEWS];
 		uint32_t fov_save_count = (active_view_count < view_count) ? active_view_count : view_count;
-		if (have_kooima_fov && have_view_state) {
+		if (have_kooima_fov && (have_view_state || rig_active)) {
 			for (uint32_t ei = 0; ei < fov_save_count; ei++) {
 				kooima_fovs[ei] = fovs[ei];
 			}
@@ -1497,10 +1689,10 @@ oxr_session_locate_views(struct oxr_logger *log,
 		OXR_CHECK_XRET(log, sess, xret, xrt_device_get_view_poses);
 
 		// Restore client-side Kooima FOVs only when the client has local
-		// 3D state (non-IPC mode). In IPC mode, the server already
-		// computes 3D-adjusted Kooima FOVs and returns them via
-		// get_view_poses — don't override those.
-		if (have_kooima_fov && have_view_state) {
+		// 3D state (non-IPC mode) or a chained view rig. In IPC mode, the
+		// server already computes 3D-adjusted Kooima FOVs and returns them
+		// via get_view_poses — don't override those.
+		if (have_kooima_fov && (have_view_state || rig_active)) {
 			for (uint32_t ei = 0; ei < fov_save_count; ei++) {
 				fovs[ei] = kooima_fovs[ei];
 			}

--- a/test_apps/cube_handle_d3d11_win/main.cpp
+++ b/test_apps/cube_handle_d3d11_win/main.cpp
@@ -213,26 +213,16 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
             return 0;
         }
         // XR_EXT_view_rig verify toggle (app-local; 'R' is unused by the
-        // shared input handler). Turning the runtime rig ON also enters the
-        // app's camera mode (same state the shared 'C' handler sets) so the
-        // chained XrCameraRigEXT gets the camera-mode vantage — R then A/Bs
-        // runtime-rig vs app-side math with identical tunables.
+        // shared input handler). R A/Bs runtime-rig vs app-side math for
+        // WHICHEVER rig the app is currently in (C still selects the rig):
+        // display-centric -> chain XrDisplayRigEXT, camera-centric -> chain
+        // XrCameraRigEXT, both from the same g_inputState tunables.
         if (wParam == 'R' && g_hasViewRigExt) {
             g_useRuntimeRig = !g_useRuntimeRig;
             g_rigRawLogged = false;
-            if (g_useRuntimeRig && !g_inputState.cameraMode) {
-                g_inputState.cameraMode = true;
-                g_inputState.cameraPosX = 0.0f;
-                g_inputState.cameraPosY = 0.0f;
-                g_inputState.cameraPosZ = g_inputState.nominalViewerZ;
-                g_inputState.yaw = 0.0f;
-                g_inputState.pitch = 0.0f;
-                if (g_inputState.nominalViewerZ > 0.0f)
-                    g_inputState.viewParams.invConvergenceDistance = 1.0f / g_inputState.nominalViewerZ;
-                g_inputState.viewParams.zoomFactor = 1.0f;
-            }
-            LOG_INFO("View rig: %s", g_useRuntimeRig ? "RUNTIME (XR_EXT_view_rig camera rig)"
-                                                     : "APP-SIDE (local Kooima math)");
+            LOG_INFO("View rig: %s (%s rig)",
+                     g_useRuntimeRig ? "RUNTIME (XR_EXT_view_rig)" : "APP-SIDE (local Kooima math)",
+                     g_inputState.cameraMode ? "camera" : "display");
             return 0;
         }
         break;
@@ -519,26 +509,41 @@ static void RenderOneFrame(RenderState& rs) {
                     XrView rawViews[8];
                     for (uint32_t vi = 0; vi < 8; vi++) rawViews[vi] = {XR_TYPE_VIEW};
 
-                    // XR_EXT_view_rig (R toggle): drive the runtime's camera
-                    // rig with the SAME app tunables the local Kooima block
-                    // uses, and chain the raw-input result for cross-checking.
+                    // XR_EXT_view_rig (R toggle): drive the runtime rig
+                    // matching the app's current mode (C selects the rig) with
+                    // the SAME app tunables the local Kooima block uses, and
+                    // chain the raw-input result for cross-checking.
                     const bool runtimeRig = g_useRuntimeRig && g_hasViewRigExt;
+                    const bool runtimeRigCamera = runtimeRig && g_inputState.cameraMode;
                     XrCameraRigEXT cameraRig = {XR_TYPE_CAMERA_RIG_EXT};
+                    XrDisplayRigEXT displayRig = {XR_TYPE_DISPLAY_RIG_EXT};
                     XrViewDisplayRawEXT viewRigRaw = {XR_TYPE_VIEW_DISPLAY_RAW_EXT};
                     if (runtimeRig) {
                         XMVECTOR rigOri = XMQuaternionRotationRollPitchYaw(
                             g_inputState.pitch, g_inputState.yaw, 0);
                         XMFLOAT4 rq;
                         XMStoreFloat4(&rq, rigOri);
-                        cameraRig.pose.orientation = {rq.x, rq.y, rq.z, rq.w};
-                        cameraRig.pose.position = {g_inputState.cameraPosX, g_inputState.cameraPosY,
-                                                   g_inputState.cameraPosZ};
-                        cameraRig.ipdFactor = g_inputState.viewParams.ipdFactor;
-                        cameraRig.parallaxFactor = g_inputState.viewParams.parallaxFactor;
-                        cameraRig.convergenceDiopters = g_inputState.viewParams.invConvergenceDistance;
-                        cameraRig.verticalFov =
-                            2.0f * atanf(CAMERA_HALF_TAN_VFOV / g_inputState.viewParams.zoomFactor);
-                        locateInfo.next = &cameraRig;
+                        XrPosef rigPose;
+                        rigPose.orientation = {rq.x, rq.y, rq.z, rq.w};
+                        rigPose.position = {g_inputState.cameraPosX, g_inputState.cameraPosY,
+                                            g_inputState.cameraPosZ};
+                        if (runtimeRigCamera) {
+                            cameraRig.pose = rigPose;
+                            cameraRig.ipdFactor = g_inputState.viewParams.ipdFactor;
+                            cameraRig.parallaxFactor = g_inputState.viewParams.parallaxFactor;
+                            cameraRig.convergenceDiopters = g_inputState.viewParams.invConvergenceDistance;
+                            cameraRig.verticalFov =
+                                2.0f * atanf(CAMERA_HALF_TAN_VFOV / g_inputState.viewParams.zoomFactor);
+                            locateInfo.next = &cameraRig;
+                        } else {
+                            displayRig.pose = rigPose;
+                            displayRig.virtualDisplayHeight =
+                                g_inputState.viewParams.virtualDisplayHeight / g_inputState.viewParams.scaleFactor;
+                            displayRig.ipdFactor = g_inputState.viewParams.ipdFactor;
+                            displayRig.parallaxFactor = g_inputState.viewParams.parallaxFactor;
+                            displayRig.perspectiveFactor = g_inputState.viewParams.perspectiveFactor;
+                            locateInfo.next = &displayRig;
+                        }
                         viewState.next = &viewRigRaw;
                     }
 
@@ -552,14 +557,27 @@ static void RenderOneFrame(RenderState& rs) {
                     std::vector<Display3DView> stereoViews(eyeCount);
                     bool useAppProjection = (xr.hasDisplayInfoExt && xr.displayWidthM > 0.0f);
                     if (useAppProjection && runtimeRig) {
-                        // XR_EXT_view_rig path: the runtime ran the camera rig
-                        // for us — consume render-ready XrView{pose, fov}
-                        // directly. Only clip policy (near/far + the GL→[0,1]
-                        // depth remap) stays app-side, by design.
+                        // XR_EXT_view_rig path: the runtime ran the rig for us
+                        // — consume render-ready XrView{pose, fov} directly.
+                        // Only clip policy (near/far + the GL→[0,1] depth
+                        // remap) stays app-side, by design. Camera rig: same
+                        // absolute clip as the app's camera path. Display rig:
+                        // the app's ZDP-anchored clip (near = ez - vH, far =
+                        // ez + 1000·vH; ez = eye distance to the virtual
+                        // display plane, which is pose.position.z for the
+                        // identity display pose this app uses).
+                        const float rigVH =
+                            g_inputState.viewParams.virtualDisplayHeight / g_inputState.viewParams.scaleFactor;
                         for (int i = 0; i < eyeCount; i++) {
                             const XrView& v = rawViews[(i < (int)viewCount) ? i : 0];
                             ViewMatrixFromXrPose(v.pose, stereoViews[i].view_matrix);
-                            ProjectionFromXrFov(v.fov, 0.01f, 100.0f, stereoViews[i].projection_matrix);
+                            float nearZ = 0.01f, farZ = 100.0f;
+                            if (!runtimeRigCamera) {
+                                float ez = v.pose.position.z;
+                                nearZ = (ez - rigVH > 0.001f) ? (ez - rigVH) : 0.001f;
+                                farZ = ez + 1000.0f * rigVH;
+                            }
+                            ProjectionFromXrFov(v.fov, nearZ, farZ, stereoViews[i].projection_matrix);
                             convert_projection_gl_to_zero_to_one(stereoViews[i].projection_matrix);
                             stereoViews[i].fov = v.fov;
                             stereoViews[i].eye_world = v.pose.position;
@@ -568,6 +586,7 @@ static void RenderOneFrame(RenderState& rs) {
                         // One-shot raw-channel cross-check log.
                         if (!g_rigRawLogged) {
                             g_rigRawLogged = true;
+                            LOG_INFO("ViewRig MODE: %s rig", runtimeRigCamera ? "camera" : "display");
                             LOG_INFO("ViewRig RAW: eyes=%u [0]=(%.4f,%.4f,%.4f) [1]=(%.4f,%.4f,%.4f) "
                                      "canvas=(%d,%d %dx%d) %.4fx%.4fm sampleNs=%lld tracking=%d",
                                      viewRigRaw.eyeCountOutput,
@@ -704,7 +723,9 @@ static void RenderOneFrame(RenderState& rs) {
                                 L"\nKooima: Display-Centric [C=Toggle]";
                             if (g_hasViewRigExt) {
                                 modeText += g_useRuntimeRig ?
-                                    L"\nView rig: RUNTIME camera rig [R=Toggle]" :
+                                    (g_inputState.cameraMode ?
+                                        L"\nView rig: RUNTIME camera rig [R=Toggle]" :
+                                        L"\nView rig: RUNTIME display rig [R=Toggle]") :
                                     L"\nView rig: app-side math [R=Toggle]";
                             }
 

--- a/test_apps/cube_handle_d3d11_win/main.cpp
+++ b/test_apps/cube_handle_d3d11_win/main.cpp
@@ -58,6 +58,60 @@ static bool g_fullscreen = false;
 static RECT g_savedWindowRect = {};
 static DWORD g_savedWindowStyle = 0;
 
+// XR_EXT_view_rig (#396 W7) verify hook: R toggles between the app-side
+// Kooima block (default, today's path) and the runtime rig — chain
+// XrCameraRigEXT on xrLocateViews and consume the runtime's render-ready
+// XrView{pose, fov} directly. Also chains XrViewDisplayRawEXT and one-shot
+// logs the raw inputs as a cross-check against the app's own locate data.
+static bool g_useRuntimeRig = false;
+static bool g_rigRawLogged = false;
+
+// Column-major view matrix from a render-ready XrView pose:
+// viewMatrix = R^T * translate(-position) — same construction as the
+// displayxr::math rigs, so the runtime-rig path feeds the renderer the
+// identical convention.
+static void ViewMatrixFromXrPose(const XrPosef& pose, float* out) {
+    const float qx = pose.orientation.x, qy = pose.orientation.y;
+    const float qz = pose.orientation.z, qw = pose.orientation.w;
+    float rot[16] = {};
+    rot[0] = 1.0f - 2.0f * (qy * qy + qz * qz);
+    rot[1] = 2.0f * (qx * qy + qz * qw);
+    rot[2] = 2.0f * (qx * qz - qy * qw);
+    rot[4] = 2.0f * (qx * qy - qz * qw);
+    rot[5] = 1.0f - 2.0f * (qx * qx + qz * qz);
+    rot[6] = 2.0f * (qy * qz + qx * qw);
+    rot[8] = 2.0f * (qx * qz + qy * qw);
+    rot[9] = 2.0f * (qy * qz - qx * qw);
+    rot[10] = 1.0f - 2.0f * (qx * qx + qy * qy);
+    rot[15] = 1.0f;
+    for (int i = 0; i < 16; i++) out[i] = 0.0f;
+    for (int i = 0; i < 3; i++)
+        for (int j = 0; j < 3; j++)
+            out[j * 4 + i] = rot[i * 4 + j]; // R^T
+    out[15] = 1.0f;
+    out[12] = -(out[0] * pose.position.x + out[4] * pose.position.y + out[8] * pose.position.z);
+    out[13] = -(out[1] * pose.position.x + out[5] * pose.position.y + out[9] * pose.position.z);
+    out[14] = -(out[2] * pose.position.x + out[6] * pose.position.y + out[10] * pose.position.z);
+}
+
+// Column-major GL ([-1,1] clip-z) off-axis projection from a render-ready
+// XrView fov + the app's own clip policy (fov is clip-independent). Pair with
+// convert_projection_gl_to_zero_to_one() for D3D.
+static void ProjectionFromXrFov(const XrFovf& fov, float nearZ, float farZ, float* out) {
+    const float l = tanf(fov.angleLeft) * nearZ;
+    const float r = tanf(fov.angleRight) * nearZ;
+    const float b = tanf(fov.angleDown) * nearZ;
+    const float t = tanf(fov.angleUp) * nearZ;
+    for (int i = 0; i < 16; i++) out[i] = 0.0f;
+    out[0] = 2.0f * nearZ / (r - l);
+    out[5] = 2.0f * nearZ / (t - b);
+    out[8] = (r + l) / (r - l);
+    out[9] = (t + b) / (t - b);
+    out[10] = -(farZ + nearZ) / (farZ - nearZ);
+    out[11] = -1.0f;
+    out[14] = -2.0f * farZ * nearZ / (farZ - nearZ);
+}
+
 // Forward declaration — defined after PerformanceStats
 struct RenderState;
 static RenderState* g_renderState = nullptr;
@@ -156,6 +210,29 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
     case WM_KEYDOWN:
         if (wParam == VK_ESCAPE) {
             PostMessage(hwnd, WM_CLOSE, 0, 0);
+            return 0;
+        }
+        // XR_EXT_view_rig verify toggle (app-local; 'R' is unused by the
+        // shared input handler). Turning the runtime rig ON also enters the
+        // app's camera mode (same state the shared 'C' handler sets) so the
+        // chained XrCameraRigEXT gets the camera-mode vantage — R then A/Bs
+        // runtime-rig vs app-side math with identical tunables.
+        if (wParam == 'R' && g_hasViewRigExt) {
+            g_useRuntimeRig = !g_useRuntimeRig;
+            g_rigRawLogged = false;
+            if (g_useRuntimeRig && !g_inputState.cameraMode) {
+                g_inputState.cameraMode = true;
+                g_inputState.cameraPosX = 0.0f;
+                g_inputState.cameraPosY = 0.0f;
+                g_inputState.cameraPosZ = g_inputState.nominalViewerZ;
+                g_inputState.yaw = 0.0f;
+                g_inputState.pitch = 0.0f;
+                if (g_inputState.nominalViewerZ > 0.0f)
+                    g_inputState.viewParams.invConvergenceDistance = 1.0f / g_inputState.nominalViewerZ;
+                g_inputState.viewParams.zoomFactor = 1.0f;
+            }
+            LOG_INFO("View rig: %s", g_useRuntimeRig ? "RUNTIME (XR_EXT_view_rig camera rig)"
+                                                     : "APP-SIDE (local Kooima math)");
             return 0;
         }
         break;
@@ -441,6 +518,30 @@ static void RenderOneFrame(RenderState& rs) {
                     uint32_t viewCount = 8;
                     XrView rawViews[8];
                     for (uint32_t vi = 0; vi < 8; vi++) rawViews[vi] = {XR_TYPE_VIEW};
+
+                    // XR_EXT_view_rig (R toggle): drive the runtime's camera
+                    // rig with the SAME app tunables the local Kooima block
+                    // uses, and chain the raw-input result for cross-checking.
+                    const bool runtimeRig = g_useRuntimeRig && g_hasViewRigExt;
+                    XrCameraRigEXT cameraRig = {XR_TYPE_CAMERA_RIG_EXT};
+                    XrViewDisplayRawEXT viewRigRaw = {XR_TYPE_VIEW_DISPLAY_RAW_EXT};
+                    if (runtimeRig) {
+                        XMVECTOR rigOri = XMQuaternionRotationRollPitchYaw(
+                            g_inputState.pitch, g_inputState.yaw, 0);
+                        XMFLOAT4 rq;
+                        XMStoreFloat4(&rq, rigOri);
+                        cameraRig.pose.orientation = {rq.x, rq.y, rq.z, rq.w};
+                        cameraRig.pose.position = {g_inputState.cameraPosX, g_inputState.cameraPosY,
+                                                   g_inputState.cameraPosZ};
+                        cameraRig.ipdFactor = g_inputState.viewParams.ipdFactor;
+                        cameraRig.parallaxFactor = g_inputState.viewParams.parallaxFactor;
+                        cameraRig.convergenceDiopters = g_inputState.viewParams.invConvergenceDistance;
+                        cameraRig.verticalFov =
+                            2.0f * atanf(CAMERA_HALF_TAN_VFOV / g_inputState.viewParams.zoomFactor);
+                        locateInfo.next = &cameraRig;
+                        viewState.next = &viewRigRaw;
+                    }
+
                     xrLocateViews(xr.session, &locateInfo, &viewState, 8, &viewCount, rawViews);
 
                     // --- App-side Kooima projection (RAW mode, app-owned camera model) ---
@@ -450,7 +551,39 @@ static void RenderOneFrame(RenderState& rs) {
 
                     std::vector<Display3DView> stereoViews(eyeCount);
                     bool useAppProjection = (xr.hasDisplayInfoExt && xr.displayWidthM > 0.0f);
-                    if (useAppProjection) {
+                    if (useAppProjection && runtimeRig) {
+                        // XR_EXT_view_rig path: the runtime ran the camera rig
+                        // for us — consume render-ready XrView{pose, fov}
+                        // directly. Only clip policy (near/far + the GL→[0,1]
+                        // depth remap) stays app-side, by design.
+                        for (int i = 0; i < eyeCount; i++) {
+                            const XrView& v = rawViews[(i < (int)viewCount) ? i : 0];
+                            ViewMatrixFromXrPose(v.pose, stereoViews[i].view_matrix);
+                            ProjectionFromXrFov(v.fov, 0.01f, 100.0f, stereoViews[i].projection_matrix);
+                            convert_projection_gl_to_zero_to_one(stereoViews[i].projection_matrix);
+                            stereoViews[i].fov = v.fov;
+                            stereoViews[i].eye_world = v.pose.position;
+                        }
+
+                        // One-shot raw-channel cross-check log.
+                        if (!g_rigRawLogged) {
+                            g_rigRawLogged = true;
+                            LOG_INFO("ViewRig RAW: eyes=%u [0]=(%.4f,%.4f,%.4f) [1]=(%.4f,%.4f,%.4f) "
+                                     "canvas=(%d,%d %dx%d) %.4fx%.4fm sampleNs=%lld tracking=%d",
+                                     viewRigRaw.eyeCountOutput,
+                                     viewRigRaw.rawEyes[0].x, viewRigRaw.rawEyes[0].y, viewRigRaw.rawEyes[0].z,
+                                     viewRigRaw.rawEyes[1].x, viewRigRaw.rawEyes[1].y, viewRigRaw.rawEyes[1].z,
+                                     viewRigRaw.canvasRectPx.offset.x, viewRigRaw.canvasRectPx.offset.y,
+                                     viewRigRaw.canvasRectPx.extent.width, viewRigRaw.canvasRectPx.extent.height,
+                                     viewRigRaw.canvasSizeMeters.width, viewRigRaw.canvasSizeMeters.height,
+                                     (long long)viewRigRaw.sampleTimeNs, (int)viewRigRaw.isTracking);
+                            LOG_INFO("ViewRig VIEW[0]: pos=(%.4f,%.4f,%.4f) fov L=%.4f R=%.4f U=%.4f D=%.4f",
+                                     rawViews[0].pose.position.x, rawViews[0].pose.position.y,
+                                     rawViews[0].pose.position.z, rawViews[0].fov.angleLeft,
+                                     rawViews[0].fov.angleRight, rawViews[0].fov.angleUp,
+                                     rawViews[0].fov.angleDown);
+                        }
+                    } else if (useAppProjection) {
                         // Window-relative Kooima: the window's placement on the
                         // display + raw eyes -> Kooima screen dims + window-relative
                         // eyes, via the shared displayxr::math helper (#396 Layer 1).
@@ -569,6 +702,11 @@ static void RenderOneFrame(RenderState& rs) {
                             modeText += g_inputState.cameraMode ?
                                 L"\nKooima: Camera-Centric [C=Toggle]" :
                                 L"\nKooima: Display-Centric [C=Toggle]";
+                            if (g_hasViewRigExt) {
+                                modeText += g_useRuntimeRig ?
+                                    L"\nView rig: RUNTIME camera rig [R=Toggle]" :
+                                    L"\nView rig: app-side math [R=Toggle]";
+                            }
 
                             // Dynamic render dims matching the actual viewport computation
                             bool dispMonoMode = (xr.renderingModeCount > 0 && !xr.renderingModeDisplay3D[xr.currentModeIndex]);

--- a/test_apps/cube_handle_d3d11_win/xr_session.cpp
+++ b/test_apps/cube_handle_d3d11_win/xr_session.cpp
@@ -9,6 +9,9 @@
 #include "logging.h"
 #include <cstring>
 
+// XR_EXT_view_rig (#396 W7): app-local availability flag (see xr_session.h).
+bool g_hasViewRigExt = false;
+
 // Helper macro for XR error checking with logging
 #define XR_CHECK(call) \
     do { \
@@ -90,6 +93,9 @@ bool InitializeOpenXR(XrSessionManager& xr) {
         if (strcmp(ext.extensionName, XR_EXT_MCP_TOOLS_EXTENSION_NAME) == 0) {
             xr.hasMcpToolsExt = true;
         }
+        if (strcmp(ext.extensionName, XR_EXT_VIEW_RIG_EXTENSION_NAME) == 0) {
+            g_hasViewRigExt = true;
+        }
     }
 
     LOG_INFO("XR_KHR_D3D11_enable: %s", hasD3D11 ? "AVAILABLE" : "NOT FOUND");
@@ -98,6 +104,7 @@ bool InitializeOpenXR(XrSessionManager& xr) {
     LOG_INFO("XR_EXT_workspace_file_dialog: %s", xr.hasFileDialogExt ? "AVAILABLE" : "NOT FOUND");
     LOG_INFO("XR_EXT_atlas_capture: %s", xr.hasAtlasCaptureExt ? "AVAILABLE" : "NOT FOUND");
     LOG_INFO("XR_EXT_mcp_tools: %s", xr.hasMcpToolsExt ? "AVAILABLE" : "NOT FOUND");
+    LOG_INFO("XR_EXT_view_rig: %s", g_hasViewRigExt ? "AVAILABLE" : "NOT FOUND");
 
     if (!hasD3D11) {
         LOG_ERROR("XR_KHR_D3D11_enable extension not available - cannot continue");
@@ -126,6 +133,9 @@ bool InitializeOpenXR(XrSessionManager& xr) {
     }
     if (xr.hasMcpToolsExt) {
         enabledExtensions.push_back(XR_EXT_MCP_TOOLS_EXTENSION_NAME);
+    }
+    if (g_hasViewRigExt) {
+        enabledExtensions.push_back(XR_EXT_VIEW_RIG_EXTENSION_NAME);
     }
 
     LOG_INFO("Enabling %zu extensions", enabledExtensions.size());

--- a/test_apps/cube_handle_d3d11_win/xr_session.h
+++ b/test_apps/cube_handle_d3d11_win/xr_session.h
@@ -13,6 +13,12 @@
 #include <d3d11.h>
 #define XR_USE_GRAPHICS_API_D3D11
 #include "xr_session_common.h"
+#include <openxr/XR_EXT_view_rig.h>
+
+// XR_EXT_view_rig (#396 W7) available + enabled on the instance. App-local
+// (not on the shared XrSessionManager) — this app is the extension's verify
+// vehicle; promote to xr_session_common when more consumers adopt it.
+extern bool g_hasViewRigExt;
 
 // Initialize OpenXR instance and check for XR_EXT_win32_window_binding support
 bool InitializeOpenXR(XrSessionManager& xr);


### PR DESCRIPTION
## Summary

W7 of #396, **extension surface only** (the type-neutral `displayxr::math` core fold-in replacing `m_*_view` is a follow-up phase). Design locked in `docs/roadmap/raw-vs-render-ready-views.md` — this implements it against the existing runtime math.

- **New `XR_EXT_view_rig`** (types 1000999140–142, **no new entry points** — pure next-chain structs on `xrLocateViews`):
  - Request: chain exactly one of `XrDisplayRigEXT{pose, virtualDisplayHeight, ipdFactor, parallaxFactor, perspectiveFactor}` / `XrCameraRigEXT{pose, ipdFactor, parallaxFactor, convergenceDiopters, verticalFov}` on `XrViewLocateInfo::next`.
  - Result: `XrViewDisplayRawEXT` on `XrViewState::next` — DP eyes verbatim, display plane pose, effective canvas rect (px+m), sample time, isTracking (surfaced past the compositor for the first time).
- **Registration** mirrors `EXT_atlas_capture` (extension_support block + GENERATE; header via `xrt_openxr_includes.h`; auto-syncs to displayxr-extensions on merge).
- **A chained rig drives the existing two-rig math and lifts the `!has_external_window` display-centric forcing** — the explicit descriptor is the knowledge that guard substituted for. Non-chaining sessions keep today's behavior exactly (all conditions reduce to the prior expressions).
- **Per-locate, not sticky**: a non-chained locate keeps the raw-eye transport contract in `XrView.pose` that external-window app math depends on.
- Validation: clamp + one-shot WARN, never reject; camera rig wins if both chained.
- Verify vehicle: `cube_handle_d3d11_win` **R toggle** A/Bs runtime-rig vs app-side math for whichever rig C selects (both rigs covered), + one-shot raw-channel cross-check log.
- Phase-1 gaps documented in the design doc: IPC sessions parse-but-inert, texture canvas sub-rect, surplus-eye exposure, workspace constraint hook.

## Verification (Leia, live)

- Both rigs render correctly through the runtime on an external-window app (forcing provably lifted); fov tangents hand-checked exact vs the lib math.
- Live eye tracking through the rig + raw channel (tracking=1, real IPD spread in `XrViewDisplayRawEXT`).
- Spread / convergence / zoom controls flow through the per-frame chained descriptor.
- Non-chaining baseline pixel-unchanged; R off→on→off round-trip stable.
- `displayxr-cli selftest` PASS.

Closes nothing on its own — tick the W7 extension-surface box on #396.

🤖 Generated with [Claude Code](https://claude.com/claude-code)