### PR TITLE
feat(#510): Leia CNSDK display processor out-of-process on Android (M2)

### DIFF
--- a/src/xrt/auxiliary/android/CMakeLists.txt
+++ b/src/xrt/auxiliary/android/CMakeLists.txt
@@ -25,6 +25,8 @@ add_library(
 	android_load_class.hpp
 	android_looper.cpp
 	android_looper.h
+	android_main_thread.c
+	android_main_thread.h
 	org.freedesktop.monado.auxiliary.cpp
 	org.freedesktop.monado.auxiliary.hpp
 	org.freedesktop.monado.auxiliary.impl.hpp

--- a/src/xrt/auxiliary/android/android_main_thread.c
+++ b/src/xrt/auxiliary/android/android_main_thread.c
@@ -1,0 +1,171 @@
+// Copyright 2026, DisplayXR.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  Implementation of Android main-thread dispatch (NDK self-pipe + ALooper).
+ * @ingroup aux_android
+ */
+
+#include "android_main_thread.h"
+
+#ifdef XRT_OS_ANDROID
+
+#include "util/u_logging.h"
+
+#include <android/looper.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <string.h>
+#include <unistd.h>
+
+/*!
+ * One unit of work posted to the main thread. Allocated by the caller (on its
+ * stack); its pointer is written down the pipe. The caller blocks on @ref cond
+ * until the main-thread callback sets @ref done.
+ */
+struct main_thread_task
+{
+	void (*fn)(void *);
+	void *data;
+	pthread_mutex_t lock;
+	pthread_cond_t cond;
+	bool done;
+};
+
+static struct
+{
+	bool initialized;
+	ALooper *looper;
+	int pipe_read;
+	int pipe_write;
+	pthread_t main_thread;
+	pthread_mutex_t submit_lock;
+} g_dispatch = {
+    .initialized = false,
+    .looper = NULL,
+    .pipe_read = -1,
+    .pipe_write = -1,
+    .submit_lock = PTHREAD_MUTEX_INITIALIZER,
+};
+
+/*!
+ * ALooper fd callback — runs on the main thread when the pipe becomes readable.
+ * Drains every queued task pointer, runs it, and signals its waiter. Returns 1 to
+ * stay registered.
+ */
+static int
+on_pipe_readable(int fd, int events, void *data)
+{
+	(void)events;
+	(void)data;
+
+	struct main_thread_task *task = NULL;
+	while (true) {
+		ssize_t n = read(fd, &task, sizeof(task));
+		if (n == (ssize_t)sizeof(task) && task != NULL) {
+			task->fn(task->data);
+
+			pthread_mutex_lock(&task->lock);
+			task->done = true;
+			pthread_cond_signal(&task->cond);
+			pthread_mutex_unlock(&task->lock);
+			continue;
+		}
+		// n <= 0 (EAGAIN/empty) or a short read: nothing more to drain.
+		break;
+	}
+	return 1; // keep the fd registered
+}
+
+void
+android_main_thread_dispatch_init(void)
+{
+	if (g_dispatch.initialized) {
+		return;
+	}
+
+	ALooper *looper = ALooper_forThread();
+	if (looper == NULL) {
+		U_LOG_W("android_main_thread: no Looper on the calling thread; main-thread "
+		        "dispatch disabled (callbacks will run inline)");
+		return;
+	}
+
+	int fds[2];
+	if (pipe(fds) != 0) {
+		U_LOG_E("android_main_thread: pipe() failed: %s", strerror(errno));
+		return;
+	}
+
+	// Read end non-blocking so the drain loop terminates cleanly on EAGAIN.
+	int flags = fcntl(fds[0], F_GETFL, 0);
+	fcntl(fds[0], F_SETFL, flags | O_NONBLOCK);
+
+	ALooper_acquire(looper);
+	int ret = ALooper_addFd(looper, fds[0], ALOOPER_POLL_CALLBACK, ALOOPER_EVENT_INPUT,
+	                        on_pipe_readable, NULL);
+	if (ret != 1) {
+		U_LOG_E("android_main_thread: ALooper_addFd failed (%d)", ret);
+		ALooper_release(looper);
+		close(fds[0]);
+		close(fds[1]);
+		return;
+	}
+
+	g_dispatch.looper = looper;
+	g_dispatch.pipe_read = fds[0];
+	g_dispatch.pipe_write = fds[1];
+	g_dispatch.main_thread = pthread_self();
+	g_dispatch.initialized = true;
+
+	U_LOG_W("android_main_thread: main-thread dispatch ready (pipe r=%d w=%d)", fds[0], fds[1]);
+}
+
+xrt_result_t
+android_run_on_main_thread_blocking(void (*fn)(void *), void *data)
+{
+	if (fn == NULL) {
+		return XRT_SUCCESS;
+	}
+
+	// Not initialized, or we're already on the main thread → run inline (no
+	// marshaling needed, and avoids deadlocking on ourselves).
+	if (!g_dispatch.initialized || pthread_equal(pthread_self(), g_dispatch.main_thread)) {
+		fn(data);
+		return XRT_SUCCESS;
+	}
+
+	struct main_thread_task task = {
+	    .fn = fn,
+	    .data = data,
+	    .lock = PTHREAD_MUTEX_INITIALIZER,
+	    .cond = PTHREAD_COND_INITIALIZER,
+	    .done = false,
+	};
+	struct main_thread_task *task_ptr = &task;
+
+	// Serialize submissions so two posters can't interleave their pointer writes.
+	pthread_mutex_lock(&g_dispatch.submit_lock);
+	ssize_t n = write(g_dispatch.pipe_write, &task_ptr, sizeof(task_ptr));
+	pthread_mutex_unlock(&g_dispatch.submit_lock);
+
+	if (n != (ssize_t)sizeof(task_ptr)) {
+		U_LOG_E("android_main_thread: failed to post task (%zd, %s); running inline", n,
+		        strerror(errno));
+		fn(data);
+		return XRT_SUCCESS;
+	}
+
+	pthread_mutex_lock(&task.lock);
+	while (!task.done) {
+		pthread_cond_wait(&task.cond, &task.lock);
+	}
+	pthread_mutex_unlock(&task.lock);
+
+	return XRT_SUCCESS;
+}
+
+#endif // XRT_OS_ANDROID

--- a/src/xrt/auxiliary/android/android_main_thread.h
+++ b/src/xrt/auxiliary/android/android_main_thread.h
@@ -1,0 +1,62 @@
+// Copyright 2026, DisplayXR.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  Run a native callback on the Android service main thread (main Looper).
+ * @ingroup aux_android
+ *
+ * Some vendor display-processor plug-ins (notably the Leia CNSDK) require their
+ * async init to be *kicked off* from a thread that owns a pumped Android Looper —
+ * `leia_core_init_async()` posts to the calling thread's Looper, and on a bare
+ * worker thread (no Looper) the init immediately tears down and hangs (#510 M2).
+ *
+ * The out-of-process service creates the per-session display processor on the
+ * comp_multi render worker thread, which has no Looper. This helper marshals a
+ * callback onto the service main thread (which owns the Java main Looper) using an
+ * NDK self-pipe + `ALooper_addFd`: the Java `MessageQueue.next()` services the fd
+ * callback (same underlying `android::Looper`), so the callback runs on the real
+ * main thread (tid==pid). No JNI is performed by the transport — only the marshaled
+ * callback (already on the JNI-attached main thread) touches JNI/CNSDK. This also
+ * avoids the multi-classloader JNI-registration unreliability seen in #507.
+ */
+
+#pragma once
+
+#include <xrt/xrt_config_os.h>
+#include <xrt/xrt_results.h>
+
+#ifdef XRT_OS_ANDROID
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*!
+ * Initialize main-thread dispatch. MUST be called once on the Android main thread
+ * (e.g. from the service JNI `nativeStartServer`, which runs on the main thread).
+ * Captures the main Looper and registers a self-pipe fd callback on it. Idempotent.
+ * @ingroup aux_android
+ */
+void
+android_main_thread_dispatch_init(void);
+
+/*!
+ * Run @p fn (@p data) on the Android main thread and block the caller until it
+ * completes.
+ *
+ * If dispatch has not been initialized, or the caller is already the main thread,
+ * @p fn is invoked inline on the calling thread (graceful fallback).
+ *
+ * @param fn   the callback to run on the main thread.
+ * @param data opaque argument forwarded to @p fn.
+ * @return XRT_SUCCESS once @p fn has run (inline or on the main thread).
+ * @ingroup aux_android
+ */
+xrt_result_t
+android_run_on_main_thread_blocking(void (*fn)(void *), void *data);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // XRT_OS_ANDROID

--- a/src/xrt/compositor/main/comp_target_swapchain.c
+++ b/src/xrt/compositor/main/comp_target_swapchain.c
@@ -886,14 +886,48 @@ comp_target_swapchain_acquire_next_image(struct comp_target *ct, uint32_t *out_i
 		VkSurfaceCapabilitiesKHR caps;
 		VkResult cres = vk->vkGetPhysicalDeviceSurfaceCapabilitiesKHR(vk->physical_device,
 		                                                              cts->surface.handle, &caps);
-		if (cres == VK_SUCCESS && caps.currentExtent.width != (uint32_t)-1 &&
-		    caps.currentExtent.width != 0 && caps.currentExtent.height != 0 &&
-		    (caps.currentExtent.width != cts->base.width ||
-		     caps.currentExtent.height != cts->base.height)) {
-			U_LOG_W("comp_window_android: surface extent %ux%u -> %ux%u (rotation), recreating",
-			        cts->base.width, cts->base.height, caps.currentExtent.width,
-			        caps.currentExtent.height);
-			return VK_ERROR_OUT_OF_DATE_KHR;
+		bool valid_extent = cres == VK_SUCCESS && caps.currentExtent.width != (uint32_t)-1 &&
+		                    caps.currentExtent.width != 0 && caps.currentExtent.height != 0;
+		bool differs = valid_extent && (caps.currentExtent.width != cts->base.width ||
+		                                caps.currentExtent.height != cts->base.height);
+		if (!differs) {
+			// Settled (or no caps) — drop any pending debounce.
+			cts->pending_extent.since_ns = 0;
+		} else {
+			// A real orientation change flips which dimension is larger; honor it
+			// immediately. A same-orientation resize (transient startup inset flap,
+			// e.g. 1600<->1540) must persist before we churn the swapchain, which
+			// otherwise stalls the Android BufferQueue / pacing (#510).
+			bool cur_landscape = cts->base.width >= cts->base.height;
+			bool new_landscape = caps.currentExtent.width >= caps.currentExtent.height;
+			bool orientation_flip = cur_landscape != new_landscape;
+
+			const int64_t same_orient_debounce_ns = 2500 * 1000 * 1000LL; // 2.5 s
+			int64_t now_ns = os_monotonic_get_ns();
+			bool persisted = false;
+			if (!orientation_flip) {
+				if (caps.currentExtent.width == cts->pending_extent.width &&
+				    caps.currentExtent.height == cts->pending_extent.height &&
+				    cts->pending_extent.since_ns != 0) {
+					persisted = (now_ns - cts->pending_extent.since_ns) >= same_orient_debounce_ns;
+				} else {
+					// New pending value — start its timer.
+					cts->pending_extent.width = caps.currentExtent.width;
+					cts->pending_extent.height = caps.currentExtent.height;
+					cts->pending_extent.since_ns = now_ns;
+				}
+			}
+
+			if (orientation_flip || persisted) {
+				U_LOG_W("comp_window_android: surface extent %ux%u -> %ux%u (%s), recreating",
+				        cts->base.width, cts->base.height, caps.currentExtent.width,
+				        caps.currentExtent.height,
+				        orientation_flip ? "rotation" : "resize-debounced");
+				cts->pending_extent.since_ns = 0;
+				return VK_ERROR_OUT_OF_DATE_KHR;
+			}
+			// Same-orientation flap, not yet persistent: keep the current swapchain
+			// (present is at worst slightly scaled) and acquire normally.
 		}
 	}
 #endif

--- a/src/xrt/compositor/main/comp_target_swapchain.h
+++ b/src/xrt/compositor/main/comp_target_swapchain.h
@@ -63,6 +63,25 @@ struct comp_target_swapchain
 		VkExtent2D extent;
 	} override;
 
+#ifdef XRT_OS_ANDROID
+	/*!
+	 * Android live-rotation extent-change debounce (#510). The startup
+	 * inset-settle flaps the surface extent (e.g. 2560x1600 -> 1540 -> 1600)
+	 * over ~1.5 s; recreating the swapchain on every flap stalls the Android
+	 * BufferQueue (acquire blocks) / frame pacing. A real orientation change
+	 * (landscape<->portrait) flips which dimension is larger and is honored
+	 * immediately; a same-orientation resize (inset) is only honored after it
+	 * persists past @ref same_orient_debounce_ns. See
+	 * comp_target_swapchain_acquire_next_image.
+	 */
+	struct
+	{
+		uint32_t width;
+		uint32_t height;
+		int64_t since_ns;
+	} pending_extent;
+#endif
+
 	struct
 	{
 		VkSwapchainKHR handle;

--- a/src/xrt/compositor/multi/comp_multi_compositor.c
+++ b/src/xrt/compositor/multi/comp_multi_compositor.c
@@ -61,6 +61,27 @@
 #ifdef XRT_OS_ANDROID
 #include "android/android_custom_surface.h"
 #include "android/android_globals.h"
+#include "android/android_main_thread.h"
+
+//! Context for marshaling the vendor DP factory call onto the service main thread.
+struct dp_factory_call_ctx
+{
+	xrt_dp_factory_vk_fn_t factory;
+	void *vk_bundle;
+	void *vk_cmd_pool;
+	void *window_handle;
+	int32_t target_format;
+	struct xrt_display_processor **out_xdp;
+	xrt_result_t result;
+};
+
+static void
+run_dp_factory_on_main_thread(void *data)
+{
+	struct dp_factory_call_ctx *c = (struct dp_factory_call_ctx *)data;
+	c->result =
+	    c->factory(c->vk_bundle, c->vk_cmd_pool, c->window_handle, c->target_format, c->out_xdp);
+}
 #endif
 
 DEBUG_GET_ONCE_LOG_OPTION(app_frame_lag_level, "XRT_APP_FRAME_LAG_LOG_AS_LEVEL", U_LOGGING_DEBUG)
@@ -1692,12 +1713,32 @@ multi_compositor_init_session_render(struct multi_compositor *mc)
 		xrt_dp_factory_vk_fn_t factory =
 		    (xrt_dp_factory_vk_fn_t)mc->msc->base.info.dp_factory_vk;
 		if (factory != NULL) {
+#ifdef XRT_OS_ANDROID
+			// The Leia CNSDK (and likely other Android vendor DPs) must have their
+			// async init kicked off from a Looper-bearing thread. This code runs on
+			// the comp_multi render worker (no Looper), so marshal the factory call
+			// onto the service main thread, which owns the pumped main Looper. The
+			// call is brief (the init is async on the DP's own thread) and the worker
+			// holds list_and_timing_lock only for that window. (#510 M2)
+			struct dp_factory_call_ctx ctx = {
+			    .factory = factory,
+			    .vk_bundle = vk,
+			    .vk_cmd_pool = (void *)(uintptr_t)mc->session_render.cmd_pool,
+			    .window_handle = mc->session_render.external_window_handle,
+			    .target_format = (int32_t)ct->format,
+			    .out_xdp = &mc->session_render.display_processor,
+			    .result = XRT_SUCCESS,
+			};
+			android_run_on_main_thread_blocking(run_dp_factory_on_main_thread, &ctx);
+			xrt_result_t dp_ret = ctx.result;
+#else
 			xrt_result_t dp_ret = factory(
 			    vk,                                          // vk_bundle
 			    (void *)(uintptr_t)mc->session_render.cmd_pool, // cmd_pool
 			    mc->session_render.external_window_handle,   // window_handle
 			    (int32_t)ct->format,                         // target_format
 			    &mc->session_render.display_processor);      // out_xdp
+#endif
 			if (dp_ret != XRT_SUCCESS) {
 				U_LOG_W("Display processor factory failed: %d (continuing without)", dp_ret);
 				mc->session_render.display_processor = NULL;

--- a/src/xrt/compositor/multi/comp_multi_system.c
+++ b/src/xrt/compositor/multi/comp_multi_system.c
@@ -1450,6 +1450,11 @@ recreate_session_swapchain(struct multi_compositor *mc, struct vk_bundle *vk)
 			vk->vkWaitForFences(vk->device, 1, &mc->session_render.fences[i], VK_TRUE, UINT64_MAX);
 		}
 	}
+	// Fences only cover render work; a present (vkQueuePresentKHR) can still be in
+	// flight holding a BufferQueue slot. Drain the whole device so destroying the
+	// old swapchain releases every buffer back to the queue — otherwise the new
+	// swapchain's first vkAcquireNextImageKHR can block forever on Android (#510).
+	vk->vkDeviceWaitIdle(vk->device);
 
 	uint32_t old_image_count = mc->session_render.buffer_count;
 

--- a/src/xrt/compositor/multi/comp_multi_system.c
+++ b/src/xrt/compositor/multi/comp_multi_system.c
@@ -2601,6 +2601,16 @@ render_session_to_own_target(struct multi_compositor *mc, struct vk_bundle *vk, 
 			                         VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
 			                         0, 0, NULL, 0, NULL, 1, &pre_weave);
 
+			// Hand the DP the target swapchain image view BEFORE process_atlas.
+			// A self-submitting DP (Leia CNSDK) builds its own destination
+			// framebuffer and needs this view; without it get_or_create_weave_fb
+			// bails ("no target view from compositor") and the weave is skipped
+			// every frame → black. The in-process compositor already does this
+			// (comp_vk_native_compositor.c); the OOP per-session path was missing
+			// it — which is why in-process Leia 3D works but OOP was black. (#510 M2)
+			xrt_display_processor_set_target_color_view(mc->session_render.display_processor,
+			                                            ct->images[buffer_index].view);
+
 			// Call display processor with atlas input
 			xrt_display_processor_process_atlas(
 			    mc->session_render.display_processor, cmd,

--- a/src/xrt/ipc/android/src/main/java/org/freedesktop/monado/ipc/MonadoImpl.java
+++ b/src/xrt/ipc/android/src/main/java/org/freedesktop/monado/ipc/MonadoImpl.java
@@ -43,7 +43,13 @@ public class MonadoImpl extends IMonado.Stub {
 
     public MonadoImpl(@NonNull Context context) {
         this.context = context.getApplicationContext();
-        nativeStartServer(this.context);
+        // #510: hand the native side the *original* context (the Service), not the
+        // application context. A vendor display-processor plug-in run out-of-process
+        // (Leia CNSDK) calls Context#getApplication() during init — that method exists
+        // on Activity/Service but NOT on Application, so passing the application
+        // context made CNSDK throw NoSuchMethodError and tear down (refCount=0). The
+        // Service is also process-lived, so holding a global ref to it is fine.
+        nativeStartServer(context);
     }
 
     @Override

--- a/src/xrt/targets/common/target_plugin_loader.c
+++ b/src/xrt/targets/common/target_plugin_loader.c
@@ -408,7 +408,9 @@ load_and_probe_one(const struct plugin_entry *e,
 	// Android plug-ins need the host's JavaVM/activity for vendor-SDK init
 	// (their own statically-linked aux_android copy is never populated).
 	host.get_android_vm = plugin_host_get_android_vm;
-	host.get_android_activity = android_globals_get_activity;
+	// Activity when in-process; Service Context when out-of-process (CNSDK only
+	// needs an android.content.Context to bind the on-device tracking service).
+	host.get_android_activity = plugin_host_get_android_activity;
 #endif
 
 	struct xrt_plugin_iface *iface = NULL;
@@ -817,6 +819,28 @@ plugin_host_get_android_vm(void)
 }
 
 /*
+ * Host-iface callback: hand the plug-in an Android `Context` (as a jobject
+ * `void *`) for vendor-SDK init — e.g. CNSDK's loader, which binds the
+ * on-device LeiaSR face-tracking service (the same out-of-process flow the
+ * stock CNSDK apps use) and needs only an `android.content.Context`, not an
+ * Activity. In-process the host is an Activity (returned verbatim, so the
+ * plug-in's Activity-only paths like orientation-locking still work); in the
+ * out-of-process SERVICE there is no Activity, only the Service `Context`
+ * stored by nativeStartServer → android_globals_store_vm_and_context. The
+ * callback is named *_activity for back-compat with the host-iface slot, but
+ * it returns the Activity when present and otherwise the Service Context.
+ * Without this, get_android_activity() returned NULL in the service process →
+ * CNSDK aborted with "android context and JavaVM must be specified" → no
+ * tracked eyes (#510 M2).
+ */
+static void *
+plugin_host_get_android_activity(void)
+{
+	void *activity = android_globals_get_activity();
+	return activity != NULL ? activity : android_globals_get_context();
+}
+
+/*
  * Discovery contract: see docs/specs/runtime/plugin-discovery.md §3.2.
  *
  * Android v1 uses **convention-driven** discovery rather than the JSON
@@ -1117,7 +1141,9 @@ try_load_one(const struct plugin_entry *e, struct xrt_plugin_instance **out_inst
 	// Android plug-ins need the host's JavaVM/activity for vendor-SDK init
 	// (their own statically-linked aux_android copy is never populated).
 	host.get_android_vm = plugin_host_get_android_vm;
-	host.get_android_activity = android_globals_get_activity;
+	// Activity when in-process; Service Context when out-of-process (CNSDK only
+	// needs an android.content.Context to bind the on-device tracking service).
+	host.get_android_activity = plugin_host_get_android_activity;
 #endif
 
 	struct xrt_plugin_iface *iface = NULL;
@@ -1610,7 +1636,9 @@ try_load_one(const struct plugin_entry *e, struct xrt_plugin_instance **out_inst
 	// Android plug-ins need the host's JavaVM/activity for vendor-SDK init
 	// (their own statically-linked aux_android copy is never populated).
 	host.get_android_vm = plugin_host_get_android_vm;
-	host.get_android_activity = android_globals_get_activity;
+	// Activity when in-process; Service Context when out-of-process (CNSDK only
+	// needs an android.content.Context to bind the on-device tracking service).
+	host.get_android_activity = plugin_host_get_android_activity;
 #endif
 
 	struct xrt_plugin_iface *iface = NULL;

--- a/src/xrt/targets/openxr_android/build.gradle
+++ b/src/xrt/targets/openxr_android/build.gradle
@@ -180,6 +180,42 @@ if (project.hasProperty("sharedStl") && project.getProperty("sharedStl")) {
     println "Using SHARED C++ standard library"
 }
 
+// CNSDK Java glue for the OUT-OF-PROCESS service (#510 M2). When the Leia
+// CNSDK plug-in (libdxrp050_leia_cnsdk.so) runs in the runtime SERVICE
+// process, its loader resolves the on-device LeiaSR core impl through a
+// DexClassLoader that needs the com.leia.* glue classes present in THIS
+// process — the in-process path gets them from the host app's APK, but the
+// service must bundle them itself. Resolve sdk-<ver>.aar from `cnsdk.dir`
+// (local.properties) or -PcnsdkDir; if unset, the service builds CNSDK-free
+// (sim_display fallback), matching the cube's opt-in pattern + ADR-019 (no
+// vendor SDK in default/CI builds). The .aar is the SOLE source of the CNSDK
+// native runtime (libleiaCore-loader.so + libleiaSDK-jni.so) for this APK;
+// only the Leia plug-in itself (libdxrp050_leia_cnsdk.so) lives in jniLibs.
+def resolveCnsdkDir = {
+    def fromProp = project.findProperty('cnsdkDir') ?: project.findProperty('cnsdk.dir')
+    if (fromProp) {
+        def f = new File(fromProp as String)
+        return (f.isAbsolute() ? f : new File(rootProject.projectDir, fromProp as String)).absolutePath
+    }
+    def lp = new File(rootProject.projectDir, 'local.properties')
+    if (lp.exists()) {
+        def props = new Properties()
+        lp.withReader('UTF-8') { props.load(it) }
+        def d = props.getProperty('cnsdk.dir')
+        if (d) {
+            def f = new File(d)
+            return (f.isAbsolute() ? f : new File(rootProject.projectDir, d)).absolutePath
+        }
+    }
+    return null
+}
+def cnsdkDir = resolveCnsdkDir()
+def cnsdkVersionFile = cnsdkDir ? new File("${cnsdkDir}/VERSION.txt") : null
+def cnsdkVersion = (cnsdkVersionFile?.exists()) ? cnsdkVersionFile.text.trim() : null
+def cnsdkAar = (cnsdkDir && cnsdkVersion) ? new File("${cnsdkDir}/android/sdk-${cnsdkVersion}.aar") : null
+def hasCnsdk = cnsdkAar?.exists()
+println "openxr_android: out-of-process CNSDK Java glue ${hasCnsdk ? "ENABLED (${cnsdkAar})" : 'disabled (sim_display path)'}"
+
 android {
     compileSdk project.sharedCompileSdk
     buildToolsVersion = buildToolsVersion
@@ -362,6 +398,16 @@ dependencies {
     // for Hilt dependency injection
     implementation "com.google.dagger:hilt-android:$hiltVersion"
     kapt "com.google.dagger:hilt-compiler:$hiltVersion"
+
+    // CNSDK Java glue (com.leia.* classes) for the out-of-process SERVICE only,
+    // when cnsdk.dir is set. The Leia plug-in's loader resolves the on-device
+    // core impl via a DexClassLoader that FindClass()es these in the service
+    // process; the in-process flavor gets them from the host app instead. The
+    // .aar's native .so are excluded in packagingOptions above (#510 M2).
+    if (hasCnsdk) {
+        outOfProcessImplementation files(cnsdkAar)
+        outOfProcessImplementation "androidx.annotation:annotation:$androidxAnnotationVersion"
+    }
 }
 
 // For signing of release binaries - env var must contain an absolute path

--- a/src/xrt/targets/openxr_android/src/main/AndroidManifest.xml
+++ b/src/xrt/targets/openxr_android/src/main/AndroidManifest.xml
@@ -44,6 +44,23 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
 
+    <!--
+        Android 11+ package visibility: the out-of-process runtime SERVICE
+        hosts the vendor display-processor plug-in (e.g. the Leia CNSDK),
+        whose loader calls PackageManager.getPackageInfo() on the on-device
+        LeiaSR services to bind them for display config + face tracking. Under
+        package visibility those packages are invisible unless declared here —
+        without this the CNSDK loader gets a NameNotFoundException it doesn't
+        clear, and the next JNI call trips CheckJNI → the service process
+        aborts (no tracked eyes). In-process apps declare these in their own
+        manifest; the OOP service must declare them itself. (#510 M2)
+    -->
+    <queries>
+        <package android:name="com.leialoft.display.config" />
+        <package android:name="com.leia.headtrackingservice" />
+        <package android:name="com.leiainc.media.service" />
+    </queries>
+
     <application
         android:name="org.freedesktop.monado.openxr_runtime.MonadoOpenXrApplication"
         android:allowBackup="true"

--- a/src/xrt/targets/service-lib/service_target.cpp
+++ b/src/xrt/targets/service-lib/service_target.cpp
@@ -21,6 +21,7 @@
 #include <android/native_window_jni.h>
 
 #include "android/android_globals.h"
+#include "android/android_main_thread.h"
 
 #include <chrono>
 #include <memory>
@@ -147,6 +148,12 @@ Java_org_freedesktop_monado_ipc_MonadoImpl_nativeStartServer(JNIEnv *env, jobjec
 	U_LOG_D("service: Called nativeStartServer");
 
 	android_globals_store_vm_and_context(jvm, context);
+
+	// nativeStartServer runs on the service main thread (Service.onCreate → MonadoImpl
+	// ctor). Capture the main Looper here so vendor display-processor init (e.g. the
+	// Leia CNSDK) can be marshaled onto it from the comp_multi render worker — that
+	// init must be kicked off from a Looper-bearing thread or it hangs (#510 M2).
+	android_main_thread_dispatch_init();
 
 	IpcServerHelper::instance().startServer();
 }


### PR DESCRIPTION
## Summary

Brings up the vendor (Leia SR CNSDK) **display processor out-of-process** on Android — the runtime service loads the CNSDK plug-in, inits it, and weaves head-tracked Leia 3D, while the app links only the OpenXR loader (ADR-019 / ADR-025). Closes the M2 milestone of #510. **Validated on-device (nubia NP02J): head-tracked Leia 3D renders out-of-process.**

The app submits frames over IPC; the service's `comp_multi` per-session renderer drives the Leia weave + present. Getting there required unwinding several stacked, on-device-only failures (each root-caused on hardware):

## What's fixed

1. **CNSDK init must run on the service main thread** (`android_main_thread.{h,c}` + `service_target.cpp` + `comp_multi_compositor.c`). `leia_core_init_async()` must be kicked off from a Looper-bearing thread; the comp_multi render worker has none, so the core tore down immediately. Marshal the DP-factory call onto the service main thread via a pure-NDK ALooper self-pipe (no JNI from the transport — sidesteps the #507 multi-classloader trap). Confined to the OOP path (`#ifdef XRT_OS_ANDROID`); in-process (`comp_vk_native`) and Windows (`comp_d3d11_service`) are untouched.

2. **Service context, not application context** (`MonadoImpl.java`). CNSDK calls `Context#getApplication()` during init — exists on Activity/Service but not Application — so the application context threw `NoSuchMethodError` and tore the core down. Pass the original Service context.

3. **DP target color view in the OOP render path** (`comp_multi_system.c`) — *the fix that makes it actually render*. A self-submitting DP (Leia CNSDK) builds its own destination framebuffer and needs the target swapchain image view via `set_target_color_view()`. The in-process compositor already did this; the OOP per-session path didn't, so the weave was silently skipped every frame → black. (Plug-in `find_input` / head-pose input is a sibling fix in `displayxr-leia-plugin`.)

4. **Startup robustness** (`comp_target_swapchain.{c,h}` + `comp_multi_system.c`) — debounce the transient startup surface-extent flap (only recreate the swapchain on a real orientation flip, not a same-orientation inset resize, which churned the Android BufferQueue) and `vkDeviceWaitIdle` before recreate.

Plus the prior M2 wiring (Android Context for the plug-in, `<queries>` package visibility, CNSDK `.aar` in the outOfProcess flavor) from the base commit.

## Scope / safety

- All behavioral changes are Android- and OOP-path-gated. In-process Leia 3D and OOP `sim_display` both still render (verified on-device).
- Cross-platform CI exercises the compile + the headless `sim_display` selftest.

## Follow-up (tracked separately)

- Android 3D `view_scale` is `0.5×1.0` (per-eye 1280×1600 — horizontal tile split only); should be device-config-tile-derived. Filed as a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)