### PR TITLE
fix(#521) + feat(#522): Android OOP 2D centering + MANAGED/MANUAL eye-tracking

### DIFF
--- a/src/xrt/compositor/d3d11/comp_d3d11_compositor.cpp
+++ b/src/xrt/compositor/d3d11/comp_d3d11_compositor.cpp
@@ -4145,6 +4145,20 @@ comp_d3d11_compositor_request_display_mode(struct xrt_compositor *xc, bool enabl
 }
 
 extern "C" void
+comp_d3d11_compositor_set_eye_tracking_mode(struct xrt_compositor *xc, uint32_t mode)
+{
+	if (xc == nullptr) {
+		return;
+	}
+
+	struct comp_d3d11_compositor *c = d3d11_comp(xc);
+
+	if (c->display_processor != nullptr) {
+		xrt_display_processor_d3d11_set_eye_tracking_mode(c->display_processor, mode);
+	}
+}
+
+extern "C" void
 comp_d3d11_compositor_set_system_devices(struct xrt_compositor *xc,
                                           struct xrt_system_devices *xsysd)
 {

--- a/src/xrt/compositor/d3d11/comp_d3d11_compositor.h
+++ b/src/xrt/compositor/d3d11/comp_d3d11_compositor.h
@@ -278,6 +278,19 @@ bool
 comp_d3d11_compositor_request_display_mode(struct xrt_compositor *xc, bool enable_3d);
 
 /*!
+ * Select the eye-tracking control mode (MANAGED=0 / MANUAL=1) on the display
+ * processor — the policy counterpart to @ref
+ * comp_d3d11_compositor_request_display_mode. No-op if the DP doesn't react.
+ *
+ * @param xc The compositor.
+ * @param mode 0 = MANAGED, 1 = MANUAL.
+ *
+ * @ingroup comp_d3d11
+ */
+void
+comp_d3d11_compositor_set_eye_tracking_mode(struct xrt_compositor *xc, uint32_t mode);
+
+/*!
  * Set the system devices for the debug GUI (needed for qwerty driver support).
  *
  * This should be called after creating the compositor when xsysd is available.

--- a/src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp
+++ b/src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp
@@ -2662,6 +2662,20 @@ comp_d3d12_compositor_request_display_mode(struct xrt_compositor *xc, bool enabl
 }
 
 extern "C" void
+comp_d3d12_compositor_set_eye_tracking_mode(struct xrt_compositor *xc, uint32_t mode)
+{
+	if (xc == nullptr) {
+		return;
+	}
+
+	struct comp_d3d12_compositor *c = d3d12_comp(xc);
+
+	if (c->display_processor != nullptr) {
+		xrt_display_processor_d3d12_set_eye_tracking_mode(c->display_processor, mode);
+	}
+}
+
+extern "C" void
 comp_d3d12_compositor_set_system_devices(struct xrt_compositor *xc,
                                           struct xrt_system_devices *xsysd)
 {

--- a/src/xrt/compositor/d3d12/comp_d3d12_compositor.h
+++ b/src/xrt/compositor/d3d12/comp_d3d12_compositor.h
@@ -120,6 +120,19 @@ bool
 comp_d3d12_compositor_request_display_mode(struct xrt_compositor *xc, bool enable_3d);
 
 /*!
+ * Select the eye-tracking control mode (MANAGED=0 / MANUAL=1) on the display
+ * processor — the policy counterpart to @ref
+ * comp_d3d12_compositor_request_display_mode. No-op if the DP doesn't react.
+ *
+ * @param xc The compositor.
+ * @param mode 0 = MANAGED, 1 = MANUAL.
+ *
+ * @ingroup comp_d3d12
+ */
+void
+comp_d3d12_compositor_set_eye_tracking_mode(struct xrt_compositor *xc, uint32_t mode);
+
+/*!
  * Set the system devices for the debug GUI (needed for qwerty driver support).
  *
  * @param xc The compositor.

--- a/src/xrt/compositor/gl/comp_gl_compositor.cpp
+++ b/src/xrt/compositor/gl/comp_gl_compositor.cpp
@@ -3392,6 +3392,20 @@ comp_gl_compositor_request_display_mode(struct xrt_compositor *xc, bool enable_3
 	return false;
 }
 
+void
+comp_gl_compositor_set_eye_tracking_mode(struct xrt_compositor *xc, uint32_t mode)
+{
+	if (xc == NULL) {
+		return;
+	}
+
+	struct comp_gl_compositor *c = gl_comp(xc);
+
+	if (c->display_processor != NULL) {
+		xrt_display_processor_gl_set_eye_tracking_mode(c->display_processor, mode);
+	}
+}
+
 bool
 comp_gl_compositor_get_predicted_eye_positions(struct xrt_compositor *xc,
                                                struct xrt_eye_positions *out_eye_pos)

--- a/src/xrt/compositor/gl/comp_gl_compositor.h
+++ b/src/xrt/compositor/gl/comp_gl_compositor.h
@@ -124,6 +124,19 @@ bool
 comp_gl_compositor_request_display_mode(struct xrt_compositor *xc, bool enable_3d);
 
 /*!
+ * Select the eye-tracking control mode (MANAGED=0 / MANUAL=1) on the GL display
+ * processor — the policy counterpart to @ref
+ * comp_gl_compositor_request_display_mode. No-op if the DP doesn't react.
+ *
+ * @param xc   GL compositor base.
+ * @param mode 0 = MANAGED, 1 = MANUAL.
+ *
+ * @ingroup comp_gl
+ */
+void
+comp_gl_compositor_set_eye_tracking_mode(struct xrt_compositor *xc, uint32_t mode);
+
+/*!
  * Get predicted eye positions from the GL display processor.
  *
  * @param xc            GL compositor base.

--- a/src/xrt/compositor/metal/comp_metal_compositor.h
+++ b/src/xrt/compositor/metal/comp_metal_compositor.h
@@ -234,6 +234,14 @@ bool
 comp_metal_compositor_request_display_mode(struct xrt_compositor *xc, bool enable_3d);
 
 /*!
+ * Select the eye-tracking control mode (MANAGED=0 / MANUAL=1) on the Metal
+ * display processor — the policy counterpart to @ref
+ * comp_metal_compositor_request_display_mode. No-op if the DP doesn't react.
+ */
+void
+comp_metal_compositor_set_eye_tracking_mode(struct xrt_compositor *xc, uint32_t mode);
+
+/*!
  * Set system devices for qwerty driver support.
  */
 void

--- a/src/xrt/compositor/metal/comp_metal_compositor.m
+++ b/src/xrt/compositor/metal/comp_metal_compositor.m
@@ -4068,6 +4068,17 @@ comp_metal_compositor_request_display_mode(struct xrt_compositor *xc, bool enabl
 }
 
 void
+comp_metal_compositor_set_eye_tracking_mode(struct xrt_compositor *xc, uint32_t mode)
+{
+	struct comp_metal_compositor *c = metal_comp(xc);
+	if (c->display_processor == NULL) {
+		return;
+	}
+	// Delegate to display processor (a no-op for sim_display, which has no tracking)
+	xrt_display_processor_metal_set_eye_tracking_mode(c->display_processor, mode);
+}
+
+void
 comp_metal_compositor_set_system_devices(struct xrt_compositor *xc,
                                          struct xrt_system_devices *xsysd)
 {

--- a/src/xrt/compositor/multi/comp_multi_compositor.c
+++ b/src/xrt/compositor/multi/comp_multi_compositor.c
@@ -1997,6 +1997,21 @@ multi_compositor_request_display_mode(struct multi_compositor *mc, bool enable_3
 	return false;
 }
 
+void
+multi_compositor_set_eye_tracking_mode(struct multi_compositor *mc, uint32_t mode)
+{
+	if (mc == NULL || !mc->session_render.initialized) {
+		return;
+	}
+
+	// Policy counterpart to multi_compositor_request_display_mode: tell the
+	// out-of-process DP whether the vendor (MANAGED) or the app (MANUAL) owns
+	// the tracking-loss lifecycle. No-op for DPs that don't react to the slot.
+	if (mc->session_render.display_processor != NULL) {
+		xrt_display_processor_set_eye_tracking_mode(mc->session_render.display_processor, mode);
+	}
+}
+
 xrt_result_t
 multi_compositor_create(struct multi_system_compositor *msc,
                         const struct xrt_session_info *xsi,

--- a/src/xrt/compositor/multi/comp_multi_private.h
+++ b/src/xrt/compositor/multi/comp_multi_private.h
@@ -672,6 +672,20 @@ multi_compositor_get_window_metrics(struct multi_compositor *mc, struct xrt_wind
 bool
 multi_compositor_request_display_mode(struct multi_compositor *mc, bool enable_3d);
 
+/*!
+ * Select the eye-tracking control mode (MANAGED=0 / MANUAL=1) on the
+ * out-of-process display processor — the policy counterpart to @ref
+ * multi_compositor_request_display_mode. No-op if the DP doesn't react.
+ *
+ * @param mc   The multi_compositor (must have per-session rendering initialized)
+ * @param mode 0 = MANAGED, 1 = MANUAL.
+ *
+ * @ingroup comp_multi
+ * @private @memberof multi_compositor
+ */
+void
+multi_compositor_set_eye_tracking_mode(struct multi_compositor *mc, uint32_t mode);
+
 
 #ifdef __cplusplus
 }

--- a/src/xrt/compositor/vk_native/comp_vk_native_compositor.c
+++ b/src/xrt/compositor/vk_native/comp_vk_native_compositor.c
@@ -3615,6 +3615,17 @@ comp_vk_native_compositor_request_display_mode(struct xrt_compositor *xc, bool e
 }
 
 void
+comp_vk_native_compositor_set_eye_tracking_mode(struct xrt_compositor *xc, uint32_t mode)
+{
+	if (xc == NULL) return;
+	struct comp_vk_native_compositor *c = vk_comp(xc);
+
+	if (c->display_processor != NULL) {
+		xrt_display_processor_set_eye_tracking_mode(c->display_processor, mode);
+	}
+}
+
+void
 comp_vk_native_compositor_set_system_devices(struct xrt_compositor *xc,
                                               struct xrt_system_devices *xsysd)
 {

--- a/src/xrt/compositor/vk_native/comp_vk_native_compositor.h
+++ b/src/xrt/compositor/vk_native/comp_vk_native_compositor.h
@@ -123,6 +123,19 @@ bool
 comp_vk_native_compositor_request_display_mode(struct xrt_compositor *xc, bool enable_3d);
 
 /*!
+ * Select the eye-tracking control mode (MANAGED=0 / MANUAL=1) on the display
+ * processor — the policy counterpart to @ref
+ * comp_vk_native_compositor_request_display_mode. No-op if the DP doesn't react.
+ *
+ * @param xc   The compositor.
+ * @param mode 0 = MANAGED, 1 = MANUAL.
+ *
+ * @ingroup comp_vk_native
+ */
+void
+comp_vk_native_compositor_set_eye_tracking_mode(struct xrt_compositor *xc, uint32_t mode);
+
+/*!
  * Set the system devices for the debug GUI (needed for qwerty driver support).
  *
  * @param xc The compositor.

--- a/src/xrt/include/xrt/xrt_display_processor.h
+++ b/src/xrt/include/xrt/xrt_display_processor.h
@@ -396,6 +396,35 @@ struct xrt_display_processor
 	                          uint32_t width,
 	                          uint32_t height);
 
+	/*!
+	 * Select the eye-tracking control mode this DP should enact
+	 * (MANAGED vs MANUAL — see @ref docs/specs/vendor/eye-tracking-modes.md).
+	 * This is the *policy* counterpart to @ref request_display_mode (an
+	 * imperative 2D/3D hardware command): it tells the vendor whether to own
+	 * the tracking-loss lifecycle on its side.
+	 *
+	 *   - mode 0 (MANAGED): the vendor SDK runs the grace period + collapse
+	 *     animation + auto 2D⇄3D switch on tracking loss/recovery; the app is
+	 *     passive and reads filtered positions + `isTracking`.
+	 *   - mode 1 (MANUAL): the vendor stands down (no animation, no auto-switch,
+	 *     reports `isTracking` immediately); the app drives 2D⇄3D itself via
+	 *     @ref request_display_mode / xrRequestDisplayRenderingModeEXT.
+	 *
+	 * The runtime only ever passes a mode the DP's plug-in advertised in
+	 * `xrt_plugin_display_info.supported_eye_tracking_modes`, and pushes the
+	 * advertised default once at session start. The runtime carries no
+	 * MANAGED/MANUAL assumption — a DP that supports only one mode (or none)
+	 * simply leaves this slot NULL or ignores the unsupported value.
+	 *
+	 * Optional — an absent slot (older plug-in `struct_size`) or NULL means the
+	 * DP doesn't react to mode selection. Appended at the end per ADR-020
+	 * (append-only within a major; no version bump — gated by @ref XRT_DP_HAS_SLOT).
+	 *
+	 * @param xdp   Pointer to self.
+	 * @param mode  0 = MANAGED, 1 = MANUAL.
+	 */
+	void (*set_eye_tracking_mode)(struct xrt_display_processor *xdp, uint32_t mode);
+
 	/*! @} */
 };
 
@@ -470,7 +499,8 @@ XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, get_handoff_color_capab
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, set_atlas_encoding)            == XRT_DP_BASE_OFF + 15 * sizeof(void *), XRT_DP_ABI_MSG);
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, set_target_color_view)        == XRT_DP_BASE_OFF + 16 * sizeof(void *), XRT_DP_ABI_MSG);
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, set_background_2d)             == XRT_DP_BASE_OFF + 17 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(sizeof(struct xrt_display_processor)                                 == XRT_DP_BASE_OFF + 18 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, set_eye_tracking_mode)         == XRT_DP_BASE_OFF + 18 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(sizeof(struct xrt_display_processor)                                 == XRT_DP_BASE_OFF + 19 * sizeof(void *), XRT_DP_ABI_MSG);
 // clang-format on
 
 /*!
@@ -776,6 +806,23 @@ xrt_display_processor_set_background_2d(struct xrt_display_processor *xdp,
 		return;
 	}
 	xdp->set_background_2d(xdp, background_view, width, height);
+}
+
+/*!
+ * @copydoc xrt_display_processor::set_eye_tracking_mode
+ *
+ * No-op when the DP doesn't expose the slot (older plug-in) or leaves it NULL —
+ * the DP then doesn't react to the app's MANAGED/MANUAL selection.
+ *
+ * @public @memberof xrt_display_processor
+ */
+static inline void
+xrt_display_processor_set_eye_tracking_mode(struct xrt_display_processor *xdp, uint32_t mode)
+{
+	if (!XRT_DP_HAS_SLOT(xdp, set_eye_tracking_mode) || xdp->set_eye_tracking_mode == NULL) {
+		return;
+	}
+	xdp->set_eye_tracking_mode(xdp, mode);
 }
 
 /*!

--- a/src/xrt/include/xrt/xrt_display_processor_d3d11.h
+++ b/src/xrt/include/xrt/xrt_display_processor_d3d11.h
@@ -294,6 +294,18 @@ struct xrt_display_processor_d3d11
 	                          void *background_srv,
 	                          uint32_t width,
 	                          uint32_t height);
+
+	/*!
+	 * Select the eye-tracking control mode (MANAGED=0 / MANUAL=1) — the policy
+	 * counterpart to @ref request_display_mode. See the base
+	 * @ref xrt_display_processor::set_eye_tracking_mode and
+	 * docs/specs/vendor/eye-tracking-modes.md. Optional — absent slot or NULL
+	 * means the DP doesn't react. Appended per ADR-020 (append-only).
+	 *
+	 * @param xdp   Pointer to self.
+	 * @param mode  0 = MANAGED, 1 = MANUAL.
+	 */
+	void (*set_eye_tracking_mode)(struct xrt_display_processor_d3d11 *xdp, uint32_t mode);
 };
 
 /*
@@ -343,7 +355,8 @@ XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, get_local_zone_ca
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, publish_local_zone_mask)      == XRT_DP_D3D11_BASE_OFF + 13 * sizeof(void *), XRT_DP_ABI_MSG);
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, clear_local_zone_mask)        == XRT_DP_D3D11_BASE_OFF + 14 * sizeof(void *), XRT_DP_ABI_MSG);
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, set_background_2d)            == XRT_DP_D3D11_BASE_OFF + 15 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(sizeof(struct xrt_display_processor_d3d11)                                == XRT_DP_D3D11_BASE_OFF + 16 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, set_eye_tracking_mode)        == XRT_DP_D3D11_BASE_OFF + 16 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(sizeof(struct xrt_display_processor_d3d11)                                == XRT_DP_D3D11_BASE_OFF + 17 * sizeof(void *), XRT_DP_ABI_MSG);
 // clang-format on
 
 /*!
@@ -595,6 +608,20 @@ xrt_display_processor_d3d11_set_background_2d(struct xrt_display_processor_d3d11
 		return;
 	}
 	xdp->set_background_2d(xdp, background_srv, width, height);
+}
+
+/*!
+ * @copydoc xrt_display_processor_d3d11::set_eye_tracking_mode
+ * No-op when the DP doesn't expose the slot (older plug-in) or leaves it NULL.
+ * @public @memberof xrt_display_processor_d3d11
+ */
+static inline void
+xrt_display_processor_d3d11_set_eye_tracking_mode(struct xrt_display_processor_d3d11 *xdp, uint32_t mode)
+{
+	if (!XRT_DP_HAS_SLOT(xdp, set_eye_tracking_mode) || xdp->set_eye_tracking_mode == NULL) {
+		return;
+	}
+	xdp->set_eye_tracking_mode(xdp, mode);
 }
 
 /*!

--- a/src/xrt/include/xrt/xrt_display_processor_d3d12.h
+++ b/src/xrt/include/xrt/xrt_display_processor_d3d12.h
@@ -226,6 +226,18 @@ struct xrt_display_processor_d3d12
 	                          void *background_resource,
 	                          uint32_t width,
 	                          uint32_t height);
+
+	/*!
+	 * Select the eye-tracking control mode (MANAGED=0 / MANUAL=1) — the policy
+	 * counterpart to @ref request_display_mode. See the base
+	 * @ref xrt_display_processor::set_eye_tracking_mode and
+	 * docs/specs/vendor/eye-tracking-modes.md. Optional — absent slot or NULL
+	 * means the DP doesn't react. Appended per ADR-020 (append-only).
+	 *
+	 * @param xdp   Pointer to self.
+	 * @param mode  0 = MANAGED, 1 = MANUAL.
+	 */
+	void (*set_eye_tracking_mode)(struct xrt_display_processor_d3d12 *xdp, uint32_t mode);
 };
 
 /*
@@ -272,7 +284,8 @@ XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d12, destroy)         
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d12, get_handoff_color_capability) == XRT_DP_D3D12_BASE_OFF + 11 * sizeof(void *), XRT_DP_ABI_MSG);
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d12, set_atlas_encoding)           == XRT_DP_D3D12_BASE_OFF + 12 * sizeof(void *), XRT_DP_ABI_MSG);
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d12, set_background_2d)            == XRT_DP_D3D12_BASE_OFF + 13 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(sizeof(struct xrt_display_processor_d3d12)                                == XRT_DP_D3D12_BASE_OFF + 14 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d12, set_eye_tracking_mode)        == XRT_DP_D3D12_BASE_OFF + 14 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(sizeof(struct xrt_display_processor_d3d12)                                == XRT_DP_D3D12_BASE_OFF + 15 * sizeof(void *), XRT_DP_ABI_MSG);
 // clang-format on
 
 /*!
@@ -488,6 +501,20 @@ xrt_display_processor_d3d12_set_background_2d(struct xrt_display_processor_d3d12
 		return;
 	}
 	xdp->set_background_2d(xdp, background_resource, width, height);
+}
+
+/*!
+ * @copydoc xrt_display_processor_d3d12::set_eye_tracking_mode
+ * No-op when the DP doesn't expose the slot (older plug-in) or leaves it NULL.
+ * @public @memberof xrt_display_processor_d3d12
+ */
+static inline void
+xrt_display_processor_d3d12_set_eye_tracking_mode(struct xrt_display_processor_d3d12 *xdp, uint32_t mode)
+{
+	if (!XRT_DP_HAS_SLOT(xdp, set_eye_tracking_mode) || xdp->set_eye_tracking_mode == NULL) {
+		return;
+	}
+	xdp->set_eye_tracking_mode(xdp, mode);
 }
 
 /*!

--- a/src/xrt/include/xrt/xrt_display_processor_gl.h
+++ b/src/xrt/include/xrt/xrt_display_processor_gl.h
@@ -207,6 +207,18 @@ struct xrt_display_processor_gl
 	                          uint32_t background_tex,
 	                          uint32_t width,
 	                          uint32_t height);
+
+	/*!
+	 * Select the eye-tracking control mode (MANAGED=0 / MANUAL=1) — the policy
+	 * counterpart to @ref request_display_mode. See the base
+	 * @ref xrt_display_processor::set_eye_tracking_mode and
+	 * docs/specs/vendor/eye-tracking-modes.md. Optional — absent slot or NULL
+	 * means the DP doesn't react. Appended per ADR-020 (append-only).
+	 *
+	 * @param xdp   Pointer to self.
+	 * @param mode  0 = MANAGED, 1 = MANUAL.
+	 */
+	void (*set_eye_tracking_mode)(struct xrt_display_processor_gl *xdp, uint32_t mode);
 };
 
 /*
@@ -251,7 +263,8 @@ XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_gl, destroy)            
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_gl, get_handoff_color_capability) == XRT_DP_GL_BASE_OFF + 10 * sizeof(void *), XRT_DP_ABI_MSG);
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_gl, set_atlas_encoding)           == XRT_DP_GL_BASE_OFF + 11 * sizeof(void *), XRT_DP_ABI_MSG);
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_gl, set_background_2d)            == XRT_DP_GL_BASE_OFF + 12 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(sizeof(struct xrt_display_processor_gl)                                == XRT_DP_GL_BASE_OFF + 13 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_gl, set_eye_tracking_mode)        == XRT_DP_GL_BASE_OFF + 13 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(sizeof(struct xrt_display_processor_gl)                                == XRT_DP_GL_BASE_OFF + 14 * sizeof(void *), XRT_DP_ABI_MSG);
 // clang-format on
 
 /*!
@@ -448,6 +461,20 @@ xrt_display_processor_gl_set_background_2d(struct xrt_display_processor_gl *xdp,
 		return;
 	}
 	xdp->set_background_2d(xdp, background_tex, width, height);
+}
+
+/*!
+ * @copydoc xrt_display_processor_gl::set_eye_tracking_mode
+ * No-op when the DP doesn't expose the slot (older plug-in) or leaves it NULL.
+ * @public @memberof xrt_display_processor_gl
+ */
+static inline void
+xrt_display_processor_gl_set_eye_tracking_mode(struct xrt_display_processor_gl *xdp, uint32_t mode)
+{
+	if (!XRT_DP_HAS_SLOT(xdp, set_eye_tracking_mode) || xdp->set_eye_tracking_mode == NULL) {
+		return;
+	}
+	xdp->set_eye_tracking_mode(xdp, mode);
 }
 
 /*!

--- a/src/xrt/include/xrt/xrt_display_processor_metal.h
+++ b/src/xrt/include/xrt/xrt_display_processor_metal.h
@@ -207,6 +207,18 @@ struct xrt_display_processor_metal
 	                          void *background_texture,
 	                          uint32_t width,
 	                          uint32_t height);
+
+	/*!
+	 * Select the eye-tracking control mode (MANAGED=0 / MANUAL=1) — the policy
+	 * counterpart to @ref request_display_mode. See the base
+	 * @ref xrt_display_processor::set_eye_tracking_mode and
+	 * docs/specs/vendor/eye-tracking-modes.md. Optional — absent slot or NULL
+	 * means the DP doesn't react. Appended per ADR-020 (append-only).
+	 *
+	 * @param xdp   Pointer to self.
+	 * @param mode  0 = MANAGED, 1 = MANUAL.
+	 */
+	void (*set_eye_tracking_mode)(struct xrt_display_processor_metal *xdp, uint32_t mode);
 };
 
 /*
@@ -251,7 +263,8 @@ XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_metal, destroy)         
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_metal, get_handoff_color_capability) == XRT_DP_METAL_BASE_OFF + 10 * sizeof(void *), XRT_DP_ABI_MSG);
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_metal, set_atlas_encoding)           == XRT_DP_METAL_BASE_OFF + 11 * sizeof(void *), XRT_DP_ABI_MSG);
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_metal, set_background_2d)            == XRT_DP_METAL_BASE_OFF + 12 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(sizeof(struct xrt_display_processor_metal)                                == XRT_DP_METAL_BASE_OFF + 13 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_metal, set_eye_tracking_mode)        == XRT_DP_METAL_BASE_OFF + 13 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(sizeof(struct xrt_display_processor_metal)                                == XRT_DP_METAL_BASE_OFF + 14 * sizeof(void *), XRT_DP_ABI_MSG);
 // clang-format on
 
 /*!
@@ -450,6 +463,20 @@ xrt_display_processor_metal_set_background_2d(struct xrt_display_processor_metal
 		return;
 	}
 	xdp->set_background_2d(xdp, background_texture, width, height);
+}
+
+/*!
+ * @copydoc xrt_display_processor_metal::set_eye_tracking_mode
+ * No-op when the DP doesn't expose the slot (older plug-in) or leaves it NULL.
+ * @public @memberof xrt_display_processor_metal
+ */
+static inline void
+xrt_display_processor_metal_set_eye_tracking_mode(struct xrt_display_processor_metal *xdp, uint32_t mode)
+{
+	if (!XRT_DP_HAS_SLOT(xdp, set_eye_tracking_mode) || xdp->set_eye_tracking_mode == NULL) {
+		return;
+	}
+	xdp->set_eye_tracking_mode(xdp, mode);
 }
 
 /*!

--- a/src/xrt/ipc/client/ipc_client_compositor.c
+++ b/src/xrt/ipc/client/ipc_client_compositor.c
@@ -218,6 +218,28 @@ comp_ipc_client_compositor_get_window_metrics(struct xrt_compositor *xc, struct 
 }
 
 /*
+ * Push the session's eye-tracking control mode (MANAGED=0 / MANUAL=1) to the
+ * out-of-process display processor (#522). Same gating contract as
+ * comp_ipc_client_compositor_get_window_metrics: only call when `xc` is an
+ * ipc_client_compositor (the OpenXR state tracker gates on is_service_mode &&
+ * !is_*_native_compositor). Best-effort — no-op on IPC failure.
+ */
+void
+comp_ipc_client_compositor_set_eye_tracking_mode(struct xrt_compositor *xc, uint32_t mode)
+{
+	if (xc == NULL) {
+		return;
+	}
+
+	struct ipc_client_compositor *icc = ipc_client_compositor(xc);
+	if (icc == NULL || icc->ipc_c == NULL) {
+		return;
+	}
+
+	(void)ipc_call_compositor_set_eye_tracking_mode(icc->ipc_c, mode);
+}
+
+/*
  * Full DP eye-position struct incl. is_tracking, over IPC (#441 Phase 2).
  * Same gating contract as comp_ipc_client_compositor_get_window_metrics:
  * only safe to call when `xc` is an ipc_client_compositor (the OpenXR state

--- a/src/xrt/ipc/server/ipc_server_handler.c
+++ b/src/xrt/ipc/server/ipc_server_handler.c
@@ -859,13 +859,26 @@ ipc_try_get_android_view_poses(volatile struct ipc_client_state *ics,
 		head_eyes[1] = (struct xrt_vec3){nx + ipd * 0.5f, ny, nz};
 	}
 
-	// Render input. 2D / mono (view_count == 1): collapse to a CENTERED eye so
-	// the off-axis frustum is symmetric (no off-center crop). 3D: per-eye
-	// off-axis. Gate on the active mode's view_count directly (the cube is an
-	// extension app, so the in-process legacy_app_tile_scaling gate doesn't apply).
+	// Render input. 2D / mono: collapse to a CENTERED eye so the off-axis frustum
+	// is symmetric (no off-center crop / parallax shift). 3D: per-eye off-axis.
+	//
+	// #521: the gate must be the ACTIVE RENDERING MODE's view_count, NOT the
+	// locate's `view_count` param. An extension app locates against its stereo
+	// view-config (always 2 views) and merely *submits* 1 in 2D mode — so
+	// `view_count` stays 2 even in 2D. Gating on it left views[0] as the off-axis
+	// LEFT eye, which the app then presented as its mono 2D image → the cube
+	// rendered shifted. The server head device's active_rendering_mode_index is
+	// NOT reliable in OOP (OUTPUT_MODE doesn't cross IPC), so the client forwards
+	// the active mode's view count in rig->render_view_count. Fall back to the
+	// located view_count when unset (0).
+	uint32_t active_view_count = view_count;
+	if (rig != NULL && rig->render_view_count > 0) {
+		active_view_count = rig->render_view_count;
+	}
+
 	struct xrt_vec3 raw_eyes[XRT_MAX_VIEWS] = {0};
 	uint32_t eye_count;
-	if (view_count == 1) {
+	if (active_view_count == 1) {
 		raw_eyes[0] = (struct xrt_vec3){
 		    0.5f * (head_eyes[0].x + head_eyes[1].x),
 		    0.5f * (head_eyes[0].y + head_eyes[1].y),

--- a/src/xrt/ipc/server/ipc_server_handler.c
+++ b/src/xrt/ipc/server/ipc_server_handler.c
@@ -2125,6 +2125,31 @@ ipc_handle_compositor_request_display_refresh_rate(volatile struct ipc_client_st
 }
 
 xrt_result_t
+ipc_handle_compositor_set_eye_tracking_mode(volatile struct ipc_client_state *ics, uint32_t mode)
+{
+	IPC_TRACE_MARKER();
+
+	if (ics->xc == NULL) {
+		return XRT_ERROR_IPC_SESSION_NOT_CREATED;
+	}
+
+	// Per-session DP policy (MANAGED/MANUAL). The out-of-process per-client
+	// compositor is a multi_compositor; forward to its DP. Only the Android
+	// null+comp_multi service reaches the DP this way (#510/#522); on the
+	// Windows D3D11 service the workspace owns mode and the in-process native
+	// path handles handle apps, so this is a no-op there.
+#ifdef XRT_OS_ANDROID
+	struct multi_compositor *mc = multi_compositor((struct xrt_compositor *)ics->xc);
+	if (mc != NULL) {
+		multi_compositor_set_eye_tracking_mode(mc, mode);
+	}
+#else
+	(void)mode;
+#endif
+	return XRT_SUCCESS;
+}
+
+xrt_result_t
 ipc_handle_compositor_set_performance_level(volatile struct ipc_client_state *ics,
                                             enum xrt_perf_domain domain,
                                             enum xrt_perf_set_level level)

--- a/src/xrt/ipc/shared/ipc_protocol.h
+++ b/src/xrt/ipc/shared/ipc_protocol.h
@@ -756,6 +756,13 @@ struct ipc_view_rig_info
 	float half_tan_vfov;            //!< Camera rig only
 	float ipd_factor;               //!< Both rigs
 	float parallax_factor;          //!< Both rigs
+	//! Active rendering mode's view count (1 = mono/2D, 2 = stereo/3D). #521:
+	//! the located view_count is the app's stereo view-config (always 2) and does
+	//! NOT drop to 1 in 2D mode; OUTPUT_MODE doesn't cross IPC, so the server
+	//! can't read the mode from the head device. The client (which owns the
+	//! active mode) forwards it here so the server collapses to a centered eye in
+	//! 2D. 0 = unknown → server falls back to the located view_count.
+	uint32_t render_view_count;
 };
 
 /*!

--- a/src/xrt/ipc/shared/proto.json
+++ b/src/xrt/ipc/shared/proto.json
@@ -565,6 +565,12 @@
 		]
 	},
 
+	"compositor_set_eye_tracking_mode": {
+		"in": [
+			{"name": "mode", "type": "uint32_t"}
+		]
+	},
+
 	"compositor_get_reference_bounds_rect": {
 		"in": [
 			{"name": "reference_space_type", "type": "enum xrt_reference_space_type"}

--- a/src/xrt/state_trackers/oxr/oxr_api_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_api_session.c
@@ -1359,7 +1359,19 @@ oxr_xrRequestEyeTrackingModeEXT(XrSession session, XrEyeTrackingModeEXT mode)
 		                 "Eye tracking mode %d not supported by this system", (int)mode);
 	}
 
+	// Store the session preference unconditionally (spec: it stays latent until
+	// honored — XrViewEyeTrackingStateEXT.activeMode keeps reporting it).
 	sess->eye_tracking_mode = (uint32_t)mode;
+
+	// Push the selection to the display processor, but only when this session
+	// has authority to drive global vendor policy: in single-app out-of-process
+	// (no workspace controller) the lone app owns it; under a workspace only the
+	// active controller does. Mirrors the #518 display-mode authority gate.
+	bool workspace_gated =
+	    sess->sys->inst->workspace_controller_active && !sess->is_active_workspace_controller;
+	if (!workspace_gated) {
+		oxr_session_set_eye_tracking_mode(sess, (uint32_t)mode);
+	}
 	return XR_SUCCESS;
 }
 

--- a/src/xrt/state_trackers/oxr/oxr_objects.h
+++ b/src/xrt/state_trackers/oxr/oxr_objects.h
@@ -931,6 +931,15 @@ oxr_session_request_exit(struct oxr_logger *log, struct oxr_session *sess);
  */
 XrResult
 oxr_session_request_display_mode(struct oxr_logger *log, struct oxr_session *sess, bool enable_3d);
