### PR TITLE
fix(vk_native): #524 — macOS canvas/rig metrics track live window resize + position

### DIFF
--- a/src/xrt/compositor/vk_native/comp_vk_native_compositor.c
+++ b/src/xrt/compositor/vk_native/comp_vk_native_compositor.c
@@ -882,6 +882,11 @@ vk_compositor_begin_frame(struct xrt_compositor *xc, int64_t frame_id)
 			        c->settings.preferred.width, c->settings.preferred.height,
 			        new_width, new_height);
 
+			// MoltenVK derives the surface currentExtent from the
+			// CAMetalLayer drawableSize — sync it to the live view
+			// bounds before recreating the swapchain (#524).
+			comp_vk_native_window_macos_sync_drawable_size(c->macos_window);
+
 			if (c->target != NULL) {
 				comp_vk_native_target_resize(c->target, new_width, new_height);
 			}
@@ -3485,60 +3490,87 @@ comp_vk_native_compositor_get_window_metrics(struct xrt_compositor *xc,
 	u_canvas_apply_to_metrics(out_metrics, &c->canvas);
 	return true;
 #elif defined(XRT_OS_MACOS)
-	// On macOS, delegate to display processor if available
-	if (c->display_processor != NULL) {
-		// Use xrt_display_processor_get_display_pixel_info + dimensions
-		uint32_t disp_px_w = 0, disp_px_h = 0;
-		int32_t disp_left = 0, disp_top = 0;
-		if (!xrt_display_processor_get_display_pixel_info(
-		        c->display_processor, &disp_px_w, &disp_px_h,
-		        &disp_left, &disp_top)) {
-			return false;
-		}
-		if (disp_px_w == 0 || disp_px_h == 0) return false;
-
-		float disp_w_m = 0.0f, disp_h_m = 0.0f;
-		if (!xrt_display_processor_get_display_dimensions(
-		        c->display_processor, &disp_w_m, &disp_h_m)) {
-			return false;
-		}
-
-		uint32_t win_px_w = c->settings.preferred.width;
-		uint32_t win_px_h = c->settings.preferred.height;
-		if (win_px_w == 0 || win_px_h == 0) return false;
-
-		float pixel_size_x = disp_w_m / (float)disp_px_w;
-		float pixel_size_y = disp_h_m / (float)disp_px_h;
-
-		out_metrics->display_width_m = disp_w_m;
-		out_metrics->display_height_m = disp_h_m;
-		out_metrics->display_pixel_width = disp_px_w;
-		out_metrics->display_pixel_height = disp_px_h;
-		out_metrics->display_screen_left = disp_left;
-		out_metrics->display_screen_top = disp_top;
-
-		out_metrics->window_pixel_width = win_px_w;
-		out_metrics->window_pixel_height = win_px_h;
-		out_metrics->window_screen_left = 0;
-		out_metrics->window_screen_top = 0;
-
-		out_metrics->window_width_m = (float)win_px_w * pixel_size_x;
-		out_metrics->window_height_m = (float)win_px_h * pixel_size_y;
-
-		// Center offset (assume centered for now)
-		float win_center_px_x = (float)win_px_w / 2.0f;
-		float win_center_px_y = (float)win_px_h / 2.0f;
-		float disp_center_px_x = (float)disp_px_w / 2.0f;
-		float disp_center_px_y = (float)disp_px_h / 2.0f;
-
-		out_metrics->window_center_offset_x_m = (win_center_px_x - disp_center_px_x) * pixel_size_x;
-		out_metrics->window_center_offset_y_m = -((win_center_px_y - disp_center_px_y) * pixel_size_y);
-
-		out_metrics->valid = true;
-		u_canvas_apply_to_metrics(out_metrics, &c->canvas);
-		return true;
+	// Compute compositor-side from the live NSView — own window (hosted) or
+	// the app's external view (handle). #524: the old code froze the window
+	// at settings.preferred (the initial size) and assumed centered, so the
+	// rig fov/canvas did not track live resize or window moves. Display info
+	// comes from the DP when it implements pixel info, else from sys_info
+	// (the VK sim DP implements neither on macOS). Mirrors the Metal
+	// compositor's get_window_metrics + the Windows GetClientRect path above.
+	if (c->macos_window == NULL) {
+		return false;
 	}
-	return false;
+
+	uint32_t disp_px_w = 0, disp_px_h = 0;
+	int32_t disp_left = 0, disp_top = 0;
+	float disp_w_m = 0.0f, disp_h_m = 0.0f;
+	bool have_disp = false;
+	if (c->display_processor != NULL &&
+	    xrt_display_processor_get_display_pixel_info(
+	        c->display_processor, &disp_px_w, &disp_px_h,
+	        &disp_left, &disp_top) &&
+	    disp_px_w > 0 && disp_px_h > 0 &&
+	    xrt_display_processor_get_display_dimensions(
+	        c->display_processor, &disp_w_m, &disp_h_m) &&
+	    disp_w_m > 0.0f && disp_h_m > 0.0f) {
+		have_disp = true;
+	}
+	if (!have_disp && c->sys_info_set &&
+	    c->sys_info.display_pixel_width > 0 && c->sys_info.display_pixel_height > 0 &&
+	    c->sys_info.display_width_m > 0.0f && c->sys_info.display_height_m > 0.0f) {
+		disp_px_w = c->sys_info.display_pixel_width;
+		disp_px_h = c->sys_info.display_pixel_height;
+		disp_left = c->sys_info.display_screen_left;
+		disp_top = c->sys_info.display_screen_top;
+		disp_w_m = c->sys_info.display_width_m;
+		disp_h_m = c->sys_info.display_height_m;
+		have_disp = true;
+	}
+	if (!have_disp) {
+		return false;
+	}
+
+	uint32_t win_px_w = 0, win_px_h = 0;
+	comp_vk_native_window_macos_get_dimensions(c->macos_window, &win_px_w, &win_px_h);
+	if (win_px_w == 0 || win_px_h == 0) return false;
+
+	float pixel_size_x = disp_w_m / (float)disp_px_w;
+	float pixel_size_y = disp_h_m / (float)disp_px_h;
+
+	out_metrics->display_width_m = disp_w_m;
+	out_metrics->display_height_m = disp_h_m;
+	out_metrics->display_pixel_width = disp_px_w;
+	out_metrics->display_pixel_height = disp_px_h;
+	out_metrics->display_screen_left = disp_left;
+	out_metrics->display_screen_top = disp_top;
+
+	out_metrics->window_pixel_width = win_px_w;
+	out_metrics->window_pixel_height = win_px_h;
+
+	out_metrics->window_width_m = (float)win_px_w * pixel_size_x;
+	out_metrics->window_height_m = (float)win_px_h * pixel_size_y;
+
+	// Window centre offset within the display: real on-screen position when
+	// available (so window-relative 3D tracks window moves), else centred.
+	float disp_center_px_x = (float)disp_px_w / 2.0f;
+	float disp_center_px_y = (float)disp_px_h / 2.0f;
+	float win_center_px_x = disp_center_px_x;
+	float win_center_px_y = disp_center_px_y;
+	int32_t win_left = 0, win_top = 0;
+	if (comp_vk_native_window_macos_get_screen_position(
+	        c->macos_window, &win_left, &win_top)) {
+		win_center_px_x = (float)(win_left - disp_left) + (float)win_px_w / 2.0f;
+		win_center_px_y = (float)(win_top - disp_top) + (float)win_px_h / 2.0f;
+	}
+	out_metrics->window_screen_left = win_left;
+	out_metrics->window_screen_top = win_top;
+
+	out_metrics->window_center_offset_x_m = (win_center_px_x - disp_center_px_x) * pixel_size_x;
+	out_metrics->window_center_offset_y_m = -((win_center_px_y - disp_center_px_y) * pixel_size_y);
+
+	out_metrics->valid = true;
+	u_canvas_apply_to_metrics(out_metrics, &c->canvas);
+	return true;
 #else
 	// Android: report the LIVE (orientation-aware) target surface extent in
 	// pixels. The physical panel meters live in the runtime's xsysc->info (the

--- a/src/xrt/compositor/vk_native/comp_vk_native_window_macos.h
+++ b/src/xrt/compositor/vk_native/comp_vk_native_window_macos.h
@@ -77,6 +77,9 @@ comp_vk_native_window_macos_get_layer(struct comp_vk_native_window_macos *win);
 /*!
  * Get the current backing pixel dimensions.
  *
+ * Computed live from the view's bounds (so it tracks window resize, #524);
+ * falls back to the CAMetalLayer drawableSize when no view is available.
+ *
  * @param win        The window handle.
  * @param out_width  Pointer to receive width in pixels.
  * @param out_height Pointer to receive height in pixels.
@@ -85,6 +88,33 @@ void
 comp_vk_native_window_macos_get_dimensions(struct comp_vk_native_window_macos *win,
                                             uint32_t *out_width,
                                             uint32_t *out_height);
+
+/*!
+ * Sync the CAMetalLayer drawableSize to the live view backing size.
+ *
+ * MoltenVK derives the VkSurface currentExtent from the layer's
+ * drawableSize, so this must be called before recreating the swapchain
+ * on a window resize (#524).
+ *
+ * @param win The window handle.
+ */
+void
+comp_vk_native_window_macos_sync_drawable_size(struct comp_vk_native_window_macos *win);
+
+/*!
+ * Get the view's on-screen position in top-down backing pixels,
+ * relative to the origin of the screen the window is on.
+ *
+ * @param win          The window handle.
+ * @param out_left_px  Pointer to receive the view's left edge in pixels.
+ * @param out_top_px   Pointer to receive the view's top edge in pixels.
+ *
+ * @return true if the position could be determined.
+ */
+bool
+comp_vk_native_window_macos_get_screen_position(struct comp_vk_native_window_macos *win,
+                                                 int32_t *out_left_px,
+                                                 int32_t *out_top_px);
 
 /*!
  * Check if the window is still valid (not closed by user).

--- a/src/xrt/compositor/vk_native/comp_vk_native_window_macos.m
+++ b/src/xrt/compositor/vk_native/comp_vk_native_window_macos.m
@@ -257,9 +257,75 @@ comp_vk_native_window_macos_get_dimensions(struct comp_vk_native_window_macos *w
 		return;
 	}
 
+	// Live view size in backing pixels. The layer's drawableSize was
+	// explicitly assigned at creation, which decouples it from the layer
+	// bounds — so it goes stale on window resize (#524). Mirrors the
+	// per-frame poll in comp_metal_compositor.m.
+	if (win->view != nil) {
+		NSRect backing = [win->view convertRectToBacking:win->view.bounds];
+		if (backing.size.width > 0 && backing.size.height > 0) {
+			*out_width = (uint32_t)backing.size.width;
+			*out_height = (uint32_t)backing.size.height;
+			return;
+		}
+	}
+
 	CGSize size = win->metal_layer.drawableSize;
 	*out_width = (uint32_t)size.width;
 	*out_height = (uint32_t)size.height;
+}
+
+void
+comp_vk_native_window_macos_sync_drawable_size(struct comp_vk_native_window_macos *win)
+{
+	if (win == NULL || win->metal_layer == nil || win->view == nil) {
+		return;
+	}
+
+	NSRect backing = [win->view convertRectToBacking:win->view.bounds];
+	CGSize new_size = CGSizeMake(backing.size.width, backing.size.height);
+	if (new_size.width <= 0 || new_size.height <= 0) {
+		return;
+	}
+	if (win->metal_layer.drawableSize.width != new_size.width ||
+	    win->metal_layer.drawableSize.height != new_size.height) {
+		win->metal_layer.drawableSize = new_size;
+	}
+}
+
+bool
+comp_vk_native_window_macos_get_screen_position(struct comp_vk_native_window_macos *win,
+                                                 int32_t *out_left_px,
+                                                 int32_t *out_top_px)
+{
+	if (win == NULL || win->view == nil) {
+		return false;
+	}
+
+	NSView *view = win->view;
+	NSWindow *ns_win = view.window != nil ? view.window : win->window;
+	if (ns_win == nil) {
+		return false;
+	}
+	NSScreen *screen = ns_win.screen ?: [NSScreen mainScreen];
+	if (screen == nil) {
+		return false;
+	}
+
+	// View bounds → screen points (AppKit bottom-up) → top-down backing px
+	// relative to the screen origin. Mirrors comp_metal_compositor.m.
+	NSRect view_in_win = [view convertRect:view.bounds toView:nil];
+	NSRect view_in_screen = [ns_win convertRectToScreen:view_in_win];
+	NSRect screen_frame = [screen frame];
+	CGFloat bs = [screen backingScaleFactor];
+
+	float left_px = (float)((view_in_screen.origin.x - screen_frame.origin.x) * bs);
+	// Flip Y to top-down: distance from the screen top to the view top.
+	float top_pts = (float)((screen_frame.origin.y + screen_frame.size.height) -
+	                        (view_in_screen.origin.y + view_in_screen.size.height));
+	*out_left_px = (int32_t)left_px;
+	*out_top_px = (int32_t)(top_pts * bs);
+	return true;
 }
 
 bool


### PR DESCRIPTION
Fixes #524.

On macOS the view-rig/Kooima canvas didn't track live window resize — resizing a native VK app window distorted the off-axis 3D aspect (Windows was fine).

## Root cause (three stacked gaps in the macOS vk_native path)

1. `comp_vk_native_window_macos_get_dimensions` returned the CAMetalLayer `drawableSize`, which is explicitly assigned at window creation — explicit assignment decouples it from layer bounds, so it never changed again. The existing `begin_frame` resize poll therefore never fired.
2. Even when a resize was detected, the swapchain recreate would have come back at the old extent: MoltenVK derives the surface `currentExtent` from `drawableSize`.
3. The `get_window_metrics` macOS branch required the DP to implement `get_display_pixel_info` + `get_display_dimensions` — the VK sim DP implements neither on macOS, so the branch **always returned false** with sim_display and the runtime ran display-scoped (the stretch). It also used the stale `settings.preferred` size and hardcoded "assume centered".

## Fix (macOS vk_native only — Windows path untouched; Metal already did all of this)

- `get_dimensions` reads live `convertRectToBacking(view.bounds)`, mirroring the Metal compositor's per-frame poll; falls back to `drawableSize` when no view.
- New `sync_drawable_size`, called in `begin_frame` before `target_resize`, so the MoltenVK swapchain recreates at the new extent.
- New `get_screen_position` (view origin in top-down backing px, Metal-compositor math) feeds real `window_center_offset_*` so window-relative 3D tracks window moves.
- `get_window_metrics` macOS branch rewritten compositor-side with a `sys_info` fallback for display info, mirroring `comp_metal_compositor_get_window_metrics`.

## Verified live (macOS, sim_display anaglyph)

- `cube_handle_vk_macos`: resized across wide/tall/square aspects — cube stays un-stretched, off-axis tracks the new rect (user-eyeballed).
- Regression check `gaussian_splatting_handle_vk_macos` (W7 build, gauss `feat/w7-view-rig-macos`): same, looks good. Bonus: the first-frame poll corrected a startup mismatch the old code silently carried (`Window resized: 2560x1440 -> 1462x1440`).
- Mid-drag stretch remains and is expected: the test apps drive the frame loop on the main thread, which AppKit blocks in its resize-tracking run loop; macOS scales the last drawable until frames flow again. App-side fix (display link + `presentsWithTransaction`), out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)