### PR TITLE
fix(#507): Android in-process app freezes on background→resume

### DIFF
--- a/src/xrt/auxiliary/android/android_custom_surface.cpp
+++ b/src/xrt/auxiliary/android/android_custom_surface.cpp
@@ -44,66 +44,6 @@ struct android_custom_surface
 };
 
 
-/*!
- * JNI: MonadoView.surfaceChanged() / first surfaceCreated() hands us a brand-new
- * android.view.Surface. Acquire an ANativeWindow from it (+1 ref) and publish it
- * as the current versioned surface; the compositor target picks the change up on
- * its next frame and rebuilds VkSurfaceKHR + swapchain. The previously published
- * window is released by the compositor when it tears its old surface down (single
- * producer/consumer handoff — see comp_vk_native_target sync_surface), so we never
- * release here. #507
- */
-static void
-MonadoView_nativeSurfaceAvailable(JNIEnv *env, jobject /*thiz*/, jobject surface)
-{
-	if (surface == nullptr) {
-		U_LOG_W("nativeSurfaceAvailable: null Surface");
-		return;
-	}
-	ANativeWindow *win = ANativeWindow_fromSurface(env, surface);
-	if (win == nullptr) {
-		U_LOG_E("nativeSurfaceAvailable: ANativeWindow_fromSurface returned NULL");
-		return;
-	}
-
-	// Dedupe: the very first surfaceChanged re-announces the same surface that
-	// the init path (android_custom_surface_wait_get_surface) already acquired.
-	// fromSurface returns the same ANativeWindow* (with an extra ref) for the
-	// same Surface — drop the extra ref and skip, so we don't churn a spurious
-	// surface rebuild or leak a reference. A genuinely new surface (resume) has
-	// a different pointer and falls through to publish.
-	struct _ANativeWindow *current = nullptr;
-	bool current_valid = false;
-	android_globals_get_window_state(&current, nullptr, &current_valid);
-	if (current_valid && (struct _ANativeWindow *)win == current) {
-		ANativeWindow_release(win);
-		return;
-	}
-
-	U_LOG_I("nativeSurfaceAvailable: publishing ANativeWindow %p", (void *)win);
-	android_globals_set_window((struct _ANativeWindow *)win);
-}
-
-/*!
- * JNI: MonadoView.surfaceDestroyed() — the SurfaceView's surface is gone. Mark
- * the current window invalid so the compositor stops presenting to a dead surface
- * and tears its VkSurfaceKHR down (instead of wedging in vkAcquireNextImageKHR /
- * present, which on Adreno never reports VK_ERROR_OUT_OF_DATE_KHR on background).
- * #507
- */
-static void
-MonadoView_nativeSurfaceDestroyed(JNIEnv * /*env*/, jobject /*thiz*/)
-{
-	U_LOG_I("nativeSurfaceDestroyed: marking surface invalid");
-	android_globals_clear_window();
-}
-
-static JNINativeMethod surfaceMethods[] = {
-    {(char *)"nativeSurfaceAvailable", (char *)"(Landroid/view/Surface;)V",
-     (void *)&MonadoView_nativeSurfaceAvailable},
-    {(char *)"nativeSurfaceDestroyed", (char *)"()V", (void *)&MonadoView_nativeSurfaceDestroyed},
-};
-
 android_custom_surface::android_custom_surface() {}
 
 android_custom_surface::~android_custom_surface()
@@ -150,15 +90,6 @@ android_custom_surface_async_start(
 		if (clazz_name != MonadoView::getFullyQualifiedTypeName()) {
 			U_LOG_E("Unexpected class name: %s", clazz_name.c_str());
 			return nullptr;
-		}
-
-		// Wire the surface-lifecycle natives so MonadoView can hand us a new
-		// surface on resume / signal loss on background (#507). Mirrors the
-		// RegisterNatives pattern in android_lifecycle_callbacks.cpp.
-		if (jni::env()->RegisterNatives((jclass)clazz.object().getHandle(), surfaceMethods,
-		                                sizeof(surfaceMethods) / sizeof(surfaceMethods[0])) != 0) {
-			U_LOG_E("Failed to RegisterNatives for MonadoView surface callbacks");
-			// Non-fatal: the initial surface still works; only resume recovery is lost.
 		}
 
 		Context ctx = Context((jobject)context);
@@ -265,10 +196,10 @@ android_custom_surface_wait_get_surface(struct android_custom_surface *custom_su
 		return nullptr;
 	}
 
-	// If surfaceChanged already fired, nativeSurfaceAvailable has acquired +
-	// published the ANativeWindow — reuse it so we keep a single owning reference
-	// (the compositor releases exactly one ref on teardown). Only if nothing has
-	// been published yet (we won the race) do we acquire + publish here. #507
+	// If the periodic pull (android_custom_surface_refresh_window) already
+	// published this surface's ANativeWindow, reuse it so we keep a single owning
+	// reference (the compositor releases exactly one ref on teardown). Only if
+	// nothing has been published yet do we acquire + publish here. #507
 	struct _ANativeWindow *published = nullptr;
 	bool valid = false;
 	android_globals_get_window_state(&published, nullptr, &valid);
@@ -281,6 +212,59 @@ android_custom_surface_wait_get_surface(struct android_custom_surface *custom_su
 		android_globals_set_window((struct _ANativeWindow *)win);
 	}
 	return win;
+}
+
+void
+android_custom_surface_refresh_window(struct android_custom_surface *custom_surface)
+{
+	if (custom_surface == NULL) {
+		return;
+	}
+
+	// Pull the current SurfaceView surface (non-blocking). The Java
+	// surfaceCreated/Changed/Destroyed callbacks keep currentSurfaceHolder up to
+	// date, so a null holder means "backgrounded" and a non-null one means a live
+	// (possibly brand-new, post-resume) surface. This is the robust alternative to
+	// JNI surface-callback registration, which the in-process runtime's multiple
+	// MonadoView classloaders make unreliable. #507
+	SurfaceHolder holder{};
+	try {
+		holder = custom_surface->monadoView.waitGetSurfaceHolder(0);
+	} catch (std::exception const &e) {
+		return;
+	}
+
+	if (holder.isNull()) {
+		// Surface gone — mark invalid so the compositor tears its VkSurfaceKHR down
+		// instead of presenting to a dead window.
+		android_globals_clear_window();
+		return;
+	}
+	auto surf = holder.getSurface();
+	if (surf.isNull()) {
+		android_globals_clear_window();
+		return;
+	}
+
+	ANativeWindow *win = ANativeWindow_fromSurface(jni::env(), surf.object().makeLocalReference());
+	if (win == nullptr) {
+		return;
+	}
+
+	// Dedupe vs the currently published window: ANativeWindow_fromSurface returns
+	// the same pointer for an unchanged Surface, so drop the extra ref and skip
+	// when nothing changed. A genuinely new surface (resume) has a different
+	// pointer (or the current one is invalid) and is published for the compositor
+	// to adopt + rebuild from.
+	struct _ANativeWindow *cur = nullptr;
+	bool cur_valid = false;
+	android_globals_get_window_state(&cur, nullptr, &cur_valid);
+	if (cur_valid && (struct _ANativeWindow *)win == cur) {
+		ANativeWindow_release(win);
+		return;
+	}
+
+	android_globals_set_window((struct _ANativeWindow *)win);
 }
 
 bool