+
+/*!
+ * Push the session's eye-tracking control mode (MANAGED=0 / MANUAL=1) to the
+ * display processor (#522). Best-effort policy hint; the DP enacts whatever the
+ * vendor advertised. Routed in-process via the native compositor or
+ * out-of-process via IPC to the server DP.
+ */
+void
+oxr_session_set_eye_tracking_mode(struct oxr_session *sess, uint32_t mode);
 #endif
 
 #ifdef OXR_HAVE_EXT_view_rig

--- a/src/xrt/state_trackers/oxr/oxr_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_session.c
@@ -1944,6 +1944,18 @@ oxr_session_locate_views(struct oxr_logger *log,
 			rig_info.parallax_factor = sess->view_rig.parallax_factor;
 		}
 
+		// #521: forward the ACTIVE rendering mode's view count (1 = mono/2D,
+		// 2 = stereo/3D). The located view_count is always the stereo view-config
+		// count and OUTPUT_MODE doesn't cross IPC, so this is how the server learns
+		// the app is in 2D and collapses to a centered eye. The client head proxy's
+		// active_rendering_mode_index is kept current by xrRequestDisplayRenderingModeEXT.
+		rig_info.render_view_count = 0;
+		if (xdev != NULL && xdev->hmd != NULL && xdev->rendering_mode_count > 0 &&
+		    xdev->hmd->active_rendering_mode_index < xdev->rendering_mode_count) {
+			rig_info.render_view_count =
+			    xdev->rendering_modes[xdev->hmd->active_rendering_mode_index].view_count;
+		}
+
 		uint32_t wire_views = (view_count < XRT_MAX_VIEWS) ? view_count : XRT_MAX_VIEWS;
 		struct ipc_info_locate_views_rig reply = {0};
 		xrt_result_t xret =

