### PR TITLE
ci(#33): make cts.yml run end-to-end on a clean GitHub runner

### DIFF
--- a/.github/workflows/cts.yml
+++ b/.github/workflows/cts.yml
@@ -121,8 +121,11 @@ jobs:
         run: |
           cmake -S . -B build -G "Ninja Multi-Config" `
             -DCMAKE_TOOLCHAIN_FILE="${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake" `
+            -DVCPKG_MANIFEST_FEATURES=gui `
+            -DX_VCPKG_APPLOCAL_DEPS_INSTALL=ON `
             -DCMAKE_INSTALL_PREFIX=_package `
             -DXRT_FEATURE_SERVICE=ON `
+            -DXRT_FEATURE_HYBRID_MODE=ON `
             -DOpenXR_ROOT="${{ github.workspace }}/openxr_sdk"
           cmake --build build --config Release --target install
 

--- a/scripts/fetch_build_cts.bat
+++ b/scripts/fetch_build_cts.bat
@@ -26,11 +26,22 @@ set NINJA_DIR=%LOCALAPPDATA%\Microsoft\WinGet\Packages\Ninja-build.Ninja_Microso
 :: 1. MSVC environment (same as build_windows.bat)
 :: ------------------------------------------------------------
 echo === Setting up MSVC environment ===
+:: Skip vcvars if MSVC is already on PATH (e.g. CI ran msvc-dev-cmd).
+where cl.exe >nul 2>&1
+if %ERRORLEVEL% EQU 0 goto :msvc_ready
+:: Find any VS 2022 edition (Community/Professional/Enterprise/BuildTools) via vswhere.
+set "_VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+if exist "%_VSWHERE%" for /f "usebackq tokens=*" %%i in (`"%_VSWHERE%" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do call "%%i\VC\Auxiliary\Build\vcvars64.bat" >nul 2>&1
+where cl.exe >nul 2>&1
+if %ERRORLEVEL% EQU 0 goto :msvc_ready
+:: Last-resort hardcoded Community path.
 call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat" >nul 2>&1
+where cl.exe >nul 2>&1
 if %ERRORLEVEL% NEQ 0 (
-    echo ERROR: Could not find Visual Studio 2022. Install VS 2022 with C++ workload.
+    echo ERROR: Could not find Visual Studio 2022 C++ tools ^(tried PATH, vswhere, Community^).
     exit /b 1
 )
+:msvc_ready
 if exist "%NINJA_DIR%\ninja.exe" set "PATH=%NINJA_DIR%;%PATH%"
 if exist "%VULKAN_SDK%\Bin" set "PATH=%VULKAN_SDK%\Bin;%PATH%"
 

--- a/scripts/run_cts.ps1
+++ b/scripts/run_cts.ps1
@@ -50,6 +50,9 @@ $xrKey  = "HKLM:\Software\Khronos\OpenXR\1"
 $dpKey  = "HKLM:\Software\DisplayXR\DisplayProcessors\$Plugin"
 
 # ---- snapshot ----
+# A clean machine (CI runner with no OpenXR runtime installed) has no Khronos key
+# at all; track that so we can fully undo what we create.
+$xrKeyPreexisted = Test-Path $xrKey
 $origRuntime   = (Get-ItemProperty $xrKey -Name ActiveRuntime -ErrorAction SilentlyContinue).ActiveRuntime
 $origProbe     = $null
 if ($Plugin -ne "none") {
@@ -71,6 +74,7 @@ if ($ConformanceLayer -and $explicitKeyPreexisted) {
 
 try {
   # ---- apply ----
+  if (-not (Test-Path $xrKey)) { New-Item -Path $xrKey -Force | Out-Null }
   Set-ItemProperty $xrKey -Name ActiveRuntime -Value $devManifest -Type String
   if ($Plugin -ne "none") {
     Set-ItemProperty $dpKey -Name ProbeOrder -Value 5 -Type DWord   # below leia-sr (50)
@@ -118,12 +122,11 @@ try {
 }
 finally {
   # ---- restore (always) ----
-  if ($null -ne $origRuntime) {
-    Set-ItemProperty $xrKey -Name ActiveRuntime -Value $origRuntime -Type String
-  }
   if ($Plugin -ne "none" -and $null -ne $origProbe) {
     Set-ItemProperty $dpKey -Name ProbeOrder -Value ([int]$origProbe) -Type DWord
   }
+  # Remove the conformance-layer registrations we added (before any wholesale
+  # key removal below).
   if ($ConformanceLayer -and (Test-Path $explicitKey)) {
     foreach ($lj in $layerJsons) {
       if (-not $preRegistered[$lj]) { Remove-ItemProperty -Path $explicitKey -Name $lj -ErrorAction SilentlyContinue }
@@ -131,9 +134,19 @@ finally {
     if (-not $explicitKeyPreexisted) { Remove-Item -Path $explicitKey -Force -ErrorAction SilentlyContinue }
     Write-Output "RESTORED conformance layer registration removed"
   }
-  Write-Output "RESTORED ActiveRuntime = $((Get-ItemProperty $xrKey -Name ActiveRuntime).ActiveRuntime)"
+  if ($null -ne $origRuntime) {
+    Set-ItemProperty $xrKey -Name ActiveRuntime -Value $origRuntime -Type String
+    Write-Output "RESTORED ActiveRuntime = $((Get-ItemProperty $xrKey -Name ActiveRuntime -ErrorAction SilentlyContinue).ActiveRuntime)"
+  } elseif (-not $xrKeyPreexisted) {
+    # Clean machine: we created the Khronos key — remove it wholesale.
+    Remove-Item -Path $xrKey -Recurse -Force -ErrorAction SilentlyContinue
+    Write-Output "RESTORED ActiveRuntime = (Khronos key removed; did not pre-exist)"
+  } else {
+    Remove-ItemProperty -Path $xrKey -Name ActiveRuntime -ErrorAction SilentlyContinue
+    Write-Output "RESTORED ActiveRuntime = (value removed; did not pre-exist)"
+  }
   if ($Plugin -ne "none") {
-    Write-Output "RESTORED $Plugin ProbeOrder = $((Get-ItemProperty $dpKey -Name ProbeOrder).ProbeOrder)"
+    Write-Output "RESTORED $Plugin ProbeOrder = $((Get-ItemProperty $dpKey -Name ProbeOrder -ErrorAction SilentlyContinue).ProbeOrder)"
   }
 }
 


### PR DESCRIPTION
Three clean-environment fixes found by dispatching `cts.yml` on a GitHub runner (none were on the dev box):
1. **Build flags** — `Generate` was missing `-DXRT_FEATURE_HYBRID_MODE=ON` (+ vcpkg `gui`/applocal), so `displayxr-service.exe` failed to link.
2. **VS detection** — `fetch_build_cts.bat` hardcoded the Community vcvars path; runners have Enterprise. Now honors an already-set MSVC env, then `vswhere` (any edition), then Community.
3. **Registry** — `run_cts.ps1` assumed `HKLM\…\Khronos\OpenXR\1` exists; a clean runner has no OpenXR runtime installed. Create it when missing; restore by removing what we created.

**Validated:** `workflow_dispatch` smoke/d3d11 → **12,367 assertions, 0 failures** on a GPU-less runner. The D3D11 native compositor builds a window + device via WARP (Vulkan gracefully falls back). So no self-hosted GPU runner is needed. Follows #502.

🤖 Generated with [Claude Code](https://claude.com/claude-code)