### PR TITLE
OpenXR CTS conformance: Windows/D3D11 bring-up — harness, runtime fixes, tiered CI (#33)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -352,7 +352,11 @@ option(XRT_FEATURE_OPENXR_INTERACTION_TOUCH_PRO "Enable XR_FB_touch_controller_p
 option(XRT_FEATURE_OPENXR_INTERACTION_TOUCH_PLUS "Enable XR_META_touch_controller_plus" ON)
 
 # Defaults for OpenXR layer support
-option(XRT_FEATURE_OPENXR_LAYER_DEPTH "Enable XR_KHR_composition_layer_depth" ON)
+# Off: DisplayXR is a flat lightfield display, not a reprojecting HMD, so a
+# submitted depth layer is only ever validated, never used (no timewarp). It is
+# also untestable by the CTS, which hardcodes 2 depth swapchains for stereo while
+# DisplayXR enumerates its multi-view display as PRIMARY_STEREO with >2 views.
+option(XRT_FEATURE_OPENXR_LAYER_DEPTH "Enable XR_KHR_composition_layer_depth" OFF)
 option(XRT_FEATURE_OPENXR_LAYER_COLOR_SCALE_BIAS "Enable XR_KHR_composition_layer_color_scale_bias" OFF)
 option(XRT_FEATURE_OPENXR_LAYER_CUBE "Enable XR_KHR_composition_layer_cube" OFF)
 option(XRT_FEATURE_OPENXR_LAYER_CYLINDER "Enable XR_KHR_composition_layer_cylinder" ON)

--- a/docs/roadmap/cts-windows-handoff.md
+++ b/docs/roadmap/cts-windows-handoff.md
@@ -1,0 +1,112 @@
+# CTS bring-up — Windows handoff runbook (#33)
+
+Picks up where the macOS session left off. The platform-agnostic half of
+"pass the non-interactive OpenXR CTS subset" is done and on this branch
+(`feature/cts-conformance-automation`). The remaining work is **inherently
+Windows**: build the Khronos conformance suite, run it against the runtime, and
+iterate. First target: **Windows + D3D11**.
+
+## What's already done (this branch)
+
+`XR_EXT_conformance_automation` — the mechanism the CTS uses to inject synthetic
+controller input — is implemented (was header-only before). See commit
+`feat(#33): implement XR_EXT_conformance_automation`:
+
+- 5 entry points wired + advertised: `xrSetInputDeviceActive/StateBool/
+  StateFloat/StateVector2f/LocationEXT`.
+- Per-session override store in `oxr_conformance.c` keyed by the input **source
+  path** (== `oxr_action_input.bound_path`, so apply is a direct XrPath compare).
+- Value overrides applied in `oxr_input_combine_input` (`oxr_input.c`); pose
+  overrides in `oxr_space_locate` (`oxr_space.c`). State freed in
+  `oxr_session_destroy` — nothing survives the CTS load/unload cycling.
+- Compiles + links clean on macOS (full runtime build).
+
+## Setup — work in a worktree on this branch
+
+This box may have its own working state; do not disturb it. Create an isolated
+worktree on the existing branch:
+
+```bat
+cd C:\path\to\displayxr-runtime
+git fetch origin
+git worktree add .claude\worktrees\cts feature/cts-conformance-automation
+cd .claude\worktrees\cts
+```
+
+Build the runtime from the worktree per CLAUDE.md (`scripts\build_windows.bat
+all`). Confirm the conformance build compiles on MSVC (macOS only proved Clang).
+
+## Phase 1 — stand up the CTS harness + baseline
+
+1. Fetch + build the Khronos **OpenXR-CTS** (`conformance_cli` +
+   `conformance_test`) for Windows/x64. Add a fetch script under `scripts\`
+   (out-of-tree, like the vcpkg/loader fetch in `build_windows.bat`).
+2. Register the dev runtime so the **Khronos loader** finds it — reuse the
+   `openxr_displayxr-dev.json` manifest + `HKLM\...\Khronos\OpenXR\1\
+   ActiveRuntime`. Run `conformance_cli` from a **non-elevated** shell (the
+   bundled loader ignores `XR_RUNTIME_JSON` when elevated — see CLAUDE.md).
+3. Run with **core + `XR_KHR_D3D11_enable` only**, selecting the non-interactive
+   categories. Confirm via `%LOCALAPPDATA%\DisplayXR\...log` (`loaded from:`)
+   that our DLL was loaded.
+4. **Capture the failure baseline.** Triage into: (a) needs conformance_
+   automation, (b) error-code/quirk mismatches, (c) over-advertisement, (d)
+   graphics/frame-submission. Expect much to pass already (Monado lineage).
+
+## Phase 2 — validate + iterate conformance_automation
+
+This is the part that needed real CTS to verify. Confirm an input test that
+previously errored now passes: `xrSetInputDeviceStateBoolEXT` →
+`xrSyncActions` → `xrGetActionStateBoolean` returns the injected value with
+correct `isActive` / `lastChangeTime`, on `/interaction_profiles/khr/
+simple_controller`.
+
+Three known items flagged in the implementation to resolve against CTS output:
+
+1. **R1 — role ownership (verify first).** The oxr-level injection only surfaces
+   if the **qwerty** device owns `/user/hand/left|right` under the CTS launch
+   config. `sim_display` claims only `head`, so qwerty's `certain.left/right`
+   (`target_builder_qwerty.c`) should win — but assert it (a `displayxr-cli`
+   line or log that L/R roles resolve to a Qwerty device). If a display plug-in
+   ever claims hand roles, the fallback is a dedicated `drv_conformance` device.
+2. **Device-inactive suppression.** `xrSetInputDeviceActiveEXT(false)` currently
+   suppresses only *overridden* inputs, not un-overridden qwerty defaults. If
+   CTS asserts a fully-inactive device reports `isActive=false` for all sources,
+   extend the apply path to gate qwerty's own inputs for that top-level path
+   (needs the action_input's top-level path at combine time — thread it through
+   or compare the bound_path's owning role).
+3. **Pose space-relative.** `xrSetInputDeviceLocationEXT` applies the pose in
+   base-space; if CTS pose tests fail, resolve it through the supplied `XrSpace`
+   in `oxr_api_conformance.c` / the `oxr_space_locate` hook.
+
+## Phase 3 — conformance-targeted run config
+
+Run CTS requesting **only** what the runtime can back: core + D3D11 +
+conformance_automation + the profiles qwerty advertises (simple/touch/index/
+vive/WMR). Document the in-scope vs excluded set. For anything CTS still selects
+that's unbackable (hand_tracking, eye_gaze, vendor controllers): implement
+minimal backing or exclude via the run manifest — and **log every exclusion**
+(no silent truncation).
+
+## Phase 4 — triage to green + tiered CI
+
+- Error-code quirks go through the existing `quirks` mechanism (pattern at
+  `oxr_api_space.c:205` `no_validation_error_in_create_ref_space`).
+- Graphics/frame-submission failures: fix in the D3D11 native compositor path.
+- Watch for the upstream teardown/destruction race (CTS loads/unloads hundreds
+  of times — `docs/legacy-monado/tracing-perfetto.md`). Our conformance state is
+  per-session and freed in destroy, but validate clean re-init under load.
+- **CI cadence (don't run full CTS on every PR):**
+  - PR, path-filtered to `state_trackers/oxr/` · compositor · CTS harness →
+    **smoke subset, D3D11** (~2–5 min).
+  - Nightly cron on `main` → **full** non-interactive suite.
+  - Release tag `v*` → **full** suite as a hard gate (next to the ABI gate).
+  - `workflow_dispatch` → on-demand full/any-API.
+- Update #33 with the supported-category matrix; note form-factor categories
+  out of scope by design (CTS interactive tests assume an HMD + controllers).
+
+## Reference
+
+- Full plan: this repo's planning notes (the `unified-bubbling-perlis` plan).
+- Extension spec: `XR_EXT_conformance_automation` (openxr.h, spec v3).
+- Eye-tracking / sim_display fake-tracking knobs: CLAUDE.md "Simulating eye
+  tracking without hardware".

--- a/scripts/fetch_build_cts.bat
+++ b/scripts/fetch_build_cts.bat
@@ -1,0 +1,84 @@
+@echo off
+setlocal enabledelayedexpansion
+
+:: ============================================================
+:: DisplayXR — fetch + build the Khronos OpenXR-CTS (Windows/x64)
+::
+:: Builds conformance_cli + conformance_test out-of-tree under
+:: build-cts\ (gitignored). Mirrors the dep/env setup in
+:: build_windows.bat. NOT wired into build_windows.bat — the CTS is
+:: a developer/CI harness, not a runtime artifact.
+::
+:: Usage: scripts\fetch_build_cts.bat
+::   Pin via CTS_TAG below; matches the runtime's OpenXR loader (1.1.43).
+:: Output: build-cts\build\...\conformance_cli.exe (path echoed at end).
+:: ============================================================
+
+set REPO=%~dp0..\
+set CTS_TAG=openxr-cts-1.1.43.0
+set CTS_ROOT=%REPO%build-cts
+set CTS_SRC=%CTS_ROOT%\OpenXR-CTS
+set CTS_BUILD=%CTS_ROOT%\build
+set VULKAN_SDK=C:\VulkanSDK\1.4.341.1
+set NINJA_DIR=%LOCALAPPDATA%\Microsoft\WinGet\Packages\Ninja-build.Ninja_Microsoft.Winget.Source_8wekyb3d8bbwe
+
+:: ------------------------------------------------------------
+:: 1. MSVC environment (same as build_windows.bat)
+:: ------------------------------------------------------------
+echo === Setting up MSVC environment ===
+call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat" >nul 2>&1
+if %ERRORLEVEL% NEQ 0 (
+    echo ERROR: Could not find Visual Studio 2022. Install VS 2022 with C++ workload.
+    exit /b 1
+)
+if exist "%NINJA_DIR%\ninja.exe" set "PATH=%NINJA_DIR%;%PATH%"
+if exist "%VULKAN_SDK%\Bin" set "PATH=%VULKAN_SDK%\Bin;%PATH%"
+
+where ninja >nul 2>&1 || ( echo ERROR: ninja not found. winget install Ninja-build.Ninja & exit /b 1 )
+where cmake >nul 2>&1 || ( echo ERROR: cmake not found. & exit /b 1 )
+where python >nul 2>&1 || ( echo ERROR: python not found ^(CTS generates sources via Python^). & exit /b 1 )
+
+:: ------------------------------------------------------------
+:: 2. Fetch OpenXR-CTS at the pinned tag (out-of-tree)
+:: ------------------------------------------------------------
+if not exist "%CTS_ROOT%" mkdir "%CTS_ROOT%"
+
+if not exist "%CTS_SRC%\.git" (
+    echo === Cloning OpenXR-CTS @ %CTS_TAG% ===
+    git clone --depth 1 --branch %CTS_TAG% https://github.com/KhronosGroup/OpenXR-CTS.git "%CTS_SRC%"
+    if %ERRORLEVEL% NEQ 0 ( echo CTS clone FAILED & exit /b 1 )
+) else (
+    echo === OpenXR-CTS present; ensuring tag %CTS_TAG% ===
+    git -C "%CTS_SRC%" fetch --depth 1 origin tag %CTS_TAG% >nul 2>&1
+    git -C "%CTS_SRC%" checkout -q %CTS_TAG%
+    if %ERRORLEVEL% NEQ 0 ( echo CTS checkout FAILED & exit /b 1 )
+)
+
+:: ------------------------------------------------------------
+:: 3. Configure (Ninja Multi-Config). The CTS vendors its own deps
+::    (Catch2, jsoncpp, tinygltf, ...) in src/external — no vcpkg,
+::    no submodules. The OpenXR loader links statically (default);
+::    conformance_cli finds the runtime via the Khronos loader's
+::    normal discovery (HKLM ActiveRuntime on Windows).
+:: ------------------------------------------------------------
+echo === CMake configure (CTS) ===
+cmake -S "%CTS_SRC%" -B "%CTS_BUILD%" -G "Ninja Multi-Config"
+if %ERRORLEVEL% NEQ 0 ( echo CTS CMake configure FAILED & exit /b 1 )
+
+:: ------------------------------------------------------------
+:: 4. Build only the conformance harness (skips hello_xr, spec, etc.)
+:: ------------------------------------------------------------
+echo === Building conformance_cli + conformance_test (RelWithDebInfo) ===
+cmake --build "%CTS_BUILD%" --config RelWithDebInfo --target conformance_cli conformance_test
+if %ERRORLEVEL% NEQ 0 ( echo CTS build FAILED & exit /b 1 )
+
+:: ------------------------------------------------------------
+:: 5. Report the conformance_cli location
+:: ------------------------------------------------------------
+echo.
+echo === CTS build complete ===
+for /r "%CTS_BUILD%" %%F in (conformance_cli.exe) do echo   conformance_cli: %%F
+for /r "%CTS_BUILD%" %%F in (conformance_test.dll) do echo   conformance_test: %%F
+echo.
+echo === DONE ===
+endlocal

--- a/scripts/probe_leak.ps1
+++ b/scripts/probe_leak.ps1
@@ -1,0 +1,54 @@
+<#
+.SYNOPSIS
+  Characterize the per-session resource leak: run a session-churning CTS test
+  against the dev runtime while sampling the conformance_cli process's handle
+  count, GDI/USER objects, and working set. Registry snapshot/restore in finally.
+#>
+param(
+  [string]$TestSpec = "xrCreateSession,xrDestroySession,SessionState",
+  [int]   $TimeoutSec = 300,
+  [string]$Tag = "leakprobe"
+)
+$ErrorActionPreference = "Stop"
+$wt   = (Resolve-Path "$PSScriptRoot\..").Path
+$base = "$wt\build-cts\build\src\conformance\conformance_cli"
+$exe  = "$base\RelWithDebInfo\conformance_cli.exe"
+$devManifest = "$wt\build\Release\openxr_displayxr-dev.json"
+$tmp  = $env:TEMP
+$sample = "$tmp\cts_${Tag}_samples.csv"
+
+Add-Type @'
+using System;using System.Runtime.InteropServices;
+public class GObj {
+  [DllImport("user32.dll")] public static extern int GetGuiResources(IntPtr h,int flags);
+}
+'@
+
+$xrKey="HKLM:\Software\Khronos\OpenXR\1"; $dpKey="HKLM:\Software\DisplayXR\DisplayProcessors\sim-display"
+$origRT=(Get-ItemProperty $xrKey -Name ActiveRuntime).ActiveRuntime
+$origPO=(Get-ItemProperty $dpKey -Name ProbeOrder).ProbeOrder
+$env:DISPLAYXR_MCP="0"; $env:VK_LOADER_LAYERS_DISABLE="*"
+"t_s,handles,gdi,user,ws_mb" | Out-File $sample -Encoding ASCII
+try {
+  Set-ItemProperty $xrKey -Name ActiveRuntime -Value $devManifest -Type String
+  Set-ItemProperty $dpKey -Name ProbeOrder -Value 5 -Type DWord
+  $p = Start-Process -FilePath $exe -ArgumentList @($TestSpec,"-G","d3d11","--apiVersion","1.1") `
+         -WorkingDirectory $base -PassThru -NoNewWindow -RedirectStandardOutput "$tmp\cts_${Tag}.out" -RedirectStandardError "$tmp\cts_${Tag}.err"
+  $t0 = 0
+  while (-not $p.HasExited -and $t0 -lt $TimeoutSec) {
+    Start-Sleep -Seconds 2; $t0 += 2
+    try {
+      $p.Refresh()
+      $gdi  = [GObj]::GetGuiResources($p.Handle, 0)  # GR_GDIOBJECTS
+      $user = [GObj]::GetGuiResources($p.Handle, 1)  # GR_USEROBJECTS
+      "$t0,$($p.HandleCount),$gdi,$user,$([math]::Round($p.WorkingSet64/1MB))" | Out-File $sample -Append -Encoding ASCII
+    } catch {}
+  }
+  if (-not $p.HasExited) { try { $p.Kill() } catch {}; "RESULT: TIMEOUT/killed" } else { "RESULT: exited code=$($p.ExitCode)" }
+}
+finally {
+  Set-ItemProperty $xrKey -Name ActiveRuntime -Value $origRT -Type String
+  Set-ItemProperty $dpKey -Name ProbeOrder -Value ([int]$origPO) -Type DWord
+  "RESTORED rt=$((Get-ItemProperty $xrKey -Name ActiveRuntime).ActiveRuntime) po=$((Get-ItemProperty $dpKey -Name ProbeOrder).ProbeOrder)"
+}
+Write-Output "samples -> $sample"

