### PR TITLE
fix(#533): 2D mono view ~2x zoom (oxr halves the collapsed eye distance)

### DIFF
--- a/src/xrt/ipc/server/ipc_server_handler.c
+++ b/src/xrt/ipc/server/ipc_server_handler.c
@@ -944,6 +944,20 @@ ipc_try_get_android_view_poses(volatile struct ipc_client_state *ics,
 		}
 	}
 
+	// #533: when the active mode is 2D, oxr's locate path treats the view as mono
+	// (active_view_count==1) and sets XrView.pose to the CENTROID of
+	// view_eye_world[0..nc) / nc (nc = DP eye count, typically 2). But here we
+	// already collapsed to the cyclopean and filled only eye_world[0..eye_count);
+	// for a 2D collapse (eye_count==1) the surplus stays 0, so oxr averages
+	// (cyclopean + 0)/2 → HALF the eye distance → the asset renders ~2x zoomed.
+	// Duplicate the collapsed eye into the surplus entries so the centroid equals
+	// it. (out_fovs/out_poses are duplicated separately by fill_surplus_view_poses.)
+	if (rig_reply != NULL && eye_count > 0) {
+		for (uint32_t i = eye_count; i < XRT_MAX_VIEWS; i++) {
+			rig_reply->eye_world[i] = rig_reply->eye_world[eye_count - 1];
+		}
+	}
+
 	// XR_EXT_view_rig raw channel: the head's actual display-space eyes (the
 	// face-dot the app HUD reads), plus the display plane + canvas. Reported
 	// independent of the 2D render collapse above.


### PR DESCRIPTION
## Symptom
In single-app out-of-process 2D mode (nubia NP02J), the asset renders ~2x too large. 100% reproducible in the model viewer; intermittent on the cube.

## Root cause — oxr locate path, not tiling/weave
For a mono view (`active_view_count==1`), oxr (`oxr_session.c` ~2187) sets `XrView.pose.position` to the **centroid of `view_eye_world[0..nc)` divided by `nc`** (nc = DP eye count, typically 2). The server-side rig path (`ipc_try_get_android_view_poses`) already collapses 2D to the cyclopean and fills only `eye_world[0..eye_count)`. For a 2D collapse (`eye_count==1`) the surplus entries stay **zero**, so oxr averages `(cyclopean + 0) / 2` → **half the eye distance**. Same FOV at half the distance ⇒ the model rendered ~2x larger.

Verified on-device: the handler computes `eye_world.z = 4.076` in both 2D and 3D, but the app received `pose.z = 2.038` in 2D — exactly half. The cube's tiny `rig_vh` (0.24) hid it; the model viewer's model-derived `rig_vh` makes it a clean 2x.

## Fix
In the handler, duplicate the collapsed cyclopean eye into the surplus `rig_reply->eye_world` entries so oxr's centroid equals it. `out_fovs`/`out_poses` are already duplicated by `fill_surplus_view_poses`; this brings `eye_world` in line. App-agnostic, runtime-only.

**Validated on nubia:** 2D `pose.z` now matches 3D (4.076); asset is the correct size; 3D unchanged. Confirmed by David on-device.

## Companion
- Model viewer (`displayxr-demo-modelviewer`): submits 1 view in 2D (the active mode's view count) so 2D takes the clean mono path instead of weaving 2 duplicated views as SBS; adds a `debug.dxr.mode` adb test hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)