### PR TITLE
fix(#533): decouple hardware 2D/3D from content; unify the 2D/3D render path

### DIFF
--- a/src/xrt/compositor/multi/comp_multi_compositor.c
+++ b/src/xrt/compositor/multi/comp_multi_compositor.c
@@ -2040,6 +2040,14 @@ multi_compositor_request_display_mode(struct multi_compositor *mc, bool enable_3
 		return false;
 	}
 
+	// #533: this is the authoritative HARDWARE 2D/3D signal (the weave-state),
+	// DECOUPLED from the per-frame content (the app's submitted tile count). Record
+	// it so the per-session render drives the DP's mode_3d from the request, not from
+	// how many tiles the app happened to submit this frame. (Out-of-process the
+	// device-mode sync can't see this — OUTPUT_MODE doesn't cross IPC — so this flag
+	// IS the source of truth there.)
+	mc->hardware_display_3d = enable_3d;
+
 	// Prefer display processor path (vendor-specific, e.g. SR SwitchableLensHint)
 	if (mc->session_render.display_processor != NULL) {
 		if (xrt_display_processor_request_display_mode(

--- a/src/xrt/compositor/multi/comp_multi_system.c
+++ b/src/xrt/compositor/multi/comp_multi_system.c
@@ -1590,30 +1590,6 @@ recreate_session_swapchain(struct multi_compositor *mc, struct vk_bundle *vk)
 
 
 /*!
- * Get tile layout from the active rendering mode of the head device.
- * Defaults to 2 columns, 1 row (stereo) if not available.
- */
-static void
-get_active_tile_layout(struct multi_compositor *mc, uint32_t *out_tile_columns, uint32_t *out_tile_rows)
-{
-	*out_tile_columns = 2;
-	*out_tile_rows = 1;
-
-	struct xrt_device *xdev_head = (mc->xsysd != NULL) ? mc->xsysd->static_roles.head : NULL;
-	if (xdev_head != NULL && xdev_head->hmd != NULL) {
-		uint32_t idx = xdev_head->hmd->active_rendering_mode_index;
-		if (idx < xdev_head->rendering_mode_count) {
-			uint32_t tc = xdev_head->rendering_modes[idx].tile_columns;
-			uint32_t tr = xdev_head->rendering_modes[idx].tile_rows;
-			if (tc > 0 && tr > 0) {
-				*out_tile_columns = tc;
-				*out_tile_rows = tr;
-			}
-		}
-	}
-}
-
-/*!
  * Ensure the atlas intermediate image exists for display processors
  * that prefer packed atlas input. Creates a single image at
  * (tile_columns * per_eye_width x tile_rows * height) so all views can be
@@ -2085,18 +2061,19 @@ render_session_to_own_target(struct multi_compositor *mc, struct vk_bundle *vk, 
 		return;
 	}
 
-	// Sync hardware_display_3d from device's active rendering mode
+	// HARDWARE 2D/3D (the weave-state) is set by multi_compositor_request_display_mode
+	// — the app's xrRequestDisplayRenderingModeEXT, which now crosses IPC out-of-process
+	// (#533). It is DECOUPLED from the per-frame CONTENT (how many tiles the app
+	// submitted): content drives the atlas, mc->hardware_display_3d drives the DP weave.
+	// In-process the device's active rendering mode is the same authority, so sync from
+	// it when the head device is available (no-op out-of-process: head is NULL there, so
+	// the request-set value stands).
 	struct xrt_device *xdev_head = (mc->xsysd != NULL) ? mc->xsysd->static_roles.head : NULL;
 	if (xdev_head != NULL && xdev_head->hmd != NULL) {
 		uint32_t idx = xdev_head->hmd->active_rendering_mode_index;
 		if (idx < xdev_head->rendering_mode_count) {
 			mc->hardware_display_3d = xdev_head->rendering_modes[idx].hardware_display_3d;
 		}
-	}
-
-	// App-submitted mono (viewCount=1) forces 2D path regardless of device mode
-	if (layer->data.view_count == 1) {
-		mc->hardware_display_3d = false;
 	}
 
 	// Runtime-side 2D/3D toggle from qwerty V key
@@ -2140,8 +2117,13 @@ render_session_to_own_target(struct multi_compositor *mc, struct vk_bundle *vk, 
 	}
 #endif
 
-	// Extract per-view info (N-view generalized)
-	uint32_t view_count = mc->hardware_display_3d ? layer->data.view_count : 1;
+	// CONTENT: the atlas holds exactly the tiles the app submitted (1 = 2D, ≥2 = 3D),
+	// independent of the hardware weave-state (#533 decouple). The app submits the
+	// active mode's tile count with per-view imageRects; the DP weaves or shows flat
+	// per mc->hardware_display_3d.
+	uint32_t view_count = layer->data.view_count;
+	if (view_count < 1)
+		view_count = 1;
 	if (view_count > XRT_MAX_VIEWS)
 		view_count = XRT_MAX_VIEWS;
 
@@ -2283,162 +2265,16 @@ render_session_to_own_target(struct multi_compositor *mc, struct vk_bundle *vk, 
 		return;
 	}
 
-	// Mono (2D) path: blit single view directly to target, skip atlas and weaving.
-	// In 2D mode the app submits only one view (viewCount=1). We blit it
-	// directly to the presentation target without atlas packing or
-	// light-field interlacing (weaving).
-	if (!mc->hardware_display_3d) {
-		// Mono + window-space overlays: composite projection + HUD overlays
-		// into an intermediate image, then blit left eye to target.
-		// Works for both app-submitted mono (viewCount=1) and runtime-forced
-		// 2D mode (viewCount=2): composite_layers_to_intermediate() duplicates
-		// the left view for the right eye when only 1 view is submitted.
-		if (has_window_space_layers(mc)) {
-			VkImageView comp_left = VK_NULL_HANDLE, comp_right = VK_NULL_HANDLE;
-			if (composite_layers_to_intermediate(mc, vk, cmd, &comp_left, &comp_right)) {
-				// composite_images[0] is in SHADER_READ_ONLY_OPTIMAL.
-				// Transition it to TRANSFER_SRC, target to TRANSFER_DST.
-				VkImageMemoryBarrier hud_mono_pre[2] = {
-				    {
-				        .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
-				        .srcAccessMask = VK_ACCESS_SHADER_READ_BIT,
-				        .dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT,
-				        .oldLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
-				        .newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-				        .image = mc->session_render.composite_images[0],
-				        .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1},
-				    },
-				    {
-				        .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
-				        .srcAccessMask = 0,
-				        .dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
-				        .oldLayout = VK_IMAGE_LAYOUT_UNDEFINED,
-				        .newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-				        .image = ct->images[buffer_index].handle,
-				        .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1},
-				    },
-				};
-				vk->vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
-				                         VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, NULL, 0, NULL,
-				                         2, hud_mono_pre);
+	// #533: 2D is no longer a special-cased mono blit. Both 2D and 3D flow through
+	// the unified atlas → display-processor path below. The app submits the active
+	// mode's tiles (1 for 2D, 2 for 3D) with per-view imageRects; the runtime packs
+	// them into a matching atlas (view_count×1) and hands it to the DP, which weaves
+	// (hardware 3D) or shows the single tile flat (hardware 2D, mode_3d=false). The
+	// window-space HUD is composited in the atlas path too (composite_layers_to_-
+	// intermediate below), so it survives the unification. Content (tile count) and
+	// hardware (mode_3d) are now fully decoupled — the old mono-blit branch is gone.
 
-				uint32_t cw = mc->session_render.composite_width;
-				uint32_t ch = mc->session_render.composite_height;
-
-				VkImageBlit hud_mono_blit = {
-				    .srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1},
-				    .srcOffsets = {{0, 0, 0}, {(int32_t)cw, (int32_t)ch, 1}},
-				    .dstSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1},
-				    .dstOffsets = {{0, 0, 0},
-				                  {(int32_t)framebufferWidth, (int32_t)framebufferHeight, 1}},
-				};
-				vk->vkCmdBlitImage(cmd, mc->session_render.composite_images[0],
-				                   VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-				                   ct->images[buffer_index].handle,
-				                   VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &hud_mono_blit,
-				                   VK_FILTER_LINEAR);
-
-				// Post: target TRANSFER_DST → PRESENT_SRC
-				VkImageMemoryBarrier hud_mono_post = {
-				    .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
-				    .srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
-				    .dstAccessMask = 0,
-				    .oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-				    .newLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
-				    .image = ct->images[buffer_index].handle,
-				    .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1},
-				};
-				vk->vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT,
-				                         VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, 0, 0, NULL,
-				                         0, NULL, 1, &hud_mono_post);
-
-				static bool mono_hud_logged = false;
-				if (!mono_hud_logged) {
-					U_LOG_W("[per-session] Mono (2D) + window-space HUD: "
-					        "composited %ux%u -> %ux%u (viewCount=%u)",
-					        cw, ch, framebufferWidth, framebufferHeight,
-					        layer->data.view_count);
-					mono_hud_logged = true;
-				}
-				goto submit_and_present;
-			}
-			// Fallthrough to direct blit if compositing fails
-		}
-
-		bool flip_y = layer->data.flip_y;
-		int src_top = viewOffsetY[0] + (flip_y ? imageHeight : 0);
-		int src_bot = viewOffsetY[0] + (flip_y ? 0 : imageHeight);
-
-		// Pre-barriers: source GENERAL → TRANSFER_SRC, target UNDEFINED → TRANSFER_DST
-		VkImageMemoryBarrier mono_pre[2] = {
-		    {
-		        .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
-		        .srcAccessMask = 0,
-		        .dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT,
-		        .oldLayout = VK_IMAGE_LAYOUT_GENERAL,
-		        .newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-		        .image = viewImages[0],
-		        .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, viewArrayIndices[0], 1},
-		    },
-		    {
-		        .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
-		        .srcAccessMask = 0,
-		        .dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
-		        .oldLayout = VK_IMAGE_LAYOUT_UNDEFINED,
-		        .newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-		        .image = ct->images[buffer_index].handle,
-		        .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1},
-		    },
-		};
-		vk->vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
-		                         VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, NULL, 0, NULL, 2, mono_pre);
-
-		// Blit mono view to fill entire target
-		VkImageBlit mono_blit = {
-		    .srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, viewArrayIndices[0], 1},
-		    .srcOffsets = {{viewOffsetX[0], src_top, 0}, {viewOffsetX[0] + imageWidth, src_bot, 1}},
-		    .dstSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1},
-		    .dstOffsets = {{0, 0, 0}, {(int32_t)framebufferWidth, (int32_t)framebufferHeight, 1}},
-		};
-		vk->vkCmdBlitImage(cmd, viewImages[0], VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-		                   ct->images[buffer_index].handle, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1,
-		                   &mono_blit, VK_FILTER_LINEAR);
-
-		// Post-barriers: source → GENERAL, target → PRESENT_SRC_KHR
-		VkImageMemoryBarrier mono_post[2] = {
-		    {
-		        .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
-		        .srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT,
-		        .dstAccessMask = 0,
-		        .oldLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-		        .newLayout = VK_IMAGE_LAYOUT_GENERAL,
-		        .image = viewImages[0],
-		        .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, viewArrayIndices[0], 1},
-		    },
-		    {
-		        .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
-		        .srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
-		        .dstAccessMask = 0,
-		        .oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-		        .newLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
-		        .image = ct->images[buffer_index].handle,
-		        .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1},
-		    },
-		};
-		vk->vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT,
-		                         VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, 0, 0, NULL, 0, NULL, 2,
-		                         mono_post);
-
-		static bool mono_logged = false;
-		if (!mono_logged) {
-			U_LOG_W("[per-session] Mono (2D) blit: %dx%d -> %ux%u (flip_y=%d)", imageWidth,
-			        imageHeight, framebufferWidth, framebufferHeight, flip_y);
-			mono_logged = true;
-		}
-		goto submit_and_present;
-	}
-
-	// Stereo (3D) path: display processing or SR weaving
+	// Unified display-processor path
 
 	// Get the framebuffer for the current swapchain image
 	VkFramebuffer framebuffer = VK_NULL_HANDLE;
@@ -2465,9 +2301,16 @@ render_session_to_own_target(struct multi_compositor *mc, struct vk_bundle *vk, 
 		// for stereo).
 		// ================================================================
 		{
-			// Get tile layout from active rendering mode
-			uint32_t tile_columns, tile_rows;
-			get_active_tile_layout(mc, &tile_columns, &tile_rows);
+			// #533 decouple: the atlas layout is the CONTENT the app submitted, not
+			// the (out-of-process stale) server rendering mode. The app submits
+			// view_count tiles with per-view imageRects in a horizontal strip — 1
+			// tile (2D) or 2 (3D) — so build a matching view_count×1 atlas. This keeps
+			// the atlas in lockstep with the submission across a 2D⇄3D transition,
+			// even when the hardware flag (flipped on the fast IPC request) briefly
+			// leads the content by a frame — otherwise a stale 2x1 layout × a 2D-sized
+			// tile builds an oversized atlas that overflows the app swapchain.
+			uint32_t tile_columns = view_count > 0 ? view_count : 1;
+			uint32_t tile_rows = 1;
 
 			// Determine blit sources — either composited overlay images or
 			// direct swapchain sub-regions.

--- a/src/xrt/ipc/client/ipc_client_compositor.c
+++ b/src/xrt/ipc/client/ipc_client_compositor.c
@@ -240,6 +240,28 @@ comp_ipc_client_compositor_set_eye_tracking_mode(struct xrt_compositor *xc, uint
 }
 
 /*
+ * Request the HARDWARE 2D/3D display mode on the out-of-process DP (#533). This
+ * is the hardware weave-state signal, DECOUPLED from the per-frame content (how
+ * many tiles the app submits): the app requests "panel → 2D/3D" here while it
+ * independently submits 1- or 2-tile atlases. Same gating contract as
+ * comp_ipc_client_compositor_set_eye_tracking_mode. Best-effort — no-op on IPC failure.
+ */
+void
+comp_ipc_client_compositor_request_display_mode(struct xrt_compositor *xc, uint32_t enable_3d)
+{
+	if (xc == NULL) {
+		return;
+	}
+
+	struct ipc_client_compositor *icc = ipc_client_compositor(xc);
+	if (icc == NULL || icc->ipc_c == NULL) {
+		return;
+	}
+
+	(void)ipc_call_compositor_request_display_mode(icc->ipc_c, enable_3d);
+}
+
+/*
  * Full DP eye-position struct incl. is_tracking, over IPC (#441 Phase 2).
  * Same gating contract as comp_ipc_client_compositor_get_window_metrics:
  * only safe to call when `xc` is an ipc_client_compositor (the OpenXR state

--- a/src/xrt/ipc/server/ipc_server_handler.c
+++ b/src/xrt/ipc/server/ipc_server_handler.c
@@ -2177,6 +2177,30 @@ ipc_handle_compositor_set_eye_tracking_mode(volatile struct ipc_client_state *ic
 }
 
 xrt_result_t
+ipc_handle_compositor_request_display_mode(volatile struct ipc_client_state *ics, uint32_t enable_3d)
+{
+	IPC_TRACE_MARKER();
+
+	if (ics->xc == NULL) {
+		return XRT_ERROR_IPC_SESSION_NOT_CREATED;
+	}
+
+	// HARDWARE 2D/3D request (#533) — the weave-state signal, DECOUPLED from the
+	// per-frame content (atlas tile count). The out-of-process per-client
+	// compositor is a multi_compositor; forward to its DP. Only the Android
+	// null+comp_multi service reaches the DP this way.
+#ifdef XRT_OS_ANDROID
+	struct multi_compositor *mc = multi_compositor((struct xrt_compositor *)ics->xc);
+	if (mc != NULL) {
+		multi_compositor_request_display_mode(mc, enable_3d != 0u);
+	}
+#else
+	(void)enable_3d;
+#endif
+	return XRT_SUCCESS;
+}
+
+xrt_result_t
 ipc_handle_compositor_set_performance_level(volatile struct ipc_client_state *ics,
                                             enum xrt_perf_domain domain,
                                             enum xrt_perf_set_level level)

--- a/src/xrt/ipc/shared/proto.json
+++ b/src/xrt/ipc/shared/proto.json
@@ -571,6 +571,12 @@
 		]
 	},
 
+	"compositor_request_display_mode": {
+		"in": [
+			{"name": "enable_3d", "type": "uint32_t"}
+		]
+	},
+
 	"compositor_get_reference_bounds_rect": {
 		"in": [
 			{"name": "reference_space_type", "type": "enum xrt_reference_space_type"}

--- a/src/xrt/state_trackers/oxr/oxr_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_session.c
@@ -120,6 +120,11 @@ comp_ipc_client_compositor_get_predicted_eye_positions(struct xrt_compositor *xc
 void
 comp_ipc_client_compositor_set_eye_tracking_mode(struct xrt_compositor *xc, uint32_t mode);
 
+// IPC-client HARDWARE 2D/3D request to the out-of-process DP (#533) — same
+// linkage pattern. The hardware weave-state, decoupled from per-frame content.
+void
+comp_ipc_client_compositor_request_display_mode(struct xrt_compositor *xc, uint32_t enable_3d);
+
 // Same fetch via the SYSTEM compositor (#449) for compositor-less sessions
 // (headless XR_MND_headless clients like the WebXR bridge, which have no
 // xcn). Same linkage pattern as above.
@@ -447,13 +452,24 @@ oxr_session_request_display_mode(struct oxr_logger *log, struct oxr_session *ses
 
 	// In-process multi compositor path (not used for IPC clients).
 	// IPC clients have an ipc_client_compositor, not a multi_compositor.
-	if (sess->sys->xsysc->xmcc != NULL) {
+	if (sess->sys->xsysc != NULL && sess->sys->xsysc->xmcc != NULL) {
 		struct multi_compositor *mc = multi_compositor(&sess->xcn->base);
 		success = multi_compositor_request_display_mode(mc, enable_3d);
 		if (success) {
 			sess->hardware_display_3d = enable_3d;
 		}
 		return XR_SUCCESS;
+	}
+
+	// Out-of-process IPC client (single-app OOP Android, #533): push the HARDWARE
+	// 2D/3D request to the server DP over IPC. This is the weave-state signal,
+	// decoupled from the per-frame content (the app's submitted view count). Without
+	// it the request was a no-op out-of-process and the runtime had to infer the
+	// hardware mode from the tile count (the old conflation). Bridge-relay sessions
+	// forward to the browser and own no DP.
+	if (!sess->is_bridge_relay) {
+		comp_ipc_client_compositor_request_display_mode(&sess->xcn->base, enable_3d ? 1u : 0u);
+		sess->hardware_display_3d = enable_3d;
 	}
 
 	(void)success;


### PR DESCRIPTION
Follow-up to #538 (the 2D eye-distance z-fix, already merged). Addresses the architectural conflation surfaced during on-device review.

## Problem
The Android OOP per-session render fused two independent concerns into one `hardware_display_3d` flag:
- **Hardware** — the panel's lenticular weave on/off (a DP operation).
- **Content** — how many tiles the app submits (1 = 2D, 2 = 3D).

It *derived* the hardware state from the submitted view count because `xrRequestDisplayRenderingModeEXT` was a **no-op for IPC clients** (`oxr_session.c` fell through). Consequences: the flag latched false after any 2D frame and never recovered (**2D→3D one-way** out-of-process), and 2D took a **mono-blit path that bypassed the DP** entirely.

## Fix — decouple + unify
- **Hardware**: new IPC `compositor_request_display_mode` (mirrors `compositor_set_eye_tracking_mode`) carries the app's 2D/3D request to the server DP out-of-process. `multi_compositor_request_display_mode` records `mc->hardware_display_3d`; the render path drives the DP's `mode_3d` from it and never re-derives it from tile count.
- **Content**: the atlas holds exactly the submitted tiles (`view_count×1`, per-view `imageRect`s), sized from the submission — not the stale OOP server mode. Fixes a transient where the fast hardware flip built a 2×1 atlas from a 2D-sized tile and overflowed the app swapchain.
- **Unify**: the mono-blit 2D special-case is **removed** — 2D and 3D both flow through the atlas → DP path (DP weaves for hardware-3D, shows the single tile flat for hardware-2D). The window-space HUD is composited in the atlas path, so it survives. `get_active_tile_layout` retired.

## Validation (nubia NP02J)
All four tile configs confirmed correct:

| Config | tile | layout | atlas |
|---|---|---|---|
| 3D landscape | 1920×1200 | 2×1 | 3840×1200 |
| 3D portrait | 1200×1920 | 2×1 | 2400×1920 |
| 2D landscape | 2560×1600 | 1×1 | 2560×1600 |
| 2D portrait | 1600×2560 | 1×1 | 1600×2560 |

2D renders native (no upscale) and flat through the DP; 2D⇄3D switch robust under rapid toggling. Companion: model viewer single-atlas tiling (displayxr-demo-modelviewer#28).

**Scope note:** touches `comp_multi_system.c` (the VK per-session render — Android OOP path) + the IPC layer (codegen, cross-platform; the new handler is `XRT_OS_ANDROID`-guarded). Windows D3D11-service render is a separate path and unaffected. Known follow-up: a 1-frame hardware-leads-content transient on switch (timing lead/lag refinement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)