### PR TITLE
feat(#439): cross-API base leg — XR_EXT_local_3d_zone v2, D3D12+VK forwarding + stubs

### DIFF
--- a/docs/roadmap/unified-2d-3d-crossapi-impl.md
+++ b/docs/roadmap/unified-2d-3d-crossapi-impl.md
@@ -1,0 +1,102 @@
+# Cross-API rollout of the local-3D-zone mask consumer — D3D12 + VK legs
+
+**Branch:** `feature/unified-2d3d-crossapi` (base leg), off `main` post-Phase-2.
+**Spec:** [`unified-2d-3d-compositing.md`](unified-2d-3d-compositing.md) §4 (composite pass + output-alpha), §5.1 (coordinate contract), §8 (rollout priority). Epic #439.
+**Builds on:** D3D11 Phases 0–2 (merged: PR #469 + #471) — the proven pathfinder every port references.
+
+> **STATUS: base leg in progress.** This doc + the base leg (header v2, oxr forwarding, comp stubs) ship together; the D3D12 and VK consumer legs follow as parallel hand-offs.
+
+---
+
+## 1. Three legs, two boundaries
+
+| Leg | What | Where | Mergeable alone? |
+|---|---|---|---|
+| **Base** (this session, macOS) | Header v2 (D3D12/VK Tier-3 binding structs), oxr forwarding branches, comp entry points **stubbed** | oxr + headers + 2 stub blocks | **Yes** — caps report `supported=false` for D3D12/VK until each leg flips; stubs return `XRT_ERROR_NOT_IMPLEMENTED` |
+| **D3D12 consumer** (Windows) | Real zone-mask object + masked composite + effective-canvas rule | `comp_d3d12_compositor.cpp` (+ renderer) | Yes, after base |
+| **VK consumer** (see §4 — scoped) | Same, for `vk_native` | `comp_vk_native_compositor.c` (+ renderer) | Yes, after base |
+
+**Why stubs, not Phase-1's declared-but-unimplemented boundary:** `XRT_HAVE_VK_NATIVE_COMPOSITOR` is defined on **every platform** (`oxr/CMakeLists.txt`: `XRT_HAVE_VULKAN AND TARGET comp_vk_native` — true on macOS/MoltenVK and Android, not just Windows). Declared-only VK entry points would break the macOS link immediately. Real stubs keep every platform green and make the base leg mergeable — which is what lets the two consumer legs run as **parallel sessions against `main`** instead of stacking on an unmerged branch.
+
+## 2. Base leg (macOS, this session)
+
+### 2.1 Header v2 — `XR_EXT_local_3d_zone.h`, SPEC_VERSION 2
+
+Two new Tier-3 binding structs (model: the D3D11 one at type `...132`):
+
+```c
+#define XR_TYPE_LOCAL_3D_ZONE_RENDER_TARGET_D3D12_EXT  ((XrStructureType)1000999133)
+#define XR_TYPE_LOCAL_3D_ZONE_RENDER_TARGET_VULKAN_EXT ((XrStructureType)1000999134)
+
+// D3D12: the runtime returns the ID3D12Resource* (R8_UNORM, w×h client px);
+// the app creates its OWN RTV on it (descriptor heaps are app-owned in D3D12).
+// Sync: the in-process D3D12 compositor runs on the APP'S device AND queue
+// (comp_d3d12_compositor.cpp:86–89), so same-queue submission order is the
+// sync contract — draw the mask, then xrSubmitLocal3DZoneEXT; no fence needed.
+typedef struct XrLocal3DZoneRenderTargetD3D12EXT { type; next;
+    void *resource; uint32_t width, height; } ...;
+
+// Vulkan: VkImage + VkImageView (R8_UNORM). The vk_native compositor shares
+// the APP'S VkDevice (vk_init_from_given, comp_vk_native_compositor.c:2747),
+// so the handles are app-usable directly; same-queue ordering applies.
+typedef struct XrLocal3DZoneRenderTargetVulkanEXT { type; next;
+    void *image; void *imageView; uint32_t width, height; } ...;
+```
+
+### 2.2 comp entry points — declarations + stubs
+
+Mirror the six D3D11 signatures (`comp_d3d11_compositor.h:130-…`) in:
+- `comp_d3d12_compositor.h` + stubs in `comp_d3d12_compositor.cpp` (Windows-compiled; PR CI validates)
+- `comp_vk_native_compositor.h` + stubs in `comp_vk_native_compositor.c` (macOS-verified locally)
+
+Acquire differs per API: D3D12 returns `void **out_resource`; VK returns `void **out_image, void **out_image_view`. All stubs return `XRT_ERROR_NOT_IMPLEMENTED` (`zone_mask_destroy` stubs are no-ops).
+
+### 2.3 oxr forwarding — `oxr_local_3d_zone.c`
+
+Add `#ifdef XRT_HAVE_D3D12_NATIVE_COMPOSITOR` / `XRT_HAVE_VK_NATIVE_COMPOSITOR` branches beside every D3D11 branch (7 handlers + destroy_cb), modeled on the 5-way surround handler (`oxr_api_session.c:1590`). Specifics:
+- **Caps**: D3D12/VK branches report `supported = XR_FALSE` until the consumer leg flips them (one-line change per leg, listed in each leg's done-when). Honest contract: apps that check caps never hit a stub.
+- **Create**: map `XRT_ERROR_NOT_IMPLEMENTED` → `XR_ERROR_FEATURE_UNSUPPORTED` (apps that skip the caps check get the right error, not RUNTIME_FAILURE).
+- **AcquireRT**: validate the binding `type` per session API (D3D12_EXT / VULKAN_EXT).
+
+## 3. D3D12 consumer leg (Windows hand-off) — fully viable now
+
+Everything the port needs already exists on the D3D12 side:
+- **2D source**: surround is implemented — Spec v6 KeyedMutex (`comp_d3d12_compositor_set_surround_2d`) + Spec v7 fence variant (`..._set_surround_2d_fence`, `comp_d3d12_compositor.h:199–203`).
+- **Test app**: `cube_texture_d3d12_win` exists — port the `cube_texture_d3d11_win` 'Z'-cycle harness (Phase-1 commit `17ae19294`).
+- **Sync simplification vs D3D11**: compositor uses the **app's queue**, so Tier-3 authoring needs no fence (§2.1). The *surround* producer keeps its existing v6/v7 sync.
+
+Port checklist (reference: D3D11 commits `17ae19294` Phase 1 + `b67f9f6f1` Phase 2):
+1. Zone-mask object: R8_UNORM committed resource + RTV (runtime-side, for Tier 1/2 clears) + staged snapshot copy + `submitted` flag; submit snapshots under the compositor lock (atomicity, spec §9 Q3).
+2. Tier 1 = `ClearRenderTargetView`; Tier 2 = clear + per-rect clears (D3D12: `ClearRenderTargetView` takes rects natively — simpler than D3D11's `ClearView`).
+3. Masked composite: port `comp_d3d11_renderer_composite_2d_masked` (t0 surround / t1 mask / t2 weave-snapshot, `use_rect_mask` flag, §4.2 output-alpha rule) to a D3D12 PSO; weave-target → SRV-capable scratch copy before the lerp.
+4. `d3d12_effective_canvas` — the Phase-2 supersede rule at every canvas read site of the D3D12 frame path (find the analogs of the 8 D3D11 sites).
+5. Flip caps `supported = XR_TRUE` for the D3D12 branch.
+6. Validation on Leia (capture + on-glass): the Phase-1 §6 matrix + Phase-2 §5 matrix, on `cube_texture_d3d12_win`. No-mask path byte-identical (zero regression).
+
+## 4. VK consumer leg — the 2D-source reality check (scope honestly)
+
+The masked composite needs **2D pixels** to lerp toward. On VK, today, there are none:
+- Every VK app in the tree is **handle-class** (demos: gaussian-splat, mediaplayer plan; `cube_handle_vk_*`) — handle apps have no surround (that's a texture-app feature) and no 2D layer until **Phase 3**.
+- `vk_native` has **no surround implementation** (post-Phase-C TODO at `comp_vk_native_compositor.c:3401`); there is no VK texture test app.
+
+So a full Phase-1-style VK port has nothing to composite and nothing to validate against. **Recommended scope:**
+
+- **Now (base leg)**: stubs + `supported=false` (done in §2). Demos can code against the authoring API guarded by the caps query.
+- **VK mask-object mechanism** (optional intermediate, macOS-developable): implement create/tiers/submit/destroy for real (R8 image + clears + staged copy — portable `vk_bundle` code, testable with `cube_handle_vk_macos` + sim_display), leaving the composite consumer for later. Cheap, but unconsumed until a 2D source exists.
+- **VK composite consumer**: ride with **Phase 3** — the 2D-as-`xrEndFrame`-layer work gives handle apps (i.e. *all* demos) their 2D source, and §6 already plans Phase 3 as "D3D11, then cross-API". Building VK surround + a VK texture app just to validate the composite earlier is throwaway work against the §7 migration story.
+- **Interim demo story**: demos wanting 2D/3D zones *before* Phase 3 are served by the **hardware-DP leg** (#224 / `local-3d-zones.md`) — publishing the mask to the panel needs no 2D pixels at all; the degenerate 1×1 grid = per-window auto 2D/3D today.
+
+## 5. Done-when
+
+**Base leg**
+- [ ] Header v2 (two structs, SPEC_VERSION 2) syncs to `displayxr-extensions` on merge.
+- [ ] oxr branches + stubs build green on macOS (`build_macos.sh`) and Windows (PR CI).
+- [ ] Caps report `supported=false` on D3D12/VK; create returns `XR_ERROR_FEATURE_UNSUPPORTED`.
+
+**D3D12 leg**
+- [ ] §3 checklist 1–5; caps flipped.
+- [ ] Phase-1 + Phase-2 validation matrices green on `cube_texture_d3d12_win` (Leia, capture + on-glass); no-mask diff 0.
+- [ ] Epic #439 "D3D12 — all engine plugins" box ticked.
+
+**VK leg**
+- [ ] Scope decision recorded (this doc §4); composite consumer tracked into the Phase-3 plan.

--- a/src/external/openxr_includes/openxr/XR_EXT_local_3d_zone.h
+++ b/src/external/openxr_includes/openxr/XR_EXT_local_3d_zone.h
@@ -33,7 +33,7 @@ extern "C" {
 #endif
 
 #define XR_EXT_local_3d_zone 1
-#define XR_EXT_local_3d_zone_SPEC_VERSION 1
+#define XR_EXT_local_3d_zone_SPEC_VERSION 2
 #define XR_EXT_LOCAL_3D_ZONE_EXTENSION_NAME "XR_EXT_local_3d_zone"
 
 // Vendor extension range (1000999xxx); replace with a Khronos-assigned value
@@ -41,6 +41,9 @@ extern "C" {
 #define XR_TYPE_LOCAL_3D_ZONE_CAPABILITIES_EXT      ((XrStructureType)1000999130)
 #define XR_TYPE_LOCAL_3D_ZONE_MASK_CREATE_INFO_EXT  ((XrStructureType)1000999131)
 #define XR_TYPE_LOCAL_3D_ZONE_RENDER_TARGET_D3D11_EXT ((XrStructureType)1000999132)
+// Spec v2 additions — D3D12 + Vulkan Tier-3 bindings.
+#define XR_TYPE_LOCAL_3D_ZONE_RENDER_TARGET_D3D12_EXT  ((XrStructureType)1000999133)
+#define XR_TYPE_LOCAL_3D_ZONE_RENDER_TARGET_VULKAN_EXT ((XrStructureType)1000999134)
 
 XR_DEFINE_HANDLE(XrLocal3DZoneMaskEXT)
 
@@ -91,6 +94,40 @@ typedef struct XrLocal3DZoneRenderTargetD3D11EXT {
     uint32_t           width;
     uint32_t           height;
 } XrLocal3DZoneRenderTargetD3D11EXT;
+
+/*!
+ * @brief Tier-3 freeform binding, D3D12 variant (spec v2). The runtime
+ *        returns the ID3D12Resource* (R8_UNORM, client-window pixels); the
+ *        app creates its OWN render-target descriptor on it (descriptor
+ *        heaps are app-owned in D3D12) and writes M (3D-ness) to .r.
+ *
+ * Sync contract: the in-process D3D12 native compositor runs on the app's
+ * device AND command queue, so same-queue submission order is the contract —
+ * execute the mask draw, then call xrSubmitLocal3DZoneEXT. No fence.
+ */
+typedef struct XrLocal3DZoneRenderTargetD3D12EXT {
+    XrStructureType    type;   //!< XR_TYPE_LOCAL_3D_ZONE_RENDER_TARGET_D3D12_EXT
+    void* XR_MAY_ALIAS next;
+    void*              resource; //!< ID3D12Resource*
+    uint32_t           width;
+    uint32_t           height;
+} XrLocal3DZoneRenderTargetD3D12EXT;
+
+/*!
+ * @brief Tier-3 freeform binding, Vulkan variant (spec v2). VkImage +
+ *        VkImageView on an R8_UNORM image in client-window pixels; write M
+ *        (3D-ness) to .r. The vk_native compositor shares the app's
+ *        VkDevice, so the handles are directly usable by the app; same-queue
+ *        submission ordering is the sync contract (as D3D12).
+ */
+typedef struct XrLocal3DZoneRenderTargetVulkanEXT {
+    XrStructureType    type;   //!< XR_TYPE_LOCAL_3D_ZONE_RENDER_TARGET_VULKAN_EXT
+    void* XR_MAY_ALIAS next;
+    void*              image;     //!< VkImage
+    void*              imageView; //!< VkImageView
+    uint32_t           width;
+    uint32_t           height;
+} XrLocal3DZoneRenderTargetVulkanEXT;
 
 typedef XrResult (XRAPI_PTR *PFN_xrGetLocal3DZoneCapabilitiesEXT)(
     XrSession session, XrLocal3DZoneCapabilitiesEXT* capabilities);

--- a/src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp
+++ b/src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp
@@ -2816,3 +2816,74 @@ comp_d3d12_compositor_set_surround_2d_fence(struct xrt_compositor *xc,
 	            (unsigned)sd.Format,
 	            (unsigned long long)await_fence_value);
 }
+
+
+/*
+ *
+ * XR_EXT_local_3d_zone — D3D12 consumer leg STUBS (#439 cross-API).
+ *
+ * The oxr layer forwards here for D3D12 sessions; until the consumer leg
+ * lands (docs/roadmap/unified-2d-3d-crossapi-impl.md §3) these return
+ * XRT_ERROR_NOT_IMPLEMENTED and the oxr caps query reports
+ * supported = false, so a caps-honoring app never reaches them.
+ *
+ */
+
+extern "C" xrt_result_t
+comp_d3d12_compositor_zone_mask_create(struct xrt_compositor *xc, uint32_t w, uint32_t h, void **out_mask)
+{
+	(void)xc;
+	(void)w;
+	(void)h;
+	(void)out_mask;
+	return XRT_ERROR_NOT_IMPLEMENTED;
+}
+
+extern "C" xrt_result_t
+comp_d3d12_compositor_zone_mask_set_whole(struct xrt_compositor *xc, void *mask, bool enable_3d)
+{
+	(void)xc;
+	(void)mask;
+	(void)enable_3d;
+	return XRT_ERROR_NOT_IMPLEMENTED;
+}
+
+extern "C" xrt_result_t
+comp_d3d12_compositor_zone_mask_set_rects(struct xrt_compositor *xc,
+                                          void *mask,
+                                          uint32_t count,
+                                          const struct xrt_rect *rects)
+{
+	(void)xc;
+	(void)mask;
+	(void)count;
+	(void)rects;
+	return XRT_ERROR_NOT_IMPLEMENTED;
+}
+
+extern "C" xrt_result_t
+comp_d3d12_compositor_zone_mask_acquire_rt(
+    struct xrt_compositor *xc, void *mask, void **out_resource, uint32_t *out_w, uint32_t *out_h)
+{
+	(void)xc;
+	(void)mask;
+	(void)out_resource;
+	(void)out_w;
+	(void)out_h;
+	return XRT_ERROR_NOT_IMPLEMENTED;
+}
+
+extern "C" xrt_result_t
+comp_d3d12_compositor_zone_mask_submit(struct xrt_compositor *xc, void *mask)
+{
+	(void)xc;
+	(void)mask;
+	return XRT_ERROR_NOT_IMPLEMENTED;
+}
+
+extern "C" void
+comp_d3d12_compositor_zone_mask_destroy(struct xrt_compositor *xc, void *mask)
+{
+	(void)xc;
+	(void)mask;
+}

--- a/src/xrt/compositor/d3d12/comp_d3d12_compositor.h
+++ b/src/xrt/compositor/d3d12/comp_d3d12_compositor.h
@@ -202,6 +202,78 @@ comp_d3d12_compositor_set_surround_2d_fence(struct xrt_compositor *xc,
                                               void *shared_fence_handle,
                                               uint64_t await_fence_value);
 
+/*
+ * XR_EXT_local_3d_zone — authored 2D/3D mask consumer, D3D12 leg.
+ * Contracts + porting reference (the shipped D3D11 consumer):
+ * docs/roadmap/unified-2d-3d-crossapi-impl.md §3.
+ *
+ * STUBS until the D3D12 consumer leg lands — all return
+ * XRT_ERROR_NOT_IMPLEMENTED and the oxr caps query reports
+ * supported = false for D3D12 sessions until then.
+ */
+
+/*!
+ * Create the compositor-side mask state (R8_UNORM resource, w×h client px).
+ *
+ * @ingroup comp_d3d12
+ */
+xrt_result_t
+comp_d3d12_compositor_zone_mask_create(struct xrt_compositor *xc,
+                                       uint32_t w, uint32_t h,
+                                       void **out_mask);
+
+/*!
+ * Tier 1 — fill the whole mask: all-3D (enable_3d) or all-2D.
+ *
+ * @ingroup comp_d3d12
+ */
+xrt_result_t
+comp_d3d12_compositor_zone_mask_set_whole(struct xrt_compositor *xc,
+                                          void *mask,
+                                          bool enable_3d);
+
+/*!
+ * Tier 2 — rasterize client-window-pixel rects as the 3D region.
+ *
+ * @ingroup comp_d3d12
+ */
+xrt_result_t
+comp_d3d12_compositor_zone_mask_set_rects(struct xrt_compositor *xc,
+                                          void *mask,
+                                          uint32_t count,
+                                          const struct xrt_rect *rects);
+
+/*!
+ * Tier 3 — hand back the ID3D12Resource* for freeform app drawing (the app
+ * creates its own RTV; same-queue submission order is the sync contract).
+ *
+ * @param out_resource Receives an ID3D12Resource* (as void*).
+ *
+ * @ingroup comp_d3d12
+ */
+xrt_result_t
+comp_d3d12_compositor_zone_mask_acquire_rt(struct xrt_compositor *xc,
+                                           void *mask,
+                                           void **out_resource,
+                                           uint32_t *out_w,
+                                           uint32_t *out_h);
+
+/*!
+ * Stage the mask's current contents for the next frame submission.
+ *
+ * @ingroup comp_d3d12
+ */
+xrt_result_t
+comp_d3d12_compositor_zone_mask_submit(struct xrt_compositor *xc, void *mask);
+
+/*!
+ * Destroy the compositor-side mask state.
+ *
+ * @ingroup comp_d3d12
+ */
+void
+comp_d3d12_compositor_zone_mask_destroy(struct xrt_compositor *xc, void *mask);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/xrt/compositor/vk_native/comp_vk_native_compositor.c
+++ b/src/xrt/compositor/vk_native/comp_vk_native_compositor.c
@@ -3411,3 +3411,81 @@ comp_vk_native_compositor_get_queue_family(struct comp_vk_native_compositor *c)
 {
 	return c->queue_family_index;
 }
+
+
+/*
+ *
+ * XR_EXT_local_3d_zone — VK consumer leg STUBS (#439 cross-API).
+ *
+ * The oxr layer forwards here for VK sessions; the composite consumer rides
+ * with Phase 3 (docs/roadmap/unified-2d-3d-crossapi-impl.md §4). Until then
+ * these return XRT_ERROR_NOT_IMPLEMENTED and the oxr caps query reports
+ * supported = false, so a caps-honoring app never reaches them. They must
+ * stay real symbols: XRT_HAVE_VK_NATIVE_COMPOSITOR is defined on every
+ * platform (macOS/MoltenVK + Android included).
+ *
+ */
+
+xrt_result_t
+comp_vk_native_compositor_zone_mask_create(struct xrt_compositor *xc, uint32_t w, uint32_t h, void **out_mask)
+{
+	(void)xc;
+	(void)w;
+	(void)h;
+	(void)out_mask;
+	return XRT_ERROR_NOT_IMPLEMENTED;
+}
+
+xrt_result_t
+comp_vk_native_compositor_zone_mask_set_whole(struct xrt_compositor *xc, void *mask, bool enable_3d)
+{
+	(void)xc;
+	(void)mask;
+	(void)enable_3d;
+	return XRT_ERROR_NOT_IMPLEMENTED;
+}
+
+xrt_result_t
+comp_vk_native_compositor_zone_mask_set_rects(struct xrt_compositor *xc,
+                                              void *mask,
+                                              uint32_t count,
+                                              const struct xrt_rect *rects)
+{
+	(void)xc;
+	(void)mask;
+	(void)count;
+	(void)rects;
+	return XRT_ERROR_NOT_IMPLEMENTED;
+}
+
+xrt_result_t
+comp_vk_native_compositor_zone_mask_acquire_rt(struct xrt_compositor *xc,
+                                               void *mask,
+                                               void **out_image,
+                                               void **out_image_view,
+                                               uint32_t *out_w,
+                                               uint32_t *out_h)
+{
+	(void)xc;
+	(void)mask;
+	(void)out_image;
+	(void)out_image_view;
+	(void)out_w;
+	(void)out_h;
+	return XRT_ERROR_NOT_IMPLEMENTED;
+}
+
+xrt_result_t
+comp_vk_native_compositor_zone_mask_submit(struct xrt_compositor *xc, void *mask)
+{
+	(void)xc;
+	(void)mask;
+	return XRT_ERROR_NOT_IMPLEMENTED;
+}
+
+void
+comp_vk_native_compositor_zone_mask_destroy(struct xrt_compositor *xc, void *mask)
+{
+	(void)xc;
+	(void)mask;
+}

--- a/src/xrt/compositor/vk_native/comp_vk_native_compositor.h
+++ b/src/xrt/compositor/vk_native/comp_vk_native_compositor.h
@@ -192,6 +192,83 @@ comp_vk_native_compositor_get_vk(struct comp_vk_native_compositor *c);
 uint32_t
 comp_vk_native_compositor_get_queue_family(struct comp_vk_native_compositor *c);
 
+/*
+ * XR_EXT_local_3d_zone — authored 2D/3D mask consumer, VK leg.
+ * Contracts + scoping (the composite consumer rides with Phase 3 — handle
+ * apps have no 2D source before the xrEndFrame 2D layer):
+ * docs/roadmap/unified-2d-3d-crossapi-impl.md §4.
+ *
+ * STUBS until that leg lands — all return XRT_ERROR_NOT_IMPLEMENTED and the
+ * oxr caps query reports supported = false for VK sessions until then.
+ * NOTE: unlike the D3D11/D3D12 guards, XRT_HAVE_VK_NATIVE_COMPOSITOR is
+ * defined on every platform, so these must stay real (linkable) symbols.
+ */
+
+/*!
+ * Create the compositor-side mask state (R8_UNORM image, w×h client px).
+ *
+ * @ingroup comp_vk_native
+ */
+xrt_result_t
+comp_vk_native_compositor_zone_mask_create(struct xrt_compositor *xc,
+                                           uint32_t w, uint32_t h,
+                                           void **out_mask);
+
+/*!
+ * Tier 1 — fill the whole mask: all-3D (enable_3d) or all-2D.
+ *
+ * @ingroup comp_vk_native
+ */
+xrt_result_t
+comp_vk_native_compositor_zone_mask_set_whole(struct xrt_compositor *xc,
+                                              void *mask,
+                                              bool enable_3d);
+
+/*!
+ * Tier 2 — rasterize client-window-pixel rects as the 3D region.
+ *
+ * @ingroup comp_vk_native
+ */
+xrt_result_t
+comp_vk_native_compositor_zone_mask_set_rects(struct xrt_compositor *xc,
+                                              void *mask,
+                                              uint32_t count,
+                                              const struct xrt_rect *rects);
+
+/*!
+ * Tier 3 — hand back the VkImage + VkImageView for freeform app drawing
+ * (the compositor shares the app's VkDevice; same-queue submission order is
+ * the sync contract).
+ *
+ * @param out_image      Receives a VkImage (as void*).
+ * @param out_image_view Receives a VkImageView (as void*).
+ *
+ * @ingroup comp_vk_native
+ */
+xrt_result_t
+comp_vk_native_compositor_zone_mask_acquire_rt(struct xrt_compositor *xc,
+                                               void *mask,
+                                               void **out_image,
+                                               void **out_image_view,
+                                               uint32_t *out_w,
+                                               uint32_t *out_h);
+
+/*!
+ * Stage the mask's current contents for the next frame submission.
+ *
+ * @ingroup comp_vk_native
+ */
+xrt_result_t
+comp_vk_native_compositor_zone_mask_submit(struct xrt_compositor *xc, void *mask);
+
+/*!
+ * Destroy the compositor-side mask state.
+ *
+ * @ingroup comp_vk_native
+ */
+void
+comp_vk_native_compositor_zone_mask_destroy(struct xrt_compositor *xc, void *mask);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/xrt/state_trackers/oxr/oxr_local_3d_zone.c
+++ b/src/xrt/state_trackers/oxr/oxr_local_3d_zone.c
@@ -2,16 +2,19 @@
 // SPDX-License-Identifier: BSL-1.0
 /*!
  * @file
- * @brief  XR_EXT_local_3d_zone entrypoints — authored 2D/3D mask (Phase 1 of
- *         unified 2D/3D compositing, docs/roadmap/unified-2d-3d-phase1-impl.md).
+ * @brief  XR_EXT_local_3d_zone entrypoints — authored 2D/3D mask (#439,
+ *         unified 2D/3D compositing).
  * @author David Fattal
  * @ingroup oxr_api
  *
  * The oxr layer owns the mask handle lifecycle and forwards authoring calls to
- * the native compositor's zone-mask entry points. Phase 1 wires the D3D11
- * consumer only; every other compositor falls through to
- * XR_ERROR_FEATURE_UNSUPPORTED (the caps query reports supported = false
- * instead of erroring).
+ * the native compositor's zone-mask entry points. The D3D11 consumer shipped
+ * with Phases 1–2 (docs/roadmap/unified-2d-3d-phase1-impl.md, -phase2-impl.md);
+ * D3D12 and VK forward to stubs until their consumer legs land
+ * (docs/roadmap/unified-2d-3d-crossapi-impl.md) — the caps query reports
+ * supported = false for those sessions, and a stubbed compositor's
+ * XRT_ERROR_NOT_IMPLEMENTED maps to XR_ERROR_FEATURE_UNSUPPORTED. Every other
+ * compositor falls through to XR_ERROR_FEATURE_UNSUPPORTED.
  */
 
 #include <stdlib.h>
@@ -32,10 +35,43 @@
 #include "d3d11/comp_d3d11_compositor.h"
 #endif
 
+#ifdef XRT_HAVE_D3D12_NATIVE_COMPOSITOR
+#include "d3d12/comp_d3d12_compositor.h"
+#endif
+
+#ifdef XRT_HAVE_VK_NATIVE_COMPOSITOR
+#include "vk_native/comp_vk_native_compositor.h"
+#endif
+
 #ifdef OXR_HAVE_EXT_local_3d_zone
 
-//! D3D11 max texture dimension — bounds the authored mask size.
+//! D3D11/D3D12/VK max texture dimension — bounds the authored mask size.
 #define OXR_LOCAL_3D_ZONE_MAX_MASK_DIM 16384
+
+#if defined(XRT_HAVE_D3D11_NATIVE_COMPOSITOR) || defined(XRT_HAVE_D3D12_NATIVE_COMPOSITOR) ||                          \
+    defined(XRT_HAVE_VK_NATIVE_COMPOSITOR)
+#define OXR_LOCAL_3D_ZONE_HAVE_ANY_COMPOSITOR
+#endif
+
+#ifdef OXR_LOCAL_3D_ZONE_HAVE_ANY_COMPOSITOR
+/*!
+ * Map a compositor zone-mask result: stubs (consumer leg not landed) report
+ * XRT_ERROR_NOT_IMPLEMENTED → XR_ERROR_FEATURE_UNSUPPORTED; anything else
+ * non-success is a runtime failure.
+ */
+static XrResult
+zone_mask_xret_to_xr(struct oxr_logger *log, xrt_result_t xret, const char *what)
+{
+	if (xret == XRT_SUCCESS) {
+		return XR_SUCCESS;
+	}
+	if (xret == XRT_ERROR_NOT_IMPLEMENTED) {
+		return oxr_error(log, XR_ERROR_FEATURE_UNSUPPORTED,
+		                 "%s: local 3D zone consumer not implemented for this compositor yet", what);
+	}
+	return oxr_error(log, XR_ERROR_RUNTIME_FAILURE, "%s failed (%d)", what, xret);
+}
+#endif
 
 
 /*
@@ -49,12 +85,26 @@ oxr_local_3d_zone_destroy_cb(struct oxr_logger *log, struct oxr_handle_base *hb)
 {
 	struct oxr_local_3d_zone_ext *zone = (struct oxr_local_3d_zone_ext *)hb;
 
-#ifdef XRT_HAVE_D3D11_NATIVE_COMPOSITOR
+#ifdef OXR_LOCAL_3D_ZONE_HAVE_ANY_COMPOSITOR
 	struct oxr_session *sess = zone->sess;
-	if (zone->comp_mask != NULL && sess != NULL && sess->is_d3d11_native_compositor && sess->xcn != NULL) {
-		comp_d3d11_compositor_zone_mask_destroy(&sess->xcn->base, zone->comp_mask);
-	}
+	if (zone->comp_mask != NULL && sess != NULL && sess->xcn != NULL) {
+#ifdef XRT_HAVE_D3D11_NATIVE_COMPOSITOR
+		if (sess->is_d3d11_native_compositor) {
+			comp_d3d11_compositor_zone_mask_destroy(&sess->xcn->base, zone->comp_mask);
+		}
 #endif
+#ifdef XRT_HAVE_D3D12_NATIVE_COMPOSITOR
+		if (sess->is_d3d12_native_compositor) {
+			comp_d3d12_compositor_zone_mask_destroy(&sess->xcn->base, zone->comp_mask);
+		}
+#endif
+#ifdef XRT_HAVE_VK_NATIVE_COMPOSITOR
+		if (sess->is_vk_native_compositor) {
+			comp_vk_native_compositor_zone_mask_destroy(&sess->xcn->base, zone->comp_mask);
+		}
+#endif
+	}
+#endif // OXR_LOCAL_3D_ZONE_HAVE_ANY_COMPOSITOR
 	zone->comp_mask = NULL;
 
 	free(zone);
@@ -80,6 +130,8 @@ oxr_xrGetLocal3DZoneCapabilitiesEXT(XrSession session, XrLocal3DZoneCapabilities
 	OXR_VERIFY_ARG_TYPE_AND_NOT_NULL(&log, capabilities, XR_TYPE_LOCAL_3D_ZONE_CAPABILITIES_EXT);
 
 	// Never errors on an unsupported compositor — reports supported = false.
+	// D3D12 + VK sessions also report false until their consumer legs land
+	// (docs/roadmap/unified-2d-3d-crossapi-impl.md — flip here per leg).
 	capabilities->supported = XR_FALSE;
 	capabilities->hardwareZoneGridWidth = 0;
 	capabilities->hardwareZoneGridHeight = 0;
@@ -120,8 +172,20 @@ oxr_xrCreateLocal3DZoneMaskEXT(XrSession session,
 		                 createInfo->maskWidth, createInfo->maskHeight, OXR_LOCAL_3D_ZONE_MAX_MASK_DIM);
 	}
 
+#ifdef OXR_LOCAL_3D_ZONE_HAVE_ANY_COMPOSITOR
+	bool api_matched = false;
+	if (sess->xcn != NULL) {
 #ifdef XRT_HAVE_D3D11_NATIVE_COMPOSITOR
-	if (sess->is_d3d11_native_compositor && sess->xcn != NULL) {
+		api_matched = api_matched || sess->is_d3d11_native_compositor;
+#endif
+#ifdef XRT_HAVE_D3D12_NATIVE_COMPOSITOR
+		api_matched = api_matched || sess->is_d3d12_native_compositor;
+#endif
+#ifdef XRT_HAVE_VK_NATIVE_COMPOSITOR
+		api_matched = api_matched || sess->is_vk_native_compositor;
+#endif
+	}
+	if (api_matched) {
 		struct oxr_local_3d_zone_ext *zone = NULL;
 		OXR_ALLOCATE_HANDLE_OR_RETURN(&log, zone, OXR_XR_DEBUG_LOCAL3DZONE, oxr_local_3d_zone_destroy_cb,
 		                              &sess->handle);
@@ -131,11 +195,27 @@ oxr_xrCreateLocal3DZoneMaskEXT(XrSession session,
 		zone->width = createInfo->maskWidth;
 		zone->height = createInfo->maskHeight;
 
-		xrt_result_t xret = comp_d3d11_compositor_zone_mask_create(&sess->xcn->base, zone->width,
-		                                                           zone->height, &zone->comp_mask);
+		xrt_result_t xret = XRT_ERROR_NOT_IMPLEMENTED;
+#ifdef XRT_HAVE_D3D11_NATIVE_COMPOSITOR
+		if (sess->is_d3d11_native_compositor) {
+			xret = comp_d3d11_compositor_zone_mask_create(&sess->xcn->base, zone->width, zone->height,
+			                                              &zone->comp_mask);
+		}
+#endif
+#ifdef XRT_HAVE_D3D12_NATIVE_COMPOSITOR
+		if (sess->is_d3d12_native_compositor) {
+			xret = comp_d3d12_compositor_zone_mask_create(&sess->xcn->base, zone->width, zone->height,
+			                                              &zone->comp_mask);
+		}
+#endif
+#ifdef XRT_HAVE_VK_NATIVE_COMPOSITOR
+		if (sess->is_vk_native_compositor) {
+			xret = comp_vk_native_compositor_zone_mask_create(&sess->xcn->base, zone->width, zone->height,
+			                                                  &zone->comp_mask);
+		}
+#endif
 		if (xret != XRT_SUCCESS) {
-			XrResult ret = oxr_error(&log, XR_ERROR_RUNTIME_FAILURE,
-			                         "Failed to create compositor zone mask (%d)", xret);
+			XrResult ret = zone_mask_xret_to_xr(&log, xret, "xrCreateLocal3DZoneMaskEXT");
 			oxr_handle_destroy(&log, &zone->handle);
 			return ret;
 		}
@@ -143,7 +223,7 @@ oxr_xrCreateLocal3DZoneMaskEXT(XrSession session,
 		*mask = oxr_local_3d_zone_to_openxr(zone);
 		return XR_SUCCESS;
 	}
-#endif
+#endif // OXR_LOCAL_3D_ZONE_HAVE_ANY_COMPOSITOR
 
 	return oxr_error(&log, XR_ERROR_FEATURE_UNSUPPORTED,
 	                 "Local 3D zone masks are not supported for this compositor");
@@ -158,20 +238,37 @@ oxr_xrSetLocal3DZoneWholeWindowEXT(XrLocal3DZoneMaskEXT mask, XrBool32 enable3D)
 	struct oxr_logger log;
 	OXR_VERIFY_LOCAL_3D_ZONE_AND_INIT_LOG(&log, mask, zone, "xrSetLocal3DZoneWholeWindowEXT");
 
-#ifdef XRT_HAVE_D3D11_NATIVE_COMPOSITOR
+#ifdef OXR_LOCAL_3D_ZONE_HAVE_ANY_COMPOSITOR
 	struct oxr_session *sess = zone->sess;
-	if (sess->is_d3d11_native_compositor && sess->xcn != NULL) {
-		xrt_result_t xret =
-		    comp_d3d11_compositor_zone_mask_set_whole(&sess->xcn->base, zone->comp_mask, enable3D == XR_TRUE);
-		if (xret != XRT_SUCCESS) {
-			return oxr_error(&log, XR_ERROR_RUNTIME_FAILURE, "Failed to set whole-window zone mask (%d)",
-			                 xret);
+	if (sess->xcn != NULL) {
+#ifdef XRT_HAVE_D3D11_NATIVE_COMPOSITOR
+		if (sess->is_d3d11_native_compositor) {
+			return zone_mask_xret_to_xr(&log,
+			                            comp_d3d11_compositor_zone_mask_set_whole(
+			                                &sess->xcn->base, zone->comp_mask, enable3D == XR_TRUE),
+			                            "xrSetLocal3DZoneWholeWindowEXT");
 		}
-		return XR_SUCCESS;
+#endif
+#ifdef XRT_HAVE_D3D12_NATIVE_COMPOSITOR
+		if (sess->is_d3d12_native_compositor) {
+			return zone_mask_xret_to_xr(&log,
+			                            comp_d3d12_compositor_zone_mask_set_whole(
+			                                &sess->xcn->base, zone->comp_mask, enable3D == XR_TRUE),
+			                            "xrSetLocal3DZoneWholeWindowEXT");
+		}
+#endif
+#ifdef XRT_HAVE_VK_NATIVE_COMPOSITOR
+		if (sess->is_vk_native_compositor) {
+			return zone_mask_xret_to_xr(&log,
+			                            comp_vk_native_compositor_zone_mask_set_whole(
+			                                &sess->xcn->base, zone->comp_mask, enable3D == XR_TRUE),
+			                            "xrSetLocal3DZoneWholeWindowEXT");
+		}
+#endif
 	}
 #else
 	(void)enable3D;
-#endif
+#endif // OXR_LOCAL_3D_ZONE_HAVE_ANY_COMPOSITOR
 
 	return oxr_error(&log, XR_ERROR_FEATURE_UNSUPPORTED,
 	                 "Local 3D zone masks are not supported for this compositor");
@@ -191,9 +288,9 @@ oxr_xrSetLocal3DZoneFromRectsEXT(XrLocal3DZoneMaskEXT mask, uint32_t rectCount, 
 		return oxr_error(&log, XR_ERROR_VALIDATION_FAILURE, "(rectCount == 0) must be at least one rect");
 	}
 
-#ifdef XRT_HAVE_D3D11_NATIVE_COMPOSITOR
+#ifdef OXR_LOCAL_3D_ZONE_HAVE_ANY_COMPOSITOR
 	struct oxr_session *sess = zone->sess;
-	if (sess->is_d3d11_native_compositor && sess->xcn != NULL) {
+	if (sess->xcn != NULL) {
 		struct xrt_rect *xrects = U_TYPED_ARRAY_CALLOC(struct xrt_rect, rectCount);
 		if (xrects == NULL) {
 			return oxr_error(&log, XR_ERROR_OUT_OF_MEMORY, "Failed to allocate rect array");
@@ -205,15 +302,35 @@ oxr_xrSetLocal3DZoneFromRectsEXT(XrLocal3DZoneMaskEXT mask, uint32_t rectCount, 
 			xrects[i].extent.h = rects[i].extent.height;
 		}
 
-		xrt_result_t xret =
-		    comp_d3d11_compositor_zone_mask_set_rects(&sess->xcn->base, zone->comp_mask, rectCount, xrects);
-		free(xrects);
-		if (xret != XRT_SUCCESS) {
-			return oxr_error(&log, XR_ERROR_RUNTIME_FAILURE, "Failed to set zone mask rects (%d)", xret);
+		xrt_result_t xret = XRT_ERROR_NOT_IMPLEMENTED;
+		bool api_matched = false;
+#ifdef XRT_HAVE_D3D11_NATIVE_COMPOSITOR
+		if (sess->is_d3d11_native_compositor) {
+			xret = comp_d3d11_compositor_zone_mask_set_rects(&sess->xcn->base, zone->comp_mask, rectCount,
+			                                                 xrects);
+			api_matched = true;
 		}
-		return XR_SUCCESS;
-	}
 #endif
+#ifdef XRT_HAVE_D3D12_NATIVE_COMPOSITOR
+		if (!api_matched && sess->is_d3d12_native_compositor) {
+			xret = comp_d3d12_compositor_zone_mask_set_rects(&sess->xcn->base, zone->comp_mask, rectCount,
+			                                                 xrects);
+			api_matched = true;
+		}
+#endif
+#ifdef XRT_HAVE_VK_NATIVE_COMPOSITOR
+		if (!api_matched && sess->is_vk_native_compositor) {
+			xret = comp_vk_native_compositor_zone_mask_set_rects(&sess->xcn->base, zone->comp_mask,
+			                                                     rectCount, xrects);
+			api_matched = true;
+		}
+#endif
+		free(xrects);
+		if (api_matched) {
+			return zone_mask_xret_to_xr(&log, xret, "xrSetLocal3DZoneFromRectsEXT");
+		}
+	}
+#endif // OXR_LOCAL_3D_ZONE_HAVE_ANY_COMPOSITOR
 
 	return oxr_error(&log, XR_ERROR_FEATURE_UNSUPPORTED,
 	                 "Local 3D zone masks are not supported for this compositor");
@@ -229,9 +346,16 @@ oxr_xrAcquireLocal3DZoneRenderTargetEXT(XrLocal3DZoneMaskEXT mask, void *binding
 	OXR_VERIFY_LOCAL_3D_ZONE_AND_INIT_LOG(&log, mask, zone, "xrAcquireLocal3DZoneRenderTargetEXT");
 	OXR_VERIFY_ARG_NOT_NULL(&log, binding);
 
-#ifdef XRT_HAVE_D3D11_NATIVE_COMPOSITOR
+#ifdef OXR_LOCAL_3D_ZONE_HAVE_ANY_COMPOSITOR
 	struct oxr_session *sess = zone->sess;
-	if (sess->is_d3d11_native_compositor && sess->xcn != NULL) {
+	if (sess->xcn == NULL) {
+		return oxr_error(&log, XR_ERROR_FEATURE_UNSUPPORTED,
+		                 "Local 3D zone masks are not supported for this compositor");
+	}
+#endif
+
+#ifdef XRT_HAVE_D3D11_NATIVE_COMPOSITOR
+	if (sess->is_d3d11_native_compositor) {
 		XrLocal3DZoneRenderTargetD3D11EXT *d3d11_binding = (XrLocal3DZoneRenderTargetD3D11EXT *)binding;
 		if (d3d11_binding->type != XR_TYPE_LOCAL_3D_ZONE_RENDER_TARGET_D3D11_EXT) {
 			return oxr_error(&log, XR_ERROR_VALIDATION_FAILURE,
@@ -243,13 +367,60 @@ oxr_xrAcquireLocal3DZoneRenderTargetEXT(XrLocal3DZoneMaskEXT mask, void *binding
 		xrt_result_t xret =
 		    comp_d3d11_compositor_zone_mask_acquire_rt(&sess->xcn->base, zone->comp_mask, &rtv, &w, &h);
 		if (xret != XRT_SUCCESS) {
-			return oxr_error(&log, XR_ERROR_RUNTIME_FAILURE,
-			                 "Failed to acquire zone mask render target (%d)", xret);
+			return zone_mask_xret_to_xr(&log, xret, "xrAcquireLocal3DZoneRenderTargetEXT");
 		}
 
 		d3d11_binding->renderTargetView = rtv;
 		d3d11_binding->width = w;
 		d3d11_binding->height = h;
+		return XR_SUCCESS;
+	}
+#endif
+
+#ifdef XRT_HAVE_D3D12_NATIVE_COMPOSITOR
+	if (sess->is_d3d12_native_compositor) {
+		XrLocal3DZoneRenderTargetD3D12EXT *d3d12_binding = (XrLocal3DZoneRenderTargetD3D12EXT *)binding;
+		if (d3d12_binding->type != XR_TYPE_LOCAL_3D_ZONE_RENDER_TARGET_D3D12_EXT) {
+			return oxr_error(&log, XR_ERROR_VALIDATION_FAILURE,
+			                 "(binding->type) expected XR_TYPE_LOCAL_3D_ZONE_RENDER_TARGET_D3D12_EXT");
+		}
+
+		void *resource = NULL;
+		uint32_t w = 0, h = 0;
+		xrt_result_t xret =
+		    comp_d3d12_compositor_zone_mask_acquire_rt(&sess->xcn->base, zone->comp_mask, &resource, &w, &h);
+		if (xret != XRT_SUCCESS) {
+			return zone_mask_xret_to_xr(&log, xret, "xrAcquireLocal3DZoneRenderTargetEXT");
+		}
+
+		d3d12_binding->resource = resource;
+		d3d12_binding->width = w;
+		d3d12_binding->height = h;
+		return XR_SUCCESS;
+	}
+#endif
+
+#ifdef XRT_HAVE_VK_NATIVE_COMPOSITOR
+	if (sess->is_vk_native_compositor) {
+		XrLocal3DZoneRenderTargetVulkanEXT *vk_binding = (XrLocal3DZoneRenderTargetVulkanEXT *)binding;
+		if (vk_binding->type != XR_TYPE_LOCAL_3D_ZONE_RENDER_TARGET_VULKAN_EXT) {
+			return oxr_error(&log, XR_ERROR_VALIDATION_FAILURE,
+			                 "(binding->type) expected XR_TYPE_LOCAL_3D_ZONE_RENDER_TARGET_VULKAN_EXT");
+		}
+
+		void *image = NULL;
+		void *image_view = NULL;
+		uint32_t w = 0, h = 0;
+		xrt_result_t xret = comp_vk_native_compositor_zone_mask_acquire_rt(&sess->xcn->base, zone->comp_mask,
+		                                                                   &image, &image_view, &w, &h);
+		if (xret != XRT_SUCCESS) {
+			return zone_mask_xret_to_xr(&log, xret, "xrAcquireLocal3DZoneRenderTargetEXT");
+		}
+
+		vk_binding->image = image;
+		vk_binding->imageView = image_view;
+		vk_binding->width = w;
+		vk_binding->height = h;
 		return XR_SUCCESS;
 	}
 #endif
@@ -267,16 +438,32 @@ oxr_xrSubmitLocal3DZoneEXT(XrLocal3DZoneMaskEXT mask)
 	struct oxr_logger log;
 	OXR_VERIFY_LOCAL_3D_ZONE_AND_INIT_LOG(&log, mask, zone, "xrSubmitLocal3DZoneEXT");
 
-#ifdef XRT_HAVE_D3D11_NATIVE_COMPOSITOR
+#ifdef OXR_LOCAL_3D_ZONE_HAVE_ANY_COMPOSITOR
 	struct oxr_session *sess = zone->sess;
-	if (sess->is_d3d11_native_compositor && sess->xcn != NULL) {
-		xrt_result_t xret = comp_d3d11_compositor_zone_mask_submit(&sess->xcn->base, zone->comp_mask);
-		if (xret != XRT_SUCCESS) {
-			return oxr_error(&log, XR_ERROR_RUNTIME_FAILURE, "Failed to submit zone mask (%d)", xret);
+	if (sess->xcn != NULL) {
+#ifdef XRT_HAVE_D3D11_NATIVE_COMPOSITOR
+		if (sess->is_d3d11_native_compositor) {
+			return zone_mask_xret_to_xr(
+			    &log, comp_d3d11_compositor_zone_mask_submit(&sess->xcn->base, zone->comp_mask),
+			    "xrSubmitLocal3DZoneEXT");
 		}
-		return XR_SUCCESS;
-	}
 #endif
+#ifdef XRT_HAVE_D3D12_NATIVE_COMPOSITOR
+		if (sess->is_d3d12_native_compositor) {
+			return zone_mask_xret_to_xr(
+			    &log, comp_d3d12_compositor_zone_mask_submit(&sess->xcn->base, zone->comp_mask),
+			    "xrSubmitLocal3DZoneEXT");
+		}
+#endif
+#ifdef XRT_HAVE_VK_NATIVE_COMPOSITOR
+		if (sess->is_vk_native_compositor) {
+			return zone_mask_xret_to_xr(
+			    &log, comp_vk_native_compositor_zone_mask_submit(&sess->xcn->base, zone->comp_mask),
+			    "xrSubmitLocal3DZoneEXT");
+		}
+#endif
+	}
+#endif // OXR_LOCAL_3D_ZONE_HAVE_ANY_COMPOSITOR
 
 	return oxr_error(&log, XR_ERROR_FEATURE_UNSUPPORTED,
 	                 "Local 3D zone masks are not supported for this compositor");


### PR DESCRIPTION
## Summary
Base leg of the cross-API rollout (spec §8) — makes the D3D12 and VK consumer legs independently startable against `main`:

- **Header v2** (`XR_EXT_local_3d_zone.h`, SPEC_VERSION 2): `XrLocal3DZoneRenderTargetD3D12EXT` (ID3D12Resource*, app-owned RTV descriptor, same-queue sync contract) + `XrLocal3DZoneRenderTargetVulkanEXT` (VkImage + VkImageView on the app's shared VkDevice). Auto-syncs to `displayxr-extensions` on merge.
- **oxr**: three-way D3D11/D3D12/VK dispatch in all handlers; per-API Tier-3 binding validation; `XRT_ERROR_NOT_IMPLEMENTED` → `XR_ERROR_FEATURE_UNSUPPORTED`; caps report `supported=false` for D3D12/VK until each leg flips.
- **comp stubs** (not Phase-1's declared-only boundary): `XRT_HAVE_VK_NATIVE_COMPOSITOR` is defined on every platform, so declared-only symbols would break the macOS link — real `NOT_IMPLEMENTED` stubs keep all platforms green and make this PR mergeable alone.
- **Plan**: `docs/roadmap/unified-2d-3d-crossapi-impl.md` — incl. the VK scoping decision (handle apps have no 2D source until Phase 3, so the VK composite consumer rides with Phase 3; D3D12 leg is fully viable now via `cube_texture_d3d12_win` + the shipping v6/v7 surround).

## Behavior change
None reachable: caps-honoring apps see `supported=false` on D3D12/VK; apps that skip the check get `XR_ERROR_FEATURE_UNSUPPORTED` instead of nothing. D3D11 path untouched.

## Test plan
- [x] `./scripts/build_macos.sh` green; VK stubs verified linked (`nm`)
- [ ] Windows CI (this PR) validates the D3D12 stub compile
- [ ] `displayxr-cli selftest` unchanged (no DP/discovery surface touched)

Refs #439

🤖 Generated with [Claude Code](https://claude.com/claude-code)