### PR TITLE
fix(#506): accept window-space layers on IPC-service and vk_native sessions

### DIFF
--- a/src/xrt/ipc/server/ipc_server_handler.c
+++ b/src/xrt/ipc/server/ipc_server_handler.c
@@ -2420,7 +2420,8 @@ _update_window_space_layer(struct xrt_compositor *xc,
                            uint32_t i)
 {
 	// Window-space layers are silently skipped if the compositor doesn't implement them.
-	// The D3D11 service compositor accumulates them but doesn't render them yet (Phase 0D).
+	// Both service compositors render them: D3D11 service inline (ws_snapshot HUD path),
+	// comp_multi via composite_layers_to_intermediate (#506).
 	if (xc->layer_window_space == NULL) {
 		return true;
 	}

--- a/src/xrt/state_trackers/oxr/oxr_session_frame_end.c
+++ b/src/xrt/state_trackers/oxr/oxr_session_frame_end.c
@@ -1214,11 +1214,21 @@ verify_window_space_layer(struct oxr_session *sess,
                           struct xrt_device *head,
                           uint64_t timestamp)
 {
-	// Window-space layers require a session created with XR_EXT_win32_window_binding
-	if (!sess->is_d3d11_native_compositor && !sess->is_d3d12_native_compositor && !sess->is_metal_native_compositor && !sess->is_gl_native_compositor && !sess->has_external_window) {
+	/*
+	 * Window-space layers need a compositor that can place a 2D layer in
+	 * window coordinates: any native compositor (all five implement the
+	 * composite), an IPC service-mode session (the service compositor
+	 * composites server-side — comp_multi on Android, D3D11 service on
+	 * Windows), or a session with a bound external window.
+	 */
+	bool is_native_compositor = sess->is_d3d11_native_compositor || sess->is_d3d12_native_compositor ||
+	                            sess->is_metal_native_compositor || sess->is_gl_native_compositor ||
+	                            sess->is_vk_native_compositor;
+	bool is_ipc_service = sess->sys->xsysc != NULL && sess->sys->xsysc->info.is_service_mode;
+	if (!is_native_compositor && !is_ipc_service && !sess->has_external_window) {
 		return oxr_error(log, XR_ERROR_LAYER_INVALID,
-		                 "(frameEndInfo->layers[%u]) window-space layer requires session created with "
-		                 "XR_EXT_win32_window_binding",
+		                 "(frameEndInfo->layers[%u]) window-space layer requires a native-compositor "
+		                 "session, an IPC service session, or a window binding extension",
 		                 layer_index);
 	}
 


### PR DESCRIPTION
## Summary

Unblocks real `XrCompositionLayerWindowSpaceEXT` layers on the Android out-of-process path (and, at the gate level, in-process vk_native) — #506 scope item 1 for OOP.

`verify_window_space_layer` (oxr_session_frame_end.c) rejected any session that wasn't a d3d11/d3d12/metal/gl native compositor or win32/cocoa window-bound. That blocked the two paths whose composite already exists:

- **IPC service-mode sessions** — the transport (`ipc_client_compositor` → shm slots → `ipc_server_handler`) and the server composite (`multi_compositor_layer_window_space` → `composite_layers_to_intermediate`) are platform-neutral and were ready but never reachable. On Android OOP this gate was the *single* blocker: `xrEndFrame` failed `XR_ERROR_LAYER_INVALID`.
- **vk_native sessions** — `comp_vk_native` already has the full per-tile pre-weave composite (`composite_window_space_layers_per_tile`); only the flag was missing from the gate.

### Windows scoping

The service-mode acceptance is deliberately **not** `#ifdef XRT_OS_ANDROID`: the Windows D3D11 service compositor renders window-space layers inline (the `ws_snapshot` HUD path, #206/#429 lineage), and Windows IPC handle apps already exercise that server code by passing this gate via `has_external_window`. Admitting window-binding-less IPC sessions routes to identical server-side code that never touches a client HWND. **Follow-up:** Windows e2e of that newly-admitted case (window-binding-less IPC client) needs a Windows session.

The sibling `verify_local_2d_layer` gate is intentionally unchanged (local-2D is #439's per-backend rollout; comp_multi drops it by design and vk_native has no `layer_local_2d` vtable entry).

Also fixes a stale `ipc_server_handler.c` comment claiming the D3D11 service doesn't render window-space layers yet.

## Live verification (nubia NP02J, OOP runtime + Leia CNSDK DP)

Runtime `v1.2.0-625-g87ab0b4e5` installed over the existing OOP install; test client = `displayxr-demo-modelviewer` `feat/w7-android-modelviewer` tap-to-show button bar (`debug.dxr.mv.ws_ui=1`), **zero app changes**:

- Layer accepted: no `XR_ERROR_LAYER_INVALID`, no app self-disable
- Bar visible over the weave (user-confirmed on the pad)
- Hit-testing through the layer: Mode toggled 3D↔2D repeatedly, bar correct in both modes incl. the 1-view collapse
- Open → SAF picker → BACK round-trip recovers cleanly (#528 surface re-sync path)
- 20 fps steady before/during/after; no per-frame log spam
- MinGW compile-check passed

Fixes nothing else in #506 scope 3 (cube HUD migration to a real layer) — that's re-scoped to a follow-up (see issue comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)