### PR TITLE
feat(#396): W7 dogfood — test apps consume runtime render-ready XrView, delete app-side Kooima

### DIFF
--- a/docs/architecture/separation-of-concerns.md
+++ b/docs/architecture/separation-of-concerns.md
@@ -72,7 +72,7 @@ Implementations live in `src/xrt/drivers/` (vendor-specific) or `src/xrt/composi
 | Atlas → display | — | — | calls DP | DP implements |
 | Eye positions | — | queries | extracts from DP | DP provides |
 | Display dimensions | — | queries | — | DP provides |
-| Window metrics | — | — | queries from DP | DP provides |
+| Window metrics | — | — | computes from HWND + DP display info | DP provides display dims/pixels only |
 
 ## Vendor Isolation Rule
 

--- a/src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp
+++ b/src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp
@@ -2457,19 +2457,109 @@ extern "C" bool
 comp_d3d12_compositor_get_window_metrics(struct xrt_compositor *xc,
                                           struct xrt_window_metrics *out_metrics)
 {
+	if (xc == nullptr || out_metrics == nullptr) {
+		if (out_metrics != nullptr) {
+			out_metrics->valid = false;
+		}
+		return false;
+	}
+
 	struct comp_d3d12_compositor *c = d3d12_comp(xc);
 
+	// Prefer a DP-provided window metrics implementation if one exists.
 	bool ok = xrt_display_processor_d3d12_get_window_metrics(c->display_processor, out_metrics);
-	if (ok) {
-		// #439 Phase 2: the active zone mask supersedes the canvas — the
-		// Kooima/adaptive-FOV metrics follow the same authority as the
-		// weave region. (This path doesn't take c->mutex; the canvas/mask
-		// fields are pointer-sized reads updated under the lock in another
-		// function — the pointer check in d3d12_effective_canvas is benign.)
-		const struct u_canvas_rect eff_canvas = d3d12_effective_canvas(c);
-		u_canvas_apply_to_metrics(out_metrics, &eff_canvas);
+	if (!ok) {
+		// No DP implementation (the in-tree sim_display DP and the Leia
+		// plug-in delegate window placement to the runtime). Compute the
+		// metrics directly from the HWND — same construction as the d3d11
+		// native compositor. Without this, d3d12 handle/texture sessions
+		// had NO window metrics and the runtime-side Kooima (rig path, raw
+		// channel, legacy-2D fovs) ran display-scoped, so window-relative
+		// 3D and the rig's rotation pivot were wrong (#396 W7 dogfood).
+		memset(out_metrics, 0, sizeof(*out_metrics));
+
+		// Shared-texture (texture-app) sessions carry the app's window in
+		// app_hwnd (c->hwnd stays null); u_canvas_apply_to_metrics below
+		// rewrites the result to the canvas sub-rect.
+		HWND metrics_hwnd = c->hwnd != nullptr ? c->hwnd : c->app_hwnd;
+		if (c->display_processor == nullptr || metrics_hwnd == nullptr) {
+			return false;
+		}
+
+		uint32_t disp_px_w = 0, disp_px_h = 0;
+		int32_t disp_left = 0, disp_top = 0;
+		if (!xrt_display_processor_d3d12_get_display_pixel_info(
+		        c->display_processor, &disp_px_w, &disp_px_h, &disp_left, &disp_top)) {
+			return false;
+		}
+		if (disp_px_w == 0 || disp_px_h == 0) {
+			return false;
+		}
+
+		float disp_w_m = 0.0f, disp_h_m = 0.0f;
+		if (!xrt_display_processor_d3d12_get_display_dimensions(
+		        c->display_processor, &disp_w_m, &disp_h_m)) {
+			return false;
+		}
+
+		RECT rect;
+		if (!GetClientRect(metrics_hwnd, &rect)) {
+			return false;
+		}
+		uint32_t win_px_w = static_cast<uint32_t>(rect.right - rect.left);
+		uint32_t win_px_h = static_cast<uint32_t>(rect.bottom - rect.top);
+		if (win_px_w == 0 || win_px_h == 0) {
+			return false;
+		}
+
+		POINT client_origin = {0, 0};
+		ClientToScreen(metrics_hwnd, &client_origin);
+
+		float pixel_size_x = disp_w_m / (float)disp_px_w;
+		float pixel_size_y = disp_h_m / (float)disp_px_h;
+
+		float win_w_m = (float)win_px_w * pixel_size_x;
+		float win_h_m = (float)win_px_h * pixel_size_y;
+
+		float win_center_px_x = (float)(client_origin.x - disp_left) + (float)win_px_w / 2.0f;
+		float win_center_px_y = (float)(client_origin.y - disp_top) + (float)win_px_h / 2.0f;
+		float disp_center_px_x = (float)disp_px_w / 2.0f;
+		float disp_center_px_y = (float)disp_px_h / 2.0f;
+
+		// X: +right (screen and eye coords agree). Y: negated (screen
+		// Y-down, eye Y-up).
+		float offset_x_m = (win_center_px_x - disp_center_px_x) * pixel_size_x;
+		float offset_y_m = -((win_center_px_y - disp_center_px_y) * pixel_size_y);
+
+		out_metrics->display_width_m = disp_w_m;
+		out_metrics->display_height_m = disp_h_m;
+		out_metrics->display_pixel_width = disp_px_w;
+		out_metrics->display_pixel_height = disp_px_h;
+		out_metrics->display_screen_left = disp_left;
+		out_metrics->display_screen_top = disp_top;
+
+		out_metrics->window_pixel_width = win_px_w;
+		out_metrics->window_pixel_height = win_px_h;
+		out_metrics->window_screen_left = static_cast<int32_t>(client_origin.x);
+		out_metrics->window_screen_top = static_cast<int32_t>(client_origin.y);
+
+		out_metrics->window_width_m = win_w_m;
+		out_metrics->window_height_m = win_h_m;
+		out_metrics->window_center_offset_x_m = offset_x_m;
+		out_metrics->window_center_offset_y_m = offset_y_m;
+
+		out_metrics->valid = true;
 	}
-	return ok;
+
+	// #439 Phase 2: the active zone mask supersedes the canvas — the
+	// Kooima/adaptive-FOV metrics follow the same authority as the
+	// weave region. (This path doesn't take c->mutex; the canvas/mask
+	// fields are pointer-sized reads updated under the lock in another
+	// function — the pointer check in d3d12_effective_canvas is benign.)
+	const struct u_canvas_rect eff_canvas = d3d12_effective_canvas(c);
+	u_canvas_apply_to_metrics(out_metrics, &eff_canvas);
+
+	return true;
 }
 
 extern "C" bool

--- a/test_apps/cube_handle_d3d11_win/main.cpp
+++ b/test_apps/cube_handle_d3d11_win/main.cpp
@@ -20,9 +20,7 @@
 #include "text_overlay.h"
 #include "hud_renderer.h"
 #include "xr_session.h"
-#include "display3d_view.h"
 #include "projection_depth.h"
-#include "camera3d_view.h"
 #include "atlas_capture.h"
 
 #include <chrono>
@@ -58,13 +56,16 @@ static bool g_fullscreen = false;
 static RECT g_savedWindowRect = {};
 static DWORD g_savedWindowStyle = 0;
 
-// XR_EXT_view_rig (#396 W7) verify hook: R toggles between the app-side
-// Kooima block (default, today's path) and the runtime rig — chain
-// XrCameraRigEXT on xrLocateViews and consume the runtime's render-ready
-// XrView{pose, fov} directly. Also chains XrViewDisplayRawEXT and one-shot
-// logs the raw inputs as a cross-check against the app's own locate data.
-static bool g_useRuntimeRig = false;
-static bool g_rigRawLogged = false;
+// XR_EXT_view_rig (#396 W7 dogfood): the app chains a rig descriptor on every
+// xrLocateViews and consumes the runtime's render-ready XrView{pose, fov}
+// directly — the per-frame Kooima generation (display3d_resolve_window_rect +
+// *_compute_views) is deleted; only clip policy stays app-side. Per-view
+// staging container for the consumed views (matrices column-major):
+struct RigView {
+    float view_matrix[16];
+    float projection_matrix[16];
+    XrFovf fov;
+};
 
 // Column-major view matrix from a render-ready XrView pose:
 // viewMatrix = R^T * translate(-position) — same construction as the
@@ -110,6 +111,24 @@ static void ProjectionFromXrFov(const XrFovf& fov, float nearZ, float farZ, floa
     out[10] = -(farZ + nearZ) / (farZ - nearZ);
     out[11] = -1.0f;
     out[14] = -2.0f * farZ * nearZ / (farZ - nearZ);
+}
+
+// Display-local eye distance for the ZDP-anchored clip: z of (rigPose^-1 *
+// eyeWorld). The display rig places the virtual display plane at the rig
+// pose, so the eye's distance to that plane is the rig-local z — NOT
+// pose.position.z once the player flies (non-identity rig pose). Degenerates
+// to pose.position.z at identity.
+static float RigLocalEyeZ(const XrPosef& rig, const XrVector3f& eyeWorld) {
+    const float dx = eyeWorld.x - rig.position.x;
+    const float dy = eyeWorld.y - rig.position.y;
+    const float dz = eyeWorld.z - rig.position.z;
+    // Rotate the delta by the conjugate quaternion (inverse rotation).
+    const float qx = -rig.orientation.x, qy = -rig.orientation.y;
+    const float qz = -rig.orientation.z, qw = rig.orientation.w;
+    // v' = v + 2*q_vec x (q_vec x v + qw*v); we only need the z component.
+    const float cx = qy * dz - qz * dy + qw * dx;
+    const float cy = qz * dx - qx * dz + qw * dy;
+    return dz + 2.0f * (qx * cy - qy * cx);
 }
 
 // Forward declaration — defined after PerformanceStats
@@ -210,19 +229,6 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
     case WM_KEYDOWN:
         if (wParam == VK_ESCAPE) {
             PostMessage(hwnd, WM_CLOSE, 0, 0);
-            return 0;
-        }
-        // XR_EXT_view_rig verify toggle (app-local; 'R' is unused by the
-        // shared input handler). R A/Bs runtime-rig vs app-side math for
-        // WHICHEVER rig the app is currently in (C still selects the rig):
-        // display-centric -> chain XrDisplayRigEXT, camera-centric -> chain
-        // XrCameraRigEXT, both from the same g_inputState tunables.
-        if (wParam == 'R' && g_hasViewRigExt) {
-            g_useRuntimeRig = !g_useRuntimeRig;
-            g_rigRawLogged = false;
-            LOG_INFO("View rig: %s (%s rig)",
-                     g_useRuntimeRig ? "RUNTIME (XR_EXT_view_rig)" : "APP-SIDE (local Kooima math)",
-                     g_inputState.cameraMode ? "camera" : "display");
             return 0;
         }
         break;
@@ -509,25 +515,27 @@ static void RenderOneFrame(RenderState& rs) {
                     XrView rawViews[8];
                     for (uint32_t vi = 0; vi < 8; vi++) rawViews[vi] = {XR_TYPE_VIEW};
 
-                    // XR_EXT_view_rig (R toggle): drive the runtime rig
-                    // matching the app's current mode (C selects the rig) with
-                    // the SAME app tunables the local Kooima block uses, and
-                    // chain the raw-input result for cross-checking.
-                    const bool runtimeRig = g_useRuntimeRig && g_hasViewRigExt;
-                    const bool runtimeRigCamera = runtimeRig && g_inputState.cameraMode;
+                    // XR_EXT_view_rig (#396 W7): drive the runtime rig matching
+                    // the app's current mode (C selects the rig) with the app's
+                    // tunables — the runtime owns the window/canvas resolve and
+                    // the Kooima math, and returns render-ready XrView{pose, fov}.
+                    // Per-locate semantics: the rig must be chained on every
+                    // consume locate.
+                    const bool useAppProjection =
+                        xr.hasDisplayInfoExt && xr.displayWidthM > 0.0f && g_hasViewRigExt;
+                    const bool rigCamera = useAppProjection && g_inputState.cameraMode;
                     XrCameraRigEXT cameraRig = {XR_TYPE_CAMERA_RIG_EXT};
                     XrDisplayRigEXT displayRig = {XR_TYPE_DISPLAY_RIG_EXT};
-                    XrViewDisplayRawEXT viewRigRaw = {XR_TYPE_VIEW_DISPLAY_RAW_EXT};
-                    if (runtimeRig) {
+                    XrPosef rigPose = {{0, 0, 0, 1}, {0, 0, 0}};
+                    if (useAppProjection) {
                         XMVECTOR rigOri = XMQuaternionRotationRollPitchYaw(
                             g_inputState.pitch, g_inputState.yaw, 0);
                         XMFLOAT4 rq;
                         XMStoreFloat4(&rq, rigOri);
-                        XrPosef rigPose;
                         rigPose.orientation = {rq.x, rq.y, rq.z, rq.w};
                         rigPose.position = {g_inputState.cameraPosX, g_inputState.cameraPosY,
                                             g_inputState.cameraPosZ};
-                        if (runtimeRigCamera) {
+                        if (rigCamera) {
                             cameraRig.pose = rigPose;
                             cameraRig.ipdFactor = g_inputState.viewParams.ipdFactor;
                             cameraRig.parallaxFactor = g_inputState.viewParams.parallaxFactor;
@@ -544,164 +552,38 @@ static void RenderOneFrame(RenderState& rs) {
                             displayRig.perspectiveFactor = g_inputState.viewParams.perspectiveFactor;
                             locateInfo.next = &displayRig;
                         }
-                        viewState.next = &viewRigRaw;
                     }
 
                     xrLocateViews(xr.session, &locateInfo, &viewState, 8, &viewCount, rawViews);
 
-                    // --- App-side Kooima projection (RAW mode, app-owned camera model) ---
                     // Max per-tile capacity from swapchain
                     uint32_t maxTileW = tileColumns > 0 ? xr.swapchain.width / tileColumns : xr.swapchain.width;
                     uint32_t maxTileH = tileRows > 0 ? xr.swapchain.height / tileRows : xr.swapchain.height;
 
-                    std::vector<Display3DView> stereoViews(eyeCount);
-                    bool useAppProjection = (xr.hasDisplayInfoExt && xr.displayWidthM > 0.0f);
-                    if (useAppProjection && runtimeRig) {
-                        // XR_EXT_view_rig path: the runtime ran the rig for us
-                        // — consume render-ready XrView{pose, fov} directly.
+                    std::vector<RigView> stereoViews(eyeCount);
+                    if (useAppProjection) {
+                        // Consume the runtime's render-ready XrView{pose, fov}.
                         // Only clip policy (near/far + the GL→[0,1] depth
-                        // remap) stays app-side, by design. Camera rig: same
-                        // absolute clip as the app's camera path. Display rig:
-                        // the app's ZDP-anchored clip (near = ez - vH, far =
-                        // ez + 1000·vH; ez = eye distance to the virtual
-                        // display plane, which is pose.position.z for the
-                        // identity display pose this app uses).
+                        // remap) stays app-side, by design (fov is
+                        // clip-independent). Camera rig: same absolute clip as
+                        // the old app-side camera path. Display rig: the
+                        // ZDP-anchored clip (near = ez - vH, far = ez +
+                        // 1000·vH; ez = eye distance to the virtual display
+                        // plane = rig-local z of the view pose).
                         const float rigVH =
                             g_inputState.viewParams.virtualDisplayHeight / g_inputState.viewParams.scaleFactor;
                         for (int i = 0; i < eyeCount; i++) {
                             const XrView& v = rawViews[(i < (int)viewCount) ? i : 0];
                             ViewMatrixFromXrPose(v.pose, stereoViews[i].view_matrix);
                             float nearZ = 0.01f, farZ = 100.0f;
-                            if (!runtimeRigCamera) {
-                                float ez = v.pose.position.z;
+                            if (!rigCamera) {
+                                float ez = RigLocalEyeZ(rigPose, v.pose.position);
                                 nearZ = (ez - rigVH > 0.001f) ? (ez - rigVH) : 0.001f;
                                 farZ = ez + 1000.0f * rigVH;
                             }
                             ProjectionFromXrFov(v.fov, nearZ, farZ, stereoViews[i].projection_matrix);
                             convert_projection_gl_to_zero_to_one(stereoViews[i].projection_matrix);
                             stereoViews[i].fov = v.fov;
-                            stereoViews[i].eye_world = v.pose.position;
-                        }
-
-                        // One-shot raw-channel cross-check log.
-                        if (!g_rigRawLogged) {
-                            g_rigRawLogged = true;
-                            LOG_INFO("ViewRig MODE: %s rig", runtimeRigCamera ? "camera" : "display");
-                            LOG_INFO("ViewRig RAW: eyes=%u [0]=(%.4f,%.4f,%.4f) [1]=(%.4f,%.4f,%.4f) "
-                                     "canvas=(%d,%d %dx%d) %.4fx%.4fm sampleNs=%lld tracking=%d",
-                                     viewRigRaw.eyeCountOutput,
-                                     viewRigRaw.rawEyes[0].x, viewRigRaw.rawEyes[0].y, viewRigRaw.rawEyes[0].z,
-                                     viewRigRaw.rawEyes[1].x, viewRigRaw.rawEyes[1].y, viewRigRaw.rawEyes[1].z,
-                                     viewRigRaw.canvasRectPx.offset.x, viewRigRaw.canvasRectPx.offset.y,
-                                     viewRigRaw.canvasRectPx.extent.width, viewRigRaw.canvasRectPx.extent.height,
-                                     viewRigRaw.canvasSizeMeters.width, viewRigRaw.canvasSizeMeters.height,
-                                     (long long)viewRigRaw.sampleTimeNs, (int)viewRigRaw.isTracking);
-                            LOG_INFO("ViewRig VIEW[0]: pos=(%.4f,%.4f,%.4f) fov L=%.4f R=%.4f U=%.4f D=%.4f",
-                                     rawViews[0].pose.position.x, rawViews[0].pose.position.y,
-                                     rawViews[0].pose.position.z, rawViews[0].fov.angleLeft,
-                                     rawViews[0].fov.angleRight, rawViews[0].fov.angleUp,
-                                     rawViews[0].fov.angleDown);
-                        }
-                    } else if (useAppProjection) {
-                        // Window-relative Kooima: the window's placement on the
-                        // display + raw eyes -> Kooima screen dims + window-relative
-                        // eyes, via the shared displayxr::math helper (#396 Layer 1).
-                        // The platform rect-fetch (ClientToScreen/MonitorInfo) stays
-                        // here; the px-size / screen / offset / Y-flip math is in the lib.
-                        Display3DWindowPlacement place;
-                        place.display_width_m   = xr.displayWidthM;
-                        place.display_height_m  = xr.displayHeightM;
-                        place.display_width_px  = (float)xr.swapchain.width;   // fallback
-                        place.display_height_px = (float)xr.swapchain.height;
-                        place.rect_width_px     = (float)g_windowWidth;
-                        place.rect_height_px    = (float)g_windowHeight;
-                        place.rect_center_x_px  = place.display_width_px * 0.5f;  // fallback: centered
-                        place.rect_center_y_px  = place.display_height_px * 0.5f;
-                        {
-                            POINT clientOrigin = {0, 0};
-                            ClientToScreen(rs.hwnd, &clientOrigin);
-                            HMONITOR hMon = MonitorFromWindow(rs.hwnd, MONITOR_DEFAULTTONEAREST);
-                            MONITORINFO mi = {sizeof(mi)};
-                            if (GetMonitorInfo(hMon, &mi)) {
-                                place.display_width_px  = (float)(mi.rcMonitor.right - mi.rcMonitor.left);
-                                place.display_height_px = (float)(mi.rcMonitor.bottom - mi.rcMonitor.top);
-                                place.rect_center_x_px  = (float)(clientOrigin.x - mi.rcMonitor.left) + g_windowWidth / 2.0f;
-                                place.rect_center_y_px  = (float)(clientOrigin.y - mi.rcMonitor.top) + g_windowHeight / 2.0f;
-                            }
-                        }
-
-                        // Gather raw (unshifted) per-view eyes, then resolve to screen
-                        // dims + window-relative eyes (in place).
-                        std::vector<XrVector3f> rawEyes(eyeCount);
-                        for (int v = 0; v < eyeCount; v++) {
-                            rawEyes[v] = (v < (int)viewCount) ? rawViews[v].pose.position : rawViews[0].pose.position;
-                        }
-                        Display3DScreen screen;
-                        display3d_resolve_window_rect(&place, rawEyes.data(), (uint32_t)eyeCount, &screen, rawEyes.data());
-
-                        // For mono: average all views to center eye
-                        if (monoMode) {
-                            XrVector3f center = {0.0f, 0.0f, 0.0f};
-                            for (int v = 0; v < (int)viewCount && v < eyeCount; v++) {
-                                center.x += rawEyes[v].x;
-                                center.y += rawEyes[v].y;
-                                center.z += rawEyes[v].z;
-                            }
-                            int cnt = (eyeCount < (int)viewCount) ? eyeCount : (int)viewCount;
-                            if (cnt < 1) cnt = 1;
-                            center.x /= cnt; center.y /= cnt; center.z /= cnt;
-                            rawEyes[0] = center;
-                        }
-
-                        // Build camera/display pose from player yaw/pitch/position
-                        XrPosef cameraPose;
-                        XMVECTOR pOri = XMQuaternionRotationRollPitchYaw(
-                            g_inputState.pitch, g_inputState.yaw, 0);
-                        XMFLOAT4 q;
-                        XMStoreFloat4(&q, pOri);
-                        cameraPose.orientation = {q.x, q.y, q.z, q.w};
-                        cameraPose.position = {g_inputState.cameraPosX, g_inputState.cameraPosY, g_inputState.cameraPosZ};
-
-                        XrVector3f nominalViewer = {xr.nominalViewerX, xr.nominalViewerY, xr.nominalViewerZ};
-
-                        if (g_inputState.cameraMode) {
-                            // Camera-centric path
-                            Camera3DTunables camTunables;
-                            camTunables.ipd_factor = g_inputState.viewParams.ipdFactor;
-                            camTunables.parallax_factor = g_inputState.viewParams.parallaxFactor;
-                            camTunables.inv_convergence_distance = g_inputState.viewParams.invConvergenceDistance;
-                            camTunables.half_tan_vfov = CAMERA_HALF_TAN_VFOV / g_inputState.viewParams.zoomFactor;
-
-                            std::vector<Camera3DView> camViews(eyeCount);
-                            camera3d_compute_views(
-                                rawEyes.data(), eyeCount, &nominalViewer,
-                                &screen, &camTunables, &cameraPose,
-                                0.01f, 100.0f, camViews.data());
-
-                            // Copy into Display3DView for uniform downstream rendering
-                            for (int i = 0; i < eyeCount; i++) {
-                                memcpy(stereoViews[i].view_matrix, camViews[i].view_matrix, sizeof(float) * 16);
-                                memcpy(stereoViews[i].projection_matrix, camViews[i].projection_matrix, sizeof(float) * 16);
-                                stereoViews[i].fov = camViews[i].fov;
-                                stereoViews[i].eye_world = camViews[i].eye_world;
-                            }
-                        } else {
-                            // Display-centric path
-                            Display3DTunables tunables;
-                            tunables.ipd_factor = g_inputState.viewParams.ipdFactor;
-                            tunables.parallax_factor = g_inputState.viewParams.parallaxFactor;
-                            tunables.perspective_factor = g_inputState.viewParams.perspectiveFactor;
-                            tunables.virtual_display_height = g_inputState.viewParams.virtualDisplayHeight / g_inputState.viewParams.scaleFactor;
-
-                            display3d_compute_views(
-                                rawEyes.data(), eyeCount, &nominalViewer,
-                                &screen, &tunables, &cameraPose,
-                                tunables.virtual_display_height, 1000.0f * tunables.virtual_display_height, /*vulkan_flip_y=*/0, stereoViews.data());
-                            // display3d emits a GL ([-1,1] clip-z) projection; D3D clips [0,1].
-                            // Remap depth on the 3D per-view projections (not the mono/legacy
-                            // xr.projMatrices path). [#396 W1]
-                            for (uint32_t _v = 0; _v < eyeCount; _v++)
-                                convert_projection_gl_to_zero_to_one(stereoViews[_v].projection_matrix);
                         }
                     }
 
@@ -721,13 +603,11 @@ static void RenderOneFrame(RenderState& rs) {
                             modeText += g_inputState.cameraMode ?
                                 L"\nKooima: Camera-Centric [C=Toggle]" :
                                 L"\nKooima: Display-Centric [C=Toggle]";
-                            if (g_hasViewRigExt) {
-                                modeText += g_useRuntimeRig ?
-                                    (g_inputState.cameraMode ?
-                                        L"\nView rig: RUNTIME camera rig [R=Toggle]" :
-                                        L"\nView rig: RUNTIME display rig [R=Toggle]") :
-                                    L"\nView rig: app-side math [R=Toggle]";
-                            }
+                            modeText += g_hasViewRigExt ?
+                                (g_inputState.cameraMode ?
+                                    L"\nView rig: RUNTIME camera rig (XR_EXT_view_rig)" :
+                                    L"\nView rig: RUNTIME display rig (XR_EXT_view_rig)") :
+                                L"\nView rig: unavailable (legacy views)";
 
                             // Dynamic render dims matching the actual viewport computation
                             bool dispMonoMode = (xr.renderingModeCount > 0 && !xr.renderingModeDisplay3D[xr.currentModeIndex]);
@@ -821,7 +701,7 @@ static void RenderOneFrame(RenderState& rs) {
                         monoPose.position.z /= cnt;
 
                         // When useAppProjection, mono view+proj come from stereoViews[0]
-                        // (library was called with center eye as both L/R above).
+                        // (the runtime centers the rig view poses in 2D mode).
                         // Only need fallback when !useAppProjection.
                         if (!useAppProjection) {
                             monoProjMatrix = xr.projMatrices[0];  // Close enough for 2D

--- a/test_apps/cube_handle_d3d12_win/main.cpp
+++ b/test_apps/cube_handle_d3d12_win/main.cpp
@@ -18,7 +18,6 @@
 #include "d3d12_renderer.h"
 #include "hud_renderer.h"
 #include "text_overlay.h"
-#include "display3d_view.h"
 #include "projection_depth.h"
 #include "atlas_capture.h"
 
@@ -59,6 +58,74 @@ static UINT g_windowHeight = 720;
 static bool g_fullscreen = false;
 static RECT g_savedWindowRect = {};
 static DWORD g_savedWindowStyle = 0;
+
+// XR_EXT_view_rig (#396 W7 dogfood): the app chains XrDisplayRigEXT on every
+// xrLocateViews and consumes the runtime's render-ready XrView{pose, fov}
+// directly — the per-frame Kooima generation is deleted; only clip policy
+// stays app-side. Per-view staging container (matrices column-major):
+struct RigView {
+    float view_matrix[16];
+    float projection_matrix[16];
+    XrFovf fov;
+};
+
+// Column-major view matrix from a render-ready XrView pose:
+// viewMatrix = R^T * translate(-position) — same construction as the
+// displayxr::math rigs.
+static void ViewMatrixFromXrPose(const XrPosef& pose, float* out) {
+    const float qx = pose.orientation.x, qy = pose.orientation.y;
+    const float qz = pose.orientation.z, qw = pose.orientation.w;
+    float rot[16] = {};
+    rot[0] = 1.0f - 2.0f * (qy * qy + qz * qz);
+    rot[1] = 2.0f * (qx * qy + qz * qw);
+    rot[2] = 2.0f * (qx * qz - qy * qw);
+    rot[4] = 2.0f * (qx * qy - qz * qw);
+    rot[5] = 1.0f - 2.0f * (qx * qx + qz * qz);
+    rot[6] = 2.0f * (qy * qz + qx * qw);
+    rot[8] = 2.0f * (qx * qz + qy * qw);
+    rot[9] = 2.0f * (qy * qz - qx * qw);
+    rot[10] = 1.0f - 2.0f * (qx * qx + qy * qy);
+    rot[15] = 1.0f;
+    for (int i = 0; i < 16; i++) out[i] = 0.0f;
+    for (int i = 0; i < 3; i++)
+        for (int j = 0; j < 3; j++)
+            out[j * 4 + i] = rot[i * 4 + j]; // R^T
+    out[15] = 1.0f;
+    out[12] = -(out[0] * pose.position.x + out[4] * pose.position.y + out[8] * pose.position.z);
+    out[13] = -(out[1] * pose.position.x + out[5] * pose.position.y + out[9] * pose.position.z);
+    out[14] = -(out[2] * pose.position.x + out[6] * pose.position.y + out[10] * pose.position.z);
+}
+
+// Column-major GL ([-1,1] clip-z) off-axis projection from a render-ready
+// XrView fov + the app's own clip policy (fov is clip-independent). Pair with
+// convert_projection_gl_to_zero_to_one() for D3D.
+static void ProjectionFromXrFov(const XrFovf& fov, float nearZ, float farZ, float* out) {
+    const float l = tanf(fov.angleLeft) * nearZ;
+    const float r = tanf(fov.angleRight) * nearZ;
+    const float b = tanf(fov.angleDown) * nearZ;
+    const float t = tanf(fov.angleUp) * nearZ;
+    for (int i = 0; i < 16; i++) out[i] = 0.0f;
+    out[0] = 2.0f * nearZ / (r - l);
+    out[5] = 2.0f * nearZ / (t - b);
+    out[8] = (r + l) / (r - l);
+    out[9] = (t + b) / (t - b);
+    out[10] = -(farZ + nearZ) / (farZ - nearZ);
+    out[11] = -1.0f;
+    out[14] = -2.0f * farZ * nearZ / (farZ - nearZ);
+}
+
+// Display-local eye distance for the ZDP-anchored clip: z of (rigPose^-1 *
+// eyeWorld). Degenerates to pose.position.z at identity rig pose.
+static float RigLocalEyeZ(const XrPosef& rig, const XrVector3f& eyeWorld) {
+    const float dx = eyeWorld.x - rig.position.x;
+    const float dy = eyeWorld.y - rig.position.y;
+    const float dz = eyeWorld.z - rig.position.z;
+    const float qx = -rig.orientation.x, qy = -rig.orientation.y;
+    const float qz = -rig.orientation.z, qw = rig.orientation.w;
+    const float cx = qy * dz - qz * dy + qw * dx;
+    const float cy = qz * dx - qx * dz + qw * dy;
+    return dz + 2.0f * (qx * cy - qy * cx);
+}
 
 // Toggle fullscreen mode for the app window
 static void ToggleFullscreen(HWND hwnd) {
@@ -349,6 +416,32 @@ static void RenderThreadFunc(
                         uint32_t viewCount = 8;
                         XrView rawViews[8];
                         for (uint32_t vi = 0; vi < 8; vi++) rawViews[vi] = {XR_TYPE_VIEW};
+
+                        // XR_EXT_view_rig (#396 W7): drive the runtime display
+                        // rig with the app's tunables — the runtime owns the
+                        // window resolve and the Kooima math, and returns
+                        // render-ready XrView{pose, fov}. Per-locate semantics:
+                        // chain the rig on every consume locate.
+                        const bool useAppProjection =
+                            xr->hasDisplayInfoExt && xr->displayWidthM > 0.0f && g_hasViewRigExt;
+                        XrDisplayRigEXT displayRig = {XR_TYPE_DISPLAY_RIG_EXT};
+                        XrPosef rigPose = {{0, 0, 0, 1}, {0, 0, 0}};
+                        if (useAppProjection) {
+                            XMVECTOR rigOri = XMQuaternionRotationRollPitchYaw(
+                                inputSnapshot.pitch, inputSnapshot.yaw, 0);
+                            XMFLOAT4 rq;
+                            XMStoreFloat4(&rq, rigOri);
+                            rigPose.orientation = {rq.x, rq.y, rq.z, rq.w};
+                            rigPose.position = {inputSnapshot.cameraPosX, inputSnapshot.cameraPosY,
+                                                inputSnapshot.cameraPosZ};
+                            displayRig.pose = rigPose;
+                            displayRig.virtualDisplayHeight =
+                                inputSnapshot.viewParams.virtualDisplayHeight / inputSnapshot.viewParams.scaleFactor;
+                            displayRig.ipdFactor = inputSnapshot.viewParams.ipdFactor;
+                            displayRig.parallaxFactor = inputSnapshot.viewParams.parallaxFactor;
+                            displayRig.perspectiveFactor = inputSnapshot.viewParams.perspectiveFactor;
+                            locateInfo.next = &displayRig;
+                        }
                         xrLocateViews(xr->session, &locateInfo, &viewState, 8, &viewCount, rawViews);
 
                         // Max per-tile capacity from swapchain
@@ -369,81 +462,25 @@ static void RenderThreadFunc(
                             if (renderH > maxTileH) renderH = maxTileH;
                         }
 
-                        // --- App-side Kooima via canonical library ---
-                        std::vector<Display3DView> stereoViews(eyeCount);
-                        bool useAppProjection = (xr->hasDisplayInfoExt && xr->displayWidthM > 0.0f);
+                        // --- Consume the runtime's render-ready XrView{pose, fov} ---
+                        // Only clip policy (near/far + the GL→[0,1] depth remap)
+                        // stays app-side, by design (fov is clip-independent).
+                        // ZDP-anchored clip: near = ez - vH, far = ez + 1000·vH;
+                        // ez = rig-local z of the view pose.
+                        std::vector<RigView> stereoViews(eyeCount);
                         if (useAppProjection) {
-                            float dispPxW = xr->displayPixelWidth > 0 ? (float)xr->displayPixelWidth : (float)xr->swapchain.width;
-                            float dispPxH = xr->displayPixelHeight > 0 ? (float)xr->displayPixelHeight : (float)xr->swapchain.height;
-                            float pxSizeX = xr->displayWidthM / dispPxW;
-                            float pxSizeY = xr->displayHeightM / dispPxH;
-                            float winW_m = (float)windowW * pxSizeX;
-                            float winH_m = (float)windowH * pxSizeY;
-
-                            // Window-relative Kooima: compute eye offset from window center
-                            float eyeOffsetX = 0.0f, eyeOffsetY = 0.0f;
-                            {
-                                POINT clientOrigin = {0, 0};
-                                ClientToScreen(hwnd, &clientOrigin);
-                                HMONITOR hMon = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
-                                MONITORINFO mi = {sizeof(mi)};
-                                if (GetMonitorInfo(hMon, &mi)) {
-                                    float winCenterX = (float)(clientOrigin.x - mi.rcMonitor.left) + windowW / 2.0f;
-                                    float winCenterY = (float)(clientOrigin.y - mi.rcMonitor.top) + windowH / 2.0f;
-                                    float dispW = (float)(mi.rcMonitor.right - mi.rcMonitor.left);
-                                    float dispH = (float)(mi.rcMonitor.bottom - mi.rcMonitor.top);
-                                    eyeOffsetX = (winCenterX - dispW / 2.0f) * pxSizeX;
-                                    eyeOffsetY = -((winCenterY - dispH / 2.0f) * pxSizeY);
-                                }
+                            const float rigVH =
+                                inputSnapshot.viewParams.virtualDisplayHeight / inputSnapshot.viewParams.scaleFactor;
+                            for (int i = 0; i < eyeCount; i++) {
+                                const XrView& v = rawViews[(i < (int)viewCount) ? i : 0];
+                                ViewMatrixFromXrPose(v.pose, stereoViews[i].view_matrix);
+                                float ez = RigLocalEyeZ(rigPose, v.pose.position);
+                                float nearZ = (ez - rigVH > 0.001f) ? (ez - rigVH) : 0.001f;
+                                float farZ = ez + 1000.0f * rigVH;
+                                ProjectionFromXrFov(v.fov, nearZ, farZ, stereoViews[i].projection_matrix);
+                                convert_projection_gl_to_zero_to_one(stereoViews[i].projection_matrix);
+                                stereoViews[i].fov = v.fov;
                             }
-
-                            // Build per-view eye positions (shifted to window center)
-                            std::vector<XrVector3f> rawEyes(eyeCount);
-                            for (int v = 0; v < eyeCount; v++) {
-                                XrVector3f pos = (v < (int)viewCount) ? rawViews[v].pose.position : rawViews[0].pose.position;
-                                rawEyes[v] = {pos.x - eyeOffsetX, pos.y - eyeOffsetY, pos.z};
-                            }
-
-                            // For mono: average all views to center eye
-                            if (monoMode) {
-                                XrVector3f center = {0.0f, 0.0f, 0.0f};
-                                for (int v = 0; v < (int)viewCount && v < eyeCount; v++) {
-                                    center.x += rawEyes[v].x;
-                                    center.y += rawEyes[v].y;
-                                    center.z += rawEyes[v].z;
-                                }
-                                int cnt = (eyeCount < (int)viewCount) ? eyeCount : (int)viewCount;
-                                if (cnt < 1) cnt = 1;
-                                center.x /= cnt; center.y /= cnt; center.z /= cnt;
-                                rawEyes[0] = center;
-                            }
-
-                            Display3DTunables tunables;
-                            tunables.ipd_factor = inputSnapshot.viewParams.ipdFactor;
-                            tunables.parallax_factor = inputSnapshot.viewParams.parallaxFactor;
-                            tunables.perspective_factor = inputSnapshot.viewParams.perspectiveFactor;
-                            tunables.virtual_display_height = inputSnapshot.viewParams.virtualDisplayHeight / inputSnapshot.viewParams.scaleFactor;
-
-                            XrPosef displayPose;
-                            XMVECTOR pOri = XMQuaternionRotationRollPitchYaw(
-                                inputSnapshot.pitch, inputSnapshot.yaw, 0);
-                            XMFLOAT4 q;
-                            XMStoreFloat4(&q, pOri);
-                            displayPose.orientation = {q.x, q.y, q.z, q.w};
-                            displayPose.position = {inputSnapshot.cameraPosX, inputSnapshot.cameraPosY, inputSnapshot.cameraPosZ};
-
-                            XrVector3f nominalViewer = {xr->nominalViewerX, xr->nominalViewerY, xr->nominalViewerZ};
-                            Display3DScreen screen = {winW_m, winH_m};
-
-                            display3d_compute_views(
-                                rawEyes.data(), eyeCount, &nominalViewer,
-                                &screen, &tunables, &displayPose,
-                                tunables.virtual_display_height, 1000.0f * tunables.virtual_display_height, /*vulkan_flip_y=*/0, stereoViews.data());
-                            // display3d emits a GL ([-1,1] clip-z) projection; D3D clips [0,1].
-                            // Remap depth on the 3D per-view projections (not the mono/legacy
-                            // xr.projMatrices path). [#396 W1]
-                            for (uint32_t _v = 0; _v < eyeCount; _v++)
-                                convert_projection_gl_to_zero_to_one(stereoViews[_v].projection_matrix);
                         }
 
                         rendered = true;

--- a/test_apps/cube_handle_d3d12_win/xr_session.cpp
+++ b/test_apps/cube_handle_d3d12_win/xr_session.cpp
@@ -9,6 +9,8 @@
 #include "logging.h"
 #include <cstring>
 
+bool g_hasViewRigExt = false;
+
 #define XR_CHECK(call) \
     do { \
         XrResult result = (call); \
@@ -84,12 +86,16 @@ bool InitializeOpenXR(XrSessionManager& xr) {
         if (strcmp(ext.extensionName, XR_EXT_MCP_TOOLS_EXTENSION_NAME) == 0) {
             xr.hasMcpToolsExt = true;
         }
+        if (strcmp(ext.extensionName, XR_EXT_VIEW_RIG_EXTENSION_NAME) == 0) {
+            g_hasViewRigExt = true;
+        }
     }
 
     LOG_INFO("XR_KHR_D3D12_enable: %s", hasD3D12 ? "AVAILABLE" : "NOT FOUND");
     LOG_INFO("XR_EXT_win32_window_binding: %s", xr.hasWin32WindowBindingExt ? "AVAILABLE" : "NOT FOUND");
     LOG_INFO("XR_EXT_display_info: %s", xr.hasDisplayInfoExt ? "AVAILABLE" : "NOT FOUND");
     LOG_INFO("XR_EXT_mcp_tools: %s", xr.hasMcpToolsExt ? "AVAILABLE" : "NOT FOUND");
+    LOG_INFO("XR_EXT_view_rig: %s", g_hasViewRigExt ? "AVAILABLE" : "NOT FOUND");
 
     if (!hasD3D12) {
         LOG_ERROR("XR_KHR_D3D12_enable extension not available - cannot continue");
@@ -109,6 +115,9 @@ bool InitializeOpenXR(XrSessionManager& xr) {
     }
     if (xr.hasMcpToolsExt) {
         enabledExtensions.push_back(XR_EXT_MCP_TOOLS_EXTENSION_NAME);
+    }
+    if (g_hasViewRigExt) {
+        enabledExtensions.push_back(XR_EXT_VIEW_RIG_EXTENSION_NAME);
     }
 
     LOG_INFO("Enabling %zu extensions", enabledExtensions.size());

--- a/test_apps/cube_handle_d3d12_win/xr_session.h
+++ b/test_apps/cube_handle_d3d12_win/xr_session.h
@@ -11,6 +11,12 @@
 #include <dxgi1_6.h>
 #define XR_USE_GRAPHICS_API_D3D12
 #include "xr_session_common.h"
+#include <openxr/XR_EXT_view_rig.h>
+
+// XR_EXT_view_rig (#396 W7) available + enabled on the instance. App-local
+// (not on the shared XrSessionManager); promote to xr_session_common when
+// more consumers adopt it.
+extern bool g_hasViewRigExt;
 
 // Initialize OpenXR instance with D3D12 + win32_window_binding extensions
 bool InitializeOpenXR(XrSessionManager& xr);

--- a/test_apps/cube_handle_gl_macos/main.mm
+++ b/test_apps/cube_handle_gl_macos/main.mm
@@ -39,14 +39,13 @@
 
 // stb_image implementation TU lives in displayxr::common (stb_image_impl_macos.cpp) — declarations only here (#396 W4).
 #include "stb_image.h"
-#include "display3d_view.h"
-#include "camera3d_view.h"
 #include "view_params.h"
 #include "atlas_capture.h"
 #include "xr_window_space_hud.h"
 #include "hud_renderer_macos.h"
 #include <openxr/XR_EXT_display_info.h>
 #include <openxr/XR_EXT_atlas_capture.h>
+#include <openxr/XR_EXT_view_rig.h>
 
 // ============================================================================
 // Logging
@@ -170,6 +169,21 @@ static void quat_rotate_vec3(XrQuaternionf q, float vx, float vy, float vz,
     *ox = vx + q.w * tx + (q.y * tz - q.z * ty);
     *oy = vy + q.w * ty + (q.z * tx - q.x * tz);
     *oz = vz + q.w * tz + (q.x * ty - q.y * tx);
+}
+
+// Display-local eye distance for the ZDP-anchored clip (#396 W7 consume
+// path): z of (rigPose^-1 * eyeWorld). Degenerates to pose.position.z at
+// identity rig pose.
+static float RigLocalEyeZ(const XrPosef &rig, const XrVector3f &eyeWorld) {
+    XrQuaternionf inv = {-rig.orientation.x, -rig.orientation.y,
+                         -rig.orientation.z, rig.orientation.w};
+    float ox, oy, oz;
+    quat_rotate_vec3(inv,
+                     eyeWorld.x - rig.position.x,
+                     eyeWorld.y - rig.position.y,
+                     eyeWorld.z - rig.position.z,
+                     &ox, &oy, &oz);
+    return oz;
 }
 
 // ============================================================================
@@ -1087,6 +1101,7 @@ struct AppXrSession {
 
     // XR_EXT_atlas_capture (W6 of #396): runtime-owned 'I'-key atlas capture.
     bool hasAtlasCaptureExt = false;
+    bool hasViewRigExt = false;  // XR_EXT_view_rig (#396 W7)
     PFN_xrCaptureAtlasEXT pfnCaptureAtlasEXT = nullptr;
     // Enumerated rendering mode info. currentModeIndex is initialized to mode 1
     // as a fallback for runtimes that don't expose isActive; v13+ runtimes
@@ -1139,6 +1154,8 @@ static bool InitializeOpenXR(AppXrSession &app)
             app.hasDisplayInfoExt = true;
         if (strcmp(e.extensionName, XR_EXT_ATLAS_CAPTURE_EXTENSION_NAME) == 0)
             app.hasAtlasCaptureExt = true;
+        if (strcmp(e.extensionName, XR_EXT_VIEW_RIG_EXTENSION_NAME) == 0)
+            app.hasViewRigExt = true;
     }
 
     if (!app.hasMacosGlBinding) {
@@ -1150,6 +1167,7 @@ static bool InitializeOpenXR(AppXrSession &app)
     }
     LOG_INFO("XR_EXT_display_info: %s", app.hasDisplayInfoExt ? "available" : "not available");
     LOG_INFO("XR_EXT_atlas_capture: %s", app.hasAtlasCaptureExt ? "available" : "not available");
+    LOG_INFO("XR_EXT_view_rig: %s", app.hasViewRigExt ? "AVAILABLE" : "NOT FOUND");
 
     // Enable extensions
     std::vector<const char *> enabledExts = {XR_EXT_MACOS_GL_BINDING_EXTENSION_NAME};
@@ -1164,6 +1182,9 @@ static bool InitializeOpenXR(AppXrSession &app)
     }
     if (app.hasAtlasCaptureExt) {
         enabledExts.push_back(XR_EXT_ATLAS_CAPTURE_EXTENSION_NAME);
+    }
+    if (app.hasViewRigExt) {
+        enabledExts.push_back(XR_EXT_VIEW_RIG_EXTENSION_NAME);
     }
 
     XrInstanceCreateInfo createInfo = {XR_TYPE_INSTANCE_CREATE_INFO};
@@ -1660,6 +1681,43 @@ int main(int argc, char **argv)
         locateInfo.displayTime = frameState.predictedDisplayTime;
         locateInfo.space = app.localSpace;
 
+        // XR_EXT_view_rig (#396 W7): drive the runtime rig matching the app's
+        // current mode (C selects the rig) with the app's tunables — the
+        // runtime owns the window resolve and the Kooima math, and returns
+        // render-ready XrView{pose, fov}. Per-locate semantics: chain the rig
+        // on every consume locate. The raw result struct feeds the HUD's
+        // display-space eye readout (under the rig, views[] carries world
+        // eyes, not raw display eyes).
+        const bool useRig =
+            app.hasViewRigExt && app.displayWidthM > 0 && app.displayHeightM > 0;
+        const bool rigCamera = useRig && g_input.cameraMode;
+        XrCameraRigEXT cameraRig = {XR_TYPE_CAMERA_RIG_EXT};
+        XrDisplayRigEXT displayRig = {XR_TYPE_DISPLAY_RIG_EXT};
+        XrViewDisplayRawEXT viewRigRaw = {XR_TYPE_VIEW_DISPLAY_RAW_EXT};
+        XrPosef rigPose = {{0, 0, 0, 1}, {0, 0, 0}};
+        if (useRig) {
+            quat_from_yaw_pitch(g_input.yaw, g_input.pitch, &rigPose.orientation);
+            rigPose.position = {g_input.cameraPosX, g_input.cameraPosY, g_input.cameraPosZ};
+            if (rigCamera) {
+                cameraRig.pose = rigPose;
+                cameraRig.ipdFactor = g_input.viewParams.ipdFactor;
+                cameraRig.parallaxFactor = g_input.viewParams.parallaxFactor;
+                cameraRig.convergenceDiopters = g_input.viewParams.invConvergenceDistance;
+                cameraRig.verticalFov =
+                    2.0f * atanf(CAMERA_HALF_TAN_VFOV / g_input.viewParams.zoomFactor);
+                locateInfo.next = &cameraRig;
+            } else {
+                displayRig.pose = rigPose;
+                displayRig.virtualDisplayHeight =
+                    g_input.viewParams.virtualDisplayHeight / g_input.viewParams.scaleFactor;
+                displayRig.ipdFactor = g_input.viewParams.ipdFactor;
+                displayRig.parallaxFactor = g_input.viewParams.parallaxFactor;
+                displayRig.perspectiveFactor = g_input.viewParams.perspectiveFactor;
+                locateInfo.next = &displayRig;
+            }
+            viewState.next = &viewRigRaw;
+        }
+
         uint32_t viewCount = 0;
         xrLocateViews(app.session, &locateInfo, &viewState, (uint32_t)views.size(), &viewCount, views.data());
 
@@ -1697,37 +1755,23 @@ int main(int argc, char **argv)
 
         // Render
         if (frameState.shouldRender && viewCount >= 1) {
-            // Save raw display-space eye positions for Kooima + HUD
+            // Save display-space eye positions for the HUD. Under the rig,
+            // views[] carries render-ready world eyes — the raw channel
+            // (XrViewDisplayRawEXT) keeps the HUD readout in display space.
             app.eyeCount = modeViewCount;
-            for (uint32_t v = 0; v < viewCount && v < 8; v++) {
-                app.eyePositions[v][0] = views[v].pose.position.x;
-                app.eyePositions[v][1] = views[v].pose.position.y;
-                app.eyePositions[v][2] = views[v].pose.position.z;
-            }
-            std::vector<XrVector3f> rawEyePos(modeViewCount);
-            for (uint32_t v = 0; v < modeViewCount; v++) {
-                rawEyePos[v] = (v < viewCount) ? views[v].pose.position : views[0].pose.position;
-            }
-
-            // In mono mode, use center eye
-            if (!display3D && modeViewCount >= 2) {
-                XrVector3f center = {0, 0, 0};
-                for (uint32_t v = 0; v < modeViewCount; v++) {
-                    center.x += rawEyePos[v].x;
-                    center.y += rawEyePos[v].y;
-                    center.z += rawEyePos[v].z;
+            if (useRig && viewRigRaw.eyeCountOutput > 0) {
+                for (uint32_t v = 0; v < viewRigRaw.eyeCountOutput && v < 8; v++) {
+                    app.eyePositions[v][0] = viewRigRaw.rawEyes[v].x;
+                    app.eyePositions[v][1] = viewRigRaw.rawEyes[v].y;
+                    app.eyePositions[v][2] = viewRigRaw.rawEyes[v].z;
                 }
-                center.x /= modeViewCount;
-                center.y /= modeViewCount;
-                center.z /= modeViewCount;
-                rawEyePos[0] = center;
+            } else {
+                for (uint32_t v = 0; v < viewCount && v < 8; v++) {
+                    app.eyePositions[v][0] = views[v].pose.position.x;
+                    app.eyePositions[v][1] = views[v].pose.position.y;
+                    app.eyePositions[v][2] = views[v].pose.position.z;
+                }
             }
-
-            XrPosef cameraPose;
-            quat_from_yaw_pitch(g_input.yaw, g_input.pitch, &cameraPose.orientation);
-            cameraPose.position = {g_input.cameraPosX, g_input.cameraPosY, g_input.cameraPosZ};
-
-            XrVector3f nominalViewer = {app.nominalViewerX, app.nominalViewerY, app.nominalViewerZ};
 
             float scaleX = (app.currentModeIndex < app.renderingModeCount)
                 ? app.renderingModeScaleX[app.currentModeIndex] : 0.5f;
@@ -1752,94 +1796,28 @@ int main(int argc, char **argv)
             g_renderW = renderW;
             g_renderH = renderH;
 
-            // Compute N views using display3d or camera3d library
-            std::vector<Display3DView> d3dViews(eyeCount);
-            bool hasKooima = (app.displayWidthM > 0 && app.displayHeightM > 0);
-            if (hasKooima) {
-                float dispPxW = app.displayPixelWidth > 0 ? (float)app.displayPixelWidth : (float)app.swapchain.width;
-                float dispPxH = app.displayPixelHeight > 0 ? (float)app.displayPixelHeight : (float)app.swapchain.height;
-                float pxSizeX = app.displayWidthM / dispPxW;
-                float pxSizeY = app.displayHeightM / dispPxH;
-                float winW_m = (float)g_windowW * pxSizeX;
-                float winH_m = (float)g_windowH * pxSizeY;
-
-                // Window-relative Kooima: compute eye offset from window center
-                float eyeOffsetX = 0.0f, eyeOffsetY = 0.0f;
-                if (g_window != nil) {
-                    NSRect winFrame = [g_window frame];
-                    NSScreen *screen_ns = [g_window screen] ?: [NSScreen mainScreen];
-                    NSRect screenFrame = [screen_ns frame];
-                    float winCenterX = (winFrame.origin.x - screenFrame.origin.x) + winFrame.size.width / 2.0f;
-                    float winCenterY = (winFrame.origin.y - screenFrame.origin.y) + winFrame.size.height / 2.0f;
-                    float dispCenterX = screenFrame.size.width / 2.0f;
-                    float dispCenterY = screenFrame.size.height / 2.0f;
-                    CGFloat backingScale = [g_window backingScaleFactor];
-                    float pxSizeXBacking = pxSizeX / (float)backingScale;
-                    float pxSizeYBacking = pxSizeY / (float)backingScale;
-                    eyeOffsetX = (winCenterX - dispCenterX) * pxSizeXBacking;
-                    eyeOffsetY = (winCenterY - dispCenterY) * pxSizeYBacking;
-                }
-
-                Display3DScreen screen;
-                screen.width_m = winW_m;
-                screen.height_m = winH_m;
-
-                // Apply window center offset to raw eye positions
-                for (uint32_t v = 0; v < modeViewCount; v++) {
-                    rawEyePos[v].x -= eyeOffsetX;
-                    rawEyePos[v].y -= eyeOffsetY;
-                }
-
-                if (g_input.cameraMode) {
-                    Camera3DTunables camTunables;
-                    camTunables.ipd_factor = g_input.viewParams.ipdFactor;
-                    camTunables.parallax_factor = g_input.viewParams.parallaxFactor;
-                    camTunables.inv_convergence_distance = g_input.viewParams.invConvergenceDistance;
-                    camTunables.half_tan_vfov = CAMERA_HALF_TAN_VFOV / g_input.viewParams.zoomFactor;
-
-                    std::vector<Camera3DView> camViews(eyeCount);
-                    camera3d_compute_views(
-                        rawEyePos.data(), eyeCount, &nominalViewer,
-                        &screen, &camTunables, &cameraPose,
-                        0.01f, 100.0f, camViews.data());
-
-                    for (int i = 0; i < eyeCount; i++) {
-                        memcpy(d3dViews[i].view_matrix, camViews[i].view_matrix, sizeof(float) * 16);
-                        memcpy(d3dViews[i].projection_matrix, camViews[i].projection_matrix, sizeof(float) * 16);
-                        d3dViews[i].fov = camViews[i].fov;
-                        d3dViews[i].eye_world = camViews[i].eye_world;
-                    }
-                } else {
-                    Display3DTunables tunables;
-                    tunables.ipd_factor = g_input.viewParams.ipdFactor;
-                    tunables.parallax_factor = g_input.viewParams.parallaxFactor;
-                    tunables.perspective_factor = g_input.viewParams.perspectiveFactor;
-                    tunables.virtual_display_height = g_input.viewParams.virtualDisplayHeight / g_input.viewParams.scaleFactor;
-
-                    display3d_compute_views(
-                        rawEyePos.data(), eyeCount, &nominalViewer,
-                        &screen, &tunables, &cameraPose,
-                        tunables.virtual_display_height, 1000.0f * tunables.virtual_display_height, /*vulkan_flip_y=*/0, d3dViews.data());
-                }
-
-                // display3d/camera3d already produce OpenGL-convention z[-1,1] — no conversion needed
-            }
+            // --- Consume the runtime's render-ready XrView{pose, fov} ---
+            // (#396 W7) Only clip policy stays app-side, by design (fov is
+            // clip-independent). Camera rig: same absolute clip as the old
+            // app-side camera path. Display rig: ZDP-anchored clip (near =
+            // ez - vH, far = ez + 1000·vH; ez = rig-local z of the view
+            // pose). mat4_from_xr_fov is GL [-1,1]-convention — no remap.
+            const float rigVH =
+                g_input.viewParams.virtualDisplayHeight / g_input.viewParams.scaleFactor;
 
             rendered = true;
             std::vector<EyeRenderParams> eyeParams(eyeCount);
             for (int eye = 0; eye < eyeCount; eye++) {
-                XrFovf submitFov = views[eye < (int)viewCount ? eye : 0].fov;
-                if (hasKooima) {
-                    memcpy(eyeParams[eye].viewMat, d3dViews[eye].view_matrix, sizeof(float) * 16);
-                    memcpy(eyeParams[eye].projMat, d3dViews[eye].projection_matrix, sizeof(float) * 16);
-                    submitFov = d3dViews[eye].fov;
-                    views[eye < (int)viewCount ? eye : 0].pose.position = d3dViews[eye].eye_world;
-                    views[eye < (int)viewCount ? eye : 0].pose.orientation = cameraPose.orientation;
-                } else {
-                    int vi = eye < (int)viewCount ? eye : 0;
-                    mat4_view_from_xr_pose(eyeParams[eye].viewMat, views[vi].pose);
-                    mat4_from_xr_fov(eyeParams[eye].projMat, views[vi].fov, 0.01f, 100.0f);
+                int vi = eye < (int)viewCount ? eye : 0;
+                XrFovf submitFov = views[vi].fov;
+                float nearZ = 0.01f, farZ = 100.0f;
+                if (useRig && !rigCamera) {
+                    float ez = RigLocalEyeZ(rigPose, views[vi].pose.position);
+                    nearZ = (ez - rigVH > 0.001f) ? (ez - rigVH) : 0.001f;
+                    farZ = ez + 1000.0f * rigVH;
                 }
+                mat4_view_from_xr_pose(eyeParams[eye].viewMat, views[vi].pose);
+                mat4_from_xr_fov(eyeParams[eye].projMat, views[vi].fov, nearZ, farZ);
 
                 // Tile-aware viewport: place each view in the correct tile position
                 uint32_t tileX = display3D ? (eye % tileColumns) : 0;

--- a/test_apps/cube_handle_gl_win/main.cpp
+++ b/test_apps/cube_handle_gl_win/main.cpp
@@ -18,7 +18,6 @@
 #include "gl_renderer.h"
 #include "hud_renderer.h"
 #include "text_overlay.h"
-#include "display3d_view.h"
 #include "atlas_capture.h"
 
 #include <atomic>
@@ -53,6 +52,74 @@ static UINT g_windowHeight = 720;
 static bool g_fullscreen = false;
 static RECT g_savedWindowRect = {};
 static DWORD g_savedWindowStyle = 0;
+
+// XR_EXT_view_rig (#396 W7 dogfood): the app chains XrDisplayRigEXT on every
+// xrLocateViews and consumes the runtime's render-ready XrView{pose, fov}
+// directly — the per-frame Kooima generation is deleted; only clip policy
+// stays app-side. Per-view staging container (matrices column-major):
+struct RigView {
+    float view_matrix[16];
+    float projection_matrix[16];
+    XrFovf fov;
+};
+
+// Column-major view matrix from a render-ready XrView pose:
+// viewMatrix = R^T * translate(-position) — same construction as the
+// displayxr::math rigs.
+static void ViewMatrixFromXrPose(const XrPosef& pose, float* out) {
+    const float qx = pose.orientation.x, qy = pose.orientation.y;
+    const float qz = pose.orientation.z, qw = pose.orientation.w;
+    float rot[16] = {};
+    rot[0] = 1.0f - 2.0f * (qy * qy + qz * qz);
+    rot[1] = 2.0f * (qx * qy + qz * qw);
+    rot[2] = 2.0f * (qx * qz - qy * qw);
+    rot[4] = 2.0f * (qx * qy - qz * qw);
+    rot[5] = 1.0f - 2.0f * (qx * qx + qz * qz);
+    rot[6] = 2.0f * (qy * qz + qx * qw);
+    rot[8] = 2.0f * (qx * qz + qy * qw);
+    rot[9] = 2.0f * (qy * qz - qx * qw);
+    rot[10] = 1.0f - 2.0f * (qx * qx + qy * qy);
+    rot[15] = 1.0f;
+    for (int i = 0; i < 16; i++) out[i] = 0.0f;
+    for (int i = 0; i < 3; i++)
+        for (int j = 0; j < 3; j++)
+            out[j * 4 + i] = rot[i * 4 + j]; // R^T
+    out[15] = 1.0f;
+    out[12] = -(out[0] * pose.position.x + out[4] * pose.position.y + out[8] * pose.position.z);
+    out[13] = -(out[1] * pose.position.x + out[5] * pose.position.y + out[9] * pose.position.z);
+    out[14] = -(out[2] * pose.position.x + out[6] * pose.position.y + out[10] * pose.position.z);
+}
+
+// Column-major GL ([-1,1] clip-z) off-axis projection from a render-ready
+// XrView fov + the app's own clip policy (fov is clip-independent). GL keeps
+// the [-1,1] convention — no depth remap.
+static void ProjectionFromXrFov(const XrFovf& fov, float nearZ, float farZ, float* out) {
+    const float l = tanf(fov.angleLeft) * nearZ;
+    const float r = tanf(fov.angleRight) * nearZ;
+    const float b = tanf(fov.angleDown) * nearZ;
+    const float t = tanf(fov.angleUp) * nearZ;
+    for (int i = 0; i < 16; i++) out[i] = 0.0f;
+    out[0] = 2.0f * nearZ / (r - l);
+    out[5] = 2.0f * nearZ / (t - b);
+    out[8] = (r + l) / (r - l);
+    out[9] = (t + b) / (t - b);
+    out[10] = -(farZ + nearZ) / (farZ - nearZ);
+    out[11] = -1.0f;
+    out[14] = -2.0f * farZ * nearZ / (farZ - nearZ);
+}
+
+// Display-local eye distance for the ZDP-anchored clip: z of (rigPose^-1 *
+// eyeWorld). Degenerates to pose.position.z at identity rig pose.
+static float RigLocalEyeZ(const XrPosef& rig, const XrVector3f& eyeWorld) {
+    const float dx = eyeWorld.x - rig.position.x;
+    const float dy = eyeWorld.y - rig.position.y;
+    const float dz = eyeWorld.z - rig.position.z;
+    const float qx = -rig.orientation.x, qy = -rig.orientation.y;
+    const float qz = -rig.orientation.z, qw = rig.orientation.w;
+    const float cx = qy * dz - qz * dy + qw * dx;
+    const float cy = qz * dx - qx * dz + qw * dy;
+    return dz + 2.0f * (qx * cy - qy * cx);
+}
 
 // Toggle fullscreen mode for the app window
 static void ToggleFullscreen(HWND hwnd) {
@@ -422,6 +489,32 @@ static void RenderThreadFunc(
                         uint32_t viewCount = 8;
                         XrView rawViews[8];
                         for (uint32_t vi = 0; vi < 8; vi++) rawViews[vi] = {XR_TYPE_VIEW};
+
+                        // XR_EXT_view_rig (#396 W7): drive the runtime display
+                        // rig with the app's tunables — the runtime owns the
+                        // window resolve and the Kooima math, and returns
+                        // render-ready XrView{pose, fov}. Per-locate semantics:
+                        // chain the rig on every consume locate.
+                        const bool useAppProjection =
+                            xr->hasDisplayInfoExt && xr->displayWidthM > 0.0f && g_hasViewRigExt;
+                        XrDisplayRigEXT displayRig = {XR_TYPE_DISPLAY_RIG_EXT};
+                        XrPosef rigPose = {{0, 0, 0, 1}, {0, 0, 0}};
+                        if (useAppProjection) {
+                            XMVECTOR rigOri = XMQuaternionRotationRollPitchYaw(
+                                inputSnapshot.pitch, inputSnapshot.yaw, 0);
+                            XMFLOAT4 rq;
+                            XMStoreFloat4(&rq, rigOri);
+                            rigPose.orientation = {rq.x, rq.y, rq.z, rq.w};
+                            rigPose.position = {inputSnapshot.cameraPosX, inputSnapshot.cameraPosY,
+                                                inputSnapshot.cameraPosZ};
+                            displayRig.pose = rigPose;
+                            displayRig.virtualDisplayHeight =
+                                inputSnapshot.viewParams.virtualDisplayHeight / inputSnapshot.viewParams.scaleFactor;
+                            displayRig.ipdFactor = inputSnapshot.viewParams.ipdFactor;
+                            displayRig.parallaxFactor = inputSnapshot.viewParams.parallaxFactor;
+                            displayRig.perspectiveFactor = inputSnapshot.viewParams.perspectiveFactor;
+                            locateInfo.next = &displayRig;
+                        }
                         xrLocateViews(xr->session, &locateInfo, &viewState, 8, &viewCount, rawViews);
 
                         // Max per-tile capacity from swapchain
@@ -442,82 +535,24 @@ static void RenderThreadFunc(
                             if (renderH > maxTileH) renderH = maxTileH;
                         }
 
-                        // Build N-view raw eye positions
-                        std::vector<XrVector3f> rawEyes(eyeCount);
-                        for (int v = 0; v < eyeCount; v++) {
-                            rawEyes[v] = (v < (int)viewCount) ? rawViews[v].pose.position : rawViews[0].pose.position;
-                        }
-
-                        // In mono mode, average all eye positions to center
-                        if (monoMode && modeViewCount >= 2) {
-                            XrVector3f center = {0, 0, 0};
-                            for (uint32_t v = 0; v < modeViewCount; v++) {
-                                XrVector3f pos = (v < viewCount) ? rawViews[v].pose.position : rawViews[0].pose.position;
-                                center.x += pos.x;
-                                center.y += pos.y;
-                                center.z += pos.z;
-                            }
-                            center.x /= modeViewCount;
-                            center.y /= modeViewCount;
-                            center.z /= modeViewCount;
-                            rawEyes[0] = center;
-                        }
-
-                        // --- App-side Kooima via canonical library ---
-                        std::vector<Display3DView> stereoViews(eyeCount);
-                        bool useAppProjection = (xr->hasDisplayInfoExt && xr->displayWidthM > 0.0f);
+                        // --- Consume the runtime's render-ready XrView{pose, fov} ---
+                        // Only clip policy (near/far) stays app-side, by design
+                        // (fov is clip-independent). ZDP-anchored clip: near =
+                        // ez - vH, far = ez + 1000·vH; ez = rig-local z of the
+                        // view pose. GL keeps the [-1,1] clip-z — no remap.
+                        std::vector<RigView> stereoViews(eyeCount);
                         if (useAppProjection) {
-                            float dispPxW = xr->displayPixelWidth > 0 ? (float)xr->displayPixelWidth : (float)xr->swapchain.width;
-                            float dispPxH = xr->displayPixelHeight > 0 ? (float)xr->displayPixelHeight : (float)xr->swapchain.height;
-                            float pxSizeX = xr->displayWidthM / dispPxW;
-                            float pxSizeY = xr->displayHeightM / dispPxH;
-                            float winW_m = (float)windowW * pxSizeX;
-                            float winH_m = (float)windowH * pxSizeY;
-
-                            // Window-relative Kooima: compute eye offset from window center
-                            float eyeOffsetX = 0.0f, eyeOffsetY = 0.0f;
-                            {
-                                POINT clientOrigin = {0, 0};
-                                ClientToScreen(hwnd, &clientOrigin);
-                                HMONITOR hMon = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
-                                MONITORINFO mi = {sizeof(mi)};
-                                if (GetMonitorInfo(hMon, &mi)) {
-                                    float winCenterX = (float)(clientOrigin.x - mi.rcMonitor.left) + windowW / 2.0f;
-                                    float winCenterY = (float)(clientOrigin.y - mi.rcMonitor.top) + windowH / 2.0f;
-                                    float dispW = (float)(mi.rcMonitor.right - mi.rcMonitor.left);
-                                    float dispH = (float)(mi.rcMonitor.bottom - mi.rcMonitor.top);
-                                    eyeOffsetX = (winCenterX - dispW / 2.0f) * pxSizeX;
-                                    eyeOffsetY = -((winCenterY - dispH / 2.0f) * pxSizeY);
-                                }
+                            const float rigVH =
+                                inputSnapshot.viewParams.virtualDisplayHeight / inputSnapshot.viewParams.scaleFactor;
+                            for (int i = 0; i < eyeCount; i++) {
+                                const XrView& v = rawViews[(i < (int)viewCount) ? i : 0];
+                                ViewMatrixFromXrPose(v.pose, stereoViews[i].view_matrix);
+                                float ez = RigLocalEyeZ(rigPose, v.pose.position);
+                                float nearZ = (ez - rigVH > 0.001f) ? (ez - rigVH) : 0.001f;
+                                float farZ = ez + 1000.0f * rigVH;
+                                ProjectionFromXrFov(v.fov, nearZ, farZ, stereoViews[i].projection_matrix);
+                                stereoViews[i].fov = v.fov;
                             }
-
-                            // Apply window center offset to raw eye positions
-                            for (int v = 0; v < eyeCount; v++) {
-                                rawEyes[v].x -= eyeOffsetX;
-                                rawEyes[v].y -= eyeOffsetY;
-                            }
-
-                            Display3DTunables tunables;
-                            tunables.ipd_factor = inputSnapshot.viewParams.ipdFactor;
-                            tunables.parallax_factor = inputSnapshot.viewParams.parallaxFactor;
-                            tunables.perspective_factor = inputSnapshot.viewParams.perspectiveFactor;
-                            tunables.virtual_display_height = inputSnapshot.viewParams.virtualDisplayHeight / inputSnapshot.viewParams.scaleFactor;
-
-                            XrPosef displayPose;
-                            XMVECTOR pOri = XMQuaternionRotationRollPitchYaw(
-                                inputSnapshot.pitch, inputSnapshot.yaw, 0);
-                            XMFLOAT4 q;
-                            XMStoreFloat4(&q, pOri);
-                            displayPose.orientation = {q.x, q.y, q.z, q.w};
-                            displayPose.position = {inputSnapshot.cameraPosX, inputSnapshot.cameraPosY, inputSnapshot.cameraPosZ};
-
-                            XrVector3f nominalViewer = {xr->nominalViewerX, xr->nominalViewerY, xr->nominalViewerZ};
-                            Display3DScreen screen = {winW_m, winH_m};
-
-                            display3d_compute_views(
-                                rawEyes.data(), eyeCount, &nominalViewer,
-                                &screen, &tunables, &displayPose,
-                                tunables.virtual_display_height, 1000.0f * tunables.virtual_display_height, /*vulkan_flip_y=*/0, stereoViews.data());
                         }
 
                         rendered = true;
@@ -527,9 +562,18 @@ static void RenderThreadFunc(
                         XrFovf monoFov = {};
                         XrPosef monoPose = rawViews[0].pose;
                         if (monoMode) {
-                            monoPose.position.x = rawEyes[0].x;
-                            monoPose.position.y = rawEyes[0].y;
-                            monoPose.position.z = rawEyes[0].z;
+                            // Center eye = average of all view positions
+                            XrVector3f center = {0.0f, 0.0f, 0.0f};
+                            int cnt = (int)viewCount;
+                            if (cnt < 1) cnt = 1;
+                            for (int v = 0; v < cnt; v++) {
+                                center.x += rawViews[v].pose.position.x;
+                                center.y += rawViews[v].pose.position.y;
+                                center.z += rawViews[v].pose.position.z;
+                            }
+                            monoPose.position.x = center.x / cnt;
+                            monoPose.position.y = center.y / cnt;
+                            monoPose.position.z = center.z / cnt;
 
                             // When useAppProjection, mono view+proj come from stereoViews[0]
                             if (!useAppProjection) {

--- a/test_apps/cube_handle_gl_win/xr_session.cpp
+++ b/test_apps/cube_handle_gl_win/xr_session.cpp
@@ -9,6 +9,8 @@
 #include "logging.h"
 #include <cstring>
 
+bool g_hasViewRigExt = false;
+
 #define XR_CHECK(call) \
     do { \
         XrResult result = (call); \
@@ -87,12 +89,16 @@ bool InitializeOpenXR(XrSessionManager& xr) {
         if (strcmp(ext.extensionName, XR_EXT_MCP_TOOLS_EXTENSION_NAME) == 0) {
             xr.hasMcpToolsExt = true;
         }
+        if (strcmp(ext.extensionName, XR_EXT_VIEW_RIG_EXTENSION_NAME) == 0) {
+            g_hasViewRigExt = true;
+        }
     }
 
     LOG_INFO("XR_KHR_opengl_enable: %s", hasOpenGL ? "AVAILABLE" : "NOT FOUND");
     LOG_INFO("XR_EXT_win32_window_binding: %s", xr.hasWin32WindowBindingExt ? "AVAILABLE" : "NOT FOUND");
     LOG_INFO("XR_EXT_display_info: %s", xr.hasDisplayInfoExt ? "AVAILABLE" : "NOT FOUND");
     LOG_INFO("XR_EXT_mcp_tools: %s", xr.hasMcpToolsExt ? "AVAILABLE" : "NOT FOUND");
+    LOG_INFO("XR_EXT_view_rig: %s", g_hasViewRigExt ? "AVAILABLE" : "NOT FOUND");
 
     if (!hasOpenGL) {
         LOG_ERROR("XR_KHR_opengl_enable extension not available");
@@ -112,6 +118,9 @@ bool InitializeOpenXR(XrSessionManager& xr) {
     }
     if (xr.hasMcpToolsExt) {
         enabledExtensions.push_back(XR_EXT_MCP_TOOLS_EXTENSION_NAME);
+    }
+    if (g_hasViewRigExt) {
+        enabledExtensions.push_back(XR_EXT_VIEW_RIG_EXTENSION_NAME);
     }
 
     XrInstanceCreateInfo createInfo = {XR_TYPE_INSTANCE_CREATE_INFO};

--- a/test_apps/cube_handle_gl_win/xr_session.h
+++ b/test_apps/cube_handle_gl_win/xr_session.h
@@ -10,6 +10,12 @@
 #define XR_USE_GRAPHICS_API_OPENGL
 #include "xr_session_common.h"
 #include <GL/gl.h>
+#include <openxr/XR_EXT_view_rig.h>
+
+// XR_EXT_view_rig (#396 W7) available + enabled on the instance. App-local
+// (not on the shared XrSessionManager); promote to xr_session_common when
+// more consumers adopt it.
+extern bool g_hasViewRigExt;
 
 // Initialize OpenXR instance with OpenGL + win32_window_binding extensions
 bool InitializeOpenXR(XrSessionManager& xr);

--- a/test_apps/cube_handle_metal_macos/main.mm
+++ b/test_apps/cube_handle_metal_macos/main.mm
@@ -37,8 +37,6 @@
 
 // stb_image implementation TU lives in displayxr::common (stb_image_impl_macos.cpp) — declarations only here (#396 W4).
 #include "stb_image.h"
-#include "display3d_view.h"
-#include "camera3d_view.h"
 #include "view_params.h"
 #include "atlas_capture.h"
 #include "xr_window_space_hud.h"
@@ -46,6 +44,7 @@
 #include <openxr/XR_EXT_display_info.h>
 #include <openxr/XR_EXT_atlas_capture.h>
 #include <openxr/XR_EXT_mcp_tools.h>
+#include <openxr/XR_EXT_view_rig.h>
 
 // ============================================================================
 // Logging
@@ -192,12 +191,19 @@ static void quat_rotate_vec3(XrQuaternionf q, float vx, float vy, float vz,
     *oz = vz + q.w * tz + (q.x * ty - q.y * tx);
 }
 
-// Convert display3d/camera3d projection (OpenGL z[-1,1]) to Metal z[0,1]
-static void convert_projection_gl_to_metal(float m[16]) {
-    m[2]  = 0.5f * m[2]  + 0.5f * m[3];
-    m[6]  = 0.5f * m[6]  + 0.5f * m[7];
-    m[10] = 0.5f * m[10] + 0.5f * m[11];
-    m[14] = 0.5f * m[14] + 0.5f * m[15];
+// Display-local eye distance for the ZDP-anchored clip (#396 W7 consume
+// path): z of (rigPose^-1 * eyeWorld). Degenerates to pose.position.z at
+// identity rig pose.
+static float RigLocalEyeZ(const XrPosef &rig, const XrVector3f &eyeWorld) {
+    XrQuaternionf inv = {-rig.orientation.x, -rig.orientation.y,
+                         -rig.orientation.z, rig.orientation.w};
+    float ox, oy, oz;
+    quat_rotate_vec3(inv,
+                     eyeWorld.x - rig.position.x,
+                     eyeWorld.y - rig.position.y,
+                     eyeWorld.z - rig.position.z,
+                     &ox, &oy, &oz);
+    return oz;
 }
 
 // ============================================================================
@@ -1143,6 +1149,7 @@ struct AppXrSession {
 
     // XR_EXT_atlas_capture (W6 of #396): runtime-owned 'I'-key atlas capture.
     bool hasAtlasCaptureExt = false;
+    bool hasViewRigExt = false;  // XR_EXT_view_rig (#396 W7)
     PFN_xrCaptureAtlasEXT pfnCaptureAtlasEXT = nullptr;
 
     // Enumerated rendering mode info. currentModeIndex is initialized to mode 1
@@ -1195,6 +1202,8 @@ static bool InitializeOpenXR(AppXrSession &app)
             app.hasAtlasCaptureExt = true;
         if (strcmp(e.extensionName, XR_EXT_MCP_TOOLS_EXTENSION_NAME) == 0)
             g_hasMcpToolsExt = true;
+        if (strcmp(e.extensionName, XR_EXT_VIEW_RIG_EXTENSION_NAME) == 0)
+            app.hasViewRigExt = true;
     }
 
     if (!hasMetalEnable) {
@@ -1206,6 +1215,7 @@ static bool InitializeOpenXR(AppXrSession &app)
     }
     LOG_INFO("XR_EXT_display_info: %s", app.hasDisplayInfoExt ? "available" : "not available");
     LOG_INFO("XR_EXT_atlas_capture: %s", app.hasAtlasCaptureExt ? "available" : "not available");
+    LOG_INFO("XR_EXT_view_rig: %s", app.hasViewRigExt ? "AVAILABLE" : "NOT FOUND");
 
     // Enable extensions
     std::vector<const char *> enabledExts = {XR_KHR_METAL_ENABLE_EXTENSION_NAME};
@@ -1220,6 +1230,9 @@ static bool InitializeOpenXR(AppXrSession &app)
     }
     if (g_hasMcpToolsExt) {
         enabledExts.push_back(XR_EXT_MCP_TOOLS_EXTENSION_NAME);
+    }
+    if (app.hasViewRigExt) {
+        enabledExts.push_back(XR_EXT_VIEW_RIG_EXTENSION_NAME);
     }
 
     XrInstanceCreateInfo createInfo = {XR_TYPE_INSTANCE_CREATE_INFO};
@@ -1779,6 +1792,43 @@ int main(int argc, char **argv)
         locateInfo.displayTime = frameState.predictedDisplayTime;
         locateInfo.space = app.localSpace;
 
+        // XR_EXT_view_rig (#396 W7): drive the runtime rig matching the app's
+        // current mode (C selects the rig) with the app's tunables — the
+        // runtime owns the window resolve and the Kooima math, and returns
+        // render-ready XrView{pose, fov}. Per-locate semantics: chain the rig
+        // on every consume locate. The raw result struct feeds the HUD's
+        // display-space eye readout (under the rig, views[] carries world
+        // eyes, not raw display eyes).
+        const bool useRig =
+            app.hasViewRigExt && app.displayWidthM > 0 && app.displayHeightM > 0;
+        const bool rigCamera = useRig && g_input.cameraMode;
+        XrCameraRigEXT cameraRig = {XR_TYPE_CAMERA_RIG_EXT};
+        XrDisplayRigEXT displayRig = {XR_TYPE_DISPLAY_RIG_EXT};
+        XrViewDisplayRawEXT viewRigRaw = {XR_TYPE_VIEW_DISPLAY_RAW_EXT};
+        XrPosef rigPose = {{0, 0, 0, 1}, {0, 0, 0}};
+        if (useRig) {
+            quat_from_yaw_pitch(g_input.yaw, g_input.pitch, &rigPose.orientation);
+            rigPose.position = {g_input.cameraPosX, g_input.cameraPosY, g_input.cameraPosZ};
+            if (rigCamera) {
+                cameraRig.pose = rigPose;
+                cameraRig.ipdFactor = g_input.viewParams.ipdFactor;
+                cameraRig.parallaxFactor = g_input.viewParams.parallaxFactor;
+                cameraRig.convergenceDiopters = g_input.viewParams.invConvergenceDistance;
+                cameraRig.verticalFov =
+                    2.0f * atanf(CAMERA_HALF_TAN_VFOV / g_input.viewParams.zoomFactor);
+                locateInfo.next = &cameraRig;
+            } else {
+                displayRig.pose = rigPose;
+                displayRig.virtualDisplayHeight =
+                    g_input.viewParams.virtualDisplayHeight / g_input.viewParams.scaleFactor;
+                displayRig.ipdFactor = g_input.viewParams.ipdFactor;
+                displayRig.parallaxFactor = g_input.viewParams.parallaxFactor;
+                displayRig.perspectiveFactor = g_input.viewParams.perspectiveFactor;
+                locateInfo.next = &displayRig;
+            }
+            viewState.next = &viewRigRaw;
+        }
+
         uint32_t viewCount = 0;
         xrLocateViews(app.session, &locateInfo, &viewState, (uint32_t)views.size(), &viewCount, views.data());
 
@@ -1816,38 +1866,23 @@ int main(int argc, char **argv)
 
         // Render
         if (frameState.shouldRender && viewCount >= 1) {
-            // Save raw display-space eye positions for Kooima + HUD
+            // Save display-space eye positions for the HUD. Under the rig,
+            // views[] carries render-ready world eyes — the raw channel
+            // (XrViewDisplayRawEXT) keeps the HUD readout in display space.
             app.eyeCount = modeViewCount;
-            for (uint32_t v = 0; v < viewCount && v < 8; v++) {
-                app.eyePositions[v][0] = views[v].pose.position.x;
-                app.eyePositions[v][1] = views[v].pose.position.y;
-                app.eyePositions[v][2] = views[v].pose.position.z;
-            }
-            std::vector<XrVector3f> rawEyePos(modeViewCount);
-            for (uint32_t v = 0; v < modeViewCount; v++) {
-                rawEyePos[v] = (v < viewCount) ? views[v].pose.position : views[0].pose.position;
-            }
-
-            // In mono mode, use center eye
-            if (!display3D && modeViewCount >= 2) {
-                XrVector3f center = {0, 0, 0};
-                for (uint32_t v = 0; v < modeViewCount; v++) {
-                    center.x += rawEyePos[v].x;
-                    center.y += rawEyePos[v].y;
-                    center.z += rawEyePos[v].z;
+            if (useRig && viewRigRaw.eyeCountOutput > 0) {
+                for (uint32_t v = 0; v < viewRigRaw.eyeCountOutput && v < 8; v++) {
+                    app.eyePositions[v][0] = viewRigRaw.rawEyes[v].x;
+                    app.eyePositions[v][1] = viewRigRaw.rawEyes[v].y;
+                    app.eyePositions[v][2] = viewRigRaw.rawEyes[v].z;
                 }
-                center.x /= modeViewCount;
-                center.y /= modeViewCount;
-                center.z /= modeViewCount;
-                rawEyePos[0] = center;
+            } else {
+                for (uint32_t v = 0; v < viewCount && v < 8; v++) {
+                    app.eyePositions[v][0] = views[v].pose.position.x;
+                    app.eyePositions[v][1] = views[v].pose.position.y;
+                    app.eyePositions[v][2] = views[v].pose.position.z;
+                }
             }
-
-            // Build camera/display pose from player transform
-            XrPosef cameraPose;
-            quat_from_yaw_pitch(g_input.yaw, g_input.pitch, &cameraPose.orientation);
-            cameraPose.position = {g_input.cameraPosX, g_input.cameraPosY, g_input.cameraPosZ};
-
-            XrVector3f nominalViewer = {app.nominalViewerX, app.nominalViewerY, app.nominalViewerZ};
 
             // Compute render dims from enumerated mode info
             float scaleX = (app.currentModeIndex < app.renderingModeCount)
@@ -1873,98 +1908,28 @@ int main(int argc, char **argv)
             g_renderW = renderW;
             g_renderH = renderH;
 
-            // Compute N views using display3d or camera3d library
-            std::vector<Display3DView> d3dViews(eyeCount);
-            bool hasKooima = (app.displayWidthM > 0 && app.displayHeightM > 0);
-            if (hasKooima) {
-                float dispPxW = app.displayPixelWidth > 0 ? (float)app.displayPixelWidth : (float)app.swapchain.width;
-                float dispPxH = app.displayPixelHeight > 0 ? (float)app.displayPixelHeight : (float)app.swapchain.height;
-                float pxSizeX = app.displayWidthM / dispPxW;
-                float pxSizeY = app.displayHeightM / dispPxH;
-                float winW_m = (float)g_windowW * pxSizeX;
-                float winH_m = (float)g_windowH * pxSizeY;
-
-                // Window-relative Kooima: compute eye offset from window center
-                float eyeOffsetX = 0.0f, eyeOffsetY = 0.0f;
-                if (g_window != nil) {
-                    NSRect winFrame = [g_window frame];
-                    NSScreen *screen_ns = [g_window screen] ?: [NSScreen mainScreen];
-                    NSRect screenFrame = [screen_ns frame];
-                    // macOS: origin is bottom-left, Y-up — matches eye coords
-                    float winCenterX = (winFrame.origin.x - screenFrame.origin.x) + winFrame.size.width / 2.0f;
-                    float winCenterY = (winFrame.origin.y - screenFrame.origin.y) + winFrame.size.height / 2.0f;
-                    float dispCenterX = screenFrame.size.width / 2.0f;
-                    float dispCenterY = screenFrame.size.height / 2.0f;
-                    CGFloat backingScale = [g_window backingScaleFactor];
-                    float pxSizeXBacking = pxSizeX / (float)backingScale;
-                    float pxSizeYBacking = pxSizeY / (float)backingScale;
-                    eyeOffsetX = (winCenterX - dispCenterX) * pxSizeXBacking;
-                    eyeOffsetY = (winCenterY - dispCenterY) * pxSizeYBacking;
-                }
-
-                // Apply window center offset to raw eye positions
-                for (uint32_t v = 0; v < modeViewCount; v++) {
-                    rawEyePos[v].x -= eyeOffsetX;
-                    rawEyePos[v].y -= eyeOffsetY;
-                }
-
-                Display3DScreen screen;
-                screen.width_m = winW_m;
-                screen.height_m = winH_m;
-
-                if (g_input.cameraMode) {
-                    Camera3DTunables camTunables;
-                    camTunables.ipd_factor = g_input.viewParams.ipdFactor;
-                    camTunables.parallax_factor = g_input.viewParams.parallaxFactor;
-                    camTunables.inv_convergence_distance = g_input.viewParams.invConvergenceDistance;
-                    camTunables.half_tan_vfov = CAMERA_HALF_TAN_VFOV / g_input.viewParams.zoomFactor;
-
-                    std::vector<Camera3DView> camViews(eyeCount);
-                    camera3d_compute_views(
-                        rawEyePos.data(), eyeCount, &nominalViewer,
-                        &screen, &camTunables, &cameraPose,
-                        0.01f, 100.0f, camViews.data());
-
-                    for (int i = 0; i < eyeCount; i++) {
-                        memcpy(d3dViews[i].view_matrix, camViews[i].view_matrix, sizeof(float) * 16);
-                        memcpy(d3dViews[i].projection_matrix, camViews[i].projection_matrix, sizeof(float) * 16);
-                        d3dViews[i].fov = camViews[i].fov;
-                        d3dViews[i].eye_world = camViews[i].eye_world;
-                    }
-                } else {
-                    Display3DTunables tunables;
-                    tunables.ipd_factor = g_input.viewParams.ipdFactor;
-                    tunables.parallax_factor = g_input.viewParams.parallaxFactor;
-                    tunables.perspective_factor = g_input.viewParams.perspectiveFactor;
-                    tunables.virtual_display_height = g_input.viewParams.virtualDisplayHeight / g_input.viewParams.scaleFactor;
-
-                    display3d_compute_views(
-                        rawEyePos.data(), eyeCount, &nominalViewer,
-                        &screen, &tunables, &cameraPose,
-                        tunables.virtual_display_height, 1000.0f * tunables.virtual_display_height, /*vulkan_flip_y=*/0, d3dViews.data());
-                }
-
-                // Convert projection matrices from OpenGL z[-1,1] to Metal z[0,1]
-                for (int i = 0; i < eyeCount; i++) {
-                    convert_projection_gl_to_metal(d3dViews[i].projection_matrix);
-                }
-            }
+            // --- Consume the runtime's render-ready XrView{pose, fov} ---
+            // (#396 W7) Only clip policy stays app-side, by design (fov is
+            // clip-independent). Camera rig: same absolute clip as the old
+            // app-side camera path. Display rig: ZDP-anchored clip (near =
+            // ez - vH, far = ez + 1000·vH; ez = rig-local z of the view
+            // pose). mat4_from_xr_fov is Metal [0,1]-native — no remap.
+            const float rigVH =
+                g_input.viewParams.virtualDisplayHeight / g_input.viewParams.scaleFactor;
 
             rendered = true;
             std::vector<EyeRenderParams> eyeParams(eyeCount);
             for (int eye = 0; eye < eyeCount; eye++) {
-                XrFovf submitFov = views[eye < (int)viewCount ? eye : 0].fov;
-                if (hasKooima) {
-                    memcpy(eyeParams[eye].viewMat, d3dViews[eye].view_matrix, sizeof(float) * 16);
-                    memcpy(eyeParams[eye].projMat, d3dViews[eye].projection_matrix, sizeof(float) * 16);
-                    submitFov = d3dViews[eye].fov;
-                    views[eye < (int)viewCount ? eye : 0].pose.position = d3dViews[eye].eye_world;
-                    views[eye < (int)viewCount ? eye : 0].pose.orientation = cameraPose.orientation;
-                } else {
-                    int vi = eye < (int)viewCount ? eye : 0;
-                    mat4_view_from_xr_pose(eyeParams[eye].viewMat, views[vi].pose);
-                    mat4_from_xr_fov(eyeParams[eye].projMat, views[vi].fov, 0.01f, 100.0f);
+                int vi = eye < (int)viewCount ? eye : 0;
+                XrFovf submitFov = views[vi].fov;
+                float nearZ = 0.01f, farZ = 100.0f;
+                if (useRig && !rigCamera) {
+                    float ez = RigLocalEyeZ(rigPose, views[vi].pose.position);
+                    nearZ = (ez - rigVH > 0.001f) ? (ez - rigVH) : 0.001f;
+                    farZ = ez + 1000.0f * rigVH;
                 }
+                mat4_view_from_xr_pose(eyeParams[eye].viewMat, views[vi].pose);
+                mat4_from_xr_fov(eyeParams[eye].projMat, views[vi].fov, nearZ, farZ);
 
                 // Tile-aware viewport: place each view in the correct tile position
                 uint32_t tileX = display3D ? (eye % tileColumns) : 0;

--- a/test_apps/cube_handle_vk_macos/main.mm
+++ b/test_apps/cube_handle_vk_macos/main.mm
@@ -29,6 +29,7 @@
 #include <openxr/XR_EXT_cocoa_window_binding.h>
 #include <openxr/XR_EXT_display_info.h>
 #include <openxr/XR_EXT_atlas_capture.h>
+#include <openxr/XR_EXT_view_rig.h>
 
 #include <cmath>
 #include <csignal>
@@ -42,9 +43,7 @@
 #include <unistd.h>
 
 #include "view_params.h"
-#include "display3d_view.h"
 #include "projection_depth.h"
-#include "camera3d_view.h"
 #include "atlas_capture.h"
 #include "xr_window_space_hud.h"
 #include "hud_renderer_macos.h"
@@ -290,6 +289,21 @@ static void quat_rotate_vec3(XrQuaternionf q, float vx, float vy, float vz,
     *oz = vz + q.w * tz + (q.x * ty - q.y * tx);
 }
 
+// Display-local eye distance for the ZDP-anchored clip (#396 W7 consume
+// path): z of (rigPose^-1 * eyeWorld). Degenerates to pose.position.z at
+// identity rig pose.
+static float RigLocalEyeZ(const XrPosef &rig, const XrVector3f &eyeWorld) {
+    XrQuaternionf inv = {-rig.orientation.x, -rig.orientation.y,
+                         -rig.orientation.z, rig.orientation.w};
+    float ox, oy, oz;
+    quat_rotate_vec3(inv,
+                     eyeWorld.x - rig.position.x,
+                     eyeWorld.y - rig.position.y,
+                     eyeWorld.z - rig.position.z,
+                     &ox, &oy, &oz);
+    return oz;
+}
+
 // Hamilton product: a * b
 static XrQuaternionf quat_multiply(XrQuaternionf a, XrQuaternionf b) {
     return {
@@ -299,8 +313,6 @@ static XrQuaternionf quat_multiply(XrQuaternionf a, XrQuaternionf b) {
         a.w * b.w - a.x * b.x - a.y * b.y - a.z * b.z
     };
 }
-
-// Kooima projection and FOV now provided by display3d_view.h
 
 // ============================================================================
 // SPIR-V shaders (embedded)
@@ -1926,6 +1938,7 @@ struct AppXrSession {
 
     // XR_EXT_atlas_capture (W6 of #396): runtime-owned 'I'-key atlas capture.
     bool hasAtlasCaptureExt = false;
+    bool hasViewRigExt = false;  // XR_EXT_view_rig (#396 W7)
     PFN_xrCaptureAtlasEXT pfnCaptureAtlasEXT = nullptr;
     // Enumerated rendering mode info. currentModeIndex is initialized to mode 1
     // as a fallback for runtimes that don't expose isActive; v13+ runtimes
@@ -1978,6 +1991,9 @@ static bool InitializeOpenXR(AppXrSession& xr) {
         if (strcmp(ext.extensionName, XR_EXT_ATLAS_CAPTURE_EXTENSION_NAME) == 0) {
             xr.hasAtlasCaptureExt = true;
         }
+        if (strcmp(ext.extensionName, XR_EXT_VIEW_RIG_EXTENSION_NAME) == 0) {
+            xr.hasViewRigExt = true;
+        }
     }
 
     if (!hasVulkan) {
@@ -1988,6 +2004,7 @@ static bool InitializeOpenXR(AppXrSession& xr) {
     LOG_INFO("XR_EXT_cocoa_window_binding: %s", xr.hasCocoaWindowBinding ? "available" : "not available");
     LOG_INFO("XR_EXT_display_info: %s", xr.hasDisplayInfoExt ? "available" : "not available");
     LOG_INFO("XR_EXT_atlas_capture: %s", xr.hasAtlasCaptureExt ? "available" : "not available");
+    LOG_INFO("XR_EXT_view_rig: %s", xr.hasViewRigExt ? "AVAILABLE" : "NOT FOUND");
 
     // Build extension list
     std::vector<const char*> enabledExtensions;
@@ -2000,6 +2017,9 @@ static bool InitializeOpenXR(AppXrSession& xr) {
     }
     if (xr.hasAtlasCaptureExt) {
         enabledExtensions.push_back(XR_EXT_ATLAS_CAPTURE_EXTENSION_NAME);
+    }
+    if (xr.hasViewRigExt) {
+        enabledExtensions.push_back(XR_EXT_VIEW_RIG_EXTENSION_NAME);
     }
 
     XrInstanceCreateInfo createInfo = {XR_TYPE_INSTANCE_CREATE_INFO};
@@ -2975,6 +2995,43 @@ int main() {
                     eyeTrackingState.type = (XrStructureType)XR_TYPE_VIEW_EYE_TRACKING_STATE_EXT;
                     viewState.next = &eyeTrackingState;
 
+                    // XR_EXT_view_rig (#396 W7): drive the runtime rig matching
+                    // the app's current mode (C selects the rig) with the app's
+                    // tunables — the runtime owns the window resolve and the
+                    // Kooima math, and returns render-ready XrView{pose, fov}.
+                    // Per-locate semantics: chain the rig on every consume
+                    // locate. The raw result struct (chained behind the eye
+                    // tracking state) feeds the HUD's display-space eye readout.
+                    const bool useRig =
+                        xr.hasViewRigExt && xr.displayWidthM > 0 && xr.displayHeightM > 0;
+                    const bool rigCamera = useRig && g_input.cameraMode;
+                    XrCameraRigEXT cameraRig = {XR_TYPE_CAMERA_RIG_EXT};
+                    XrDisplayRigEXT displayRig = {XR_TYPE_DISPLAY_RIG_EXT};
+                    XrViewDisplayRawEXT viewRigRaw = {XR_TYPE_VIEW_DISPLAY_RAW_EXT};
+                    XrPosef rigPose = {{0, 0, 0, 1}, {0, 0, 0}};
+                    if (useRig) {
+                        quat_from_yaw_pitch(g_input.yaw, g_input.pitch, &rigPose.orientation);
+                        rigPose.position = {g_input.cameraPosX, g_input.cameraPosY, g_input.cameraPosZ};
+                        if (rigCamera) {
+                            cameraRig.pose = rigPose;
+                            cameraRig.ipdFactor = g_input.viewParams.ipdFactor;
+                            cameraRig.parallaxFactor = g_input.viewParams.parallaxFactor;
+                            cameraRig.convergenceDiopters = g_input.viewParams.invConvergenceDistance;
+                            cameraRig.verticalFov =
+                                2.0f * atanf(CAMERA_HALF_TAN_VFOV / g_input.viewParams.zoomFactor);
+                            locateInfo.next = &cameraRig;
+                        } else {
+                            displayRig.pose = rigPose;
+                            displayRig.virtualDisplayHeight =
+                                g_input.viewParams.virtualDisplayHeight / g_input.viewParams.scaleFactor;
+                            displayRig.ipdFactor = g_input.viewParams.ipdFactor;
+                            displayRig.parallaxFactor = g_input.viewParams.parallaxFactor;
+                            displayRig.perspectiveFactor = g_input.viewParams.perspectiveFactor;
+                            locateInfo.next = &displayRig;
+                        }
+                        eyeTrackingState.next = &viewRigRaw;
+                    }
+
                     uint32_t viewCount = (uint32_t)xr.configViews.size();
                     std::vector<XrView> views(viewCount, {XR_TYPE_VIEW});
 
@@ -2984,42 +3041,28 @@ int main() {
                         (viewState.viewStateFlags & XR_VIEW_STATE_POSITION_VALID_BIT) &&
                         (viewState.viewStateFlags & XR_VIEW_STATE_ORIENTATION_VALID_BIT))
                     {
-                        // Save raw display-space eye positions for Kooima + HUD
+                        // Save display-space eye positions for the HUD. Under
+                        // the rig, views[] carries render-ready world eyes —
+                        // the raw channel (XrViewDisplayRawEXT) keeps the HUD
+                        // readout in display space.
                         xr.eyeCount = modeViewCount;
-                        for (uint32_t v = 0; v < viewCount && v < 8; v++) {
-                            xr.eyePositions[v][0] = views[v].pose.position.x;
-                            xr.eyePositions[v][1] = views[v].pose.position.y;
-                            xr.eyePositions[v][2] = views[v].pose.position.z;
-                        }
-                        std::vector<XrVector3f> rawEyePos(modeViewCount);
-                        for (uint32_t v = 0; v < modeViewCount; v++) {
-                            rawEyePos[v] = (v < viewCount) ? views[v].pose.position : views[0].pose.position;
+                        if (useRig && viewRigRaw.eyeCountOutput > 0) {
+                            for (uint32_t v = 0; v < viewRigRaw.eyeCountOutput && v < 8; v++) {
+                                xr.eyePositions[v][0] = viewRigRaw.rawEyes[v].x;
+                                xr.eyePositions[v][1] = viewRigRaw.rawEyes[v].y;
+                                xr.eyePositions[v][2] = viewRigRaw.rawEyes[v].z;
+                            }
+                        } else {
+                            for (uint32_t v = 0; v < viewCount && v < 8; v++) {
+                                xr.eyePositions[v][0] = views[v].pose.position.x;
+                                xr.eyePositions[v][1] = views[v].pose.position.y;
+                                xr.eyePositions[v][2] = views[v].pose.position.z;
+                            }
                         }
 
                         xr.isEyeTracking = (eyeTrackingState.isTracking == XR_TRUE);
                         xr.activeEyeTrackingMode = (uint32_t)eyeTrackingState.activeMode;
                         xr.eyeTrackingActive = xr.isEyeTracking;
-
-                        // In mono mode, use center eye (average of all views)
-                        if (!display3D && modeViewCount >= 2) {
-                            XrVector3f center = {0, 0, 0};
-                            for (uint32_t v = 0; v < modeViewCount; v++) {
-                                center.x += rawEyePos[v].x;
-                                center.y += rawEyePos[v].y;
-                                center.z += rawEyePos[v].z;
-                            }
-                            center.x /= modeViewCount;
-                            center.y /= modeViewCount;
-                            center.z /= modeViewCount;
-                            rawEyePos[0] = center;
-                        }
-
-                        // Build camera/display pose from player transform
-                        XrPosef cameraPose;
-                        quat_from_yaw_pitch(g_input.yaw, g_input.pitch, &cameraPose.orientation);
-                        cameraPose.position = {g_input.cameraPosX, g_input.cameraPosY, g_input.cameraPosZ};
-
-                        XrVector3f nominalViewer = {xr.nominalViewerX, xr.nominalViewerY, xr.nominalViewerZ};
 
                         // Compute render dims for SBS single-swapchain.
                         // Scale depends on current output mode (may change at runtime):
@@ -3047,101 +3090,35 @@ int main() {
                         g_renderW = renderW;
                         g_renderH = renderH;
 
-                        // Compute N views using display3d or camera3d library
-                        std::vector<Display3DView> d3dViews(eyeCount);
-                        bool hasKooima = (xr.displayWidthM > 0 && xr.displayHeightM > 0);
-                        if (hasKooima) {
-                            // Compute viewport-scaled screen dimensions in meters
-                            float dispPxW = xr.displayPixelWidth > 0 ? (float)xr.displayPixelWidth : (float)xr.swapchain.width;
-                            float dispPxH = xr.displayPixelHeight > 0 ? (float)xr.displayPixelHeight : (float)xr.swapchain.height;
-                            float pxSizeX = xr.displayWidthM / dispPxW;
-                            float pxSizeY = xr.displayHeightM / dispPxH;
-                            float winW_m = (float)g_windowW * pxSizeX;
-                            float winH_m = (float)g_windowH * pxSizeY;
-
-                            // Window-relative Kooima: compute eye offset from window center
-                            float eyeOffsetX = 0.0f, eyeOffsetY = 0.0f;
-                            if (g_window != nil) {
-                                NSRect winFrame = [g_window frame];
-                                NSScreen *screen_ns = [g_window screen] ?: [NSScreen mainScreen];
-                                NSRect screenFrame = [screen_ns frame];
-                                float winCenterX = (winFrame.origin.x - screenFrame.origin.x) + winFrame.size.width / 2.0f;
-                                float winCenterY = (winFrame.origin.y - screenFrame.origin.y) + winFrame.size.height / 2.0f;
-                                float dispCenterX = screenFrame.size.width / 2.0f;
-                                float dispCenterY = screenFrame.size.height / 2.0f;
-                                CGFloat backingScale = [g_window backingScaleFactor];
-                                float pxSizeXBacking = pxSizeX / (float)backingScale;
-                                float pxSizeYBacking = pxSizeY / (float)backingScale;
-                                eyeOffsetX = (winCenterX - dispCenterX) * pxSizeXBacking;
-                                eyeOffsetY = (winCenterY - dispCenterY) * pxSizeYBacking;
-                            }
-
-                            // Apply window center offset to raw eye positions
-                            for (uint32_t v = 0; v < modeViewCount; v++) {
-                                rawEyePos[v].x -= eyeOffsetX;
-                                rawEyePos[v].y -= eyeOffsetY;
-                            }
-
-                            Display3DScreen screen;
-                            screen.width_m = winW_m;
-                            screen.height_m = winH_m;
-
-                            if (g_input.cameraMode) {
-                                // Camera-centric path
-                                Camera3DTunables camTunables;
-                                camTunables.ipd_factor = g_input.viewParams.ipdFactor;
-                                camTunables.parallax_factor = g_input.viewParams.parallaxFactor;
-                                camTunables.inv_convergence_distance = g_input.viewParams.invConvergenceDistance;
-                                camTunables.half_tan_vfov = CAMERA_HALF_TAN_VFOV / g_input.viewParams.zoomFactor;
-
-                                std::vector<Camera3DView> camViews(eyeCount);
-                                camera3d_compute_views(
-                                    rawEyePos.data(), eyeCount, &nominalViewer,
-                                    &screen, &camTunables, &cameraPose,
-                                    0.01f, 100.0f, camViews.data());
-
-                                // Copy into Display3DView for uniform downstream rendering
-                                for (int i = 0; i < eyeCount; i++) {
-                                    memcpy(d3dViews[i].view_matrix, camViews[i].view_matrix, sizeof(float) * 16);
-                                    memcpy(d3dViews[i].projection_matrix, camViews[i].projection_matrix, sizeof(float) * 16);
-                                    d3dViews[i].fov = camViews[i].fov;
-                                    d3dViews[i].eye_world = camViews[i].eye_world;
-                                }
-                            } else {
-                                // Display-centric path
-                                Display3DTunables tunables;
-                                tunables.ipd_factor = g_input.viewParams.ipdFactor;
-                                tunables.parallax_factor = g_input.viewParams.parallaxFactor;
-                                tunables.perspective_factor = g_input.viewParams.perspectiveFactor;
-                                tunables.virtual_display_height = g_input.viewParams.virtualDisplayHeight / g_input.viewParams.scaleFactor;
-
-                                display3d_compute_views(
-                                    rawEyePos.data(), eyeCount, &nominalViewer,
-                                    &screen, &tunables, &cameraPose,
-                                    tunables.virtual_display_height, 1000.0f * tunables.virtual_display_height, /*vulkan_flip_y=*/0, d3dViews.data());
-                                // display3d emits a GL ([-1,1] clip-z) projection; Vulkan clips [0,1].
-                                // Remap depth on the 3D per-view projections (not the mono/legacy
-                                // xr.projMatrices path). [#396 W1]
-                                for (uint32_t _v = 0; _v < eyeCount; _v++)
-                                    convert_projection_gl_to_zero_to_one(d3dViews[_v].projection_matrix);
-                            }
-                        }
+                        // --- Consume the runtime's render-ready XrView{pose, fov} ---
+                        // (#396 W7) Only clip policy (near/far + the GL→[0,1]
+                        // depth remap) stays app-side, by design (fov is
+                        // clip-independent). Camera rig: same absolute clip as
+                        // the old app-side camera path. Display rig:
+                        // ZDP-anchored clip (near = ez - vH, far = ez +
+                        // 1000·vH; ez = rig-local z of the view pose).
+                        const float rigVH =
+                            g_input.viewParams.virtualDisplayHeight / g_input.viewParams.scaleFactor;
 
                         rendered = true;
                         uint32_t imageIndex;
                         if (AcquireSwapchainImage(xr, imageIndex)) {
                             std::vector<EyeRenderParams> eyeParams(eyeCount);
                             for (int eye = 0; eye < eyeCount; eye++) {
-                                XrFovf submitFov = views[eye < (int)viewCount ? eye : 0].fov;
-                                if (hasKooima) {
-                                    memcpy(eyeParams[eye].viewMat, d3dViews[eye].view_matrix, sizeof(float) * 16);
-                                    memcpy(eyeParams[eye].projMat, d3dViews[eye].projection_matrix, sizeof(float) * 16);
-                                    submitFov = d3dViews[eye].fov;
-                                    // Update view pose for layer submission
-                                    views[eye < (int)viewCount ? eye : 0].pose.position = d3dViews[eye].eye_world;
-                                    views[eye < (int)viewCount ? eye : 0].pose.orientation = cameraPose.orientation;
+                                int vi = eye < (int)viewCount ? eye : 0;
+                                XrFovf submitFov = views[vi].fov;
+                                if (useRig) {
+                                    float nearZ = 0.01f, farZ = 100.0f;
+                                    if (!rigCamera) {
+                                        float ez = RigLocalEyeZ(rigPose, views[vi].pose.position);
+                                        nearZ = (ez - rigVH > 0.001f) ? (ez - rigVH) : 0.001f;
+                                        farZ = ez + 1000.0f * rigVH;
+                                    }
+                                    mat4_view_from_xr_pose(eyeParams[eye].viewMat, views[vi].pose);
+                                    // mat4_from_xr_fov is GL-convention; Vulkan clips [0,1].
+                                    mat4_from_xr_fov(eyeParams[eye].projMat, views[vi].fov, nearZ, farZ);
+                                    convert_projection_gl_to_zero_to_one(eyeParams[eye].projMat);
                                 } else {
-                                    int vi = eye < (int)viewCount ? eye : 0;
                                     mat4_view_from_xr_pose(eyeParams[eye].viewMat, views[vi].pose);
                                     mat4_from_xr_fov(eyeParams[eye].projMat, views[vi].fov, 0.01f, 100.0f);
                                 }

--- a/test_apps/cube_handle_vk_win/main.cpp
+++ b/test_apps/cube_handle_vk_win/main.cpp
@@ -16,9 +16,7 @@
 #include "input_handler.h"
 #include "xr_session.h"
 #include "vk_renderer.h"
-#include "display3d_view.h"
 #include "projection_depth.h"
-#include "camera3d_view.h"
 
 #include "hud_renderer.h"
 #include "text_overlay.h"
@@ -76,6 +74,75 @@ static UINT g_windowHeight = 720;
 static bool g_fullscreen = false;
 static RECT g_savedWindowRect = {};
 static DWORD g_savedWindowStyle = 0;
+
+// XR_EXT_view_rig (#396 W7 dogfood): the app chains a rig descriptor
+// (XrDisplayRigEXT, or XrCameraRigEXT in camera mode) on every xrLocateViews
+// and consumes the runtime's render-ready XrView{pose, fov} directly — the
+// per-frame Kooima generation is deleted; only clip policy stays app-side.
+// Per-view staging container (matrices column-major):
+struct RigView {
+    float view_matrix[16];
+    float projection_matrix[16];
+    XrFovf fov;
+};
+
+// Column-major view matrix from a render-ready XrView pose:
+// viewMatrix = R^T * translate(-position) — same construction as the
+// displayxr::math rigs.
+static void ViewMatrixFromXrPose(const XrPosef& pose, float* out) {
+    const float qx = pose.orientation.x, qy = pose.orientation.y;
+    const float qz = pose.orientation.z, qw = pose.orientation.w;
+    float rot[16] = {};
+    rot[0] = 1.0f - 2.0f * (qy * qy + qz * qz);
+    rot[1] = 2.0f * (qx * qy + qz * qw);
+    rot[2] = 2.0f * (qx * qz - qy * qw);
+    rot[4] = 2.0f * (qx * qy - qz * qw);
+    rot[5] = 1.0f - 2.0f * (qx * qx + qz * qz);
+    rot[6] = 2.0f * (qy * qz + qx * qw);
+    rot[8] = 2.0f * (qx * qz + qy * qw);
+    rot[9] = 2.0f * (qy * qz - qx * qw);
+    rot[10] = 1.0f - 2.0f * (qx * qx + qy * qy);
+    rot[15] = 1.0f;
+    for (int i = 0; i < 16; i++) out[i] = 0.0f;
+    for (int i = 0; i < 3; i++)
+        for (int j = 0; j < 3; j++)
+            out[j * 4 + i] = rot[i * 4 + j]; // R^T
+    out[15] = 1.0f;
+    out[12] = -(out[0] * pose.position.x + out[4] * pose.position.y + out[8] * pose.position.z);
+    out[13] = -(out[1] * pose.position.x + out[5] * pose.position.y + out[9] * pose.position.z);
+    out[14] = -(out[2] * pose.position.x + out[6] * pose.position.y + out[10] * pose.position.z);
+}
+
+// Column-major GL ([-1,1] clip-z) off-axis projection from a render-ready
+// XrView fov + the app's own clip policy (fov is clip-independent). Pair with
+// convert_projection_gl_to_zero_to_one() for Vulkan.
+static void ProjectionFromXrFov(const XrFovf& fov, float nearZ, float farZ, float* out) {
+    const float l = tanf(fov.angleLeft) * nearZ;
+    const float r = tanf(fov.angleRight) * nearZ;
+    const float b = tanf(fov.angleDown) * nearZ;
+    const float t = tanf(fov.angleUp) * nearZ;
+    for (int i = 0; i < 16; i++) out[i] = 0.0f;
+    out[0] = 2.0f * nearZ / (r - l);
+    out[5] = 2.0f * nearZ / (t - b);
+    out[8] = (r + l) / (r - l);
+    out[9] = (t + b) / (t - b);
+    out[10] = -(farZ + nearZ) / (farZ - nearZ);
+    out[11] = -1.0f;
+    out[14] = -2.0f * farZ * nearZ / (farZ - nearZ);
+}
+
+// Display-local eye distance for the ZDP-anchored clip: z of (rigPose^-1 *
+// eyeWorld). Degenerates to pose.position.z at identity rig pose.
+static float RigLocalEyeZ(const XrPosef& rig, const XrVector3f& eyeWorld) {
+    const float dx = eyeWorld.x - rig.position.x;
+    const float dy = eyeWorld.y - rig.position.y;
+    const float dz = eyeWorld.z - rig.position.z;
+    const float qx = -rig.orientation.x, qy = -rig.orientation.y;
+    const float qz = -rig.orientation.z, qw = rig.orientation.w;
+    const float cx = qy * dz - qz * dy + qw * dx;
+    const float cy = qz * dx - qx * dz + qw * dy;
+    return dz + 2.0f * (qx * cy - qy * cx);
+}
 
 // Toggle fullscreen mode for the app window
 static void ToggleFullscreen(HWND hwnd) {
@@ -363,6 +430,45 @@ static void RenderThreadFunc(
                         uint32_t viewCount = 8;
                         XrView rawViews[8];
                         for (uint32_t vi = 0; vi < 8; vi++) rawViews[vi] = {XR_TYPE_VIEW};
+
+                        // XR_EXT_view_rig (#396 W7): drive the runtime rig
+                        // matching the app's current mode (C selects the rig)
+                        // with the app's tunables — the runtime owns the window
+                        // resolve and the Kooima math, and returns render-ready
+                        // XrView{pose, fov}. Per-locate semantics: chain the
+                        // rig on every consume locate.
+                        const bool useAppProjection =
+                            xr->hasDisplayInfoExt && xr->displayWidthM > 0.0f && g_hasViewRigExt;
+                        const bool rigCamera = useAppProjection && inputSnapshot.cameraMode;
+                        XrCameraRigEXT cameraRig = {XR_TYPE_CAMERA_RIG_EXT};
+                        XrDisplayRigEXT displayRig = {XR_TYPE_DISPLAY_RIG_EXT};
+                        XrPosef rigPose = {{0, 0, 0, 1}, {0, 0, 0}};
+                        if (useAppProjection) {
+                            XMVECTOR rigOri = XMQuaternionRotationRollPitchYaw(
+                                inputSnapshot.pitch, inputSnapshot.yaw, 0);
+                            XMFLOAT4 rq;
+                            XMStoreFloat4(&rq, rigOri);
+                            rigPose.orientation = {rq.x, rq.y, rq.z, rq.w};
+                            rigPose.position = {inputSnapshot.cameraPosX, inputSnapshot.cameraPosY,
+                                                inputSnapshot.cameraPosZ};
+                            if (rigCamera) {
+                                cameraRig.pose = rigPose;
+                                cameraRig.ipdFactor = inputSnapshot.viewParams.ipdFactor;
+                                cameraRig.parallaxFactor = inputSnapshot.viewParams.parallaxFactor;
+                                cameraRig.convergenceDiopters = inputSnapshot.viewParams.invConvergenceDistance;
+                                cameraRig.verticalFov =
+                                    2.0f * atanf(CAMERA_HALF_TAN_VFOV / inputSnapshot.viewParams.zoomFactor);
+                                locateInfo.next = &cameraRig;
+                            } else {
+                                displayRig.pose = rigPose;
+                                displayRig.virtualDisplayHeight =
+                                    inputSnapshot.viewParams.virtualDisplayHeight / inputSnapshot.viewParams.scaleFactor;
+                                displayRig.ipdFactor = inputSnapshot.viewParams.ipdFactor;
+                                displayRig.parallaxFactor = inputSnapshot.viewParams.parallaxFactor;
+                                displayRig.perspectiveFactor = inputSnapshot.viewParams.perspectiveFactor;
+                                locateInfo.next = &displayRig;
+                            }
+                        }
                         xrLocateViews(xr->session, &locateInfo, &viewState, 8, &viewCount, rawViews);
                         LOG_INFO("[FRAME] Raw LocateViews done");
 
@@ -384,105 +490,29 @@ static void RenderThreadFunc(
                             if (renderH > maxTileH) renderH = maxTileH;
                         }
 
-                        // --- App-side Kooima via canonical library ---
-                        std::vector<Display3DView> stereoViews(eyeCount);
-                        bool useAppProjection = (xr->hasDisplayInfoExt && xr->displayWidthM > 0.0f);
+                        // --- Consume the runtime's render-ready XrView{pose, fov} ---
+                        // Only clip policy (near/far + the GL→[0,1] depth remap)
+                        // stays app-side, by design (fov is clip-independent).
+                        // Camera rig: same absolute clip as the old app-side
+                        // camera path. Display rig: ZDP-anchored clip (near =
+                        // ez - vH, far = ez + 1000·vH; ez = rig-local z of the
+                        // view pose).
+                        std::vector<RigView> stereoViews(eyeCount);
                         if (useAppProjection) {
-                            float dispPxW = xr->displayPixelWidth > 0 ? (float)xr->displayPixelWidth : (float)xr->swapchain.width;
-                            float dispPxH = xr->displayPixelHeight > 0 ? (float)xr->displayPixelHeight : (float)xr->swapchain.height;
-                            float pxSizeX = xr->displayWidthM / dispPxW;
-                            float pxSizeY = xr->displayHeightM / dispPxH;
-                            float winW_m = (float)windowW * pxSizeX;
-                            float winH_m = (float)windowH * pxSizeY;
-
-                            // Window-relative Kooima: compute eye offset from window center
-                            float eyeOffsetX = 0.0f, eyeOffsetY = 0.0f;
-                            {
-                                POINT clientOrigin = {0, 0};
-                                ClientToScreen(hwnd, &clientOrigin);
-                                HMONITOR hMon = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
-                                MONITORINFO mi = {sizeof(mi)};
-                                if (GetMonitorInfo(hMon, &mi)) {
-                                    float winCenterX = (float)(clientOrigin.x - mi.rcMonitor.left) + windowW / 2.0f;
-                                    float winCenterY = (float)(clientOrigin.y - mi.rcMonitor.top) + windowH / 2.0f;
-                                    float dispW = (float)(mi.rcMonitor.right - mi.rcMonitor.left);
-                                    float dispH = (float)(mi.rcMonitor.bottom - mi.rcMonitor.top);
-                                    eyeOffsetX = (winCenterX - dispW / 2.0f) * pxSizeX;
-                                    eyeOffsetY = -((winCenterY - dispH / 2.0f) * pxSizeY);
+                            const float rigVH =
+                                inputSnapshot.viewParams.virtualDisplayHeight / inputSnapshot.viewParams.scaleFactor;
+                            for (int i = 0; i < eyeCount; i++) {
+                                const XrView& v = rawViews[(i < (int)viewCount) ? i : 0];
+                                ViewMatrixFromXrPose(v.pose, stereoViews[i].view_matrix);
+                                float nearZ = 0.01f, farZ = 100.0f;
+                                if (!rigCamera) {
+                                    float ez = RigLocalEyeZ(rigPose, v.pose.position);
+                                    nearZ = (ez - rigVH > 0.001f) ? (ez - rigVH) : 0.001f;
+                                    farZ = ez + 1000.0f * rigVH;
                                 }
-                            }
-
-                            // Build per-view eye positions (shifted to window center)
-                            std::vector<XrVector3f> rawEyes(eyeCount);
-                            for (int v = 0; v < eyeCount; v++) {
-                                XrVector3f pos = (v < (int)viewCount) ? rawViews[v].pose.position : rawViews[0].pose.position;
-                                rawEyes[v] = {pos.x - eyeOffsetX, pos.y - eyeOffsetY, pos.z};
-                            }
-
-                            // For mono: average all views to center eye
-                            if (monoMode) {
-                                XrVector3f center = {0.0f, 0.0f, 0.0f};
-                                for (int v = 0; v < (int)viewCount && v < eyeCount; v++) {
-                                    center.x += rawEyes[v].x;
-                                    center.y += rawEyes[v].y;
-                                    center.z += rawEyes[v].z;
-                                }
-                                int cnt = (eyeCount < (int)viewCount) ? eyeCount : (int)viewCount;
-                                if (cnt < 1) cnt = 1;
-                                center.x /= cnt; center.y /= cnt; center.z /= cnt;
-                                rawEyes[0] = center;
-                            }
-
-                            // Build camera/display pose from player yaw/pitch/position
-                            XrPosef cameraPose;
-                            XMVECTOR pOri = XMQuaternionRotationRollPitchYaw(
-                                inputSnapshot.pitch, inputSnapshot.yaw, 0);
-                            XMFLOAT4 q;
-                            XMStoreFloat4(&q, pOri);
-                            cameraPose.orientation = {q.x, q.y, q.z, q.w};
-                            cameraPose.position = {inputSnapshot.cameraPosX, inputSnapshot.cameraPosY, inputSnapshot.cameraPosZ};
-
-                            XrVector3f nominalViewer = {xr->nominalViewerX, xr->nominalViewerY, xr->nominalViewerZ};
-                            Display3DScreen screen = {winW_m, winH_m};
-
-                            if (inputSnapshot.cameraMode) {
-                                // Camera-centric path
-                                Camera3DTunables camTunables;
-                                camTunables.ipd_factor = inputSnapshot.viewParams.ipdFactor;
-                                camTunables.parallax_factor = inputSnapshot.viewParams.parallaxFactor;
-                                camTunables.inv_convergence_distance = inputSnapshot.viewParams.invConvergenceDistance;
-                                camTunables.half_tan_vfov = CAMERA_HALF_TAN_VFOV / inputSnapshot.viewParams.zoomFactor;
-
-                                std::vector<Camera3DView> camViews(eyeCount);
-                                camera3d_compute_views(
-                                    rawEyes.data(), eyeCount, &nominalViewer,
-                                    &screen, &camTunables, &cameraPose,
-                                    0.01f, 100.0f, camViews.data());
-
-                                // Copy into Display3DView for uniform downstream rendering
-                                for (int i = 0; i < eyeCount; i++) {
-                                    memcpy(stereoViews[i].view_matrix, camViews[i].view_matrix, sizeof(float) * 16);
-                                    memcpy(stereoViews[i].projection_matrix, camViews[i].projection_matrix, sizeof(float) * 16);
-                                    stereoViews[i].fov = camViews[i].fov;
-                                    stereoViews[i].eye_world = camViews[i].eye_world;
-                                }
-                            } else {
-                                // Display-centric path
-                                Display3DTunables tunables;
-                                tunables.ipd_factor = inputSnapshot.viewParams.ipdFactor;
-                                tunables.parallax_factor = inputSnapshot.viewParams.parallaxFactor;
-                                tunables.perspective_factor = inputSnapshot.viewParams.perspectiveFactor;
-                                tunables.virtual_display_height = inputSnapshot.viewParams.virtualDisplayHeight / inputSnapshot.viewParams.scaleFactor;
-
-                                display3d_compute_views(
-                                    rawEyes.data(), eyeCount, &nominalViewer,
-                                    &screen, &tunables, &cameraPose,
-                                    tunables.virtual_display_height, 1000.0f * tunables.virtual_display_height, /*vulkan_flip_y=*/0, stereoViews.data());
-                                // display3d emits a GL ([-1,1] clip-z) projection; Vulkan clips [0,1].
-                                // Remap depth on the 3D per-view projections (not the mono/legacy
-                                // xr.projMatrices path). [#396 W1]
-                                for (uint32_t _v = 0; _v < eyeCount; _v++)
-                                    convert_projection_gl_to_zero_to_one(stereoViews[_v].projection_matrix);
+                                ProjectionFromXrFov(v.fov, nearZ, farZ, stereoViews[i].projection_matrix);
+                                convert_projection_gl_to_zero_to_one(stereoViews[i].projection_matrix);
+                                stereoViews[i].fov = v.fov;
                             }
                         }
 

--- a/test_apps/cube_handle_vk_win/xr_session.cpp
+++ b/test_apps/cube_handle_vk_win/xr_session.cpp
@@ -9,6 +9,8 @@
 #include "logging.h"
 #include <cstring>
 
+bool g_hasViewRigExt = false;
+
 #define XR_CHECK(call) \
     do { \
         XrResult result = (call); \
@@ -56,12 +58,16 @@ bool InitializeOpenXR(XrSessionManager& xr) {
         if (strcmp(ext.extensionName, XR_EXT_MCP_TOOLS_EXTENSION_NAME) == 0) {
             xr.hasMcpToolsExt = true;
         }
+        if (strcmp(ext.extensionName, XR_EXT_VIEW_RIG_EXTENSION_NAME) == 0) {
+            g_hasViewRigExt = true;
+        }
     }
 
     LOG_INFO("XR_KHR_vulkan_enable: %s", hasVulkan ? "AVAILABLE" : "NOT FOUND");
     LOG_INFO("XR_EXT_win32_window_binding: %s", xr.hasWin32WindowBindingExt ? "AVAILABLE" : "NOT FOUND");
     LOG_INFO("XR_EXT_display_info: %s", xr.hasDisplayInfoExt ? "AVAILABLE" : "NOT FOUND");
     LOG_INFO("XR_EXT_mcp_tools: %s", xr.hasMcpToolsExt ? "AVAILABLE" : "NOT FOUND");
+    LOG_INFO("XR_EXT_view_rig: %s", g_hasViewRigExt ? "AVAILABLE" : "NOT FOUND");
 
     if (!hasVulkan) {
         LOG_ERROR("XR_KHR_vulkan_enable extension not available");
@@ -81,6 +87,9 @@ bool InitializeOpenXR(XrSessionManager& xr) {
     }
     if (xr.hasMcpToolsExt) {
         enabledExtensions.push_back(XR_EXT_MCP_TOOLS_EXTENSION_NAME);
+    }
+    if (g_hasViewRigExt) {
+        enabledExtensions.push_back(XR_EXT_VIEW_RIG_EXTENSION_NAME);
     }
 
     XrInstanceCreateInfo createInfo = {XR_TYPE_INSTANCE_CREATE_INFO};

--- a/test_apps/cube_handle_vk_win/xr_session.h
+++ b/test_apps/cube_handle_vk_win/xr_session.h
@@ -11,6 +11,12 @@
 #include <vulkan/vulkan.h>
 #define XR_USE_GRAPHICS_API_VULKAN
 #include "xr_session_common.h"
+#include <openxr/XR_EXT_view_rig.h>
+
+// XR_EXT_view_rig (#396 W7) available + enabled on the instance. App-local
+// (not on the shared XrSessionManager); promote to xr_session_common when
+// more consumers adopt it.
+extern bool g_hasViewRigExt;
 
 // Initialize OpenXR instance with Vulkan + win32_window_binding extensions
 bool InitializeOpenXR(XrSessionManager& xr);

--- a/test_apps/cube_texture_d3d11_win/main.cpp
+++ b/test_apps/cube_texture_d3d11_win/main.cpp
@@ -29,9 +29,7 @@
 #include "text_overlay.h"
 #include "hud_renderer.h"
 #include "xr_session.h"
-#include "display3d_view.h"
 #include "projection_depth.h"
-#include "camera3d_view.h"
 
 #include <chrono>
 #include <cmath>
@@ -62,6 +60,77 @@ static const float HUD_WIDTH_FRACTION = 0.30f;
 static bool g_fullscreen = false;
 static RECT g_savedWindowRect = {};
 static DWORD g_savedWindowStyle = 0;
+
+// XR_EXT_view_rig (#396 W7 dogfood): the app chains a rig descriptor
+// (XrDisplayRigEXT, or XrCameraRigEXT in camera mode) on every xrLocateViews
+// and consumes the runtime's render-ready XrView{pose, fov} directly — the
+// per-frame Kooima generation is deleted; only clip policy stays app-side.
+// The runtime resolves the CANVAS sub-rect itself (get_window_metrics +
+// u_canvas_apply_to_metrics), so the app keeps zero canvas geometry for view
+// generation. Per-view staging container (matrices column-major):
+struct RigView {
+    float view_matrix[16];
+    float projection_matrix[16];
+    XrFovf fov;
+};
+
+// Column-major view matrix from a render-ready XrView pose:
+// viewMatrix = R^T * translate(-position) — same construction as the
+// displayxr::math rigs.
+static void ViewMatrixFromXrPose(const XrPosef& pose, float* out) {
+    const float qx = pose.orientation.x, qy = pose.orientation.y;
+    const float qz = pose.orientation.z, qw = pose.orientation.w;
+    float rot[16] = {};
+    rot[0] = 1.0f - 2.0f * (qy * qy + qz * qz);
+    rot[1] = 2.0f * (qx * qy + qz * qw);
+    rot[2] = 2.0f * (qx * qz - qy * qw);
+    rot[4] = 2.0f * (qx * qy - qz * qw);
+    rot[5] = 1.0f - 2.0f * (qx * qx + qz * qz);
+    rot[6] = 2.0f * (qy * qz + qx * qw);
+    rot[8] = 2.0f * (qx * qz + qy * qw);
+    rot[9] = 2.0f * (qy * qz - qx * qw);
+    rot[10] = 1.0f - 2.0f * (qx * qx + qy * qy);
+    rot[15] = 1.0f;
+    for (int i = 0; i < 16; i++) out[i] = 0.0f;
+    for (int i = 0; i < 3; i++)
+        for (int j = 0; j < 3; j++)
+            out[j * 4 + i] = rot[i * 4 + j]; // R^T
+    out[15] = 1.0f;
+    out[12] = -(out[0] * pose.position.x + out[4] * pose.position.y + out[8] * pose.position.z);
+    out[13] = -(out[1] * pose.position.x + out[5] * pose.position.y + out[9] * pose.position.z);
+    out[14] = -(out[2] * pose.position.x + out[6] * pose.position.y + out[10] * pose.position.z);
+}
+
+// Column-major GL ([-1,1] clip-z) off-axis projection from a render-ready
+// XrView fov + the app's own clip policy (fov is clip-independent). Pair with
+// convert_projection_gl_to_zero_to_one() for D3D.
+static void ProjectionFromXrFov(const XrFovf& fov, float nearZ, float farZ, float* out) {
+    const float l = tanf(fov.angleLeft) * nearZ;
+    const float r = tanf(fov.angleRight) * nearZ;
+    const float b = tanf(fov.angleDown) * nearZ;
+    const float t = tanf(fov.angleUp) * nearZ;
+    for (int i = 0; i < 16; i++) out[i] = 0.0f;
+    out[0] = 2.0f * nearZ / (r - l);
+    out[5] = 2.0f * nearZ / (t - b);
+    out[8] = (r + l) / (r - l);
+    out[9] = (t + b) / (t - b);
+    out[10] = -(farZ + nearZ) / (farZ - nearZ);
+    out[11] = -1.0f;
+    out[14] = -2.0f * farZ * nearZ / (farZ - nearZ);
+}
+
+// Display-local eye distance for the ZDP-anchored clip: z of (rigPose^-1 *
+// eyeWorld). Degenerates to pose.position.z at identity rig pose.
+static float RigLocalEyeZ(const XrPosef& rig, const XrVector3f& eyeWorld) {
+    const float dx = eyeWorld.x - rig.position.x;
+    const float dy = eyeWorld.y - rig.position.y;
+    const float dz = eyeWorld.z - rig.position.z;
+    const float qx = -rig.orientation.x, qy = -rig.orientation.y;
+    const float qz = -rig.orientation.z, qw = rig.orientation.w;
+    const float cx = qy * dz - qz * dy + qw * dx;
+    const float cy = qz * dx - qx * dz + qw * dy;
+    return dz + 2.0f * (qx * cy - qy * cx);
+}
 
 // Shared texture resources
 static ComPtr<ID3D11Texture2D> g_sharedTexture;
@@ -823,13 +892,54 @@ static void RenderOneFrame(RenderState& rs) {
                     for (int i = 0; i < 8; i++) rawViews[i].type = XR_TYPE_VIEW;
 
                     // XR_EXT_view_rig raw channel (#396 W7): chain the raw
-                    // result struct (no rig request) — the one-shot log below
-                    // proves canvasRectPx reports this texture app's canvas
-                    // SUB-RECT (xrSetSharedTextureOutputRectEXT), not the
-                    // window client area.
+                    // result struct — the one-shot log below proves
+                    // canvasRectPx reports this texture app's canvas SUB-RECT
+                    // (xrSetSharedTextureOutputRectEXT), not the window client
+                    // area. Coexists with the rig request below (independent
+                    // chains: raw on XrViewState::next, rig on
+                    // XrViewLocateInfo::next).
                     XrViewDisplayRawEXT viewRigRaw = {XR_TYPE_VIEW_DISPLAY_RAW_EXT};
                     if (g_hasViewRigExt) {
                         viewState.next = &viewRigRaw;
+                    }
+
+                    // XR_EXT_view_rig rig request: drive the runtime rig
+                    // matching the app's current mode (C selects the rig) with
+                    // the app's tunables — the runtime owns the canvas resolve
+                    // and the Kooima math, and returns render-ready
+                    // XrView{pose, fov}. Per-locate semantics: chain the rig
+                    // on every consume locate.
+                    const bool useAppProjection =
+                        xr.hasDisplayInfoExt && xr.displayWidthM > 0.0f && g_hasViewRigExt;
+                    const bool rigCamera = useAppProjection && g_inputState.cameraMode;
+                    XrCameraRigEXT cameraRig = {XR_TYPE_CAMERA_RIG_EXT};
+                    XrDisplayRigEXT displayRig = {XR_TYPE_DISPLAY_RIG_EXT};
+                    XrPosef rigPose = {{0, 0, 0, 1}, {0, 0, 0}};
+                    if (useAppProjection) {
+                        XMVECTOR rigOri = XMQuaternionRotationRollPitchYaw(
+                            g_inputState.pitch, g_inputState.yaw, 0);
+                        XMFLOAT4 rq;
+                        XMStoreFloat4(&rq, rigOri);
+                        rigPose.orientation = {rq.x, rq.y, rq.z, rq.w};
+                        rigPose.position = {g_inputState.cameraPosX, g_inputState.cameraPosY,
+                                            g_inputState.cameraPosZ};
+                        if (rigCamera) {
+                            cameraRig.pose = rigPose;
+                            cameraRig.ipdFactor = g_inputState.viewParams.ipdFactor;
+                            cameraRig.parallaxFactor = g_inputState.viewParams.parallaxFactor;
+                            cameraRig.convergenceDiopters = g_inputState.viewParams.invConvergenceDistance;
+                            cameraRig.verticalFov =
+                                2.0f * atanf(CAMERA_HALF_TAN_VFOV / g_inputState.viewParams.zoomFactor);
+                            locateInfo.next = &cameraRig;
+                        } else {
+                            displayRig.pose = rigPose;
+                            displayRig.virtualDisplayHeight =
+                                g_inputState.viewParams.virtualDisplayHeight / g_inputState.viewParams.scaleFactor;
+                            displayRig.ipdFactor = g_inputState.viewParams.ipdFactor;
+                            displayRig.parallaxFactor = g_inputState.viewParams.parallaxFactor;
+                            displayRig.perspectiveFactor = g_inputState.viewParams.perspectiveFactor;
+                            locateInfo.next = &displayRig;
+                        }
                     }
 
                     xrLocateViews(xr.session, &locateInfo, &viewState, 8, &viewCount, rawViews);
@@ -860,103 +970,28 @@ static void RenderOneFrame(RenderState& rs) {
                     uint32_t maxTileW = tileColumns > 0 ? xr.swapchain.width / tileColumns : xr.swapchain.width;
                     uint32_t maxTileH = tileRows > 0 ? xr.swapchain.height / tileRows : xr.swapchain.height;
 
-                    std::vector<Display3DView> stereoViews(eyeCount);
-                    bool useAppProjection = (xr.hasDisplayInfoExt && xr.displayWidthM > 0.0f);
+                    // --- Consume the runtime's render-ready XrView{pose, fov} ---
+                    // Only clip policy (near/far + the GL→[0,1] depth remap)
+                    // stays app-side, by design (fov is clip-independent).
+                    // Camera rig: same absolute clip as the old app-side camera
+                    // path. Display rig: ZDP-anchored clip (near = ez - vH,
+                    // far = ez + 1000·vH; ez = rig-local z of the view pose).
+                    std::vector<RigView> stereoViews(eyeCount);
                     if (useAppProjection) {
-                        // Canvas-relative Kooima: the CANVAS sub-rect's placement on the
-                        // display + raw eyes -> Kooima screen dims + canvas-relative eyes,
-                        // via the shared displayxr::math helper (#396 Layer 1). Same call
-                        // as a handle app — just the canvas sub-rect instead of the full
-                        // window (no app-class branching in the lib). Platform rect-fetch
-                        // (incl. the canvas's offset within the window) stays here.
-                        float canvas_off_x = (float)g_windowWidth  / 4.0f;
-                        float canvas_off_y = (float)g_windowHeight / 4.0f;
-                        Display3DWindowPlacement place;
-                        place.display_width_m   = xr.displayWidthM;
-                        place.display_height_m  = xr.displayHeightM;
-                        place.display_width_px  = (float)xr.displayPixelWidth;   // fallback
-                        place.display_height_px = (float)xr.displayPixelHeight;
-                        place.rect_width_px     = (float)g_canvasW;
-                        place.rect_height_px    = (float)g_canvasH;
-                        place.rect_center_x_px  = place.display_width_px * 0.5f;  // fallback: centered
-                        place.rect_center_y_px  = place.display_height_px * 0.5f;
-                        {
-                            POINT clientOrigin = {0, 0};
-                            ClientToScreen(rs.hwnd, &clientOrigin);
-                            HMONITOR hMon = MonitorFromWindow(rs.hwnd, MONITOR_DEFAULTTONEAREST);
-                            MONITORINFO mi = {sizeof(mi)};
-                            if (GetMonitorInfo(hMon, &mi)) {
-                                place.display_width_px  = (float)(mi.rcMonitor.right - mi.rcMonitor.left);
-                                place.display_height_px = (float)(mi.rcMonitor.bottom - mi.rcMonitor.top);
-                                place.rect_center_x_px  = (float)(clientOrigin.x - mi.rcMonitor.left) + canvas_off_x + g_canvasW / 2.0f;
-                                place.rect_center_y_px  = (float)(clientOrigin.y - mi.rcMonitor.top)  + canvas_off_y + g_canvasH / 2.0f;
+                        const float rigVH =
+                            g_inputState.viewParams.virtualDisplayHeight / g_inputState.viewParams.scaleFactor;
+                        for (int i = 0; i < eyeCount; i++) {
+                            const XrView& v = rawViews[(i < (int)viewCount) ? i : 0];
+                            ViewMatrixFromXrPose(v.pose, stereoViews[i].view_matrix);
+                            float nearZ = 0.01f, farZ = 100.0f;
+                            if (!rigCamera) {
+                                float ez = RigLocalEyeZ(rigPose, v.pose.position);
+                                nearZ = (ez - rigVH > 0.001f) ? (ez - rigVH) : 0.001f;
+                                farZ = ez + 1000.0f * rigVH;
                             }
-                        }
-
-                        std::vector<XrVector3f> rawEyes(modeViewCount);
-                        for (uint32_t v = 0; v < modeViewCount; v++) {
-                            rawEyes[v] = (v < viewCount) ? rawViews[v].pose.position : rawViews[0].pose.position;
-                        }
-                        Display3DScreen screen;
-                        display3d_resolve_window_rect(&place, rawEyes.data(), modeViewCount, &screen, rawEyes.data());
-                        if (monoMode && modeViewCount >= 2) {
-                            XrVector3f center = {0, 0, 0};
-                            for (uint32_t v = 0; v < modeViewCount; v++) {
-                                center.x += rawEyes[v].x;
-                                center.y += rawEyes[v].y;
-                                center.z += rawEyes[v].z;
-                            }
-                            center.x /= modeViewCount;
-                            center.y /= modeViewCount;
-                            center.z /= modeViewCount;
-                            rawEyes[0] = center;
-                        }
-
-                        XrPosef cameraPose;
-                        XMVECTOR pOri = XMQuaternionRotationRollPitchYaw(
-                            g_inputState.pitch, g_inputState.yaw, 0);
-                        XMFLOAT4 q;
-                        XMStoreFloat4(&q, pOri);
-                        cameraPose.orientation = {q.x, q.y, q.z, q.w};
-                        cameraPose.position = {g_inputState.cameraPosX, g_inputState.cameraPosY, g_inputState.cameraPosZ};
-
-                        XrVector3f nominalViewer = {xr.nominalViewerX, xr.nominalViewerY, xr.nominalViewerZ};
-
-                        if (g_inputState.cameraMode) {
-                            Camera3DTunables camTunables;
-                            camTunables.ipd_factor = g_inputState.viewParams.ipdFactor;
-                            camTunables.parallax_factor = g_inputState.viewParams.parallaxFactor;
-                            camTunables.inv_convergence_distance = g_inputState.viewParams.invConvergenceDistance;
-                            camTunables.half_tan_vfov = CAMERA_HALF_TAN_VFOV / g_inputState.viewParams.zoomFactor;
-
-                            std::vector<Camera3DView> camViews(eyeCount);
-                            camera3d_compute_views(
-                                rawEyes.data(), eyeCount, &nominalViewer,
-                                &screen, &camTunables, &cameraPose,
-                                0.01f, 100.0f, camViews.data());
-
-                            for (int i = 0; i < eyeCount; i++) {
-                                memcpy(stereoViews[i].view_matrix, camViews[i].view_matrix, sizeof(float) * 16);
-                                memcpy(stereoViews[i].projection_matrix, camViews[i].projection_matrix, sizeof(float) * 16);
-                                stereoViews[i].fov = camViews[i].fov;
-                                stereoViews[i].eye_world = camViews[i].eye_world;
-                            }
-                        } else {
-                            Display3DTunables tunables;
-                            tunables.ipd_factor = g_inputState.viewParams.ipdFactor;
-                            tunables.parallax_factor = g_inputState.viewParams.parallaxFactor;
-                            tunables.perspective_factor = g_inputState.viewParams.perspectiveFactor;
-                            tunables.virtual_display_height = g_inputState.viewParams.virtualDisplayHeight / g_inputState.viewParams.scaleFactor;
-
-                            display3d_compute_views(
-                                rawEyes.data(), eyeCount, &nominalViewer,
-                                &screen, &tunables, &cameraPose,
-                                tunables.virtual_display_height, 1000.0f * tunables.virtual_display_height, /*vulkan_flip_y=*/0, stereoViews.data());
-                            // display3d emits a GL ([-1,1] clip-z) projection; D3D clips [0,1].
-                            // Remap depth on the 3D per-view projections (not the mono/legacy
-                            // xr.projMatrices path). [#396 W1]
-                            for (uint32_t _v = 0; _v < eyeCount; _v++)
-                                convert_projection_gl_to_zero_to_one(stereoViews[_v].projection_matrix);
+                            ProjectionFromXrFov(v.fov, nearZ, farZ, stereoViews[i].projection_matrix);
+                            convert_projection_gl_to_zero_to_one(stereoViews[i].projection_matrix);
+                            stereoViews[i].fov = v.fov;
                         }
                     }
 

--- a/test_apps/cube_texture_d3d12_win/main.cpp
+++ b/test_apps/cube_texture_d3d12_win/main.cpp
@@ -30,9 +30,7 @@
 #include "hud_renderer.h"
 #include "text_overlay.h"
 #include "xr_session.h"
-#include "display3d_view.h"
 #include "projection_depth.h"
-#include "camera3d_view.h"
 
 #include <chrono>
 #include <cmath>
@@ -65,6 +63,77 @@ static const float HUD_WIDTH_FRACTION = 0.30f;
 static bool g_fullscreen = false;
 static RECT g_savedWindowRect = {};
 static DWORD g_savedWindowStyle = 0;
+
+// XR_EXT_view_rig (#396 W7 dogfood): the app chains a rig descriptor
+// (XrDisplayRigEXT, or XrCameraRigEXT in camera mode) on every xrLocateViews
+// and consumes the runtime's render-ready XrView{pose, fov} directly — the
+// per-frame Kooima generation is deleted; only clip policy stays app-side.
+// The runtime resolves the CANVAS sub-rect itself (the d3d12 compositor
+// delegates window metrics to the DP). Per-view staging container (matrices
+// column-major):
+struct RigView {
+    float view_matrix[16];
+    float projection_matrix[16];
+    XrFovf fov;
+};
+
+// Column-major view matrix from a render-ready XrView pose:
+// viewMatrix = R^T * translate(-position) — same construction as the
+// displayxr::math rigs.
+static void ViewMatrixFromXrPose(const XrPosef& pose, float* out) {
+    const float qx = pose.orientation.x, qy = pose.orientation.y;
+    const float qz = pose.orientation.z, qw = pose.orientation.w;
+    float rot[16] = {};
+    rot[0] = 1.0f - 2.0f * (qy * qy + qz * qz);
+    rot[1] = 2.0f * (qx * qy + qz * qw);
+    rot[2] = 2.0f * (qx * qz - qy * qw);
+    rot[4] = 2.0f * (qx * qy - qz * qw);
+    rot[5] = 1.0f - 2.0f * (qx * qx + qz * qz);
+    rot[6] = 2.0f * (qy * qz + qx * qw);
+    rot[8] = 2.0f * (qx * qz + qy * qw);
+    rot[9] = 2.0f * (qy * qz - qx * qw);
+    rot[10] = 1.0f - 2.0f * (qx * qx + qy * qy);
+    rot[15] = 1.0f;
+    for (int i = 0; i < 16; i++) out[i] = 0.0f;
+    for (int i = 0; i < 3; i++)
+        for (int j = 0; j < 3; j++)
+            out[j * 4 + i] = rot[i * 4 + j]; // R^T
+    out[15] = 1.0f;
+    out[12] = -(out[0] * pose.position.x + out[4] * pose.position.y + out[8] * pose.position.z);
+    out[13] = -(out[1] * pose.position.x + out[5] * pose.position.y + out[9] * pose.position.z);
+    out[14] = -(out[2] * pose.position.x + out[6] * pose.position.y + out[10] * pose.position.z);
+}
+
+// Column-major GL ([-1,1] clip-z) off-axis projection from a render-ready
+// XrView fov + the app's own clip policy (fov is clip-independent). Pair with
+// convert_projection_gl_to_zero_to_one() for D3D.
+static void ProjectionFromXrFov(const XrFovf& fov, float nearZ, float farZ, float* out) {
+    const float l = tanf(fov.angleLeft) * nearZ;
+    const float r = tanf(fov.angleRight) * nearZ;
+    const float b = tanf(fov.angleDown) * nearZ;
+    const float t = tanf(fov.angleUp) * nearZ;
+    for (int i = 0; i < 16; i++) out[i] = 0.0f;
+    out[0] = 2.0f * nearZ / (r - l);
+    out[5] = 2.0f * nearZ / (t - b);
+    out[8] = (r + l) / (r - l);
+    out[9] = (t + b) / (t - b);
+    out[10] = -(farZ + nearZ) / (farZ - nearZ);
+    out[11] = -1.0f;
+    out[14] = -2.0f * farZ * nearZ / (farZ - nearZ);
+}
+
+// Display-local eye distance for the ZDP-anchored clip: z of (rigPose^-1 *
+// eyeWorld). Degenerates to pose.position.z at identity rig pose.
+static float RigLocalEyeZ(const XrPosef& rig, const XrVector3f& eyeWorld) {
+    const float dx = eyeWorld.x - rig.position.x;
+    const float dy = eyeWorld.y - rig.position.y;
+    const float dz = eyeWorld.z - rig.position.z;
+    const float qx = -rig.orientation.x, qy = -rig.orientation.y;
+    const float qz = -rig.orientation.z, qw = rig.orientation.w;
+    const float cx = qy * dz - qz * dy + qw * dx;
+    const float cy = qz * dx - qx * dz + qw * dy;
+    return dz + 2.0f * (qx * cy - qy * cx);
+}
 
 // Shared texture resources (D3D12)
 static ComPtr<ID3D12Resource> g_sharedTexture;
@@ -1126,6 +1195,45 @@ static void RenderOneFrame(RenderState& rs) {
                     uint32_t viewCount = 0;
                     XrView rawViews[8] = {};
                     for (int i = 0; i < 8; i++) rawViews[i].type = XR_TYPE_VIEW;
+
+                    // XR_EXT_view_rig (#396 W7): drive the runtime rig matching
+                    // the app's current mode (C selects the rig) with the app's
+                    // tunables — the runtime owns the canvas resolve and the
+                    // Kooima math, and returns render-ready XrView{pose, fov}.
+                    // Per-locate semantics: chain the rig on every consume
+                    // locate.
+                    const bool useAppProjection =
+                        xr.hasDisplayInfoExt && xr.displayWidthM > 0.0f && g_hasViewRigExt;
+                    const bool rigCamera = useAppProjection && g_inputState.cameraMode;
+                    XrCameraRigEXT cameraRig = {XR_TYPE_CAMERA_RIG_EXT};
+                    XrDisplayRigEXT displayRig = {XR_TYPE_DISPLAY_RIG_EXT};
+                    XrPosef rigPose = {{0, 0, 0, 1}, {0, 0, 0}};
+                    if (useAppProjection) {
+                        XMVECTOR rigOri = XMQuaternionRotationRollPitchYaw(
+                            g_inputState.pitch, g_inputState.yaw, 0);
+                        XMFLOAT4 rq;
+                        XMStoreFloat4(&rq, rigOri);
+                        rigPose.orientation = {rq.x, rq.y, rq.z, rq.w};
+                        rigPose.position = {g_inputState.cameraPosX, g_inputState.cameraPosY,
+                                            g_inputState.cameraPosZ};
+                        if (rigCamera) {
+                            cameraRig.pose = rigPose;
+                            cameraRig.ipdFactor = g_inputState.viewParams.ipdFactor;
+                            cameraRig.parallaxFactor = g_inputState.viewParams.parallaxFactor;
+                            cameraRig.convergenceDiopters = g_inputState.viewParams.invConvergenceDistance;
+                            cameraRig.verticalFov =
+                                2.0f * atanf(CAMERA_HALF_TAN_VFOV / g_inputState.viewParams.zoomFactor);
+                            locateInfo.next = &cameraRig;
+                        } else {
+                            displayRig.pose = rigPose;
+                            displayRig.virtualDisplayHeight =
+                                g_inputState.viewParams.virtualDisplayHeight / g_inputState.viewParams.scaleFactor;
+                            displayRig.ipdFactor = g_inputState.viewParams.ipdFactor;
+                            displayRig.parallaxFactor = g_inputState.viewParams.parallaxFactor;
+                            displayRig.perspectiveFactor = g_inputState.viewParams.perspectiveFactor;
+                            locateInfo.next = &displayRig;
+                        }
+                    }
                     xrLocateViews(xr.session, &locateInfo, &viewState, 8, &viewCount, rawViews);
 
                     uint32_t maxTileW = tileColumns > 0 ? xr.swapchain.width / tileColumns : xr.swapchain.width;
@@ -1176,99 +1284,28 @@ static void RenderOneFrame(RenderState& rs) {
                         }
                     }
 
-                    // Kooima projection using canvas dims
-                    std::vector<Display3DView> stereoViews(eyeCount);
-                    bool useAppProjection = (xr.hasDisplayInfoExt && xr.displayWidthM > 0.0f);
+                    // --- Consume the runtime's render-ready XrView{pose, fov} ---
+                    // Only clip policy (near/far + the GL→[0,1] depth remap)
+                    // stays app-side, by design (fov is clip-independent).
+                    // Camera rig: same absolute clip as the old app-side camera
+                    // path. Display rig: ZDP-anchored clip (near = ez - vH,
+                    // far = ez + 1000·vH; ez = rig-local z of the view pose).
+                    std::vector<RigView> stereoViews(eyeCount);
                     if (useAppProjection) {
-                        float pxSizeX = xr.displayWidthM / (float)xr.displayPixelWidth;
-                        float pxSizeY = xr.displayHeightM / (float)xr.displayPixelHeight;
-                        float canvasW_m = (float)g_canvasW * pxSizeX;
-                        float canvasH_m = (float)g_canvasH * pxSizeY;
-
-                        // Canvas-relative Kooima: physical size + eye offset both anchored
-                        // on the canvas region within the window (not the window itself).
-                        float canvas_off_x = (float)g_windowWidth  / 4.0f;
-                        float canvas_off_y = (float)g_windowHeight / 4.0f;
-                        float eyeOffsetX = 0.0f, eyeOffsetY = 0.0f;
-                        {
-                            POINT clientOrigin = {0, 0};
-                            ClientToScreen(rs.hwnd, &clientOrigin);
-                            HMONITOR hMon = MonitorFromWindow(rs.hwnd, MONITOR_DEFAULTTONEAREST);
-                            MONITORINFO mi = {sizeof(mi)};
-                            if (GetMonitorInfo(hMon, &mi)) {
-                                float canvasCenterX = (float)(clientOrigin.x - mi.rcMonitor.left) + canvas_off_x + g_canvasW / 2.0f;
-                                float canvasCenterY = (float)(clientOrigin.y - mi.rcMonitor.top)  + canvas_off_y + g_canvasH / 2.0f;
-                                float dispW = (float)(mi.rcMonitor.right - mi.rcMonitor.left);
-                                float dispH = (float)(mi.rcMonitor.bottom - mi.rcMonitor.top);
-                                eyeOffsetX =  (canvasCenterX - dispW / 2.0f) * pxSizeX;
-                                eyeOffsetY = -((canvasCenterY - dispH / 2.0f) * pxSizeY);
+                        const float rigVH =
+                            g_inputState.viewParams.virtualDisplayHeight / g_inputState.viewParams.scaleFactor;
+                        for (int i = 0; i < eyeCount; i++) {
+                            const XrView& v = rawViews[(i < (int)viewCount) ? i : 0];
+                            ViewMatrixFromXrPose(v.pose, stereoViews[i].view_matrix);
+                            float nearZ = 0.01f, farZ = 100.0f;
+                            if (!rigCamera) {
+                                float ez = RigLocalEyeZ(rigPose, v.pose.position);
+                                nearZ = (ez - rigVH > 0.001f) ? (ez - rigVH) : 0.001f;
+                                farZ = ez + 1000.0f * rigVH;
                             }
-                        }
-
-                        std::vector<XrVector3f> rawEyes(modeViewCount);
-                        for (uint32_t v = 0; v < modeViewCount; v++) {
-                            XrVector3f pos = (v < viewCount) ? rawViews[v].pose.position : rawViews[0].pose.position;
-                            rawEyes[v] = {pos.x - eyeOffsetX, pos.y - eyeOffsetY, pos.z};
-                        }
-                        if (monoMode && modeViewCount >= 2) {
-                            XrVector3f center = {0, 0, 0};
-                            for (uint32_t v = 0; v < modeViewCount; v++) {
-                                center.x += rawEyes[v].x;
-                                center.y += rawEyes[v].y;
-                                center.z += rawEyes[v].z;
-                            }
-                            center.x /= modeViewCount;
-                            center.y /= modeViewCount;
-                            center.z /= modeViewCount;
-                            rawEyes[0] = center;
-                        }
-
-                        XrPosef cameraPose;
-                        XMVECTOR pOri = XMQuaternionRotationRollPitchYaw(
-                            g_inputState.pitch, g_inputState.yaw, 0);
-                        XMFLOAT4 q;
-                        XMStoreFloat4(&q, pOri);
-                        cameraPose.orientation = {q.x, q.y, q.z, q.w};
-                        cameraPose.position = {g_inputState.cameraPosX, g_inputState.cameraPosY, g_inputState.cameraPosZ};
-
-                        XrVector3f nominalViewer = {xr.nominalViewerX, xr.nominalViewerY, xr.nominalViewerZ};
-                        Display3DScreen screen = {canvasW_m, canvasH_m};
-
-                        if (g_inputState.cameraMode) {
-                            Camera3DTunables camTunables;
-                            camTunables.ipd_factor = g_inputState.viewParams.ipdFactor;
-                            camTunables.parallax_factor = g_inputState.viewParams.parallaxFactor;
-                            camTunables.inv_convergence_distance = g_inputState.viewParams.invConvergenceDistance;
-                            camTunables.half_tan_vfov = CAMERA_HALF_TAN_VFOV / g_inputState.viewParams.zoomFactor;
-
-                            std::vector<Camera3DView> camViews(eyeCount);
-                            camera3d_compute_views(
-                                rawEyes.data(), eyeCount, &nominalViewer,
-                                &screen, &camTunables, &cameraPose,
-                                0.01f, 100.0f, camViews.data());
-
-                            for (int i = 0; i < eyeCount; i++) {
-                                memcpy(stereoViews[i].view_matrix, camViews[i].view_matrix, sizeof(float) * 16);
-                                memcpy(stereoViews[i].projection_matrix, camViews[i].projection_matrix, sizeof(float) * 16);
-                                stereoViews[i].fov = camViews[i].fov;
-                                stereoViews[i].eye_world = camViews[i].eye_world;
-                            }
-                        } else {
-                            Display3DTunables tunables;
-                            tunables.ipd_factor = g_inputState.viewParams.ipdFactor;
-                            tunables.parallax_factor = g_inputState.viewParams.parallaxFactor;
-                            tunables.perspective_factor = g_inputState.viewParams.perspectiveFactor;
-                            tunables.virtual_display_height = g_inputState.viewParams.virtualDisplayHeight / g_inputState.viewParams.scaleFactor;
-
-                            display3d_compute_views(
-                                rawEyes.data(), eyeCount, &nominalViewer,
-                                &screen, &tunables, &cameraPose,
-                                tunables.virtual_display_height, 1000.0f * tunables.virtual_display_height, /*vulkan_flip_y=*/0, stereoViews.data());
-                            // display3d emits a GL ([-1,1] clip-z) projection; D3D clips [0,1].
-                            // Remap depth on the 3D per-view projections (not the mono/legacy
-                            // xr.projMatrices path). [#396 W1]
-                            for (uint32_t _v = 0; _v < eyeCount; _v++)
-                                convert_projection_gl_to_zero_to_one(stereoViews[_v].projection_matrix);
+                            ProjectionFromXrFov(v.fov, nearZ, farZ, stereoViews[i].projection_matrix);
+                            convert_projection_gl_to_zero_to_one(stereoViews[i].projection_matrix);
+                            stereoViews[i].fov = v.fov;
                         }
                     }
 

--- a/test_apps/cube_texture_d3d12_win/xr_session.cpp
+++ b/test_apps/cube_texture_d3d12_win/xr_session.cpp
@@ -11,6 +11,7 @@
 
 // #439 — XR_EXT_local_3d_zone harness state (see xr_session.h).
 ZoneMaskHarness g_zone;
+bool g_hasViewRigExt = false;
 
 #define XR_CHECK(call) \
     do { \
@@ -81,12 +82,16 @@ bool InitializeOpenXR(XrSessionManager& xr) {
         if (strcmp(ext.extensionName, XR_EXT_LOCAL_3D_ZONE_EXTENSION_NAME) == 0) {
             g_zone.available = true;
         }
+        if (strcmp(ext.extensionName, XR_EXT_VIEW_RIG_EXTENSION_NAME) == 0) {
+            g_hasViewRigExt = true;
+        }
     }
 
     LOG_INFO("XR_KHR_D3D12_enable: %s", hasD3D12 ? "AVAILABLE" : "NOT FOUND");
     LOG_INFO("XR_EXT_win32_window_binding: %s", xr.hasWin32WindowBindingExt ? "AVAILABLE" : "NOT FOUND");
     LOG_INFO("XR_EXT_display_info: %s", xr.hasDisplayInfoExt ? "AVAILABLE" : "NOT FOUND");
     LOG_INFO("XR_EXT_local_3d_zone: %s", g_zone.available ? "AVAILABLE" : "NOT FOUND");
+    LOG_INFO("XR_EXT_view_rig: %s", g_hasViewRigExt ? "AVAILABLE" : "NOT FOUND");
 
     if (!hasD3D12) {
         LOG_ERROR("XR_KHR_D3D12_enable extension not available");
@@ -106,6 +111,9 @@ bool InitializeOpenXR(XrSessionManager& xr) {
     }
     if (g_zone.available) {
         enabledExtensions.push_back(XR_EXT_LOCAL_3D_ZONE_EXTENSION_NAME);
+    }
+    if (g_hasViewRigExt) {
+        enabledExtensions.push_back(XR_EXT_VIEW_RIG_EXTENSION_NAME);
     }
 
     LOG_INFO("Enabling %zu extensions", enabledExtensions.size());

--- a/test_apps/cube_texture_d3d12_win/xr_session.h
+++ b/test_apps/cube_texture_d3d12_win/xr_session.h
@@ -16,6 +16,12 @@
 #define XR_USE_GRAPHICS_API_D3D12
 #include "xr_session_common.h"
 #include <openxr/XR_EXT_local_3d_zone.h>
+#include <openxr/XR_EXT_view_rig.h>
+
+// XR_EXT_view_rig (#396 W7) available + enabled on the instance. App-local
+// (not on the shared XrSessionManager); promote to xr_session_common when
+// more consumers adopt it.
+extern bool g_hasViewRigExt;
 
 // #439 — XR_EXT_local_3d_zone test harness state (D3D12 port of the
 // cube_texture_d3d11_win Phase-1 harness). App-local: the shared

--- a/test_apps/cube_texture_metal_macos/main.mm
+++ b/test_apps/cube_texture_metal_macos/main.mm
@@ -54,12 +54,11 @@
 
 // stb_image implementation TU lives in displayxr::common (stb_image_impl_macos.cpp) — declarations only here (#396 W4).
 #include "stb_image.h"
-#include "display3d_view.h"
-#include "camera3d_view.h"
 #include "view_params.h"
 #include "xr_window_space_hud.h"
 #include "hud_renderer_macos.h"
 #include <openxr/XR_EXT_display_info.h>
+#include <openxr/XR_EXT_view_rig.h>
 
 // ============================================================================
 // Logging
@@ -184,12 +183,19 @@ static void quat_rotate_vec3(XrQuaternionf q, float vx, float vy, float vz,
     *oz = vz + q.w * tz + (q.x * ty - q.y * tx);
 }
 
-// Convert display3d/camera3d projection (OpenGL z[-1,1]) to Metal z[0,1]
-static void convert_projection_gl_to_metal(float m[16]) {
-    m[2]  = 0.5f * m[2]  + 0.5f * m[3];
-    m[6]  = 0.5f * m[6]  + 0.5f * m[7];
-    m[10] = 0.5f * m[10] + 0.5f * m[11];
-    m[14] = 0.5f * m[14] + 0.5f * m[15];
+// Display-local eye distance for the ZDP-anchored clip (#396 W7 consume
+// path): z of (rigPose^-1 * eyeWorld). Degenerates to pose.position.z at
+// identity rig pose.
+static float RigLocalEyeZ(const XrPosef &rig, const XrVector3f &eyeWorld) {
+    XrQuaternionf inv = {-rig.orientation.x, -rig.orientation.y,
+                         -rig.orientation.z, rig.orientation.w};
+    float ox, oy, oz;
+    quat_rotate_vec3(inv,
+                     eyeWorld.x - rig.position.x,
+                     eyeWorld.y - rig.position.y,
+                     eyeWorld.z - rig.position.z,
+                     &ox, &oy, &oz);
+    return oz;
 }
 
 // ============================================================================
@@ -1520,6 +1526,7 @@ struct AppXrSession {
 
     // XR_EXT_display_info
     bool hasDisplayInfoExt;
+    bool hasViewRigExt = false;  // XR_EXT_view_rig (#396 W7)
     float displayWidthM;
     float displayHeightM;
     float nominalViewerX, nominalViewerY, nominalViewerZ;
@@ -1577,6 +1584,8 @@ static bool InitializeOpenXR(AppXrSession &app)
             app.hasCocoaWindowBinding = true;
         if (strcmp(e.extensionName, XR_EXT_DISPLAY_INFO_EXTENSION_NAME) == 0)
             app.hasDisplayInfoExt = true;
+        if (strcmp(e.extensionName, XR_EXT_VIEW_RIG_EXTENSION_NAME) == 0)
+            app.hasViewRigExt = true;
     }
 
     if (!hasMetalEnable) {
@@ -1588,6 +1597,7 @@ static bool InitializeOpenXR(AppXrSession &app)
         return false;
     }
     LOG_INFO("XR_EXT_display_info: %s", app.hasDisplayInfoExt ? "available" : "not available");
+    LOG_INFO("XR_EXT_view_rig: %s", app.hasViewRigExt ? "AVAILABLE" : "NOT FOUND");
 
     // Enable extensions
     std::vector<const char *> enabledExts = {
@@ -1596,6 +1606,9 @@ static bool InitializeOpenXR(AppXrSession &app)
     };
     if (app.hasDisplayInfoExt) {
         enabledExts.push_back(XR_EXT_DISPLAY_INFO_EXTENSION_NAME);
+    }
+    if (app.hasViewRigExt) {
+        enabledExts.push_back(XR_EXT_VIEW_RIG_EXTENSION_NAME);
     }
 
     XrInstanceCreateInfo createInfo = {XR_TYPE_INSTANCE_CREATE_INFO};
@@ -2150,6 +2163,42 @@ int main(int argc, char **argv)
         locateInfo.displayTime = frameState.predictedDisplayTime;
         locateInfo.space = app.localSpace;
 
+        // XR_EXT_view_rig (#396 W7): drive the runtime rig matching the app's
+        // current mode (C selects the rig) with the app's tunables — the
+        // runtime owns the CANVAS sub-rect resolve and the Kooima math, and
+        // returns render-ready XrView{pose, fov}. Per-locate semantics: chain
+        // the rig on every consume locate. The raw result struct feeds the
+        // HUD's display-space eye readout.
+        const bool useRig =
+            app.hasViewRigExt && app.displayWidthM > 0 && app.displayHeightM > 0;
+        const bool rigCamera = useRig && g_input.cameraMode;
+        XrCameraRigEXT cameraRig = {XR_TYPE_CAMERA_RIG_EXT};
+        XrDisplayRigEXT displayRig = {XR_TYPE_DISPLAY_RIG_EXT};
+        XrViewDisplayRawEXT viewRigRaw = {XR_TYPE_VIEW_DISPLAY_RAW_EXT};
+        XrPosef rigPose = {{0, 0, 0, 1}, {0, 0, 0}};
+        if (useRig) {
+            quat_from_yaw_pitch(g_input.yaw, g_input.pitch, &rigPose.orientation);
+            rigPose.position = {g_input.cameraPosX, g_input.cameraPosY, g_input.cameraPosZ};
+            if (rigCamera) {
+                cameraRig.pose = rigPose;
+                cameraRig.ipdFactor = g_input.viewParams.ipdFactor;
+                cameraRig.parallaxFactor = g_input.viewParams.parallaxFactor;
+                cameraRig.convergenceDiopters = g_input.viewParams.invConvergenceDistance;
+                cameraRig.verticalFov =
+                    2.0f * atanf(CAMERA_HALF_TAN_VFOV / g_input.viewParams.zoomFactor);
+                locateInfo.next = &cameraRig;
+            } else {
+                displayRig.pose = rigPose;
+                displayRig.virtualDisplayHeight =
+                    g_input.viewParams.virtualDisplayHeight / g_input.viewParams.scaleFactor;
+                displayRig.ipdFactor = g_input.viewParams.ipdFactor;
+                displayRig.parallaxFactor = g_input.viewParams.parallaxFactor;
+                displayRig.perspectiveFactor = g_input.viewParams.perspectiveFactor;
+                locateInfo.next = &displayRig;
+            }
+            viewState.next = &viewRigRaw;
+        }
+
         uint32_t viewCount = 0;
         xrLocateViews(app.session, &locateInfo, &viewState, (uint32_t)views.size(), &viewCount, views.data());
 
@@ -2183,35 +2232,23 @@ int main(int argc, char **argv)
 
         // Render
         if (frameState.shouldRender && viewCount >= 1) {
-            std::vector<XrVector3f> rawEyePos(modeViewCount);
-            for (uint32_t v = 0; v < modeViewCount; v++) {
-                rawEyePos[v] = (v < viewCount) ? views[v].pose.position : views[0].pose.position;
-            }
+            // Save display-space eye positions for the HUD. Under the rig,
+            // views[] carries render-ready world eyes — the raw channel
+            // (XrViewDisplayRawEXT) keeps the HUD readout in display space.
             app.eyeCount = modeViewCount;
-            for (uint32_t v = 0; v < modeViewCount && v < 8; v++) {
-                app.eyePositions[v][0] = rawEyePos[v].x;
-                app.eyePositions[v][1] = rawEyePos[v].y;
-                app.eyePositions[v][2] = rawEyePos[v].z;
-            }
-
-            if (!display3D && modeViewCount >= 2) {
-                XrVector3f center = {0, 0, 0};
-                for (uint32_t v = 0; v < modeViewCount; v++) {
-                    center.x += rawEyePos[v].x;
-                    center.y += rawEyePos[v].y;
-                    center.z += rawEyePos[v].z;
+            if (useRig && viewRigRaw.eyeCountOutput > 0) {
+                for (uint32_t v = 0; v < viewRigRaw.eyeCountOutput && v < 8; v++) {
+                    app.eyePositions[v][0] = viewRigRaw.rawEyes[v].x;
+                    app.eyePositions[v][1] = viewRigRaw.rawEyes[v].y;
+                    app.eyePositions[v][2] = viewRigRaw.rawEyes[v].z;
                 }
-                center.x /= modeViewCount;
-                center.y /= modeViewCount;
-                center.z /= modeViewCount;
-                rawEyePos[0] = center;
+            } else {
+                for (uint32_t v = 0; v < viewCount && v < 8; v++) {
+                    app.eyePositions[v][0] = views[v].pose.position.x;
+                    app.eyePositions[v][1] = views[v].pose.position.y;
+                    app.eyePositions[v][2] = views[v].pose.position.z;
+                }
             }
-
-            XrPosef cameraPose;
-            quat_from_yaw_pitch(g_input.yaw, g_input.pitch, &cameraPose.orientation);
-            cameraPose.position = {g_input.cameraPosX, g_input.cameraPosY, g_input.cameraPosZ};
-
-            XrVector3f nominalViewer = {app.nominalViewerX, app.nominalViewerY, app.nominalViewerZ};
 
             float scaleX = (app.currentModeIndex < app.renderingModeCount)
                 ? app.renderingModeScaleX[app.currentModeIndex] : 0.5f;
@@ -2236,112 +2273,31 @@ int main(int argc, char **argv)
             g_renderW = renderW;
             g_renderH = renderH;
 
-            // Compute stereo views
-            std::vector<Display3DView> d3dViews(eyeCount);
-            bool hasKooima = (app.displayWidthM > 0 && app.displayHeightM > 0);
-            if (hasKooima) {
-                float dispPxW = app.displayPixelWidth > 0 ? (float)app.displayPixelWidth : (float)app.swapchain.width;
-                float dispPxH = app.displayPixelHeight > 0 ? (float)app.displayPixelHeight : (float)app.swapchain.height;
-                float pxSizeX = app.displayWidthM / dispPxW;
-                float pxSizeY = app.displayHeightM / dispPxH;
-                float canvasW_m = (float)g_canvasW * pxSizeX;
-                float canvasH_m = (float)g_canvasH * pxSizeY;
-
-                // Canvas-relative Kooima: physical size + eye offset both anchored
-                // on the canvas region within the window (not the window itself).
-                // The Metal view fills the window now, so derive the canvas rect
-                // logically (top-down backing px) and convert to AppKit's
-                // bottom-up point space for the screen conversion.
-                float eyeOffsetX = 0.0f, eyeOffsetY = 0.0f;
-                if (g_window != nil && g_metalView != nil) {
-                    NSScreen *screen_ns = [g_window screen] ?: [NSScreen mainScreen];
-                    NSRect screenFrame = [screen_ns frame];
-                    int32_t ccx, ccy;
-                    uint32_t ccw, cch;
-                    ComputeCanvasRectPx(&ccx, &ccy, &ccw, &cch);
-                    CGFloat cbs = [g_window backingScaleFactor];
-                    NSView *content = [g_window contentView];
-                    NSSize winPts = [content bounds].size;
-                    NSRect canvasInContent = NSMakeRect(
-                        (CGFloat)ccx / cbs,
-                        winPts.height - (CGFloat)(ccy + (int32_t)cch) / cbs, // top-down -> bottom-up
-                        (CGFloat)ccw / cbs,
-                        (CGFloat)cch / cbs);
-                    NSRect canvasInWindow = [content convertRect:canvasInContent toView:nil];
-                    NSRect canvasInScreen = [g_window convertRectToScreen:canvasInWindow];
-                    float canvasCenterX = (canvasInScreen.origin.x - screenFrame.origin.x) + canvasInScreen.size.width / 2.0f;
-                    float canvasCenterY = (canvasInScreen.origin.y - screenFrame.origin.y) + canvasInScreen.size.height / 2.0f;
-                    float dispCenterX = screenFrame.size.width / 2.0f;
-                    float dispCenterY = screenFrame.size.height / 2.0f;
-                    CGFloat backingScale = [g_window backingScaleFactor];
-                    float pxSizeXBacking = pxSizeX / (float)backingScale;
-                    float pxSizeYBacking = pxSizeY / (float)backingScale;
-                    eyeOffsetX = (canvasCenterX - dispCenterX) * pxSizeXBacking;
-                    eyeOffsetY = (canvasCenterY - dispCenterY) * pxSizeYBacking;
-                }
-
-                // Apply canvas-center offset to raw eye positions
-                for (uint32_t v = 0; v < modeViewCount; v++) {
-                    rawEyePos[v].x -= eyeOffsetX;
-                    rawEyePos[v].y -= eyeOffsetY;
-                }
-
-                Display3DScreen screen;
-                screen.width_m = canvasW_m;
-                screen.height_m = canvasH_m;
-
-                if (g_input.cameraMode) {
-                    Camera3DTunables camTunables;
-                    camTunables.ipd_factor = g_input.viewParams.ipdFactor;
-                    camTunables.parallax_factor = g_input.viewParams.parallaxFactor;
-                    camTunables.inv_convergence_distance = g_input.viewParams.invConvergenceDistance;
-                    camTunables.half_tan_vfov = CAMERA_HALF_TAN_VFOV / g_input.viewParams.zoomFactor;
-
-                    std::vector<Camera3DView> camViews(eyeCount);
-                    camera3d_compute_views(
-                        rawEyePos.data(), eyeCount, &nominalViewer,
-                        &screen, &camTunables, &cameraPose,
-                        0.01f, 100.0f, camViews.data());
-
-                    for (int i = 0; i < eyeCount; i++) {
-                        memcpy(d3dViews[i].view_matrix, camViews[i].view_matrix, sizeof(float) * 16);
-                        memcpy(d3dViews[i].projection_matrix, camViews[i].projection_matrix, sizeof(float) * 16);
-                        d3dViews[i].fov = camViews[i].fov;
-                        d3dViews[i].eye_world = camViews[i].eye_world;
-                    }
-                } else {
-                    Display3DTunables tunables;
-                    tunables.ipd_factor = g_input.viewParams.ipdFactor;
-                    tunables.parallax_factor = g_input.viewParams.parallaxFactor;
-                    tunables.perspective_factor = g_input.viewParams.perspectiveFactor;
-                    tunables.virtual_display_height = g_input.viewParams.virtualDisplayHeight / g_input.viewParams.scaleFactor;
-
-                    display3d_compute_views(
-                        rawEyePos.data(), eyeCount, &nominalViewer,
-                        &screen, &tunables, &cameraPose,
-                        tunables.virtual_display_height, 1000.0f * tunables.virtual_display_height, /*vulkan_flip_y=*/0, d3dViews.data());
-                }
-
-                for (int i = 0; i < eyeCount; i++) {
-                    convert_projection_gl_to_metal(d3dViews[i].projection_matrix);
-                }
-            }
+            // --- Consume the runtime's render-ready XrView{pose, fov} ---
+            // (#396 W7) The runtime resolves the CANVAS sub-rect itself
+            // (get_window_metrics + u_canvas_apply_to_metrics), so the app
+            // keeps zero canvas geometry for view generation. Only clip
+            // policy stays app-side, by design (fov is clip-independent).
+            // Camera rig: same absolute clip as the old app-side camera
+            // path. Display rig: ZDP-anchored clip (near = ez - vH, far =
+            // ez + 1000·vH; ez = rig-local z of the view pose).
+            // mat4_from_xr_fov is Metal [0,1]-native — no remap.
+            const float rigVH =
+                g_input.viewParams.virtualDisplayHeight / g_input.viewParams.scaleFactor;
 
             rendered = true;
             std::vector<EyeRenderParams> eyeParams(eyeCount);
             for (int eye = 0; eye < eyeCount; eye++) {
                 int viewIdx = eye < (int)viewCount ? eye : 0;
                 XrFovf submitFov = views[viewIdx].fov;
-                if (hasKooima) {
-                    memcpy(eyeParams[eye].viewMat, d3dViews[eye].view_matrix, sizeof(float) * 16);
-                    memcpy(eyeParams[eye].projMat, d3dViews[eye].projection_matrix, sizeof(float) * 16);
-                    submitFov = d3dViews[eye].fov;
-                    views[viewIdx].pose.position = d3dViews[eye].eye_world;
-                    views[viewIdx].pose.orientation = cameraPose.orientation;
-                } else {
-                    mat4_view_from_xr_pose(eyeParams[eye].viewMat, views[viewIdx].pose);
-                    mat4_from_xr_fov(eyeParams[eye].projMat, views[viewIdx].fov, 0.01f, 100.0f);
+                float nearZ = 0.01f, farZ = 100.0f;
+                if (useRig && !rigCamera) {
+                    float ez = RigLocalEyeZ(rigPose, views[viewIdx].pose.position);
+                    nearZ = (ez - rigVH > 0.001f) ? (ez - rigVH) : 0.001f;
+                    farZ = ez + 1000.0f * rigVH;
                 }
+                mat4_view_from_xr_pose(eyeParams[eye].viewMat, views[viewIdx].pose);
+                mat4_from_xr_fov(eyeParams[eye].projMat, views[viewIdx].fov, nearZ, farZ);
 
                 uint32_t tileX = display3D ? (eye % tileColumns) : 0;
                 uint32_t tileY = display3D ? (eye / tileColumns) : 0;


### PR DESCRIPTION
## What

Epic #396 W7 dogfood: the runtime test apps now **consume** the runtime's render-ready `XrView{pose, fov}` and **delete** their vendored Kooima generation (`display3d_resolve_window_rect`, `display3d_compute_views`, `camera3d_compute_views`, and all monitor/window-rect gathering). This proves "runtime render-ready ≡ app-from-raw" end-to-end and is the visible payoff of the math fold-in (#477).

Each app chains an `XR_EXT_view_rig` descriptor (`XrDisplayRigEXT`, or `XrCameraRigEXT` in camera mode) built from its existing tunables on every `xrLocateViews`, then builds its view matrix from `rawViews[i].pose` and projection from `rawViews[i].fov` + an app-side clip. Only clip policy stays app-side (fov is clip-independent by design).

## Apps (10)

- **Windows (Leia-eyeballed):** `cube_handle_{d3d11,d3d12,gl,vk}_win`, `cube_texture_{d3d11,d3d12}_win`
- **macOS (CI-compile only, Mac eyeball pending):** `cube_handle_{metal,gl,vk}_macos`, `cube_texture_metal_macos`

## Key details

- `RigLocalEyeZ` fixes the R-toggle template's `ez = pose.position.z` (only valid at identity rig pose) so the ZDP clip stays correct while flying (WASD/yaw/pitch).
- `cube_handle_d3d11_win`: R-toggle A/B scaffolding removed (it was the #477 verification harness); consume is now the only 3D path.
- `cube_texture_d3d11_win` keeps its raw-canvas verify hook (`XrViewDisplayRawEXT` one-shot canvas log) alongside the rig request.
- macOS apps feed the HUD eye readout from the raw channel (under the rig, `views[]` carries world eyes); metal's now-unused `convert_projection_gl_to_metal` deleted.
- `cube_handle_gl_win` mono-pose source changes from window-rebased to the plain `rawViews` display-space average (rawEyes deleted with produce).
- xr_session ext plumbing (detect + enable + log) added to d3d12/gl/vk handle + texture d3d12; d3d11 + texture d3d11 already had it.
- Apps are now plain OpenXR render-ready consumers — displayxr::math usage shrinks to `projection_depth.h` where the API needs `[0,1]`.

## Runtime fix (dogfood-exposed)

The d3d12 native compositor's `get_window_metrics` delegated *entirely* to the DP's slot, which the Leia d3d12 DP sets to NULL → d3d12 sessions ran display-scoped (window-relative 3D + rig pivot wrong). Now it computes from the HWND like d3d11/gl/vk — the documented architecture (the d3d11 DP's own `get_window_metrics` returns false with the comment "the compositor handles this via display pixel info and Win32 calls"). Vendor isolation preserved.

## Verification

On-glass on the Leia display: all 6 Windows apps pixel-identical to before (cube size, ZDP, parallax, near-plane truncation at vH, window-drag correctness, vH/scale + ipd/parallax knobs, C camera toggle where supported, V 2D/3D, WASD flying). Plus one `XRT_FORCE_MODE=ipc` run of the d3d11 cube — window-relative Kooima works over the service (rig window-scopes to the client HWND, PR #479 path).

macOS apps compile in `build-macos.yml` only — **Mac eyeball pending**.

## Follow-ups filed

Two pre-existing IPC/service issues surfaced (not caused) during IPC verification: #482 (phase-snap doesn't engage while dragging an external-window app), #483 (focus-resize transient shows one view stretched 2x).

Remaining dogfood targets (deferred, per-repo): demos (gauss/modelviewer), engines (Unity/Unreal), WebXR bridge raw. Runtime follow-up: centroid the rig input eyes in 2D mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)