### PR TITLE
fix(extensions): resolve XrStructureType value collisions + allocation registry

### DIFF
--- a/docs/roadmap/unified-2d-3d-crossapi-impl.md
+++ b/docs/roadmap/unified-2d-3d-crossapi-impl.md
@@ -22,11 +22,11 @@
 
 ### 2.1 Header v2 — `XR_EXT_local_3d_zone.h`, SPEC_VERSION 2
 
-Two new Tier-3 binding structs (model: the D3D11 one at type `...132`):
+Two new Tier-3 binding structs (model: the D3D11 one at type `...162`):
 
 ```c
-#define XR_TYPE_LOCAL_3D_ZONE_RENDER_TARGET_D3D12_EXT  ((XrStructureType)1000999133)
-#define XR_TYPE_LOCAL_3D_ZONE_RENDER_TARGET_VULKAN_EXT ((XrStructureType)1000999134)
+#define XR_TYPE_LOCAL_3D_ZONE_RENDER_TARGET_D3D12_EXT  ((XrStructureType)1000999163)
+#define XR_TYPE_LOCAL_3D_ZONE_RENDER_TARGET_VULKAN_EXT ((XrStructureType)1000999164)
 
 // D3D12: the runtime returns the ID3D12Resource* (R8_UNORM, w×h client px);
 // the app creates its OWN RTV on it (descriptor heaps are app-owned in D3D12).

--- a/docs/roadmap/unified-2d-3d-phase3-impl.md
+++ b/docs/roadmap/unified-2d-3d-phase3-impl.md
@@ -31,8 +31,8 @@ Decisions made by precedent (no open question):
 ## 3. API (header v3)
 
 ```c
-#define XR_TYPE_COMPOSITION_LAYER_LOCAL_2D_EXT            ((XrStructureType)1000999135)
-#define XR_TYPE_EVENT_DATA_LOCAL_3D_ZONE_VIEW_SIZE_CHANGED_EXT ((XrStructureType)1000999136)
+#define XR_TYPE_COMPOSITION_LAYER_LOCAL_2D_EXT            ((XrStructureType)1000999165)
+#define XR_TYPE_EVENT_DATA_LOCAL_3D_ZONE_VIEW_SIZE_CHANGED_EXT ((XrStructureType)1000999166)
 
 // Post-weave 2D content at a client-window pixel rect, mask-gated:
 // final = M·weave + (1−M)·flatten(local2D layers). Premultiplied alpha unless

