### PR TITLE
test(#396): consistent view-rig RAW log across all rig-driving cube apps

### DIFF
--- a/test_apps/cube_handle_d3d12_win/main.cpp
+++ b/test_apps/cube_handle_d3d12_win/main.cpp
@@ -625,6 +625,17 @@ static void RenderThreadFunc(
                         XrView rawViews[8];
                         for (uint32_t vi = 0; vi < 8; vi++) rawViews[vi] = {XR_TYPE_VIEW};
 
+                        // XR_EXT_view_rig raw-channel verification (#396 W7):
+                        // chain XrViewDisplayRawEXT so the runtime reports the
+                        // DP's full per-view eye set. Logged once below to
+                        // confirm eyeCountOutput == viewCount with sane
+                        // positions (esp. in >2-view modes, where the DP — not
+                        // the runtime — fills N).
+                        XrViewDisplayRawEXT rawProbe = {XR_TYPE_VIEW_DISPLAY_RAW_EXT};
+                        if (g_hasViewRigExt) {
+                            viewState.next = &rawProbe;
+                        }
+
                         // XR_EXT_view_rig (#396 W7): drive the runtime display
                         // rig with the app's tunables — the runtime owns the
                         // window resolve and the Kooima math, and returns
@@ -651,6 +662,22 @@ static void RenderThreadFunc(
                             locateInfo.next = &displayRig;
                         }
                         xrLocateViews(xr->session, &locateInfo, &viewState, 8, &viewCount, rawViews);
+
+                        // XR_EXT_view_rig raw-channel verification (#396 W7):
+                        // one-shot proof the raw channel reports the DP's full
+                        // per-view set.
+                        if (g_hasViewRigExt) {
+                            static int rawLogged = 0;
+                            if (rawLogged < 3) {
+                                rawLogged++;
+                                LOG_INFO("view-rig RAW: eyeCountOutput=%u viewCount=%u isTracking=%d",
+                                         rawProbe.eyeCountOutput, viewCount, (int)rawProbe.isTracking);
+                                for (uint32_t i = 0; i < rawProbe.eyeCountOutput && i < 8; i++) {
+                                    LOG_INFO("  rawEyes[%u]=(%.4f,%.4f,%.4f)", i, rawProbe.rawEyes[i].x,
+                                             rawProbe.rawEyes[i].y, rawProbe.rawEyes[i].z);
+                                }
+                            }
+                        }
 
                         // Max per-tile capacity from swapchain
                         uint32_t maxTileW = tileColumns > 0 ? xr->swapchain.width / tileColumns : xr->swapchain.width;

--- a/test_apps/cube_handle_gl_win/main.cpp
+++ b/test_apps/cube_handle_gl_win/main.cpp
@@ -630,6 +630,17 @@ static void RenderThreadFunc(
                         XrView rawViews[8];
                         for (uint32_t vi = 0; vi < 8; vi++) rawViews[vi] = {XR_TYPE_VIEW};
 
+                        // XR_EXT_view_rig raw-channel verification (#396 W7):
+                        // chain XrViewDisplayRawEXT so the runtime reports the
+                        // DP's full per-view eye set. Logged once below to
+                        // confirm eyeCountOutput == viewCount with sane
+                        // positions (esp. in >2-view modes, where the DP — not
+                        // the runtime — fills N).
+                        XrViewDisplayRawEXT rawProbe = {XR_TYPE_VIEW_DISPLAY_RAW_EXT};
+                        if (g_hasViewRigExt) {
+                            viewState.next = &rawProbe;
+                        }
+
                         // XR_EXT_view_rig (#396 W7): drive the runtime display
                         // rig with the app's tunables — the runtime owns the
                         // window resolve and the Kooima math, and returns
@@ -656,6 +667,22 @@ static void RenderThreadFunc(
                             locateInfo.next = &displayRig;
                         }
                         xrLocateViews(xr->session, &locateInfo, &viewState, 8, &viewCount, rawViews);
+
+                        // XR_EXT_view_rig raw-channel verification (#396 W7):
+                        // one-shot proof the raw channel reports the DP's full
+                        // per-view set.
+                        if (g_hasViewRigExt) {
+                            static int rawLogged = 0;
+                            if (rawLogged < 3) {
+                                rawLogged++;
+                                LOG_INFO("view-rig RAW: eyeCountOutput=%u viewCount=%u isTracking=%d",
+                                         rawProbe.eyeCountOutput, viewCount, (int)rawProbe.isTracking);
+                                for (uint32_t i = 0; i < rawProbe.eyeCountOutput && i < 8; i++) {
+                                    LOG_INFO("  rawEyes[%u]=(%.4f,%.4f,%.4f)", i, rawProbe.rawEyes[i].x,
+                                             rawProbe.rawEyes[i].y, rawProbe.rawEyes[i].z);
+                                }
+                            }
+                        }
 
                         // Max per-tile capacity from swapchain
                         uint32_t maxTileW = tileColumns > 0 ? xr->swapchain.width / tileColumns : xr->swapchain.width;

--- a/test_apps/cube_handle_metal_macos/main.mm
+++ b/test_apps/cube_handle_metal_macos/main.mm
@@ -2092,6 +2092,21 @@ int main(int argc, char **argv)
         uint32_t viewCount = 0;
         xrLocateViews(app.session, &locateInfo, &viewState, (uint32_t)views.size(), &viewCount, views.data());
 
+        // XR_EXT_view_rig raw-channel verification (#396 W7): one-shot proof
+        // the raw channel reports the DP's full per-view set.
+        if (useRig) {
+            static int rawLogged = 0;
+            if (rawLogged < 3) {
+                rawLogged++;
+                LOG_INFO("view-rig RAW: eyeCountOutput=%u viewCount=%u isTracking=%d",
+                         viewRigRaw.eyeCountOutput, viewCount, (int)viewRigRaw.isTracking);
+                for (uint32_t i = 0; i < viewRigRaw.eyeCountOutput && i < 8; i++) {
+                    LOG_INFO("  rawEyes[%u]=(%.4f,%.4f,%.4f)", i, viewRigRaw.rawEyes[i].x,
+                             viewRigRaw.rawEyes[i].y, viewRigRaw.rawEyes[i].z);
+                }
+            }
+        }
+
         // Acquire swapchain image
         XrSwapchainImageAcquireInfo acqInfo = {XR_TYPE_SWAPCHAIN_IMAGE_ACQUIRE_INFO};
         uint32_t imageIndex = 0;

--- a/test_apps/cube_handle_vk_win/main.cpp
+++ b/test_apps/cube_handle_vk_win/main.cpp
@@ -651,6 +651,17 @@ static void RenderThreadFunc(
                         XrView rawViews[8];
                         for (uint32_t vi = 0; vi < 8; vi++) rawViews[vi] = {XR_TYPE_VIEW};
 
+                        // XR_EXT_view_rig raw-channel verification (#396 W7):
+                        // chain XrViewDisplayRawEXT so the runtime reports the
+                        // DP's full per-view eye set. Logged once below to
+                        // confirm eyeCountOutput == viewCount with sane
+                        // positions (esp. in >2-view modes, where the DP — not
+                        // the runtime — fills N).
+                        XrViewDisplayRawEXT rawProbe = {XR_TYPE_VIEW_DISPLAY_RAW_EXT};
+                        if (g_hasViewRigExt) {
+                            viewState.next = &rawProbe;
+                        }
+
                         // XR_EXT_view_rig (#396 W7): drive the runtime rig
                         // matching the app's current mode (C selects the rig)
                         // with the app's tunables — the runtime owns the window
@@ -691,6 +702,22 @@ static void RenderThreadFunc(
                         }
                         xrLocateViews(xr->session, &locateInfo, &viewState, 8, &viewCount, rawViews);
                         LOG_INFO("[FRAME] Raw LocateViews done");
+
+                        // XR_EXT_view_rig raw-channel verification (#396 W7):
+                        // one-shot proof the raw channel reports the DP's full
+                        // per-view set.
+                        if (g_hasViewRigExt) {
+                            static int rawLogged = 0;
+                            if (rawLogged < 3) {
+                                rawLogged++;
+                                LOG_INFO("view-rig RAW: eyeCountOutput=%u viewCount=%u isTracking=%d",
+                                         rawProbe.eyeCountOutput, viewCount, (int)rawProbe.isTracking);
+                                for (uint32_t i = 0; i < rawProbe.eyeCountOutput && i < 8; i++) {
+                                    LOG_INFO("  rawEyes[%u]=(%.4f,%.4f,%.4f)", i, rawProbe.rawEyes[i].x,
+                                             rawProbe.rawEyes[i].y, rawProbe.rawEyes[i].z);
+                                }
+                            }
+                        }
 
                         // Max per-tile capacity from swapchain
                         uint32_t maxTileW = tileColumns > 0 ? xr->swapchain.width / tileColumns : xr->swapchain.width;

--- a/test_apps/cube_texture_d3d11_win/main.cpp
+++ b/test_apps/cube_texture_d3d11_win/main.cpp
@@ -1175,7 +1175,7 @@ static void RenderOneFrame(RenderState& rs) {
                         if (!rawLogged && viewRigRaw.eyeCountOutput > 0 &&
                             (viewRigRaw.canvasRectPx.extent.width > 0 || rawFrames >= 120)) {
                             rawLogged = true;
-                            LOG_INFO("ViewRig RAW (texture): eyes=%u [0]=(%.4f,%.4f,%.4f) "
+                            LOG_INFO("view-rig RAW (texture): eyes=%u [0]=(%.4f,%.4f,%.4f) "
                                      "canvas=(%d,%d %dx%d) %.4fx%.4fm tracking=%d",
                                      viewRigRaw.eyeCountOutput,
                                      viewRigRaw.rawEyes[0].x, viewRigRaw.rawEyes[0].y, viewRigRaw.rawEyes[0].z,

--- a/test_apps/cube_texture_d3d12_win/main.cpp
+++ b/test_apps/cube_texture_d3d12_win/main.cpp
@@ -1196,6 +1196,18 @@ static void RenderOneFrame(RenderState& rs) {
                     XrView rawViews[8] = {};
                     for (int i = 0; i < 8; i++) rawViews[i].type = XR_TYPE_VIEW;
 
+                    // XR_EXT_view_rig raw channel (#396 W7): chain the raw
+                    // result struct — the one-shot log below proves
+                    // canvasRectPx reports this texture app's canvas SUB-RECT
+                    // (xrSetSharedTextureOutputRectEXT), not the window client
+                    // area. Coexists with the rig request below (independent
+                    // chains: raw on XrViewState::next, rig on
+                    // XrViewLocateInfo::next).
+                    XrViewDisplayRawEXT viewRigRaw = {XR_TYPE_VIEW_DISPLAY_RAW_EXT};
+                    if (g_hasViewRigExt) {
+                        viewState.next = &viewRigRaw;
+                    }
+
                     // XR_EXT_view_rig (#396 W7): drive the runtime rig matching
                     // the app's current mode (C selects the rig) with the app's
                     // tunables — the runtime owns the canvas resolve and the
@@ -1235,6 +1247,29 @@ static void RenderOneFrame(RenderState& rs) {
                         }
                     }
                     xrLocateViews(xr.session, &locateInfo, &viewState, 8, &viewCount, rawViews);
+
+                    if (g_hasViewRigExt) {
+                        // Latch on the first locate with a real canvas rect —
+                        // the earliest frames run before the window metrics /
+                        // output rect exist and report the display fallback.
+                        // Frame ~120 fallback: log whatever we have so a
+                        // missing rect is visible in the log too.
+                        static bool rawLogged = false;
+                        static int rawFrames = 0;
+                        rawFrames++;
+                        if (!rawLogged && viewRigRaw.eyeCountOutput > 0 &&
+                            (viewRigRaw.canvasRectPx.extent.width > 0 || rawFrames >= 120)) {
+                            rawLogged = true;
+                            LOG_INFO("view-rig RAW (texture): eyes=%u [0]=(%.4f,%.4f,%.4f) "
+                                     "canvas=(%d,%d %dx%d) %.4fx%.4fm tracking=%d",
+                                     viewRigRaw.eyeCountOutput,
+                                     viewRigRaw.rawEyes[0].x, viewRigRaw.rawEyes[0].y, viewRigRaw.rawEyes[0].z,
+                                     viewRigRaw.canvasRectPx.offset.x, viewRigRaw.canvasRectPx.offset.y,
+                                     viewRigRaw.canvasRectPx.extent.width, viewRigRaw.canvasRectPx.extent.height,
+                                     viewRigRaw.canvasSizeMeters.width, viewRigRaw.canvasSizeMeters.height,
+                                     (int)viewRigRaw.isTracking);
+                        }
+                    }
 
                     uint32_t maxTileW = tileColumns > 0 ? xr.swapchain.width / tileColumns : xr.swapchain.width;
                     uint32_t maxTileH = tileRows > 0 ? xr.swapchain.height / tileRows : xr.swapchain.height;

--- a/test_apps/cube_texture_metal_macos/main.mm
+++ b/test_apps/cube_texture_metal_macos/main.mm
@@ -2409,6 +2409,29 @@ int main(int argc, char **argv)
         uint32_t viewCount = 0;
         xrLocateViews(app.session, &locateInfo, &viewState, (uint32_t)views.size(), &viewCount, views.data());
 
+        // XR_EXT_view_rig raw channel (#396 W7): one-shot proof canvasRectPx
+        // reports this texture app's canvas SUB-RECT (the output rect), not
+        // the window client area. Latch on the first locate with a real canvas
+        // rect; frame ~120 fallback logs whatever we have so a missing rect is
+        // visible too.
+        if (useRig) {
+            static bool rawLogged = false;
+            static int rawFrames = 0;
+            rawFrames++;
+            if (!rawLogged && viewRigRaw.eyeCountOutput > 0 &&
+                (viewRigRaw.canvasRectPx.extent.width > 0 || rawFrames >= 120)) {
+                rawLogged = true;
+                LOG_INFO("view-rig RAW (texture): eyes=%u [0]=(%.4f,%.4f,%.4f) "
+                         "canvas=(%d,%d %dx%d) %.4fx%.4fm tracking=%d",
+                         viewRigRaw.eyeCountOutput,
+                         viewRigRaw.rawEyes[0].x, viewRigRaw.rawEyes[0].y, viewRigRaw.rawEyes[0].z,
+                         viewRigRaw.canvasRectPx.offset.x, viewRigRaw.canvasRectPx.offset.y,
+                         viewRigRaw.canvasRectPx.extent.width, viewRigRaw.canvasRectPx.extent.height,
+                         viewRigRaw.canvasSizeMeters.width, viewRigRaw.canvasSizeMeters.height,
+                         (int)viewRigRaw.isTracking);
+            }
+        }
+
         // Acquire swapchain image
         XrSwapchainImageAcquireInfo acqInfo = {XR_TYPE_SWAPCHAIN_IMAGE_ACQUIRE_INFO};
         uint32_t imageIndex = 0;


### PR DESCRIPTION
## What

Normalize the `XR_EXT_view_rig` raw-channel verification log so **every** rig-driving cube app emits a greppable `view-rig RAW` line. Previously only `cube_handle_d3d11_win` logged it; the other 7 apps chained (or could chain) `XrViewDisplayRawEXT` but were silent, so the EXT-rig path could only be confirmed indirectly (this came up while verifying resize on VK — had to reason from `useAppProjection` prerequisites instead of reading one line).

## Changes

| App | Change |
|---|---|
| cube_handle_d3d12_win / gl_win / vk_win | add one-shot 3-frame `view-rig RAW: eyeCountOutput/viewCount/isTracking` + rawEyes |
| cube_texture_d3d11_win | normalize prefix `ViewRig RAW` → `view-rig RAW` |
| cube_texture_d3d12_win | add probe (had none) + canvas-aware latched line |
| cube_handle_metal_macos | add canonical line (consumed raw eyes, no log) |
| cube_texture_metal_macos | add canvas-aware line (consumed raw eyes, no log) |

Handle apps emit the simple line; texture apps emit the richer `view-rig RAW (texture): … canvas=…` (latched on first real rect) because verifying `canvasRectPx` = the output **sub-rect** is the texture app's distinguishing concern. `grep "view-rig RAW"` now hits every app.

## Verification

- All 5 Windows apps build clean (`ALL DONE`, no `error C`).
- `cube_handle_d3d12_win` smoke-tested live — emits `view-rig RAW: eyeCountOutput=2 viewCount=2`.
- macOS metal apps are **code-only** (no Mac available; needs a Mac eyeball).

Diagnostic-only; no hardware/runtime behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)