### PR TITLE
fix(edid): DisplayConfig fallback when the registry EDID blob is missing

### DIFF
--- a/src/xrt/auxiliary/os/os_display_edid.h
+++ b/src/xrt/auxiliary/os/os_display_edid.h
@@ -63,8 +63,9 @@ struct os_display_edid_list
 	// Diagnostic fields (set on both success and failure for debugging)
 	enum os_edid_diag_error diag_error; //!< What went wrong (0 = OK)
 	uint32_t diag_gdi_count;            //!< Number of GDI monitors found
-	uint32_t diag_setupdi_count;        //!< Number of SetupDi devices with EDID
+	uint32_t diag_setupdi_count;        //!< Number of SetupDi monitor devices enumerated
 	uint32_t diag_edid_read_count;      //!< Number of EDID blobs successfully read
+	uint32_t diag_displayconfig_count;  //!< Monitors recovered via the DisplayConfig fallback
 	uint32_t diag_win32_error;          //!< GetLastError() value if SetupDi failed
 	char diag_gdi_device_ids[OS_DISPLAY_EDID_MAX_MONITORS][256]; //!< GDI device ID strings
 };

--- a/src/xrt/auxiliary/os/os_display_edid_win32.c
+++ b/src/xrt/auxiliary/os/os_display_edid_win32.c
@@ -20,6 +20,7 @@
 #include <setupapi.h>
 #include <string.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 // Monitor device class GUID: {4D36E96E-E325-11CE-BFC1-08002BE10318}
 static const GUID GUID_DEVCLASS_MONITOR_LOCAL = {
@@ -117,6 +118,206 @@ extract_hardware_id(const char *device_path, char *out_hwid, size_t hwid_size)
 	return len > 0;
 }
 