--- a/scripts/run_cts.ps1
+++ b/scripts/run_cts.ps1
@@ -1,0 +1,108 @@
+<#
+.SYNOPSIS
+  Run the OpenXR CTS against the freshly-built DisplayXR dev runtime, backed by
+  a chosen display-processor plugin, with guaranteed registry restore.
+
+.DESCRIPTION
+  On this box the Khronos loader runs elevated and therefore ignores
+  XR_RUNTIME_JSON, so we point it at the dev build via HKLM ActiveRuntime, and
+  force the desired DP plugin by temporarily lowering its ProbeOrder (lower =
+  wins). BOTH registry edits are snapshotted and restored in a finally block —
+  the box is left exactly as found even if the run hangs and is killed.
+
+  Defaults run the non-interactive ("automated") subset on D3D11 / OpenXR 1.1,
+  emitting a ctsxml report (for the pass/fail matrix) plus a console log.
+
+.PARAMETER Plugin     sim-display (default) | leia-sr | none (leave plugins as-is)
+.PARAMETER Graphics   d3d11 (default) | d3d12 | vulkan | opengl
+.PARAMETER ApiVersion 1.1 (default) | 1.0
+.PARAMETER TestSpec   Catch2 spec; default "exclude:[interactive]"
+.PARAMETER TimeoutSec Kill + restore after this many seconds (default 1800)
+.PARAMETER Tag        Label for output files (default automated_<graphics>_<api>)
+#>
+param(
+  [string]$Plugin     = "sim-display",
+  [string]$Graphics   = "d3d11",
+  [string]$ApiVersion = "1.1",
+  [string]$TestSpec   = "exclude:[interactive]",
+  [int]   $TimeoutSec = 1800,
+  [string]$Tag        = ""
+)
+
+$ErrorActionPreference = "Stop"
+$wt   = (Resolve-Path "$PSScriptRoot\..").Path   # repo/worktree root (scripts/..)
+$base = "$wt\build-cts\build\src\conformance\conformance_cli"
+$exe  = "$base\RelWithDebInfo\conformance_cli.exe"
+$devManifest = "$wt\build\Release\openxr_displayxr-dev.json"
+
+if (-not $Tag) { $Tag = "${Graphics}_${ApiVersion}" }
+$tmp     = $env:TEMP
+$xml     = "$tmp\cts_${Tag}.xml"
+$console = "$tmp\cts_${Tag}_console.log"
+
+foreach ($p in @($exe,$devManifest)) { if (-not (Test-Path $p)) { throw "missing: $p" } }
+
+$xrKey  = "HKLM:\Software\Khronos\OpenXR\1"
+$dpKey  = "HKLM:\Software\DisplayXR\DisplayProcessors\$Plugin"
+
+# ---- snapshot ----
+$origRuntime   = (Get-ItemProperty $xrKey -Name ActiveRuntime -ErrorAction SilentlyContinue).ActiveRuntime
+$origProbe     = $null
+if ($Plugin -ne "none") {
+  $origProbe = (Get-ItemProperty $dpKey -Name ProbeOrder -ErrorAction SilentlyContinue).ProbeOrder
+}
+Write-Output "SNAPSHOT ActiveRuntime = $origRuntime"
+Write-Output "SNAPSHOT $Plugin ProbeOrder = $origProbe"
+
+try {
+  # ---- apply ----
+  Set-ItemProperty $xrKey -Name ActiveRuntime -Value $devManifest -Type String
+  if ($Plugin -ne "none") {
+    Set-ItemProperty $dpKey -Name ProbeOrder -Value 5 -Type DWord   # below leia-sr (50)
+  }
+  Write-Output "APPLIED ActiveRuntime -> $devManifest"
+  Write-Output "APPLIED $Plugin ProbeOrder -> 5 (wins)"
+
+  if (Test-Path $xml)     { Remove-Item $xml -Force }
+  if (Test-Path $console) { Remove-Item $console -Force }
+
+  # Reduce per-instance overhead/noise: the CTS creates hundreds of instances.
+  # MCP spins a named-pipe server per instance; implicit Vulkan layers (e.g. an
+  # FPS overlay) can crash the runtime's internal VK device. Neither is under test.
+  $env:DISPLAYXR_MCP = "0"
+  $env:VK_LOADER_LAYERS_DISABLE = "*"
+
+  $cliArgs = @(
+    $TestSpec, "-G", $Graphics, "--apiVersion", $ApiVersion,
+    "--reporter", "ctsxml::out=$xml",
+    "--reporter", "console::out=$console"
+  )
+  Write-Output "RUN: conformance_cli $($cliArgs -join ' ')"
+  Write-Output "CWD: $base"
+
+  $proc = Start-Process -FilePath $exe -ArgumentList $cliArgs -WorkingDirectory $base -PassThru -NoNewWindow
+  if (-not $proc.WaitForExit($TimeoutSec * 1000)) {
+    Write-Output "TIMEOUT after ${TimeoutSec}s - killing."
+    try { $proc.Kill() } catch {}
+    $proc.WaitForExit(10000) | Out-Null
+    Write-Output "EXITCODE: (killed)"
+  } else {
+    Write-Output "EXITCODE: $($proc.ExitCode)"
+  }
+}
+finally {
+  # ---- restore (always) ----
+  if ($null -ne $origRuntime) {
+    Set-ItemProperty $xrKey -Name ActiveRuntime -Value $origRuntime -Type String
+  }
+  if ($Plugin -ne "none" -and $null -ne $origProbe) {
+    Set-ItemProperty $dpKey -Name ProbeOrder -Value ([int]$origProbe) -Type DWord
+  }
+  Write-Output "RESTORED ActiveRuntime = $((Get-ItemProperty $xrKey -Name ActiveRuntime).ActiveRuntime)"
+  if ($Plugin -ne "none") {
+    Write-Output "RESTORED $Plugin ProbeOrder = $((Get-ItemProperty $dpKey -Name ProbeOrder).ProbeOrder)"
+  }
+}
+
+Write-Output "XML:     $xml"
+Write-Output "CONSOLE: $console"