--- a/src/xrt/state_trackers/oxr/oxr_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_session.c
@@ -114,6 +114,11 @@ bool
 comp_ipc_client_compositor_get_predicted_eye_positions(struct xrt_compositor *xc,
                                                        struct xrt_eye_positions *out_eyes);
 
+// IPC-client eye-tracking-mode push to the out-of-process DP (#522) — same
+// linkage pattern as above. Best-effort; no-op on IPC failure.
+void
+comp_ipc_client_compositor_set_eye_tracking_mode(struct xrt_compositor *xc, uint32_t mode);
+
 // Same fetch via the SYSTEM compositor (#449) for compositor-less sessions
 // (headless XR_MND_headless clients like the WebXR bridge, which have no
 // xcn). Same linkage pattern as above.
@@ -452,6 +457,66 @@ oxr_session_request_display_mode(struct oxr_logger *log, struct oxr_session *ses
 
 	(void)success;
 	return XR_SUCCESS;
+}
+
+void
+oxr_session_set_eye_tracking_mode(struct oxr_session *sess, uint32_t mode)
+{
+	if (sess == NULL || sess->xcn == NULL) {
+		return;
+	}
+
+	// Policy push to the display processor (MANAGED=0 / MANUAL=1), mirroring the
+	// oxr_session_request_display_mode dispatch. The DP enacts whatever the
+	// vendor advertised; the runtime carries no MANAGED/MANUAL assumption.
+#ifdef XRT_HAVE_D3D11_NATIVE_COMPOSITOR
+	if (sess->is_d3d11_native_compositor) {
+		comp_d3d11_compositor_set_eye_tracking_mode(&sess->xcn->base, mode);
+		return;
+	}
+#endif
+
+#ifdef XRT_HAVE_D3D12_NATIVE_COMPOSITOR
+	if (sess->is_d3d12_native_compositor) {
+		comp_d3d12_compositor_set_eye_tracking_mode(&sess->xcn->base, mode);
+		return;
+	}
+#endif
+
+#ifdef XRT_HAVE_METAL_NATIVE_COMPOSITOR
+	if (sess->is_metal_native_compositor) {
+		comp_metal_compositor_set_eye_tracking_mode(&sess->xcn->base, mode);
+		return;
+	}
+#endif
+
+#ifdef XRT_HAVE_GL_NATIVE_COMPOSITOR
+	if (sess->is_gl_native_compositor) {
+		comp_gl_compositor_set_eye_tracking_mode(&sess->xcn->base, mode);
+		return;
+	}
+#endif
+
+#ifdef XRT_HAVE_VK_NATIVE_COMPOSITOR
+	if (sess->is_vk_native_compositor) {
+		comp_vk_native_compositor_set_eye_tracking_mode(&sess->xcn->base, mode);
+		return;
+	}
+#endif
+
+	// In-process multi compositor path (not used for IPC clients).
+	if (sess->sys->xsysc != NULL && sess->sys->xsysc->xmcc != NULL) {
+		struct multi_compositor *mc = multi_compositor(&sess->xcn->base);
+		multi_compositor_set_eye_tracking_mode(mc, mode);
+		return;
+	}
+
+	// Out-of-process IPC client (single-app OOP Android, #522): the per-client
+	// compositor is an ipc_client_compositor; push the mode to the server DP
+	// over IPC. Bridge-relay sessions forward eyes to the browser and own no DP.
+	if (!sess->is_bridge_relay) {
+		comp_ipc_client_compositor_set_eye_tracking_mode(&sess->xcn->base, mode);
+	}
 }
 #endif // OXR_HAVE_EXT_display_info
 