+/*!
+ * Decode an EDID manufacturer + product pair from a PnP hardware-ID string
+ * such as "DEL4147" (3-letter vendor code + 4 hex product digits). Windows
+ * derives this hwid directly from the monitor's EDID, so the values it yields
+ * are bit-identical to the raw EDID bytes the registry path reads — and to
+ * the {manufacturer_id, product_id} entries the vendor match tables hold:
+ *   - manufacturer: 3 letters → 5-bit packed big-endian word → byte-swapped
+ *     to the little-endian form EDID bytes 8-9 are read as (DEL → 0xAC10).
+ *   - product: 4 hex chars → 16-bit value matching EDID bytes 10-11 LE
+ *     (4147 → 0x4147).
+ * Returns false if the string is not a well-formed PnP id.
+ */
+static bool
+pnp_hwid_to_ids(const char *hwid, uint16_t *out_mfr, uint16_t *out_prod)
+{
+	if (hwid == NULL || strlen(hwid) < 7) {
+		return false;
+	}
+
+	// 3 vendor letters → 5-bit packed (A=1) big-endian word.
+	uint16_t packed = 0;
+	for (int i = 0; i < 3; i++) {
+		char c = hwid[i];
+		if (c >= 'a' && c <= 'z') {
+			c = (char)(c - 'a' + 'A');
+		}
+		if (c < 'A' || c > 'Z') {
+			return false;
+		}
+		packed = (uint16_t)((packed << 5) | (uint16_t)(c - 'A' + 1));
+	}
+	// EDID stores that word big-endian; match the little-endian read the
+	// registry path (read_edid_from_regkey) and the tables use.
+	uint16_t mfr = (uint16_t)((packed >> 8) | (packed << 8));
+
+	// 4 hex product digits.
+	uint16_t prod = 0;
+	for (int i = 3; i < 7; i++) {
+		char c = hwid[i];
+		uint16_t v;
+		if (c >= '0' && c <= '9') {
+			v = (uint16_t)(c - '0');
+		} else if (c >= 'a' && c <= 'f') {
+			v = (uint16_t)(c - 'a' + 10);
+		} else if (c >= 'A' && c <= 'F') {
+			v = (uint16_t)(c - 'A' + 10);
+		} else {
+			return false;
+		}
+		prod = (uint16_t)((prod << 4) | v);
+	}
+
+	*out_mfr = mfr;
+	*out_prod = prod;
+	return true;
+}
+
+/*!
+ * Pull the PnP hardware id out of a DisplayConfig monitorDevicePath such as
+ * L"\\?\DISPLAY#DEL4147#5&abcd&0&UID256#{guid}" → "DEL4147". (The leading
+ * "\\?\" defeats the generic extract_hardware_id delimiter scan, so this
+ * keys off the "DISPLAY#" segment instead.) ASCII output.
+ */
+static bool
+extract_pnp_hwid_from_devicepath(const wchar_t *device_path, char *out_hwid, size_t hwid_size)
+{
+	if (device_path == NULL) {
+		return false;
+	}
+	const wchar_t *tag = L"DISPLAY#";
+	const wchar_t *p = wcsstr(device_path, tag);
+	if (p == NULL) {
+		return false;
+	}
+	p += wcslen(tag);
+
+	size_t n = 0;
+	while (p[n] != L'\0' && p[n] != L'#' && n + 1 < hwid_size) {
+		out_hwid[n] = (char)p[n]; // PnP ids are ASCII
+		n++;
+	}
+	out_hwid[n] = '\0';
+	return n > 0;
+}
+
+/*!
+ * Durable EDID fallback via the DisplayConfig (CCD) API.
+ *
+ * The SetupAPI path reads the cached EDID *blob* from each monitor's
+ * registry "Device Parameters\\EDID" value. That value is frequently absent
+ * — behind DisplayPort-MST hubs, docking stations, KVMs, or with generic /
+ * indirect monitor drivers that never cache it — even though the panel is
+ * present and GDI sees it (issue: CZ Dell SR Pro 2 reported gdi=1 but
+ * setupdi=0/edid_reads=0). QueryDisplayConfig + DISPLAYCONFIG_TARGET_DEVICE_NAME
+ * report each active target's EDID manufacturer/product directly from the
+ * OS display topology without touching the registry blob, so they resolve
+ * panels the registry path misses.
+ *
+ * Appends any monitor not already in @p out_list, correlating screen
+ * geometry / refresh / HMONITOR back to the GDI enumeration by source GDI
+ * device name. Best-effort: any failure simply contributes no entries.
+ */
+static void
+enumerate_via_displayconfig(struct os_display_edid_list *out_list, const struct monitor_enum_context *gdi_ctx)
+{
+	UINT32 num_paths = 0;
+	UINT32 num_modes = 0;
+	if (GetDisplayConfigBufferSizes(QDC_ONLY_ACTIVE_PATHS, &num_paths, &num_modes) != ERROR_SUCCESS) {
+		return;
+	}
+
+	DISPLAYCONFIG_PATH_INFO *paths = (DISPLAYCONFIG_PATH_INFO *)calloc(num_paths, sizeof(*paths));
+	DISPLAYCONFIG_MODE_INFO *modes = (DISPLAYCONFIG_MODE_INFO *)calloc(num_modes, sizeof(*modes));
+	if (paths == NULL || modes == NULL) {
+		free(paths);
+		free(modes);
+		return;
+	}
+
+	if (QueryDisplayConfig(QDC_ONLY_ACTIVE_PATHS, &num_paths, paths, &num_modes, modes, NULL) != ERROR_SUCCESS) {
+		free(paths);
+		free(modes);
+		return;
+	}
+
+	for (UINT32 p = 0; p < num_paths && out_list->count < OS_DISPLAY_EDID_MAX_MONITORS; p++) {
+		// Target name → EDID ids + monitor device path.
+		DISPLAYCONFIG_TARGET_DEVICE_NAME tname;
+		memset(&tname, 0, sizeof(tname));
+		tname.header.type = DISPLAYCONFIG_DEVICE_INFO_GET_TARGET_NAME;
+		tname.header.size = sizeof(tname);
+		tname.header.adapterId = paths[p].targetInfo.adapterId;
+		tname.header.id = paths[p].targetInfo.id;
+		if (DisplayConfigGetDeviceInfo(&tname.header) != ERROR_SUCCESS) {
+			continue;
+		}
+
+		// Prefer the device-path hwid (proven byte-order match to the
+		// tables); fall back to the numeric EDID ids when present.
+		uint16_t mfr = 0;
+		uint16_t prod = 0;
+		bool got = false;
+		char hwid[64];
+		if (extract_pnp_hwid_from_devicepath(tname.monitorDevicePath, hwid, sizeof(hwid))) {
+			got = pnp_hwid_to_ids(hwid, &mfr, &prod);
+		}
+		if (!got && tname.flags.edidIdsValid && tname.edidManufactureId != 0) {
+			mfr = tname.edidManufactureId;
+			prod = tname.edidProductCodeId;
+			got = true;
+		}
+		if (!got) {
+			continue;
+		}
+
+		struct os_display_edid_monitor *mon = &out_list->monitors[out_list->count];
+		memset(mon, 0, sizeof(*mon));
+		mon->manufacturer_id = mfr;
+		mon->product_id = prod;
+
+		// Source name → GDI device name → screen geometry / refresh / HMONITOR.
+		DISPLAYCONFIG_SOURCE_DEVICE_NAME sname;
+		memset(&sname, 0, sizeof(sname));
+		sname.header.type = DISPLAYCONFIG_DEVICE_INFO_GET_SOURCE_NAME;
+		sname.header.size = sizeof(sname);
+		sname.header.adapterId = paths[p].sourceInfo.adapterId;
+		sname.header.id = paths[p].sourceInfo.id;
+		if (DisplayConfigGetDeviceInfo(&sname.header) == ERROR_SUCCESS) {
+			char gdi_name[32];
+			WideCharToMultiByte(CP_ACP, 0, sname.viewGdiDeviceName, -1, gdi_name, sizeof(gdi_name), NULL,
+			                    NULL);
+			for (uint32_t g = 0; g < gdi_ctx->count; g++) {
+				if (_stricmp(gdi_name, gdi_ctx->infos[g].szDevice) != 0) {
+					continue;
+				}
+				mon->screen_left = gdi_ctx->rects[g].left;
+				mon->screen_top = gdi_ctx->rects[g].top;
+				mon->pixel_width = (uint32_t)(gdi_ctx->rects[g].right - gdi_ctx->rects[g].left);
+				mon->pixel_height = (uint32_t)(gdi_ctx->rects[g].bottom - gdi_ctx->rects[g].top);
+				mon->is_primary = (gdi_ctx->infos[g].dwFlags & MONITORINFOF_PRIMARY) != 0;
+				mon->hmonitor = (void *)gdi_ctx->handles[g];
+
+				DEVMODEA dm;
+				memset(&dm, 0, sizeof(dm));
+				dm.dmSize = sizeof(dm);
+				if (EnumDisplaySettingsA(gdi_ctx->infos[g].szDevice, ENUM_CURRENT_SETTINGS, &dm)) {
+					mon->refresh_hz = dm.dmDisplayFrequency;
+				}
+				break;
+			}
+		}
+
+		out_list->count++;
+		out_list->diag_displayconfig_count++;
+	}
+
+	free(paths);
+	free(modes);
+}
+
 bool
 os_display_edid_enumerate(struct os_display_edid_list *out_list)
 {
@@ -167,7 +368,9 @@ os_display_edid_enumerate(struct os_display_edid_list *out_list)
 	if (dev_info == INVALID_HANDLE_VALUE) {
 		out_list->diag_error = OS_EDID_DIAG_SETUPDI_FAILED;
 		out_list->diag_win32_error = GetLastError();
-		return false;
+		// SetupAPI itself is unavailable — still try the DisplayConfig path.
+		enumerate_via_displayconfig(out_list, &gdi_ctx);
+		return out_list->count > 0;
 	}
 
 	// Collect all SetupDi devices with their EDID and instance IDs
@@ -177,7 +380,8 @@ os_display_edid_enumerate(struct os_display_edid_list *out_list)
 		uint16_t prod_id;
 		char hwid[64]; // Extracted hardware ID (e.g., "AUO2E9A")
 	} setupdi_devices[OS_DISPLAY_EDID_MAX_MONITORS];
