### PR TITLE
feat(workspace): controller-driven reserved keys + chord-preserving forward (spec_version 24)

### DIFF
--- a/src/external/openxr_includes/openxr/XR_EXT_spatial_workspace.h
+++ b/src/external/openxr_includes/openxr/XR_EXT_spatial_workspace.h
@@ -25,7 +25,7 @@ extern "C" {
 #endif
 
 #define XR_EXT_spatial_workspace 1
-#define XR_EXT_spatial_workspace_SPEC_VERSION 23
+#define XR_EXT_spatial_workspace_SPEC_VERSION 24
 #define XR_EXT_SPATIAL_WORKSPACE_EXTENSION_NAME "XR_EXT_spatial_workspace"
 
 // Provisional XrStructureType values. The 1000999100..110 range is reserved for
@@ -278,10 +278,11 @@ typedef XrResult (XRAPI_PTR *PFN_xrSetWorkspaceClientFrameRateCapEXT)(
 /*!
  * @brief Set the workspace's focused client.
  *
- * The runtime forwards keyboard input (other than runtime-reserved keys
- * TAB/DELETE/ESC) and click-through events to the focused client's HWND.
- * The workspace controller decides who gets focus from its interpretation
- * of pointer events drained via xrEnumerateWorkspaceInputEventsEXT.
+ * The runtime forwards keyboard input (other than chords the controller has
+ * reserved via xrSetWorkspaceReservedKeysEXT) and click-through events to the
+ * focused client's HWND. The workspace controller decides who gets focus from
+ * its interpretation of pointer events drained via
+ * xrEnumerateWorkspaceInputEventsEXT.
  *
  * @param session   A valid workspace session.
  * @param clientId  The client to focus, or XR_NULL_WORKSPACE_CLIENT_ID
@@ -301,6 +302,52 @@ typedef XrResult (XRAPI_PTR *PFN_xrSetWorkspaceFocusedClientEXT)(
 typedef XrResult (XRAPI_PTR *PFN_xrGetWorkspaceFocusedClientEXT)(
     XrSession            session,
     XrWorkspaceClientId *outClientId);
+
+// ---- Reserved keys (spec_version 24) ----
+
+/*!
+ * @brief One reserved key chord the controller owns.
+ *
+ * A key event matches an entry only when BOTH its vkCode and its modifier
+ * mask equal the entry exactly. The mask uses the same 3-bit convention as
+ * the KEY input event (bit0=SHIFT, bit1=CTRL, bit2=ALT), so {VK_TAB, 0}
+ * reserves bare Tab while {VK_TAB, SHIFT} is a distinct, unreserved chord
+ * that still forwards to the focused client.
+ */
+typedef struct XrWorkspaceReservedKeyEXT {
+    uint32_t vkCode;     // Win32 VK_*
+    uint32_t modifiers;  // bit0=SHIFT, bit1=CTRL, bit2=ALT
+} XrWorkspaceReservedKeyEXT;
+
+#define XR_WORKSPACE_MAX_RESERVED_KEYS_EXT 32
+
+/*!
+ * @brief Declare the set of key chords the controller reserves.
+ *
+ * Reserved chords are still emitted on the input-event queue (so the
+ * controller can act on them) but are NOT forwarded to the focused client's
+ * HWND. This replaces the runtime's hardcoded reserved-key policy: the
+ * controller is the single source of truth for which chords it owns.
+ *
+ * Matching is exact on (vkCode, modifiers) — see XrWorkspaceReservedKeyEXT.
+ * Non-reserved key chords are forwarded to the focused client with their
+ * modifier state preserved.
+ *
+ * @param session   A valid workspace session.
+ * @param keyCount  Number of entries in @p keys (0 restores the runtime's
+ *                  built-in default set; at most
+ *                  XR_WORKSPACE_MAX_RESERVED_KEYS_EXT).
+ * @param keys      Array of reserved chords; may be NULL when keyCount == 0.
+ *
+ * @return XR_SUCCESS on success,
+ *         XR_ERROR_VALIDATION_FAILURE if keyCount exceeds the max or keys is
+ *         NULL with keyCount > 0,
+ *         XR_ERROR_FEATURE_UNSUPPORTED if @p session is not the active workspace.
+ */
+typedef XrResult (XRAPI_PTR *PFN_xrSetWorkspaceReservedKeysEXT)(
+    XrSession                        session,
+    uint32_t                         keyCount,
+    const XrWorkspaceReservedKeyEXT *keys);
 
 // ---- Input event drain + pointer capture (spec_version 4) ----
 
@@ -330,12 +377,12 @@ typedef enum XrWorkspaceInputEventTypeEXT {
  * clientId / region / UV fields itself from its own eye→cursor raycast (the
  * runtime no longer computes them at drain time).
  *
- * Hardcoded MVP key policy (see xrEnumerateWorkspaceInputEventsEXT):
- *   - TAB and DELETE are consumed by the runtime (never delivered to the
- *     focused HWND, but still emitted on this queue for visibility).
- *   - ESC is consumed when any window is maximized.
- *   - Everything else is delivered via this queue AND forwarded to the
- *     focused client's HWND.
+ * Key forwarding policy (spec_version 24): the controller declares the chords
+ * it reserves via xrSetWorkspaceReservedKeysEXT. Reserved chords are emitted
+ * on this queue but NOT forwarded to the focused HWND; every other chord is
+ * both emitted here AND forwarded to the focused client with its modifier
+ * state preserved. Until the controller registers a set, the runtime falls
+ * back to a built-in default (bare TAB/DELETE/ESC/[/]).
  *
  * Pointer motion events (spec_version 6) deliver per-frame WM_MOUSEMOVE while
  * pointer capture is enabled. Controllers wanting hover feedback without

--- a/src/xrt/compositor/d3d11/comp_d3d11_window.cpp
+++ b/src/xrt/compositor/d3d11/comp_d3d11_window.cpp
@@ -229,6 +229,17 @@ struct comp_d3d11_window
 
 	//! Signaled by window thread after SetForegroundWindow completes.
 	volatile LONG foreground_done;
+
+	//! Controller-supplied reserved-key table (XR_EXT_spatial_workspace spec_version
+	//! 24). The controller declares which (vkCode, modifiers) chords it owns via
+	//! xrSetWorkspaceReservedKeysEXT; reserved chords are still emitted on the public
+	//! ring but never forwarded to the focused app. reserved_key_count is the publish
+	//! barrier: the service thread fills reserved_keys[] then InterlockedExchanges the
+	//! count LAST, so the WndProc thread never reads a half-written table. -1 means the
+	//! controller has not registered a set — fall back to is_workspace_reserved_key's
+	//! built-in default. >= 0 is the controller's table size.
+	struct { uint32_t vk; uint32_t mods; } reserved_keys[WORKSPACE_RESERVED_KEYS_MAX];
+	volatile LONG reserved_key_count;
 };
 
 // Forward declarations
@@ -239,6 +250,18 @@ static void set_fullscreen(HWND hWnd, bool fullscreen);
 // (WM_USER + 101) was WM_WORKSPACE_LAUNCH_APP — removed in #376; the
 // browse + launch affordance is controller-owned now.
 #define WM_WORKSPACE_SET_CAPTURE   (WM_USER + 102) //!< Phase 2.K: wParam=enabled (0/1).
+
+// spec_version 24: when a key/char message is PostMessage'd to a composited IPC
+// app, the runtime stamps the current modifier mask into spare lParam bits so
+// the client-side shim (oxr_workspace_modal_win32.c) can restore the app
+// thread's keyboard state before TranslateMessage / GetKeyState — PostMessage
+// alone does not carry modifier state across processes. Bit 28 marks a forwarded
+// message; bits 25-27 hold SHIFT/CTRL/ALT (same 3-bit mask as
+// workspace_compute_modifiers()). These are Windows-reserved lParam bits (25-28)
+// that TranslateMessage ignores; the shim clears them before the app sees them.
+// KEEP IN SYNC with the decoder in oxr_workspace_modal_win32.c.
+#define DXR_FWD_KEY_MARKER_BIT  (1u << 28)
+#define DXR_FWD_KEY_MODS_SHIFT  25
 
 /*!
  * Push an input event into the ring buffer (WndProc thread only).
@@ -321,14 +344,15 @@ workspace_compute_modifiers(void)
 }
 
 /*!
- * Check if a virtual key code is reserved for workspace controls.
- * These keys are NOT forwarded to the focused app in workspace mode.
+ * The built-in default reserved-key policy, used until a controller registers
+ * its own table via xrSetWorkspaceReservedKeysEXT. These keys are NOT forwarded
+ * to the focused app in workspace mode.
  *
- * SHIFT+TAB is forwarded (apps use it as a HUD toggle); only bare TAB
- * is reserved for workspace focus cycling.
+ * SHIFT+TAB is forwarded (apps use it as a HUD toggle); only bare TAB is
+ * reserved for workspace focus cycling.
  */
 static bool
-is_workspace_reserved_key(WPARAM vk, bool shift)
+is_default_reserved_key(WPARAM vk, bool shift)
 {
 	// Only true workspace-management keys are reserved.
 	// V, P, 0-9 are forwarded to the app (it may use them for its own purposes).
@@ -350,6 +374,32 @@ is_workspace_reserved_key(WPARAM vk, bool shift)
 	case VK_OEM_6:  return true;    // ] = window Z forward
 	default:        return false;
 	}
+}
+
+/*!
+ * Decide whether a key event is reserved (consumed by the workspace, never
+ * forwarded to the focused app). spec_version 24: if the controller has
+ * registered a reserved-key table, match exactly on (vkCode, modifiers) against
+ * it — so {TAB,0} reserves bare Tab while Shift+Tab forwards. Until then, fall
+ * back to the built-in default policy above.
+ */
+static bool
+is_workspace_reserved_key(struct comp_d3d11_window *w, WPARAM vk)
+{
+	LONG n = InterlockedCompareExchange(&w->reserved_key_count, 0, 0);
+	if (n < 0) {
+		// No controller table yet — use the built-in default.
+		bool shift = (GetKeyState(VK_SHIFT) & 0x8000) != 0;
+		return is_default_reserved_key(vk, shift);
+	}
+	uint32_t mods = workspace_compute_modifiers();
+	for (LONG i = 0; i < n; i++) {
+		if (w->reserved_keys[i].vk == (uint32_t)vk &&
+		    w->reserved_keys[i].mods == mods) {
+			return true;
+		}
+	}
+	return false;
 }
 
 /*!
@@ -532,7 +582,10 @@ wnd_proc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 					// Capture client: buffer for SendInput dispatch
 					input_ring_push(w, message, (uint64_t)wParam, (int64_t)lParam, -1, -1);
 				} else {
-					PostMessage(fwd, message, wParam, lParam);
+					LPARAM lp = (LPARAM)lParam | DXR_FWD_KEY_MARKER_BIT |
+					            ((LPARAM)(workspace_compute_modifiers() & 0x7u)
+					             << DXR_FWD_KEY_MODS_SHIFT);
+					PostMessage(fwd, message, wParam, lp);
 				}
 				return 0;
 			}
@@ -552,10 +605,11 @@ wnd_proc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 				                     message, wParam, lParam, &handled);
 			}
 #endif
-			bool shift = (GetKeyState(VK_SHIFT) & 0x8000) != 0;
-			if (is_workspace_reserved_key(wParam, shift)) {
-				// Workspace-only keys (bare TAB, DELETE) → don't forward to app.
-				// SHIFT+TAB falls through and gets PostMessage'd below.
+			if (is_workspace_reserved_key(w, wParam)) {
+				// Controller-reserved chord (or built-in default: bare
+				// TAB/DELETE/ESC/[/]) → emitted on the public ring above but
+				// NOT forwarded to the app. Non-reserved chords (e.g. Shift+Tab,
+				// Ctrl+C) fall through and get forwarded below.
 				return 0;
 			}
 			// #307: ESC is no longer suppressed here. The maximize state
@@ -568,11 +622,18 @@ wnd_proc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 			// They flow through the public input-event drain so a workspace
 			// controller can bind them to its own layout presets.
 			if (is_capture) {
-				// Capture client: buffer for SendInput dispatch
+				// Capture client: buffer for SendInput dispatch. SendInput
+				// injects into the real OS input queue (modifier VK keydowns
+				// included), so chords are already preserved — no mask needed.
 				input_ring_push(w, message, (uint64_t)wParam, (int64_t)lParam, -1, -1);
 			} else {
-				// IPC app: forward via PostMessage (works fine)
-				PostMessage(fwd, message, wParam, lParam);
+				// IPC app: PostMessage can't carry keyboard state across
+				// processes, so stamp the modifier mask into spare lParam bits
+				// for the client-side shim to restore (spec_version 24).
+				LPARAM lp = (LPARAM)lParam | DXR_FWD_KEY_MARKER_BIT |
+				            ((LPARAM)(workspace_compute_modifiers() & 0x7u)
+				             << DXR_FWD_KEY_MODS_SHIFT);
+				PostMessage(fwd, message, wParam, lp);
 			}
 			return 0;
 		}
@@ -1191,6 +1252,10 @@ comp_d3d11_window_create(uint32_t width,
 	w->display_screen_top = screen_top;
 	w->xsysd = NULL;
 	w->qwerty_enabled = true;  // Always enabled for DisplayXR-owned windows
+	// -1 = controller has not registered a reserved-key set yet; the WndProc
+	// gate falls back to the built-in default until xrSetWorkspaceReservedKeysEXT
+	// arrives (U_TYPED_CALLOC would otherwise leave this 0 = "empty set").
+	w->reserved_key_count = -1;
 
 	U_LOG_W("D3D11 window: QWERTY input ENABLED");
 
@@ -1423,6 +1488,36 @@ comp_d3d11_window_set_input_forward(struct comp_d3d11_window *window,
 	} else {
 		U_LOG_W("D3D11 window: input forwarding disabled");
 	}
+}
+
+extern "C" void
+comp_d3d11_window_set_reserved_keys(struct comp_d3d11_window *window,
+                                    const uint32_t *vks,
+                                    const uint32_t *mods,
+                                    uint32_t count)
+{
+	if (window == NULL) {
+		return;
+	}
+	if (count == 0 || vks == NULL || mods == NULL) {
+		// Restore the built-in default policy.
+		InterlockedExchange(&window->reserved_key_count, -1);
+		U_LOG_W("D3D11 window: reserved keys reset to built-in default");
+		return;
+	}
+	if (count > WORKSPACE_RESERVED_KEYS_MAX) {
+		count = WORKSPACE_RESERVED_KEYS_MAX;
+	}
+	// Fill the table BEFORE publishing the count: the WndProc reader keys off
+	// reserved_key_count, so the array must be fully written when the count
+	// becomes visible. InterlockedExchange of the count is the publish barrier.
+	for (uint32_t i = 0; i < count; i++) {
+		window->reserved_keys[i].vk = vks[i];
+		window->reserved_keys[i].mods = mods[i];
+	}
+	MemoryBarrier();
+	InterlockedExchange(&window->reserved_key_count, (LONG)count);
+	U_LOG_W("D3D11 window: controller registered %u reserved key chord(s)", count);
 }
 
 void *

--- a/src/xrt/compositor/d3d11/comp_d3d11_window.h
+++ b/src/xrt/compositor/d3d11/comp_d3d11_window.h
@@ -43,6 +43,11 @@ struct workspace_input_event
 
 #define WORKSPACE_INPUT_RING_SIZE 64
 
+//! Max controller-supplied reserved-key chords (spec_version 24). Must match
+//! XR_WORKSPACE_MAX_RESERVED_KEYS_EXT in the OpenXR extension header — kept as a
+//! local define so this compositor header doesn't pull in the OpenXR headers.
+#define WORKSPACE_RESERVED_KEYS_MAX 32
+
 /*!
  * Phase 2.D: raw event captured by WndProc for the public-API event drain
  * (xrEnumerateWorkspaceInputEventsEXT). The service-side drain enriches each
@@ -250,6 +255,25 @@ comp_d3d11_window_set_input_forward(struct comp_d3d11_window *window,
                                      int32_t rect_w,
                                      int32_t rect_h,
                                      bool is_capture);
+
+/*!
+ * Install the controller's reserved-key table (XR_EXT_spatial_workspace
+ * spec_version 24). Each (vks[i], mods[i]) is a chord the controller owns:
+ * matching key events are still emitted on the public ring but NOT forwarded
+ * to the focused app. mods uses the 3-bit KEY-event mask (bit0=SHIFT,
+ * bit1=CTRL, bit2=ALT); matching is exact on (vk, mods).
+ *
+ * Pass count == 0 (or NULL arrays) to restore the runtime's built-in default
+ * reserved set. count is clamped to WORKSPACE_RESERVED_KEYS_MAX.
+ *
+ * Thread-safe: the service thread calls this; the WndProc thread reads the
+ * table. The count is published last as the visibility barrier.
+ */
+void
+comp_d3d11_window_set_reserved_keys(struct comp_d3d11_window *window,
+                                    const uint32_t *vks,
+                                    const uint32_t *mods,
+                                    uint32_t count);
 
 /*!
  * Return the HWND the most recent button-DOWN was forwarded to, or NULL if it

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -12639,6 +12639,37 @@ comp_d3d11_service_workspace_set_cursor(struct xrt_system_compositor *xsysc,
 	return XRT_SUCCESS;
 }
 
+// spec_version 24: install the controller's reserved-key table on the workspace
+// window. Reserved chords are emitted on the public ring but not forwarded to
+// the focused app. count == 0 restores the runtime's built-in default set.
+extern "C" xrt_result_t
+comp_d3d11_service_workspace_set_reserved_keys(struct xrt_system_compositor *xsysc,
+                                                const struct ipc_workspace_reserved_keys *table)
+{
+	if (xsysc == nullptr || table == nullptr) {
+		return XRT_ERROR_IPC_FAILURE;
+	}
+	struct d3d11_service_system *sys = d3d11_service_system_from_xrt(xsysc);
+	struct d3d11_multi_compositor *mc = sys->multi_comp;
+	if (mc == nullptr || mc->window == nullptr) {
+		return XRT_ERROR_IPC_FAILURE;
+	}
+	uint32_t count = table->count;
+	if (count > IPC_WORKSPACE_MAX_RESERVED_KEYS) {
+		count = IPC_WORKSPACE_MAX_RESERVED_KEYS;
+	}
+	// Unpack the interleaved wire form into the parallel arrays the window
+	// setter takes. count is small (<= 32) so stack arrays are fine.
+	uint32_t vks[IPC_WORKSPACE_MAX_RESERVED_KEYS];
+	uint32_t mods[IPC_WORKSPACE_MAX_RESERVED_KEYS];
+	for (uint32_t i = 0; i < count; i++) {
+		vks[i] = table->keys[i].vk_code;
+		mods[i] = table->keys[i].modifiers;
+	}
+	comp_d3d11_window_set_reserved_keys(mc->window, vks, mods, count);
+	return XRT_SUCCESS;
+}
+
 // spec_version 17: store the controller-pushed overlay source. xsc may be NULL
 // (caller passed XR_NULL_HANDLE / invalid swapchain) — that hides the overlay
 // without tearing anything down. The runtime composites this swapchain at z = 0

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.h
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.h
@@ -30,6 +30,7 @@ struct u_system;
 // Forward decls from ipc_protocol.h — full definition is included by callers.
 struct ipc_capture_result;
 struct ipc_workspace_chrome_layout;
+struct ipc_workspace_reserved_keys;
 struct ipc_file_picker_info;
 struct ipc_file_picker_result_path;
 
@@ -649,6 +650,16 @@ comp_d3d11_service_workspace_set_cursor(struct xrt_system_compositor *xsysc,
                                          float hot_x, float hot_y,
                                          float size_meters,
                                          bool visible);
+
+/*!
+ * spec_version 24: install the controller's reserved-key table on the workspace
+ * window. Reserved (vkCode, modifiers) chords are emitted on the public input
+ * ring but not forwarded to the focused app. table->count == 0 restores the
+ * runtime's built-in default reserved set.
+ */
+xrt_result_t
+comp_d3d11_service_workspace_set_reserved_keys(struct xrt_system_compositor *xsysc,
+                                                const struct ipc_workspace_reserved_keys *table);
 
 /*!
  * spec_version 17: set the active controller-pushed overlay source (display-

--- a/src/xrt/ipc/client/ipc_client.h
+++ b/src/xrt/ipc/client/ipc_client.h
@@ -270,6 +270,10 @@ xrt_result_t
 comp_ipc_client_compositor_workspace_set_focused_client(struct xrt_compositor *xc, uint32_t client_id);
 
 xrt_result_t
+comp_ipc_client_compositor_workspace_set_reserved_keys(struct xrt_compositor *xc,
+                                                       const struct ipc_workspace_reserved_keys *table);
+
+xrt_result_t
 comp_ipc_client_compositor_workspace_get_focused_client(struct xrt_compositor *xc, uint32_t *out_client_id);
 
 xrt_result_t

--- a/src/xrt/ipc/client/ipc_client_compositor.c
+++ b/src/xrt/ipc/client/ipc_client_compositor.c
@@ -532,6 +532,20 @@ comp_ipc_client_compositor_workspace_set_focused_client(struct xrt_compositor *x
 }
 
 xrt_result_t
+comp_ipc_client_compositor_workspace_set_reserved_keys(struct xrt_compositor *xc,
+                                                       const struct ipc_workspace_reserved_keys *table)
+{
+	if (xc == NULL || table == NULL) {
+		return XRT_ERROR_IPC_FAILURE;
+	}
+	struct ipc_client_compositor *icc = ipc_client_compositor(xc);
+	if (icc == NULL || icc->ipc_c == NULL) {
+		return XRT_ERROR_IPC_FAILURE;
+	}
+	return ipc_call_workspace_set_reserved_keys(icc->ipc_c, table);
+}
+
+xrt_result_t
 comp_ipc_client_compositor_workspace_get_focused_client(struct xrt_compositor *xc, uint32_t *out_client_id)
 {
 	if (xc == NULL || out_client_id == NULL) {

--- a/src/xrt/ipc/server/ipc_server_handler.c
+++ b/src/xrt/ipc/server/ipc_server_handler.c
@@ -4011,6 +4011,32 @@ ipc_handle_workspace_set_chrome_layout(volatile struct ipc_client_state *_ics,
 }
 
 xrt_result_t
+ipc_handle_workspace_set_reserved_keys(volatile struct ipc_client_state *_ics,
+                                       const struct ipc_workspace_reserved_keys *table)
+{
+	struct ipc_server *s = _ics->server;
+
+	// PID-auth gate matches workspace_activate / set_focused_client: the
+	// reserved-key policy is owned by the registered workspace controller.
+	unsigned long expected_pid = get_orchestrator_workspace_pid();
+	unsigned long caller_pid = (unsigned long)_ics->client_state.pid;
+	if (expected_pid != 0 && caller_pid != expected_pid) {
+		return XRT_ERROR_NOT_AUTHORIZED;
+	}
+
+#if defined(XRT_HAVE_D3D11_SERVICE_COMPOSITOR)
+	if (s->xsysc == NULL || table == NULL) {
+		return XRT_ERROR_IPC_FAILURE;
+	}
+	return comp_d3d11_service_workspace_set_reserved_keys(s->xsysc, table);
+#else
+	(void)s;
+	(void)table;
+	return XRT_ERROR_IPC_FAILURE;
+#endif
+}
+
+xrt_result_t
 ipc_handle_workspace_set_cursor(volatile struct ipc_client_state *_ics,
                                  const struct ipc_workspace_cursor_info *info)
 {

--- a/src/xrt/ipc/shared/ipc_protocol.h
+++ b/src/xrt/ipc/shared/ipc_protocol.h
@@ -604,6 +604,35 @@ struct ipc_workspace_chrome_layout
 };
 
 /*!
+ * spec_version 24: maximum controller-reserved key chords per registration.
+ * Mirrors XR_WORKSPACE_MAX_RESERVED_KEYS_EXT — kept fixed-size so the wire
+ * form stays POD.
+ *
+ * @ingroup ipc
+ */
+#define IPC_WORKSPACE_MAX_RESERVED_KEYS 32
+
+/*!
+ * spec_version 24: the controller's reserved-key table. POD mirror of the
+ * XrWorkspaceReservedKeyEXT[] passed to xrSetWorkspaceReservedKeysEXT, inlined
+ * as a fixed-size array so the wire stays POD. count == 0 restores the
+ * runtime's built-in default reserved set.
+ *
+ * @ingroup ipc
+ */
+struct ipc_workspace_reserved_key
+{
+	uint32_t vk_code;   //!< Win32 VK_*
+	uint32_t modifiers; //!< bit0=SHIFT, bit1=CTRL, bit2=ALT
+};
+
+struct ipc_workspace_reserved_keys
+{
+	uint32_t count;     //!< <= IPC_WORKSPACE_MAX_RESERVED_KEYS
+	struct ipc_workspace_reserved_key keys[IPC_WORKSPACE_MAX_RESERVED_KEYS];
+};
+
+/*!
  * spec_version 13: session-global cursor source. The controller renders
  * its cursor sprite into a swapchain (allocated via
  * xrCreateWorkspaceCursorSwapchainEXT) and points the runtime at it via

--- a/src/xrt/ipc/shared/proto.json
+++ b/src/xrt/ipc/shared/proto.json
@@ -141,6 +141,12 @@
 		]
 	},
 
+	"workspace_set_reserved_keys": {
+		"in": [
+			{"name": "table", "type": "struct ipc_workspace_reserved_keys"}
+		]
+	},
+
 	"workspace_get_focused_client": {
 		"out": [
 			{"name": "client_id", "type": "uint32_t"}

--- a/src/xrt/state_trackers/oxr/oxr_api_funcs.h
+++ b/src/xrt/state_trackers/oxr/oxr_api_funcs.h
@@ -835,6 +835,11 @@ oxr_xrSetWorkspaceClientVisibilityEXT(XrSession session, XrWorkspaceClientId cli
 //! OpenXR API function @ep{xrSetWorkspaceFocusedClientEXT}
 XRAPI_ATTR XrResult XRAPI_CALL
 oxr_xrSetWorkspaceFocusedClientEXT(XrSession session, XrWorkspaceClientId clientId);
+//! OpenXR API function @ep{xrSetWorkspaceReservedKeysEXT}
+XRAPI_ATTR XrResult XRAPI_CALL
+oxr_xrSetWorkspaceReservedKeysEXT(XrSession session,
+                                 uint32_t keyCount,
+                                 const XrWorkspaceReservedKeyEXT *keys);
 //! OpenXR API function @ep{xrGetWorkspaceFocusedClientEXT}
 XRAPI_ATTR XrResult XRAPI_CALL
 oxr_xrGetWorkspaceFocusedClientEXT(XrSession session, XrWorkspaceClientId *outClientId);

--- a/src/xrt/state_trackers/oxr/oxr_api_negotiate.c
+++ b/src/xrt/state_trackers/oxr/oxr_api_negotiate.c
@@ -453,6 +453,7 @@ handle_non_null(struct oxr_instance *inst, struct oxr_logger *log, const char *n
 	ENTRY_IF_EXT(xrGetWorkspaceClientWindowPoseEXT, EXT_spatial_workspace);
 	ENTRY_IF_EXT(xrSetWorkspaceClientVisibilityEXT, EXT_spatial_workspace);
 	ENTRY_IF_EXT(xrSetWorkspaceFocusedClientEXT, EXT_spatial_workspace);
+	ENTRY_IF_EXT(xrSetWorkspaceReservedKeysEXT, EXT_spatial_workspace);
 	ENTRY_IF_EXT(xrGetWorkspaceFocusedClientEXT, EXT_spatial_workspace);
 	ENTRY_IF_EXT(xrSetWorkspaceClientFrameRateCapEXT, EXT_spatial_workspace);
 	ENTRY_IF_EXT(xrEnumerateWorkspaceInputEventsEXT, EXT_spatial_workspace);

--- a/src/xrt/state_trackers/oxr/oxr_workspace.c
+++ b/src/xrt/state_trackers/oxr/oxr_workspace.c
@@ -76,6 +76,11 @@ comp_ipc_client_compositor_workspace_set_window_visibility(struct xrt_compositor
                                                            bool visible);
 xrt_result_t
 comp_ipc_client_compositor_workspace_set_focused_client(struct xrt_compositor *xc, uint32_t client_id);
+// spec_version 24: controller-reserved key table.
+struct ipc_workspace_reserved_keys;
+xrt_result_t
+comp_ipc_client_compositor_workspace_set_reserved_keys(struct xrt_compositor *xc,
+                                                       const struct ipc_workspace_reserved_keys *table);
 xrt_result_t
 comp_ipc_client_compositor_workspace_set_input_grab(struct xrt_compositor *xc, bool grab);
 xrt_result_t
@@ -548,6 +553,51 @@ oxr_xrSetWorkspaceFocusedClientEXT(XrSession session, XrWorkspaceClientId client
 	xrt_result_t xret = comp_ipc_client_compositor_workspace_set_focused_client(&sess->xcn->base,
 	                                                                            (uint32_t)clientId);
 	return xret_to_xr_result(&log, xret, "workspace_set_focused_client");
+}
+
+/*
+ * Reserved keys (spec_version 24)
+ */
+
+XRAPI_ATTR XrResult XRAPI_CALL
+oxr_xrSetWorkspaceReservedKeysEXT(XrSession session,
+                                  uint32_t keyCount,
+                                  const XrWorkspaceReservedKeyEXT *keys)
+{
+	OXR_TRACE_MARKER();
+
+	struct oxr_session *sess = NULL;
+	struct oxr_logger log;
+	OXR_VERIFY_SESSION_AND_INIT_LOG(&log, session, sess, "xrSetWorkspaceReservedKeysEXT");
+	OXR_VERIFY_SESSION_NOT_LOST(&log, sess);
+	OXR_VERIFY_EXTENSION(&log, sess->sys->inst, EXT_spatial_workspace);
+
+	if (keyCount > XR_WORKSPACE_MAX_RESERVED_KEYS_EXT) {
+		return oxr_error(&log, XR_ERROR_VALIDATION_FAILURE,
+		                 "xrSetWorkspaceReservedKeysEXT: keyCount %u exceeds max %u",
+		                 keyCount, XR_WORKSPACE_MAX_RESERVED_KEYS_EXT);
+	}
+	if (keyCount > 0 && keys == NULL) {
+		return oxr_error(&log, XR_ERROR_VALIDATION_FAILURE,
+		                 "xrSetWorkspaceReservedKeysEXT: keys must not be NULL when keyCount > 0");
+	}
+
+	if (!session_is_ipc_client(sess)) {
+		return oxr_error(&log, XR_ERROR_FEATURE_UNSUPPORTED,
+		                 "xrSetWorkspaceReservedKeysEXT requires an IPC-mode session");
+	}
+
+	struct ipc_workspace_reserved_keys table;
+	memset(&table, 0, sizeof(table));
+	table.count = keyCount;
+	for (uint32_t i = 0; i < keyCount; i++) {
+		table.keys[i].vk_code = keys[i].vkCode;
+		table.keys[i].modifiers = keys[i].modifiers;
+	}
+
+	xrt_result_t xret =
+	    comp_ipc_client_compositor_workspace_set_reserved_keys(&sess->xcn->base, &table);
+	return xret_to_xr_result(&log, xret, "workspace_set_reserved_keys");
 }
 
 /*

--- a/src/xrt/state_trackers/oxr/oxr_workspace_modal_win32.c
+++ b/src/xrt/state_trackers/oxr/oxr_workspace_modal_win32.c
@@ -51,6 +51,7 @@
 
 #include <windows.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <string.h>
 
 // Bridge to the IPC client compositor — declared here rather than via
@@ -65,9 +66,22 @@ comp_ipc_client_compositor_session_set_modal_state(struct xrt_compositor *xc, bo
 #define MODAL_OWNER_CLASS L"DisplayXRModalDialogOwner"
 #define MAX_TRACKED_DIALOGS 16
 
+// spec_version 24: when the runtime forwards a keystroke to a composited IPC app
+// via PostMessage, it stamps the current modifier mask into spare lParam bits —
+// PostMessage cannot carry keyboard state across processes, so the app thread's
+// GetKeyState / TranslateMessage would otherwise see no modifiers (Ctrl+L → 'l',
+// Shift+Tab → bare Tab). The WH_GETMESSAGE hook below decodes the mask and
+// SetKeyboardState's the app thread to match before the app's own message loop
+// translates / dispatches the key. Bit 28 marks a forwarded message; bits 25-27
+// hold SHIFT/CTRL/ALT. KEEP IN SYNC with the encoder in comp_d3d11_window.cpp.
+#define DXR_FWD_KEY_MARKER_BIT  (1u << 28)
+#define DXR_FWD_KEY_MODS_SHIFT  25
+#define DXR_FWD_KEY_BITS_MASK   (0xFu << DXR_FWD_KEY_MODS_SHIFT) // bits 25-28
+
 static HWND s_app_hidden_hwnd = NULL;
 static HWND s_dialog_owner_hwnd = NULL;
 static HHOOK s_cbt_hook = NULL;
+static HHOOK s_getmsg_hook = NULL;
 static struct xrt_compositor *s_workspace_xc = NULL;
 static int s_modal_open_depth = 0;
 static HWND s_tracked_dialogs[MAX_TRACKED_DIALOGS];
@@ -210,6 +224,62 @@ cbt_hook_proc(int code, WPARAM wParam, LPARAM lParam)
 	return CallNextHookEx(NULL, code, wParam, lParam);
 }
 
+// Force the app thread's keyboard state to match the forwarded modifier mask
+// (bit0=SHIFT, bit1=CTRL, bit2=ALT) so the app's own TranslateMessage and any
+// GetKeyState in its WindowProc see the real chord. Runs on the app UI thread.
+static void
+apply_forwarded_modifiers(uint32_t mods)
+{
+	BYTE state[256];
+	if (!GetKeyboardState(state)) {
+		return;
+	}
+	BYTE shift = (mods & 0x1u) ? (BYTE)0x80 : (BYTE)0x00;
+	BYTE ctrl  = (mods & 0x2u) ? (BYTE)0x80 : (BYTE)0x00;
+	BYTE alt   = (mods & 0x4u) ? (BYTE)0x80 : (BYTE)0x00;
+	// Set both the generic and the left-hand specific VKs so GetKeyState
+	// (generic) and TranslateMessage both observe the right state.
+	state[VK_SHIFT]    = shift;
+	state[VK_LSHIFT]   = shift;
+	state[VK_CONTROL]  = ctrl;
+	state[VK_LCONTROL] = ctrl;
+	state[VK_MENU]     = alt;
+	state[VK_LMENU]    = alt;
+	(void)SetKeyboardState(state);
+}
+
+// WH_GETMESSAGE hook on the app UI thread. Fires from inside the app's
+// GetMessage/PeekMessage, before it TranslateMessage's / DispatchMessage's the
+// message — exactly where the keyboard state must be right. For forwarded key
+// messages (marker bit set) we apply the carried modifier mask and strip our
+// private lParam bits so the app sees a clean message.
+static LRESULT CALLBACK
+getmsg_hook_proc(int code, WPARAM wParam, LPARAM lParam)
+{
+	if (code == HC_ACTION && wParam == PM_REMOVE) {
+		MSG *msg = (MSG *)lParam;
+		if (msg != NULL) {
+			switch (msg->message) {
+			case WM_KEYDOWN:
+			case WM_KEYUP:
+			case WM_SYSKEYDOWN:
+			case WM_SYSKEYUP:
+			case WM_CHAR:
+			case WM_SYSCHAR:
+				if (msg->lParam & (LPARAM)DXR_FWD_KEY_MARKER_BIT) {
+					uint32_t mods = (uint32_t)((msg->lParam >> DXR_FWD_KEY_MODS_SHIFT) & 0x7u);
+					apply_forwarded_modifiers(mods);
+					msg->lParam &= ~(LPARAM)DXR_FWD_KEY_BITS_MASK;
+				}
+				break;
+			default:
+				break;
+			}
+		}
+	}
+	return CallNextHookEx(NULL, code, wParam, lParam);
+}
+
 static bool
 ensure_class_registered(void)
 {
@@ -293,10 +363,22 @@ oxr_workspace_modal_win32_init(struct oxr_session *sess, void *app_hwnd)
 		return;
 	}
 
+	// spec_version 24: per-thread WH_GETMESSAGE hook that restores forwarded
+	// modifier state before the app translates/dispatches the key. Same thread
+	// scope as the CBT hook. A failure here is non-fatal — chord forwarding
+	// degrades but modal re-parenting still works — so we keep going.
+	HHOOK getmsg = SetWindowsHookExW(WH_GETMESSAGE, getmsg_hook_proc, NULL, GetCurrentThreadId());
+	if (getmsg == NULL) {
+		U_LOG_W("workspace_modal: SetWindowsHookExW(WH_GETMESSAGE) failed: 0x%08lx — "
+		        "forwarded key chords may lose modifiers",
+		        GetLastError());
+	}
+
 	EnterCriticalSection(&s_lock);
 	s_app_hidden_hwnd = (HWND)app_hwnd;
 	s_dialog_owner_hwnd = owner;
 	s_cbt_hook = hook;
+	s_getmsg_hook = getmsg;
 	s_workspace_xc = (sess->xcn != NULL) ? &sess->xcn->base : NULL;
 	s_modal_open_depth = 0;
 	s_tracked_dialog_count = 0;
@@ -332,10 +414,13 @@ oxr_workspace_modal_win32_fini(struct oxr_session *sess)
 	// Process globals cleared first so any in-flight hook callback no-ops.
 	EnterCriticalSection(&s_lock);
 	bool was_active = (s_cbt_hook == hook && hook != NULL);
+	HHOOK getmsg = NULL;
 	if (was_active) {
 		s_app_hidden_hwnd = NULL;
 		s_dialog_owner_hwnd = NULL;
 		s_cbt_hook = NULL;
+		getmsg = s_getmsg_hook; // unhook outside the lock (paired with the CBT hook)
+		s_getmsg_hook = NULL;
 		s_workspace_xc = NULL;
 		s_modal_open_depth = 0;
 		s_tracked_dialog_count = 0;
@@ -345,6 +430,9 @@ oxr_workspace_modal_win32_fini(struct oxr_session *sess)
 	if (was_active) {
 		if (hook != NULL) {
 			(void)UnhookWindowsHookEx(hook);
+		}
+		if (getmsg != NULL) {
+			(void)UnhookWindowsHookEx(getmsg);
 		}
 		if (owner != NULL) {
 			(void)DestroyWindow(owner);


### PR DESCRIPTION
## What

Adds a controller-driven **reserved-key API** to `XR_EXT_spatial_workspace` and makes key forwarding **modifier-preserving** (spec_version 23 → 24).

Two problems this fixes:
1. **Shell chords leaked their base key.** The runtime hardcoded the reserved set, so Ctrl+L (shell launcher) also typed a literal `l` into the focused app.
2. **Forwarded chords lost their modifiers.** `PostMessage` to a composited IPC app doesn't carry keyboard state across processes, so Shift+Tab arrived as a bare Tab and Ctrl+C as a bare `c`.

## How

- **`xrSetWorkspaceReservedKeysEXT(session, count, keys)`** — the controller declares the `(vkCode, modifiers)` chords it owns. Reserved chords are still emitted on the public input ring but not forwarded to the app. Exact match on `(vk, mods)` (bare Tab reserved, Shift+Tab forwards). `count == 0` restores the built-in default; an unregistered controller keeps the old hardcoded set (backward compatible).
- **Modifier preservation** — the PostMessage path stamps the 3-bit modifier mask into spare `lParam` bits (25–28); a per-thread `WH_GETMESSAGE` shim on the app UI thread (alongside the existing modal CBT hook) `SetKeyboardState`s before the app translates/dispatches the key. The capture/`SendInput` path already injected modifiers and is unchanged.

Full PFN chain: `proto.json` + `ipc_protocol.h` → `oxr_workspace.c` / api funcs / negotiate → client bridge → PID-authed server handler → `comp_d3d11_service` → window setter + `is_workspace_reserved_key` rewrite.

## Cross-repo

On merge, `publish-extensions.yml` mirrors spec 24 to `DisplayXR/displayxr-extensions`. The companion shell PR (`displayxr-shell-pvt`) registers the shell's chord table and depends on that mirror — **merge this first.**

## Testing

Built (RelWithDebInfo) and **verified on a Leia SR display**: Ctrl+L no longer types `l`; Ctrl+Shift+O / Ctrl+1/2 / Ctrl+Shift+C / Tab / F11 / `[` / `]` / Delete don't leak; Ctrl+V still pastes + toggles; Esc still reaches the app + restores maximize; Shift+Tab and Ctrl+C reach apps as real chords.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
