### PR TITLE
feat(#439): D3D12 Local2D consumer — masked 2D-over-3D composite (Phase 3)

### DIFF
--- a/src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp
+++ b/src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp
@@ -215,6 +215,31 @@ struct comp_d3d12_compositor
 	ID3D12Resource *surround_scratch;
 	ID3D12Resource *weave_scratch;
 
+	//! #439 Phase 3 — Local2D consumer state (mirrors the D3D11 leg). True if
+	//! this frame's accumulator carried any XRT_LAYER_LOCAL_2D layer; set once
+	//! under c->mutex at the top of layer_commit. Drives the effective-canvas
+	//! supersede + the composite's have_local_2d branch.
+	bool local_2d_last_frame;
+
+	//! Implicit zone mask rasterized from the frame's Local2D layer rects
+	//! (R8_UNORM RT + staged SRV copy), reused across frames via dirty-check.
+	//! INVERSE of an authored set_rects mask: M=1 (keep weave) everywhere, M=0
+	//! (show the flattened 2D) inside the layer rects.
+	ID3D12Resource *implicit_mask_tex;
+	ID3D12DescriptorHeap *implicit_mask_rtv_heap;
+	ID3D12Resource *implicit_mask_staged;
+	uint32_t implicit_mask_w, implicit_mask_h;
+	uint32_t implicit_rect_count;
+	struct xrt_rect implicit_rects[XRT_MAX_LAYERS];
+
+	//! Flattened Local2D layers (the `twod` source). R8G8B8A8_UNORM render
+	//! target — dedicated, NOT shared with surround_scratch (avoids an
+	//! RTV-dangle when the app switches between the surround and Local2D
+	//! models). Lazily (re)allocated window-sized.
+	ID3D12Resource *local2d_scratch;
+	ID3D12DescriptorHeap *local2d_scratch_rtv_heap;
+	uint32_t local2d_scratch_w, local2d_scratch_h;
+
 	//! HUD overlay.
 	struct u_hud *hud;
 
@@ -300,7 +325,9 @@ static void d3d12_maybe_capture_surround_target(struct comp_d3d12_compositor *c,
 static struct u_canvas_rect
 d3d12_effective_canvas(struct comp_d3d12_compositor *c)
 {
-	if (c->active_zone_mask == nullptr) {
+	// #439 Phase 3: Local2D layers supersede the canvas the same way an
+	// authored mask does — the composite writes the whole window region.
+	if (c->active_zone_mask == nullptr && !c->local_2d_last_frame) {
 		return c->canvas;
 	}
 	struct u_canvas_rect win = {};
@@ -1302,12 +1329,23 @@ d3d12_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 	}
 #endif
 
+	// #439 Phase 3: detect Local2D layers once per frame (under c->mutex).
+	// Drives the effective-canvas supersede + the composite's have_local_2d
+	// branch — mirrors the D3D11 leg (set before eff_canvas is computed).
+	c->local_2d_last_frame = false;
+	for (uint32_t i = 0; i < c->layer_accum.layer_count; i++) {
+		if (c->layer_accum.layers[i].data.type == XRT_LAYER_LOCAL_2D) {
+			c->local_2d_last_frame = true;
+			break;
+		}
+	}
+
 	// #439 Phase 2: the one canvas authority for this frame. While a zone
-	// mask is active this is the client-window rect (the mask supersedes
-	// the output rect); otherwise it is c->canvas unchanged. Computed once
-	// under c->mutex (held for this whole function) so the weave region,
-	// view dims, and composite all see the same rect even if submit/destroy
-	// race the frame.
+	// mask is active (or Local2D layers are present) this is the client-window
+	// rect (it supersedes the output rect); otherwise it is c->canvas
+	// unchanged. Computed once under c->mutex (held for this whole function)
+	// so the weave region, view dims, and composite all see the same rect even
+	// if submit/destroy race the frame.
 	const struct u_canvas_rect eff_canvas = d3d12_effective_canvas(c);
 
 	// Get target dimensions
@@ -3111,6 +3149,32 @@ d3d12_release_zone_state(struct comp_d3d12_compositor *c)
 		c->weave_scratch->Release();
 		c->weave_scratch = nullptr;
 	}
+	// #439 Phase 3 — Local2D consumer scratches + implicit mask.
+	if (c->local2d_scratch != nullptr) {
+		c->local2d_scratch->Release();
+		c->local2d_scratch = nullptr;
+	}
+	if (c->local2d_scratch_rtv_heap != nullptr) {
+		c->local2d_scratch_rtv_heap->Release();
+		c->local2d_scratch_rtv_heap = nullptr;
+	}
+	c->local2d_scratch_w = 0;
+	c->local2d_scratch_h = 0;
+	if (c->implicit_mask_staged != nullptr) {
+		c->implicit_mask_staged->Release();
+		c->implicit_mask_staged = nullptr;
+	}
+	if (c->implicit_mask_rtv_heap != nullptr) {
+		c->implicit_mask_rtv_heap->Release();
+		c->implicit_mask_rtv_heap = nullptr;
+	}
+	if (c->implicit_mask_tex != nullptr) {
+		c->implicit_mask_tex->Release();
+		c->implicit_mask_tex = nullptr;
+	}
+	c->implicit_mask_w = 0;
+	c->implicit_mask_h = 0;
+	c->implicit_rect_count = 0;
 }
 
 // (Re)allocate a DEFAULT-heap committed scratch texture at the given
@@ -3186,6 +3250,340 @@ d3d12_zone_cmd_execute(struct comp_d3d12_compositor *c)
 	gpu_wait_idle(c);
 }
 
