### PR TITLE
feat(release): restore "Release vX.Y.Z" marker commits across all release flows

### DIFF
--- a/.claude/skills/dxr-release/SKILL.md
+++ b/.claude/skills/dxr-release/SKILL.md
@@ -116,15 +116,32 @@ PREV_TAG=$(git tag --sort=-creatordate | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | h
 
 ---
 
-## PHASE 2: TAG
+## PHASE 2: MARKER COMMIT + TAG
+
+Create an **empty** "Release vX.Y.Z" marker commit on the sibling's
+`main` and tag THAT commit — same pattern as `/release` on the runtime
+and the Unity/Unreal plugin repos, so every repo's history shows an
+obvious release boundary (which release got which commits). Empty
+commit = no version content = no drift vector.
 
 ```bash
+git commit --allow-empty -m "Release $NEW_TAG"
+# Retry once if main moved underneath us (the empty commit rebases trivially).
+git push origin HEAD:main || (git pull --rebase origin main && git push origin HEAD:main)
 git tag -a "$NEW_TAG" -m "$NEW_TAG
 
 Commits since $PREV_TAG:
 $(git log --oneline --no-merges "$PREV_TAG..HEAD" 2>/dev/null | head -20)"
 git push origin "$NEW_TAG"
 ```
+
+Notes:
+- The marker push fires the sibling's regular main-push CI alongside
+  the tag-triggered release run — a harmless (if slightly wasteful)
+  duplicate. Siblings can adopt the runtime's empty-diff →
+  docs_only=true `DetectChanges` short-circuit to make it ~free.
+- If the sibling's ruleset rejects the direct push to main, fall back
+  to tagging HEAD directly and flag it in the Phase 6 report.
 
 The temp clone can be deleted after the tag is pushed — the rest of the
 flow polls GitHub via `gh api`, no local checkout needed. Keep it until

--- a/.claude/skills/installer-release/SKILL.md
+++ b/.claude/skills/installer-release/SKILL.md
@@ -103,8 +103,30 @@ component release first, then re-run.
 
 ---
 
-## PHASE 2: FIRE THE DISPATCH
+## PHASE 2: MARKER COMMIT + FIRE THE DISPATCH
 
+### Step 2.0: Push the empty release-marker commit
+Same pattern as every other DisplayXR repo's release flow (`/release`,
+`/dxr-release`, Unity/Unreal plugins): an **empty** "Release vX.Y.Z"
+commit on `main` so the history shows an obvious release boundary.
+Because the dispatch below runs `--ref main`, the workflow's
+`GITHUB_SHA` — and therefore the tag `softprops/action-gh-release`
+creates — lands on this marker commit.
+
+```bash
+WORK=$(mktemp -d)
+gh repo clone DisplayXR/displayxr-installer "$WORK/repo" -- --quiet --depth 30
+cd "$WORK/repo"
+git commit --allow-empty -m "Release $TAG"
+# Retry once if a versions.json mirror commit raced us (empty commit rebases trivially).
+git push origin HEAD:main || (git pull --rebase origin main && git push origin HEAD:main)
+cd - && rm -rf "$WORK"
+```
+
+The marker changes no files, so the pre-checked `versions.json` sync
+assertion (Step 1.2 / `assert-versions-in-sync`) is unaffected.
+
+### Step 2.1: Fire the dispatch
 `publish-bundle.yml` is `workflow_dispatch`-only. Fire it via the gh
 CLI with the tag input.
 
@@ -118,7 +140,8 @@ gh workflow run publish-bundle.yml \
 
 The workflow creates the actual tag itself during the release step
 (`softprops/action-gh-release@v2` with `tag_name: ${{ inputs.tag }}`),
-so no `git tag && git push` needed beforehand.
+so no `git tag && git push` needed beforehand — only the Step 2.0
+marker push.
 
 ---
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -36,7 +36,7 @@ version-spec:
 /release patch
   │   (bumps from latest v[0-9]+.[0-9]+.[0-9]+ tag)
   ├─ Pre-flight (clean tree, on main, tag not taken)
