### PR TITLE
feat(#491): 2D-under-3D backdrop — runtime + D3D12 DP (part 3)

### DIFF
--- a/src/xrt/compositor/d3d11/comp_d3d11_compositor.cpp
+++ b/src/xrt/compositor/d3d11/comp_d3d11_compositor.cpp
@@ -196,6 +196,15 @@ struct comp_d3d11_compositor
 	ID3D11ShaderResourceView *local2d_scratch_srv;
 	ID3D11RenderTargetView *local2d_scratch_rtv;
 
+	//! #491 part 3 — 2D-under backdrop flatten target (RT+SRV), same trio as
+	//! local2d_scratch. The frame's UNDER Local2D layers (before the projection
+	//! in list order) flatten here PRE-weave; the SRV is handed to the DP via
+	//! set_background_2d so it composites `backdrop over captured-desktop` under
+	//! the 3D. Compositor-owned so it outlives process_atlas.
+	ID3D11Texture2D *backdrop_scratch;
+	ID3D11ShaderResourceView *backdrop_scratch_srv;
+	ID3D11RenderTargetView *backdrop_scratch_rtv;
+
 	//! #439 Phase 3 — runtime-owned IMPLICIT zone mask, rasterized from the
 	//! frame's Local2D layer rects (Q3): M=1 (keep the weave) everywhere,
 	//! M=0 (show the 2D layers) inside the union of the layer rects. Used as
@@ -359,6 +368,11 @@ d3d11_composite_zone_mask(struct comp_d3d11_compositor *c,
                           uint32_t dst_w,
                           uint32_t dst_h,
                           const struct u_canvas_rect *eff_canvas);
+// #491 part 3 — pre-weave 2D-under backdrop flatten (defined with the other
+// Local2D helpers near the bottom; called from the process_atlas sites above).
+static ID3D11ShaderResourceView *
+d3d11_flatten_backdrop_2d(struct comp_d3d11_compositor *c, uint32_t dst_w, uint32_t dst_h, uint32_t *out_w,
+                          uint32_t *out_h);
 static void
 d3d11_release_zone_state(struct comp_d3d11_compositor *c);
 // #224 hardware-DP zone leg: per-frame sideband publish of the active mask to
@@ -1740,6 +1754,15 @@ d3d11_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 			uint32_t dp_target_w = st_desc.Width;
 			uint32_t dp_target_h = st_desc.Height;
 
+			// #491 part 3 — flatten the 2D-under layers PRE-weave and hand them
+			// to the DP (it composites `backdrop over captured-desktop` under
+			// the 3D). The flatten unbinds its RTV; the shared RTV is bound
+			// after. NULL ⟹ no under-layers (DP clears its backdrop).
+			uint32_t bd_w = 0, bd_h = 0;
+			ID3D11ShaderResourceView *bd_srv =
+			    d3d11_flatten_backdrop_2d(c, dp_target_w, dp_target_h, &bd_w, &bd_h);
+			xrt_display_processor_d3d11_set_background_2d(c->display_processor, bd_srv, bd_w, bd_h);
+
 			c->context->OMSetRenderTargets(1, &c->shared_rtv, nullptr);
 
 			xrt_display_processor_d3d11_process_atlas(
@@ -1827,6 +1850,18 @@ d3d11_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 
 		uint32_t target_width, target_height;
 		comp_d3d11_target_get_dimensions(c->target, &target_width, &target_height);
+
+		// #491 part 3 — flatten the 2D-under layers PRE-weave and hand them to
+		// the DP (it composites `backdrop over captured-desktop` under the 3D).
+		// The flatten binds/unbinds its own RTV, so re-bind the target RTV after
+		// (the DP writes to the currently bound target). NULL ⟹ no under-layers.
+		uint32_t bd_w = 0, bd_h = 0;
+		ID3D11ShaderResourceView *bd_srv =
+		    d3d11_flatten_backdrop_2d(c, target_width, target_height, &bd_w, &bd_h);
+		xrt_display_processor_d3d11_set_background_2d(c->display_processor, bd_srv, bd_w, bd_h);
+		if (bd_srv != nullptr) {
+			comp_d3d11_target_bind(c->target);
+		}
 
 		xrt_display_processor_d3d11_process_atlas(
 		    c->display_processor, c->context, atlas_srv, view_width, view_height,
@@ -2887,6 +2922,19 @@ d3d11_release_zone_state(struct comp_d3d11_compositor *c)
 		c->local2d_scratch->Release();
 		c->local2d_scratch = nullptr;
 	}
+	// #491 part 3 — 2D-under backdrop flatten scratch.
+	if (c->backdrop_scratch_rtv != nullptr) {
+		c->backdrop_scratch_rtv->Release();
+		c->backdrop_scratch_rtv = nullptr;
+	}
+	if (c->backdrop_scratch_srv != nullptr) {
+		c->backdrop_scratch_srv->Release();
+		c->backdrop_scratch_srv = nullptr;
+	}
+	if (c->backdrop_scratch != nullptr) {
+		c->backdrop_scratch->Release();
+		c->backdrop_scratch = nullptr;
+	}
 	if (c->implicit_mask_staged_srv != nullptr) {
 		c->implicit_mask_staged_srv->Release();
 		c->implicit_mask_staged_srv = nullptr;
@@ -3249,14 +3297,88 @@ d3d11_update_implicit_mask(struct comp_d3d11_compositor *c,
 	return c->implicit_mask_staged_srv;
 }
 
-// #439 Phase 3 — flatten this frame's Local2D layers into local2d_scratch (the
-// `twod` source the masked composite reads). Clears transparent, then draws each
-// layer in list order (later = on top) with premultiplied (or straight-alpha)
-// over. Dest rects are clipped to the window region; the clip fractions, the
-// layer's norm_rect, and flip_y are carried into the source UVs. Caller holds
-// c->mutex and has already (re)allocated local2d_scratch (+RTV) at region dims.
+// #439 Phase 3 — flatten one Local2D layer into @p rtv (premultiplied or
+// straight-alpha over), clipped to the window region with clip/norm_rect/flip_y
+// carried into the source UVs. Shared by the post-weave overlay flatten and the
+// pre-weave 2D-under backdrop flatten (#491 part 3). Caller holds c->mutex.
+static void
+d3d11_flatten_one_local2d_layer(struct comp_d3d11_compositor *c,
+                                ID3D11RenderTargetView *rtv,
+                                struct comp_layer *layer,
+                                uint32_t region_w,
+                                uint32_t region_h)
+{
+	struct xrt_swapchain *sc = layer->sc_array[0];
+	if (sc == nullptr) {
+		return;
+	}
+	uint32_t img_idx = layer->data.local_2d.sub.image_index;
+	// sRGB-passthrough: get_srv returns the swapchain's UNORM sibling SRV
+	// (no auto-decode), the same SRV the projection draws sample.
+	ID3D11ShaderResourceView *src_srv =
+	    static_cast<ID3D11ShaderResourceView *>(comp_d3d11_swapchain_get_srv(sc, img_idx));
+	if (src_srv == nullptr) {
+		return; // swapchain not SAMPLED — nothing to flatten
+	}
+
+	// Dest rect (client-window px), clipped to the window region.
+	const struct xrt_rect *dr = &layer->data.local_2d.rect;
+	int32_t dx = dr->offset.w;
+	int32_t dy = dr->offset.h;
+	int32_t dw = dr->extent.w;
+	int32_t dh = dr->extent.h;
+	if (dw <= 0 || dh <= 0) {
+		return;
+	}
+	int32_t x0 = dx < 0 ? 0 : dx;
+	int32_t y0 = dy < 0 ? 0 : dy;
+	int32_t x1 = (dx + dw) > (int32_t)region_w ? (int32_t)region_w : (dx + dw);
+	int32_t y1 = (dy + dh) > (int32_t)region_h ? (int32_t)region_h : (dy + dh);
+	if (x1 <= x0 || y1 <= y0) {
+		return; // clipped fully out
+	}
+
+	// Clip fractions within the original dest rect (carry into the UVs so
+	// the correct source region is sampled when the rect is clipped).
+	float fx0 = (float)(x0 - dx) / (float)dw;
+	float fy0 = (float)(y0 - dy) / (float)dh;
+	float fx1 = (float)(x1 - dx) / (float)dw;
+	float fy1 = (float)(y1 - dy) / (float)dh;
+
+	// App sub-rect within the swapchain image (normalized). Default full.
+	struct xrt_normalized_rect nr = layer->data.local_2d.sub.norm_rect;
+	if (nr.w <= 0.0f || nr.h <= 0.0f) {
+		nr.x = 0.0f;
+		nr.y = 0.0f;
+		nr.w = 1.0f;
+		nr.h = 1.0f;
+	}
+
+	// Source rect (normalized) carrying clip + flip_y. flip_y: start at
+	// the bottom of the sub-rect and sample upward (negative height).
+	float src_x = nr.x + nr.w * fx0;
+	float src_w = nr.w * (fx1 - fx0);
+	float src_y, src_h;
+	if (layer->data.flip_y) {
+		src_y = nr.y + nr.h * (1.0f - fy0);
+		src_h = -(nr.h * (fy1 - fy0));
+	} else {
+		src_y = nr.y + nr.h * fy0;
+		src_h = nr.h * (fy1 - fy0);
+	}
+
+	bool unpremult = (layer->data.flags & XRT_LAYER_COMPOSITION_UNPREMULTIPLIED_ALPHA_BIT) != 0;
+
+	comp_d3d11_renderer_flatten_local_2d(c->renderer, rtv, src_srv, x0, y0, (uint32_t)(x1 - x0),
+	                                     (uint32_t)(y1 - y0), src_x, src_y, src_w, src_h, unpremult);
+}
+
+// #439 Phase 3 — flatten this frame's OVER Local2D layers into local2d_scratch
+// (the `twod` source the masked composite reads). Under-layers (#491 part 3,
+// before the projection in list order) are the DP backdrop and are skipped here.
+// Caller holds c->mutex and has already (re)allocated local2d_scratch (+RTV).
 static bool
-d3d11_flatten_local_2d_layers(struct comp_d3d11_compositor *c, uint32_t region_w, uint32_t region_h)
+d3d11_flatten_local_2d_layers(struct comp_d3d11_compositor *c, uint32_t region_w, uint32_t region_h, int32_t proj_idx)
 {
 	// Clear transparent once. Where a pixel is M=0 (2D) but no layer covers
 	// it, twod stays (0,0,0,0) → final.a → 0 → the desktop shows through (Q2,
@@ -3269,70 +3391,11 @@ d3d11_flatten_local_2d_layers(struct comp_d3d11_compositor *c, uint32_t region_w
 		if (layer->data.type != XRT_LAYER_LOCAL_2D) {
 			continue;
 		}
-		struct xrt_swapchain *sc = layer->sc_array[0];
-		if (sc == nullptr) {
+		// #491 part 3 — under-layers are the DP backdrop (handled pre-weave).
+		if (proj_idx >= 0 && (int32_t)i < proj_idx) {
 			continue;
 		}
-		uint32_t img_idx = layer->data.local_2d.sub.image_index;
-		// sRGB-passthrough: get_srv returns the swapchain's UNORM sibling SRV
-		// (no auto-decode), the same SRV the projection draws sample.
-		ID3D11ShaderResourceView *src_srv =
-		    static_cast<ID3D11ShaderResourceView *>(comp_d3d11_swapchain_get_srv(sc, img_idx));
-		if (src_srv == nullptr) {
-			continue; // swapchain not SAMPLED — nothing to flatten
-		}
-
-		// Dest rect (client-window px), clipped to the window region.
-		const struct xrt_rect *dr = &layer->data.local_2d.rect;
-		int32_t dx = dr->offset.w;
-		int32_t dy = dr->offset.h;
-		int32_t dw = dr->extent.w;
-		int32_t dh = dr->extent.h;
-		if (dw <= 0 || dh <= 0) {
-			continue;
-		}
-		int32_t x0 = dx < 0 ? 0 : dx;
-		int32_t y0 = dy < 0 ? 0 : dy;
-		int32_t x1 = (dx + dw) > (int32_t)region_w ? (int32_t)region_w : (dx + dw);
-		int32_t y1 = (dy + dh) > (int32_t)region_h ? (int32_t)region_h : (dy + dh);
-		if (x1 <= x0 || y1 <= y0) {
-			continue; // clipped fully out
-		}
-
-		// Clip fractions within the original dest rect (carry into the UVs so
-		// the correct source region is sampled when the rect is clipped).
-		float fx0 = (float)(x0 - dx) / (float)dw;
-		float fy0 = (float)(y0 - dy) / (float)dh;
-		float fx1 = (float)(x1 - dx) / (float)dw;
-		float fy1 = (float)(y1 - dy) / (float)dh;
-
-		// App sub-rect within the swapchain image (normalized). Default full.
-		struct xrt_normalized_rect nr = layer->data.local_2d.sub.norm_rect;
-		if (nr.w <= 0.0f || nr.h <= 0.0f) {
-			nr.x = 0.0f;
-			nr.y = 0.0f;
-			nr.w = 1.0f;
-			nr.h = 1.0f;
-		}
-
-		// Source rect (normalized) carrying clip + flip_y. flip_y: start at
-		// the bottom of the sub-rect and sample upward (negative height).
-		float src_x = nr.x + nr.w * fx0;
-		float src_w = nr.w * (fx1 - fx0);
-		float src_y, src_h;
-		if (layer->data.flip_y) {
-			src_y = nr.y + nr.h * (1.0f - fy0);
-			src_h = -(nr.h * (fy1 - fy0));
-		} else {
-			src_y = nr.y + nr.h * fy0;
-			src_h = nr.h * (fy1 - fy0);
-		}
-
-		bool unpremult = (layer->data.flags & XRT_LAYER_COMPOSITION_UNPREMULTIPLIED_ALPHA_BIT) != 0;
-
-		comp_d3d11_renderer_flatten_local_2d(c->renderer, c->local2d_scratch_rtv, src_srv, x0, y0,
-		                                     (uint32_t)(x1 - x0), (uint32_t)(y1 - y0), src_x, src_y, src_w,
-		                                     src_h, unpremult);
+		d3d11_flatten_one_local2d_layer(c, c->local2d_scratch_rtv, layer, region_w, region_h);
 	}
 
 	// Unbind the scratch RTV so the masked composite can sample it as an SRV
@@ -3340,6 +3403,92 @@ d3d11_flatten_local_2d_layers(struct comp_d3d11_compositor *c, uint32_t region_w
 	ID3D11RenderTargetView *null_rtv = nullptr;
 	c->context->OMSetRenderTargets(1, &null_rtv, nullptr);
 	return true;
+}
+
+// #491 part 3 — flatten this frame's 2D-UNDER Local2D layers (before the
+// projection in list order) into backdrop_scratch PRE-weave and return its SRV
+// (+ region dims) so the caller hands it to the DP via set_background_2d (the DP
+// composites `backdrop over captured-desktop` under the 3D). Returns nullptr
+// (out dims 0) when there are no under-layers. Caller holds c->mutex; the
+// immediate context orders these draws before the subsequent process_atlas.
+static ID3D11ShaderResourceView *
+d3d11_flatten_backdrop_2d(struct comp_d3d11_compositor *c, uint32_t dst_w, uint32_t dst_h, uint32_t *out_w,
+                          uint32_t *out_h)
+{
+	*out_w = 0;
+	*out_h = 0;
+	if (!c->local_2d_last_frame || c->renderer == nullptr) {
+		return nullptr;
+	}
+
+	// Under = Local2D layers BEFORE the projection. No projection ⟹ no backdrop.
+	int32_t proj_idx = -1;
+	for (uint32_t i = 0; i < c->layer_accum.layer_count; i++) {
+		enum xrt_layer_type t = c->layer_accum.layers[i].data.type;
+		if (t == XRT_LAYER_PROJECTION || t == XRT_LAYER_PROJECTION_DEPTH) {
+			proj_idx = (int32_t)i;
+			break;
+		}
+	}
+	if (proj_idx < 0) {
+		return nullptr;
+	}
+	bool have_under = false;
+	for (int32_t i = 0; i < proj_idx; i++) {
+		if (c->layer_accum.layers[i].data.type == XRT_LAYER_LOCAL_2D) {
+			have_under = true;
+			break;
+		}
+	}
+	if (!have_under) {
+		return nullptr;
+	}
+
+	// Window region inside the worst-case dst (#464).
+	uint32_t region_w = dst_w;
+	uint32_t region_h = dst_h;
+	HWND wnd = c->hwnd != nullptr ? c->hwnd : c->app_hwnd;
+	if (wnd != nullptr) {
+		RECT r;
+		if (GetClientRect(wnd, &r) && r.right > 0 && r.bottom > 0) {
+			region_w = ((uint32_t)r.right < dst_w) ? (uint32_t)r.right : dst_w;
+			region_h = ((uint32_t)r.bottom < dst_h) ? (uint32_t)r.bottom : dst_h;
+		}
+	}
+	if (region_w == 0 || region_h == 0) {
+		return nullptr;
+	}
+
+	// Premultiplied RGBA, UNORM (sRGB-passthrough) like local2d_scratch.
+	if (!d3d11_ensure_rt_srv_scratch(c, &c->backdrop_scratch, &c->backdrop_scratch_srv, &c->backdrop_scratch_rtv,
+	                                 region_w, region_h, DXGI_FORMAT_R8G8B8A8_UNORM, "backdrop scratch")) {
+		return nullptr;
+	}
+
+	const float transparent[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+	c->context->ClearRenderTargetView(c->backdrop_scratch_rtv, transparent);
+
+	for (int32_t i = 0; i < proj_idx; i++) {
+		struct comp_layer *layer = &c->layer_accum.layers[i];
+		if (layer->data.type != XRT_LAYER_LOCAL_2D) {
+			continue;
+		}
+		d3d11_flatten_one_local2d_layer(c, c->backdrop_scratch_rtv, layer, region_w, region_h);
+	}
+
+	ID3D11RenderTargetView *null_rtv = nullptr;
+	c->context->OMSetRenderTargets(1, &null_rtv, nullptr);
+
+	static bool logged = false;
+	if (!logged) {
+		logged = true;
+		U_LOG_W("D3D11 #491 part3: flattened 2D-under backdrop %ux%u (handed to DP set_background_2d)",
+		        region_w, region_h);
+	}
+
+	*out_w = region_w;
+	*out_h = region_h;
+	return c->backdrop_scratch_srv;
 }
 
 // #439 Phase 1 — composite the authored zone mask. Runs INSTEAD of the rect
@@ -3387,8 +3536,20 @@ d3d11_composite_zone_mask(struct comp_d3d11_compositor *c,
 	D3D11_TEXTURE2D_DESC dd;
 	dst->GetDesc(&dd);
 
+	// #491 part 3 — split Local2D by list order vs the projection: layers BEFORE
+	// the projection are the 2D-under backdrop (handled pre-weave by the DP) and
+	// are excluded from the overlay mask + flatten here. is_over == !under.
+	int32_t proj_idx = -1;
+	for (uint32_t i = 0; i < c->layer_accum.layer_count; i++) {
+		enum xrt_layer_type t = c->layer_accum.layers[i].data.type;
+		if (t == XRT_LAYER_PROJECTION || t == XRT_LAYER_PROJECTION_DEPTH) {
+			proj_idx = (int32_t)i;
+			break;
+		}
+	}
+
 	// Resolve the frame's mask source: an explicit submitted mask wins; else
-	// rasterize the implicit Tier-2-style mask from the Local2D layer rects
+	// rasterize the implicit Tier-2-style mask from the OVER Local2D layer rects
 	// (Q3 — M=0 inside the rect union, M=1 elsewhere).
 	ID3D11ShaderResourceView *mask_srv = nullptr;
 	if (have_explicit) {
@@ -3397,9 +3558,13 @@ d3d11_composite_zone_mask(struct comp_d3d11_compositor *c,
 		struct xrt_rect rects[XRT_MAX_LAYERS];
 		uint32_t rect_count = 0;
 		for (uint32_t i = 0; i < c->layer_accum.layer_count && rect_count < XRT_MAX_LAYERS; i++) {
-			if (c->layer_accum.layers[i].data.type == XRT_LAYER_LOCAL_2D) {
-				rects[rect_count++] = c->layer_accum.layers[i].data.local_2d.rect;
+			if (c->layer_accum.layers[i].data.type != XRT_LAYER_LOCAL_2D) {
+				continue;
 			}
+			if (proj_idx >= 0 && (int32_t)i < proj_idx) {
+				continue; // under-layer (backdrop) — not part of the overlay mask
+			}
+			rects[rect_count++] = c->layer_accum.layers[i].data.local_2d.rect;
 		}
 		mask_srv = d3d11_update_implicit_mask(c, rects, rect_count, region_w, region_h);
 	}
@@ -3425,7 +3590,7 @@ d3d11_composite_zone_mask(struct comp_d3d11_compositor *c,
 		                              unorm_fmt, "local2d weave")) {
 			return false;
 		}
-		if (!d3d11_flatten_local_2d_layers(c, region_w, region_h)) {
+		if (!d3d11_flatten_local_2d_layers(c, region_w, region_h, proj_idx)) {
 			return false;
 		}
 		twod_srv = c->local2d_scratch_srv;

--- a/src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp
+++ b/src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp
@@ -240,6 +240,15 @@ struct comp_d3d12_compositor
 	ID3D12DescriptorHeap *local2d_scratch_rtv_heap;
 	uint32_t local2d_scratch_w, local2d_scratch_h;
 
+	//! #491 part 3 — 2D-under backdrop flatten target (same trio as
+	//! local2d_scratch). UNDER Local2D layers (before the projection in list
+	//! order) flatten here PRE-weave, left in PIXEL_SHADER_RESOURCE; the
+	//! ID3D12Resource* is handed to the DP via set_background_2d (the DP creates
+	//! its own shader-visible SRV). Compositor-owned so it outlives process_atlas.
+	ID3D12Resource *backdrop_scratch;
+	ID3D12DescriptorHeap *backdrop_scratch_rtv_heap;
+	uint32_t backdrop_scratch_w, backdrop_scratch_h;
+
 	//! HUD overlay.
 	struct u_hud *hud;
 
@@ -305,6 +314,10 @@ static bool d3d12_composite_zone_mask(struct comp_d3d12_compositor *c,
                                        D3D12_RESOURCE_STATES dst_post_state,
                                        uint32_t dst_w, uint32_t dst_h,
                                        const struct u_canvas_rect *eff_canvas);
+// #491 part 3 — pre-weave 2D-under backdrop flatten (defined with the Local2D
+// helpers near the bottom; called from the process_atlas sites above).
+static ID3D12Resource *d3d12_flatten_backdrop_2d(struct comp_d3d12_compositor *c, uint32_t dst_w, uint32_t dst_h,
+                                                 uint32_t *out_w, uint32_t *out_h);
 static void d3d12_release_zone_state(struct comp_d3d12_compositor *c);
 // #439 surround-capture probe (DISPLAYXR_SURROUND_CAPTURE); defined with the
 // zone helpers, called after each path's fence wait in layer_commit.
@@ -1609,6 +1622,13 @@ d3d12_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 				pa_log++;
 			}
 
+			// #491 part 3 — flatten the 2D-under layers PRE-weave (records into
+			// the open cmd_list, leaves backdrop_scratch in PSR) and hand the
+			// resource to the DP. NULL ⟹ no under-layers (DP clears its backdrop).
+			uint32_t bd_w = 0, bd_h = 0;
+			ID3D12Resource *bd_res = d3d12_flatten_backdrop_2d(c, dp_target_w, dp_target_h, &bd_w, &bd_h);
+			xrt_display_processor_d3d12_set_background_2d(c->display_processor, bd_res, bd_w, bd_h);
+
 			xrt_display_processor_d3d12_process_atlas(
 			    c->display_processor,
 			    c->cmd_list,
@@ -1801,6 +1821,14 @@ d3d12_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 			uint32_t content_h = tile_rows * view_height;
 			ID3D12Resource *dp_resource = d3d12_crop_atlas_for_dp(
 			    c, atlas_resource, content_w, content_h);
+
+			// #491 part 3 — flatten the 2D-under layers PRE-weave and hand the
+			// resource to the DP. Done BEFORE the DP viewport/scissor setup
+			// below (the flatten sets its own viewport/scissor; the runtime
+			// re-sets the DP's afterward). NULL ⟹ no under-layers.
+			uint32_t bd_w = 0, bd_h = 0;
+			ID3D12Resource *bd_res = d3d12_flatten_backdrop_2d(c, tgt_width, tgt_height, &bd_w, &bd_h);
+			xrt_display_processor_d3d12_set_background_2d(c->display_processor, bd_res, bd_w, bd_h);
 
 			D3D12_VIEWPORT viewport = {};
 			viewport.TopLeftX = 0.0f;
@@ -3160,6 +3188,17 @@ d3d12_release_zone_state(struct comp_d3d12_compositor *c)
 	}
 	c->local2d_scratch_w = 0;
 	c->local2d_scratch_h = 0;
+	// #491 part 3 — 2D-under backdrop scratch.
+	if (c->backdrop_scratch != nullptr) {
+		c->backdrop_scratch->Release();
+		c->backdrop_scratch = nullptr;
+	}
+	if (c->backdrop_scratch_rtv_heap != nullptr) {
+		c->backdrop_scratch_rtv_heap->Release();
+		c->backdrop_scratch_rtv_heap = nullptr;
+	}
+	c->backdrop_scratch_w = 0;
+	c->backdrop_scratch_h = 0;
 	if (c->implicit_mask_staged != nullptr) {
 		c->implicit_mask_staged->Release();
 		c->implicit_mask_staged = nullptr;
@@ -3489,7 +3528,7 @@ d3d12_update_implicit_mask(struct comp_d3d12_compositor *c,
 // source UVs (matches d3d11_flatten_local_2d_layers). Caller holds c->mutex and
 // has ensured local2d_scratch at (region_w, region_h). Returns false on error.
 static bool
-d3d12_flatten_local_2d_layers(struct comp_d3d12_compositor *c, uint32_t region_w, uint32_t region_h)
+d3d12_flatten_local_2d_layers(struct comp_d3d12_compositor *c, uint32_t region_w, uint32_t region_h, int32_t proj_idx)
 {
 	D3D12_CPU_DESCRIPTOR_HANDLE rtv = c->local2d_scratch_rtv_heap->GetCPUDescriptorHandleForHeapStart();
 
@@ -3507,10 +3546,13 @@ d3d12_flatten_local_2d_layers(struct comp_d3d12_compositor *c, uint32_t region_w
 	const float transparent[4] = {0.0f, 0.0f, 0.0f, 0.0f};
 	c->cmd_list->ClearRenderTargetView(rtv, transparent, 0, nullptr);
 
-	uint32_t slot = 0;
 	for (uint32_t i = 0; i < c->layer_accum.layer_count; i++) {
 		struct comp_layer *layer = &c->layer_accum.layers[i];
 		if (layer->data.type != XRT_LAYER_LOCAL_2D) {
+			continue;
+		}
+		// #491 part 3 — under-layers (before the projection) are the DP backdrop.
+		if (proj_idx >= 0 && (int32_t)i < proj_idx) {
 			continue;
 		}
 		struct xrt_swapchain *sc = layer->sc_array[0];
@@ -3568,7 +3610,10 @@ d3d12_flatten_local_2d_layers(struct comp_d3d12_compositor *c, uint32_t region_w
 
 		bool unpremult = (layer->data.flags & XRT_LAYER_COMPOSITION_UNPREMULTIPLIED_ALPHA_BIT) != 0;
 
-		comp_d3d12_renderer_flatten_local_2d(c->renderer, c->cmd_list, rtv.ptr, src_res, slot++, x0, y0,
+		// #491 part 3 — use the layer's accum index as the flatten descriptor
+		// slot (unique across the pre-weave backdrop + this post-weave overlay,
+		// which share flatten_srv_heap within the one deferred cmd list).
+		comp_d3d12_renderer_flatten_local_2d(c->renderer, c->cmd_list, rtv.ptr, src_res, i, x0, y0,
 		                                     (uint32_t)(x1 - x0), (uint32_t)(y1 - y0), src_x, src_y, src_w,
 		                                     src_h, unpremult);
 	}
@@ -3582,6 +3627,210 @@ d3d12_flatten_local_2d_layers(struct comp_d3d12_compositor *c, uint32_t region_w
 	to_psr.Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
 	c->cmd_list->ResourceBarrier(1, &to_psr);
 	return true;
+}
+
+// #491 part 3 — ensure the 2D-under backdrop scratch (clone of
+// d3d12_ensure_local2d_scratch; separate so a model switch can't dangle it).
+static bool
+d3d12_ensure_backdrop_scratch(struct comp_d3d12_compositor *c, uint32_t w, uint32_t h)
+{
+	if (c->backdrop_scratch != nullptr && c->backdrop_scratch_w == w && c->backdrop_scratch_h == h) {
+		return true;
+	}
+	if (c->backdrop_scratch != nullptr) {
+		c->backdrop_scratch->Release();
+		c->backdrop_scratch = nullptr;
+	}
+	c->backdrop_scratch_w = 0;
+	c->backdrop_scratch_h = 0;
+
+	D3D12_RESOURCE_DESC desc = {};
+	desc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
+	desc.Width = w;
+	desc.Height = h;
+	desc.DepthOrArraySize = 1;
+	desc.MipLevels = 1;
+	desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	desc.SampleDesc.Count = 1;
+	desc.Flags = D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET;
+
+	D3D12_HEAP_PROPERTIES heap = {};
+	heap.Type = D3D12_HEAP_TYPE_DEFAULT;
+
+	D3D12_CLEAR_VALUE clear = {};
+	clear.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+
+	HRESULT hr = c->device->CreateCommittedResource(&heap, D3D12_HEAP_FLAG_NONE, &desc,
+	                                                D3D12_RESOURCE_STATE_COMMON, &clear,
+	                                                IID_PPV_ARGS(&c->backdrop_scratch));
+	if (FAILED(hr) || c->backdrop_scratch == nullptr) {
+		U_LOG_W("backdrop scratch alloc (%ux%u) failed: 0x%08x", w, h, hr);
+		c->backdrop_scratch = nullptr;
+		return false;
+	}
+
+	if (c->backdrop_scratch_rtv_heap == nullptr) {
+		D3D12_DESCRIPTOR_HEAP_DESC rtv_desc = {};
+		rtv_desc.NumDescriptors = 1;
+		rtv_desc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+		hr = c->device->CreateDescriptorHeap(&rtv_desc, IID_PPV_ARGS(&c->backdrop_scratch_rtv_heap));
+		if (FAILED(hr) || c->backdrop_scratch_rtv_heap == nullptr) {
+			U_LOG_W("backdrop scratch RTV heap failed: 0x%08x", hr);
+			c->backdrop_scratch->Release();
+			c->backdrop_scratch = nullptr;
+			return false;
+		}
+	}
+	c->device->CreateRenderTargetView(c->backdrop_scratch, nullptr,
+	                                  c->backdrop_scratch_rtv_heap->GetCPUDescriptorHandleForHeapStart());
+	c->backdrop_scratch_w = w;
+	c->backdrop_scratch_h = h;
+	return true;
+}
+
+// #491 part 3 — flatten this frame's 2D-UNDER Local2D layers (before the
+// projection in list order) into backdrop_scratch PRE-weave and return the
+// ID3D12Resource* (+ region dims) for set_background_2d (the DP creates its own
+// shader-visible SRV; the compose then puts `backdrop over captured-desktop`
+// under the 3D). Returns nullptr (out dims 0) when there are no under-layers.
+// Records into the OPEN c->cmd_list; leaves backdrop_scratch in
+// PIXEL_SHADER_RESOURCE (DP-sampleable, outlives process_atlas). Caller holds
+// c->mutex. Uses each layer's accum index as the flatten slot (unique vs the
+// post-weave overlay flatten that shares flatten_srv_heap in this cmd list).
+static ID3D12Resource *
+d3d12_flatten_backdrop_2d(struct comp_d3d12_compositor *c, uint32_t dst_w, uint32_t dst_h, uint32_t *out_w,
+                          uint32_t *out_h)
+{
+	*out_w = 0;
+	*out_h = 0;
+	if (!c->local_2d_last_frame || c->renderer == nullptr) {
+		return nullptr;
+	}
+
+	int32_t proj_idx = -1;
+	for (uint32_t i = 0; i < c->layer_accum.layer_count; i++) {
+		enum xrt_layer_type t = c->layer_accum.layers[i].data.type;
+		if (t == XRT_LAYER_PROJECTION || t == XRT_LAYER_PROJECTION_DEPTH) {
+			proj_idx = (int32_t)i;
+			break;
+		}
+	}
+	if (proj_idx < 0) {
+		return nullptr;
+	}
+	bool have_under = false;
+	for (int32_t i = 0; i < proj_idx; i++) {
+		if (c->layer_accum.layers[i].data.type == XRT_LAYER_LOCAL_2D) {
+			have_under = true;
+			break;
+		}
+	}
+	if (!have_under) {
+		return nullptr;
+	}
+
+	uint32_t region_w = dst_w;
+	uint32_t region_h = dst_h;
+	HWND wnd = c->hwnd != nullptr ? c->hwnd : c->app_hwnd;
+	if (wnd != nullptr) {
+		RECT r;
+		if (GetClientRect(wnd, &r) && r.right > 0 && r.bottom > 0) {
+			region_w = ((uint32_t)r.right < dst_w) ? (uint32_t)r.right : dst_w;
+			region_h = ((uint32_t)r.bottom < dst_h) ? (uint32_t)r.bottom : dst_h;
+		}
+	}
+	if (region_w == 0 || region_h == 0) {
+		return nullptr;
+	}
+
+	if (!d3d12_ensure_backdrop_scratch(c, region_w, region_h)) {
+		return nullptr;
+	}
+
+	D3D12_CPU_DESCRIPTOR_HANDLE rtv = c->backdrop_scratch_rtv_heap->GetCPUDescriptorHandleForHeapStart();
+
+	D3D12_RESOURCE_BARRIER to_rt = {};
+	to_rt.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+	to_rt.Transition.pResource = c->backdrop_scratch;
+	to_rt.Transition.StateBefore = D3D12_RESOURCE_STATE_COMMON;
+	to_rt.Transition.StateAfter = D3D12_RESOURCE_STATE_RENDER_TARGET;
+	to_rt.Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+	c->cmd_list->ResourceBarrier(1, &to_rt);
+
+	const float transparent[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+	c->cmd_list->ClearRenderTargetView(rtv, transparent, 0, nullptr);
+
+	for (int32_t i = 0; i < proj_idx; i++) {
+		struct comp_layer *layer = &c->layer_accum.layers[i];
+		if (layer->data.type != XRT_LAYER_LOCAL_2D) {
+			continue;
+		}
+		struct xrt_swapchain *sc = layer->sc_array[0];
+		if (sc == nullptr) {
+			continue;
+		}
+		uint32_t img_idx = layer->data.local_2d.sub.image_index;
+		ID3D12Resource *src_res = static_cast<ID3D12Resource *>(comp_d3d12_swapchain_get_resource(sc, img_idx));
+		if (src_res == nullptr) {
+			continue;
+		}
+		const struct xrt_rect *dr = &layer->data.local_2d.rect;
+		int32_t dx = dr->offset.w, dy = dr->offset.h, dw = dr->extent.w, dh = dr->extent.h;
+		if (dw <= 0 || dh <= 0) {
+			continue;
+		}
+		int32_t x0 = dx < 0 ? 0 : dx;
+		int32_t y0 = dy < 0 ? 0 : dy;
+		int32_t x1 = (dx + dw) > (int32_t)region_w ? (int32_t)region_w : (dx + dw);
+		int32_t y1 = (dy + dh) > (int32_t)region_h ? (int32_t)region_h : (dy + dh);
+		if (x1 <= x0 || y1 <= y0) {
+			continue;
+		}
+		float fx0 = (float)(x0 - dx) / (float)dw;
+		float fy0 = (float)(y0 - dy) / (float)dh;
+		float fx1 = (float)(x1 - dx) / (float)dw;
+		float fy1 = (float)(y1 - dy) / (float)dh;
+		struct xrt_normalized_rect nr = layer->data.local_2d.sub.norm_rect;
+		if (nr.w <= 0.0f || nr.h <= 0.0f) {
+			nr.x = 0.0f;
+			nr.y = 0.0f;
+			nr.w = 1.0f;
+			nr.h = 1.0f;
+		}
+		float src_x = nr.x + nr.w * fx0;
+		float src_w = nr.w * (fx1 - fx0);
+		float src_y, src_h;
+		if (layer->data.flip_y) {
+			src_y = nr.y + nr.h * (1.0f - fy0);
+			src_h = -(nr.h * (fy1 - fy0));
+		} else {
+			src_y = nr.y + nr.h * fy0;
+			src_h = nr.h * (fy1 - fy0);
+		}
+		bool unpremult = (layer->data.flags & XRT_LAYER_COMPOSITION_UNPREMULTIPLIED_ALPHA_BIT) != 0;
+		comp_d3d12_renderer_flatten_local_2d(c->renderer, c->cmd_list, rtv.ptr, src_res, i, x0, y0,
+		                                     (uint32_t)(x1 - x0), (uint32_t)(y1 - y0), src_x, src_y, src_w,
+		                                     src_h, unpremult);
+	}
+
+	D3D12_RESOURCE_BARRIER to_psr = {};
+	to_psr.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+	to_psr.Transition.pResource = c->backdrop_scratch;
+	to_psr.Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
+	to_psr.Transition.StateAfter = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+	to_psr.Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+	c->cmd_list->ResourceBarrier(1, &to_psr);
+
+	static bool logged = false;
+	if (!logged) {
+		logged = true;
+		U_LOG_W("D3D12 #491 part3: flattened 2D-under backdrop %ux%u (handed to DP set_background_2d)",
+		        region_w, region_h);
+	}
+
+	*out_w = region_w;
+	*out_h = region_h;
+	return c->backdrop_scratch;
 }
 
 // #439 — composite the authored zone mask. Records into the OPEN c->cmd_list
@@ -3653,6 +3902,17 @@ d3d12_composite_zone_mask(struct comp_d3d12_compositor *c,
 	// Resolve the mask source: an explicit submitted mask wins; else
 	// rasterize the implicit mask from the Local2D layer rects (M=0 inside the
 	// rect union, M=1 elsewhere — records onto the open cmd-list).
+	// #491 part 3 — split Local2D by list order vs the projection: under-layers
+	// (before the projection) are the DP backdrop, excluded from the overlay.
+	int32_t proj_idx = -1;
+	for (uint32_t i = 0; i < c->layer_accum.layer_count; i++) {
+		enum xrt_layer_type t = c->layer_accum.layers[i].data.type;
+		if (t == XRT_LAYER_PROJECTION || t == XRT_LAYER_PROJECTION_DEPTH) {
+			proj_idx = (int32_t)i;
+			break;
+		}
+	}
+
 	ID3D12Resource *mask_res = nullptr;
 	if (have_explicit) {
 		mask_res = mask->staged;
@@ -3660,9 +3920,13 @@ d3d12_composite_zone_mask(struct comp_d3d12_compositor *c,
 		struct xrt_rect rects[XRT_MAX_LAYERS];
 		uint32_t rect_count = 0;
 		for (uint32_t i = 0; i < c->layer_accum.layer_count && rect_count < XRT_MAX_LAYERS; i++) {
-			if (c->layer_accum.layers[i].data.type == XRT_LAYER_LOCAL_2D) {
-				rects[rect_count++] = c->layer_accum.layers[i].data.local_2d.rect;
+			if (c->layer_accum.layers[i].data.type != XRT_LAYER_LOCAL_2D) {
+				continue;
 			}
+			if (proj_idx >= 0 && (int32_t)i < proj_idx) {
+				continue; // under-layer (backdrop) — not part of the overlay mask
+			}
+			rects[rect_count++] = c->layer_accum.layers[i].data.local_2d.rect;
 		}
 		mask_res = d3d12_update_implicit_mask(c, rects, rect_count, region_w, region_h);
 	}
@@ -3682,7 +3946,7 @@ d3d12_composite_zone_mask(struct comp_d3d12_compositor *c,
 		if (!d3d12_ensure_scratch(c, &c->weave_scratch, region_w, region_h, dd.Format, "local2d weave")) {
 			return false;
 		}
-		if (!d3d12_flatten_local_2d_layers(c, region_w, region_h)) {
+		if (!d3d12_flatten_local_2d_layers(c, region_w, region_h, proj_idx)) {
 			return false;
 		}
 		twod_res = c->local2d_scratch;

--- a/src/xrt/compositor/gl/comp_gl_compositor.cpp
+++ b/src/xrt/compositor/gl/comp_gl_compositor.cpp
@@ -368,6 +368,11 @@ struct comp_gl_compositor
 	GLuint local2d_scratch_tex, local2d_scratch_fbo;
 	GLuint implicit_mask_tex, implicit_mask_fbo;
 	uint32_t composite_scratch_w, composite_scratch_h; // weave + local2d dims
+	//! #491 part 3 — the flattened 2D-UNDER backdrop (Local2D layers before the
+	//! projection in list order), handed to the DP via set_background_2d so it
+	//! composites `backdrop over captured-desktop` under the 3D weave. Own FBO.
+	GLuint backdrop_scratch_tex, backdrop_scratch_fbo;
+	uint32_t backdrop_scratch_w, backdrop_scratch_h;
 	uint32_t implicit_mask_w, implicit_mask_h;
 	uint32_t implicit_rect_count;
 	struct xrt_rect implicit_rects[XRT_MAX_LAYERS];
@@ -1073,6 +1078,11 @@ gl_compositor_render_hud(struct comp_gl_compositor *c, float dt, uint32_t win_w,
  *
  */
 
+// #491 part 3 — defined below near the composite; called here pre-weave.
+static GLuint
+gl_flatten_backdrop_2d(struct comp_gl_compositor *c, uint32_t dst_w, uint32_t dst_h, uint32_t *out_w,
+                       uint32_t *out_h);
+
 /*!
  * Crop the valid content region from the (potentially oversized) atlas texture
  * and pass it to the display processor. If the atlas exactly matches the
@@ -1089,6 +1099,22 @@ gl_crop_and_process_dp(struct comp_gl_compositor *c,
                        uint32_t output_w,
                        uint32_t output_h)
 {
+	// #491 part 3 — flatten the 2D-under layers PRE-weave and hand them to the DP
+	// (it composites `backdrop over captured-desktop` under the 3D). 0 ⟹ no
+	// under-layers (DP clears its backdrop). Covers the plain present, the
+	// shared-texture/IOSurface paths, and the under-only fallback from the masked
+	// composite. The flatten binds its own FBO, so snapshot/restore the caller's
+	// draw FBO (the shared-texture path binds c->fbo before calling) so the DP
+	// weaves into the intended target.
+	{
+		GLint prev_draw_fbo = 0;
+		glGetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, &prev_draw_fbo);
+		uint32_t bd_w = 0, bd_h = 0;
+		GLuint bd_tex = gl_flatten_backdrop_2d(c, output_w, output_h, &bd_w, &bd_h);
+		xrt_display_processor_gl_set_background_2d(c->display_processor, bd_tex, bd_w, bd_h);
+		glBindFramebuffer(GL_FRAMEBUFFER, (GLuint)prev_draw_fbo);
+	}
+
 	uint32_t content_w = c->tile_columns * c->view_width;
 	uint32_t content_h = c->tile_rows * c->view_height;
 
@@ -1297,12 +1323,89 @@ gl_update_implicit_mask(struct comp_gl_compositor *c,
 	return c->implicit_mask_tex;
 }
 
-// #439 Phase 3 — flatten this frame's Local2D layers into local2d_scratch (the
-// `twod` source). Clears transparent, draws each layer in list order (later =
-// on top) with premultiplied (or straight) "over" via program_window_space.
-// Dest rects clip to the window region; flip Y for the bottom-left GL FBO.
+// #439 Phase 3 — draw one Local2D layer into the currently-bound flatten FBO
+// (premultiplied or straight "over"). Assumes program_window_space is bound and
+// the loc_* uniforms fetched by the caller. Dest rect clips to the window region;
+// Y is flipped for the bottom-left GL framebuffer.
 static void
-gl_flatten_local_2d_layers(struct comp_gl_compositor *c, uint32_t region_w, uint32_t region_h)
+gl_flatten_one_local2d_layer(struct comp_gl_compositor *c, struct comp_layer *layer, uint32_t region_w,
+                             uint32_t region_h, GLint loc_rect, GLint loc_tex, GLint loc_src, bool skip_decode)
+{
+	struct xrt_swapchain *sc = layer->sc_array[0];
+	if (sc == NULL) {
+		return;
+	}
+	struct comp_gl_swapchain *gsc = gl_swapchain(sc);
+	uint32_t img_idx = layer->data.local_2d.sub.image_index;
+	if (img_idx >= gsc->image_count) {
+		return;
+	}
+	GLuint src_tex = gsc->textures[img_idx];
+
+	const struct xrt_rect *dr = &layer->data.local_2d.rect;
+	float dx = (float)dr->offset.w;
+	float dy = (float)dr->offset.h;
+	float dw = (float)dr->extent.w;
+	float dh = (float)dr->extent.h;
+	if (dw <= 0.0f || dh <= 0.0f) {
+		return;
+	}
+
+	// NDC rect for the positioned-quad VS. Window pixels are top-left origin;
+	// flip Y for the bottom-left GL framebuffer: the panel's GL bottom edge is
+	// region_h - (dy + dh).
+	float nx = dx / (float)region_w * 2.0f - 1.0f;
+	float ny = ((float)region_h - (dy + dh)) / (float)region_h * 2.0f - 1.0f;
+	float nw = dw / (float)region_w * 2.0f;
+	float nh = dh / (float)region_h * 2.0f;
+
+	// App sub-rect within the swapchain image (normalized). Default full.
+	struct xrt_normalized_rect nr = layer->data.local_2d.sub.norm_rect;
+	if (nr.w <= 0.0f || nr.h <= 0.0f) {
+		nr.x = 0.0f;
+		nr.y = 0.0f;
+		nr.w = 1.0f;
+		nr.h = 1.0f;
+	}
+	// VS_WINDOW_SPACE maps the NDC top to v_uv.y=0; combined with the GL
+	// bottom-left flip above, sample the source bottom-up so the panel is
+	// upright. flip_y inverts that.
+	float src_x = nr.x;
+	float src_w = nr.w;
+	float src_y, src_h;
+	if (layer->data.flip_y) {
+		src_y = nr.y;
+		src_h = nr.h;
+	} else {
+		src_y = nr.y + nr.h;
+		src_h = -nr.h;
+	}
+
+	bool unpremult = (layer->data.flags & XRT_LAYER_COMPOSITION_UNPREMULTIPLIED_ALPHA_BIT) != 0;
+	glEnable(GL_BLEND);
+	if (unpremult) {
+		glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
+	} else {
+		glBlendFuncSeparate(GL_ONE, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
+	}
+
+	glActiveTexture(GL_TEXTURE0);
+	glBindTexture(GL_TEXTURE_2D, src_tex);
+	if (skip_decode) {
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SRGB_DECODE_EXT, GL_SKIP_DECODE_EXT);
+	}
+	glUniform1i(loc_tex, 0);
+	glUniform4f(loc_rect, nx, ny, nw, nh);
+	glUniform4f(loc_src, src_x, src_y, src_w, src_h);
+	glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+}
+
+// #439 Phase 3 — flatten this frame's OVER Local2D layers into local2d_scratch
+// (the `twod` source). Clears transparent, draws each layer in list order (later
+// = on top). #491 part 3: under-layers (before the projection in list order,
+// proj_idx) are the DP backdrop and are skipped here.
+static void
+gl_flatten_local_2d_layers(struct comp_gl_compositor *c, uint32_t region_w, uint32_t region_h, int32_t proj_idx)
 {
 	glBindFramebuffer(GL_FRAMEBUFFER, c->local2d_scratch_fbo);
 	glViewport(0, 0, region_w, region_h);
@@ -1322,78 +1425,107 @@ gl_flatten_local_2d_layers(struct comp_gl_compositor *c, uint32_t region_w, uint
 		if (layer->data.type != XRT_LAYER_LOCAL_2D) {
 			continue;
 		}
-		struct xrt_swapchain *sc = layer->sc_array[0];
-		if (sc == NULL) {
+		// #491 part 3 — under-layers are the DP backdrop (handled pre-weave).
+		if (proj_idx >= 0 && (int32_t)i < proj_idx) {
 			continue;
 		}
-		struct comp_gl_swapchain *gsc = gl_swapchain(sc);
-		uint32_t img_idx = layer->data.local_2d.sub.image_index;
-		if (img_idx >= gsc->image_count) {
-			continue;
-		}
-		GLuint src_tex = gsc->textures[img_idx];
-
-		const struct xrt_rect *dr = &layer->data.local_2d.rect;
-		float dx = (float)dr->offset.w;
-		float dy = (float)dr->offset.h;
-		float dw = (float)dr->extent.w;
-		float dh = (float)dr->extent.h;
-		if (dw <= 0.0f || dh <= 0.0f) {
-			continue;
-		}
-
-		// NDC rect for the positioned-quad VS. Window pixels are top-left
-		// origin; flip Y for the bottom-left GL framebuffer: the panel's GL
-		// bottom edge is region_h - (dy + dh).
-		float nx = dx / (float)region_w * 2.0f - 1.0f;
-		float ny = ((float)region_h - (dy + dh)) / (float)region_h * 2.0f - 1.0f;
-		float nw = dw / (float)region_w * 2.0f;
-		float nh = dh / (float)region_h * 2.0f;
-
-		// App sub-rect within the swapchain image (normalized). Default full.
-		struct xrt_normalized_rect nr = layer->data.local_2d.sub.norm_rect;
-		if (nr.w <= 0.0f || nr.h <= 0.0f) {
-			nr.x = 0.0f;
-			nr.y = 0.0f;
-			nr.w = 1.0f;
-			nr.h = 1.0f;
-		}
-		// VS_WINDOW_SPACE maps the NDC top to v_uv.y=0; combined with the GL
-		// bottom-left flip above, sample the source bottom-up so the panel is
-		// upright. flip_y inverts that.
-		float src_x = nr.x;
-		float src_w = nr.w;
-		float src_y, src_h;
-		if (layer->data.flip_y) {
-			src_y = nr.y;
-			src_h = nr.h;
-		} else {
-			src_y = nr.y + nr.h;
-			src_h = -nr.h;
-		}
-
-		bool unpremult = (layer->data.flags & XRT_LAYER_COMPOSITION_UNPREMULTIPLIED_ALPHA_BIT) != 0;
-		glEnable(GL_BLEND);
-		if (unpremult) {
-			glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
-		} else {
-			glBlendFuncSeparate(GL_ONE, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
-		}
-
-		glActiveTexture(GL_TEXTURE0);
-		glBindTexture(GL_TEXTURE_2D, src_tex);
-		if (skip_decode) {
-			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SRGB_DECODE_EXT, GL_SKIP_DECODE_EXT);
-		}
-		glUniform1i(loc_tex, 0);
-		glUniform4f(loc_rect, nx, ny, nw, nh);
-		glUniform4f(loc_src, src_x, src_y, src_w, src_h);
-		glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+		gl_flatten_one_local2d_layer(c, layer, region_w, region_h, loc_rect, loc_tex, loc_src, skip_decode);
 	}
 
 	glDisable(GL_BLEND);
 	glBindTexture(GL_TEXTURE_2D, 0);
 	glBindFramebuffer(GL_FRAMEBUFFER, 0);
+}
+
+// #491 part 3 — flatten this frame's 2D-UNDER Local2D layers (before the
+// projection in list order) into backdrop_scratch PRE-weave and return its GL
+// texture name (+ region dims) so the caller hands it to the DP via
+// set_background_2d (the DP composites `backdrop over captured-desktop` under the
+// 3D). Returns 0 (out dims 0) when there are no under-layers.
+//
+// NOTE: the GL Leia DP is chroma-key-only (no WGC compose-under-bg path, see
+// project_leia_transparency_model) → the backdrop has nowhere to composite, so
+// the GL leg's set_background_2d is a VISUAL NO-OP today; the wiring lands so it
+// works once GL transparency/compose lands (separate deferred follow-up).
+static GLuint
+gl_flatten_backdrop_2d(struct comp_gl_compositor *c, uint32_t dst_w, uint32_t dst_h, uint32_t *out_w,
+                       uint32_t *out_h)
+{
+	*out_w = 0;
+	*out_h = 0;
+	if (!c->local_2d_last_frame) {
+		return 0;
+	}
+
+	// Under = Local2D layers BEFORE the projection. No projection ⟹ no backdrop.
+	int32_t proj_idx = -1;
+	for (uint32_t i = 0; i < c->layer_accum.layer_count; i++) {
+		enum xrt_layer_type t = c->layer_accum.layers[i].data.type;
+		if (t == XRT_LAYER_PROJECTION || t == XRT_LAYER_PROJECTION_DEPTH) {
+			proj_idx = (int32_t)i;
+			break;
+		}
+	}
+	if (proj_idx < 0) {
+		return 0;
+	}
+	bool have_under = false;
+	for (int32_t i = 0; i < proj_idx; i++) {
+		if (c->layer_accum.layers[i].data.type == XRT_LAYER_LOCAL_2D) {
+			have_under = true;
+			break;
+		}
+	}
+	if (!have_under) {
+		return 0;
+	}
+
+	uint32_t region_w = dst_w;
+	uint32_t region_h = dst_h;
+	if (region_w == 0 || region_h == 0) {
+		return 0;
+	}
+	if (!gl_ensure_color_tex_fbo(&c->backdrop_scratch_tex, &c->backdrop_scratch_fbo, &c->backdrop_scratch_w,
+	                             &c->backdrop_scratch_h, region_w, region_h)) {
+		return 0;
+	}
+
+	glBindFramebuffer(GL_FRAMEBUFFER, c->backdrop_scratch_fbo);
+	glViewport(0, 0, region_w, region_h);
+	glDisable(GL_SCISSOR_TEST);
+	glClearColor(0.0f, 0.0f, 0.0f, 0.0f); // transparent where no under-layer covers
+	glClear(GL_COLOR_BUFFER_BIT);
+
+	glUseProgram(c->program_window_space);
+	glBindVertexArray(c->vao_empty);
+	GLint loc_rect = glGetUniformLocation(c->program_window_space, "u_rect");
+	GLint loc_tex = glGetUniformLocation(c->program_window_space, "u_texture");
+	GLint loc_src = glGetUniformLocation(c->program_window_space, "u_src_rect");
+	const bool skip_decode = gl_has_srgb_decode_ext();
+
+	for (int32_t i = 0; i < proj_idx; i++) {
+		struct comp_layer *layer = &c->layer_accum.layers[i];
+		if (layer->data.type != XRT_LAYER_LOCAL_2D) {
+			continue;
+		}
+		gl_flatten_one_local2d_layer(c, layer, region_w, region_h, loc_rect, loc_tex, loc_src, skip_decode);
+	}
+
+	glDisable(GL_BLEND);
+	glBindTexture(GL_TEXTURE_2D, 0);
+	glBindFramebuffer(GL_FRAMEBUFFER, 0);
+
+	static bool logged = false;
+	if (!logged) {
+		logged = true;
+		U_LOG_W("GL #491 part3: flattened 2D-under backdrop %ux%u (handed to DP set_background_2d; "
+		        "GL DP is chroma-key-only → visual no-op until GL compose lands)",
+		        region_w, region_h);
+	}
+
+	*out_w = region_w;
+	*out_h = region_h;
+	return c->backdrop_scratch_tex;
 }
 
 // Weave the (cropped) atlas into an arbitrary target FBO — same crop logic as
@@ -1460,6 +1592,18 @@ gl_composite_local_2d(struct comp_gl_compositor *c, GLuint atlas_tex, GLuint tar
 		return false;
 	}
 
+	// #491 part 3 — split Local2D by list order vs the projection: layers BEFORE
+	// the projection are the 2D-under backdrop (handed to the DP pre-weave) and
+	// are excluded from the overlay mask + flatten here.
+	int32_t proj_idx = -1;
+	for (uint32_t i = 0; i < c->layer_accum.layer_count; i++) {
+		enum xrt_layer_type t = c->layer_accum.layers[i].data.type;
+		if (t == XRT_LAYER_PROJECTION || t == XRT_LAYER_PROJECTION_DEPTH) {
+			proj_idx = (int32_t)i;
+			break;
+		}
+	}
+
 	// weave_tex + local2d_scratch are both window-sized; (re)allocate them
 	// together under one dims guard (composite_scratch_w/h is the canonical
 	// pair). The inner ensure's throwaway dims are fine — it only runs when the
@@ -1484,9 +1628,13 @@ gl_composite_local_2d(struct comp_gl_compositor *c, GLuint atlas_tex, GLuint tar
 		struct xrt_rect rects[XRT_MAX_LAYERS];
 		uint32_t rect_count = 0;
 		for (uint32_t i = 0; i < c->layer_accum.layer_count && rect_count < XRT_MAX_LAYERS; i++) {
-			if (c->layer_accum.layers[i].data.type == XRT_LAYER_LOCAL_2D) {
-				rects[rect_count++] = c->layer_accum.layers[i].data.local_2d.rect;
+			if (c->layer_accum.layers[i].data.type != XRT_LAYER_LOCAL_2D) {
+				continue;
 			}
+			if (proj_idx >= 0 && (int32_t)i < proj_idx) {
+				continue; // under-layer (backdrop) — not part of the overlay mask
+			}
+			rects[rect_count++] = c->layer_accum.layers[i].data.local_2d.rect;
 		}
 		mask_tex = gl_update_implicit_mask(c, rects, rect_count, output_w, output_h);
 	}
@@ -1498,13 +1646,22 @@ gl_composite_local_2d(struct comp_gl_compositor *c, GLuint atlas_tex, GLuint tar
 	// pure explicit-mask frame) the scratch stays transparent → the masked
 	// region shows the desktop, matching the VK leg.
 	if (have_local_2d) {
-		gl_flatten_local_2d_layers(c, output_w, output_h);
+		gl_flatten_local_2d_layers(c, output_w, output_h, proj_idx);
 	} else {
 		glBindFramebuffer(GL_FRAMEBUFFER, c->local2d_scratch_fbo);
 		glViewport(0, 0, output_w, output_h);
 		glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
 		glClear(GL_COLOR_BUFFER_BIT);
 		glBindFramebuffer(GL_FRAMEBUFFER, 0);
+	}
+
+	// #491 part 3 — flatten the 2D-under layers PRE-weave and hand them to the DP
+	// (it composites `backdrop over captured-desktop` under the 3D weave). 0 ⟹ no
+	// under-layers. Must precede the weave redirect below.
+	{
+		uint32_t bd_w = 0, bd_h = 0;
+		GLuint bd_tex = gl_flatten_backdrop_2d(c, output_w, output_h, &bd_w, &bd_h);
+		xrt_display_processor_gl_set_background_2d(c->display_processor, bd_tex, bd_w, bd_h);
 	}
 
 	// Redirect the DP weave into weave_tex.
@@ -2306,6 +2463,9 @@ gl_compositor_destroy(struct xrt_compositor *xc)
 	if (c->local2d_scratch_fbo) glDeleteFramebuffers(1, &c->local2d_scratch_fbo);
 	if (c->implicit_mask_tex) glDeleteTextures(1, &c->implicit_mask_tex);
 	if (c->implicit_mask_fbo) glDeleteFramebuffers(1, &c->implicit_mask_fbo);
+	// #491 part 3 — 2D-under backdrop scratch.
+	if (c->backdrop_scratch_tex) glDeleteTextures(1, &c->backdrop_scratch_tex);
+	if (c->backdrop_scratch_fbo) glDeleteFramebuffers(1, &c->backdrop_scratch_fbo);
 
 #ifdef XRT_OS_WINDOWS
 	// Clean up D3D11 interop resources

--- a/src/xrt/compositor/metal/comp_metal_compositor.m
+++ b/src/xrt/compositor/metal/comp_metal_compositor.m
@@ -282,6 +282,13 @@ struct comp_metal_compositor
 	uint32_t composite_w;               //!< Current scratch width (0 = not allocated)
 	uint32_t composite_h;               //!< Current scratch height
 
+	//! #491 part 3 — the flattened 2D-UNDER backdrop (Local2D layers before the
+	//! projection in list order), handed to the DP via set_background_2d so it
+	//! composites `backdrop over captured-desktop` under the 3D weave.
+	id<MTLTexture> backdrop_scratch;
+	uint32_t backdrop_w;                //!< Current backdrop scratch width (0 = none)
+	uint32_t backdrop_h;
+
 	//! Pipelines for the Local2D flatten (premultiplied over / unpremultiplied
 	//! source) and the masked composite pass.
 	id<MTLRenderPipelineState> local2d_premult_pipeline;
@@ -1954,6 +1961,232 @@ metal_ensure_composite_scratch(struct comp_metal_compositor *c, uint32_t w, uint
 	return true;
 }
 
+// #491 part 3 — (re)allocate the 2D-under backdrop scratch (BGRA8, render-target
+// + shader-read, premultiplied) at w×h. No-op when already matching.
+static bool
+metal_ensure_backdrop_scratch(struct comp_metal_compositor *c, uint32_t w, uint32_t h)
+{
+	if (c->backdrop_w == w && c->backdrop_h == h && c->backdrop_scratch != nil) {
+		return true;
+	}
+	[c->backdrop_scratch release];
+	c->backdrop_scratch = nil;
+	c->backdrop_w = 0;
+	c->backdrop_h = 0;
+
+	MTLTextureDescriptor *desc =
+	    [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:MTLPixelFormatBGRA8Unorm
+	                                                       width:w
+	                                                      height:h
+	                                                   mipmapped:NO];
+	desc.usage = MTLTextureUsageRenderTarget | MTLTextureUsageShaderRead;
+	c->backdrop_scratch = [c->device newTextureWithDescriptor:desc];
+	if (c->backdrop_scratch == nil) {
+		U_LOG_E("Failed to allocate backdrop scratch texture (%ux%u)", w, h);
+		return false;
+	}
+	c->backdrop_w = w;
+	c->backdrop_h = h;
+	return true;
+}
+
+// #439 Phase 3 / #491 part 3 — draw one Local2D layer into the currently-bound
+// flatten render encoder (premultiplied / unpremultiplied "over", sRGB
+// passthrough). Dest rect clips to the w×h window scratch; clipped fractions
+// carry into the source UVs. Shared by the over-flatten (masked composite) and
+// the under-flatten (backdrop).
+static void
+metal_flatten_one_local2d_layer(struct comp_metal_compositor *c,
+                                id<MTLRenderCommandEncoder> enc,
+                                struct comp_layer *layer,
+                                uint32_t w,
+                                uint32_t h)
+{
+	struct xrt_swapchain *sc = layer->sc_array[0];
+	if (sc == NULL) {
+		return;
+	}
+	struct comp_metal_swapchain *msc = metal_swapchain(sc);
+	uint32_t img_idx = layer->data.local_2d.sub.image_index;
+	if (img_idx >= msc->image_count || msc->images[img_idx] == nil) {
+		return;
+	}
+
+	// Clip the dest rect to the window scratch; carry the clipped fractions
+	// into the source UVs.
+	const struct xrt_rect *dr = &layer->data.local_2d.rect;
+	int32_t dx = dr->offset.w;
+	int32_t dy = dr->offset.h;
+	int32_t dw = dr->extent.w;
+	int32_t dh = dr->extent.h;
+	if (dw <= 0 || dh <= 0) {
+		return;
+	}
+	int32_t x0 = dx < 0 ? 0 : dx;
+	int32_t y0 = dy < 0 ? 0 : dy;
+	int32_t x1 = (dx + dw) > (int32_t)w ? (int32_t)w : (dx + dw);
+	int32_t y1 = (dy + dh) > (int32_t)h ? (int32_t)h : (dy + dh);
+	if (x1 <= x0 || y1 <= y0) {
+		return;
+	}
+	float fx0 = (float)(x0 - dx) / (float)dw;
+	float fy0 = (float)(y0 - dy) / (float)dh;
+	float fx1 = (float)(x1 - dx) / (float)dw;
+	float fy1 = (float)(y1 - dy) / (float)dh;
+
+	struct xrt_normalized_rect nr = layer->data.local_2d.sub.norm_rect;
+	if (nr.w <= 0.0f || nr.h <= 0.0f) {
+		nr.x = 0.0f;
+		nr.y = 0.0f;
+		nr.w = 1.0f;
+		nr.h = 1.0f;
+	}
+
+	// sRGB passthrough (see projection pass).
+	id<MTLTexture> src_tex = msc->images[img_idx];
+	id<MTLTexture> src_view = nil;
+	{
+		MTLPixelFormat unorm_fmt = metal_srgb_to_unorm(src_tex.pixelFormat);
+		if (unorm_fmt != src_tex.pixelFormat) {
+			src_view = [src_tex newTextureViewWithPixelFormat:unorm_fmt];
+			if (src_view != nil) {
+				src_tex = src_view;
+			}
+		}
+	}
+
+	MTLViewport vp;
+	vp.originX = x0;
+	vp.originY = y0;
+	vp.width = x1 - x0;
+	vp.height = y1 - y0;
+	vp.znear = 0.0;
+	vp.zfar = 1.0;
+	[enc setViewport:vp];
+
+	bool unpremult = (layer->data.flags & XRT_LAYER_COMPOSITION_UNPREMULTIPLIED_ALPHA_BIT) != 0;
+	[enc setRenderPipelineState:unpremult ? c->local2d_unpremult_pipeline : c->local2d_premult_pipeline];
+	[enc setFragmentTexture:src_tex atIndex:0];
+	[enc setFragmentSamplerState:c->sampler_linear atIndex:0];
+
+	struct {
+		float viewport[4];
+		float src_rect[4];
+		float color_scale[4];
+		float color_bias[4];
+		float swizzle_rb;
+		float _pad[3];
+	} constants;
+
+	constants.viewport[0] = 0.0f;
+	constants.viewport[1] = 0.0f;
+	constants.viewport[2] = 1.0f;
+	constants.viewport[3] = 1.0f;
+
+	constants.src_rect[0] = nr.x + nr.w * fx0;
+	constants.src_rect[2] = nr.w * (fx1 - fx0);
+	if (layer->data.flip_y) {
+		constants.src_rect[1] = nr.y + nr.h * (1.0f - fy0);
+		constants.src_rect[3] = -(nr.h * (fy1 - fy0));
+	} else {
+		constants.src_rect[1] = nr.y + nr.h * fy0;
+		constants.src_rect[3] = nr.h * (fy1 - fy0);
+	}
+
+	constants.color_scale[0] = 1.0f;
+	constants.color_scale[1] = 1.0f;
+	constants.color_scale[2] = 1.0f;
+	constants.color_scale[3] = 1.0f;
+	constants.color_bias[0] = 0.0f;
+	constants.color_bias[1] = 0.0f;
+	constants.color_bias[2] = 0.0f;
+	constants.color_bias[3] = 0.0f;
+	constants.swizzle_rb = 0.0f;
+	constants._pad[0] = constants._pad[1] = constants._pad[2] = 0.0f;
+
+	[enc setVertexBytes:&constants length:sizeof(constants) atIndex:0];
+	[enc setFragmentBytes:&constants length:sizeof(constants) atIndex:0];
+	[enc drawPrimitives:MTLPrimitiveTypeTriangle vertexStart:0 vertexCount:3];
+
+	[src_view release];
+}
+
+// #491 part 3 — flatten this frame's 2D-UNDER Local2D layers (before the
+// projection in list order) into backdrop_scratch PRE-weave and return it (+
+// region dims) so the caller hands it to the DP via set_background_2d (the DP
+// composites `backdrop over captured-desktop` under the 3D). Returns nil (out
+// dims 0) when there are no under-layers. The flatten is encoded on @p cmd_buf
+// before the DP's process_atlas.
+static id<MTLTexture>
+metal_flatten_backdrop_2d(struct comp_metal_compositor *c,
+                          id<MTLCommandBuffer> cmd_buf,
+                          uint32_t dst_w,
+                          uint32_t dst_h,
+                          uint32_t *out_w,
+                          uint32_t *out_h)
+{
+	*out_w = 0;
+	*out_h = 0;
+	if (!c->local_2d_last_frame || dst_w == 0 || dst_h == 0) {
+		return nil;
+	}
+
+	// Under = Local2D layers BEFORE the projection. No projection ⟹ no backdrop.
+	int32_t proj_idx = -1;
+	for (uint32_t i = 0; i < c->layer_accum.layer_count; i++) {
+		enum xrt_layer_type t = c->layer_accum.layers[i].data.type;
+		if (t == XRT_LAYER_PROJECTION || t == XRT_LAYER_PROJECTION_DEPTH) {
+			proj_idx = (int32_t)i;
+			break;
+		}
+	}
+	if (proj_idx < 0) {
+		return nil;
+	}
+	bool have_under = false;
+	for (int32_t i = 0; i < proj_idx; i++) {
+		if (c->layer_accum.layers[i].data.type == XRT_LAYER_LOCAL_2D) {
+			have_under = true;
+			break;
+		}
+	}
+	if (!have_under) {
+		return nil;
+	}
+
+	uint32_t w = dst_w;
+	uint32_t h = dst_h;
+	if (!metal_ensure_backdrop_scratch(c, w, h)) {
+		return nil;
+	}
+
+	MTLRenderPassDescriptor *pass = [MTLRenderPassDescriptor renderPassDescriptor];
+	pass.colorAttachments[0].texture = c->backdrop_scratch;
+	pass.colorAttachments[0].loadAction = MTLLoadActionClear;
+	pass.colorAttachments[0].storeAction = MTLStoreActionStore;
+	pass.colorAttachments[0].clearColor = MTLClearColorMake(0.0, 0.0, 0.0, 0.0);
+
+	id<MTLRenderCommandEncoder> enc = [cmd_buf renderCommandEncoderWithDescriptor:pass];
+	for (int32_t i = 0; i < proj_idx; i++) {
+		struct comp_layer *layer = &c->layer_accum.layers[i];
+		if (layer->data.type != XRT_LAYER_LOCAL_2D) {
+			continue;
+		}
+		metal_flatten_one_local2d_layer(c, enc, layer, w, h);
+	}
+	[enc endEncoding];
+
+	static bool logged = false;
+	if (!logged) {
+		logged = true;
+		U_LOG_W("Metal #491 part3: flattened 2D-under backdrop %ux%u (handed to DP set_background_2d)", w, h);
+	}
+
+	*out_w = w;
+	*out_h = h;
+	return c->backdrop_scratch;
+}
+
 /*!
  * The Metal Local-2D consumer (#439 Phase 3, impl doc §4 steps 2/4/5):
  * resolve the frame's mask (explicit staged, else implicit from layer
@@ -2002,6 +2235,18 @@ metal_composite_local_2d(struct comp_metal_compositor *c,
 	if (w > (uint32_t)output_texture.width) w = (uint32_t)output_texture.width;
 	if (h > (uint32_t)output_texture.height) h = (uint32_t)output_texture.height;
 
+	// #491 part 3 — split Local2D by list order vs the projection: layers BEFORE
+	// the projection are the 2D-under backdrop (handed to the DP pre-weave) and
+	// are excluded from the overlay mask + flatten here.
+	int32_t proj_idx = -1;
+	for (uint32_t i = 0; i < c->layer_accum.layer_count; i++) {
+		enum xrt_layer_type t = c->layer_accum.layers[i].data.type;
+		if (t == XRT_LAYER_PROJECTION || t == XRT_LAYER_PROJECTION_DEPTH) {
+			proj_idx = (int32_t)i;
+			break;
+		}
+	}
+
 	// Step 2 — resolve the frame's mask.
 	id<MTLTexture> mask_tex = nil;
 	if (c->zone_mask_active != NULL && c->zone_mask_active->submitted) {
@@ -2010,9 +2255,13 @@ metal_composite_local_2d(struct comp_metal_compositor *c,
 		struct xrt_rect rects[XRT_MAX_LAYERS];
 		uint32_t rect_count = 0;
 		for (uint32_t i = 0; i < c->layer_accum.layer_count && rect_count < XRT_MAX_LAYERS; i++) {
-			if (c->layer_accum.layers[i].data.type == XRT_LAYER_LOCAL_2D) {
-				rects[rect_count++] = c->layer_accum.layers[i].data.local_2d.rect;
+			if (c->layer_accum.layers[i].data.type != XRT_LAYER_LOCAL_2D) {
+				continue;
 			}
+			if (proj_idx >= 0 && (int32_t)i < proj_idx) {
+				continue; // under-layer (backdrop) — not part of the overlay mask
+			}
+			rects[rect_count++] = c->layer_accum.layers[i].data.local_2d.rect;
 		}
 		mask_tex = metal_update_implicit_mask(c, rects, rect_count, w, h);
 	}
@@ -2034,120 +2283,18 @@ metal_composite_local_2d(struct comp_metal_compositor *c,
 
 		id<MTLRenderCommandEncoder> enc = [cmd_buf renderCommandEncoderWithDescriptor:pass];
 
-		// Flatten Local2D layers in layer-list (accumulation) order.
+		// Flatten the OVER Local2D layers in layer-list (accumulation) order.
+		// #491 part 3: under-layers (before the projection) are the DP backdrop
+		// and are skipped here.
 		for (uint32_t i = 0; have_local_2d && i < c->layer_accum.layer_count; i++) {
 			struct comp_layer *layer = &c->layer_accum.layers[i];
 			if (layer->data.type != XRT_LAYER_LOCAL_2D) {
 				continue;
 			}
-			struct xrt_swapchain *sc = layer->sc_array[0];
-			if (sc == NULL) {
-				continue;
+			if (proj_idx >= 0 && (int32_t)i < proj_idx) {
+				continue; // under-layer (backdrop) — handled pre-weave
 			}
-			struct comp_metal_swapchain *msc = metal_swapchain(sc);
-			uint32_t img_idx = layer->data.local_2d.sub.image_index;
-			if (img_idx >= msc->image_count || msc->images[img_idx] == nil) {
-				continue;
-			}
-
-			// Clip the dest rect to the window scratch; carry the
-			// clipped fractions into the source UVs.
-			const struct xrt_rect *dr = &layer->data.local_2d.rect;
-			int32_t dx = dr->offset.w;
-			int32_t dy = dr->offset.h;
-			int32_t dw = dr->extent.w;
-			int32_t dh = dr->extent.h;
-			if (dw <= 0 || dh <= 0) {
-				continue;
-			}
-			int32_t x0 = dx < 0 ? 0 : dx;
-			int32_t y0 = dy < 0 ? 0 : dy;
-			int32_t x1 = (dx + dw) > (int32_t)w ? (int32_t)w : (dx + dw);
-			int32_t y1 = (dy + dh) > (int32_t)h ? (int32_t)h : (dy + dh);
-			if (x1 <= x0 || y1 <= y0) {
-				continue;
-			}
-			float fx0 = (float)(x0 - dx) / (float)dw;
-			float fy0 = (float)(y0 - dy) / (float)dh;
-			float fx1 = (float)(x1 - dx) / (float)dw;
-			float fy1 = (float)(y1 - dy) / (float)dh;
-
-			struct xrt_normalized_rect nr = layer->data.local_2d.sub.norm_rect;
-			if (nr.w <= 0.0f || nr.h <= 0.0f) {
-				nr.x = 0.0f;
-				nr.y = 0.0f;
-				nr.w = 1.0f;
-				nr.h = 1.0f;
-			}
-
-			// sRGB passthrough (see projection pass).
-			id<MTLTexture> src_tex = msc->images[img_idx];
-			id<MTLTexture> src_view = nil;
-			{
-				MTLPixelFormat unorm_fmt = metal_srgb_to_unorm(src_tex.pixelFormat);
-				if (unorm_fmt != src_tex.pixelFormat) {
-					src_view = [src_tex newTextureViewWithPixelFormat:unorm_fmt];
-					if (src_view != nil) {
-						src_tex = src_view;
-					}
-				}
-			}
-
-			MTLViewport vp;
-			vp.originX = x0;
-			vp.originY = y0;
-			vp.width = x1 - x0;
-			vp.height = y1 - y0;
-			vp.znear = 0.0;
-			vp.zfar = 1.0;
-			[enc setViewport:vp];
-
-			bool unpremult = (layer->data.flags & XRT_LAYER_COMPOSITION_UNPREMULTIPLIED_ALPHA_BIT) != 0;
-			[enc setRenderPipelineState:unpremult ? c->local2d_unpremult_pipeline
-			                                      : c->local2d_premult_pipeline];
-			[enc setFragmentTexture:src_tex atIndex:0];
-			[enc setFragmentSamplerState:c->sampler_linear atIndex:0];
-
-			struct {
-				float viewport[4];
-				float src_rect[4];
-				float color_scale[4];
-				float color_bias[4];
-				float swizzle_rb;
-				float _pad[3];
-			} constants;
-
-			constants.viewport[0] = 0.0f;
-			constants.viewport[1] = 0.0f;
-			constants.viewport[2] = 1.0f;
-			constants.viewport[3] = 1.0f;
-
-			constants.src_rect[0] = nr.x + nr.w * fx0;
-			constants.src_rect[2] = nr.w * (fx1 - fx0);
-			if (layer->data.flip_y) {
-				constants.src_rect[1] = nr.y + nr.h * (1.0f - fy0);
-				constants.src_rect[3] = -(nr.h * (fy1 - fy0));
-			} else {
-				constants.src_rect[1] = nr.y + nr.h * fy0;
-				constants.src_rect[3] = nr.h * (fy1 - fy0);
-			}
-
-			constants.color_scale[0] = 1.0f;
-			constants.color_scale[1] = 1.0f;
-			constants.color_scale[2] = 1.0f;
-			constants.color_scale[3] = 1.0f;
-			constants.color_bias[0] = 0.0f;
-			constants.color_bias[1] = 0.0f;
-			constants.color_bias[2] = 0.0f;
-			constants.color_bias[3] = 0.0f;
-			constants.swizzle_rb = 0.0f;
-			constants._pad[0] = constants._pad[1] = constants._pad[2] = 0.0f;
-
-			[enc setVertexBytes:&constants length:sizeof(constants) atIndex:0];
-			[enc setFragmentBytes:&constants length:sizeof(constants) atIndex:0];
-			[enc drawPrimitives:MTLPrimitiveTypeTriangle vertexStart:0 vertexCount:3];
-
-			[src_view release];
+			metal_flatten_one_local2d_layer(c, enc, layer, w, h);
 		}
 
 		[enc endEncoding];
@@ -2857,6 +3004,19 @@ metal_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 		uint32_t dp_target_w = (uint32_t)output_texture.width;
 		uint32_t dp_target_h = (uint32_t)output_texture.height;
 
+		// #491 part 3 — flatten the 2D-under layers PRE-weave and hand them to
+		// the DP (it composites `backdrop over captured-desktop` under the 3D).
+		// nil ⟹ no under-layers (DP clears its backdrop). Encoded on cmd_buf
+		// before process_atlas. (Code-only on Windows — macOS CI gates the
+		// compile; visual needs a Mac+Leia eyeball.)
+		{
+			uint32_t bd_w = 0, bd_h = 0;
+			id<MTLTexture> bd_tex =
+			    metal_flatten_backdrop_2d(c, cmd_buf, dp_target_w, dp_target_h, &bd_w, &bd_h);
+			xrt_display_processor_metal_set_background_2d(c->display_processor,
+			                                              (__bridge void *)bd_tex, bd_w, bd_h);
+		}
+
 		// Effective canvas (#439): while a mask is active this is the
 		// full client-window rect — the DP weaves every pixel the mask
 		// can select (Phase-2 rule).
@@ -3111,6 +3271,8 @@ metal_compositor_destroy(struct xrt_compositor *xc)
 	c->local2d_scratch = nil;
 	[c->weave_scratch release];
 	c->weave_scratch = nil;
+	[c->backdrop_scratch release]; // #491 part 3
+	c->backdrop_scratch = nil;
 	[c->local2d_premult_pipeline release];
 	c->local2d_premult_pipeline = nil;
 	[c->local2d_unpremult_pipeline release];

--- a/src/xrt/compositor/vk_native/comp_vk_native_compositor.c
+++ b/src/xrt/compositor/vk_native/comp_vk_native_compositor.c
@@ -236,13 +236,26 @@ struct comp_vk_native_compositor
 	bool local2d_initialized;
 
 	//! twod flatten scratch (B8G8R8A8_UNORM, COLOR_ATTACHMENT|SAMPLED). The
-	//! frame's Local2D layers are flattened here, then sampled as `twod` by the
-	//! masked composite. Lazily (re)allocated to the window region dims.
+	//! frame's OVER Local2D layers (after the projection in list order) are
+	//! flattened here, then sampled as `twod` by the masked composite. Lazily
+	//! (re)allocated to the window region dims.
 	VkImage local2d_scratch;
 	VkDeviceMemory local2d_scratch_mem;
 	VkImageView local2d_scratch_view;
 	VkFramebuffer local2d_scratch_fb;
 	uint32_t local2d_scratch_w, local2d_scratch_h;
+
+	//! #491 part 3 — 2D-under backdrop scratch (same fmt/usage as
+	//! local2d_scratch). The frame's UNDER Local2D layers (before the projection
+	//! in list order) are flattened here PRE-weave and handed to the DP via
+	//! set_background_2d, so the DP composites `backdrop over captured-desktop`
+	//! as the under-3D background. Compositor-owned so it outlives process_atlas
+	//! (the DP samples it). Left in SHADER_READ_ONLY_OPTIMAL after the flatten.
+	VkImage backdrop_scratch;
+	VkDeviceMemory backdrop_scratch_mem;
+	VkImageView backdrop_scratch_view;
+	VkFramebuffer backdrop_scratch_fb;
+	uint32_t backdrop_scratch_w, backdrop_scratch_h;
 
 	//! Weave snapshot scratch (target format, TRANSFER_DST|SAMPLED). The DP
 	//! wrote the woven 3D into the target (RT≠SRV), so the lerp reads this
@@ -277,6 +290,13 @@ struct comp_vk_native_compositor
 	//! implicit mask's canvas-supersede visible to vk_effective_canvas. Set once
 	//! under the frame path at the top of layer_commit.
 	bool local_2d_last_frame;
+
+	//! #491 part 3 — guards vk_local2d_composite_begin_frame (which resets the
+	//! shared descriptor pool) to run at most once per frame. Both the pre-weave
+	//! backdrop flatten and the post-weave overlay composite allocate from the
+	//! one pool; resetting it twice while a shared cmd buffer still references
+	//! the earlier sets is a use-after-reset. Cleared at the top of layer_commit.
+	bool local2d_pool_reset_this_frame;
 };
 
 /*
@@ -1992,6 +2012,15 @@ vk_composite_local_2d(struct comp_vk_native_compositor *c,
                       uint32_t dst_h,
                       VkImageLayout dst_incoming,
                       VkImageLayout dst_outgoing);
+// #491 part 3 — pre-weave 2D-under backdrop flatten (defined below near the
+// composite). Called before process_atlas; result handed to the DP.
+static VkImageView
+vk_flatten_backdrop_2d(struct comp_vk_native_compositor *c,
+                       VkCommandBuffer cmd,
+                       uint32_t dst_w,
+                       uint32_t dst_h,
+                       uint32_t *out_w,
+                       uint32_t *out_h);
 static void
 vk_release_local2d_state(struct comp_vk_native_compositor *c);
 
@@ -2016,6 +2045,11 @@ vk_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t
 			break;
 		}
 	}
+
+	// #491 part 3 — the Local2D descriptor pool is reset on first use this
+	// frame (vk_local2d_begin_frame_once); both the pre-weave backdrop flatten
+	// and the post-weave overlay composite share it. Reset the per-frame guard.
+	c->local2d_pool_reset_this_frame = false;
 
 	// Phase 1 diagnostic — env-gated per-client commit interval. Mirrors
 	// the same `[CLIENT_FRAME_NS]` line emitted by the D3D11 in-process and
@@ -2324,12 +2358,23 @@ vk_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t
 				dp_target_h = c->canvas.h;
 			}
 
+			// #491 part 3 — flatten this frame's 2D-under layers PRE-weave (into
+			// backdrop_scratch) and hand them to the DP so it composites
+			// `backdrop over captured-desktop` under the 3D. Recorded into `cmd`
+			// here; the dp_self_submits flush below makes the backdrop visible
+			// (in SHADER_READ) before the DP's internal weave samples it. On the
+			// non-self-submit path the flatten's SHADER_READ barrier orders it
+			// within the one submit. VK_NULL_HANDLE ⟹ no under-layers this frame.
+			uint32_t bd_w = 0, bd_h = 0;
+			VkImageView bd_view = vk_flatten_backdrop_2d(c, cmd, dp_target_w, dp_target_h, &bd_w, &bd_h);
+
 			bool dp_self_submits =
 			    xrt_display_processor_is_self_submitting(c->display_processor);
 
 			if (dp_self_submits) {
-				// Flush pre-DP work (window-space composite, atlas crop)
-				// so the DP's internal submit sees a coherent atlas.
+				// Flush pre-DP work (window-space composite, atlas crop,
+				// 2D-under backdrop flatten) so the DP's internal submit sees a
+				// coherent atlas + backdrop.
 				vk->vkEndCommandBuffer(cmd);
 				VkSubmitInfo pre_si = {
 				    .sType = VK_STRUCTURE_TYPE_SUBMIT_INFO,
@@ -2341,6 +2386,10 @@ vk_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t
 					vk->vkQueueWaitIdle(vk->main_queue->queue);
 				}
 			}
+
+			// Hand the DP this frame's backdrop (NULL ⟹ clears it → desktop-only
+			// background). Must precede process_atlas.
+			xrt_display_processor_set_background_2d(c->display_processor, bd_view, bd_w, bd_h);
 
 			xrt_display_processor_process_atlas(
 			    c->display_processor,
@@ -2527,6 +2576,17 @@ vk_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t
 					vk->vkCreateFramebuffer(vk->device, &fb_ci, NULL, &target_fb);
 				}
 
+				// #491 part 3 — flatten this frame's 2D-under layers PRE-weave
+				// (into backdrop_scratch) and hand them to the DP so it
+				// composites `backdrop over captured-desktop` under the 3D.
+				// Recorded into `cmd`; the dp_self_submits flush below makes the
+				// backdrop visible (SHADER_READ) before the DP's internal weave
+				// samples it. Independent of target_image, so its order vs the
+				// pre-weave target barrier is irrelevant. NULL ⟹ no under-layers.
+				uint32_t bd_w = 0, bd_h = 0;
+				VkImageView bd_view =
+				    vk_flatten_backdrop_2d(c, cmd, tgt_width, tgt_height, &bd_w, &bd_h);
+
 				// Pre-weave barrier: target → COLOR_ATTACHMENT_OPTIMAL
 				VkImageMemoryBarrier pre_weave = {
 				    .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
@@ -2566,6 +2626,10 @@ vk_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t
 				// that don't expose the slot.
 				xrt_display_processor_set_target_color_view(
 				    c->display_processor, (VkImageView)(uintptr_t)target_view);
+
+				// #491 part 3 — hand the DP this frame's backdrop (NULL ⟹ clears
+				// it → desktop-only background). Must precede process_atlas.
+				xrt_display_processor_set_background_2d(c->display_processor, bd_view, bd_w, bd_h);
 
 				// Call display processor with atlas (or zero-copy swapchain) texture
 				xrt_display_processor_process_atlas(
@@ -3791,12 +3855,204 @@ vk_window_region(struct comp_vk_native_compositor *c, uint32_t dst_w, uint32_t d
 #endif
 }
 
+// #491 part 3 — reset the Local2D descriptor pool at most once per frame. Both
+// the pre-weave backdrop flatten and the post-weave overlay composite allocate
+// sets from the one pool; vk_local2d_composite_begin_frame resets it, which
+// would invalidate sets still referenced by a shared (un-submitted) cmd buffer
+// if called twice. The per-frame guard is cleared at the top of layer_commit.
+static void
+vk_local2d_begin_frame_once(struct comp_vk_native_compositor *c)
+{
+	if (c->local2d_pool_reset_this_frame) {
+		return;
+	}
+	vk_local2d_composite_begin_frame(&c->local2d, &c->vk);
+	c->local2d_pool_reset_this_frame = true;
+}
+
+// Flatten one Local2D layer into @p target_fb (premultiplied), clamped to the
+// region. Shared by the pre-weave backdrop flatten (#491 part 3, under-layers)
+// and the post-weave overlay flatten (#439 Phase 3, over-layers) so the source
+// geometry / flip / unpremult handling stays identical between the two.
+static void
+vk_flatten_one_local2d_layer(struct comp_vk_native_compositor *c,
+                             VkCommandBuffer cmd,
+                             VkFramebuffer target_fb,
+                             struct comp_layer *layer,
+                             uint32_t region_w,
+                             uint32_t region_h)
+{
+	struct vk_bundle *vk = &c->vk;
+	struct xrt_swapchain *sc = layer->sc_array[0];
+	if (sc == NULL) {
+		return;
+	}
+	uint32_t img_idx = layer->data.local_2d.sub.image_index;
+	// sRGB-passthrough: sample the layer's own view (the projection path
+	// samples the same). UNORM-sibling decode is a follow-up if a layer
+	// ever uses an _SRGB swapchain.
+	VkImageView src_view = (VkImageView)(uintptr_t)comp_vk_native_swapchain_get_image_view(sc, img_idx);
+	if (src_view == VK_NULL_HANDLE) {
+		return;
+	}
+
+	const struct xrt_rect *dr = &layer->data.local_2d.rect;
+	int32_t dx = dr->offset.w, dy = dr->offset.h, dw = dr->extent.w, dh = dr->extent.h;
+	if (dw <= 0 || dh <= 0) {
+		return;
+	}
+	int32_t x0 = dx < 0 ? 0 : dx;
+	int32_t y0 = dy < 0 ? 0 : dy;
+	int32_t x1 = (dx + dw) > (int32_t)region_w ? (int32_t)region_w : (dx + dw);
+	int32_t y1 = (dy + dh) > (int32_t)region_h ? (int32_t)region_h : (dy + dh);
+	if (x1 <= x0 || y1 <= y0) {
+		return;
+	}
+	float fx0 = (float)(x0 - dx) / (float)dw;
+	float fy0 = (float)(y0 - dy) / (float)dh;
+	float fx1 = (float)(x1 - dx) / (float)dw;
+	float fy1 = (float)(y1 - dy) / (float)dh;
+
+	struct xrt_normalized_rect nr = layer->data.local_2d.sub.norm_rect;
+	if (nr.w <= 0.0f || nr.h <= 0.0f) {
+		nr.x = 0.0f;
+		nr.y = 0.0f;
+		nr.w = 1.0f;
+		nr.h = 1.0f;
+	}
+	float src_x = nr.x + nr.w * fx0;
+	float src_w = nr.w * (fx1 - fx0);
+	float src_y, src_h;
+	if (layer->data.flip_y) {
+		src_y = nr.y + nr.h * (1.0f - fy0);
+		src_h = -(nr.h * (fy1 - fy0));
+	} else {
+		src_y = nr.y + nr.h * fy0;
+		src_h = nr.h * (fy1 - fy0);
+	}
+	bool unpremult = (layer->data.flags & XRT_LAYER_COMPOSITION_UNPREMULTIPLIED_ALPHA_BIT) != 0;
+
+	vk_local2d_composite_flatten_draw(&c->local2d, vk, cmd, target_fb, region_w, region_h, src_view, x0, y0,
+	                                  (uint32_t)(x1 - x0), (uint32_t)(y1 - y0), src_x, src_y, src_w, src_h,
+	                                  unpremult);
+}
+
+// #491 part 3 — flatten the frame's 2D-UNDER Local2D layers (those BEFORE the
+// projection in xrEndFrame list order) into backdrop_scratch (premultiplied),
+// PRE-weave, and return its view + dims so the caller can hand it to the DP via
+// xrt_display_processor_set_background_2d. The DP composites `backdrop over
+// captured-desktop` as the under-3D background, so a semi-transparent backdrop
+// reveals the desktop. Returns VK_NULL_HANDLE (out dims 0) when there are no
+// under-layers (no projection, or all Local2D layers are over-layers) — the
+// caller then clears the DP backdrop. Records into @p cmd only (does NOT
+// submit); leaves backdrop_scratch in SHADER_READ_ONLY_OPTIMAL so it is
+// DP-sampleable and outlives the process_atlas call (compositor-owned image).
+static VkImageView
+vk_flatten_backdrop_2d(struct comp_vk_native_compositor *c,
+                       VkCommandBuffer cmd,
+                       uint32_t dst_w,
+                       uint32_t dst_h,
+                       uint32_t *out_w,
+                       uint32_t *out_h)
+{
+	struct vk_bundle *vk = &c->vk;
+	*out_w = 0;
+	*out_h = 0;
+
+	if (!c->local2d_initialized || !c->local_2d_last_frame) {
+		return VK_NULL_HANDLE;
+	}
+
+	// Under = Local2D layers BEFORE the projection in list order. No projection
+	// ⟹ everything is an over-layer ⟹ no backdrop.
+	int32_t proj_idx = -1;
+	for (uint32_t i = 0; i < c->layer_accum.layer_count; i++) {
+		enum xrt_layer_type t = c->layer_accum.layers[i].data.type;
+		if (t == XRT_LAYER_PROJECTION || t == XRT_LAYER_PROJECTION_DEPTH) {
+			proj_idx = (int32_t)i;
+			break;
+		}
+	}
+	if (proj_idx < 0) {
+		return VK_NULL_HANDLE;
+	}
+	bool have_under = false;
+	for (int32_t i = 0; i < proj_idx; i++) {
+		if (c->layer_accum.layers[i].data.type == XRT_LAYER_LOCAL_2D) {
+			have_under = true;
+			break;
+		}
+	}
+	if (!have_under) {
+		return VK_NULL_HANDLE;
+	}
+
+	uint32_t region_w, region_h;
+	vk_window_region(c, dst_w, dst_h, &region_w, &region_h);
+	if (region_w == 0 || region_h == 0) {
+		return VK_NULL_HANDLE;
+	}
+
+	const VkFormat scratch_fmt = VK_FORMAT_B8G8R8A8_UNORM;
+	if (!vk_ensure_rt(c, &c->backdrop_scratch, &c->backdrop_scratch_mem, &c->backdrop_scratch_view,
+	                  &c->backdrop_scratch_fb, &c->backdrop_scratch_w, &c->backdrop_scratch_h, region_w,
+	                  region_h, scratch_fmt,
+	                  VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT |
+	                      VK_IMAGE_USAGE_TRANSFER_DST_BIT,
+	                  c->local2d.flatten_rp, "backdrop scratch")) {
+		return VK_NULL_HANDLE;
+	}
+
+	vk_local2d_begin_frame_once(c);
+
+	// Clear transparent + → COLOR_ATTACHMENT (mirrors the local2d_scratch prep).
+	vk_cmd_image_barrier_locked(vk, cmd, c->backdrop_scratch, 0, VK_ACCESS_TRANSFER_WRITE_BIT,
+	                            VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+	                            VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, k_color_sub);
+	VkClearColorValue transparent = {.float32 = {0.0f, 0.0f, 0.0f, 0.0f}};
+	vk->vkCmdClearColorImage(cmd, c->backdrop_scratch, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, &transparent, 1,
+	                         &k_color_sub);
+	vk_cmd_image_barrier_locked(vk, cmd, c->backdrop_scratch, VK_ACCESS_TRANSFER_WRITE_BIT,
+	                            VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+	                            VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+	                            VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+	                            k_color_sub);
+
+	// Flatten ONLY the under-layers (before the projection) into the backdrop.
+	for (int32_t i = 0; i < proj_idx; i++) {
+		struct comp_layer *layer = &c->layer_accum.layers[i];
+		if (layer->data.type != XRT_LAYER_LOCAL_2D) {
+			continue;
+		}
+		vk_flatten_one_local2d_layer(c, cmd, c->backdrop_scratch_fb, layer, region_w, region_h);
+	}
+
+	vk_cmd_image_barrier_locked(vk, cmd, c->backdrop_scratch, VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+	                            VK_ACCESS_SHADER_READ_BIT, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+	                            VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+	                            VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+	                            VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, k_color_sub);
+
+	static bool logged = false;
+	if (!logged) {
+		logged = true;
+		U_LOG_W("VK #491 part3: flattened 2D-under backdrop %ux%u (handed to DP set_background_2d)",
+		        region_w, region_h);
+	}
+
+	*out_w = region_w;
+	*out_h = region_h;
+	return c->backdrop_scratch_view;
+}
+
 // #439 Phase 3 — masked 2D-over-3D composite, POST-weave. The DP has woven the
 // 3D into `dst`; this overlays the frame's 2D content where the zone mask says
-// "2D". Runs only when the frame carries Local2D layers (the `twod` source); a
-// pure explicit-mask-only frame has no 2D pixels on VK (no surround) and is
-// skipped. Returns true if it composited (dst left in dst_outgoing) or false if
-// it skipped (dst untouched, still in dst_incoming).
+// "2D". Runs only when the frame carries OVER Local2D layers (the `twod`
+// source); under-layers (before the projection) are the DP backdrop and are
+// handled pre-weave by vk_flatten_backdrop_2d. A frame whose only Local2D
+// layers are under-layers has no over pixels and is skipped. Returns true if it
+// composited (dst left in dst_outgoing) or false if it skipped (dst untouched,
+// still in dst_incoming).
 static bool
 vk_composite_local_2d(struct comp_vk_native_compositor *c,
                       VkCommandBuffer cmd,
@@ -3823,16 +4079,34 @@ vk_composite_local_2d(struct comp_vk_native_compositor *c,
 	const VkFormat scratch_fmt = VK_FORMAT_B8G8R8A8_UNORM; // matches target (raw weave copy)
 	const VkFormat mask_fmt = VK_FORMAT_R8_UNORM;
 
-	// Collect this frame's Local2D layer rects (for the implicit mask) once.
+	// #491 part 3 — split Local2D layers by list order vs the projection. A
+	// layer BEFORE the projection is a 2D-under backdrop (handled pre-weave by
+	// vk_flatten_backdrop_2d → the DP); AFTER (or with no projection) it is a
+	// 2D-over overlay handled here. is_over(i) == !(proj_idx >= 0 && i < proj_idx).
+	int32_t proj_idx = -1;
+	for (uint32_t i = 0; i < c->layer_accum.layer_count; i++) {
+		enum xrt_layer_type t = c->layer_accum.layers[i].data.type;
+		if (t == XRT_LAYER_PROJECTION || t == XRT_LAYER_PROJECTION_DEPTH) {
+			proj_idx = (int32_t)i;
+			break;
+		}
+	}
+
+	// Collect this frame's OVER Local2D layer rects (for the implicit mask) once
+	// — under-layers are the backdrop, not part of the overlay mask.
 	struct xrt_rect rects[XRT_MAX_LAYERS];
 	uint32_t rect_count = 0;
 	for (uint32_t i = 0; i < c->layer_accum.layer_count && rect_count < XRT_MAX_LAYERS; i++) {
-		if (c->layer_accum.layers[i].data.type == XRT_LAYER_LOCAL_2D) {
-			rects[rect_count++] = c->layer_accum.layers[i].data.local_2d.rect;
+		if (c->layer_accum.layers[i].data.type != XRT_LAYER_LOCAL_2D) {
+			continue;
 		}
+		if (proj_idx >= 0 && (int32_t)i < proj_idx) {
+			continue; // under-layer (backdrop) — skip
+		}
+		rects[rect_count++] = c->layer_accum.layers[i].data.local_2d.rect;
 	}
 	if (rect_count == 0) {
-		return false; // local_2d_last_frame stale vs accum — nothing to draw
+		return false; // only under-layers (or stale flag) — nothing to overlay
 	}
 
 	// Resolve the `twod` source: flatten the Local2D layers into local2d_scratch.
@@ -3852,7 +4126,7 @@ vk_composite_local_2d(struct comp_vk_native_compositor *c,
 		return false;
 	}
 
-	vk_local2d_composite_begin_frame(&c->local2d, vk);
+	vk_local2d_begin_frame_once(c);
 
 	// --- twod: clear local2d_scratch transparent, flatten layers, → SHADER_READ.
 	vk_cmd_image_barrier_locked(vk, cmd, c->local2d_scratch, 0, VK_ACCESS_TRANSFER_WRITE_BIT,
@@ -3873,59 +4147,12 @@ vk_composite_local_2d(struct comp_vk_native_compositor *c,
 		if (layer->data.type != XRT_LAYER_LOCAL_2D) {
 			continue;
 		}
-		struct xrt_swapchain *sc = layer->sc_array[0];
-		if (sc == NULL) {
+		// #491 part 3 — under-layers are the DP backdrop (handled pre-weave);
+		// the overlay flattens only over-layers.
+		if (proj_idx >= 0 && (int32_t)i < proj_idx) {
 			continue;
 		}
-		uint32_t img_idx = layer->data.local_2d.sub.image_index;
-		// sRGB-passthrough: sample the layer's own view (the projection path
-		// samples the same). UNORM-sibling decode is a follow-up if a layer
-		// ever uses an _SRGB swapchain.
-		VkImageView src_view =
-		    (VkImageView)(uintptr_t)comp_vk_native_swapchain_get_image_view(sc, img_idx);
-		if (src_view == VK_NULL_HANDLE) {
-			continue;
-		}
-
-		const struct xrt_rect *dr = &layer->data.local_2d.rect;
-		int32_t dx = dr->offset.w, dy = dr->offset.h, dw = dr->extent.w, dh = dr->extent.h;
-		if (dw <= 0 || dh <= 0) {
-			continue;
-		}
-		int32_t x0 = dx < 0 ? 0 : dx;
-		int32_t y0 = dy < 0 ? 0 : dy;
-		int32_t x1 = (dx + dw) > (int32_t)region_w ? (int32_t)region_w : (dx + dw);
-		int32_t y1 = (dy + dh) > (int32_t)region_h ? (int32_t)region_h : (dy + dh);
-		if (x1 <= x0 || y1 <= y0) {
-			continue;
-		}
-		float fx0 = (float)(x0 - dx) / (float)dw;
-		float fy0 = (float)(y0 - dy) / (float)dh;
-		float fx1 = (float)(x1 - dx) / (float)dw;
-		float fy1 = (float)(y1 - dy) / (float)dh;
-
-		struct xrt_normalized_rect nr = layer->data.local_2d.sub.norm_rect;
-		if (nr.w <= 0.0f || nr.h <= 0.0f) {
-			nr.x = 0.0f;
-			nr.y = 0.0f;
-			nr.w = 1.0f;
-			nr.h = 1.0f;
-		}
-		float src_x = nr.x + nr.w * fx0;
-		float src_w = nr.w * (fx1 - fx0);
-		float src_y, src_h;
-		if (layer->data.flip_y) {
-			src_y = nr.y + nr.h * (1.0f - fy0);
-			src_h = -(nr.h * (fy1 - fy0));
-		} else {
-			src_y = nr.y + nr.h * fy0;
-			src_h = nr.h * (fy1 - fy0);
-		}
-		bool unpremult = (layer->data.flags & XRT_LAYER_COMPOSITION_UNPREMULTIPLIED_ALPHA_BIT) != 0;
-
-		vk_local2d_composite_flatten_draw(&c->local2d, vk, cmd, c->local2d_scratch_fb, region_w,
-		                                  region_h, src_view, x0, y0, (uint32_t)(x1 - x0),
-		                                  (uint32_t)(y1 - y0), src_x, src_y, src_w, src_h, unpremult);
+		vk_flatten_one_local2d_layer(c, cmd, c->local2d_scratch_fb, layer, region_w, region_h);
 	}
 	vk_cmd_image_barrier_locked(vk, cmd, c->local2d_scratch, VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
 	                            VK_ACCESS_SHADER_READ_BIT, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
@@ -4066,6 +4293,8 @@ vk_release_local2d_state(struct comp_vk_native_compositor *c)
 	}
 	vk_destroy_rt(c, &c->local2d_scratch, &c->local2d_scratch_mem, &c->local2d_scratch_view,
 	              &c->local2d_scratch_fb);
+	vk_destroy_rt(c, &c->backdrop_scratch, &c->backdrop_scratch_mem, &c->backdrop_scratch_view,
+	              &c->backdrop_scratch_fb);
 	vk_destroy_rt(c, &c->weave_scratch, &c->weave_scratch_mem, &c->weave_scratch_view, NULL);
 	vk_destroy_rt(c, &c->implicit_mask_tex, &c->implicit_mask_mem, &c->implicit_mask_view,
 	              &c->implicit_mask_fb);

--- a/src/xrt/drivers/sim_display/sim_display_processor.c
+++ b/src/xrt/drivers/sim_display/sim_display_processor.c
@@ -63,6 +63,15 @@ struct sim_display_processor
 	//! When true, the app requested a transparent background — clear the
 	//! weave target to alpha=0 so alpha<1 regions stay see-through.
 	bool transparent_bg;
+
+	//! #491 part 3 — the runtime's flattened 2D-under backdrop for the next
+	//! process_atlas (set via set_background_2d). sim_display is a test double:
+	//! it records the handoff (proving the runtime wiring) but does not capture
+	//! a desktop, so it has no `backdrop over desktop` to weave under (the real
+	//! visual proof is the Leia DP). Stored + logged so the slot is a non-NULL
+	//! in-repo consumer exercisable headlessly. VK_NULL_HANDLE ⟹ no backdrop.
+	VkImageView bg_view;
+	uint32_t bg_w, bg_h;
 };
 
 static inline struct sim_display_processor *
@@ -598,6 +607,31 @@ sim_dp_set_chroma_key(struct xrt_display_processor *xdp,
 	sim_display_processor(xdp)->transparent_bg = transparent_bg_enabled;
 }
 
+// #491 part 3 — store the runtime's flattened 2D-under backdrop for the next
+// process_atlas. sim_display is a test double (no captured desktop), so it
+// records the handoff rather than compositing pixels; the one-shot WARN proves
+// the runtime → DP set_background_2d wiring works without Leia hardware.
+static void
+sim_dp_set_background_2d(struct xrt_display_processor *xdp,
+                         VkImageView background_view,
+                         uint32_t width,
+                         uint32_t height)
+{
+	struct sim_display_processor *sdp = sim_display_processor(xdp);
+	sdp->bg_view = background_view;
+	sdp->bg_w = width;
+	sdp->bg_h = height;
+	if (background_view != VK_NULL_HANDLE) {
+		static bool logged = false;
+		if (!logged) {
+			logged = true;
+			U_LOG_W("sim_display #491 part3: received 2D-under backdrop %ux%u via set_background_2d "
+			        "(test double — handoff recorded, not composited)",
+			        width, height);
+		}
+	}
+}
+
 
 /*
  *
@@ -628,6 +662,7 @@ sim_display_processor_create(enum sim_display_output_mode mode,
 	sdp->base.get_predicted_eye_positions = sim_dp_get_predicted_eye_positions;
 	sdp->base.is_alpha_native = sim_dp_is_alpha_native;
 	sdp->base.set_chroma_key = sim_dp_set_chroma_key;
+	sdp->base.set_background_2d = sim_dp_set_background_2d; // #491 part 3
 
 	// Nominal viewer parameters (same defaults as sim_display_hmd_create)
 	sdp->ipd_m = 0.06f;

--- a/src/xrt/drivers/sim_display/sim_display_processor_d3d11.cpp
+++ b/src/xrt/drivers/sim_display/sim_display_processor_d3d11.cpp
@@ -429,6 +429,27 @@ sim_dp_d3d11_set_atlas_encoding(struct xrt_display_processor_d3d11 *xdp, enum xr
 	sim_dp_d3d11(xdp)->atlas_encoding = atlas_encoding;
 }
 
+// #491 part 3 — test double: record the 2D-under backdrop handoff (no captured
+// desktop to composite under). The one-shot WARN proves the runtime → DP
+// set_background_2d wiring works without Leia hardware.
+static void
+sim_dp_d3d11_set_background_2d(struct xrt_display_processor_d3d11 *xdp,
+                              void *background_srv,
+                              uint32_t width,
+                              uint32_t height)
+{
+	(void)xdp;
+	if (background_srv != nullptr) {
+		static bool logged = false;
+		if (!logged) {
+			logged = true;
+			U_LOG_W("sim_display D3D11 #491 part3: received 2D-under backdrop %ux%u via "
+			        "set_background_2d (test double — handoff recorded, not composited)",
+			        width, height);
+		}
+	}
+}
+
 
 /*
  *
@@ -634,6 +655,7 @@ sim_display_processor_d3d11_create(enum sim_display_output_mode mode,
 	sdp->base.get_local_zone_caps = sim_dp_d3d11_get_local_zone_caps;
 	sdp->base.publish_local_zone_mask = sim_dp_d3d11_publish_local_zone_mask;
 	sdp->base.clear_local_zone_mask = sim_dp_d3d11_clear_local_zone_mask;
+	sdp->base.set_background_2d = sim_dp_d3d11_set_background_2d; // #491 part 3
 
 	// #224 local-zone test double config (see the zone section above).
 	sdp->zone_grid_w = 1;

--- a/src/xrt/drivers/sim_display/sim_display_processor_d3d12.cpp
+++ b/src/xrt/drivers/sim_display/sim_display_processor_d3d12.cpp
@@ -469,6 +469,27 @@ sim_dp_d3d12_set_chroma_key(struct xrt_display_processor_d3d12 *xdp,
 	// Alpha-native — no chroma-key fill/strip required.
 }
 
+// #491 part 3 — test double: record the 2D-under backdrop handoff (no captured
+// desktop to composite under). The one-shot WARN proves the runtime → DP
+// set_background_2d wiring works without Leia hardware.
+static void
+sim_dp_d3d12_set_background_2d(struct xrt_display_processor_d3d12 *xdp,
+                              void *background_resource,
+                              uint32_t width,
+                              uint32_t height)
+{
+	(void)xdp;
+	if (background_resource != nullptr) {
+		static bool logged = false;
+		if (!logged) {
+			logged = true;
+			U_LOG_W("sim_display D3D12 #491 part3: received 2D-under backdrop %ux%u via "
+			        "set_background_2d (test double — handoff recorded, not composited)",
+			        width, height);
+		}
+	}
+}
+
 
 /*
  *
@@ -503,6 +524,7 @@ sim_display_processor_d3d12_create(enum sim_display_output_mode mode,
 	sdp->base.get_predicted_eye_positions = sim_dp_d3d12_get_predicted_eye_positions;
 	sdp->base.is_alpha_native = sim_dp_d3d12_is_alpha_native;
 	sdp->base.set_chroma_key = sim_dp_d3d12_set_chroma_key;
+	sdp->base.set_background_2d = sim_dp_d3d12_set_background_2d; // #491 part 3
 
 	// Nominal viewer parameters (same defaults as sim_display_hmd_create)
 	sdp->ipd_m = 0.06f;

--- a/src/xrt/drivers/sim_display/sim_display_processor_gl.c
+++ b/src/xrt/drivers/sim_display/sim_display_processor_gl.c
@@ -404,6 +404,27 @@ sim_dp_gl_set_chroma_key(struct xrt_display_processor_gl *xdp,
 	// Alpha-native — no chroma-key fill/strip required.
 }
 
+// #491 part 3 — test double: record the 2D-under backdrop handoff (no captured
+// desktop to composite under). The one-shot WARN proves the runtime → DP
+// set_background_2d wiring works without Leia hardware.
+static void
+sim_dp_gl_set_background_2d(struct xrt_display_processor_gl *xdp,
+                            uint32_t background_tex,
+                            uint32_t width,
+                            uint32_t height)
+{
+	(void)xdp;
+	if (background_tex != 0) {
+		static bool logged = false;
+		if (!logged) {
+			logged = true;
+			U_LOG_W("sim_display GL #491 part3: received 2D-under backdrop %ux%u via set_background_2d "
+			        "(test double — handoff recorded, not composited)",
+			        width, height);
+		}
+	}
+}
+
 
 /*
  *
@@ -431,6 +452,7 @@ sim_display_processor_gl_create(enum sim_display_output_mode mode,
 	sdp->base.get_predicted_eye_positions = sim_dp_gl_get_predicted_eye_positions;
 	sdp->base.is_alpha_native = sim_dp_gl_is_alpha_native;
 	sdp->base.set_chroma_key = sim_dp_gl_set_chroma_key;
+	sdp->base.set_background_2d = sim_dp_gl_set_background_2d; // #491 part 3
 
 	// Nominal viewer parameters (same defaults as sim_display_hmd_create)
 	sdp->ipd_m = 0.06f;

--- a/src/xrt/drivers/sim_display/sim_display_processor_metal.m
+++ b/src/xrt/drivers/sim_display/sim_display_processor_metal.m
@@ -420,6 +420,27 @@ sim_dp_metal_set_chroma_key(struct xrt_display_processor_metal *xdp,
 	// Alpha-native — no chroma-key fill/strip required.
 }
 
+// #491 part 3 — test double: record the 2D-under backdrop handoff (no captured
+// desktop to composite under). The one-shot WARN proves the runtime → DP
+// set_background_2d wiring works without Leia hardware.
+static void
+sim_dp_metal_set_background_2d(struct xrt_display_processor_metal *xdp,
+                               void *background_texture,
+                               uint32_t width,
+                               uint32_t height)
+{
+	(void)xdp;
+	if (background_texture != NULL) {
+		static bool logged = false;
+		if (!logged) {
+			logged = true;
+			U_LOG_W("sim_display Metal #491 part3: received 2D-under backdrop %ux%u via "
+			        "set_background_2d (test double — handoff recorded, not composited)",
+			        width, height);
+		}
+	}
+}
+
 
 /*
  *
@@ -453,6 +474,7 @@ sim_display_processor_metal_create(enum sim_display_output_mode mode,
 	sdp->base.get_predicted_eye_positions = sim_dp_metal_get_predicted_eye_positions;
 	sdp->base.is_alpha_native = sim_dp_metal_is_alpha_native;
 	sdp->base.set_chroma_key = sim_dp_metal_set_chroma_key;
+	sdp->base.set_background_2d = sim_dp_metal_set_background_2d; // #491 part 3
 
 	// Nominal viewer parameters (same defaults as sim_display_hmd_create)
 	sdp->ipd_m = 0.06f;

--- a/src/xrt/include/xrt/xrt_display_processor.h
+++ b/src/xrt/include/xrt/xrt_display_processor.h
@@ -365,6 +365,37 @@ struct xrt_display_processor
 	void (*set_target_color_view)(struct xrt_display_processor *xdp,
 	                              VkImageView color_view);
 
+	/*!
+	 * Hand the DP this frame's flattened 2D-under backdrop (#491 part 3).
+	 * Called once per frame, immediately before @ref process_atlas, when the
+	 * frame carries Local2D layers that sit *before* the projection in
+	 * xrEndFrame list order (the "under" layers). The runtime flattens them
+	 * into a single premultiplied-RGBA texture in the same client-window pixel
+	 * space / canvas rect as process_atlas and passes its view here. The DP
+	 * composites it OVER its captured desktop background (`backdrop over
+	 * desktop`, honoring the backdrop's alpha so a semi-transparent backdrop
+	 * reveals the desktop) and uses the result as the under-3D background for
+	 * the NEXT process_atlas. The view is left in SHADER_READ_ONLY_OPTIMAL /
+	 * SAMPLED and outlives the process_atlas call.
+	 *
+	 * Pass VK_NULL_HANDLE (or width/height 0) to clear — no backdrop this
+	 * frame, so the DP falls back to its desktop-only background (today's
+	 * behavior).
+	 *
+	 * Optional — an absent slot (older plug-in `struct_size`) or NULL means the
+	 * runtime keeps part-1-only behavior (overlay-only, no under-layer) so old
+	 * plug-ins are unaffected. Appended per ADR-020 (append-only within a major).
+	 *
+	 * @param xdp            Pointer to self.
+	 * @param background_view Flattened premultiplied backdrop view (or NULL to clear).
+	 * @param width          Backdrop width in pixels.
+	 * @param height         Backdrop height in pixels.
+	 */
+	void (*set_background_2d)(struct xrt_display_processor *xdp,
+	                          VkImageView background_view,
+	                          uint32_t width,
+	                          uint32_t height);
+
 	/*! @} */
 };
 
@@ -438,7 +469,8 @@ XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, destroy)               
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, get_handoff_color_capability) == XRT_DP_BASE_OFF + 14 * sizeof(void *), XRT_DP_ABI_MSG);
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, set_atlas_encoding)            == XRT_DP_BASE_OFF + 15 * sizeof(void *), XRT_DP_ABI_MSG);
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, set_target_color_view)        == XRT_DP_BASE_OFF + 16 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(sizeof(struct xrt_display_processor)                                 == XRT_DP_BASE_OFF + 17 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, set_background_2d)             == XRT_DP_BASE_OFF + 17 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(sizeof(struct xrt_display_processor)                                 == XRT_DP_BASE_OFF + 18 * sizeof(void *), XRT_DP_ABI_MSG);
 // clang-format on
 
 /*!
@@ -724,6 +756,26 @@ xrt_display_processor_set_target_color_view(struct xrt_display_processor *xdp, V
 		return;
 	}
 	xdp->set_target_color_view(xdp, color_view);
+}
+
+/*!
+ * @copydoc xrt_display_processor::set_background_2d
+ *
+ * No-op when the DP doesn't expose the slot (older plug-in) or leaves it NULL —
+ * the runtime then keeps part-1-only behavior (no 2D-under backdrop).
+ *
+ * @public @memberof xrt_display_processor
+ */
+static inline void
+xrt_display_processor_set_background_2d(struct xrt_display_processor *xdp,
+                                        VkImageView background_view,
+                                        uint32_t width,
+                                        uint32_t height)
+{
+	if (!XRT_DP_HAS_SLOT(xdp, set_background_2d) || xdp->set_background_2d == NULL) {
+		return;
+	}
+	xdp->set_background_2d(xdp, background_view, width, height);
 }
 
 /*!

--- a/src/xrt/include/xrt/xrt_display_processor_d3d11.h
+++ b/src/xrt/include/xrt/xrt_display_processor_d3d11.h
@@ -269,6 +269,31 @@ struct xrt_display_processor_d3d11
 	 * @return true if the clear was accepted.
 	 */
 	bool (*clear_local_zone_mask)(struct xrt_display_processor_d3d11 *xdp);
+
+	/*!
+	 * Hand the DP this frame's flattened 2D-under backdrop (#491 part 3).
+	 * Called once per frame, immediately before @ref process_atlas, when the
+	 * frame carries Local2D layers before the projection (the "under" layers).
+	 * The runtime flattens them into a single premultiplied-RGBA texture in the
+	 * client-window pixel space / canvas rect and passes its SRV here. The DP
+	 * composites it OVER its captured desktop background and uses the result as
+	 * the under-3D background for the NEXT process_atlas. The SRV must outlive
+	 * that call.
+	 *
+	 * Pass NULL (or width/height 0) to clear — desktop-only background.
+	 *
+	 * Optional — absent slot or NULL ⟹ no-op (part-1-only behavior). Appended
+	 * per ADR-020 (append-only within a major).
+	 *
+	 * @param xdp             Pointer to self.
+	 * @param background_srv  ID3D11ShaderResourceView* of the flattened backdrop (or NULL to clear).
+	 * @param width           Backdrop width in pixels.
+	 * @param height          Backdrop height in pixels.
+	 */
+	void (*set_background_2d)(struct xrt_display_processor_d3d11 *xdp,
+	                          void *background_srv,
+	                          uint32_t width,
+	                          uint32_t height);
 };
 
 /*
@@ -317,7 +342,8 @@ XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, set_atlas_encodin
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, get_local_zone_caps)          == XRT_DP_D3D11_BASE_OFF + 12 * sizeof(void *), XRT_DP_ABI_MSG);
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, publish_local_zone_mask)      == XRT_DP_D3D11_BASE_OFF + 13 * sizeof(void *), XRT_DP_ABI_MSG);
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, clear_local_zone_mask)        == XRT_DP_D3D11_BASE_OFF + 14 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(sizeof(struct xrt_display_processor_d3d11)                                == XRT_DP_D3D11_BASE_OFF + 15 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, set_background_2d)            == XRT_DP_D3D11_BASE_OFF + 15 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(sizeof(struct xrt_display_processor_d3d11)                                == XRT_DP_D3D11_BASE_OFF + 16 * sizeof(void *), XRT_DP_ABI_MSG);
 // clang-format on
 
 /*!
@@ -552,6 +578,23 @@ xrt_display_processor_d3d11_clear_local_zone_mask(struct xrt_display_processor_d
 		return false;
 	}
 	return xdp->clear_local_zone_mask(xdp);
+}
+
+/*!
+ * @copydoc xrt_display_processor_d3d11::set_background_2d
+ * No-op when the DP doesn't expose the slot (older plug-in) or leaves it NULL.
+ * @public @memberof xrt_display_processor_d3d11
+ */
+static inline void
+xrt_display_processor_d3d11_set_background_2d(struct xrt_display_processor_d3d11 *xdp,
+                                              void *background_srv,
+                                              uint32_t width,
+                                              uint32_t height)
+{
+	if (!XRT_DP_HAS_SLOT(xdp, set_background_2d) || xdp->set_background_2d == NULL) {
+		return;
+	}
+	xdp->set_background_2d(xdp, background_srv, width, height);
 }
 
 /*!

--- a/src/xrt/include/xrt/xrt_display_processor_d3d12.h
+++ b/src/xrt/include/xrt/xrt_display_processor_d3d12.h
@@ -201,6 +201,31 @@ struct xrt_display_processor_d3d12
 	 * absent slot or NULL ⟹ DP assumes @ref XRT_ATLAS_ENCODING_ENCODED.
 	 */
 	void (*set_atlas_encoding)(struct xrt_display_processor_d3d12 *xdp, enum xrt_atlas_encoding atlas_encoding);
+
+	/*!
+	 * Hand the DP this frame's flattened 2D-under backdrop (#491 part 3).
+	 * Called once per frame, immediately before @ref process_atlas, when the
+	 * frame carries Local2D layers before the projection (the "under" layers).
+	 * The runtime flattens them into a single premultiplied-RGBA texture in the
+	 * client-window pixel space / canvas rect and passes the resource here. The
+	 * DP composites it OVER its captured desktop background and uses the result
+	 * as the under-3D background for the NEXT process_atlas. The resource must
+	 * outlive that call and be left in a shader-readable state.
+	 *
+	 * Pass NULL (or width/height 0) to clear — desktop-only background.
+	 *
+	 * Optional — absent slot or NULL ⟹ no-op (part-1-only behavior). Appended
+	 * per ADR-020 (append-only within a major).
+	 *
+	 * @param xdp                  Pointer to self.
+	 * @param background_resource  ID3D12Resource* of the flattened backdrop (or NULL to clear).
+	 * @param width                Backdrop width in pixels.
+	 * @param height               Backdrop height in pixels.
+	 */
+	void (*set_background_2d)(struct xrt_display_processor_d3d12 *xdp,
+	                          void *background_resource,
+	                          uint32_t width,
+	                          uint32_t height);
 };
 
 /*
@@ -246,7 +271,8 @@ XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d12, set_chroma_key)  
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d12, destroy)                     == XRT_DP_D3D12_BASE_OFF + 10 * sizeof(void *), XRT_DP_ABI_MSG);
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d12, get_handoff_color_capability) == XRT_DP_D3D12_BASE_OFF + 11 * sizeof(void *), XRT_DP_ABI_MSG);
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d12, set_atlas_encoding)           == XRT_DP_D3D12_BASE_OFF + 12 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(sizeof(struct xrt_display_processor_d3d12)                                == XRT_DP_D3D12_BASE_OFF + 13 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d12, set_background_2d)            == XRT_DP_D3D12_BASE_OFF + 13 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(sizeof(struct xrt_display_processor_d3d12)                                == XRT_DP_D3D12_BASE_OFF + 14 * sizeof(void *), XRT_DP_ABI_MSG);
 // clang-format on
 
 /*!
@@ -445,6 +471,23 @@ xrt_display_processor_d3d12_set_atlas_encoding(struct xrt_display_processor_d3d1
 		return;
 	}
 	xdp->set_atlas_encoding(xdp, atlas_encoding);
+}
+
+/*!
+ * @copydoc xrt_display_processor_d3d12::set_background_2d
+ * No-op when the DP doesn't expose the slot (older plug-in) or leaves it NULL.
+ * @public @memberof xrt_display_processor_d3d12
+ */
+static inline void
+xrt_display_processor_d3d12_set_background_2d(struct xrt_display_processor_d3d12 *xdp,
+                                              void *background_resource,
+                                              uint32_t width,
+                                              uint32_t height)
+{
+	if (!XRT_DP_HAS_SLOT(xdp, set_background_2d) || xdp->set_background_2d == NULL) {
+		return;
+	}
+	xdp->set_background_2d(xdp, background_resource, width, height);
 }
 
 /*!

--- a/src/xrt/include/xrt/xrt_display_processor_gl.h
+++ b/src/xrt/include/xrt/xrt_display_processor_gl.h
@@ -182,6 +182,31 @@ struct xrt_display_processor_gl
 	 * absent slot or NULL ⟹ DP assumes @ref XRT_ATLAS_ENCODING_ENCODED.
 	 */
 	void (*set_atlas_encoding)(struct xrt_display_processor_gl *xdp, enum xrt_atlas_encoding atlas_encoding);
+
+	/*!
+	 * Hand the DP this frame's flattened 2D-under backdrop (#491 part 3).
+	 * Called once per frame, immediately before @ref process_atlas, when the
+	 * frame carries Local2D layers before the projection (the "under" layers).
+	 * The runtime flattens them into a single premultiplied-RGBA GL texture in
+	 * the client-window pixel space / canvas rect and passes its name here. The
+	 * DP composites it OVER its captured desktop background and uses the result
+	 * as the under-3D background for the NEXT process_atlas. The texture must
+	 * outlive that call.
+	 *
+	 * Pass 0 (or width/height 0) to clear — desktop-only background.
+	 *
+	 * Optional — absent slot or NULL ⟹ no-op (part-1-only behavior). Appended
+	 * per ADR-020 (append-only within a major).
+	 *
+	 * @param xdp             Pointer to self.
+	 * @param background_tex  GLuint name of the flattened backdrop (or 0 to clear).
+	 * @param width           Backdrop width in pixels.
+	 * @param height          Backdrop height in pixels.
+	 */
+	void (*set_background_2d)(struct xrt_display_processor_gl *xdp,
+	                          uint32_t background_tex,
+	                          uint32_t width,
+	                          uint32_t height);
 };
 
 /*
@@ -225,7 +250,8 @@ XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_gl, set_chroma_key)     
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_gl, destroy)                     == XRT_DP_GL_BASE_OFF + 9 * sizeof(void *), XRT_DP_ABI_MSG);
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_gl, get_handoff_color_capability) == XRT_DP_GL_BASE_OFF + 10 * sizeof(void *), XRT_DP_ABI_MSG);
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_gl, set_atlas_encoding)           == XRT_DP_GL_BASE_OFF + 11 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(sizeof(struct xrt_display_processor_gl)                                == XRT_DP_GL_BASE_OFF + 12 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_gl, set_background_2d)            == XRT_DP_GL_BASE_OFF + 12 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(sizeof(struct xrt_display_processor_gl)                                == XRT_DP_GL_BASE_OFF + 13 * sizeof(void *), XRT_DP_ABI_MSG);
 // clang-format on
 
 /*!
@@ -405,6 +431,23 @@ xrt_display_processor_gl_set_atlas_encoding(struct xrt_display_processor_gl *xdp
 		return;
 	}
 	xdp->set_atlas_encoding(xdp, atlas_encoding);
+}
+
+/*!
+ * @copydoc xrt_display_processor_gl::set_background_2d
+ * No-op when the DP doesn't expose the slot (older plug-in) or leaves it NULL.
+ * @public @memberof xrt_display_processor_gl
+ */
+static inline void
+xrt_display_processor_gl_set_background_2d(struct xrt_display_processor_gl *xdp,
+                                           uint32_t background_tex,
+                                           uint32_t width,
+                                           uint32_t height)
+{
+	if (!XRT_DP_HAS_SLOT(xdp, set_background_2d) || xdp->set_background_2d == NULL) {
+		return;
+	}
+	xdp->set_background_2d(xdp, background_tex, width, height);
 }
 
 /*!

--- a/src/xrt/include/xrt/xrt_display_processor_metal.h
+++ b/src/xrt/include/xrt/xrt_display_processor_metal.h
@@ -182,6 +182,31 @@ struct xrt_display_processor_metal
 	 * absent slot or NULL ⟹ DP assumes @ref XRT_ATLAS_ENCODING_ENCODED.
 	 */
 	void (*set_atlas_encoding)(struct xrt_display_processor_metal *xdp, enum xrt_atlas_encoding atlas_encoding);
+
+	/*!
+	 * Hand the DP this frame's flattened 2D-under backdrop (#491 part 3).
+	 * Called once per frame, immediately before @ref process_atlas, when the
+	 * frame carries Local2D layers before the projection (the "under" layers).
+	 * The runtime flattens them into a single premultiplied-RGBA Metal texture
+	 * in the client-window pixel space / canvas rect and passes it here. The DP
+	 * composites it OVER its captured desktop background and uses the result as
+	 * the under-3D background for the NEXT process_atlas. The texture must
+	 * outlive that call and be sampleable.
+	 *
+	 * Pass NULL (or width/height 0) to clear — desktop-only background.
+	 *
+	 * Optional — absent slot or NULL ⟹ no-op (part-1-only behavior). Appended
+	 * per ADR-020 (append-only within a major).
+	 *
+	 * @param xdp              Pointer to self.
+	 * @param background_texture id<MTLTexture> of the flattened backdrop (or NULL to clear).
+	 * @param width            Backdrop width in pixels.
+	 * @param height           Backdrop height in pixels.
+	 */
+	void (*set_background_2d)(struct xrt_display_processor_metal *xdp,
+	                          void *background_texture,
+	                          uint32_t width,
+	                          uint32_t height);
 };
 
 /*
@@ -225,7 +250,8 @@ XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_metal, set_chroma_key)  
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_metal, destroy)                     == XRT_DP_METAL_BASE_OFF + 9 * sizeof(void *), XRT_DP_ABI_MSG);
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_metal, get_handoff_color_capability) == XRT_DP_METAL_BASE_OFF + 10 * sizeof(void *), XRT_DP_ABI_MSG);
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_metal, set_atlas_encoding)           == XRT_DP_METAL_BASE_OFF + 11 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(sizeof(struct xrt_display_processor_metal)                                == XRT_DP_METAL_BASE_OFF + 12 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_metal, set_background_2d)            == XRT_DP_METAL_BASE_OFF + 12 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(sizeof(struct xrt_display_processor_metal)                                == XRT_DP_METAL_BASE_OFF + 13 * sizeof(void *), XRT_DP_ABI_MSG);
 // clang-format on
 
 /*!
@@ -407,6 +433,23 @@ xrt_display_processor_metal_set_atlas_encoding(struct xrt_display_processor_meta
 		return;
 	}
 	xdp->set_atlas_encoding(xdp, atlas_encoding);
+}
+
+/*!
+ * @copydoc xrt_display_processor_metal::set_background_2d
+ * No-op when the DP doesn't expose the slot (older plug-in) or leaves it NULL.
+ * @public @memberof xrt_display_processor_metal
+ */
+static inline void
+xrt_display_processor_metal_set_background_2d(struct xrt_display_processor_metal *xdp,
+                                              void *background_texture,
+                                              uint32_t width,
+                                              uint32_t height)
+{
+	if (!XRT_DP_HAS_SLOT(xdp, set_background_2d) || xdp->set_background_2d == NULL) {
+		return;
+	}
+	xdp->set_background_2d(xdp, background_texture, width, height);
 }
 
 /*!

--- a/test_apps/cube_handle_d3d11_win/main.cpp
+++ b/test_apps/cube_handle_d3d11_win/main.cpp
@@ -69,6 +69,8 @@ static DWORD g_savedWindowStyle = 0;
 static bool g_l2dPanel = false;
 static bool g_l2dMask = false;
 static bool g_l2dPanel2 = false;
+// #491 part 3 — 2D-under backdrop (0=off, 2=opaque, 3=semi-transparent).
+static int g_l2dBackdropVariant = 0;
 static bool g_l2dActive = false; // set once panels (+ optional mask) are live
 static long g_l2dFrameCounter = 0;
 static const long g_l2dActivationFrame = 10;
@@ -77,8 +79,8 @@ struct L2DPanel {
     XrSwapchain swapchain = XR_NULL_HANDLE;
     uint32_t w = 0, h = 0;
 };
-static L2DPanel g_panel1, g_panel2;
-static XrRect2Di g_panel1Rect, g_panel2Rect;
+static L2DPanel g_panel1, g_panel2, g_backdrop;
+static XrRect2Di g_panel1Rect, g_panel2Rect, g_backdropRect;
 
 // XR_EXT_view_rig (#396 W7 dogfood): the app chains a rig descriptor on every
 // xrLocateViews and consumes the runtime's render-ready XrView{pose, fov}
@@ -436,7 +438,17 @@ static bool CreateAndFillL2DPanel(XrSessionManager& xr, ID3D11Device* device, ID
         uint8_t* row = buf.data() + (size_t)y * stride;
         for (uint32_t x = 0; x < w; x++) {
             uint8_t* px = row + (size_t)x * 4; // B,G,R,A
-            if (variant == 0) {
+            if (variant == 2) {
+                // #491 part 3 backdrop (opaque): coarse cyan/blue checker.
+                bool check = (((x / 32) + (y / 32)) & 1) != 0;
+                px[0] = check ? 200 : 90; px[1] = check ? 120 : 40; px[2] = 0; px[3] = 255;
+            } else if (variant == 3) {
+                // #491 part 3 backdrop (semi-transparent ~50%, PREMULTIPLIED) —
+                // the desktop shows through it.
+                bool check = (((x / 32) + (y / 32)) & 1) != 0;
+                if (check) { px[0] = 110; px[1] = 0; px[2] = 110; px[3] = 128; }
+                else       { px[0] = 0; px[1] = 90; px[2] = 90; px[3] = 128; }
+            } else if (variant == 0) {
                 bool inBorder = (x < border || y < border || x >= w - border || y >= h - border);
                 if (inBorder) {
                     // Half-transparent green, PREMULTIPLIED bytes.
@@ -1014,6 +1026,17 @@ static void RenderOneFrame(RenderState& rs) {
                     bool ok = CreateAndFillL2DPanel(xr, renderer.device.Get(), renderer.context.Get(), pw, ph,
                                                     p1variant, g_panel1);
 
+                    // #491 part 3 — large backdrop submitted BEFORE the projection
+                    // (a 2D-under layer): the flat 2D plane the cube floats in front of.
+                    if (ok && g_l2dBackdropVariant != 0) {
+                        uint32_t bw = winW * 3 / 4;
+                        uint32_t bh = winH * 3 / 4;
+                        g_backdropRect.offset = {(int32_t)(winW / 2 - bw / 2), (int32_t)(winH / 2 - bh / 2)};
+                        g_backdropRect.extent = {(int32_t)bw, (int32_t)bh};
+                        ok = CreateAndFillL2DPanel(xr, renderer.device.Get(), renderer.context.Get(), bw, bh,
+                                                   g_l2dBackdropVariant, g_backdrop);
+                    }
+
                     if (ok && g_l2dPanel2) {
                         // Overlaps panel 1's top-right quadrant — list-order
                         // stacking check (panel 2 is later in the list = on top).
@@ -1072,9 +1095,23 @@ static void RenderOneFrame(RenderState& rs) {
                     (XrStructureType)XR_TYPE_COMPOSITION_LAYER_LOCAL_2D_EXT};
                 XrCompositionLayerLocal2DEXT panel2Layer = {
                     (XrStructureType)XR_TYPE_COMPOSITION_LAYER_LOCAL_2D_EXT};
-                const XrCompositionLayerBaseHeader* layers[3] = {
-                    (XrCompositionLayerBaseHeader*)&projLayer, nullptr, nullptr};
-                uint32_t layerCount = 1;
+                XrCompositionLayerLocal2DEXT backdropLayer = {
+                    (XrStructureType)XR_TYPE_COMPOSITION_LAYER_LOCAL_2D_EXT};
+                const XrCompositionLayerBaseHeader* layers[4] = {nullptr, nullptr, nullptr, nullptr};
+                uint32_t layerCount = 0;
+
+                // #491 part 3 — backdrop BEFORE the projection (a 2D-under layer).
+                if (g_l2dBackdropVariant != 0 && g_backdrop.swapchain != XR_NULL_HANDLE) {
+                    backdropLayer.layerFlags = 0; // premultiplied bytes
+                    backdropLayer.subImage.swapchain = g_backdrop.swapchain;
+                    backdropLayer.subImage.imageRect.offset = {0, 0};
+                    backdropLayer.subImage.imageRect.extent = {(int32_t)g_backdrop.w, (int32_t)g_backdrop.h};
+                    backdropLayer.subImage.imageArrayIndex = 0;
+                    backdropLayer.rect = g_backdropRect;
+                    layers[layerCount++] = (XrCompositionLayerBaseHeader*)&backdropLayer;
+                }
+
+                layers[layerCount++] = (XrCompositionLayerBaseHeader*)&projLayer;
 
                 panel1Layer.layerFlags = 0; // premultiplied bytes
                 panel1Layer.subImage.swapchain = g_panel1.swapchain;
@@ -1148,10 +1185,19 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         if (e && *e == '1') g_l2dMask = true;
         e = getenv("DXR_LOCAL2D_PANEL2");
         if (e && *e == '1') g_l2dPanel2 = true;
+        // #491 part 3 — DXR_LOCAL2D_BACKDROP=1 ⟹ opaque (variant 2); =2 ⟹
+        // semi-transparent (variant 3, desktop shows through). Implies the panel path.
+        e = getenv("DXR_LOCAL2D_BACKDROP");
+        if (e && (*e == '1' || *e == '2')) {
+            g_l2dBackdropVariant = (*e == '2') ? 3 : 2;
+            g_l2dPanel = true;
+        }
         if (g_l2dPanel) {
-            LOG_INFO("DXR_LOCAL2D_PANEL=1 — Local2D panel layer%s%s",
+            LOG_INFO("DXR_LOCAL2D_PANEL=1 — Local2D panel layer%s%s%s",
                 g_l2dPanel2 ? " + panel2 (unpremultiplied, overlapping)" : "",
-                g_l2dMask ? " + explicit Tier-2 island mask" : " (implicit mask)");
+                g_l2dMask ? " + explicit Tier-2 island mask" : " (implicit mask)",
+                g_l2dBackdropVariant == 2 ? " + opaque 2D-under backdrop" :
+                g_l2dBackdropVariant == 3 ? " + semi-transparent 2D-under backdrop" : "");
         }
     }
 

--- a/test_apps/cube_handle_d3d12_win/main.cpp
+++ b/test_apps/cube_handle_d3d12_win/main.cpp
@@ -72,6 +72,8 @@ static DWORD g_savedWindowStyle = 0;
 static bool g_l2dPanel = false;
 static bool g_l2dMask = false;
 static bool g_l2dPanel2 = false;
+// #491 part 3 — 2D-under backdrop (0=off, 2=opaque, 3=semi-transparent).
+static int g_l2dBackdropVariant = 0;
 static bool g_l2dActive = false; // set once panels (+ optional mask) are live
 static long g_l2dFrameCounter = 0;
 static const long g_l2dActivationFrame = 10;
@@ -80,7 +82,8 @@ struct L2DPanel {
     XrSwapchain swapchain = XR_NULL_HANDLE;
     uint32_t w = 0, h = 0;
 };
-static L2DPanel g_panel1, g_panel2;
+static L2DPanel g_panel1, g_panel2, g_backdrop;
+static XrRect2Di g_backdropRect;
 static XrRect2Di g_panel1Rect, g_panel2Rect;
 
 // XR_EXT_view_rig (#396 W7 dogfood): the app chains XrDisplayRigEXT on every
@@ -379,7 +382,16 @@ static bool CreateAndFillL2DPanel(XrSessionManager& xr, ID3D12Device* device, ID
         uint8_t* row = buf.data() + (size_t)y * srcStride;
         for (uint32_t x = 0; x < w; x++) {
             uint8_t* px = row + (size_t)x * 4; // B,G,R,A
-            if (variant == 0) {
+            if (variant == 2) {
+                // #491 part 3 backdrop (opaque): coarse cyan/blue checker.
+                bool check = (((x / 32) + (y / 32)) & 1) != 0;
+                px[0] = check ? 200 : 90; px[1] = check ? 120 : 40; px[2] = 0; px[3] = 255;
+            } else if (variant == 3) {
+                // #491 part 3 backdrop (semi-transparent ~50%, PREMULTIPLIED).
+                bool check = (((x / 32) + (y / 32)) & 1) != 0;
+                if (check) { px[0] = 110; px[1] = 0; px[2] = 110; px[3] = 128; }
+                else       { px[0] = 0; px[1] = 90; px[2] = 90; px[3] = 128; }
+            } else if (variant == 0) {
                 bool inBorder = (x < border || y < border || x >= w - border || y >= h - border);
                 if (inBorder) {
                     px[0] = 0; px[1] = 128; px[2] = 0; px[3] = 128; // half-transparent green, premultiplied
@@ -943,6 +955,16 @@ static void RenderThreadFunc(
                         bool ok = CreateAndFillL2DPanel(*xr, renderer->device.Get(), renderer->commandQueue.Get(),
                                                         pw, ph, p1variant, g_panel1);
 
+                        // #491 part 3 — large backdrop submitted BEFORE the projection.
+                        if (ok && g_l2dBackdropVariant != 0) {
+                            uint32_t bw = winW * 3 / 4;
+                            uint32_t bh = winH * 3 / 4;
+                            g_backdropRect.offset = {(int32_t)(winW / 2 - bw / 2), (int32_t)(winH / 2 - bh / 2)};
+                            g_backdropRect.extent = {(int32_t)bw, (int32_t)bh};
+                            ok = CreateAndFillL2DPanel(*xr, renderer->device.Get(), renderer->commandQueue.Get(),
+                                                       bw, bh, g_l2dBackdropVariant, g_backdrop);
+                        }
+
                         if (ok && g_l2dPanel2) {
                             // Overlaps panel 1's top-right quadrant — list-order
                             // stacking check (panel 2 is later = on top).
@@ -1003,9 +1025,23 @@ static void RenderThreadFunc(
                         (XrStructureType)XR_TYPE_COMPOSITION_LAYER_LOCAL_2D_EXT};
                     XrCompositionLayerLocal2DEXT panel2Layer = {
                         (XrStructureType)XR_TYPE_COMPOSITION_LAYER_LOCAL_2D_EXT};
-                    const XrCompositionLayerBaseHeader* layers[3] = {
-                        (XrCompositionLayerBaseHeader*)&projLayer, nullptr, nullptr};
-                    uint32_t layerCount = 1;
+                    XrCompositionLayerLocal2DEXT backdropLayer = {
+                        (XrStructureType)XR_TYPE_COMPOSITION_LAYER_LOCAL_2D_EXT};
+                    const XrCompositionLayerBaseHeader* layers[4] = {nullptr, nullptr, nullptr, nullptr};
+                    uint32_t layerCount = 0;
+
+                    // #491 part 3 — backdrop BEFORE the projection (a 2D-under layer).
+                    if (g_l2dBackdropVariant != 0 && g_backdrop.swapchain != XR_NULL_HANDLE) {
+                        backdropLayer.layerFlags = 0; // premultiplied bytes
+                        backdropLayer.subImage.swapchain = g_backdrop.swapchain;
+                        backdropLayer.subImage.imageRect.offset = {0, 0};
+                        backdropLayer.subImage.imageRect.extent = {(int32_t)g_backdrop.w, (int32_t)g_backdrop.h};
+                        backdropLayer.subImage.imageArrayIndex = 0;
+                        backdropLayer.rect = g_backdropRect;
+                        layers[layerCount++] = (XrCompositionLayerBaseHeader*)&backdropLayer;
+                    }
+
+                    layers[layerCount++] = (XrCompositionLayerBaseHeader*)&projLayer;
 
                     panel1Layer.layerFlags = 0; // premultiplied bytes
                     panel1Layer.subImage.swapchain = g_panel1.swapchain;
@@ -1087,10 +1123,19 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         if (e && *e == '1') g_l2dMask = true;
         e = getenv("DXR_LOCAL2D_PANEL2");
         if (e && *e == '1') g_l2dPanel2 = true;
+        // #491 part 3 — DXR_LOCAL2D_BACKDROP=1 ⟹ opaque (variant 2); =2 ⟹
+        // semi-transparent (variant 3). Implies the panel path.
+        e = getenv("DXR_LOCAL2D_BACKDROP");
+        if (e && (*e == '1' || *e == '2')) {
+            g_l2dBackdropVariant = (*e == '2') ? 3 : 2;
+            g_l2dPanel = true;
+        }
         if (g_l2dPanel) {
-            LOG_INFO("DXR_LOCAL2D_PANEL=1 — Local2D panel layer%s%s",
+            LOG_INFO("DXR_LOCAL2D_PANEL=1 — Local2D panel layer%s%s%s",
                 g_l2dPanel2 ? " + panel2 (unpremultiplied, overlapping)" : "",
-                g_l2dMask ? " + explicit Tier-2 island mask" : " (implicit mask)");
+                g_l2dMask ? " + explicit Tier-2 island mask" : " (implicit mask)",
+                g_l2dBackdropVariant == 2 ? " + opaque 2D-under backdrop" :
+                g_l2dBackdropVariant == 3 ? " + semi-transparent 2D-under backdrop" : "");
         }
     }
 

--- a/test_apps/cube_handle_gl_win/main.cpp
+++ b/test_apps/cube_handle_gl_win/main.cpp
@@ -57,6 +57,8 @@ static bool g_l2dPanel = false;
 static bool g_l2dMask = false;
 static bool g_l2dPanel2 = false;
 static bool g_l2dActive = false;
+// #491 part 3 — 2D-under backdrop (0=off, 2=opaque, 3=semi-transparent).
+static int g_l2dBackdropVariant = 0;
 static long g_l2dFrameCounter = 0;
 static const long g_l2dActivationFrame = 10;
 
@@ -64,8 +66,8 @@ struct L2DPanel {
     XrSwapchain swapchain = XR_NULL_HANDLE;
     uint32_t w = 0, h = 0;
 };
-static L2DPanel g_panel1, g_panel2;
-static XrRect2Di g_panel1Rect, g_panel2Rect;
+static L2DPanel g_panel1, g_panel2, g_backdrop;
+static XrRect2Di g_panel1Rect, g_panel2Rect, g_backdropRect;
 
 // Fullscreen state
 static bool g_fullscreen = false;
@@ -436,7 +438,17 @@ static bool CreateAndFillL2DPanel(XrSessionManager& xr, uint32_t w, uint32_t h, 
         uint8_t* row = buf.data() + (size_t)y * stride;
         for (uint32_t x = 0; x < w; x++) {
             uint8_t* px = row + (size_t)x * 4; // R,G,B,A
-            if (variant == 0) {
+            if (variant == 2) {
+                // #491 part 3 backdrop (opaque): coarse cyan/blue checker.
+                bool check = (((x / 32) + (y / 32)) & 1) != 0;
+                px[0] = 0; px[1] = check ? 120 : 40; px[2] = check ? 200 : 90; px[3] = 255;
+            } else if (variant == 3) {
+                // #491 part 3 backdrop (semi-transparent ~50%, PREMULTIPLIED) —
+                // the desktop shows through it.
+                bool check = (((x / 32) + (y / 32)) & 1) != 0;
+                if (check) { px[0] = 110; px[1] = 0; px[2] = 110; px[3] = 128; }
+                else       { px[0] = 90; px[1] = 90; px[2] = 0; px[3] = 128; }
+            } else if (variant == 0) {
                 bool inBorder = (x < border || y < border || x >= w - border || y >= h - border);
                 if (inBorder) {
                     px[0] = 0; px[1] = 128; px[2] = 0; px[3] = 128; // half-transparent green, premultiplied
@@ -910,6 +922,16 @@ static void RenderThreadFunc(
                         g_panel1Rect.extent = {(int32_t)pw, (int32_t)ph};
                         bool ok = CreateAndFillL2DPanel(*xr, pw, ph, p1variant, g_panel1);
 
+                        // #491 part 3 — large backdrop submitted BEFORE the projection
+                        // (a 2D-under layer): the flat 2D plane the cube floats in front of.
+                        if (ok && g_l2dBackdropVariant != 0) {
+                            uint32_t bw = winW * 3 / 4;
+                            uint32_t bh = winH * 3 / 4;
+                            g_backdropRect.offset = {(int32_t)(winW / 2 - bw / 2), (int32_t)(winH / 2 - bh / 2)};
+                            g_backdropRect.extent = {(int32_t)bw, (int32_t)bh};
+                            ok = CreateAndFillL2DPanel(*xr, bw, bh, g_l2dBackdropVariant, g_backdrop);
+                        }
+
                         if (ok && g_l2dPanel2) {
                             g_panel2Rect.offset = {g_panel1Rect.offset.x + (int32_t)(pw / 2),
                                                    g_panel1Rect.offset.y - (int32_t)(ph / 4)};
@@ -961,9 +983,23 @@ static void RenderThreadFunc(
                         (XrStructureType)XR_TYPE_COMPOSITION_LAYER_LOCAL_2D_EXT};
                     XrCompositionLayerLocal2DEXT panel2Layer = {
                         (XrStructureType)XR_TYPE_COMPOSITION_LAYER_LOCAL_2D_EXT};
-                    const XrCompositionLayerBaseHeader* layers[3] = {
-                        (XrCompositionLayerBaseHeader*)&projLayer, nullptr, nullptr};
-                    uint32_t layerCount = 1;
+                    XrCompositionLayerLocal2DEXT backdropLayer = {
+                        (XrStructureType)XR_TYPE_COMPOSITION_LAYER_LOCAL_2D_EXT};
+                    const XrCompositionLayerBaseHeader* layers[4] = {nullptr, nullptr, nullptr, nullptr};
+                    uint32_t layerCount = 0;
+
+                    // #491 part 3 — backdrop BEFORE the projection (a 2D-under layer).
+                    if (g_l2dBackdropVariant != 0 && g_backdrop.swapchain != XR_NULL_HANDLE) {
+                        backdropLayer.layerFlags = 0; // premultiplied bytes
+                        backdropLayer.subImage.swapchain = g_backdrop.swapchain;
+                        backdropLayer.subImage.imageRect.offset = {0, 0};
+                        backdropLayer.subImage.imageRect.extent = {(int32_t)g_backdrop.w, (int32_t)g_backdrop.h};
+                        backdropLayer.subImage.imageArrayIndex = 0;
+                        backdropLayer.rect = g_backdropRect;
+                        layers[layerCount++] = (XrCompositionLayerBaseHeader*)&backdropLayer;
+                    }
+
+                    layers[layerCount++] = (XrCompositionLayerBaseHeader*)&projLayer;
 
                     panel1Layer.layerFlags = 0; // premultiplied bytes
                     panel1Layer.subImage.swapchain = g_panel1.swapchain;
@@ -1042,10 +1078,19 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         if (e && *e == '1') g_l2dMask = true;
         e = getenv("DXR_LOCAL2D_PANEL2");
         if (e && *e == '1') g_l2dPanel2 = true;
+        // #491 part 3 — DXR_LOCAL2D_BACKDROP=1 ⟹ opaque (variant 2); =2 ⟹
+        // semi-transparent (variant 3, desktop shows through). Implies the panel path.
+        e = getenv("DXR_LOCAL2D_BACKDROP");
+        if (e && (*e == '1' || *e == '2')) {
+            g_l2dBackdropVariant = (*e == '2') ? 3 : 2;
+            g_l2dPanel = true;
+        }
         if (g_l2dPanel) {
-            LOG_INFO("DXR_LOCAL2D_PANEL=1 — Local2D panel layer%s%s",
+            LOG_INFO("DXR_LOCAL2D_PANEL=1 — Local2D panel layer%s%s%s",
                 g_l2dPanel2 ? " + panel2 (unpremultiplied, overlapping)" : "",
-                g_l2dMask ? " + explicit Tier-2 island mask" : " (implicit mask)");
+                g_l2dMask ? " + explicit Tier-2 island mask" : " (implicit mask)",
+                g_l2dBackdropVariant == 2 ? " + opaque 2D-under backdrop" :
+                g_l2dBackdropVariant == 3 ? " + semi-transparent 2D-under backdrop" : "");
         }
     }
 

--- a/test_apps/cube_handle_vk_win/main.cpp
+++ b/test_apps/cube_handle_vk_win/main.cpp
@@ -86,6 +86,10 @@ static DWORD g_savedWindowStyle = 0;
 static bool g_l2dPanel = false;
 static bool g_l2dMask = false;
 static bool g_l2dPanel2 = false;
+// #491 part 3 — a Local2D backdrop submitted BEFORE the projection (an UNDER
+// layer). 0 = off, 2 = opaque checker, 3 = semi-transparent (desktop shows
+// through). DXR_LOCAL2D_BACKDROP=1 ⟹ opaque (2); =2 ⟹ semi-transparent (3).
+static int g_l2dBackdropVariant = 0;
 static bool g_l2dActive = false; // set once panels (+ optional mask) are live
 static long g_l2dFrameCounter = 0;
 static const long g_l2dActivationFrame = 10;
@@ -98,8 +102,8 @@ struct L2DPanel {
     uint32_t imageIndex = 0;
     uint32_t w = 0, h = 0;
 };
-static L2DPanel g_panel1, g_panel2;
-static XrRect2Di g_panel1Rect, g_panel2Rect;
+static L2DPanel g_panel1, g_panel2, g_backdrop;
+static XrRect2Di g_panel1Rect, g_panel2Rect, g_backdropRect;
 
 // XR_EXT_view_rig (#396 W7 dogfood): the app chains a rig descriptor
 // (XrDisplayRigEXT, or XrCameraRigEXT in camera mode) on every xrLocateViews
@@ -397,7 +401,28 @@ static bool CreateAndFillL2DPanel(XrSessionManager& xr, VkRenderer* renderer, Vk
         uint8_t* row = buf.data() + (size_t)y * stride;
         for (uint32_t x = 0; x < w; x++) {
             uint8_t* px = row + (size_t)x * 4; // B,G,R,A
-            if (variant == 0) {
+            if (variant == 2) {
+                // #491 part 3 backdrop (opaque): coarse cyan/blue checker — an
+                // obvious flat 2D plane that the floating 3D cube sits in front
+                // of. The 2D-under layer (submitted before the projection).
+                bool check = (((x / 32) + (y / 32)) & 1) != 0;
+                px[0] = check ? 200 : 90;  // B
+                px[1] = check ? 120 : 40;  // G
+                px[2] = 0;                 // R
+                px[3] = 255;               // opaque
+            } else if (variant == 3) {
+                // #491 part 3 backdrop (semi-transparent): coarse magenta
+                // checker at ~50% alpha, PREMULTIPLIED (rgb already scaled by
+                // a=0.5). The desktop must show through it (`desktop ⊕ backdrop`)
+                // — the case the runtime-only prototype could NOT do, the whole
+                // point of routing the backdrop through the DP.
+                bool check = (((x / 32) + (y / 32)) & 1) != 0;
+                if (check) {
+                    px[0] = 110; px[1] = 0; px[2] = 110; px[3] = 128; // 50% magenta (premul)
+                } else {
+                    px[0] = 0; px[1] = 90; px[2] = 90; px[3] = 128;   // 50% teal (premul)
+                }
+            } else if (variant == 0) {
                 bool inBorder = (x < border || y < border || x >= w - border || y >= h - border);
                 if (inBorder) {
                     px[0] = 0; px[1] = 128; px[2] = 0; px[3] = 128; // half-transparent green (premul)
@@ -1014,6 +1039,20 @@ static void RenderThreadFunc(
                         g_panel1Rect.extent = {(int32_t)pw, (int32_t)ph};
                         bool ok = CreateAndFillL2DPanel(*xr, renderer, hudCmdPool, pw, ph, p1variant, g_panel1);
 
+                        // #491 part 3 — a large backdrop submitted BEFORE the
+                        // projection (an UNDER layer): the flat 2D plane the
+                        // transparent-bg cube floats in front of. Variant 2 =
+                        // opaque, 3 = semi-transparent (desktop shows through).
+                        if (ok && g_l2dBackdropVariant != 0) {
+                            uint32_t bw = winW * 3 / 4;
+                            uint32_t bh = winH * 3 / 4;
+                            g_backdropRect.offset = {(int32_t)(winW / 2 - bw / 2),
+                                                     (int32_t)(winH / 2 - bh / 2)};
+                            g_backdropRect.extent = {(int32_t)bw, (int32_t)bh};
+                            ok = CreateAndFillL2DPanel(*xr, renderer, hudCmdPool, bw, bh,
+                                                       g_l2dBackdropVariant, g_backdrop);
+                        }
+
                         if (ok && g_l2dPanel2) {
                             // Overlaps panel 1's top-right quadrant — list-order
                             // stacking check (panel 2 later = on top).
@@ -1070,9 +1109,26 @@ static void RenderThreadFunc(
                         (XrStructureType)XR_TYPE_COMPOSITION_LAYER_LOCAL_2D_EXT};
                     XrCompositionLayerLocal2DEXT panel2Layer = {
                         (XrStructureType)XR_TYPE_COMPOSITION_LAYER_LOCAL_2D_EXT};
-                    const XrCompositionLayerBaseHeader* layers[3] = {
-                        (XrCompositionLayerBaseHeader*)&projLayer, nullptr, nullptr};
-                    uint32_t layerCount = 1;
+                    XrCompositionLayerLocal2DEXT backdropLayer = {
+                        (XrStructureType)XR_TYPE_COMPOSITION_LAYER_LOCAL_2D_EXT};
+                    const XrCompositionLayerBaseHeader* layers[4] = {nullptr, nullptr, nullptr, nullptr};
+                    uint32_t layerCount = 0;
+
+                    // #491 part 3 — the backdrop goes BEFORE the projection in
+                    // list order (an UNDER layer → flat 2D behind the 3D, routed
+                    // to the DP via set_background_2d).
+                    if (g_l2dBackdropVariant != 0 && g_backdrop.swapchain != XR_NULL_HANDLE) {
+                        backdropLayer.layerFlags = 0; // premultiplied bytes
+                        backdropLayer.subImage.swapchain = g_backdrop.swapchain;
+                        backdropLayer.subImage.imageRect.offset = {0, 0};
+                        backdropLayer.subImage.imageRect.extent = {(int32_t)g_backdrop.w,
+                                                                   (int32_t)g_backdrop.h};
+                        backdropLayer.subImage.imageArrayIndex = 0;
+                        backdropLayer.rect = g_backdropRect;
+                        layers[layerCount++] = (XrCompositionLayerBaseHeader*)&backdropLayer;
+                    }
+
+                    layers[layerCount++] = (XrCompositionLayerBaseHeader*)&projLayer;
 
                     panel1Layer.layerFlags = 0; // premultiplied bytes
                     panel1Layer.subImage.swapchain = g_panel1.swapchain;
@@ -1187,10 +1243,20 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         if (e && *e == '1') g_l2dMask = true;
         e = getenv("DXR_LOCAL2D_PANEL2");
         if (e && *e == '1') g_l2dPanel2 = true;
+        // #491 part 3 — DXR_LOCAL2D_BACKDROP=1 ⟹ opaque backdrop (variant 2);
+        // =2 ⟹ semi-transparent backdrop (variant 3, desktop shows through).
+        // Either implies the Local2D panel path is active.
+        e = getenv("DXR_LOCAL2D_BACKDROP");
+        if (e && (*e == '1' || *e == '2')) {
+            g_l2dBackdropVariant = (*e == '2') ? 3 : 2;
+            g_l2dPanel = true;
+        }
         if (g_l2dPanel) {
-            LOG_INFO("DXR_LOCAL2D_PANEL=1 — Local2D panel layer%s%s",
+            LOG_INFO("DXR_LOCAL2D_PANEL=1 — Local2D panel layer%s%s%s",
                 g_l2dPanel2 ? " + panel2 (unpremultiplied, overlapping)" : "",
-                g_l2dMask ? " + explicit Tier-2 island mask" : " (implicit mask)");
+                g_l2dMask ? " + explicit Tier-2 island mask" : " (implicit mask)",
+                g_l2dBackdropVariant == 2 ? " + opaque 2D-under backdrop" :
+                g_l2dBackdropVariant == 3 ? " + semi-transparent 2D-under backdrop" : "");
         }
     }
 


### PR DESCRIPTION
Completes **#491 part 3** — flat 2D layers *under* the 3D scene, giving the full
designer stack `desktop → 2D-under backdrop → 3D weave → 2D-over overlay`.

The runtime flattens this frame's **under** Local2D layers (those before the
projection in list order) into a `backdrop_scratch` pre-weave and hands it to the
DP via the appended `set_background_2d` vtable slot; the DP composites
`backdrop over captured-desktop` so a semi-transparent backdrop reveals the
desktop. The post-weave composite is OVER-layers only. (The runtime-side
weave-over-backdrop prototype was the wrong layer — see the design doc.)

## What's in this PR (runtime)
- `set_background_2d` DP slot in all 5 headers (no ABI bump; `check_plugin_abi.py`
  green, ABI v3) — VK 17 / D3D11 15 / D3D12 13 / GL 12 / Metal 12.
- **VK** + **D3D11** runtime backdrop flatten + over-only composite (prior commits).
- **D3D12** runtime half (prior commit).
- **GL** (this work): `gl_flatten_backdrop_2d` (fwd-declared), set_background_2d
  before both process_atlas sites, over-only composite + implicit mask, factored
  `gl_flatten_one_local2d_layer`. cube_handle_gl_win gets the `DXR_LOCAL2D_BACKDROP`
  knob. **GL backdrop is a documented VISUAL NO-OP** (GL Leia DP is chroma-key-only).
- **Metal** (this work, code-only): `metal_flatten_backdrop_2d` + over-only composite,
  factored `metal_flatten_one_local2d_layer`. macOS CI gates the compile.

## Paired plugin PR
The matching Leia DP changes ship in `displayxr-leia-plugin`
(`feature/491-part3-dp-backdrop`: VK + D3D11 + **D3D12** DPs compose the backdrop).
**Coupled-release ordering:** this runtime must release first (carries the slot);
the plugin then re-pins `DXR_RUNTIME_GIT_TAG` to that tag.

## Validation (Leia)
- **D3D12** DP: opaque backdrop occludes behind the cube; semi-transparent reveals
  the desktop — both eyeballed green.
- **GL**: no-regression eyeballed (cube + over-panel weave normally; under/over split
  correct — backdrop excluded from the overlay mask; backdrop invisible as expected).
- **Metal**: code-only (macOS CI compile; Mac+Leia eyeball later).
- `displayxr-cli selftest` green (Leia, ABI v3).

surround_2D consolidation deferred to #504 (semantically entangled with
transparent_background; GL/VK surround is a from-scratch import feature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)