@@ -2638,7 +2703,11 @@ oxr_session_allocate_and_init(struct oxr_logger *log,
 	sess->frame_timing_wait_sleep_ms = debug_get_num_option_wait_frame_sleep();
 
 #ifdef OXR_HAVE_EXT_display_info
-	// Initialize eye tracking mode from driver's default
+	// Initialize eye tracking mode from driver's default. We do NOT push this to
+	// the DP here: out-of-process the DP is created lazily on the first frame, so
+	// a push now would no-op. The DP self-initializes to the same advertised
+	// default (the vendor owns it); the runtime only pushes on an explicit
+	// xrRequestEyeTrackingModeEXT (#522, oxr_session_set_eye_tracking_mode).
 	if (sys->xsysc) {
 		sess->eye_tracking_mode = sys->xsysc->info.default_eye_tracking_mode;
 	}

--- a/src/xrt/targets/openxr_android/build.gradle
+++ b/src/xrt/targets/openxr_android/build.gradle
@@ -261,6 +261,15 @@ android {
             if (project.hasProperty('dxrForceVendoredCjson')) {
                 cmake.arguments "-DCMAKE_DISABLE_FIND_PACKAGE_cJSON=ON"
             }
+
+            // Dev override: build the Kooima math (displayxr-common) from a local
+            // checkout instead of the pinned GIT_TAG, for iterating on the shared
+            // core (e.g. #521). Pass -PdxrCommonSrc=/abs/path/to/displayxr-common.
+            // CMake's FetchContent honors FETCHCONTENT_SOURCE_DIR_<name> to swap
+            // the fetched source for a local dir. No effect when unset.
+            if (project.hasProperty('dxrCommonSrc')) {
+                cmake.arguments "-DFETCHCONTENT_SOURCE_DIR_DISPLAYXR_COMMON=${project.dxrCommonSrc}"
+            }
         }
 
         // Be sure to copy over licenses formatted as required.

--- a/test_apps/cube_handle_vk_android/src/main/cpp/main.cpp
+++ b/test_apps/cube_handle_vk_android/src/main/cpp/main.cpp
@@ -191,6 +191,8 @@ AAssetManager *g_asset_manager = nullptr;
 // XR_EXT_display_info entry points (resolved after the session exists).
 PFN_xrEnumerateDisplayRenderingModesEXT g_pfnEnumModes = nullptr;
 PFN_xrRequestDisplayRenderingModeEXT g_pfnRequestMode = nullptr;
+// #522 test hook: select MANAGED/MANUAL via `setprop debug.dxr.eyemode N`.
+PFN_xrRequestEyeTrackingModeEXT g_pfnRequestEyeMode = nullptr;
 
 // Single tiled-atlas swapchain shared by all views. Each view writes into its
 // tile via a viewport/scissor offset inside one render pass; xrEndFrame submits
@@ -789,6 +791,8 @@ query_display_info_and_modes()
 		                      reinterpret_cast<PFN_xrVoidFunction *>(&g_pfnEnumModes));
 		xrGetInstanceProcAddr(g_instance, "xrRequestDisplayRenderingModeEXT",
 		                      reinterpret_cast<PFN_xrVoidFunction *>(&g_pfnRequestMode));