-  ├─ Tag HEAD → push tag
+  ├─ Empty "Release vX.Y.Z" marker commit → push main → tag it → push tag
   │
   │  (CI takes over here — build-windows.yml patches CMakeLists.txt
   │   VERSION from the tag at build time per PR #353, then both
@@ -52,14 +52,19 @@ version-spec:
   └─ Report (includes auto-bump SHAs + any ABI-mismatch issue link)
 ```
 
-The skill no longer touches CMakeLists.txt — CI is authoritative for
+The skill never touches CMakeLists.txt — CI is authoritative for
 the source-tree VERSION (synced from `git describe --tags --abbrev=0`
 on every Windows build per PR #353; macOS derives version directly
-from `GITHUB_REF` in build-macos.yml). The previous flow's "Release
-X.Y.Z" version-bump commit was both redundant (CI overrode it anyway)
-and a drift vector if the bump was forgotten — that's exactly what
-landed PR #353 (after the in-tree value pinned at 1.2.3 silently
-drifted for three releases past v1.3.0 in displayxr-shell-pvt).
+from `GITHUB_REF` in build-macos.yml). The old flow's "Release X.Y.Z"
+*version-bump* commit was a drift vector if the bump was forgotten —
+that's exactly what landed PR #353 (after the in-tree value pinned at
+1.2.3 silently drifted for three releases past v1.3.0 in
+displayxr-shell-pvt). The marker commit reintroduced here is **empty**
+(`--allow-empty`, no version content), so it restores the obvious
+"Release vX.Y.Z" boundary in the main history without restoring the
+drift vector. Every DisplayXR repo's release flow uses the same marker
+pattern (`/dxr-release`, `/installer-release`, and the Unity/Unreal
+plugin repos).
 
 The skill also no longer downloads or re-uploads any artifacts — that
 moved into the workflows themselves per #290.
@@ -126,25 +131,38 @@ If empty, PREV_TAG=<empty> → use "Initial release" in notes.
 
 ---
 
-## PHASE 2: TAG
+## PHASE 2: MARKER COMMIT + TAG
 
-### Step 2.1: Tag HEAD and push the tag
-The skill no longer commits anything to `main` — CI patches
-CMakeLists.txt VERSION from the tag at build time (PR #353). Just tag
-the current `main` HEAD and push the tag.
+### Step 2.1: Create the empty release-marker commit, push it, tag it
+The marker is an **empty** commit — it exists purely so `git log` /
+graph views show an obvious "Release vX.Y.Z" boundary on main (which
+release got which commits). It carries no version content, so the
+CMakeLists drift vector that killed the old version-bump commit
+(PR #353) does not apply — CI still patches VERSION from the tag at
+build time.
 
 ```bash
+git commit --allow-empty -m "Release [FULL_TAG]"
+git push origin main
 git tag [FULL_TAG]
 git push origin [FULL_TAG]
 ```
 
-Store the tagged commit SHA for later monitoring: `RELEASE_SHA=$(git rev-parse [FULL_TAG]^{commit})`.
+Store the tagged commit SHA for later monitoring:
+`RELEASE_SHA=$(git rev-parse [FULL_TAG]^{commit})` (this is the marker
+commit). Also keep it as `MARKER_SHA` for Phase 7 rollback.
 
-### Step 2.2: Branch protection note
-Branch protection on `main` does not apply to tag pushes, so no
-admin override is needed. (Earlier versions of this skill committed a
-"Release vX.Y.Z" version-bump to `main`; that step is gone — see the
-Architecture diagram.)
+### Step 2.2: Branch protection + duplicate-CI notes
+- Branch protection on `main` allows the owner's direct push; tag
+  pushes are unaffected by protection. If the marker push is ever
+  rejected (ruleset change), fall back to tagging HEAD directly (the
+  pre-marker flow) and flag it in the final report.
+- The marker push to `main` fires its own build-windows + build-macos
+  runs alongside the tag runs. Both workflows' `DetectChanges` treat
+  an **empty diff as docs_only=true**, so the main-push runs
+  short-circuit in ~30 s — the real release build is the tag run.
+  Phase 3's run lookup already disambiguates the two same-SHA runs by
+  `headBranch == [FULL_TAG]`.
 
 ---
 
@@ -398,8 +416,22 @@ git tag -d [FULL_TAG]
 git push --delete origin [FULL_TAG]
 ```
 
-There's nothing else to revert — Phase 2 no longer commits anything to
-`main`, so deleting the tag fully rolls back the release.
+### Step 7.2: Remove the marker commit (only if still main's tip)
+The marker commit is empty, so leaving it is harmless to the build —
+but misleading (a "Release vX.Y.Z" marker with no release). Remove it
+only if `main` hasn't moved past it; never force-push over someone
+else's commits:
+
+```bash
+git fetch origin main
+if [ "$(git rev-parse origin/main)" = "$MARKER_SHA" ]; then
+  git push --force-with-lease=main:"$MARKER_SHA" origin "$MARKER_SHA^:main"
+  git reset --hard origin/main
+else
+  echo "main moved past the marker — leaving it; note in report that"
+  echo "the [FULL_TAG] marker commit is orphaned (release rolled back)."
+fi
+```
 
 ### Step 7.2: Error summary + report
 ```bash
@@ -414,7 +446,7 @@ Report the error and that the tag has been deleted. STOP.
 ```
 /release v1.2.1
     → explicit version
-    → tags current main HEAD as v1.2.1 (no source-tree commit)
+    → empty "Release v1.2.1" marker commit on main, tagged v1.2.1
     → push v1.2.1 → CI patches CMakeLists VERSION → builds installer
     → workflows attach installer to the GH release
 

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -62,8 +62,10 @@ jobs:
             BASE=${{ github.event.before }}
           fi
           CHANGED=$(git diff --name-only "$BASE" HEAD)
+          # Empty diff = /release's empty "Release vX.Y.Z" marker commit on
+          # main; the real build runs on the tag push (docs_only=false above).
           NON_DOC=$(echo "$CHANGED" | grep -vE '^(docs/|.*\.md$|LICENSE$|\.github/ISSUE_TEMPLATE/)' || true)
-          if [ -n "$CHANGED" ] && [ -z "$NON_DOC" ]; then
+          if [ -z "$NON_DOC" ]; then
             echo "docs_only=true" >> "$GITHUB_OUTPUT"
           else
             echo "docs_only=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -77,8 +77,13 @@ jobs:
           # When true, Runtime (and downstream test-app jobs) still RUN — to
           # report a status for branch protection — but skip their heavy
           # steps via per-step `if:`.
+          # An EMPTY diff also counts as docs_only: the only zero-file pushes
+          # to main are /release's empty "Release vX.Y.Z" marker commits, and
+          # their real build runs on the tag push (forced docs_only=false
+          # above). A bad BASE object can't masquerade as an empty diff — the
+          # step runs under bash -e, so a failed `git diff` fails the job.
           NON_DOC=$(echo "$CHANGED" | grep -vE '^(docs/|.*\.md$|LICENSE$|\.github/ISSUE_TEMPLATE/)' || true)
-          if [ -n "$CHANGED" ] && [ -z "$NON_DOC" ]; then
+          if [ -z "$NON_DOC" ]; then
             echo "docs_only=true" >> "$GITHUB_OUTPUT"
           else
             echo "docs_only=false" >> "$GITHUB_OUTPUT"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,7 +141,7 @@ This repo IS the public runtime (no private→public mirror). A release is a `vX
 /release v1.2.1   # explicit            /release patch
 /release minor                          /release major
 ```
-`/release` tags `main` HEAD (CI patches `CMakeLists.txt VERSION` from `git describe` at build time, so the source-tree value isn't committed), watches both CI workflows, writes curated notes, then waits for `BumpVersionsJsonOnTag` (ABI gate + `versions.json` bump + mirror to `displayxr-installer`). macOS `.pkg` is a soft requirement (warns, doesn't block). Auto-bump regex is strict (`^v[0-9]+\.[0-9]+\.[0-9]+$`) so non-canonical tags are skipped. See `.claude/skills/release/SKILL.md`.
+`/release` pushes an **empty "Release vX.Y.Z" marker commit** to `main` and tags it (so the graph shows an obvious release boundary; CI still patches `CMakeLists.txt VERSION` from `git describe` at build time — the marker carries no version content, so PR #353's drift vector stays dead; the marker's main-push CI short-circuits via the empty-diff → docs_only rule in `DetectChanges`), watches both CI workflows, writes curated notes, then waits for `BumpVersionsJsonOnTag` (ABI gate + `versions.json` bump + mirror to `displayxr-installer`). `/dxr-release` and `/installer-release` push the same marker commit to their target repos. macOS `.pkg` is a soft requirement (warns, doesn't block). Auto-bump regex is strict (`^v[0-9]+\.[0-9]+\.[0-9]+$`) so non-canonical tags are skipped. See `.claude/skills/release/SKILL.md`.
 
 **Sibling release flows (NOT `/release` in this repo):**
 


### PR DESCRIPTION
## Summary

Restores the old "Release vX.Y.Z" boundary commits in the main-branch history (lost when PR #353 removed the version-bump commit), as **empty** marker commits — the tag points at the marker, so graph views make it obvious which release got which commits, with zero CMakeLists drift risk (CI still patches VERSION from the tag at build time).

Applied uniformly to every DisplayXR release flow, matching what the Unity/Unreal plugin repos already do:

- **`/release`** (runtime): empty `Release vX.Y.Z` commit pushed to main, tagged; rollback removes it via guarded `--force-with-lease` only if still main's tip.
- **`/dxr-release`** (shell, leia-plugin, mcp, 3 demos): same marker on the sibling's main before tagging, with a rebase-retry against mirror-commit races.
- **`/installer-release`**: marker pushed to `displayxr-installer/main` before the `workflow_dispatch`, so the workflow-created tag lands on it.
- **CI**: `DetectChanges` in both build workflows now treats an **empty diff on a main push as `docs_only=true`**, so the marker push's duplicate run short-circuits in ~30 s — the real release build is the tag-push run (which forces `docs_only=false`). A failed `git diff` still fails the job under `bash -e`, so it can't masquerade as an empty diff.

## Test plan

- [ ] CI green on this PR (DetectChanges sees a normal non-empty diff → full build)
- [ ] Next `/release` produces the marker commit + a ~30 s short-circuited main-push run + a full tag run

🤖 Generated with [Claude Code](https://claude.com/claude-code)
