### PR TITLE
feat(#396): W7 v2 — DP-owned raw eyes + xrSetWorkspaceViewRigEXT override

### DIFF
--- a/src/external/openxr_includes/openxr/XR_EXT_view_rig.h
+++ b/src/external/openxr_includes/openxr/XR_EXT_view_rig.h
@@ -30,9 +30,12 @@
  * frame), and a locate that chains nothing keeps the default behavior —
  * including the raw-eye transport in XrView.pose for external-window apps.
  *
- * This extension adds no entry points — it is pure next-chain structs on
- * xrLocateViews. Full design: docs/roadmap/raw-vs-render-ready-views.md
- * (W7 of issue #396).
+ * The app-facing halves are pure next-chain structs on xrLocateViews. The one
+ * entry point, xrSetWorkspaceViewRigEXT, is for the workspace controller only:
+ * an app's own rig is honored by default (app visual policy within its canvas),
+ * but in workspace mode the controller may take over the clients' view geometry
+ * through this call (e.g. forcing identity m2v during a layout animation). Full
+ * design: docs/roadmap/raw-vs-render-ready-views.md (W7 of issue #396).
  */
 #ifndef XR_EXT_VIEW_RIG_H
 #define XR_EXT_VIEW_RIG_H 1
@@ -44,7 +47,7 @@ extern "C" {
 #endif
 
 #define XR_EXT_view_rig 1
-#define XR_EXT_view_rig_SPEC_VERSION 1
+#define XR_EXT_view_rig_SPEC_VERSION 2
 #define XR_EXT_VIEW_RIG_EXTENSION_NAME "XR_EXT_view_rig"
 
 // Reserved 1000999xxx range, next free block after mcp_tools (…130-132).
@@ -102,16 +105,18 @@ typedef struct XrCameraRigEXT {
  * the canvas rect yourself, e.g. via display3d_resolve_window_rect), the
  * display-plane pose, the effective canvas the runtime resolved for this
  * session, the eye-sample timestamp and the physical tracker lock. Reported
- * eyes are the tracked set only (synthesized surplus eyes for >2-view modes
- * stay runtime-internal); when the tracker has no lock the runtime still
- * reports nominal-viewer eyes with isTracking = XR_FALSE.
+ * eyes are the DP's full per-view set verbatim — one eye per active view
+ * (the display processor owns multi-view fill: e.g. it reports N eyes for an
+ * N-view mode; the runtime never synthesizes eyes). When the tracker has no
+ * lock the runtime still reports nominal-viewer eyes with isTracking = XR_FALSE.
  */
 typedef struct XrViewDisplayRawEXT {
     XrStructureType    type;       //!< Must be XR_TYPE_VIEW_DISPLAY_RAW_EXT
     void* XR_MAY_ALIAS next;
     XrVector3f  rawEyes[XR_VIEW_RIG_MAX_RAW_EYES_EXT]; //!< display-space eye positions (meters,
                                    //!< display-center origin, +X right +Y up +Z toward viewer)
-    uint32_t    eyeCountOutput;    //!< tracked eyes actually written
+    uint32_t    eyeCountOutput;    //!< eyes written = the DP's per-view count
+                                   //!< for this locate (one per active view)
     XrPosef     displayPlanePose;  //!< physical display plane in the locate space
     XrRect2Di   canvasRectPx;      //!< effective canvas on the panel (window client
                                    //!< area / texture sub-rect / runtime window)
@@ -120,8 +125,25 @@ typedef struct XrViewDisplayRawEXT {
     XrBool32    isTracking;        //!< physical tracker lock (vs nominal fallback)
 } XrViewDisplayRawEXT;
 
-// This extension defines no functions — both halves ride existing calls
-// (request structs on XrViewLocateInfo::next, result on XrViewState::next).
+// ---- Entry point: workspace controller only. ----
+
+// Impose a view rig on the workspace's app clients (or clear it). By default an
+// app's own rig is honored within its canvas; while an override is set here, the
+// runtime applies THIS rig to the clients' locates instead — the controller
+// takes over view geometry (e.g. forcing identity m2v during a layout animation).
+//
+//   session — the active workspace controller's session (else
+//             XR_ERROR_VALIDATION_FAILURE).
+//   rig     — NULL, or an XrDisplayRigEXT / XrCameraRigEXT (its `type` selects
+//             which); NULL clears the override so clients fall back to honoring
+//             their own rigs. Out-of-range tunables are clamped.
+//
+// Per-call, not chained: the override stays in effect until changed or cleared.
+typedef XrResult(XRAPI_PTR *PFN_xrSetWorkspaceViewRigEXT)(XrSession session, const void *rig);
+
+#ifndef XR_NO_PROTOTYPES
+XRAPI_ATTR XrResult XRAPI_CALL xrSetWorkspaceViewRigEXT(XrSession session, const void *rig);
+#endif
 
 #ifdef __cplusplus
 }

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -579,6 +579,14 @@ struct d3d11_service_system
 	//! Read from base.info.workspace_mode on first client connect.
 	bool workspace_mode;
 
+	//! XR_EXT_view_rig (#396 W7): the workspace controller's imposed view rig,
+	//! applied to app-client locates server-side (ipc_try_get_sr_view_poses).
+	//! type == XRT_VIEW_RIG_NONE when no override is set. Guarded by its own
+	//! lightweight mutex (NOT render_mutex) so the per-locate read never
+	//! contends with rendering. Set rarely (controller layout policy).
+	struct xrt_view_rig workspace_view_rig;
+	std::mutex workspace_view_rig_mutex;
+
 	//! Multi-compositor (NULL when workspace_mode is false).
 	struct d3d11_multi_compositor *multi_comp;
 
@@ -10435,6 +10443,16 @@ system_request_workspace_mode_flip(struct xrt_system_compositor *xsysc, uint32_t
 	return comp_d3d11_service_workspace_request_mode_flip(xsysc, mode_index);
 }
 
+/*!
+ * Hook for oxr_xrSetWorkspaceViewRigEXT (#396 W7). Stores the controller's
+ * imposed view rig; ipc_try_get_sr_view_poses applies it to app-client locates.
+ */
+static bool
+system_set_workspace_view_rig(struct xrt_system_compositor *xsysc, const struct xrt_view_rig *rig)
+{
+	return comp_d3d11_service_set_workspace_view_rig(xsysc, rig);
+}
+
 static void
 system_destroy(struct xrt_system_compositor *xsysc)
 {
@@ -10673,6 +10691,7 @@ comp_d3d11_service_create_system(struct xrt_device *xdev,
 	sys->base.create_native_compositor = system_create_native_compositor;
 	sys->base.destroy = system_destroy;
 	sys->base.request_workspace_mode_flip = system_request_workspace_mode_flip;
+	sys->base.set_workspace_view_rig = system_set_workspace_view_rig;
 
 	// Set up multi-compositor control for session state management
 	sys->xmcc.set_state = system_set_state;
@@ -13144,6 +13163,43 @@ comp_d3d11_service_workspace_request_mode_flip(struct xrt_system_compositor *xsy
 	// origin_slot = -1 (system origin) — the workspace controller is logically
 	// the system, not a renderable slot.
 	multi_compositor_request_mode_flip(sys, mode_index, /*origin=*/-1);
+	return true;
+}
+
+extern "C" bool
+comp_d3d11_service_set_workspace_view_rig(struct xrt_system_compositor *xsysc, const struct xrt_view_rig *rig)
+{
+	if (xsysc == nullptr) {
+		return false;
+	}
+	struct d3d11_service_system *sys = d3d11_service_system_from_xrt(xsysc);
+	if (sys == nullptr) {
+		return false;
+	}
+	std::lock_guard<std::mutex> lock(sys->workspace_view_rig_mutex);
+	if (rig == nullptr) {
+		sys->workspace_view_rig.type = XRT_VIEW_RIG_NONE;
+	} else {
+		sys->workspace_view_rig = *rig;
+	}
+	U_LOG_I("[view_rig] workspace override %s (type=%d)",
+	        sys->workspace_view_rig.type == XRT_VIEW_RIG_NONE ? "cleared" : "set",
+	        (int)sys->workspace_view_rig.type);
+	return true;
+}
+
+extern "C" bool
+comp_d3d11_service_get_workspace_view_rig(struct xrt_system_compositor *xsysc, struct xrt_view_rig *out_rig)
+{
+	if (xsysc == nullptr || out_rig == nullptr) {
+		return false;
+	}
+	struct d3d11_service_system *sys = d3d11_service_system_from_xrt(xsysc);
+	if (sys == nullptr) {
+		return false;
+	}
+	std::lock_guard<std::mutex> lock(sys->workspace_view_rig_mutex);
+	*out_rig = sys->workspace_view_rig;
 	return true;
 }
 

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.h
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.h
@@ -801,6 +801,23 @@ comp_d3d11_service_workspace_request_mode_flip(struct xrt_system_compositor *xsy
                                                uint32_t mode_index);
 
 /*!
+ * XR_EXT_view_rig (#396 W7): store / clear the workspace controller's imposed
+ * view rig. In workspace mode the workspace owns view geometry — a client's own
+ * chained rig is gated inert, and this override (applied in
+ * ipc_try_get_sr_view_poses) governs the app clients' locates. Pass a rig with
+ * type == XRT_VIEW_RIG_NONE, or @p rig == NULL, to clear. Returns true on success.
+ */
+bool
+comp_d3d11_service_set_workspace_view_rig(struct xrt_system_compositor *xsysc, const struct xrt_view_rig *rig);
+
+/*!
+ * XR_EXT_view_rig (#396 W7): read the current workspace view-rig override into
+ * @p out_rig (type == XRT_VIEW_RIG_NONE when none). Returns true on success.
+ */
+bool
+comp_d3d11_service_get_workspace_view_rig(struct xrt_system_compositor *xsysc, struct xrt_view_rig *out_rig);
+
+/*!
  * Force-reset the display to 3D on workspace activate (#234).
  *
  * Bypasses the acked-flip state machine's no-op guard so the DP gets

--- a/src/xrt/include/xrt/xrt_compositor.h
+++ b/src/xrt/include/xrt/xrt_compositor.h
@@ -2695,6 +2695,43 @@ struct xrt_system_compositor_info
 struct xrt_system_compositor;
 
 /*!
+ * XR_EXT_view_rig (#396 W7): kind of view rig, for the workspace controller
+ * override carried over the @ref xrt_system_compositor vtable. Mirrors the
+ * oxr-side `enum oxr_view_rig_type` and the IPC `IPC_VIEW_RIG_*` wire enum.
+ */
+enum xrt_view_rig_type
+{
+	XRT_VIEW_RIG_NONE = 0,
+	XRT_VIEW_RIG_DISPLAY,
+	XRT_VIEW_RIG_CAMERA,
+};
+
+/*!
+ * XR_EXT_view_rig (#396 W7): a view-rig descriptor at the xrt boundary —
+ * post-clamp, post-boundary-conversion (convergenceDiopters →
+ * inv_convergence_distance, verticalFov → half_tan_vfov), i.e. exactly the
+ * shape the shared view math consumes. Used by the workspace controller to
+ * impose a rig on its app clients via @ref xrt_system_compositor::set_workspace_view_rig.
+ */
+struct xrt_view_rig
+{
+	enum xrt_view_rig_type type;
+	struct xrt_pose pose; //!< display-plane (display rig) or camera (camera rig) pose
+
+	// Display-rig tunables.
+	float virtual_display_height;
+	float perspective_factor;
+
+	// Camera-rig tunables.
+	float inv_convergence_distance;
+	float half_tan_vfov;
+
+	// Shared tunables.
+	float ipd_factor;
+	float parallax_factor;
+};
+
+/*!
  * @interface xrt_multi_compositor_control
  * Special functions to control multi session/clients.
  * Effectively an optional aspect of @ref xrt_system_compositor
@@ -2815,6 +2852,21 @@ struct xrt_system_compositor
 	 * legacy immediate flip); false to fall back.
 	 */
 	bool (*request_workspace_mode_flip)(struct xrt_system_compositor *xsc, uint32_t mode_index);
+
+	/*!
+	 * Optional. XR_EXT_view_rig (#396 W7): workspace controller's request to
+	 * impose a view rig on its app clients. By default an app's own rig is
+	 * honored within its canvas; this hook lets the controller take over view
+	 * geometry server-side (the override substitutes for the app's forwarded
+	 * rig on non-controller locates). Pass a rig with
+	 * `type == XRT_VIEW_RIG_NONE` (or @p rig == NULL) to clear the override.
+	 * NULL on backends without multi-compositor support.
+	 *
+	 * Set by `comp_d3d11_service` during system compositor creation. Called
+	 * from `oxr_xrSetWorkspaceViewRigEXT` when the calling session is the
+	 * active workspace controller. Returns true if accepted.
+	 */
+	bool (*set_workspace_view_rig)(struct xrt_system_compositor *xsc, const struct xrt_view_rig *rig);
 };
 
 /*!

--- a/src/xrt/ipc/client/ipc_client_compositor.c
+++ b/src/xrt/ipc/client/ipc_client_compositor.c
@@ -2055,6 +2055,40 @@ ipc_syscomp_request_workspace_mode_flip(struct xrt_system_compositor *xsc, uint3
 	return r == XRT_SUCCESS;
 }
 
+/*!
+ * Workspace controller view-rig override hook (#396 W7). Marshals the xrt rig
+ * into the IPC wire shape and forwards it to the server-side
+ * comp_d3d11_service_set_workspace_view_rig via the workspace_set_view_rig RPC.
+ * The server applies it to the workspace's app-client locates. Returns true on
+ * success so the OXR layer reports XR_SUCCESS.
+ */
+static bool
+ipc_syscomp_set_workspace_view_rig(struct xrt_system_compositor *xsc, const struct xrt_view_rig *rig)
+{
+	if (xsc == NULL) {
+		return false;
+	}
+	struct ipc_client_compositor *icc = container_of(xsc, struct ipc_client_compositor, system);
+	if (icc == NULL || icc->ipc_c == NULL) {
+		return false;
+	}
+	struct ipc_view_rig_info wire = {0};
+	if (rig != NULL) {
+		wire.rig_type = (rig->type == XRT_VIEW_RIG_CAMERA)
+		                    ? IPC_VIEW_RIG_CAMERA
+		                    : (rig->type == XRT_VIEW_RIG_DISPLAY ? IPC_VIEW_RIG_DISPLAY : IPC_VIEW_RIG_NONE);
+		wire.pose = rig->pose;
+		wire.virtual_display_height = rig->virtual_display_height;
+		wire.perspective_factor = rig->perspective_factor;
+		wire.inv_convergence_distance = rig->inv_convergence_distance;
+		wire.half_tan_vfov = rig->half_tan_vfov;
+		wire.ipd_factor = rig->ipd_factor;
+		wire.parallax_factor = rig->parallax_factor;
+	}
+	xrt_result_t r = ipc_call_workspace_set_view_rig(icc->ipc_c, &wire);
+	return r == XRT_SUCCESS;
+}
+
 static void
 ipc_syscomp_destroy(struct xrt_system_compositor *xsc)
 {
@@ -2135,6 +2169,7 @@ ipc_client_create_system_compositor(struct ipc_connection *ipc_c,
 	// marshal the request to the server-side comp_d3d11_service hook so
 	// it routes through the acked-flip + curtain path.
 	c->system.request_workspace_mode_flip = ipc_syscomp_request_workspace_mode_flip;
+	c->system.set_workspace_view_rig = ipc_syscomp_set_workspace_view_rig;
 	c->ipc_c = ipc_c;
 	c->xina = xina;
 

--- a/src/xrt/ipc/server/ipc_server_handler.c
+++ b/src/xrt/ipc/server/ipc_server_handler.c
@@ -243,20 +243,34 @@ ipc_try_get_sr_view_poses(volatile struct ipc_client_state *ics,
 		if (eye_count > 1) raw_eyes[1] = right_eye;
 	}
 
-	// XR_EXT_view_rig raw channel (#396 W7): capture the raw display-space
-	// eyes VERBATIM — before the window/canvas rebase below, mirroring the
-	// in-process rule (raw = the untransformed input set; the consumer
-	// applies the window/canvas resolve itself). Timestamp + tracking lock
-	// come from the full DP eye query.
+	// XR_EXT_view_rig raw channel (#396 W7): report the DP's eyes VERBATIM —
+	// the FULL per-view set the DP provides (sim_display fills N for >2-view
+	// modes; Leia is 2-view), not the 2-eye render pair above. The runtime
+	// never synthesizes eyes; multi-view fill is the DP's responsibility, so
+	// the raw consumer (WebXR bridge / aware app over IPC) gets every view's
+	// eye — not a truncated 2. Raw is the untransformed input set (pre
+	// window/canvas rebase below — the consumer applies the resolve itself).
+	// Timestamp + tracking lock come from the same full DP eye query.
 	if (rig_reply != NULL) {
-		for (uint32_t i = 0; i < eye_count; i++) {
-			rig_reply->raw.eyes[i] = raw_eyes[i];
-		}
-		rig_reply->raw.eye_count = eye_count;
 		struct xrt_eye_positions full_eyes = {0};
 		if (comp_d3d11_service_get_predicted_eye_positions_full(s->xsysc, &full_eyes) && full_eyes.valid) {
+			uint32_t raw_n = full_eyes.count;
+			if (raw_n > XRT_MAX_VIEWS) {
+				raw_n = XRT_MAX_VIEWS;
+			}
+			for (uint32_t i = 0; i < raw_n; i++) {
+				rig_reply->raw.eyes[i] = (struct xrt_vec3){
+				    full_eyes.eyes[i].x, full_eyes.eyes[i].y, full_eyes.eyes[i].z};
+			}
+			rig_reply->raw.eye_count = raw_n;
 			rig_reply->raw.sample_time_ns = full_eyes.timestamp_ns;
 			rig_reply->raw.is_tracking = full_eyes.is_tracking ? 1u : 0u;
+		} else {
+			// Full query unavailable — fall back to the 2-eye render pair.
+			for (uint32_t i = 0; i < eye_count; i++) {
+				rig_reply->raw.eyes[i] = raw_eyes[i];
+			}
+			rig_reply->raw.eye_count = eye_count;
 		}
 		rig_reply->raw.valid = 1;
 	}
@@ -515,13 +529,42 @@ ipc_try_get_sr_view_poses(volatile struct ipc_client_state *ics,
 		return true;
 	}
 
+	// Workspace rig override (#396 W7): in workspace mode an app's own rig is
+	// honored by default (app visual policy within its canvas), but the
+	// controller can take over via xrSetWorkspaceViewRigEXT. When an override
+	// is set, substitute it for the forwarded rig on NON-controller locates —
+	// this is the sole enforcement point ("workspace can own view geometry"),
+	// no client-side gate. The controller's own chrome locates (caller PID ==
+	// workspace controller PID) keep whatever they chained. ws_override is
+	// function-scoped so `rig` can point at it for the rest of this call.
+	struct ipc_view_rig_info ws_override;
+	{
+		unsigned long caller_pid = (unsigned long)ics->client_state.pid;
+		bool is_controller = s->workspace_controller_pid != 0 && caller_pid == s->workspace_controller_pid;
+		struct xrt_view_rig ws_rig;
+		if (!is_controller && comp_d3d11_service_get_workspace_view_rig(s->xsysc, &ws_rig) &&
+		    ws_rig.type != XRT_VIEW_RIG_NONE) {
+			ws_override = (struct ipc_view_rig_info){
+			    .rig_type = (ws_rig.type == XRT_VIEW_RIG_CAMERA) ? IPC_VIEW_RIG_CAMERA : IPC_VIEW_RIG_DISPLAY,
+			    .pose = ws_rig.pose,
+			    .virtual_display_height = ws_rig.virtual_display_height,
+			    .perspective_factor = ws_rig.perspective_factor,
+			    .inv_convergence_distance = ws_rig.inv_convergence_distance,
+			    .half_tan_vfov = ws_rig.half_tan_vfov,
+			    .ipd_factor = ws_rig.ipd_factor,
+			    .parallax_factor = ws_rig.parallax_factor,
+			};
+			rig = &ws_override;
+		}
+	}
+
 	// XR_EXT_view_rig (#396 W7): a chained rig drives the math below in
 	// place of the qwerty debug state — its pose replaces the qwerty/zero
 	// display pose, its tunables take the corresponding branch regardless
 	// of use_qwerty_head (lifting the identity-m2v forcing, mirroring the
 	// in-process oxr_session.c semantics). Strictly per-locate: the rig
-	// arrives in the call payload, nothing is latched. Values arrive
-	// pre-clamped by the client's chain parser.
+	// arrives in the call payload (or the workspace override above), nothing
+	// is latched. Values arrive pre-clamped.
 	const bool rig_display = rig != NULL && rig->rig_type == IPC_VIEW_RIG_DISPLAY;
 	const bool rig_camera = rig != NULL && rig->rig_type == IPC_VIEW_RIG_CAMERA;
 	if (rig_display || rig_camera) {
@@ -2674,6 +2717,48 @@ ipc_handle_workspace_request_display_mode(volatile struct ipc_client_state *_ics
 	}
 #else
 	(void)mode_index;
+	return XRT_ERROR_NOT_IMPLEMENTED;
+#endif
+
+	return XRT_SUCCESS;
+}
+
+xrt_result_t
+ipc_handle_workspace_set_view_rig(volatile struct ipc_client_state *_ics, const struct ipc_view_rig_info *rig)
+{
+	struct ipc_server *s = _ics->server;
+
+	// PID-match auth: only the registered workspace controller may impose a
+	// rig on the workspace's app clients (mirrors workspace_request_display_mode).
+	unsigned long expected_pid = s->workspace_controller_pid;
+	unsigned long caller_pid = (unsigned long)_ics->client_state.pid;
+	if (expected_pid == 0 || caller_pid != expected_pid) {
+		IPC_WARN(s, "workspace_set_view_rig: PID mismatch (caller=%lu, controller=%lu) — denied", caller_pid,
+		         expected_pid);
+		return XRT_ERROR_NOT_AUTHORIZED;
+	}
+
+	if (s->xsysc == NULL) {
+		return XRT_ERROR_IPC_FAILURE;
+	}
+
+#if defined(XRT_HAVE_D3D11_SERVICE_COMPOSITOR)
+	struct xrt_view_rig xr = {0};
+	xr.type = (rig->rig_type == IPC_VIEW_RIG_CAMERA)
+	              ? XRT_VIEW_RIG_CAMERA
+	              : (rig->rig_type == IPC_VIEW_RIG_DISPLAY ? XRT_VIEW_RIG_DISPLAY : XRT_VIEW_RIG_NONE);
+	xr.pose = rig->pose;
+	xr.virtual_display_height = rig->virtual_display_height;
+	xr.perspective_factor = rig->perspective_factor;
+	xr.inv_convergence_distance = rig->inv_convergence_distance;
+	xr.half_tan_vfov = rig->half_tan_vfov;
+	xr.ipd_factor = rig->ipd_factor;
+	xr.parallax_factor = rig->parallax_factor;
+	if (!comp_d3d11_service_set_workspace_view_rig(s->xsysc, &xr)) {
+		return XRT_ERROR_NOT_IMPLEMENTED;
+	}
+#else
+	(void)rig;
 	return XRT_ERROR_NOT_IMPLEMENTED;
 #endif
 

--- a/src/xrt/ipc/shared/ipc_protocol.h
+++ b/src/xrt/ipc/shared/ipc_protocol.h
@@ -732,8 +732,9 @@ struct ipc_view_rig_info
 /*!
  * XR_EXT_view_rig over IPC (#396 W7): the XrViewDisplayRawEXT payload,
  * gathered service-side from the same inputs the server rig math consumes —
- * raw display-space eyes VERBATIM (pre window/canvas rebase, pre surplus
- * synthesis), the per-client effective canvas (window metrics after
+ * the DP's full per-view eye set VERBATIM (one eye per active view; the DP
+ * owns multi-view fill, the runtime never synthesizes), pre window/canvas
+ * rebase, the per-client effective canvas (window metrics after
  * u_canvas_apply_to_metrics), the display-plane pose, and the DP sample
  * timestamp / tracking lock.
  *

--- a/src/xrt/ipc/shared/proto.json
+++ b/src/xrt/ipc/shared/proto.json
@@ -75,6 +75,12 @@
 		]
 	},
 
+	"workspace_set_view_rig": {
+		"in": [
+			{"name": "rig", "type": "struct ipc_view_rig_info"}
+		]
+	},
+
 	"workspace_get_state": {
 		"out": [
 			{"name": "active", "type": "bool"}

--- a/src/xrt/state_trackers/oxr/oxr_api_funcs.h
+++ b/src/xrt/state_trackers/oxr/oxr_api_funcs.h
@@ -790,6 +790,9 @@ oxr_xrEnumerateDisplayRenderingModesEXT(XrSession session,
                                         uint32_t modeCapacityInput,
                                         uint32_t *modeCountOutput,
                                         XrDisplayRenderingModeInfoEXT *modes);
+//! OpenXR API function @ep{xrSetWorkspaceViewRigEXT}
+XRAPI_ATTR XrResult XRAPI_CALL
+oxr_xrSetWorkspaceViewRigEXT(XrSession session, const void *rig);
 
 #endif
 

--- a/src/xrt/state_trackers/oxr/oxr_api_negotiate.c
+++ b/src/xrt/state_trackers/oxr/oxr_api_negotiate.c
@@ -439,6 +439,10 @@ handle_non_null(struct oxr_instance *inst, struct oxr_logger *log, const char *n
 	ENTRY_IF_EXT(xrEnumerateDisplayRenderingModesEXT, EXT_display_info);
 #endif
 
+#ifdef OXR_HAVE_EXT_view_rig
+	ENTRY_IF_EXT(xrSetWorkspaceViewRigEXT, EXT_view_rig);
+#endif
+
 #ifdef OXR_HAVE_EXT_spatial_workspace
 	ENTRY_IF_EXT(xrActivateSpatialWorkspaceEXT, EXT_spatial_workspace);
 	ENTRY_IF_EXT(xrDeactivateSpatialWorkspaceEXT, EXT_spatial_workspace);

--- a/src/xrt/state_trackers/oxr/oxr_api_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_api_session.c
@@ -1452,6 +1452,31 @@ oxr_xrRequestDisplayRenderingModeEXT(XrSession session, uint32_t modeIndex)
 }
 
 XRAPI_ATTR XrResult XRAPI_CALL
+oxr_xrSetWorkspaceViewRigEXT(XrSession session, const void *rig)
+{
+	OXR_TRACE_MARKER();
+
+	struct oxr_session *sess;
+	struct oxr_logger log;
+	OXR_VERIFY_SESSION_AND_INIT_LOG(&log, session, sess, "xrSetWorkspaceViewRigEXT");
+
+#ifdef OXR_HAVE_EXT_view_rig
+	// Workspace controller only: this imposes view geometry on the workspace's
+	// app clients (the "workspace owns view geometry" contract). A non-
+	// controller caller has no authority here. The server also PID-gates the
+	// IPC RPC, so an app cannot forge the call.
+	if (!sess->is_active_workspace_controller) {
+		return oxr_error(&log, XR_ERROR_VALIDATION_FAILURE,
+		                 "xrSetWorkspaceViewRigEXT: caller is not the active workspace controller");
+	}
+	return oxr_session_set_workspace_view_rig(&log, sess, rig);
+#else
+	(void)rig;
+	return oxr_error(&log, XR_ERROR_FUNCTION_UNSUPPORTED, "XR_EXT_view_rig not supported");
+#endif
+}
+
+XRAPI_ATTR XrResult XRAPI_CALL
 oxr_xrEnumerateDisplayRenderingModesEXT(XrSession session,
                                         uint32_t modeCapacityInput,
                                         uint32_t *modeCountOutput,

--- a/src/xrt/state_trackers/oxr/oxr_objects.h
+++ b/src/xrt/state_trackers/oxr/oxr_objects.h
@@ -846,6 +846,16 @@ XrResult
 oxr_session_request_display_mode(struct oxr_logger *log, struct oxr_session *sess, bool enable_3d);
 #endif
 
+#ifdef OXR_HAVE_EXT_view_rig
+/*!
+ * XR_EXT_view_rig (#396 W7): parse + clamp a workspace-controller rig override
+ * (NULL clears) and push it to the system compositor. Caller must already have
+ * verified the session is the active workspace controller.
+ */
+XrResult
+oxr_session_set_workspace_view_rig(struct oxr_logger *log, struct oxr_session *sess, const void *rig);
+#endif
+
 XRT_CHECK_RESULT XrResult
 oxr_session_poll(struct oxr_logger *log, struct oxr_session *sess);
 

--- a/src/xrt/state_trackers/oxr/oxr_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_session.c
@@ -1172,6 +1172,14 @@ view_rig_update_from_chain(struct oxr_session *sess, const XrViewLocateInfo *vie
 	struct oxr_view_rig_state *rig = &sess->view_rig;
 	bool clamped = false;
 
+	// Workspace note: a non-controller workspace client's own rig is honored
+	// by default (app visual policy within its canvas). The workspace
+	// controller can take it over via xrSetWorkspaceViewRigEXT, applied
+	// SERVER-side (ipc_try_get_sr_view_poses substitutes the controller
+	// override for the forwarded rig on non-controller locates). There is no
+	// client-side gate — gating here would drop the locate off the rig IPC
+	// route and break a rig-consuming app's render-ready expectation.
+
 	if (drig != NULL && crig != NULL && !rig->clamp_warned) {
 		U_LOG_W("XR_EXT_view_rig: both XrDisplayRigEXT and XrCameraRigEXT chained — "
 		        "chain exactly one; using the camera rig");
@@ -1207,6 +1215,70 @@ view_rig_update_from_chain(struct oxr_session *sess, const XrViewLocateInfo *vie
 	}
 
 	return rig->type;
+}
+
+/*
+ * XR_EXT_view_rig (#396 W7) workspace-controller override: parse + clamp a rig
+ * descriptor (NULL clears) into the xrt-boundary shape and push it to the
+ * system compositor, which applies it to the workspace's app-client locates
+ * server-side. Same clamp policy + boundary conversions as the per-locate
+ * chain parser above. Caller (oxr_xrSetWorkspaceViewRigEXT) has already
+ * verified the session is the active workspace controller.
+ */
+XrResult
+oxr_session_set_workspace_view_rig(struct oxr_logger *log, struct oxr_session *sess, const void *rig)
+{
+	struct xrt_system_compositor *xsysc = sess->sys != NULL ? sess->sys->xsysc : NULL;
+	if (xsysc == NULL || xsysc->set_workspace_view_rig == NULL) {
+		return oxr_error(log, XR_ERROR_FUNCTION_UNSUPPORTED,
+		                 "xrSetWorkspaceViewRigEXT: not supported by this compositor");
+	}
+
+	struct xrt_view_rig out = {0};
+	out.type = XRT_VIEW_RIG_NONE;
+
+	const XrBaseInStructure *base = (const XrBaseInStructure *)rig;
+	if (base != NULL && base->type == XR_TYPE_CAMERA_RIG_EXT) {
+		const XrCameraRigEXT *crig = (const XrCameraRigEXT *)rig;
+		bool clamped = false;
+		out.type = XRT_VIEW_RIG_CAMERA;
+		out.pose = (struct xrt_pose){
+		    {crig->pose.orientation.x, crig->pose.orientation.y, crig->pose.orientation.z,
+		     crig->pose.orientation.w},
+		    {crig->pose.position.x, crig->pose.position.y, crig->pose.position.z}};
+		out.ipd_factor = view_rig_clampf(crig->ipdFactor, 0.0f, 1.0f, &clamped);
+		out.parallax_factor = view_rig_clampf(crig->parallaxFactor, 0.0f, 1.0f, &clamped);
+		out.inv_convergence_distance = view_rig_clampf(crig->convergenceDiopters, 0.0f, 20.0f, &clamped);
+		out.half_tan_vfov = tanf(view_rig_clampf(crig->verticalFov, 0.01f, 3.13f, &clamped) * 0.5f);
+		if (clamped) {
+			U_LOG_W("xrSetWorkspaceViewRigEXT: camera rig value(s) out of range — clamped");
+		}
+	} else if (base != NULL && base->type == XR_TYPE_DISPLAY_RIG_EXT) {
+		const XrDisplayRigEXT *drig = (const XrDisplayRigEXT *)rig;
+		bool clamped = false;
+		out.type = XRT_VIEW_RIG_DISPLAY;
+		out.pose = (struct xrt_pose){
+		    {drig->pose.orientation.x, drig->pose.orientation.y, drig->pose.orientation.z,
+		     drig->pose.orientation.w},
+		    {drig->pose.position.x, drig->pose.position.y, drig->pose.position.z}};
+		out.virtual_display_height = view_rig_clampf(drig->virtualDisplayHeight, 0.01f, 1000.0f, &clamped);
+		out.ipd_factor = view_rig_clampf(drig->ipdFactor, 0.0f, 1.0f, &clamped);
+		out.parallax_factor = view_rig_clampf(drig->parallaxFactor, 0.0f, 1.0f, &clamped);
+		out.perspective_factor = view_rig_clampf(drig->perspectiveFactor, 0.1f, 10.0f, &clamped);
+		if (clamped) {
+			U_LOG_W("xrSetWorkspaceViewRigEXT: display rig value(s) out of range — clamped");
+		}
+	} else if (base != NULL) {
+		return oxr_error(log, XR_ERROR_VALIDATION_FAILURE,
+		                 "xrSetWorkspaceViewRigEXT: rig must be XrDisplayRigEXT, XrCameraRigEXT, or NULL");
+	}
+	// base == NULL → clear the override (out.type stays XRT_VIEW_RIG_NONE).
+
+	if (!xsysc->set_workspace_view_rig(xsysc, &out)) {
+		return oxr_error(log, XR_ERROR_RUNTIME_FAILURE,
+		                 "xrSetWorkspaceViewRigEXT: compositor rejected the rig");
+	}
+	return XR_SUCCESS;
 }
 #endif // OXR_HAVE_EXT_view_rig
 
@@ -1435,11 +1507,13 @@ oxr_session_locate_views(struct oxr_logger *log,
 		}
 
 #ifdef OXR_HAVE_EXT_view_rig
-		// XR_EXT_view_rig raw channel: report the rig INPUT eyes verbatim
-		// in display space — tracked set when the DP provides one, else
-		// the nominal-viewer pair (isTracking=false). Captured before the
-		// legacy-2D center override and the surplus-view synthesis below:
-		// both are rig-side concepts, not raw inputs.
+		// XR_EXT_view_rig raw channel: report the DP's eyes verbatim in
+		// display space — the full per-view set the DP provides (sim_display
+		// fills N for >2-view modes; Leia is 2-view), or the nominal-viewer
+		// pair (isTracking=false) when no DP eyes. The runtime never
+		// synthesizes eyes; multi-view fill is the DP's responsibility.
+		// Captured before the legacy-2D center override below (a render-side
+		// concept, not a raw input).
 		if (view_raw != NULL && have_eye_positions) {
 			uint32_t raw_count = eye_count;
 			if (raw_count > XR_VIEW_RIG_MAX_RAW_EYES_EXT) {
@@ -1557,20 +1631,23 @@ oxr_session_locate_views(struct oxr_logger *log,
 				struct xrt_vec3 nominal = {0, si->nominal_viewer_y_m, si->nominal_viewer_z_m};
 				struct xrt_vec3 raw_eyes[XRT_MAX_VIEWS];
 
-				// Extend adj_eyes[] to active_view_count when the tile mode wants more
-				// views than the tracker provides (e.g. Quad mode = 4 views, tracker = 2).
-				// Each synthesized eye = tracked-eye-0 + (per-view-offset[ei] - per-view-offset[0])
-				// — i.e. apply the tile's role in the mode's optical layout to the tracked
-				// reference eye. Entries [0, eye_count) stay as-is to preserve tracker IPD.
-				if (xdev->hmd != NULL && active_view_count > eye_count &&
-				    active_view_count <= XRT_MAX_VIEWS) {
-					const struct xrt_vec3 *off = xdev->hmd->view_eye_offsets;
-					for (uint32_t ei = eye_count; ei < active_view_count; ei++) {
-						adj_eyes[ei].x = adj_eyes[0].x + (off[ei].x - off[0].x);
-						adj_eyes[ei].y = adj_eyes[0].y + (off[ei].y - off[0].y);
-						adj_eyes[ei].z = adj_eyes[0].z + (off[ei].z - off[0].z);
+				// The DP owns multi-view eye fill: it must report one eye
+				// position per active view (sim_display fills N; Leia is
+				// 2-view, 2 eyes). The runtime never synthesizes eyes — the
+				// per-mode optical layout is DP knowledge, and the
+				// XR_EXT_view_rig raw channel reports the DP's eyes verbatim.
+				// If a DP ever under-reports vs the active mode, surface it
+				// once rather than papering over it: views beyond eye_count
+				// then fall back to device-default FOV below.
+				if (active_view_count > eye_count) {
+					static bool warned_dp_under_report = false;
+					if (!warned_dp_under_report) {
+						warned_dp_under_report = true;
+						U_LOG_W("DP reported %u eye position(s) for a %u-view mode — "
+						        "the DP must report one eye per active view; views "
+						        "beyond %u use device-default FOV",
+						        eye_count, active_view_count, eye_count);
 					}
-					eye_count = active_view_count;
 				}
 
 				for (uint32_t ei = 0; ei < eye_count; ei++) {
@@ -1728,7 +1805,11 @@ oxr_session_locate_views(struct oxr_logger *log,
 	if ((rig_route_native || rig_route_bridge) && ipc_service_mode) {
 		struct ipc_view_rig_info rig_info = {0};
 		// Bridge relays keep rig_type NONE (descriptors inert); only native
-		// routes carry the chained rig overrides.
+		// routes carry the chained rig overrides. In workspace mode the app's
+		// own rig is honored by default (app visual policy within its canvas);
+		// the workspace controller can take over via xrSetWorkspaceViewRigEXT,
+		// applied SERVER-side in ipc_try_get_sr_view_poses (the override
+		// substitutes for the forwarded rig on non-controller locates).
 		if (rig_route_native && rig_camera) {
 			rig_info.rig_type = IPC_VIEW_RIG_CAMERA;
 		} else if (rig_route_native && rig_display) {

--- a/test_apps/cube_handle_d3d11_win/main.cpp
+++ b/test_apps/cube_handle_d3d11_win/main.cpp
@@ -641,6 +641,16 @@ static void RenderOneFrame(RenderState& rs) {
                     XrView rawViews[8];
                     for (uint32_t vi = 0; vi < 8; vi++) rawViews[vi] = {XR_TYPE_VIEW};
 
+                    // XR_EXT_view_rig raw-channel verification (#396 W7): chain
+                    // XrViewDisplayRawEXT so the runtime reports the DP's full
+                    // per-view eye set. Logged once below to confirm
+                    // eyeCountOutput == viewCount with sane positions (esp. in
+                    // >2-view modes, where the DP — not the runtime — fills N).
+                    XrViewDisplayRawEXT rawProbe = {XR_TYPE_VIEW_DISPLAY_RAW_EXT};
+                    if (g_hasViewRigExt) {
+                        viewState.next = &rawProbe;
+                    }
+
                     // XR_EXT_view_rig (#396 W7): drive the runtime rig matching
                     // the app's current mode (C selects the rig) with the app's
                     // tunables — the runtime owns the window/canvas resolve and
@@ -681,6 +691,21 @@ static void RenderOneFrame(RenderState& rs) {
                     }
 
                     xrLocateViews(xr.session, &locateInfo, &viewState, 8, &viewCount, rawViews);
+
+                    // XR_EXT_view_rig raw-channel verification (#396 W7): one-shot
+                    // proof the raw channel reports the DP's full per-view set.
+                    if (g_hasViewRigExt) {
+                        static int rawLogged = 0;
+                        if (rawLogged < 3) {
+                            rawLogged++;
+                            LOG_INFO("view-rig RAW: eyeCountOutput=%u viewCount=%u isTracking=%d",
+                                     rawProbe.eyeCountOutput, viewCount, (int)rawProbe.isTracking);
+                            for (uint32_t i = 0; i < rawProbe.eyeCountOutput && i < 8; i++) {
+                                LOG_INFO("  rawEyes[%u]=(%.4f,%.4f,%.4f)", i, rawProbe.rawEyes[i].x,
+                                         rawProbe.rawEyes[i].y, rawProbe.rawEyes[i].z);
+                            }
+                        }
+                    }
 
                     // Max per-tile capacity from swapchain
                     uint32_t maxTileW = tileColumns > 0 ? xr.swapchain.width / tileColumns : xr.swapchain.width;


### PR DESCRIPTION
Closes the W7 "v2" completeness tails of Epic #396 (`XR_EXT_view_rig`). Branches off current `main` (the WebXR bridge that consumes `XrViewDisplayRawEXT` is already merged).

## A — Raw channel reports the DP's eyes verbatim
The runtime must never synthesize eyes — multi-view fill is the display processor's job (`sim_display` already reports N for >2-view modes; Leia is 2-view, 2 eyes).

- **Delete** the redundant runtime surplus-eye synthesis in `oxr_session.c`. It only fired when a DP under-reported vs the active mode, which no current DP does (sim reports `count=4` for quad). Replaced with a one-shot WARN that surfaces a future under-reporting DP instead of papering over it.
- **Uncap** the IPC server raw block (`ipc_server_handler.c`) — report the DP's full `count` instead of the hard-coded `// DP currently reports max 2`, so a raw consumer over IPC (WebXR bridge / aware app) sees every view's eye in >2-view modes.
- No `XrViewDisplayRawEXT` struct change. Leia's 2-eye path is **byte-identical**.

## B — `xrSetWorkspaceViewRigEXT` (controller view-rig override)
The workspace controller can take over its app clients' view geometry (e.g. force identity m2v during a layout animation). An app's own rig is **honored by default** (app visual policy within its canvas, per the design doc); while an override is set, the server substitutes it for non-controller locates — no client-side gate.

Full IPC channel mirrors `request_workspace_mode_flip`: oxr entry point (controller-only) → xrt vtable `set_workspace_view_rig` + `struct xrt_view_rig` → ipc client proxy → `workspace_set_view_rig` RPC (PID-gated handler) → `d3d11_service` storage → per-locate injection in `ipc_try_get_sr_view_poses`. `XR_EXT_view_rig_SPEC_VERSION` → 2.

**Inert until adopted:** no workspace app consumes the rig API yet and the shell doesn't call this entry point, so B is a no-op for all current configs (the per-locate injection finds no override and leaves the rig untouched). Full e2e validation lands when the shell adopts the call.

## Verification
- Hardware (Leia, dev runtime from worktree): cube renders correct 3D, rig R/C toggles work, **no regression**.
- Raw channel: `view-rig RAW: eyeCountOutput=2 viewCount=2` — one eye per view, verbatim; extension advertised as `v2`.
- >2-view exposure is code-verified (sim_display reports 4 → passed through verbatim); the runtime synthesis deletion is a no-op for all current DPs.

#396 stays open; this clears the W7 v2 tails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)