--- a/src/xrt/auxiliary/android/android_custom_surface.cpp
+++ b/src/xrt/auxiliary/android/android_custom_surface.cpp
@@ -44,6 +44,66 @@ struct android_custom_surface
 };
 
 
+/*!
+ * JNI: MonadoView.surfaceChanged() / first surfaceCreated() hands us a brand-new
+ * android.view.Surface. Acquire an ANativeWindow from it (+1 ref) and publish it
+ * as the current versioned surface; the compositor target picks the change up on
+ * its next frame and rebuilds VkSurfaceKHR + swapchain. The previously published
+ * window is released by the compositor when it tears its old surface down (single
+ * producer/consumer handoff — see comp_vk_native_target sync_surface), so we never
+ * release here. #507
+ */
+static void
+MonadoView_nativeSurfaceAvailable(JNIEnv *env, jobject /*thiz*/, jobject surface)
+{
+	if (surface == nullptr) {
+		U_LOG_W("nativeSurfaceAvailable: null Surface");
+		return;
+	}
+	ANativeWindow *win = ANativeWindow_fromSurface(env, surface);
+	if (win == nullptr) {
+		U_LOG_E("nativeSurfaceAvailable: ANativeWindow_fromSurface returned NULL");
+		return;
+	}
+
+	// Dedupe: the very first surfaceChanged re-announces the same surface that
+	// the init path (android_custom_surface_wait_get_surface) already acquired.
+	// fromSurface returns the same ANativeWindow* (with an extra ref) for the
+	// same Surface — drop the extra ref and skip, so we don't churn a spurious
+	// surface rebuild or leak a reference. A genuinely new surface (resume) has
+	// a different pointer and falls through to publish.
+	struct _ANativeWindow *current = nullptr;
+	bool current_valid = false;
+	android_globals_get_window_state(&current, nullptr, &current_valid);
+	if (current_valid && (struct _ANativeWindow *)win == current) {
+		ANativeWindow_release(win);
+		return;
+	}
+
+	U_LOG_I("nativeSurfaceAvailable: publishing ANativeWindow %p", (void *)win);
+	android_globals_set_window((struct _ANativeWindow *)win);
+}
+
+/*!
+ * JNI: MonadoView.surfaceDestroyed() — the SurfaceView's surface is gone. Mark
+ * the current window invalid so the compositor stops presenting to a dead surface
+ * and tears its VkSurfaceKHR down (instead of wedging in vkAcquireNextImageKHR /
+ * present, which on Adreno never reports VK_ERROR_OUT_OF_DATE_KHR on background).
+ * #507
+ */
+static void
+MonadoView_nativeSurfaceDestroyed(JNIEnv * /*env*/, jobject /*thiz*/)
+{
+	U_LOG_I("nativeSurfaceDestroyed: marking surface invalid");
+	android_globals_clear_window();
+}
+
+static JNINativeMethod surfaceMethods[] = {
+    {(char *)"nativeSurfaceAvailable", (char *)"(Landroid/view/Surface;)V",
+     (void *)&MonadoView_nativeSurfaceAvailable},
+    {(char *)"nativeSurfaceDestroyed", (char *)"()V", (void *)&MonadoView_nativeSurfaceDestroyed},
+};
+
 android_custom_surface::android_custom_surface() {}
 
 android_custom_surface::~android_custom_surface()
