### PR TITLE
fix(gl): #524 follow-up — macOS GL window metrics use real on-screen position

### DIFF
--- a/src/xrt/compositor/gl/comp_gl_compositor.cpp
+++ b/src/xrt/compositor/gl/comp_gl_compositor.cpp
@@ -3507,17 +3507,24 @@ comp_gl_compositor_get_window_metrics(struct xrt_compositor *xc,
 
 	out_metrics->window_pixel_width = win_px_w;
 	out_metrics->window_pixel_height = win_px_h;
-	out_metrics->window_screen_left = 0;
-	out_metrics->window_screen_top = 0;
 
 	out_metrics->window_width_m = (float)win_px_w * pixel_size_x;
 	out_metrics->window_height_m = (float)win_px_h * pixel_size_y;
 
-	// Center offset (assume centered — no screen position API for GL macOS window yet)
-	float win_center_px_x = (float)win_px_w / 2.0f;
-	float win_center_px_y = (float)win_px_h / 2.0f;
+	// Window centre offset within the display: real on-screen position when
+	// available (so window-relative 3D tracks window moves), else centred.
+	// Mirrors the VK native / Metal macOS paths (#524).
 	float disp_center_px_x = (float)disp_px_w / 2.0f;
 	float disp_center_px_y = (float)disp_px_h / 2.0f;
+	float win_center_px_x = disp_center_px_x;
+	float win_center_px_y = disp_center_px_y;
+	int32_t win_left = 0, win_top = 0;
+	if (comp_gl_window_macos_get_screen_position(c->macos_window, &win_left, &win_top)) {
+		win_center_px_x = (float)win_left + (float)win_px_w / 2.0f;
+		win_center_px_y = (float)win_top + (float)win_px_h / 2.0f;
+	}
+	out_metrics->window_screen_left = win_left;
+	out_metrics->window_screen_top = win_top;
 
 	out_metrics->window_center_offset_x_m = (win_center_px_x - disp_center_px_x) * pixel_size_x;
 	out_metrics->window_center_offset_y_m = -((win_center_px_y - disp_center_px_y) * pixel_size_y);

--- a/src/xrt/compositor/gl/comp_gl_window_macos.h
+++ b/src/xrt/compositor/gl/comp_gl_window_macos.h
@@ -131,6 +131,21 @@ comp_gl_window_macos_get_dimensions(struct comp_gl_window_macos *win,
                                     uint32_t *out_height);
 
 /*!
+ * Get the view's on-screen position in top-down backing pixels,
+ * relative to the origin of the screen the window is on (#524).
+ *
+ * @param win          The window handle.
+ * @param out_left_px  Pointer to receive the view's left edge in pixels.
+ * @param out_top_px   Pointer to receive the view's top edge in pixels.
+ *
+ * @return true if the position could be determined.
+ */
+bool
+comp_gl_window_macos_get_screen_position(struct comp_gl_window_macos *win,
+                                         int32_t *out_left_px,
+                                         int32_t *out_top_px);
+
+/*!
  * Check if the window is still valid (not closed by user).
  *
  * @param win The window handle.

--- a/src/xrt/compositor/gl/comp_gl_window_macos.m
+++ b/src/xrt/compositor/gl/comp_gl_window_macos.m
@@ -453,6 +453,42 @@ comp_gl_window_macos_get_dimensions(struct comp_gl_window_macos *win,
 }
 
 bool
+comp_gl_window_macos_get_screen_position(struct comp_gl_window_macos *win,
+                                         int32_t *out_left_px,
+                                         int32_t *out_top_px)
+{
+	if (win == NULL || win->view == nil) {
+		return false;
+	}
+
+	NSView *view = win->view;
+	NSWindow *ns_win = view.window != nil ? view.window : win->window;
+	if (ns_win == nil) {
+		return false;
+	}
+	NSScreen *screen = ns_win.screen ?: [NSScreen mainScreen];
+	if (screen == nil) {
+		return false;
+	}
+
+	// View bounds → screen points (AppKit bottom-up) → top-down backing px
+	// relative to the screen origin. Mirrors comp_vk_native_window_macos.m /
+	// comp_metal_compositor.m (#524).
+	NSRect view_in_win = [view convertRect:view.bounds toView:nil];
+	NSRect view_in_screen = [ns_win convertRectToScreen:view_in_win];
+	NSRect screen_frame = [screen frame];
+	CGFloat bs = [screen backingScaleFactor];
+
+	float left_px = (float)((view_in_screen.origin.x - screen_frame.origin.x) * bs);
+	// Flip Y to top-down: distance from the screen top to the view top.
+	float top_pts = (float)((screen_frame.origin.y + screen_frame.size.height) -
+	                        (view_in_screen.origin.y + view_in_screen.size.height));
+	*out_left_px = (int32_t)left_px;
+	*out_top_px = (int32_t)(top_pts * bs);
+	return true;
+}
+
+bool
 comp_gl_window_macos_is_valid(struct comp_gl_window_macos *win)
 {
 	if (win == NULL) return false;


### PR DESCRIPTION
Follow-up to #526 (issue #524), closing the same gap in the GL macOS path.

Survey of the remaining macOS compositor paths after the VK fix:
- **Metal** — already correct (live `convertRectToBacking` poll + real screen position in metrics). No change.
- **GL** — resize was already live (`get_dimensions` reads `convertRectToBacking`), but `get_window_metrics` hardcoded "assume centered — no screen position API for GL macOS window yet", so window-relative 3D didn't track window moves.

## Fix

- New `comp_gl_window_macos_get_screen_position`: view origin in top-down backing pixels relative to the window's screen — identical math to `comp_vk_native_window_macos.m` / `comp_metal_compositor.m`.
- `get_window_metrics` macOS branch derives `window_center_offset_*` from it; centered remains the fallback when no screen is resolvable.

## Verified live (macOS, sim_display anaglyph)

`cube_handle_gl_macos`: off-axis projection now skews with the window position when dragging across the screen; resize unchanged (was already live). User-eyeballed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)