+		xrGetInstanceProcAddr(g_instance, "xrRequestEyeTrackingModeEXT",
+		                      reinterpret_cast<PFN_xrVoidFunction *>(&g_pfnRequestEyeMode));
 	}
 
 	// Enumerate rendering modes (view counts, tile layouts, scales). The
@@ -2208,6 +2212,19 @@ render_frame()
 		if (want >= 0 && want != last_prop_mode) {
 			last_prop_mode = want;
 			request_mode((uint32_t)want);
+		}
+	}
+
+	// #522 test hook: eye-tracking mode via adb:
+	//   `setprop debug.dxr.eyemode 0` → MANAGED (vendor auto-2D on tracking loss)
+	//   `setprop debug.dxr.eyemode 1` → MANUAL  (app owns 2D⇄3D; immediate isTracking)
+	{
+		static int last_eyemode = -1;
+		int want = (int)get_prop_float("debug.dxr.eyemode", -1.0f);
+		if (want >= 0 && want != last_eyemode && g_pfnRequestEyeMode != nullptr) {
+			last_eyemode = want;
+			XrResult r = g_pfnRequestEyeMode(g_session, (XrEyeTrackingModeEXT)want);
+			log_xr_result("xrRequestEyeTrackingModeEXT", r);
 		}
 	}
 


