### PR TITLE
fix(#528): OOP Android compositor follows the client surface lifecycle

### DIFF
--- a/src/xrt/auxiliary/android/src/main/java/org/freedesktop/monado/auxiliary/MonadoView.java
+++ b/src/xrt/auxiliary/android/src/main/java/org/freedesktop/monado/auxiliary/MonadoView.java
@@ -32,6 +32,24 @@ public class MonadoView extends SurfaceView
         implements SurfaceHolder.Callback, SurfaceHolder.Callback2 {
     private static final String TAG = "MonadoView";
 
+    /**
+     * Observer for the surface lifecycle, fired from the SurfaceHolder callbacks on the UI thread.
+     *
+     * <p>Used by the out-of-process IPC client to forward surface destroy/recreate across the
+     * binder boundary so the service compositor can rebuild its VkSurfaceKHR (#528). Pure Java by
+     * design — JNI callback registration proved unreliable across classloaders (#507).
+     */
+    @Keep
+    public interface SurfaceStateListener {
+        /** A live surface is available (surfaceCreated/surfaceChanged). UI thread. */
+        void onSurfaceAvailable(@NonNull SurfaceHolder holder);
+
+        /** The current surface was destroyed. UI thread. */
+        void onSurfaceDestroyed();
+    }
+
+    @Nullable private SurfaceStateListener surfaceStateListener = null;
+
     private final Object currentSurfaceHolderSync = new Object();
 
     public int width = -1;
@@ -89,7 +107,25 @@ public class MonadoView extends SurfaceView
      */
     @NonNull @Keep
     public static MonadoView attachToActivity(@NonNull final Activity activity) {
+        return attachToActivity(activity, null);
+    }
+
+    /**
+     * Construct and start attaching a MonadoView to a client application, observing the surface
+     * lifecycle.
+     *
+     * <p>The listener is set before the view is posted to the window manager, so the first
+     * surfaceCreated is never missed.
+     *
+     * @param activity The activity to attach to.
+     * @param listener Surface lifecycle observer, may be null.
+     * @return The MonadoView instance created and asynchronously attached.
+     */
+    @NonNull @Keep
+    public static MonadoView attachToActivity(
+            @NonNull final Activity activity, @Nullable SurfaceStateListener listener) {
         final MonadoView view = new MonadoView(activity);
+        view.surfaceStateListener = listener;
         WindowManager.LayoutParams lp = new WindowManager.LayoutParams();
         lp.flags =
                 WindowManager.LayoutParams.FLAG_FULLSCREEN
@@ -291,6 +327,9 @@ public class MonadoView extends SurfaceView
             currentSurfaceHolderSync.notifyAll();
         }
         Log.i(TAG, "surfaceCreated: Got a surface holder!");
+        if (surfaceStateListener != null) {
+            surfaceStateListener.onSurfaceAvailable(surfaceHolder);
+        }
     }
 
     @Override
@@ -313,7 +352,11 @@ public class MonadoView extends SurfaceView
                         + " holder "
                         + currentSurfaceHolder.toString());
         // The native side pulls this updated surface via android_custom_surface_
-        // refresh_window() on its next poll (#507) — no push needed here.
+        // refresh_window() on its next poll (#507) — no push needed here. The
+        // out-of-process client instead observes via the listener (#528).
+        if (surfaceStateListener != null) {
+            surfaceStateListener.onSurfaceAvailable(surfaceHolder);
+        }
     }
 
     @Override
@@ -338,6 +381,9 @@ public class MonadoView extends SurfaceView
             // surfaceCreated/surfaceChanged that resume needs. The teardown handshake
             // stays in the session-destroy path (android_custom_surface destructor →
             // markAsDiscardedByNative); it does not belong on a transient surface loss.
+            if (surfaceStateListener != null) {
+                surfaceStateListener.onSurfaceDestroyed();
+            }
         }
     }
 

--- a/src/xrt/compositor/main/comp_target_swapchain.c
+++ b/src/xrt/compositor/main/comp_target_swapchain.c
@@ -21,6 +21,12 @@
 #include "main/comp_compositor.h"
 #include "main/comp_target_swapchain.h"
 
+#ifdef XRT_OS_ANDROID
+#include "android/android_globals.h"
+#include "util/u_time.h"
+#include <android/native_window.h>
+#endif
+
 #include <assert.h>
 #include <stdlib.h>
 
@@ -862,11 +868,181 @@ comp_target_swapchain_has_images(struct comp_target *ct)
 	return cts->surface.handle != VK_NULL_HANDLE && cts->swapchain.handle != VK_NULL_HANDLE;
 }
 
