### PR TITLE
feat(#518): Android Leia config-derived 3D view_scale + 2 modes + rotation-aware sizing

### DIFF
--- a/docs/adr/ADR-026-orientation-aware-view-scaling.md
+++ b/docs/adr/ADR-026-orientation-aware-view-scaling.md
@@ -1,0 +1,87 @@
+---
+status: Accepted
+date: 2026-06-10
+---
+# ADR-026: Orientation-Independent Rendering Modes, Config-Derived View Scale, Rotation-Aware Worst-Case Atlas
+
+## Context
+
+A 3D display renders each eye at a per-view resolution that is a fraction of the panel —
+the **view scale**. On Windows the Leia DP advertises this from the SR SDK
+(`drv_leia/leia_device.c` mode 1 = 0.5×0.5; `leia_plugin.c` computes it from the SDK's
+recommended view dims). On **Android** the Leia DP originally hardcoded
+`recommended_view_scale = 1.0×1.0` and advertised **no** rendering modes, so each eye
+over-rendered at display×(0.5 from the 2×1 SBS tile split)×1.0 — e.g. 1280×1600 on a
+2560×1600 panel, with the wrong aspect for the lenticular weave (#518).
+
+Two things make Android harder than Windows:
+
+1. **The tile geometry is device-config-driven and asynchronous.** CNSDK exposes the
+   per-view tile via `LEIA_DEVICE_CONFIG_PROPERTY_VIEW_RESOLUTION_PX` (e.g. 1200×1920 on
+   the nubia NP02J), in the device **natural** orientation (portrait on that unit). The
+   config is only readable after the async core init, but rendering modes + display info
+   are queried at `xrCreateInstance`.
+
+2. **The device rotates, and the app's render swapchain is never recreated on rotation.**
+   The cube (and OpenXR apps generally) create their swapchain once at session start; on
+   rotation the runtime swaps the Kooima FOV meters (`oxr_session.c`) and the CNSDK weave
+   rotates the physical interlacing, but the app keeps the same swapchain. So the per-eye
+   geometry differs by orientation (1920×1200 landscape vs 1200×1920 portrait) on a
+   **fixed** swapchain.
+
+## Decision
+
+1. **Rendering modes are content modes, orientation-independent.** A device advertises 2D
+   (scale 1×1, mono) and Leia 3D (2×1 SBS, config-derived scale). **Orientation is NOT a
+   rendering mode** — modes are baked at `xrCreateInstance` and re-negotiating them on
+   every rotation fights that. Orientation is handled orthogonally (below).
+
+2. **3D `view_scale` = tile ÷ panel**, both in the device natural orientation, mapped to
+   the orientation the display dims are reported in (axes swapped when they differ; a
+   symmetric tile like the nubia's 0.75×0.75 is invariant). The plug-in reads
+   `VIEW_RESOLUTION_PX` on the worker and logs it; because the panel + tile are
+   device-intrinsic, the modes/`display_info` use a fixed-device **baseline** at create
+   time (the async value confirms it on-device and serves late re-queries). The runtime
+   prefers the plug-in's `recommended_view_scale` (`target_instance.c`).
+
+3. **Per-mode `XRT_RENDERING_MODE_FLAG_CAN_ROTATE`** — a new `mode_flags` bit
+   (`xrt_device.h`), NOT a new struct field, per [ADR-022](ADR-022-per-mode-capability-flags-frozen-enum-structs.md)
+   (the `xrt_rendering_mode` struct stride is a plug-in ABI contract). Set when a mode is
+   usable in either orientation; clear = orientation-locked. Default 0 keeps existing
+   modes (sim_display's 5, the Windows Leia modes) at single-orientation sizing — pure
+   back-compat; only opt-in modes change.
+
+4. **Worst-case atlas spans both orientations for CAN_ROTATE modes.** Because the app
+   swapchain is never recreated on rotation, it is sized to the worst case across modes
+   **and** orientations (`u_tiling_compute_system_atlas_oriented`, called from
+   `target_instance.c`): each mode contributes its native atlas and, if CAN_ROTATE, also
+   its 90°-swapped atlas. The app renders a **per-orientation sub-rect** of that fixed
+   swapchain (per-eye = current-orientation display × view_scale), so each held
+   orientation is rendered at its correct native tile resolution. Validated on the nubia:
+   live landscape↔portrait swaps the per-eye 1920×1200 ↔ 1200×1920 on a fixed 3840×2560
+   atlas, weave correct in both.
+
+## Alternatives considered
+
+- **Separate rendering modes per orientation** (landscape-3D / portrait-3D): rejected —
+  conflates content mode with orientation, requires auto-switching + re-negotiation on
+  every rotation, and the baked-at-startup mode table doesn't support it cleanly.
+- **Recreate the app swapchain on rotation**: rejected — OpenXR apps don't expect a
+  mid-session view-config resize; the fixed-worst-case + per-orientation sub-rect is the
+  idiomatic approach (swapchain = max, render to recommended rect).
+- **A `supported_orientations` bitmask** (mirroring CNSDK `leia_legal_orientations`):
+  deferred — for *dimension* sizing only the 90° wide-vs-tall distinction matters
+  (reverse-landscape has the same extent as landscape), so a single CAN_ROTATE bit
+  suffices. A bitmask is a future enhancement if per-orientation *policy* is needed.
+
+## Consequences
+
+- Android Leia 3D now renders each eye at the panel's true per-view tile resolution and
+  aspect, in both orientations, without over-rendering.
+- Asymmetric panels (view_scale_x ≠ view_scale_y) need the runtime to swap the scale axes
+  on the rotation event that already swaps the display dims — not yet implemented; the
+  current symmetric nubia path needs none. Tracked as follow-up.
+- Files: `xrt_device.h` (flag), `util/u_tiling.h` (oriented worst-case helper),
+  `targets/common/target_instance.c` (call site); plug-in
+  `drv_leia_android/{leia_cnsdk.*,leia_plugin_android.c}`; reference app
+  `test_apps/cube_handle_vk_android`.

--- a/src/xrt/auxiliary/util/u_tiling.h
+++ b/src/xrt/auxiliary/util/u_tiling.h
@@ -79,6 +79,60 @@ u_tiling_compute_system_atlas(const struct xrt_rendering_mode *modes,
 }
 
 /*!
+ * Worst-case atlas dimensions across all modes, spanning device orientation for
+ * modes flagged @ref XRT_RENDERING_MODE_FLAG_CAN_ROTATE.
+ *
+ * For each mode the atlas is sized at the given (display_w, display_h); if the mode
+ * sets CAN_ROTATE it is ALSO sized at the 90°-swapped (display_h, display_w), and the
+ * global per-dimension max is taken. On Android the app's render swapchain is never
+ * recreated on rotation, so it must be allocated to this worst case to survive a flip;
+ * orientation-locked modes (flag clear) only contribute their native orientation.
+ *
+ * Computes from view_scale_x/y + tile_columns/rows directly (does NOT require or mutate
+ * the modes' runtime-computed fields), so it is independent of @ref u_tiling_compute_mode.
+ *
+ * @param modes        Array of rendering modes (tile_columns/rows + view_scale_x/y set).
+ * @param count        Number of modes.
+ * @param display_w    Native (current) display width in pixels.
+ * @param display_h    Native (current) display height in pixels.
+ * @param[out] out_w   Worst-case atlas width.
+ * @param[out] out_h   Worst-case atlas height.
+ */
+static inline void
+u_tiling_compute_system_atlas_oriented(const struct xrt_rendering_mode *modes,
+                                       uint32_t count,
+                                       uint32_t display_w,
+                                       uint32_t display_h,
+                                       uint32_t *out_w,
+                                       uint32_t *out_h)
+{
+	uint32_t max_w = 0, max_h = 0;
+	for (uint32_t i = 0; i < count; i++) {
+		const struct xrt_rendering_mode *m = &modes[i];
+		// Native orientation, plus the 90°-swapped one when the mode can rotate.
+		uint32_t dims[2][2] = {{display_w, display_h}, {display_h, display_w}};
+		uint32_t n = (m->mode_flags & XRT_RENDERING_MODE_FLAG_CAN_ROTATE) ? 2u : 1u;
+		for (uint32_t o = 0; o < n; o++) {
+			uint32_t dw = dims[o][0], dh = dims[o][1];
+			uint32_t vw = (uint32_t)(dw * m->view_scale_x);
+			uint32_t vh = (uint32_t)(dh * m->view_scale_y);
+			if (vw == 0)
+				vw = dw;
+			if (vh == 0)
+				vh = dh;
+			uint32_t aw = m->tile_columns * vw;
+			uint32_t ah = m->tile_rows * vh;
+			if (aw > max_w)
+				max_w = aw;
+			if (ah > max_h)
+				max_h = ah;
+		}
+	}
+	*out_w = max_w;
+	*out_h = max_h;
+}
+
+/*!
  * Compute the origin of a view within the atlas.
  *
  * @param view_index  Index of the view (0..N-1).

--- a/src/xrt/include/xrt/xrt_device.h
+++ b/src/xrt/include/xrt/xrt_device.h
@@ -252,6 +252,11 @@ struct xrt_binding_profile
  * @ingroup xrt_iface
  */
 #define XRT_RENDERING_MODE_FLAG_HAS_TRACKING (1u << 0) //!< Mode consumes live eye tracking
+//! Mode is usable in either device orientation (landscape AND portrait). When set, the
+//! worst-case atlas sizing (u_tiling_compute_system_atlas_oriented) spans both
+//! orientations so the app's swapchain — never recreated on rotation — fits either. When
+//! clear, the mode is orientation-locked and only its native orientation is sized for.
+#define XRT_RENDERING_MODE_FLAG_CAN_ROTATE   (1u << 1)
 
 /*!
  * A named rendering mode exposed by a device.

--- a/src/xrt/state_trackers/oxr/oxr_api_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_api_session.c
@@ -1389,8 +1389,12 @@ oxr_xrRequestDisplayRenderingModeEXT(XrSession session, uint32_t modeIndex)
 	// `renderingModeViewCounts[active_idx]=0` reads and `XR_ERROR_POSE_INVALID`
 	// at xrEndFrame across cube/gauss/others. Apps need the full enumerator
 	// to interpret indices that arrive via XrEventDataRenderingModeChangedEXT.
+	// #518: only gate when a workspace controller is ACTUALLY active. In
+	// single-app out-of-process (no shell), no controller exists, so the lone app
+	// owns its display mode — otherwise nobody could ever switch 2D<->3D in OOP.
 	if (sess->sys->xsysc != NULL && sess->sys->xsysc->info.is_service_mode &&
 	    sess->compositor != NULL &&
+	    sess->sys->inst->workspace_controller_active &&
 	    !sess->is_active_workspace_controller) {
 		return XR_SUCCESS;
 	}
@@ -1522,6 +1526,7 @@ oxr_xrEnumerateDisplayRenderingModesEXT(XrSession session,
 	XrBool32 session_is_requestable = XR_TRUE;
 	if (sess->sys->xsysc != NULL && sess->sys->xsysc->info.is_service_mode &&
 	    sess->compositor != NULL &&
+	    sess->sys->inst->workspace_controller_active && // #518: only when a workspace is active
 	    !sess->is_active_workspace_controller) {
 		session_is_requestable = XR_FALSE;
 	}

--- a/src/xrt/state_trackers/oxr/oxr_objects.h
+++ b/src/xrt/state_trackers/oxr/oxr_objects.h
@@ -2141,6 +2141,13 @@ struct oxr_instance
 	bool debug_spaces;
 	bool debug_bindings;
 
+	//! True while some session is the active workspace controller (shell). The
+	//! "workspace owns the display mode" gate in xrRequestDisplayRenderingModeEXT /
+	//! the isRequestable enumeration only applies when a workspace is actually
+	//! managing — single-app out-of-process (no controller) lets the lone app
+	//! request modes itself. Set/cleared in xrActivate/DeactivateSpatialWorkspaceEXT.
+	bool workspace_controller_active;
+
 #ifdef XRT_FEATURE_RENDERDOC
 	RENDERDOC_API_1_4_1 *rdoc_api;
 #endif

--- a/src/xrt/state_trackers/oxr/oxr_workspace.c
+++ b/src/xrt/state_trackers/oxr/oxr_workspace.c
@@ -261,6 +261,9 @@ oxr_xrActivateSpatialWorkspaceEXT(XrSession session)
 		// its own chrome) have `compositor != NULL` and would otherwise be
 		// gated alongside actual workspace apps.
 		sess->is_active_workspace_controller = true;
+		// A workspace is now managing the display — re-arm the mode-request gate
+		// for non-controller apps (#518: relaxed for single-app OOP otherwise).
+		sess->sys->inst->workspace_controller_active = true;
 	}
 	return xret_to_xr_result(&log, xret, "workspace_activate");
 }
@@ -284,6 +287,7 @@ oxr_xrDeactivateSpatialWorkspaceEXT(XrSession session)
 	xrt_result_t xret = comp_ipc_client_compositor_workspace_deactivate(&sess->xcn->base);
 	if (xret == XRT_SUCCESS) {
 		sess->is_active_workspace_controller = false;
+		sess->sys->inst->workspace_controller_active = false;
 	}
 	return xret_to_xr_result(&log, xret, "workspace_deactivate");
 }

--- a/src/xrt/targets/common/target_instance.c
+++ b/src/xrt/targets/common/target_instance.c
@@ -332,15 +332,21 @@ out:
 					}
 				}
 
-				// Compute tiling once we have native pixel dims.
+				// Compute tiling once we have native pixel dims. The per-mode
+				// fields are filled for the current orientation, but the
+				// system-wide atlas is the worst case ACROSS orientations for
+				// modes that can rotate (XRT_RENDERING_MODE_FLAG_CAN_ROTATE) —
+				// on Android the app's render swapchain is never recreated on a
+				// device flip, so it must be allocated large enough for either.
 				if (pdi.display_pixel_width > 0 && pdi.display_pixel_height > 0) {
 					for (uint32_t mi = 0; mi < head->rendering_mode_count; mi++) {
 						u_tiling_compute_mode(&head->rendering_modes[mi],
 						                      pdi.display_pixel_width,
 						                      pdi.display_pixel_height);
 					}
-					u_tiling_compute_system_atlas(
+					u_tiling_compute_system_atlas_oriented(
 					    head->rendering_modes, head->rendering_mode_count,
+					    pdi.display_pixel_width, pdi.display_pixel_height,
 					    &xsysc->info.atlas_width_pixels,
 					    &xsysc->info.atlas_height_pixels);
 				}

--- a/test_apps/cube_handle_vk_android/src/main/AndroidManifest.xml
+++ b/test_apps/cube_handle_vk_android/src/main/AndroidManifest.xml
@@ -3,7 +3,8 @@
     Copyright 2026, Leia Inc.
     SPDX-License-Identifier: BSL-1.0
 -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <!--
         Android 12+ package-visibility restriction: cross-package
@@ -26,7 +27,13 @@
              null cursor → xrCreateInstance fails with RUNTIME_UNAVAILABLE
              (the app shows a black screen). The authority is shared by both
              runtime flavors. (#510) -->
-        <provider android:authorities="org.khronos.openxr.runtime_broker" />
+        <!-- tools:replace resolves the merge conflict with the openxr_loader AAR
+             (1.1.41+), which declares the same broker provider authority. The cube
+             only needs visibility of the user-installed runtime's runtime_broker;
+             the loader AAR's system_runtime_broker (for system runtimes) is N/A here. -->
+        <provider
+            android:authorities="org.khronos.openxr.runtime_broker"
+            tools:replace="android:authorities" />
         <!-- Explicit package visibility so we can wake the DisplayXR runtime
              out of Android's "stopped" state and bind its IPC service before
              xrCreateInstance. Both flavors are listed so the same cube APK runs

--- a/test_apps/cube_handle_vk_android/src/main/cpp/main.cpp
+++ b/test_apps/cube_handle_vk_android/src/main/cpp/main.cpp
@@ -706,25 +706,47 @@ active_view_count()
 	return vc;
 }
 
-// Per-tile render size + tile grid for the active mode, inside the atlas.
-// Mirrors cube_handle_vk_win: renderW = atlas.width × scaleX, clamped to the
-// per-tile capacity atlas.width / tileColumns (so tiles never overlap).
+// Per-tile render size + tile grid for the active mode, sized for the CURRENTLY
+// HELD orientation (#518). Each eye renders at current_display × view_scale — so
+// landscape gives e.g. 1920×1200 and portrait 1200×1920 (the device's per-eye tile
+// in that orientation), not a fixed startup-orientation size. The swapchain/atlas is
+// allocated worst-case across orientations (create_swapchains), so the per-frame tile
+// is a sub-rect of it; render_w/render_h drive both the render viewport and the
+// submitted subImage.imageRect, so the weave reads the correct per-orientation tile.
 void
 active_tile_dims(uint32_t *render_w, uint32_t *render_h, uint32_t *cols, uint32_t *rows)
 {
 	const RenderingModeInfo &m = active_mode();
 	uint32_t c = m.tile_columns ? m.tile_columns : 1;
 	uint32_t r = m.tile_rows ? m.tile_rows : 1;
+
+	// Panel long/short edges are fixed; the held orientation (g_display_rotation
+	// 1/3 = portrait) decides which is width vs height. g_display_px is the startup
+	// orientation, so derive orientation-independent long/short first.
+	uint32_t big = g_display_px_w >= g_display_px_h ? g_display_px_w : g_display_px_h;
+	uint32_t small = g_display_px_w >= g_display_px_h ? g_display_px_h : g_display_px_w;
+	int rot = g_display_rotation.load(std::memory_order_relaxed);
+	bool portrait = (rot == 1 || rot == 3);
+	uint32_t disp_w = portrait ? small : big;
+	uint32_t disp_h = portrait ? big : small;
+	if (disp_w == 0 || disp_h == 0) { // no display info yet — fall back to atlas tiles
+		disp_w = g_atlas.width / c;
+		disp_h = g_atlas.height / r;
+	}
+
+	uint32_t rw = (uint32_t)((double)disp_w * m.view_scale_x);
+	uint32_t rh = (uint32_t)((double)disp_h * m.view_scale_y);
+	if (rw == 0)
+		rw = disp_w;
+	if (rh == 0)
+		rh = disp_h;
+	// Never exceed the atlas tile capacity (tiles must not overlap / overflow).
 	uint32_t max_tw = g_atlas.width / c;
 	uint32_t max_th = g_atlas.height / r;
-	uint32_t rw = (uint32_t)((double)g_atlas.width * m.view_scale_x);
-	uint32_t rh = (uint32_t)((double)g_atlas.height * m.view_scale_y);
-	if (rw == 0 || rw > max_tw) {
+	if (rw > max_tw)
 		rw = max_tw;
-	}
-	if (rh == 0 || rh > max_th) {
+	if (rh > max_th)
 		rh = max_th;
-	}
 	*render_w = rw;
 	*render_h = rh;
 	*cols = c;
@@ -877,23 +899,30 @@ create_swapchains()
 	}
 	LOGI("Chose swapchain format: 0x%x", (uint32_t)g_swapchain_format);
 
-	// Atlas dims = max over all modes of (cols × scaleX × panelW) × (rows ×
-	// scaleY × panelH), floored at the panel resolution. For sim_display this
-	// is exactly panelW × panelH.
+	// Atlas dims = worst case over all modes AND BOTH ORIENTATIONS (#518). The
+	// swapchain is never recreated on device rotation, so it must hold either
+	// orientation's largest tile layout; each frame renders a per-orientation
+	// sub-rect of it (active_tile_dims). For each mode the atlas is sized for
+	// (long×short) and (short×long); the global max per dim is taken.
 	uint32_t atlas_w = 0, atlas_h = 0;
 	if (g_display_px_w > 0 && g_display_px_h > 0) {
-		atlas_w = g_display_px_w;
-		atlas_h = g_display_px_h;
+		uint32_t big = g_display_px_w >= g_display_px_h ? g_display_px_w : g_display_px_h;
+		uint32_t small = g_display_px_w >= g_display_px_h ? g_display_px_h : g_display_px_w;
+		atlas_w = big;
+		atlas_h = big; // square lower bound — either orientation's long edge can be width or height
 		for (uint32_t i = 0; i < g_mode_count; ++i) {
-			uint32_t aw = (uint32_t)((double)g_modes[i].tile_columns * g_modes[i].view_scale_x *
-			                         (double)g_display_px_w);
-			uint32_t ah = (uint32_t)((double)g_modes[i].tile_rows * g_modes[i].view_scale_y *
-			                         (double)g_display_px_h);
-			if (aw > atlas_w) {
-				atlas_w = aw;
-			}
-			if (ah > atlas_h) {
-				atlas_h = ah;
+			const uint32_t dims[2][2] = {{big, small}, {small, big}}; // landscape, portrait
+			for (uint32_t o = 0; o < 2; ++o) {
+				uint32_t aw = (uint32_t)((double)g_modes[i].tile_columns *
+				                         g_modes[i].view_scale_x * (double)dims[o][0]);
+				uint32_t ah = (uint32_t)((double)g_modes[i].tile_rows *
+				                         g_modes[i].view_scale_y * (double)dims[o][1]);
+				if (aw > atlas_w) {
+					atlas_w = aw;
+				}
+				if (ah > atlas_h) {
+					atlas_h = ah;
+				}
 			}
 		}
 	} else {


### PR DESCRIPTION
## Summary

Fixes #518 — the Android Leia 3D per-eye render was over-rendered (1280×1600 = display × 0.5×1.0, naive SBS split, wrong aspect). Now the per-eye resolution is **derived from the panel's real per-view tile** (CNSDK `VIEW_RESOLUTION_PX` ÷ `PANEL_RESOLUTION_PX`), the DP advertises **2 rendering modes** (2D + Leia 3D), and sizing is **rotation-aware**. Brings Android to parity with the Windows Leia DP.

Validated on the nubia NP02J: per-eye **1920×1200 landscape / 1200×1920 portrait** (was 1280×1600), live rotation swaps the tile correctly, weave correct in both orientations, 2D + 3D both render.

## Changes (runtime; the plug-in half is displayxr-leia-plugin)

1. **`CAN_ROTATE` rendering-mode flag + rotation-aware worst-case atlas** (`xrt_device.h`, `u_tiling.h`, `target_instance.c`). New `XRT_RENDERING_MODE_FLAG_CAN_ROTATE` (a `mode_flags` bit — no struct change, per ADR-022); `u_tiling_compute_system_atlas_oriented` sizes the system atlas worst-case across modes **and** both orientations for rotatable modes. The app swapchain is never recreated on a device flip, so it must fit either orientation. Default-0 = orientation-locked = unchanged for sim_display/Windows.

2. **Cube per-orientation tiling + manifest fix** (`cube_handle_vk_android`). `active_tile_dims` sizes each eye from the *held* orientation's display dims × `view_scale`; `create_swapchains` allocates worst-case across orientations; app renders the per-orientation sub-rect. Plus `tools:replace` on the `runtime_broker` `<queries>` provider (resolves the merge conflict with `openxr_loader_for_android` 1.1.41).

3. **Single-app OOP mode-request gate relaxation** (`oxr_*`). The "workspace owns the display mode" gate (#233) blocked *all* mode requests in service mode when no controller exists, so nothing could toggle 2D⇄3D in single-app OOP. Now gated only when a workspace controller is actually active (new instance flag). Multi-app workspace unchanged. Verified: `setprop debug.dxr.mode 0|1` toggles live.

Design recorded in **ADR-026**.

## Follow-ups (filed separately)

- 2D center-eye fov↔pose consistency in `displayxr_common` (`compute_views` applies the parallax lerp to the projection but not the pose → single 2D view shifts; 3D is masked).
- Auto-switch to 2D on tracking loss using the runtime's `isTracking` (CNSDK's NoFaceMode is deliberately disabled by the plug-in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)