### PR TITLE
feat(#449): WebXR bridge adopts the #441 v14 tracking primitives

### DIFF
--- a/src/xrt/ipc/client/ipc_client_compositor.c
+++ b/src/xrt/ipc/client/ipc_client_compositor.c
@@ -249,6 +249,35 @@ comp_ipc_client_compositor_get_predicted_eye_positions(struct xrt_compositor *xc
 }
 
 /*
+ * Same fetch reached through the SYSTEM compositor (#449). Compositor-less
+ * sessions — headless XR_MND_headless clients like the WebXR bridge — have no
+ * xcn to route through, but their xsysc IS the embedded system proxy of this
+ * file's ipc_client_compositor, so container_of recovers the connection.
+ * Only safe to call when `xsysc` is the IPC client system compositor (the
+ * OpenXR state tracker gates on info.is_service_mode && xmcc == NULL).
+ */
+bool
+comp_ipc_client_system_compositor_get_predicted_eye_positions(struct xrt_system_compositor *xsysc,
+                                                              struct xrt_eye_positions *out_eyes)
+{
+	if (xsysc == NULL || out_eyes == NULL) {
+		return false;
+	}
+
+	struct ipc_client_compositor *icc = container_of(xsysc, struct ipc_client_compositor, system);
+	if (icc->ipc_c == NULL) {
+		return false;
+	}
+
+	xrt_result_t xret = ipc_call_compositor_get_predicted_eye_positions(icc->ipc_c, out_eyes);
+	if (xret != XRT_SUCCESS) {
+		return false;
+	}
+
+	return out_eyes->valid;
+}
+
+/*
  * Phase 2 — workspace_sync_fence bridges (D3D11 client compositor only).
  * Same gating contract: only safe to call when `xc` is an ipc_client_compositor.
  *

--- a/src/xrt/state_trackers/oxr/oxr_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_session.c
@@ -109,6 +109,14 @@ bool
 comp_ipc_client_compositor_get_predicted_eye_positions(struct xrt_compositor *xc,
                                                        struct xrt_eye_positions *out_eyes);
 
+// Same fetch via the SYSTEM compositor (#449) for compositor-less sessions
+// (headless XR_MND_headless clients like the WebXR bridge, which have no
+// xcn). Same linkage pattern as above.
+struct xrt_system_compositor;
+bool
+comp_ipc_client_system_compositor_get_predicted_eye_positions(struct xrt_system_compositor *xsysc,
+                                                              struct xrt_eye_positions *out_eyes);
+
 #ifdef OXR_HAVE_EXT_view_rig
 // XR_EXT_view_rig over IPC (#396 W7) — same linkage pattern as above; the
 // wire structs come from shared/ipc_protocol.h (include precedent:
@@ -2078,13 +2086,25 @@ oxr_session_locate_views(struct oxr_logger *log,
 		// server-computed view poses (the Phase-0 multi-comp regression).
 		// Skipped when the active mode is untracked: the result would be
 		// FALSE either way, so don't pay the round-trip.
-		if (!got_eye_positions && mode_has_tracking && sess->xcn != NULL &&
+		if (!got_eye_positions && mode_has_tracking &&
 		    sess->sys->xsysc != NULL && sess->sys->xsysc->info.is_service_mode &&
 		    !sess->is_d3d11_native_compositor && !sess->is_d3d12_native_compositor &&
 		    !sess->is_gl_native_compositor && !sess->is_vk_native_compositor &&
 		    !sess->is_metal_native_compositor && sess->sys->xsysc->xmcc == NULL) {
 			struct xrt_eye_positions ipc_eyes;
-			if (comp_ipc_client_compositor_get_predicted_eye_positions(&sess->xcn->base, &ipc_eyes)) {
+			bool got = false;
+			if (sess->xcn != NULL) {
+				got = comp_ipc_client_compositor_get_predicted_eye_positions(&sess->xcn->base, &ipc_eyes);
+			} else {
+				// Compositor-less sessions (#449): headless clients
+				// like the WebXR bridge have no xcn — route the same
+				// RPC through the IPC system-compositor proxy so
+				// their derived isTracking (and the edge event) is
+				// truthful instead of constant-FALSE.
+				got = comp_ipc_client_system_compositor_get_predicted_eye_positions(sess->sys->xsysc,
+				                                                                    &ipc_eyes);
+			}
+			if (got) {
 				is_tracking = ipc_eyes.is_tracking;
 			}
 		}

--- a/src/xrt/targets/webxr_bridge/main.cpp
+++ b/src/xrt/targets/webxr_bridge/main.cpp
@@ -441,8 +441,19 @@ struct Bridge {
 	XrDisplayInfoEXT display_info{};
 	XrEyeTrackingModeCapabilitiesEXT eye_tracking_caps{};
 	std::vector<XrDisplayRenderingModeInfoEXT> modes;
+	// Per-mode tracking capability (#441 v14), parallel to `modes`. Filled by
+	// the chained-struct opt-in at enumerate time; hasTracking == XR_FALSE for
+	// modes that never consume live eye tracking (e.g. every sim_display mode).
+	std::vector<XrDisplayRenderingModeTrackingInfoEXT> mode_tracking;
 	uint32_t current_mode_index = 0;
 	std::vector<XrViewConfigurationView> config_views;
+
+	// Last-known derived isTracking (#441 v14): -1 = unknown (no locate yet),
+	// 0/1 otherwise. Seeded from the XrViewEyeTrackingStateEXT chain on
+	// xrLocateViews and kept current by XrEventDataEyeTrackingStateChangedEXT
+	// edges. Serialized into display-info so late-joining WS clients get the
+	// current state (the event itself is edge-triggered only).
+	int eye_tracking_state = -1;
 
 	// Compositor window metrics (polled from service HWND).
 	WindowMetrics window_metrics;
@@ -895,13 +906,19 @@ static std::string build_display_info_json(const Bridge &b) {
 	for (size_t i = 0; i < b.modes.size(); i++) {
 		if (i) s += ",";
 		const auto &m = b.modes[i];
+		// hasTracking (#441 v14): whether the mode consumes live eye
+		// tracking. When the ACTIVE mode has hasTracking == false,
+		// isTracking is always false regardless of tracker state.
+		const bool has_trk = i < b.mode_tracking.size() &&
+		                     b.mode_tracking[i].hasTracking == XR_TRUE;
 		s += "{\"index\":" + json_u(m.modeIndex)
 		   + ",\"name\":\"" + json_escape(m.modeName) + "\""
 		   + ",\"viewCount\":" + json_u(m.viewCount)
 		   + ",\"tileColumns\":" + json_u(m.tileColumns)
 		   + ",\"tileRows\":" + json_u(m.tileRows)
 		   + ",\"viewScale\":[" + json_f(m.viewScaleX) + "," + json_f(m.viewScaleY) + "]"
-		   + ",\"hardware3D\":" + (m.hardwareDisplay3D ? "true" : "false") + "}";
+		   + ",\"hardware3D\":" + (m.hardwareDisplay3D ? "true" : "false")
+		   + ",\"hasTracking\":" + (has_trk ? "true" : "false") + "}";
 	}
 	s += "]";
 
@@ -920,7 +937,15 @@ static std::string build_display_info_json(const Bridge &b) {
 	if (has_manual)  { if (!first) s += ","; s += "\"MANUAL\""; }
 	s += "],\"defaultMode\":\"";
 	s += (b.eye_tracking_caps.defaultMode == XR_EYE_TRACKING_MODE_MANUAL_EXT) ? "MANUAL" : "MANAGED";
-	s += "\"}";
+	s += "\"";
+	// Last-known derived isTracking (#449). Omitted while unknown (no
+	// xrLocateViews yet) — pages treat absence as "state not yet known".
+	// Kept current by eye-tracking-state-changed messages afterwards.
+	if (b.eye_tracking_state >= 0) {
+		s += ",\"isTracking\":";
+		s += (b.eye_tracking_state == 1) ? "true" : "false";
+	}
+	s += "}";
 
 	s += build_window_info_fields(b.window_metrics);
 	s += "}";
@@ -941,6 +966,15 @@ static std::string build_mode_changed_json(uint32_t prev, uint32_t curr, bool hw
 static std::string build_hardware_state_json(bool hw3d) {
 	return "{\"type\":\"hardware-state-changed\",\"version\":1,\"hardware3D\":"
 	       + std::string(hw3d ? "true" : "false") + "}";
+}
+
+static std::string build_eye_tracking_state_json(bool is_tracking, XrEyeTrackingModeEXT mode) {
+	std::string s = "{\"type\":\"eye-tracking-state-changed\",\"version\":1,\"isTracking\":";
+	s += (is_tracking ? "true" : "false");
+	s += ",\"activeMode\":\"";
+	s += (mode == XR_EYE_TRACKING_MODE_MANUAL_EXT) ? "MANUAL" : "MANAGED";
+	s += "\"}";
+	return s;
 }
 
 static std::string build_input_event_json(const InputEvent &e) {
@@ -1646,9 +1680,18 @@ static bool create_session_and_enumerate_modes(Bridge &b) {
 		return true;
 	}
 	b.modes.resize(mode_count);
-	for (auto &m : b.modes) {
-		m.type = XR_TYPE_DISPLAY_RENDERING_MODE_INFO_EXT;
-		m.next = nullptr;
+	// Per-mode tracking capability (#441 v14, #449) — chained-struct opt-in:
+	// pre-set each element's type AND chain the tracking struct on next
+	// BEFORE the fill call. The runtime only walks elements carrying the
+	// pre-set type, so v13 binaries (uninitialized type/next) are untouched.
+	// Mirrors the reference adoption in cube_handle_d3d11_win/xr_session.cpp.
+	b.mode_tracking.resize(mode_count);
+	for (uint32_t i = 0; i < mode_count; i++) {
+		b.mode_tracking[i].type = (XrStructureType)XR_TYPE_DISPLAY_RENDERING_MODE_TRACKING_INFO_EXT;
+		b.mode_tracking[i].next = nullptr;
+		b.mode_tracking[i].hasTracking = XR_FALSE;
+		b.modes[i].type = XR_TYPE_DISPLAY_RENDERING_MODE_INFO_EXT;
+		b.modes[i].next = &b.mode_tracking[i];
 	}
 	r = b.pfnEnumerateDisplayRenderingModes(b.session, mode_count, &mode_count, b.modes.data());
 	if (XR_FAILED(r)) {
@@ -1660,9 +1703,10 @@ static bool create_session_and_enumerate_modes(Bridge &b) {
 	LOG_I("Display rendering modes (%u):", mode_count);
 	for (uint32_t i = 0; i < mode_count; i++) {
 		const auto &m = b.modes[i];
-		LOG_I("  [%u] \"%s\" views=%u tiles=%ux%u viewScale=%.3fx%.3f hw3D=%d",
+		LOG_I("  [%u] \"%s\" views=%u tiles=%ux%u viewScale=%.3fx%.3f hw3D=%d tracked=%d",
 		      m.modeIndex, m.modeName, m.viewCount, m.tileColumns, m.tileRows,
-		      m.viewScaleX, m.viewScaleY, (int)m.hardwareDisplay3D);
+		      m.viewScaleX, m.viewScaleY, (int)m.hardwareDisplay3D,
+		      (int)(b.mode_tracking[i].hasTracking == XR_TRUE));
 	}
 
 	// Default current_mode_index to the first 3D mode (Leia device starts in 3D).
@@ -1759,6 +1803,22 @@ static void handle_event(Bridge &b, const XrEventDataBuffer &evt) {
 		}
 	} break;
 
+	case XR_TYPE_EVENT_DATA_EYE_TRACKING_STATE_CHANGED_EXT: {
+		// Edge-triggered tracking loss/recovery (#441 v14, #449). The runtime
+		// derives isTracking as activeMode.hasTracking && dp.is_tracking and
+		// fires this on every edge — DP tracking loss/recovery AND mode
+		// switches into/out of untracked modes. Forwarded to the page so web
+		// content gets event-driven loss/recovery instead of polling.
+		auto *e = reinterpret_cast<const XrEventDataEyeTrackingStateChangedEXT *>(&evt);
+		LOG_I("EYE_TRACKING_STATE_CHANGED isTracking=%s activeMode=%d",
+		      e->isTracking == XR_TRUE ? "YES" : "NO", (int)e->activeMode);
+		b.eye_tracking_state = (e->isTracking == XR_TRUE) ? 1 : 0;
+		if (b.ws_client_connected.load()) {
+			b.outgoing.push(build_eye_tracking_state_json(
+			    e->isTracking == XR_TRUE, e->activeMode));
+		}
+	} break;
+
 	case XR_TYPE_EVENT_DATA_HARDWARE_DISPLAY_STATE_CHANGED_EXT: {
 		LOG_I("HARDWARE_DISPLAY_STATE_CHANGED_EXT (physical 3D state flipped)");
 		if (b.ws_client_connected.load()) {
@@ -1780,18 +1840,28 @@ static void handle_event(Bridge &b, const XrEventDataBuffer &evt) {
 // ---------------------------------------------------------------------------
 
 static void poll_eye_poses(Bridge &b) {
-	if (!b.stream_eye_poses || b.local_space == XR_NULL_HANDLE || !b.session_begun)
-		return;
-	if (!b.ws_client_connected.load())
+	if (b.local_space == XR_NULL_HANDLE || !b.session_begun)
 		return;
 
-	// Backpressure: skip if the outgoing queue has pending messages.
-	// Eye poses are stateless — only the latest matters. Dropping
-	// intermediate samples prevents TCP buffer overflow which causes
-	// WS disconnect/reconnect loops and loses mode-changed events.
-	{
+	const bool streaming = b.stream_eye_poses && b.ws_client_connected.load();
+	if (streaming) {
+		// Backpressure: skip if the outgoing queue has pending messages.
+		// Eye poses are stateless — only the latest matters. Dropping
+		// intermediate samples prevents TCP buffer overflow which causes
+		// WS disconnect/reconnect loops and loses mode-changed events.
 		std::lock_guard<std::mutex> lk(b.outgoing.mtx);
 		if (b.outgoing.q.size() > 2) return;
+	} else {
+		// Not streaming — still locate at a low rate (~4 Hz vs the 10 ms
+		// loop). The runtime's isTracking edge detection runs in its
+		// xrLocateViews path (#441 v14): a session that never locates views
+		// receives no XrEventDataEyeTrackingStateChangedEXT events. This
+		// keeps tracking-loss edges flowing when the page configured
+		// eyePoseFormat "none" (and keeps b.eye_tracking_state seeded
+		// before any WS client connects).
+		static int idle_locate_counter = 0;
+		if (++idle_locate_counter < 25) return;
+		idle_locate_counter = 0;
 	}
 
 	XrViewLocateInfo vli{XR_TYPE_VIEW_LOCATE_INFO};
@@ -1801,7 +1871,12 @@ static void poll_eye_poses(Bridge &b) {
 	vli.displayTime = now.QuadPart;
 	vli.space = b.local_space;
 
+	// Chain per-frame eye-tracking state (#446 truthful isTracking) so the
+	// cached value is seeded before the first edge event — display-info
+	// serializes it for late-joining WS clients.
+	XrViewEyeTrackingStateEXT et_state{(XrStructureType)XR_TYPE_VIEW_EYE_TRACKING_STATE_EXT};
 	XrViewState vs{XR_TYPE_VIEW_STATE};
+	vs.next = &et_state;
 	uint32_t view_count = 8;
 	XrView views[8];
 	for (uint32_t i = 0; i < 8; i++) views[i] = {XR_TYPE_VIEW};
@@ -1809,7 +1884,11 @@ static void poll_eye_poses(Bridge &b) {
 	XrResult r = xrLocateViews(b.session, &vli, &vs, 8, &view_count, views);
 	if (XR_FAILED(r)) return;
 
-	b.outgoing.push(build_eye_poses_json(views, view_count));
+	b.eye_tracking_state = (et_state.isTracking == XR_TRUE) ? 1 : 0;
+
+	if (streaming) {
+		b.outgoing.push(build_eye_poses_json(views, view_count));
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/webxr-bridge/DEVELOPER.md
+++ b/webxr-bridge/DEVELOPER.md
@@ -66,6 +66,7 @@ Apps MUST `await session.displayXR.ready` before reading `displayInfo`, `renderi
 | `eyePoses` | array | Streaming tracked eyes (call `configureEyePoses('raw')` first). |
 | `eyeTracking.supportedModes` | `string[]` | Modes the DP advertises (subset of `['MANAGED', 'MANUAL']`). |
 | `eyeTracking.defaultMode` | `'MANAGED'` \| `'MANUAL'` | Mode active if the app doesn't request one. |
+| `eyeTracking.isTracking` | `boolean` \| `undefined` | Last-known derived tracking state (`undefined` while unknown). Kept current by `eyetrackingstatechange` events. |
 
 ### Session bootstrap
 
@@ -109,6 +110,7 @@ Each mode object carries:
 | `viewScale` | `[sx, sy]` — per-tile scale relative to display. |
 | `viewCount` | Eyes per frame (1 mono, 2 stereo, etc.). |
 | `hardware3D` | Whether the display is in 3D-emit mode for this mode. |
+| `hasTracking` | Whether the mode consumes live eye tracking. `false` for export modes (SBS/anaglyph) — in those, `eyeTracking.isTracking` is always `false`. |
 
 ```js
 // List modes (e.g. for a UI dropdown):
@@ -172,6 +174,19 @@ if (canToggle) displayXR.requestEyeTrackingMode(wantManual ? 1 : 0);
 
 The bridge rejects unsupported mode requests with a log-only warning; this guard exists so your UI matches the device's actual state.
 
+**Tracking loss/recovery — don't poll.** Subscribe to `eyetrackingstatechange`; it fires on every edge of the derived tracking state (DP tracking loss/recovery *and* mode switches into/out of untracked modes):
+
+```js
+session.addEventListener('eyetrackingstatechange', e => {
+  if (!e.detail.isTracking) {
+    // e.g. freeze head-coupled rendering, run your own fade, or
+    // displayXR.requestRenderingMode(MODE_2D) when your transition is done.
+  }
+});
+// Current state without waiting for an edge:
+const tracking = displayXR.eyeTracking.isTracking; // undefined while unknown
+```
+
 ### HUD
 
 Compositor-side overlay. Send up to 8 lines, label + text:
@@ -208,6 +223,7 @@ The bridge auto-suppresses mouse events while the compositor window is in a moda
 | `renderingmodechange` | Mode switched (via your request OR vendor SDK). | Refresh tile layout; update UI selector. |
 | `windowinfochange` | Window moved / resized. | Recompute Kooima screen dims + center offset. |
 | `hardwarestatechange` | Display backlight toggled 3D ↔ 2D. | **Debounce** ≥ 600 ms before reacting (see Pitfalls). |
+| `eyetrackingstatechange` | Derived tracking state flipped (tracker loss/recovery, or mode switch into/out of an untracked mode). | Freeze head-coupled rendering / run your own loss transition. |
 | `bridgestatus` | Bridge process connected / disconnected. | Update status UI. |
 | `displayxrinput` | Key / mouse / wheel from compositor focus. | App input. |
 

--- a/webxr-bridge/PROTOCOL.md
+++ b/webxr-bridge/PROTOCOL.md
@@ -46,15 +46,15 @@ Bridge calls `xrRequestDisplayRenderingModeEXT(session, modeIndex)`. Runtime pro
   "recommendedViewScale": [0.5, 0.5],
   "nominalViewerPosition": [0.0, 0.1, 0.6],
   "renderingModes": [
-    { "index": 0, "name": "2D", "viewCount": 1, "tileColumns": 1, "tileRows": 1, "viewScale": [1.0, 1.0], "hardware3D": false },
-    { "index": 1, "name": "LeiaSR", "viewCount": 2, "tileColumns": 2, "tileRows": 1, "viewScale": [0.5, 0.5], "hardware3D": true }
+    { "index": 0, "name": "2D", "viewCount": 1, "tileColumns": 1, "tileRows": 1, "viewScale": [1.0, 1.0], "hardware3D": false, "hasTracking": false },
+    { "index": 1, "name": "LeiaSR", "viewCount": 2, "tileColumns": 2, "tileRows": 1, "viewScale": [0.5, 0.5], "hardware3D": true, "hasTracking": true }
   ],
   "currentModeIndex": 1,
   "views": [
     { "index": 0, "recommendedImageRectWidth": 1920, "recommendedImageRectHeight": 1080, "maxImageRectWidth": 3840, "maxImageRectHeight": 2160 },
     { "index": 1, "recommendedImageRectWidth": 1920, "recommendedImageRectHeight": 1080, "maxImageRectWidth": 3840, "maxImageRectHeight": 2160 }
   ],
-  "eyeTracking": { "supportedModes": ["MANAGED"], "defaultMode": "MANAGED" },
+  "eyeTracking": { "supportedModes": ["MANAGED"], "defaultMode": "MANAGED", "isTracking": true },
   "windowInfo": {
     "valid": true,
     "windowPixelSize": [1920, 1080],
@@ -71,6 +71,10 @@ Bridge calls `xrRequestDisplayRenderingModeEXT(session, modeIndex)`. Runtime pro
 `viewWidth` and `viewHeight` are the compositor's actual per-view tile dimensions in pixels, read from the compositor's HWND properties. These are deferred-resize-aware — they don't update mid-drag, only after the compositor finishes resizing its atlas. Pages should use these for per-tile viewport sizing instead of computing from `displayPixelSize × viewScale` or dividing the framebuffer by the tile grid. Present when the compositor has published its view dims; absent on older bridges.
 
 `eyeTracking.supportedModes` is an array of the eye-tracking modes the DP actually supports (currently one of `"MANAGED"`, `"MANUAL"`, or both). Apps **MUST** check membership before calling `requestEyeTrackingMode` — requesting an unsupported mode is ignored by the bridge (logged) and never reaches the DP. Leia's DP today reports `["MANAGED"]`. `eyeTracking.defaultMode` is the mode the DP uses when the app hasn't requested one.
+
+`eyeTracking.isTracking` is the last-known derived tracking state — `activeMode.hasTracking && tracker lock` (#441 v14). Omitted while still unknown (no view locate yet). It is a snapshot for late-joining clients; live edges arrive via `eye-tracking-state-changed` messages.
+
+`renderingModes[].hasTracking` is the per-mode tracking capability (#441 v14): whether the mode consumes live eye tracking. When the **active** mode has `hasTracking: false` (export modes like SBS/anaglyph; every sim_display mode), `isTracking` is always `false` regardless of tracker state. Absent on older bridges — treat absence as `false`-unknown.
 
 ### `window-info`
 
@@ -136,6 +140,19 @@ Sent on every `XrEventDataRenderingModeChangedEXT`. The `views` array contains r
 ```
 
 Sent on `XrEventDataHardwareDisplayStateChangedEXT` (physical display's 3D backlight state changed).
+
+### `eye-tracking-state-changed`
+
+```json
+{
+  "type": "eye-tracking-state-changed",
+  "version": 1,
+  "isTracking": false,
+  "activeMode": "MANAGED"
+}
+```
+
+Sent on `XrEventDataEyeTrackingStateChangedEXT` (#441 v14) — edge-triggered on every flip of the derived `isTracking` value (`activeMode.hasTracking && tracker lock`). Fires on DP tracking loss/recovery **and** on rendering-mode switches into/out of untracked modes. The extension dispatches an `eyetrackingstatechange` event on the session with `event.detail = { isTracking, activeMode }` and keeps `displayXR.eyeTracking.isTracking` current. Pages should use this instead of polling — e.g. pause head-coupled rendering on loss, or request a 2D mode after their own transition.
 
 ### `eye-poses`
 

--- a/webxr-bridge/extension/src/main-world.js
+++ b/webxr-bridge/extension/src/main-world.js
@@ -135,6 +135,9 @@
       // Eye-tracking capabilities advertised by the DP.
       //   supportedModes: string[] of 'MANAGED' / 'MANUAL'
       //   defaultMode:    'MANAGED' | 'MANUAL'
+      //   isTracking:     boolean — last-known derived tracking state (#449);
+      //                   undefined while unknown. Kept current by
+      //                   'eyetrackingstatechange' session events.
       // Apps MUST check supportedModes before calling requestEyeTrackingMode
       // — some devices only support one mode (e.g. Leia is MANAGED-only).
       eyeTracking: di.eyeTracking || { supportedModes: [], defaultMode: 'MANAGED' },
@@ -155,6 +158,7 @@
         tileRows: getModeField('tileRows', rm.currentModeIndex),
         viewScale: getModeField('viewScale', rm.currentModeIndex),
         hardware3D: rm.hardware3D !== undefined ? rm.hardware3D : false,
+        hasTracking: getModeField('hasTracking', rm.currentModeIndex) || false,
         views: rm.views || di.views || []
       } : buildRenderingModeFromDisplayInfo(di),
 
@@ -200,6 +204,10 @@
       tileRows: mode.tileRows || 1,
       viewScale: mode.viewScale || [1, 1],
       hardware3D: mode.hardware3D || false,
+      // Per-mode tracking capability (#449): does this mode consume live eye
+      // tracking? false for export/untracked modes (and absent→false on
+      // older bridges).
+      hasTracking: mode.hasTracking || false,
       views: di.views || []
     };
   }
@@ -274,6 +282,20 @@
       activeSessions.forEach(function (entry) {
         try {
           entry.session.dispatchEvent(new CustomEvent('hardwarestatechange', { detail: hwDetail }));
+        } catch (e) {}
+      });
+    } else if (msg.type === 'eye-tracking-state-changed') {
+      // Edge-triggered tracking loss/recovery (#449) — fires on DP tracking
+      // loss/recovery AND on mode switches into/out of untracked modes.
+      // Keep the cached eyeTracking surface current so displayXR reads after
+      // the edge see the latest state without waiting for the next event.
+      if (latestDisplayInfo && latestDisplayInfo.eyeTracking) {
+        latestDisplayInfo.eyeTracking.isTracking = msg.isTracking;
+      }
+      var etDetail = { isTracking: msg.isTracking, activeMode: msg.activeMode };
+      activeSessions.forEach(function (entry) {
+        try {
+          entry.session.dispatchEvent(new CustomEvent('eyetrackingstatechange', { detail: etDetail }));
         } catch (e) {}
       });
     } else if (msg.type === 'bridge-status') {

--- a/webxr-bridge/sample/sample.js
+++ b/webxr-bridge/sample/sample.js
@@ -105,6 +105,7 @@ const VK = {
 const keyDown = new Set();           // VK codes currently down
 let lastRequestedMode = -1;          // V key: track locally (async mode-changed is stale)
 let eyeTrackingMode = 0;            // 0=MANAGED, 1=MANUAL (T key toggle)
+let eyeTrackingActive = null;        // last-known isTracking (#449); null=unknown
 let hudVisible = false;              // TAB key toggle
 let hudJustToggled = false;          // Send one frame after toggle-off to clear
 let mouseLookDown = false;           // Left-mouse-drag for look (matches cube_handle)
@@ -852,6 +853,12 @@ async function enterXR() {
     } else {
       eyeTrackingMode = 0;
     }
+    // Seed last-known tracking state (#449) — display-info carries it when
+    // the bridge has located views at least once; edges arrive via the
+    // 'eyetrackingstatechange' session event afterwards.
+    if (displayXR.eyeTracking && typeof displayXR.eyeTracking.isTracking === 'boolean') {
+      eyeTrackingActive = displayXR.eyeTracking.isTracking;
+    }
     populateModeButtons();
     refreshEyeTrackingButton();
   } else {
@@ -908,6 +915,17 @@ async function enterXR() {
   xrSession.addEventListener('bridgestatus', (event) => {
     setDot(dotBridge, event.detail.connected ? 'ok' : 'err');
     log('BRIDGE: ' + (event.detail.connected ? 'connected' : 'disconnected — is displayxr-webxr-bridge running?'));
+  });
+
+  // Edge-triggered tracking loss/recovery (#449). Fires on DP tracking
+  // loss/recovery AND on mode switches into/out of untracked modes — no
+  // per-frame polling needed. The sample just surfaces it in the status
+  // panel; a real app might pause head-coupled rendering or request a 2D
+  // mode on loss.
+  xrSession.addEventListener('eyetrackingstatechange', (event) => {
+    eyeTrackingActive = event.detail.isTracking;
+    log('EYE TRACKING: ' + (event.detail.isTracking ? 'TRACKING' : 'LOST') +
+        ' [' + event.detail.activeMode + ']');
   });
 
   // Debounce hardwarestatechange: the Leia driver briefly flaps 3D→2D→3D
@@ -1258,6 +1276,7 @@ function updateBridgeStatePanel() {
     lines.push('window  : (waiting)');
   }
   lines.push('tracking: ' + (eyeTrackingMode === 1 ? 'MANUAL' : 'MANAGED') +
+             (eyeTrackingActive === null ? '' : (eyeTrackingActive ? ' ● live' : ' ○ lost')) +
              '  eyes=' + eyes.length);
   if (eyes.length > 0) {
     for (let i = 0; i < eyes.length; i++) {


### PR DESCRIPTION
Adopts the two opt-in primitives shipped in extension header v14 (#441) in the WebXR bridge, plus the runtime enabler that makes them reachable for a headless bridge session. Closes #449.

## Bridge host (`webxr_bridge/main.cpp`)
- **Per-mode `hasTracking`** — chain `XrDisplayRenderingModeTrackingInfoEXT` at `xrEnumerateDisplayRenderingModesEXT` (the opt-in handshake: pre-set `type` + chain on `next` before the fill), mirroring the cube reference adoption. Emitted as `renderingModes[].hasTracking` in `display-info`.
- **`XrEventDataEyeTrackingStateChangedEXT`** → new WS message `eye-tracking-state-changed {isTracking, activeMode}`.
- **Truthful `isTracking`** — chain `XrViewEyeTrackingStateEXT` in `poll_eye_poses`; serialize the last-known derived state as `eyeTracking.isTracking` in `display-info` for late-joining clients. Keep a ~4 Hz idle `xrLocateViews` when eye-pose streaming is off, since the runtime's edge detection lives in its locate path (a never-locating session gets no edge events).

## Runtime enabler (`oxr_session.c`, `ipc_client_compositor.c`)
The #441 Phase-2 IPC tracking-state fetch required `sess->xcn`, but a headless `XR_MND_headless` session (the bridge) has none — so its derived `isTracking` was constant-FALSE and no edge could ever fire. Added `comp_ipc_client_system_compositor_get_predicted_eye_positions()` (same RPC routed through the IPC system-compositor proxy via `container_of`) and extended the `oxr_session_locate_views` gate to the `xcn == NULL` case. The existing `is_service_mode && xmcc == NULL && !is_*_native_compositor` gates keep the cast safe.

## Extension / sample / docs
- `eyetrackingstatechange` session event + live `displayXR.eyeTracking.isTracking` + `renderingMode.hasTracking`.
- Sample logs edges and shows `● live / ○ lost` in the status panel.
- PROTOCOL.md + DEVELOPER.md document the additive v1 fields. Protocol stays v1; pages that ignore the fields are unaffected.

## Test (on the Leia box, worktree build deployed to Program Files)
- Bridge enumerate: `LeiaSR … tracked=1`, `2D … tracked=0`. ✅
- End-to-end via Chrome + the unpacked extension: session FOCUSED, Bridge dot green, `display-info` carried `renderingModes[].hasTracking` + `eyeTracking.isTracking`; sample HUD showed `tracking: MANAGED ○ lost`. ✅
- Eye-pose streaming intact (regression-free). ✅
- The live lost→live edge needs a face locked at the SR camera (physical) — wiring verified; left for an eyeball pass.

> Note: a separate double-cube/large-disparity observation during testing was traced to the view-pose path (identical per-eye positions + symmetric FOV reaching the page) — that's #396/rig territory, not this metadata sideband.

🤖 Generated with [Claude Code](https://claude.com/claude-code)