### PR TITLE
fix(display-zones): skip the content-alpha edge fade in Tier-2 wish mode (demo polish)

### DIFF
--- a/test_apps/cube_zones_d3d11_win/main.cpp
+++ b/test_apps/cube_zones_d3d11_win/main.cpp
@@ -1073,15 +1073,24 @@ static void RenderZonesFrame(RenderState& rs, const XrFrameState& frameState) {
         // whatever is behind it — desktop OR another zone (the union wish
         // mask cannot express per-zone fades inside an overlap). One pass
         // per view tile, after the scene render.
-        for (uint32_t vi = 0; vi < n; vi++) {
-            D3D11_VIEWPORT vp = {};
-            vp.TopLeftX = (FLOAT)(vi * z.tileW);
-            vp.TopLeftY = 0.0f;
-            vp.Width = (FLOAT)z.tileW;
-            vp.Height = (FLOAT)z.tileH;
-            vp.MaxDepth = 1.0f;
-            renderer.context->RSSetViewports(1, &vp);
-            DrawZoneEdgeFade(renderer, rtv, z.tileW, z.tileH);
+        //
+        // Skipped in wish mode 1 (explicit Tier-2 rects): that wish is
+        // M=1 out to the exact rect edge, and weave output carries no
+        // alpha — content faded inside a hard-M=1 band weaves to opaque
+        // black (the dark-halo mechanism), not to the desktop. Tier-2
+        // content must fill its rect to the hard edge; soft outer edges
+        // belong to AUTO / Tier-3, whose wish feathers M inward to 0.
+        if (g_wishMode != 1) {
+            for (uint32_t vi = 0; vi < n; vi++) {
+                D3D11_VIEWPORT vp = {};
+                vp.TopLeftX = (FLOAT)(vi * z.tileW);
+                vp.TopLeftY = 0.0f;
+                vp.Width = (FLOAT)z.tileW;
+                vp.Height = (FLOAT)z.tileH;
+                vp.MaxDepth = 1.0f;
+                renderer.context->RSSetViewports(1, &vp);
+                DrawZoneEdgeFade(renderer, rtv, z.tileW, z.tileH);
+            }
         }
 
         if (rtv) rtv->Release();

--- a/test_apps/cube_zones_metal_macos/main.mm
+++ b/test_apps/cube_zones_metal_macos/main.mm
@@ -2323,7 +2323,11 @@ static void RenderZoneScene(MetalRenderer &r, id<MTLTexture> target, DisplayZone
     }
 
     // --- Content-alpha edge fade per view tile (after the scene) ---
-    {
+    // Skipped in wish mode 1 (explicit Tier-2 rects): that wish is M=1 out
+    // to the exact rect edge, and weave output carries no alpha — content
+    // faded inside a hard-M=1 band weaves to opaque black (dark halo), not
+    // to the desktop. Tier-2 content must fill its rect to the hard edge.
+    if (g_wishMode != 1) {
         FadeUniforms fu = {};
         fu.tile_px[0] = (float)z.tileW;
         fu.tile_px[1] = (float)z.tileH;


### PR DESCRIPTION
## What

The Tier-2 explicit-rects wish is M=1 out to the exact rect edge, and weave output carries no alpha — content faded inside that hard-M=1 band weaves to **opaque black** (the dark-halo mechanism), not to the desktop. The zones demo ran its 16-px content-alpha edge fade in every wish mode, so mode 1 framed each zone in a black border instead of meeting the desktop.

Gate the fade pass on `g_wishMode != 1`:
- `cube_zones_d3d11_win`: Tier-2 now shows content filling its rect to a crisp hard edge against the desktop (the honest look for the binary tier); AUTO and Tier-3 keep their feathers.
- `cube_zones_metal_macos`: same gate (it has the same fade + a Tier-2 mode). Code-only pending the usual Mac eyeball.
- `cube_zones_vk_macos`: no content fade — untouched.

## Validation

On glass (Leia SR, dev runtime @ fe509b180): mode 1 black frame gone, crisp hard edge against desktop incl. overlap; modes 0/2 feathers unchanged. User-eyeballed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)