### PR TITLE
feat(#224): Phase 0 hardware-DP zone leg — stateless publish vtable + runtime publish path + sim double

### DIFF
--- a/docs/reference/xrt_plugin_iface.md
+++ b/docs/reference/xrt_plugin_iface.md
@@ -107,6 +107,10 @@ Construct the per-graphics-API display processor. Called per app session, per gr
 
 Each factory's signature is owned by `xrt_display_processor_<api>.h` and is unchanged from the pre-plug-in shape — see those headers for the exact contracts. The plug-in iface just hands one back per supported API.
 
+**Optional DP-vtable extensions a vendor can implement** (appended slots, gated by the DP `struct_size` per ADR-020 — an older plug-in simply doesn't have them):
+- `get_handoff_color_capability` / `set_atlas_encoding` — ADR-021 color contract.
+- `get_local_zone_caps` / `publish_local_zone_mask` / `clear_local_zone_mask` (D3D11, slots 12–14) — the local 2D/3D-zone hardware leg (#224, `docs/roadmap/local-3d-zones.md`): the runtime publishes the authored `XR_EXT_local_3d_zone` mask (R8 SRV + physical-pixel screen anchor, per frame while active) so switchable-lens panels can track per-window 3D. Report `zone_grid = 1×1` to OR-collapse to a global on/off panel — bit-compatible with today's `request_display_mode` arbitration. Caps struct: `xrt_display_zones.h`.
+
 ### `destroy`
 
 ```c

--- a/docs/roadmap/local-3d-zones.md
+++ b/docs/roadmap/local-3d-zones.md
@@ -1,6 +1,6 @@
 # Local 2D/3D Zones — Per-Window 3D Without Switching the Whole Screen
 
-**Status**: design draft (May 2026). Pre-implementation.
+**Status**: Phase 0 runtime side IMPLEMENTED (June 2026) — D3D11 DP vtable additions (`get_local_zone_caps` / `publish_local_zone_mask` / `clear_local_zone_mask`, appended per ADR-020), the compositor per-frame publish path, hwGrid caps wiring, and the sim_display test double (`SIM_DISPLAY_ZONE_GRID` / `SIM_DISPLAY_ZONE_DUMP`). The authoring extension shipped earlier via #439 Phases 1–2. **Revised from the original draft:** the in-process D3D11 vtable contract is *stateless publish* (runtime-owned mask texture, SRV passed per publish) instead of the DP-allocated create/publish/clear/destroy lifecycle below — see "DP vtable contract". Remaining: first-vendor (Leia) 1×1 implementation, occlusion subtraction, per-zone hardware.
 **Scope**: regular Windows desktop, no shell, single or multiple 3D apps in normal windows. Shell-mode generalization is a superset of this and not covered here.
 **Audience**: DisplayXR runtime contributors; vendors implementing the display processor (DP) vtable.
 
@@ -61,67 +61,57 @@ Two channels per app: (1) the swap chain DWM sees (interlaced inside 3D rects, m
 
 ---
 
-## DP vtable contract
+## DP vtable contract (as implemented — Phase 0, D3D11)
 
-This is the only surface between runtime and vendor. Extends `xrt_display_processor` (`src/xrt/include/xrt/xrt_display_processor.h`).
+This is the only surface between runtime and vendor. Three methods appended to `xrt_display_processor_d3d11` (`src/xrt/include/xrt/xrt_display_processor_d3d11.h`, slots 12–14; shared caps struct in `xrt_display_zones.h`), append-only within the ABI major per ADR-020 — older plug-ins report a smaller `struct_size` and the runtime treats the slots as absent (legacy DP).
+
+> **Design revision vs. the original draft.** The draft had the DP allocate a shared mask texture behind a create/publish/clear/destroy handle lifecycle — a shape motivated by cross-process sharing. The shipped `XR_EXT_local_3d_zone` compositor consumer (#439) already owns a window-sized R8_UNORM staged mask on the session's own in-process D3D11 device, so the in-process contract is **stateless publish**: the runtime passes the mask SRV per publish and the DP samples/copies it during the call (the immediate context serializes against the runtime's writes; the DP must not hold the SRV past return). DP-side lifecycle methods can be appended later when a cross-process leg (IPC/service zone masks) needs real sharing primitives.
 
 ### Capability query
 
 ```c
-struct xrt_dp_local_zone_caps {
-    bool     supported;            // false on DPs that don't implement local zones
-    uint32_t zone_grid_width;      // hardware cells across (1 = global on/off)
-    uint32_t zone_grid_height;     // hardware cells down
-    uint32_t max_mask_width;       // upper bound on client-published mask resolution
+struct xrt_dp_local_zone_caps {        // xrt_display_zones.h — fixed-width, struct_size-headed (ADR-020)
+    uint32_t struct_size;              // pre-set by the CALLER (runtime); DP writes only fields within
+    uint32_t supported;                // 0 on DPs that don't implement local zones
+    uint32_t zone_grid_width;          // hardware cells across (1 = global on/off)
+    uint32_t zone_grid_height;         // hardware cells down
+    uint32_t max_mask_width;           // upper bound on the published mask resolution (0 = no preference)
     uint32_t max_mask_height;
-    uint32_t max_update_hz;        // 0 = unlimited; vendor's preferred max mask refresh
+    uint32_t max_update_hz;            // 0 = unlimited; vendor's preferred max mask refresh (advisory in Phase 0)
 };
 
-xrt_result_t xrt_dp_get_local_zone_caps(struct xrt_display_processor *dp,
-                                        struct xrt_dp_local_zone_caps *caps);
+bool (*get_local_zone_caps)(struct xrt_display_processor_d3d11 *xdp,
+                            struct xrt_dp_local_zone_caps *out_caps);
 ```
 
 Three meaningful return shapes:
 
-- `supported = false`: legacy DP. Runtime falls back to the existing global `request_display_mode` path. App-facing extension reports unsupported.
-- `supported = true, zone_grid = 1×1`: vendor implements the new API but the hardware is single-zone. OR-union of all client masks collapses to "any client requesting any 3D anywhere → screen is 3D" — identical to today's bool arbitration.
-- `supported = true, zone_grid > 1×1`: real local zones. Same runtime path; vendor does the heavy lifting.
+- slot absent / NULL / `supported = 0`: legacy DP. Runtime keeps the existing global `request_display_mode` path and never calls the publish methods. `xrGetLocal3DZoneCapabilitiesEXT` reports `hardwareZoneGrid = 0×0` (the compositor consumer still works — the mask composites, it just can't drive the panel).
+- `supported = 1, zone_grid = 1×1`: vendor implements the new API but the hardware is single-zone. OR-union of all client masks collapses to "any client requesting any 3D anywhere → screen is 3D" — identical to today's bool arbitration.
+- `supported = 1, zone_grid > 1×1`: real local zones. Same runtime path; vendor does the heavy lifting.
 
-### Per-client mask publish
-
-The runtime holds one **mask handle** per active client (per-session in the OpenXR sense). Lifecycle:
+### Per-client mask publish (stateless)
 
 ```c
-// Allocate a mask. Vendor returns an opaque handle plus a shared GPU texture
-// the runtime can write into. The shared-texture format and sync primitive
-// are API-specific (D3D11 NT handle, D3D12 fence, Vulkan external memory, etc.)
-// and selected based on the graphics binding the session was created with.
-xrt_result_t xrt_dp_create_local_zone_mask(
-    struct xrt_display_processor *dp,
-    const struct xrt_dp_mask_create_info *info,   // graphics API, initial resolution
-    struct xrt_dp_local_zone_mask **out_mask);
+// Per-frame publish. The runtime owns the mask texture (the staged
+// XR_EXT_local_3d_zone snapshot — R8_UNORM, client-window pixels, non-zero =
+// 3D) and passes an SRV on the session's own D3D11 device. screen_x/y/w/h
+// anchor the mask's pixel space on the panel (physical pixels, post-DPI
+// client rect). seq is a monotonic per-session publish counter for
+// vendor-side coalescing. The DP samples or copies DURING the call.
+bool (*publish_local_zone_mask)(struct xrt_display_processor_d3d11 *xdp,
+                                void *d3d11_context, void *mask_srv,
+                                uint32_t mask_width, uint32_t mask_height,
+                                int32_t screen_x, int32_t screen_y,
+                                uint32_t screen_w, uint32_t screen_h,
+                                uint64_t seq);
 
-// Per-frame publish. Tells the vendor: this mask handle's texture has been
-// updated; sample it as covering this screen rect (physical pixels, post-DPI).
-// Sync token (fence/event) is on the mask object; vendor reads after runtime
-// signals it.
-xrt_result_t xrt_dp_publish_local_zone_mask(
-    struct xrt_display_processor *dp,
-    struct xrt_dp_local_zone_mask *mask,
-    const struct xrt_rect2di *screen_rect_px,     // top-left + size in physical pixels
-    uint64_t sync_token);                          // monotonic per-mask seq
-
-// Equivalent to "this client is fully 2D." Cheaper than publishing an empty mask.
-xrt_result_t xrt_dp_clear_local_zone_mask(
-    struct xrt_display_processor *dp,
-    struct xrt_dp_local_zone_mask *mask);
-
-xrt_result_t xrt_dp_destroy_local_zone_mask(
-    struct xrt_display_processor *dp,
-    struct xrt_dp_local_zone_mask *mask);
+// Equivalent to "this client is fully 2D." Cheaper than publishing an empty
+// mask. Called on the active→inactive edge (mask destroyed, session ends).
+bool (*clear_local_zone_mask)(struct xrt_display_processor_d3d11 *xdp);
 ```
 
-Texture format is **binary** (1 channel, 1 = 3D, 0 = 2D). The vendor may treat any non-zero value as 3D for tolerance. Resolution is chosen by the runtime (informed by `max_mask_width/height` from caps) and is in **client-window pixels** — the runtime tells the vendor where that pixel space maps onto the screen via `screen_rect_px`.
+Mask values: 1 channel; the vendor must treat **any non-zero value as 3D** (the authored mask has fractional anti-aliased edges — the OR rule makes them conservative). Resolution is the authored mask resolution in **client-window pixels**; the runtime tells the vendor where that pixel space maps onto the screen via the `screen_*` args, and republishes every frame while a mask is active so the anchor tracks window moves/resizes (vendors coalesce per `max_update_hz`).
 
 ### What the DP vtable specifies
 
@@ -205,12 +195,12 @@ In all three tiers the wire-level primitive — what reaches the DP — is the s
 
 ### Runtime per-frame work (for each session with an active mask)
 
-On every `xrEndFrame` (or rate-limited if the DP caps say so):
+On every `xrEndFrame` (as implemented: `d3d11_sync_zone_mask_to_dp` in `comp_d3d11_compositor.cpp`, under the same `c->mutex` scope as the zone composite so the two mask consumers see identical state):
 
-1. **HWND screen rect**: `GetWindowRect(hwnd)` in physical pixels with per-monitor DPI awareness. Cache; invalidate on `WM_MOVE` / `WM_SIZE` / `WM_DPICHANGED` (subclass or `SetWinEventHook` on `EVENT_OBJECT_LOCATIONCHANGE`).
-2. **Z-order occlusion**: walk `GetWindow(hwnd, GW_HWNDPREV)` up to the top; for each top-level window above ours, intersect its rect with ours and accumulate into a "visible region in client-window pixels."
-3. **Apply occlusion to the client mask**: small compute shader ANDs the app-published mask with the rasterized visible region. Result is "what this client contributes to the panel."
-4. **Publish**: bump the sync token on the mask object, call `xrt_dp_publish_local_zone_mask(dp, mask, screen_rect_px, token)`.
+1. **Client screen rect**: `GetClientRect(hwnd)` + `ClientToScreen` each frame (physical pixels, same convention as `get_window_metrics`).
+2. **Z-order occlusion** — *deferred (Phase-0 publishes the un-occluded mask)*: walk `GetWindow(hwnd, GW_HWNDPREV)` up to the top; intersect each window above ours and accumulate a "visible region in client-window pixels."
+3. **Apply occlusion to the client mask** — *deferred with 2*: small shader ANDs the staged mask with the rasterized visible region. On 1×1-grid hardware the deferral changes nothing (the union result is identical); it starts mattering when overlapping windows meet per-zone hardware.
+4. **Publish**: bump the per-session seq, call `publish_local_zone_mask(dp, ctx, staged_srv, mask_w, mask_h, screen rect, seq)`. On the active→inactive edge (mask destroyed / teardown), call `clear_local_zone_mask` once.
 
 Occlusion is the runtime's responsibility, not the vendor's. The DP vtable sees only "this client wants this region in screen space, post-occlusion."
 
@@ -279,10 +269,10 @@ xrSubmitLocal3DZoneEXT(mask);
 ## Phasing
 
 **Phase 0 — DP vtable additions land in the runtime, on top of existing hardware.**
-First-vendor DP implements `xrt_dp_get_local_zone_caps` reporting `supported = true, zone_grid = 1×1`. Internally OR-collapses to today's global on/off path. Runtime can plumb the full extension end-to-end. Existing apps unaffected. Validates the API surface before any per-zone hardware exists.
+*Runtime side DONE (June 2026): D3D11 vtable slots 12–14, compositor per-frame publish/clear, hwGrid caps wiring, sim_display test double (`SIM_DISPLAY_ZONE_GRID=WxH` simulated grid + `SIM_DISPLAY_ZONE_DUMP=1` OR-downsampled per-cell readback logging — the hardware-free end-to-end check).* Remaining: first-vendor (Leia) DP implements `get_local_zone_caps` reporting `supported = 1, zone_grid = 1×1` and OR-collapses publishes to today's global on/off path. Existing apps unaffected. Validates the API surface before any per-zone hardware exists.
 
 **Phase 1 — runtime ships `XR_EXT_local_3d_zone`.**
-DisplayXR apps adopt it. On single-zone hardware, behavior identical to today. Occlusion subtraction starts working in preparation for Phase 2. Any vendor wanting to participate implements the DP vtable additions; the bar is low (1×1 grid + the new vtable methods is enough).
+*Authoring API + compositor consumer SHIPPED via #439 Phases 1–2 (ahead of this leg).* Remaining here: occlusion subtraction (deferred from Phase 0) in preparation for Phase 2. Any vendor wanting to participate implements the DP vtable additions; the bar is low (1×1 grid + the new vtable methods is enough).
 
 **Phase 2 — per-zone hardware lands** (from any vendor).
 That vendor's DP reports a real `zone_grid_width/height`. Same client code now produces per-window 3D zones. No app changes; runtime changes are confined to capability reporting and any optional vendor-specific tuning.
@@ -294,7 +284,7 @@ Shell becomes one more client publishing a mask; multi-app per-window 3D in shel
 
 ## Cross-references
 
-- DP vtable (existing): `src/xrt/include/xrt/xrt_display_processor.h:152–164` — `get_hardware_3d_state`, `request_display_mode`, `process_atlas`. The local-zone methods sit alongside these.
+- DP vtable: `src/xrt/include/xrt/xrt_display_processor_d3d11.h` — the local-zone methods (slots 12–14) sit after `set_atlas_encoding`; shared caps struct in `xrt_display_zones.h`. The base/Vulkan and other per-API vtables get the same append when their consumer legs land (zone masks are in-process D3D11 only today).
 - Vendor integration guide: `docs/guides/vendor-plugin-onboarding.md` — to be extended with the local-zone vtable methods once this spec lands.
 - Vendor-initiated state change events (today): `comp_d3d11_service.cpp:10180–10230`, `oxr_session.c:968` — the polling/event pattern that the new local-zone path coexists with, not replaces.
 - ADR-014 (shell owns rendering mode): generalizes in the zone world — the shell becomes one mask publisher among many rather than the sole policy holder.

--- a/src/xrt/compositor/d3d11/comp_d3d11_compositor.cpp
+++ b/src/xrt/compositor/d3d11/comp_d3d11_compositor.cpp
@@ -185,6 +185,19 @@ struct comp_d3d11_compositor
 	ID3D11Texture2D *weave_scratch;
 	ID3D11ShaderResourceView *weave_scratch_srv;
 
+	//! #224 hardware-DP zone leg: cached get_local_zone_caps result.
+	//! 0 = not queried yet (calloc default), 1 = supported, 2 = legacy DP
+	//! (slot absent / caps unsupported — never publish).
+	int zone_dp_state;
+	//! DP zone caps when zone_dp_state == 1 (grid dims surface through
+	//! comp_d3d11_compositor_zone_get_hw_caps → xrGetLocal3DZoneCapabilitiesEXT).
+	struct xrt_dp_local_zone_caps zone_dp_caps;
+	//! Monotonic per-session publish sequence (bumped on every publish).
+	uint64_t zone_publish_seq;
+	//! True while this client's mask is published to the DP — drives the
+	//! clear-on-deactivate edge (mask destroyed / compositor teardown).
+	bool zone_published;
+
 	//! Generic D3D11 display processor (vendor-agnostic weaving).
 	struct xrt_display_processor_d3d11 *display_processor;
 
@@ -312,6 +325,11 @@ d3d11_composite_zone_mask(struct comp_d3d11_compositor *c,
                           const struct u_canvas_rect *eff_canvas);
 static void
 d3d11_release_zone_state(struct comp_d3d11_compositor *c);
+// #224 hardware-DP zone leg: per-frame sideband publish of the active mask to
+// the display processor (and the clear-on-deactivate edge). Defined with the
+// other zone helpers near the bottom.
+static void
+d3d11_sync_zone_mask_to_dp(struct comp_d3d11_compositor *c);
 
 // #439 Phase 2: an active zone mask supersedes the canvas output rect —
 // the weave region, view dims, Kooima metrics, and composite region all
@@ -1379,6 +1397,12 @@ d3d11_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 	// view dims, and composite all see the same rect even if submit/destroy
 	// race the frame.
 	const struct u_canvas_rect eff_canvas = d3d11_effective_canvas(c);
+
+	// #224 hardware-DP zone leg: sideband-publish the active mask (or clear
+	// it on the inactive edge) so switchable-lens cells track the authored
+	// zones. Same mutex scope as the composite — the DP sees the same mask
+	// state as this frame's weave/composite (the two consumers must agree).
+	d3d11_sync_zone_mask_to_dp(c);
 
 	// Get target (window) dimensions for mono viewport sizing.
 	// In shared texture mode (no target), use canvas dims if available —
@@ -2764,6 +2788,7 @@ static void
 d3d11_release_zone_state(struct comp_d3d11_compositor *c)
 {
 	c->active_zone_mask = nullptr;
+	d3d11_sync_zone_mask_to_dp(c); // withdraw this client's DP zone contribution (#224)
 	if (c->weave_scratch_srv != nullptr) {
 		c->weave_scratch_srv->Release();
 		c->weave_scratch_srv = nullptr;
@@ -2771,6 +2796,76 @@ d3d11_release_zone_state(struct comp_d3d11_compositor *c)
 	if (c->weave_scratch != nullptr) {
 		c->weave_scratch->Release();
 		c->weave_scratch = nullptr;
+	}
+}
+
+// #224 hardware-DP zone leg — keep the DP's view of this client's zone mask in
+// sync with the compositor's. While a submitted mask is active, republish it
+// every frame (the screen rect tracks window moves/resizes; vendors coalesce
+// per their max_update_hz). On the active→inactive edge (mask destroyed,
+// compositor teardown), clear once so this client's contribution drops out of
+// the vendor's OR-union. Caller holds c->mutex (layer_commit / the zone entry
+// points), matching the rest of the zone state machine.
+//
+// Occlusion subtraction (Z-order walk, local-3d-zones.md "runtime per-frame
+// work" step 2-3) is deferred — Phase 0 publishes the un-occluded mask; on
+// 1×1-grid hardware the union result is identical.
+// One-time DP zone-capability probe, cached on the compositor (caller holds
+// c->mutex). Returns true when the DP consumes published zone masks; caps are
+// then in c->zone_dp_caps.
+static bool
+d3d11_zone_dp_supported(struct comp_d3d11_compositor *c)
+{
+	if (c->display_processor == nullptr) {
+		return false;
+	}
+	if (c->zone_dp_state == 0) { // 0 = unqueried, 1 = supported, 2 = legacy
+		struct xrt_dp_local_zone_caps caps = {};
+		caps.struct_size = sizeof(caps);
+		bool ok = xrt_display_processor_d3d11_get_local_zone_caps(c->display_processor, &caps);
+		c->zone_dp_state = (ok && caps.supported != 0) ? 1 : 2;
+		if (c->zone_dp_state == 1) {
+			c->zone_dp_caps = caps;
+			U_LOG_W("D3D11 zone DP: local zones supported, grid %ux%u max_mask %ux%u max_hz %u",
+			        caps.zone_grid_width, caps.zone_grid_height, caps.max_mask_width, caps.max_mask_height,
+			        caps.max_update_hz);
+		}
+	}
+	return c->zone_dp_state == 1;
+}
+
+static void
+d3d11_sync_zone_mask_to_dp(struct comp_d3d11_compositor *c)
+{
+	if (!d3d11_zone_dp_supported(c)) {
+		return; // legacy DP — global request_display_mode path unchanged.
+	}
+
+	struct comp_d3d11_zone_mask *mask = c->active_zone_mask;
+	if (mask == nullptr || !mask->submitted || mask->staged_srv == nullptr) {
+		if (c->zone_published) {
+			xrt_display_processor_d3d11_clear_local_zone_mask(c->display_processor);
+			c->zone_published = false;
+		}
+		return;
+	}
+
+	// Screen-anchor the mask: client-area origin in physical screen pixels.
+	// No HWND (pure offscreen) → nothing to anchor to; skip the publish.
+	HWND wnd = c->hwnd != nullptr ? c->hwnd : c->app_hwnd;
+	RECT r;
+	POINT origin = {0, 0};
+	if (wnd == nullptr || !GetClientRect(wnd, &r) || r.right <= 0 || r.bottom <= 0 ||
+	    !ClientToScreen(wnd, &origin)) {
+		return;
+	}
+
+	c->zone_publish_seq++;
+	bool ok = xrt_display_processor_d3d11_publish_local_zone_mask(
+	    c->display_processor, c->context, mask->staged_srv, mask->w, mask->h, (int32_t)origin.x,
+	    (int32_t)origin.y, (uint32_t)r.right, (uint32_t)r.bottom, c->zone_publish_seq);
+	if (ok) {
+		c->zone_published = true;
 	}
 }
 
@@ -3168,6 +3263,10 @@ comp_d3d11_compositor_zone_mask_destroy(struct xrt_compositor *xc, void *mask_pt
 	}
 	if (c->active_zone_mask == mask) {
 		c->active_zone_mask = nullptr; // revert to rect-surround behavior
+		// #224: withdraw the DP zone contribution now — the session may not
+		// commit another frame (teardown-path destroy), and the per-frame
+		// sync would otherwise leave the panel pinned by a dead client.
+		d3d11_sync_zone_mask_to_dp(c);
 	}
 	if (mask->staged_srv != nullptr) {
 		mask->staged_srv->Release();
@@ -3182,6 +3281,32 @@ comp_d3d11_compositor_zone_mask_destroy(struct xrt_compositor *xc, void *mask_pt
 		mask->tex->Release();
 	}
 	free(mask);
+}
+
+extern "C" bool
+comp_d3d11_compositor_zone_get_hw_caps(struct xrt_compositor *xc,
+                                       uint32_t *out_grid_w,
+                                       uint32_t *out_grid_h)
+{
+	struct comp_d3d11_compositor *c = d3d11_comp(xc);
+	std::lock_guard<std::mutex> lock(c->mutex);
+
+	if (out_grid_w != nullptr) {
+		*out_grid_w = 0;
+	}
+	if (out_grid_h != nullptr) {
+		*out_grid_h = 0;
+	}
+	if (!d3d11_zone_dp_supported(c)) {
+		return false;
+	}
+	if (out_grid_w != nullptr) {
+		*out_grid_w = c->zone_dp_caps.zone_grid_width;
+	}
+	if (out_grid_h != nullptr) {
+		*out_grid_h = c->zone_dp_caps.zone_grid_height;
+	}
+	return true;
 }
 
 extern "C" bool

--- a/src/xrt/compositor/d3d11/comp_d3d11_compositor.h
+++ b/src/xrt/compositor/d3d11/comp_d3d11_compositor.h
@@ -195,6 +195,19 @@ void
 comp_d3d11_compositor_zone_mask_destroy(struct xrt_compositor *xc, void *mask);
 
 /*!
+ * Query the display processor's hardware zone grid (#224 hardware-DP leg).
+ * Returns false on a legacy DP (no zone support) with grids zeroed; on true
+ * the grid dims feed XrLocal3DZoneCapabilitiesEXT.hardwareZoneGridWidth/Height
+ * (1×1 = global on/off panel).
+ *
+ * @ingroup comp_d3d11
+ */
+bool
+comp_d3d11_compositor_zone_get_hw_caps(struct xrt_compositor *xc,
+                                       uint32_t *out_grid_w,
+                                       uint32_t *out_grid_h);
+
+/*!
  * Get the predicted eye positions from the display processor.
  *
  * @param xc The compositor.

--- a/src/xrt/drivers/sim_display/sim_display_processor_d3d11.cpp
+++ b/src/xrt/drivers/sim_display/sim_display_processor_d3d11.cpp
@@ -26,6 +26,7 @@
 #include <d3d11.h>
 #include <d3dcompiler.h>
 
+#include <cstdio> // sscanf — SIM_DISPLAY_ZONE_GRID parsing (#224)
 #include <cstdlib>
 #include <cstring>
 
@@ -176,6 +177,23 @@ struct sim_display_processor_d3d11_impl
 	//! ADR-021: encoding the runtime declared for the next process_atlas (set via
 	//! set_atlas_encoding). calloc-zeroed ⟹ XRT_ATLAS_ENCODING_ENCODED (Model A).
 	enum xrt_atlas_encoding atlas_encoding;
+
+	//! #224 local-zone test double: simulated hardware zone grid (from
+	//! SIM_DISPLAY_ZONE_GRID="WxH", default 1x1 = global on/off).
+	uint32_t zone_grid_w;
+	uint32_t zone_grid_h;
+	//! Last published screen rect + mask dims, for change-gated logging.
+	int32_t zone_last_x, zone_last_y;
+	uint32_t zone_last_w, zone_last_h;
+	uint32_t zone_last_mask_w, zone_last_mask_h;
+	uint64_t zone_last_seq;
+	bool zone_active; //!< A client mask is currently published (not cleared).
+	//! SIM_DISPLAY_ZONE_DUMP=1: CPU OR-downsample readback of each published
+	//! mask into the zone grid (change-gated log). Staging tex lazily sized.
+	bool zone_dump;
+	ID3D11Texture2D *zone_staging;
+	uint32_t zone_staging_w, zone_staging_h;
+	char zone_last_map[257]; //!< Last logged cell map ('0'/'1' row-major).
 };
 
 static inline struct sim_display_processor_d3d11_impl *
@@ -337,6 +355,9 @@ sim_dp_d3d11_destroy(struct xrt_display_processor_d3d11 *xdp)
 	if (sdp->tile_cb != nullptr) {
 		sdp->tile_cb->Release();
 	}
+	if (sdp->zone_staging != nullptr) {
+		sdp->zone_staging->Release();
+	}
 
 	free(sdp);
 }
@@ -411,6 +432,172 @@ sim_dp_d3d11_set_atlas_encoding(struct xrt_display_processor_d3d11 *xdp, enum xr
 
 /*
  *
+ * #224 local 2D/3D zones — in-repo test double for the hardware-DP leg.
+ *
+ * sim_display has no switchable lens, so "hardware zone state" here is a
+ * change-gated log line: enough for a hardware-free end-to-end check that the
+ * runtime publishes the right mask at the right screen anchor (CI-greppable),
+ * without faking panel behavior. SIM_DISPLAY_ZONE_GRID="WxH" picks the
+ * simulated cell grid (default 1x1, today's global on/off shape);
+ * SIM_DISPLAY_ZONE_DUMP=1 additionally reads the published mask back and logs
+ * the OR-downsampled per-cell map whenever it changes.
+ *
+ */
+
+static bool
+sim_dp_d3d11_get_local_zone_caps(struct xrt_display_processor_d3d11 *xdp, struct xrt_dp_local_zone_caps *out_caps)
+{
+	struct sim_display_processor_d3d11_impl *sdp = sim_dp_d3d11(xdp);
+	if (out_caps == nullptr || out_caps->struct_size < sizeof(struct xrt_dp_local_zone_caps)) {
+		// v1 is the minimum shape; a smaller caller struct would mean a
+		// runtime older than this header — impossible in-tree.
+		return false;
+	}
+	out_caps->supported = 1;
+	out_caps->zone_grid_width = sdp->zone_grid_w;
+	out_caps->zone_grid_height = sdp->zone_grid_h;
+	out_caps->max_mask_width = 16384;
+	out_caps->max_mask_height = 16384;
+	out_caps->max_update_hz = 0; // unlimited — it's a log line.
+	return true;
+}
+
+static bool
+sim_dp_d3d11_publish_local_zone_mask(struct xrt_display_processor_d3d11 *xdp,
+                                     void *d3d11_context,
+                                     void *mask_srv,
+                                     uint32_t mask_width,
+                                     uint32_t mask_height,
+                                     int32_t screen_x,
+                                     int32_t screen_y,
+                                     uint32_t screen_w,
+                                     uint32_t screen_h,
+                                     uint64_t seq)
+{
+	struct sim_display_processor_d3d11_impl *sdp = sim_dp_d3d11(xdp);
+	ID3D11DeviceContext *ctx = static_cast<ID3D11DeviceContext *>(d3d11_context);
+	ID3D11ShaderResourceView *srv = static_cast<ID3D11ShaderResourceView *>(mask_srv);
+	if (ctx == nullptr || srv == nullptr || mask_width == 0 || mask_height == 0) {
+		return false;
+	}
+
+	// Change-gated geometry log (seq ticks every frame — not a change).
+	bool geo_changed = !sdp->zone_active || screen_x != sdp->zone_last_x || screen_y != sdp->zone_last_y ||
+	                   screen_w != sdp->zone_last_w || screen_h != sdp->zone_last_h ||
+	                   mask_width != sdp->zone_last_mask_w || mask_height != sdp->zone_last_mask_h;
+	if (geo_changed) {
+		U_LOG_W("SIM ZONE PUBLISH: mask=%ux%u screen=(%d,%d %ux%u) grid=%ux%u seq=%llu", mask_width,
+		        mask_height, screen_x, screen_y, screen_w, screen_h, sdp->zone_grid_w, sdp->zone_grid_h,
+		        (unsigned long long)seq);
+	}
+	sdp->zone_active = true;
+	sdp->zone_last_x = screen_x;
+	sdp->zone_last_y = screen_y;
+	sdp->zone_last_w = screen_w;
+	sdp->zone_last_h = screen_h;
+	sdp->zone_last_mask_w = mask_width;
+	sdp->zone_last_mask_h = mask_height;
+	sdp->zone_last_seq = seq;
+
+	// Optional content readback: OR-downsample the mask into the cell grid
+	// (any non-zero pixel in a cell ⟹ cell is 3D — the arbitration rule from
+	// docs/roadmap/local-3d-zones.md) and log the map when it changes.
+	uint32_t cells = sdp->zone_grid_w * sdp->zone_grid_h;
+	if (!sdp->zone_dump || cells == 0 || cells > 256) {
+		return true;
+	}
+
+	ID3D11Resource *res = nullptr;
+	srv->GetResource(&res);
+	if (res == nullptr) {
+		return true;
+	}
+	ID3D11Device *device = nullptr;
+	ctx->GetDevice(&device);
+	if (device == nullptr) {
+		res->Release();
+		return true;
+	}
+	if (sdp->zone_staging == nullptr || sdp->zone_staging_w != mask_width || sdp->zone_staging_h != mask_height) {
+		if (sdp->zone_staging != nullptr) {
+			sdp->zone_staging->Release();
+			sdp->zone_staging = nullptr;
+		}
+		D3D11_TEXTURE2D_DESC td = {};
+		td.Width = mask_width;
+		td.Height = mask_height;
+		td.MipLevels = 1;
+		td.ArraySize = 1;
+		td.Format = DXGI_FORMAT_R8_UNORM; // the XR_EXT_local_3d_zone mask format
+		td.SampleDesc.Count = 1;
+		td.Usage = D3D11_USAGE_STAGING;
+		td.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
+		if (FAILED(device->CreateTexture2D(&td, nullptr, &sdp->zone_staging))) {
+			sdp->zone_staging = nullptr;
+		}
+		sdp->zone_staging_w = mask_width;
+		sdp->zone_staging_h = mask_height;
+	}
+	device->Release();
+	if (sdp->zone_staging == nullptr) {
+		res->Release();
+		return true;
+	}
+
+	ctx->CopyResource(sdp->zone_staging, res);
+	res->Release();
+
+	D3D11_MAPPED_SUBRESOURCE mapped = {};
+	if (FAILED(ctx->Map(sdp->zone_staging, 0, D3D11_MAP_READ, 0, &mapped))) {
+		return true;
+	}
+	char map[257];
+	for (uint32_t cy = 0; cy < sdp->zone_grid_h; cy++) {
+		uint32_t y0 = (cy * mask_height) / sdp->zone_grid_h;
+		uint32_t y1 = ((cy + 1) * mask_height) / sdp->zone_grid_h;
+		for (uint32_t cx = 0; cx < sdp->zone_grid_w; cx++) {
+			uint32_t x0 = (cx * mask_width) / sdp->zone_grid_w;
+			uint32_t x1 = ((cx + 1) * mask_width) / sdp->zone_grid_w;
+			char bit = '0';
+			for (uint32_t y = y0; y < y1 && bit == '0'; y++) {
+				const uint8_t *row = static_cast<const uint8_t *>(mapped.pData) + (size_t)y * mapped.RowPitch;
+				for (uint32_t x = x0; x < x1; x++) {
+					if (row[x] != 0) {
+						bit = '1';
+						break;
+					}
+				}
+			}
+			map[cy * sdp->zone_grid_w + cx] = bit;
+		}
+	}
+	map[cells] = '\0';
+	ctx->Unmap(sdp->zone_staging, 0);
+
+	if (strcmp(map, sdp->zone_last_map) != 0) {
+		U_LOG_W("SIM ZONE CELLS [%ux%u]: %s (seq=%llu)", sdp->zone_grid_w, sdp->zone_grid_h, map,
+		        (unsigned long long)seq);
+		memcpy(sdp->zone_last_map, map, sizeof(map));
+	}
+	return true;
+}
+
+static bool
+sim_dp_d3d11_clear_local_zone_mask(struct xrt_display_processor_d3d11 *xdp)
+{
+	struct sim_display_processor_d3d11_impl *sdp = sim_dp_d3d11(xdp);
+	if (sdp->zone_active) {
+		U_LOG_W("SIM ZONE CLEAR: client contribution withdrawn (last seq=%llu)",
+		        (unsigned long long)sdp->zone_last_seq);
+	}
+	sdp->zone_active = false;
+	sdp->zone_last_map[0] = '\0';
+	return true;
+}
+
+
+/*
+ *
  * Exported creation function.
  *
  */
@@ -444,6 +631,27 @@ sim_display_processor_d3d11_create(enum sim_display_output_mode mode,
 	sdp->base.set_chroma_key = sim_dp_d3d11_set_chroma_key;
 	sdp->base.get_handoff_color_capability = sim_dp_d3d11_get_handoff_color_capability;
 	sdp->base.set_atlas_encoding = sim_dp_d3d11_set_atlas_encoding;
+	sdp->base.get_local_zone_caps = sim_dp_d3d11_get_local_zone_caps;
+	sdp->base.publish_local_zone_mask = sim_dp_d3d11_publish_local_zone_mask;
+	sdp->base.clear_local_zone_mask = sim_dp_d3d11_clear_local_zone_mask;
+
+	// #224 local-zone test double config (see the zone section above).
+	sdp->zone_grid_w = 1;
+	sdp->zone_grid_h = 1;
+	const char *zone_grid_env = getenv("SIM_DISPLAY_ZONE_GRID");
+	if (zone_grid_env != nullptr && zone_grid_env[0] != '\0') {
+		unsigned gw = 0;
+		unsigned gh = 0;
+		if (sscanf(zone_grid_env, "%ux%u", &gw, &gh) == 2 && gw >= 1 && gh >= 1 && gw <= 256 && gh <= 256) {
+			sdp->zone_grid_w = gw;
+			sdp->zone_grid_h = gh;
+		} else {
+			U_LOG_W("sim_display D3D11: bad SIM_DISPLAY_ZONE_GRID '%s' (want WxH, 1..256) — using 1x1",
+			        zone_grid_env);
+		}
+	}
+	const char *zone_dump_env = getenv("SIM_DISPLAY_ZONE_DUMP");
+	sdp->zone_dump = (zone_dump_env != nullptr && zone_dump_env[0] != '\0' && zone_dump_env[0] != '0');
 
 	// Nominal viewer parameters (same defaults as sim_display_hmd_create)
 	sdp->ipd_m = 0.06f;

--- a/src/xrt/include/xrt/xrt_display_processor_d3d11.h
+++ b/src/xrt/include/xrt/xrt_display_processor_d3d11.h
@@ -21,6 +21,7 @@
 #include "xrt/xrt_compiler.h"
 #include "xrt/xrt_results.h"
 #include "xrt/xrt_display_color.h"
+#include "xrt/xrt_display_zones.h"
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -188,6 +189,83 @@ struct xrt_display_processor_d3d11
 	 * Optional — absent slot or NULL ⟹ DP assumes @ref XRT_ATLAS_ENCODING_ENCODED.
 	 */
 	void (*set_atlas_encoding)(struct xrt_display_processor_d3d11 *xdp, enum xrt_atlas_encoding atlas_encoding);
+
+	/*!
+	 * Query the DP's local 2D/3D-zone capability (#224 Phase 0,
+	 * docs/roadmap/local-3d-zones.md). The caller pre-sets
+	 * @ref xrt_dp_local_zone_caps::struct_size; the DP writes only fields
+	 * within it.
+	 *
+	 * Optional — absent slot (older plug-in `struct_size`) or NULL ⟹ legacy
+	 * DP: the runtime keeps the global request_display_mode path and never
+	 * calls the zone publish methods. Appended per ADR-020 (append-only
+	 * within a major).
+	 *
+	 * @param      xdp       Pointer to self.
+	 * @param[out] out_caps  Filled by the DP (struct_size pre-set by caller).
+	 * @return true if @p out_caps was filled.
+	 */
+	bool (*get_local_zone_caps)(struct xrt_display_processor_d3d11 *xdp,
+	                            struct xrt_dp_local_zone_caps *out_caps);
+
+	/*!
+	 * Publish this client's screen-anchored 3D-zone mask (#224 Phase 0).
+	 *
+	 * Stateless in-process contract: the runtime owns the mask texture (the
+	 * staged XR_EXT_local_3d_zone snapshot — R8_UNORM, client-window pixels,
+	 * non-zero = 3D) and passes an SRV on the session's own D3D11 device; the
+	 * DP samples or copies it DURING this call (the immediate context
+	 * serializes against the runtime's writes), and must not hold the SRV
+	 * past return. @p screen_x/y/w/h anchor the mask's pixel space on the
+	 * panel in physical screen pixels (post-DPI client rect). @p seq is a
+	 * monotonic per-session publish counter for vendor-side coalescing.
+	 *
+	 * Downsample-and-arbitrate rule: any non-zero mask pixel overlapping a
+	 * hardware cell ⟹ that cell is 3D (OR union across all connected
+	 * clients) — which makes the 1×1 grid bit-compatible with today's global
+	 * bool arbitration. A vendor admin force-2D override supersedes the
+	 * union. The runtime republishes every frame while a mask is active
+	 * (screen rect tracks the window); vendors coalesce per their
+	 * max_update_hz.
+	 *
+	 * Optional — absent slot or NULL ⟹ not supported (see
+	 * @ref get_local_zone_caps). Appended per ADR-020.
+	 *
+	 * @param xdp            Pointer to self.
+	 * @param d3d11_context  D3D11 immediate context (ID3D11DeviceContext*).
+	 * @param mask_srv       Mask SRV (ID3D11ShaderResourceView*, R8_UNORM).
+	 * @param mask_width     Mask width in client-window pixels.
+	 * @param mask_height    Mask height in client-window pixels.
+	 * @param screen_x       Client-area left edge in physical screen pixels.
+	 * @param screen_y       Client-area top edge in physical screen pixels.
+	 * @param screen_w       Client-area width in physical screen pixels.
+	 * @param screen_h       Client-area height in physical screen pixels.
+	 * @param seq            Monotonic per-session publish sequence number.
+	 * @return true if the publish was accepted.
+	 */
+	bool (*publish_local_zone_mask)(struct xrt_display_processor_d3d11 *xdp,
+	                                void *d3d11_context,
+	                                void *mask_srv,
+	                                uint32_t mask_width,
+	                                uint32_t mask_height,
+	                                int32_t screen_x,
+	                                int32_t screen_y,
+	                                uint32_t screen_w,
+	                                uint32_t screen_h,
+	                                uint64_t seq);
+
+	/*!
+	 * Withdraw this client's zone contribution (#224 Phase 0) — equivalent to
+	 * (and cheaper than) publishing an all-zero mask. Called when the active
+	 * mask is destroyed or the session ends; the client's contribution
+	 * disappears from the vendor's union on the next arbitration pass.
+	 *
+	 * Optional — absent slot or NULL ⟹ not supported. Appended per ADR-020.
+	 *
+	 * @param xdp Pointer to self.
+	 * @return true if the clear was accepted.
+	 */
+	bool (*clear_local_zone_mask)(struct xrt_display_processor_d3d11 *xdp);
 };
 
 /*
@@ -233,7 +311,10 @@ XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, set_chroma_key)  
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, destroy)                     == XRT_DP_D3D11_BASE_OFF + 9 * sizeof(void *), XRT_DP_ABI_MSG);
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, get_handoff_color_capability) == XRT_DP_D3D11_BASE_OFF + 10 * sizeof(void *), XRT_DP_ABI_MSG);
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, set_atlas_encoding)           == XRT_DP_D3D11_BASE_OFF + 11 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(sizeof(struct xrt_display_processor_d3d11)                                == XRT_DP_D3D11_BASE_OFF + 12 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, get_local_zone_caps)          == XRT_DP_D3D11_BASE_OFF + 12 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, publish_local_zone_mask)      == XRT_DP_D3D11_BASE_OFF + 13 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, clear_local_zone_mask)        == XRT_DP_D3D11_BASE_OFF + 14 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(sizeof(struct xrt_display_processor_d3d11)                                == XRT_DP_D3D11_BASE_OFF + 15 * sizeof(void *), XRT_DP_ABI_MSG);
 // clang-format on
 
 /*!
@@ -414,6 +495,60 @@ xrt_display_processor_d3d11_set_atlas_encoding(struct xrt_display_processor_d3d1
 		return;
 	}
 	xdp->set_atlas_encoding(xdp, atlas_encoding);
+}
+
+/*!
+ * @copydoc xrt_display_processor_d3d11::get_local_zone_caps
+ * Returns false (legacy DP — caps untouched) if not supported (slot absent or
+ * NULL). The caller must pre-set out_caps->struct_size.
+ * @public @memberof xrt_display_processor_d3d11
+ */
+static inline bool
+xrt_display_processor_d3d11_get_local_zone_caps(struct xrt_display_processor_d3d11 *xdp,
+                                                struct xrt_dp_local_zone_caps *out_caps)
+{
+	if (!XRT_DP_HAS_SLOT(xdp, get_local_zone_caps) || xdp->get_local_zone_caps == NULL) {
+		return false;
+	}
+	return xdp->get_local_zone_caps(xdp, out_caps);
+}
+
+/*!
+ * @copydoc xrt_display_processor_d3d11::publish_local_zone_mask
+ * Returns false if not supported (slot absent or NULL).
+ * @public @memberof xrt_display_processor_d3d11
+ */
+static inline bool
+xrt_display_processor_d3d11_publish_local_zone_mask(struct xrt_display_processor_d3d11 *xdp,
+                                                    void *d3d11_context,
+                                                    void *mask_srv,
+                                                    uint32_t mask_width,
+                                                    uint32_t mask_height,
+                                                    int32_t screen_x,
+                                                    int32_t screen_y,
+                                                    uint32_t screen_w,
+                                                    uint32_t screen_h,
+                                                    uint64_t seq)
+{
+	if (!XRT_DP_HAS_SLOT(xdp, publish_local_zone_mask) || xdp->publish_local_zone_mask == NULL) {
+		return false;
+	}
+	return xdp->publish_local_zone_mask(xdp, d3d11_context, mask_srv, mask_width, mask_height, screen_x, screen_y,
+	                                    screen_w, screen_h, seq);
+}
+
+/*!
+ * @copydoc xrt_display_processor_d3d11::clear_local_zone_mask
+ * Returns false if not supported (slot absent or NULL).
+ * @public @memberof xrt_display_processor_d3d11
+ */
+static inline bool
+xrt_display_processor_d3d11_clear_local_zone_mask(struct xrt_display_processor_d3d11 *xdp)
+{
+	if (!XRT_DP_HAS_SLOT(xdp, clear_local_zone_mask) || xdp->clear_local_zone_mask == NULL) {
+		return false;
+	}
+	return xdp->clear_local_zone_mask(xdp);
 }
 
 /*!

--- a/src/xrt/include/xrt/xrt_display_zones.h
+++ b/src/xrt/include/xrt/xrt_display_zones.h
@@ -1,0 +1,75 @@
+// Copyright 2026, Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  Local 2D/3D zone types shared across the display processor
+ *         interface (#224, docs/roadmap/local-3d-zones.md).
+ *
+ * The hardware-consumer leg of the shared XR_EXT_local_3d_zone mask: the
+ * runtime publishes the authored, screen-anchored 3D-zone mask to the vendor
+ * display processor so switchable-lens panels can track which window regions
+ * are 3D. The struct below is the capability half of that contract; the
+ * publish methods live on the per-API DP vtables (appended per ADR-020).
+ *
+ * Lives in its own leaf header (like xrt_display_color.h) because the per-API
+ * DP headers are independent translation units — each includes this one so
+ * the caps struct is a single source of truth.
+ *
+ * @ingroup xrt_iface
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*!
+ * Local-zone capabilities of a display processor (#224 Phase 0).
+ *
+ * Crosses the runtime ↔ plug-in ABI boundary, so it follows the ADR-020
+ * struct conventions: the CALLER (runtime) sets @ref struct_size to its
+ * compile-time sizeof before the query; the plug-in must only write fields
+ * that fall inside that size, so the struct is append-only extensible within
+ * an ABI major. All fields are fixed-width — no bool — for deterministic
+ * layout across compilers.
+ *
+ * Three meaningful shapes (docs/roadmap/local-3d-zones.md):
+ *  - `supported == 0`: legacy DP — the runtime keeps the existing global
+ *    request_display_mode path and never calls the publish methods.
+ *  - `supported == 1, zone_grid == 1×1`: the DP implements the zone API but
+ *    the hardware is single-zone. The OR-union of published masks collapses
+ *    to "any client wants 3D anywhere → panel is 3D" — bit-compatible with
+ *    today's global arbitration.
+ *  - `supported == 1, zone_grid > 1×1`: real per-zone hardware.
+ */
+struct xrt_dp_local_zone_caps
+{
+	//! sizeof(struct xrt_dp_local_zone_caps) at the RUNTIME's compile time.
+	//! Set by the caller before get_local_zone_caps; the plug-in writes only
+	//! fields within this size (ADR-020 append-only).
+	uint32_t struct_size;
+
+	//! 1 when this DP consumes published zone masks, 0 for legacy DPs.
+	uint32_t supported;
+
+	//! Hardware switchable cells across (1 = global on/off).
+	uint32_t zone_grid_width;
+	//! Hardware switchable cells down.
+	uint32_t zone_grid_height;
+
+	//! Upper bound on the published mask resolution the DP will sample.
+	//! 0 = no preference (runtime publishes at its native mask resolution).
+	uint32_t max_mask_width;
+	uint32_t max_mask_height;
+
+	//! Vendor's preferred max mask-refresh rate; 0 = unlimited. Advisory in
+	//! Phase 0 — the runtime publishes per frame and the vendor coalesces.
+	uint32_t max_update_hz;
+};
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/xrt/state_trackers/oxr/oxr_local_3d_zone.c
+++ b/src/xrt/state_trackers/oxr/oxr_local_3d_zone.c
@@ -141,9 +141,14 @@ oxr_xrGetLocal3DZoneCapabilitiesEXT(XrSession session, XrLocal3DZoneCapabilities
 #ifdef XRT_HAVE_D3D11_NATIVE_COMPOSITOR
 	if (sess->is_d3d11_native_compositor && sess->xcn != NULL) {
 		capabilities->supported = XR_TRUE;
-		// Compositor consumer only — no hardware-zone DP leg yet.
-		capabilities->hardwareZoneGridWidth = 0;
-		capabilities->hardwareZoneGridHeight = 0;
+		// #224 hardware-DP leg: surface the DP's switchable-lens zone grid
+		// (1×1 = global on/off panel; 0×0 = legacy DP, compositor consumer
+		// only — the mask still composites, it just can't drive the panel).
+		uint32_t grid_w = 0;
+		uint32_t grid_h = 0;
+		comp_d3d11_compositor_zone_get_hw_caps(&sess->xcn->base, &grid_w, &grid_h);
+		capabilities->hardwareZoneGridWidth = grid_w;
+		capabilities->hardwareZoneGridHeight = grid_h;
 		capabilities->maxMaskWidth = OXR_LOCAL_3D_ZONE_MAX_MASK_DIM;
 		capabilities->maxMaskHeight = OXR_LOCAL_3D_ZONE_MAX_MASK_DIM;
 	}


### PR DESCRIPTION
## Summary

The hardware-consumer leg of the shared `XR_EXT_local_3d_zone` mask (#224, design: `docs/roadmap/local-3d-zones.md`): the runtime now publishes the authored, screen-anchored 3D-zone mask to the display processor each frame, so switchable-lens panels can track which window regions are 3D. Runtime + in-repo test double only — the first-vendor (Leia, 1×1 grid) implementation is the follow-up in `displayxr-leia-plugin`.

- **Plugin ABI** (ADR-020 append-only, no major bump): three slots appended to `xrt_display_processor_d3d11` (12–14) — `get_local_zone_caps` (struct_size-headed caps in new `xrt_display_zones.h`), `publish_local_zone_mask`, `clear_local_zone_mask`. Older plug-ins read as legacy via the `struct_size` gate.
- **Stateless in-process contract** (revised from the doc's draft DP-allocated lifecycle): the runtime owns the mask texture (the #439 staged R8 snapshot) and passes an SRV per publish with a physical-pixel screen anchor + monotonic seq; the DP samples during the call. Lifecycle methods can be appended later for a cross-process leg.
- **Publish path**: `d3d11_sync_zone_mask_to_dp` once per frame in `layer_commit` under `c->mutex` — the panel and the zone composite see identical mask state (the two consumers must agree). Republish per frame while active (anchor tracks window moves); clear once on the active→inactive edge incl. the destroy hook (teardown must not leave the panel pinned by a dead client). Legacy DPs keep the global `request_display_mode` path untouched.
- **Caps wiring**: `xrGetLocal3DZoneCapabilitiesEXT.hardwareZoneGridWidth/Height` now surface the DP's real grid (0×0 = legacy DP, compositor consumer only — unchanged meaning).
- **sim_display test double**: `SIM_DISPLAY_ZONE_GRID=WxH` simulated grid (default 1×1), change-gated `SIM ZONE PUBLISH/CELLS/CLEAR` logging, `SIM_DISPLAY_ZONE_DUMP=1` OR-downsample readback — the hardware-free end-to-end check.
- **Occlusion subtraction deferred** (documented): un-occluded publish is union-identical on 1×1 grids.
- Docs: `local-3d-zones.md` revised to as-built (status, vtable contract, per-frame work, phasing); `xrt_plugin_iface.md` vendor catalog extended.

## Validation (this box)

| Check | Result |
|---|---|
| `displayxr-cli selftest` with the **current (older) Leia plugin** | PASS — appended slots read as absent, ABI v3 unchanged |
| Leia leg: `Zone caps: supported=1 hwGrid=0x0`, zero publish calls, #439 Phase-2 weave behavior intact | PASS |
| Sim leg (`SIM_DISPLAY_ZONE_GRID=8x4` + dump, probe-order swap): caps probe logs `grid 8x4`; publish logs `mask=1280x720 screen=(138,194 1280x720) seq=…` | PASS |
| Cell maps decode exactly to the authored 'Z' states — 1: all-1s · 2: centered canvas block `00111100` rows 1-2 · 3: three islands `01100110/00011000` · 4: disc | PASS |
| Clear on mask destroy (`SIM ZONE CLEAR … last seq=2259`) | PASS |

Epic #224 Phase-0 runtime side; the issue checkbox ticks when the Leia 1×1 leg lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)