-	uint32_t setupdi_count = 0;
+	uint32_t setupdi_count = 0;     // devices that yielded a readable EDID blob
+	uint32_t setupdi_enumerated = 0; // monitor-class devices enumerated at all
 
 	for (DWORD idx = 0; idx < 64; idx++) {
 		SP_DEVINFO_DATA dev_info_data;
@@ -187,6 +391,7 @@ os_display_edid_enumerate(struct os_display_edid_list *out_list)
 		if (!SetupDiEnumDeviceInfo(dev_info, idx, &dev_info_data)) {
 			break;
 		}
+		setupdi_enumerated++;
 
 		// Read EDID from device registry
 		HKEY hKey = SetupDiOpenDevRegKey(dev_info, &dev_info_data, DICS_FLAG_GLOBAL, 0, DIREG_DEV, KEY_READ);
@@ -219,15 +424,16 @@ os_display_edid_enumerate(struct os_display_edid_list *out_list)
 
 	SetupDiDestroyDeviceInfoList(dev_info);
 
-	out_list->diag_setupdi_count = setupdi_count;
+	// Split counters so a field report distinguishes "no monitor devices"
+	// (setupdi_devices=0) from "devices present but no cached EDID blob"
+	// (setupdi_devices=N, edid_reads=0) — both previously collapsed to the
+	// same diag=3.
+	out_list->diag_setupdi_count = setupdi_enumerated;
 	out_list->diag_edid_read_count = setupdi_count;
 
-	if (setupdi_count == 0) {
-		out_list->diag_error = OS_EDID_DIAG_NO_EDID_DATA;
-		return false;
-	}
-
-	// Step 3: Correlate SetupDi devices with GDI monitors by hardware ID
+	// Step 3: Correlate SetupDi devices with GDI monitors by hardware ID.
+	// (No-op when setupdi_count == 0; the DisplayConfig fallback below picks
+	// up that case.)
 	for (uint32_t g = 0; g < gdi_ctx.count; g++) {
 		if (!gdi_has_hwid[g]) {
 			continue;
@@ -266,8 +472,16 @@ os_display_edid_enumerate(struct os_display_edid_list *out_list)
 		}
 	}
 
+	// Durable fallback: the registry EDID blob was missing or uncorrelated
+	// on this box. Resolve panels straight from the OS display topology.
 	if (out_list->count == 0) {
-		out_list->diag_error = OS_EDID_DIAG_NO_CORRELATION;
+		enumerate_via_displayconfig(out_list, &gdi_ctx);
+	}
+
+	if (out_list->count == 0) {
+		// Report the primary failure that drove us to (a failed) fallback.
+		out_list->diag_error =
+		    (setupdi_count == 0) ? OS_EDID_DIAG_NO_EDID_DATA : OS_EDID_DIAG_NO_CORRELATION;
 	}
 
 	return out_list->count > 0;

--- a/src/xrt/targets/cli/cli_cmd_displays.c
+++ b/src/xrt/targets/cli/cli_cmd_displays.c
@@ -189,6 +189,7 @@ cli_cmd_displays(int argc, const char **argv)
 		cJSON_AddNumberToObject(diag, "gdi_count", (double)list.diag_gdi_count);
 		cJSON_AddNumberToObject(diag, "setupdi_count", (double)list.diag_setupdi_count);
 		cJSON_AddNumberToObject(diag, "edid_read_count", (double)list.diag_edid_read_count);
+		cJSON_AddNumberToObject(diag, "displayconfig_count", (double)list.diag_displayconfig_count);
 		cJSON_AddNumberToObject(diag, "win32_error", (double)list.diag_win32_error);
 
 		char *out = cJSON_Print(root);


### PR DESCRIPTION
## Problem

The Leia DP probe declines (→ runtime falls back to **sim-display**) whenever `os_display_edid_enumerate()` can't read a monitor's **cached registry EDID blob** (`SetupAPI` `DIREG_DEV` `"EDID"` value). That blob is frequently absent behind DP-MST hubs, docks, KVMs, or with generic/indirect monitor drivers.

Field repro — a **CZ Dell SR Pro 2** (a panel that **is** in the match table, `{44048, 16711}`): GDI saw `MONITOR\DEL4147` but `setupdi=0 edid_reads=0 diag=3`, so the enumerator returned 0 monitors before it could ever match, and the box silently ran sim-display instead of Leia.

## Fix (durable)

Add a `QueryDisplayConfig` (CCD) fallback that reads each active target's EDID manufacturer/product via `DISPLAYCONFIG_TARGET_DEVICE_NAME` **without** the registry blob, correlating screen geometry/refresh/HMONITOR back to the GDI enumeration by source device name. It prefers parsing the `monitorDevicePath` PnP id (`DEL4147` → `44048/16711`, byte-order-proven to match the tables) and uses the numeric `edidManufactureId/edidProductCodeId` only as a secondary.

Wired in at all three SetupAPI failure points (init failure, `setupdi_count==0`, post-correlation `count==0`).

**Safe on working hardware:** the fallback only runs when the existing SetupAPI path returns zero monitors, so boxes where it already succeeds are byte-for-byte unchanged.

## Also
- Split the `setupdi`/`edid_read` diagnostic counters so `diag=3` now distinguishes "no monitor device" from "device present, EDID blob missing".
- Surface `displayconfig_count` in `displayxr-cli displays`.

## Validation
- `/W4` clean compile + full `build_windows.bat` runtime build (`ALL DONE`, 0 errors).
- **Not yet hardware-validated on the CZ box** — pending an on-device session. CI cannot validate this (no Leia hardware). Consumed by the Leia plug-in (links `aux_os`), so it also **needs a plug-in rebuild** to take effect on a device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)