### PR TITLE
Android out-of-process runtime (#510): M1 — cube renders via service, CNSDK-free

### DIFF
--- a/src/xrt/compositor/main/comp_compositor.h
+++ b/src/xrt/compositor/main/comp_compositor.h
@@ -1,0 +1,69 @@
+// Copyright 2019-2023, Collabora, Ltd.
+// Copyright 2026, Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  Minimal comp_compositor shim for the lightweight fork.
+ * @ingroup comp_main
+ *
+ * The full Monado main compositor (comp_main / comp_compositor.c) was removed
+ * from this fork (issue #25 — native per-API compositors replaced it). A few
+ * shared helpers kept in `main/` still reference `struct comp_compositor` —
+ * notably @ref comp_target_swapchain, which the out-of-process Android service
+ * path reuses (#510). It needs only three things from the compositor: the
+ * embedded @ref vk_bundle (`base.vk`), a fake-pacing frame interval
+ * (`frame_interval_ns`), and a log level for the COMP_* macros.
+ *
+ * This shim provides exactly that surface. It is layout-compatible at offset 0
+ * with any @ref comp_base subclass (e.g. @ref null_compositor), so a subclass
+ * pointer up-cast to `struct comp_compositor *` resolves `base.vk` correctly —
+ * the documented null-compositor reuse pattern. Fields past `base` (settings,
+ * frame_interval_ns) do NOT line up across that cast: callers must pre-create
+ * the @ref comp_target_swapchain pacer so `frame_interval_ns` is never read,
+ * and the COMP_* log level is best-effort (cosmetic if it reads across a cast).
+ *
+ * If the full main compositor is ever reintroduced, this shim must be replaced
+ * by the real header.
+ */
+
+#pragma once
+
+#include "util/comp_base.h"
+#include "util/u_logging.h"
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*!
+ * Minimal stand-in for the removed Monado main compositor struct. See file docs.
+ *
+ * @ingroup comp_main
+ */
+struct comp_compositor
+{
+	//! Must be first — shared layout with every @ref comp_base subclass.
+	struct comp_base base;
+
+	//! Only @p log_level is consumed (by the COMP_* macros below).
+	struct
+	{
+		enum u_logging_level log_level;
+	} settings;
+
+	//! Fake-pacing frame interval; only read by comp_target_swapchain when its
+	//! pacer was not pre-created. The service path pre-creates the pacer.
+	int64_t frame_interval_ns;
+};
+
+#define COMP_SPEW(c, ...) U_LOG_IFL_T((c)->settings.log_level, __VA_ARGS__);
+#define COMP_DEBUG(c, ...) U_LOG_IFL_D((c)->settings.log_level, __VA_ARGS__);
+#define COMP_INFO(c, ...) U_LOG_IFL_I((c)->settings.log_level, __VA_ARGS__);
+#define COMP_WARN(c, ...) U_LOG_IFL_W((c)->settings.log_level, __VA_ARGS__);
+#define COMP_ERROR(c, ...) U_LOG_IFL_E((c)->settings.log_level, __VA_ARGS__);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/xrt/compositor/main/comp_target_swapchain.c
+++ b/src/xrt/compositor/main/comp_target_swapchain.c
@@ -873,6 +873,31 @@ comp_target_swapchain_acquire_next_image(struct comp_target *ct, uint32_t *out_i
 		return VK_ERROR_INITIALIZATION_FAILED;
 	}
 
+#ifdef XRT_OS_ANDROID
+	// Live device rotation (#510, mirrors the in-process vk_native poll #507):
+	// Adreno does NOT report VK_ERROR_OUT_OF_DATE_KHR when the device rotates,
+	// and with preTransform forced to IDENTITY the swapchain extent must track
+	// the live surface currentExtent or the present is stretched / wrong
+	// orientation. Poll the surface caps each acquire and force a recreate (via
+	// the caller's OUT_OF_DATE handling) when the extent flips. The recreate
+	// updates cts->base.width/height, which flows to the client's oxr Kooima
+	// over IPC (multi_compositor_get_window_metrics) so the FOV re-orients too.
+	{
+		VkSurfaceCapabilitiesKHR caps;
+		VkResult cres = vk->vkGetPhysicalDeviceSurfaceCapabilitiesKHR(vk->physical_device,
+		                                                              cts->surface.handle, &caps);
+		if (cres == VK_SUCCESS && caps.currentExtent.width != (uint32_t)-1 &&
+		    caps.currentExtent.width != 0 && caps.currentExtent.height != 0 &&
+		    (caps.currentExtent.width != cts->base.width ||
+		     caps.currentExtent.height != cts->base.height)) {
+			U_LOG_W("comp_window_android: surface extent %ux%u -> %ux%u (rotation), recreating",
+			        cts->base.width, cts->base.height, caps.currentExtent.width,
+			        caps.currentExtent.height);
+			return VK_ERROR_OUT_OF_DATE_KHR;
+		}
+	}
+#endif
+
 	return vk->vkAcquireNextImageKHR(          //
 	    vk->device,                            // device
 	    cts->swapchain.handle,                 // swapchain

--- a/src/xrt/compositor/main/comp_target_swapchain.c
+++ b/src/xrt/compositor/main/comp_target_swapchain.c
@@ -724,11 +724,26 @@ comp_target_swapchain_create_images(struct comp_target *ct, const struct comp_ta
 	 * Non-failable selections.
 	 */
 
+	// Pick the surface pre-transform. Default: match the surface's current
+	// transform so the WSI rotates our output for us.
+	VkSurfaceTransformFlagBitsKHR pre_transform = surface_caps.currentTransform;
+#ifdef XRT_OS_ANDROID
+	// Match in-process vk_native (LOXR-730/733): on Android pre-rotation the
+	// surface reports panel-native extent + currentTransform=ROTATE_90 when the
+	// device is held rotated. Presenting with preTransform=ROTATE_90 makes the
+	// WSI rotate our composited buffer, which out-of-process shows up as a
+	// wrong-orientation image. Force IDENTITY so the buffer scans out 1:1 onto
+	// the panel; orientation is handled upstream (Kooima aspect / DP weave).
+	if (surface_caps.supportedTransforms & VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR) {
+		pre_transform = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR;
+	}
+#endif
+
 	// Get the extents of the swapchain.
 	VkExtent2D extent = select_extent(cts, surface_caps, create_info->extent);
 
-	if (surface_caps.currentTransform & VK_SURFACE_TRANSFORM_ROTATE_90_BIT_KHR ||
-	    surface_caps.currentTransform & VK_SURFACE_TRANSFORM_ROTATE_270_BIT_KHR) {
+	if (pre_transform & VK_SURFACE_TRANSFORM_ROTATE_90_BIT_KHR ||
+	    pre_transform & VK_SURFACE_TRANSFORM_ROTATE_270_BIT_KHR) {
 		COMP_DEBUG(ct->c, "Swapping width and height, since we are going to pre rotate");
 		uint32_t w2 = extent.width;
 		uint32_t h2 = extent.height;
@@ -776,7 +791,7 @@ comp_target_swapchain_create_images(struct comp_target *ct, const struct comp_ta
 	    .imageUsage = create_info->image_usage,
 	    .imageSharingMode = VK_SHARING_MODE_EXCLUSIVE,
 	    .queueFamilyIndexCount = 0,
-	    .preTransform = surface_caps.currentTransform,
+	    .preTransform = pre_transform,
 	    .compositeAlpha = composite_alpha,
 	    .presentMode = cts->present_mode,
 	    .clipped = VK_TRUE,
@@ -808,7 +823,7 @@ comp_target_swapchain_create_images(struct comp_target *ct, const struct comp_ta
 	cts->base.height = extent.height;
 	cts->base.format = cts->surface.format.format;
 	cts->base.final_layout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
-	cts->base.surface_transform = surface_caps.currentTransform;
+	cts->base.surface_transform = pre_transform;
 
 	create_image_views(cts);
 

--- a/src/xrt/compositor/main/comp_window_android.c
+++ b/src/xrt/compositor/main/comp_window_android.c
@@ -1,0 +1,185 @@
+// Copyright 2019-2020, Collabora, Ltd.
+// Copyright 2026, Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  Android present target for the out-of-process service compositor.
+ * @author Rylie Pavlik <rylie.pavlik@collabora.com>
+ * @author Lubosz Sarnecki <lubosz.sarnecki@collabora.com>
+ * @author Jakob Bornecrantz <jakob@collabora.com>
+ * @ingroup comp_main
+ *
+ * DisplayXR (#510): ported from the Monado-legacy comp_window_android, trimmed
+ * to the out-of-process service case. The app hands its surface across the IPC
+ * boundary (Client.java passAppSurface → MonadoImpl → android_globals); this
+ * target pulls the ANativeWindow from android_globals and presents to it via a
+ * VK_KHR_android_surface swapchain. The legacy in-process branches (creating a
+ * MonadoView from an Activity, the SYSTEM_ALERT_WINDOW overlay path) and the
+ * comp_target_factory are intentionally omitted: the runtime service has no
+ * Activity, and the null/service compositor creates this target directly via
+ * its comp_target_service, not through a factory.
+ */
+
+#include "xrt/xrt_compiler.h"
+
+#include "util/u_misc.h"
+#include "util/u_logging.h"
+#include "util/u_time.h"
+
+#include "os/os_time.h"
+
+#include "android/android_globals.h"
+
+#include "main/comp_compositor.h"
+#include "main/comp_target_swapchain.h"
+#include "main/comp_window_android.h"
+
+#include <android/native_window.h>
+
+#include <stdlib.h>
+
+
+/*
+ *
+ * Private structs.
+ *
+ */
+
+/*!
+ * An Android present target.
+ *
+ * @implements comp_target_swapchain
+ */
+struct comp_window_android
+{
+	struct comp_target_swapchain base;
+};
+
+
+/*
+ *
+ * Functions.
+ *
+ */
+
+static inline struct vk_bundle *
+get_vk(struct comp_window_android *cwa)
+{
+	// cwa->base.base.c is the owning compositor. In the service this is a
+	// null_compositor up-cast to comp_compositor; both begin with comp_base,
+	// so base.vk is the same bundle the system compositor allocates from.
+	return &cwa->base.base.c->base.vk;
+}
+
+static bool
+comp_window_android_init(struct comp_target *ct)
+{
+	(void)ct;
+	return true;
+}
+
+static void
+comp_window_android_destroy(struct comp_target *ct)
+{
+	struct comp_window_android *cwa = (struct comp_window_android *)ct;
+
+	comp_target_swapchain_cleanup(&cwa->base);
+
+	free(ct);
+}
+
+static void
+comp_window_android_update_window_title(struct comp_target *ct, const char *title)
+{
+	(void)ct;
+	(void)title;
+}
+
+static VkResult
+comp_window_android_create_surface(struct comp_window_android *cwa,
+                                   struct ANativeWindow *window,
+                                   VkSurfaceKHR *out_surface)
+{
+	struct vk_bundle *vk = get_vk(cwa);
+	VkResult ret;
+
+	VkAndroidSurfaceCreateInfoKHR surface_info = {
+	    .sType = VK_STRUCTURE_TYPE_ANDROID_SURFACE_CREATE_INFO_KHR,
+	    .flags = 0,
+	    .window = window,
+	};
+
+	VkSurfaceKHR surface = VK_NULL_HANDLE;
+	ret = vk->vkCreateAndroidSurfaceKHR(vk->instance, &surface_info, NULL, &surface);
+	if (ret != VK_SUCCESS) {
+		U_LOG_E("comp_window_android: vkCreateAndroidSurfaceKHR: %s", vk_result_string(ret));
+		return ret;
+	}
+
+	VK_NAME_SURFACE(vk, surface, "comp_window_android surface");
+	*out_surface = surface;
+
+	return VK_SUCCESS;
+}
+
+static bool
+comp_window_android_init_swapchain(struct comp_target *ct, uint32_t width, uint32_t height)
+{
+	struct comp_window_android *cwa = (struct comp_window_android *)ct;
+	(void)width;
+	(void)height;
+
+	// Out-of-process: poll for the surface the app pushed across IPC
+	// (Client.java blockingConnect → passAppSurface → android_globals). It is
+	// normally already present by the time the session reaches this point.
+	struct ANativeWindow *window = NULL;
+	for (int i = 0; i < 100; i++) {
+		window = (struct ANativeWindow *)android_globals_get_window();
+		if (window != NULL) {
+			break;
+		}
+		os_nanosleep(20 * U_TIME_1MS_IN_NS);
+	}
+
+	if (window == NULL) {
+		U_LOG_E("comp_window_android: no ANativeWindow available from android_globals");
+		return false;
+	}
+
+	VkResult ret = comp_window_android_create_surface(cwa, window, &cwa->base.surface.handle);
+	if (ret != VK_SUCCESS) {
+		U_LOG_E("comp_window_android: failed to create surface: %s", vk_result_string(ret));
+		return false;
+	}
+
+	U_LOG_W("comp_window_android: VkSurfaceKHR created from ANativeWindow %p", (void *)window);
+	return true;
+}
+
+static void
+comp_window_android_flush(struct comp_target *ct)
+{
+	(void)ct;
+}
+
+struct comp_target *
+comp_window_android_create(struct comp_compositor *c)
+{
+	struct comp_window_android *w = U_TYPED_CALLOC(struct comp_window_android);
+	if (w == NULL) {
+		return NULL;
+	}
+
+	// The display-timing code path hasn't been exercised on Android; force fake timing.
+	comp_target_swapchain_init_and_set_fnptrs(&w->base, COMP_TARGET_FORCE_FAKE_DISPLAY_TIMING);
+
+	w->base.base.name = "Android";
+	w->base.base.destroy = comp_window_android_destroy;
+	w->base.base.flush = comp_window_android_flush;
+	w->base.base.init_pre_vulkan = comp_window_android_init;
+	w->base.base.init_post_vulkan = comp_window_android_init_swapchain;
+	w->base.base.set_title = comp_window_android_update_window_title;
+	w->base.base.c = c;
+
+	return &w->base.base;
+}

--- a/src/xrt/compositor/main/comp_window_android.h
+++ b/src/xrt/compositor/main/comp_window_android.h
@@ -1,0 +1,41 @@
+// Copyright 2019-2020, Collabora, Ltd.
+// Copyright 2026, Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  Android present target for the out-of-process service compositor.
+ * @ingroup comp_main
+ *
+ * DisplayXR (#510): a @ref comp_target_swapchain subclass that presents to the
+ * app's ANativeWindow inside the runtime service process. The window is the one
+ * the app handed across the IPC boundary (Client.java passAppSurface →
+ * MonadoImpl → android_globals); this target pulls it from android_globals
+ * rather than receiving a window handle through IPC. Ported from the
+ * Monado-legacy comp_window_android (the factory + in-process Activity/custom
+ * surface branches are dropped — the service has no Activity).
+ */
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct comp_compositor;
+struct comp_target;
+
+/*!
+ * Create an Android present target. @p c is the owning compositor (in the
+ * service this is a @ref null_compositor up-cast to @ref comp_compositor — both
+ * start with @ref comp_base, so @p c->base.vk is valid). Returns the target's
+ * @ref comp_target base, or NULL on allocation failure. The VkSurfaceKHR is not
+ * created until @ref comp_target::init_post_vulkan runs.
+ *
+ * @ingroup comp_main
+ */
+struct comp_target *
+comp_window_android_create(struct comp_compositor *c);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/xrt/compositor/multi/comp_multi_compositor.c
+++ b/src/xrt/compositor/multi/comp_multi_compositor.c
@@ -1889,6 +1889,31 @@ multi_compositor_get_window_metrics(struct multi_compositor *mc, struct xrt_wind
 			    mc->session_render.external_window_handle, info, out_metrics);
 		}
 #endif
+
+#ifdef XRT_OS_ANDROID
+		// Out-of-process Android (#510): report the live present-target extent
+		// in pixels so the client's oxr can swap the display meters to match the
+		// held orientation (#499 Kooima aspect — landscape atlas on a portrait
+		// panel). Pixels only; oxr derives meters from the display dims + the
+		// orientation swap. Runs after the DP path so a vendor DP (Leia) can
+		// still provide precise metrics; sim_display's DP returns none.
+		if (mc->session_render.use_android_surface && mc->session_render.target != NULL) {
+			struct comp_target *ct = mc->session_render.target;
+			if (ct->width > 0 && ct->height > 0) {
+				out_metrics->window_pixel_width = ct->width;
+				out_metrics->window_pixel_height = ct->height;
+				out_metrics->display_pixel_width = ct->width;
+				out_metrics->display_pixel_height = ct->height;
+				out_metrics->window_screen_left = 0;
+				out_metrics->window_screen_top = 0;
+				out_metrics->display_screen_left = 0;
+				out_metrics->display_screen_top = 0;
+				out_metrics->window_orientation = (struct xrt_quat){0, 0, 0, 1};
+				out_metrics->valid = true;
+				return true;
+			}
+		}
+#endif
 	}
 
 	// No main compositor available — metrics only from per-session paths above.

--- a/src/xrt/compositor/multi/comp_multi_compositor.c
+++ b/src/xrt/compositor/multi/comp_multi_compositor.c
@@ -589,6 +589,16 @@ multi_compositor_begin_session(struct xrt_compositor *xc, const struct xrt_begin
 			}
 		}
 #endif
+
+#ifdef XRT_OS_ANDROID
+		// Out-of-process Android (#510): the app's surface reaches the service
+		// over the IPC injection path (Client.java passAppSurface →
+		// MonadoImpl → android_globals), not as an external_window_handle
+		// through IPC. Engage per-session rendering; the Android comp_target
+		// (comp_window_android) pulls the live surface from android_globals.
+		mc->session_render.use_android_surface = true;
+		U_LOG_I("Android: enabling per-session rendering (surface via android_globals)");
+#endif
 		multi_system_compositor_update_session_status(mc->msc, true);
 		mc->state.session_active = true;
 	}
@@ -1442,9 +1452,11 @@ multi_compositor_init_session_render(struct multi_compositor *mc)
 		return true;
 	}
 
-	// No external window handle, readback callback, or shared texture - use shared native compositor
+	// No external window handle, readback callback, or shared texture - use shared native compositor.
+	// On Android (#510) the surface arrives out-of-band via android_globals, so use_android_surface
+	// is the signal to proceed even though all the handle fields are NULL.
 	if (mc->session_render.external_window_handle == NULL && mc->session_render.readback_callback == NULL &&
-	    mc->session_render.shared_texture_handle == NULL) {
+	    mc->session_render.shared_texture_handle == NULL && !mc->session_render.use_android_surface) {
 		U_LOG_I("init_session_render: no window handle, readback callback, or shared texture, using shared "
 		        "compositor");
 		return false;

--- a/src/xrt/compositor/multi/comp_multi_private.h
+++ b/src/xrt/compositor/multi/comp_multi_private.h
@@ -244,6 +244,13 @@ struct multi_compositor
 		//! (HANDLE on Win32, IOSurfaceRef on macOS). NULL if not used.
 		void *shared_texture_handle;
 
+		//! Android out-of-process: the app's surface arrives via the IPC
+		//! injection path (passAppSurface → android_globals), not as an
+		//! external_window_handle over IPC. When true, per-session rendering
+		//! engages and the Android comp_target pulls the surface from
+		//! android_globals. (#510)
+		bool use_android_surface;
+
 		//! Per-session render target (VkSwapchain from external HWND)
 		struct comp_target *target;
 
@@ -615,7 +622,7 @@ static inline bool
 multi_compositor_has_session_render(struct multi_compositor *mc)
 {
 	return mc->session_render.external_window_handle != NULL || mc->session_render.readback_callback != NULL ||
-	       mc->session_render.shared_texture_handle != NULL;
+	       mc->session_render.shared_texture_handle != NULL || mc->session_render.use_android_surface;
 }
 
 /*!

--- a/src/xrt/compositor/multi/comp_multi_system.c
+++ b/src/xrt/compositor/multi/comp_multi_system.c
@@ -2166,6 +2166,21 @@ render_session_to_own_target(struct multi_compositor *mc, struct vk_bundle *vk, 
 	}
 #endif
 
+	// Establish frame pacing so the per-session comp_target_swapchain has a
+	// valid current_frame_id before acquire/present. render_session_to_own_target
+	// is the only consumer of this target, so it must drive pacing itself —
+	// without this, comp_target_swapchain_present asserts current_frame_id > 0.
+	// (#510: first path to actually exercise comp_window_android present.)
+	{
+		int64_t frame_id = -1;
+		int64_t wake_up_ns = 0, desired_present_ns = 0, present_slop_ns = 0, predicted_display_ns = 0;
+		comp_target_calc_frame_pacing(ct, &frame_id, &wake_up_ns, &desired_present_ns, &present_slop_ns,
+		                              &predicted_display_ns);
+		int64_t now_ns = os_monotonic_get_ns();
+		comp_target_mark_wake_up(ct, frame_id, now_ns);
+		comp_target_mark_begin(ct, frame_id, now_ns);
+	}
+
 	// Acquire the next swapchain image from the per-session target
 	uint32_t buffer_index = 0;
 	VkResult ret = comp_target_acquire(ct, &buffer_index);

--- a/src/xrt/compositor/null/CMakeLists.txt
+++ b/src/xrt/compositor/null/CMakeLists.txt
@@ -13,3 +13,19 @@ target_link_libraries(
 		comp_multi
 	)
 target_include_directories(comp_null PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..)
+
+# Android out-of-process present path (#510): the null compositor is the runtime
+# service's system compositor on Android, and drives a per-session
+# comp_target_swapchain that presents to the app's ANativeWindow
+# (comp_window_android, surface injected via android_globals). Those shared
+# main/ sources are not built anywhere else in the lightweight fork (comp_main
+# was removed, #25), so compile them here.
+if(ANDROID)
+	target_sources(
+		comp_null
+		PRIVATE
+			${CMAKE_CURRENT_SOURCE_DIR}/../main/comp_target_swapchain.c
+			${CMAKE_CURRENT_SOURCE_DIR}/../main/comp_window_android.c
+		)
+	target_link_libraries(comp_null PRIVATE aux_android)
+endif()

--- a/src/xrt/compositor/null/null_compositor.c
+++ b/src/xrt/compositor/null/null_compositor.c
@@ -31,6 +31,9 @@
 
 #include "multi/comp_multi_interface.h"
 #include "main/comp_target_swapchain.h"
+#ifdef XRT_OS_ANDROID
+#include "main/comp_window_android.h"
+#endif
 #include "xrt/xrt_compositor.h"
 #include "xrt/xrt_device.h"
 
@@ -78,6 +81,12 @@ static const char *instance_extensions_common[] = {
     VK_KHR_SURFACE_EXTENSION_NAME,                          //
 #ifdef XRT_OS_WINDOWS
     VK_KHR_WIN32_SURFACE_EXTENSION_NAME,                    //
+#endif
+#ifdef XRT_OS_ANDROID
+    // Out-of-process present path (#510): the null compositor is the runtime
+    // service's system compositor on Android and presents per-session via
+    // comp_window_android → vkCreateAndroidSurfaceKHR.
+    VK_KHR_ANDROID_SURFACE_EXTENSION_NAME,                  //
 #endif
 };
 
@@ -719,6 +728,106 @@ null_target_service_get_vk(struct comp_target_service *service)
 
 #endif // XRT_OS_WINDOWS && XRT_MODULE_COMPOSITOR_MAIN
 
+#if defined(XRT_OS_ANDROID)
+
+/*!
+ * Service callback (Android, #510): create the per-session present target.
+ *
+ * Out-of-process on Android, the app's surface arrives over the IPC injection
+ * path (Client.java passAppSurface → MonadoImpl → android_globals), not as a
+ * window handle through IPC — so @p external_window_handle is NULL and the
+ * Android comp_target (@ref comp_window_android) pulls the ANativeWindow from
+ * android_globals. Mirrors the Windows path otherwise.
+ */
+static xrt_result_t
+null_target_service_create_from_window_android(struct comp_target_service *service,
+                                               void *external_window_handle,
+                                               struct comp_target **out_target)
+{
+	(void)external_window_handle; // surface comes from android_globals
+	struct null_compositor *nc = (struct null_compositor *)service->context;
+
+	// Up-cast: comp_target_swapchain reads ct->c->base.vk, which is at offset 0
+	// in both comp_compositor and null_compositor (shared comp_base). See
+	// main/comp_compositor.h.
+	struct comp_compositor *c_alias = (struct comp_compositor *)nc;
+
+	struct comp_target *ct = comp_window_android_create(c_alias);
+	if (ct == NULL) {
+		NULL_ERROR(nc, "Android: failed to allocate per-session comp_target");
+		return XRT_ERROR_ALLOCATION;
+	}
+
+	// Pre-create fake pacing BEFORE create_images so comp_target_swapchain does
+	// not read ct->c->frame_interval_ns (wrong offset across the cast above).
+	{
+		struct comp_target_swapchain *cts = (struct comp_target_swapchain *)ct;
+		if (cts->upc == NULL) {
+			int64_t now_ns = os_monotonic_get_ns();
+			u_pc_fake_create(nc->settings.frame_interval_ns, now_ns, &cts->upc);
+		}
+	}
+
+	// init_post_vulkan pulls the ANativeWindow from android_globals and creates
+	// the VkSurfaceKHR. The preferred extent is taken from the system info; the
+	// swapchain clamps to the surface's actual extent.
+	uint32_t w = nc->sys_info.display_pixel_width;
+	uint32_t h = nc->sys_info.display_pixel_height;
+	if (w == 0 || h == 0) {
+		w = 1920;
+		h = 1080;
+	}
+
+	if (!comp_target_init_post_vulkan(ct, w, h)) {
+		NULL_ERROR(nc, "Android: failed to init post-vulkan for per-session target");
+		comp_target_destroy(&ct);
+		return XRT_ERROR_VULKAN;
+	}
+
+	struct comp_target_create_images_info info = {
+	    .extent = {.width = w, .height = h},
+	    .image_usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT,
+	    .color_space = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR,
+	    .present_mode = VK_PRESENT_MODE_FIFO_KHR,
+	    .format_count = 4,
+	    .formats =
+	        {
+	            VK_FORMAT_R8G8B8A8_UNORM,
+	            VK_FORMAT_B8G8R8A8_UNORM,
+	            VK_FORMAT_R8G8B8A8_SRGB,
+	            VK_FORMAT_B8G8R8A8_SRGB,
+	        },
+	};
+
+	comp_target_create_images(ct, &info);
+
+	if (!comp_target_has_images(ct)) {
+		NULL_ERROR(nc, "Android: failed to create swapchain images for per-session target");
+		comp_target_destroy(&ct);
+		return XRT_ERROR_VULKAN;
+	}
+
+	NULL_INFO(nc, "Android: created per-session present target (%ux%u)", ct->width, ct->height);
+	*out_target = ct;
+	return XRT_SUCCESS;
+}
+
+static void
+null_target_service_destroy_target_android(struct comp_target_service *service, struct comp_target **target)
+{
+	(void)service;
+	comp_target_destroy(target);
+}
+
+static struct vk_bundle *
+null_target_service_get_vk_android(struct comp_target_service *service)
+{
+	struct null_compositor *nc = (struct null_compositor *)service->context;
+	return get_vk(nc);
+}
+
+#endif // XRT_OS_ANDROID
+
 /*!
  * Initialize the target service on a null compositor.
  * Called during compositor creation after Vulkan init.
@@ -730,6 +839,12 @@ null_compositor_init_target_service(struct null_compositor *nc)
 	nc->target_service.create_from_window = null_target_service_create_from_window;
 	nc->target_service.destroy_target = null_target_service_destroy_target;
 	nc->target_service.get_vk = null_target_service_get_vk;
+	nc->target_service.context = nc;
+#elif defined(XRT_OS_ANDROID)
+	// Out-of-process Android present path (#510).
+	nc->target_service.create_from_window = null_target_service_create_from_window_android;
+	nc->target_service.destroy_target = null_target_service_destroy_target_android;
+	nc->target_service.get_vk = null_target_service_get_vk_android;
 	nc->target_service.context = nc;
 #endif
 }

--- a/src/xrt/ipc/android/build.gradle
+++ b/src/xrt/ipc/android/build.gradle
@@ -21,7 +21,7 @@ android {
         minSdkVersion 26
         targetSdkVersion project.sharedTargetSdk
 
-        def defaultServiceLibName = "monado-service"
+        def defaultServiceLibName = "displayxr-service"
         def serviceLibName = project.hasProperty("serviceLibName") ?
             project.serviceLibName : defaultServiceLibName
         if (serviceLibName == null || serviceLibName.length() == 0) {

--- a/src/xrt/ipc/server/ipc_server_handler.c
+++ b/src/xrt/ipc/server/ipc_server_handler.c
@@ -40,6 +40,11 @@
  * specific vendor (issue #256 / ADR-019).
  */
 #include "d3d11_service/comp_d3d11_service.h"
+#ifdef XRT_OS_ANDROID
+// Out-of-process Android (#510): the per-client compositor is a multi_compositor;
+// the server pulls its live present-target extent for the client's Kooima.
+#include "multi/comp_multi_private.h"
+#endif
 // Shared Kooima rig math (#396 W7): same displayxr-common core as the
 // in-process oxr_session.c path and every app/engine consumer.
 #include "displayxr_math_xrt.h"
@@ -1744,6 +1749,14 @@ ipc_handle_compositor_get_window_metrics(volatile struct ipc_client_state *ics,
 			         (double)wm.window_center_offset_y_m,
 			         (double)wm.window_center_offset_z_m);
 		}
+	}
+#elif defined(XRT_OS_ANDROID)
+	// Out-of-process Android (#510): the per-client compositor is a
+	// multi_compositor driving a per-session comp_window_android target. Return
+	// its live extent so the client's oxr swaps the Kooima display meters to the
+	// held orientation (#499). xc is NULL for headless / pre-render sessions.
+	if (ics->xc != NULL) {
+		(void)multi_compositor_get_window_metrics(multi_compositor(ics->xc), &wm);
 	}
 #else
 	(void)ics;

--- a/src/xrt/targets/openxr_android/build.gradle
+++ b/src/xrt/targets/openxr_android/build.gradle
@@ -294,7 +294,7 @@ android {
             dimension 'deployment'
             applicationIdSuffix '.out_of_process'
             externalNativeBuild.cmake.arguments += "-DXRT_FEATURE_SERVICE=ON"
-            externalNativeBuild.cmake.targets "openxr_displayxr", "monado-service", "drv_sim_display_plugin"
+            externalNativeBuild.cmake.targets "openxr_displayxr", "displayxr-service", "drv_sim_display_plugin"
 
             buildConfigField "boolean", "inProcess", "false"
             resValue "string", "app_name", "DisplayXR"

--- a/test_apps/cube_handle_vk_android/src/main/AndroidManifest.xml
+++ b/test_apps/cube_handle_vk_android/src/main/AndroidManifest.xml
@@ -19,9 +19,25 @@
         <intent>
             <action android:name="org.khronos.openxr.OpenXRRuntimeService" />
         </intent>
+        <!-- The Khronos loader resolves the active runtime through this broker
+             ContentProvider. Under Android 11+ package visibility the provider
+             is invisible unless we declare its authority here; without it the
+             loader gets "Failed to find provider info … runtime_broker" → a
+             null cursor → xrCreateInstance fails with RUNTIME_UNAVAILABLE
+             (the app shows a black screen). The authority is shared by both
+             runtime flavors. (#510) -->
+        <provider android:authorities="org.khronos.openxr.runtime_broker" />
         <!-- Explicit package visibility so we can wake the DisplayXR runtime
-             out of Android's "stopped" state before xrCreateInstance. -->
+             out of Android's "stopped" state and bind its IPC service before
+             xrCreateInstance. Both flavors are listed so the same cube APK runs
+             against either: in_process (dev) or out_of_process (#510, vendor
+             DPs run in the runtime service). -->
         <package android:name="org.freedesktop.monado.openxr_runtime.in_process" />
+        <package android:name="org.freedesktop.monado.openxr_runtime.out_of_process" />
+        <!-- IPC bind to the out-of-process runtime service. -->
+        <intent>
+            <action android:name="org.freedesktop.monado.ipc.CONNECT" />
+        </intent>
     </queries>
 
     <uses-feature


### PR DESCRIPTION
Implements **M1** of #510 — running the runtime out-of-process on Android so apps link only the OpenXR loader and never bundle a vendor SDK (the ADR-019 boundary, enforced on Android by ADR-025). Validated on a nubia NP02J: the cube renders via the `out_of_process` runtime service with **sim_display**, zero CNSDK in the app, zero-copy AHardwareBuffer frame path over IPC.

## What works (validated on-device)
- `xrCreateSession` → `session state 3/4/5` → AHardwareBuffer atlas swapchains allocated server-side and imported by the cube over IPC → continuous per-session present, no crash.
- The cube is **visible** on the panel. Landscape: correct aspect, image upright.

## Commits
- **`monado-service` → `displayxr-service`** — the stale CMake target name (in `openxr_android/build.gradle` + `ipc/android/build.gradle` `SERVICE_LIB_NAME`) had kept the entire `out_of_process` flavor from ever building / the service `.so` from loading.
- **Cube discovery/bind** — cube `<queries>` now declares the `runtime_broker` provider + the `out_of_process` package + the ipc `CONNECT` action (without it: "Failed to find provider info for runtime_broker" → `RUNTIME_UNAVAILABLE` → black screen).
- **Android present path (`comp_target_service`)** — the service runs null + comp_multi with Vulkan + AHB swapchains + the per-session render loop, but comp_multi had no Android `comp_target_service` (it was `#if XRT_OS_WINDOWS && XRT_MODULE_COMPOSITOR_MAIN`). Adds: ported `comp_window_android` (a `comp_target_swapchain` pulling the app's ANativeWindow from `android_globals` — the `passAppSurface`-injected surface); a minimal `comp_compositor.h` shim so the kept-but-uncompiled `comp_target_swapchain.c` builds in the lightweight fork; the null compositor's Android target-service; a `use_android_surface` flag so per-session rendering engages without an IPC window handle; `VK_KHR_android_surface`; and a latent pacing fix (`render_session_to_own_target` now drives `calc_frame_pacing` before present — this path had never run, since Windows uses `comp_d3d11_service`).
- **Orientation infra** — IDENTITY pre-transform (mirrors vk_native LOXR-730/733; fixes the rotated image), live-rotation surface recreate (Adreno gives no `OUT_OF_DATE` on rotate, #507 parity), and window-metrics over IPC (`multi_compositor_get_window_metrics` Android branch + server handler) so the live extent reaches the client.

ADR-025 is already on `main` (`a7e0ab987`).

## Known-remaining (tracked; not blockers for M1)
- **Server-side Android Kooima** — the orientation-aware view/FOV computation (`ipc_try_get_sr_view_poses`) is gated to the D3D11 service compositor, so the Android path falls back to sim_display's *fixed landscape device FOV*. Result: portrait is stretched and the 2D mono view is slightly off-center (off-axis left-eye). The window metrics are now plumbed for a consumer; building a server-side Kooima for the null+comp_multi path is the next task — **also required for correct M2/Leia 3D**.
- **M1b** (surface lifecycle over IPC: background→resume), **M2** (Leia out-of-process), **M3** (CNSDK-free cube renders Leia 3D + remove the aar conditional) — follow-ups per #510.
- `outOfProcess` flavor shows the default Monado launcher icon (no flavor icon override) — cosmetic.

Refs #510.

🤖 Generated with [Claude Code](https://claude.com/claude-code)