+#ifdef XRT_OS_ANDROID
+/*!
+ * Tear down everything tied to the current Android output surface: image
+ * views, swapchain, VkSurfaceKHR and our ref on the ANativeWindow. Order
+ * mirrors the in-process comp_vk_native_target_sync_surface (#507): idle the
+ * GPU first so nothing is in flight against the dying swapchain. Deliberately
+ * NOT comp_target_swapchain_cleanup() — that also destroys the semaphores and
+ * the pacer, which the per-session render path still needs.
+ */
+static void
+android_surface_teardown(struct comp_target_swapchain *cts)
+{
+	struct vk_bundle *vk = get_vk(cts);
+
+	vk->vkDeviceWaitIdle(vk->device);
+
+	destroy_image_views(cts);
+
+	if (cts->swapchain.handle != VK_NULL_HANDLE) {
+		vk->vkDestroySwapchainKHR(vk->device, cts->swapchain.handle, NULL);
+		cts->swapchain.handle = VK_NULL_HANDLE;
+	}
+
+	if (cts->surface.handle != VK_NULL_HANDLE) {
+		vk->vkDestroySurfaceKHR(vk->instance, cts->surface.handle, NULL);
+		cts->surface.handle = VK_NULL_HANDLE;
+	}
+
+	if (cts->android_surface.window != NULL) {
+		ANativeWindow_release((ANativeWindow *)cts->android_surface.window);
+		cts->android_surface.window = NULL;
+	}
+}
+
+/*!
+ * Follow the android_globals versioned window state (#528): the client
+ * forwards surfaceDestroyed / new-surface events over binder
+ * (clearAppSurface / passAppSurface), and this per-acquire sync makes the
+ * present target track them — instead of presenting into the abandoned
+ * BufferQueue forever.
+ *
+ * Returns:
+ * - VK_SUCCESS — surface healthy, proceed with the acquire.
+ * - VK_ERROR_OUT_OF_DATE_KHR — a fresh VkSurfaceKHR was just built (or the
+ *   swapchain is missing); the caller's existing recreate path must rebuild
+ *   the swapchain images.
+ * - VK_ERROR_SURFACE_LOST_KHR — no live output surface; skip the frame
+ *   quietly and retry next frame.
+ */
+static VkResult
+android_surface_sync(struct comp_target_swapchain *cts)
+{
+	struct _ANativeWindow *cur_window = NULL;
+	uint64_t cur_gen = 0;
+	bool cur_valid = false;
+	android_globals_get_window_state(&cur_window, &cur_gen, &cur_valid);
+
+	if (cur_gen == cts->android_surface.generation) {
+		if (cts->android_surface.lost) {
+			// Steady-state while backgrounded: stay torn down, presents paused.
+			int64_t now_ns = os_monotonic_get_ns();
+			if (now_ns - cts->android_surface.last_skip_log_ns >= U_TIME_1S_IN_NS) {
+				cts->android_surface.last_skip_log_ns = now_ns;
+				U_LOG_I("comp_window_android: no output surface — presents paused (#528)");
+			}
+			return VK_ERROR_SURFACE_LOST_KHR;
+		}
+
+		if (cts->surface.handle != VK_NULL_HANDLE && cts->swapchain.handle == VK_NULL_HANDLE) {
+			// The swapchain rebuild we asked for didn't happen or failed.
+			if (!cts->android_surface.recreate_requested) {
+				// Ask once more.
+				cts->android_surface.recreate_requested = true;
+				return VK_ERROR_OUT_OF_DATE_KHR;
+			}
+			// Two consecutive failures on this surface: give up until the
+			// next generation instead of spinning a hot recreate-fail loop.
+			U_LOG_W("comp_window_android: swapchain rebuild failed twice — pausing presents "
+			        "until a new surface arrives (#528)");
+			android_surface_teardown(cts);
+			cts->android_surface.lost = true;
+			cts->android_surface.last_skip_log_ns = os_monotonic_get_ns();
+			return VK_ERROR_SURFACE_LOST_KHR;
+		}
+
+		// Healthy.
+		cts->android_surface.recreate_requested = false;
+		return VK_SUCCESS;
+	}
+
+	// Generation changed: the surface was destroyed or replaced under us.
+	android_surface_teardown(cts);
+	cts->android_surface.generation = cur_gen;
+	cts->android_surface.recreate_requested = false;
+	// Drop any pending #510 extent debounce from the old surface.
+	cts->pending_extent.since_ns = 0;
+
+	if (!cur_valid || cur_window == NULL) {
+		// Backgrounded: no live surface. Stay torn down until the client
+		// passes the replacement (#528).
+		cts->android_surface.lost = true;
+		cts->android_surface.last_skip_log_ns = os_monotonic_get_ns();
+		U_LOG_W("comp_window_android: output surface lost — target torn down, presents paused (#528)");
+		return VK_ERROR_SURFACE_LOST_KHR;
+	}
+
+	// Resume: rebuild the VkSurfaceKHR from the new ANativeWindow. The caller's
+	// OUT_OF_DATE handling rebuilds the swapchain images at the new extent.
+	struct vk_bundle *vk = get_vk(cts);
+
+	VkAndroidSurfaceCreateInfoKHR surface_info = {
+	    .sType = VK_STRUCTURE_TYPE_ANDROID_SURFACE_CREATE_INFO_KHR,
+	    .flags = 0,
+	    .window = (struct ANativeWindow *)cur_window,
+	};
+
+	VkSurfaceKHR surface = VK_NULL_HANDLE;
+	VkResult ret = vk->vkCreateAndroidSurfaceKHR(vk->instance, &surface_info, NULL, &surface);
+	if (ret != VK_SUCCESS) {
+		U_LOG_E("comp_window_android: vkCreateAndroidSurfaceKHR on resume failed: %s", vk_result_string(ret));
+		cts->android_surface.lost = true;
+		cts->android_surface.last_skip_log_ns = os_monotonic_get_ns();
+		return VK_ERROR_SURFACE_LOST_KHR;
+	}
+
+	cts->surface.handle = surface;
+	// Take ownership of the published ref (released at the next teardown). A
+	// window published and replaced between two syncs leaks one ref — bounded
+	// and rare, same accepted behavior as the in-process path (#507).
+	cts->android_surface.window = cur_window;
+	cts->android_surface.lost = false;
+
+	U_LOG_W("comp_window_android: surface recreated from new ANativeWindow %p, requesting swapchain "
+	        "rebuild (#528)",
+	        (void *)cur_window);
+
+	return VK_ERROR_OUT_OF_DATE_KHR;
+}
+
+/*!
+ * Handle a spontaneous VK_ERROR_SURFACE_LOST_KHR from the driver (the surface
+ * died before the client's clearAppSurface arrived over binder): tear down and
+ * pause presents; the pending generation bump rebuilds us when it lands.
+ */
+static VkResult
+android_surface_spontaneous_loss(struct comp_target_swapchain *cts, const char *where)
+{
+	U_LOG_W("comp_window_android: %s reported VK_ERROR_SURFACE_LOST_KHR — target torn down, presents "
+	        "paused (#528)",
+	        where);
+	android_surface_teardown(cts);
+	cts->android_surface.lost = true;
+	cts->android_surface.last_skip_log_ns = os_monotonic_get_ns();
+	return VK_ERROR_SURFACE_LOST_KHR;
+}
+#endif // XRT_OS_ANDROID
+
 static VkResult
 comp_target_swapchain_acquire_next_image(struct comp_target *ct, uint32_t *out_index)
 {
 	struct comp_target_swapchain *cts = (struct comp_target_swapchain *)ct;
 	struct vk_bundle *vk = get_vk(cts);
+
+#ifdef XRT_OS_ANDROID
+	// Follow the client's surface lifecycle before touching the swapchain:
+	// tears down on surfaceDestroyed, rebuilds the VkSurfaceKHR on the
+	// replacement surface and asks the caller (OUT_OF_DATE) to rebuild the
+	// swapchain (#528).
+	{
+		VkResult sres = android_surface_sync(cts);
+		if (sres != VK_SUCCESS) {
+			return sres;
+		}
+	}
+#endif
 
 	if (!comp_target_swapchain_has_images(ct)) {
 		//! @todo what error to return here?
@@ -886,6 +1062,10 @@ comp_target_swapchain_acquire_next_image(struct comp_target *ct, uint32_t *out_i
 		VkSurfaceCapabilitiesKHR caps;
 		VkResult cres = vk->vkGetPhysicalDeviceSurfaceCapabilitiesKHR(vk->physical_device,
 		                                                              cts->surface.handle, &caps);
+		if (cres == VK_ERROR_SURFACE_LOST_KHR) {
+			// The surface died before the client's clearAppSurface arrived (#528).
+			return android_surface_spontaneous_loss(cts, "surface-caps query");
+		}
 		bool valid_extent = cres == VK_SUCCESS && caps.currentExtent.width != (uint32_t)-1 &&
 		                    caps.currentExtent.width != 0 && caps.currentExtent.height != 0;
 		bool differs = valid_extent && (caps.currentExtent.width != cts->base.width ||
@@ -932,13 +1112,22 @@ comp_target_swapchain_acquire_next_image(struct comp_target *ct, uint32_t *out_i
 	}
 #endif
 
-	return vk->vkAcquireNextImageKHR(          //
+	VkResult ret = vk->vkAcquireNextImageKHR(  //
 	    vk->device,                            // device
 	    cts->swapchain.handle,                 // swapchain
 	    UINT64_MAX,                            // timeout
 	    cts->base.semaphores.present_complete, // semaphore
 	    VK_NULL_HANDLE,                        // fence
 	    out_index);                            // pImageIndex
+
+#ifdef XRT_OS_ANDROID
+	if (ret == VK_ERROR_SURFACE_LOST_KHR) {
+		// The surface died before the client's clearAppSurface arrived (#528).
+		return android_surface_spontaneous_loss(cts, "acquire");
+	}
+#endif
+
+	return ret;
 }
 
 static VkResult
@@ -1195,6 +1384,14 @@ comp_target_swapchain_cleanup(struct comp_target_swapchain *cts)
 		    NULL);               //
 		cts->surface.handle = VK_NULL_HANDLE;
 	}
+
+#ifdef XRT_OS_ANDROID
+	// Release our ref on the ANativeWindow the surface was built from (#528).
+	if (cts->android_surface.window != NULL) {
+		ANativeWindow_release((ANativeWindow *)cts->android_surface.window);
+		cts->android_surface.window = NULL;
+	}
+#endif
 
 	target_fini_semaphores(cts);
 

--- a/src/xrt/compositor/main/comp_target_swapchain.h
+++ b/src/xrt/compositor/main/comp_target_swapchain.h
@@ -80,6 +80,29 @@ struct comp_target_swapchain
 		uint32_t height;
 		int64_t since_ns;
 	} pending_extent;
+
+	/*!
+	 * Surface lifecycle tracking for the out-of-process present target
+	 * (#528, mirrors the in-process comp_vk_native_target sync #507). The
+	 * client forwards surfaceDestroyed/new-surface events over binder into
+	 * android_globals' versioned window state; the per-acquire sync
+	 * (comp_target_swapchain_acquire_next_image) follows the generation:
+	 * tears the VkSwapchainKHR + VkSurfaceKHR down on loss, rebuilds from
+	 * the new ANativeWindow on resume.
+	 */
+	struct
+	{
+		//! Published ANativeWindow the surface was built from; we own one ref.
+		struct _ANativeWindow *window;
+		//! android_globals generation the current surface matches.
+		uint64_t generation;
+		//! True while torn down (no live output surface); presents paused.
+		bool lost;
+		//! An OUT_OF_DATE was already returned for a missing swapchain.
+		bool recreate_requested;
+		//! Throttle for the while-lost skip log.
+		int64_t last_skip_log_ns;
+	} android_surface;
 #endif
 
 	struct

--- a/src/xrt/compositor/main/comp_window_android.c
+++ b/src/xrt/compositor/main/comp_window_android.c
@@ -132,17 +132,22 @@ comp_window_android_init_swapchain(struct comp_target *ct, uint32_t width, uint3
 	// Out-of-process: poll for the surface the app pushed across IPC
 	// (Client.java blockingConnect → passAppSurface → android_globals). It is
 	// normally already present by the time the session reaches this point.
+	// Use the versioned window state so the per-acquire surface sync (#528)
+	// and this init agree on the generation the surface was built from.
 	struct ANativeWindow *window = NULL;
+	uint64_t generation = 0;
+	bool valid = false;
 	for (int i = 0; i < 100; i++) {
-		window = (struct ANativeWindow *)android_globals_get_window();
-		if (window != NULL) {
+		android_globals_get_window_state((struct _ANativeWindow **)&window, &generation, &valid);
+		if (valid && window != NULL) {
 			break;
 		}
+		window = NULL;
 		os_nanosleep(20 * U_TIME_1MS_IN_NS);
 	}
 
 	if (window == NULL) {
-		U_LOG_E("comp_window_android: no ANativeWindow available from android_globals");
+		U_LOG_E("comp_window_android: no live ANativeWindow available from android_globals");
 		return false;
 	}
 
@@ -152,7 +157,15 @@ comp_window_android_init_swapchain(struct comp_target *ct, uint32_t width, uint3
 		return false;
 	}
 
-	U_LOG_W("comp_window_android: VkSurfaceKHR created from ANativeWindow %p", (void *)window);
+	// Seed the surface-lifecycle tracking (#528): take ownership of the
+	// published window ref, released when the sync tears the target down.
+	cwa->base.android_surface.window = (struct _ANativeWindow *)window;
+	cwa->base.android_surface.generation = generation;
+	cwa->base.android_surface.lost = false;
+	cwa->base.android_surface.recreate_requested = false;
+
+	U_LOG_W("comp_window_android: VkSurfaceKHR created from ANativeWindow %p (gen %llu)", (void *)window,
+	        (unsigned long long)generation);
 	return true;
 }
 

--- a/src/xrt/compositor/multi/comp_multi_compositor.c
+++ b/src/xrt/compositor/multi/comp_multi_compositor.c
@@ -636,6 +636,19 @@ multi_compositor_end_session(struct xrt_compositor *xc)
 
 	assert(mc->state.session_active);
 	if (mc->state.session_active) {
+		// Deactivate the session FIRST, under the lock the render thread holds
+		// in transfer_layers_locked: on Android use_android_surface keeps
+		// has_session_render() true even after the handle clears below, so the
+		// lazy re-init gate keys on session_active — flipping it only after
+		// the teardown left a window where the render thread rebuilt the very
+		// target we are tearing down, racing vkCreateAndroidSurfaceKHR against
+		// the old swapchain's BufferQueue connection (#528,
+		// VK_ERROR_NATIVE_WINDOW_IN_USE_KHR storm).
+		os_mutex_lock(&mc->msc->list_and_timing_lock);
+		mc->state.session_active = false;
+		os_mutex_unlock(&mc->msc->list_and_timing_lock);
+		multi_system_compositor_update_session_status(mc->msc, false);
+
 		// Clean up per-session render resources
 		if (mc->session_render.initialized) {
 			// Save handle for logging before we NULL it
@@ -724,9 +737,6 @@ multi_compositor_end_session(struct xrt_compositor *xc)
 		mc->session_render.owns_window = false;
 #endif
 		mc->session_render.window_close_exit_sent = false;
-
-		multi_system_compositor_update_session_status(mc->msc, false);
-		mc->state.session_active = false;
 	}
 
 	return XRT_SUCCESS;

--- a/src/xrt/compositor/multi/comp_multi_compositor.c
+++ b/src/xrt/compositor/multi/comp_multi_compositor.c
@@ -675,8 +675,20 @@ multi_compositor_end_session(struct xrt_compositor *xc)
 				mc->session_render.fenced_buffer = -1;
 			}
 
+#ifdef XRT_OS_ANDROID
+			// Keep the display processor (and, below, its borrowed command
+			// pool) alive across end→begin: session end/begin is a routine
+			// cycle now (SAF picker round-trip, #528), vendor DP creation is
+			// expensive (CNSDK init ~1 s), and CNSDK teardown is unreliable —
+			// leiaCore 0.10.x core release joins an internal thread that never
+			// exits, hanging this IPC handler and deadlocking the client in
+			// xrEndSession (displayxr-leia-plugin#39). init_session_render
+			// reuses the cached pair; the real destroy happens at client
+			// teardown.
+#else
 			// Destroy display processor (owns any vendor SDK handles)
 			xrt_display_processor_destroy(&mc->session_render.display_processor);
+#endif
 
 			// Destroy fences (generic Vulkan)
 			if (vk != NULL && mc->session_render.fences != NULL) {
@@ -690,6 +702,16 @@ multi_compositor_end_session(struct xrt_compositor *xc)
 			mc->session_render.fences = NULL;
 
 			// Free command buffer array (command buffers destroyed with pool)
+#ifdef XRT_OS_ANDROID
+			// The pool survives end_session here (cached with the DP), so the
+			// buffers must be freed explicitly.
+			if (vk != NULL && mc->session_render.cmd_buffers != NULL &&
+			    mc->session_render.cmd_pool != VK_NULL_HANDLE && mc->session_render.buffer_count > 0) {
+				vk->vkFreeCommandBuffers(vk->device, mc->session_render.cmd_pool,
+				                         mc->session_render.buffer_count,
+				                         mc->session_render.cmd_buffers);
+			}
+#endif
 			free(mc->session_render.cmd_buffers);
 			mc->session_render.cmd_buffers = NULL;
 
@@ -714,12 +736,17 @@ multi_compositor_end_session(struct xrt_compositor *xc)
 			}
 
 			// Destroy command pool
+#ifndef XRT_OS_ANDROID
+			// On Android the pool is cached across end→begin together with
+			// the display processor, which borrowed it at factory time and
+			// allocates per-frame command buffers from it (#528).
 			if (mc->session_render.cmd_pool != VK_NULL_HANDLE) {
 				if (vk != NULL) {
 					vk->vkDestroyCommandPool(vk->device, mc->session_render.cmd_pool, NULL);
 				}
 				mc->session_render.cmd_pool = VK_NULL_HANDLE;
 			}
+#endif
 
 			// Destroy per-session target using the service
 			if (mc->session_render.target != NULL && mc->msc->target_service != NULL) {
@@ -1571,18 +1598,22 @@ multi_compositor_init_session_render(struct multi_compositor *mc)
 	U_LOG_W("Got Vulkan bundle: device=%p, physical=%p, queue=%p",
 	        (void *)vk->device, (void *)vk->physical_device, (void *)vk->main_queue->queue);
 
-	// Create command pool
-	VkCommandPoolCreateInfo pool_info = {
-	    .sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,
-	    .queueFamilyIndex = vk->main_queue->family_index,
-	    .flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT,
-	};
+	// Create command pool — unless one survived a previous end_session (Android
+	// caches it together with the display processor that borrowed it, #528).
+	VkResult vk_ret;
+	if (mc->session_render.cmd_pool == VK_NULL_HANDLE) {
+		VkCommandPoolCreateInfo pool_info = {
+		    .sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,
+		    .queueFamilyIndex = vk->main_queue->family_index,
+		    .flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT,
+		};
 
-	VkResult vk_ret = vk->vkCreateCommandPool(vk->device, &pool_info, NULL, &mc->session_render.cmd_pool);
-	if (vk_ret != VK_SUCCESS) {
-		U_LOG_E("Failed to create command pool: %d", vk_ret);
-		comp_target_service_destroy(mc->msc->target_service, &mc->session_render.target);
-		return false;
+		vk_ret = vk->vkCreateCommandPool(vk->device, &pool_info, NULL, &mc->session_render.cmd_pool);
+		if (vk_ret != VK_SUCCESS) {
+			U_LOG_E("Failed to create command pool: %d", vk_ret);
+			comp_target_service_destroy(mc->msc->target_service, &mc->session_render.target);
+			return false;
+		}
 	}
 
 	// Allocate command buffer ring and fences (one per swapchain image)
@@ -1719,7 +1750,16 @@ multi_compositor_init_session_render(struct multi_compositor *mc)
 	// DISPLAY PROCESSOR: create via factory (set by driver at init time)
 	//
 
-	{
+	if (mc->session_render.display_processor != NULL) {
+		// Cached from a previous end_session (Android, #528): vendor DP
+		// creation is expensive and CNSDK teardown can hang
+		// (displayxr-leia-plugin#39), so the DP rides across session
+		// end→begin. It is not bound to the (recreated) swapchain — the
+		// target color view is set per frame — and its borrowed command
+		// pool was cached alongside it.
+		U_LOG_W("Reusing cached display processor for HWND %p (#528)",
+		        mc->session_render.external_window_handle);
+	} else {
 		xrt_dp_factory_vk_fn_t factory =
 		    (xrt_dp_factory_vk_fn_t)mc->msc->base.info.dp_factory_vk;
 		if (factory != NULL) {

--- a/src/xrt/compositor/multi/comp_multi_system.c
+++ b/src/xrt/compositor/multi/comp_multi_system.c
@@ -2051,6 +2051,14 @@ render_session_to_own_target(struct multi_compositor *mc, struct vk_bundle *vk, 
 	} else
 #endif
 	if (mc->session_render.swapchain_needs_recreate) {
+		// Never recreate against a torn-down target (Android surface loss,
+		// #528): create_images on a VK_NULL_HANDLE surface is invalid usage.
+		// The acquire-time surface sync rebuilds the target when a new
+		// surface arrives.
+		if (!comp_target_check_ready(ct)) {
+			mc->session_render.swapchain_needs_recreate = false;
+			return;
+		}
 		recreate_session_swapchain(mc, vk);
 		// Re-read ct since create_images updates it in place
 		ct = mc->session_render.target;
@@ -2210,11 +2218,21 @@ render_session_to_own_target(struct multi_compositor *mc, struct vk_bundle *vk, 
 		// Accept VK_SUBOPTIMAL_KHR — the image IS acquired, it's just not
 		// optimal (e.g. overlay window still resizing asynchronously).
 		ret = comp_target_acquire(ct, &buffer_index);
+		if (ret == VK_ERROR_SURFACE_LOST_KHR || ret == VK_ERROR_OUT_OF_DATE_KHR) {
+			// Surface gone / still settling (Android background, #528):
+			// skip this frame quietly, the target logs the transition.
+			return;
+		}
 		if (ret != VK_SUCCESS && ret != VK_SUBOPTIMAL_KHR) {
 			U_LOG_E("[per-session] Failed to acquire after swapchain recreation: %s",
 			        vk_result_string(ret));
 			return;
 		}
+	} else if (ret == VK_ERROR_SURFACE_LOST_KHR) {
+		// No live output surface (Android client backgrounded, #528): skip
+		// quietly. The delivered frame is still retired by the caller, so
+		// client frame pacing keeps flowing and xrWaitFrame never stalls.
+		return;
 	} else if (ret != VK_SUCCESS && ret != VK_SUBOPTIMAL_KHR) {
 		U_LOG_E("[per-session] Failed to acquire per-session target image: %s", vk_result_string(ret));
 		return;
@@ -2702,6 +2720,12 @@ submit_and_present:
 	if (ret == VK_ERROR_OUT_OF_DATE_KHR) {
 		U_LOG_W("[per-session] Present returned OUT_OF_DATE, flagging for recreation");
 		mc->session_render.swapchain_needs_recreate = true;
+	} else if (ret == VK_ERROR_SURFACE_LOST_KHR) {
+		// Surface died mid-frame (Android background, #528). Do NOT flag a
+		// recreate — the swapchain can't be rebuilt on a dead surface; the
+		// next acquire's surface sync tears the target down and pauses
+		// presents until the client passes a replacement surface.
+		U_LOG_W("[per-session] Present returned SURFACE_LOST, waiting for a new surface");
 	} else if (ret == VK_SUBOPTIMAL_KHR) {
 		// Presentation succeeded — swapchain size differs from surface but content is shown.
 	} else if (ret != VK_SUCCESS) {

--- a/src/xrt/compositor/multi/comp_multi_system.c
+++ b/src/xrt/compositor/multi/comp_multi_system.c
@@ -2826,9 +2826,15 @@ transfer_layers_locked(struct multi_system_compositor *msc, int64_t display_time
 
 		// Lazily initialize per-session render resources if session has external HWND or readback
 		// This creates the per-session comp_target and display processor for multi-app support
-		// Skip re-init if window close is in progress (avoids VK_ERROR_SURFACE_LOST_KHR on dead HWND)
-		if (multi_compositor_has_session_render(mc) && !mc->session_render.initialized &&
-		    !mc->session_render.window_close_exit_sent) {
+		// Skip re-init if window close is in progress (avoids VK_ERROR_SURFACE_LOST_KHR on dead HWND).
+		// Also require an ACTIVE session: end_session tears the target down on purpose
+		// (xrEndSession when the app backgrounds behind a picker, #528) — re-initializing
+		// here while it is still tearing down races vkCreateAndroidSurfaceKHR against the
+		// old swapchain's BufferQueue connection (VK_ERROR_NATIVE_WINDOW_IN_USE_KHR storm)
+		// and pointlessly rebuilds a target no layers will reach. begin_session flips
+		// session_active back on and the next pass re-inits from the then-current surface.
+		if (mc->state.session_active && multi_compositor_has_session_render(mc) &&
+		    !mc->session_render.initialized && !mc->session_render.window_close_exit_sent) {
 			multi_compositor_init_session_render(mc);
 		}
 

--- a/src/xrt/ipc/android/src/main/aidl/org/freedesktop/monado/ipc/IMonado.aidl
+++ b/src/xrt/ipc/android/src/main/aidl/org/freedesktop/monado/ipc/IMonado.aidl
@@ -27,4 +27,12 @@ interface IMonado {
      * Asking service whether it has the capbility to draw over other apps or not.
      */
     boolean canDrawOverOtherApps();
+
+    /*!
+     * Tell the service the previously passed app surface was destroyed (e.g. the
+     * client backgrounded behind a file picker), so the compositor stops
+     * presenting into the dead BufferQueue and tears its VkSurfaceKHR down.
+     * The client passes the replacement via passAppSurface on resume. #528
+     */
+    void clearAppSurface();
 }

--- a/src/xrt/ipc/android/src/main/java/org/freedesktop/monado/ipc/Client.java
+++ b/src/xrt/ipc/android/src/main/java/org/freedesktop/monado/ipc/Client.java
@@ -76,6 +76,19 @@ public class Client implements ServiceConnection {
     /** Control system ui visibility */
     private SystemUiController systemUiController = null;
 
+    /** The view we injected into the client activity; retained to observe its surface (#528). */
+    private MonadoView monadoView = null;
+
+    /** Guards lastSurfaceSent. */
+    private final Object surfaceSync = new Object();
+
+    /**
+     * The last Surface forwarded to the service via passAppSurface, for dedupe. Nulled on surface
+     * loss so the next available surface is always re-sent, even if the platform reuses the
+     * Surface object.
+     */
+    private Surface lastSurfaceSent = null;
+
     /**
      * Constructor
      *
@@ -173,7 +186,7 @@ public class Client implements ServiceConnection {
                                         return;
                                     }
 
-                                    monado.passAppSurface(surface);
+                                    sendSurfaceIfNew(surface);
                                 }
                             } catch (RemoteException e) {
                                 e.printStackTrace();
@@ -277,7 +290,24 @@ public class Client implements ServiceConnection {
     }
 
     @Nullable private Surface attachViewAndGetSurface(Activity activity) {
-        MonadoView monadoView = MonadoView.attachToActivity(activity);
+        // Observe the surface lifecycle so a background→resume cycle (e.g. a SAF
+        // file picker) forwards the destroy + the NEW surface to the service —
+        // otherwise the service compositor keeps presenting into the abandoned
+        // BufferQueue and the panel freezes (#528).
+        monadoView =
+                MonadoView.attachToActivity(
+                        activity,
+                        new MonadoView.SurfaceStateListener() {
+                            @Override
+                            public void onSurfaceAvailable(SurfaceHolder holder) {
+                                sendSurfaceIfNew(holder.getSurface());
+                            }
+
+                            @Override
+                            public void onSurfaceDestroyed() {
+                                notifySurfaceLost();
+                            }
+                        });
         SurfaceHolder holder = monadoView.waitGetSurfaceHolder(2000);
         Surface surface = null;
         if (holder != null) {
@@ -285,6 +315,57 @@ public class Client implements ServiceConnection {
         }
 
         return surface;
+    }
+
+    /**
+     * Forward the surface to the service unless it is the one we already sent.
+     *
+     * <p>Identity dedupe is enough: a size-only surfaceChanged keeps the same Surface, and the
+     * service tracks extent changes itself by polling the surface caps each acquire (#510).
+     * Called from both the blockingConnect worker thread and the UI-thread surface callbacks.
+     */
+    private void sendSurfaceIfNew(@Nullable Surface surface) {
+        synchronized (surfaceSync) {
+            if (surface == null || !surface.isValid() || surface == lastSurfaceSent) {
+                return;
+            }
+            IMonado service = monado;
+            if (service == null) {
+                return;
+            }
+            try {
+                service.passAppSurface(surface);
+                lastSurfaceSent = surface;
+                Log.i(TAG, "passAppSurface: forwarded new surface to service (#528)");
+            } catch (RemoteException e) {
+                Log.e(TAG, "passAppSurface failed: " + e);
+            }
+        }
+    }
+
+    /**
+     * Tell the service the surface is gone so its compositor stops presenting into the dead
+     * BufferQueue and tears its VkSurfaceKHR down (#528).
+     *
+     * <p>Synchronous binder call on purpose: returning from surfaceDestroyed is what invalidates
+     * the surface, so the service's generation bump must land before that.
+     */
+    private void notifySurfaceLost() {
+        synchronized (surfaceSync) {
+            // Null first: guarantees the next available surface is re-sent even if
+            // the platform hands back the same Surface object on resume.
+            lastSurfaceSent = null;
+            IMonado service = monado;
+            if (service == null) {
+                return;
+            }
+            try {
+                service.clearAppSurface();
+                Log.i(TAG, "clearAppSurface: notified service of surface loss (#528)");
+            } catch (RemoteException e) {
+                Log.e(TAG, "clearAppSurface failed: " + e);
+            }
+        }
     }
 
     /**

--- a/src/xrt/ipc/android/src/main/java/org/freedesktop/monado/ipc/MonadoImpl.java
+++ b/src/xrt/ipc/android/src/main/java/org/freedesktop/monado/ipc/MonadoImpl.java
@@ -92,6 +92,12 @@ public class MonadoImpl extends IMonado.Stub {
         return Settings.canDrawOverlays(context);
     }
 
+    @Override
+    public void clearAppSurface() {
+        Log.i(TAG, "clearAppSurface");
+        nativeClearAppSurface();
+    }
+
     public void shutdown() {
         Log.i(TAG, "shutdown");
         nativeShutdownServer();
@@ -121,6 +127,17 @@ public class MonadoImpl extends IMonado.Stub {
      */
     @SuppressWarnings("JavaJniMissingFunction")
     private native void nativeAppSurface(@NonNull Surface surface);
+
+    /**
+     * Native handling of the client's surface being destroyed (background → file picker etc.):
+     * marks the published window invalid so the compositor tears its VkSurfaceKHR down instead of
+     * presenting into the dead BufferQueue (#528).
+     *
+     * <p>Ignore warnings that this function is missing: it is not, it is just in a different
+     * module. See `src/xrt/targets/service-lib/service_target.cpp` for the implementation.
+     */
+    @SuppressWarnings("JavaJniMissingFunction")
+    private native void nativeClearAppSurface();
 
     /**
      * Native handling of receiving an FD for a new client: the FD should be used to start up the

--- a/src/xrt/targets/service-lib/service_target.cpp
+++ b/src/xrt/targets/service-lib/service_target.cpp
@@ -181,7 +181,20 @@ Java_org_freedesktop_monado_ipc_MonadoImpl_nativeAppSurface(JNIEnv *env, jobject
 
 	ANativeWindow *nativeWindow = ANativeWindow_fromSurface(env, surface);
 	android_globals_store_window((struct _ANativeWindow *)nativeWindow);
-	U_LOG_D("Stored ANativeWindow: %p", (void *)nativeWindow);
+	U_LOG_I("service: app surface published: ANativeWindow %p (#528)", (void *)nativeWindow);
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_org_freedesktop_monado_ipc_MonadoImpl_nativeClearAppSurface(JNIEnv *env, jobject thiz)
+{
+	jni::init(env);
+	jni::Object monadoImpl(thiz);
+
+	// Mark the published window invalid + bump the generation; the compositor's
+	// per-acquire surface sync tears its VkSurfaceKHR down and pauses presents
+	// until the client passes the replacement surface (#528).
+	android_globals_clear_window();
+	U_LOG_I("service: app surface cleared (#528)");
 }
 
 extern "C" JNIEXPORT jint JNICALL


### PR DESCRIPTION
Fixes #528.

## Problem

After the client app backgrounds (SAF file picker, permission dialog, any sub-activity) and returns, the out-of-process compositor kept presenting into the client's **abandoned** ANativeWindow/BlastBufferQueue — 35k+ `BufferQueue has been abandoned` logcat lines, client stalled in `xrWaitFrame`, panel frozen until a client cold-restart. Root cause was two-sided:

1. **Client → service surface propagation was one-shot**: `Client.java` passed the Surface over binder once at connect and discarded the `MonadoView`; nothing forwarded `surfaceDestroyed` or the replacement surface (the #507 pull loop only runs in-process).
2. **The OOP present target never re-synced**: `comp_window_android` pulled the window once at init via the legacy getter; nothing consumed the versioned `android_globals` generation/valid state, and present-time errors were ignored.

## Fix (mirrors the proven in-process #507 pattern, end-to-end across binder)

- **MonadoView**: pure-Java `SurfaceStateListener` fired from the SurfaceHolder callbacks (no JNI registration — #507 found that unreliable across classloaders).
- **Client.java**: retains the view; `surfaceDestroyed` → new **`IMonado.clearAppSurface()`** (synchronous so the service's generation bump lands before the surface dies); new surfaces re-sent via `passAppSurface` with identity dedupe (size-only changes ride the existing #510 extent poll).
- **service_target**: `nativeClearAppSurface` → `android_globals_clear_window()`.
- **comp_target_swapchain**: per-acquire `android_surface_sync` — on generation change: `vkDeviceWaitIdle`, destroy views+swapchain+`VkSurfaceKHR`, release the tracked window ref; invalid → pause presents (`VK_ERROR_SURFACE_LOST_KHR`, throttled logs); valid new window → rebuild the surface and return `OUT_OF_DATE` so the existing `recreate_session_swapchain` machinery rebuilds the images (format kept, per 36b5d1994). Hardening: spontaneous `SURFACE_LOST` from caps query/acquire tears down the same way; a twice-failed rebuild gives up until the next generation (no hot recreate-fail loop).
- **comp_multi_system**: `SURFACE_LOST` is the quiet 'client backgrounded' steady state — skip the frame silently, keep retiring delivered frames (client pacing flows, `xrWaitFrame` never stalls); never run a recreate against a torn-down target; present-time `SURFACE_LOST` doesn't flag a recreate.
- **Session-end races** (exposed with the CNSDK DP whose teardown isn't instant): gate the lazy per-session re-init on `state.session_active`, and flip `session_active=false` at the **top** of `multi_compositor_end_session` under the render-thread lock — otherwise the render thread rebuilt the target mid-teardown (`VK_ERROR_NATIVE_WINDOW_IN_USE_KHR` storm).
- **DP cache across session end/begin (Android)**: `xrEndSession` no longer destroys the vendor display processor — CNSDK 0.10.x core release joins an internal leiaCore-impl thread that never exits (displayxr-leia-plugin#39, reproduced even with face tracking stopped first), which hung `end_session`, never sent the `session_end` IPC reply and deadlocked the client inside `xrEndSession` (black screen). The DP — and the command pool it borrowed at factory time — now ride across end→begin (DP creation also costs ~1 s of CNSDK init per picker cycle); `init_session_render` reuses the cached pair; the real destroy stays at client teardown. Pairs with the plug-in's weave-fb cache flush (displayxr-leia-plugin `c6a9ff8`).

## Validation (NP02J, OOP runtime via LAUNCHER, mediaplayer SAF picker)

**sim_display stack** — full end-to-end: picker round-trip ×2 (different files), home → relaunch, rapid churn; zero abandoned-BufferQueue lines (was 35k+); picked media plays at steady 20 fps; no client/service restarts.

**Leia CNSDK stack** — full end-to-end with the DP cache + plug-in fixes (post-v1.6.4 `909a546`+`c6a9ff8`): repeated picker round-trips play picked videos AND stereo LIFs, weaved, with face tracking live. User-confirmed on the panel.

Follow-ups: #535 (per-session target init races surface validity after rapid client restart), displayxr-leia-plugin#39 stays open for the CNSDK core-release join hang (now only reachable at client teardown).

Desktop builds unaffected (native changes Android-#ifdef'd or no-ops there; `comp_multi` compile-checked on macOS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)