+// #439 Phase 3 — (re)allocate the dedicated Local2D flatten scratch
+// (R8G8B8A8_UNORM, ALLOW_RENDER_TARGET, steady COMMON) + its RTV heap. Kept
+// separate from surround_scratch so switching between the surround and Local2D
+// models can't dangle an RTV. Returns false on allocation failure.
+static bool
+d3d12_ensure_local2d_scratch(struct comp_d3d12_compositor *c, uint32_t w, uint32_t h)
+{
+	if (c->local2d_scratch != nullptr && c->local2d_scratch_w == w && c->local2d_scratch_h == h) {
+		return true;
+	}
+	if (c->local2d_scratch != nullptr) {
+		c->local2d_scratch->Release();
+		c->local2d_scratch = nullptr;
+	}
+	c->local2d_scratch_w = 0;
+	c->local2d_scratch_h = 0;
+
+	D3D12_RESOURCE_DESC desc = {};
+	desc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
+	desc.Width = w;
+	desc.Height = h;
+	desc.DepthOrArraySize = 1;
+	desc.MipLevels = 1;
+	desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	desc.SampleDesc.Count = 1;
+	desc.Flags = D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET;
+
+	D3D12_HEAP_PROPERTIES heap = {};
+	heap.Type = D3D12_HEAP_TYPE_DEFAULT;
+
+	D3D12_CLEAR_VALUE clear = {};
+	clear.Format = DXGI_FORMAT_R8G8B8A8_UNORM; // transparent (flatten clears to 0,0,0,0)
+
+	HRESULT hr = c->device->CreateCommittedResource(
+	    &heap, D3D12_HEAP_FLAG_NONE, &desc, D3D12_RESOURCE_STATE_COMMON, &clear, IID_PPV_ARGS(&c->local2d_scratch));
+	if (FAILED(hr) || c->local2d_scratch == nullptr) {
+		U_LOG_W("local2d scratch alloc (%ux%u) failed: 0x%08x", w, h, hr);
+		c->local2d_scratch = nullptr;
+		return false;
+	}
+
+	if (c->local2d_scratch_rtv_heap == nullptr) {
+		D3D12_DESCRIPTOR_HEAP_DESC rtv_desc = {};
+		rtv_desc.NumDescriptors = 1;
+		rtv_desc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+		hr = c->device->CreateDescriptorHeap(&rtv_desc, IID_PPV_ARGS(&c->local2d_scratch_rtv_heap));
+		if (FAILED(hr) || c->local2d_scratch_rtv_heap == nullptr) {
+			U_LOG_W("local2d scratch RTV heap failed: 0x%08x", hr);
+			c->local2d_scratch->Release();
+			c->local2d_scratch = nullptr;
+			return false;
+		}
+	}
+	c->device->CreateRenderTargetView(c->local2d_scratch, nullptr,
+	                                  c->local2d_scratch_rtv_heap->GetCPUDescriptorHandleForHeapStart());
+	c->local2d_scratch_w = w;
+	c->local2d_scratch_h = h;
+	return true;
+}
+
+// #439 Phase 3 — (re)rasterize the runtime-owned IMPLICIT zone mask from this
+// frame's Local2D layer rects. Inverse of zone_mask_set_rects: M=1 (keep the
+// weave / 3D) everywhere, then M=0 (show the flattened 2D) inside each layer
+// rect. The masked-composite shader lerps M*weave + (1-M)*twod, so M=0 in the
+// rects is what surfaces the 2D content there. Records the raster + staging
+// copy into the OPEN c->cmd_list (mid-frame, like the surround copy). Re-rasters
+// only when the rect set or dims change (steady-state frames reuse the staged
+// snapshot). Returns the staged R8 resource (sampled by the composite) or
+// nullptr on failure. Caller holds c->mutex.
+static ID3D12Resource *
+d3d12_update_implicit_mask(struct comp_d3d12_compositor *c,
+                           const struct xrt_rect *rects,
+                           uint32_t rect_count,
+                           uint32_t w,
+                           uint32_t h)
+{
+	if (w == 0 || h == 0 || rect_count == 0) {
+		return nullptr;
+	}
+
+	bool dirty = c->implicit_mask_tex == nullptr || c->implicit_mask_staged == nullptr ||
+	             c->implicit_mask_w != w || c->implicit_mask_h != h || c->implicit_rect_count != rect_count;
+	for (uint32_t i = 0; !dirty && i < rect_count; i++) {
+		if (memcmp(&c->implicit_rects[i], &rects[i], sizeof(rects[i])) != 0) {
+			dirty = true;
+		}
+	}
+	if (!dirty) {
+		return c->implicit_mask_staged; // steady PSR, reuse
+	}
+
+	// (Re)allocate the R8 RT + staged copy on dims change (mirrors
+	// zone_mask_create — tex steady RENDER_TARGET, staged steady PSR).
+	if (c->implicit_mask_tex == nullptr || c->implicit_mask_w != w || c->implicit_mask_h != h) {
+		if (c->implicit_mask_staged != nullptr) {
+			c->implicit_mask_staged->Release();
+			c->implicit_mask_staged = nullptr;
+		}
+		if (c->implicit_mask_rtv_heap != nullptr) {
+			c->implicit_mask_rtv_heap->Release();
+			c->implicit_mask_rtv_heap = nullptr;
+		}
+		if (c->implicit_mask_tex != nullptr) {
+			c->implicit_mask_tex->Release();
+			c->implicit_mask_tex = nullptr;
+		}
+		c->implicit_mask_w = 0;
+		c->implicit_mask_h = 0;
+
+		D3D12_RESOURCE_DESC td = {};
+		td.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
+		td.Width = w;
+		td.Height = h;
+		td.DepthOrArraySize = 1;
+		td.MipLevels = 1;
+		td.Format = DXGI_FORMAT_R8_UNORM;
+		td.SampleDesc.Count = 1;
+		td.Flags = D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET;
+
+		D3D12_HEAP_PROPERTIES heap = {};
+		heap.Type = D3D12_HEAP_TYPE_DEFAULT;
+
+		D3D12_CLEAR_VALUE clear = {};
+		clear.Format = DXGI_FORMAT_R8_UNORM;
+		clear.Color[0] = 1.0f;
+
+		HRESULT hr = c->device->CreateCommittedResource(&heap, D3D12_HEAP_FLAG_NONE, &td,
+		                                                D3D12_RESOURCE_STATE_RENDER_TARGET, &clear,
+		                                                IID_PPV_ARGS(&c->implicit_mask_tex));
+		if (SUCCEEDED(hr) && c->implicit_mask_tex != nullptr) {
+			D3D12_DESCRIPTOR_HEAP_DESC rtv_desc = {};
+			rtv_desc.NumDescriptors = 1;
+			rtv_desc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+			hr = c->device->CreateDescriptorHeap(&rtv_desc, IID_PPV_ARGS(&c->implicit_mask_rtv_heap));
+		}
+		if (SUCCEEDED(hr) && c->implicit_mask_rtv_heap != nullptr) {
+			c->device->CreateRenderTargetView(c->implicit_mask_tex, nullptr,
+			                                  c->implicit_mask_rtv_heap->GetCPUDescriptorHandleForHeapStart());
+			td.Flags = D3D12_RESOURCE_FLAG_NONE;
+			hr = c->device->CreateCommittedResource(&heap, D3D12_HEAP_FLAG_NONE, &td,
+			                                        D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, nullptr,
+			                                        IID_PPV_ARGS(&c->implicit_mask_staged));
+		}
+		if (FAILED(hr) || c->implicit_mask_staged == nullptr) {
+			U_LOG_E("implicit zone mask: D3D12 resource creation failed: 0x%08x", hr);
+			if (c->implicit_mask_rtv_heap != nullptr) {
+				c->implicit_mask_rtv_heap->Release();
+				c->implicit_mask_rtv_heap = nullptr;
+			}
+			if (c->implicit_mask_tex != nullptr) {
+				c->implicit_mask_tex->Release();
+				c->implicit_mask_tex = nullptr;
+			}
+			return nullptr;
+		}
+		c->implicit_mask_w = w;
+		c->implicit_mask_h = h;
+	}
+
+	// Clamp the layer rects → D3D12_RECT (client-window px); skip degenerate
+	// / fully-outside ones.
+	D3D12_RECT drs[XRT_MAX_LAYERS];
+	uint32_t n = 0;
+	for (uint32_t i = 0; i < rect_count && n < XRT_MAX_LAYERS; i++) {
+		int32_t left = rects[i].offset.w;
+		int32_t top = rects[i].offset.h;
+		int32_t right = left + rects[i].extent.w;
+		int32_t bottom = top + rects[i].extent.h;
+		if (left < 0) {
+			left = 0;
+		}
+		if (top < 0) {
+			top = 0;
+		}
+		if (right > (int32_t)w) {
+			right = (int32_t)w;
+		}
+		if (bottom > (int32_t)h) {
+			bottom = (int32_t)h;
+		}
+		if (right <= left || bottom <= top) {
+			continue;
+		}
+		drs[n].left = left;
+		drs[n].top = top;
+		drs[n].right = right;
+		drs[n].bottom = bottom;
+		n++;
+	}
+
+	// Raster onto the open cmd-list: M=1 everywhere, then M=0 inside the rects
+	// (tex is in its steady RENDER_TARGET state). D3D12's ClearRenderTargetView
+	// takes the rect array natively (one call vs D3D11's per-rect ClearView).
+	D3D12_CPU_DESCRIPTOR_HANDLE rtv = c->implicit_mask_rtv_heap->GetCPUDescriptorHandleForHeapStart();
+	const float all_3d[4] = {1.0f, 0.0f, 0.0f, 0.0f};
+	c->cmd_list->ClearRenderTargetView(rtv, all_3d, 0, nullptr);
+	if (n > 0) {
+		const float all_2d[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+		c->cmd_list->ClearRenderTargetView(rtv, all_2d, n, drs);
+	}
+
+	// Stage the snapshot the composite samples (RT≠SRV; decouple as the
+	// explicit mask's submit does). Leaves tex in RENDER_TARGET, staged in PSR.
+	D3D12_RESOURCE_BARRIER to_copy[2] = {};
+	to_copy[0].Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+	to_copy[0].Transition.pResource = c->implicit_mask_tex;
+	to_copy[0].Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
+	to_copy[0].Transition.StateAfter = D3D12_RESOURCE_STATE_COPY_SOURCE;
+	to_copy[0].Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+	to_copy[1].Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+	to_copy[1].Transition.pResource = c->implicit_mask_staged;
+	to_copy[1].Transition.StateBefore = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+	to_copy[1].Transition.StateAfter = D3D12_RESOURCE_STATE_COPY_DEST;
+	to_copy[1].Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+	c->cmd_list->ResourceBarrier(2, to_copy);
+
+	c->cmd_list->CopyResource(c->implicit_mask_staged, c->implicit_mask_tex);
+
+	std::swap(to_copy[0].Transition.StateBefore, to_copy[0].Transition.StateAfter);
+	std::swap(to_copy[1].Transition.StateBefore, to_copy[1].Transition.StateAfter);
+	c->cmd_list->ResourceBarrier(2, to_copy);
+
+	memcpy(c->implicit_rects, rects, sizeof(rects[0]) * rect_count);
+	c->implicit_rect_count = rect_count;
+
+	// One-off-ish lifecycle event (fires only on a rect/dims change).
+	U_LOG_W("implicit zone mask: %ux%u, %u Local2D rect(s)", w, h, rect_count);
+	return c->implicit_mask_staged;
+}
+
+// #439 Phase 3 — flatten this frame's Local2D layers into local2d_scratch (the
+// `twod` source the masked composite reads). Records into the OPEN c->cmd_list:
+// transition the scratch to RENDER_TARGET, clear transparent, draw each layer
+// in list order (later = on top) with premultiplied (or straight) "over", then
+// transition to PIXEL_SHADER_RESOURCE. Dest rects clip to the window region;
+// the clip fractions, the layer's norm_rect, and flip_y are carried into the
+// source UVs (matches d3d11_flatten_local_2d_layers). Caller holds c->mutex and
+// has ensured local2d_scratch at (region_w, region_h). Returns false on error.
+static bool
+d3d12_flatten_local_2d_layers(struct comp_d3d12_compositor *c, uint32_t region_w, uint32_t region_h)
+{
+	D3D12_CPU_DESCRIPTOR_HANDLE rtv = c->local2d_scratch_rtv_heap->GetCPUDescriptorHandleForHeapStart();
+
+	// Scratch COMMON → RENDER_TARGET, clear transparent. Where a pixel is M=0
+	// (2D) but no layer covers it, twod stays (0,0,0,0) → final.a → 0 → the
+	// desktop shows through (the §4.2 output-alpha rule).
+	D3D12_RESOURCE_BARRIER to_rt = {};
+	to_rt.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+	to_rt.Transition.pResource = c->local2d_scratch;
+	to_rt.Transition.StateBefore = D3D12_RESOURCE_STATE_COMMON;
+	to_rt.Transition.StateAfter = D3D12_RESOURCE_STATE_RENDER_TARGET;
+	to_rt.Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+	c->cmd_list->ResourceBarrier(1, &to_rt);
+
+	const float transparent[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+	c->cmd_list->ClearRenderTargetView(rtv, transparent, 0, nullptr);
+
+	uint32_t slot = 0;
+	for (uint32_t i = 0; i < c->layer_accum.layer_count; i++) {
+		struct comp_layer *layer = &c->layer_accum.layers[i];
+		if (layer->data.type != XRT_LAYER_LOCAL_2D) {
+			continue;
+		}
+		struct xrt_swapchain *sc = layer->sc_array[0];
+		if (sc == nullptr) {
+			continue;
+		}
+		uint32_t img_idx = layer->data.local_2d.sub.image_index;
+		ID3D12Resource *src_res = static_cast<ID3D12Resource *>(comp_d3d12_swapchain_get_resource(sc, img_idx));
+		if (src_res == nullptr) {
+			continue;
+		}
+
+		// Dest rect (client-window px), clipped to the window region.
+		const struct xrt_rect *dr = &layer->data.local_2d.rect;
+		int32_t dx = dr->offset.w;
+		int32_t dy = dr->offset.h;
+		int32_t dw = dr->extent.w;
+		int32_t dh = dr->extent.h;
+		if (dw <= 0 || dh <= 0) {
+			continue;
+		}
+		int32_t x0 = dx < 0 ? 0 : dx;
+		int32_t y0 = dy < 0 ? 0 : dy;
+		int32_t x1 = (dx + dw) > (int32_t)region_w ? (int32_t)region_w : (dx + dw);
+		int32_t y1 = (dy + dh) > (int32_t)region_h ? (int32_t)region_h : (dy + dh);
+		if (x1 <= x0 || y1 <= y0) {
+			continue;
+		}
+
+		// Clip fractions within the original dest rect (carry into the UVs).
+		float fx0 = (float)(x0 - dx) / (float)dw;
+		float fy0 = (float)(y0 - dy) / (float)dh;
+		float fx1 = (float)(x1 - dx) / (float)dw;
+		float fy1 = (float)(y1 - dy) / (float)dh;
+
+		// App sub-rect within the swapchain image (normalized). Default full.
+		struct xrt_normalized_rect nr = layer->data.local_2d.sub.norm_rect;
+		if (nr.w <= 0.0f || nr.h <= 0.0f) {
+			nr.x = 0.0f;
+			nr.y = 0.0f;
+			nr.w = 1.0f;
+			nr.h = 1.0f;
+		}
+
+		float src_x = nr.x + nr.w * fx0;
+		float src_w = nr.w * (fx1 - fx0);
+		float src_y, src_h;
+		if (layer->data.flip_y) {
+			src_y = nr.y + nr.h * (1.0f - fy0);
+			src_h = -(nr.h * (fy1 - fy0));
+		} else {
+			src_y = nr.y + nr.h * fy0;
+			src_h = nr.h * (fy1 - fy0);
+		}
+
+		bool unpremult = (layer->data.flags & XRT_LAYER_COMPOSITION_UNPREMULTIPLIED_ALPHA_BIT) != 0;
+
+		comp_d3d12_renderer_flatten_local_2d(c->renderer, c->cmd_list, rtv.ptr, src_res, slot++, x0, y0,
+		                                     (uint32_t)(x1 - x0), (uint32_t)(y1 - y0), src_x, src_y, src_w,
+		                                     src_h, unpremult);
+	}
+
+	// Scratch → sampleable for the masked composite.
+	D3D12_RESOURCE_BARRIER to_psr = {};
+	to_psr.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+	to_psr.Transition.pResource = c->local2d_scratch;
+	to_psr.Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
+	to_psr.Transition.StateAfter = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+	to_psr.Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+	c->cmd_list->ResourceBarrier(1, &to_psr);
+	return true;
+}
+
 // #439 — composite the authored zone mask. Records into the OPEN c->cmd_list
 // (both call sites are mid-recording in layer_commit). Runs INSTEAD of the
 // rect surround path when an active submitted mask exists (the mask-lerp
@@ -3213,8 +3611,14 @@ d3d12_composite_zone_mask(struct comp_d3d12_compositor *c,
                           uint32_t dst_h,
                           const struct u_canvas_rect *eff_canvas)
 {
+	// #439 Phase 3: run when EITHER an explicit submitted mask exists (legacy
+	// `texture + mask`, surround supplies the 2D pixels) OR this frame carries
+	// Local2D layers (the layers supply both the 2D pixels and an implicit
+	// mask). Mirrors the D3D11 leg.
 	struct comp_d3d12_zone_mask *mask = c->active_zone_mask;
-	if (mask == nullptr || !mask->submitted || dst == nullptr || dst_rtv == 0 || c->renderer == nullptr) {
+	const bool have_explicit = (mask != nullptr && mask->submitted);
+	const bool have_local_2d = c->local_2d_last_frame;
+	if ((!have_explicit && !have_local_2d) || dst == nullptr || dst_rtv == 0 || c->renderer == nullptr) {
 		return false;
 	}
 
@@ -3231,126 +3635,178 @@ d3d12_composite_zone_mask(struct comp_d3d12_compositor *c,
 		}
 	}
 
-	// The composite is `texture + mask` (impl doc §2): the surround supplies
-	// the 2D pixels. Without one there is nothing to composite — full weave.
-	// D3D12 accepts either sync flavor: keyed mutex (spec v6) or fence (v7).
-	const bool use_fence = (c->surround_fence != nullptr);
-	if (!c->surround_2d.valid || c->surround_texture == nullptr ||
-	    (!use_fence && c->surround_mutex == nullptr)) {
-		static bool no_surround_logged = false;
-		if (!no_surround_logged) {
-			U_LOG_W("D3D12 zone mask: no 2D surround registered — mask ignored "
-			        "(the composite needs xrSetSharedTextureSurround2D(Fence)EXT for the 2D pixels)");
-			no_surround_logged = true;
-		}
-		return false;
-	}
-
-	// Relaxed dims contract (#464): accept a window-sized surround or the
-	// legacy display-sized one — content is top-left-anchored in both; we
-	// copy only the window region.
-	if (c->surround_2d.w < region_w || c->surround_2d.h < region_h) {
-		static bool dims_logged = false;
-		if (!dims_logged) {
-			U_LOG_W("D3D12 zone mask: surround %ux%u smaller than window region %ux%u — "
-			        "mask ignored. Re-register surround on window resize.",
-			        c->surround_2d.w, c->surround_2d.h, region_w, region_h);
-			dims_logged = true;
-		}
-		return false;
-	}
-
-	// Format contract: surround must match dst (same rule as the rect path),
-	// and dst must be one of the two formats the composite has a PSO for —
-	// app-created shared textures are BGRA8 in the wild, DXGI targets RGBA8.
-	D3D12_RESOURCE_DESC sd = c->surround_texture->GetDesc();
+	// Validate the weave-target format up front (both paths): the composite
+	// has PSOs only for RGBA8/BGRA8 UNORM (the lerp is channel-agnostic —
+	// app shared textures are BGRA8 in the wild, DXGI targets RGBA8).
 	D3D12_RESOURCE_DESC dd = dst->GetDesc();
-	if (sd.Format != dd.Format ||
-	    (dd.Format != DXGI_FORMAT_R8G8B8A8_UNORM && dd.Format != DXGI_FORMAT_B8G8R8A8_UNORM)) {
-		static bool fmt_logged = false;
-		if (!fmt_logged) {
-			U_LOG_W("D3D12 zone mask: format mismatch — surround=%u, target=%u "
+	if (dd.Format != DXGI_FORMAT_R8G8B8A8_UNORM && dd.Format != DXGI_FORMAT_B8G8R8A8_UNORM) {
+		static bool dfmt_logged = false;
+		if (!dfmt_logged) {
+			U_LOG_W("D3D12 zone mask: target format %u unsupported "
 			        "(composite PSOs cover R8G8B8A8/B8G8R8A8 UNORM) — mask ignored",
-			        (unsigned)sd.Format, (unsigned)dd.Format);
-			fmt_logged = true;
+			        (unsigned)dd.Format);
+			dfmt_logged = true;
 		}
 		return false;
 	}
 
-	// Window-sized scratches (the shader samples uv [0,1] over the window
-	// region, so inputs must carry exactly that region).
-	if (!d3d12_ensure_scratch(c, &c->surround_scratch, region_w, region_h, sd.Format, "zone_mask surround")) {
-		return false;
+	// Resolve the mask source: an explicit submitted mask wins; else
+	// rasterize the implicit mask from the Local2D layer rects (M=0 inside the
+	// rect union, M=1 elsewhere — records onto the open cmd-list).
+	ID3D12Resource *mask_res = nullptr;
+	if (have_explicit) {
+		mask_res = mask->staged;
+	} else {
+		struct xrt_rect rects[XRT_MAX_LAYERS];
+		uint32_t rect_count = 0;
+		for (uint32_t i = 0; i < c->layer_accum.layer_count && rect_count < XRT_MAX_LAYERS; i++) {
+			if (c->layer_accum.layers[i].data.type == XRT_LAYER_LOCAL_2D) {
+				rects[rect_count++] = c->layer_accum.layers[i].data.local_2d.rect;
+			}
+		}
+		mask_res = d3d12_update_implicit_mask(c, rects, rect_count, region_w, region_h);
 	}
-	if (!d3d12_ensure_scratch(c, &c->weave_scratch, region_w, region_h, dd.Format, "zone_mask weave")) {
+	if (mask_res == nullptr) {
 		return false;
 	}
 
-	// Surround sync — same flavors as d3d12_blit_surround_strips: fence →
-	// queue->Wait gates the caller's later ExecuteCommandLists; mutex →
-	// AcquireSync(0, 16) bracket around the recording (the shipping v6
-	// pattern), short timeout — skip a frame rather than stall.
-	if (use_fence) {
-		HRESULT hr = c->command_queue->Wait(c->surround_fence, c->surround_await_fence_value);
-		if (FAILED(hr)) {
-			static bool wait_logged = false;
-			if (!wait_logged) {
-				U_LOG_W("D3D12 zone mask: queue->Wait(fence=%p, value=%llu) failed (hr=0x%08x). "
-				        "Composite skipped.",
-				        (void *)c->surround_fence,
-				        (unsigned long long)c->surround_await_fence_value, hr);
-				wait_logged = true;
+	// Resolve the `twod` source + a window-sized weave snapshot scratch.
+	// Local2D layers (Phase 3) SUPERSEDE any registered surround for this
+	// frame: flatten them into the dedicated local2d_scratch. Otherwise the
+	// legacy `texture + mask` path copies the app surround.
+	ID3D12Resource *twod_res = nullptr;
+	if (have_local_2d) {
+		if (!d3d12_ensure_local2d_scratch(c, region_w, region_h)) {
+			return false;
+		}
+		if (!d3d12_ensure_scratch(c, &c->weave_scratch, region_w, region_h, dd.Format, "local2d weave")) {
+			return false;
+		}
+		if (!d3d12_flatten_local_2d_layers(c, region_w, region_h)) {
+			return false;
+		}
+		twod_res = c->local2d_scratch;
+	} else {
+		// The composite is `texture + mask` (impl doc §2): the surround
+		// supplies the 2D pixels. Without one there is nothing to composite —
+		// full weave. D3D12 accepts either sync flavor: keyed mutex (v6) or
+		// fence (v7). These guards gate ONLY this path so the legacy behavior
+		// stays byte-identical when no Local2D layers are present.
+		const bool use_fence = (c->surround_fence != nullptr);
+		if (!c->surround_2d.valid || c->surround_texture == nullptr ||
+		    (!use_fence && c->surround_mutex == nullptr)) {
+			static bool no_surround_logged = false;
+			if (!no_surround_logged) {
+				U_LOG_W("D3D12 zone mask: no 2D surround registered — mask ignored "
+				        "(the composite needs xrSetSharedTextureSurround2D(Fence)EXT for the 2D pixels)");
+				no_surround_logged = true;
 			}
 			return false;
 		}
-	} else {
-		HRESULT hr = c->surround_mutex->AcquireSync(0, 16);
-		if (FAILED(hr)) {
-			return false; // timeout/abandoned — previous frame's pixels stay.
+
+		// Relaxed dims contract (#464): accept a window-sized surround or the
+		// legacy display-sized one — content is top-left-anchored in both; we
+		// copy only the window region.
+		if (c->surround_2d.w < region_w || c->surround_2d.h < region_h) {
+			static bool dims_logged = false;
+			if (!dims_logged) {
+				U_LOG_W("D3D12 zone mask: surround %ux%u smaller than window region %ux%u — "
+				        "mask ignored. Re-register surround on window resize.",
+				        c->surround_2d.w, c->surround_2d.h, region_w, region_h);
+				dims_logged = true;
+			}
+			return false;
 		}
-	}
 
-	// Copy the window region of the app surround into its scratch.
-	D3D12_RESOURCE_BARRIER enter[2] = {};
-	enter[0].Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
-	enter[0].Transition.pResource = c->surround_texture;
-	enter[0].Transition.StateBefore = D3D12_RESOURCE_STATE_COMMON;
-	enter[0].Transition.StateAfter = D3D12_RESOURCE_STATE_COPY_SOURCE;
-	enter[0].Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
-	enter[1].Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
-	enter[1].Transition.pResource = c->surround_scratch;
-	enter[1].Transition.StateBefore = D3D12_RESOURCE_STATE_COMMON;
-	enter[1].Transition.StateAfter = D3D12_RESOURCE_STATE_COPY_DEST;
-	enter[1].Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
-	c->cmd_list->ResourceBarrier(2, enter);
+		// Format contract: surround must match dst (same rule as the rect path).
+		D3D12_RESOURCE_DESC sd = c->surround_texture->GetDesc();
+		if (sd.Format != dd.Format) {
+			static bool fmt_logged = false;
+			if (!fmt_logged) {
+				U_LOG_W("D3D12 zone mask: format mismatch — surround=%u, target=%u — mask ignored",
+				        (unsigned)sd.Format, (unsigned)dd.Format);
+				fmt_logged = true;
+			}
+			return false;
+		}
 
-	D3D12_TEXTURE_COPY_LOCATION dst_loc = {};
-	dst_loc.pResource = c->surround_scratch;
-	dst_loc.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
-	dst_loc.SubresourceIndex = 0;
-	D3D12_TEXTURE_COPY_LOCATION src_loc = {};
-	src_loc.pResource = c->surround_texture;
-	src_loc.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
-	src_loc.SubresourceIndex = 0;
-	D3D12_BOX region_box = {0, 0, 0, region_w, region_h, 1};
-	c->cmd_list->CopyTextureRegion(&dst_loc, 0, 0, 0, &src_loc, &region_box);
+		// Window-sized scratches (the shader samples uv [0,1] over the window
+		// region, so inputs must carry exactly that region).
+		if (!d3d12_ensure_scratch(c, &c->surround_scratch, region_w, region_h, sd.Format,
+		                          "zone_mask surround")) {
+			return false;
+		}
+		if (!d3d12_ensure_scratch(c, &c->weave_scratch, region_w, region_h, dd.Format, "zone_mask weave")) {
+			return false;
+		}
 
-	// Surround back to COMMON (cross-process invariant), scratch → sampleable.
-	D3D12_RESOURCE_BARRIER exit_sr[2] = {};
-	exit_sr[0].Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
-	exit_sr[0].Transition.pResource = c->surround_texture;
-	exit_sr[0].Transition.StateBefore = D3D12_RESOURCE_STATE_COPY_SOURCE;
-	exit_sr[0].Transition.StateAfter = D3D12_RESOURCE_STATE_COMMON;
-	exit_sr[0].Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
-	exit_sr[1].Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
-	exit_sr[1].Transition.pResource = c->surround_scratch;
-	exit_sr[1].Transition.StateBefore = D3D12_RESOURCE_STATE_COPY_DEST;
-	exit_sr[1].Transition.StateAfter = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
-	exit_sr[1].Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
-	c->cmd_list->ResourceBarrier(2, exit_sr);
+		// Surround sync — same flavors as d3d12_blit_surround_strips: fence →
+		// queue->Wait gates the caller's later ExecuteCommandLists; mutex →
+		// AcquireSync(0, 16) bracket around the recording (the shipping v6
+		// pattern), short timeout — skip a frame rather than stall.
+		if (use_fence) {
+			HRESULT hr = c->command_queue->Wait(c->surround_fence, c->surround_await_fence_value);
+			if (FAILED(hr)) {
+				static bool wait_logged = false;
+				if (!wait_logged) {
+					U_LOG_W("D3D12 zone mask: queue->Wait(fence=%p, value=%llu) failed (hr=0x%08x). "
+					        "Composite skipped.",
+					        (void *)c->surround_fence,
+					        (unsigned long long)c->surround_await_fence_value, hr);
+					wait_logged = true;
+				}
+				return false;
+			}
+		} else {
+			HRESULT hr = c->surround_mutex->AcquireSync(0, 16);
+			if (FAILED(hr)) {
+				return false; // timeout/abandoned — previous frame's pixels stay.
+			}
+		}
 
-	if (!use_fence) {
-		c->surround_mutex->ReleaseSync(0);
+		// Copy the window region of the app surround into its scratch.
+		D3D12_RESOURCE_BARRIER enter[2] = {};
+		enter[0].Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+		enter[0].Transition.pResource = c->surround_texture;
+		enter[0].Transition.StateBefore = D3D12_RESOURCE_STATE_COMMON;
+		enter[0].Transition.StateAfter = D3D12_RESOURCE_STATE_COPY_SOURCE;
+		enter[0].Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+		enter[1].Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+		enter[1].Transition.pResource = c->surround_scratch;
+		enter[1].Transition.StateBefore = D3D12_RESOURCE_STATE_COMMON;
+		enter[1].Transition.StateAfter = D3D12_RESOURCE_STATE_COPY_DEST;
+		enter[1].Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+		c->cmd_list->ResourceBarrier(2, enter);
+
+		D3D12_TEXTURE_COPY_LOCATION dst_loc = {};
+		dst_loc.pResource = c->surround_scratch;
+		dst_loc.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
+		dst_loc.SubresourceIndex = 0;
+		D3D12_TEXTURE_COPY_LOCATION src_loc = {};
+		src_loc.pResource = c->surround_texture;
+		src_loc.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
+		src_loc.SubresourceIndex = 0;
+		D3D12_BOX region_box = {0, 0, 0, region_w, region_h, 1};
+		c->cmd_list->CopyTextureRegion(&dst_loc, 0, 0, 0, &src_loc, &region_box);
+
+		// Surround back to COMMON (cross-process invariant), scratch → sampleable.
+		D3D12_RESOURCE_BARRIER exit_sr[2] = {};
+		exit_sr[0].Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+		exit_sr[0].Transition.pResource = c->surround_texture;
+		exit_sr[0].Transition.StateBefore = D3D12_RESOURCE_STATE_COPY_SOURCE;
+		exit_sr[0].Transition.StateAfter = D3D12_RESOURCE_STATE_COMMON;
+		exit_sr[0].Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+		exit_sr[1].Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+		exit_sr[1].Transition.pResource = c->surround_scratch;
+		exit_sr[1].Transition.StateBefore = D3D12_RESOURCE_STATE_COPY_DEST;
+		exit_sr[1].Transition.StateAfter = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+		exit_sr[1].Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+		c->cmd_list->ResourceBarrier(2, exit_sr);
+
+		if (!use_fence) {
+			c->surround_mutex->ReleaseSync(0);
+		}
+		twod_res = c->surround_scratch;
 	}
 
 	// Snapshot the window region of the weave (the DP wrote dst; the weave
@@ -3368,9 +3824,16 @@ d3d12_composite_zone_mask(struct comp_d3d12_compositor *c,
 	weave_enter[1].Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
 	c->cmd_list->ResourceBarrier(2, weave_enter);
 
-	dst_loc.pResource = c->weave_scratch;
-	src_loc.pResource = dst;
-	c->cmd_list->CopyTextureRegion(&dst_loc, 0, 0, 0, &src_loc, &region_box);
+	D3D12_TEXTURE_COPY_LOCATION weave_dst_loc = {};
+	weave_dst_loc.pResource = c->weave_scratch;
+	weave_dst_loc.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
+	weave_dst_loc.SubresourceIndex = 0;
+	D3D12_TEXTURE_COPY_LOCATION weave_src_loc = {};
+	weave_src_loc.pResource = dst;
+	weave_src_loc.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
+	weave_src_loc.SubresourceIndex = 0;
+	D3D12_BOX weave_box = {0, 0, 0, region_w, region_h, 1};
+	c->cmd_list->CopyTextureRegion(&weave_dst_loc, 0, 0, 0, &weave_src_loc, &weave_box);
 
 	// Weave scratch → sampleable; dst → RENDER_TARGET for the composite draw.
 	D3D12_RESOURCE_BARRIER weave_exit[2] = {};
@@ -3402,11 +3865,22 @@ d3d12_composite_zone_mask(struct comp_d3d12_compositor *c,
 	uint32_t cright = (cx_u + cw > region_w) ? region_w : cx_u + cw;
 	uint32_t cbottom = (cy_u + ch > region_h) ? region_h : cy_u + ch;
 
+	// One-shot proof-of-life (capture is pre-weave, #492 — this is how we
+	// confirm the post-weave composite ran without a live eyeball).
+	static bool composite_logged = false;
+	if (!composite_logged) {
+		U_LOG_W("D3D12 Local2D composite: %ux%u region, %s mask, twod=%s", region_w, region_h,
+		        have_explicit ? "explicit" : "implicit", have_local_2d ? "local2d layers" : "surround");
+		composite_logged = true;
+	}
+
 	xrt_result_t xret = comp_d3d12_renderer_composite_2d_masked(
-	    c->renderer, c->cmd_list, dst_rtv, static_cast<uint32_t>(dd.Format), c->surround_scratch, mask->staged,
+	    c->renderer, c->cmd_list, dst_rtv, static_cast<uint32_t>(dd.Format), twod_res, mask_res,
 	    c->weave_scratch, region_w, region_h, (int32_t)cx_u, (int32_t)cy_u, cright - cx_u, cbottom - cy_u);
 
 	// Restore steady states: dst → caller's post state, scratches → COMMON.
+	// twod_res is whichever scratch supplied the 2D pixels (local2d or
+	// surround); both sit in PIXEL_SHADER_RESOURCE after their setup above.
 	D3D12_RESOURCE_BARRIER restore[3] = {};
 	uint32_t n = 0;
 	if (dst_post_state != D3D12_RESOURCE_STATE_RENDER_TARGET) {
@@ -3418,7 +3892,7 @@ d3d12_composite_zone_mask(struct comp_d3d12_compositor *c,
 		n++;
 	}
 	restore[n].Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
-	restore[n].Transition.pResource = c->surround_scratch;
+	restore[n].Transition.pResource = twod_res;
 	restore[n].Transition.StateBefore = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
 	restore[n].Transition.StateAfter = D3D12_RESOURCE_STATE_COMMON;
 	restore[n].Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
@@ -3740,6 +4214,30 @@ comp_d3d12_compositor_zone_mask_destroy(struct xrt_compositor *xc, void *mask_pt
 		mask->tex->Release();
 	}
 	free(mask);
+}
+
+// #439 Phase 3 Q4 — the compositor's current recommended per-view render size,
+// polled at frame end by oxr to fire XrEventDataLocal3DZoneViewSizeChangedEXT
+// on a change (mask/Local2D activation or window resize supersedes the canvas).
+// Returns false if no renderer / zero dims. Mirrors the D3D11 getter.
+extern "C" bool
+comp_d3d12_compositor_get_recommended_view_size(struct xrt_compositor *xc, uint32_t *out_w, uint32_t *out_h)
+{
+	struct comp_d3d12_compositor *c = d3d12_comp(xc);
+	std::lock_guard<std::mutex> lock(c->mutex);
+
+	if (out_w == nullptr || out_h == nullptr || c->renderer == nullptr) {
+		return false;
+	}
+	uint32_t vw = 0;
+	uint32_t vh = 0;
+	comp_d3d12_renderer_get_view_dimensions(c->renderer, &vw, &vh);
+	if (vw == 0 || vh == 0) {
+		return false;
+	}
+	*out_w = vw;
+	*out_h = vh;
+	return true;
 }
 
 /*

--- a/src/xrt/compositor/d3d12/comp_d3d12_compositor.h
+++ b/src/xrt/compositor/d3d12/comp_d3d12_compositor.h
@@ -270,6 +270,16 @@ comp_d3d12_compositor_zone_mask_submit(struct xrt_compositor *xc, void *mask);
 void
 comp_d3d12_compositor_zone_mask_destroy(struct xrt_compositor *xc, void *mask);
 
+/*!
+ * Current recommended per-view render size (#439 Phase 3 Q4). Polled at frame
+ * end so oxr can fire XrEventDataLocal3DZoneViewSizeChangedEXT when a mask /
+ * Local2D activation or window resize changes it. Returns false if unavailable.
+ *
+ * @ingroup comp_d3d12
+ */
+bool
+comp_d3d12_compositor_get_recommended_view_size(struct xrt_compositor *xc, uint32_t *out_w, uint32_t *out_h);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/xrt/compositor/d3d12/comp_d3d12_renderer.cpp
+++ b/src/xrt/compositor/d3d12/comp_d3d12_renderer.cpp
@@ -231,6 +231,33 @@ struct CompositeParams
 	uint32_t _pad;
 };
 
+// #439 Phase 3 — Local2D flatten. Reuses the masked_composite fullscreen-triangle
+// VS (uv 0..1 over the viewport); the PS samples the source image through
+// src_rect (origin + size; size.y < 0 => flip_y). Premultiplied vs straight
+// "over" is the PSO blend state, not the shader. Byte-aligned with the D3D11
+// local2d_flatten reference (comp_d3d11_renderer.cpp).
+static const char *local2d_flatten_ps_source = R"(
+Texture2D src_tex : register(t0);
+SamplerState samp : register(s0);
+
+cbuffer FlattenParams : register(b0)
+{
+    float4 src_rect; // xy = origin (norm), zw = size (norm; zw.y < 0 => flip_y)
+};
+
+struct VS_OUTPUT
+{
+    float4 position : SV_Position;
+    float2 uv : TEXCOORD0;
+};
+
+float4 PSMain(VS_OUTPUT input) : SV_Target
+{
+    float2 src_uv = src_rect.xy + input.uv * src_rect.zw;
+    return src_tex.Sample(samp, src_uv);
+}
+)";
+
 /*!
  * D3D12 renderer structure.
  */
@@ -285,6 +312,18 @@ struct comp_d3d12_renderer
 	//! (t0 = 2D surround, t1 = authored mask, t2 = weave snapshot).
 	//! SRVs are written fresh on every composite call.
 	ID3D12DescriptorHeap *composite_srv_heap;
+
+	//! #439 Phase 3 — Local2D flatten pipeline. Each Local2D layer is drawn
+	//! into a runtime scratch with premultiplied (or straight) "over"; the
+	//! masked composite then lerps that scratch under the weave. Reuses the
+	//! masked_composite VS; the PS samples through src_rect.
+	ID3D12RootSignature *flatten_root_signature;
+	ID3D12PipelineState *flatten_pso_premul;   // SrcBlend = ONE
+	ID3D12PipelineState *flatten_pso_straight; // SrcBlend = SRC_ALPHA
+	//! Shader-visible SRV heap for flatten source images — one slot per layer
+	//! draw (D3D12 consumes descriptors at GPU-execute time, so concurrent
+	//! draws in one cmd-list each need their own slot). Written fresh / frame.
+	ID3D12DescriptorHeap *flatten_srv_heap;
 
 	//! Descriptor sizes.
 	uint32_t rtv_descriptor_size;
@@ -1070,6 +1109,136 @@ comp_d3d12_renderer_create(struct comp_d3d12_compositor *c,
 		return XRT_ERROR_D3D;
 	}
 
+	// --- #439 Phase 3: Local2D flatten root signature (SRV table of 1 [t0
+	// source] + 4 root constants [src_rect, b0] + static LINEAR sampler —
+	// linear matches the D3D11 flatten's bilinear sub-rect sampling). ---
+	D3D12_DESCRIPTOR_RANGE flat_srv_range = {};
+	flat_srv_range.RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
+	flat_srv_range.NumDescriptors = 1;
+	flat_srv_range.BaseShaderRegister = 0;
+	flat_srv_range.OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
+
+	D3D12_ROOT_PARAMETER flat_root_params[2] = {};
+	flat_root_params[0].ParameterType = D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;
+	flat_root_params[0].DescriptorTable.NumDescriptorRanges = 1;
+	flat_root_params[0].DescriptorTable.pDescriptorRanges = &flat_srv_range;
+	flat_root_params[0].ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
+	flat_root_params[1].ParameterType = D3D12_ROOT_PARAMETER_TYPE_32BIT_CONSTANTS;
+	flat_root_params[1].Constants.ShaderRegister = 0;
+	flat_root_params[1].Constants.RegisterSpace = 0;
+	flat_root_params[1].Constants.Num32BitValues = 4; // src_rect float4
+	flat_root_params[1].ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
+
+	D3D12_STATIC_SAMPLER_DESC flat_sampler = {};
+	flat_sampler.Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
+	flat_sampler.AddressU = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
+	flat_sampler.AddressV = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
+	flat_sampler.AddressW = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
+	flat_sampler.ComparisonFunc = D3D12_COMPARISON_FUNC_NEVER;
+	flat_sampler.MaxLOD = D3D12_FLOAT32_MAX;
+	flat_sampler.ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
+
+	D3D12_ROOT_SIGNATURE_DESC flat_rs_desc = {};
+	flat_rs_desc.NumParameters = 2;
+	flat_rs_desc.pParameters = flat_root_params;
+	flat_rs_desc.NumStaticSamplers = 1;
+	flat_rs_desc.pStaticSamplers = &flat_sampler;
+	flat_rs_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_NONE;
+
+	sig_blob = nullptr;
+	error_blob = nullptr;
+	hr = D3D12SerializeRootSignature(&flat_rs_desc, D3D_ROOT_SIGNATURE_VERSION_1, &sig_blob, &error_blob);
+	if (FAILED(hr)) {
+		if (error_blob != nullptr) {
+			U_LOG_E("Flatten root signature serialize error: %s",
+			        static_cast<const char *>(error_blob->GetBufferPointer()));
+			error_blob->Release();
+		}
+		comp_d3d12_renderer_destroy(&r);
+		return XRT_ERROR_D3D;
+	}
+	hr = device->CreateRootSignature(0, sig_blob->GetBufferPointer(), sig_blob->GetBufferSize(),
+	                                  __uuidof(ID3D12RootSignature),
+	                                  reinterpret_cast<void **>(&r->flatten_root_signature));
+	sig_blob->Release();
+	if (FAILED(hr)) {
+		U_LOG_E("Failed to create flatten root signature: 0x%08x", hr);
+		comp_d3d12_renderer_destroy(&r);
+		return XRT_ERROR_D3D;
+	}
+
+	// Flatten PSOs: shared masked_composite VS + local2d_flatten PS. The
+	// scratch is always R8G8B8A8_UNORM (the masked composite is channel-
+	// agnostic), so one RTV format covers both blend variants.
+	ID3DBlob *flat_vs_blob = nullptr;
+	ID3DBlob *flat_ps_blob = nullptr;
+	hr = compile_shader(masked_composite_vs_source, "VSMain", "vs_5_0", &flat_vs_blob);
+	if (FAILED(hr)) {
+		comp_d3d12_renderer_destroy(&r);
+		return XRT_ERROR_D3D;
+	}
+	hr = compile_shader(local2d_flatten_ps_source, "PSMain", "ps_5_0", &flat_ps_blob);
+	if (FAILED(hr)) {
+		flat_vs_blob->Release();
+		comp_d3d12_renderer_destroy(&r);
+		return XRT_ERROR_D3D;
+	}
+
+	D3D12_GRAPHICS_PIPELINE_STATE_DESC flat_pso_desc = {};
+	flat_pso_desc.pRootSignature = r->flatten_root_signature;
+	flat_pso_desc.VS.pShaderBytecode = flat_vs_blob->GetBufferPointer();
+	flat_pso_desc.VS.BytecodeLength = flat_vs_blob->GetBufferSize();
+	flat_pso_desc.PS.pShaderBytecode = flat_ps_blob->GetBufferPointer();
+	flat_pso_desc.PS.BytecodeLength = flat_ps_blob->GetBufferSize();
+	// Straight-alpha "over": SrcBlend = SRC_ALPHA. Alpha channel composes
+	// Porter-Duff over (SrcAlpha = ONE, DestAlpha = INV_SRC_ALPHA) so stacked
+	// layers accumulate coverage.
+	flat_pso_desc.BlendState.RenderTarget[0].BlendEnable = TRUE;
+	flat_pso_desc.BlendState.RenderTarget[0].SrcBlend = D3D12_BLEND_SRC_ALPHA;
+	flat_pso_desc.BlendState.RenderTarget[0].DestBlend = D3D12_BLEND_INV_SRC_ALPHA;
+	flat_pso_desc.BlendState.RenderTarget[0].BlendOp = D3D12_BLEND_OP_ADD;
+	flat_pso_desc.BlendState.RenderTarget[0].SrcBlendAlpha = D3D12_BLEND_ONE;
+	flat_pso_desc.BlendState.RenderTarget[0].DestBlendAlpha = D3D12_BLEND_INV_SRC_ALPHA;
+	flat_pso_desc.BlendState.RenderTarget[0].BlendOpAlpha = D3D12_BLEND_OP_ADD;
+	flat_pso_desc.BlendState.RenderTarget[0].RenderTargetWriteMask = D3D12_COLOR_WRITE_ENABLE_ALL;
+	flat_pso_desc.RasterizerState.FillMode = D3D12_FILL_MODE_SOLID;
+	flat_pso_desc.RasterizerState.CullMode = D3D12_CULL_MODE_NONE;
+	flat_pso_desc.RasterizerState.DepthClipEnable = TRUE;
+	flat_pso_desc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+	flat_pso_desc.NumRenderTargets = 1;
+	flat_pso_desc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+	flat_pso_desc.SampleDesc.Count = 1;
+	flat_pso_desc.SampleMask = UINT_MAX;
+
+	hr = device->CreateGraphicsPipelineState(&flat_pso_desc, __uuidof(ID3D12PipelineState),
+	                                          reinterpret_cast<void **>(&r->flatten_pso_straight));
+	if (SUCCEEDED(hr)) {
+		// Premultiplied "over": SrcBlend = ONE (the default for Local2D).
+		flat_pso_desc.BlendState.RenderTarget[0].SrcBlend = D3D12_BLEND_ONE;
+		hr = device->CreateGraphicsPipelineState(&flat_pso_desc, __uuidof(ID3D12PipelineState),
+		                                          reinterpret_cast<void **>(&r->flatten_pso_premul));
+	}
+	flat_vs_blob->Release();
+	flat_ps_blob->Release();
+	if (FAILED(hr)) {
+		U_LOG_E("Failed to create flatten PSO: 0x%08x", hr);
+		comp_d3d12_renderer_destroy(&r);
+		return XRT_ERROR_D3D;
+	}
+
+	// Shader-visible heap for flatten source SRVs — one slot per Local2D layer.
+	D3D12_DESCRIPTOR_HEAP_DESC flat_heap_desc = {};
+	flat_heap_desc.NumDescriptors = XRT_MAX_LAYERS;
+	flat_heap_desc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+	flat_heap_desc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+	hr = device->CreateDescriptorHeap(
+	    &flat_heap_desc, __uuidof(ID3D12DescriptorHeap), reinterpret_cast<void **>(&r->flatten_srv_heap));
+	if (FAILED(hr)) {
+		U_LOG_E("Failed to create flatten SRV heap: 0x%08x", hr);
+		comp_d3d12_renderer_destroy(&r);
+		return XRT_ERROR_D3D;
+	}
+
 	*out_renderer = r;
 
 	U_LOG_I("Created D3D12 renderer: %ux%u per view, atlas %ux%u (%u cols x %u rows), texture_h=%u",
@@ -1090,6 +1259,18 @@ comp_d3d12_renderer_destroy(struct comp_d3d12_renderer **renderer_ptr)
 
 	comp_d3d12_renderer *r = *renderer_ptr;
 
+	if (r->flatten_srv_heap != nullptr) {
+		r->flatten_srv_heap->Release();
+	}
+	if (r->flatten_pso_premul != nullptr) {
+		r->flatten_pso_premul->Release();
+	}
+	if (r->flatten_pso_straight != nullptr) {
+		r->flatten_pso_straight->Release();
+	}
+	if (r->flatten_root_signature != nullptr) {
+		r->flatten_root_signature->Release();
+	}
 	if (r->composite_srv_heap != nullptr) {
 		r->composite_srv_heap->Release();
 	}
@@ -1644,6 +1825,106 @@ comp_d3d12_renderer_composite_2d_masked(struct comp_d3d12_renderer *renderer,
 	cmd_list->SetGraphicsRootDescriptorTable(0, renderer->composite_srv_heap->GetGPUDescriptorHandleForHeapStart());
 	cmd_list->SetGraphicsRoot32BitConstants(1, 8, &params, 0);
 	cmd_list->DrawInstanced(3, 1, 0, 0);
+
+	return XRT_SUCCESS;
+}
+
+// #439 Phase 3 — flatten one Local2D layer into the scratch RTV (the `twod`
+// source the masked composite reads). Records into the OPEN cmd-list mid-frame;
+// the caller has already bound nothing (we set our own RTV) and transitioned
+// the scratch to RENDER_TARGET + cleared it. Ported from the D3D11
+// comp_d3d11_renderer_flatten_local_2d: a fullscreen triangle whose viewport
+// is the clipped dest sub-rect, sampling the source through src_rect (with
+// flip_y via a negative src_h). Premultiplied vs straight "over" is the PSO.
+//
+// slot_index gives this draw its own flatten_srv_heap slot — D3D12 consumes
+// descriptors at GPU-execute time, so concurrent draws can't share one slot.
+// The source image is transitioned RENDER_TARGET<->PIXEL_SHADER_RESOURCE around
+// the draw, the same steady-state convention render_window_space_layer uses for
+// app color swapchains.
+extern "C" xrt_result_t
+comp_d3d12_renderer_flatten_local_2d(struct comp_d3d12_renderer *renderer,
+                                     void *cmd_list_ptr,
+                                     uint64_t scratch_rtv_handle,
+                                     void *src_resource,
+                                     uint32_t slot_index,
+                                     int32_t dst_x,
+                                     int32_t dst_y,
+                                     uint32_t dst_w,
+                                     uint32_t dst_h,
+                                     float src_x,
+                                     float src_y,
+                                     float src_w,
+                                     float src_h,
+                                     bool unpremultiplied)
+{
+	if (renderer == nullptr || cmd_list_ptr == nullptr || scratch_rtv_handle == 0 || src_resource == nullptr) {
+		return XRT_ERROR_DEVICE_CREATION_FAILED;
+	}
+	if (slot_index >= XRT_MAX_LAYERS) {
+		U_LOG_E("D3D12 flatten: SRV slot %u >= %u", slot_index, (uint32_t)XRT_MAX_LAYERS);
+		return XRT_ERROR_D3D;
+	}
+
+	auto internals = get_internals(renderer->c);
+	ID3D12Device *device = internals->device;
+	auto *cmd_list = static_cast<ID3D12GraphicsCommandList *>(cmd_list_ptr);
+	auto *src = static_cast<ID3D12Resource *>(src_resource);
+
+	// Source image → sampleable. Sample app color swapchains as their UNORM
+	// sibling (no implicit sRGB decode — the DP wants display-referred bytes).
+	D3D12_RESOURCE_BARRIER src_barrier = {};
+	src_barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+	src_barrier.Transition.pResource = src;
+	src_barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
+	src_barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+	src_barrier.Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+	cmd_list->ResourceBarrier(1, &src_barrier);
+
+	D3D12_RESOURCE_DESC rd = src->GetDesc();
+	D3D12_SHADER_RESOURCE_VIEW_DESC srv_desc = {};
+	srv_desc.Format = d3d_dxgi_format_to_unorm_sample(rd.Format);
+	srv_desc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+	srv_desc.Texture2D.MipLevels = 1;
+	srv_desc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+	D3D12_CPU_DESCRIPTOR_HANDLE srv_cpu = renderer->flatten_srv_heap->GetCPUDescriptorHandleForHeapStart();
+	srv_cpu.ptr += renderer->srv_descriptor_size * slot_index;
+	device->CreateShaderResourceView(src, &srv_desc, srv_cpu);
+
+	cmd_list->SetDescriptorHeaps(1, &renderer->flatten_srv_heap);
+	cmd_list->SetGraphicsRootSignature(renderer->flatten_root_signature);
+	cmd_list->SetPipelineState(unpremultiplied ? renderer->flatten_pso_straight : renderer->flatten_pso_premul);
+
+	D3D12_CPU_DESCRIPTOR_HANDLE rtv = {};
+	rtv.ptr = static_cast<SIZE_T>(scratch_rtv_handle);
+	cmd_list->OMSetRenderTargets(1, &rtv, FALSE, nullptr);
+
+	// Viewport = clipped dest sub-rect; the fullscreen triangle's uv [0,1]
+	// spans it, mapping through src_rect into the source image.
+	D3D12_VIEWPORT vp = {};
+	vp.TopLeftX = static_cast<float>(dst_x);
+	vp.TopLeftY = static_cast<float>(dst_y);
+	vp.Width = static_cast<float>(dst_w);
+	vp.Height = static_cast<float>(dst_h);
+	vp.MaxDepth = 1.0f;
+	cmd_list->RSSetViewports(1, &vp);
+	D3D12_RECT scissor = {dst_x, dst_y, dst_x + (int32_t)dst_w, dst_y + (int32_t)dst_h};
+	cmd_list->RSSetScissorRects(1, &scissor);
+
+	float src_rect[4] = {src_x, src_y, src_w, src_h};
+	cmd_list->SetGraphicsRoot32BitConstants(1, 4, src_rect, 0);
+
+	D3D12_GPU_DESCRIPTOR_HANDLE gpu_srv = renderer->flatten_srv_heap->GetGPUDescriptorHandleForHeapStart();
+	gpu_srv.ptr += renderer->srv_descriptor_size * slot_index;
+	cmd_list->SetGraphicsRootDescriptorTable(0, gpu_srv);
+
+	cmd_list->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+	cmd_list->DrawInstanced(3, 1, 0, 0);
+
+	// Source back to its steady RENDER_TARGET state.
+	src_barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+	src_barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_RENDER_TARGET;
+	cmd_list->ResourceBarrier(1, &src_barrier);
 
 	return XRT_SUCCESS;
 }

--- a/src/xrt/compositor/d3d12/comp_d3d12_renderer.h
+++ b/src/xrt/compositor/d3d12/comp_d3d12_renderer.h
@@ -245,6 +245,45 @@ comp_d3d12_renderer_composite_2d_masked(struct comp_d3d12_renderer *renderer,
                                         uint32_t ch);
 
 /*!
+ * Flatten one Local2D layer into the scratch RTV (#439 Phase 3, the `twod`
+ * source for comp_d3d12_renderer_composite_2d_masked). Records a
+ * fullscreen-triangle draw into @p cmd_list whose viewport is the clipped dest
+ * sub-rect, sampling the source image through src_rect (flip_y via negative
+ * src_h). Premultiplied vs straight "over" is chosen by @p unpremultiplied.
+ *
+ * The caller has transitioned the scratch to RENDER_TARGET and cleared it; this
+ * function transitions the source image RENDER_TARGET<->PIXEL_SHADER_RESOURCE
+ * around its own draw. Each call needs a distinct @p slot_index (D3D12 consumes
+ * descriptors at GPU-execute time).
+ *
+ * @param renderer The renderer.
+ * @param cmd_list Open D3D12 command list (void* = ID3D12GraphicsCommandList*).
+ * @param scratch_rtv_handle CPU RTV handle of the Local2D scratch (R8G8B8A8_UNORM).
+ * @param src_resource The layer's swapchain image (ID3D12Resource*).
+ * @param slot_index Unique flatten-heap SRV slot for this draw (< XRT_MAX_LAYERS).
+ * @param dst_x,dst_y,dst_w,dst_h Clipped dest sub-rect (viewport) in pixels.
+ * @param src_x,src_y,src_w,src_h Source rect (normalized; src_h < 0 => flip_y).
+ * @param unpremultiplied True for straight-alpha layers (XRT_LAYER_COMPOSITION_UNPREMULTIPLIED_ALPHA_BIT).
+ *
+ * @ingroup comp_d3d12
+ */
+xrt_result_t
+comp_d3d12_renderer_flatten_local_2d(struct comp_d3d12_renderer *renderer,
+                                     void *cmd_list,
+                                     uint64_t scratch_rtv_handle,
+                                     void *src_resource,
+                                     uint32_t slot_index,
+                                     int32_t dst_x,
+                                     int32_t dst_y,
+                                     uint32_t dst_w,
+                                     uint32_t dst_h,
+                                     float src_x,
+                                     float src_y,
+                                     float src_w,
+                                     float src_h,
+                                     bool unpremultiplied);
+
+/*!
  * Resize the renderer's atlas texture to match a new view size.
  *
  * Recreates the atlas texture, RTV, and SRV at the new dimensions.

--- a/src/xrt/state_trackers/oxr/oxr_session_frame_end.c
+++ b/src/xrt/state_trackers/oxr/oxr_session_frame_end.c
@@ -40,6 +40,10 @@
 #include "d3d11/comp_d3d11_compositor.h"
 #endif
 
+#ifdef XRT_HAVE_D3D12_NATIVE_COMPOSITOR
+#include "d3d12/comp_d3d12_compositor.h"
+#endif
+
 #ifdef XRT_HAVE_METAL_NATIVE_COMPOSITOR
 #include "metal/comp_metal_compositor.h"
 #endif
@@ -2143,6 +2147,12 @@ oxr_session_frame_end(struct oxr_logger *log, struct oxr_session *sess, const Xr
 		if (sess->is_d3d11_native_compositor) {
 			have_dims =
 			    comp_d3d11_compositor_get_recommended_view_size(&sess->xcn->base, &view_w, &view_h);
+		}
+#endif
+#ifdef XRT_HAVE_D3D12_NATIVE_COMPOSITOR
+		if (sess->is_d3d12_native_compositor) {
+			have_dims =
+			    comp_d3d12_compositor_get_recommended_view_size(&sess->xcn->base, &view_w, &view_h);
 		}
 #endif
 #ifdef XRT_HAVE_METAL_NATIVE_COMPOSITOR

--- a/test_apps/cube_handle_d3d12_win/main.cpp
+++ b/test_apps/cube_handle_d3d12_win/main.cpp
@@ -59,6 +59,30 @@ static bool g_fullscreen = false;
 static RECT g_savedWindowRect = {};
 static DWORD g_savedWindowStyle = 0;
 
+// #439 Phase 3 — handle + mask + Local2D layer modes (§8 cases 2/3/4), D3D12 leg.
+// DXR_LOCAL2D_PANEL=1  — submit a Local2D panel layer (case 3: layer-only,
+//                        IMPLICIT mask from the panel rect, zero mask calls).
+// DXR_LOCAL2D_MASK=1   — additionally create + submit an explicit Tier-2 mask
+//                        with 3D island rects (case 2: handle + mask + layer —
+//                        islands weave, panel crisp, desktop where neither
+//                        covers).
+// DXR_LOCAL2D_PANEL2=1 — additionally submit a second, overlapping panel with
+//                        XR_COMPOSITION_LAYER_UNPREMULTIPLIED_ALPHA_BIT (case 4:
+//                        list-order stacking + alpha fringing).
+static bool g_l2dPanel = false;
+static bool g_l2dMask = false;
+static bool g_l2dPanel2 = false;
+static bool g_l2dActive = false; // set once panels (+ optional mask) are live
+static long g_l2dFrameCounter = 0;
+static const long g_l2dActivationFrame = 10;
+
+struct L2DPanel {
+    XrSwapchain swapchain = XR_NULL_HANDLE;
+    uint32_t w = 0, h = 0;
+};
+static L2DPanel g_panel1, g_panel2;
+static XrRect2Di g_panel1Rect, g_panel2Rect;
+
 // XR_EXT_view_rig (#396 W7 dogfood): the app chains XrDisplayRigEXT on every
 // xrLocateViews and consumes the runtime's render-ready XrView{pose, fov}
 // directly — the per-frame Kooima generation is deleted; only clip policy
@@ -292,6 +316,178 @@ static void UpdatePerformanceStats(PerformanceStats& stats) {
         stats.frameCount = 0;
         stats.fpsAccumulator = 0.0f;
     }
+}
+
+// #439 Phase 3 — create a window-anchored Local2D panel swapchain and fill it
+// once (static content: acquire/fill/release once; the layer references the
+// released image every frame). D3D12 fill = an UPLOAD-heap staging buffer copied
+// into the swapchain image via a one-shot DIRECT command list (the same pattern
+// the HUD path uses), leaving the image in RENDER_TARGET (the swapchain's
+// created/contract state — the runtime's flatten samples it as RENDER_TARGET).
+//  variant 0 — crispness panel: opaque fine 8-px checker core with a 24-px
+//              half-transparent green border (PREMULTIPLIED bytes), so the
+//              border resolves against the desktop where M=0.
+//  variant 1 — stacking/alpha panel: UNPREMULTIPLIED orange at a=128 with
+//              opaque white diagonal stripes; submitted with
+//              XR_COMPOSITION_LAYER_UNPREMULTIPLIED_ALPHA_BIT (fringing check
+//              for the SrcAlpha flatten path).
+static bool CreateAndFillL2DPanel(XrSessionManager& xr, ID3D12Device* device, ID3D12CommandQueue* queue,
+                                  uint32_t w, uint32_t h, int variant, L2DPanel& out) {
+    if (w == 0 || h == 0 || device == nullptr || queue == nullptr) {
+        return false;
+    }
+
+    XrSwapchainCreateInfo sci = {XR_TYPE_SWAPCHAIN_CREATE_INFO};
+    sci.usageFlags = XR_SWAPCHAIN_USAGE_COLOR_ATTACHMENT_BIT | XR_SWAPCHAIN_USAGE_SAMPLED_BIT;
+    sci.format = (int64_t)DXGI_FORMAT_B8G8R8A8_UNORM;
+    sci.sampleCount = 1;
+    sci.width = w;
+    sci.height = h;
+    sci.faceCount = 1;
+    sci.arraySize = 1;
+    sci.mipCount = 1;
+    if (XR_FAILED(xrCreateSwapchain(xr.session, &sci, &out.swapchain))) {
+        LOG_ERROR("Local2D panel: xrCreateSwapchain failed");
+        return false;
+    }
+    out.w = w;
+    out.h = h;
+
+    uint32_t n = 0;
+    xrEnumerateSwapchainImages(out.swapchain, 0, &n, nullptr);
+    std::vector<XrSwapchainImageD3D12KHR> imgs(n, {XR_TYPE_SWAPCHAIN_IMAGE_D3D12_KHR});
+    if (n == 0 || XR_FAILED(xrEnumerateSwapchainImages(out.swapchain, n, &n,
+                                                       (XrSwapchainImageBaseHeader*)imgs.data()))) {
+        LOG_ERROR("Local2D panel: xrEnumerateSwapchainImages failed");
+        return false;
+    }
+
+    XrSwapchainImageAcquireInfo ai = {XR_TYPE_SWAPCHAIN_IMAGE_ACQUIRE_INFO};
+    uint32_t idx = 0;
+    if (XR_FAILED(xrAcquireSwapchainImage(out.swapchain, &ai, &idx))) {
+        return false;
+    }
+    XrSwapchainImageWaitInfo wi = {XR_TYPE_SWAPCHAIN_IMAGE_WAIT_INFO};
+    wi.timeout = XR_INFINITE_DURATION;
+    xrWaitSwapchainImage(out.swapchain, &wi);
+
+    // Build the BGRA8 content (same probe imagery as the D3D11 leg).
+    size_t srcStride = (size_t)w * 4;
+    std::vector<uint8_t> buf(srcStride * h);
+    const uint32_t border = 24;
+    for (uint32_t y = 0; y < h; y++) {
+        uint8_t* row = buf.data() + (size_t)y * srcStride;
+        for (uint32_t x = 0; x < w; x++) {
+            uint8_t* px = row + (size_t)x * 4; // B,G,R,A
+            if (variant == 0) {
+                bool inBorder = (x < border || y < border || x >= w - border || y >= h - border);
+                if (inBorder) {
+                    px[0] = 0; px[1] = 128; px[2] = 0; px[3] = 128; // half-transparent green, premultiplied
+                } else {
+                    bool check = (((x / 8) + (y / 8)) & 1) != 0;
+                    uint8_t v = check ? 235 : 40;
+                    px[0] = v; px[1] = v; px[2] = v; px[3] = 255; // opaque fine checker
+                }
+            } else {
+                bool stripe = (((x + y) / 16) & 1) != 0;
+                if (stripe) {
+                    px[0] = 255; px[1] = 255; px[2] = 255; px[3] = 255; // opaque white stripes
+                } else {
+                    px[0] = 0; px[1] = 165; px[2] = 255; px[3] = 128; // UNPREMULTIPLIED orange a=128
+                }
+            }
+        }
+    }
+
+    // Upload buffer (256-byte-aligned rows per the D3D12 placed-footprint rule).
+    const uint32_t alignedRowPitch =
+        (uint32_t)((srcStride + D3D12_TEXTURE_DATA_PITCH_ALIGNMENT - 1) & ~(size_t)(D3D12_TEXTURE_DATA_PITCH_ALIGNMENT - 1));
+    const uint64_t uploadSize = (uint64_t)alignedRowPitch * h;
+
+    D3D12_HEAP_PROPERTIES uploadHeap = {};
+    uploadHeap.Type = D3D12_HEAP_TYPE_UPLOAD;
+    D3D12_RESOURCE_DESC ubDesc = {};
+    ubDesc.Dimension = D3D12_RESOURCE_DIMENSION_BUFFER;
+    ubDesc.Width = uploadSize;
+    ubDesc.Height = 1;
+    ubDesc.DepthOrArraySize = 1;
+    ubDesc.MipLevels = 1;
+    ubDesc.Format = DXGI_FORMAT_UNKNOWN;
+    ubDesc.SampleDesc.Count = 1;
+    ubDesc.Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
+
+    Microsoft::WRL::ComPtr<ID3D12Resource> upload;
+    if (FAILED(device->CreateCommittedResource(&uploadHeap, D3D12_HEAP_FLAG_NONE, &ubDesc,
+                                               D3D12_RESOURCE_STATE_GENERIC_READ, nullptr,
+                                               IID_PPV_ARGS(&upload)))) {
+        LOG_ERROR("Local2D panel: upload buffer create failed");
+        return false;
+    }
+    uint8_t* mapped = nullptr;
+    D3D12_RANGE noRead = {0, 0};
+    if (FAILED(upload->Map(0, &noRead, (void**)&mapped))) {
+        LOG_ERROR("Local2D panel: upload buffer map failed");
+        return false;
+    }
+    for (uint32_t y = 0; y < h; y++) {
+        memcpy(mapped + (size_t)y * alignedRowPitch, buf.data() + (size_t)y * srcStride, srcStride);
+    }
+    upload->Unmap(0, nullptr);
+
+    // One-shot DIRECT command list: RENDER_TARGET -> COPY_DEST, copy, -> RENDER_TARGET.
+    Microsoft::WRL::ComPtr<ID3D12CommandAllocator> alloc;
+    Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList> cl;
+    Microsoft::WRL::ComPtr<ID3D12Fence> fence;
+    if (FAILED(device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&alloc))) ||
+        FAILED(device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, alloc.Get(), nullptr,
+                                         IID_PPV_ARGS(&cl))) ||
+        FAILED(device->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&fence)))) {
+        LOG_ERROR("Local2D panel: command objects create failed");
+        return false;
+    }
+
+    ID3D12Resource* tex = imgs[idx].texture;
+    D3D12_RESOURCE_BARRIER barrier = {};
+    barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+    barrier.Transition.pResource = tex;
+    barrier.Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+    barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
+    barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_COPY_DEST;
+    cl->ResourceBarrier(1, &barrier);
+
+    D3D12_TEXTURE_COPY_LOCATION srcLoc = {};
+    srcLoc.pResource = upload.Get();
+    srcLoc.Type = D3D12_TEXTURE_COPY_TYPE_PLACED_FOOTPRINT;
+    srcLoc.PlacedFootprint.Offset = 0;
+    srcLoc.PlacedFootprint.Footprint.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
+    srcLoc.PlacedFootprint.Footprint.Width = w;
+    srcLoc.PlacedFootprint.Footprint.Height = h;
+    srcLoc.PlacedFootprint.Footprint.Depth = 1;
+    srcLoc.PlacedFootprint.Footprint.RowPitch = alignedRowPitch;
+    D3D12_TEXTURE_COPY_LOCATION dstLoc = {};
+    dstLoc.pResource = tex;
+    dstLoc.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
+    dstLoc.SubresourceIndex = 0;
+    cl->CopyTextureRegion(&dstLoc, 0, 0, 0, &srcLoc, nullptr);
+
+    barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_COPY_DEST;
+    barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_RENDER_TARGET;
+    cl->ResourceBarrier(1, &barrier);
+    cl->Close();
+
+    ID3D12CommandList* lists[] = {cl.Get()};
+    queue->ExecuteCommandLists(1, lists);
+    HANDLE ev = CreateEventW(nullptr, FALSE, FALSE, nullptr);
+    queue->Signal(fence.Get(), 1);
+    if (fence->GetCompletedValue() < 1) {
+        fence->SetEventOnCompletion(1, ev);
+        WaitForSingleObject(ev, INFINITE);
+    }
+    CloseHandle(ev);
+
+    XrSwapchainImageReleaseInfo ri = {XR_TYPE_SWAPCHAIN_IMAGE_RELEASE_INFO};
+    xrReleaseSwapchainImage(out.swapchain, &ri);
+    return true;
 }
 
 static void RenderThreadFunc(
@@ -721,10 +917,117 @@ static void RenderThreadFunc(
                     }
                 }
 
-                // End frame: use window-space HUD layer if available
+                // #439 cases 2/3/4 activation: create + fill the panel
+                // swapchain(s) (+ the explicit Tier-2 island mask for case 2) a
+                // few frames in, once the session is running and dims settled.
+                if (g_l2dPanel && !g_l2dActive && g_l2dFrameCounter >= g_l2dActivationFrame) {
+                    static bool attempted = false;
+                    if (!attempted) {
+                        attempted = true;
+                        uint32_t winW = g_windowWidth;
+                        uint32_t winH = g_windowHeight;
+                        uint32_t pw = winW * 3 / 8;
+                        uint32_t ph = winH * 5 / 16;
+                        g_panel1Rect.offset = {(int32_t)(winW / 16), (int32_t)(winH * 9 / 16)};
+                        g_panel1Rect.extent = {(int32_t)pw, (int32_t)ph};
+                        bool ok = CreateAndFillL2DPanel(*xr, renderer->device.Get(), renderer->commandQueue.Get(),
+                                                        pw, ph, 0, g_panel1);
+
+                        if (ok && g_l2dPanel2) {
+                            // Overlaps panel 1's top-right quadrant — list-order
+                            // stacking check (panel 2 is later = on top).
+                            g_panel2Rect.offset = {g_panel1Rect.offset.x + (int32_t)(pw / 2),
+                                                   g_panel1Rect.offset.y - (int32_t)(ph / 4)};
+                            g_panel2Rect.extent = {(int32_t)pw, (int32_t)ph};
+                            ok = CreateAndFillL2DPanel(*xr, renderer->device.Get(), renderer->commandQueue.Get(),
+                                                       pw, ph, 1, g_panel2);
+                        }
+
+                        if (ok && g_l2dMask && g_zone.available && g_zone.pfnCreate && g_zone.pfnSetRects &&
+                            g_zone.pfnSubmit) {
+                            XrLocal3DZoneMaskCreateInfoEXT mci = {
+                                (XrStructureType)XR_TYPE_LOCAL_3D_ZONE_MASK_CREATE_INFO_EXT};
+                            mci.maskWidth = 0; // runtime picks the window backing size
+                            mci.maskHeight = 0;
+                            ok = XR_SUCCEEDED(g_zone.pfnCreate(xr->session, &mci, &g_zone.mask));
+                            if (ok) {
+                                // Two 3D islands: a large center-right one and a
+                                // small top-left one. Everything else is 2D — the
+                                // panel where it covers, desktop (final.a = 0)
+                                // where nothing does.
+                                XrRect2Di islands[2];
+                                islands[0].offset = {(int32_t)(winW * 7 / 16), (int32_t)(winH / 4)};
+                                islands[0].extent = {(int32_t)(winW * 7 / 16), (int32_t)(winH / 2)};
+                                islands[1].offset = {(int32_t)(winW / 16), (int32_t)(winH / 16)};
+                                islands[1].extent = {(int32_t)(winW / 4), (int32_t)(winH / 4)};
+                                ok = XR_SUCCEEDED(g_zone.pfnSetRects(g_zone.mask, 2, islands)) &&
+                                     XR_SUCCEEDED(g_zone.pfnSubmit(g_zone.mask));
+                            }
+                        }
+
+                        if (ok) {
+                            g_l2dActive = true;
+                            LOG_INFO("Local2D panels active: panel1 %d,%d %ux%u%s%s",
+                                     g_panel1Rect.offset.x, g_panel1Rect.offset.y, pw, ph,
+                                     g_l2dPanel2 ? " + panel2 (unpremultiplied, overlapping)" : "",
+                                     g_l2dMask ? " + explicit Tier-2 island mask" : " (implicit mask)");
+                        } else {
+                            LOG_ERROR("Local2D panel activation failed");
+                        }
+                    }
+                }
+
+                // End frame. #439 cases 2/3/4: when Local2D panels are active,
+                // build the layer list manually (projection + panels in list
+                // order) and submit raw — the shared EndFrame helpers don't
+                // carry the Local2D layer type. Otherwise the normal paths.
                 uint32_t submitViewCount = (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount) ? xr->renderingModeViewCounts[xr->currentModeIndex] : 2;
                 LOG_INFO("[FRAME] EndFrame: rendered=%d hudSubmitted=%d viewCount=%u", rendered, hudSubmitted, submitViewCount);
-                if (rendered && hudSubmitted) {
+                if (g_l2dActive && g_panel1.swapchain != XR_NULL_HANDLE) {
+                    XrCompositionLayerProjection projLayer = {XR_TYPE_COMPOSITION_LAYER_PROJECTION};
+                    projLayer.space = xr->localSpace;
+                    projLayer.viewCount = (uint32_t)eyeCount;
+                    projLayer.views = projectionViews.data();
+
+                    XrCompositionLayerLocal2DEXT panel1Layer = {
+                        (XrStructureType)XR_TYPE_COMPOSITION_LAYER_LOCAL_2D_EXT};
+                    XrCompositionLayerLocal2DEXT panel2Layer = {
+                        (XrStructureType)XR_TYPE_COMPOSITION_LAYER_LOCAL_2D_EXT};
+                    const XrCompositionLayerBaseHeader* layers[3] = {
+                        (XrCompositionLayerBaseHeader*)&projLayer, nullptr, nullptr};
+                    uint32_t layerCount = 1;
+
+                    panel1Layer.layerFlags = 0; // premultiplied bytes
+                    panel1Layer.subImage.swapchain = g_panel1.swapchain;
+                    panel1Layer.subImage.imageRect.offset = {0, 0};
+                    panel1Layer.subImage.imageRect.extent = {(int32_t)g_panel1.w, (int32_t)g_panel1.h};
+                    panel1Layer.subImage.imageArrayIndex = 0;
+                    panel1Layer.rect = g_panel1Rect;
+                    layers[layerCount++] = (XrCompositionLayerBaseHeader*)&panel1Layer;
+
+                    if (g_l2dPanel2 && g_panel2.swapchain != XR_NULL_HANDLE) {
+                        panel2Layer.layerFlags = XR_COMPOSITION_LAYER_UNPREMULTIPLIED_ALPHA_BIT;
+                        panel2Layer.subImage.swapchain = g_panel2.swapchain;
+                        panel2Layer.subImage.imageRect.offset = {0, 0};
+                        panel2Layer.subImage.imageRect.extent = {(int32_t)g_panel2.w, (int32_t)g_panel2.h};
+                        panel2Layer.subImage.imageArrayIndex = 0;
+                        panel2Layer.rect = g_panel2Rect;
+                        layers[layerCount++] = (XrCompositionLayerBaseHeader*)&panel2Layer;
+                    }
+
+                    // ALPHA_BLEND is what makes the desktop show through where
+                    // the mask is 2D + the layer alpha < 1 (§4.2 output rule +
+                    // the panel's half-transparent border). runtimeSupportsAlphaBlend
+                    // is resolved by the pre-activation frames' SelectEnvBlendMode.
+                    XrFrameEndInfo endInfo = {XR_TYPE_FRAME_END_INFO};
+                    endInfo.displayTime = frameState.predictedDisplayTime;
+                    endInfo.environmentBlendMode = xr->runtimeSupportsAlphaBlend
+                        ? XR_ENVIRONMENT_BLEND_MODE_ALPHA_BLEND
+                        : XR_ENVIRONMENT_BLEND_MODE_OPAQUE;
+                    endInfo.layerCount = layerCount;
+                    endInfo.layers = layers;
+                    xrEndFrame(xr->session, &endInfo);
+                } else if (rendered && hudSubmitted) {
                     float hudAR = (float)HUD_PIXEL_WIDTH / (float)HUD_PIXEL_HEIGHT;
                     float windowAR = (windowW > 0 && windowH > 0) ? (float)windowW / (float)windowH : 1.0f;
                     float fracW = HUD_WIDTH_FRACTION;
@@ -742,6 +1045,7 @@ static void RenderThreadFunc(
                     endInfo.layers = nullptr;
                     xrEndFrame(xr->session, &endInfo);
                 }
+                g_l2dFrameCounter++;
             }
         } else {
             Sleep(100);
@@ -764,6 +1068,21 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
     }
 
     LOG_INFO("=== SR Cube OpenXR Ext D3D12 Application ===");
+
+    // #439 Phase 3 — handle + mask + Local2D layer modes (§8 cases 2/3/4).
+    {
+        const char* e = getenv("DXR_LOCAL2D_PANEL");
+        if (e && *e == '1') g_l2dPanel = true;
+        e = getenv("DXR_LOCAL2D_MASK");
+        if (e && *e == '1') g_l2dMask = true;
+        e = getenv("DXR_LOCAL2D_PANEL2");
+        if (e && *e == '1') g_l2dPanel2 = true;
+        if (g_l2dPanel) {
+            LOG_INFO("DXR_LOCAL2D_PANEL=1 — Local2D panel layer%s%s",
+                g_l2dPanel2 ? " + panel2 (unpremultiplied, overlapping)" : "",
+                g_l2dMask ? " + explicit Tier-2 island mask" : " (implicit mask)");
+        }
+    }
 
     HWND hwnd = CreateAppWindow(hInstance, g_windowWidth, g_windowHeight);
     if (!hwnd) {

--- a/test_apps/cube_handle_d3d12_win/xr_session.cpp
+++ b/test_apps/cube_handle_d3d12_win/xr_session.cpp
@@ -11,6 +11,9 @@
 
 bool g_hasViewRigExt = false;
 
+// #439 Phase 3 — XR_EXT_local_3d_zone harness (see xr_session.h).
+ZoneMaskHarness g_zone;
+
 #define XR_CHECK(call) \
     do { \
         XrResult result = (call); \
@@ -89,6 +92,9 @@ bool InitializeOpenXR(XrSessionManager& xr) {
         if (strcmp(ext.extensionName, XR_EXT_VIEW_RIG_EXTENSION_NAME) == 0) {
             g_hasViewRigExt = true;
         }
+        if (strcmp(ext.extensionName, XR_EXT_LOCAL_3D_ZONE_EXTENSION_NAME) == 0) {
+            g_zone.available = true;
+        }
     }
 
     LOG_INFO("XR_KHR_D3D12_enable: %s", hasD3D12 ? "AVAILABLE" : "NOT FOUND");
@@ -96,6 +102,7 @@ bool InitializeOpenXR(XrSessionManager& xr) {
     LOG_INFO("XR_EXT_display_info: %s", xr.hasDisplayInfoExt ? "AVAILABLE" : "NOT FOUND");
     LOG_INFO("XR_EXT_mcp_tools: %s", xr.hasMcpToolsExt ? "AVAILABLE" : "NOT FOUND");
     LOG_INFO("XR_EXT_view_rig: %s", g_hasViewRigExt ? "AVAILABLE" : "NOT FOUND");
+    LOG_INFO("XR_EXT_local_3d_zone: %s", g_zone.available ? "AVAILABLE" : "NOT FOUND");
 
     if (!hasD3D12) {
         LOG_ERROR("XR_KHR_D3D12_enable extension not available - cannot continue");
@@ -118,6 +125,9 @@ bool InitializeOpenXR(XrSessionManager& xr) {
     }
     if (g_hasViewRigExt) {
         enabledExtensions.push_back(XR_EXT_VIEW_RIG_EXTENSION_NAME);
+    }
+    if (g_zone.available) {
+        enabledExtensions.push_back(XR_EXT_LOCAL_3D_ZONE_EXTENSION_NAME);
     }
 
     LOG_INFO("Enabling %zu extensions", enabledExtensions.size());
@@ -271,6 +281,23 @@ bool CreateSession(XrSessionManager& xr, ID3D12Device* device, ID3D12CommandQueu
     LOG_INFO("Calling xrCreateSession...");
     XR_CHECK_LOG(xrCreateSession(xr.instance, &sessionInfo, &xr.session));
     LOG_INFO("Session created: 0x%p", (void*)xr.session);
+
+    // #439 Phase 3 — XR_EXT_local_3d_zone entry points (app-local harness; the
+    // handle-app panel modes use the explicit Tier-2 island mask for case 2).
+    if (g_zone.available) {
+        xrGetInstanceProcAddr(xr.instance, "xrCreateLocal3DZoneMaskEXT",
+            (PFN_xrVoidFunction*)&g_zone.pfnCreate);
+        xrGetInstanceProcAddr(xr.instance, "xrSetLocal3DZoneFromRectsEXT",
+            (PFN_xrVoidFunction*)&g_zone.pfnSetRects);
+        xrGetInstanceProcAddr(xr.instance, "xrSubmitLocal3DZoneEXT",
+            (PFN_xrVoidFunction*)&g_zone.pfnSubmit);
+        xrGetInstanceProcAddr(xr.instance, "xrDestroyLocal3DZoneMaskEXT",
+            (PFN_xrVoidFunction*)&g_zone.pfnDestroy);
+        if (!g_zone.pfnCreate || !g_zone.pfnSetRects || !g_zone.pfnSubmit || !g_zone.pfnDestroy) {
+            LOG_WARN("XR_EXT_local_3d_zone advertised but entry points missing — harness disabled");
+            g_zone.available = false;
+        }
+    }
 
     // XR_EXT_mcp_tools (#457): declare identity + register agent tools. The
     // appId MUST match `id` in displayxr/cube_handle_d3d12_win.displayxr.json

--- a/test_apps/cube_handle_d3d12_win/xr_session.h
+++ b/test_apps/cube_handle_d3d12_win/xr_session.h
@@ -12,11 +12,27 @@
 #define XR_USE_GRAPHICS_API_D3D12
 #include "xr_session_common.h"
 #include <openxr/XR_EXT_view_rig.h>
+#include <openxr/XR_EXT_local_3d_zone.h>
 
 // XR_EXT_view_rig (#396 W7) available + enabled on the instance. App-local
 // (not on the shared XrSessionManager); promote to xr_session_common when
 // more consumers adopt it.
 extern bool g_hasViewRigExt;
+
+// #439 Phase 3 — XR_EXT_local_3d_zone harness (header v3 carries the Local2D
+// composition-layer + view-size-changed types). App-local for the same reason
+// as the view-rig flag: the shared XrSessionManager doesn't carry this
+// extension yet. Populated by InitializeOpenXR; drives the handle-app panel
+// modes (DXR_LOCAL2D_PANEL / +DXR_LOCAL2D_MASK / +DXR_LOCAL2D_PANEL2).
+struct ZoneMaskHarness {
+    bool available = false;
+    PFN_xrCreateLocal3DZoneMaskEXT pfnCreate = nullptr;
+    PFN_xrSetLocal3DZoneFromRectsEXT pfnSetRects = nullptr;
+    PFN_xrSubmitLocal3DZoneEXT pfnSubmit = nullptr;
+    PFN_xrDestroyLocal3DZoneMaskEXT pfnDestroy = nullptr;
+    XrLocal3DZoneMaskEXT mask = XR_NULL_HANDLE;
+};
+extern ZoneMaskHarness g_zone;
 
 // Initialize OpenXR instance with D3D12 + win32_window_binding extensions
 bool InitializeOpenXR(XrSessionManager& xr);


### PR DESCRIPTION
## Summary

Brings the **D3D12** native compositor to current-behaviour parity with the D3D11 / macOS / Metal / VK legs for issue #439 Phase 3 (2D as a first-class composition layer, `XrCompositionLayerLocal2DEXT`). D3D12 already shipped the zone-mask API + masked composite + oxr wiring (Phase 0–2); this is the **Phase-3 delta only** — the Local2D *layer consumer*.

**Parity only** — same hard-mask composite (`final = M·weave + (1−M)·twod`) the other four legs ship. The translucent-2D-over-3D blend redesign is #491 (separate, all-five-legs, later).

## Runtime (mirrors the D3D11 reference)
- `local_2d_last_frame` flag set once under `c->mutex` at the top of `layer_commit`; `d3d12_effective_canvas` supersedes the canvas on it.
- `d3d12_update_implicit_mask` — R8 implicit mask rasterized from the frame's Local2D rects (M=1 keep weave, M=0 inside rects), via D3D12's native `ClearRenderTargetView` rect-array, recorded onto the open cmd-list + staged to a PSR copy.
- `d3d12_flatten_local_2d_layers` + `comp_d3d12_renderer_flatten_local_2d` — dedicated R8G8B8A8_UNORM `local2d_scratch` (own RTV heap, NOT shared with `surround_scratch`) flattened via a new pipeline (masked_composite VS + local2d_flatten PS, premul/straight blend PSOs, per-layer flatten SRV-heap slot, sRGB-passthrough UNORM-sample sibling).
- `have_local_2d` branch in `d3d12_composite_zone_mask`: mask = explicit staged else implicit; twod = flattened layers else surround. **Legacy surround path byte-identical** gated on `!have_local_2d`.
- `comp_d3d12_compositor_get_recommended_view_size` + the D3D12 frame-end poll branch in `oxr_session_frame_end.c`.

## Test app
`cube_handle_d3d12_win` gains the `DXR_LOCAL2D_PANEL` / `+MASK` / `+PANEL2` modes (ported from D3D11/VK; D3D12 upload-heap panel fill). `cube_texture_d3d12_win` already exists → §8 case 1.

## Validation (eyeballed on Leia, D3D12 DP)
All four §8 cases confirmed correct on the live Leia display (capture is pre-weave, #492 — verified by eyeball + one-shot composite WARNs):
- **Case 1** (texture canvas sub-rect + surround) — legacy path, no regression. ✅
- **Case 2** (panel + explicit Tier-2 island mask) — islands weave, panel crisp, desktop where neither covers. ✅
- **Case 3** (panel only, implicit mask) — panel crisp, desktop through translucent border, cube weaves elsewhere. ✅
- **Case 4** (two panels, panel 2 unpremultiplied) — list-order stacking + alpha. ✅

`displayxr-cli selftest` green (Leia SR plugin, ABI v3).

refs #439

🤖 Generated with [Claude Code](https://claude.com/claude-code)