### PR TITLE
refactor(#224): publish seq = mask content generation, not a frame counter

### DIFF
--- a/docs/roadmap/local-3d-zones.md
+++ b/docs/roadmap/local-3d-zones.md
@@ -97,8 +97,10 @@ Three meaningful return shapes:
 // XR_EXT_local_3d_zone snapshot — R8_UNORM, client-window pixels, non-zero =
 // 3D) and passes an SRV on the session's own D3D11 device. screen_x/y/w/h
 // anchor the mask's pixel space on the panel (physical pixels, post-DPI
-// client rect). seq is a monotonic per-session publish counter for
-// vendor-side coalescing. The DP samples or copies DURING the call.
+// client rect). seq is the mask CONTENT generation — bumped only on
+// xrSubmitLocal3DZoneEXT; same-seq publishes differ only in the screen
+// anchor, so a vendor evaluates content once per generation, not per
+// frame. The DP samples or copies DURING the call.
 bool (*publish_local_zone_mask)(struct xrt_display_processor_d3d11 *xdp,
                                 void *d3d11_context, void *mask_srv,
                                 uint32_t mask_width, uint32_t mask_height,

--- a/src/xrt/compositor/d3d11/comp_d3d11_compositor.cpp
+++ b/src/xrt/compositor/d3d11/comp_d3d11_compositor.cpp
@@ -192,7 +192,10 @@ struct comp_d3d11_compositor
 	//! DP zone caps when zone_dp_state == 1 (grid dims surface through
 	//! comp_d3d11_compositor_zone_get_hw_caps → xrGetLocal3DZoneCapabilitiesEXT).
 	struct xrt_dp_local_zone_caps zone_dp_caps;
-	//! Monotonic per-session publish sequence (bumped on every publish).
+	//! Zone-mask content generation: bumped on every zone_mask_submit (the
+	//! only point the staged content can change). Per-frame publishes carry
+	//! the current generation, so a vendor evaluates mask CONTENT once per
+	//! generation and treats same-seq publishes as screen-anchor-only updates.
 	uint64_t zone_publish_seq;
 	//! True while this client's mask is published to the DP — drives the
 	//! clear-on-deactivate edge (mask destroyed / compositor teardown).
@@ -2860,7 +2863,10 @@ d3d11_sync_zone_mask_to_dp(struct comp_d3d11_compositor *c)
 		return;
 	}
 
-	c->zone_publish_seq++;
+	// seq is the content GENERATION (bumped in zone_mask_submit), not a frame
+	// counter — same-seq publishes differ only in the screen anchor, so a
+	// vendor's content evaluation (e.g. the 1×1 any-nonzero check) runs once
+	// per submit instead of once per frame.
 	bool ok = xrt_display_processor_d3d11_publish_local_zone_mask(
 	    c->display_processor, c->context, mask->staged_srv, mask->w, mask->h, (int32_t)origin.x,
 	    (int32_t)origin.y, (uint32_t)r.right, (uint32_t)r.bottom, c->zone_publish_seq);
@@ -3248,6 +3254,7 @@ comp_d3d11_compositor_zone_mask_submit(struct xrt_compositor *xc, void *mask_ptr
 	c->context->CopyResource(mask->staged, mask->tex);
 	mask->submitted = true;
 	c->active_zone_mask = mask;
+	c->zone_publish_seq++; // #224: new content generation for the DP publish
 	return XRT_SUCCESS;
 }
 

--- a/src/xrt/include/xrt/xrt_display_processor_d3d11.h
+++ b/src/xrt/include/xrt/xrt_display_processor_d3d11.h
@@ -217,8 +217,11 @@ struct xrt_display_processor_d3d11
 	 * DP samples or copies it DURING this call (the immediate context
 	 * serializes against the runtime's writes), and must not hold the SRV
 	 * past return. @p screen_x/y/w/h anchor the mask's pixel space on the
-	 * panel in physical screen pixels (post-DPI client rect). @p seq is a
-	 * monotonic per-session publish counter for vendor-side coalescing.
+	 * panel in physical screen pixels (post-DPI client rect). @p seq is the
+	 * mask CONTENT generation — monotonic, bumped only when the staged mask
+	 * content changes (xrSubmitLocal3DZoneEXT); publishes carrying the same
+	 * seq differ only in the screen anchor, so a vendor evaluates content
+	 * (downsample, any-nonzero check) once per generation, not per frame.
 	 *
 	 * Downsample-and-arbitrate rule: any non-zero mask pixel overlapping a
 	 * hardware cell ⟹ that cell is 3D (OR union across all connected
@@ -240,7 +243,7 @@ struct xrt_display_processor_d3d11
 	 * @param screen_y       Client-area top edge in physical screen pixels.
 	 * @param screen_w       Client-area width in physical screen pixels.
 	 * @param screen_h       Client-area height in physical screen pixels.
-	 * @param seq            Monotonic per-session publish sequence number.
+	 * @param seq            Mask content generation (bumped per submit).
 	 * @return true if the publish was accepted.
 	 */
 	bool (*publish_local_zone_mask)(struct xrt_display_processor_d3d11 *xdp,


### PR DESCRIPTION
Follow-up to #474, before any vendor consumes the contract: `seq` on `publish_local_zone_mask` is now the **mask content generation** — bumped only in `zone_mask_submit` (the only point the staged content can change) rather than per publish. Same-seq publishes differ only in the screen anchor.

Why: the Leia 1×1 leg's OR-collapse needs a content readback (an all-zero mask — Tier-1 `enable3D=FALSE` — must collapse to 2D, so "any active publish ⟹ 3D" is wrong). With seq as a generation, that readback runs once per submit instead of once per frame.

No ABI change — the parameter's type/position is untouched; only its meaning is pinned (header doc + `local-3d-zones.md` updated). Sim double unaffected (it logs seq, content-change-gated either way).

🤖 Generated with [Claude Code](https://claude.com/claude-code)