### PR TITLE
feat(#439): D3D12 zone-mask consumer — masked composite + effective canvas

### DIFF
--- a/docs/roadmap/unified-2d-3d-crossapi-impl.md
+++ b/docs/roadmap/unified-2d-3d-crossapi-impl.md
@@ -4,7 +4,7 @@
 **Spec:** [`unified-2d-3d-compositing.md`](unified-2d-3d-compositing.md) §4 (composite pass + output-alpha), §5.1 (coordinate contract), §8 (rollout priority). Epic #439.
 **Builds on:** D3D11 Phases 0–2 (merged: PR #469 + #471) — the proven pathfinder every port references.
 
-> **STATUS: base leg in progress.** This doc + the base leg (header v2, oxr forwarding, comp stubs) ship together; the D3D12 and VK consumer legs follow as parallel hand-offs.
+> **STATUS: base leg merged (PR #473); D3D12 consumer leg implemented + capture-validated** (Z-cycle states 0–4 on `cube_texture_d3d12_win` via the ported `DISPLAYXR_SURROUND_CAPTURE` probe; on-glass Leia eyeball pending as the merge gate). VK leg scoped to ride with Phase 3 (§4).
 
 ---
 
@@ -89,13 +89,13 @@ So a full Phase-1-style VK port has nothing to composite and nothing to validate
 ## 5. Done-when
 
 **Base leg**
-- [ ] Header v2 (two structs, SPEC_VERSION 2) syncs to `displayxr-extensions` on merge.
-- [ ] oxr branches + stubs build green on macOS (`build_macos.sh`) and Windows (PR CI).
-- [ ] Caps report `supported=false` on D3D12/VK; create returns `XR_ERROR_FEATURE_UNSUPPORTED`.
+- [x] Header v2 (two structs, SPEC_VERSION 2) syncs to `displayxr-extensions` on merge.
+- [x] oxr branches + stubs build green on macOS (`build_macos.sh`) and Windows (PR CI).
+- [x] Caps report `supported=false` on D3D12/VK; create returns `XR_ERROR_FEATURE_UNSUPPORTED`. *(Merged as PR #473.)*
 
 **D3D12 leg**
-- [ ] §3 checklist 1–5; caps flipped.
-- [ ] Phase-1 + Phase-2 validation matrices green on `cube_texture_d3d12_win` (Leia, capture + on-glass); no-mask diff 0.
+- [x] §3 checklist 1–5; caps flipped. *(Plus the `DISPLAYXR_SURROUND_CAPTURE` probe ported — the D3D12 compositor had no composite-target capture; the matrices depend on it. Composite PSOs cover RGBA8 + BGRA8 — D3D12 bakes the RTV format into the PSO and app shared textures are BGRA8 in the wild.)*
+- [ ] Phase-1 + Phase-2 validation matrices green on `cube_texture_d3d12_win` (Leia, capture + on-glass); no-mask diff 0. *(Capture leg green — Z-cycle 0→4 + wrap-around, view dims resize both directions, beyond-window untouched; on-glass interlace eyeball pending.)*
 - [ ] Epic #439 "D3D12 — all engine plugins" box ticked.
 
 **VK leg**

--- a/docs/roadmap/unified-2d-3d-crossapi-impl.md
+++ b/docs/roadmap/unified-2d-3d-crossapi-impl.md
@@ -4,7 +4,7 @@
 **Spec:** [`unified-2d-3d-compositing.md`](unified-2d-3d-compositing.md) §4 (composite pass + output-alpha), §5.1 (coordinate contract), §8 (rollout priority). Epic #439.
 **Builds on:** D3D11 Phases 0–2 (merged: PR #469 + #471) — the proven pathfinder every port references.
 
-> **STATUS: base leg merged (PR #473); D3D12 consumer leg implemented + capture-validated** (Z-cycle states 0–4 on `cube_texture_d3d12_win` via the ported `DISPLAYXR_SURROUND_CAPTURE` probe; on-glass Leia eyeball pending as the merge gate). VK leg scoped to ride with Phase 3 (§4).
+> **STATUS: base leg merged (PR #473); D3D12 consumer leg DONE** — implemented, capture-validated (Z-cycle states 0–4 via the ported `DISPLAYXR_SURROUND_CAPTURE` probe) and Leia on-glass validated (PR #476). VK leg scoped to ride with Phase 3 (§4).
 
 ---
 
@@ -95,8 +95,8 @@ So a full Phase-1-style VK port has nothing to composite and nothing to validate
 
 **D3D12 leg**
 - [x] §3 checklist 1–5; caps flipped. *(Plus the `DISPLAYXR_SURROUND_CAPTURE` probe ported — the D3D12 compositor had no composite-target capture; the matrices depend on it. Composite PSOs cover RGBA8 + BGRA8 — D3D12 bakes the RTV format into the PSO and app shared textures are BGRA8 in the wild.)*
-- [ ] Phase-1 + Phase-2 validation matrices green on `cube_texture_d3d12_win` (Leia, capture + on-glass); no-mask diff 0. *(Capture leg green — Z-cycle 0→4 + wrap-around, view dims resize both directions, beyond-window untouched; on-glass interlace eyeball pending.)*
-- [ ] Epic #439 "D3D12 — all engine plugins" box ticked.
+- [x] Phase-1 + Phase-2 validation matrices green on `cube_texture_d3d12_win` (Leia, capture + on-glass); no-mask diff 0. *(Capture leg: Z-cycle 0→4 + wrap-around, view dims resize both directions, beyond-window untouched. On-glass eyeballed by user 2026-06-07 — interlace correct at islands + gradient feather.)*
+- [x] Epic #439 "D3D12 — all engine plugins" box ticked.
 
 **VK leg**
 - [ ] Scope decision recorded (this doc §4); composite consumer tracked into the Phase-3 plan.

--- a/src/external/openxr_includes/openxr/XR_EXT_local_3d_zone.h
+++ b/src/external/openxr_includes/openxr/XR_EXT_local_3d_zone.h
@@ -104,6 +104,11 @@ typedef struct XrLocal3DZoneRenderTargetD3D11EXT {
  * Sync contract: the in-process D3D12 native compositor runs on the app's
  * device AND command queue, so same-queue submission order is the contract —
  * execute the mask draw, then call xrSubmitLocal3DZoneEXT. No fence.
+ *
+ * State contract: the resource is handed out in
+ * D3D12_RESOURCE_STATE_RENDER_TARGET; the app must transition it back to
+ * RENDER_TARGET before calling xrSubmitLocal3DZoneEXT (the runtime's Tier-1/2
+ * clears and submit snapshot assume that steady state).
  */
 typedef struct XrLocal3DZoneRenderTargetD3D12EXT {
     XrStructureType    type;   //!< XR_TYPE_LOCAL_3D_ZONE_RENDER_TARGET_D3D12_EXT

--- a/src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp
+++ b/src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp
@@ -201,6 +201,20 @@ struct comp_d3d12_compositor
 	//! Cached dimensions for lazy reallocation.
 	uint32_t dp_input_width, dp_input_height;
 
+	//! Active authored zone mask (#439, XR_EXT_local_3d_zone). Set by
+	//! comp_d3d12_compositor_zone_mask_submit (sticky, last-submit-wins),
+	//! cleared when that mask is destroyed. NOT owned — the oxr handle owns
+	//! the mask; lifetime is guaranteed by the destroy hook clearing this.
+	struct comp_d3d12_zone_mask *active_zone_mask;
+
+	//! Scratch copies for the masked composite (#439): the window region of
+	//! the app 2D surround and of the weave target (RTV-only → the lerp
+	//! samples this snapshot). Lazily (re)allocated window-sized (#464);
+	//! steady state COMMON. Removed in Phase 3 when the weave lands in an
+	//! SRV-capable RT directly.
+	ID3D12Resource *surround_scratch;
+	ID3D12Resource *weave_scratch;
+
 	//! HUD overlay.
 	struct u_hud *hud;
 
@@ -256,6 +270,52 @@ static void d3d12_blit_surround_strips(struct comp_d3d12_compositor *c,
                                         uint32_t dst_w, uint32_t dst_h,
                                         int32_t cx, int32_t cy,
                                         uint32_t cw, uint32_t ch);
+// #439 authored zone-mask helpers (XR_EXT_local_3d_zone). Defined near the
+// bottom of the file alongside the comp_d3d12_compositor_zone_mask_* entry
+// points, called from the layer-commit paths + destroy above them.
+static bool d3d12_composite_zone_mask(struct comp_d3d12_compositor *c,
+                                       ID3D12Resource *dst,
+                                       uint64_t dst_rtv,
+                                       D3D12_RESOURCE_STATES dst_pre_state,
+                                       D3D12_RESOURCE_STATES dst_post_state,
+                                       uint32_t dst_w, uint32_t dst_h,
+                                       const struct u_canvas_rect *eff_canvas);
+static void d3d12_release_zone_state(struct comp_d3d12_compositor *c);
+// #439 surround-capture probe (DISPLAYXR_SURROUND_CAPTURE); defined with the
+// zone helpers, called after each path's fence wait in layer_commit.
+static void d3d12_maybe_capture_surround_target(struct comp_d3d12_compositor *c,
+                                                 ID3D12Resource *dst,
+                                                 uint32_t dst_w, uint32_t dst_h,
+                                                 D3D12_RESOURCE_STATES pre_state);
+
+// #439 Phase 2: an active zone mask supersedes the canvas output rect —
+// the weave region, view dims, Kooima metrics, and composite region all
+// become the client-window rect (top-left anchored per #464). With no mask
+// this returns c->canvas verbatim, so the no-mask path is unchanged.
+// Returning a *valid* window rect (not just "invalid") matters on the
+// shared-texture path: the texture is display-sized worst-case, so an
+// invalid canvas there would fall back to display dims — the window rect
+// keeps the #464 clamp. Callers in the frame path hold c->mutex, which
+// zone_mask_submit/destroy also take, so the mask cannot flip mid-frame.
+static struct u_canvas_rect
+d3d12_effective_canvas(struct comp_d3d12_compositor *c)
+{
+	if (c->active_zone_mask == nullptr) {
+		return c->canvas;
+	}
+	struct u_canvas_rect win = {};
+	HWND wnd = c->hwnd != nullptr ? c->hwnd : c->app_hwnd;
+	RECT r;
+	if (wnd != nullptr && GetClientRect(wnd, &r) && r.right > 0 && r.bottom > 0) {
+		win.valid = true;
+		win.x = 0;
+		win.y = 0;
+		win.w = (uint32_t)r.right;
+		win.h = (uint32_t)r.bottom;
+		return win;
+	}
+	return win; // invalid → existing full-target fallbacks
+}
 
 /*!
  * Wait for GPU to finish all submitted work.
@@ -1225,6 +1285,14 @@ d3d12_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 	}
 #endif
 
+	// #439 Phase 2: the one canvas authority for this frame. While a zone
+	// mask is active this is the client-window rect (the mask supersedes
+	// the output rect); otherwise it is c->canvas unchanged. Computed once
+	// under c->mutex (held for this whole function) so the weave region,
+	// view dims, and composite all see the same rect even if submit/destroy
+	// race the frame.
+	const struct u_canvas_rect eff_canvas = d3d12_effective_canvas(c);
+
 	// Get target dimensions
 	uint32_t tgt_width = c->settings.preferred.width;
 	uint32_t tgt_height = c->settings.preferred.height;
@@ -1244,8 +1312,8 @@ d3d12_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 			if (mode->view_width_pixels > 0) {
 				uint32_t new_vw = mode->view_width_pixels;
 				uint32_t new_vh = mode->view_height_pixels;
-				if (c->canvas.valid) {
-					u_tiling_compute_canvas_view(mode, c->canvas.w, c->canvas.h,
+				if (eff_canvas.valid) {
+					u_tiling_compute_canvas_view(mode, eff_canvas.w, eff_canvas.h,
 					                             &new_vw, &new_vh);
 				} else if (!c->owns_window && tgt_width > 0 && tgt_height > 0) {
 					// Handle app: window may differ from display size,
@@ -1479,10 +1547,10 @@ d3d12_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 				        "canvas=(%d,%d %ux%u)",
 				        view_width, view_height, tile_columns, tile_rows,
 				        dp_target_w, dp_target_h,
-				        c->canvas.valid ? c->canvas.x : -1,
-				        c->canvas.valid ? c->canvas.y : -1,
-				        c->canvas.valid ? c->canvas.w : 0,
-				        c->canvas.valid ? c->canvas.h : 0);
+				        eff_canvas.valid ? eff_canvas.x : -1,
+				        eff_canvas.valid ? eff_canvas.y : -1,
+				        eff_canvas.valid ? eff_canvas.w : 0,
+				        eff_canvas.valid ? eff_canvas.h : 0);
 				pa_log++;
 			}
 
@@ -1497,10 +1565,10 @@ d3d12_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 			    tile_columns, tile_rows,
 			    static_cast<uint32_t>(DXGI_FORMAT_R8G8B8A8_UNORM),
 			    dp_target_w, dp_target_h,
-			    c->canvas.valid ? c->canvas.x : 0,
-			    c->canvas.valid ? c->canvas.y : 0,
-			    c->canvas.valid ? c->canvas.w : 0,
-			    c->canvas.valid ? c->canvas.h : 0);
+			    eff_canvas.valid ? eff_canvas.x : 0,
+			    eff_canvas.valid ? eff_canvas.y : 0,
+			    eff_canvas.valid ? eff_canvas.w : 0,
+			    eff_canvas.valid ? eff_canvas.h : 0);
 
 			// Transition: atlas COMMON→PSR, shared texture RT→COMMON
 			barriers[0].Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
@@ -1512,14 +1580,24 @@ d3d12_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 			// Spec v6 surround blit: fill non-canvas pixels of the shared
 			// texture from the app-supplied 2D surround texture. dst is in
 			// COMMON (just transitioned above); leave it in COMMON after.
-			d3d12_blit_surround_strips(
-			    c, c->shared_texture,
+			// #439: an authored zone mask (XR_EXT_local_3d_zone) replaces
+			// the rect-derived region selection entirely — the mask-lerp
+			// writes every window pixel, so the strip path must be skipped
+			// when it runs (strips would clobber soft edges).
+			bool surround_done = d3d12_composite_zone_mask(
+			    c, c->shared_texture, st_rtv.ptr,
 			    D3D12_RESOURCE_STATE_COMMON, D3D12_RESOURCE_STATE_COMMON,
-			    dp_target_w, dp_target_h,
-			    c->canvas.valid ? c->canvas.x : 0,
-			    c->canvas.valid ? c->canvas.y : 0,
-			    c->canvas.valid ? c->canvas.w : dp_target_w,
-			    c->canvas.valid ? c->canvas.h : dp_target_h);
+			    dp_target_w, dp_target_h, &eff_canvas);
+			if (!surround_done) {
+				d3d12_blit_surround_strips(
+				    c, c->shared_texture,
+				    D3D12_RESOURCE_STATE_COMMON, D3D12_RESOURCE_STATE_COMMON,
+				    dp_target_w, dp_target_h,
+				    eff_canvas.valid ? eff_canvas.x : 0,
+				    eff_canvas.valid ? eff_canvas.y : 0,
+				    eff_canvas.valid ? eff_canvas.w : dp_target_w,
+				    eff_canvas.valid ? eff_canvas.h : dp_target_h);
+			}
 
 		} else if (atlas_resource != nullptr) {
 			// No DP: raw copy atlas to shared texture (2D mode fallback)
@@ -1557,6 +1635,16 @@ d3d12_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 		if (c->fence->GetCompletedValue() < c->fence_value) {
 			c->fence->SetEventOnCompletion(c->fence_value, c->fence_event);
 			WaitForSingleObject(c->fence_event, INFINITE);
+		}
+
+		// #439 A/B validation probe (no-op unless DISPLAYXR_SURROUND_CAPTURE
+		// is set + trigger file exists). Runs post-fence: the probe re-arms
+		// the cmd list for its readback, which needs the GPU idle.
+		if (c->has_shared_texture && c->shared_texture != nullptr) {
+			D3D12_RESOURCE_DESC std_desc = c->shared_texture->GetDesc();
+			d3d12_maybe_capture_surround_target(c, c->shared_texture,
+			                                    (uint32_t)std_desc.Width, std_desc.Height,
+			                                    D3D12_RESOURCE_STATE_COMMON);
 		}
 
 		return XRT_SUCCESS;
@@ -1689,24 +1777,32 @@ d3d12_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 			    tile_columns, tile_rows,
 			    static_cast<uint32_t>(DXGI_FORMAT_R8G8B8A8_UNORM),
 			    tgt_width, tgt_height,
-			    c->canvas.valid ? c->canvas.x : 0,
-			    c->canvas.valid ? c->canvas.y : 0,
-			    c->canvas.valid ? c->canvas.w : 0,
-			    c->canvas.valid ? c->canvas.h : 0);
+			    eff_canvas.valid ? eff_canvas.x : 0,
+			    eff_canvas.valid ? eff_canvas.y : 0,
+			    eff_canvas.valid ? eff_canvas.w : 0,
+			    eff_canvas.valid ? eff_canvas.h : 0);
 
 			// Spec v6 surround blit: fill non-canvas pixels of the back
 			// buffer from the app-supplied 2D surround texture. Back
 			// buffer is still in RENDER_TARGET from the DP; leave it
 			// in RENDER_TARGET so HUD's existing RT→COPY_DEST transition
 			// (below) proceeds unchanged.
-			d3d12_blit_surround_strips(
-			    c, back_buffer,
+			// #439: an authored zone mask replaces the rect-derived region
+			// selection entirely (see the shared-texture path).
+			bool surround_done = d3d12_composite_zone_mask(
+			    c, back_buffer, rtv_handle.ptr,
 			    D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_RENDER_TARGET,
-			    tgt_width, tgt_height,
-			    c->canvas.valid ? c->canvas.x : 0,
-			    c->canvas.valid ? c->canvas.y : 0,
-			    c->canvas.valid ? c->canvas.w : tgt_width,
-			    c->canvas.valid ? c->canvas.h : tgt_height);
+			    tgt_width, tgt_height, &eff_canvas);
+			if (!surround_done) {
+				d3d12_blit_surround_strips(
+				    c, back_buffer,
+				    D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_RENDER_TARGET,
+				    tgt_width, tgt_height,
+				    eff_canvas.valid ? eff_canvas.x : 0,
+				    eff_canvas.valid ? eff_canvas.y : 0,
+				    eff_canvas.valid ? eff_canvas.w : tgt_width,
+				    eff_canvas.valid ? eff_canvas.h : tgt_height);
+			}
 
 			// Transition atlas back: COMMON → PIXEL_SHADER_RESOURCE
 			atlas_barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_COMMON;
@@ -1741,6 +1837,15 @@ d3d12_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 		c->cmd_list->Close();
 		ID3D12CommandList *weave_lists[] = {c->cmd_list};
 		c->command_queue->ExecuteCommandLists(1, weave_lists);
+
+		// #439 A/B validation probe (no-op unless DISPLAYXR_SURROUND_CAPTURE
+		// is set + trigger file exists). Must read the back buffer BEFORE
+		// Present — flip-model contents are undefined after. When triggered
+		// it drains the GPU itself before re-arming the cmd list.
+		if (back_buffer != nullptr) {
+			d3d12_maybe_capture_surround_target(c, back_buffer, tgt_width, tgt_height,
+			                                    D3D12_RESOURCE_STATE_PRESENT);
+		}
 
 		// Present with VSync
 		comp_d3d12_target_present(c->target, 1);
@@ -1883,6 +1988,10 @@ d3d12_compositor_destroy(struct xrt_compositor *xc)
 	// Spec v6: release the 2D surround texture + keyed mutex if registered.
 	d3d12_release_surround(c);
 	c->surround_2d = {};
+
+	// #439: release the zone-mask scratches + detach any active mask (the
+	// oxr handle owns the mask object itself).
+	d3d12_release_zone_state(c);
 
 	if (c->shared_texture != nullptr) {
 		c->shared_texture->Release();
@@ -2352,7 +2461,13 @@ comp_d3d12_compositor_get_window_metrics(struct xrt_compositor *xc,
 
 	bool ok = xrt_display_processor_d3d12_get_window_metrics(c->display_processor, out_metrics);
 	if (ok) {
-		u_canvas_apply_to_metrics(out_metrics, &c->canvas);
+		// #439 Phase 2: the active zone mask supersedes the canvas — the
+		// Kooima/adaptive-FOV metrics follow the same authority as the
+		// weave region. (This path doesn't take c->mutex; the canvas/mask
+		// fields are pointer-sized reads updated under the lock in another
+		// function — the pointer check in d3d12_effective_canvas is benign.)
+		const struct u_canvas_rect eff_canvas = d3d12_effective_canvas(c);
+		u_canvas_apply_to_metrics(out_metrics, &eff_canvas);
 	}
 	return ok;
 }
@@ -2820,70 +2935,864 @@ comp_d3d12_compositor_set_surround_2d_fence(struct xrt_compositor *xc,
 
 /*
  *
- * XR_EXT_local_3d_zone — D3D12 consumer leg STUBS (#439 cross-API).
+ * XR_EXT_local_3d_zone — authored 2D/3D mask consumer (#439 cross-API leg).
  *
- * The oxr layer forwards here for D3D12 sessions; until the consumer leg
- * lands (docs/roadmap/unified-2d-3d-crossapi-impl.md §3) these return
- * XRT_ERROR_NOT_IMPLEMENTED and the oxr caps query reports
- * supported = false, so a caps-honoring app never reaches them.
+ * Port of the D3D11 Phase 1+2 consumer (comp_d3d11_compositor.cpp). The oxr
+ * handlers (oxr_local_3d_zone.c) forward here. The mask generalizes the
+ * surround path's rect-derived 2D region to an arbitrary scalar mask: the
+ * masked-composite shader's use_rect_mask = 0 path lerps
+ * M·weave + (1−M)·twod per pixel. Authoring happens on the app's thread,
+ * consumption inside d3d12_compositor_layer_commit — both serialize on
+ * c->mutex (the entry points lock it; layer_commit already holds it), which
+ * also makes submit atomic against an in-flight frame (spec §9 Q3).
+ *
+ * D3D12 specifics vs the D3D11 reference:
+ *  - No immediate context: each authoring op re-arms c->cmd_allocator /
+ *    c->cmd_list (Reset → record → Close → Execute → gpu_wait_idle) under
+ *    c->mutex — the same pattern d3d12_compositor_capture_atlas_to_png uses;
+ *    the list is provably idle whenever an entry point holds the mutex
+ *    (every layer_commit exit closes + executes + fence-waits).
+ *  - Tier 3 hands the app the ID3D12Resource* (descriptor heaps are
+ *    app-owned); the resource is in RENDER_TARGET state and must be returned
+ *    to RENDER_TARGET before xrSubmitLocal3DZoneEXT. Same device AND queue
+ *    (in-process), so submission order is the sync — no fence.
+ *  - Tier 2 uses ClearRenderTargetView's native rect array (one call).
+ *
+ * #464: the mask + 2D layer are window-sized (client-window pixels, matching
+ * XrLocal3DZoneMaskCreateInfoEXT); the composite operates on the window rect
+ * at the top-left anchor of the worst-case surface, never beyond it.
  *
  */
+
+/*!
+ * Compositor-side state for one authored zone mask. Owned by the oxr handle
+ * (oxr_local_3d_zone_ext::comp_mask); the compositor only borrows the
+ * pointer in active_zone_mask while the mask is submitted.
+ */
+struct comp_d3d12_zone_mask
+{
+	//! Authoring texture: R8_UNORM, M in [0,1] (1 = 3D / keep the weave).
+	//! Steady state RENDER_TARGET (clears need it; Tier-3 contract returns it).
+	ID3D12Resource *tex;
+	//! 1-descriptor RTV heap for tex — used for Tier 1/2 fills (Tier 3 apps
+	//! create their own RTV on the returned resource).
+	ID3D12DescriptorHeap *rtv_heap;
+	//! Staged snapshot sampled by the composite (decouples in-progress
+	//! authoring from the frame; refreshed by zone_mask_submit). Steady
+	//! state PIXEL_SHADER_RESOURCE.
+	ID3D12Resource *staged;
+	//! Mask dimensions in client-window pixels.
+	uint32_t w, h;
+	//! True once submitted at least once (an unsubmitted mask is invisible).
+	bool submitted;
+};
+
+// Release the compositor-owned zone consumables (scratches) and detach any
+// active mask (the oxr handle owns the mask object itself). Idempotent;
+// called from d3d12_compositor_destroy only — NOT from the surround release
+// path, which also runs on surround re-registration.
+static void
+d3d12_release_zone_state(struct comp_d3d12_compositor *c)
+{
+	c->active_zone_mask = nullptr;
+	if (c->surround_scratch != nullptr) {
+		c->surround_scratch->Release();
+		c->surround_scratch = nullptr;
+	}
+	if (c->weave_scratch != nullptr) {
+		c->weave_scratch->Release();
+		c->weave_scratch = nullptr;
+	}
+}
+
+// (Re)allocate a DEFAULT-heap committed scratch texture at the given
+// dims/format (no-op when it already matches). D3D12 textures are SRV-able
+// without bind flags; created in COMMON (the steady state between frames).
+// Returns false on allocation failure (with *res released and nulled).
+static bool
+d3d12_ensure_scratch(struct comp_d3d12_compositor *c,
+                     ID3D12Resource **res,
+                     uint32_t w,
+                     uint32_t h,
+                     DXGI_FORMAT fmt,
+                     const char *what)
+{
+	bool need_alloc = *res == nullptr;
+	if (!need_alloc) {
+		D3D12_RESOURCE_DESC cur = (*res)->GetDesc();
+		need_alloc = (cur.Width != w || cur.Height != h || cur.Format != fmt);
+	}
+	if (!need_alloc) {
+		return true;
+	}
+	if (*res != nullptr) {
+		(*res)->Release();
+		*res = nullptr;
+	}
+
+	D3D12_RESOURCE_DESC desc = {};
+	desc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
+	desc.Width = w;
+	desc.Height = h;
+	desc.DepthOrArraySize = 1;
+	desc.MipLevels = 1;
+	desc.Format = fmt;
+	desc.SampleDesc.Count = 1;
+	desc.Flags = D3D12_RESOURCE_FLAG_NONE;
+
+	D3D12_HEAP_PROPERTIES heap = {};
+	heap.Type = D3D12_HEAP_TYPE_DEFAULT;
+
+	HRESULT hr = c->device->CreateCommittedResource(
+	    &heap, D3D12_HEAP_FLAG_NONE, &desc,
+	    D3D12_RESOURCE_STATE_COMMON, nullptr,
+	    IID_PPV_ARGS(res));
+	if (FAILED(hr) || *res == nullptr) {
+		U_LOG_W("%s: scratch alloc (%ux%u fmt=%u) failed: 0x%08x", what, w, h, fmt, hr);
+		*res = nullptr;
+		return false;
+	}
+	return true;
+}
+
+// Re-arm the compositor's command list for a zone-authoring op. Caller holds
+// c->mutex; the list is closed + the GPU idle whenever that's true (see the
+// section comment), so the allocator Reset is safe.
+static void
+d3d12_zone_cmd_begin(struct comp_d3d12_compositor *c)
+{
+	c->cmd_allocator->Reset();
+	c->cmd_list->Reset(c->cmd_allocator, nullptr);
+}
+
+// Close + execute the zone-authoring command list and wait for completion,
+// restoring the "closed list, idle GPU" invariant before the mutex releases.
+// The CPU wait also makes zone_mask_submit's staged copy atomic against the
+// next frame (spec §9 Q3).
+static void
+d3d12_zone_cmd_execute(struct comp_d3d12_compositor *c)
+{
+	c->cmd_list->Close();
+	ID3D12CommandList *lists[] = {c->cmd_list};
+	c->command_queue->ExecuteCommandLists(1, lists);
+	gpu_wait_idle(c);
+}
+
+// #439 — composite the authored zone mask. Records into the OPEN c->cmd_list
+// (both call sites are mid-recording in layer_commit). Runs INSTEAD of the
+// rect surround path when an active submitted mask exists (the mask-lerp
+// writes every window pixel, so the strip path must not also run). Returns
+// false → caller falls through to the rect-strip behavior.
+//
+// dst_pre_state/dst_post_state parameterize the weave target's states the
+// same way d3d12_blit_surround_strips does (COMMON/COMMON on the shared-
+// texture path, RENDER_TARGET/RENDER_TARGET on the window-DP path).
+//
+// #464 window clamping: all inputs are window-sized; the pass writes only the
+// window region at the top-left anchor of the (worst-case-allocated) dst.
+//
+// #439 Phase 2: eff_canvas is the caller's per-frame effective canvas
+// (d3d12_effective_canvas under c->mutex) — the window rect while the mask
+// is active, so the composite region and the weave region share one
+// authority.
+static bool
+d3d12_composite_zone_mask(struct comp_d3d12_compositor *c,
+                          ID3D12Resource *dst,
+                          uint64_t dst_rtv,
+                          D3D12_RESOURCE_STATES dst_pre_state,
+                          D3D12_RESOURCE_STATES dst_post_state,
+                          uint32_t dst_w,
+                          uint32_t dst_h,
+                          const struct u_canvas_rect *eff_canvas)
+{
+	struct comp_d3d12_zone_mask *mask = c->active_zone_mask;
+	if (mask == nullptr || !mask->submitted || dst == nullptr || dst_rtv == 0 || c->renderer == nullptr) {
+		return false;
+	}
+
+	// The window region inside the worst-case surface (#464). No HWND →
+	// the dst is the window-sized target already.
+	uint32_t region_w = dst_w;
+	uint32_t region_h = dst_h;
+	HWND wnd = c->hwnd != nullptr ? c->hwnd : c->app_hwnd;
+	if (wnd != nullptr) {
+		RECT r;
+		if (GetClientRect(wnd, &r) && r.right > 0 && r.bottom > 0) {
+			region_w = ((uint32_t)r.right < dst_w) ? (uint32_t)r.right : dst_w;
+			region_h = ((uint32_t)r.bottom < dst_h) ? (uint32_t)r.bottom : dst_h;
+		}
+	}
+
+	// The composite is `texture + mask` (impl doc §2): the surround supplies
+	// the 2D pixels. Without one there is nothing to composite — full weave.
+	// D3D12 accepts either sync flavor: keyed mutex (spec v6) or fence (v7).
+	const bool use_fence = (c->surround_fence != nullptr);
+	if (!c->surround_2d.valid || c->surround_texture == nullptr ||
+	    (!use_fence && c->surround_mutex == nullptr)) {
+		static bool no_surround_logged = false;
+		if (!no_surround_logged) {
+			U_LOG_W("D3D12 zone mask: no 2D surround registered — mask ignored "
+			        "(the composite needs xrSetSharedTextureSurround2D(Fence)EXT for the 2D pixels)");
+			no_surround_logged = true;
+		}
+		return false;
+	}
+
+	// Relaxed dims contract (#464): accept a window-sized surround or the
+	// legacy display-sized one — content is top-left-anchored in both; we
+	// copy only the window region.
+	if (c->surround_2d.w < region_w || c->surround_2d.h < region_h) {
+		static bool dims_logged = false;
+		if (!dims_logged) {
+			U_LOG_W("D3D12 zone mask: surround %ux%u smaller than window region %ux%u — "
+			        "mask ignored. Re-register surround on window resize.",
+			        c->surround_2d.w, c->surround_2d.h, region_w, region_h);
+			dims_logged = true;
+		}
+		return false;
+	}
+
+	// Format contract: surround must match dst (same rule as the rect path),
+	// and dst must be R8G8B8A8_UNORM — the composite PSO's fixed RTV format
+	// (the same assumption the blit PSO and process_atlas already bake in).
+	D3D12_RESOURCE_DESC sd = c->surround_texture->GetDesc();
+	D3D12_RESOURCE_DESC dd = dst->GetDesc();
+	if (sd.Format != dd.Format || dd.Format != DXGI_FORMAT_R8G8B8A8_UNORM) {
+		static bool fmt_logged = false;
+		if (!fmt_logged) {
+			U_LOG_W("D3D12 zone mask: format mismatch — surround=%u, target=%u "
+			        "(composite PSO needs R8G8B8A8_UNORM) — mask ignored",
+			        (unsigned)sd.Format, (unsigned)dd.Format);
+			fmt_logged = true;
+		}
+		return false;
+	}
+
+	// Window-sized scratches (the shader samples uv [0,1] over the window
+	// region, so inputs must carry exactly that region).
+	if (!d3d12_ensure_scratch(c, &c->surround_scratch, region_w, region_h, sd.Format, "zone_mask surround")) {
+		return false;
+	}
+	if (!d3d12_ensure_scratch(c, &c->weave_scratch, region_w, region_h, dd.Format, "zone_mask weave")) {
+		return false;
+	}
+
+	// Surround sync — same flavors as d3d12_blit_surround_strips: fence →
+	// queue->Wait gates the caller's later ExecuteCommandLists; mutex →
+	// AcquireSync(0, 16) bracket around the recording (the shipping v6
+	// pattern), short timeout — skip a frame rather than stall.
+	if (use_fence) {
+		HRESULT hr = c->command_queue->Wait(c->surround_fence, c->surround_await_fence_value);
+		if (FAILED(hr)) {
+			static bool wait_logged = false;
+			if (!wait_logged) {
+				U_LOG_W("D3D12 zone mask: queue->Wait(fence=%p, value=%llu) failed (hr=0x%08x). "
+				        "Composite skipped.",
+				        (void *)c->surround_fence,
+				        (unsigned long long)c->surround_await_fence_value, hr);
+				wait_logged = true;
+			}
+			return false;
+		}
+	} else {
+		HRESULT hr = c->surround_mutex->AcquireSync(0, 16);
+		if (FAILED(hr)) {
+			return false; // timeout/abandoned — previous frame's pixels stay.
+		}
+	}
+
+	// Copy the window region of the app surround into its scratch.
+	D3D12_RESOURCE_BARRIER enter[2] = {};
+	enter[0].Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+	enter[0].Transition.pResource = c->surround_texture;
+	enter[0].Transition.StateBefore = D3D12_RESOURCE_STATE_COMMON;
+	enter[0].Transition.StateAfter = D3D12_RESOURCE_STATE_COPY_SOURCE;
+	enter[0].Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+	enter[1].Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+	enter[1].Transition.pResource = c->surround_scratch;
+	enter[1].Transition.StateBefore = D3D12_RESOURCE_STATE_COMMON;
+	enter[1].Transition.StateAfter = D3D12_RESOURCE_STATE_COPY_DEST;
+	enter[1].Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+	c->cmd_list->ResourceBarrier(2, enter);
+
+	D3D12_TEXTURE_COPY_LOCATION dst_loc = {};
+	dst_loc.pResource = c->surround_scratch;
+	dst_loc.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
+	dst_loc.SubresourceIndex = 0;
+	D3D12_TEXTURE_COPY_LOCATION src_loc = {};
+	src_loc.pResource = c->surround_texture;
+	src_loc.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
+	src_loc.SubresourceIndex = 0;
+	D3D12_BOX region_box = {0, 0, 0, region_w, region_h, 1};
+	c->cmd_list->CopyTextureRegion(&dst_loc, 0, 0, 0, &src_loc, &region_box);
+
+	// Surround back to COMMON (cross-process invariant), scratch → sampleable.
+	D3D12_RESOURCE_BARRIER exit_sr[2] = {};
+	exit_sr[0].Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+	exit_sr[0].Transition.pResource = c->surround_texture;
+	exit_sr[0].Transition.StateBefore = D3D12_RESOURCE_STATE_COPY_SOURCE;
+	exit_sr[0].Transition.StateAfter = D3D12_RESOURCE_STATE_COMMON;
+	exit_sr[0].Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+	exit_sr[1].Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+	exit_sr[1].Transition.pResource = c->surround_scratch;
+	exit_sr[1].Transition.StateBefore = D3D12_RESOURCE_STATE_COPY_DEST;
+	exit_sr[1].Transition.StateAfter = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+	exit_sr[1].Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+	c->cmd_list->ResourceBarrier(2, exit_sr);
+
+	if (!use_fence) {
+		c->surround_mutex->ReleaseSync(0);
+	}
+
+	// Snapshot the window region of the weave (the DP wrote dst; the weave
+	// target is RTV-only to the shader, so the lerp reads this copy).
+	D3D12_RESOURCE_BARRIER weave_enter[2] = {};
+	weave_enter[0].Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+	weave_enter[0].Transition.pResource = dst;
+	weave_enter[0].Transition.StateBefore = dst_pre_state;
+	weave_enter[0].Transition.StateAfter = D3D12_RESOURCE_STATE_COPY_SOURCE;
+	weave_enter[0].Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+	weave_enter[1].Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+	weave_enter[1].Transition.pResource = c->weave_scratch;
+	weave_enter[1].Transition.StateBefore = D3D12_RESOURCE_STATE_COMMON;
+	weave_enter[1].Transition.StateAfter = D3D12_RESOURCE_STATE_COPY_DEST;
+	weave_enter[1].Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+	c->cmd_list->ResourceBarrier(2, weave_enter);
+
+	dst_loc.pResource = c->weave_scratch;
+	src_loc.pResource = dst;
+	c->cmd_list->CopyTextureRegion(&dst_loc, 0, 0, 0, &src_loc, &region_box);
+
+	// Weave scratch → sampleable; dst → RENDER_TARGET for the composite draw.
+	D3D12_RESOURCE_BARRIER weave_exit[2] = {};
+	weave_exit[0].Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+	weave_exit[0].Transition.pResource = dst;
+	weave_exit[0].Transition.StateBefore = D3D12_RESOURCE_STATE_COPY_SOURCE;
+	weave_exit[0].Transition.StateAfter = D3D12_RESOURCE_STATE_RENDER_TARGET;
+	weave_exit[0].Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+	weave_exit[1].Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+	weave_exit[1].Transition.pResource = c->weave_scratch;
+	weave_exit[1].Transition.StateBefore = D3D12_RESOURCE_STATE_COPY_DEST;
+	weave_exit[1].Transition.StateAfter = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+	weave_exit[1].Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+	c->cmd_list->ResourceBarrier(2, weave_exit);
+
+	// Effective canvas rect clamped to the window region (the shader ignores
+	// it on the mask path; kept coherent for the constants anyway). Phase 2:
+	// this is the window rect while the mask is active.
+	int32_t cx = eff_canvas->valid ? eff_canvas->x : 0;
+	int32_t cy = eff_canvas->valid ? eff_canvas->y : 0;
+	uint32_t cw = eff_canvas->valid ? eff_canvas->w : region_w;
+	uint32_t ch = eff_canvas->valid ? eff_canvas->h : region_h;
+	uint32_t cx_u = (cx < 0) ? 0u : (uint32_t)cx;
+	uint32_t cy_u = (cy < 0) ? 0u : (uint32_t)cy;
+	if (cx_u > region_w)
+		cx_u = region_w;
+	if (cy_u > region_h)
+		cy_u = region_h;
+	uint32_t cright = (cx_u + cw > region_w) ? region_w : cx_u + cw;
+	uint32_t cbottom = (cy_u + ch > region_h) ? region_h : cy_u + ch;
+
+	xrt_result_t xret = comp_d3d12_renderer_composite_2d_masked(
+	    c->renderer, c->cmd_list, dst_rtv, c->surround_scratch, mask->staged, c->weave_scratch,
+	    region_w, region_h, (int32_t)cx_u, (int32_t)cy_u, cright - cx_u, cbottom - cy_u);
+
+	// Restore steady states: dst → caller's post state, scratches → COMMON.
+	D3D12_RESOURCE_BARRIER restore[3] = {};
+	uint32_t n = 0;
+	if (dst_post_state != D3D12_RESOURCE_STATE_RENDER_TARGET) {
+		restore[n].Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+		restore[n].Transition.pResource = dst;
+		restore[n].Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
+		restore[n].Transition.StateAfter = dst_post_state;
+		restore[n].Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+		n++;
+	}
+	restore[n].Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+	restore[n].Transition.pResource = c->surround_scratch;
+	restore[n].Transition.StateBefore = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+	restore[n].Transition.StateAfter = D3D12_RESOURCE_STATE_COMMON;
+	restore[n].Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+	n++;
+	restore[n].Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+	restore[n].Transition.pResource = c->weave_scratch;
+	restore[n].Transition.StateBefore = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+	restore[n].Transition.StateAfter = D3D12_RESOURCE_STATE_COMMON;
+	restore[n].Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+	n++;
+	c->cmd_list->ResourceBarrier(n, restore);
+
+	return xret == XRT_SUCCESS;
+}
 
 extern "C" xrt_result_t
 comp_d3d12_compositor_zone_mask_create(struct xrt_compositor *xc, uint32_t w, uint32_t h, void **out_mask)
 {
-	(void)xc;
-	(void)w;
-	(void)h;
-	(void)out_mask;
-	return XRT_ERROR_NOT_IMPLEMENTED;
+	struct comp_d3d12_compositor *c = d3d12_comp(xc);
+	std::lock_guard<std::mutex> lock(c->mutex);
+
+	if (out_mask == nullptr) {
+		return XRT_ERROR_ALLOCATION;
+	}
+
+	// 0 → runtime chooses: the client-window dims (#464 — the mask is
+	// window-sized by definition), falling back to the render surface.
+	if (w == 0 || h == 0) {
+		HWND wnd = c->hwnd != nullptr ? c->hwnd : c->app_hwnd;
+		RECT r;
+		if (wnd != nullptr && GetClientRect(wnd, &r) && r.right > 0 && r.bottom > 0) {
+			w = (uint32_t)r.right;
+			h = (uint32_t)r.bottom;
+		} else if (c->shared_texture != nullptr) {
+			D3D12_RESOURCE_DESC td = c->shared_texture->GetDesc();
+			w = (uint32_t)td.Width;
+			h = td.Height;
+		} else if (c->target != nullptr) {
+			comp_d3d12_target_get_dimensions(c->target, &w, &h);
+		}
+	}
+	if (w == 0 || h == 0) {
+		U_LOG_E("zone_mask_create: no window/surface to derive mask dims from");
+		return XRT_ERROR_ALLOCATION;
+	}
+
+	struct comp_d3d12_zone_mask *mask = U_TYPED_CALLOC(struct comp_d3d12_zone_mask);
+	if (mask == nullptr) {
+		return XRT_ERROR_ALLOCATION;
+	}
+	mask->w = w;
+	mask->h = h;
+
+	// Authoring texture: committed R8_UNORM render target, steady state
+	// RENDER_TARGET, optimized clear = all-3D (matches the default fill).
+	D3D12_RESOURCE_DESC td = {};
+	td.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
+	td.Width = w;
+	td.Height = h;
+	td.DepthOrArraySize = 1;
+	td.MipLevels = 1;
+	td.Format = DXGI_FORMAT_R8_UNORM;
+	td.SampleDesc.Count = 1;
+	td.Flags = D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET;
+
+	D3D12_HEAP_PROPERTIES heap = {};
+	heap.Type = D3D12_HEAP_TYPE_DEFAULT;
+
+	D3D12_CLEAR_VALUE clear = {};
+	clear.Format = DXGI_FORMAT_R8_UNORM;
+	clear.Color[0] = 1.0f;
+
+	HRESULT hr = c->device->CreateCommittedResource(
+	    &heap, D3D12_HEAP_FLAG_NONE, &td,
+	    D3D12_RESOURCE_STATE_RENDER_TARGET, &clear,
+	    IID_PPV_ARGS(&mask->tex));
+
+	if (SUCCEEDED(hr) && mask->tex != nullptr) {
+		D3D12_DESCRIPTOR_HEAP_DESC rtv_desc = {};
+		rtv_desc.NumDescriptors = 1;
+		rtv_desc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+		hr = c->device->CreateDescriptorHeap(&rtv_desc, IID_PPV_ARGS(&mask->rtv_heap));
+	}
+	if (SUCCEEDED(hr) && mask->rtv_heap != nullptr) {
+		c->device->CreateRenderTargetView(mask->tex, nullptr,
+		                                  mask->rtv_heap->GetCPUDescriptorHandleForHeapStart());
+		// Staged snapshot: plain texture, steady PIXEL_SHADER_RESOURCE.
+		td.Flags = D3D12_RESOURCE_FLAG_NONE;
+		hr = c->device->CreateCommittedResource(
+		    &heap, D3D12_HEAP_FLAG_NONE, &td,
+		    D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, nullptr,
+		    IID_PPV_ARGS(&mask->staged));
+	}
+	if (FAILED(hr) || mask->staged == nullptr) {
+		U_LOG_E("zone_mask_create: D3D12 resource creation failed: 0x%08x", hr);
+		if (mask->rtv_heap != nullptr) {
+			mask->rtv_heap->Release();
+		}
+		if (mask->tex != nullptr) {
+			mask->tex->Release();
+		}
+		free(mask);
+		return XRT_ERROR_ALLOCATION;
+	}
+
+	// Default to all-3D (M=1): an unauthored-but-submitted mask degrades to
+	// the full weave (the no-2D-declared analog), never a blanked canvas.
+	// Also prime the staged copy so a create→submit with no authoring is
+	// coherent. Recorded + executed via the zone-op re-arm pattern.
+	d3d12_zone_cmd_begin(c);
+	const float all_3d[4] = {1.0f, 0.0f, 0.0f, 0.0f};
+	c->cmd_list->ClearRenderTargetView(mask->rtv_heap->GetCPUDescriptorHandleForHeapStart(), all_3d, 0, nullptr);
+
+	D3D12_RESOURCE_BARRIER to_copy[2] = {};
+	to_copy[0].Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+	to_copy[0].Transition.pResource = mask->tex;
+	to_copy[0].Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
+	to_copy[0].Transition.StateAfter = D3D12_RESOURCE_STATE_COPY_SOURCE;
+	to_copy[0].Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+	to_copy[1].Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+	to_copy[1].Transition.pResource = mask->staged;
+	to_copy[1].Transition.StateBefore = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+	to_copy[1].Transition.StateAfter = D3D12_RESOURCE_STATE_COPY_DEST;
+	to_copy[1].Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+	c->cmd_list->ResourceBarrier(2, to_copy);
+
+	c->cmd_list->CopyResource(mask->staged, mask->tex);
+
+	std::swap(to_copy[0].Transition.StateBefore, to_copy[0].Transition.StateAfter);
+	std::swap(to_copy[1].Transition.StateBefore, to_copy[1].Transition.StateAfter);
+	c->cmd_list->ResourceBarrier(2, to_copy);
+	d3d12_zone_cmd_execute(c);
+
+	// One-off lifecycle event (WARN per the debug-logging convention so it
+	// survives the hot-path INFO filter).
+	U_LOG_W("zone_mask_create: %ux%u (client-window px)", w, h);
+	*out_mask = mask;
+	return XRT_SUCCESS;
 }
 
 extern "C" xrt_result_t
-comp_d3d12_compositor_zone_mask_set_whole(struct xrt_compositor *xc, void *mask, bool enable_3d)
+comp_d3d12_compositor_zone_mask_set_whole(struct xrt_compositor *xc, void *mask_ptr, bool enable_3d)
 {
-	(void)xc;
-	(void)mask;
-	(void)enable_3d;
-	return XRT_ERROR_NOT_IMPLEMENTED;
+	struct comp_d3d12_compositor *c = d3d12_comp(xc);
+	std::lock_guard<std::mutex> lock(c->mutex);
+
+	struct comp_d3d12_zone_mask *mask = static_cast<struct comp_d3d12_zone_mask *>(mask_ptr);
+	if (mask == nullptr || mask->rtv_heap == nullptr) {
+		return XRT_ERROR_ALLOCATION;
+	}
+
+	// Tier 1: one full clear (mask->tex sits in RENDER_TARGET).
+	d3d12_zone_cmd_begin(c);
+	const float m[4] = {enable_3d ? 1.0f : 0.0f, 0.0f, 0.0f, 0.0f};
+	c->cmd_list->ClearRenderTargetView(mask->rtv_heap->GetCPUDescriptorHandleForHeapStart(), m, 0, nullptr);
+	d3d12_zone_cmd_execute(c);
+	return XRT_SUCCESS;
 }
 
 extern "C" xrt_result_t
 comp_d3d12_compositor_zone_mask_set_rects(struct xrt_compositor *xc,
-                                          void *mask,
+                                          void *mask_ptr,
                                           uint32_t count,
                                           const struct xrt_rect *rects)
 {
-	(void)xc;
-	(void)mask;
-	(void)count;
-	(void)rects;
-	return XRT_ERROR_NOT_IMPLEMENTED;
+	struct comp_d3d12_compositor *c = d3d12_comp(xc);
+	std::lock_guard<std::mutex> lock(c->mutex);
+
+	struct comp_d3d12_zone_mask *mask = static_cast<struct comp_d3d12_zone_mask *>(mask_ptr);
+	if (mask == nullptr || mask->rtv_heap == nullptr || (count > 0 && rects == nullptr)) {
+		return XRT_ERROR_ALLOCATION;
+	}
+
+	// Clamp the rects up-front (client-window px); skip fully-outside /
+	// degenerate ones. D3D12's ClearRenderTargetView takes the rect array
+	// natively — one call, vs D3D11's per-rect ClearView loop.
+	D3D12_RECT *drs = nullptr;
+	uint32_t n = 0;
+	if (count > 0) {
+		drs = U_TYPED_ARRAY_CALLOC(D3D12_RECT, count);
+		if (drs == nullptr) {
+			return XRT_ERROR_ALLOCATION;
+		}
+		for (uint32_t i = 0; i < count; i++) {
+			int32_t left = rects[i].offset.w;
+			int32_t top = rects[i].offset.h;
+			int32_t right = left + rects[i].extent.w;
+			int32_t bottom = top + rects[i].extent.h;
+			if (left < 0) {
+				left = 0;
+			}
+			if (top < 0) {
+				top = 0;
+			}
+			if (right > (int32_t)mask->w) {
+				right = (int32_t)mask->w;
+			}
+			if (bottom > (int32_t)mask->h) {
+				bottom = (int32_t)mask->h;
+			}
+			if (right <= left || bottom <= top) {
+				continue;
+			}
+			drs[n].left = left;
+			drs[n].top = top;
+			drs[n].right = right;
+			drs[n].bottom = bottom;
+			n++;
+		}
+	}
+
+	// M=0 everywhere, then M=1 inside the surviving rects.
+	d3d12_zone_cmd_begin(c);
+	D3D12_CPU_DESCRIPTOR_HANDLE rtv = mask->rtv_heap->GetCPUDescriptorHandleForHeapStart();
+	const float all_2d[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+	c->cmd_list->ClearRenderTargetView(rtv, all_2d, 0, nullptr);
+	if (n > 0) {
+		const float all_3d[4] = {1.0f, 0.0f, 0.0f, 0.0f};
+		c->cmd_list->ClearRenderTargetView(rtv, all_3d, n, drs);
+	}
+	d3d12_zone_cmd_execute(c);
+
+	free(drs);
+	return XRT_SUCCESS;
 }
 
 extern "C" xrt_result_t
 comp_d3d12_compositor_zone_mask_acquire_rt(
-    struct xrt_compositor *xc, void *mask, void **out_resource, uint32_t *out_w, uint32_t *out_h)
+    struct xrt_compositor *xc, void *mask_ptr, void **out_resource, uint32_t *out_w, uint32_t *out_h)
 {
-	(void)xc;
-	(void)mask;
-	(void)out_resource;
-	(void)out_w;
-	(void)out_h;
-	return XRT_ERROR_NOT_IMPLEMENTED;
+	struct comp_d3d12_compositor *c = d3d12_comp(xc);
+	std::lock_guard<std::mutex> lock(c->mutex);
+
+	struct comp_d3d12_zone_mask *mask = static_cast<struct comp_d3d12_zone_mask *>(mask_ptr);
+	if (mask == nullptr || mask->tex == nullptr || out_resource == nullptr || out_w == nullptr ||
+	    out_h == nullptr) {
+		return XRT_ERROR_ALLOCATION;
+	}
+
+	// The runtime retains ownership of the resource (the app must not
+	// Release it); valid until the mask handle is destroyed. The compositor
+	// device + queue are the app's own in-process, so the app records its
+	// own RTV (descriptor heaps are app-owned in D3D12) and draws directly;
+	// submission order is the sync. State contract: handed out in
+	// RENDER_TARGET, must be back in RENDER_TARGET before submit.
+	*out_resource = mask->tex;
+	*out_w = mask->w;
+	*out_h = mask->h;
+	return XRT_SUCCESS;
 }
 
 extern "C" xrt_result_t
-comp_d3d12_compositor_zone_mask_submit(struct xrt_compositor *xc, void *mask)
+comp_d3d12_compositor_zone_mask_submit(struct xrt_compositor *xc, void *mask_ptr)
 {
-	(void)xc;
-	(void)mask;
-	return XRT_ERROR_NOT_IMPLEMENTED;
+	struct comp_d3d12_compositor *c = d3d12_comp(xc);
+	std::lock_guard<std::mutex> lock(c->mutex);
+
+	struct comp_d3d12_zone_mask *mask = static_cast<struct comp_d3d12_zone_mask *>(mask_ptr);
+	if (mask == nullptr || mask->staged == nullptr) {
+		return XRT_ERROR_ALLOCATION;
+	}
+
+	// Snapshot the authoring texture so in-progress Tier-3 drawing can never
+	// tear into a frame, and make this the active mask. Sticky
+	// last-submit-wins: it stays active across frames until re-submit or
+	// destroy (destroy reverts to the rect-surround behavior). The same-queue
+	// ExecuteCommandLists + CPU wait below orders the copy after any Tier-3
+	// authoring the app already submitted (no fence — same queue).
+	d3d12_zone_cmd_begin(c);
+
+	D3D12_RESOURCE_BARRIER to_copy[2] = {};
+	to_copy[0].Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+	to_copy[0].Transition.pResource = mask->tex;
+	to_copy[0].Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
+	to_copy[0].Transition.StateAfter = D3D12_RESOURCE_STATE_COPY_SOURCE;
+	to_copy[0].Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+	to_copy[1].Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+	to_copy[1].Transition.pResource = mask->staged;
+	to_copy[1].Transition.StateBefore = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+	to_copy[1].Transition.StateAfter = D3D12_RESOURCE_STATE_COPY_DEST;
+	to_copy[1].Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+	c->cmd_list->ResourceBarrier(2, to_copy);
+
+	c->cmd_list->CopyResource(mask->staged, mask->tex);
+
+	std::swap(to_copy[0].Transition.StateBefore, to_copy[0].Transition.StateAfter);
+	std::swap(to_copy[1].Transition.StateBefore, to_copy[1].Transition.StateAfter);
+	c->cmd_list->ResourceBarrier(2, to_copy);
+	d3d12_zone_cmd_execute(c);
+
+	mask->submitted = true;
+	c->active_zone_mask = mask;
+	return XRT_SUCCESS;
 }
 
 extern "C" void
-comp_d3d12_compositor_zone_mask_destroy(struct xrt_compositor *xc, void *mask)
+comp_d3d12_compositor_zone_mask_destroy(struct xrt_compositor *xc, void *mask_ptr)
 {
-	(void)xc;
-	(void)mask;
+	struct comp_d3d12_compositor *c = d3d12_comp(xc);
+	std::lock_guard<std::mutex> lock(c->mutex);
+
+	struct comp_d3d12_zone_mask *mask = static_cast<struct comp_d3d12_zone_mask *>(mask_ptr);
+	if (mask == nullptr) {
+		return;
+	}
+	if (c->active_zone_mask == mask) {
+		c->active_zone_mask = nullptr; // revert to rect-surround behavior
+	}
+	// The frame that might still reference these resources has fence-waited
+	// before layer_commit returned (the mutex we hold serializes us behind
+	// it), so an immediate Release is safe.
+	if (mask->staged != nullptr) {
+		mask->staged->Release();
+	}
+	if (mask->rtv_heap != nullptr) {
+		mask->rtv_heap->Release();
+	}
+	if (mask->tex != nullptr) {
+		mask->tex->Release();
+	}
+	free(mask);
+}
+
+/*
+ *
+ * #439 surround-capture probe (DISPLAYXR_SURROUND_CAPTURE).
+ *
+ */
+
+// Read back an arbitrary R8G8B8A8 resource region and write it as PNG.
+// Generalizes the atlas capture above to any resource/state: barrier
+// pre_state → COPY_SOURCE, placed-footprint copy into a transient READBACK
+// buffer, restore, execute + wait, repack + stbi_write_png.
+//
+// Re-arms c->cmd_allocator / c->cmd_list for its private use — caller must
+// ensure the list is CLOSED and the GPU idle on entry (call after the frame
+// fence wait, mirroring d3d12_compositor_capture_atlas_to_png).
+static bool
+d3d12_capture_resource_to_png(struct comp_d3d12_compositor *c,
+                              ID3D12Resource *res,
+                              uint32_t w,
+                              uint32_t h,
+                              D3D12_RESOURCE_STATES pre_state,
+                              const char *path)
+{
+	if (res == nullptr || w == 0 || h == 0) {
+		return false;
+	}
+
+	// D3D12 readback row pitch must be aligned to 256.
+	const UINT64 align = D3D12_TEXTURE_DATA_PITCH_ALIGNMENT;
+	UINT64 row_pitch = ((UINT64)w * 4 + align - 1) & ~(align - 1);
+	UINT64 rb_bytes = row_pitch * h;
+
+	D3D12_HEAP_PROPERTIES heap_props = {};
+	heap_props.Type = D3D12_HEAP_TYPE_READBACK;
+	D3D12_RESOURCE_DESC rb_desc = {};
+	rb_desc.Dimension = D3D12_RESOURCE_DIMENSION_BUFFER;
+	rb_desc.Width = rb_bytes;
+	rb_desc.Height = 1;
+	rb_desc.DepthOrArraySize = 1;
+	rb_desc.MipLevels = 1;
+	rb_desc.Format = DXGI_FORMAT_UNKNOWN;
+	rb_desc.SampleDesc.Count = 1;
+	rb_desc.Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
+	rb_desc.Flags = D3D12_RESOURCE_FLAG_NONE;
+
+	ID3D12Resource *readback = nullptr;
+	if (FAILED(c->device->CreateCommittedResource(
+	        &heap_props, D3D12_HEAP_FLAG_NONE, &rb_desc,
+	        D3D12_RESOURCE_STATE_COPY_DEST, nullptr,
+	        IID_PPV_ARGS(&readback))) || readback == nullptr) {
+		return false;
+	}
+
+	c->cmd_allocator->Reset();
+	c->cmd_list->Reset(c->cmd_allocator, nullptr);
+
+	D3D12_RESOURCE_BARRIER b = {};
+	b.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+	b.Transition.pResource = res;
+	b.Transition.Subresource = 0;
+	b.Transition.StateBefore = pre_state;
+	b.Transition.StateAfter = D3D12_RESOURCE_STATE_COPY_SOURCE;
+	c->cmd_list->ResourceBarrier(1, &b);
+
+	D3D12_TEXTURE_COPY_LOCATION src_loc = {};
+	src_loc.pResource = res;
+	src_loc.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
+	src_loc.SubresourceIndex = 0;
+
+	D3D12_TEXTURE_COPY_LOCATION dst_loc = {};
+	dst_loc.pResource = readback;
+	dst_loc.Type = D3D12_TEXTURE_COPY_TYPE_PLACED_FOOTPRINT;
+	dst_loc.PlacedFootprint.Offset = 0;
+	dst_loc.PlacedFootprint.Footprint.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	dst_loc.PlacedFootprint.Footprint.Width = w;
+	dst_loc.PlacedFootprint.Footprint.Height = h;
+	dst_loc.PlacedFootprint.Footprint.Depth = 1;
+	dst_loc.PlacedFootprint.Footprint.RowPitch = (UINT)row_pitch;
+
+	D3D12_BOX src_box = {0, 0, 0, w, h, 1};
+	c->cmd_list->CopyTextureRegion(&dst_loc, 0, 0, 0, &src_loc, &src_box);
+
+	std::swap(b.Transition.StateBefore, b.Transition.StateAfter);
+	c->cmd_list->ResourceBarrier(1, &b);
+
+	c->cmd_list->Close();
+	ID3D12CommandList *lists[] = {c->cmd_list};
+	c->command_queue->ExecuteCommandLists(1, lists);
+	gpu_wait_idle(c);
+
+	bool ok = false;
+	void *mapped = nullptr;
+	D3D12_RANGE read_range = {0, (SIZE_T)rb_bytes};
+	if (SUCCEEDED(readback->Map(0, &read_range, &mapped)) && mapped != nullptr) {
+		size_t tight_pitch = (size_t)w * 4;
+		uint8_t *tight = (uint8_t *)malloc(tight_pitch * h);
+		if (tight != nullptr) {
+			const uint8_t *rb_pixels = (const uint8_t *)mapped;
+			for (uint32_t y = 0; y < h; y++) {
+				memcpy(tight + (size_t)y * tight_pitch,
+				       rb_pixels + (size_t)y * row_pitch,
+				       tight_pitch);
+			}
+			// Composited-output alpha is undefined for display output —
+			// force opaque so the PNG doesn't render transparent (#425).
+			// Both A and B captures go through this same writer, so the
+			// §6 diff is unaffected.
+			u_image_force_opaque_rgba8(tight, w, h, tight_pitch);
+			ok = stbi_write_png(path, (int)w, (int)h, 4, tight, (int)tight_pitch) != 0;
+			free(tight);
+		}
+		D3D12_RANGE empty_range = {0, 0};
+		readback->Unmap(0, &empty_range);
+	}
+
+	readback->Release();
+	return ok;
+}
+
+// #439 validation probe — env-gated (DISPLAYXR_SURROUND_CAPTURE=1)
+// file-trigger dump of the final surround-composited target. The normal
+// POST_COMPOSE capture reads the renderer ATLAS, which the surround/zone
+// pass never touches, so the §6 A/B pixel-identity diff needs this
+// dedicated probe. Trigger: %TEMP%\displayxr_surround_trigger →
+// %TEMP%\displayxr_surround.png. Default-off, zero per-frame cost when
+// unset. Called AFTER the frame fence wait (the readback re-arms the
+// cmd list), unlike the D3D11 mid-recording call site.
+static void
+d3d12_maybe_capture_surround_target(struct comp_d3d12_compositor *c,
+                                    ID3D12Resource *dst,
+                                    uint32_t dst_w,
+                                    uint32_t dst_h,
+                                    D3D12_RESOURCE_STATES pre_state)
+{
+	static int enabled = -1;
+	if (enabled < 0) {
+		const char *e = getenv("DISPLAYXR_SURROUND_CAPTURE");
+		enabled = (e != nullptr && e[0] != '\0' && e[0] != '0') ? 1 : 0;
+	}
+	if (!enabled || dst == nullptr) {
+		return;
+	}
+	static char trig[MAX_PATH] = {0};
+	static char outp[MAX_PATH] = {0};
+	if (trig[0] == '\0') {
+		const char *tmp = getenv("TEMP");
+		if (tmp == nullptr || tmp[0] == '\0') {
+			tmp = "C:\\Temp";
+		}
+		snprintf(trig, sizeof(trig), "%s\\displayxr_surround_trigger", tmp);
+		snprintf(outp, sizeof(outp), "%s\\displayxr_surround.png", tmp);
+	}
+	if (GetFileAttributesA(trig) == INVALID_FILE_ATTRIBUTES) {
+		return;
+	}
+	DeleteFileA(trig);
+	// The frame's commands may still be in flight (the window path calls us
+	// between ExecuteCommandLists and Present); drain before the readback
+	// re-arms the cmd allocator. Triggered frames only — zero steady cost.
+	gpu_wait_idle(c);
+	bool ok = d3d12_capture_resource_to_png(c, dst, dst_w, dst_h, pre_state, outp);
+	U_LOG_W("Surround composite capture %s -> %s (zone_mask=%d)", ok ? "written" : "FAILED", outp,
+	        c->active_zone_mask != nullptr ? 1 : 0);
 }

--- a/src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp
+++ b/src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp
@@ -3153,15 +3153,16 @@ d3d12_composite_zone_mask(struct comp_d3d12_compositor *c,
 	}
 
 	// Format contract: surround must match dst (same rule as the rect path),
-	// and dst must be R8G8B8A8_UNORM — the composite PSO's fixed RTV format
-	// (the same assumption the blit PSO and process_atlas already bake in).
+	// and dst must be one of the two formats the composite has a PSO for —
+	// app-created shared textures are BGRA8 in the wild, DXGI targets RGBA8.
 	D3D12_RESOURCE_DESC sd = c->surround_texture->GetDesc();
 	D3D12_RESOURCE_DESC dd = dst->GetDesc();
-	if (sd.Format != dd.Format || dd.Format != DXGI_FORMAT_R8G8B8A8_UNORM) {
+	if (sd.Format != dd.Format ||
+	    (dd.Format != DXGI_FORMAT_R8G8B8A8_UNORM && dd.Format != DXGI_FORMAT_B8G8R8A8_UNORM)) {
 		static bool fmt_logged = false;
 		if (!fmt_logged) {
 			U_LOG_W("D3D12 zone mask: format mismatch — surround=%u, target=%u "
-			        "(composite PSO needs R8G8B8A8_UNORM) — mask ignored",
+			        "(composite PSOs cover R8G8B8A8/B8G8R8A8 UNORM) — mask ignored",
 			        (unsigned)sd.Format, (unsigned)dd.Format);
 			fmt_logged = true;
 		}
@@ -3294,8 +3295,8 @@ d3d12_composite_zone_mask(struct comp_d3d12_compositor *c,
 	uint32_t cbottom = (cy_u + ch > region_h) ? region_h : cy_u + ch;
 
 	xrt_result_t xret = comp_d3d12_renderer_composite_2d_masked(
-	    c->renderer, c->cmd_list, dst_rtv, c->surround_scratch, mask->staged, c->weave_scratch,
-	    region_w, region_h, (int32_t)cx_u, (int32_t)cy_u, cright - cx_u, cbottom - cy_u);
+	    c->renderer, c->cmd_list, dst_rtv, static_cast<uint32_t>(dd.Format), c->surround_scratch, mask->staged,
+	    c->weave_scratch, region_w, region_h, (int32_t)cx_u, (int32_t)cy_u, cright - cx_u, cbottom - cy_u);
 
 	// Restore steady states: dst → caller's post state, scratches → COMMON.
 	D3D12_RESOURCE_BARRIER restore[3] = {};
@@ -3639,10 +3640,12 @@ comp_d3d12_compositor_zone_mask_destroy(struct xrt_compositor *xc, void *mask_pt
  *
  */
 
-// Read back an arbitrary R8G8B8A8 resource region and write it as PNG.
-// Generalizes the atlas capture above to any resource/state: barrier
+// Read back a 4-byte-UNORM (RGBA8/BGRA8) resource region and write it as
+// PNG. Generalizes the atlas capture above to any resource/state: barrier
 // pre_state → COPY_SOURCE, placed-footprint copy into a transient READBACK
-// buffer, restore, execute + wait, repack + stbi_write_png.
+// buffer, restore, execute + wait, repack (+ BGRA→RGBA swizzle) +
+// stbi_write_png. The placed footprint MUST use the resource's own format —
+// app shared textures are BGRA8 in the wild.
 //
 // Re-arms c->cmd_allocator / c->cmd_list for its private use — caller must
 // ensure the list is CLOSED and the GPU idle on entry (call after the frame
@@ -3656,6 +3659,13 @@ d3d12_capture_resource_to_png(struct comp_d3d12_compositor *c,
                               const char *path)
 {
 	if (res == nullptr || w == 0 || h == 0) {
+		return false;
+	}
+
+	D3D12_RESOURCE_DESC res_desc = res->GetDesc();
+	const bool is_bgra = res_desc.Format == DXGI_FORMAT_B8G8R8A8_UNORM;
+	if (!is_bgra && res_desc.Format != DXGI_FORMAT_R8G8B8A8_UNORM) {
+		U_LOG_W("d3d12_capture_resource_to_png: unsupported format %u", (unsigned)res_desc.Format);
 		return false;
 	}
 
@@ -3705,7 +3715,7 @@ d3d12_capture_resource_to_png(struct comp_d3d12_compositor *c,
 	dst_loc.pResource = readback;
 	dst_loc.Type = D3D12_TEXTURE_COPY_TYPE_PLACED_FOOTPRINT;
 	dst_loc.PlacedFootprint.Offset = 0;
-	dst_loc.PlacedFootprint.Footprint.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	dst_loc.PlacedFootprint.Footprint.Format = res_desc.Format;
 	dst_loc.PlacedFootprint.Footprint.Width = w;
 	dst_loc.PlacedFootprint.Footprint.Height = h;
 	dst_loc.PlacedFootprint.Footprint.Depth = 1;
@@ -3735,10 +3745,18 @@ d3d12_capture_resource_to_png(struct comp_d3d12_compositor *c,
 				       rb_pixels + (size_t)y * row_pitch,
 				       tight_pitch);
 			}
+			// BGRA targets: swizzle to the RGBA byte order stbi expects.
+			// Identical for both A and B captures, so the §6 diff is
+			// unaffected.
+			if (is_bgra) {
+				for (size_t i = 0; i < tight_pitch * h; i += 4) {
+					uint8_t tmp = tight[i];
+					tight[i] = tight[i + 2];
+					tight[i + 2] = tmp;
+				}
+			}
 			// Composited-output alpha is undefined for display output —
 			// force opaque so the PNG doesn't render transparent (#425).
-			// Both A and B captures go through this same writer, so the
-			// §6 diff is unaffected.
 			u_image_force_opaque_rgba8(tight, w, h, tight_pitch);
 			ok = stbi_write_png(path, (int)w, (int)h, 4, tight, (int)tight_pitch) != 0;
 			free(tight);

--- a/src/xrt/compositor/d3d12/comp_d3d12_compositor.h
+++ b/src/xrt/compositor/d3d12/comp_d3d12_compositor.h
@@ -203,13 +203,9 @@ comp_d3d12_compositor_set_surround_2d_fence(struct xrt_compositor *xc,
                                               uint64_t await_fence_value);
 
 /*
- * XR_EXT_local_3d_zone — authored 2D/3D mask consumer, D3D12 leg.
- * Contracts + porting reference (the shipped D3D11 consumer):
+ * XR_EXT_local_3d_zone — authored 2D/3D mask consumer, D3D12 leg (#439).
+ * Contracts + the D3D11 porting reference:
  * docs/roadmap/unified-2d-3d-crossapi-impl.md §3.
- *
- * STUBS until the D3D12 consumer leg lands — all return
- * XRT_ERROR_NOT_IMPLEMENTED and the oxr caps query reports
- * supported = false for D3D12 sessions until then.
  */
 
 /*!

--- a/src/xrt/compositor/d3d12/comp_d3d12_renderer.cpp
+++ b/src/xrt/compositor/d3d12/comp_d3d12_renderer.cpp
@@ -273,8 +273,13 @@ struct comp_d3d12_renderer
 	//! Root signature for the masked 2D-over-3D composite (#439).
 	ID3D12RootSignature *composite_root_signature;
 
-	//! Masked-composite PSO (opaque, fullscreen triangle).
-	ID3D12PipelineState *composite_pso;
+	//! Masked-composite PSOs (opaque, fullscreen triangle). D3D12 bakes the
+	//! RTV format into the PSO (unlike D3D11's format-agnostic RTV), and the
+	//! weave target's format is the app's choice — shared textures in the
+	//! wild are BGRA8 (cube_texture_d3d12_win) while DXGI targets are RGBA8.
+	//! The lerp shader is channel-agnostic, so the two PSOs share bytecode.
+	ID3D12PipelineState *composite_pso;      // DXGI_FORMAT_R8G8B8A8_UNORM
+	ID3D12PipelineState *composite_pso_bgra; // DXGI_FORMAT_B8G8R8A8_UNORM
 
 	//! Shader-visible 3-slot SRV heap for the composite pass
 	//! (t0 = 2D surround, t1 = authored mask, t2 = weave snapshot).
@@ -1034,6 +1039,13 @@ comp_d3d12_renderer_create(struct comp_d3d12_compositor *c,
 
 	hr = device->CreateGraphicsPipelineState(&comp_pso_desc, __uuidof(ID3D12PipelineState),
 	                                          reinterpret_cast<void **>(&r->composite_pso));
+
+	if (SUCCEEDED(hr)) {
+		// BGRA8 variant — same shader/state, only the baked RTV format differs.
+		comp_pso_desc.RTVFormats[0] = DXGI_FORMAT_B8G8R8A8_UNORM;
+		hr = device->CreateGraphicsPipelineState(&comp_pso_desc, __uuidof(ID3D12PipelineState),
+		                                          reinterpret_cast<void **>(&r->composite_pso_bgra));
+	}
 	comp_vs_blob->Release();
 	comp_ps_blob->Release();
 
@@ -1080,6 +1092,9 @@ comp_d3d12_renderer_destroy(struct comp_d3d12_renderer **renderer_ptr)
 
 	if (r->composite_srv_heap != nullptr) {
 		r->composite_srv_heap->Release();
+	}
+	if (r->composite_pso_bgra != nullptr) {
+		r->composite_pso_bgra->Release();
 	}
 	if (r->composite_pso != nullptr) {
 		r->composite_pso->Release();
@@ -1538,6 +1553,7 @@ extern "C" xrt_result_t
 comp_d3d12_renderer_composite_2d_masked(struct comp_d3d12_renderer *renderer,
                                         void *cmd_list_ptr,
                                         uint64_t dst_rtv_handle,
+                                        uint32_t dst_format,
                                         void *twod_resource,
                                         void *mask_resource,
                                         void *weave_resource,
@@ -1551,6 +1567,17 @@ comp_d3d12_renderer_composite_2d_masked(struct comp_d3d12_renderer *renderer,
 	if (renderer == nullptr || cmd_list_ptr == nullptr || dst_rtv_handle == 0 || twod_resource == nullptr ||
 	    mask_resource == nullptr || weave_resource == nullptr) {
 		return XRT_ERROR_DEVICE_CREATION_FAILED;
+	}
+
+	// PSO by target format — D3D12 bakes the RTV format into the PSO.
+	ID3D12PipelineState *pso = nullptr;
+	switch (static_cast<DXGI_FORMAT>(dst_format)) {
+	case DXGI_FORMAT_R8G8B8A8_UNORM: pso = renderer->composite_pso; break;
+	case DXGI_FORMAT_B8G8R8A8_UNORM: pso = renderer->composite_pso_bgra; break;
+	default: break;
+	}
+	if (pso == nullptr) {
+		return XRT_ERROR_D3D;
 	}
 
 	auto internals = get_internals(renderer->c);
@@ -1609,7 +1636,7 @@ comp_d3d12_renderer_composite_2d_masked(struct comp_d3d12_renderer *renderer,
 	// composite; HUD + capture are copy ops) re-binds what it needs.
 	cmd_list->SetDescriptorHeaps(1, &renderer->composite_srv_heap);
 	cmd_list->SetGraphicsRootSignature(renderer->composite_root_signature);
-	cmd_list->SetPipelineState(renderer->composite_pso);
+	cmd_list->SetPipelineState(pso);
 	cmd_list->OMSetRenderTargets(1, &rtv, FALSE, nullptr);
 	cmd_list->RSSetViewports(1, &vp);
 	cmd_list->RSSetScissorRects(1, &scissor);

--- a/src/xrt/compositor/d3d12/comp_d3d12_renderer.cpp
+++ b/src/xrt/compositor/d3d12/comp_d3d12_renderer.cpp
@@ -135,6 +135,102 @@ float4 main(VS_OUTPUT input) : SV_Target {
 }
 )";
 
+// Masked 2D-over-3D composite (#439 cross-API leg). Keep byte-aligned with
+// the D3D11 reference (comp_d3d11_renderer.cpp / shaders/masked_composite.hlsl).
+// The lerp path samples the authored mask (t1) against the weave snapshot (t2);
+// the analytic rect path (use_rect_mask) is kept for shader parity but the
+// D3D12 leg always passes a mask (the no-mask path stays on the strip copies).
+static const char *masked_composite_vs_source = R"(
+struct VS_OUTPUT
+{
+    float4 position : SV_Position;
+    float2 uv : TEXCOORD0;
+};
+
+static const float2 positions[3] = {
+    float2(-1.0, -1.0),
+    float2(-1.0,  3.0),
+    float2( 3.0, -1.0),
+};
+static const float2 uvs[3] = {
+    float2(0.0, 1.0),
+    float2(0.0, -1.0),
+    float2(2.0, 1.0),
+};
+
+VS_OUTPUT VSMain(uint vertex_id : SV_VertexID)
+{
+    VS_OUTPUT o;
+    o.position = float4(positions[vertex_id], 0.0, 1.0);
+    o.uv = uvs[vertex_id];
+    return o;
+}
+)";
+
+static const char *masked_composite_ps_source = R"(
+Texture2D twod_tex   : register(t0);
+Texture2D mask_tex   : register(t1);
+Texture2D weave_tex  : register(t2);
+SamplerState samp    : register(s0);
+
+cbuffer CompositeParams : register(b0)
+{
+    float2 dst_dims;
+    float2 canvas_origin;
+    float2 canvas_size;
+    uint   use_rect_mask;
+    uint   _pad;
+};
+
+struct VS_OUTPUT
+{
+    float4 position : SV_Position;
+    float2 uv : TEXCOORD0;
+};
+
+float region_mask(float2 px, float2 uv)
+{
+    if (use_rect_mask)
+    {
+        bool inside =
+            px.x >= canvas_origin.x && px.x < canvas_origin.x + canvas_size.x &&
+            px.y >= canvas_origin.y && px.y < canvas_origin.y + canvas_size.y;
+        return inside ? 1.0 : 0.0;
+    }
+    return saturate(mask_tex.Sample(samp, uv).r);
+}
+
+float4 PSMain(VS_OUTPUT input) : SV_Target
+{
+    float2 px = input.uv * dst_dims;
+    float M = region_mask(px, input.uv);
+
+    if (use_rect_mask)
+    {
+        if (M >= 0.5)
+            discard;
+        return twod_tex.Sample(samp, input.uv);
+    }
+
+    float4 twod  = twod_tex.Sample(samp, input.uv);
+    float4 weave = weave_tex.Sample(samp, input.uv);
+    return M * weave + (1.0 - M) * twod;
+}
+)";
+
+/*!
+ * Composite shader constants — 8 DWORDs, passed as root constants (b0).
+ * Layout matches the D3D11 CompositeParams CB (HLSL packing: two float4 rows).
+ */
+struct CompositeParams
+{
+	float dst_dims[2];
+	float canvas_origin[2];
+	float canvas_size[2];
+	uint32_t use_rect_mask;
+	uint32_t _pad;
+};
+
 /*!
  * D3D12 renderer structure.
  */
@@ -173,6 +269,17 @@ struct comp_d3d12_renderer
 
 	//! Quad PSO with premultiplied alpha blending.
 	ID3D12PipelineState *quad_pso_premul;
+
+	//! Root signature for the masked 2D-over-3D composite (#439).
+	ID3D12RootSignature *composite_root_signature;
+
+	//! Masked-composite PSO (opaque, fullscreen triangle).
+	ID3D12PipelineState *composite_pso;
+
+	//! Shader-visible 3-slot SRV heap for the composite pass
+	//! (t0 = 2D surround, t1 = authored mask, t2 = weave snapshot).
+	//! SRVs are written fresh on every composite call.
+	ID3D12DescriptorHeap *composite_srv_heap;
 
 	//! Descriptor sizes.
 	uint32_t rtv_descriptor_size;
@@ -829,6 +936,128 @@ comp_d3d12_renderer_create(struct comp_d3d12_compositor *c,
 		return XRT_ERROR_D3D;
 	}
 
+	// --- Masked-composite root signature (#439): SRV table of 3 (t0 2D /
+	// t1 mask / t2 weave snapshot) + 8 root constants (CompositeParams, b0)
+	// + static POINT sampler (byte-identity with the strip copies). ---
+	D3D12_DESCRIPTOR_RANGE comp_srv_range = {};
+	comp_srv_range.RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
+	comp_srv_range.NumDescriptors = 3;
+	comp_srv_range.BaseShaderRegister = 0;
+	comp_srv_range.OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
+
+	D3D12_ROOT_PARAMETER comp_root_params[2] = {};
+
+	// Param 0: SRV descriptor table (t0..t2)
+	comp_root_params[0].ParameterType = D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;
+	comp_root_params[0].DescriptorTable.NumDescriptorRanges = 1;
+	comp_root_params[0].DescriptorTable.pDescriptorRanges = &comp_srv_range;
+	comp_root_params[0].ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
+
+	// Param 1: 8 root constants (CompositeParams — 2x float2 + float2 + 2x uint)
+	comp_root_params[1].ParameterType = D3D12_ROOT_PARAMETER_TYPE_32BIT_CONSTANTS;
+	comp_root_params[1].Constants.ShaderRegister = 0;
+	comp_root_params[1].Constants.RegisterSpace = 0;
+	comp_root_params[1].Constants.Num32BitValues = 8;
+	comp_root_params[1].ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
+
+	D3D12_STATIC_SAMPLER_DESC comp_sampler = {};
+	comp_sampler.Filter = D3D12_FILTER_MIN_MAG_MIP_POINT;
+	comp_sampler.AddressU = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
+	comp_sampler.AddressV = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
+	comp_sampler.AddressW = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
+	comp_sampler.ComparisonFunc = D3D12_COMPARISON_FUNC_NEVER;
+	comp_sampler.MaxLOD = D3D12_FLOAT32_MAX;
+	comp_sampler.ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
+
+	D3D12_ROOT_SIGNATURE_DESC comp_rs_desc = {};
+	comp_rs_desc.NumParameters = 2;
+	comp_rs_desc.pParameters = comp_root_params;
+	comp_rs_desc.NumStaticSamplers = 1;
+	comp_rs_desc.pStaticSamplers = &comp_sampler;
+	comp_rs_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_NONE;
+
+	sig_blob = nullptr;
+	error_blob = nullptr;
+	hr = D3D12SerializeRootSignature(&comp_rs_desc, D3D_ROOT_SIGNATURE_VERSION_1, &sig_blob, &error_blob);
+	if (FAILED(hr)) {
+		if (error_blob != nullptr) {
+			U_LOG_E("Composite root signature serialize error: %s",
+			        static_cast<const char *>(error_blob->GetBufferPointer()));
+			error_blob->Release();
+		}
+		comp_d3d12_renderer_destroy(&r);
+		return XRT_ERROR_D3D;
+	}
+
+	hr = device->CreateRootSignature(0, sig_blob->GetBufferPointer(), sig_blob->GetBufferSize(),
+	                                  __uuidof(ID3D12RootSignature),
+	                                  reinterpret_cast<void **>(&r->composite_root_signature));
+	sig_blob->Release();
+	if (FAILED(hr)) {
+		U_LOG_E("Failed to create composite root signature: 0x%08x", hr);
+		comp_d3d12_renderer_destroy(&r);
+		return XRT_ERROR_D3D;
+	}
+
+	// --- Compile masked-composite shaders and create the opaque PSO ---
+	ID3DBlob *comp_vs_blob = nullptr;
+	ID3DBlob *comp_ps_blob = nullptr;
+
+	hr = compile_shader(masked_composite_vs_source, "VSMain", "vs_5_0", &comp_vs_blob);
+	if (FAILED(hr)) {
+		comp_d3d12_renderer_destroy(&r);
+		return XRT_ERROR_D3D;
+	}
+
+	hr = compile_shader(masked_composite_ps_source, "PSMain", "ps_5_0", &comp_ps_blob);
+	if (FAILED(hr)) {
+		comp_vs_blob->Release();
+		comp_d3d12_renderer_destroy(&r);
+		return XRT_ERROR_D3D;
+	}
+
+	D3D12_GRAPHICS_PIPELINE_STATE_DESC comp_pso_desc = {};
+	comp_pso_desc.pRootSignature = r->composite_root_signature;
+	comp_pso_desc.VS.pShaderBytecode = comp_vs_blob->GetBufferPointer();
+	comp_pso_desc.VS.BytecodeLength = comp_vs_blob->GetBufferSize();
+	comp_pso_desc.PS.pShaderBytecode = comp_ps_blob->GetBufferPointer();
+	comp_pso_desc.PS.BytecodeLength = comp_ps_blob->GetBufferSize();
+	comp_pso_desc.BlendState.RenderTarget[0].RenderTargetWriteMask = D3D12_COLOR_WRITE_ENABLE_ALL;
+	comp_pso_desc.RasterizerState.FillMode = D3D12_FILL_MODE_SOLID;
+	comp_pso_desc.RasterizerState.CullMode = D3D12_CULL_MODE_NONE;
+	comp_pso_desc.RasterizerState.DepthClipEnable = TRUE;
+	comp_pso_desc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+	comp_pso_desc.NumRenderTargets = 1;
+	comp_pso_desc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+	comp_pso_desc.SampleDesc.Count = 1;
+	comp_pso_desc.SampleMask = UINT_MAX;
+
+	hr = device->CreateGraphicsPipelineState(&comp_pso_desc, __uuidof(ID3D12PipelineState),
+	                                          reinterpret_cast<void **>(&r->composite_pso));
+	comp_vs_blob->Release();
+	comp_ps_blob->Release();
+
+	if (FAILED(hr)) {
+		U_LOG_E("Failed to create composite PSO: 0x%08x", hr);
+		comp_d3d12_renderer_destroy(&r);
+		return XRT_ERROR_D3D;
+	}
+
+	// Dedicated shader-visible heap for the composite's 3 SRVs — written
+	// fresh per composite call so a stale slot can never be sampled.
+	D3D12_DESCRIPTOR_HEAP_DESC comp_heap_desc = {};
+	comp_heap_desc.NumDescriptors = 3;
+	comp_heap_desc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+	comp_heap_desc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+
+	hr = device->CreateDescriptorHeap(
+	    &comp_heap_desc, __uuidof(ID3D12DescriptorHeap), reinterpret_cast<void **>(&r->composite_srv_heap));
+	if (FAILED(hr)) {
+		U_LOG_E("Failed to create composite SRV heap: 0x%08x", hr);
+		comp_d3d12_renderer_destroy(&r);
+		return XRT_ERROR_D3D;
+	}
+
 	*out_renderer = r;
 
 	U_LOG_I("Created D3D12 renderer: %ux%u per view, atlas %ux%u (%u cols x %u rows), texture_h=%u",
@@ -849,6 +1078,15 @@ comp_d3d12_renderer_destroy(struct comp_d3d12_renderer **renderer_ptr)
 
 	comp_d3d12_renderer *r = *renderer_ptr;
 
+	if (r->composite_srv_heap != nullptr) {
+		r->composite_srv_heap->Release();
+	}
+	if (r->composite_pso != nullptr) {
+		r->composite_pso->Release();
+	}
+	if (r->composite_root_signature != nullptr) {
+		r->composite_root_signature->Release();
+	}
 	if (r->quad_pso_premul != nullptr) {
 		r->quad_pso_premul->Release();
 	}
@@ -1294,4 +1532,91 @@ comp_d3d12_renderer_resize(struct comp_d3d12_renderer *renderer,
 	// Recreate atlas texture with new dimensions
 	auto internals = get_internals(renderer->c);
 	return create_atlas_texture(renderer, internals->device, new_view_width, new_view_height);
+}
+
+extern "C" xrt_result_t
+comp_d3d12_renderer_composite_2d_masked(struct comp_d3d12_renderer *renderer,
+                                        void *cmd_list_ptr,
+                                        uint64_t dst_rtv_handle,
+                                        void *twod_resource,
+                                        void *mask_resource,
+                                        void *weave_resource,
+                                        uint32_t region_w,
+                                        uint32_t region_h,
+                                        int32_t cx,
+                                        int32_t cy,
+                                        uint32_t cw,
+                                        uint32_t ch)
+{
+	if (renderer == nullptr || cmd_list_ptr == nullptr || dst_rtv_handle == 0 || twod_resource == nullptr ||
+	    mask_resource == nullptr || weave_resource == nullptr) {
+		return XRT_ERROR_DEVICE_CREATION_FAILED;
+	}
+
+	auto internals = get_internals(renderer->c);
+	ID3D12Device *device = internals->device;
+	auto *cmd_list = static_cast<ID3D12GraphicsCommandList *>(cmd_list_ptr);
+
+	// Write the 3 SRVs fresh into the dedicated shader-visible heap
+	// (t0 = 2D surround scratch, t1 = authored mask staged copy, t2 = weave
+	// snapshot scratch). Formats come from each resource — the scratches are
+	// runtime-created with concrete formats, the mask is R8_UNORM.
+	ID3D12Resource *srcs[3] = {
+	    static_cast<ID3D12Resource *>(twod_resource),
+	    static_cast<ID3D12Resource *>(mask_resource),
+	    static_cast<ID3D12Resource *>(weave_resource),
+	};
+	D3D12_CPU_DESCRIPTOR_HANDLE srv_cpu = renderer->composite_srv_heap->GetCPUDescriptorHandleForHeapStart();
+	for (int i = 0; i < 3; i++) {
+		D3D12_RESOURCE_DESC rd = srcs[i]->GetDesc();
+		D3D12_SHADER_RESOURCE_VIEW_DESC srv_desc = {};
+		srv_desc.Format = rd.Format;
+		srv_desc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+		srv_desc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+		srv_desc.Texture2D.MipLevels = 1;
+		device->CreateShaderResourceView(srcs[i], &srv_desc, srv_cpu);
+		srv_cpu.ptr += renderer->srv_descriptor_size;
+	}
+
+	// #464: the composite region is window-sized at the top-left anchor of
+	// the (worst-case-allocated) surface; pixels beyond it are never written.
+	// The full-screen triangle's uv [0,1] spans the viewport, so region-sized
+	// SRVs sample 1:1.
+	D3D12_VIEWPORT vp = {};
+	vp.Width = static_cast<float>(region_w);
+	vp.Height = static_cast<float>(region_h);
+	vp.MaxDepth = 1.0f;
+	D3D12_RECT scissor = {};
+	scissor.right = static_cast<LONG>(region_w);
+	scissor.bottom = static_cast<LONG>(region_h);
+
+	CompositeParams params = {};
+	params.dst_dims[0] = static_cast<float>(region_w);
+	params.dst_dims[1] = static_cast<float>(region_h);
+	params.canvas_origin[0] = static_cast<float>(cx);
+	params.canvas_origin[1] = static_cast<float>(cy);
+	params.canvas_size[0] = static_cast<float>(cw);
+	params.canvas_size[1] = static_cast<float>(ch);
+	// The D3D12 leg always composites an authored mask; the analytic rect
+	// path (use_rect_mask=1) exists for shader parity with D3D11 only.
+	params.use_rect_mask = 0;
+
+	D3D12_CPU_DESCRIPTOR_HANDLE rtv = {};
+	rtv.ptr = static_cast<SIZE_T>(dst_rtv_handle);
+
+	// NOTE: this leaves the composite heap / root signature / PSO bound —
+	// downstream recording (strips fallback never runs after a successful
+	// composite; HUD + capture are copy ops) re-binds what it needs.
+	cmd_list->SetDescriptorHeaps(1, &renderer->composite_srv_heap);
+	cmd_list->SetGraphicsRootSignature(renderer->composite_root_signature);
+	cmd_list->SetPipelineState(renderer->composite_pso);
+	cmd_list->OMSetRenderTargets(1, &rtv, FALSE, nullptr);
+	cmd_list->RSSetViewports(1, &vp);
+	cmd_list->RSSetScissorRects(1, &scissor);
+	cmd_list->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+	cmd_list->SetGraphicsRootDescriptorTable(0, renderer->composite_srv_heap->GetGPUDescriptorHandleForHeapStart());
+	cmd_list->SetGraphicsRoot32BitConstants(1, 8, &params, 0);
+	cmd_list->DrawInstanced(3, 1, 0, 0);
+
+	return XRT_SUCCESS;
 }

--- a/src/xrt/compositor/d3d12/comp_d3d12_renderer.h
+++ b/src/xrt/compositor/d3d12/comp_d3d12_renderer.h
@@ -207,6 +207,41 @@ void *
 comp_d3d12_renderer_get_atlas_resource(struct comp_d3d12_renderer *renderer);
 
 /*!
+ * Masked 2D-over-3D composite (#439, XR_EXT_local_3d_zone): records a
+ * fullscreen-triangle draw into @p cmd_list that writes every pixel of the
+ * window region as `M*weave + (1-M)*twod` (per-channel, preserving each
+ * layer's own alpha — spec §4.2).
+ *
+ * The caller owns all resource states: the three sources must be in
+ * PIXEL_SHADER_RESOURCE and the destination in RENDER_TARGET when the draw
+ * executes. Leaves the composite heap/root-signature/PSO bound on the list.
+ *
+ * @param renderer The renderer.
+ * @param cmd_list Open D3D12 command list (void* = ID3D12GraphicsCommandList*).
+ * @param dst_rtv_handle CPU RTV handle of the weave target (D3D12_CPU_DESCRIPTOR_HANDLE::ptr).
+ * @param twod_resource 2D surround scratch (ID3D12Resource*, region-sized).
+ * @param mask_resource Authored mask staged copy (ID3D12Resource*, R8_UNORM).
+ * @param weave_resource Weave snapshot scratch (ID3D12Resource*, region-sized).
+ * @param region_w,region_h Window region (viewport) in pixels (#464 top-left anchor).
+ * @param cx,cy,cw,ch Canvas rect for the analytic-rect shader path (parity only).
+ *
+ * @ingroup comp_d3d12
+ */
+xrt_result_t
+comp_d3d12_renderer_composite_2d_masked(struct comp_d3d12_renderer *renderer,
+                                        void *cmd_list,
+                                        uint64_t dst_rtv_handle,
+                                        void *twod_resource,
+                                        void *mask_resource,
+                                        void *weave_resource,
+                                        uint32_t region_w,
+                                        uint32_t region_h,
+                                        int32_t cx,
+                                        int32_t cy,
+                                        uint32_t cw,
+                                        uint32_t ch);
+
+/*!
  * Resize the renderer's atlas texture to match a new view size.
  *
  * Recreates the atlas texture, RTV, and SRV at the new dimensions.

--- a/src/xrt/compositor/d3d12/comp_d3d12_renderer.h
+++ b/src/xrt/compositor/d3d12/comp_d3d12_renderer.h
@@ -219,6 +219,8 @@ comp_d3d12_renderer_get_atlas_resource(struct comp_d3d12_renderer *renderer);
  * @param renderer The renderer.
  * @param cmd_list Open D3D12 command list (void* = ID3D12GraphicsCommandList*).
  * @param dst_rtv_handle CPU RTV handle of the weave target (D3D12_CPU_DESCRIPTOR_HANDLE::ptr).
+ * @param dst_format DXGI_FORMAT of the weave target — selects the PSO
+ *                   (R8G8B8A8_UNORM or B8G8R8A8_UNORM; anything else errors).
  * @param twod_resource 2D surround scratch (ID3D12Resource*, region-sized).
  * @param mask_resource Authored mask staged copy (ID3D12Resource*, R8_UNORM).
  * @param weave_resource Weave snapshot scratch (ID3D12Resource*, region-sized).
@@ -231,6 +233,7 @@ xrt_result_t
 comp_d3d12_renderer_composite_2d_masked(struct comp_d3d12_renderer *renderer,
                                         void *cmd_list,
                                         uint64_t dst_rtv_handle,
+                                        uint32_t dst_format,
                                         void *twod_resource,
                                         void *mask_resource,
                                         void *weave_resource,

--- a/src/xrt/state_trackers/oxr/oxr_local_3d_zone.c
+++ b/src/xrt/state_trackers/oxr/oxr_local_3d_zone.c
@@ -10,11 +10,12 @@
  * The oxr layer owns the mask handle lifecycle and forwards authoring calls to
  * the native compositor's zone-mask entry points. The D3D11 consumer shipped
  * with Phases 1–2 (docs/roadmap/unified-2d-3d-phase1-impl.md, -phase2-impl.md);
- * D3D12 and VK forward to stubs until their consumer legs land
- * (docs/roadmap/unified-2d-3d-crossapi-impl.md) — the caps query reports
- * supported = false for those sessions, and a stubbed compositor's
- * XRT_ERROR_NOT_IMPLEMENTED maps to XR_ERROR_FEATURE_UNSUPPORTED. Every other
- * compositor falls through to XR_ERROR_FEATURE_UNSUPPORTED.
+ * the D3D12 consumer with the cross-API leg
+ * (docs/roadmap/unified-2d-3d-crossapi-impl.md §3). VK forwards to stubs until
+ * its consumer leg lands — the caps query reports supported = false for those
+ * sessions, and a stubbed compositor's XRT_ERROR_NOT_IMPLEMENTED maps to
+ * XR_ERROR_FEATURE_UNSUPPORTED. Every other compositor falls through to
+ * XR_ERROR_FEATURE_UNSUPPORTED.
  */
 
 #include <stdlib.h>
@@ -130,7 +131,7 @@ oxr_xrGetLocal3DZoneCapabilitiesEXT(XrSession session, XrLocal3DZoneCapabilities
 	OXR_VERIFY_ARG_TYPE_AND_NOT_NULL(&log, capabilities, XR_TYPE_LOCAL_3D_ZONE_CAPABILITIES_EXT);
 
 	// Never errors on an unsupported compositor — reports supported = false.
-	// D3D12 + VK sessions also report false until their consumer legs land
+	// VK sessions also report false until that consumer leg lands
 	// (docs/roadmap/unified-2d-3d-crossapi-impl.md — flip here per leg).
 	capabilities->supported = XR_FALSE;
 	capabilities->hardwareZoneGridWidth = 0;
@@ -142,6 +143,17 @@ oxr_xrGetLocal3DZoneCapabilitiesEXT(XrSession session, XrLocal3DZoneCapabilities
 	if (sess->is_d3d11_native_compositor && sess->xcn != NULL) {
 		capabilities->supported = XR_TRUE;
 		// Compositor consumer only — no hardware-zone DP leg yet.
+		capabilities->hardwareZoneGridWidth = 0;
+		capabilities->hardwareZoneGridHeight = 0;
+		capabilities->maxMaskWidth = OXR_LOCAL_3D_ZONE_MAX_MASK_DIM;
+		capabilities->maxMaskHeight = OXR_LOCAL_3D_ZONE_MAX_MASK_DIM;
+	}
+#endif
+
+#ifdef XRT_HAVE_D3D12_NATIVE_COMPOSITOR
+	if (sess->is_d3d12_native_compositor && sess->xcn != NULL) {
+		// #439 D3D12 consumer leg — parity with the D3D11 consumer.
+		capabilities->supported = XR_TRUE;
 		capabilities->hardwareZoneGridWidth = 0;
 		capabilities->hardwareZoneGridHeight = 0;
 		capabilities->maxMaskWidth = OXR_LOCAL_3D_ZONE_MAX_MASK_DIM;

--- a/test_apps/cube_texture_d3d12_win/main.cpp
+++ b/test_apps/cube_texture_d3d12_win/main.cpp
@@ -114,6 +114,9 @@ struct RenderState;
 static RenderState* g_renderState = nullptr;
 static void RenderOneFrame(RenderState& rs);
 
+// #439 — 'Z' cycles the zone-mask harness states (consumed in RenderOneFrame).
+static bool g_zoneCycleRequested = false;
+
 static void ToggleFullscreen(HWND hwnd) {
     if (g_fullscreen) {
         SetWindowLong(hwnd, GWL_STYLE, g_savedWindowStyle);
@@ -186,6 +189,11 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
     case WM_SYSKEYDOWN:
         return 0;
     case WM_KEYDOWN:
+        if (wParam == 'Z') {
+            // #439 — cycle the XR_EXT_local_3d_zone harness state.
+            g_zoneCycleRequested = true;
+            return 0;
+        }
         if (wParam == VK_ESCAPE) {
             PostMessage(hwnd, WM_CLOSE, 0, 0);
             return 0;
@@ -815,6 +823,199 @@ static void UpdatePerformanceStats(PerformanceStats& stats) {
 
 // ---- Render State & Frame Loop ----
 
+// #439 — XR_EXT_local_3d_zone authoring harness (D3D12 port of the
+// cube_texture_d3d11_win Phase-1 'Z' cycle):
+//   0 no mask (rect-surround behavior)
+//   1 Tier-1 whole-window 3D (full weave, no 2D anywhere)
+//   2 Tier-2 single rect == the canvas rect (must match the analytic
+//     rect-surround output inside the window — impl doc §6 case 3)
+//   3 Tier-2 multi-rect: three disconnected 3D islands
+//   4 Tier-3 freeform: CPU radial gradient uploaded onto the mask resource
+//     (soft 2D↔3D edge — validates the mask-lerp, impl doc §6 case 4)
+static void ZoneMaskApplyNextState(XrSessionManager& xr, D3D12Renderer& renderer) {
+    if (!g_zone.available || xr.session == XR_NULL_HANDLE) {
+        LOG_WARN("Zone mask: XR_EXT_local_3d_zone not available on this runtime");
+        return;
+    }
+
+    int next = (g_zone.state + 1) % 5;
+
+    if (next == 0) {
+        if (g_zone.mask != XR_NULL_HANDLE) {
+            g_zone.pfnDestroy(g_zone.mask);
+            g_zone.mask = XR_NULL_HANDLE;
+        }
+        g_zone.state = 0;
+        LOG_INFO("Zone mask [0]: destroyed — rect-surround behavior restored");
+        return;
+    }
+
+    if (g_zone.mask == XR_NULL_HANDLE) {
+        XrLocal3DZoneCapabilitiesEXT caps = {XR_TYPE_LOCAL_3D_ZONE_CAPABILITIES_EXT};
+        if (g_zone.pfnGetCaps && XR_SUCCEEDED(g_zone.pfnGetCaps(xr.session, &caps))) {
+            LOG_INFO("Zone caps: supported=%d hwGrid=%ux%u maxMask=%ux%u", caps.supported,
+                caps.hardwareZoneGridWidth, caps.hardwareZoneGridHeight,
+                caps.maxMaskWidth, caps.maxMaskHeight);
+        }
+        XrLocal3DZoneMaskCreateInfoEXT ci = {XR_TYPE_LOCAL_3D_ZONE_MASK_CREATE_INFO_EXT};
+        ci.maskWidth = 0;  // 0 = runtime chooses the client-window dims (#464)
+        ci.maskHeight = 0;
+        XrResult res = g_zone.pfnCreate(xr.session, &ci, &g_zone.mask);
+        if (XR_FAILED(res)) {
+            LogXrResult("xrCreateLocal3DZoneMaskEXT", res);
+            return;
+        }
+    }
+
+    XrResult res = XR_SUCCESS;
+    switch (next) {
+    case 1: // Tier 1 — whole window 3D
+        res = g_zone.pfnSetWhole(g_zone.mask, XR_TRUE);
+        LOG_INFO("Zone mask [1]: Tier-1 whole-window 3D (full weave)");
+        break;
+    case 2: { // Tier 2 — single rect == the canvas rect (centered 50%)
+        XrRect2Di rect = {};
+        rect.offset.x = (int32_t)(g_windowWidth / 4);
+        rect.offset.y = (int32_t)(g_windowHeight / 4);
+        rect.extent.width = (int32_t)g_canvasW;
+        rect.extent.height = (int32_t)g_canvasH;
+        res = g_zone.pfnSetRects(g_zone.mask, 1, &rect);
+        LOG_INFO("Zone mask [2]: Tier-2 single rect == canvas (%d,%d %dx%d)",
+            rect.offset.x, rect.offset.y, rect.extent.width, rect.extent.height);
+        break;
+    }
+    case 3: { // Tier 2 — three disconnected 3D islands
+        const int32_t w = (int32_t)g_windowWidth;
+        const int32_t h = (int32_t)g_windowHeight;
+        XrRect2Di rects[3] = {};
+        rects[0].offset = {w / 8, h / 8};
+        rects[0].extent = {w / 4, h / 4};
+        rects[1].offset = {5 * w / 8, h / 8};
+        rects[1].extent = {w / 4, h / 4};
+        rects[2].offset = {3 * w / 8, 5 * h / 8};
+        rects[2].extent = {w / 4, h / 4};
+        res = g_zone.pfnSetRects(g_zone.mask, 3, rects);
+        LOG_INFO("Zone mask [3]: Tier-2 multi-rect — 3 disconnected 3D islands");
+        break;
+    }
+    case 4: { // Tier 3 — freeform radial gradient drawn by the app
+        XrLocal3DZoneRenderTargetD3D12EXT binding = {XR_TYPE_LOCAL_3D_ZONE_RENDER_TARGET_D3D12_EXT};
+        res = g_zone.pfnAcquireRT(g_zone.mask, &binding);
+        if (XR_SUCCEEDED(res) && binding.resource != nullptr &&
+            binding.width > 0 && binding.height > 0) {
+            // The mask resource lives on the app's own device + queue
+            // in-process (header v2 sync contract: same-queue submission
+            // order, no fence). D3D12 has no UpdateSubresource — stage the
+            // CPU radial gradient (M=1 core → soft falloff → M=0) through a
+            // transient UPLOAD buffer + CopyTextureRegion, honoring the
+            // RENDER_TARGET in/out state contract.
+            ID3D12Resource* maskRes = static_cast<ID3D12Resource*>(binding.resource);
+            const uint32_t mw = binding.width;
+            const uint32_t mh = binding.height;
+            const uint32_t pitch =
+                (mw + D3D12_TEXTURE_DATA_PITCH_ALIGNMENT - 1) & ~(D3D12_TEXTURE_DATA_PITCH_ALIGNMENT - 1);
+            std::vector<uint8_t> pixels((size_t)pitch * mh, 0);
+            const float cxf = mw * 0.5f;
+            const float cyf = mh * 0.5f;
+            const float r3d = 0.30f * (float)(mw < mh ? mw : mh);  // full-3D core
+            const float feather = 0.5f * r3d;                      // soft edge
+            for (uint32_t y = 0; y < mh; y++) {
+                for (uint32_t x = 0; x < mw; x++) {
+                    float dx = (float)x - cxf;
+                    float dy = (float)y - cyf;
+                    float d = sqrtf(dx * dx + dy * dy);
+                    float m = 1.0f - (d - r3d) / feather;
+                    m = m < 0.0f ? 0.0f : (m > 1.0f ? 1.0f : m);
+                    pixels[(size_t)y * pitch + x] = (uint8_t)(m * 255.0f + 0.5f);
+                }
+            }
+
+            // Transient UPLOAD buffer (alive through the WaitForGpu below).
+            ComPtr<ID3D12Resource> upload;
+            D3D12_HEAP_PROPERTIES up = {};
+            up.Type = D3D12_HEAP_TYPE_UPLOAD;
+            D3D12_RESOURCE_DESC bd = {};
+            bd.Dimension = D3D12_RESOURCE_DIMENSION_BUFFER;
+            bd.Width = (UINT64)pitch * mh;
+            bd.Height = 1;
+            bd.DepthOrArraySize = 1;
+            bd.MipLevels = 1;
+            bd.SampleDesc.Count = 1;
+            bd.Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
+            HRESULT hr = renderer.device->CreateCommittedResource(
+                &up, D3D12_HEAP_FLAG_NONE, &bd, D3D12_RESOURCE_STATE_GENERIC_READ,
+                nullptr, IID_PPV_ARGS(&upload));
+            if (FAILED(hr)) {
+                LOG_WARN("Zone mask [4]: upload buffer creation failed (0x%08lx)", hr);
+                break;
+            }
+            void* mapped = nullptr;
+            if (FAILED(upload->Map(0, nullptr, &mapped)) || mapped == nullptr) {
+                LOG_WARN("Zone mask [4]: upload buffer map failed");
+                break;
+            }
+            memcpy(mapped, pixels.data(), pixels.size());
+            upload->Unmap(0, nullptr);
+
+            renderer.commandAllocator->Reset();
+            renderer.commandList->Reset(renderer.commandAllocator.Get(), nullptr);
+
+            D3D12_RESOURCE_BARRIER barrier = {};
+            barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+            barrier.Transition.pResource = maskRes;
+            barrier.Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+            barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
+            barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_COPY_DEST;
+            renderer.commandList->ResourceBarrier(1, &barrier);
+
+            D3D12_TEXTURE_COPY_LOCATION dstLoc = {};
+            dstLoc.pResource = maskRes;
+            dstLoc.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
+            dstLoc.SubresourceIndex = 0;
+            D3D12_TEXTURE_COPY_LOCATION srcLoc = {};
+            srcLoc.pResource = upload.Get();
+            srcLoc.Type = D3D12_TEXTURE_COPY_TYPE_PLACED_FOOTPRINT;
+            srcLoc.PlacedFootprint.Offset = 0;
+            srcLoc.PlacedFootprint.Footprint.Format = DXGI_FORMAT_R8_UNORM;
+            srcLoc.PlacedFootprint.Footprint.Width = mw;
+            srcLoc.PlacedFootprint.Footprint.Height = mh;
+            srcLoc.PlacedFootprint.Footprint.Depth = 1;
+            srcLoc.PlacedFootprint.Footprint.RowPitch = pitch;
+            renderer.commandList->CopyTextureRegion(&dstLoc, 0, 0, 0, &srcLoc, nullptr);
+
+            // Back to RENDER_TARGET per the Tier-3 state contract.
+            barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_COPY_DEST;
+            barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_RENDER_TARGET;
+            renderer.commandList->ResourceBarrier(1, &barrier);
+
+            renderer.commandList->Close();
+            ID3D12CommandList* lists[] = {renderer.commandList.Get()};
+            renderer.commandQueue->ExecuteCommandLists(1, lists);
+            WaitForGpu(renderer);  // keeps `upload` alive until the copy lands
+
+            LOG_INFO("Zone mask [4]: Tier-3 radial gradient (%ux%u, core r=%.0f, feather=%.0f)",
+                mw, mh, r3d, feather);
+        } else {
+            LogXrResult("xrAcquireLocal3DZoneRenderTargetEXT", res);
+        }
+        break;
+    }
+    default:
+        break;
+    }
+    if (XR_FAILED(res)) {
+        LogXrResult("zone mask authoring", res);
+        return;
+    }
+
+    res = g_zone.pfnSubmit(g_zone.mask);
+    if (XR_FAILED(res)) {
+        LogXrResult("xrSubmitLocal3DZoneEXT", res);
+        return;
+    }
+    g_zone.state = next;
+}
+
 struct RenderState {
     HWND hwnd;
     XrSessionManager* xr;
@@ -876,6 +1077,12 @@ static void RenderOneFrame(RenderState& rs) {
                 ? XR_EYE_TRACKING_MODE_MANUAL_EXT : XR_EYE_TRACKING_MODE_MANAGED_EXT;
             xr.pfnRequestEyeTrackingModeEXT(xr.session, newMode);
         }
+    }
+    // #439 — apply a pending 'Z' zone-mask cycle (before any frame recording;
+    // the Tier-3 path re-arms the renderer's command list for its upload).
+    if (g_zoneCycleRequested) {
+        g_zoneCycleRequested = false;
+        ZoneMaskApplyNextState(xr, renderer);
     }
     UpdateScene(renderer, rs.perfStats->deltaTime);
     PollEvents(xr);
@@ -1708,7 +1915,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
     LOG_INFO("");
     LOG_INFO("=== Entering main loop ===");
     LOG_INFO("Shared texture mode: runtime renders to shared texture, app blits to window");
-    LOG_INFO("Controls: WASD=Fly, Mouse=Look, Space=Reset, V=Mode, SHIFT+TAB=HUD, F11=Fullscreen, ESC=Quit");
+    LOG_INFO("Controls: WASD=Fly, Mouse=Look, Space=Reset, V=Mode, Z=ZoneMask, SHIFT+TAB=HUD, F11=Fullscreen, ESC=Quit");
 
     PerformanceStats perfStats = {};
     perfStats.lastTime = std::chrono::high_resolution_clock::now();
@@ -1786,6 +1993,14 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
     g_blitPSO.Reset();
     g_blitRootSig.Reset();
     g_blitSrvHeap.Reset();
+
+    // #439: destroy the zone mask before session teardown (the oxr handle
+    // cascade would also do it; explicit keeps ordering obvious).
+    if (g_zone.mask != XR_NULL_HANDLE && g_zone.pfnDestroy) {
+        g_zone.pfnDestroy(g_zone.mask);
+        g_zone.mask = XR_NULL_HANDLE;
+        g_zone.state = 0;
+    }
 
     // Clear surround registration before dropping our refs so the runtime
     // releases its opened ID3D12Resource + ID3D12Fence views of the shared

--- a/test_apps/cube_texture_d3d12_win/xr_session.cpp
+++ b/test_apps/cube_texture_d3d12_win/xr_session.cpp
@@ -9,6 +9,9 @@
 #include "logging.h"
 #include <cstring>
 
+// #439 — XR_EXT_local_3d_zone harness state (see xr_session.h).
+ZoneMaskHarness g_zone;
+
 #define XR_CHECK(call) \
     do { \
         XrResult result = (call); \
@@ -75,11 +78,15 @@ bool InitializeOpenXR(XrSessionManager& xr) {
         if (strcmp(ext.extensionName, XR_EXT_DISPLAY_INFO_EXTENSION_NAME) == 0) {
             xr.hasDisplayInfoExt = true;
         }
+        if (strcmp(ext.extensionName, XR_EXT_LOCAL_3D_ZONE_EXTENSION_NAME) == 0) {
+            g_zone.available = true;
+        }
     }
 
     LOG_INFO("XR_KHR_D3D12_enable: %s", hasD3D12 ? "AVAILABLE" : "NOT FOUND");
     LOG_INFO("XR_EXT_win32_window_binding: %s", xr.hasWin32WindowBindingExt ? "AVAILABLE" : "NOT FOUND");
     LOG_INFO("XR_EXT_display_info: %s", xr.hasDisplayInfoExt ? "AVAILABLE" : "NOT FOUND");
+    LOG_INFO("XR_EXT_local_3d_zone: %s", g_zone.available ? "AVAILABLE" : "NOT FOUND");
 
     if (!hasD3D12) {
         LOG_ERROR("XR_KHR_D3D12_enable extension not available");
@@ -96,6 +103,9 @@ bool InitializeOpenXR(XrSessionManager& xr) {
     enabledExtensions.push_back(XR_EXT_WIN32_WINDOW_BINDING_EXTENSION_NAME);
     if (xr.hasDisplayInfoExt) {
         enabledExtensions.push_back(XR_EXT_DISPLAY_INFO_EXTENSION_NAME);
+    }
+    if (g_zone.available) {
+        enabledExtensions.push_back(XR_EXT_LOCAL_3D_ZONE_EXTENSION_NAME);
     }
 
     LOG_INFO("Enabling %zu extensions", enabledExtensions.size());
@@ -164,6 +174,28 @@ bool InitializeOpenXR(XrSessionManager& xr) {
             (PFN_xrVoidFunction*)&xr.pfnSetSharedTextureSurround2DEXT);
         xrGetInstanceProcAddr(xr.instance, "xrSetSharedTextureSurround2DFenceEXT",
             (PFN_xrVoidFunction*)&xr.pfnSetSharedTextureSurround2DFenceEXT);
+    }
+
+    // #439 — XR_EXT_local_3d_zone entry points (app-local harness).
+    if (g_zone.available) {
+        xrGetInstanceProcAddr(xr.instance, "xrGetLocal3DZoneCapabilitiesEXT",
+            (PFN_xrVoidFunction*)&g_zone.pfnGetCaps);
+        xrGetInstanceProcAddr(xr.instance, "xrCreateLocal3DZoneMaskEXT",
+            (PFN_xrVoidFunction*)&g_zone.pfnCreate);
+        xrGetInstanceProcAddr(xr.instance, "xrSetLocal3DZoneWholeWindowEXT",
+            (PFN_xrVoidFunction*)&g_zone.pfnSetWhole);
+        xrGetInstanceProcAddr(xr.instance, "xrSetLocal3DZoneFromRectsEXT",
+            (PFN_xrVoidFunction*)&g_zone.pfnSetRects);
+        xrGetInstanceProcAddr(xr.instance, "xrAcquireLocal3DZoneRenderTargetEXT",
+            (PFN_xrVoidFunction*)&g_zone.pfnAcquireRT);
+        xrGetInstanceProcAddr(xr.instance, "xrSubmitLocal3DZoneEXT",
+            (PFN_xrVoidFunction*)&g_zone.pfnSubmit);
+        xrGetInstanceProcAddr(xr.instance, "xrDestroyLocal3DZoneMaskEXT",
+            (PFN_xrVoidFunction*)&g_zone.pfnDestroy);
+        if (!g_zone.pfnCreate || !g_zone.pfnSubmit || !g_zone.pfnDestroy) {
+            LOG_WARN("XR_EXT_local_3d_zone advertised but entry points missing — harness disabled");
+            g_zone.available = false;
+        }
     }
 
     // Get view configuration views

--- a/test_apps/cube_texture_d3d12_win/xr_session.h
+++ b/test_apps/cube_texture_d3d12_win/xr_session.h
@@ -15,6 +15,29 @@
 #include <dxgi1_6.h>
 #define XR_USE_GRAPHICS_API_D3D12
 #include "xr_session_common.h"
+#include <openxr/XR_EXT_local_3d_zone.h>
+
+// #439 — XR_EXT_local_3d_zone test harness state (D3D12 port of the
+// cube_texture_d3d11_win Phase-1 harness). App-local: the shared
+// XrSessionManager lives in displayxr-common, which doesn't carry this
+// extension yet. Populated by InitializeOpenXR, driven by the 'Z' key cycle
+// in main.cpp.
+struct ZoneMaskHarness {
+    bool available = false;
+    PFN_xrGetLocal3DZoneCapabilitiesEXT pfnGetCaps = nullptr;
+    PFN_xrCreateLocal3DZoneMaskEXT pfnCreate = nullptr;
+    PFN_xrSetLocal3DZoneWholeWindowEXT pfnSetWhole = nullptr;
+    PFN_xrSetLocal3DZoneFromRectsEXT pfnSetRects = nullptr;
+    PFN_xrAcquireLocal3DZoneRenderTargetEXT pfnAcquireRT = nullptr;
+    PFN_xrSubmitLocal3DZoneEXT pfnSubmit = nullptr;
+    PFN_xrDestroyLocal3DZoneMaskEXT pfnDestroy = nullptr;
+    XrLocal3DZoneMaskEXT mask = XR_NULL_HANDLE;
+    // 0 = no mask (rect-surround behavior), 1 = Tier-1 whole-window 3D,
+    // 2 = Tier-2 single rect == canvas, 3 = Tier-2 multi-rect islands,
+    // 4 = Tier-3 freeform radial gradient.
+    int state = 0;
+};
+extern ZoneMaskHarness g_zone;
 
 // Initialize OpenXR instance with D3D12 + win32_window_binding (mandatory) extensions
 bool InitializeOpenXR(XrSessionManager& xr);


### PR DESCRIPTION
## Summary

The **D3D12 consumer leg** of the cross-API zone-mask rollout ([`unified-2d-3d-crossapi-impl.md` §3](../blob/main/docs/roadmap/unified-2d-3d-crossapi-impl.md)) — replaces the 6 `comp_d3d12_compositor_zone_mask_*` stubs from the base leg (#473) with the real consumer, ported from the shipped D3D11 reference (`17ae19294` Phase 1 + `b67f9f6f1` Phase 2).

- **Zone-mask object**: R8_UNORM committed resource (steady `RENDER_TARGET`, own 1-slot RTV heap) + staged snapshot (steady `PIXEL_SHADER_RESOURCE`) + `submitted` flag. Authoring ops re-arm the compositor cmd list under `c->mutex` (Reset → record → Close → Execute → `gpu_wait_idle` — the existing capture pattern; the list is provably idle whenever an entry point holds the mutex).
- **Tier 1** = `ClearRenderTargetView`; **Tier 2** = M=0 clear + ONE native rect-array clear (simpler than D3D11's per-rect `ClearView` loop).
- **Tier 3** returns the `ID3D12Resource*` (app-owned RTV descriptor; same device+queue → submission order is the sync, no fence). State contract (out/in `RENDER_TARGET`) documented in the header v2 comment — comment-only, SPEC_VERSION stays 2.
- **Masked composite**: new renderer root sig + PSOs (t0 surround / t1 mask / t2 weave-snapshot, 8 root constants, point sampler; §4.2 output-alpha rule `M·weave + (1−M)·twod`), recorded into the open frame list with parameterized dst states like the strips helper; the weave target snapshots into an SRV scratch before the lerp. Two PSOs (RGBA8 + BGRA8) — D3D12 bakes the RTV format into the PSO and app shared textures are BGRA8 in the wild. Accepts both surround sync flavors (v6 keyed mutex / v7 fence). Bail-false → strips fallback.
- **`d3d12_effective_canvas`** (Phase-2 supersede): applied at every frame-path canvas read — view-dims sync, `process_atlas` both paths, strips/composite both paths, one-shot log, `get_window_metrics`. *Deliberate non-site:* the D3D12 target-dims block never read the canvas (unlike D3D11's fallback there) — left untouched so the no-mask path is unchanged.
- **`DISPLAYXR_SURROUND_CAPTURE` probe ported** (D3D12 had no composite-target capture; the validation matrices depend on it). Window-path call sits **before** `Present` — flip-model back-buffer contents are undefined after — and drains the GPU itself when triggered.
- **Caps flipped**: D3D12 sessions report `supported=TRUE` (`oxr_local_3d_zone.c`).
- **Harness**: `cube_texture_d3d12_win` 'Z'-cycle ported (states 0–4); Tier-3 gradient through an UPLOAD buffer + `CopyTextureRegion` with the RT→COPY_DEST→RT contract.

## Validation (capture leg — green)

Dev runtime + Leia SR plug-in, `cube_texture_d3d12_win` via `XR_RUNTIME_JSON`, captures via the ported probe:

| Case | Result |
|---|---|
| State 0 no-mask baseline | weave in canvas rect (320,180 640×360), strips elsewhere, beyond-window untouched |
| Tier-1 whole-window | window-spanning weave, view dims 320×180 → **640×360** (window-derived; resize logged) |
| Tier-2 rect == canvas | window-spanning weave cropped to the rect (Phase-2 re-baselined golden) |
| Tier-2 3 islands | real weave in all 3, incl. **outside** the old canvas rect (the Phase-2 win) |
| Tier-3 radial gradient | clean soft 2D↔3D blend, no hard edge |
| Wrap-around (destroy) | canvas + strips restored, view dims back to 320×180, no flicker/crash |
| `displayxr-cli selftest` | PASS (Leia plug-in, ABI v3) |

**Merge gate: Leia on-glass eyeball** (interlace correctness at islands/gradient + drag-resize during mask-active) — hardware-behavior change, do not auto-merge before. Run `_package\run_cube_texture_d3d12_zonetest.bat` (non-elevated) and cycle Z.

After validation + merge: tick the doc §5 matrices box + epic #439 "D3D12 — all engine plugins".

Refs #439.

🤖 Generated with [Claude Code](https://claude.com/claude-code)