### PR TITLE
build(windows): auto-detect VS edition via vswhere

### DIFF
--- a/scripts/build_windows.bat
+++ b/scripts/build_windows.bat
@@ -29,9 +29,34 @@ if "%TARGET%"=="" set TARGET=all
 :: 1. Setup MSVC environment
 :: ============================================================
 echo === Setting up MSVC environment ===
-call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat" >nul 2>&1
+:: Locate the VS install via vswhere (the official MS way) so any edition
+:: works - Community / Professional / Enterprise / BuildTools - instead of
+:: hardcoding one. vswhere always lives in 32-bit Program Files.
+set "VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+set "VS_INSTALL="
+if exist "%VSWHERE%" (
+    for /f "usebackq tokens=*" %%i in (`"%VSWHERE%" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do set "VS_INSTALL=%%i"
+)
+
+set "VCVARS="
+if defined VS_INSTALL if exist "%VS_INSTALL%\VC\Auxiliary\Build\vcvars64.bat" set "VCVARS=%VS_INSTALL%\VC\Auxiliary\Build\vcvars64.bat"
+
+:: Fallback: probe the known editions if vswhere is unavailable (older installs).
+if not defined VCVARS (
+    for %%E in (Community Professional Enterprise BuildTools) do (
+        if not defined VCVARS if exist "C:\Program Files\Microsoft Visual Studio\2022\%%E\VC\Auxiliary\Build\vcvars64.bat" set "VCVARS=C:\Program Files\Microsoft Visual Studio\2022\%%E\VC\Auxiliary\Build\vcvars64.bat"
+    )
+)
+
+if not defined VCVARS (
+    echo ERROR: Could not find Visual Studio 2022 with the C++ workload.
+    echo Install VS 2022 ^(any edition^) with "Desktop development with C++".
+    exit /b 1
+)
+
+call "%VCVARS%" >nul 2>&1
 if %ERRORLEVEL% NEQ 0 (
-    echo ERROR: Could not find Visual Studio 2022. Install VS 2022 with C++ workload.
+    echo ERROR: vcvars64.bat failed: %VCVARS%
     exit /b 1
 )
 

--- a/scripts/poc_shared_fence.bat
+++ b/scripts/poc_shared_fence.bat
@@ -11,10 +11,26 @@ set "POC_EXE=%POC_OUT_DIR%\poc_shared_fence.exe"
 
 if not exist "%POC_OUT_DIR%" mkdir "%POC_OUT_DIR%"
 
-REM Mirror build_windows.bat: source VS2022 Community vcvars64.
-call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat" >nul 2>&1
+REM Mirror build_windows.bat: locate any VS2022 edition via vswhere.
+set "VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+set "VCVARS="
+if exist "%VSWHERE%" (
+    for /f "usebackq tokens=*" %%i in (`"%VSWHERE%" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do (
+        if exist "%%i\VC\Auxiliary\Build\vcvars64.bat" set "VCVARS=%%i\VC\Auxiliary\Build\vcvars64.bat"
+    )
+)
+if not defined VCVARS (
+    for %%E in (Community Professional Enterprise BuildTools) do (
+        if not defined VCVARS if exist "C:\Program Files\Microsoft Visual Studio\2022\%%E\VC\Auxiliary\Build\vcvars64.bat" set "VCVARS=C:\Program Files\Microsoft Visual Studio\2022\%%E\VC\Auxiliary\Build\vcvars64.bat"
+    )
+)
+if not defined VCVARS (
+    echo [poc] FAIL: could not find VS2022 vcvars64.bat ^(any edition^)
+    exit /b 1
+)
+call "%VCVARS%" >nul 2>&1
 if errorlevel 1 (
-    echo [poc] FAIL: could not find VS2022 Community vcvars64.bat
+    echo [poc] FAIL: vcvars64.bat failed: %VCVARS%
     exit /b 1
 )
 


### PR DESCRIPTION
## Problem
`scripts/build_windows.bat` hardcoded the **VS2022 Community** `vcvars64.bat` path. Contributors on **Professional/Enterprise/BuildTools** had to hand-edit the script before they could build — reported by a new contributor on Professional.

## Fix
- `build_windows.bat`: locate the toolchain via **`vswhere`** (`-requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64`), the official MS mechanism — covers every edition. Falls back to probing the four known edition paths if `vswhere` is absent; clear error if none found.
- `poc_shared_fence.bat`: same pattern (it had the identical hardcoded line).
- `fetch_build_cts.bat`: untouched — already does vswhere-first.

Detection avoids delayed-expansion (`if defined` + loop vars) so it's robust regardless of each script's `setlocal` mode.

## Test
Build scripts only; no runtime/code change. Should be verified with a clean `scripts\build_windows.bat generate` on a non-Community install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)