--- a/scripts/run_cts.ps1
+++ b/scripts/run_cts.ps1
@@ -71,6 +71,10 @@ try {
   # FPS overlay) can crash the runtime's internal VK device. Neither is under test.
   $env:DISPLAYXR_MCP = "0"
   $env:VK_LOADER_LAYERS_DISABLE = "*"
+  # The CTS app has no window of its own, so the D3D11 native compositor
+  # self-creates one per session. Keep it windowed (not fullscreen) so a run
+  # doesn't repeatedly take over the display.
+  $env:XRT_COMPOSITOR_START_WINDOWED = "true"
 
   $cliArgs = @(
     $TestSpec, "-G", $Graphics, "--apiVersion", $ApiVersion,

--- a/scripts/run_cts.ps1
+++ b/scripts/run_cts.ps1
@@ -26,7 +26,11 @@ param(
   [string]$ApiVersion = "1.1",
   [string]$TestSpec   = "exclude:[interactive]",
   [int]   $TimeoutSec = 1800,
-  [string]$Tag        = ""
+  [string]$Tag        = "",
+  # Enable the CTS's required XR_APILAYER_KHRONOS_runtime_conformance layer for a
+  # submission-valid run. Registered in HKLM (the elevated loader ignores
+  # XR_API_LAYER_PATH) and requested via -L; snapshot/restored like the rest.
+  [switch]$ConformanceLayer
 )
 
 $ErrorActionPreference = "Stop"
@@ -54,6 +58,17 @@ if ($Plugin -ne "none") {
 Write-Output "SNAPSHOT ActiveRuntime = $origRuntime"
 Write-Output "SNAPSHOT $Plugin ProbeOrder = $origProbe"
 
+# Both CTS layers: the runtime-conformance validation layer (requested via -L)
+# and the conformance_test_layer (== conformance_test.dll; validApiLayer requests
+# it itself). Register both as Explicit so the elevated loader can find them.
+$layerJsons  = @("$base\XrApiLayer_runtime_conformance.json", "$base\XrApiLayer_conformance_test_layer.json")
+$explicitKey  = "$xrKey\ApiLayers\Explicit"
+$explicitKeyPreexisted = Test-Path $explicitKey
+$preRegistered = @{}
+if ($ConformanceLayer -and $explicitKeyPreexisted) {
+  foreach ($lj in $layerJsons) { $preRegistered[$lj] = $null -ne (Get-ItemProperty $explicitKey -Name $lj -ErrorAction SilentlyContinue) }
+}
+
 try {
   # ---- apply ----
   Set-ItemProperty $xrKey -Name ActiveRuntime -Value $devManifest -Type String
@@ -62,6 +77,12 @@ try {
   }
   Write-Output "APPLIED ActiveRuntime -> $devManifest"
   Write-Output "APPLIED $Plugin ProbeOrder -> 5 (wins)"
+
+  if ($ConformanceLayer) {
+    if (-not (Test-Path $explicitKey)) { New-Item -Path $explicitKey -Force | Out-Null }
+    foreach ($lj in $layerJsons) { New-ItemProperty -Path $explicitKey -Name $lj -Value 0 -PropertyType DWord -Force | Out-Null }
+    Write-Output "APPLIED $($layerJsons.Count) conformance layers (HKLM Explicit)"
+  }
 
   if (Test-Path $xml)     { Remove-Item $xml -Force }
   if (Test-Path $console) { Remove-Item $console -Force }
@@ -81,6 +102,7 @@ try {
     "--reporter", "ctsxml::out=$xml",
     "--reporter", "console::out=$console"
   )
+  if ($ConformanceLayer) { $cliArgs += @("-L", "XR_APILAYER_KHRONOS_runtime_conformance") }
   Write-Output "RUN: conformance_cli $($cliArgs -join ' ')"
   Write-Output "CWD: $base"
 
@@ -101,6 +123,13 @@ finally {
   }
   if ($Plugin -ne "none" -and $null -ne $origProbe) {
     Set-ItemProperty $dpKey -Name ProbeOrder -Value ([int]$origProbe) -Type DWord
+  }
+  if ($ConformanceLayer -and (Test-Path $explicitKey)) {
+    foreach ($lj in $layerJsons) {
+      if (-not $preRegistered[$lj]) { Remove-ItemProperty -Path $explicitKey -Name $lj -ErrorAction SilentlyContinue }
+    }
+    if (-not $explicitKeyPreexisted) { Remove-Item -Path $explicitKey -Force -ErrorAction SilentlyContinue }
+    Write-Output "RESTORED conformance layer registration removed"
   }
   Write-Output "RESTORED ActiveRuntime = $((Get-ItemProperty $xrKey -Name ActiveRuntime).ActiveRuntime)"
   if ($Plugin -ne "none") {

--- a/scripts/run_cts_sharded.ps1
+++ b/scripts/run_cts_sharded.ps1
@@ -1,0 +1,135 @@
+<#
+.SYNOPSIS
+  Crash-isolated CTS baseline: run each automated test case in its own
+  conformance_cli process so a hard crash (access violation) is attributed to
+  one test instead of aborting the whole suite. Registry is applied once and
+  restored in finally (same contract as run_cts.ps1).
+
+.OUTPUTS
+  A results CSV at %TEMP%\cts_<Tag>_shards.csv : name,result,exit,fails,skips
+  result in { PASS, FAIL, SKIP, CRASH, TIMEOUT }.
+#>
+param(
+  [string]$Plugin     = "sim-display",
+  [string]$Graphics   = "d3d11",
+  [string]$ApiVersion = "1.1",
+  [string]$Spec       = "exclude:[interactive]",
+  [int]   $PerTestTimeoutSec = 90,
+  [string]$Tag        = "sharded_d3d11_1_1",
+  # Enable the CTS's required XR_APILAYER_KHRONOS_runtime_conformance layer by
+  # pointing the loader at the dir holding its manifest. "" disables it.
+  [string]$ApiLayerPath = "USE_BASE",
+  # Read test-case names from this file (one per line) instead of enumerating.
+  # Enumeration via --list-tests is flaky because the CTS prints the runtime
+  # banner over the list; a pre-captured canonical list is deterministic.
+  [string]$NamesFile  = ""
+)
+$ErrorActionPreference = "Stop"
+$wt   = (Resolve-Path "$PSScriptRoot\..").Path   # repo/worktree root (scripts/..)
+$base = "$wt\build-cts\build\src\conformance\conformance_cli"
+$exe  = "$base\RelWithDebInfo\conformance_cli.exe"
+$devManifest = "$wt\build\Release\openxr_displayxr-dev.json"
+$tmp  = $env:TEMP
+$shardDir = "$tmp\cts_shards"
+$csv  = "$tmp\cts_${Tag}_shards.csv"
+if (Test-Path $shardDir) { Remove-Item $shardDir -Recurse -Force }
+New-Item -ItemType Directory -Path $shardDir | Out-Null
+
+# Get automated test-case names: from a canonical file if given, else slice the
+# CTS --list-tests output (between the "Test names:" header and the next "***"
+# banner, keeping only identifier-like tokens to drop interleaved runtime noise).
+if ($NamesFile -and (Test-Path $NamesFile)) {
+  $names = Get-Content $NamesFile | ForEach-Object { $_.Trim() } | Where-Object { $_ }
+  Write-Output "Loaded $($names.Count) test-case names from $NamesFile"
+} else {
+  Push-Location $base
+  try { $raw = & $exe $Spec --list-tests --verbosity quiet 2>$null } finally { Pop-Location }
+  $start = ($raw | Select-String -Pattern '^Test names:').LineNumber | Select-Object -First 1
+  $names = @()
+  for ($i = $start; $i -lt $raw.Count; $i++) {
+    if ($raw[$i] -match '^\*{3,}') { break }
+    $t = $raw[$i].Trim()
+    if ($t -and $t -match '^[A-Za-z_][A-Za-z0-9_./-]*$') { $names += $t }
+  }
+  Write-Output "Enumerated $($names.Count) automated test cases."
+}
+$names = $names | Select-Object -Unique
+
+$xrKey = "HKLM:\Software\Khronos\OpenXR\1"
+$dpKey = "HKLM:\Software\DisplayXR\DisplayProcessors\$Plugin"
+$origRuntime = (Get-ItemProperty $xrKey -Name ActiveRuntime -ErrorAction SilentlyContinue).ActiveRuntime
+$origProbe   = (Get-ItemProperty $dpKey -Name ProbeOrder   -ErrorAction SilentlyContinue).ProbeOrder
+$env:DISPLAYXR_MCP = "0"; $env:VK_LOADER_LAYERS_DISABLE = "*"
+if ($ApiLayerPath -eq "USE_BASE") { $ApiLayerPath = $base }
+if ($ApiLayerPath) {
+  $env:XR_API_LAYER_PATH = $ApiLayerPath
+  Write-Output "XR_API_LAYER_PATH = $ApiLayerPath (CTS conformance layer enabled)"
+} else {
+  Remove-Item Env:\XR_API_LAYER_PATH -ErrorAction SilentlyContinue
+}
+
+# Escape a test name into a Catch2 single-test spec (escape , [ ] * \).
+function Esc([string]$n) { ($n -replace '([,\[\]\*\\])','\$1') }
+
+$results = @()
+try {
+  Set-ItemProperty $xrKey -Name ActiveRuntime -Value $devManifest -Type String
+  Set-ItemProperty $dpKey -Name ProbeOrder -Value 5 -Type DWord
+
+  $i = 0
+  foreach ($n in $names) {
+    $i++
+    $safe = ($n -replace '[^A-Za-z0-9._-]','_'); if ($safe.Length -gt 80) { $safe = $safe.Substring(0,80) }
+    $sx = "$shardDir\$('{0:D3}' -f $i)_$safe.xml"
+    $so = "$shardDir\$('{0:D3}' -f $i)_$safe.out"
+    $spec = Esc $n
+    $cliArgs = @($spec, "-G", $Graphics, "--apiVersion", $ApiVersion, "--reporter", "ctsxml::out=$sx")
+    if ($ApiLayerPath) { $cliArgs += @("-L", "XR_APILAYER_KHRONOS_runtime_conformance") }
+    $p = Start-Process -FilePath $exe -ArgumentList $cliArgs -WorkingDirectory $base -PassThru -NoNewWindow `
+           -RedirectStandardOutput $so -RedirectStandardError "$so.err"
+    $res = ""; $code = ""
+    if (-not $p.WaitForExit($PerTestTimeoutSec * 1000)) {
+      try { $p.Kill() } catch {}; $p.WaitForExit(5000) | Out-Null
+      $res = "TIMEOUT"
+    } else {
+      try { $p.WaitForExit() | Out-Null; $code = $p.ExitCode } catch { $code = "" }
+    }
+    # Classify from the XML assertions, NOT the exit code: the runtime crashes
+    # on instance/process teardown (Monado destruction race), so a non-zero exit
+    # with failures==0 is a PASS-with-teardown-crash, not a test failure. A
+    # genuine in-test crash leaves NO recorded testcases (tcs==0) or a truncated
+    # XML, which we surface as CRASH.
+    $fails = 0; $skips = 0; $tcs = 0; $haveXml = $false
+    if (Test-Path $sx) {
+      try {
+        $raw = Get-Content $sx -Raw
+        $idx = $raw.LastIndexOf('</testcase>')
+        if ($idx -ge 0) { $raw = $raw.Substring(0,$idx+11) + "`n</testsuite></testsuites>" }
+        $x = [xml]$raw
+        $ts = $x.testsuites.testsuite
+        if ($ts) { $fails=[int]$ts.failures; $skips=[int]$ts.skipped; $tcs=[int]$ts.tests; $haveXml=$true }
+      } catch {}
+    }
+    if (-not $res) {
+      if (-not $haveXml -or $tcs -eq 0) { $res = "CRASH" }
+      elseif ($fails -gt 0)             { $res = "FAIL" }
+      elseif ($skips -ge $tcs)          { $res = "SKIP" }
+      else                              { $res = "PASS" }
+    }
+    $teardown = if ($res -in 'PASS','FAIL','SKIP' -and "$code" -ne "0" -and "$code" -ne "") { 1 } else { 0 }
+    $results += [pscustomobject]@{ name=$n; result=$res; teardownCrash=$teardown; exit=$code; fails=$fails; skips=$skips; asserts=$tcs }
+    Write-Output ("[{0,3}/{1}] {2,-7} {3}" -f $i,$names.Count,$res,$n)
+  }
+}
+finally {
+  if ($origRuntime) { Set-ItemProperty $xrKey -Name ActiveRuntime -Value $origRuntime -Type String }
+  if ($origProbe -ne $null) { Set-ItemProperty $dpKey -Name ProbeOrder -Value ([int]$origProbe) -Type DWord }
+  Write-Output "RESTORED ActiveRuntime=$((Get-ItemProperty $xrKey -Name ActiveRuntime).ActiveRuntime)"
+  Write-Output "RESTORED $Plugin ProbeOrder=$((Get-ItemProperty $dpKey -Name ProbeOrder).ProbeOrder)"
+}
+
+$results | Export-Csv -Path $csv -NoTypeInformation -Encoding UTF8
+$g = $results | Group-Object result | Sort-Object Name
+Write-Output "`n=== SUMMARY ==="
+$g | ForEach-Object { Write-Output ("  {0,-7} {1}" -f $_.Name, $_.Count) }
+Write-Output "CSV: $csv"

--- a/scripts/run_cts_sharded.ps1
+++ b/scripts/run_cts_sharded.ps1
@@ -59,7 +59,7 @@ $xrKey = "HKLM:\Software\Khronos\OpenXR\1"
 $dpKey = "HKLM:\Software\DisplayXR\DisplayProcessors\$Plugin"
 $origRuntime = (Get-ItemProperty $xrKey -Name ActiveRuntime -ErrorAction SilentlyContinue).ActiveRuntime
 $origProbe   = (Get-ItemProperty $dpKey -Name ProbeOrder   -ErrorAction SilentlyContinue).ProbeOrder
-$env:DISPLAYXR_MCP = "0"; $env:VK_LOADER_LAYERS_DISABLE = "*"
+$env:DISPLAYXR_MCP = "0"; $env:VK_LOADER_LAYERS_DISABLE = "*"; $env:XRT_COMPOSITOR_START_WINDOWED = "true"
 if ($ApiLayerPath -eq "USE_BASE") { $ApiLayerPath = $base }
 if ($ApiLayerPath) {
   $env:XR_API_LAYER_PATH = $ApiLayerPath

--- a/src/xrt/auxiliary/util/u_visibility_mask.c
+++ b/src/xrt/auxiliary/util/u_visibility_mask.c
@@ -122,3 +122,24 @@ u_visibility_mask_get_default(enum xrt_visibility_mask_type type,
 out:
 	*out_mask = mask; // Always NULL or allocated data.
 }
+
+void
+u_visibility_mask_get_empty(enum xrt_visibility_mask_type type, struct xrt_visibility_mask **out_mask)
+{
+	// Flat panel: nothing is occluded, so every mask type is empty. This is a
+	// valid "no view mask" per the OpenXR spec and keeps all three types
+	// consistent (the CTS requires all-or-none).
+	struct xrt_visibility_mask *mask =
+	    U_CALLOC_WITH_CAST(struct xrt_visibility_mask, sizeof(struct xrt_visibility_mask));
+	if (mask == NULL) {
+		U_LOG_E("failed to allocate out xrt_visibility_mask");
+		*out_mask = NULL;
+		return;
+	}
+
+	mask->type = type;
+	mask->index_count = 0;
+	mask->vertex_count = 0;
+
+	*out_mask = mask;
+}

--- a/src/xrt/auxiliary/util/u_visibility_mask.h
+++ b/src/xrt/auxiliary/util/u_visibility_mask.h
@@ -29,6 +29,20 @@ u_visibility_mask_get_default(enum xrt_visibility_mask_type type,
                               const struct xrt_fov *fov,
                               struct xrt_visibility_mask **out_mask);
 
+/*!
+ * Empty visibility mask (zero vertices / indices) for the given type. A flat
+ * panel has no lens cut-out, so nothing is occluded and the whole view is
+ * visible — which OpenXR represents as "no view mask available" (the spec lets a
+ * runtime return zero vertices). Returning empty for *every* mask type also
+ * satisfies the CTS's all-types-or-no-types rule, and sidesteps the
+ * FoV-scaled @ref u_visibility_mask_get_default, whose winding is invalid for an
+ * off-axis / asymmetric projection. The caller de-allocates the mask.
+ *
+ * @ingroup aux_util
+ */
+void
+u_visibility_mask_get_empty(enum xrt_visibility_mask_type type, struct xrt_visibility_mask **out_mask);
+
 
 #ifdef __cplusplus
 }

--- a/src/xrt/compositor/d3d11/comp_d3d11_swapchain.cpp
+++ b/src/xrt/compositor/d3d11/comp_d3d11_swapchain.cpp
@@ -368,29 +368,37 @@ comp_d3d11_swapchain_create(struct comp_d3d11_compositor *c,
 	if (bind_flags & D3D11_BIND_DEPTH_STENCIL) {
 		is_depth = true;
 
-		// Only promote to TYPELESS when SRV is also requested —
-		// that's the only case D3D11 actually requires it.
-		if (bind_flags & D3D11_BIND_SHADER_RESOURCE) {
-			switch (dxgi_format) {
-			case DXGI_FORMAT_D24_UNORM_S8_UINT:
-				texture_format = DXGI_FORMAT_R24G8_TYPELESS;
-				dsv_format = DXGI_FORMAT_D24_UNORM_S8_UINT;
-				srv_format = DXGI_FORMAT_R24_UNORM_X8_TYPELESS;
-				break;
-			case DXGI_FORMAT_D32_FLOAT:
-				texture_format = DXGI_FORMAT_R32_TYPELESS;
-				dsv_format = DXGI_FORMAT_D32_FLOAT;
-				srv_format = DXGI_FORMAT_R32_FLOAT;
-				break;
-			case DXGI_FORMAT_D16_UNORM:
-				texture_format = DXGI_FORMAT_R16_TYPELESS;
-				dsv_format = DXGI_FORMAT_D16_UNORM;
-				srv_format = DXGI_FORMAT_R16_UNORM;
-				break;
-			default:
-				// Use format as-is for other depth formats
-				break;
-			}
+		// Create depth textures with a TYPELESS format and hand the app a
+		// typeless image, so it can build its own typed DSV/SRV. This matches
+		// the OpenXR D3D11 spec (and the D3D12 native compositor, which already
+		// does this), and is required by the CTS Swapchains format check, which
+		// expects e.g. D24_UNORM_S8_UINT -> R24G8_TYPELESS. The typed
+		// dsv_format/srv_format below are used for the runtime's own views.
+		//
+		// (This restores the original always-typeless behaviour. The previous
+		// "only typeless when SRV requested" variant — #91, c08148c32 — kept
+		// depth typed for a Unity D3D11 path; Unity defaults to D3D12, which has
+		// always created depth typeless without issue, so the typed special-case
+		// is unnecessary and non-conformant.)
+		switch (dxgi_format) {
+		case DXGI_FORMAT_D24_UNORM_S8_UINT:
+			texture_format = DXGI_FORMAT_R24G8_TYPELESS;
+			dsv_format = DXGI_FORMAT_D24_UNORM_S8_UINT;
+			srv_format = DXGI_FORMAT_R24_UNORM_X8_TYPELESS;
+			break;
+		case DXGI_FORMAT_D32_FLOAT:
+			texture_format = DXGI_FORMAT_R32_TYPELESS;
+			dsv_format = DXGI_FORMAT_D32_FLOAT;
+			srv_format = DXGI_FORMAT_R32_FLOAT;
+			break;
+		case DXGI_FORMAT_D16_UNORM:
+			texture_format = DXGI_FORMAT_R16_TYPELESS;
+			dsv_format = DXGI_FORMAT_D16_UNORM;
+			srv_format = DXGI_FORMAT_R16_UNORM;
+			break;
+		default:
+			// Use format as-is for other depth formats
+			break;
 		}
 	}
 

--- a/src/xrt/compositor/d3d11/comp_d3d11_swapchain.cpp
+++ b/src/xrt/compositor/d3d11/comp_d3d11_swapchain.cpp
@@ -54,14 +54,14 @@ struct comp_d3d11_swapchain
 	//! Creation info.
 	struct xrt_swapchain_create_info info;
 
-	//! Currently acquired image index (-1 if none).
-	int32_t acquired_index;
+	//! Number of images currently acquired (acquired, not yet released).
+	//! OpenXR permits acquiring up to image_count images before any wait/
+	//! release (the CTS Swapchains tests acquire all of them in a loop), so we
+	//! track a count + a ring cursor instead of a single acquired index.
+	uint32_t num_acquired;
 
-	//! Currently waited image index (-1 if none).
-	int32_t waited_index;
-
-	//! Last released image index (for round-robin).
-	uint32_t last_released_index;
+	//! Next ring index that acquire() will hand out.
+	uint32_t next_acquire;
 
 	//! D3D11.4 fence for efficient GPU→CPU release notification.
 	//! Signaled at xrReleaseSwapchainImage; waited in layer_commit.
@@ -162,16 +162,18 @@ d3d11_swapchain_acquire_image(struct xrt_swapchain *xsc, uint32_t *out_index)
 {
 	struct comp_d3d11_swapchain *sc = d3d11_sc(xsc);
 
-	if (sc->acquired_index >= 0) {
-		U_LOG_E("Image already acquired");
-		return XRT_ERROR_IPC_FAILURE;
+	// OpenXR allows up to image_count images to be acquired concurrently. The
+	// oxr state tracker already bounds this before calling us, but guard too.
+	if (sc->num_acquired >= sc->image_count) {
+		U_LOG_E("All %u swapchain images already acquired", sc->image_count);
+		return XRT_ERROR_NO_IMAGE_AVAILABLE;
 	}
 
-	// Round-robin acquisition using per-swapchain counter
-	// Find next available index (start from last released + 1)
-	uint32_t index = (sc->last_released_index + 1) % sc->image_count;
-
-	sc->acquired_index = static_cast<int32_t>(index);
+	// Hand out the next ring index; images are acquired/waited/released in FIFO
+	// order, which the oxr layer enforces.
+	uint32_t index = sc->next_acquire;
+	sc->next_acquire = (sc->next_acquire + 1) % sc->image_count;
+	sc->num_acquired++;
 	*out_index = index;
 
 	return XRT_SUCCESS;
@@ -183,18 +185,13 @@ d3d11_swapchain_wait_image(struct xrt_swapchain *xsc, int64_t timeout_ns, uint32
 	struct comp_d3d11_swapchain *sc = d3d11_sc(xsc);
 	(void)timeout_ns;
 
-	if (sc->acquired_index < 0) {
-		U_LOG_E("No image acquired");
-		return XRT_ERROR_IPC_FAILURE;
+	// The app owns these textures; there is no runtime-side GPU work to wait on
+	// here (the to-comp barrier does the GPU handoff at release time). The oxr
+	// layer enforces acquire->wait->release ordering, so just range-check.
+	if (index >= sc->image_count) {
+		U_LOG_E("Wait index %u out of range (image_count=%u)", index, sc->image_count);
+		return XRT_ERROR_NO_IMAGE_AVAILABLE;
 	}
-
-	if (static_cast<uint32_t>(sc->acquired_index) != index) {
-		U_LOG_E("Wait index %u doesn't match acquired index %d", index, sc->acquired_index);
-		return XRT_ERROR_IPC_FAILURE;
-	}
-
-	sc->waited_index = sc->acquired_index;
-	sc->acquired_index = -1;
 
 	return XRT_SUCCESS;
 }
@@ -239,19 +236,16 @@ d3d11_swapchain_release_image(struct xrt_swapchain *xsc, uint32_t index)
 {
 	struct comp_d3d11_swapchain *sc = d3d11_sc(xsc);
 
-	if (sc->waited_index < 0) {
-		U_LOG_E("No image to release");
-		return XRT_ERROR_IPC_FAILURE;
+	if (sc->num_acquired == 0) {
+		U_LOG_E("Release with no acquired image");
+		return XRT_ERROR_NO_IMAGE_AVAILABLE;
+	}
+	if (index >= sc->image_count) {
+		U_LOG_E("Release index %u out of range (image_count=%u)", index, sc->image_count);
+		return XRT_ERROR_NO_IMAGE_AVAILABLE;
 	}
 
-	if (static_cast<uint32_t>(sc->waited_index) != index) {
-		U_LOG_E("Release index %u doesn't match waited index %d", index, sc->waited_index);
-		return XRT_ERROR_IPC_FAILURE;
-	}
-
-	// Track the last released index for round-robin acquisition
-	sc->last_released_index = index;
-	sc->waited_index = -1;
+	sc->num_acquired--;
 
 	return XRT_SUCCESS;
 }
@@ -296,8 +290,10 @@ comp_d3d11_swapchain_create(struct comp_d3d11_compositor *c,
 {
 	auto internals = get_internals(c);
 
-	// Validate image count
-	uint32_t image_count = 3; // Default to triple buffering
+	// Static swapchains (XR_SWAPCHAIN_CREATE_STATIC_IMAGE_BIT) hold exactly one
+	// image and may be acquired only once (OpenXR spec); dynamic swapchains use
+	// triple buffering.
+	uint32_t image_count = (info->create & XRT_SWAPCHAIN_CREATE_STATIC_IMAGE) ? 1u : 3u;
 	if (image_count > MAX_SWAPCHAIN_IMAGES) {
 		image_count = MAX_SWAPCHAIN_IMAGES;
 	}
@@ -309,9 +305,8 @@ comp_d3d11_swapchain_create(struct comp_d3d11_compositor *c,
 	sc->c = c;
 	sc->info = *info;
 	sc->image_count = image_count;
-	sc->acquired_index = -1;
-	sc->waited_index = -1;
-	sc->last_released_index = image_count - 1; // Start so first acquire returns index 0
+	sc->num_acquired = 0;
+	sc->next_acquire = 0; // First acquire returns index 0
 	sc->release_fence = nullptr;
 	sc->release_event = nullptr;
 	sc->release_fence_value = 0;

--- a/src/xrt/compositor/d3d11/comp_d3d11_window.cpp
+++ b/src/xrt/compositor/d3d11/comp_d3d11_window.cpp
@@ -118,6 +118,12 @@ struct comp_d3d11_window
 	//! True if user closed the window (window thread writes, compositor reads)
 	volatile LONG should_exit;
 
+	//! Two-party cleanup vote. The window thread (on exit) and
+	//! comp_d3d11_window_destroy each vote exactly once via window_release();
+	//! the second voter frees the struct. This guarantees w outlives both users
+	//! with no use-after-free and no leak, regardless of teardown timing.
+	volatile LONG cleanup_votes;
+
 	//! True while inside a modal move/size loop (window thread writes, compositor reads)
 	volatile LONG in_size_move;
 
@@ -992,6 +998,38 @@ wnd_proc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 }
 
 /*!
+ * Two-party cleanup for @ref comp_d3d11_window. Both the window thread (when it
+ * exits) and @ref comp_d3d11_window_destroy call this exactly once. The second
+ * caller (vote reaches 2) frees the struct and closes its handles; the first
+ * caller returns, leaving the struct alive for the other party still using it.
+ *
+ * This is the fix for the CTS full-run crash: previously destroy freed @p w on a
+ * wait timeout while the window thread was still inside DestroyWindow (its window
+ * proc reads @p w back from GWLP_USERDATA), causing a use-after-free
+ * ACCESS_VIOLATION. Now whoever finishes last frees, so @p w always outlives both.
+ */
+static void
+window_release(struct comp_d3d11_window *w)
+{
+	if (InterlockedIncrement(&w->cleanup_votes) < 2) {
+		return; // other party is still using w; it will free.
+	}
+	if (w->thread_handle != NULL) {
+		CloseHandle(w->thread_handle);
+	}
+	if (w->window_ready_event != NULL) {
+		CloseHandle(w->window_ready_event);
+	}
+	if (w->paint_requested_event != NULL) {
+		CloseHandle(w->paint_requested_event);
+	}
+	if (w->paint_done_event != NULL) {
+		CloseHandle(w->paint_done_event);
+	}
+	free(w);
+}
+
+/*!
  * Window thread function.
  *
  * Creates the window, runs the message loop, and cleans up the window class
@@ -1024,6 +1062,7 @@ window_thread_func(LPVOID param)
 		} else {
 			U_LOG_E("D3D11 window thread: RegisterClassExW failed with error %lu", err);
 			SetEvent(w->window_ready_event);
+			window_release(w);
 			return 1;
 		}
 	}
@@ -1058,6 +1097,7 @@ window_thread_func(LPVOID param)
 			w->window_class = 0;
 		}
 		SetEvent(w->window_ready_event);
+		window_release(w);
 		return 1;
 	}
 
@@ -1122,6 +1162,7 @@ window_thread_func(LPVOID param)
 	}
 
 	U_LOG_W("D3D11 window thread: exiting");
+	window_release(w);
 	return 0;
 }
 
@@ -1190,21 +1231,20 @@ comp_d3d11_window_create(uint32_t width,
 	DWORD wait_result = WaitForSingleObject(w->window_ready_event, 10000);
 	if (wait_result != WAIT_OBJECT_0) {
 		U_LOG_E("D3D11 window: Timeout waiting for window thread to create HWND");
-		// Try to terminate the thread gracefully
-		WaitForSingleObject(w->thread_handle, 1000);
-		CloseHandle(w->thread_handle);
-		CloseHandle(w->window_ready_event);
-		free(w);
+		// The thread is still running and still references w. Vote and let the
+		// thread free w when it eventually exits (window_release: last voter
+		// frees). Freeing here would be a use-after-free.
+		window_release(w);
 		return XRT_ERROR_DEVICE_CREATION_FAILED;
 	}
 
 	// Check if the window was actually created
 	if (w->hwnd == NULL) {
 		U_LOG_E("D3D11 window: Window thread failed to create HWND");
+		// The thread took an error exit and already cast its vote; wait for it
+		// to finish, then this second vote frees w.
 		WaitForSingleObject(w->thread_handle, 5000);
-		CloseHandle(w->thread_handle);
-		CloseHandle(w->window_ready_event);
-		free(w);
+		window_release(w);
 		return XRT_ERROR_DEVICE_CREATION_FAILED;
 	}
 
@@ -1222,37 +1262,34 @@ comp_d3d11_window_destroy(struct comp_d3d11_window **window)
 	}
 
 	struct comp_d3d11_window *w = *window;
+	*window = NULL;
 
 	U_LOG_W("D3D11 window: Destroying window");
 
-	// Tell the window thread to close (PostMessage is safe cross-thread)
+	// Ask the window thread to close: WM_CLOSE -> DestroyWindow -> WM_DESTROY ->
+	// PostQuitMessage breaks its message loop, after which it frees its own
+	// resources and votes via window_release().
+	InterlockedExchange(&w->should_exit, TRUE);
 	if (w->hwnd != NULL) {
 		PostMessageW(w->hwnd, WM_CLOSE, 0, 0);
 	}
 
-	// Wait for window thread to exit
+	// Wait so the caller (compositor teardown) knows the window is gone before it
+	// releases the D3D device the thread renders with. The WM_CLOSE handler
+	// switches the DP to 2D and runs DestroyWindow, which synchronously re-enters
+	// the window proc (it reads w back from GWLP_USERDATA), so under the CTS's
+	// heavy create/destroy churn this can take a while — allow a generous timeout.
+	// If it still hasn't exited we proceed anyway: window_release() guarantees we
+	// never free w while the thread is alive (whoever finishes last frees), which
+	// eliminates the use-after-free ACCESS_VIOLATION that crashed the CTS run.
 	if (w->thread_handle != NULL) {
-		DWORD wait_result = WaitForSingleObject(w->thread_handle, 5000);
-		if (wait_result != WAIT_OBJECT_0) {
-			U_LOG_W("D3D11 window: Window thread did not exit within timeout");
+		if (WaitForSingleObject(w->thread_handle, 30000) != WAIT_OBJECT_0) {
+			U_LOG_E("D3D11 window: thread still running after 30s; deferring "
+			        "cleanup to it (no use-after-free)");
 		}
-		CloseHandle(w->thread_handle);
 	}
 
-	if (w->window_ready_event != NULL) {
-		CloseHandle(w->window_ready_event);
-	}
-
-	if (w->paint_requested_event != NULL) {
-		CloseHandle(w->paint_requested_event);
-	}
-
-	if (w->paint_done_event != NULL) {
-		CloseHandle(w->paint_done_event);
-	}
-
-	free(w);
-	*window = NULL;
+	window_release(w);
 }
 
 extern "C" void *

--- a/src/xrt/compositor/d3d12/comp_d3d12_swapchain.cpp
+++ b/src/xrt/compositor/d3d12/comp_d3d12_swapchain.cpp
@@ -214,7 +214,11 @@ comp_d3d12_swapchain_create(struct comp_d3d12_compositor *c,
 {
 	auto internals = get_internals(c);
 
-	uint32_t image_count = 3; // Triple buffering
+	// Static swapchains (XR_SWAPCHAIN_CREATE_STATIC_IMAGE_BIT) hold exactly one
+	// image and may be acquired only once (OpenXR spec); dynamic swapchains use
+	// triple buffering. (Mirrors the D3D11 fix; CTS Swapchains "Non-default
+	// create flags" otherwise saw 3 images and got XR_ERROR_CALL_ORDER_INVALID.)
+	uint32_t image_count = (info->create & XRT_SWAPCHAIN_CREATE_STATIC_IMAGE) ? 1u : 3u;
 	if (image_count > MAX_SWAPCHAIN_IMAGES) {
 		image_count = MAX_SWAPCHAIN_IMAGES;
 	}

--- a/src/xrt/state_trackers/oxr/CMakeLists.txt
+++ b/src/xrt/state_trackers/oxr/CMakeLists.txt
@@ -10,6 +10,7 @@ add_subdirectory(oxr_bindings)
 add_library(
 	st_oxr STATIC
 	oxr_api_action.c
+	oxr_api_conformance.c
 	oxr_api_funcs.h
 	oxr_api_instance.c
 	oxr_api_negotiate.c
@@ -21,6 +22,7 @@ add_library(
 	oxr_api_xdev.c
 	oxr_binding.c
 	oxr_capture.c
+	oxr_conformance.c
 	oxr_chain.h
 	oxr_dpad.c
 	oxr_event.c

--- a/src/xrt/state_trackers/oxr/oxr_api_conformance.c
+++ b/src/xrt/state_trackers/oxr/oxr_api_conformance.c
@@ -1,0 +1,200 @@
+// Copyright 2026, DisplayXR contributors.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  XR_EXT_conformance_automation entrypoint functions.
+ *
+ * Thin verification layer over @ref oxr_conformance.c. The Khronos CTS calls
+ * these to inject synthetic controller state; we validate the arguments and
+ * forward to the per-session override store.
+ *
+ * @ingroup oxr_api
+ */
+
+#include "oxr_objects.h"
+#include "oxr_logger.h"
+#include "oxr_handle.h"
+
+#include "oxr_api_funcs.h"
+#include "oxr_api_verify.h"
+
+#include <string.h>
+
+#ifdef OXR_HAVE_EXT_conformance_automation
+
+/*
+ *
+ * Argument verification helpers.
+ *
+ */
+
+//! Validate a top-level user path (e.g. /user/hand/left). Returns
+//! XR_ERROR_PATH_UNSUPPORTED for a path the runtime has no role for.
+static XrResult
+verify_top_level_path(struct oxr_logger *log, struct oxr_session *sess, XrPath top_level_path)
+{
+	struct oxr_subaction_paths paths;
+	if (top_level_path == XR_NULL_PATH) {
+		return oxr_error(log, XR_ERROR_PATH_INVALID, "(topLevelPath == XR_NULL_PATH)");
+	}
+	if (!oxr_classify_subaction_paths(log, sess->sys->inst, 1, &top_level_path, &paths)) {
+		return oxr_error(log, XR_ERROR_PATH_UNSUPPORTED, "(topLevelPath) is not a supported top-level user path");
+	}
+	return XR_SUCCESS;
+}
+
+//! Validate an input source path resolves to a string in the instance path
+//! cache. We do not require it to match a current binding — an unbound source
+//! simply never gets applied — but a malformed XrPath is rejected.
+static XrResult
+verify_source_path(struct oxr_logger *log, struct oxr_session *sess, XrPath source_path)
+{
+	const char *str = NULL;
+	size_t length = 0;
+	if (source_path == XR_NULL_PATH) {
+		return oxr_error(log, XR_ERROR_PATH_INVALID, "(inputSourcePath == XR_NULL_PATH)");
+	}
+	if (oxr_path_get_string(log, sess->sys->inst, source_path, &str, &length) != XR_SUCCESS) {
+		return oxr_error(log, XR_ERROR_PATH_INVALID, "(inputSourcePath) is not a valid path");
+	}
+	return XR_SUCCESS;
+}
+
+
+/*
+ *
+ * Entrypoints.
+ *
+ */
+
+XRAPI_ATTR XrResult XRAPI_CALL
+oxr_xrSetInputDeviceActiveEXT(XrSession session, XrPath interactionProfile, XrPath topLevelPath, XrBool32 isActive)
+{
+	struct oxr_session *sess;
+	struct oxr_logger log;
+	OXR_VERIFY_SESSION_AND_INIT_LOG(&log, session, sess, "xrSetInputDeviceActiveEXT");
+	OXR_VERIFY_EXTENSION(&log, sess->sys->inst, EXT_conformance_automation);
+
+	XrResult ret = verify_top_level_path(&log, sess, topLevelPath);
+	if (ret != XR_SUCCESS) {
+		return ret;
+	}
+	// interactionProfile may be XR_NULL_PATH (means "any"); if set, validate it.
+	if (interactionProfile != XR_NULL_PATH) {
+		const char *str = NULL;
+		size_t length = 0;
+		if (oxr_path_get_string(&log, sess->sys->inst, interactionProfile, &str, &length) != XR_SUCCESS) {
+			return oxr_error(&log, XR_ERROR_PATH_INVALID, "(interactionProfile) is not a valid path");
+		}
+	}
+
+	return oxr_conformance_set_device_active(&log, sess, topLevelPath, isActive == XR_TRUE);
+}
+
+XRAPI_ATTR XrResult XRAPI_CALL
+oxr_xrSetInputDeviceStateBoolEXT(XrSession session, XrPath topLevelPath, XrPath inputSourcePath, XrBool32 state)
+{
+	struct oxr_session *sess;
+	struct oxr_logger log;
+	OXR_VERIFY_SESSION_AND_INIT_LOG(&log, session, sess, "xrSetInputDeviceStateBoolEXT");
+	OXR_VERIFY_EXTENSION(&log, sess->sys->inst, EXT_conformance_automation);
+
+	XrResult ret = verify_top_level_path(&log, sess, topLevelPath);
+	if (ret != XR_SUCCESS) {
+		return ret;
+	}
+	ret = verify_source_path(&log, sess, inputSourcePath);
+	if (ret != XR_SUCCESS) {
+		return ret;
+	}
+
+	union xrt_input_value value;
+	memset(&value, 0, sizeof(value));
+	value.boolean = state == XR_TRUE;
+	return oxr_conformance_set_input_value(&log, sess, topLevelPath, inputSourcePath, XRT_INPUT_TYPE_BOOLEAN, value);
+}
+
+XRAPI_ATTR XrResult XRAPI_CALL
+oxr_xrSetInputDeviceStateFloatEXT(XrSession session, XrPath topLevelPath, XrPath inputSourcePath, float state)
+{
+	struct oxr_session *sess;
+	struct oxr_logger log;
+	OXR_VERIFY_SESSION_AND_INIT_LOG(&log, session, sess, "xrSetInputDeviceStateFloatEXT");
+	OXR_VERIFY_EXTENSION(&log, sess->sys->inst, EXT_conformance_automation);
+
+	XrResult ret = verify_top_level_path(&log, sess, topLevelPath);
+	if (ret != XR_SUCCESS) {
+		return ret;
+	}
+	ret = verify_source_path(&log, sess, inputSourcePath);
+	if (ret != XR_SUCCESS) {
+		return ret;
+	}
+
+	union xrt_input_value value;
+	memset(&value, 0, sizeof(value));
+	value.vec1.x = state;
+	return oxr_conformance_set_input_value(&log, sess, topLevelPath, inputSourcePath,
+	                                       XRT_INPUT_TYPE_VEC1_ZERO_TO_ONE, value);
+}
+
+XRAPI_ATTR XrResult XRAPI_CALL
+oxr_xrSetInputDeviceStateVector2fEXT(XrSession session, XrPath topLevelPath, XrPath inputSourcePath, XrVector2f state)
+{
+	struct oxr_session *sess;
+	struct oxr_logger log;
+	OXR_VERIFY_SESSION_AND_INIT_LOG(&log, session, sess, "xrSetInputDeviceStateVector2fEXT");
+	OXR_VERIFY_EXTENSION(&log, sess->sys->inst, EXT_conformance_automation);
+
+	XrResult ret = verify_top_level_path(&log, sess, topLevelPath);
+	if (ret != XR_SUCCESS) {
+		return ret;
+	}
+	ret = verify_source_path(&log, sess, inputSourcePath);
+	if (ret != XR_SUCCESS) {
+		return ret;
+	}
+
+	union xrt_input_value value;
+	memset(&value, 0, sizeof(value));
+	value.vec2.x = state.x;
+	value.vec2.y = state.y;
+	return oxr_conformance_set_input_value(&log, sess, topLevelPath, inputSourcePath,
+	                                       XRT_INPUT_TYPE_VEC2_MINUS_ONE_TO_ONE, value);
+}
+
+XRAPI_ATTR XrResult XRAPI_CALL
+oxr_xrSetInputDeviceLocationEXT(
+    XrSession session, XrPath topLevelPath, XrPath inputSourcePath, XrSpace space, XrPosef pose)
+{
+	struct oxr_session *sess;
+	struct oxr_logger log;
+	OXR_VERIFY_SESSION_AND_INIT_LOG(&log, session, sess, "xrSetInputDeviceLocationEXT");
+	OXR_VERIFY_EXTENSION(&log, sess->sys->inst, EXT_conformance_automation);
+
+	XrResult ret = verify_top_level_path(&log, sess, topLevelPath);
+	if (ret != XR_SUCCESS) {
+		return ret;
+	}
+	ret = verify_source_path(&log, sess, inputSourcePath);
+	if (ret != XR_SUCCESS) {
+		return ret;
+	}
+	OXR_VERIFY_ARG_NOT_ZERO(&log, space);
+
+	// NOTE: the pose is interpreted relative to the runtime's tracking origin.
+	// Resolving it through the supplied XrSpace is a refinement to validate
+	// against CTS pose tests on Windows (see handoff notes).
+	struct xrt_pose xpose;
+	xpose.position.x = pose.position.x;
+	xpose.position.y = pose.position.y;
+	xpose.position.z = pose.position.z;
+	xpose.orientation.x = pose.orientation.x;
+	xpose.orientation.y = pose.orientation.y;
+	xpose.orientation.z = pose.orientation.z;
+	xpose.orientation.w = pose.orientation.w;
+
+	return oxr_conformance_set_input_pose(&log, sess, topLevelPath, inputSourcePath, xpose);
+}
+
+#endif // OXR_HAVE_EXT_conformance_automation

--- a/src/xrt/state_trackers/oxr/oxr_api_funcs.h
+++ b/src/xrt/state_trackers/oxr/oxr_api_funcs.h
@@ -1032,6 +1032,29 @@ XRAPI_ATTR XrResult XRAPI_CALL
 oxr_xrDestroyLocal3DZoneMaskEXT(XrLocal3DZoneMaskEXT mask);
 #endif
 
+#ifdef OXR_HAVE_EXT_conformance_automation
+//! OpenXR API function @ep{xrSetInputDeviceActiveEXT}
+XRAPI_ATTR XrResult XRAPI_CALL
+oxr_xrSetInputDeviceActiveEXT(XrSession session, XrPath interactionProfile, XrPath topLevelPath, XrBool32 isActive);
+
+//! OpenXR API function @ep{xrSetInputDeviceStateBoolEXT}
+XRAPI_ATTR XrResult XRAPI_CALL
+oxr_xrSetInputDeviceStateBoolEXT(XrSession session, XrPath topLevelPath, XrPath inputSourcePath, XrBool32 state);
+
+//! OpenXR API function @ep{xrSetInputDeviceStateFloatEXT}
+XRAPI_ATTR XrResult XRAPI_CALL
+oxr_xrSetInputDeviceStateFloatEXT(XrSession session, XrPath topLevelPath, XrPath inputSourcePath, float state);
+
+//! OpenXR API function @ep{xrSetInputDeviceStateVector2fEXT}
+XRAPI_ATTR XrResult XRAPI_CALL
+oxr_xrSetInputDeviceStateVector2fEXT(XrSession session, XrPath topLevelPath, XrPath inputSourcePath, XrVector2f state);
+
+//! OpenXR API function @ep{xrSetInputDeviceLocationEXT}
+XRAPI_ATTR XrResult XRAPI_CALL
+oxr_xrSetInputDeviceLocationEXT(
+    XrSession session, XrPath topLevelPath, XrPath inputSourcePath, XrSpace space, XrPosef pose);
+#endif
+
 /*!
  * @}
  */

--- a/src/xrt/state_trackers/oxr/oxr_api_negotiate.c
+++ b/src/xrt/state_trackers/oxr/oxr_api_negotiate.c
@@ -505,6 +505,14 @@ handle_non_null(struct oxr_instance *inst, struct oxr_logger *log, const char *n
 	ENTRY_IF_EXT(xrSubmitMCPToolResultEXT, EXT_mcp_tools);
 #endif
 
+#ifdef OXR_HAVE_EXT_conformance_automation
+	ENTRY_IF_EXT(xrSetInputDeviceActiveEXT, EXT_conformance_automation);
+	ENTRY_IF_EXT(xrSetInputDeviceStateBoolEXT, EXT_conformance_automation);
+	ENTRY_IF_EXT(xrSetInputDeviceStateFloatEXT, EXT_conformance_automation);
+	ENTRY_IF_EXT(xrSetInputDeviceStateVector2fEXT, EXT_conformance_automation);
+	ENTRY_IF_EXT(xrSetInputDeviceLocationEXT, EXT_conformance_automation);
+#endif
+
 	// xrSetSharedTextureOutputRectEXT — canvas sub-rect, part of window binding extensions
 #ifdef OXR_HAVE_EXT_win32_window_binding
 	ENTRY_IF_EXT(xrSetSharedTextureOutputRectEXT, EXT_win32_window_binding);

--- a/src/xrt/state_trackers/oxr/oxr_api_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_api_session.c
@@ -15,6 +15,8 @@
 #include "math/m_space.h"
 #include "xrt/xrt_compiler.h"
 
+#include "os/os_threading.h"
+
 #include "util/u_debug.h"
 #include "util/u_trace_marker.h"
 
@@ -74,12 +76,14 @@ oxr_xrCreateSession(XrInstance instance, const XrSessionCreateInfo *createInfo, 
 
 	*out_session = oxr_session_to_openxr(sess);
 
-	/* Add to session list */
+	/* Add to session list (under lock — concurrent with poll/destroy). */
+	os_mutex_lock(&inst->sessions_mutex);
 	link = &inst->sessions;
 	while (*link) {
 		link = &(*link)->next;
 	}
 	*link = sess;
+	os_mutex_unlock(&inst->sessions_mutex);
 
 	return XR_SUCCESS;
 }
@@ -95,13 +99,17 @@ oxr_xrDestroySession(XrSession session)
 	struct oxr_logger log;
 	OXR_VERIFY_SESSION_AND_INIT_LOG(&log, session, sess, "xrDestroySession");
 
-	/* Remove from session list */
+	/* Remove from the session list under lock BEFORE freeing the session, so a
+	 * concurrent oxr_poll_event walk never reaches a freed session. The actual
+	 * teardown runs outside the lock — once unlinked, no walker can reach it. */
 	inst = sess->sys->inst;
+	os_mutex_lock(&inst->sessions_mutex);
 	link = &inst->sessions;
 	while (*link != sess) {
 		link = &(*link)->next;
 	}
 	*link = sess->next;
+	os_mutex_unlock(&inst->sessions_mutex);
 
 	return oxr_handle_destroy(&log, &sess->handle);
 }

--- a/src/xrt/state_trackers/oxr/oxr_conformance.c
+++ b/src/xrt/state_trackers/oxr/oxr_conformance.c
@@ -1,0 +1,287 @@
+// Copyright 2026, DisplayXR contributors.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  Synthetic-input backend for XR_EXT_conformance_automation.
+ *
+ * The Khronos OpenXR Conformance Test Suite (CTS) injects controller state
+ * through this extension so it can drive the action/input pipeline without a
+ * human pressing buttons. We store the injected state per @ref oxr_session and
+ * apply it inside xrSyncActions / the action-space locate path.
+ *
+ * Design: overrides are keyed by `source_path`, which is the suggested-binding
+ * path the CTS passes as `inputSourcePath`. That same XrPath is stored on each
+ * resolved input as @ref oxr_action_input::bound_path, so the apply side is a
+ * direct XrPath compare — no reverse mapping from path to a device input index.
+ *
+ * Lifetime: all state lives in @ref oxr_session::conformance and is freed with
+ * the session (see @ref oxr_conformance_teardown). Nothing is process-global —
+ * the CTS creates and destroys the runtime hundreds of times per run.
+ *
+ * @ingroup oxr_main
+ */
+
+#include "oxr_objects.h"
+#include "oxr_logger.h"
+
+#include "os/os_threading.h"
+#include "os/os_time.h"
+
+#include <string.h>
+
+/*
+ *
+ * Helpers.
+ *
+ */
+
+//! Is the conformance extension enabled and the state ready to use?
+static bool
+conformance_enabled(struct oxr_session *sess)
+{
+	return sess != NULL && sess->sys->inst->extensions.EXT_conformance_automation && sess->conformance.inited;
+}
+
+//! Caller must hold the conformance mutex.
+static bool
+device_is_active(struct oxr_conformance_state *c, XrPath top_level_path)
+{
+	for (size_t i = 0; i < c->active_device_count; i++) {
+		if (c->active_devices[i] == top_level_path) {
+			return true;
+		}
+	}
+	return false;
+}
+
+//! Caller must hold the conformance mutex. Finds an existing override for
+//! @p source_path, or the first free slot, or NULL if the table is full.
+static struct oxr_conformance_override *
+find_or_alloc_override(struct oxr_conformance_state *c, XrPath source_path)
+{
+	struct oxr_conformance_override *free_slot = NULL;
+	for (size_t i = 0; i < OXR_MAX_CONFORMANCE_OVERRIDES; i++) {
+		struct oxr_conformance_override *o = &c->overrides[i];
+		if (o->used && o->source_path == source_path) {
+			return o;
+		}
+		if (!o->used && free_slot == NULL) {
+			free_slot = o;
+		}
+	}
+	return free_slot;
+}
+
+
+/*
+ *
+ * Lifecycle.
+ *
+ */
+
+XrResult
+oxr_conformance_init(struct oxr_logger *log, struct oxr_session *sess)
+{
+	struct oxr_conformance_state *c = &sess->conformance;
+	if (c->inited) {
+		return XR_SUCCESS;
+	}
+
+	int ret = os_mutex_init(&c->mutex);
+	if (ret != 0) {
+		return oxr_error(log, XR_ERROR_RUNTIME_FAILURE,
+		                 "Failed to init conformance-automation mutex (%i)", ret);
+	}
+
+	c->active_device_count = 0;
+	memset(c->overrides, 0, sizeof(c->overrides));
+	c->inited = true;
+	return XR_SUCCESS;
+}
+
+void
+oxr_conformance_teardown(struct oxr_session *sess)
+{
+	struct oxr_conformance_state *c = &sess->conformance;
+	if (!c->inited) {
+		return;
+	}
+	os_mutex_destroy(&c->mutex);
+	c->inited = false;
+	c->active_device_count = 0;
+	memset(c->overrides, 0, sizeof(c->overrides));
+}
+
+
+/*
+ *
+ * Setters (called from the API entry points).
+ *
+ */
+
+XrResult
+oxr_conformance_set_device_active(
+    struct oxr_logger *log, struct oxr_session *sess, XrPath top_level_path, bool active)
+{
+	XrResult res = oxr_conformance_init(log, sess);
+	if (res != XR_SUCCESS) {
+		return res;
+	}
+	struct oxr_conformance_state *c = &sess->conformance;
+
+	os_mutex_lock(&c->mutex);
+
+	bool present = device_is_active(c, top_level_path);
+	if (active && !present) {
+		if (c->active_device_count >= OXR_MAX_CONFORMANCE_DEVICES) {
+			os_mutex_unlock(&c->mutex);
+			return oxr_error(log, XR_ERROR_RUNTIME_FAILURE,
+			                 "conformance-automation active-device table full");
+		}
+		c->active_devices[c->active_device_count++] = top_level_path;
+	} else if (!active && present) {
+		// Compact the array, preserving order is unimportant.
+		for (size_t i = 0; i < c->active_device_count; i++) {
+			if (c->active_devices[i] == top_level_path) {
+				c->active_devices[i] = c->active_devices[c->active_device_count - 1];
+				c->active_device_count--;
+				break;
+			}
+		}
+	}
+
+	os_mutex_unlock(&c->mutex);
+	return XR_SUCCESS;
+}
+
+XrResult
+oxr_conformance_set_input_value(struct oxr_logger *log,
+                                struct oxr_session *sess,
+                                XrPath top_level_path,
+                                XrPath source_path,
+                                enum xrt_input_type type,
+                                union xrt_input_value value)
+{
+	XrResult res = oxr_conformance_init(log, sess);
+	if (res != XR_SUCCESS) {
+		return res;
+	}
+	struct oxr_conformance_state *c = &sess->conformance;
+
+	os_mutex_lock(&c->mutex);
+
+	struct oxr_conformance_override *o = find_or_alloc_override(c, source_path);
+	if (o == NULL) {
+		os_mutex_unlock(&c->mutex);
+		return oxr_error(log, XR_ERROR_RUNTIME_FAILURE, "conformance-automation override table full");
+	}
+
+	o->used = true;
+	o->top_level_path = top_level_path;
+	o->source_path = source_path;
+	o->type = type;
+	o->value = value;
+	o->is_pose = false;
+	// Monotonic-ish timestamp so lastChangeTime advances on each set.
+	o->timestamp = os_monotonic_get_ns();
+
+	os_mutex_unlock(&c->mutex);
+	return XR_SUCCESS;
+}
+
+XrResult
+oxr_conformance_set_input_pose(struct oxr_logger *log,
+                               struct oxr_session *sess,
+                               XrPath top_level_path,
+                               XrPath source_path,
+                               struct xrt_pose pose)
+{
+	XrResult res = oxr_conformance_init(log, sess);
+	if (res != XR_SUCCESS) {
+		return res;
+	}
+	struct oxr_conformance_state *c = &sess->conformance;
+
+	os_mutex_lock(&c->mutex);
+
+	struct oxr_conformance_override *o = find_or_alloc_override(c, source_path);
+	if (o == NULL) {
+		os_mutex_unlock(&c->mutex);
+		return oxr_error(log, XR_ERROR_RUNTIME_FAILURE, "conformance-automation override table full");
+	}
+
+	o->used = true;
+	o->top_level_path = top_level_path;
+	o->source_path = source_path;
+	o->is_pose = true;
+	o->pose.pose = pose;
+	o->pose.relation_flags = XRT_SPACE_RELATION_ORIENTATION_VALID_BIT | XRT_SPACE_RELATION_POSITION_VALID_BIT |
+	                         XRT_SPACE_RELATION_ORIENTATION_TRACKED_BIT | XRT_SPACE_RELATION_POSITION_TRACKED_BIT;
+	o->timestamp = os_monotonic_get_ns();
+
+	os_mutex_unlock(&c->mutex);
+	return XR_SUCCESS;
+}
+
+
+/*
+ *
+ * Lookups (called from the xrSyncActions / locate hot paths).
+ *
+ */
+
+bool
+oxr_conformance_lookup_value(struct oxr_session *sess,
+                             XrPath source_path,
+                             union xrt_input_value *out_value,
+                             int64_t *out_timestamp)
+{
+	if (!conformance_enabled(sess) || source_path == XR_NULL_PATH) {
+		return false;
+	}
+	struct oxr_conformance_state *c = &sess->conformance;
+
+	bool found = false;
+	os_mutex_lock(&c->mutex);
+	for (size_t i = 0; i < OXR_MAX_CONFORMANCE_OVERRIDES; i++) {
+		struct oxr_conformance_override *o = &c->overrides[i];
+		if (!o->used || o->is_pose || o->source_path != source_path) {
+			continue;
+		}
+		if (!device_is_active(c, o->top_level_path)) {
+			break; // Override exists but its device is inactive; suppress.
+		}
+		*out_value = o->value;
+		*out_timestamp = o->timestamp;
+		found = true;
+		break;
+	}
+	os_mutex_unlock(&c->mutex);
+	return found;
+}
+
+bool
+oxr_conformance_lookup_pose(struct oxr_session *sess, XrPath source_path, struct xrt_space_relation *out_relation)
+{
+	if (!conformance_enabled(sess) || source_path == XR_NULL_PATH) {
+		return false;
+	}
+	struct oxr_conformance_state *c = &sess->conformance;
+
+	bool found = false;
+	os_mutex_lock(&c->mutex);
+	for (size_t i = 0; i < OXR_MAX_CONFORMANCE_OVERRIDES; i++) {
+		struct oxr_conformance_override *o = &c->overrides[i];
+		if (!o->used || !o->is_pose || o->source_path != source_path) {
+			continue;
+		}
+		if (!device_is_active(c, o->top_level_path)) {
+			break;
+		}
+		*out_relation = o->pose;
+		found = true;
+		break;
+	}
+	os_mutex_unlock(&c->mutex);
+	return found;
+}

--- a/src/xrt/state_trackers/oxr/oxr_event.c
+++ b/src/xrt/state_trackers/oxr/oxr_event.c
@@ -600,23 +600,35 @@ oxr_event_remove_session_events(struct oxr_logger *log, struct oxr_session *sess
 
 	lock(inst);
 
+	// Walk the queue removing this session's events, keeping `prev` pointed at
+	// the last KEPT node so the list is correctly relinked. The old code only
+	// fixed event.next/last and never updated the predecessor's ->next, so
+	// removing a *middle* event left a dangling ->next to freed memory — a later
+	// walk/pop then read a freed-and-reused node (use-after-free). The CTS
+	// multithreading test intersperses events from rapid session create/destroy,
+	// so it routinely removes middle events and hit this.
+	struct oxr_event *prev = NULL;
 	struct oxr_event *e = inst->event.next;
 	while (e != NULL) {
 		struct oxr_event *cur = e;
 		e = e->next;
 
 		if (!is_session_link_to_event(cur, session)) {
+			prev = cur;
 			continue;
 		}
 
-		if (cur == inst->event.next) {
+		// Unlink cur from the list.
+		if (prev != NULL) {
+			prev->next = cur->next;
+		} else {
 			inst->event.next = cur->next;
 		}
-
 		if (cur == inst->event.last) {
-			inst->event.last = NULL;
+			inst->event.last = prev;
 		}
 		free(cur);
+		// prev stays the same — cur is gone.
 	}
 
 	unlock(inst);

--- a/src/xrt/state_trackers/oxr/oxr_event.c
+++ b/src/xrt/state_trackers/oxr/oxr_event.c
@@ -627,17 +627,23 @@ oxr_event_remove_session_events(struct oxr_logger *log, struct oxr_session *sess
 XrResult
 oxr_poll_event(struct oxr_logger *log, struct oxr_instance *inst, XrEventDataBuffer *eventData)
 {
-	struct oxr_session *sess = inst->sessions;
 	XrResult ret;
 
-	while (sess) {
+	// Walk the session list under its lock so a concurrent xrCreateSession /
+	// xrDestroySession can't mutate the list or free a session mid-walk. The
+	// CTS multithreading test calls all three from different threads at once;
+	// without this the walk reads a freed session's ->next -> heap corruption.
+	// oxr_session_poll is non-blocking on this path, so holding the lock across
+	// it does not meaningfully stall create/destroy.
+	os_mutex_lock(&inst->sessions_mutex);
+	for (struct oxr_session *sess = inst->sessions; sess != NULL; sess = sess->next) {
 		ret = oxr_session_poll(log, sess);
 		if (ret != XR_SUCCESS) {
+			os_mutex_unlock(&inst->sessions_mutex);
 			return ret;
 		}
-
-		sess = sess->next;
 	}
+	os_mutex_unlock(&inst->sessions_mutex);
 
 	lock(inst);
 	struct oxr_event *event = pop(inst);

--- a/src/xrt/state_trackers/oxr/oxr_extension_support.h
+++ b/src/xrt/state_trackers/oxr/oxr_extension_support.h
@@ -358,6 +358,18 @@
 
 
 /*
+ * XR_EXT_conformance_automation
+ */
+#if defined(XR_EXT_conformance_automation)
+#define OXR_HAVE_EXT_conformance_automation
+#define OXR_EXTENSION_SUPPORT_EXT_conformance_automation(_) \
+    _(EXT_conformance_automation, EXT_CONFORMANCE_AUTOMATION)
+#else
+#define OXR_EXTENSION_SUPPORT_EXT_conformance_automation(_)
+#endif
+
+
+/*
  * XR_EXT_dpad_binding
  */
 #if defined(XR_EXT_dpad_binding)
@@ -1091,6 +1103,7 @@
     OXR_EXTENSION_SUPPORT_KHR_vulkan_swapchain_format_list(_) \
     OXR_EXTENSION_SUPPORT_KHR_win32_convert_performance_counter_time(_) \
     OXR_EXTENSION_SUPPORT_EXT_active_action_set_priority(_) \
+    OXR_EXTENSION_SUPPORT_EXT_conformance_automation(_) \
     OXR_EXTENSION_SUPPORT_EXT_debug_utils(_) \
     OXR_EXTENSION_SUPPORT_EXT_dpad_binding(_) \
     OXR_EXTENSION_SUPPORT_EXT_eye_gaze_interaction(_) \

--- a/src/xrt/state_trackers/oxr/oxr_input.c
+++ b/src/xrt/state_trackers/oxr/oxr_input.c
@@ -1050,9 +1050,16 @@ oxr_input_combine_input(struct oxr_session *sess,
 			continue;
 		}
 
+		// XR_EXT_conformance_automation: the CTS may have injected a
+		// synthetic value for this bound source. Returns false (no copy)
+		// when the extension is disabled, so non-CTS sessions pay one bool.
+		union xrt_input_value eff_value = input->value;
+		int64_t eff_timestamp = input->timestamp;
+		oxr_conformance_lookup_value(sess, action_input->bound_path, &eff_value, &eff_timestamp);
+
 		struct oxr_input_value_tagged raw_input = {
 		    .type = XRT_GET_INPUT_TYPE(input->name),
-		    .value = input->value,
+		    .value = eff_value,
 		};
 
 		struct oxr_input_value_tagged transformed = {0};
@@ -1075,18 +1082,18 @@ oxr_input_combine_input(struct oxr_session *sess,
 			 * OR. The action only changes to true on the earliest
 			 * input that sets it to true, and to false on the
 			 * latest input that is false. */
-			if (res.value.boolean && transformed.value.boolean && input->timestamp < res_timestamp) {
-				res_timestamp = input->timestamp;
+			if (res.value.boolean && transformed.value.boolean && eff_timestamp < res_timestamp) {
+				res_timestamp = eff_timestamp;
 			} else if (!res.value.boolean && !transformed.value.boolean &&
-			           input->timestamp > res_timestamp) {
-				res_timestamp = input->timestamp;
+			           eff_timestamp > res_timestamp) {
+				res_timestamp = eff_timestamp;
 			}
 			break;
 		case XRT_INPUT_TYPE_VEC1_MINUS_ONE_TO_ONE:
 		case XRT_INPUT_TYPE_VEC1_ZERO_TO_ONE:
 			if (fabsf(transformed.value.vec1.x) > fabsf(res.value.vec1.x)) {
 				res.value.vec1.x = transformed.value.vec1.x;
-				res_timestamp = input->timestamp;
+				res_timestamp = eff_timestamp;
 			}
 			break;
 		case XRT_INPUT_TYPE_VEC2_MINUS_ONE_TO_ONE: {
@@ -1095,7 +1102,7 @@ oxr_input_combine_input(struct oxr_session *sess,
 			                 transformed.value.vec2.y * transformed.value.vec2.y;
 			if (trans_sq > res_sq) {
 				res.value.vec2 = transformed.value.vec2;
-				res_timestamp = input->timestamp;
+				res_timestamp = eff_timestamp;
 			}
 		} break;
 		case XRT_INPUT_TYPE_VEC3_MINUS_ONE_TO_ONE:

--- a/src/xrt/state_trackers/oxr/oxr_instance.c
+++ b/src/xrt/state_trackers/oxr/oxr_instance.c
@@ -157,6 +157,7 @@ oxr_instance_destroy(struct oxr_logger *log, struct oxr_handle_base *hb)
 	time_state_destroy(&inst->timekeeping);
 
 	// Mutex goes last.
+	os_mutex_destroy(&inst->sessions_mutex);
 	os_mutex_destroy(&inst->event.mutex);
 
 	// Keep the allocation alive as a tombstone so that post-destroy
@@ -350,6 +351,12 @@ oxr_instance_create(struct oxr_logger *log,
 	m_ret = os_mutex_init(&inst->event.mutex);
 	if (m_ret < 0) {
 		ret = oxr_error(log, XR_ERROR_RUNTIME_FAILURE, "Failed to init mutex");
+		return ret;
+	}
+
+	m_ret = os_mutex_init(&inst->sessions_mutex);
+	if (m_ret < 0) {
+		ret = oxr_error(log, XR_ERROR_RUNTIME_FAILURE, "Failed to init sessions mutex");
 		return ret;
 	}
 

--- a/src/xrt/state_trackers/oxr/oxr_objects.h
+++ b/src/xrt/state_trackers/oxr/oxr_objects.h
@@ -2083,6 +2083,13 @@ struct oxr_instance
 
 	struct oxr_session *sessions;
 
+	//! Guards the @ref sessions linked list. xrCreateSession appends,
+	//! xrDestroySession unlinks, and oxr_poll_event walks it — the CTS
+	//! multithreading test does all three concurrently, so the walk must not
+	//! race a concurrent unlink+free (heap corruption). Held across the
+	//! per-session poll, which is non-blocking on this path.
+	struct os_mutex sessions_mutex;
+
 	struct
 	{
 

--- a/src/xrt/state_trackers/oxr/oxr_objects.h
+++ b/src/xrt/state_trackers/oxr/oxr_objects.h
@@ -510,6 +510,93 @@ oxr_action_get_pose_input(struct oxr_session *sess,
                           const struct oxr_subaction_paths *subaction_paths_ptr,
                           struct oxr_action_input **out_input);
 
+
+/*
+ *
+ * oxr_conformance.c — XR_EXT_conformance_automation synthetic input.
+ *
+ */
+
+/*!
+ * Lazily initialize the session's conformance-automation state (mutex etc.).
+ * Idempotent. Called from the entry points before mutating state.
+ *
+ * @public @memberof oxr_session
+ */
+XrResult
+oxr_conformance_init(struct oxr_logger *log, struct oxr_session *sess);
+
+/*!
+ * Tear down the conformance-automation state. Safe to call on a session that
+ * never used the extension (no-op when not inited).
+ *
+ * @public @memberof oxr_session
+ */
+void
+oxr_conformance_teardown(struct oxr_session *sess);
+
+/*!
+ * Mark a top-level user path (device) active/inactive — xrSetInputDeviceActiveEXT.
+ *
+ * @public @memberof oxr_session
+ */
+XrResult
+oxr_conformance_set_device_active(
+    struct oxr_logger *log, struct oxr_session *sess, XrPath top_level_path, bool active);
+
+/*!
+ * Store a synthetic value (bool/float/vec2) for an input source — the
+ * xrSetInputDeviceState*EXT family. @p type selects the union member in @p value.
+ *
+ * @public @memberof oxr_session
+ */
+XrResult
+oxr_conformance_set_input_value(struct oxr_logger *log,
+                                struct oxr_session *sess,
+                                XrPath top_level_path,
+                                XrPath source_path,
+                                enum xrt_input_type type,
+                                union xrt_input_value value);
+
+/*!
+ * Store a synthetic pose for an input source — xrSetInputDeviceLocationEXT.
+ *
+ * @public @memberof oxr_session
+ */
+XrResult
+oxr_conformance_set_input_pose(struct oxr_logger *log,
+                               struct oxr_session *sess,
+                               XrPath top_level_path,
+                               XrPath source_path,
+                               struct xrt_pose pose);
+
+/*!
+ * Look up a value override for a bound input source. Returns true and fills the
+ * out params when an override applies (extension enabled, override present, and
+ * the owning device marked active). Called from the xrSyncActions hot path —
+ * returns false immediately when the extension is disabled.
+ *
+ * @public @memberof oxr_session
+ */
+bool
+oxr_conformance_lookup_value(struct oxr_session *sess,
+                             XrPath source_path,
+                             union xrt_input_value *out_value,
+                             int64_t *out_timestamp);
+
+/*!
+ * Look up a pose override for a bound input source. Returns true and fills
+ * @p out_relation when a pose override applies. Hot-path safe like
+ * @ref oxr_conformance_lookup_value.
+ *
+ * @public @memberof oxr_session
+ */
+bool
+oxr_conformance_lookup_pose(struct oxr_session *sess,
+                            XrPath source_path,
+                            struct xrt_space_relation *out_relation);
+
+
 /*!
  * @public @memberof oxr_instance
  */
@@ -2099,6 +2186,63 @@ struct oxr_view_rig_state
 };
 
 /*!
+ * Maximum number of distinct input sources the conformance-automation
+ * extension (@ref XR_EXT_conformance_automation) can hold synthetic state for
+ * at once. The CTS drives only a handful of sources per session; this is a
+ * generous bound.
+ */
+#define OXR_MAX_CONFORMANCE_OVERRIDES 64
+
+/*!
+ * Maximum number of top-level user paths (e.g. /user/hand/left) the
+ * conformance-automation extension tracks an active/inactive flag for.
+ */
+#define OXR_MAX_CONFORMANCE_DEVICES 8
+
+/*!
+ * One synthetic input value injected via @ref XR_EXT_conformance_automation.
+ * Keyed by @ref source_path which equals the suggested-binding path the CTS
+ * passes as `inputSourcePath` — the same value stored in
+ * @ref oxr_action_input::bound_path, so no reverse path→device mapping is
+ * needed.
+ *
+ * @ingroup oxr_input
+ */
+struct oxr_conformance_override
+{
+	bool used;
+	XrPath top_level_path; //!< Owning device, e.g. /user/hand/left.
+	XrPath source_path;    //!< Matches @ref oxr_action_input::bound_path.
+
+	enum xrt_input_type type;
+	union xrt_input_value value;
+	int64_t timestamp;
+
+	bool is_pose;                   //!< True for xrSetInputDeviceLocationEXT.
+	struct xrt_space_relation pose; //!< Synthetic pose when @ref is_pose.
+};
+
+/*!
+ * Per-session synthetic-input state for @ref XR_EXT_conformance_automation.
+ * Lives inside @ref oxr_session so it is created and freed with the session —
+ * the CTS loads and unloads the runtime hundreds of times, so no state may
+ * outlive the instance (see ADR notes / legacy-monado teardown race).
+ *
+ * @ingroup oxr_input
+ */
+struct oxr_conformance_state
+{
+	bool inited;
+	struct os_mutex mutex; //!< Guards all fields below vs xrSyncActions.
+
+	//! Top-level paths the CTS has marked active via xrSetInputDeviceActiveEXT.
+	XrPath active_devices[OXR_MAX_CONFORMANCE_DEVICES];
+	size_t active_device_count;
+
+	struct oxr_conformance_override overrides[OXR_MAX_CONFORMANCE_OVERRIDES];
+};
+
+/*!
  * Object that client program interact with.
  *
  * Parent type/handle is @ref oxr_instance
@@ -2306,6 +2450,11 @@ struct oxr_session
 	struct xrt_space_relation local_space_pure_relation;
 
 	bool has_lost;
+
+	//! Synthetic-input state for XR_EXT_conformance_automation (CTS).
+	//! Only touched when the extension is enabled; @ref oxr_conformance_state::inited
+	//! is false otherwise.
+	struct oxr_conformance_state conformance;
 
 #ifdef XRT_OS_WINDOWS
 	/*!

--- a/src/xrt/state_trackers/oxr/oxr_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_session.c
@@ -3661,9 +3661,7 @@ oxr_session_get_visibility_mask(struct oxr_logger *log,
                                 XrVisibilityMaskKHR *visibilityMask)
 {
 	struct oxr_system *sys = sess->sys;
-	struct xrt_device *xdev = GET_XDEV_BY_ROLE(sess->sys, head);
 	enum xrt_visibility_mask_type type = convert_mask_type(visibilityMaskType);
-	xrt_result_t xret;
 
 	assert(viewIndex < ARRAY_SIZE(sys->visibility_mask));
 
@@ -3676,15 +3674,16 @@ oxr_session_get_visibility_mask(struct oxr_logger *log,
 		sys->visibility_mask[viewIndex] = NULL;
 	}
 
-	// If we didn't have any cached mask get it.
+	// If we didn't have any cached mask, build one. DisplayXR drives flat
+	// panels with no lens occlusion, so nothing is hidden and the whole view is
+	// visible — represented as an empty mask. (The head device's FoV-scaled
+	// default mask is invalid for the off-axis Kooima projection: its winding
+	// fails the CTS counter-clockwise-around-origin check.)
 	if (mask == NULL) {
-		xret = xrt_device_get_visibility_mask(xdev, type, viewIndex, &mask);
-		if (xret == XRT_ERROR_NOT_IMPLEMENTED && xdev->hmd != NULL) {
-			const struct xrt_fov fov = xdev->hmd->distortion.fov[viewIndex];
-			u_visibility_mask_get_default(type, &fov, &mask);
-			xret = XRT_SUCCESS;
+		u_visibility_mask_get_empty(type, &mask);
+		if (mask == NULL) {
+			return oxr_error(log, XR_ERROR_RUNTIME_FAILURE, "failed to allocate visibility mask");
 		}
-		OXR_CHECK_XRET(log, sess, xret, get_visibility_mask);
 		sys->visibility_mask[viewIndex] = mask;
 	}
 

--- a/src/xrt/state_trackers/oxr/oxr_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_session.c
@@ -660,14 +660,18 @@ oxr_session_begin(struct oxr_logger *log, struct oxr_session *sess, const XrSess
 			sess->compositor_focused = true;
 		}
 
-		// Trigger state transitions if visibility/focus flags are set.
-		// AppContainer apps: delay VISIBLE/FOCUSED until first xrWaitFrame.
-		if (sess->compositor_visible && sess->compositor_focused) {
+		// AppContainer (WebXR) keeps the begin-time SYNCHRONIZED shortcut; its
+		// VISIBLE/FOCUSED are completed later (do_synchronize_state_change / the
+		// poll loop). Normal graphics apps must NOT advance past READY here: per
+		// the OpenXR spec the runtime may only move READY->SYNCHRONIZED once the
+		// app begins its frame loop. oxr_session_frame_begin() fires that
+		// transition on the first xrBeginFrame, and the xrPollEvent loop then
+		// advances SYNCHRONIZED->VISIBLE->FOCUSED (every native compositor sets
+		// initial_visible/focused = true). Firing the whole chain here was the
+		// CTS SessionState failure: "must not move from READY to SYNCHRONIZED
+		// without submitting frames".
+		if (sess->is_appcontainer && sess->compositor_visible && sess->compositor_focused) {
 			oxr_session_change_state(log, sess, XR_SESSION_STATE_SYNCHRONIZED, 0);
-			if (!sess->is_appcontainer) {
-				oxr_session_change_state(log, sess, XR_SESSION_STATE_VISIBLE, 0);
-				oxr_session_change_state(log, sess, XR_SESSION_STATE_FOCUSED, 0);
-			}
 		}
 	} else {
 		// Headless, pretend we got event from the compositor.
@@ -2472,6 +2476,17 @@ oxr_session_frame_begin(struct oxr_logger *log, struct oxr_session *sess)
 	if (XR_SUCCESS != osh_ret) {
 		U_LOG_W("[frame_begin] frame_sync_release FAILED: %d", (int)osh_ret);
 		return osh_ret;
+	}
+
+	// First xrBeginFrame: synchronize the session. The OpenXR spec requires
+	// READY->SYNCHRONIZED only once the app begins its frame loop (not at
+	// xrBeginSession). Trigger here, on begin-frame, rather than on a successful
+	// xrEndFrame, so an app that submits an empty/zero-size first frame while not
+	// yet visible still progresses; the xrPollEvent loop then advances
+	// SYNCHRONIZED->VISIBLE->FOCUSED. AppContainer/WebXR keeps its begin-time
+	// path; headless (xc==NULL) synchronizes at xrBeginSession.
+	if (xc != NULL && !sess->is_appcontainer && sess->state == XR_SESSION_STATE_READY) {
+		oxr_session_change_state(log, sess, XR_SESSION_STATE_SYNCHRONIZED, 0);
 	}
 
 	return ret;

--- a/src/xrt/state_trackers/oxr/oxr_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_session.c
@@ -2500,6 +2500,11 @@ oxr_session_destroy(struct oxr_logger *log, struct oxr_handle_base *hb)
 	oxr_workspace_modal_win32_fini(sess);
 #endif
 
+	// XR_EXT_conformance_automation: free synthetic-input state (incl. mutex).
+	// No-op if the extension was never used. Done here so nothing outlives the
+	// session across the CTS's rapid create/destroy cycling.
+	oxr_conformance_teardown(sess);
+
 	XrResult ret = oxr_event_remove_session_events(log, sess);
 
 	oxr_session_binding_destroy_all(log, sess);

--- a/src/xrt/state_trackers/oxr/oxr_space.c
+++ b/src/xrt/state_trackers/oxr/oxr_space.c
@@ -500,6 +500,25 @@ oxr_space_locate(
 		    &result);                    //
 	}
 
+	/*
+	 * XR_EXT_conformance_automation: if the CTS injected a synthetic pose for
+	 * this action space's bound source, it replaces the located relation.
+	 * No-op when the extension is disabled (lookup returns false). The pose is
+	 * applied in the base-space frame — resolving it through the XrSpace the
+	 * CTS supplied is a refinement to validate against CTS on Windows.
+	 */
+	if (spc->space_type == OXR_SPACE_TYPE_ACTION) {
+		struct oxr_action_input *pose_input = NULL;
+		if (oxr_action_get_pose_input(spc->sess, spc->act_key, &spc->subaction_paths, &pose_input) ==
+		        XR_SUCCESS &&
+		    pose_input != NULL) {
+			struct xrt_space_relation override_relation = XRT_SPACE_RELATION_ZERO;
+			if (oxr_conformance_lookup_pose(spc->sess, pose_input->bound_path, &override_relation)) {
+				result = override_relation;
+			}
+		}
+	}
+
 
 	/*
 	 * Validate results


### PR DESCRIPTION
## OpenXR CTS conformance — Windows + D3D11 bring-up (#33)

Stands up the Khronos OpenXR Conformance Test Suite against the DisplayXR runtime, fixes every issue the non-interactive subset surfaced, and adds a tiered CI gate. Builds on the existing `XR_EXT_conformance_automation` implementation (already on this branch).

### Result
**Submission-valid run** (conformance API-layer enabled, sim-display, D3D11, OpenXR 1.1): **~23.5k assertions, 0 failures.** Baseline was 8 failing cases; all resolved. The two `XR_KHR_*` extensions that can't be backed honestly now skip cleanly rather than fail.

### Harness (gitignored `build-cts/`)
- `scripts/fetch_build_cts.bat` — builds `conformance_cli` + `conformance_test` pinned to `openxr-cts-1.1.43.0` (matches the loader).
- `scripts/run_cts.ps1` / `run_cts_sharded.ps1` — register the dev runtime via **HKLM ActiveRuntime** (the elevated loader ignores `XR_RUNTIME_JSON`), force the DP plug-in via ProbeOrder, and (`-ConformanceLayer`) register both CTS API layers under `HKLM …\ApiLayers\Explicit`. Snapshot + restore in `finally`.

### Runtime fixes
| Area | Fix |
|---|---|
| Swapchain | D3D11 multi-acquire ring + static-image count (was INSTANCE_LOST / CALL_ORDER_INVALID); same static-image fix for D3D12 |
| Window teardown | D3D11 window use-after-free under rapid session churn (two-party cleanup vote) |
| Session lifecycle | defer `READY→SYNCHRONIZED` until the first frame (was firing at `xrBeginSession`) |
| Depth format | D3D11 depth swapchains created **TYPELESS** (matches D3D12 + spec; restores pre-#91 behaviour) |
| Concurrency | lock the `oxr` session list (heap corruption) + relink the event queue on session-event removal (UAF) — multithreading test now 15/15 clean |
| Over-advertised exts | drop `XR_KHR_composition_layer_depth` (flat display doesn't reproject); `XR_KHR_visibility_mask` returns an empty mask (no lens occlusion) |

### CI (`.github/workflows/cts.yml`)
PR (path-filtered) → smoke · nightly cron → full · `v*` tag → full gate · `workflow_dispatch` → on-demand. Reuses the runtime build + plug-in registration patterns from `build-windows.yml`.

### Verification / merge notes
- **Leia hardware-validated** earlier: SessionState + D3D11 depth-typeless (cube in-process + shell over IPC — render correct, 3D + tracking OK).
- Unity regression-checked (D3D11 + D3D12 builds) for the depth change.
- The remaining commits (session-list lock, event-relink, depth-drop, empty visibility-mask) are runtime-correctness / headless and don't change the visual path.
- **Not auto-merging:** wants CI (incl. the new `cts.yml`) green + a sanity eyeball on the depth-advertisement drop first.
- `cts.yml`'s graphics tiers create a real D3D11 device/window on the runner; reliability on GPU-less GitHub runners is TBD on first dispatch (may need a self-hosted GPU runner for the full graphics suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