@@ -90,6 +150,15 @@ android_custom_surface_async_start(
 		if (clazz_name != MonadoView::getFullyQualifiedTypeName()) {
 			U_LOG_E("Unexpected class name: %s", clazz_name.c_str());
 			return nullptr;
+		}
+
+		// Wire the surface-lifecycle natives so MonadoView can hand us a new
+		// surface on resume / signal loss on background (#507). Mirrors the
+		// RegisterNatives pattern in android_lifecycle_callbacks.cpp.
+		if (jni::env()->RegisterNatives((jclass)clazz.object().getHandle(), surfaceMethods,
+		                                sizeof(surfaceMethods) / sizeof(surfaceMethods[0])) != 0) {
+			U_LOG_E("Failed to RegisterNatives for MonadoView surface callbacks");
+			// Non-fatal: the initial surface still works; only resume recovery is lost.
 		}
 
 		Context ctx = Context((jobject)context);
@@ -195,7 +264,23 @@ android_custom_surface_wait_get_surface(struct android_custom_surface *custom_su
 	if (surf.isNull()) {
 		return nullptr;
 	}
-	return ANativeWindow_fromSurface(jni::env(), surf.object().makeLocalReference());
+
+	// If surfaceChanged already fired, nativeSurfaceAvailable has acquired +
+	// published the ANativeWindow — reuse it so we keep a single owning reference
+	// (the compositor releases exactly one ref on teardown). Only if nothing has
+	// been published yet (we won the race) do we acquire + publish here. #507
+	struct _ANativeWindow *published = nullptr;
+	bool valid = false;
+	android_globals_get_window_state(&published, nullptr, &valid);
+	if (valid && published != nullptr) {
+		return (ANativeWindow *)published;
+	}
+
+	ANativeWindow *win = ANativeWindow_fromSurface(jni::env(), surf.object().makeLocalReference());
+	if (win != nullptr) {
+		android_globals_set_window((struct _ANativeWindow *)win);
+	}
+	return win;
 }
 
 bool

--- a/src/xrt/auxiliary/android/android_custom_surface.h
+++ b/src/xrt/auxiliary/android/android_custom_surface.h
@@ -101,6 +101,19 @@ android_custom_surface_destroy(struct android_custom_surface **ptr_custom_surfac
 ANativeWindow *
 android_custom_surface_wait_get_surface(struct android_custom_surface *custom_surface, uint64_t timeout_ms);
 
+/*!
+ * Pull the current SurfaceView surface (non-blocking) and republish it to
+ * android_globals: clears the window when the surface is gone (backgrounded) and
+ * publishes a fresh ANativeWindow when a new surface arrives (resume). Call this
+ * periodically from a JVM-attached thread (oxr_session_poll) so the compositor's
+ * surface re-sync sees background/resume without relying on JNI surface-callback
+ * registration. #507
+ *
+ * @public @memberof android_custom_surface
+ */
+void
+android_custom_surface_refresh_window(struct android_custom_surface *custom_surface);
+
 bool
 android_custom_surface_get_display_metrics(struct _JavaVM *vm,
                                            void *activity,

--- a/src/xrt/auxiliary/android/android_globals.cpp
+++ b/src/xrt/auxiliary/android/android_globals.cpp
@@ -37,6 +37,8 @@ static struct
 	struct _ANativeWindow *window = nullptr;
 	uint64_t generation = 0;
 	bool valid = false;
+	//! Active android_custom_surface (opaque), polled by oxr_session_poll. #507
+	void *custom_surface = nullptr;
 } android_surface;
 
 void
@@ -115,6 +117,20 @@ android_globals_get_window_state(struct _ANativeWindow **out_window, uint64_t *o
 	if (out_valid != nullptr) {
 		*out_valid = android_surface.valid;
 	}
+}
+
+void
+android_globals_set_custom_surface(void *custom_surface)
+{
+	std::lock_guard<std::mutex> lock(android_surface.mutex);
+	android_surface.custom_surface = custom_surface;
+}
+
+void *
+android_globals_get_custom_surface(void)
+{
+	std::lock_guard<std::mutex> lock(android_surface.mutex);
+	return android_surface.custom_surface;
 }
 
 struct _JavaVM *

--- a/src/xrt/auxiliary/android/android_globals.cpp
+++ b/src/xrt/auxiliary/android/android_globals.cpp
@@ -10,6 +10,7 @@
 #include "android_globals.h"
 
 #include <stddef.h>
+#include <mutex>
 #include <wrap/android.app.h>
 
 /*!
@@ -22,6 +23,21 @@ static struct
 	jni::Object context = {};
 	struct _ANativeWindow *window = nullptr;
 } android_globals;
+
+/*!
+ * Versioned surface state, mutated from the Java SurfaceView callbacks
+ * (surfaceChanged / surfaceDestroyed on the UI thread) and read from the
+ * compositor render thread — hence its own lock, separate from the (unlocked)
+ * legacy globals above. @ref generation is bumped on every publish/clear so the
+ * consumer can tell a brand-new surface (resume) from the one it already built.
+ */
+static struct
+{
+	std::mutex mutex;
+	struct _ANativeWindow *window = nullptr;
+	uint64_t generation = 0;
+	bool valid = false;
+} android_surface;
 
 void
 android_globals_store_vm_and_activity(struct _JavaVM *vm, void *activity)
@@ -55,12 +71,50 @@ void
 android_globals_store_window(struct _ANativeWindow *window)
 {
 	android_globals.window = window;
+	// Keep the versioned view in sync for legacy callers (IPC service path
+	// seeds the window via this entry point) so the compositor's surface
+	// re-sync sees a valid initial surface too.
+	android_globals_set_window(window);
 }
 
 struct _ANativeWindow *
 android_globals_get_window()
 {
 	return android_globals.window;
+}
+
+void
+android_globals_set_window(struct _ANativeWindow *window)
+{
+	std::lock_guard<std::mutex> lock(android_surface.mutex);
+	android_surface.window = window;
+	android_surface.valid = (window != nullptr);
+	android_surface.generation++;
+}
+
+void
+android_globals_clear_window(void)
+{
+	std::lock_guard<std::mutex> lock(android_surface.mutex);
+	// Keep the pointer (consumer releases it after idling the GPU) but mark it
+	// invalid + bump the generation so the next re-sync tears the surface down.
+	android_surface.valid = false;
+	android_surface.generation++;
+}
+
+void
+android_globals_get_window_state(struct _ANativeWindow **out_window, uint64_t *out_generation, bool *out_valid)
+{
+	std::lock_guard<std::mutex> lock(android_surface.mutex);
+	if (out_window != nullptr) {
+		*out_window = android_surface.window;
+	}
+	if (out_generation != nullptr) {
+		*out_generation = android_surface.generation;
+	}
+	if (out_valid != nullptr) {
+		*out_valid = android_surface.valid;
+	}
 }
 
 struct _JavaVM *

--- a/src/xrt/auxiliary/android/android_globals.h
+++ b/src/xrt/auxiliary/android/android_globals.h
@@ -11,6 +11,9 @@
 
 #include <xrt/xrt_config_os.h>
 
+#include <stdbool.h>
+#include <stdint.h>
+
 #ifdef XRT_OS_ANDROID
 
 #ifdef __cplusplus
@@ -74,6 +77,42 @@ android_globals_store_window(struct _ANativeWindow *window);
 
 struct _ANativeWindow *
 android_globals_get_window(void);
+
+/*!
+ * Publish a freshly-acquired ANativeWindow (e.g. from a new SurfaceView surface
+ * on resume). Bumps a monotonic generation counter and marks the window valid so
+ * a consumer (the compositor target) can detect "the surface changed under me"
+ * and rebuild its VkSurfaceKHR + swapchain. Thread-safe.
+ *
+ * @param window the new ANativeWindow (may be NULL, treated like a clear).
+ * @ingroup aux_android
+ */
+void
+android_globals_set_window(struct _ANativeWindow *window);
+
+/*!
+ * Mark the current ANativeWindow as gone (surfaceDestroyed). Bumps the generation
+ * counter and clears the valid flag so the compositor tears its surface down
+ * instead of presenting to a dead window. Thread-safe.
+ *
+ * Keeps the ANativeWindow pointer around (still the "current" window) so a
+ * consumer mid-frame can finish/idle before it next re-syncs; the consumer
+ * releases the old reference itself once it has idled the GPU.
+ * @ingroup aux_android
+ */
+void
+android_globals_clear_window(void);
+
+/*!
+ * Atomically read the current window + generation + validity.
+ *
+ * @param[out] out_window     the current ANativeWindow (may be NULL).
+ * @param[out] out_generation monotonic counter, bumped on every set/clear.
+ * @param[out] out_valid      true if a live surface is currently published.
+ * @ingroup aux_android
+ */
+void
+android_globals_get_window_state(struct _ANativeWindow **out_window, uint64_t *out_generation, bool *out_valid);
 
 #ifdef __cplusplus
 }

--- a/src/xrt/auxiliary/android/android_globals.h
+++ b/src/xrt/auxiliary/android/android_globals.h
@@ -114,6 +114,20 @@ android_globals_clear_window(void);
 void
 android_globals_get_window_state(struct _ANativeWindow **out_window, uint64_t *out_generation, bool *out_valid);
 
+/*!
+ * Store/retrieve the active android_custom_surface (opaque) so a periodic tick
+ * (oxr_session_poll) can pull the live SurfaceView surface and republish it via
+ * android_globals_set_window / android_globals_clear_window on resume/background.
+ * Avoids relying on JNI surface-callback registration, which is unreliable when
+ * the runtime loads MonadoView under multiple classloaders. #507
+ * @ingroup aux_android
+ */
+void
+android_globals_set_custom_surface(void *custom_surface);
+
+void *
+android_globals_get_custom_surface(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/xrt/auxiliary/android/src/main/java/org/freedesktop/monado/auxiliary/MonadoView.java
+++ b/src/xrt/auxiliary/android/src/main/java/org/freedesktop/monado/auxiliary/MonadoView.java
@@ -18,7 +18,6 @@ import android.os.SystemClock;
 import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.Display;
-import android.view.Surface;
 import android.view.SurfaceHolder;
 import android.view.SurfaceView;
 import android.view.WindowManager;
@@ -81,24 +80,6 @@ public class MonadoView extends SurfaceView
 
         nativeCounterpart = new NativeCounterpart(nativePointer);
     }
-
-    /**
-     * Hand a freshly-available surface to native code so the compositor can (re)bind
-     * its output to it. Called on every surfaceChanged — including the brand-new
-     * surface delivered on resume after a background→card cycle (#507).
-     *
-     * <p>Registered from native via RegisterNatives in android_custom_surface.cpp.
-     */
-    private native void nativeSurfaceAvailable(Surface surface);
-
-    /**
-     * Tell native code the surface is gone (surfaceDestroyed) so the compositor
-     * stops presenting to a dead window and tears its VkSurfaceKHR down instead of
-     * wedging the render thread (#507).
-     *
-     * <p>Registered from native via RegisterNatives in android_custom_surface.cpp.
-     */
-    private native void nativeSurfaceDestroyed();
 
     /**
      * Construct and start attaching a MonadoView to a client application.
@@ -331,18 +312,8 @@ public class MonadoView extends SurfaceView
                         + this.height
                         + " holder "
                         + currentSurfaceHolder.toString());
-
-        // Hand the (possibly brand-new, post-resume) surface to native so the
-        // compositor can rebind its output. Guard on nativeCounterpart so we only
-        // call when the surface natives have been registered (the in-process /
-        // service path that created us with a native pointer). #507
-        if (nativeCounterpart != null) {
-            try {
-                nativeSurfaceAvailable(surfaceHolder.getSurface());
-            } catch (UnsatisfiedLinkError e) {
-                Log.w(TAG, "nativeSurfaceAvailable not registered: " + e.getMessage());
-            }
-        }
+        // The native side pulls this updated surface via android_custom_surface_
+        // refresh_window() on its next poll (#507) — no push needed here.
     }
 
     @Override
@@ -356,25 +327,17 @@ public class MonadoView extends SurfaceView
             }
         }
         if (lost) {
-            // Notify native that the surface is gone so the compositor marks its
-            // output invalid and tears its VkSurfaceKHR down on its next frame
-            // (the compositor holds its own ANativeWindow ref, so teardown is safe
-            // even after Android frees this Surface). #507
+            // The native side notices the surface is gone on its next pull
+            // (android_custom_surface_refresh_window → waitGetSurfaceHolder returns
+            // null → the compositor tears its VkSurfaceKHR down). #507
             //
             // We deliberately do NOT block on nativeCounterpart.blockUntilNativeDiscard
             // here: that wait only completes when native DESTROYS the counterpart
             // (session teardown), so on a plain background→card cycle it would block
             // this UI thread forever — and a frozen UI thread can never deliver the
-            // surfaceCreated/surfaceChanged that resume needs. The block stays in the
-            // session-teardown path (android_custom_surface destructor → markAs
-            // DiscardedByNative); it does not belong on a transient surface loss.
-            if (nativeCounterpart != null) {
-                try {
-                    nativeSurfaceDestroyed();
-                } catch (UnsatisfiedLinkError e) {
-                    Log.w(TAG, "nativeSurfaceDestroyed not registered: " + e.getMessage());
-                }
-            }
+            // surfaceCreated/surfaceChanged that resume needs. The teardown handshake
+            // stays in the session-destroy path (android_custom_surface destructor →
+            // markAsDiscardedByNative); it does not belong on a transient surface loss.
         }
     }
 

--- a/src/xrt/auxiliary/android/src/main/java/org/freedesktop/monado/auxiliary/MonadoView.java
+++ b/src/xrt/auxiliary/android/src/main/java/org/freedesktop/monado/auxiliary/MonadoView.java
@@ -18,6 +18,7 @@ import android.os.SystemClock;
 import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.Display;
+import android.view.Surface;
 import android.view.SurfaceHolder;
 import android.view.SurfaceView;
 import android.view.WindowManager;
@@ -80,6 +81,24 @@ public class MonadoView extends SurfaceView
 
         nativeCounterpart = new NativeCounterpart(nativePointer);
     }
+
+    /**
+     * Hand a freshly-available surface to native code so the compositor can (re)bind
+     * its output to it. Called on every surfaceChanged — including the brand-new
+     * surface delivered on resume after a background→card cycle (#507).
+     *
+     * <p>Registered from native via RegisterNatives in android_custom_surface.cpp.
+     */
+    private native void nativeSurfaceAvailable(Surface surface);
+
+    /**
+     * Tell native code the surface is gone (surfaceDestroyed) so the compositor
+     * stops presenting to a dead window and tears its VkSurfaceKHR down instead of
+     * wedging the render thread (#507).
+     *
+     * <p>Registered from native via RegisterNatives in android_custom_surface.cpp.
+     */
+    private native void nativeSurfaceDestroyed();
 
     /**
      * Construct and start attaching a MonadoView to a client application.
@@ -312,6 +331,18 @@ public class MonadoView extends SurfaceView
                         + this.height
                         + " holder "
                         + currentSurfaceHolder.toString());
+
+        // Hand the (possibly brand-new, post-resume) surface to native so the
+        // compositor can rebind its output. Guard on nativeCounterpart so we only
+        // call when the surface natives have been registered (the in-process /
+        // service path that created us with a native pointer). #507
+        if (nativeCounterpart != null) {
+            try {
+                nativeSurfaceAvailable(surfaceHolder.getSurface());
+            } catch (UnsatisfiedLinkError e) {
+                Log.w(TAG, "nativeSurfaceAvailable not registered: " + e.getMessage());
+            }
+        }
     }
 
     @Override
@@ -325,12 +356,24 @@ public class MonadoView extends SurfaceView
             }
         }
         if (lost) {
-            // ! @todo this function should notify native code that the surface is gone.
-            if (nativeCounterpart != null && !nativeCounterpart.blockUntilNativeDiscard(TAG)) {
-                Log.i(
-                        TAG,
-                        "Interrupted in surfaceDestroyed while waiting for native code to finish"
-                                + " up.");
+            // Notify native that the surface is gone so the compositor marks its
+            // output invalid and tears its VkSurfaceKHR down on its next frame
+            // (the compositor holds its own ANativeWindow ref, so teardown is safe
+            // even after Android frees this Surface). #507
+            //
+            // We deliberately do NOT block on nativeCounterpart.blockUntilNativeDiscard
+            // here: that wait only completes when native DESTROYS the counterpart
+            // (session teardown), so on a plain background→card cycle it would block
+            // this UI thread forever — and a frozen UI thread can never deliver the
+            // surfaceCreated/surfaceChanged that resume needs. The block stays in the
+            // session-teardown path (android_custom_surface destructor → markAs
+            // DiscardedByNative); it does not belong on a transient surface loss.
+            if (nativeCounterpart != null) {
+                try {
+                    nativeSurfaceDestroyed();
+                } catch (UnsatisfiedLinkError e) {
+                    Log.w(TAG, "nativeSurfaceDestroyed not registered: " + e.getMessage());
+                }
             }
         }
     }

--- a/src/xrt/compositor/vk_native/CMakeLists.txt
+++ b/src/xrt/compositor/vk_native/CMakeLists.txt
@@ -50,6 +50,12 @@ if((WIN32 OR APPLE OR ANDROID) AND XRT_HAVE_VULKAN)
 			"-framework Cocoa" "-framework QuartzCore" "-framework IOSurface")
 	endif()
 
+	if(ANDROID)
+		# Surface-lifecycle re-sync reads the live ANativeWindow published by the
+		# SurfaceView callbacks via android_globals_* (#507).
+		target_link_libraries(comp_vk_native PRIVATE aux_android)
+	endif()
+
 	# Qwerty include path for runtime-side 2D/3D toggle polling
 	if(XRT_BUILD_DRIVER_QWERTY)
 		target_link_libraries(comp_vk_native PRIVATE drv_qwerty_includes)

--- a/src/xrt/compositor/vk_native/comp_vk_native_compositor.c
+++ b/src/xrt/compositor/vk_native/comp_vk_native_compositor.c
@@ -2456,6 +2456,18 @@ vk_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t
 
 	// If we have a target (window), present to it
 	if (c->target != NULL) {
+		// Re-sync the output surface against the live ANativeWindow (Android).
+		// On background→card the SurfaceView's surface is destroyed; presenting
+		// to that dead window wedges the render thread (Adreno never reports
+		// VK_ERROR_OUT_OF_DATE_KHR there) and the OS freezes the process. Skip
+		// acquire/present entirely while no surface exists, and pick up the new
+		// surface on resume. No-op on non-Android. #507
+		enum comp_vk_native_target_surface_state sstate =
+		    comp_vk_native_target_sync_surface(c->target);
+		if (sstate == COMP_VK_NATIVE_TARGET_SURFACE_LOST) {
+			return XRT_SUCCESS;
+		}
+
 		uint32_t target_index;
 		xret = comp_vk_native_target_acquire(c->target, &target_index);
 		if (xret != XRT_SUCCESS) {

--- a/src/xrt/compositor/vk_native/comp_vk_native_target.cpp
+++ b/src/xrt/compositor/vk_native/comp_vk_native_target.cpp
@@ -35,6 +35,7 @@
 #define VK_USE_PLATFORM_ANDROID_KHR
 #include <vulkan/vulkan_android.h>
 #include <android/native_window.h>
+#include "android/android_globals.h"
 #endif
 
 #define DCOMP_RING 2 // Number of shared back-buffers in the bridge ring
@@ -88,6 +89,22 @@ struct comp_vk_native_target
 
 	//! Window handle.
 	void *hwnd;
+
+#ifdef XRT_OS_ANDROID
+	//! The ANativeWindow the current VkSurfaceKHR was built from (owns one
+	//! reference, released when the surface is torn down). Distinct from @ref
+	//! hwnd, which is the launch window and is not re-pointed on resume.
+	void *android_window;
+
+	//! android_globals surface generation this target's VkSurfaceKHR matches.
+	//! A mismatch on the next frame means the SurfaceView handed us a new
+	//! surface (resume) — rebuild — or lost it (background) — tear down. #507
+	uint64_t surface_generation;
+
+	//! True while there is no live output surface (backgrounded). The compositor
+	//! skips acquire/present so the render thread never blocks on a dead window.
+	bool surface_lost;
+#endif
 
 	//! Queue family index for present support check.
 	uint32_t queue_family_index;
@@ -726,6 +743,14 @@ comp_vk_native_target_create(struct comp_vk_native_compositor *c,
 	target->queue_family_index = queue_family_index;
 	target->transparent_background = transparent_background;
 
+#ifdef XRT_OS_ANDROID
+	// Track the surface we build from + the generation it matches, so the
+	// per-frame re-sync can detect surface loss / replacement on resume. #507
+	target->android_window = hwnd;
+	target->surface_lost = false;
+	android_globals_get_window_state(NULL, &target->surface_generation, NULL);
+#endif
+
 #ifdef XRT_OS_WINDOWS
 	// Transparent-background path: VK -> D3D11 KMT shared -> DComp bridge,
 	// no WSI swapchain at all. Falls back to opaque WSI on failure.
@@ -933,8 +958,112 @@ comp_vk_native_target_destroy(struct comp_vk_native_target **target_ptr)
 		vk->vkDestroySurfaceKHR(vk->instance, target->surface, NULL);
 	}
 
+#ifdef XRT_OS_ANDROID
+	// Release the ANativeWindow reference aux_android handed us (the one the
+	// current VkSurfaceKHR was built from). #507
+	if (target->android_window != NULL) {
+		ANativeWindow_release((ANativeWindow *)target->android_window);
+		target->android_window = NULL;
+	}
+#endif
+
 	free(target);
 	*target_ptr = NULL;
+}
+
+enum comp_vk_native_target_surface_state
+comp_vk_native_target_sync_surface(struct comp_vk_native_target *target)
+{
+#ifndef XRT_OS_ANDROID
+	(void)target;
+	return COMP_VK_NATIVE_TARGET_SURFACE_READY;
+#else
+	struct vk_bundle *vk = target->vk;
+
+	struct _ANativeWindow *cur_window = NULL;
+	uint64_t cur_gen = 0;
+	bool cur_valid = false;
+	android_globals_get_window_state(&cur_window, &cur_gen, &cur_valid);
+
+	// Surface unchanged since we (re)built — nothing to do here. The HW_XFORM
+	// rotation-extent poll still runs in target_acquire for the live surface.
+	if (cur_gen == target->surface_generation) {
+		return target->surface_lost ? COMP_VK_NATIVE_TARGET_SURFACE_LOST
+		                            : COMP_VK_NATIVE_TARGET_SURFACE_READY;
+	}
+
+	// The SurfaceView handed us a different surface (or lost it). Idle the GPU
+	// and tear the old swapchain + VkSurfaceKHR down before touching the new one
+	// — vkDestroySwapchainKHR must precede a new swapchain on the same window,
+	// and we must not present to the dead surface.
+	vk->vkDeviceWaitIdle(vk->device);
+	destroy_swapchain_views(target);
+	if (target->swapchain != VK_NULL_HANDLE) {
+		vk->vkDestroySwapchainKHR(vk->device, target->swapchain, NULL);
+		target->swapchain = VK_NULL_HANDLE;
+	}
+	if (target->surface != VK_NULL_HANDLE) {
+		vk->vkDestroySurfaceKHR(vk->instance, target->surface, NULL);
+		target->surface = VK_NULL_HANDLE;
+	}
+	if (target->android_window != NULL) {
+		// Release the reference aux_android handed us for the old window.
+		ANativeWindow_release((ANativeWindow *)target->android_window);
+		target->android_window = NULL;
+	}
+
+	target->surface_generation = cur_gen;
+
+	if (!cur_valid || cur_window == NULL) {
+		// Backgrounded: no live surface. Stay torn down; caller skips present so
+		// the render thread never blocks on a dead window. #507
+		target->surface_lost = true;
+		U_LOG_I("Android output surface lost — target torn down (#507)");
+		return COMP_VK_NATIVE_TARGET_SURFACE_LOST;
+	}
+
+	// Resume: rebuild VkSurfaceKHR + swapchain from the new ANativeWindow,
+	// taking ownership of the reference aux_android published.
+	VkAndroidSurfaceCreateInfoKHR surface_ci = {
+	    .sType = VK_STRUCTURE_TYPE_ANDROID_SURFACE_CREATE_INFO_KHR,
+	    .pNext = NULL,
+	    .flags = 0,
+	    .window = (ANativeWindow *)cur_window,
+	};
+	VkResult res = vk->vkCreateAndroidSurfaceKHR(vk->instance, &surface_ci, NULL, &target->surface);
+	if (res != VK_SUCCESS) {
+		U_LOG_E("sync_surface: vkCreateAndroidSurfaceKHR failed: %d", res);
+		target->surface = VK_NULL_HANDLE;
+		target->surface_lost = true;
+		return COMP_VK_NATIVE_TARGET_SURFACE_LOST;
+	}
+	target->android_window = cur_window;
+
+	// Adopt the new surface's current extent (covers a portrait<->landscape flip
+	// that happened while backgrounded).
+	VkSurfaceCapabilitiesKHR caps;
+	if (vk->vkGetPhysicalDeviceSurfaceCapabilitiesKHR(vk->physical_device, target->surface, &caps) == VK_SUCCESS &&
+	    caps.currentExtent.width != UINT32_MAX && caps.currentExtent.width != 0 &&
+	    caps.currentExtent.height != 0) {
+		target->width = caps.currentExtent.width;
+		target->height = caps.currentExtent.height;
+	}
+
+	xrt_result_t xret = create_swapchain(target);
+	if (xret != XRT_SUCCESS) {
+		U_LOG_E("sync_surface: create_swapchain failed after resume");
+		vk->vkDestroySurfaceKHR(vk->instance, target->surface, NULL);
+		target->surface = VK_NULL_HANDLE;
+		ANativeWindow_release((ANativeWindow *)target->android_window);
+		target->android_window = NULL;
+		target->surface_lost = true;
+		return COMP_VK_NATIVE_TARGET_SURFACE_LOST;
+	}
+
+	target->surface_lost = false;
+	U_LOG_I("Android output surface recreated %ux%u (#507)", target->width, target->height);
+	return COMP_VK_NATIVE_TARGET_SURFACE_RECREATED;
+#endif
 }
 
 xrt_result_t

--- a/src/xrt/compositor/vk_native/comp_vk_native_target.h
+++ b/src/xrt/compositor/vk_native/comp_vk_native_target.h
@@ -128,6 +128,36 @@ comp_vk_native_target_resize(struct comp_vk_native_target *target,
                                uint32_t width,
                                uint32_t height);
 
+/*!
+ * Outcome of re-syncing the target against the current Android output surface.
+ * @ingroup comp_vk_native
+ */
+enum comp_vk_native_target_surface_state
+{
+	//! Surface unchanged and live — safe to acquire/present.
+	COMP_VK_NATIVE_TARGET_SURFACE_READY = 0,
+	//! No live surface (backgrounded) — the swapchain + VkSurfaceKHR were torn
+	//! down; the caller must skip acquire/present this frame.
+	COMP_VK_NATIVE_TARGET_SURFACE_LOST,
+	//! A new surface arrived (resume) — VkSurfaceKHR + swapchain were rebuilt;
+	//! safe to acquire/present.
+	COMP_VK_NATIVE_TARGET_SURFACE_RECREATED,
+};
+
+/*!
+ * Android only: re-sync the target's VkSurfaceKHR + swapchain against the
+ * ANativeWindow currently published by aux_android (which the SurfaceView
+ * destroy/recreate callbacks drive). Called once per frame before acquire.
+ *
+ * On surface loss it idles the GPU and destroys the swapchain + VkSurfaceKHR so
+ * the compositor never blocks acquiring/presenting on a dead window; on a new
+ * surface it rebuilds both. A no-op (returns READY) on non-Android. #507
+ *
+ * @ingroup comp_vk_native
+ */
+enum comp_vk_native_target_surface_state
+comp_vk_native_target_sync_surface(struct comp_vk_native_target *target);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/xrt/state_trackers/oxr/oxr_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_session.c
@@ -26,6 +26,11 @@
 
 #endif // XRT_HAVE_VULKAN
 
+#ifdef XRT_OS_ANDROID
+#include "android/android_globals.h"
+#include "android/android_custom_surface.h"
+#endif
+
 #include "os/os_time.h"
 
 #include "util/u_debug.h"
@@ -909,6 +914,20 @@ oxr_session_poll(struct oxr_logger *log, struct oxr_session *sess)
 #endif
 
 #ifdef XRT_OS_ANDROID
+	// Pull the live SurfaceView surface each poll and republish it to
+	// android_globals: clears it on background (surface gone) and publishes the
+	// fresh surface on resume, so the compositor's per-frame surface re-sync tears
+	// down / rebuilds its VkSurfaceKHR instead of wedging on a dead window. This
+	// runs every tick (even while backgrounded, since the app keeps polling
+	// events), on this JVM-attached thread — the robust alternative to JNI
+	// surface-callback registration. #507
+	{
+		void *cs = android_globals_get_custom_surface();
+		if (cs != NULL) {
+			android_custom_surface_refresh_window(cs);
+		}
+	}
+
 	// Most recent Android activity lifecycle event was OnPause: move toward stopping
 	if (sess->sys->inst->activity_state == XRT_ANDROID_LIVECYCLE_EVENT_ON_PAUSE) {
 		if (sess->state == XR_SESSION_STATE_FOCUSED) {

--- a/src/xrt/state_trackers/oxr/oxr_session_gfx_vk_native.c
+++ b/src/xrt/state_trackers/oxr/oxr_session_gfx_vk_native.c
@@ -299,6 +299,12 @@ oxr_session_populate_vk_native(struct oxr_logger *log,
 			                 "Android: surfaceCreated callback never fired within 5 s");
 		}
 		android_globals_store_window((struct _ANativeWindow *)win);
+		// Keep the custom surface alive + discoverable so oxr_session_poll can pull
+		// the live surface each tick and republish it on background/resume — the
+		// robust path that doesn't depend on JNI surface-callback registration
+		// (unreliable under the in-process runtime's multiple MonadoView
+		// classloaders). Last writer wins if the session is (re)created. #507
+		android_globals_set_custom_surface(cs);
 		window_handle = (void *)win;
 		U_LOG_IFL_I(U_LOGGING_INFO,
 		            "Android: ANativeWindow %p obtained via android_custom_surface", (void *)win);

--- a/test_apps/cube_handle_vk_android/src/main/cpp/main.cpp
+++ b/test_apps/cube_handle_vk_android/src/main/cpp/main.cpp
@@ -2728,18 +2728,19 @@ android_main(struct android_app *app)
 				destroy_instance();
 				return;
 			}
-			// Only render with a live surface. On background / card / split
-			// (APP_CMD_TERM_WINDOW) native_app_glue clears app->window; the
-			// runtime's MonadoView overlay is torn down with the activity, so
-			// rendering would block forever in xrWaitSwapchainImage
-			// (XR_INFINITE_DURATION) on the dead surface — the hang seen when the
-			// app is sent to the recents/card view. Skipping render while the
-			// window is gone lets the loop keep polling; the runtime recreates
-			// its target on the next frame once the surface returns (INIT_WINDOW).
-			if (app->window != nullptr && g_session_running &&
-			    (g_session_state == XR_SESSION_STATE_SYNCHRONIZED ||
-			     g_session_state == XR_SESSION_STATE_VISIBLE ||
-			     g_session_state == XR_SESSION_STATE_FOCUSED)) {
+			// Run the frame loop whenever the session is running (READY..STOPPING)
+			// and we have a live surface. We must drive frames starting in READY:
+			// a CTS-compliant runtime only advances READY->SYNCHRONIZED on the
+			// app's first xrBeginFrame, so gating render on SYNCHRONIZED+ here would
+			// deadlock (the session never leaves READY → black screen). render_frame
+			// honors frame_state.shouldRender, so it submits no layers until the
+			// runtime reports the session visible — the spec-correct bootstrap.
+			//
+			// The app->window guard is the #507 surface gate: on background / card /
+			// split, native_app_glue clears app->window, so we skip the frame loop
+			// (no wait/present on a dead surface) until the surface returns on resume
+			// (APP_CMD_INIT_WINDOW). g_session_running drops on STOPPING (xrEndSession).
+			if (app->window != nullptr && g_session_running) {
 				render_frame();
 			}
 		}


### PR DESCRIPTION
Fixes #507.

## Problem
On Android, sending an in-process OpenXR app (`cube_handle_vk_android`) to recents/card and back left it **frozen** (no new frames) until force-quit. Two compounding causes:
1. The runtime fetched the `ANativeWindow` **once** and had no destroy/recreate path — the vk_native compositor kept its `VkSurfaceKHR` bound to the dead window. Adreno never reports `VK_ERROR_OUT_OF_DATE_KHR` on background, so acquire/present wedged; the OS froze the process mid-render.
2. `MonadoView.surfaceDestroyed` blocked the UI thread forever on `blockUntilNativeDiscard` (which only completes at session teardown), so on a transient background the UI thread could never deliver the `surfaceCreated`/`surfaceChanged` that resume needs.

## Fix (runtime-side, DP-agnostic — reproduced on sim_display)

**Surface destroy/recreate (`comp_vk_native`)**
- The target tracks its `ANativeWindow` + a generation stamp. New `comp_vk_native_target_sync_surface()` (called each frame from `layer_commit`) idles + destroys the swapchain/`VkSurfaceKHR` when the surface goes away (skips acquire/present recoverably — no infinite GPU wait on a dead window) and rebuilds both from the new `ANativeWindow` on resume.

**Surface state plumbing — pull model (`aux_android` + `oxr`)**
- `android_globals` holds a generation-stamped, locked window slot. `android_custom_surface_refresh_window()` pulls the live `Surface` (non-blocking `waitGetSurfaceHolder(0)`) and republishes it (clear on background, publish new on resume).
- `oxr_session_poll` calls it every tick — a JVM-attached thread that keeps running while backgrounded — so the compositor re-syncs without any JNI surface-callback registration.
- *Why pull, not JNI push:* the in-process runtime loads `MonadoView` under multiple classloaders (`async_start` runs several times), so `RegisterNatives` binds a different class copy than the one receiving callbacks (observed on device as "No implementation found" despite a successful `RegisterNatives`); the `.so` also exports no `Java_*` symbols for name-based binding.
- `MonadoView.java`: drop the infinite `blockUntilNativeDiscard` on transient surface loss.

**Session state** — already cycles via the activity-lifecycle path (`OnPause`→STOPPING / `OnResume`→READY); no new code needed.

**Test app bootstrap** (`cube_handle_vk_android`) — run the frame loop whenever the session is running (READY..STOPPING) + a live window, not only once SYNCHRONIZED. A CTS-compliant runtime only advances READY→SYNCHRONIZED on the app's first `xrBeginFrame`, so the old SYNCHRONIZED+ gate deadlocked at READY (black screen, independent of #507). `render_frame` already honors `frame_state.shouldRender`, so this is spec-correct.

## Validation
On a nubia NP02J (sim_display, **portrait + landscape**, user-confirmed visually): two background→recents→return cycles, each with the OS freezing the process mid-render ("froze … / sync unfroze"), recover cleanly — session cycles `5→4→3→6(STOPPING)→1` then `2→3→4→5(FOCUSED)`, `VkSurfaceKHR`+swapchain rebuilt on each resume (`create_swapchain` fires per resume), app stays alive, no force-quit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)