### PR DESCRIPTION
Two Android out-of-process follow-ups from DisplayXR/displayxr-runtime#518, validated on the nubia NP02J.

## DisplayXR/displayxr-leia-plugin#90 — MANAGED/MANUAL eye-tracking modes (vendor-neutral)
- New **optional DP vtable method** `set_eye_tracking_mode` on the base + all 4 per-API `xrt_display_processor_*` structs, appended with `XRT_DP_HAS_SLOT` gating — **no ABI major bump** (ADR-020 append-only). Wrappers no-op when the slot is absent/NULL.
- oxr propagation (`oxr_session_set_eye_tracking_mode`) mirroring `oxr_session_request_display_mode`: per-API native compositor in-process; `multi_compositor` + a new per-session IPC call (`compositor_set_eye_tracking_mode`) for single-app OOP. Push gated by the DisplayXR/displayxr-runtime#518 controller rule; store always (spec). The DP self-initialises to the advertised default.
- Compositor pass-throughs for all 5 native compositors + multi.
- The runtime carries **no MANAGED/MANUAL assumption** — it validates against the vendor's advertised bits and transports the selection; the DP enacts what the vendor supports (MANAGED-only / MANUAL-only / both).
- Cube `debug.dxr.eyemode 0|1` test hook.

**Validated on nubia:** MANAGED → panel auto-2D on face removal; MANUAL → stays 3D, app owns it. Full oxr→IPC→DP→plugin chain traced.