--- a/src/external/openxr_includes/openxr/README.md
+++ b/src/external/openxr_includes/openxr/README.md
@@ -1,0 +1,43 @@
+# DisplayXR OpenXR extension headers
+
+The `XR_EXT_*.h` headers in this directory are the canonical source for
+DisplayXR's custom OpenXR extensions. They auto-sync to the public
+[`displayxr-extensions`](https://github.com/DisplayXR/displayxr-extensions)
+repo on every push to `main`.
+
+## Type-value allocation registry (`1000999xxx`)
+
+All DisplayXR extension `XrStructureType` (and extension `XrResult`) values
+live in the provisional `1000999xxx` block, pending Khronos registry
+reconciliation at spec freeze. **This table is the single source of truth for
+allocations — claim a block here BEFORE defining values in a new header.**
+Three extensions previously collided by each guessing the "next free slot" in
+their own header comments; do not repeat that.
+
+Rules:
+
+- New extension → claim the next free **decade** (10 values) below and record
+  it here in the same PR that adds the header.
+- Never renumber an existing value except to resolve a collision; a relocation
+  is a consumer-visible break → bump the extension's `SPEC_VERSION` with a
+  comment, and every consumer repo needs a header re-sync + rebuild.
+- Deliberate cross-header sharing of one value for the *same* struct (see
+  1000999002) is allowed and must be `#ifndef`-guarded + noted here.
+
+| Values | Extension | Notes |
+|---|---|---|
+| 1000999001–002 | `XR_EXT_win32_window_binding` | 002 = `XR_TYPE_COMPOSITION_LAYER_WINDOW_SPACE_EXT`, deliberately shared with the cocoa binding (`#ifndef`-guarded, same struct) |
+| 1000999003–013 | `XR_EXT_display_info` | 003, 006–008, 010–013 assigned; 005/009 unused gaps |
+| 1000999004 | `XR_EXT_cocoa_window_binding` | + shares 002 (see above) |
+| 1000999100–110 | `XR_EXT_spatial_workspace` | |
+| 1000999120–122 | `XR_EXT_workspace_file_dialog` | 122 is an `XrResult`, not an `XrStructureType` |
+| 1000999130–132 | `XR_EXT_mcp_tools` | |
+| 1000999140–142 | `XR_EXT_view_rig` | |
+| 1000999150–153 | `XR_EXT_display_zones` | reserved by the design sketch (`docs/specs/extensions/XR_EXT_display_zones.md`); header not yet authored |
+| 1000999160–166 | `XR_EXT_local_3d_zone` | relocated from 130–136 (collided with mcp_tools) — spec v4 |
+| 1000999170–171 | `XR_EXT_atlas_capture` | relocated from 120–121 (collided with workspace_file_dialog) — spec v3 |
+| 1000999180 | `XR_EXT_macos_gl_binding` | relocated from 1000999010 (collided with display_info) — spec v2 |
+| 1000999190+ | **next free** | |
+
+`XR_EXT_android_surface_binding` defines no `1000999xxx` values in this
+directory as of this writing; if it gains any, claim a decade here first.

--- a/src/external/openxr_includes/openxr/XR_EXT_atlas_capture.h
+++ b/src/external/openxr_includes/openxr/XR_EXT_atlas_capture.h
@@ -27,17 +27,20 @@ extern "C" {
 #endif
 
 #define XR_EXT_atlas_capture 1
+// SPEC_VERSION 3: XrStructureType values relocated 1000999120..121 ->
+// 1000999170..171 (the old block collided with XR_EXT_workspace_file_dialog,
+// which reserved it first). No struct/field/entry-point changes; consumers
+// only need a header re-sync + rebuild.
 // SPEC_VERSION 2: the runtime appends "_atlas_<viewCount>_<cols>x<rows>.png"
 // (was a flat "_atlas.png" in v1), and the encoded PNG is always opaque
 // (alpha forced to 255). See issue #425.
-#define XR_EXT_atlas_capture_SPEC_VERSION 2
+#define XR_EXT_atlas_capture_SPEC_VERSION 3
 #define XR_EXT_ATLAS_CAPTURE_EXTENSION_NAME "XR_EXT_atlas_capture"
 
-// Reserved 1000999xxx range, next free slot after the workspace block
-// (1000999100..110). Final values reconcile with the Khronos registry before
-// spec freeze.
-#define XR_TYPE_ATLAS_CAPTURE_INFO_EXT   ((XrStructureType)1000999120)
-#define XR_TYPE_ATLAS_CAPTURE_RESULT_EXT ((XrStructureType)1000999121)
+// Reserved 1000999170..171. Final values reconcile with the Khronos registry
+// before spec freeze. Allocation registry: README.md in this directory.
+#define XR_TYPE_ATLAS_CAPTURE_INFO_EXT   ((XrStructureType)1000999170)
+#define XR_TYPE_ATLAS_CAPTURE_RESULT_EXT ((XrStructureType)1000999171)
 
 #define XR_ATLAS_CAPTURE_PATH_MAX_EXT 256
 

--- a/src/external/openxr_includes/openxr/XR_EXT_local_3d_zone.h
+++ b/src/external/openxr_includes/openxr/XR_EXT_local_3d_zone.h
@@ -40,23 +40,28 @@ extern "C" {
 #endif
 
 #define XR_EXT_local_3d_zone 1
-#define XR_EXT_local_3d_zone_SPEC_VERSION 3
+// SPEC_VERSION 4: XrStructureType values relocated 1000999130..136 ->
+// 1000999160..166 (the 130..132 block collided with XR_EXT_mcp_tools, which
+// reserved it first). No struct/field/entry-point changes; consumers only
+// need a header re-sync + rebuild. See README.md (allocation registry) in
+// this directory.
+#define XR_EXT_local_3d_zone_SPEC_VERSION 4
 #define XR_EXT_LOCAL_3D_ZONE_EXTENSION_NAME "XR_EXT_local_3d_zone"
 
-// Vendor extension range (1000999xxx); replace with a Khronos-assigned value
-// if standardized. (XR_EXT_atlas_capture uses ...120/121.)
-#define XR_TYPE_LOCAL_3D_ZONE_CAPABILITIES_EXT      ((XrStructureType)1000999130)
-#define XR_TYPE_LOCAL_3D_ZONE_MASK_CREATE_INFO_EXT  ((XrStructureType)1000999131)
-#define XR_TYPE_LOCAL_3D_ZONE_RENDER_TARGET_D3D11_EXT ((XrStructureType)1000999132)
+// Extension type-value range (1000999xxx); replace with a Khronos-assigned
+// value if standardized. Allocation registry: README.md in this directory.
+#define XR_TYPE_LOCAL_3D_ZONE_CAPABILITIES_EXT      ((XrStructureType)1000999160)
+#define XR_TYPE_LOCAL_3D_ZONE_MASK_CREATE_INFO_EXT  ((XrStructureType)1000999161)
+#define XR_TYPE_LOCAL_3D_ZONE_RENDER_TARGET_D3D11_EXT ((XrStructureType)1000999162)
 // Spec v2 additions — D3D12 + Vulkan Tier-3 bindings. (No Metal Tier-3
 // binding yet — Tier 1/2 are API-agnostic and fully supported on Metal;
 // xrAcquireLocal3DZoneRenderTargetEXT reports XR_ERROR_FEATURE_UNSUPPORTED.)
-#define XR_TYPE_LOCAL_3D_ZONE_RENDER_TARGET_D3D12_EXT  ((XrStructureType)1000999133)
-#define XR_TYPE_LOCAL_3D_ZONE_RENDER_TARGET_VULKAN_EXT ((XrStructureType)1000999134)
+#define XR_TYPE_LOCAL_3D_ZONE_RENDER_TARGET_D3D12_EXT  ((XrStructureType)1000999163)
+#define XR_TYPE_LOCAL_3D_ZONE_RENDER_TARGET_VULKAN_EXT ((XrStructureType)1000999164)
 // Spec v3 additions — the post-weave 2D composition layer + the view-size
 // renegotiation event (#439 Phase 3).
-#define XR_TYPE_COMPOSITION_LAYER_LOCAL_2D_EXT                  ((XrStructureType)1000999135)
-#define XR_TYPE_EVENT_DATA_LOCAL_3D_ZONE_VIEW_SIZE_CHANGED_EXT ((XrStructureType)1000999136)
+#define XR_TYPE_COMPOSITION_LAYER_LOCAL_2D_EXT                  ((XrStructureType)1000999165)
+#define XR_TYPE_EVENT_DATA_LOCAL_3D_ZONE_VIEW_SIZE_CHANGED_EXT ((XrStructureType)1000999166)
 
 XR_DEFINE_HANDLE(XrLocal3DZoneMaskEXT)
 

--- a/src/external/openxr_includes/openxr/XR_EXT_macos_gl_binding.h
+++ b/src/external/openxr_includes/openxr/XR_EXT_macos_gl_binding.h
@@ -23,11 +23,16 @@ extern "C" {
 #endif
 
 #define XR_EXT_macos_gl_binding 1
-#define XR_EXT_macos_gl_binding_SPEC_VERSION 1
+// SPEC_VERSION 2: XrStructureType value relocated 1000999010 -> 1000999180
+// (the old value collided with XR_EXT_display_info's
+// XR_TYPE_EVENT_DATA_RENDERING_MODE_CHANGED_EXT). No struct/field changes;
+// consumers only need a header re-sync + rebuild.
+#define XR_EXT_macos_gl_binding_SPEC_VERSION 2
 #define XR_EXT_MACOS_GL_BINDING_EXTENSION_NAME "XR_EXT_macos_gl_binding"
 
-// Structure type in the vendor extension range
-#define XR_TYPE_GRAPHICS_BINDING_OPENGL_MACOS_EXT ((XrStructureType)1000999010)
+// Structure type in the extension type-value range. Allocation registry:
+// README.md in this directory.
+#define XR_TYPE_GRAPHICS_BINDING_OPENGL_MACOS_EXT ((XrStructureType)1000999180)
 
 /*!
  * @brief OpenGL graphics binding for macOS (CGL context).


### PR DESCRIPTION
## What

Three DisplayXR extensions independently guessed the next free slot in the provisional `1000999xxx` type-value block and collided:

| Collision | Resolution |
|---|---|
| `XR_EXT_local_3d_zone` 1000999130-136 vs `XR_EXT_mcp_tools` 130-132 | local_3d_zone -> **1000999160-166** (spec v4). mcp_tools reserved the block first and has external compiled consumers (displayxr-mcp + tool-registering apps). |
| `XR_EXT_atlas_capture` 1000999120-121 vs `XR_EXT_workspace_file_dialog` 120-122 | atlas_capture -> **1000999170-171** (spec v3). file_dialog claimed the block first (2026-05-18 vs 06-02). |
| `XR_EXT_macos_gl_binding` 1000999010 vs `XR_EXT_display_info` `XR_TYPE_EVENT_DATA_RENDERING_MODE_CHANGED_EXT` | macos_gl_binding -> **1000999180** (spec v2). The display_info events are polled by every compiled app - moving them would be rebuild-the-world. |

Values only - no struct/field/entry-point changes. In-repo code uses the symbolic names exclusively (verified no hardcoded numerics outside the headers), so this repo just rebuilds.

Also adds `src/external/openxr_includes/openxr/README.md` as the **single-source allocation registry** (auto-syncs to displayxr-extensions): new extensions claim a decade there instead of guessing in header comments. The deliberate ifndef-guarded win32/cocoa share of `XR_TYPE_COMPOSITION_LAYER_WINDOW_SPACE_EXT` (1000999002) is documented, not changed. The `1000999150-153` block stays reserved for the `XR_EXT_display_zones` design sketch (ADR-027).

## Consumer impact

Consumer repos pick up the new values on their next header sync + rebuild. Until then only the three relocated extensions mismatch, failing loud (type validation), not corrupting:

- **local_3d_zone**: consumers are in-repo (compositors + test apps) - rebuilt together.
- **atlas_capture**: the Unity plugin calls `xrCaptureAtlasEXT` directly - captures fail until its vendored header is re-synced + rebuilt. MCP `capture_frame` is runtime-internal, unaffected.
- **macos_gl_binding**: in-repo macOS GL test apps only.

## Verification

- Duplicate-value scan across all `XR_EXT_*.h`: 42 values, 41 distinct, sole remaining duplicate is the deliberate 1000999002 share.
- Local `build_windows.bat build`: ALL DONE, no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)