### PR TITLE
Display Zones P5 runtime IPC transport + demo desktop transparency

### DIFF
--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -3915,6 +3915,40 @@ compositor_layer_local_2d(struct xrt_compositor *xc,
 	return XRT_SUCCESS;
 }
 
+/*!
+ * Zone-3D layer (XR_EXT_display_zones P5, ADR-027). The IPC transport now
+ * delivers zone layers here (client serialization + _update_zone_3d_layer),
+ * but this compositor cannot yet consume them honestly: its projection path
+ * is a single-layer full-tile blit / zero-copy pipeline into the per-client
+ * atlas slot (cross-process KeyedMutex/fence sync, DP pass-through) — it has
+ * no alpha-over compositing of N placed layers, no transparent-slot
+ * semantics, and no auto-wish derivation, all of which a zones frame
+ * requires (see comp_d3d11_renderer's XRT_LAYER_ZONE_3D case for the
+ * in-process model). Rendering the zone's projection views full-tile would
+ * silently ignore the placement rect, so drop with a one-time WARN instead;
+ * never an error (layers are advisory compositing).
+ *
+ * @todo XR_EXT_display_zones P5 tail: zones_frame detection + transparent
+ *       slot clear + per-view scaled alpha-over blits at the zone rect +
+ *       auto-wish derivation for service-mode clients (the wish stays on
+ *       the tier-1 global fallback until then).
+ */
+static xrt_result_t
+compositor_layer_zone_3d(struct xrt_compositor *xc,
+                         struct xrt_device *xdev,
+                         struct xrt_swapchain *xsc[XRT_MAX_VIEWS],
+                         const struct xrt_layer_data *data)
+{
+	static bool warned = false;
+	if (!warned) {
+		warned = true;
+		U_LOG_W("Zone-3D layer reached the D3D11 service compositor (IPC transport ok) but is not "
+		        "consumed yet — dropping (one-time warning)");
+	}
+
+	return XRT_SUCCESS;
+}
+
 static xrt_result_t
 compositor_layer_passthrough(struct xrt_compositor *xc,
                               struct xrt_device *xdev,
@@ -10393,6 +10427,7 @@ system_create_native_compositor(struct xrt_system_compositor *xsysc,
 	c->base.base.layer_equirect2 = compositor_layer_equirect2;
 	c->base.base.layer_window_space = compositor_layer_window_space;
 	c->base.base.layer_local_2d = compositor_layer_local_2d;
+	c->base.base.layer_zone_3d = compositor_layer_zone_3d;
 	c->base.base.layer_passthrough = compositor_layer_passthrough;
 	c->base.base.layer_commit = compositor_layer_commit;
 	c->base.base.layer_commit_with_semaphore = compositor_layer_commit_with_semaphore;

--- a/src/xrt/compositor/multi/comp_multi_compositor.c
+++ b/src/xrt/compositor/multi/comp_multi_compositor.c
@@ -1123,11 +1123,10 @@ multi_compositor_layer_local_2d(struct xrt_compositor *xc,
 }
 
 /*!
- * 3D display zone layer (XR_EXT_display_zones, ADR-027). The service/multi-
- * compositor consumer is out of scope until the IPC transport lands (P5),
- * so drop with a one-time WARN; never an error. Deliberately NOT enqueued
- * into progress — the comp_multi_system transfer switch would log an
- * unhandled-type error.
+ * 3D display zone layer (XR_EXT_display_zones P5, ADR-027). Enqueued into
+ * the progress slot projection-style (one swapchain reference per view);
+ * comp_multi_system's transfer switch hands it to the target compositor,
+ * which drops with its own one-shot WARN if it has no zone consumer.
  */
 static xrt_result_t
 multi_compositor_layer_zone_3d(struct xrt_compositor *xc,
@@ -1135,11 +1134,14 @@ multi_compositor_layer_zone_3d(struct xrt_compositor *xc,
                                struct xrt_swapchain *xsc[XRT_MAX_VIEWS],
                                const struct xrt_layer_data *data)
 {
-	static bool warned = false;
-	if (!warned) {
-		warned = true;
-		U_LOG_W("Zone-3D layers are not consumed on the IPC/service path yet — dropping (one-time warning)");
+	struct multi_compositor *mc = multi_compositor(xc);
+
+	size_t index = mc->progress.layer_count++;
+	mc->progress.layers[index].xdev = xdev;
+	for (uint32_t i = 0; i < data->view_count; ++i) {
+		xrt_swapchain_reference(&mc->progress.layers[index].xscs[i], xsc[i]);
 	}
+	mc->progress.layers[index].data = *data;
 
 	return XRT_SUCCESS;
 }

--- a/src/xrt/compositor/multi/comp_multi_system.c
+++ b/src/xrt/compositor/multi/comp_multi_system.c
@@ -140,6 +140,43 @@ do_projection_layer_depth(struct xrt_compositor *xc,
 	xrt_comp_layer_projection_depth(xc, xdev, xsc, d_xsc, data);
 }
 
+static void
+do_zone_3d_layer(struct xrt_compositor *xc, struct multi_compositor *mc, struct multi_layer_entry *layer, uint32_t i)
+{
+	// XR_EXT_display_zones P5: the target compositor may not consume zone
+	// layers (e.g. the null compositor) — drop with a one-shot WARN,
+	// never an error (layers are advisory compositing).
+	if (xc->layer_zone_3d == NULL) {
+		static bool warned = false;
+		if (!warned) {
+			warned = true;
+			U_LOG_W("Zone-3D layers are not consumed by the target compositor — "
+			        "dropping (one-time warning)");
+		}
+		return;
+	}
+
+	struct xrt_device *xdev = layer->xdev;
+
+	// Cast away
+	struct xrt_layer_data *data = (struct xrt_layer_data *)&layer->data;
+
+	// Do not need to copy the reference, but should verify the pointers for consistency
+	for (uint32_t j = 0; j < data->view_count; j++) {
+		if (layer->xscs[j] == NULL) {
+			U_LOG_E("Invalid swap chain for zone-3D layer #%u!", i);
+			return;
+		}
+	}
+
+	if (xdev == NULL) {
+		U_LOG_E("Invalid xdev for zone-3D layer #%u!", i);
+		return;
+	}
+
+	xrt_comp_layer_zone_3d(xc, xdev, layer->xscs, data);
+}
+
 static bool
 do_single(struct xrt_compositor *xc,
           struct multi_compositor *mc,
@@ -2829,6 +2866,7 @@ transfer_layers_locked(struct multi_system_compositor *msc, int64_t display_time
 			case XRT_LAYER_CYLINDER: do_cylinder_layer(xc, mc, layer, i); break;
 			case XRT_LAYER_EQUIRECT1: do_equirect1_layer(xc, mc, layer, i); break;
 			case XRT_LAYER_EQUIRECT2: do_equirect2_layer(xc, mc, layer, i); break;
+			case XRT_LAYER_ZONE_3D: do_zone_3d_layer(xc, mc, layer, i); break;
 			default: U_LOG_E("Unhandled layer type '%i'!", layer->data.type); break;
 			}
 		}

--- a/src/xrt/ipc/client/ipc_client_compositor.c
+++ b/src/xrt/ipc/client/ipc_client_compositor.c
@@ -1774,13 +1774,10 @@ ipc_compositor_layer_local_2d(struct xrt_compositor *xc,
 }
 
 /*!
- * Zone-3D layers carry view_count swapchains (like projection), which the
- * generic single-swapchain handle_layer() cannot serialize. The IPC
- * transport rides the vendor-plugin phase (P5) — until then drop with a
- * one-time WARN, never an error.
- *
- * @todo P5: serialize multi-swapchain ids projection-style and consume in
- *       the service multi-compositor.
+ * Zone-3D layers (XR_EXT_display_zones P5) carry view_count swapchains —
+ * serialized projection-style: one swapchain id per view; the rest of the
+ * layer (per-view proj data + zone rect + zone id) rides the xrt_layer_data
+ * union verbatim in the shared-memory slot.
  */
 static xrt_result_t
 ipc_compositor_layer_zone_3d(struct xrt_compositor *xc,
@@ -1788,11 +1785,21 @@ ipc_compositor_layer_zone_3d(struct xrt_compositor *xc,
                              struct xrt_swapchain *xsc[XRT_MAX_VIEWS],
                              const struct xrt_layer_data *data)
 {
-	static bool warned = false;
-	if (!warned) {
-		warned = true;
-		U_LOG_W("Zone-3D layers are not transported over IPC yet — dropping (one-time warning)");
+	struct ipc_client_compositor *icc = ipc_client_compositor(xc);
+
+	assert(data->type == XRT_LAYER_ZONE_3D);
+
+	struct ipc_shared_memory *ism = icc->ipc_c->ism;
+	struct ipc_layer_slot *slot = &ism->slots[icc->layers.slot_id];
+	struct ipc_layer_entry *layer = &slot->layers[icc->layers.layer_count];
+	layer->xdev_id = 0; //! @todo Real id.
+	layer->data = *data;
+	for (uint32_t i = 0; i < data->view_count; ++i) {
+		struct ipc_client_swapchain *ics = ipc_client_swapchain(xsc[i]);
+		layer->swapchain_ids[i] = ics->id;
 	}
+	// Increment the number of layers.
+	icc->layers.layer_count++;
 
 	return XRT_SUCCESS;
 }

--- a/src/xrt/ipc/server/ipc_server_handler.c
+++ b/src/xrt/ipc/server/ipc_server_handler.c
@@ -14,6 +14,7 @@
 #include "util/u_pretty_print.h"
 #include "util/u_visibility_mask.h"
 #include "util/u_trace_marker.h"
+#include "util/u_canvas.h" // XR_EXT_display_zones P5: zone-scoped locate rebase
 
 #include "server/ipc_server.h"
 #include "ipc_server_generated.h"
@@ -337,6 +338,37 @@ ipc_try_get_sr_view_poses(volatile struct ipc_client_state *ics,
 		if (!have_wm && !headless_client) {
 			have_wm = comp_d3d11_service_get_window_metrics(s->xsysc, &wm) &&
 			          wm.valid && wm.window_width_m > 0.0f && wm.window_height_m > 0.0f;
+		}
+
+		// XR_EXT_display_zones P5 — zone-scoped locate over IPC: rebase
+		// the resolved window metrics to the client's forwarded zone rect,
+		// exactly like the in-process oxr_session.c zone block. The rect
+		// IS the canvas: everything below (Kooima meters, eye offsets,
+		// the raw canvas rect) then describes the zone with zero further
+		// changes. Read from the wire `rig` BEFORE the workspace-override
+		// substitution below — the zone is the app's framing request and
+		// is honored regardless of who owns the rig.
+		//
+		// Workspace caveat (v1, ADR-027): for a workspace client the
+		// metrics describe a VIRTUAL window whose meters aren't tied to
+		// the display pixel pitch, so the rebase below is approximate
+		// there — zones under a workspace are deferred anyway (the
+		// service compositor doesn't consume zone layers yet).
+		if (have_wm && rig != NULL && rig->zone_valid != 0) {
+			struct u_canvas_rect zone_canvas = {
+			    .valid = true,
+			    .x = rig->zone_x_px,
+			    .y = rig->zone_y_px,
+			    .w = (uint32_t)rig->zone_w_px,
+			    .h = (uint32_t)rig->zone_h_px,
+			};
+			u_canvas_apply_to_metrics(&wm, &zone_canvas);
+			static bool zone_locate_logged = false;
+			if (!zone_locate_logged) {
+				zone_locate_logged = true;
+				IPC_WARN(s, "ZONES IPC: first zone-scoped locate, rect=(%d,%d %dx%d) px",
+				         rig->zone_x_px, rig->zone_y_px, rig->zone_w_px, rig->zone_h_px);
+			}
 		}
 
 		if (have_wm) {
@@ -827,6 +859,11 @@ ipc_try_get_android_view_poses(volatile struct ipc_client_state *ics,
 			screen_height_m = tmp;
 		}
 	}
+	//! @todo XR_EXT_display_zones P5: rig->zone_* is not applied on this
+	//! display-centric Android path yet — it lacks the window-relative
+	//! metric baseline (display_pixel_* / display_*_m in wm) that
+	//! u_canvas_apply_to_metrics needs. Zone-scoped locates fall back to
+	//! the full-display canvas here.
 
 	// Eyes: DP-tracked if available (Leia/M2 plugs in here unchanged), else the
 	// nominal viewer + a default IPD. head_eyes is the head's actual L/R pair
@@ -2504,6 +2541,56 @@ _update_local_2d_layer(struct xrt_compositor *xc,
 }
 
 static bool
+_update_zone_3d_layer(struct xrt_compositor *xc,
+                      volatile struct ipc_client_state *ics,
+                      volatile struct ipc_layer_entry *layer,
+                      uint32_t i)
+{
+	// Zone-3D layers (XR_EXT_display_zones P5) are silently skipped if
+	// the compositor doesn't implement them — the consumers own their
+	// one-shot drop WARNs (matches the local_2d precedent).
+	if (xc->layer_zone_3d == NULL) {
+		return true;
+	}
+
+	uint32_t device_id = layer->xdev_id;
+	struct xrt_device *xdev = NULL;
+	GET_XDEV_OR_RETURN(ics, device_id, xdev);
+
+	if (xdev == NULL) {
+		U_LOG_E("Invalid xdev for zone-3D layer #%u!", i);
+		return false;
+	}
+
+	// Cast away volatile.
+	struct xrt_layer_data *data = (struct xrt_layer_data *)&layer->data;
+
+	// Multi-swapchain lookup, projection-style: one id per view. Use the
+	// layer's own view_count (the app's submitted views), like the
+	// projection-depth path — zone tiles are not tied to the device's
+	// view config.
+	uint32_t view_count = data->view_count;
+	if (view_count > XRT_MAX_VIEWS) {
+		U_LOG_E("Invalid view count %u for zone-3D layer #%u!", view_count, i);
+		return false;
+	}
+
+	struct xrt_swapchain *xcs[XRT_MAX_VIEWS];
+	for (uint32_t k = 0; k < view_count; k++) {
+		const uint32_t xsci = layer->swapchain_ids[k];
+		xcs[k] = ics->xscs[xsci];
+		if (xcs[k] == NULL) {
+			U_LOG_E("Invalid swap chain for zone-3D layer #%u!", i);
+			return false;
+		}
+	}
+
+	xrt_comp_layer_zone_3d(xc, xdev, xcs, data);
+
+	return true;
+}
+
+static bool
 _update_layers(volatile struct ipc_client_state *ics, struct xrt_compositor *xc, struct ipc_layer_slot *slot)
 {
 	IPC_TRACE_MARKER();
@@ -2563,8 +2650,9 @@ _update_layers(volatile struct ipc_client_state *ics, struct xrt_compositor *xc,
 			}
 			break;
 		case XRT_LAYER_ZONE_3D:
-			// Clients never send these yet (IPC transport is P5 of
-			// XR_EXT_display_zones); skip rather than error.
+			if (!_update_zone_3d_layer(xc, ics, layer, i)) {
+				return false;
+			}
 			break;
 		default: U_LOG_E("Unhandled layer type '%i'!", layer->data.type); break;
 		}

--- a/src/xrt/ipc/shared/ipc_protocol.h
+++ b/src/xrt/ipc/shared/ipc_protocol.h
@@ -763,6 +763,22 @@ struct ipc_view_rig_info
 	//! active mode) forwards it here so the server collapses to a centered eye in
 	//! 2D. 0 = unknown → server falls back to the located view_count.
 	uint32_t render_view_count;
+
+	/*
+	 * XR_EXT_display_zones P5 (ADR-027) — append-only past this point.
+	 */
+
+	//! Zone-scoped locate (XR_EXT_display_zones P5): nonzero when the
+	//! client's locate chained an XrDisplayZoneEXT. The server rebases its
+	//! resolved window metrics to the zone rect (u_canvas_apply_to_metrics)
+	//! exactly like the in-process oxr_session.c zone block, so the Kooima
+	//! meters, eye offsets, and the raw canvas rect all describe the zone.
+	//! Zero on legacy / non-zone locates — byte-identical behavior.
+	uint32_t zone_valid;
+	int32_t zone_x_px; //!< Zone rect left, client-window pixels (y-down)
+	int32_t zone_y_px; //!< Zone rect top, client-window pixels (y-down)
+	int32_t zone_w_px; //!< Zone rect width in pixels
+	int32_t zone_h_px; //!< Zone rect height in pixels
 };
 
 /*!

--- a/src/xrt/state_trackers/oxr/oxr_objects.h
+++ b/src/xrt/state_trackers/oxr/oxr_objects.h
@@ -2340,7 +2340,6 @@ struct oxr_session
 		uint32_t located_count;
 		uint32_t located_next_slot;
 		bool warned_bad_locate_rect;
-		bool warned_ipc_locate;
 		bool warned_no_compositor_consumer;
 		bool warned_depth_ignored;
 		bool warned_validate_unlocated;

--- a/src/xrt/state_trackers/oxr/oxr_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_session.c
@@ -1999,22 +1999,42 @@ oxr_session_locate_views(struct oxr_logger *log,
 	bool ipc_rig_done = false;
 #ifdef OXR_HAVE_EXT_view_rig
 	const bool ipc_service_mode = sess->sys->xsysc != NULL && sess->sys->xsysc->info.is_service_mode;
+	// XR_EXT_display_zones P5: a zone-chained locate must also ride the
+	// server call — the client-side Kooima block (where the in-process
+	// zone rebase lives) never runs on IPC sessions, so the zone rect can
+	// only be applied where the window metrics are resolved: server-side.
+#ifdef OXR_HAVE_EXT_display_zones
+	const bool zone_chained = zone != NULL;
+#else
+	const bool zone_chained = false;
+#endif
 	const bool rig_route_native =
-	    (rig_active || view_raw != NULL) && !sess->is_bridge_relay && sess->xcn != NULL;
+	    (rig_active || view_raw != NULL || zone_chained) && !sess->is_bridge_relay && sess->xcn != NULL;
 	const bool rig_route_bridge = view_raw != NULL && sess->is_bridge_relay;
 	if ((rig_route_native || rig_route_bridge) && ipc_service_mode) {
+		struct ipc_view_rig_info rig_info = {0};
 #ifdef OXR_HAVE_EXT_display_zones
-		// Zone-scoped locate over IPC is not implemented (rides P5):
-		// the SERVER computes views from the session canvas, so the
-		// chained zone rect is silently not applied. One-shot WARN.
-		if (zone != NULL && !sess->display_zones.warned_ipc_locate) {
-			sess->display_zones.warned_ipc_locate = true;
-			U_LOG_W("Zone-scoped locate over IPC not implemented — "
-			        "session canvas used instead of zone %u rect (one-time warning)",
-			        zone->zoneId);
+		// Zone-scoped locate over IPC (P5): forward the zone rect; the
+		// server rebases its resolved window metrics with
+		// u_canvas_apply_to_metrics (ipc_try_get_sr_view_poses),
+		// mirroring the in-process zone block above. The raw channel
+		// (XrViewDisplayRawEXT.canvasRectPx) then reports the zone rect
+		// for free — it reads the rewritten metrics. Bridge relays stay
+		// inert — the server's headless fast path returns before window
+		// resolution, matching the rig-descriptor policy.
+		//
+		// @todo P5 tail: the wish-mask cross-process transport does NOT
+		// ride this call (roadmap-sanctioned slip) — service-mode wish
+		// stays on the tier-1 global fallback until the service
+		// compositor consumes zone layers.
+		if (zone != NULL && rig_route_native) {
+			rig_info.zone_valid = 1;
+			rig_info.zone_x_px = zone->rect.offset.x;
+			rig_info.zone_y_px = zone->rect.offset.y;
+			rig_info.zone_w_px = zone->rect.extent.width;
+			rig_info.zone_h_px = zone->rect.extent.height;
 		}
 #endif
-		struct ipc_view_rig_info rig_info = {0};
 		// Bridge relays keep rig_type NONE (descriptors inert); only native
 		// routes carry the chained rig overrides. In workspace mode the app's
 		// own rig is honored by default (app visual policy within its canvas);

--- a/test_apps/cube_zones_d3d11_win/main.cpp
+++ b/test_apps/cube_zones_d3d11_win/main.cpp
@@ -333,9 +333,25 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
     return DefWindowProc(hwnd, msg, wParam, lParam);
 }
 
+// Transparent window background — ON BY DEFAULT for this app: zones
+// alpha-composite against the DESKTOP by design (translucent zone
+// backgrounds, content-alpha edge fades, transparent unzoned regions), so
+// the window uses WS_EX_NOREDIRECTIONBITMAP + a null brush so DComp can
+// show the desktop through (mirrors cube_handle's DISPLAYXR_TRANSPARENT_BG
+// plumbing, default-flipped). Set DISPLAYXR_TRANSPARENT_BG=0 to opt out
+// (opaque black floor).
+static bool TransparentBackgroundEnabled() {
+    static const bool enabled = []() {
+        const char* v = getenv("DISPLAYXR_TRANSPARENT_BG");
+        return v == nullptr || *v == '\0' || *v != '0';
+    }();
+    return enabled;
+}
+
 // Create the application window
 static HWND CreateAppWindow(HINSTANCE hInstance, int width, int height) {
-    LOG_INFO("Creating application window (%dx%d)", width, height);
+    const bool transparent = TransparentBackgroundEnabled();
+    LOG_INFO("Creating application window (%dx%d, transparent=%d)", width, height, transparent);
 
     WNDCLASSEX wc = {};
     wc.cbSize = sizeof(WNDCLASSEX);
@@ -343,7 +359,9 @@ static HWND CreateAppWindow(HINSTANCE hInstance, int width, int height) {
     wc.lpfnWndProc = WindowProc;
     wc.hInstance = hInstance;
     wc.hCursor = LoadCursor(nullptr, IDC_ARROW);
-    wc.hbrBackground = (HBRUSH)GetStockObject(BLACK_BRUSH);
+    // Null brush in transparent mode so the redirection bitmap doesn't
+    // paint an opaque floor under the DComp visual.
+    wc.hbrBackground = transparent ? nullptr : (HBRUSH)GetStockObject(BLACK_BRUSH);
     wc.lpszClassName = WINDOW_CLASS;
 
     if (!RegisterClassEx(&wc)) {
@@ -358,7 +376,7 @@ static HWND CreateAppWindow(HINSTANCE hInstance, int width, int height) {
     AdjustWindowRect(&rect, WS_OVERLAPPEDWINDOW, FALSE);
 
     HWND hwnd = CreateWindowEx(
-        0,
+        transparent ? WS_EX_NOREDIRECTIONBITMAP : 0,
         WINDOW_CLASS,
         WINDOW_TITLE,
         WS_OVERLAPPEDWINDOW,
@@ -697,7 +715,20 @@ static ID3D11BlendState* g_fadeBlend = nullptr;
 static ID3D11DepthStencilState* g_fadeDepthOff = nullptr;
 static ID3D11RasterizerState* g_fadeRaster = nullptr;
 static bool g_fadeInitTried = false;
-static const float kZoneEdgeFadePx = 16.0f;
+// Content-alpha edge fade width. DXR_ZONES_FADE_PX overrides (validation
+// runs use exaggerated widths to make the composite math obvious in
+// captures); 0 disables the fade pass.
+static float ZoneEdgeFadePx() {
+    static const float px = []() {
+        const char* v = getenv("DXR_ZONES_FADE_PX");
+        if (v != nullptr && *v != '\0') {
+            float f = (float)atof(v);
+            if (f >= 0.0f && f <= 256.0f) return f;
+        }
+        return 16.0f;
+    }();
+    return px;
+}
 
 static const char* kFadeShaderSrc = R"(
 cbuffer FadeCB : register(b0) { float2 tile_px; float feather_px; float pad; };
@@ -773,7 +804,7 @@ static bool EnsureEdgeFadePass(D3D11Renderer& renderer) {
     rd.DepthClipEnable = TRUE;
     if (FAILED(renderer.device->CreateRasterizerState(&rd, &g_fadeRaster))) return false;
 
-    LOG_INFO("[zones] content-alpha edge fade pass ready (%.0f px)", kZoneEdgeFadePx);
+    LOG_INFO("[zones] content-alpha edge fade pass ready (%.0f px)", ZoneEdgeFadePx());
     return true;
 }
 
@@ -781,11 +812,12 @@ static bool EnsureEdgeFadePass(D3D11Renderer& renderer) {
 // be the tile; rtv bound without depth).
 static void DrawZoneEdgeFade(D3D11Renderer& renderer, ID3D11RenderTargetView* rtv,
                              uint32_t tileW, uint32_t tileH) {
+    if (ZoneEdgeFadePx() <= 0.0f) return; // DXR_ZONES_FADE_PX=0 disables
     if (!EnsureEdgeFadePass(renderer)) return;
 
     D3D11_MAPPED_SUBRESOURCE mapped;
     if (SUCCEEDED(renderer.context->Map(g_fadeCB, 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped))) {
-        float cb[4] = {(float)tileW, (float)tileH, kZoneEdgeFadePx, 0.0f};
+        float cb[4] = {(float)tileW, (float)tileH, ZoneEdgeFadePx(), 0.0f};
         memcpy(mapped.pData, cb, sizeof(cb));
         renderer.context->Unmap(g_fadeCB, 0);
     }
@@ -1094,6 +1126,10 @@ static void RenderZonesFrame(RenderState& rs, const XrFrameState& frameState) {
     // "faded to black". (No DISPLAYXR_TRANSPARENT_BG gate here: desktop
     // show-through is the point of this demo, as it will be for the avatar.)
     static XrEnvironmentBlendMode zonesBlendMode = []() {
+        if (!TransparentBackgroundEnabled()) {
+            LOG_INFO("[zones] DISPLAYXR_TRANSPARENT_BG=0 — submitting OPAQUE (black window floor)");
+            return XR_ENVIRONMENT_BLEND_MODE_OPAQUE;
+        }
         XrEnvironmentBlendMode modes[8];
         uint32_t count = 0;
         if (g_xr != nullptr &&


### PR DESCRIPTION
Follow-up to #539/#543 — the runtime side of ADR-027 **Phase 5** plus the agreed demo polish.

## IPC/service transport (Phase 5 runtime legs)

- **Zone-scoped locate over IPC**: `ipc_view_rig_info` appends the zone rect (append-only); zone-only locates now take the rig route; the server applies the zone rect on top of the #479 window-scoped metric resolution, before the workspace-override substitution. Proof line: `ZONES IPC: first zone-scoped locate, rect=(0,180 640x540) px` observed against the dev service.
- **`XRT_LAYER_ZONE_3D` serialization, all four hops** (client → server → multi → system transfer), projection-style multi-swapchain ids. Transport proof observed: the service compositor's one-shot `Zone-3D layer reached the D3D11 service compositor (IPC transport ok)`.
- **D3D11 service compositor**: registered, structurally-honest drop + `@todo` — its projection consumption is a single-layer full-tile blit/zero-copy pipeline; placed zone layers need a real composite leg there (a full-tile render would silently ignore the rect).
- **Wish over IPC: slipped** (roadmap-sanctioned). Verified legacy `XR_EXT_local_3d_zone` masks don't cross IPC either (mask creation is `api_matched`-gated) so there's no existing sideband; service stays on the tier-1 global fallback.

## Demo (`cube_zones_d3d11_win`)

- **Transparent window by default** (`WS_EX_NOREDIRECTIONBITMAP` + null brush; `DISPLAYXR_TRANSPARENT_BG=0` opts out) + ALPHA_BLEND when advertised — zones now composite against the actual desktop instead of an opaque black floor (the residual "fades to black" from the eyeball rounds).
- `DXR_ZONES_FADE_PX` knob for the content-alpha edge fade (default 16; 0 disables).

## Validation

- Forced-IPC run (dev service + `XRT_FORCE_MODE=ipc`): both proof lines present, no client drop warnings.
- Atlas pixel probes (48-px exaggerated fades, overlap on): premultiplied alpha-over **exact** at every probe — overlap core `21/8/25` matches the Mac-measured Metal/VK value from #543 byte-for-byte; fade bands over content, under translucency, and to transparent all on the math.
- Zero-zone regressions, ctest 25/25, `displayxr-cli selftest`, app linter green on the rebased branch (post-#543/#533 main).

Remaining zones work after this: service-compositor zone composite leg (in-repo, @todo'd), wish-over-IPC (rides the service leg), Leia plug-in caps (P5 vendor half, own repo), avatar migration (P6, own repo) — session prompts for the last two are drafted as untracked working files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)