## DisplayXR/displayxr-runtime#521 — 2D single-view X-shift
In 2D the server handed back the off-axis **left eye** as `views[0]`, which the app presented as its mono image → shifted. Root cause: the collapse gate used the *located* `view_count` (always 2 for the stereo view-config); the 2D-ness lives in the active rendering mode, and the server head device's `active_rendering_mode_index` is unreliable in OOP (OUTPUT_MODE doesn't cross IPC). Fix: the client forwards the active mode's view count in a new `ipc_view_rig_info.render_view_count`; the server gates the centered-eye collapse on it. **The displayxr-common Kooima math was correct throughout — no common change.** Also adds a `-PdxrCommonSrc` dev knob.

**Validated on nubia:** 2D renders centered + symmetric (`eye_display.x=0`, fov `L=-R`); 3D unchanged (per-eye off-axis).

## Companion
- Plugin PR: DisplayXR/displayxr-leia-plugin (advertise + honor MANAGED/MANUAL).

## Follow-ups (separate session)
- DisplayXR/displayxr-runtime#532 (2D vertical offset), DisplayXR/displayxr-runtime#533 (2D intermittent 2× zoom), leia-plugin#40 (MANAGED eye→nominal collapse on loss).

🤖 Generated with [Claude Code](https://claude.com/claude-code)