### PR TITLE
feat(#542): decouple hardware 2D/3D state from rendered content + hardware-only xrRequestDisplayModeEXT

### DIFF
--- a/docs/specs/extensions/XR_EXT_display_info.md
+++ b/docs/specs/extensions/XR_EXT_display_info.md
@@ -920,9 +920,10 @@ if (/* a 3D-capable rendering mode exists */ false) {
 
 // Example: mono submission in 2D mode
 if (!displayMode3D) {
-    // xrLocateViews fills an 8-wide buffer; in a 2D mode viewCount comes back 1,
-    // but locate into XRT_MAX_VIEWS regardless and compute the center eye from the
-    // valid entries.
+    // xrLocateViews always reports the MAX view count (so apps size their
+    // arrays once); in a 2D mode every returned view carries the SAME
+    // centered eye pose. Locate into XRT_MAX_VIEWS and use view 0 (or the
+    // centroid — identical in 2D).
     XrView views[8];
     for (uint32_t i = 0; i < 8; i++) views[i] = {XR_TYPE_VIEW};
     uint32_t viewCount = 8;

--- a/docs/specs/extensions/XR_EXT_display_info.md
+++ b/docs/specs/extensions/XR_EXT_display_info.md
@@ -722,7 +722,9 @@ typedef struct XrDisplayInfoEXT {
 
 #### XrDisplayModeEXT
 
-> **Deprecated in v10.** `XrDisplayModeEXT` is deprecated in favor of `xrRequestDisplayRenderingModeEXT`, which provides a unified rendering mode API covering both 2D/3D switching and vendor-specific rendering variations. New applications should use `xrRequestDisplayRenderingModeEXT`. `XrDisplayModeEXT` and `xrRequestDisplayModeEXT` remain supported for backward compatibility.
+> **Repurposed in v15.** `XrDisplayModeEXT` names the two physical hardware states for
+> the [hardware-state-only override](#xrrequestdisplaymodeext). Content/mode selection
+> stays with `xrRequestDisplayRenderingModeEXT`; this enum no longer implies a mode switch.
 
 ```c
 typedef enum XrDisplayModeEXT {
@@ -748,13 +750,22 @@ This extension's current (v14) function set (v14 adds no functions — only the 
 | [`xrEnumerateDisplayRenderingModesEXT`](#enumerating-rendering-modes-v8--xrdisplayrenderingmodeinfoext--xrenumeratedisplayrenderingmodesext) | v8 | Enumerate available rendering modes (`XrDisplayRenderingModeInfoEXT`). |
 | [`xrRequestDisplayRenderingModeEXT`](#7-display-rendering-mode-control-v7) | v7 | Request a rendering mode by index (the unified mode-control API). |
 | [`xrRequestEyeTrackingModeEXT`](#new-function-xrrequesteyetrackingmodeext) | v6 | Switch between managed and manual eye tracking. |
-| `xrRequestDisplayModeEXT` | v4 (**deprecated** v10) | Legacy 2D/3D toggle — thin wrapper over `xrRequestDisplayRenderingModeEXT`. |
+| `xrRequestDisplayModeEXT` | v4 (**repurposed** v15) | Hardware-state-only override for the current mode (was a deprecated mode-switching wrapper through v14). |
 
 #### xrRequestDisplayModeEXT
 
-> **Deprecated in v10.** Use `xrRequestDisplayRenderingModeEXT` instead. See [Display Rendering Mode Control (v7)](#7-display-rendering-mode-control-v7) for the unified replacement (and [Enumerating Rendering Modes](#enumerating-rendering-modes-v8--xrdisplayrenderingmodeinfoext--xrenumeratedisplayrenderingmodesext) to discover modes). `xrRequestDisplayModeEXT` remains supported for backward compatibility as a thin wrapper that finds the first mode matching the requested hardware-3D state and delegates.
+> **Repurposed in v15.** Through v14 this function was a deprecated thin wrapper that found
+> the first rendering mode matching the requested hardware state and delegated to
+> `xrRequestDisplayRenderingModeEXT` (i.e. it *switched modes*). As of v15 it is the
+> **hardware-state-only override**: a rendering mode is a complete recipe — layout, view
+> count, scales, **and a default hardware state** — and `xrRequestDisplayRenderingModeEXT`
+> requests a mode with the hardware following automatically. THIS function sets the
+> hardware state **alone**, leaving the active mode, the application's content, and the
+> display processor's atlas processing untouched. No caller of the pre-v15 wrapper
+> behavior existed in the DisplayXR app corpus at the time of the repurpose.
 
-Requests that the runtime switch the display between 2D and 3D modes.
+Requests the physical 2D/3D display state (e.g. the switchable lenticular lens) for the
+**current** rendering mode, without changing the mode.
 
 ```c
 XrResult xrRequestDisplayModeEXT(
@@ -767,29 +778,35 @@ XrResult xrRequestDisplayModeEXT(
 | Parameter | Description |
 |---|---|
 | `session` | A valid `XrSession` handle. |
-| `mode` | The requested display mode (`XR_DISPLAY_MODE_2D_EXT` or `XR_DISPLAY_MODE_3D_EXT`). |
+| `mode` | The requested hardware state (`XR_DISPLAY_MODE_2D_EXT` or `XR_DISPLAY_MODE_3D_EXT`). |
 
 **Return Codes:**
 
 | Code | Meaning |
 |---|---|
-| `XR_SUCCESS` | The mode request was accepted by the runtime. |
-| `XR_ERROR_FEATURE_UNSUPPORTED` | The display does not support mode switching (no enumerated rendering mode reports `hardwareDisplay3D == XR_TRUE`). |
-| `XR_ERROR_SESSION_NOT_RUNNING` | The session is not in a running state. |
+| `XR_SUCCESS` | The hardware-state request was accepted by the runtime. |
+| `XR_ERROR_VALIDATION_FAILURE` | `mode` is not a valid `XrDisplayModeEXT` value. |
 | `XR_ERROR_HANDLE_INVALID` | The session handle is invalid. |
 
 **Semantics:**
 
-- This function is a **request**, not a guarantee. The runtime forwards the request to the
+- **Hardware only.** The active rendering mode (and so the advertised layout, view count
+  and scales), the application's submission, and the display processor's atlas processing
+  are unaffected. The display processor keeps weaving a multi-view atlas or flat-blitting
+  a single-view atlas exactly as the content dictates — only the physical 2D/3D element
+  changes. Requesting `XR_DISPLAY_MODE_2D_EXT` over an active 3D mode therefore shows the
+  *woven* atlas flat (blurry); an application fading its parallax to zero converges back
+  to a sharp image — the building block for app-authored 2D↔3D transitions such as the
+  MANUAL eye-tracking loss flow.
+- **Lifetime of the override.** The override holds until the next
+  `xrRequestDisplayRenderingModeEXT` call, whose mode's default hardware state then
+  applies (re-requesting the current mode index restores its default).
+- A successful state flip is reported via `XrEventDataHardwareDisplayStateChangedEXT`.
+  No `XrEventDataRenderingModeChangedEXT` is fired — the mode did not change.
+- This function is a **request**, not a guarantee. The runtime forwards it to the
   underlying platform SDK via the display processor (some vendors implement it as a
-  preference-based hint, others as direct backlight control). The platform may aggregate
+  preference-based hint, others as direct hardware control). The platform may aggregate
   requests from multiple applications or defer the switch.
-- The function returns `XR_SUCCESS` when the request has been accepted, regardless of
-  whether the display has physically completed the mode change.
-- The application **may** call this function at any time while the session is running.
-- If no enumerated rendering mode reports `hardwareDisplay3D == XR_TRUE` (the display has no 3D
-  mode), this function returns `XR_ERROR_FEATURE_UNSUPPORTED` and has no effect. (`hardwareDisplay3D`
-  is a per-mode field on `XrDisplayRenderingModeInfoEXT`; it is no longer on `XrDisplayInfoEXT`.)
 
 ### Display Mode Switching
 
@@ -2033,7 +2050,8 @@ the property) silently ignore the call — graceful degradation.
 | 10 | 2026-03-12 | David Fattal | Removed `supportsDisplayModeSwitch` (derivable from mode enumeration), renamed `display3D` to `hardwareDisplay3D`, deprecated `xrRequestDisplayModeEXT` in favor of unified `xrRequestDisplayRenderingModeEXT`, added rendering mode and hardware display state change events (`XrEventDataRenderingModeChangedEXT`, `XrEventDataHardwareDisplayStateChangedEXT`). |
 | 11 | 2026-03-20 | David Fattal | Added per-mode tile layout fields to `XrDisplayRenderingModeInfoEXT`: `tileColumns`, `tileRows`, `viewWidthPixels`, `viewHeightPixels`. Enables runtime to describe atlas layout for multi-view rendering modes (e.g., 2x2 quad). |
 | 12 | 2026-03-28 | David Fattal | Removed `hardwareDisplay3D` from `XrDisplayInfoEXT`. It remains available **per-mode** on `XrDisplayRenderingModeInfoEXT` (via `xrEnumerateDisplayRenderingModesEXT`) and is also reported by the `XrEventDataHardwareDisplayStateChangedEXT` event. Also moved `xrSetSharedTextureOutputRectEXT` to the window-binding extension headers. |
-| 13 | 2026-05-18 | David Fattal | Added per-session `isActive` and `isRequestable` fields to `XrDisplayRenderingModeInfoEXT` (#234). `isActive` lets an app learn the current mode from the first enumerate without waiting for an event; `isRequestable` tells a session whether it may request a mode (false for non-controller sessions under a workspace). **Current header version (`XR_EXT_display_info_SPEC_VERSION == 13`).** |
+| 13 | 2026-05-18 | David Fattal | Added per-session `isActive` and `isRequestable` fields to `XrDisplayRenderingModeInfoEXT` (#234). `isActive` lets an app learn the current mode from the first enumerate without waiting for an event; `isRequestable` tells a session whether it may request a mode (false for non-controller sessions under a workspace). |
+| 15 | 2026-06-11 | David Fattal | **Repurposed `xrRequestDisplayModeEXT`** (#542): no longer a deprecated mode-switching wrapper — it now sets the HARDWARE display state alone for the current mode (the mode's layout/content and the DP's atlas processing are untouched; the DP weaves or flat-blits per the atlas it is handed). Override holds until the next mode request. Reported via `XrEventDataHardwareDisplayStateChangedEXT`. No struct/ABI change. **Current header version (`XR_EXT_display_info_SPEC_VERSION == 15`).** |
 
 > The `XR_EXT_display_info_SPEC_VERSION` define in the header is the authoritative current
 > revision. Earlier revision numbers in this table reflect the proposal's editing history and do
@@ -2077,6 +2095,6 @@ The runtime is based on Monado (open-source OpenXR runtime) with native composit
 | **Screen-centered coordinates** | The coordinate frame used by RAW mode eye positions: origin at the physical display center, +X right, +Y up, +Z toward the viewer. Implicit in the returned `XrView.pose.position` — no dedicated reference space needed. |
 | **Nominal viewer position** | A static, design-time expectation of the viewer's position relative to the display. Not tracked; defines the apex of the canonical display pyramid. |
 | **Disparity** | Horizontal shift between left and right eye images, measured as a fraction of window width. Controls perceived depth of window-space layers. |
-| **Display mode** | The operational mode of a tracked 3D display: 2D (standard flat panel) or 3D (light field interlacing active). Historically controlled via `xrRequestDisplayModeEXT` (deprecated in v10). New apps use `xrRequestDisplayRenderingModeEXT` which provides unified control over both 2D/3D switching and vendor-specific rendering variations. |
+| **Display mode** | The physical 2D/3D state of a tracked 3D display's switchable element (e.g. lenticular lens). Follows the active rendering mode's default automatically; `xrRequestDisplayModeEXT` (v15) overrides it alone for the current mode, leaving content and DP processing untouched. |
 | **Display rendering mode** | A vendor-specific rendering variation within 3D mode (e.g., SBS stereo, anaglyph, lenticular). Controlled via `xrRequestDisplayRenderingModeEXT`. Mode 0 is standard; higher indices are vendor-defined. |
 | **Surface binding** | A platform-specific mechanism for the application to provide its own rendering surface to the runtime (`HWND` on Win32; `ANativeWindow*` + Java `Surface` + screen position on Android). |

--- a/src/external/openxr_includes/openxr/XR_EXT_display_info.h
+++ b/src/external/openxr_includes/openxr/XR_EXT_display_info.h
@@ -22,7 +22,7 @@ extern "C" {
 #endif
 
 #define XR_EXT_display_info 1
-#define XR_EXT_display_info_SPEC_VERSION 14
+#define XR_EXT_display_info_SPEC_VERSION 15
 #define XR_EXT_DISPLAY_INFO_EXTENSION_NAME "XR_EXT_display_info"
 
 // Reuse the type value from the deleted XR_EXT_dynamic_render_resolution
@@ -55,10 +55,7 @@ typedef struct XrDisplayInfoEXT {
 } XrDisplayInfoEXT;
 
 /*!
- * @brief Display mode for XR_EXT_display_info 2D/3D switching.
- *
- * @deprecated Use xrRequestDisplayRenderingModeEXT instead. Each rendering mode
- * carries a hardwareDisplay3D field that triggers physical switching automatically.
+ * @brief Hardware display state for xrRequestDisplayModeEXT (v15 repurpose).
  */
 typedef enum XrDisplayModeEXT {
     XR_DISPLAY_MODE_2D_EXT = 0,
@@ -67,21 +64,29 @@ typedef enum XrDisplayModeEXT {
 } XrDisplayModeEXT;
 
 /*!
- * @brief Request display mode switch (2D/3D).
+ * @brief Request the HARDWARE display state alone for the current mode
+ * (v15 repurpose — was a deprecated mode-switching wrapper through v14).
  *
- * @deprecated Use xrRequestDisplayRenderingModeEXT instead. This function is a
- * thin wrapper that finds the first rendering mode matching the requested
- * hardware display state and delegates to xrRequestDisplayRenderingModeEXT.
+ * A rendering mode is a complete recipe: layout, view count, scales, and a
+ * default hardware state. xrRequestDisplayRenderingModeEXT requests a mode
+ * and the hardware state follows automatically. THIS function overrides the
+ * hardware state ALONE: the active rendering mode, the app's submitted
+ * content, and the display processor's atlas processing are untouched —
+ * only the physical 2D/3D element (e.g. the switchable lenticular lens)
+ * changes.
  *
- * Switches the display between 2D and 3D modes. In 3D mode, the display's
- * light field hardware is active for stereoscopic viewing. In 2D mode, the
- * display behaves as a conventional 2D panel.
+ * E.g. XR_DISPLAY_MODE_2D_EXT over an active 3D mode keeps the weave
+ * running with the lens off: the panel shows the woven atlas flat (blurry),
+ * and an app fading its parallax to zero converges back to a sharp image —
+ * the building block for app-authored 2D/3D transitions such as the MANUAL
+ * eye-tracking loss flow.
  *
- * The runtime automatically switches to 3D mode on xrBeginSession and back
- * to 2D mode on xrEndSession.
+ * The override holds until the next mode request (whose default hardware
+ * state then applies) or the next call to this function. A successful state
+ * flip is reported via XrEventDataHardwareDisplayStateChangedEXT.
  *
  * @param session A valid XrSession handle.
- * @param displayMode The desired display mode (2D or 3D).
+ * @param displayMode The desired hardware state (2D or 3D).
  * @return XR_SUCCESS on success.
  */
 typedef XrResult (XRAPI_PTR *PFN_xrRequestDisplayModeEXT)(XrSession session, XrDisplayModeEXT displayMode);

--- a/src/xrt/compositor/d3d11/comp_d3d11_compositor.cpp
+++ b/src/xrt/compositor/d3d11/comp_d3d11_compositor.cpp
@@ -319,6 +319,12 @@ struct comp_d3d11_compositor
 	//! True when display is in 3D mode (weaver active). False = 2D passthrough.
 	bool hardware_display_3d;
 
+	//! Per-frame effective CONTENT layout (#542): the atlas grid actually
+	//! painted and handed to the DP this frame — submission-derived,
+	//! decoupled from hardware_display_3d. views == 0 until the first
+	//! layer commit computes it.
+	struct comp_d3d11_eff_layout eff_layout;
+
 	//! Last known 3D rendering mode index (for V-key toggle restore).
 	uint32_t last_3d_mode_index;
 
@@ -1262,13 +1268,20 @@ d3d11_capture_texture_to_png(struct comp_d3d11_compositor *c,
 	return ok;
 }
 
-// Resolve the active content region (tile_columns·view_w × tile_rows·view_h)
-// from the renderer. Returns false if the renderer hasn't been sized yet.
+// Resolve the active content region from the frame's effective layout (#542:
+// what the passes actually painted — submission-derived), falling back to the
+// renderer's mode layout before the first commit. Returns false if the
+// renderer hasn't been sized yet.
 static bool
 d3d11_compositor_content_dims(struct comp_d3d11_compositor *c, uint32_t *out_w, uint32_t *out_h)
 {
 	if (c->renderer == nullptr) {
 		return false;
+	}
+	if (c->eff_layout.views > 0 && c->eff_layout.tile_w > 0 && c->eff_layout.tile_h > 0) {
+		*out_w = c->eff_layout.cols * c->eff_layout.tile_w;
+		*out_h = c->eff_layout.rows * c->eff_layout.tile_h;
+		return true;
 	}
 	uint32_t tile_columns = 1, tile_rows = 1;
 	comp_d3d11_renderer_get_tile_layout(c->renderer, &tile_columns, &tile_rows);
@@ -1295,6 +1308,15 @@ d3d11_compositor_capture_dims_provider(void *userdata,
 	struct comp_d3d11_compositor *c = static_cast<struct comp_d3d11_compositor *>(userdata);
 	if (c == nullptr || c->renderer == nullptr) {
 		return false;
+	}
+	// #542: report the frame's effective layout (what the capture actually
+	// holds), falling back to the renderer's mode layout pre-first-commit.
+	if (c->eff_layout.views > 0 && c->eff_layout.tile_w > 0 && c->eff_layout.tile_h > 0) {
+		*out_view_w = c->eff_layout.tile_w;
+		*out_view_h = c->eff_layout.tile_h;
+		*out_tile_cols = c->eff_layout.cols;
+		*out_tile_rows = c->eff_layout.rows;
+		return true;
 	}
 	uint32_t vw = 0, vh = 0, cols = 1, rows = 1;
 	comp_d3d11_renderer_get_view_dimensions(c->renderer, &vw, &vh);
@@ -1615,6 +1637,13 @@ d3d11_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 		}
 	}
 
+	// Per-frame effective CONTENT layout (#542): tile grid/dims from the
+	// SUBMISSION, decoupled from the hardware weave-state. Feeds both
+	// renderer passes, the DP handoff, and the capture providers — they
+	// must all agree on the frame's geometry.
+	comp_d3d11_renderer_compute_effective_layout(c->renderer, &c->layer_accum, c->hardware_display_3d,
+	                                             &c->eff_layout);
+
 	// Zero-copy check: can we pass the app's swapchain directly to the DP?
 	bool zero_copy = false;
 	void *zc_srv = nullptr;
@@ -1630,7 +1659,12 @@ d3d11_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 			if (layer->data.type == XRT_LAYER_PROJECTION ||
 			    layer->data.type == XRT_LAYER_PROJECTION_DEPTH) {
 				uint32_t vc = mode->view_count;
-				bool same_sc = (vc > 0 && vc <= XRT_MAX_VIEWS && layer->sc_array[0] != NULL);
+				// #542: a hardware/content divergence frame (submitted
+				// views != mode views) must take the atlas path — the
+				// per-view loops below would read stale proj.v[] slots,
+				// and zero-copy can't re-tile a mismatched submission.
+				bool same_sc = (vc > 0 && vc <= XRT_MAX_VIEWS && layer->data.view_count == vc &&
+				                layer->sc_array[0] != NULL);
 				for (uint32_t v = 1; v < vc && same_sc; v++) {
 					if (layer->sc_array[v] != layer->sc_array[0])
 						same_sc = false;
@@ -1766,7 +1800,7 @@ d3d11_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 	xrt_result_t xret = XRT_SUCCESS;
 	if (!zero_copy) {
 		xret = comp_d3d11_renderer_draw_projection_pass(
-		    c->renderer, &c->layer_accum, &left_eye, &right_eye, tgt_width, tgt_height, c->hardware_display_3d);
+		    c->renderer, &c->layer_accum, &left_eye, &right_eye, tgt_width, tgt_height, &c->eff_layout);
 		if (xret != XRT_SUCCESS) {
 			U_LOG_E("Failed to render projection pass");
 			return xret;
@@ -1778,7 +1812,7 @@ d3d11_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 		d3d11_compositor_dispatch_capture(c, MCP_CAPTURE_MODE_PROJECTION_ONLY);
 
 		xret = comp_d3d11_renderer_draw_window_space_pass(
-		    c->renderer, &c->layer_accum, tgt_width, tgt_height, c->hardware_display_3d);
+		    c->renderer, &c->layer_accum, tgt_width, tgt_height, &c->eff_layout);
 		if (xret != XRT_SUCCESS) {
 			U_LOG_E("Failed to render window-space pass");
 			return xret;
@@ -1801,10 +1835,13 @@ d3d11_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 		// Weave/blit directly into the shared texture
 		if (c->display_processor != NULL && c->shared_rtv != nullptr) {
 			void *atlas_srv = zero_copy ? zc_srv : comp_d3d11_renderer_get_atlas_srv(c->renderer);
-			uint32_t view_width, view_height;
-			comp_d3d11_renderer_get_view_dimensions(c->renderer, &view_width, &view_height);
-			uint32_t tile_columns, tile_rows;
-			comp_d3d11_renderer_get_tile_layout(c->renderer, &tile_columns, &tile_rows);
+			// #542: the DP gets the frame's EFFECTIVE content layout —
+			// the grid the passes above actually painted (== the mode
+			// layout for matched submissions) — not the mode layout.
+			uint32_t view_width = c->eff_layout.tile_w;
+			uint32_t view_height = c->eff_layout.tile_h;
+			uint32_t tile_columns = c->eff_layout.cols;
+			uint32_t tile_rows = c->eff_layout.rows;
 
 			// Crop the renderer's atlas to content dims before passing to the
 			// DP (the renderer allocates a worst-case atlas; content sits
@@ -1909,10 +1946,13 @@ d3d11_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 
 		void *atlas_srv = zero_copy ? zc_srv : comp_d3d11_renderer_get_atlas_srv(c->renderer);
 
-		uint32_t view_width, view_height;
-		comp_d3d11_renderer_get_view_dimensions(c->renderer, &view_width, &view_height);
-		uint32_t tile_columns, tile_rows;
-		comp_d3d11_renderer_get_tile_layout(c->renderer, &tile_columns, &tile_rows);
+		// #542: the DP gets the frame's EFFECTIVE content layout — the grid
+		// the passes above actually painted (== the mode layout for matched
+		// submissions) — not the mode layout.
+		uint32_t view_width = c->eff_layout.tile_w;
+		uint32_t view_height = c->eff_layout.tile_h;
+		uint32_t tile_columns = c->eff_layout.cols;
+		uint32_t tile_rows = c->eff_layout.rows;
 
 		// Crop the renderer's atlas to content dims before passing to the DP;
 		// never crop a zero-copy atlas — the app's swapchain is already a

--- a/src/xrt/compositor/d3d11/comp_d3d11_compositor.cpp
+++ b/src/xrt/compositor/d3d11/comp_d3d11_compositor.cpp
@@ -1637,12 +1637,11 @@ d3d11_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 		}
 	}
 
-	// Per-frame effective CONTENT layout (#542): tile grid/dims from the
-	// SUBMISSION, decoupled from the hardware weave-state. Feeds both
-	// renderer passes, the DP handoff, and the capture providers — they
-	// must all agree on the frame's geometry.
-	comp_d3d11_renderer_compute_effective_layout(c->renderer, &c->layer_accum, c->hardware_display_3d,
-	                                             &c->eff_layout);
+	// Per-frame effective CONTENT layout (#542): the mode's recipe, with the
+	// submission clamped to it. Feeds both renderer passes, the DP handoff,
+	// and the capture providers — they must all agree on the frame's
+	// geometry.
+	comp_d3d11_renderer_compute_effective_layout(c->renderer, &c->layer_accum, &c->eff_layout);
 
 	// Zero-copy check: can we pass the app's swapchain directly to the DP?
 	bool zero_copy = false;

--- a/src/xrt/compositor/d3d11/comp_d3d11_renderer.cpp
+++ b/src/xrt/compositor/d3d11/comp_d3d11_renderer.cpp
@@ -1272,25 +1272,85 @@ comp_d3d11_renderer_destroy(struct comp_d3d11_renderer **renderer_ptr)
 	*renderer_ptr = nullptr;
 }
 
-// Compute effective_views consistently between the two passes (must
-// agree so window-space layers land on the same per-tile viewports
-// the projection pass painted).
-static uint32_t
-compute_effective_views(struct comp_layer_accum *layers, bool hardware_display_3d)
+// Per-frame effective CONTENT layout (#542): tile count from the SUBMISSION,
+// decoupled from the hardware weave-state. Computed once per frame and shared
+// by both passes (must agree so window-space layers land on the same per-tile
+// viewports the projection pass painted) and the DP handoff.
+extern "C" void
+comp_d3d11_renderer_compute_effective_layout(struct comp_d3d11_renderer *renderer,
+                                             struct comp_layer_accum *layers,
+                                             bool hardware_display_3d,
+                                             struct comp_d3d11_eff_layout *out_layout)
 {
-	uint32_t effective_views = 2;
+	uint32_t mode_cols = renderer->tile_columns > 0 ? renderer->tile_columns : 1;
+	uint32_t mode_rows = renderer->tile_rows > 0 ? renderer->tile_rows : 1;
+	uint32_t mode_tiles = mode_cols * mode_rows;
+
+	uint32_t views = mode_tiles;
+	const struct comp_layer *proj_layer = NULL;
 	for (uint32_t i = 0; i < layers->layer_count; i++) {
 		if (layers->layers[i].data.type == XRT_LAYER_PROJECTION ||
 		    layers->layers[i].data.type == XRT_LAYER_PROJECTION_DEPTH ||
 		    layers->layers[i].data.type == XRT_LAYER_ZONE_3D) {
-			effective_views = layers->layers[i].data.view_count;
+			proj_layer = &layers->layers[i];
+			views = proj_layer->data.view_count;
 			break;
 		}
 	}
-	if (!hardware_display_3d && effective_views > 1) {
-		effective_views = 1;
+	if (views == 0) {
+		views = 1;
 	}
-	return effective_views;
+	if (views > XRT_MAX_VIEWS) {
+		views = XRT_MAX_VIEWS;
+	}
+	// Legacy apps always submit the same views and can't author transitions
+	// — keep the hardware-keyed mono clamp so V→2D stays mono, not SBS.
+	if (renderer->legacy_app_tile_scaling && !hardware_display_3d && views > 1) {
+		views = 1;
+	}
+
+	out_layout->views = views;
+	if (views == 1) {
+		// Mono content: one tile spanning the full content region (the
+		// paint box additionally caps to the window target — see
+		// get_view_tile_box). In a matched 2D mode (1×1 grid) this IS
+		// the mode layout.
+		out_layout->cols = 1;
+		out_layout->rows = 1;
+		out_layout->tile_w = mode_cols * renderer->view_width;
+		out_layout->tile_h = mode_rows * renderer->view_height;
+	} else if (views == mode_tiles) {
+		// Matched submission: the mode layout, unchanged.
+		out_layout->cols = mode_cols;
+		out_layout->rows = mode_rows;
+		out_layout->tile_w = renderer->view_width;
+		out_layout->tile_h = renderer->view_height;
+	} else {
+		// Hardware/content divergence: a views×1 strip sized by the
+		// submitted imageRect, capped to the physical atlas so a
+		// mid-transition frame renders predictably instead of
+		// overflowing.
+		uint32_t tile_w = (mode_cols * renderer->view_width) / views;
+		uint32_t tile_h = mode_rows * renderer->view_height;
+		if (proj_layer != NULL) {
+			const struct xrt_rect *r0 = &proj_layer->data.proj.v[0].sub.rect;
+			if (r0->extent.w > 0 && r0->extent.h > 0) {
+				tile_w = static_cast<uint32_t>(r0->extent.w);
+				tile_h = static_cast<uint32_t>(r0->extent.h);
+			}
+		}
+		uint32_t atlas_w = mode_cols * renderer->view_width;
+		if (tile_w * views > atlas_w && views > 0) {
+			tile_w = atlas_w / views;
+		}
+		if (tile_h > renderer->texture_height) {
+			tile_h = renderer->texture_height;
+		}
+		out_layout->cols = views;
+		out_layout->rows = 1;
+		out_layout->tile_w = tile_w;
+		out_layout->tile_h = tile_h;
+	}
 }
 
 // Compute the per-view tile box for either pass — the box set_view_viewport
@@ -1298,7 +1358,7 @@ compute_effective_views(struct comp_layer_accum *layers, bool hardware_display_3
 static void
 get_view_tile_box(struct comp_d3d11_renderer *renderer,
                   uint32_t view_index,
-                  uint32_t effective_views,
+                  const struct comp_d3d11_eff_layout *layout,
                   uint32_t target_width,
                   uint32_t target_height,
                   float *out_x,
@@ -1306,12 +1366,11 @@ get_view_tile_box(struct comp_d3d11_renderer *renderer,
                   float *out_w,
                   float *out_h)
 {
-	if (effective_views == 1) {
+	if (layout->views == 1) {
 		// MONO: use target (window) dimensions so 2D content fills
-		// the full window. Width is capped to the atlas texture width
-		// (tile_columns*view_width); height is capped to texture_height.
-		uint32_t atlas_w = renderer->tile_columns * renderer->view_width;
-		uint32_t mono_w = (target_width < atlas_w) ? target_width : atlas_w;
+		// the full window. Width is capped to the content region
+		// (layout tile_w spans it); height is capped to texture_height.
+		uint32_t mono_w = (target_width < layout->tile_w) ? target_width : layout->tile_w;
 		uint32_t mono_h = (target_height < renderer->texture_height)
 		                      ? target_height
 		                      : renderer->texture_height;
@@ -1320,13 +1379,13 @@ get_view_tile_box(struct comp_d3d11_renderer *renderer,
 		*out_w = static_cast<float>(mono_w);
 		*out_h = static_cast<float>(mono_h);
 	} else {
-		// MULTI-VIEW: tile-based atlas layout
-		uint32_t col = view_index % renderer->tile_columns;
-		uint32_t row = view_index / renderer->tile_columns;
-		*out_x = static_cast<float>(col * renderer->view_width);
-		*out_y = static_cast<float>(row * renderer->view_height);
-		*out_w = static_cast<float>(renderer->view_width);
-		*out_h = static_cast<float>(renderer->view_height);
+		// MULTI-VIEW: tile-based atlas layout from the effective grid
+		uint32_t col = view_index % layout->cols;
+		uint32_t row = view_index / layout->cols;
+		*out_x = static_cast<float>(col * layout->tile_w);
+		*out_y = static_cast<float>(row * layout->tile_h);
+		*out_w = static_cast<float>(layout->tile_w);
+		*out_h = static_cast<float>(layout->tile_h);
 	}
 }
 
@@ -1334,13 +1393,13 @@ get_view_tile_box(struct comp_d3d11_renderer *renderer,
 static void
 set_view_viewport(struct comp_d3d11_renderer *renderer,
                   uint32_t view_index,
-                  uint32_t effective_views,
+                  const struct comp_d3d11_eff_layout *layout,
                   uint32_t target_width,
                   uint32_t target_height)
 {
 	auto internals = get_internals(renderer->c);
 	D3D11_VIEWPORT viewport = {};
-	get_view_tile_box(renderer, view_index, effective_views, target_width, target_height, &viewport.TopLeftX,
+	get_view_tile_box(renderer, view_index, layout, target_width, target_height, &viewport.TopLeftX,
 	                  &viewport.TopLeftY, &viewport.Width, &viewport.Height);
 	viewport.MinDepth = 0.0f;
 	viewport.MaxDepth = 1.0f;
@@ -1354,7 +1413,7 @@ comp_d3d11_renderer_draw_projection_pass(struct comp_d3d11_renderer *renderer,
                                           struct xrt_vec3 *right_eye,
                                           uint32_t target_width,
                                           uint32_t target_height,
-                                          bool hardware_display_3d)
+                                          const struct comp_d3d11_eff_layout *layout)
 {
 	auto internals = get_internals(renderer->c);
 
@@ -1408,10 +1467,10 @@ comp_d3d11_renderer_draw_projection_pass(struct comp_d3d11_renderer *renderer,
 		fovs[view].angle_down = -fov_angle;
 	}
 
-	uint32_t effective_views = compute_effective_views(layers, hardware_display_3d);
+	uint32_t effective_views = layout->views;
 
 	for (uint32_t view_index = 0; view_index < effective_views; view_index++) {
-		set_view_viewport(renderer, view_index, effective_views, target_width, target_height);
+		set_view_viewport(renderer, view_index, layout, target_width, target_height);
 		struct xrt_vec3 *eye = (view_index == 0) ? left_eye : right_eye;
 
 		for (uint32_t i = 0; i < layers->layer_count; i++) {
@@ -1434,7 +1493,7 @@ comp_d3d11_renderer_draw_projection_pass(struct comp_d3d11_renderer *renderer,
 					break;
 				}
 				float tx, ty, tw, th;
-				get_view_tile_box(renderer, view_index, effective_views, target_width,
+				get_view_tile_box(renderer, view_index, layout, target_width,
 				                  target_height, &tx, &ty, &tw, &th);
 				const float sx = tw / static_cast<float>(target_width);
 				const float sy = th / static_cast<float>(target_height);
@@ -1459,7 +1518,7 @@ comp_d3d11_renderer_draw_projection_pass(struct comp_d3d11_renderer *renderer,
 				// the right per-view sub/fov data unchanged.
 				render_projection_layer(renderer, layer, view_index, eye);
 				internals->context->OMSetBlendState(renderer->blend_opaque, nullptr, 0xFFFFFFFF);
-				set_view_viewport(renderer, view_index, effective_views, target_width, target_height);
+				set_view_viewport(renderer, view_index, layout, target_width, target_height);
 				break;
 			}
 
@@ -1516,11 +1575,11 @@ comp_d3d11_renderer_draw_window_space_pass(struct comp_d3d11_renderer *renderer,
                                             struct comp_layer_accum *layers,
                                             uint32_t target_width,
                                             uint32_t target_height,
-                                            bool hardware_display_3d)
+                                            const struct comp_d3d11_eff_layout *layout)
 {
-	uint32_t effective_views = compute_effective_views(layers, hardware_display_3d);
+	uint32_t effective_views = layout->views;
 	for (uint32_t view_index = 0; view_index < effective_views; view_index++) {
-		set_view_viewport(renderer, view_index, effective_views, target_width, target_height);
+		set_view_viewport(renderer, view_index, layout, target_width, target_height);
 		for (uint32_t i = 0; i < layers->layer_count; i++) {
 			struct comp_layer *layer = &layers->layers[i];
 			if (layer->data.type == XRT_LAYER_WINDOW_SPACE) {
@@ -1538,15 +1597,15 @@ comp_d3d11_renderer_draw(struct comp_d3d11_renderer *renderer,
                          struct xrt_vec3 *right_eye,
                          uint32_t target_width,
                          uint32_t target_height,
-                         bool hardware_display_3d)
+                         const struct comp_d3d11_eff_layout *layout)
 {
 	xrt_result_t xret = comp_d3d11_renderer_draw_projection_pass(
-	    renderer, layers, left_eye, right_eye, target_width, target_height, hardware_display_3d);
+	    renderer, layers, left_eye, right_eye, target_width, target_height, layout);
 	if (xret != XRT_SUCCESS) {
 		return xret;
 	}
 	return comp_d3d11_renderer_draw_window_space_pass(
-	    renderer, layers, target_width, target_height, hardware_display_3d);
+	    renderer, layers, target_width, target_height, layout);
 }
 
 extern "C" void *

--- a/src/xrt/compositor/d3d11/comp_d3d11_renderer.cpp
+++ b/src/xrt/compositor/d3d11/comp_d3d11_renderer.cpp
@@ -1272,14 +1272,20 @@ comp_d3d11_renderer_destroy(struct comp_d3d11_renderer **renderer_ptr)
 	*renderer_ptr = nullptr;
 }
 
-// Per-frame effective CONTENT layout (#542): tile count from the SUBMISSION,
-// decoupled from the hardware weave-state. Computed once per frame and shared
-// by both passes (must agree so window-space layers land on the same per-tile
-// viewports the projection pass painted) and the DP handoff.
+// Per-frame effective CONTENT layout (#542): the content recipe is the
+// ACTIVE MODE's — submissions are clamped to it, never the other way round.
+// Apps express a hardware/content divergence via the hardware-state override
+// (xrRequestDisplayModeEXT), NOT by submitting mismatched view counts: the
+// runtime always reports the max view count from xrLocateViews (identical
+// centered views in a mono mode), so always-stereo apps legitimately submit
+// 2 identical views in 2D mode and must clamp to mono (the documented compat
+// guarantee — and zone layers carry zone-sized imageRects that must never
+// define atlas geometry). Computed once per frame and shared by both passes
+// (must agree so window-space layers land on the same per-tile viewports the
+// projection pass painted) and the DP handoff.
 extern "C" void
 comp_d3d11_renderer_compute_effective_layout(struct comp_d3d11_renderer *renderer,
                                              struct comp_layer_accum *layers,
-                                             bool hardware_display_3d,
                                              struct comp_d3d11_eff_layout *out_layout)
 {
 	uint32_t mode_cols = renderer->tile_columns > 0 ? renderer->tile_columns : 1;
@@ -1287,69 +1293,42 @@ comp_d3d11_renderer_compute_effective_layout(struct comp_d3d11_renderer *rendere
 	uint32_t mode_tiles = mode_cols * mode_rows;
 
 	uint32_t views = mode_tiles;
-	const struct comp_layer *proj_layer = NULL;
 	for (uint32_t i = 0; i < layers->layer_count; i++) {
 		if (layers->layers[i].data.type == XRT_LAYER_PROJECTION ||
 		    layers->layers[i].data.type == XRT_LAYER_PROJECTION_DEPTH ||
 		    layers->layers[i].data.type == XRT_LAYER_ZONE_3D) {
-			proj_layer = &layers->layers[i];
-			views = proj_layer->data.view_count;
+			views = layers->layers[i].data.view_count;
 			break;
 		}
 	}
 	if (views == 0) {
 		views = 1;
 	}
+	if (views > mode_tiles) {
+		views = mode_tiles;
+	}
 	if (views > XRT_MAX_VIEWS) {
 		views = XRT_MAX_VIEWS;
-	}
-	// Legacy apps always submit the same views and can't author transitions
-	// — keep the hardware-keyed mono clamp so V→2D stays mono, not SBS.
-	if (renderer->legacy_app_tile_scaling && !hardware_display_3d && views > 1) {
-		views = 1;
 	}
 
 	out_layout->views = views;
 	if (views == 1) {
 		// Mono content: one tile spanning the full content region (the
 		// paint box additionally caps to the window target — see
-		// get_view_tile_box). In a matched 2D mode (1×1 grid) this IS
-		// the mode layout.
+		// get_view_tile_box). In a 2D mode (1×1 grid) this IS the mode
+		// layout; an under-submitting app in a multi-view mode gets the
+		// same full-region stretch, and the DP flat-blits the 1×1 grid.
 		out_layout->cols = 1;
 		out_layout->rows = 1;
 		out_layout->tile_w = mode_cols * renderer->view_width;
 		out_layout->tile_h = mode_rows * renderer->view_height;
-	} else if (views == mode_tiles) {
-		// Matched submission: the mode layout, unchanged.
+	} else {
+		// The mode layout; an under-submitting app (views < mode_tiles,
+		// e.g. 2 in a quad mode) paints the first `views` tiles.
 		out_layout->cols = mode_cols;
 		out_layout->rows = mode_rows;
 		out_layout->tile_w = renderer->view_width;
 		out_layout->tile_h = renderer->view_height;
-	} else {
-		// Hardware/content divergence: a views×1 strip sized by the
-		// submitted imageRect, capped to the physical atlas so a
-		// mid-transition frame renders predictably instead of
-		// overflowing.
-		uint32_t tile_w = (mode_cols * renderer->view_width) / views;
-		uint32_t tile_h = mode_rows * renderer->view_height;
-		if (proj_layer != NULL) {
-			const struct xrt_rect *r0 = &proj_layer->data.proj.v[0].sub.rect;
-			if (r0->extent.w > 0 && r0->extent.h > 0) {
-				tile_w = static_cast<uint32_t>(r0->extent.w);
-				tile_h = static_cast<uint32_t>(r0->extent.h);
-			}
-		}
-		uint32_t atlas_w = mode_cols * renderer->view_width;
-		if (tile_w * views > atlas_w && views > 0) {
-			tile_w = atlas_w / views;
-		}
-		if (tile_h > renderer->texture_height) {
-			tile_h = renderer->texture_height;
-		}
-		out_layout->cols = views;
-		out_layout->rows = 1;
-		out_layout->tile_w = tile_w;
-		out_layout->tile_h = tile_h;
 	}
 }
 

--- a/src/xrt/compositor/d3d11/comp_d3d11_renderer.h
+++ b/src/xrt/compositor/d3d11/comp_d3d11_renderer.h
@@ -26,15 +26,16 @@ extern "C" {
 
 /*!
  * Per-frame effective CONTENT layout (#542): the atlas tile grid the renderer
- * paints and the DP receives, derived from the app's SUBMISSION — decoupled
- * from the hardware weave-state (which only drives the DP's mode_3d via
- * request_display_mode). Matched submissions reproduce the mode layout
- * exactly; a hardware/content divergence gets a views×1 strip instead of
- * being clamped away.
+ * paints and the DP receives. The content recipe is the ACTIVE MODE's —
+ * submissions are clamped to it (always-stereo apps legitimately submit
+ * identical views in a mono mode; zone layers carry zone-sized imageRects).
+ * The hardware weave-state never clamps content: a divergence is expressed
+ * via the hardware-state override (xrRequestDisplayModeEXT), under which this
+ * layout keeps following the mode and the DP keeps weaving.
  */
 struct comp_d3d11_eff_layout
 {
-	uint32_t views;  //!< effective view count (post legacy clamp)
+	uint32_t views;  //!< effective view count (submission clamped to mode)
 	uint32_t cols;   //!< atlas tile columns
 	uint32_t rows;   //!< atlas tile rows
 	uint32_t tile_w; //!< per-tile width in pixels
@@ -44,20 +45,16 @@ struct comp_d3d11_eff_layout
 /*!
  * Compute the frame's effective content layout from the accumulated layers.
  *
- * views comes from the first projection-class layer's view_count (default:
- * the mode tile grid when none). Legacy apps keep the hardware-keyed mono
- * clamp — they always submit the same views and can't author transitions.
- * When views matches the mode grid the layout IS the mode layout; when it
- * is 1 the single tile spans the full content region (the mono paint box
- * additionally caps to the window target, as before); otherwise a views×1
- * strip sized by the submitted imageRect, capped to the physical atlas.
+ * views = the first projection-class layer's view_count clamped to the mode
+ * tile count (default: the mode tile count when none). views == 1 spans the
+ * full content region as one tile (the mono paint box additionally caps to
+ * the window target, as before); otherwise the mode grid.
  *
  * @ingroup comp_d3d11
  */
 void
 comp_d3d11_renderer_compute_effective_layout(struct comp_d3d11_renderer *renderer,
                                              struct comp_layer_accum *layers,
-                                             bool hardware_display_3d,
                                              struct comp_d3d11_eff_layout *out_layout);
 
 /*!

--- a/src/xrt/compositor/d3d11/comp_d3d11_renderer.h
+++ b/src/xrt/compositor/d3d11/comp_d3d11_renderer.h
@@ -25,6 +25,42 @@ extern "C" {
 #endif
 
 /*!
+ * Per-frame effective CONTENT layout (#542): the atlas tile grid the renderer
+ * paints and the DP receives, derived from the app's SUBMISSION — decoupled
+ * from the hardware weave-state (which only drives the DP's mode_3d via
+ * request_display_mode). Matched submissions reproduce the mode layout
+ * exactly; a hardware/content divergence gets a views×1 strip instead of
+ * being clamped away.
+ */
+struct comp_d3d11_eff_layout
+{
+	uint32_t views;  //!< effective view count (post legacy clamp)
+	uint32_t cols;   //!< atlas tile columns
+	uint32_t rows;   //!< atlas tile rows
+	uint32_t tile_w; //!< per-tile width in pixels
+	uint32_t tile_h; //!< per-tile height in pixels
+};
+
+/*!
+ * Compute the frame's effective content layout from the accumulated layers.
+ *
+ * views comes from the first projection-class layer's view_count (default:
+ * the mode tile grid when none). Legacy apps keep the hardware-keyed mono
+ * clamp — they always submit the same views and can't author transitions.
+ * When views matches the mode grid the layout IS the mode layout; when it
+ * is 1 the single tile spans the full content region (the mono paint box
+ * additionally caps to the window target, as before); otherwise a views×1
+ * strip sized by the submitted imageRect, capped to the physical atlas.
+ *
+ * @ingroup comp_d3d11
+ */
+void
+comp_d3d11_renderer_compute_effective_layout(struct comp_d3d11_renderer *renderer,
+                                             struct comp_layer_accum *layers,
+                                             bool hardware_display_3d,
+                                             struct comp_d3d11_eff_layout *out_layout);
+
+/*!
  * Create a D3D11 renderer.
  *
  * @param c The D3D11 compositor.
@@ -64,8 +100,8 @@ comp_d3d11_renderer_destroy(struct comp_d3d11_renderer **renderer_ptr);
  * @param target_width Width of the render target (window). Used for mono
  *        viewport sizing so 2D content fills the full window.
  * @param target_height Height of the render target (window).
- * @param hardware_display_3d True when in 3D mode (stereo rendering),
- *        false for 2D passthrough (mono rendering, single view fills window).
+ * @param layout The frame's effective content layout (#542), from
+ *        @ref comp_d3d11_renderer_compute_effective_layout.
  *
  * @return XRT_SUCCESS on success, error code otherwise.
  *
@@ -78,7 +114,7 @@ comp_d3d11_renderer_draw(struct comp_d3d11_renderer *renderer,
                          struct xrt_vec3 *right_eye,
                          uint32_t target_width,
                          uint32_t target_height,
-                         bool hardware_display_3d);
+                         const struct comp_d3d11_eff_layout *layout);
 
 /*!
  * Render the projection-class pass of the atlas (projection /
@@ -101,7 +137,7 @@ comp_d3d11_renderer_draw_projection_pass(struct comp_d3d11_renderer *renderer,
                                           struct xrt_vec3 *right_eye,
                                           uint32_t target_width,
                                           uint32_t target_height,
-                                          bool hardware_display_3d);
+                                          const struct comp_d3d11_eff_layout *layout);
 
 /*!
  * Render only window-space layers into the atlas, on top of whatever
@@ -119,7 +155,7 @@ comp_d3d11_renderer_draw_window_space_pass(struct comp_d3d11_renderer *renderer,
                                             struct comp_layer_accum *layers,
                                             uint32_t target_width,
                                             uint32_t target_height,
-                                            bool hardware_display_3d);
+                                            const struct comp_d3d11_eff_layout *layout);
 
 /*!
  * Get the atlas texture SRV for weaving.

--- a/src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp
+++ b/src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp
@@ -1529,12 +1529,11 @@ d3d12_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 		}
 	}
 
-	// Per-frame effective CONTENT layout (#542): tile grid/dims from the
-	// SUBMISSION, decoupled from the hardware weave-state. Feeds both
-	// renderer passes, the DP handoffs, and the capture providers — they
-	// must all agree on the frame's geometry.
-	comp_d3d12_renderer_compute_effective_layout(c->renderer, &c->layer_accum, c->hardware_display_3d,
-	                                             &c->eff_layout);
+	// Per-frame effective CONTENT layout (#542): the mode's recipe, with the
+	// submission clamped to it. Feeds both renderer passes, the DP handoffs,
+	// and the capture providers — they must all agree on the frame's
+	// geometry.
+	comp_d3d12_renderer_compute_effective_layout(c->renderer, &c->layer_accum, &c->eff_layout);
 
 	// Zero-copy check: can we pass the app's swapchain directly to the DP?
 	bool zero_copy = false;

--- a/src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp
+++ b/src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp
@@ -159,6 +159,12 @@ struct comp_d3d12_compositor
 	//! True when display is in 3D mode (weaver active). False = 2D passthrough.
 	bool hardware_display_3d;
 
+	//! Per-frame effective CONTENT layout (#542): the atlas grid actually
+	//! painted and handed to the DP this frame — submission-derived,
+	//! decoupled from hardware_display_3d. views == 0 until the first
+	//! layer commit computes it.
+	struct comp_d3d12_eff_layout eff_layout;
+
 	//! Last known 3D rendering mode index (for V-key toggle restore).
 	uint32_t last_3d_mode_index;
 
@@ -1156,6 +1162,15 @@ d3d12_compositor_capture_dims_provider(void *userdata,
 	if (c == nullptr || c->renderer == nullptr) {
 		return false;
 	}
+	// #542: report the frame's effective layout (what the capture actually
+	// holds), falling back to the renderer's mode layout pre-first-commit.
+	if (c->eff_layout.views > 0 && c->eff_layout.tile_w > 0 && c->eff_layout.tile_h > 0) {
+		*out_view_w = c->eff_layout.tile_w;
+		*out_view_h = c->eff_layout.tile_h;
+		*out_tile_cols = c->eff_layout.cols;
+		*out_tile_rows = c->eff_layout.rows;
+		return true;
+	}
 	uint32_t vw = 0, vh = 0, cols = 1, rows = 1;
 	comp_d3d12_renderer_get_view_dimensions(c->renderer, &vw, &vh);
 	comp_d3d12_renderer_get_tile_layout(c->renderer, &cols, &rows);
@@ -1188,10 +1203,19 @@ d3d12_compositor_capture_atlas_to_png(struct comp_d3d12_compositor *c, const cha
 		return false;
 	}
 
+	// #542: capture the frame's effective content region (what the passes
+	// painted), falling back to the renderer's mode layout pre-first-commit.
 	uint32_t tile_columns = 1, tile_rows = 1;
-	comp_d3d12_renderer_get_tile_layout(c->renderer, &tile_columns, &tile_rows);
 	uint32_t view_w = 0, view_h = 0;
-	comp_d3d12_renderer_get_view_dimensions(c->renderer, &view_w, &view_h);
+	if (c->eff_layout.views > 0 && c->eff_layout.tile_w > 0 && c->eff_layout.tile_h > 0) {
+		tile_columns = c->eff_layout.cols;
+		tile_rows = c->eff_layout.rows;
+		view_w = c->eff_layout.tile_w;
+		view_h = c->eff_layout.tile_h;
+	} else {
+		comp_d3d12_renderer_get_tile_layout(c->renderer, &tile_columns, &tile_rows);
+		comp_d3d12_renderer_get_view_dimensions(c->renderer, &view_w, &view_h);
+	}
 	if (tile_columns == 0 || tile_rows == 0 || view_w == 0 || view_h == 0) {
 		return false;
 	}
@@ -1505,6 +1529,13 @@ d3d12_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 		}
 	}
 
+	// Per-frame effective CONTENT layout (#542): tile grid/dims from the
+	// SUBMISSION, decoupled from the hardware weave-state. Feeds both
+	// renderer passes, the DP handoffs, and the capture providers — they
+	// must all agree on the frame's geometry.
+	comp_d3d12_renderer_compute_effective_layout(c->renderer, &c->layer_accum, c->hardware_display_3d,
+	                                             &c->eff_layout);
+
 	// Zero-copy check: can we pass the app's swapchain directly to the DP?
 	bool zero_copy = false;
 	void *zc_resource = nullptr;
@@ -1520,7 +1551,12 @@ d3d12_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 			if (layer->data.type == XRT_LAYER_PROJECTION ||
 			    layer->data.type == XRT_LAYER_PROJECTION_DEPTH) {
 				uint32_t vc = mode->view_count;
-				bool same_sc = (vc > 0 && vc <= XRT_MAX_VIEWS && layer->sc_array[0] != NULL);
+				// #542: a hardware/content divergence frame (submitted
+				// views != mode views) must take the atlas path — the
+				// per-view loops below would read stale proj.v[] slots,
+				// and zero-copy can't re-tile a mismatched submission.
+				bool same_sc = (vc > 0 && vc <= XRT_MAX_VIEWS && layer->data.view_count == vc &&
+				                layer->sc_array[0] != NULL);
 				for (uint32_t v = 1; v < vc && same_sc; v++) {
 					if (layer->sc_array[v] != layer->sc_array[0])
 						same_sc = false;
@@ -1601,7 +1637,7 @@ d3d12_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 	xrt_result_t xret = XRT_SUCCESS;
 	if (!zero_copy) {
 		xret = comp_d3d12_renderer_draw_projection_pass(
-		    c->renderer, c->cmd_list, &c->layer_accum, &left_eye, &right_eye, tgt_width, tgt_height, c->hardware_display_3d);
+		    c->renderer, c->cmd_list, &c->layer_accum, &left_eye, &right_eye, tgt_width, tgt_height, &c->eff_layout);
 		if (xret != XRT_SUCCESS) {
 			U_LOG_E("Failed to render projection pass");
 			return xret;
@@ -1642,7 +1678,7 @@ d3d12_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 		}
 
 		xret = comp_d3d12_renderer_draw_window_space_pass(
-		    c->renderer, c->cmd_list, &c->layer_accum, tgt_width, tgt_height, c->hardware_display_3d);
+		    c->renderer, c->cmd_list, &c->layer_accum, tgt_width, tgt_height, &c->eff_layout);
 		if (xret != XRT_SUCCESS) {
 			U_LOG_E("Failed to render window-space pass");
 			return xret;
@@ -1693,10 +1729,13 @@ d3d12_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 			D3D12_CPU_DESCRIPTOR_HANDLE st_rtv = c->shared_texture_rtv_heap->GetCPUDescriptorHandleForHeapStart();
 			c->cmd_list->OMSetRenderTargets(1, &st_rtv, FALSE, nullptr);
 
-			uint32_t view_width, view_height;
-			comp_d3d12_renderer_get_view_dimensions(c->renderer, &view_width, &view_height);
-			uint32_t tile_columns, tile_rows;
-			comp_d3d12_renderer_get_tile_layout(c->renderer, &tile_columns, &tile_rows);
+			// #542: the DP gets the frame's EFFECTIVE content layout —
+			// the grid the passes above actually painted (== the mode
+			// layout for matched submissions) — not the mode layout.
+			uint32_t view_width = c->eff_layout.tile_w;
+			uint32_t view_height = c->eff_layout.tile_h;
+			uint32_t tile_columns = c->eff_layout.cols;
+			uint32_t tile_rows = c->eff_layout.rows;
 
 			// Crop atlas to content dimensions
 			uint32_t content_w = tile_columns * view_width;
@@ -1889,8 +1928,10 @@ d3d12_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 		// Bind back buffer as render target
 		c->cmd_list->OMSetRenderTargets(1, &rtv_handle, FALSE, nullptr);
 
-		uint32_t view_width, view_height;
-		comp_d3d12_renderer_get_view_dimensions(c->renderer, &view_width, &view_height);
+		// #542: the DP gets the frame's EFFECTIVE content layout (== the
+		// mode layout for matched submissions), not the mode layout.
+		uint32_t view_width = c->eff_layout.tile_w;
+		uint32_t view_height = c->eff_layout.tile_h;
 		ID3D12Resource *atlas_resource = zero_copy
 		    ? static_cast<ID3D12Resource *>(zc_resource)
 		    : static_cast<ID3D12Resource *>(comp_d3d12_renderer_get_atlas_resource(c->renderer));
@@ -1919,8 +1960,8 @@ d3d12_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 			atlas_barrier.Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
 			c->cmd_list->ResourceBarrier(1, &atlas_barrier);
 
-			uint32_t tile_columns, tile_rows;
-			comp_d3d12_renderer_get_tile_layout(c->renderer, &tile_columns, &tile_rows);
+			uint32_t tile_columns = c->eff_layout.cols;
+			uint32_t tile_rows = c->eff_layout.rows;
 
 			// Crop atlas to content dimensions before passing to DP
 			uint32_t content_w = tile_columns * view_width;

--- a/src/xrt/compositor/d3d12/comp_d3d12_renderer.cpp
+++ b/src/xrt/compositor/d3d12/comp_d3d12_renderer.cpp
@@ -525,6 +525,8 @@ render_window_space_layer(struct comp_d3d12_renderer *r,
                           ID3D12GraphicsCommandList *cmd_list,
                           const struct comp_layer *layer,
                           uint32_t view_index,
+                          uint32_t tile_x,
+                          uint32_t tile_y,
                           uint32_t vp_w,
                           uint32_t vp_h)
 {
@@ -644,11 +646,9 @@ render_window_space_layer(struct comp_d3d12_renderer *r,
 	cmd_list->SetGraphicsRootDescriptorTable(0, gpu_srv);
 
 	// Set RTV (atlas as render target) — viewport for the current view tile
+	// (tile origin from the caller's effective layout, #542).
 	D3D12_CPU_DESCRIPTOR_HANDLE rtv = r->rtv_heap->GetCPUDescriptorHandleForHeapStart();
 	cmd_list->OMSetRenderTargets(1, &rtv, FALSE, nullptr);
-
-	uint32_t tile_x = (view_index % r->tile_columns) * r->view_width;
-	uint32_t tile_y = (view_index / r->tile_columns) * r->view_height;
 
 	D3D12_VIEWPORT vp = {};
 	vp.TopLeftX = (float)tile_x;
@@ -1363,7 +1363,7 @@ comp_d3d12_renderer_draw_projection_pass(struct comp_d3d12_renderer *renderer,
                                           struct xrt_vec3 *right_eye,
                                           uint32_t target_width,
                                           uint32_t target_height,
-                                          bool hardware_display_3d)
+                                          const struct comp_d3d12_eff_layout *layout)
 {
 	ID3D12GraphicsCommandList *cmd_list = static_cast<ID3D12GraphicsCommandList *>(cmd_list_ptr);
 
@@ -1376,9 +1376,9 @@ comp_d3d12_renderer_draw_projection_pass(struct comp_d3d12_renderer *renderer,
 	bool draw_log = (draw_counter < 5 || draw_counter % 300 == 0);
 	draw_counter++;
 	if (draw_log) {
-		U_LOG_W("D3D12 renderer draw: layers=%u, 3d=%d, view=%ux%u, target=%ux%u",
-		        layers->layer_count, hardware_display_3d,
-		        renderer->view_width, renderer->view_height,
+		U_LOG_W("D3D12 renderer draw: layers=%u, eff=%ux%u tile=%ux%u, target=%ux%u",
+		        layers->layer_count, layout->cols, layout->rows,
+		        layout->tile_w, layout->tile_h,
 		        target_width, target_height);
 	}
 
@@ -1422,8 +1422,9 @@ comp_d3d12_renderer_draw_projection_pass(struct comp_d3d12_renderer *renderer,
 	cmd_list->OMSetRenderTargets(1, &rtv, FALSE, nullptr);
 	cmd_list->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
 
-	// Determine view count
-	uint32_t view_count = hardware_display_3d ? 2 : 1;
+	// CONTENT view count from the SUBMISSION-derived effective layout
+	// (#542) — no longer clamped by the hardware weave-state.
+	uint32_t view_count = layout->views;
 
 	// For each projection / zone layer, stretch-blit swapchain images into
 	// atlas tiles (zone layers land at the zone rect scaled into the tile
@@ -1439,9 +1440,6 @@ comp_d3d12_renderer_draw_projection_pass(struct comp_d3d12_renderer *renderer,
 		}
 
 		uint32_t layer_view_count = layer->data.view_count;
-		if (!hardware_display_3d) {
-			layer_view_count = 1;
-		}
 
 		for (uint32_t vi = 0; vi < layer_view_count && vi < view_count; vi++) {
 			struct xrt_swapchain *xsc = layer->sc_array[vi];
@@ -1527,10 +1525,10 @@ comp_d3d12_renderer_draw_projection_pass(struct comp_d3d12_renderer *renderer,
 			D3D12_GPU_DESCRIPTOR_HANDLE gpu_srv = renderer->srv_heap->GetGPUDescriptorHandleForHeapStart();
 			gpu_srv.ptr += renderer->srv_descriptor_size * srv_slot;
 
-			// Tile position in atlas grid
-			uint32_t tile_idx = (layer_view_count == 1) ? 0 : vi;
-			uint32_t tile_x = (tile_idx % renderer->tile_columns) * renderer->view_width;
-			uint32_t tile_y = (tile_idx / renderer->tile_columns) * renderer->view_height;
+			// Tile position in the effective atlas grid (#542)
+			uint32_t tile_idx = vi;
+			uint32_t tile_x = (tile_idx % layout->cols) * layout->tile_w;
+			uint32_t tile_y = (tile_idx / layout->cols) * layout->tile_h;
 
 			if (draw_log) {
 				U_LOG_W("D3D12 renderer: blit layer=%u view=%u, src=%p (%llux%u), "
@@ -1538,15 +1536,14 @@ comp_d3d12_renderer_draw_projection_pass(struct comp_d3d12_renderer *renderer,
 				        li, vi, (void *)src_resource,
 				        (unsigned long long)src_desc.Width, (unsigned)src_desc.Height,
 				        src_x, src_y, src_w, src_h,
-				        tile_x, tile_y, renderer->view_width, renderer->view_height);
+				        tile_x, tile_y, layout->tile_w, layout->tile_h);
 			}
 
-			// In mono/2D mode, clamp viewport to window dims (matching D3D11)
-			uint32_t vp_w = renderer->view_width;
-			uint32_t vp_h = renderer->view_height;
-			if (!hardware_display_3d) {
-				uint32_t atlas_w = renderer->tile_columns * renderer->view_width;
-				if (target_width < atlas_w) vp_w = target_width;
+			// Mono content: clamp viewport to window dims (matching D3D11)
+			uint32_t vp_w = layout->tile_w;
+			uint32_t vp_h = layout->tile_h;
+			if (layout->views == 1) {
+				if (target_width < layout->tile_w) vp_w = target_width;
 				if (target_height < renderer->texture_height) vp_h = target_height;
 			}
 
@@ -1606,37 +1603,10 @@ comp_d3d12_renderer_draw_projection_pass(struct comp_d3d12_renderer *renderer,
 			cmd_list->SetGraphicsRoot32BitConstants(1, 4, blit_src_rect, 0);
 			cmd_list->DrawInstanced(4, 1, 0, 0);
 
-			// For mono: draw same quad again at second tile position
-			if (layer_view_count == 1 && view_count == 2) {
-				uint32_t dup_x = (1 % renderer->tile_columns) * renderer->view_width;
-				uint32_t dup_y = (1 / renderer->tile_columns) * renderer->view_height;
-
-				vp.TopLeftX = static_cast<float>(dup_x);
-				vp.TopLeftY = static_cast<float>(dup_y);
-				vp.Width = static_cast<float>(vp_w);
-				vp.Height = static_cast<float>(vp_h);
-				if (is_zone && target_width > 0 && target_height > 0) {
-					// Same zone sub-rect, duplicated into the second tile.
-					const struct xrt_rect *zr = &layer->data.zone_3d.rect;
-					const float zsx = vp.Width / static_cast<float>(target_width);
-					const float zsy = vp.Height / static_cast<float>(target_height);
-					vp.TopLeftX += static_cast<float>(zr->offset.w) * zsx;
-					vp.TopLeftY += static_cast<float>(zr->offset.h) * zsy;
-					vp.Width = static_cast<float>(zr->extent.w) * zsx;
-					vp.Height = static_cast<float>(zr->extent.h) * zsy;
-				}
-				if (vp.Width > 0.0f && vp.Height > 0.0f) {
-					cmd_list->RSSetViewports(1, &vp);
-
-					scissor.left = dup_x;
-					scissor.top = dup_y;
-					scissor.right = dup_x + vp_w;
-					scissor.bottom = dup_y + vp_h;
-					cmd_list->RSSetScissorRects(1, &scissor);
-
-					cmd_list->DrawInstanced(4, 1, 0, 0);
-				}
-			}
+			// #542: the old mono dup-to-tile-1 draw is gone — the atlas
+			// holds exactly the tiles the app submitted (1 view ⇒ a 1×1
+			// effective grid), so there is no second tile to fill. The DP
+			// weaves or flattens whatever arrives per its own mode_3d.
 
 			// XR_EXT_display_zones: restore the REPLACE blit PSO for the
 			// next (projection) draw.
@@ -1662,32 +1632,35 @@ comp_d3d12_renderer_draw_window_space_pass(struct comp_d3d12_renderer *renderer,
                                             struct comp_layer_accum *layers,
                                             uint32_t target_width,
                                             uint32_t target_height,
-                                            bool hardware_display_3d)
+                                            const struct comp_d3d12_eff_layout *layout)
 {
 	ID3D12GraphicsCommandList *cmd_list = static_cast<ID3D12GraphicsCommandList *>(cmd_list_ptr);
 	if (cmd_list == nullptr || layers == nullptr) {
 		return XRT_ERROR_IPC_FAILURE;
 	}
 
-	uint32_t view_count = hardware_display_3d ? 2 : 1;
+	// Same effective grid as the projection pass (#542) — HUD tiles must
+	// land on the per-tile viewports the projection pass painted.
+	uint32_t view_count = layout->views;
 
 	// Compute effective viewport for window-space layers (same clamp as projection)
-	uint32_t ws_vp_w = renderer->view_width;
-	uint32_t ws_vp_h = renderer->view_height;
-	if (!hardware_display_3d) {
-		uint32_t atlas_w = renderer->tile_columns * renderer->view_width;
-		if (target_width < atlas_w) ws_vp_w = target_width;
+	uint32_t ws_vp_w = layout->tile_w;
+	uint32_t ws_vp_h = layout->tile_h;
+	if (layout->views == 1) {
+		if (target_width < layout->tile_w) ws_vp_w = target_width;
 		if (target_height < renderer->texture_height) ws_vp_h = target_height;
 	}
 
 	// Draw window-space layers (atlas is in RENDER_TARGET state)
 	for (uint32_t vi = 0; vi < view_count; vi++) {
+		uint32_t tile_x = (vi % layout->cols) * layout->tile_w;
+		uint32_t tile_y = (vi / layout->cols) * layout->tile_h;
 		for (uint32_t li = 0; li < layers->layer_count; li++) {
 			struct comp_layer *layer = &layers->layers[li];
 			if (layer->data.type != XRT_LAYER_WINDOW_SPACE) {
 				continue;
 			}
-			render_window_space_layer(renderer, cmd_list, layer, vi, ws_vp_w, ws_vp_h);
+			render_window_space_layer(renderer, cmd_list, layer, vi, tile_x, tile_y, ws_vp_w, ws_vp_h);
 		}
 	}
 
@@ -1711,17 +1684,87 @@ comp_d3d12_renderer_draw(struct comp_d3d12_renderer *renderer,
                          struct xrt_vec3 *right_eye,
                          uint32_t target_width,
                          uint32_t target_height,
-                         bool hardware_display_3d)
+                         const struct comp_d3d12_eff_layout *layout)
 {
 	xrt_result_t xret = comp_d3d12_renderer_draw_projection_pass(
 	    renderer, cmd_list_ptr, layers, left_eye, right_eye,
-	    target_width, target_height, hardware_display_3d);
+	    target_width, target_height, layout);
 	if (xret != XRT_SUCCESS) {
 		return xret;
 	}
 	return comp_d3d12_renderer_draw_window_space_pass(
 	    renderer, cmd_list_ptr, layers,
-	    target_width, target_height, hardware_display_3d);
+	    target_width, target_height, layout);
+}
+
+// Per-frame effective CONTENT layout (#542) — same policy as the D3D11 leg
+// (comp_d3d11_renderer_compute_effective_layout): submission view_count, mode
+// grid when matched, views×1 strip sized by the submitted imageRect on a
+// hardware/content divergence, legacy apps keep the hardware-keyed mono clamp.
+extern "C" void
+comp_d3d12_renderer_compute_effective_layout(struct comp_d3d12_renderer *renderer,
+                                             struct comp_layer_accum *layers,
+                                             bool hardware_display_3d,
+                                             struct comp_d3d12_eff_layout *out_layout)
+{
+	uint32_t mode_cols = renderer->tile_columns > 0 ? renderer->tile_columns : 1;
+	uint32_t mode_rows = renderer->tile_rows > 0 ? renderer->tile_rows : 1;
+	uint32_t mode_tiles = mode_cols * mode_rows;
+
+	uint32_t views = mode_tiles;
+	const struct comp_layer *proj_layer = NULL;
+	for (uint32_t i = 0; i < layers->layer_count; i++) {
+		if (layers->layers[i].data.type == XRT_LAYER_PROJECTION ||
+		    layers->layers[i].data.type == XRT_LAYER_PROJECTION_DEPTH ||
+		    layers->layers[i].data.type == XRT_LAYER_ZONE_3D) {
+			proj_layer = &layers->layers[i];
+			views = proj_layer->data.view_count;
+			break;
+		}
+	}
+	if (views == 0) {
+		views = 1;
+	}
+	if (views > XRT_MAX_VIEWS) {
+		views = XRT_MAX_VIEWS;
+	}
+	if (renderer->legacy_app_tile_scaling && !hardware_display_3d && views > 1) {
+		views = 1;
+	}
+
+	out_layout->views = views;
+	if (views == 1) {
+		out_layout->cols = 1;
+		out_layout->rows = 1;
+		out_layout->tile_w = mode_cols * renderer->view_width;
+		out_layout->tile_h = mode_rows * renderer->view_height;
+	} else if (views == mode_tiles) {
+		out_layout->cols = mode_cols;
+		out_layout->rows = mode_rows;
+		out_layout->tile_w = renderer->view_width;
+		out_layout->tile_h = renderer->view_height;
+	} else {
+		uint32_t tile_w = (mode_cols * renderer->view_width) / views;
+		uint32_t tile_h = mode_rows * renderer->view_height;
+		if (proj_layer != NULL) {
+			const struct xrt_rect *r0 = &proj_layer->data.proj.v[0].sub.rect;
+			if (r0->extent.w > 0 && r0->extent.h > 0) {
+				tile_w = static_cast<uint32_t>(r0->extent.w);
+				tile_h = static_cast<uint32_t>(r0->extent.h);
+			}
+		}
+		uint32_t atlas_w = mode_cols * renderer->view_width;
+		if (tile_w * views > atlas_w && views > 0) {
+			tile_w = atlas_w / views;
+		}
+		if (tile_h > renderer->texture_height) {
+			tile_h = renderer->texture_height;
+		}
+		out_layout->cols = views;
+		out_layout->rows = 1;
+		out_layout->tile_w = tile_w;
+		out_layout->tile_h = tile_h;
+	}
 }
 
 

--- a/src/xrt/compositor/d3d12/comp_d3d12_renderer.cpp
+++ b/src/xrt/compositor/d3d12/comp_d3d12_renderer.cpp
@@ -1698,13 +1698,14 @@ comp_d3d12_renderer_draw(struct comp_d3d12_renderer *renderer,
 }
 
 // Per-frame effective CONTENT layout (#542) — same policy as the D3D11 leg
-// (comp_d3d11_renderer_compute_effective_layout): submission view_count, mode
-// grid when matched, views×1 strip sized by the submitted imageRect on a
-// hardware/content divergence, legacy apps keep the hardware-keyed mono clamp.
+// (comp_d3d11_renderer_compute_effective_layout): the content recipe is the
+// ACTIVE MODE's, submissions are clamped to it (always-stereo apps submit
+// identical views in a mono mode; zone layers carry zone-sized imageRects).
+// The hardware weave-state never clamps content — divergence is the
+// hardware-state override, under which this layout keeps following the mode.
 extern "C" void
 comp_d3d12_renderer_compute_effective_layout(struct comp_d3d12_renderer *renderer,
                                              struct comp_layer_accum *layers,
-                                             bool hardware_display_3d,
                                              struct comp_d3d12_eff_layout *out_layout)
 {
 	uint32_t mode_cols = renderer->tile_columns > 0 ? renderer->tile_columns : 1;
@@ -1712,24 +1713,22 @@ comp_d3d12_renderer_compute_effective_layout(struct comp_d3d12_renderer *rendere
 	uint32_t mode_tiles = mode_cols * mode_rows;
 
 	uint32_t views = mode_tiles;
-	const struct comp_layer *proj_layer = NULL;
 	for (uint32_t i = 0; i < layers->layer_count; i++) {
 		if (layers->layers[i].data.type == XRT_LAYER_PROJECTION ||
 		    layers->layers[i].data.type == XRT_LAYER_PROJECTION_DEPTH ||
 		    layers->layers[i].data.type == XRT_LAYER_ZONE_3D) {
-			proj_layer = &layers->layers[i];
-			views = proj_layer->data.view_count;
+			views = layers->layers[i].data.view_count;
 			break;
 		}
 	}
 	if (views == 0) {
 		views = 1;
 	}
+	if (views > mode_tiles) {
+		views = mode_tiles;
+	}
 	if (views > XRT_MAX_VIEWS) {
 		views = XRT_MAX_VIEWS;
-	}
-	if (renderer->legacy_app_tile_scaling && !hardware_display_3d && views > 1) {
-		views = 1;
 	}
 
 	out_layout->views = views;
@@ -1738,32 +1737,11 @@ comp_d3d12_renderer_compute_effective_layout(struct comp_d3d12_renderer *rendere
 		out_layout->rows = 1;
 		out_layout->tile_w = mode_cols * renderer->view_width;
 		out_layout->tile_h = mode_rows * renderer->view_height;
-	} else if (views == mode_tiles) {
+	} else {
 		out_layout->cols = mode_cols;
 		out_layout->rows = mode_rows;
 		out_layout->tile_w = renderer->view_width;
 		out_layout->tile_h = renderer->view_height;
-	} else {
-		uint32_t tile_w = (mode_cols * renderer->view_width) / views;
-		uint32_t tile_h = mode_rows * renderer->view_height;
-		if (proj_layer != NULL) {
-			const struct xrt_rect *r0 = &proj_layer->data.proj.v[0].sub.rect;
-			if (r0->extent.w > 0 && r0->extent.h > 0) {
-				tile_w = static_cast<uint32_t>(r0->extent.w);
-				tile_h = static_cast<uint32_t>(r0->extent.h);
-			}
-		}
-		uint32_t atlas_w = mode_cols * renderer->view_width;
-		if (tile_w * views > atlas_w && views > 0) {
-			tile_w = atlas_w / views;
-		}
-		if (tile_h > renderer->texture_height) {
-			tile_h = renderer->texture_height;
-		}
-		out_layout->cols = views;
-		out_layout->rows = 1;
-		out_layout->tile_w = tile_w;
-		out_layout->tile_h = tile_h;
 	}
 }
 

--- a/src/xrt/compositor/d3d12/comp_d3d12_renderer.h
+++ b/src/xrt/compositor/d3d12/comp_d3d12_renderer.h
@@ -25,6 +25,38 @@ extern "C" {
 #endif
 
 /*!
+ * Per-frame effective CONTENT layout (#542): the atlas tile grid the renderer
+ * paints and the DP receives, derived from the app's SUBMISSION — decoupled
+ * from the hardware weave-state (which only drives the DP's mode_3d via
+ * request_display_mode). Matched submissions reproduce the mode layout
+ * exactly; a hardware/content divergence gets a views×1 strip instead of
+ * being clamped away. Mirrors comp_d3d11_eff_layout.
+ */
+struct comp_d3d12_eff_layout
+{
+	uint32_t views;  //!< effective view count (post legacy clamp)
+	uint32_t cols;   //!< atlas tile columns
+	uint32_t rows;   //!< atlas tile rows
+	uint32_t tile_w; //!< per-tile width in pixels
+	uint32_t tile_h; //!< per-tile height in pixels
+};
+
+/*!
+ * Compute the frame's effective content layout from the accumulated layers.
+ * Same policy as the D3D11 leg: submission view_count (mode grid default,
+ * legacy apps keep the hardware-keyed mono clamp); matched → mode layout,
+ * mono → one tile over the full content region, divergence → views×1 strip
+ * sized by the submitted imageRect, capped to the physical atlas.
+ *
+ * @ingroup comp_d3d12
+ */
+void
+comp_d3d12_renderer_compute_effective_layout(struct comp_d3d12_renderer *renderer,
+                                             struct comp_layer_accum *layers,
+                                             bool hardware_display_3d,
+                                             struct comp_d3d12_eff_layout *out_layout);
+
+/*!
  * Create a D3D12 renderer.
  *
  * @param c The D3D12 compositor.
@@ -62,8 +94,8 @@ comp_d3d12_renderer_destroy(struct comp_d3d12_renderer **renderer_ptr);
  * @param right_eye Right eye position for projection (NULL for default).
  * @param target_width Width of the render target (window).
  * @param target_height Height of the render target (window).
- * @param hardware_display_3d True when in 3D mode (stereo rendering),
- *        false for 2D passthrough (mono rendering).
+ * @param layout The frame's effective content layout (#542), from
+ *        @ref comp_d3d12_renderer_compute_effective_layout.
  *
  * @return XRT_SUCCESS on success, error code otherwise.
  *
@@ -77,7 +109,7 @@ comp_d3d12_renderer_draw(struct comp_d3d12_renderer *renderer,
                          struct xrt_vec3 *right_eye,
                          uint32_t target_width,
                          uint32_t target_height,
-                         bool hardware_display_3d);
+                         const struct comp_d3d12_eff_layout *layout);
 
 /*!
  * Project-pass half of @ref comp_d3d12_renderer_draw. Records into
@@ -99,7 +131,7 @@ comp_d3d12_renderer_draw_projection_pass(struct comp_d3d12_renderer *renderer,
                                           struct xrt_vec3 *right_eye,
                                           uint32_t target_width,
                                           uint32_t target_height,
-                                          bool hardware_display_3d);
+                                          const struct comp_d3d12_eff_layout *layout);
 
 /*!
  * Window-space-pass half of @ref comp_d3d12_renderer_draw. Records:
@@ -117,7 +149,7 @@ comp_d3d12_renderer_draw_window_space_pass(struct comp_d3d12_renderer *renderer,
                                             struct comp_layer_accum *layers,
                                             uint32_t target_width,
                                             uint32_t target_height,
-                                            bool hardware_display_3d);
+                                            const struct comp_d3d12_eff_layout *layout);
 
 /*!
  * Get the atlas texture SRV GPU descriptor handle for weaving.

--- a/src/xrt/compositor/d3d12/comp_d3d12_renderer.h
+++ b/src/xrt/compositor/d3d12/comp_d3d12_renderer.h
@@ -26,15 +26,15 @@ extern "C" {
 
 /*!
  * Per-frame effective CONTENT layout (#542): the atlas tile grid the renderer
- * paints and the DP receives, derived from the app's SUBMISSION — decoupled
- * from the hardware weave-state (which only drives the DP's mode_3d via
- * request_display_mode). Matched submissions reproduce the mode layout
- * exactly; a hardware/content divergence gets a views×1 strip instead of
- * being clamped away. Mirrors comp_d3d11_eff_layout.
+ * paints and the DP receives. The content recipe is the ACTIVE MODE's —
+ * submissions are clamped to it. The hardware weave-state never clamps
+ * content: a divergence is expressed via the hardware-state override
+ * (xrRequestDisplayModeEXT), under which this layout keeps following the
+ * mode and the DP keeps weaving. Mirrors comp_d3d11_eff_layout.
  */
 struct comp_d3d12_eff_layout
 {
-	uint32_t views;  //!< effective view count (post legacy clamp)
+	uint32_t views;  //!< effective view count (submission clamped to mode)
 	uint32_t cols;   //!< atlas tile columns
 	uint32_t rows;   //!< atlas tile rows
 	uint32_t tile_w; //!< per-tile width in pixels
@@ -43,17 +43,15 @@ struct comp_d3d12_eff_layout
 
 /*!
  * Compute the frame's effective content layout from the accumulated layers.
- * Same policy as the D3D11 leg: submission view_count (mode grid default,
- * legacy apps keep the hardware-keyed mono clamp); matched → mode layout,
- * mono → one tile over the full content region, divergence → views×1 strip
- * sized by the submitted imageRect, capped to the physical atlas.
+ * Same policy as the D3D11 leg: views = submission clamped to the mode tile
+ * count (mode default when no projection-class layer); views == 1 spans the
+ * full content region as one tile, otherwise the mode grid.
  *
  * @ingroup comp_d3d12
  */
 void
 comp_d3d12_renderer_compute_effective_layout(struct comp_d3d12_renderer *renderer,
                                              struct comp_layer_accum *layers,
-                                             bool hardware_display_3d,
                                              struct comp_d3d12_eff_layout *out_layout);
 
 /*!

--- a/src/xrt/compositor/gl/comp_gl_compositor.cpp
+++ b/src/xrt/compositor/gl/comp_gl_compositor.cpp
@@ -2474,12 +2474,12 @@ gl_compositor_dispatch_capture(struct comp_gl_compositor *c, uint32_t mode_filte
  */
 
 // Per-frame effective CONTENT layout (#542) — same policy as the D3D11/D3D12
-// legs: views from the first projection-class layer's view_count (mode grid
-// default; legacy apps keep the hardware-keyed mono clamp); matched → the
-// mode layout (bit-identical), mono → one tile spanning the full content
-// region, divergence → views×1 strip sized by the submitted imageRect,
-// capped to the physical atlas. Decoupled from c->hardware_display_3d,
-// which only drives the DP weave (request_display_mode), HUD, and V-key.
+// legs: the content recipe is the ACTIVE MODE's, submissions are clamped to
+// it (always-stereo apps submit identical views in a mono mode; zone layers
+// carry zone-sized imageRects). The hardware weave-state never clamps
+// content — divergence is the hardware-state override
+// (xrRequestDisplayModeEXT), under which this layout keeps following the
+// mode and the DP keeps weaving.
 static void
 gl_compute_effective_layout(struct comp_gl_compositor *c)
 {
@@ -2488,24 +2488,22 @@ gl_compute_effective_layout(struct comp_gl_compositor *c)
 	uint32_t mode_tiles = mode_cols * mode_rows;
 
 	uint32_t views = mode_tiles;
-	const struct comp_layer *proj_layer = NULL;
 	for (uint32_t i = 0; i < c->layer_accum.layer_count; i++) {
 		if (c->layer_accum.layers[i].data.type == XRT_LAYER_PROJECTION ||
 		    c->layer_accum.layers[i].data.type == XRT_LAYER_PROJECTION_DEPTH ||
 		    c->layer_accum.layers[i].data.type == XRT_LAYER_ZONE_3D) {
-			proj_layer = &c->layer_accum.layers[i];
-			views = proj_layer->data.view_count;
+			views = c->layer_accum.layers[i].data.view_count;
 			break;
 		}
 	}
 	if (views == 0) {
 		views = 1;
 	}
+	if (views > mode_tiles) {
+		views = mode_tiles;
+	}
 	if (views > XRT_MAX_VIEWS) {
 		views = XRT_MAX_VIEWS;
-	}
-	if (c->legacy_app_tile_scaling && !c->hardware_display_3d && views > 1) {
-		views = 1;
 	}
 
 	c->eff_views = views;
@@ -2514,31 +2512,11 @@ gl_compute_effective_layout(struct comp_gl_compositor *c)
 		c->eff_rows = 1;
 		c->eff_tile_w = mode_cols * c->view_width;
 		c->eff_tile_h = mode_rows * c->view_height;
-	} else if (views == mode_tiles) {
+	} else {
 		c->eff_cols = mode_cols;
 		c->eff_rows = mode_rows;
 		c->eff_tile_w = c->view_width;
 		c->eff_tile_h = c->view_height;
-	} else {
-		uint32_t tile_w = (mode_cols * c->view_width) / views;
-		uint32_t tile_h = mode_rows * c->view_height;
-		if (proj_layer != NULL) {
-			const struct xrt_rect *r0 = &proj_layer->data.proj.v[0].sub.rect;
-			if (r0->extent.w > 0 && r0->extent.h > 0) {
-				tile_w = (uint32_t)r0->extent.w;
-				tile_h = (uint32_t)r0->extent.h;
-			}
-		}
-		if (tile_w * views > c->atlas_tex_width && views > 0) {
-			tile_w = c->atlas_tex_width / views;
-		}
-		if (tile_h > c->atlas_tex_height) {
-			tile_h = c->atlas_tex_height;
-		}
-		c->eff_cols = views;
-		c->eff_rows = 1;
-		c->eff_tile_w = tile_w;
-		c->eff_tile_h = tile_h;
 	}
 }
 

--- a/src/xrt/compositor/gl/comp_gl_compositor.cpp
+++ b/src/xrt/compositor/gl/comp_gl_compositor.cpp
@@ -335,6 +335,18 @@ struct comp_gl_compositor
 
 	// --- State ---
 	bool hardware_display_3d;  //!< True when in 3D mode, false = 2D passthrough
+
+	//! Per-frame effective CONTENT layout (#542): the atlas grid actually
+	//! painted and handed to the DP this frame — submission-derived,
+	//! decoupled from hardware_display_3d (which only drives the DP weave,
+	//! HUD, and V-key paths). c->tile_columns/view_width stay the MODE
+	//! layout. eff_views == 0 until the first layer commit computes it.
+	uint32_t eff_views;
+	uint32_t eff_cols;
+	uint32_t eff_rows;
+	uint32_t eff_tile_w;
+	uint32_t eff_tile_h;
+
 	uint64_t last_frame_ns;
 	struct u_hud *hud;          //!< HUD overlay (shared u_hud system)
 	GLuint hud_texture;         //!< GL texture for HUD pixel upload
@@ -1485,8 +1497,15 @@ gl_crop_and_process_dp(struct comp_gl_compositor *c,
 		glBindFramebuffer(GL_FRAMEBUFFER, (GLuint)prev_draw_fbo);
 	}
 
-	uint32_t content_w = c->tile_columns * c->view_width;
-	uint32_t content_h = c->tile_rows * c->view_height;
+	// #542: the DP gets the frame's EFFECTIVE content layout — the grid the
+	// blit passes actually painted (== the mode layout for matched
+	// submissions) — not the mode layout.
+	uint32_t eff_cols = c->eff_cols > 0 ? c->eff_cols : c->tile_columns;
+	uint32_t eff_rows = c->eff_rows > 0 ? c->eff_rows : c->tile_rows;
+	uint32_t eff_tile_w = c->eff_tile_w > 0 ? c->eff_tile_w : c->view_width;
+	uint32_t eff_tile_h = c->eff_tile_h > 0 ? c->eff_tile_h : c->view_height;
+	uint32_t content_w = eff_cols * eff_tile_w;
+	uint32_t content_h = eff_rows * eff_tile_h;
 
 	GLuint dp_tex = atlas_tex;
 
@@ -1540,10 +1559,10 @@ gl_crop_and_process_dp(struct comp_gl_compositor *c,
 	xrt_display_processor_gl_process_atlas(
 	    c->display_processor,
 	    dp_tex,
-	    c->view_width,
-	    c->view_height,
-	    c->tile_columns,
-	    c->tile_rows,
+	    eff_tile_w,
+	    eff_tile_h,
+	    eff_cols,
+	    eff_rows,
 	    GL_RGBA8,
 	    output_w,
 	    output_h,
@@ -2021,8 +2040,13 @@ static void
 gl_dp_weave_to_fbo(struct comp_gl_compositor *c, GLuint atlas_tex, GLuint target_fbo, uint32_t output_w,
                    uint32_t output_h)
 {
-	uint32_t content_w = c->tile_columns * c->view_width;
-	uint32_t content_h = c->tile_rows * c->view_height;
+	// #542: same effective-layout source as gl_crop_and_process_dp.
+	uint32_t eff_cols = c->eff_cols > 0 ? c->eff_cols : c->tile_columns;
+	uint32_t eff_rows = c->eff_rows > 0 ? c->eff_rows : c->tile_rows;
+	uint32_t eff_tile_w = c->eff_tile_w > 0 ? c->eff_tile_w : c->view_width;
+	uint32_t eff_tile_h = c->eff_tile_h > 0 ? c->eff_tile_h : c->view_height;
+	uint32_t content_w = eff_cols * eff_tile_w;
+	uint32_t content_h = eff_rows * eff_tile_h;
 	GLuint dp_tex = atlas_tex;
 
 	if (content_w != c->atlas_tex_width || content_h != c->atlas_tex_height) {
@@ -2057,8 +2081,8 @@ gl_dp_weave_to_fbo(struct comp_gl_compositor *c, GLuint atlas_tex, GLuint target
 	const bool use_canvas = c->canvas.valid && !c->zones_frame;
 	glBindFramebuffer(GL_FRAMEBUFFER, target_fbo);
 	glViewport(0, 0, output_w, output_h);
-	xrt_display_processor_gl_process_atlas(c->display_processor, dp_tex, c->view_width, c->view_height,
-	                                       c->tile_columns, c->tile_rows, GL_RGBA8, output_w, output_h,
+	xrt_display_processor_gl_process_atlas(c->display_processor, dp_tex, eff_tile_w, eff_tile_h,
+	                                       eff_cols, eff_rows, GL_RGBA8, output_w, output_h,
 	                                       use_canvas ? c->canvas.x : 0, use_canvas ? c->canvas.y : 0,
 	                                       use_canvas ? c->canvas.w : 0, use_canvas ? c->canvas.h : 0);
 }
@@ -2364,13 +2388,19 @@ gl_sync_zone_mask_to_dp(struct comp_gl_compositor *c)
 static bool
 gl_compositor_capture_atlas_to_png(struct comp_gl_compositor *c, const char *path)
 {
-	if (c->atlas_texture == 0 || c->tile_columns == 0 || c->tile_rows == 0 ||
-	    c->view_width == 0 || c->view_height == 0) {
+	// #542: capture the frame's effective content region (what the passes
+	// painted), falling back to the mode layout pre-first-commit.
+	uint32_t cap_cols = c->eff_cols > 0 ? c->eff_cols : c->tile_columns;
+	uint32_t cap_rows = c->eff_rows > 0 ? c->eff_rows : c->tile_rows;
+	uint32_t cap_tile_w = c->eff_tile_w > 0 ? c->eff_tile_w : c->view_width;
+	uint32_t cap_tile_h = c->eff_tile_h > 0 ? c->eff_tile_h : c->view_height;
+	if (c->atlas_texture == 0 || cap_cols == 0 || cap_rows == 0 ||
+	    cap_tile_w == 0 || cap_tile_h == 0) {
 		return false;
 	}
 
-	uint32_t content_w = c->tile_columns * c->view_width;
-	uint32_t content_h = c->tile_rows * c->view_height;
+	uint32_t content_w = cap_cols * cap_tile_w;
+	uint32_t content_h = cap_rows * cap_tile_h;
 	if (content_w > c->atlas_tex_width)  content_w = c->atlas_tex_width;
 	if (content_h > c->atlas_tex_height) content_h = c->atlas_tex_height;
 
@@ -2442,6 +2472,75 @@ gl_compositor_dispatch_capture(struct comp_gl_compositor *c, uint32_t mode_filte
  * Layer commit — render atlas and present
  *
  */
+
+// Per-frame effective CONTENT layout (#542) — same policy as the D3D11/D3D12
+// legs: views from the first projection-class layer's view_count (mode grid
+// default; legacy apps keep the hardware-keyed mono clamp); matched → the
+// mode layout (bit-identical), mono → one tile spanning the full content
+// region, divergence → views×1 strip sized by the submitted imageRect,
+// capped to the physical atlas. Decoupled from c->hardware_display_3d,
+// which only drives the DP weave (request_display_mode), HUD, and V-key.
+static void
+gl_compute_effective_layout(struct comp_gl_compositor *c)
+{
+	uint32_t mode_cols = c->tile_columns > 0 ? c->tile_columns : 1;
+	uint32_t mode_rows = c->tile_rows > 0 ? c->tile_rows : 1;
+	uint32_t mode_tiles = mode_cols * mode_rows;
+
+	uint32_t views = mode_tiles;
+	const struct comp_layer *proj_layer = NULL;
+	for (uint32_t i = 0; i < c->layer_accum.layer_count; i++) {
+		if (c->layer_accum.layers[i].data.type == XRT_LAYER_PROJECTION ||
+		    c->layer_accum.layers[i].data.type == XRT_LAYER_PROJECTION_DEPTH ||
+		    c->layer_accum.layers[i].data.type == XRT_LAYER_ZONE_3D) {
+			proj_layer = &c->layer_accum.layers[i];
+			views = proj_layer->data.view_count;
+			break;
+		}
+	}
+	if (views == 0) {
+		views = 1;
+	}
+	if (views > XRT_MAX_VIEWS) {
+		views = XRT_MAX_VIEWS;
+	}
+	if (c->legacy_app_tile_scaling && !c->hardware_display_3d && views > 1) {
+		views = 1;
+	}
+
+	c->eff_views = views;
+	if (views == 1) {
+		c->eff_cols = 1;
+		c->eff_rows = 1;
+		c->eff_tile_w = mode_cols * c->view_width;
+		c->eff_tile_h = mode_rows * c->view_height;
+	} else if (views == mode_tiles) {
+		c->eff_cols = mode_cols;
+		c->eff_rows = mode_rows;
+		c->eff_tile_w = c->view_width;
+		c->eff_tile_h = c->view_height;
+	} else {
+		uint32_t tile_w = (mode_cols * c->view_width) / views;
+		uint32_t tile_h = mode_rows * c->view_height;
+		if (proj_layer != NULL) {
+			const struct xrt_rect *r0 = &proj_layer->data.proj.v[0].sub.rect;
+			if (r0->extent.w > 0 && r0->extent.h > 0) {
+				tile_w = (uint32_t)r0->extent.w;
+				tile_h = (uint32_t)r0->extent.h;
+			}
+		}
+		if (tile_w * views > c->atlas_tex_width && views > 0) {
+			tile_w = c->atlas_tex_width / views;
+		}
+		if (tile_h > c->atlas_tex_height) {
+			tile_h = c->atlas_tex_height;
+		}
+		c->eff_cols = views;
+		c->eff_rows = 1;
+		c->eff_tile_w = tile_w;
+		c->eff_tile_h = tile_h;
+	}
+}
 
 static xrt_result_t
 gl_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sync_handle)
@@ -2603,6 +2702,12 @@ gl_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t
 
 	// HUD is rendered in the window-mode present path (after weave, before swap)
 
+	// Per-frame effective CONTENT layout (#542): tile grid/dims from the
+	// SUBMISSION, decoupled from the hardware weave-state. Feeds the blit
+	// passes, both DP crop helpers, the atlas dump, and the capture path —
+	// they must all agree on the frame's geometry.
+	gl_compute_effective_layout(c);
+
 	// Zero-copy check: can we pass the app's swapchain directly to the DP?
 	bool zero_copy = false;
 	GLuint zc_texture = 0;
@@ -2618,7 +2723,12 @@ gl_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t
 			if (layer->data.type == XRT_LAYER_PROJECTION ||
 			    layer->data.type == XRT_LAYER_PROJECTION_DEPTH) {
 				uint32_t vc = mode->view_count;
-				bool same_sc = (vc > 0 && vc <= XRT_MAX_VIEWS && layer->sc_array[0] != NULL);
+				// #542: a hardware/content divergence frame (submitted
+				// views != mode views) must take the atlas path — the
+				// per-view loops below would read stale proj.v[] slots,
+				// and zero-copy can't re-tile a mismatched submission.
+				bool same_sc = (vc > 0 && vc <= XRT_MAX_VIEWS && layer->data.view_count == vc &&
+				                layer->sc_array[0] != NULL);
 				for (uint32_t v = 1; v < vc && same_sc; v++) {
 					if (layer->sc_array[v] != layer->sc_array[0])
 						same_sc = false;
@@ -2719,11 +2829,11 @@ gl_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t
 			continue;
 		}
 
-		// Use min of compositor's tile count and layer's actual view count
-		// (during mode transitions the app may submit fewer views than the
-		// new tile layout expects)
-		uint32_t mode_views = c->hardware_display_3d ? (c->tile_columns * c->tile_rows) : 1;
-		uint32_t view_count = (layer->data.view_count < mode_views) ? layer->data.view_count : mode_views;
+		// CONTENT tile count from the SUBMISSION-derived effective layout
+		// (#542) — no longer clamped by the hardware weave-state. Per-layer
+		// view counts are still bounded by the frame's placement grid.
+		uint32_t view_count = layer->data.view_count;
+		if (view_count > c->eff_views) view_count = c->eff_views;
 		if (view_count == 0) view_count = 1;
 		for (uint32_t eye = 0; eye < view_count; eye++) {
 
@@ -2747,20 +2857,18 @@ gl_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t
 				nr.h = 1.0f;
 			}
 
-			// Set viewport for this eye in the atlas texture
+			// Set viewport for this eye in the atlas texture — tile-place
+			// by the effective grid (#542). Mono content (views == 1)
+			// gets one tile spanning the full content region; the DP
+			// weaves or flattens per its own mode_3d.
 			uint32_t tbx, tby, tbw, tbh; // per-view tile box
-			if (!c->hardware_display_3d) {
-				tbx = 0;
-				tby = 0;
-				tbw = c->tile_columns * c->view_width;
-				tbh = c->tile_rows * c->view_height;
-			} else {
-				uint32_t tile_x = eye % c->tile_columns;
-				uint32_t tile_y = eye / c->tile_columns;
-				tbx = tile_x * c->view_width;
-				tby = tile_y * c->view_height;
-				tbw = c->view_width;
-				tbh = c->view_height;
+			{
+				uint32_t tile_x = eye % c->eff_cols;
+				uint32_t tile_y = eye / c->eff_cols;
+				tbx = tile_x * c->eff_tile_w;
+				tby = tile_y * c->eff_tile_h;
+				tbw = c->eff_tile_w;
+				tbh = c->eff_tile_h;
 			}
 			if (is_zone) {
 				// XR_EXT_display_zones: scale the zone rect (client-
@@ -2812,9 +2920,7 @@ gl_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t
 					        "vp=(%u,%u,%u,%u) view_count=%u hw3d=%d",
 					        eye, gsc->textures[img_idx], img_idx,
 					        nr.x, nr.y, nr.w, nr.h,
-					        eye % c->tile_columns * c->view_width,
-					        eye / c->tile_columns * c->view_height,
-					        c->view_width, c->view_height,
+					        tbx, tby, tbw, tbh,
 					        view_count, c->hardware_display_3d);
 					blit_log++;
 				}
@@ -2875,16 +2981,16 @@ gl_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t
 		GLint loc_ws_tex = glGetUniformLocation(c->program_window_space, "u_texture");
 		GLint loc_ws_src = glGetUniformLocation(c->program_window_space, "u_src_rect");
 
-		uint32_t effective_views = c->hardware_display_3d ? (c->tile_columns * c->tile_rows) : 1;
+		// HUD tiles align with the projection tiles: same effective grid
+		// (#542), independent of the hardware weave-state.
+		uint32_t effective_views = c->eff_views > 0 ? c->eff_views : 1;
 		for (uint32_t eye = 0; eye < effective_views; eye++) {
-			// Set viewport for this eye
-			if (!c->hardware_display_3d) {
-				glViewport(0, 0, c->tile_columns * c->view_width, c->tile_rows * c->view_height);
-			} else {
-				uint32_t tile_x = eye % c->tile_columns;
-				uint32_t tile_y = eye / c->tile_columns;
-				glViewport(tile_x * c->view_width, tile_y * c->view_height,
-				           c->view_width, c->view_height);
+			// Set viewport for this eye in the effective grid
+			{
+				uint32_t tile_x = eye % c->eff_cols;
+				uint32_t tile_y = eye / c->eff_cols;
+				glViewport(tile_x * c->eff_tile_w, tile_y * c->eff_tile_h,
+				           c->eff_tile_w, c->eff_tile_h);
 			}
 
 			// Per-view disparity, graded across the view sweep (#413):
@@ -2923,12 +3029,13 @@ gl_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t
 	// both projection and WS-layer passes have completed.
 	{
 		struct stat _st;
-		if (c->atlas_texture != 0 && c->tile_columns > 0 && c->tile_rows > 0 &&
-		    c->view_width > 0 && c->view_height > 0 &&
+		if (c->atlas_texture != 0 && c->eff_cols > 0 && c->eff_rows > 0 &&
+		    c->eff_tile_w > 0 && c->eff_tile_h > 0 &&
 		    stat("/tmp/dxr_atlas_trigger", &_st) == 0) {
 			unlink("/tmp/dxr_atlas_trigger");
-			uint32_t cw = c->tile_columns * c->view_width;
-			uint32_t ch = c->tile_rows * c->view_height;
+			// Effective content region (#542): what this frame painted.
+			uint32_t cw = c->eff_cols * c->eff_tile_w;
+			uint32_t ch = c->eff_rows * c->eff_tile_h;
 			if (cw > c->atlas_tex_width)  cw = c->atlas_tex_width;
 			if (ch > c->atlas_tex_height) ch = c->atlas_tex_height;
 			size_t row_pitch = (size_t)cw * 4;
@@ -2991,9 +3098,9 @@ gl_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t
 				glBindVertexArray(c->vao_empty);
 				GLint loc_rect = glGetUniformLocation(c->program_blit, "u_src_rect");
 				float sh_w = (c->atlas_tex_width > 0)
-				    ? (float)(c->tile_columns * c->view_width) / (float)c->atlas_tex_width : 1.0f;
+				    ? (float)(c->eff_cols * c->eff_tile_w) / (float)c->atlas_tex_width : 1.0f;
 				float sh_h = (c->atlas_tex_height > 0)
-				    ? (float)(c->tile_rows * c->view_height) / (float)c->atlas_tex_height : 1.0f;
+				    ? (float)(c->eff_rows * c->eff_tile_h) / (float)c->atlas_tex_height : 1.0f;
 				glUniform4f(loc_rect, 0.0f, 0.0f, sh_w, sh_h);
 				GLint loc_flip = glGetUniformLocation(c->program_blit, "u_flip_y");
 				glUniform1f(loc_flip, 0.0f);
@@ -3041,9 +3148,9 @@ gl_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t
 			glBindVertexArray(c->vao_empty);
 			GLint loc_rect = glGetUniformLocation(c->program_blit, "u_src_rect");
 			float used_w = (c->atlas_tex_width > 0)
-			    ? (float)(c->tile_columns * c->view_width) / (float)c->atlas_tex_width : 1.0f;
+			    ? (float)(c->eff_cols * c->eff_tile_w) / (float)c->atlas_tex_width : 1.0f;
 			float used_h = (c->atlas_tex_height > 0)
-			    ? (float)(c->tile_rows * c->view_height) / (float)c->atlas_tex_height : 1.0f;
+			    ? (float)(c->eff_rows * c->eff_tile_h) / (float)c->atlas_tex_height : 1.0f;
 			glUniform4f(loc_rect, 0.0f, 0.0f, used_w, used_h);
 			GLint loc_flip = glGetUniformLocation(c->program_blit, "u_flip_y");
 			glUniform1f(loc_flip, 0.0f);
@@ -3118,9 +3225,9 @@ gl_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t
 			glUseProgram(c->program_blit);
 			GLint loc_rect = glGetUniformLocation(c->program_blit, "u_src_rect");
 			float blit_w = (c->atlas_tex_width > 0)
-			    ? (float)(c->tile_columns * c->view_width) / (float)c->atlas_tex_width : 1.0f;
+			    ? (float)(c->eff_cols * c->eff_tile_w) / (float)c->atlas_tex_width : 1.0f;
 			float blit_h = (c->atlas_tex_height > 0)
-			    ? (float)(c->tile_rows * c->view_height) / (float)c->atlas_tex_height : 1.0f;
+			    ? (float)(c->eff_rows * c->eff_tile_h) / (float)c->atlas_tex_height : 1.0f;
 			glUniform4f(loc_rect, 0.0f, 0.0f, blit_w, blit_h);
 			GLint loc_flip = glGetUniformLocation(c->program_blit, "u_flip_y");
 			glUniform1f(loc_flip, 0.0f);

--- a/src/xrt/compositor/metal/comp_metal_compositor.m
+++ b/src/xrt/compositor/metal/comp_metal_compositor.m
@@ -2999,6 +2999,18 @@ metal_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 		}
 	}
 
+	// Submission-derived CONTENT layout (#542): decouple the atlas tile
+	// count/size from the panel HARDWARE weave-state. The atlas holds
+	// exactly what the app submitted (view_count tiles, sized by the
+	// per-view imageRect), independent of c->hardware_display_3d — that flag
+	// drives only the DP weave via request_display_mode. Defaults are the
+	// mode-derived values, so zones frames and the no-projection-layer case
+	// stay byte-identical; the main projection layer overrides them below.
+	uint32_t atlas_view_w = c->view_width;
+	uint32_t atlas_view_h = c->view_height;
+	uint32_t atlas_cols = c->tile_columns;
+	uint32_t atlas_rows = c->tile_rows;
+
 	// Step 1: Render layers into atlas texture (skip if zero-copy)
 	if (!zero_copy && c->atlas_texture != nil && c->layer_accum.layer_count > 0) {
 		MTLRenderPassDescriptor *pass = [MTLRenderPassDescriptor renderPassDescriptor];
@@ -3078,10 +3090,27 @@ metal_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 				}
 			}
 
-			// Use min of compositor's tile count and layer's submitted views
-			uint32_t mode_views = c->hardware_display_3d ? (c->tile_columns * c->tile_rows) : 1;
-			uint32_t view_count = (layer->data.view_count < mode_views) ? layer->data.view_count : mode_views;
+			// CONTENT tile count from the SUBMISSION, not the hardware flag
+			// (#542): the atlas holds exactly the tiles the app submitted,
+			// capped only by physical capacity. No `hardware_3d ? N : 1`
+			// clamp — a hardware/content divergence renders predictably.
+			uint32_t view_count = layer->data.view_count;
 			if (view_count == 0) view_count = 1;
+			if (view_count > XRT_MAX_VIEWS) view_count = XRT_MAX_VIEWS;
+
+			// The main (non-zone) projection layer defines the frame's atlas
+			// content layout (an N×1 grid sized by the submitted imageRect);
+			// zone layers keep the mode-derived tile box (their rect is scaled
+			// into it below), so leave the defaults for them.
+			if (!is_zone) {
+				atlas_cols = view_count;
+				atlas_rows = 1;
+				const struct xrt_rect *r0 = &layer->data.proj.v[0].sub.rect;
+				if (r0->extent.w > 0 && r0->extent.h > 0) {
+					atlas_view_w = (uint32_t)r0->extent.w;
+					atlas_view_h = (uint32_t)r0->extent.h;
+				}
+			}
 			for (uint32_t eye = 0; eye < view_count; eye++) {
 				struct xrt_swapchain *sc = layer->sc_array[eye];
 				if (sc == NULL) {
@@ -3120,21 +3149,18 @@ metal_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 					nr.h = 1.0f;
 				}
 
-				// Set viewport for this eye
+				// Set viewport for this eye — always tile-place by the
+				// submission-derived grid (#542). No branch on the hardware
+				// flag: the DP weaves (hardware-3D) or shows the tiles flat
+				// (hardware-2D) per its own mode_3d from request_display_mode.
 				MTLViewport vp;
-				if (!c->hardware_display_3d) {
-					vp.originX = 0;
-					vp.originY = 0;
-					vp.width = c->tile_columns * c->view_width;
-					vp.height = c->tile_rows * c->view_height;
-				} else {
-					// Tiled layout: place each eye in its tile
-					uint32_t tile_x = eye % c->tile_columns;
-					uint32_t tile_y = eye / c->tile_columns;
-					vp.originX = tile_x * c->view_width;
-					vp.originY = tile_y * c->view_height;
-					vp.width = c->view_width;
-					vp.height = c->view_height;
+				{
+					uint32_t tile_x = eye % atlas_cols;
+					uint32_t tile_y = eye / atlas_cols;
+					vp.originX = tile_x * atlas_view_w;
+					vp.originY = tile_y * atlas_view_h;
+					vp.width = atlas_view_w;
+					vp.height = atlas_view_h;
 				}
 				if (is_zone) {
 					// XR_EXT_display_zones: scale the zone rect
@@ -3259,7 +3285,9 @@ metal_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 		// so the display processor weaves them in stereo just like projection
 		// content. Mirrors d3d11_compositor_layer_window_space + the renderer
 		// window-space pass.
-		uint32_t mode_views_ws = c->hardware_display_3d ? (c->tile_columns * c->tile_rows) : 1;
+		// HUD tiles align with the projection tiles: same submission-derived
+		// grid (#542), independent of the hardware weave-state.
+		uint32_t mode_views_ws = atlas_cols;
 		for (uint32_t i = 0; i < c->layer_accum.layer_count; i++) {
 			struct comp_layer *layer = &c->layer_accum.layers[i];
 			if (layer->data.type != XRT_LAYER_WINDOW_SPACE) {
@@ -3297,8 +3325,8 @@ metal_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 			}
 
 			for (uint32_t eye = 0; eye < mode_views_ws; eye++) {
-				uint32_t tile_x = eye % c->tile_columns;
-				uint32_t tile_y = eye / c->tile_columns;
+				uint32_t tile_x = eye % atlas_cols;
+				uint32_t tile_y = eye / atlas_cols;
 
 				// Per-view disparity, graded across the view sweep (#413):
 				// first view = -half, last = +half. Degenerates to the
@@ -3315,12 +3343,10 @@ metal_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 				// emits a fullscreen triangle in NDC; the MTLViewport
 				// clamps that to the sub-rect we want filled. This way we
 				// reuse the existing shader without per-quad geometry.
-				float tile_origin_x = c->hardware_display_3d ? (float)(tile_x * c->view_width) : 0.0f;
-				float tile_origin_y = c->hardware_display_3d ? (float)(tile_y * c->view_height) : 0.0f;
-				float tile_w = c->hardware_display_3d ? (float)c->view_width
-				                                       : (float)(c->tile_columns * c->view_width);
-				float tile_h = c->hardware_display_3d ? (float)c->view_height
-				                                       : (float)(c->tile_rows * c->view_height);
+				float tile_origin_x = (float)(tile_x * atlas_view_w);
+				float tile_origin_y = (float)(tile_y * atlas_view_h);
+				float tile_w = (float)atlas_view_w;
+				float tile_h = (float)atlas_view_h;
 
 				MTLViewport vp;
 				vp.originX = tile_origin_x + (ws->x + eye_shift) * tile_w;
@@ -3393,11 +3419,12 @@ metal_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 	{
 		const char *trigger = "/tmp/dxr_atlas_trigger";
 		struct stat st;
-		if (c->atlas_texture != nil && c->tile_columns > 0 && c->tile_rows > 0 &&
-		    c->view_width > 0 && c->view_height > 0 && stat(trigger, &st) == 0) {
+		if (c->atlas_texture != nil && atlas_cols > 0 && atlas_rows > 0 &&
+		    atlas_view_w > 0 && atlas_view_h > 0 && stat(trigger, &st) == 0) {
 			unlink(trigger);
-			uint32_t cw = c->tile_columns * c->view_width;
-			uint32_t ch = c->tile_rows * c->view_height;
+			// Submission-derived content region (#542): what the app submitted.
+			uint32_t cw = atlas_cols * atlas_view_w;
+			uint32_t ch = atlas_rows * atlas_view_h;
 			if (cw > (uint32_t)c->atlas_texture.width)  cw = (uint32_t)c->atlas_texture.width;
 			if (ch > (uint32_t)c->atlas_texture.height) ch = (uint32_t)c->atlas_texture.height;
 			size_t pitch = (size_t)cw * 4;
@@ -3439,8 +3466,10 @@ metal_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 	if (c->display_processor != NULL && atlas_src != nil) {
 		// Crop atlas to content dims before passing to DP.
 		// The DP expects texture dimensions to match content exactly.
-		uint32_t content_w = c->tile_columns * c->view_width;
-		uint32_t content_h = c->tile_rows * c->view_height;
+		// Content is the submission-derived layout (#542), not the hardware
+		// mode — the DP weaves/flattens these tiles per its own mode_3d.
+		uint32_t content_w = atlas_cols * atlas_view_w;
+		uint32_t content_h = atlas_rows * atlas_view_h;
 
 		// Verify content region fits within atlas
 		if (content_w > c->atlas_width || content_h > c->atlas_height) {
@@ -3450,8 +3479,8 @@ metal_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 				        "(vw=%u vh=%u tiles=%ux%u legacy=%d)",
 				        content_w, content_h,
 				        c->atlas_width, c->atlas_height,
-				        c->view_width, c->view_height,
-				        c->tile_columns, c->tile_rows,
+				        atlas_view_w, atlas_view_h,
+				        atlas_cols, atlas_rows,
 				        c->legacy_app_tile_scaling);
 				crop_err_log++;
 			}
@@ -3515,10 +3544,10 @@ metal_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 		    c->display_processor,
 		    (__bridge void *)cmd_buf,
 		    (__bridge void *)dp_src,
-		    c->view_width,
-		    c->view_height,
-		    c->tile_columns,
-		    c->tile_rows,
+		    atlas_view_w,
+		    atlas_view_h,
+		    atlas_cols,
+		    atlas_rows,
 		    (uint32_t)MTLPixelFormatBGRA8Unorm,
 		    (__bridge void *)output_texture,
 		    dp_target_w,

--- a/src/xrt/compositor/vk_native/comp_vk_native_compositor.c
+++ b/src/xrt/compositor/vk_native/comp_vk_native_compositor.c
@@ -2114,44 +2114,40 @@ static void
 vk_sync_zone_mask_to_dp(struct comp_vk_native_compositor *c);
 
 // Per-frame effective CONTENT layout (#542) — same policy as the D3D11/D3D12/
-// GL legs: views from the first projection-class layer's view_count (mode grid
-// default; legacy apps keep the hardware-keyed mono clamp); matched → the mode
-// layout (bit-identical), mono → one tile spanning the full content region,
-// divergence → views×1 strip sized by the submitted imageRect, capped to the
-// physical atlas. Decoupled from c->hardware_display_3d, which only drives the
-// DP weave (request_display_mode), HUD, and V-key paths.
+// GL legs: the content recipe is the ACTIVE MODE's, submissions are clamped
+// to it (always-stereo apps submit identical views in a mono mode; zone
+// layers carry zone-sized imageRects). The hardware weave-state never clamps
+// content — divergence is the hardware-state override
+// (xrRequestDisplayModeEXT), under which this layout keeps following the
+// mode and the DP keeps weaving.
 static void
 vk_compute_effective_layout(struct comp_vk_native_compositor *c)
 {
 	uint32_t mode_cols = 1, mode_rows = 1;
 	uint32_t view_w = 0, view_h = 0;
-	uint32_t atlas_w = 0, atlas_h = 0;
 	comp_vk_native_renderer_get_tile_layout(c->renderer, &mode_cols, &mode_rows);
 	comp_vk_native_renderer_get_view_dimensions(c->renderer, &view_w, &view_h);
-	comp_vk_native_renderer_get_atlas_dimensions(c->renderer, &atlas_w, &atlas_h);
 	if (mode_cols == 0) mode_cols = 1;
 	if (mode_rows == 0) mode_rows = 1;
 	uint32_t mode_tiles = mode_cols * mode_rows;
 
 	uint32_t views = mode_tiles;
-	const struct comp_layer *proj_layer = NULL;
 	for (uint32_t i = 0; i < c->layer_accum.layer_count; i++) {
 		if (c->layer_accum.layers[i].data.type == XRT_LAYER_PROJECTION ||
 		    c->layer_accum.layers[i].data.type == XRT_LAYER_PROJECTION_DEPTH ||
 		    c->layer_accum.layers[i].data.type == XRT_LAYER_ZONE_3D) {
-			proj_layer = &c->layer_accum.layers[i];
-			views = proj_layer->data.view_count;
+			views = c->layer_accum.layers[i].data.view_count;
 			break;
 		}
 	}
 	if (views == 0) {
 		views = 1;
 	}
+	if (views > mode_tiles) {
+		views = mode_tiles;
+	}
 	if (views > XRT_MAX_VIEWS) {
 		views = XRT_MAX_VIEWS;
-	}
-	if (c->legacy_app_tile_scaling && !c->hardware_display_3d && views > 1) {
-		views = 1;
 	}
 
 	c->eff_layout.views = views;
@@ -2160,31 +2156,11 @@ vk_compute_effective_layout(struct comp_vk_native_compositor *c)
 		c->eff_layout.rows = 1;
 		c->eff_layout.tile_w = mode_cols * view_w;
 		c->eff_layout.tile_h = mode_rows * view_h;
-	} else if (views == mode_tiles) {
+	} else {
 		c->eff_layout.cols = mode_cols;
 		c->eff_layout.rows = mode_rows;
 		c->eff_layout.tile_w = view_w;
 		c->eff_layout.tile_h = view_h;
-	} else {
-		uint32_t tile_w = (mode_cols * view_w) / views;
-		uint32_t tile_h = mode_rows * view_h;
-		if (proj_layer != NULL) {
-			const struct xrt_rect *r0 = &proj_layer->data.proj.v[0].sub.rect;
-			if (r0->extent.w > 0 && r0->extent.h > 0) {
-				tile_w = (uint32_t)r0->extent.w;
-				tile_h = (uint32_t)r0->extent.h;
-			}
-		}
-		if (atlas_w > 0 && tile_w * views > atlas_w && views > 0) {
-			tile_w = atlas_w / views;
-		}
-		if (atlas_h > 0 && tile_h > atlas_h) {
-			tile_h = atlas_h;
-		}
-		c->eff_layout.cols = views;
-		c->eff_layout.rows = 1;
-		c->eff_layout.tile_w = tile_w;
-		c->eff_layout.tile_h = tile_h;
 	}
 }
 

--- a/src/xrt/compositor/vk_native/comp_vk_native_compositor.c
+++ b/src/xrt/compositor/vk_native/comp_vk_native_compositor.c
@@ -159,6 +159,12 @@ struct comp_vk_native_compositor
 	//! True when display is in 3D mode (weaver active). False = 2D passthrough.
 	bool hardware_display_3d;
 
+	//! Per-frame effective CONTENT layout (#542): the atlas grid actually
+	//! painted and handed to the DP this frame — submission-derived,
+	//! decoupled from hardware_display_3d. views == 0 until the first
+	//! layer commit computes it.
+	struct comp_vk_native_eff_layout eff_layout;
+
 	//! Last known 3D rendering mode index (for V-key toggle restore).
 	uint32_t last_3d_mode_index;
 
@@ -1238,24 +1244,20 @@ vk_compositor_render_window_space_into_atlas(struct comp_vk_native_compositor *c
 		    0, 0, NULL, 0, NULL, 1, &src_to_sample);
 
 		// Per-view pass with disparity shift in tile-fraction → atlas px.
-		// Mirrors the metal/GL compositors (#413): a 2D (non-3D) mode gets
-		// ONE stamp over the full content region (tile grid × view dims);
-		// 3D modes stamp every tile. The previous code looped the tile grid
-		// unconditionally and hardcoded the 2-view disparity pair
-		// (tile_index == 0 ? -half : +half), which mis-shifts every layout
-		// other than 2 views.
-		uint32_t effective_views = c->hardware_display_3d ? (tile_columns * tile_rows) : 1;
+		// Mirrors the metal/GL compositors (#413). The caller passes the
+		// frame's EFFECTIVE content grid (#542): mono content arrives as a
+		// 1×1 grid whose tile spans the full content region, so the old
+		// hardware-keyed full-region special case is just the grid math.
+		uint32_t effective_views = tile_columns * tile_rows;
 		float half_disp = ws->disparity / 2.0f;
 		for (uint32_t eye = 0; eye < effective_views; eye++) {
 			uint32_t tile_x = eye % tile_columns;
 			uint32_t tile_y = eye / tile_columns;
 
-			float tile_origin_x = c->hardware_display_3d ? (float)(tile_x * view_w) : 0.0f;
-			float tile_origin_y = c->hardware_display_3d ? (float)(tile_y * view_h) : 0.0f;
-			float tile_w = c->hardware_display_3d ? (float)view_w
-			                                      : (float)(tile_columns * view_w);
-			float tile_h = c->hardware_display_3d ? (float)view_h
-			                                      : (float)(tile_rows * view_h);
+			float tile_origin_x = (float)(tile_x * view_w);
+			float tile_origin_y = (float)(tile_y * view_h);
+			float tile_w = (float)view_w;
+			float tile_h = (float)view_h;
 
 			// Per-view horizontal disparity, graded across the view sweep
 			// (view index = baseline order, same as the projection views):
@@ -1890,10 +1892,19 @@ vk_native_capture_atlas_to_png(struct comp_vk_native_compositor *c, const char *
 		return false;
 	}
 
+	// #542: capture the frame's effective content region (what the renderer
+	// painted), falling back to the mode layout pre-first-commit.
 	uint32_t tile_columns = 1, tile_rows = 1;
-	comp_vk_native_renderer_get_tile_layout(c->renderer, &tile_columns, &tile_rows);
 	uint32_t view_w = 0, view_h = 0;
-	comp_vk_native_renderer_get_view_dimensions(c->renderer, &view_w, &view_h);
+	if (c->eff_layout.views > 0 && c->eff_layout.tile_w > 0 && c->eff_layout.tile_h > 0) {
+		tile_columns = c->eff_layout.cols;
+		tile_rows = c->eff_layout.rows;
+		view_w = c->eff_layout.tile_w;
+		view_h = c->eff_layout.tile_h;
+	} else {
+		comp_vk_native_renderer_get_tile_layout(c->renderer, &tile_columns, &tile_rows);
+		comp_vk_native_renderer_get_view_dimensions(c->renderer, &view_w, &view_h);
+	}
 	if (tile_columns == 0 || tile_rows == 0 || view_w == 0 || view_h == 0) {
 		return false;
 	}
@@ -2102,6 +2113,81 @@ vk_zone_dp_supported(struct comp_vk_native_compositor *c);
 static void
 vk_sync_zone_mask_to_dp(struct comp_vk_native_compositor *c);
 
+// Per-frame effective CONTENT layout (#542) — same policy as the D3D11/D3D12/
+// GL legs: views from the first projection-class layer's view_count (mode grid
+// default; legacy apps keep the hardware-keyed mono clamp); matched → the mode
+// layout (bit-identical), mono → one tile spanning the full content region,
+// divergence → views×1 strip sized by the submitted imageRect, capped to the
+// physical atlas. Decoupled from c->hardware_display_3d, which only drives the
+// DP weave (request_display_mode), HUD, and V-key paths.
+static void
+vk_compute_effective_layout(struct comp_vk_native_compositor *c)
+{
+	uint32_t mode_cols = 1, mode_rows = 1;
+	uint32_t view_w = 0, view_h = 0;
+	uint32_t atlas_w = 0, atlas_h = 0;
+	comp_vk_native_renderer_get_tile_layout(c->renderer, &mode_cols, &mode_rows);
+	comp_vk_native_renderer_get_view_dimensions(c->renderer, &view_w, &view_h);
+	comp_vk_native_renderer_get_atlas_dimensions(c->renderer, &atlas_w, &atlas_h);
+	if (mode_cols == 0) mode_cols = 1;
+	if (mode_rows == 0) mode_rows = 1;
+	uint32_t mode_tiles = mode_cols * mode_rows;
+
+	uint32_t views = mode_tiles;
+	const struct comp_layer *proj_layer = NULL;
+	for (uint32_t i = 0; i < c->layer_accum.layer_count; i++) {
+		if (c->layer_accum.layers[i].data.type == XRT_LAYER_PROJECTION ||
+		    c->layer_accum.layers[i].data.type == XRT_LAYER_PROJECTION_DEPTH ||
+		    c->layer_accum.layers[i].data.type == XRT_LAYER_ZONE_3D) {
+			proj_layer = &c->layer_accum.layers[i];
+			views = proj_layer->data.view_count;
+			break;
+		}
+	}
+	if (views == 0) {
+		views = 1;
+	}
+	if (views > XRT_MAX_VIEWS) {
+		views = XRT_MAX_VIEWS;
+	}
+	if (c->legacy_app_tile_scaling && !c->hardware_display_3d && views > 1) {
+		views = 1;
+	}
+
+	c->eff_layout.views = views;
+	if (views == 1) {
+		c->eff_layout.cols = 1;
+		c->eff_layout.rows = 1;
+		c->eff_layout.tile_w = mode_cols * view_w;
+		c->eff_layout.tile_h = mode_rows * view_h;
+	} else if (views == mode_tiles) {
+		c->eff_layout.cols = mode_cols;
+		c->eff_layout.rows = mode_rows;
+		c->eff_layout.tile_w = view_w;
+		c->eff_layout.tile_h = view_h;
+	} else {
+		uint32_t tile_w = (mode_cols * view_w) / views;
+		uint32_t tile_h = mode_rows * view_h;
+		if (proj_layer != NULL) {
+			const struct xrt_rect *r0 = &proj_layer->data.proj.v[0].sub.rect;
+			if (r0->extent.w > 0 && r0->extent.h > 0) {
+				tile_w = (uint32_t)r0->extent.w;
+				tile_h = (uint32_t)r0->extent.h;
+			}
+		}
+		if (atlas_w > 0 && tile_w * views > atlas_w && views > 0) {
+			tile_w = atlas_w / views;
+		}
+		if (atlas_h > 0 && tile_h > atlas_h) {
+			tile_h = atlas_h;
+		}
+		c->eff_layout.cols = views;
+		c->eff_layout.rows = 1;
+		c->eff_layout.tile_w = tile_w;
+		c->eff_layout.tile_h = tile_h;
+	}
+}
+
 static xrt_result_t
 vk_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sync_handle)
 {
@@ -2277,6 +2363,12 @@ vk_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t
 		comp_vk_native_target_get_dimensions(c->target, &tgt_width, &tgt_height);
 	}
 
+	// Per-frame effective CONTENT layout (#542): tile grid/dims from the
+	// SUBMISSION, decoupled from the hardware weave-state. Feeds the
+	// renderer draw, the window-space pass, both DP handoffs, and the
+	// capture path — they must all agree on the frame's geometry.
+	vk_compute_effective_layout(c);
+
 	// Zero-copy check: can we pass the app's swapchain directly to the DP?
 	bool zero_copy = false;
 	uint64_t zc_image_u64 = 0;
@@ -2296,7 +2388,12 @@ vk_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t
 			if (layer->data.type == XRT_LAYER_PROJECTION ||
 			    layer->data.type == XRT_LAYER_PROJECTION_DEPTH) {
 				uint32_t vc = mode->view_count;
-				bool same_sc = (vc > 0 && vc <= XRT_MAX_VIEWS && layer->sc_array[0] != NULL);
+				// #542: a hardware/content divergence frame (submitted
+				// views != mode views) must take the atlas path — the
+				// per-view loops below would read stale proj.v[] slots,
+				// and zero-copy can't re-tile a mismatched submission.
+				bool same_sc = (vc > 0 && vc <= XRT_MAX_VIEWS && layer->data.view_count == vc &&
+				                layer->sc_array[0] != NULL);
 				for (uint32_t v = 1; v < vc && same_sc; v++) {
 					if (layer->sc_array[v] != layer->sc_array[0])
 						same_sc = false;
@@ -2346,7 +2443,7 @@ vk_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t
 	xrt_result_t xret = XRT_SUCCESS;
 	if (!zero_copy) {
 		xret = comp_vk_native_renderer_draw(
-		    c->renderer, &c->layer_accum, &left_eye, &right_eye, tgt_width, tgt_height, c->hardware_display_3d);
+		    c->renderer, &c->layer_accum, &left_eye, &right_eye, tgt_width, tgt_height, &c->eff_layout);
 		if (xret != XRT_SUCCESS) {
 			U_LOG_E("Failed to render layers");
 			return xret;
@@ -2403,8 +2500,13 @@ vk_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t
 				view_format = comp_vk_native_renderer_get_format(c->renderer);
 			}
 
-			comp_vk_native_renderer_get_view_dimensions(c->renderer, &view_width, &view_height);
-			comp_vk_native_renderer_get_tile_layout(c->renderer, &tc, &tr);
+			// #542: the DP and the window-space pass get the frame's
+			// EFFECTIVE content layout — the grid the renderer painted
+			// (== the mode layout for matched submissions).
+			view_width = c->eff_layout.tile_w;
+			view_height = c->eff_layout.tile_h;
+			tc = c->eff_layout.cols;
+			tr = c->eff_layout.rows;
 
 			// Pre-weave: composite window-space layers per-tile INTO the atlas
 			// so the DP weaves them along with the projection content. Skipped
@@ -2642,8 +2744,13 @@ vk_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t
 					view_format = comp_vk_native_renderer_get_format(c->renderer);
 				}
 
-				comp_vk_native_renderer_get_view_dimensions(c->renderer, &view_width, &view_height);
-				comp_vk_native_renderer_get_tile_layout(c->renderer, &tc, &tr);
+				// #542: the DP and the window-space pass get the frame's
+				// EFFECTIVE content layout — the grid the renderer painted
+				// (== the mode layout for matched submissions).
+				view_width = c->eff_layout.tile_w;
+				view_height = c->eff_layout.tile_h;
+				tc = c->eff_layout.cols;
+				tr = c->eff_layout.rows;
 
 				// Pre-weave: composite window-space layers per-tile INTO the
 				// atlas. Skipped in zero-copy (no atlas) and when no

--- a/src/xrt/compositor/vk_native/comp_vk_native_renderer.c
+++ b/src/xrt/compositor/vk_native/comp_vk_native_renderer.c
@@ -720,7 +720,9 @@ zone_draw_ensure_framebuffer(struct comp_vk_native_renderer *r)
 //! Every zone layer must be drawable: plain 2D swapchain (the whole-image
 //! view is a 2D view only when array_size == 1) with a valid view.
 static bool
-zone_pass_usable(struct comp_vk_native_renderer *r, struct comp_layer_accum *layers, bool hardware_display_3d)
+zone_pass_usable(struct comp_vk_native_renderer *r,
+                 struct comp_layer_accum *layers,
+                 const struct comp_vk_native_eff_layout *layout)
 {
 	if (!zone_draw_ensure(r) || !zone_draw_ensure_framebuffer(r)) {
 		return false;
@@ -731,7 +733,10 @@ zone_pass_usable(struct comp_vk_native_renderer *r, struct comp_layer_accum *lay
 		if (layer->data.type != XRT_LAYER_ZONE_3D) {
 			continue;
 		}
-		uint32_t view_count = hardware_display_3d ? layer->data.view_count : 1;
+		uint32_t view_count = layer->data.view_count;
+		if (view_count > layout->views) {
+			view_count = layout->views;
+		}
 		if (view_count == 0) {
 			view_count = 1;
 		}
@@ -767,7 +772,7 @@ draw_zones_pass(struct comp_vk_native_renderer *r,
                 struct comp_layer_accum *layers,
                 uint32_t target_width,
                 uint32_t target_height,
-                bool hardware_display_3d)
+                const struct comp_vk_native_eff_layout *layout)
 {
 	struct vk_bundle *vk = r->vk;
 
@@ -803,7 +808,10 @@ draw_zones_pass(struct comp_vk_native_renderer *r,
 		if (layer->data.type != XRT_LAYER_ZONE_3D) {
 			continue;
 		}
-		uint32_t view_count = hardware_display_3d ? layer->data.view_count : 1;
+		uint32_t view_count = layer->data.view_count;
+		if (view_count > layout->views) {
+			view_count = layout->views;
+		}
 		if (view_count == 0) {
 			view_count = 1;
 		}
@@ -856,7 +864,10 @@ draw_zones_pass(struct comp_vk_native_renderer *r,
 			continue;
 		}
 
-		uint32_t view_count = hardware_display_3d ? layer->data.view_count : 1;
+		uint32_t view_count = layer->data.view_count;
+		if (view_count > layout->views) {
+			view_count = layout->views;
+		}
 		if (view_count == 0) {
 			view_count = 1;
 		}
@@ -878,19 +889,21 @@ draw_zones_pass(struct comp_vk_native_renderer *r,
 
 			// Destination: the same tile box + zone-rect scale as the
 			// blit path (in zones frames the tile spans the full window).
+			// Tile-place by the effective grid (#542); mono content
+			// spans the full content region.
 			float dx0, dy0, dx1, dy1;
-			if (!hardware_display_3d || view_count == 1) {
+			if (layout->views == 1 || view_count == 1) {
 				dx0 = 0.0f;
 				dy0 = 0.0f;
-				dx1 = (float)(r->tile_columns * r->view_width);
-				dy1 = (float)(r->tile_rows * r->view_height);
+				dx1 = (float)(layout->cols * layout->tile_w);
+				dy1 = (float)(layout->rows * layout->tile_h);
 			} else {
-				uint32_t tile_x = eye % r->tile_columns;
-				uint32_t tile_y = eye / r->tile_columns;
-				dx0 = (float)(tile_x * r->view_width);
-				dy0 = (float)(tile_y * r->view_height);
-				dx1 = dx0 + (float)r->view_width;
-				dy1 = dy0 + (float)r->view_height;
+				uint32_t tile_x = eye % layout->cols;
+				uint32_t tile_y = eye / layout->cols;
+				dx0 = (float)(tile_x * layout->tile_w);
+				dy0 = (float)(tile_y * layout->tile_h);
+				dx1 = dx0 + (float)layout->tile_w;
+				dy1 = dy0 + (float)layout->tile_h;
 			}
 			if (target_width == 0 || target_height == 0) {
 				continue;
@@ -1040,7 +1053,7 @@ comp_vk_native_renderer_draw(struct comp_vk_native_renderer *r,
                               struct xrt_vec3 *right_eye,
                               uint32_t target_width,
                               uint32_t target_height,
-                              bool hardware_display_3d)
+                              const struct comp_vk_native_eff_layout *layout)
 {
 	struct vk_bundle *vk = r->vk;
 	(void)left_eye;
@@ -1061,8 +1074,8 @@ comp_vk_native_renderer_draw(struct comp_vk_native_renderer *r,
 	// alpha-over in layer-list order; blits cannot blend. Falls back to the
 	// blit path below (overlap overwrites, one-shot WARN) if the pipeline
 	// bundle cannot be created or a zone swapchain is layered.
-	if (zones_frame && zone_pass_usable(r, layers, hardware_display_3d)) {
-		return draw_zones_pass(r, layers, target_width, target_height, hardware_display_3d);
+	if (zones_frame && zone_pass_usable(r, layers, layout)) {
+		return draw_zones_pass(r, layers, target_width, target_height, layout);
 	}
 
 	VkCommandBufferAllocateInfo alloc_info = {
@@ -1118,16 +1131,19 @@ comp_vk_native_renderer_draw(struct comp_vk_native_renderer *r,
 			continue;
 		}
 
-		uint32_t view_count = hardware_display_3d ? layer->data.view_count : 1;
+		// CONTENT tile count from the SUBMISSION-derived effective layout
+		// (#542) — no longer clamped by the hardware weave-state.
+		uint32_t view_count = layer->data.view_count;
+		if (view_count > layout->views) view_count = layout->views;
 		if (view_count == 0) view_count = 1;
 
 		static bool blit_logged = false;
 		if (!blit_logged) {
-			U_LOG_W("Atlas blit: view_count=%u, hardware_3d=%d, tiles=%ux%u, "
-			        "view=%ux%u, layer_view_count=%u",
-			        view_count, (int)hardware_display_3d,
-			        r->tile_columns, r->tile_rows,
-			        r->view_width, r->view_height,
+			U_LOG_W("Atlas blit: view_count=%u, eff_tiles=%ux%u, "
+			        "eff_view=%ux%u, layer_view_count=%u",
+			        view_count,
+			        layout->cols, layout->rows,
+			        layout->tile_w, layout->tile_h,
 			        layer->data.view_count);
 		}
 
@@ -1160,20 +1176,20 @@ comp_vk_native_renderer_draw(struct comp_vk_native_renderer *r,
 			int32_t sy1 = sy0 + (int32_t)src_rect->extent.h;
 
 			int32_t dx0, dy0, dx1, dy1;
-			if (!hardware_display_3d || view_count == 1) {
-				// 2D mode: stretch across entire atlas
+			if (layout->views == 1 || view_count == 1) {
+				// Mono content: stretch across the full content region
 				dx0 = 0;
 				dy0 = 0;
-				dx1 = (int32_t)(r->tile_columns * r->view_width);
-				dy1 = (int32_t)(r->tile_rows * r->view_height);
+				dx1 = (int32_t)(layout->cols * layout->tile_w);
+				dy1 = (int32_t)(layout->rows * layout->tile_h);
 			} else {
-				// Tiled layout: place each eye in its tile
-				uint32_t tile_x = eye % r->tile_columns;
-				uint32_t tile_y = eye / r->tile_columns;
-				dx0 = (int32_t)(tile_x * r->view_width);
-				dy0 = (int32_t)(tile_y * r->view_height);
-				dx1 = dx0 + (int32_t)r->view_width;
-				dy1 = dy0 + (int32_t)r->view_height;
+				// Tiled layout: place each eye in its effective tile (#542)
+				uint32_t tile_x = eye % layout->cols;
+				uint32_t tile_y = eye / layout->cols;
+				dx0 = (int32_t)(tile_x * layout->tile_w);
+				dy0 = (int32_t)(tile_y * layout->tile_h);
+				dx1 = dx0 + (int32_t)layout->tile_w;
+				dy1 = dy0 + (int32_t)layout->tile_h;
 			}
 
 			// XR_EXT_display_zones: scale the zone rect (client-window

--- a/src/xrt/compositor/vk_native/comp_vk_native_renderer.h
+++ b/src/xrt/compositor/vk_native/comp_vk_native_renderer.h
@@ -25,6 +25,24 @@ extern "C" {
 #endif
 
 /*!
+ * Per-frame effective CONTENT layout (#542): the atlas tile grid the renderer
+ * paints and the DP receives, derived from the app's SUBMISSION — decoupled
+ * from the hardware weave-state (which only drives the DP's mode_3d via
+ * request_display_mode). Matched submissions reproduce the mode layout
+ * exactly; a hardware/content divergence gets a views×1 strip instead of
+ * being clamped away. Mirrors comp_d3d11_eff_layout / comp_d3d12_eff_layout.
+ * Computed once per frame by the compositor (which owns the legacy flag).
+ */
+struct comp_vk_native_eff_layout
+{
+	uint32_t views;  //!< effective view count (post legacy clamp)
+	uint32_t cols;   //!< atlas tile columns
+	uint32_t rows;   //!< atlas tile rows
+	uint32_t tile_w; //!< per-tile width in pixels
+	uint32_t tile_h; //!< per-tile height in pixels
+};
+
+/*!
  * Create a Vulkan renderer for layer compositing.
  *
  * @param c The Vulkan native compositor.
@@ -63,8 +81,8 @@ comp_vk_native_renderer_destroy(struct comp_vk_native_renderer **renderer_ptr);
  * @param right_eye Right eye position (NULL for default).
  * @param target_width Width of the render target (window).
  * @param target_height Height of the render target (window).
- * @param hardware_display_3d True when in 3D mode (stereo rendering),
- *        false for 2D passthrough (mono rendering).
+ * @param layout The frame's effective content layout (#542), computed by
+ *        the compositor.
  *
  * @return XRT_SUCCESS on success, error code otherwise.
  *
@@ -77,7 +95,7 @@ comp_vk_native_renderer_draw(struct comp_vk_native_renderer *renderer,
                               struct xrt_vec3 *right_eye,
                               uint32_t target_width,
                               uint32_t target_height,
-                              bool hardware_display_3d);
+                              const struct comp_vk_native_eff_layout *layout);
 
 /*!
  * Get the atlas VkImageView (tile_columns * view_width x tile_rows * height).

--- a/src/xrt/state_trackers/oxr/oxr_api_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_api_session.c
@@ -1318,21 +1318,30 @@ oxr_xrRequestDisplayModeEXT(XrSession session, XrDisplayModeEXT displayMode)
 		return oxr_error(&log, XR_ERROR_VALIDATION_FAILURE, "Invalid displayMode %d", (int)displayMode);
 	}
 
-	// Thin wrapper: find first mode matching hardware_display_3d, delegate to unified API
-	struct xrt_device *head = GET_XDEV_BY_ROLE(sess->sys, head);
-	if (head == NULL) {
-		return oxr_error(&log, XR_ERROR_RUNTIME_FAILURE, "No head device available");
-	}
-
+	// #542: HARDWARE-only override for the current mode. A rendering mode is
+	// a complete recipe (layout, view count, scales, default hardware state);
+	// xrRequestDisplayRenderingModeEXT requests one and the hardware follows.
+	// THIS entry point sets the hardware state ALONE — the active mode, the
+	// app's content, and the DP's processing (it weaves or flat-blits per the
+	// atlas it is handed) are untouched. E.g. hardware-2D over an active 3D
+	// mode keeps the weave running with the lens off: the panel shows the
+	// woven atlas flat (blurry), and an app fading its parallax to zero
+	// converges back to a sharp image — the MANUAL tracking-loss transition.
 	bool want_3d = (displayMode == XR_DISPLAY_MODE_3D_EXT);
-	for (uint32_t i = 0; i < head->rendering_mode_count; i++) {
-		if (head->rendering_modes[i].hardware_display_3d == want_3d) {
-			return oxr_xrRequestDisplayRenderingModeEXT(session, i);
-		}
+	bool changed = (sess->hardware_display_3d != want_3d);
+
+	XrResult res = oxr_session_request_display_mode(&log, sess, want_3d);
+	if (res != XR_SUCCESS) {
+		return res;
 	}
 
-	// No matching mode found — fall back to legacy behavior
-	return oxr_session_request_display_mode(&log, sess, want_3d);
+	// oxr_session_request_display_mode records the new state on success;
+	// surface the flip to the app the same way a mode-driven change does.
+	if (changed && sess->hardware_display_3d == want_3d) {
+		oxr_event_push_XrEventDataHardwareDisplayStateChanged(&log, sess, want_3d ? XR_TRUE : XR_FALSE);
+	}
+
+	return XR_SUCCESS;
 }
 
 XRAPI_ATTR XrResult XRAPI_CALL

--- a/test_apps/cube_handle_d3d11_win/main.cpp
+++ b/test_apps/cube_handle_d3d11_win/main.cpp
@@ -49,9 +49,17 @@ static XrSessionManager* g_xr = nullptr;
 // deliberate hardware/content divergence so the decoupled compositors can be
 // exercised (e.g. panel-2D + 2 submitted tiles). Toggle: 'L' key;
 // DXR_CUBE_PIN_CONTENT=1 starts pinned.
+// On top of the pin, two single-axis keys:
+//   'H' = HARDWARE-only: pin content at its current layout, then request the
+//         opposite-hardware mode — only the panel changes.
+//   'J' = CONTENT-only: flip the pinned submission layout to the opposite-
+//         hardware mode's layout — no runtime request, only content changes.
 static bool g_contentPinned = false;
 static bool g_contentPinTogglePending = false;
+static bool g_hwToggleRequested = false;
+static bool g_contentToggleRequested = false;
 static uint32_t g_contentPinModeIndex = 0;
+static uint32_t g_lastLive3DModeIndex = UINT32_MAX;
 static UINT g_windowWidth = 1280;
 static UINT g_windowHeight = 720;
 static bool g_inSizeMove = false;  // True while user is dragging/resizing the window
@@ -269,8 +277,17 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
         // #542 content-pin: 'L' freezes the submission-side mode snapshot
         // (handled in RenderOneFrame) while V/0-8 hardware requests still
         // go out — drives a deliberate hardware/content divergence.
+        // 'H' / 'J' toggle a single axis (hardware-only / content-only).
         if (wParam == 'L') {
             g_contentPinTogglePending = true;
+            return 0;
+        }
+        if (wParam == 'H') {
+            g_hwToggleRequested = true;
+            return 0;
+        }
+        if (wParam == 'J') {
+            g_contentToggleRequested = true;
             return 0;
         }
         break;
@@ -651,6 +668,69 @@ static void RenderOneFrame(RenderState& rs) {
             LOG_INFO("[#542] content %s (snapshot mode=%u, live mode=%u)",
                 g_contentPinned ? "PINNED" : "UNPINNED",
                 g_contentPinModeIndex, xr.currentModeIndex);
+        }
+
+        // Track the most recent live 3D mode for the "back to 3D" direction
+        // of the single-axis toggles (mirrors the runtime's V-key restore).
+        if (xr.renderingModeCount > 0 && xr.currentModeIndex < xr.renderingModeCount &&
+            xr.renderingModeDisplay3D[xr.currentModeIndex]) {
+            g_lastLive3DModeIndex = xr.currentModeIndex;
+        }
+        // Resolve a mode whose hardware state is the opposite of `from3d`:
+        // prefer the remembered 3D mode when going back to 3D, else the
+        // first mode on the other side of the hardware flag.
+        auto findOppositeMode = [&](bool from3d) -> int {
+            if (from3d == false && g_lastLive3DModeIndex < xr.renderingModeCount &&
+                xr.renderingModeDisplay3D[g_lastLive3DModeIndex]) {
+                return (int)g_lastLive3DModeIndex;
+            }
+            for (uint32_t i = 0; i < xr.renderingModeCount; i++) {
+                if (xr.renderingModeDisplay3D[i] != from3d) {
+                    return (int)i;
+                }
+            }
+            return -1;
+        };
+
+        // 'H' — HARDWARE-only: pin content where it is (so it won't follow),
+        // then request the opposite-hardware mode. Only the panel changes.
+        if (g_hwToggleRequested) {
+            g_hwToggleRequested = false;
+            if (xr.renderingModeCount > 0 && xr.session != XR_NULL_HANDLE &&
+                xr.pfnRequestDisplayRenderingModeEXT != nullptr &&
+                xr.currentModeIndex < xr.renderingModeCount) {
+                if (!g_contentPinned) {
+                    g_contentPinned = true;
+                    g_contentPinModeIndex = xr.currentModeIndex;
+                }
+                bool live3d = xr.renderingModeDisplay3D[xr.currentModeIndex];
+                int target = findOppositeMode(live3d);
+                if (target >= 0) {
+                    xr.pfnRequestDisplayRenderingModeEXT(xr.session, (uint32_t)target);
+                    LOG_INFO("[#542] H: hardware-only -> requested mode %d (%s); "
+                        "content stays pinned at mode %u layout",
+                        target, live3d ? "2D" : "3D", g_contentPinModeIndex);
+                }
+            }
+        }
+
+        // 'J' — CONTENT-only: flip the pinned submission layout to the
+        // opposite-hardware mode's layout. No runtime request goes out.
+        if (g_contentToggleRequested) {
+            g_contentToggleRequested = false;
+            if (xr.renderingModeCount > 0 && xr.currentModeIndex < xr.renderingModeCount) {
+                uint32_t cur = (g_contentPinned && g_contentPinModeIndex < xr.renderingModeCount)
+                    ? g_contentPinModeIndex : xr.currentModeIndex;
+                bool cur3d = xr.renderingModeDisplay3D[cur];
+                int target = findOppositeMode(cur3d);
+                if (target >= 0) {
+                    g_contentPinned = true;
+                    g_contentPinModeIndex = (uint32_t)target;
+                    LOG_INFO("[#542] J: content-only -> pinned at mode %d layout (%s); "
+                        "hardware untouched (live mode=%u)",
+                        target, cur3d ? "2D" : "3D", xr.currentModeIndex);
+                }
+            }
         }
     }
 

--- a/test_apps/cube_handle_d3d11_win/main.cpp
+++ b/test_apps/cube_handle_d3d11_win/main.cpp
@@ -44,22 +44,17 @@ static InputState g_inputState;
 static bool g_running = true;
 static XrSessionManager* g_xr = nullptr;
 
-// #542 content-pin (validation affordance): freeze the submission-side mode
-// snapshot while hardware mode requests (V / 0-8) still go out — drives a
-// deliberate hardware/content divergence so the decoupled compositors can be
-// exercised (e.g. panel-2D + 2 submitted tiles). Toggle: 'L' key;
-// DXR_CUBE_PIN_CONTENT=1 starts pinned.
-// On top of the pin, two single-axis keys:
-//   'H' = HARDWARE-only: pin content at its current layout, then request the
-//         opposite-hardware mode — only the panel changes.
-//   'J' = CONTENT-only: flip the pinned submission layout to the opposite-
-//         hardware mode's layout — no runtime request, only content changes.
-static bool g_contentPinned = false;
-static bool g_contentPinTogglePending = false;
+// #542 'H' (validation affordance): toggle the HARDWARE display state alone
+// for the current mode via xrRequestDisplayModeEXT — the mode, the app's
+// content, and the DP's weave/blit processing are untouched. In 3D the panel
+// shows the woven atlas flat (blurry); fading parallax to zero converges
+// back to sharp — the MANUAL tracking-loss transition shape (#522). The
+// runtime auto-clears the override on the next mode request, so the local
+// note resets whenever the mode changes.
 static bool g_hwToggleRequested = false;
-static bool g_contentToggleRequested = false;
-static uint32_t g_contentPinModeIndex = 0;
-static uint32_t g_lastLive3DModeIndex = UINT32_MAX;
+static bool g_hwOverrideActive = false;
+static bool g_hwOverride3D = false;
+static uint32_t g_hwOverrideModeIndex = 0;
 static UINT g_windowWidth = 1280;
 static UINT g_windowHeight = 720;
 static bool g_inSizeMove = false;  // True while user is dragging/resizing the window
@@ -274,20 +269,10 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
             PostMessage(hwnd, WM_CLOSE, 0, 0);
             return 0;
         }
-        // #542 content-pin: 'L' freezes the submission-side mode snapshot
-        // (handled in RenderOneFrame) while V/0-8 hardware requests still
-        // go out — drives a deliberate hardware/content divergence.
-        // 'H' / 'J' toggle a single axis (hardware-only / content-only).
-        if (wParam == 'L') {
-            g_contentPinTogglePending = true;
-            return 0;
-        }
+        // #542: 'H' toggles the HARDWARE display state alone for the current
+        // mode (xrRequestDisplayModeEXT) — handled in RenderOneFrame.
         if (wParam == 'H') {
             g_hwToggleRequested = true;
-            return 0;
-        }
-        if (wParam == 'J') {
-            g_contentToggleRequested = true;
             return 0;
         }
         break;
@@ -644,92 +629,31 @@ static void RenderOneFrame(RenderState& rs) {
         }
     }
 
-    // #542 content-pin: resolve the env start-pin once, then any pending
-    // 'L' toggle. While pinned the render/submit path below derives its
-    // layout from the SNAPSHOT mode, not the live one — mode requests keep
-    // flowing, so hardware and content diverge on purpose.
+    // #542 'H': hardware-state-only toggle for the current mode.
     {
-        static bool s_pinEnvChecked = false;
-        if (!s_pinEnvChecked && xr.sessionRunning) {
-            s_pinEnvChecked = true;
-            const char *pin = getenv("DXR_CUBE_PIN_CONTENT");
-            if (pin && pin[0] == '1') {
-                g_contentPinned = true;
-                g_contentPinModeIndex = xr.currentModeIndex;
-                LOG_INFO("[#542] content PINNED at start (mode=%u)", g_contentPinModeIndex);
-            }
+        // A mode change resets the hardware to the new mode's default —
+        // drop the local override note so the next H starts from there.
+        if (g_hwOverrideActive && xr.currentModeIndex != g_hwOverrideModeIndex) {
+            g_hwOverrideActive = false;
         }
-        if (g_contentPinTogglePending) {
-            g_contentPinTogglePending = false;
-            g_contentPinned = !g_contentPinned;
-            if (g_contentPinned) {
-                g_contentPinModeIndex = xr.currentModeIndex;
-            }
-            LOG_INFO("[#542] content %s (snapshot mode=%u, live mode=%u)",
-                g_contentPinned ? "PINNED" : "UNPINNED",
-                g_contentPinModeIndex, xr.currentModeIndex);
-        }
-
-        // Track the most recent live 3D mode for the "back to 3D" direction
-        // of the single-axis toggles (mirrors the runtime's V-key restore).
-        if (xr.renderingModeCount > 0 && xr.currentModeIndex < xr.renderingModeCount &&
-            xr.renderingModeDisplay3D[xr.currentModeIndex]) {
-            g_lastLive3DModeIndex = xr.currentModeIndex;
-        }
-        // Resolve a mode whose hardware state is the opposite of `from3d`:
-        // prefer the remembered 3D mode when going back to 3D, else the
-        // first mode on the other side of the hardware flag.
-        auto findOppositeMode = [&](bool from3d) -> int {
-            if (from3d == false && g_lastLive3DModeIndex < xr.renderingModeCount &&
-                xr.renderingModeDisplay3D[g_lastLive3DModeIndex]) {
-                return (int)g_lastLive3DModeIndex;
-            }
-            for (uint32_t i = 0; i < xr.renderingModeCount; i++) {
-                if (xr.renderingModeDisplay3D[i] != from3d) {
-                    return (int)i;
-                }
-            }
-            return -1;
-        };
-
-        // 'H' — HARDWARE-only: pin content where it is (so it won't follow),
-        // then request the opposite-hardware mode. Only the panel changes.
         if (g_hwToggleRequested) {
             g_hwToggleRequested = false;
-            if (xr.renderingModeCount > 0 && xr.session != XR_NULL_HANDLE &&
-                xr.pfnRequestDisplayRenderingModeEXT != nullptr &&
-                xr.currentModeIndex < xr.renderingModeCount) {
-                if (!g_contentPinned) {
-                    g_contentPinned = true;
-                    g_contentPinModeIndex = xr.currentModeIndex;
+            if (xr.pfnRequestDisplayModeEXT != nullptr && xr.session != XR_NULL_HANDLE &&
+                xr.renderingModeCount > 0 && xr.currentModeIndex < xr.renderingModeCount) {
+                bool mode_default_3d = xr.renderingModeDisplay3D[xr.currentModeIndex];
+                bool cur_3d = g_hwOverrideActive ? g_hwOverride3D : mode_default_3d;
+                bool want_3d = !cur_3d;
+                XrResult hres = xr.pfnRequestDisplayModeEXT(xr.session,
+                    want_3d ? XR_DISPLAY_MODE_3D_EXT : XR_DISPLAY_MODE_2D_EXT);
+                if (XR_SUCCEEDED(hres)) {
+                    g_hwOverrideActive = (want_3d != mode_default_3d);
+                    g_hwOverride3D = want_3d;
+                    g_hwOverrideModeIndex = xr.currentModeIndex;
                 }
-                bool live3d = xr.renderingModeDisplay3D[xr.currentModeIndex];
-                int target = findOppositeMode(live3d);
-                if (target >= 0) {
-                    xr.pfnRequestDisplayRenderingModeEXT(xr.session, (uint32_t)target);
-                    LOG_INFO("[#542] H: hardware-only -> requested mode %d (%s); "
-                        "content stays pinned at mode %u layout",
-                        target, live3d ? "2D" : "3D", g_contentPinModeIndex);
-                }
-            }
-        }
-
-        // 'J' — CONTENT-only: flip the pinned submission layout to the
-        // opposite-hardware mode's layout. No runtime request goes out.
-        if (g_contentToggleRequested) {
-            g_contentToggleRequested = false;
-            if (xr.renderingModeCount > 0 && xr.currentModeIndex < xr.renderingModeCount) {
-                uint32_t cur = (g_contentPinned && g_contentPinModeIndex < xr.renderingModeCount)
-                    ? g_contentPinModeIndex : xr.currentModeIndex;
-                bool cur3d = xr.renderingModeDisplay3D[cur];
-                int target = findOppositeMode(cur3d);
-                if (target >= 0) {
-                    g_contentPinned = true;
-                    g_contentPinModeIndex = (uint32_t)target;
-                    LOG_INFO("[#542] J: content-only -> pinned at mode %d layout (%s); "
-                        "hardware untouched (live mode=%u)",
-                        target, cur3d ? "2D" : "3D", xr.currentModeIndex);
-                }
+                LOG_INFO("[#542] H: hardware-only -> %s (mode %u unchanged, rc=0x%x)",
+                    want_3d ? "3D" : "2D", xr.currentModeIndex, (unsigned)hres);
+            } else {
+                LOG_INFO("[#542] H: xrRequestDisplayModeEXT unavailable");
             }
         }
     }
@@ -744,21 +668,16 @@ static void RenderOneFrame(RenderState& rs) {
     if (xr.sessionRunning) {
         XrFrameState frameState;
         if (BeginFrame(xr, frameState)) {
-                // #542 content-pin: the render/submit layout derives from the
-                // pinned snapshot when active, the live mode otherwise.
-                uint32_t contentModeIndex =
-                    (g_contentPinned && g_contentPinModeIndex < xr.renderingModeCount)
-                        ? g_contentPinModeIndex : xr.currentModeIndex;
-                uint32_t modeViewCount = (xr.renderingModeCount > 0 && contentModeIndex < xr.renderingModeCount)
-                    ? xr.renderingModeViewCounts[contentModeIndex] : 2;
-                uint32_t tileColumns = (xr.renderingModeCount > 0 && contentModeIndex < xr.renderingModeCount)
-                    ? xr.renderingModeTileColumns[contentModeIndex] : 2;
-                uint32_t tileRows = (xr.renderingModeCount > 0 && contentModeIndex < xr.renderingModeCount)
-                    ? xr.renderingModeTileRows[contentModeIndex] : 1;
-                bool monoMode = (xr.renderingModeCount > 0 && !xr.renderingModeDisplay3D[contentModeIndex]);
-                if (xr.renderingModeCount > 0 && contentModeIndex < xr.renderingModeCount) {
-                    xr.recommendedViewScaleX = xr.renderingModeScaleX[contentModeIndex];
-                    xr.recommendedViewScaleY = xr.renderingModeScaleY[contentModeIndex];
+                uint32_t modeViewCount = (xr.renderingModeCount > 0 && xr.currentModeIndex < xr.renderingModeCount)
+                    ? xr.renderingModeViewCounts[xr.currentModeIndex] : 2;
+                uint32_t tileColumns = (xr.renderingModeCount > 0 && xr.currentModeIndex < xr.renderingModeCount)
+                    ? xr.renderingModeTileColumns[xr.currentModeIndex] : 2;
+                uint32_t tileRows = (xr.renderingModeCount > 0 && xr.currentModeIndex < xr.renderingModeCount)
+                    ? xr.renderingModeTileRows[xr.currentModeIndex] : 1;
+                bool monoMode = (xr.renderingModeCount > 0 && !xr.renderingModeDisplay3D[xr.currentModeIndex]);
+                if (xr.renderingModeCount > 0 && xr.currentModeIndex < xr.renderingModeCount) {
+                    xr.recommendedViewScaleX = xr.renderingModeScaleX[xr.currentModeIndex];
+                    xr.recommendedViewScaleY = xr.renderingModeScaleY[xr.currentModeIndex];
                 }
                 int eyeCount = monoMode ? 1 : (int)modeViewCount;
                 std::vector<XrCompositionLayerProjectionView> projectionViews(eyeCount, {XR_TYPE_COMPOSITION_LAYER_PROJECTION_VIEW});
@@ -901,7 +820,6 @@ static void RenderOneFrame(RenderState& rs) {
                                 L"\nView rig: unavailable (legacy views)";
 
                             // Dynamic render dims matching the actual viewport computation
-                            // (#542: follows the content pin, like the render path)
                             bool dispMonoMode = monoMode;
                             uint32_t dispRenderW, dispRenderH;
                             if (dispMonoMode) {
@@ -926,11 +844,10 @@ static void RenderOneFrame(RenderState& rs) {
                                 xr.renderingModeCount,
                                 xr.renderingModeCount > 0 ? xr.renderingModeDisplay3D[xr.currentModeIndex] : true,
                                 xr.renderingModeCount > 0 ? xr.renderingModeIsRequestable[xr.currentModeIndex] : true);
-                            if (g_contentPinned) {
-                                wchar_t pinBuf[64];
-                                swprintf(pinBuf, 64, L"\nCONTENT PINNED [L]: %ux%u x%d",
-                                    tileColumns, tileRows, eyeCount);
-                                dispText += pinBuf;
+                            if (g_hwOverrideActive) {
+                                dispText += g_hwOverride3D
+                                    ? L"\nHW OVERRIDE [H]: 3D (mode default 2D)"
+                                    : L"\nHW OVERRIDE [H]: 2D (mode default 3D)";
                             }
                             std::wstring eyeText = FormatEyeTrackingInfo(
                                 xr.eyePositions, (uint32_t)eyeCount,

--- a/test_apps/cube_handle_d3d11_win/main.cpp
+++ b/test_apps/cube_handle_d3d11_win/main.cpp
@@ -43,6 +43,15 @@ static const wchar_t* WINDOW_TITLE = L"D3D11 Cube \u2014 D3D11 Native Compositor
 static InputState g_inputState;
 static bool g_running = true;
 static XrSessionManager* g_xr = nullptr;
+
+// #542 content-pin (validation affordance): freeze the submission-side mode
+// snapshot while hardware mode requests (V / 0-8) still go out — drives a
+// deliberate hardware/content divergence so the decoupled compositors can be
+// exercised (e.g. panel-2D + 2 submitted tiles). Toggle: 'L' key;
+// DXR_CUBE_PIN_CONTENT=1 starts pinned.
+static bool g_contentPinned = false;
+static bool g_contentPinTogglePending = false;
+static uint32_t g_contentPinModeIndex = 0;
 static UINT g_windowWidth = 1280;
 static UINT g_windowHeight = 720;
 static bool g_inSizeMove = false;  // True while user is dragging/resizing the window
@@ -255,6 +264,13 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
     case WM_KEYDOWN:
         if (wParam == VK_ESCAPE) {
             PostMessage(hwnd, WM_CLOSE, 0, 0);
+            return 0;
+        }
+        // #542 content-pin: 'L' freezes the submission-side mode snapshot
+        // (handled in RenderOneFrame) while V/0-8 hardware requests still
+        // go out — drives a deliberate hardware/content divergence.
+        if (wParam == 'L') {
+            g_contentPinTogglePending = true;
             return 0;
         }
         break;
@@ -611,6 +627,33 @@ static void RenderOneFrame(RenderState& rs) {
         }
     }
 
+    // #542 content-pin: resolve the env start-pin once, then any pending
+    // 'L' toggle. While pinned the render/submit path below derives its
+    // layout from the SNAPSHOT mode, not the live one — mode requests keep
+    // flowing, so hardware and content diverge on purpose.
+    {
+        static bool s_pinEnvChecked = false;
+        if (!s_pinEnvChecked && xr.sessionRunning) {
+            s_pinEnvChecked = true;
+            const char *pin = getenv("DXR_CUBE_PIN_CONTENT");
+            if (pin && pin[0] == '1') {
+                g_contentPinned = true;
+                g_contentPinModeIndex = xr.currentModeIndex;
+                LOG_INFO("[#542] content PINNED at start (mode=%u)", g_contentPinModeIndex);
+            }
+        }
+        if (g_contentPinTogglePending) {
+            g_contentPinTogglePending = false;
+            g_contentPinned = !g_contentPinned;
+            if (g_contentPinned) {
+                g_contentPinModeIndex = xr.currentModeIndex;
+            }
+            LOG_INFO("[#542] content %s (snapshot mode=%u, live mode=%u)",
+                g_contentPinned ? "PINNED" : "UNPINNED",
+                g_contentPinModeIndex, xr.currentModeIndex);
+        }
+    }
+
     // Update scene (cube rotation) — speed agent-settable via cube-d3d11__set_spin (#457)
     UpdateScene(renderer, rs.perfStats->deltaTime, xr.spinSpeed);
 
@@ -621,16 +664,21 @@ static void RenderOneFrame(RenderState& rs) {
     if (xr.sessionRunning) {
         XrFrameState frameState;
         if (BeginFrame(xr, frameState)) {
-                uint32_t modeViewCount = (xr.renderingModeCount > 0 && xr.currentModeIndex < xr.renderingModeCount)
-                    ? xr.renderingModeViewCounts[xr.currentModeIndex] : 2;
-                uint32_t tileColumns = (xr.renderingModeCount > 0 && xr.currentModeIndex < xr.renderingModeCount)
-                    ? xr.renderingModeTileColumns[xr.currentModeIndex] : 2;
-                uint32_t tileRows = (xr.renderingModeCount > 0 && xr.currentModeIndex < xr.renderingModeCount)
-                    ? xr.renderingModeTileRows[xr.currentModeIndex] : 1;
-                bool monoMode = (xr.renderingModeCount > 0 && !xr.renderingModeDisplay3D[xr.currentModeIndex]);
-                if (xr.renderingModeCount > 0 && xr.currentModeIndex < xr.renderingModeCount) {
-                    xr.recommendedViewScaleX = xr.renderingModeScaleX[xr.currentModeIndex];
-                    xr.recommendedViewScaleY = xr.renderingModeScaleY[xr.currentModeIndex];
+                // #542 content-pin: the render/submit layout derives from the
+                // pinned snapshot when active, the live mode otherwise.
+                uint32_t contentModeIndex =
+                    (g_contentPinned && g_contentPinModeIndex < xr.renderingModeCount)
+                        ? g_contentPinModeIndex : xr.currentModeIndex;
+                uint32_t modeViewCount = (xr.renderingModeCount > 0 && contentModeIndex < xr.renderingModeCount)
+                    ? xr.renderingModeViewCounts[contentModeIndex] : 2;
+                uint32_t tileColumns = (xr.renderingModeCount > 0 && contentModeIndex < xr.renderingModeCount)
+                    ? xr.renderingModeTileColumns[contentModeIndex] : 2;
+                uint32_t tileRows = (xr.renderingModeCount > 0 && contentModeIndex < xr.renderingModeCount)
+                    ? xr.renderingModeTileRows[contentModeIndex] : 1;
+                bool monoMode = (xr.renderingModeCount > 0 && !xr.renderingModeDisplay3D[contentModeIndex]);
+                if (xr.renderingModeCount > 0 && contentModeIndex < xr.renderingModeCount) {
+                    xr.recommendedViewScaleX = xr.renderingModeScaleX[contentModeIndex];
+                    xr.recommendedViewScaleY = xr.renderingModeScaleY[contentModeIndex];
                 }
                 int eyeCount = monoMode ? 1 : (int)modeViewCount;
                 std::vector<XrCompositionLayerProjectionView> projectionViews(eyeCount, {XR_TYPE_COMPOSITION_LAYER_PROJECTION_VIEW});
@@ -773,7 +821,8 @@ static void RenderOneFrame(RenderState& rs) {
                                 L"\nView rig: unavailable (legacy views)";
 
                             // Dynamic render dims matching the actual viewport computation
-                            bool dispMonoMode = (xr.renderingModeCount > 0 && !xr.renderingModeDisplay3D[xr.currentModeIndex]);
+                            // (#542: follows the content pin, like the render path)
+                            bool dispMonoMode = monoMode;
                             uint32_t dispRenderW, dispRenderH;
                             if (dispMonoMode) {
                                 dispRenderW = g_windowWidth;
@@ -797,6 +846,12 @@ static void RenderOneFrame(RenderState& rs) {
                                 xr.renderingModeCount,
                                 xr.renderingModeCount > 0 ? xr.renderingModeDisplay3D[xr.currentModeIndex] : true,
                                 xr.renderingModeCount > 0 ? xr.renderingModeIsRequestable[xr.currentModeIndex] : true);
+                            if (g_contentPinned) {
+                                wchar_t pinBuf[64];
+                                swprintf(pinBuf, 64, L"\nCONTENT PINNED [L]: %ux%u x%d",
+                                    tileColumns, tileRows, eyeCount);
+                                dispText += pinBuf;
+                            }
                             std::wstring eyeText = FormatEyeTrackingInfo(
                                 xr.eyePositions, (uint32_t)eyeCount,
                                 xr.eyeTrackingActive, xr.isEyeTracking,

--- a/test_apps/cube_handle_d3d12_win/main.cpp
+++ b/test_apps/cube_handle_d3d12_win/main.cpp
@@ -51,6 +51,16 @@ static InputState g_inputState;
 static std::mutex g_inputMutex;
 static std::atomic<bool> g_running{true};
 static XrSessionManager* g_xr = nullptr;
+
+// #542 content-pin (validation affordance): freeze the submission-side mode
+// snapshot while hardware mode requests (V / 0-8) still go out — drives a
+// deliberate hardware/content divergence so the decoupled compositors can be
+// exercised (e.g. panel-2D + 2 submitted tiles). Toggle: 'L' key;
+// DXR_CUBE_PIN_CONTENT=1 starts pinned. Toggle flag is atomic (set on the
+// message-pump thread, consumed on the render thread).
+static std::atomic<bool> g_contentPinTogglePending{false};
+static bool g_contentPinned = false;          // render-thread only
+static uint32_t g_contentPinModeIndex = 0;    // render-thread only
 static UINT g_windowWidth = 1280;
 static UINT g_windowHeight = 720;
 
@@ -227,6 +237,13 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
         }
         if (wParam == VK_F11) {
             ToggleFullscreen(hwnd);
+            return 0;
+        }
+        // #542 content-pin: 'L' freezes the submission-side mode snapshot
+        // (handled on the render thread) while V/0-8 hardware requests still
+        // go out — drives a deliberate hardware/content divergence.
+        if (wParam == 'L') {
+            g_contentPinTogglePending.store(true);
             return 0;
         }
         break;
@@ -589,19 +606,50 @@ static void RenderThreadFunc(
         UpdateScene(*renderer, perfStats.deltaTime, xr->spinSpeed);
         PollEvents(*xr);
 
+        // #542 content-pin: resolve the env start-pin once, then any pending
+        // 'L' toggle. While pinned the render/submit path below derives its
+        // layout from the SNAPSHOT mode, not the live one — mode requests keep
+        // flowing, so hardware and content diverge on purpose.
+        {
+            static bool s_pinEnvChecked = false;
+            if (!s_pinEnvChecked && xr->sessionRunning) {
+                s_pinEnvChecked = true;
+                const char *pin = getenv("DXR_CUBE_PIN_CONTENT");
+                if (pin && pin[0] == '1') {
+                    g_contentPinned = true;
+                    g_contentPinModeIndex = xr->currentModeIndex;
+                    LOG_INFO("[#542] content PINNED at start (mode=%u)", g_contentPinModeIndex);
+                }
+            }
+            if (g_contentPinTogglePending.exchange(false)) {
+                g_contentPinned = !g_contentPinned;
+                if (g_contentPinned) {
+                    g_contentPinModeIndex = xr->currentModeIndex;
+                }
+                LOG_INFO("[#542] content %s (snapshot mode=%u, live mode=%u)",
+                    g_contentPinned ? "PINNED" : "UNPINNED",
+                    g_contentPinModeIndex, xr->currentModeIndex);
+            }
+        }
+
         if (xr->sessionRunning) {
             XrFrameState frameState;
             if (BeginFrame(*xr, frameState)) {
-                uint32_t modeViewCount = (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount)
-                    ? xr->renderingModeViewCounts[xr->currentModeIndex] : 2;
-                uint32_t tileColumns = (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount)
-                    ? xr->renderingModeTileColumns[xr->currentModeIndex] : 2;
-                uint32_t tileRows = (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount)
-                    ? xr->renderingModeTileRows[xr->currentModeIndex] : 1;
-                bool monoMode = (xr->renderingModeCount > 0 && !xr->renderingModeDisplay3D[xr->currentModeIndex]);
-                if (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount) {
-                    xr->recommendedViewScaleX = xr->renderingModeScaleX[xr->currentModeIndex];
-                    xr->recommendedViewScaleY = xr->renderingModeScaleY[xr->currentModeIndex];
+                // #542 content-pin: the render/submit layout derives from the
+                // pinned snapshot when active, the live mode otherwise.
+                uint32_t contentModeIndex =
+                    (g_contentPinned && g_contentPinModeIndex < xr->renderingModeCount)
+                        ? g_contentPinModeIndex : xr->currentModeIndex;
+                uint32_t modeViewCount = (xr->renderingModeCount > 0 && contentModeIndex < xr->renderingModeCount)
+                    ? xr->renderingModeViewCounts[contentModeIndex] : 2;
+                uint32_t tileColumns = (xr->renderingModeCount > 0 && contentModeIndex < xr->renderingModeCount)
+                    ? xr->renderingModeTileColumns[contentModeIndex] : 2;
+                uint32_t tileRows = (xr->renderingModeCount > 0 && contentModeIndex < xr->renderingModeCount)
+                    ? xr->renderingModeTileRows[contentModeIndex] : 1;
+                bool monoMode = (xr->renderingModeCount > 0 && !xr->renderingModeDisplay3D[contentModeIndex]);
+                if (xr->renderingModeCount > 0 && contentModeIndex < xr->renderingModeCount) {
+                    xr->recommendedViewScaleX = xr->renderingModeScaleX[contentModeIndex];
+                    xr->recommendedViewScaleY = xr->renderingModeScaleY[contentModeIndex];
                 }
                 int eyeCount = monoMode ? 1 : (int)modeViewCount;
                 std::vector<XrCompositionLayerProjectionView> projectionViews(eyeCount, {XR_TYPE_COMPOSITION_LAYER_PROJECTION_VIEW});
@@ -859,6 +907,12 @@ static void RenderThreadFunc(
                                     xr->renderingModeCount,
                                     xr->renderingModeCount > 0 ? xr->renderingModeDisplay3D[xr->currentModeIndex] : true,
                                     xr->renderingModeCount > 0 ? xr->renderingModeIsRequestable[xr->currentModeIndex] : true);
+                                if (g_contentPinned) {
+                                    wchar_t pinBuf[64];
+                                    swprintf(pinBuf, 64, L"\nCONTENT PINNED [L]: %ux%u x%d",
+                                        tileColumns, tileRows, eyeCount);
+                                    dispText += pinBuf;
+                                }
                                 std::wstring eyeText = FormatEyeTrackingInfo(
                                     xr->eyePositions, (uint32_t)eyeCount,
                                     xr->eyeTrackingActive, xr->isEyeTracking,

--- a/test_apps/cube_handle_d3d12_win/main.cpp
+++ b/test_apps/cube_handle_d3d12_win/main.cpp
@@ -1094,7 +1094,8 @@ static void RenderThreadFunc(
                 // build the layer list manually (projection + panels in list
                 // order) and submit raw — the shared EndFrame helpers don't
                 // carry the Local2D layer type. Otherwise the normal paths.
-                uint32_t submitViewCount = (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount) ? xr->renderingModeViewCounts[xr->currentModeIndex] : 2;
+                // (#542: follows the content pin, like the render path)
+                uint32_t submitViewCount = (xr->renderingModeCount > 0 && contentModeIndex < xr->renderingModeCount) ? xr->renderingModeViewCounts[contentModeIndex] : 2;
                 LOG_INFO("[FRAME] EndFrame: rendered=%d hudSubmitted=%d viewCount=%u", rendered, hudSubmitted, submitViewCount);
                 if (g_l2dActive && g_panel1.swapchain != XR_NULL_HANDLE) {
                     XrCompositionLayerProjection projLayer = {XR_TYPE_COMPOSITION_LAYER_PROJECTION};

--- a/test_apps/cube_handle_d3d12_win/main.cpp
+++ b/test_apps/cube_handle_d3d12_win/main.cpp
@@ -52,23 +52,18 @@ static std::mutex g_inputMutex;
 static std::atomic<bool> g_running{true};
 static XrSessionManager* g_xr = nullptr;
 
-// #542 content-pin (validation affordance): freeze the submission-side mode
-// snapshot while hardware mode requests (V / 0-8) still go out — drives a
-// deliberate hardware/content divergence so the decoupled compositors can be
-// exercised (e.g. panel-2D + 2 submitted tiles). Toggle: 'L' key;
-// DXR_CUBE_PIN_CONTENT=1 starts pinned. Toggle flags are atomic (set on the
+// #542 'H' (validation affordance): toggle the HARDWARE display state alone
+// for the current mode via xrRequestDisplayModeEXT — the mode, the app's
+// content, and the DP's weave/blit processing are untouched. In 3D the panel
+// shows the woven atlas flat (blurry); fading parallax to zero converges
+// back to sharp — the MANUAL tracking-loss transition shape (#522). The
+// runtime auto-clears the override on the next mode request, so the local
+// note resets whenever the mode changes. Toggle flag is atomic (set on the
 // message-pump thread, consumed on the render thread).
-// On top of the pin, two single-axis keys:
-//   'H' = HARDWARE-only: pin content at its current layout, then request the
-//         opposite-hardware mode — only the panel changes.
-//   'J' = CONTENT-only: flip the pinned submission layout to the opposite-
-//         hardware mode's layout — no runtime request, only content changes.
-static std::atomic<bool> g_contentPinTogglePending{false};
 static std::atomic<bool> g_hwToggleRequested{false};
-static std::atomic<bool> g_contentToggleRequested{false};
-static bool g_contentPinned = false;          // render-thread only
-static uint32_t g_contentPinModeIndex = 0;    // render-thread only
-static uint32_t g_lastLive3DModeIndex = UINT32_MAX; // render-thread only
+static bool g_hwOverrideActive = false;       // render-thread only
+static bool g_hwOverride3D = false;           // render-thread only
+static uint32_t g_hwOverrideModeIndex = 0;    // render-thread only
 static UINT g_windowWidth = 1280;
 static UINT g_windowHeight = 720;
 
@@ -247,20 +242,10 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
             ToggleFullscreen(hwnd);
             return 0;
         }
-        // #542 content-pin: 'L' freezes the submission-side mode snapshot
-        // (handled on the render thread) while V/0-8 hardware requests still
-        // go out — drives a deliberate hardware/content divergence.
-        // 'H' / 'J' toggle a single axis (hardware-only / content-only).
-        if (wParam == 'L') {
-            g_contentPinTogglePending.store(true);
-            return 0;
-        }
+        // #542: 'H' toggles the HARDWARE display state alone for the current
+        // mode (xrRequestDisplayModeEXT) — handled on the render thread.
         if (wParam == 'H') {
             g_hwToggleRequested.store(true);
-            return 0;
-        }
-        if (wParam == 'J') {
-            g_contentToggleRequested.store(true);
             return 0;
         }
         break;
@@ -623,89 +608,30 @@ static void RenderThreadFunc(
         UpdateScene(*renderer, perfStats.deltaTime, xr->spinSpeed);
         PollEvents(*xr);
 
-        // #542 content-pin: resolve the env start-pin once, then any pending
-        // 'L' toggle. While pinned the render/submit path below derives its
-        // layout from the SNAPSHOT mode, not the live one — mode requests keep
-        // flowing, so hardware and content diverge on purpose.
+        // #542 'H': hardware-state-only toggle for the current mode.
         {
-            static bool s_pinEnvChecked = false;
-            if (!s_pinEnvChecked && xr->sessionRunning) {
-                s_pinEnvChecked = true;
-                const char *pin = getenv("DXR_CUBE_PIN_CONTENT");
-                if (pin && pin[0] == '1') {
-                    g_contentPinned = true;
-                    g_contentPinModeIndex = xr->currentModeIndex;
-                    LOG_INFO("[#542] content PINNED at start (mode=%u)", g_contentPinModeIndex);
-                }
+            // A mode change resets the hardware to the new mode's default —
+            // drop the local override note so the next H starts from there.
+            if (g_hwOverrideActive && xr->currentModeIndex != g_hwOverrideModeIndex) {
+                g_hwOverrideActive = false;
             }
-            if (g_contentPinTogglePending.exchange(false)) {
-                g_contentPinned = !g_contentPinned;
-                if (g_contentPinned) {
-                    g_contentPinModeIndex = xr->currentModeIndex;
-                }
-                LOG_INFO("[#542] content %s (snapshot mode=%u, live mode=%u)",
-                    g_contentPinned ? "PINNED" : "UNPINNED",
-                    g_contentPinModeIndex, xr->currentModeIndex);
-            }
-
-            // Track the most recent live 3D mode for the "back to 3D" direction
-            // of the single-axis toggles (mirrors the runtime's V-key restore).
-            if (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount &&
-                xr->renderingModeDisplay3D[xr->currentModeIndex]) {
-                g_lastLive3DModeIndex = xr->currentModeIndex;
-            }
-            // Resolve a mode whose hardware state is the opposite of `from3d`:
-            // prefer the remembered 3D mode when going back to 3D, else the
-            // first mode on the other side of the hardware flag.
-            auto findOppositeMode = [&](bool from3d) -> int {
-                if (from3d == false && g_lastLive3DModeIndex < xr->renderingModeCount &&
-                    xr->renderingModeDisplay3D[g_lastLive3DModeIndex]) {
-                    return (int)g_lastLive3DModeIndex;
-                }
-                for (uint32_t i = 0; i < xr->renderingModeCount; i++) {
-                    if (xr->renderingModeDisplay3D[i] != from3d) {
-                        return (int)i;
-                    }
-                }
-                return -1;
-            };
-
-            // 'H' — HARDWARE-only: pin content where it is (so it won't follow),
-            // then request the opposite-hardware mode. Only the panel changes.
             if (g_hwToggleRequested.exchange(false)) {
-                if (xr->renderingModeCount > 0 && xr->session != XR_NULL_HANDLE &&
-                    xr->pfnRequestDisplayRenderingModeEXT != nullptr &&
-                    xr->currentModeIndex < xr->renderingModeCount) {
-                    if (!g_contentPinned) {
-                        g_contentPinned = true;
-                        g_contentPinModeIndex = xr->currentModeIndex;
+                if (xr->pfnRequestDisplayModeEXT != nullptr && xr->session != XR_NULL_HANDLE &&
+                    xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount) {
+                    bool mode_default_3d = xr->renderingModeDisplay3D[xr->currentModeIndex];
+                    bool cur_3d = g_hwOverrideActive ? g_hwOverride3D : mode_default_3d;
+                    bool want_3d = !cur_3d;
+                    XrResult hres = xr->pfnRequestDisplayModeEXT(xr->session,
+                        want_3d ? XR_DISPLAY_MODE_3D_EXT : XR_DISPLAY_MODE_2D_EXT);
+                    if (XR_SUCCEEDED(hres)) {
+                        g_hwOverrideActive = (want_3d != mode_default_3d);
+                        g_hwOverride3D = want_3d;
+                        g_hwOverrideModeIndex = xr->currentModeIndex;
                     }
-                    bool live3d = xr->renderingModeDisplay3D[xr->currentModeIndex];
-                    int target = findOppositeMode(live3d);
-                    if (target >= 0) {
-                        xr->pfnRequestDisplayRenderingModeEXT(xr->session, (uint32_t)target);
-                        LOG_INFO("[#542] H: hardware-only -> requested mode %d (%s); "
-                            "content stays pinned at mode %u layout",
-                            target, live3d ? "2D" : "3D", g_contentPinModeIndex);
-                    }
-                }
-            }
-
-            // 'J' — CONTENT-only: flip the pinned submission layout to the
-            // opposite-hardware mode's layout. No runtime request goes out.
-            if (g_contentToggleRequested.exchange(false)) {
-                if (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount) {
-                    uint32_t cur = (g_contentPinned && g_contentPinModeIndex < xr->renderingModeCount)
-                        ? g_contentPinModeIndex : xr->currentModeIndex;
-                    bool cur3d = xr->renderingModeDisplay3D[cur];
-                    int target = findOppositeMode(cur3d);
-                    if (target >= 0) {
-                        g_contentPinned = true;
-                        g_contentPinModeIndex = (uint32_t)target;
-                        LOG_INFO("[#542] J: content-only -> pinned at mode %d layout (%s); "
-                            "hardware untouched (live mode=%u)",
-                            target, cur3d ? "2D" : "3D", xr->currentModeIndex);
-                    }
+                    LOG_INFO("[#542] H: hardware-only -> %s (mode %u unchanged, rc=0x%x)",
+                        want_3d ? "3D" : "2D", xr->currentModeIndex, (unsigned)hres);
+                } else {
+                    LOG_INFO("[#542] H: xrRequestDisplayModeEXT unavailable");
                 }
             }
         }
@@ -713,21 +639,16 @@ static void RenderThreadFunc(
         if (xr->sessionRunning) {
             XrFrameState frameState;
             if (BeginFrame(*xr, frameState)) {
-                // #542 content-pin: the render/submit layout derives from the
-                // pinned snapshot when active, the live mode otherwise.
-                uint32_t contentModeIndex =
-                    (g_contentPinned && g_contentPinModeIndex < xr->renderingModeCount)
-                        ? g_contentPinModeIndex : xr->currentModeIndex;
-                uint32_t modeViewCount = (xr->renderingModeCount > 0 && contentModeIndex < xr->renderingModeCount)
-                    ? xr->renderingModeViewCounts[contentModeIndex] : 2;
-                uint32_t tileColumns = (xr->renderingModeCount > 0 && contentModeIndex < xr->renderingModeCount)
-                    ? xr->renderingModeTileColumns[contentModeIndex] : 2;
-                uint32_t tileRows = (xr->renderingModeCount > 0 && contentModeIndex < xr->renderingModeCount)
-                    ? xr->renderingModeTileRows[contentModeIndex] : 1;
-                bool monoMode = (xr->renderingModeCount > 0 && !xr->renderingModeDisplay3D[contentModeIndex]);
-                if (xr->renderingModeCount > 0 && contentModeIndex < xr->renderingModeCount) {
-                    xr->recommendedViewScaleX = xr->renderingModeScaleX[contentModeIndex];
-                    xr->recommendedViewScaleY = xr->renderingModeScaleY[contentModeIndex];
+                uint32_t modeViewCount = (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount)
+                    ? xr->renderingModeViewCounts[xr->currentModeIndex] : 2;
+                uint32_t tileColumns = (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount)
+                    ? xr->renderingModeTileColumns[xr->currentModeIndex] : 2;
+                uint32_t tileRows = (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount)
+                    ? xr->renderingModeTileRows[xr->currentModeIndex] : 1;
+                bool monoMode = (xr->renderingModeCount > 0 && !xr->renderingModeDisplay3D[xr->currentModeIndex]);
+                if (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount) {
+                    xr->recommendedViewScaleX = xr->renderingModeScaleX[xr->currentModeIndex];
+                    xr->recommendedViewScaleY = xr->renderingModeScaleY[xr->currentModeIndex];
                 }
                 int eyeCount = monoMode ? 1 : (int)modeViewCount;
                 std::vector<XrCompositionLayerProjectionView> projectionViews(eyeCount, {XR_TYPE_COMPOSITION_LAYER_PROJECTION_VIEW});
@@ -985,11 +906,10 @@ static void RenderThreadFunc(
                                     xr->renderingModeCount,
                                     xr->renderingModeCount > 0 ? xr->renderingModeDisplay3D[xr->currentModeIndex] : true,
                                     xr->renderingModeCount > 0 ? xr->renderingModeIsRequestable[xr->currentModeIndex] : true);
-                                if (g_contentPinned) {
-                                    wchar_t pinBuf[64];
-                                    swprintf(pinBuf, 64, L"\nCONTENT PINNED [L]: %ux%u x%d",
-                                        tileColumns, tileRows, eyeCount);
-                                    dispText += pinBuf;
+                                if (g_hwOverrideActive) {
+                                    dispText += g_hwOverride3D
+                                        ? L"\nHW OVERRIDE [H]: 3D (mode default 2D)"
+                                        : L"\nHW OVERRIDE [H]: 2D (mode default 3D)";
                                 }
                                 std::wstring eyeText = FormatEyeTrackingInfo(
                                     xr->eyePositions, (uint32_t)eyeCount,
@@ -1172,8 +1092,7 @@ static void RenderThreadFunc(
                 // build the layer list manually (projection + panels in list
                 // order) and submit raw — the shared EndFrame helpers don't
                 // carry the Local2D layer type. Otherwise the normal paths.
-                // (#542: follows the content pin, like the render path)
-                uint32_t submitViewCount = (xr->renderingModeCount > 0 && contentModeIndex < xr->renderingModeCount) ? xr->renderingModeViewCounts[contentModeIndex] : 2;
+                uint32_t submitViewCount = (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount) ? xr->renderingModeViewCounts[xr->currentModeIndex] : 2;
                 LOG_INFO("[FRAME] EndFrame: rendered=%d hudSubmitted=%d viewCount=%u", rendered, hudSubmitted, submitViewCount);
                 if (g_l2dActive && g_panel1.swapchain != XR_NULL_HANDLE) {
                     XrCompositionLayerProjection projLayer = {XR_TYPE_COMPOSITION_LAYER_PROJECTION};

--- a/test_apps/cube_handle_d3d12_win/main.cpp
+++ b/test_apps/cube_handle_d3d12_win/main.cpp
@@ -56,11 +56,19 @@ static XrSessionManager* g_xr = nullptr;
 // snapshot while hardware mode requests (V / 0-8) still go out — drives a
 // deliberate hardware/content divergence so the decoupled compositors can be
 // exercised (e.g. panel-2D + 2 submitted tiles). Toggle: 'L' key;
-// DXR_CUBE_PIN_CONTENT=1 starts pinned. Toggle flag is atomic (set on the
+// DXR_CUBE_PIN_CONTENT=1 starts pinned. Toggle flags are atomic (set on the
 // message-pump thread, consumed on the render thread).
+// On top of the pin, two single-axis keys:
+//   'H' = HARDWARE-only: pin content at its current layout, then request the
+//         opposite-hardware mode — only the panel changes.
+//   'J' = CONTENT-only: flip the pinned submission layout to the opposite-
+//         hardware mode's layout — no runtime request, only content changes.
 static std::atomic<bool> g_contentPinTogglePending{false};
+static std::atomic<bool> g_hwToggleRequested{false};
+static std::atomic<bool> g_contentToggleRequested{false};
 static bool g_contentPinned = false;          // render-thread only
 static uint32_t g_contentPinModeIndex = 0;    // render-thread only
+static uint32_t g_lastLive3DModeIndex = UINT32_MAX; // render-thread only
 static UINT g_windowWidth = 1280;
 static UINT g_windowHeight = 720;
 
@@ -242,8 +250,17 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
         // #542 content-pin: 'L' freezes the submission-side mode snapshot
         // (handled on the render thread) while V/0-8 hardware requests still
         // go out — drives a deliberate hardware/content divergence.
+        // 'H' / 'J' toggle a single axis (hardware-only / content-only).
         if (wParam == 'L') {
             g_contentPinTogglePending.store(true);
+            return 0;
+        }
+        if (wParam == 'H') {
+            g_hwToggleRequested.store(true);
+            return 0;
+        }
+        if (wParam == 'J') {
+            g_contentToggleRequested.store(true);
             return 0;
         }
         break;
@@ -629,6 +646,67 @@ static void RenderThreadFunc(
                 LOG_INFO("[#542] content %s (snapshot mode=%u, live mode=%u)",
                     g_contentPinned ? "PINNED" : "UNPINNED",
                     g_contentPinModeIndex, xr->currentModeIndex);
+            }
+
+            // Track the most recent live 3D mode for the "back to 3D" direction
+            // of the single-axis toggles (mirrors the runtime's V-key restore).
+            if (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount &&
+                xr->renderingModeDisplay3D[xr->currentModeIndex]) {
+                g_lastLive3DModeIndex = xr->currentModeIndex;
+            }
+            // Resolve a mode whose hardware state is the opposite of `from3d`:
+            // prefer the remembered 3D mode when going back to 3D, else the
+            // first mode on the other side of the hardware flag.
+            auto findOppositeMode = [&](bool from3d) -> int {
+                if (from3d == false && g_lastLive3DModeIndex < xr->renderingModeCount &&
+                    xr->renderingModeDisplay3D[g_lastLive3DModeIndex]) {
+                    return (int)g_lastLive3DModeIndex;
+                }
+                for (uint32_t i = 0; i < xr->renderingModeCount; i++) {
+                    if (xr->renderingModeDisplay3D[i] != from3d) {
+                        return (int)i;
+                    }
+                }
+                return -1;
+            };
+
+            // 'H' — HARDWARE-only: pin content where it is (so it won't follow),
+            // then request the opposite-hardware mode. Only the panel changes.
+            if (g_hwToggleRequested.exchange(false)) {
+                if (xr->renderingModeCount > 0 && xr->session != XR_NULL_HANDLE &&
+                    xr->pfnRequestDisplayRenderingModeEXT != nullptr &&
+                    xr->currentModeIndex < xr->renderingModeCount) {
+                    if (!g_contentPinned) {
+                        g_contentPinned = true;
+                        g_contentPinModeIndex = xr->currentModeIndex;
+                    }
+                    bool live3d = xr->renderingModeDisplay3D[xr->currentModeIndex];
+                    int target = findOppositeMode(live3d);
+                    if (target >= 0) {
+                        xr->pfnRequestDisplayRenderingModeEXT(xr->session, (uint32_t)target);
+                        LOG_INFO("[#542] H: hardware-only -> requested mode %d (%s); "
+                            "content stays pinned at mode %u layout",
+                            target, live3d ? "2D" : "3D", g_contentPinModeIndex);
+                    }
+                }
+            }
+
+            // 'J' — CONTENT-only: flip the pinned submission layout to the
+            // opposite-hardware mode's layout. No runtime request goes out.
+            if (g_contentToggleRequested.exchange(false)) {
+                if (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount) {
+                    uint32_t cur = (g_contentPinned && g_contentPinModeIndex < xr->renderingModeCount)
+                        ? g_contentPinModeIndex : xr->currentModeIndex;
+                    bool cur3d = xr->renderingModeDisplay3D[cur];
+                    int target = findOppositeMode(cur3d);
+                    if (target >= 0) {
+                        g_contentPinned = true;
+                        g_contentPinModeIndex = (uint32_t)target;
+                        LOG_INFO("[#542] J: content-only -> pinned at mode %d layout (%s); "
+                            "hardware untouched (live mode=%u)",
+                            target, cur3d ? "2D" : "3D", xr->currentModeIndex);
+                    }
+                }
             }
         }
 

--- a/test_apps/cube_handle_gl_win/main.cpp
+++ b/test_apps/cube_handle_gl_win/main.cpp
@@ -46,23 +46,18 @@ static std::mutex g_inputMutex;
 static std::atomic<bool> g_running{true};
 static XrSessionManager* g_xr = nullptr;
 
-// #542 content-pin (validation affordance): freeze the submission-side mode
-// snapshot while hardware mode requests (V / 0-8) still go out — drives a
-// deliberate hardware/content divergence so the decoupled compositors can be
-// exercised (e.g. panel-2D + 2 submitted tiles). Toggle: 'L' key;
-// DXR_CUBE_PIN_CONTENT=1 starts pinned. Toggle flags are atomic (set on the
+// #542 'H' (validation affordance): toggle the HARDWARE display state alone
+// for the current mode via xrRequestDisplayModeEXT — the mode, the app's
+// content, and the DP's weave/blit processing are untouched. In 3D the panel
+// shows the woven atlas flat (blurry); fading parallax to zero converges
+// back to sharp — the MANUAL tracking-loss transition shape (#522). The
+// runtime auto-clears the override on the next mode request, so the local
+// note resets whenever the mode changes. Toggle flag is atomic (set on the
 // message-pump thread, consumed on the render thread).
-// On top of the pin, two single-axis keys:
-//   'H' = HARDWARE-only: pin content at its current layout, then request the
-//         opposite-hardware mode — only the panel changes.
-//   'J' = CONTENT-only: flip the pinned submission layout to the opposite-
-//         hardware mode's layout — no runtime request, only content changes.
-static std::atomic<bool> g_contentPinTogglePending{false};
 static std::atomic<bool> g_hwToggleRequested{false};
-static std::atomic<bool> g_contentToggleRequested{false};
-static bool g_contentPinned = false;          // render-thread only
-static uint32_t g_contentPinModeIndex = 0;    // render-thread only
-static uint32_t g_lastLive3DModeIndex = UINT32_MAX; // render-thread only
+static bool g_hwOverrideActive = false;       // render-thread only
+static bool g_hwOverride3D = false;           // render-thread only
+static uint32_t g_hwOverrideModeIndex = 0;    // render-thread only
 static UINT g_windowWidth = 1280;
 static UINT g_windowHeight = 720;
 
@@ -248,20 +243,10 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
             ToggleFullscreen(hwnd);
             return 0;
         }
-        // #542 content-pin: 'L' freezes the submission-side mode snapshot
-        // (handled on the render thread) while V/0-8 hardware requests still
-        // go out — drives a deliberate hardware/content divergence.
-        // 'H' / 'J' toggle a single axis (hardware-only / content-only).
-        if (wParam == 'L') {
-            g_contentPinTogglePending.store(true);
-            return 0;
-        }
+        // #542: 'H' toggles the HARDWARE display state alone for the current
+        // mode (xrRequestDisplayModeEXT) — handled on the render thread.
         if (wParam == 'H') {
             g_hwToggleRequested.store(true);
-            return 0;
-        }
-        if (wParam == 'J') {
-            g_contentToggleRequested.store(true);
             return 0;
         }
         break;
@@ -624,89 +609,30 @@ static void RenderThreadFunc(
         UpdateScene(*renderer, perfStats.deltaTime, xr->spinSpeed);
         PollEvents(*xr);
 
-        // #542 content-pin: resolve the env start-pin once, then any pending
-        // 'L' toggle. While pinned the render/submit path below derives its
-        // layout from the SNAPSHOT mode, not the live one — mode requests keep
-        // flowing, so hardware and content diverge on purpose.
+        // #542 'H': hardware-state-only toggle for the current mode.
         {
-            static bool s_pinEnvChecked = false;
-            if (!s_pinEnvChecked && xr->sessionRunning) {
-                s_pinEnvChecked = true;
-                const char *pin = getenv("DXR_CUBE_PIN_CONTENT");
-                if (pin && pin[0] == '1') {
-                    g_contentPinned = true;
-                    g_contentPinModeIndex = xr->currentModeIndex;
-                    LOG_INFO("[#542] content PINNED at start (mode=%u)", g_contentPinModeIndex);
-                }
+            // A mode change resets the hardware to the new mode's default —
+            // drop the local override note so the next H starts from there.
+            if (g_hwOverrideActive && xr->currentModeIndex != g_hwOverrideModeIndex) {
+                g_hwOverrideActive = false;
             }
-            if (g_contentPinTogglePending.exchange(false)) {
-                g_contentPinned = !g_contentPinned;
-                if (g_contentPinned) {
-                    g_contentPinModeIndex = xr->currentModeIndex;
-                }
-                LOG_INFO("[#542] content %s (snapshot mode=%u, live mode=%u)",
-                    g_contentPinned ? "PINNED" : "UNPINNED",
-                    g_contentPinModeIndex, xr->currentModeIndex);
-            }
-
-            // Track the most recent live 3D mode for the "back to 3D" direction
-            // of the single-axis toggles (mirrors the runtime's V-key restore).
-            if (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount &&
-                xr->renderingModeDisplay3D[xr->currentModeIndex]) {
-                g_lastLive3DModeIndex = xr->currentModeIndex;
-            }
-            // Resolve a mode whose hardware state is the opposite of `from3d`:
-            // prefer the remembered 3D mode when going back to 3D, else the
-            // first mode on the other side of the hardware flag.
-            auto findOppositeMode = [&](bool from3d) -> int {
-                if (from3d == false && g_lastLive3DModeIndex < xr->renderingModeCount &&
-                    xr->renderingModeDisplay3D[g_lastLive3DModeIndex]) {
-                    return (int)g_lastLive3DModeIndex;
-                }
-                for (uint32_t i = 0; i < xr->renderingModeCount; i++) {
-                    if (xr->renderingModeDisplay3D[i] != from3d) {
-                        return (int)i;
-                    }
-                }
-                return -1;
-            };
-
-            // 'H' — HARDWARE-only: pin content where it is (so it won't follow),
-            // then request the opposite-hardware mode. Only the panel changes.
             if (g_hwToggleRequested.exchange(false)) {
-                if (xr->renderingModeCount > 0 && xr->session != XR_NULL_HANDLE &&
-                    xr->pfnRequestDisplayRenderingModeEXT != nullptr &&
-                    xr->currentModeIndex < xr->renderingModeCount) {
-                    if (!g_contentPinned) {
-                        g_contentPinned = true;
-                        g_contentPinModeIndex = xr->currentModeIndex;
+                if (xr->pfnRequestDisplayModeEXT != nullptr && xr->session != XR_NULL_HANDLE &&
+                    xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount) {
+                    bool mode_default_3d = xr->renderingModeDisplay3D[xr->currentModeIndex];
+                    bool cur_3d = g_hwOverrideActive ? g_hwOverride3D : mode_default_3d;
+                    bool want_3d = !cur_3d;
+                    XrResult hres = xr->pfnRequestDisplayModeEXT(xr->session,
+                        want_3d ? XR_DISPLAY_MODE_3D_EXT : XR_DISPLAY_MODE_2D_EXT);
+                    if (XR_SUCCEEDED(hres)) {
+                        g_hwOverrideActive = (want_3d != mode_default_3d);
+                        g_hwOverride3D = want_3d;
+                        g_hwOverrideModeIndex = xr->currentModeIndex;
                     }
-                    bool live3d = xr->renderingModeDisplay3D[xr->currentModeIndex];
-                    int target = findOppositeMode(live3d);
-                    if (target >= 0) {
-                        xr->pfnRequestDisplayRenderingModeEXT(xr->session, (uint32_t)target);
-                        LOG_INFO("[#542] H: hardware-only -> requested mode %d (%s); "
-                            "content stays pinned at mode %u layout",
-                            target, live3d ? "2D" : "3D", g_contentPinModeIndex);
-                    }
-                }
-            }
-
-            // 'J' — CONTENT-only: flip the pinned submission layout to the
-            // opposite-hardware mode's layout. No runtime request goes out.
-            if (g_contentToggleRequested.exchange(false)) {
-                if (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount) {
-                    uint32_t cur = (g_contentPinned && g_contentPinModeIndex < xr->renderingModeCount)
-                        ? g_contentPinModeIndex : xr->currentModeIndex;
-                    bool cur3d = xr->renderingModeDisplay3D[cur];
-                    int target = findOppositeMode(cur3d);
-                    if (target >= 0) {
-                        g_contentPinned = true;
-                        g_contentPinModeIndex = (uint32_t)target;
-                        LOG_INFO("[#542] J: content-only -> pinned at mode %d layout (%s); "
-                            "hardware untouched (live mode=%u)",
-                            target, cur3d ? "2D" : "3D", xr->currentModeIndex);
-                    }
+                    LOG_INFO("[#542] H: hardware-only -> %s (mode %u unchanged, rc=0x%x)",
+                        want_3d ? "3D" : "2D", xr->currentModeIndex, (unsigned)hres);
+                } else {
+                    LOG_INFO("[#542] H: xrRequestDisplayModeEXT unavailable");
                 }
             }
         }
@@ -717,22 +643,17 @@ static void RenderThreadFunc(
                 bool rendered = false;
                 bool hudSubmitted = false;
 
-                // Get N-view mode info from enumerated rendering modes.
-                // #542 content-pin: the render/submit layout derives from the
-                // pinned snapshot when active, the live mode otherwise.
-                uint32_t contentModeIndex =
-                    (g_contentPinned && g_contentPinModeIndex < xr->renderingModeCount)
-                        ? g_contentPinModeIndex : xr->currentModeIndex;
-                uint32_t modeViewCount = (xr->renderingModeCount > 0 && contentModeIndex < xr->renderingModeCount)
-                    ? xr->renderingModeViewCounts[contentModeIndex] : 2;
-                uint32_t tileColumns = (xr->renderingModeCount > 0 && contentModeIndex < xr->renderingModeCount)
-                    ? xr->renderingModeTileColumns[contentModeIndex] : 2;
-                uint32_t tileRows = (xr->renderingModeCount > 0 && contentModeIndex < xr->renderingModeCount)
-                    ? xr->renderingModeTileRows[contentModeIndex] : 1;
-                bool monoMode = (xr->renderingModeCount > 0 && !xr->renderingModeDisplay3D[contentModeIndex]);
-                if (xr->renderingModeCount > 0 && contentModeIndex < xr->renderingModeCount) {
-                    xr->recommendedViewScaleX = xr->renderingModeScaleX[contentModeIndex];
-                    xr->recommendedViewScaleY = xr->renderingModeScaleY[contentModeIndex];
+                // Get N-view mode info from enumerated rendering modes
+                uint32_t modeViewCount = (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount)
+                    ? xr->renderingModeViewCounts[xr->currentModeIndex] : 2;
+                uint32_t tileColumns = (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount)
+                    ? xr->renderingModeTileColumns[xr->currentModeIndex] : 2;
+                uint32_t tileRows = (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount)
+                    ? xr->renderingModeTileRows[xr->currentModeIndex] : 1;
+                bool monoMode = (xr->renderingModeCount > 0 && !xr->renderingModeDisplay3D[xr->currentModeIndex]);
+                if (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount) {
+                    xr->recommendedViewScaleX = xr->renderingModeScaleX[xr->currentModeIndex];
+                    xr->recommendedViewScaleY = xr->renderingModeScaleY[xr->currentModeIndex];
                 }
                 int eyeCount = monoMode ? 1 : (int)modeViewCount;
                 std::vector<XrCompositionLayerProjectionView> projectionViews(eyeCount, {XR_TYPE_COMPOSITION_LAYER_PROJECTION_VIEW});
@@ -994,11 +915,10 @@ static void RenderThreadFunc(
                                     xr->renderingModeCount,
                                     xr->renderingModeCount > 0 ? xr->renderingModeDisplay3D[xr->currentModeIndex] : true,
                                     xr->renderingModeCount > 0 ? xr->renderingModeIsRequestable[xr->currentModeIndex] : true);
-                                if (g_contentPinned) {
-                                    wchar_t pinBuf[64];
-                                    swprintf(pinBuf, 64, L"\nCONTENT PINNED [L]: %ux%u x%d",
-                                        tileColumns, tileRows, eyeCount);
-                                    dispText += pinBuf;
+                                if (g_hwOverrideActive) {
+                                    dispText += g_hwOverride3D
+                                        ? L"\nHW OVERRIDE [H]: 3D (mode default 2D)"
+                                        : L"\nHW OVERRIDE [H]: 2D (mode default 3D)";
                                 }
                                 std::wstring eyeText = FormatEyeTrackingInfo(
                                     xr->eyePositions, (uint32_t)eyeCount,

--- a/test_apps/cube_handle_gl_win/main.cpp
+++ b/test_apps/cube_handle_gl_win/main.cpp
@@ -45,6 +45,16 @@ static InputState g_inputState;
 static std::mutex g_inputMutex;
 static std::atomic<bool> g_running{true};
 static XrSessionManager* g_xr = nullptr;
+
+// #542 content-pin (validation affordance): freeze the submission-side mode
+// snapshot while hardware mode requests (V / 0-8) still go out — drives a
+// deliberate hardware/content divergence so the decoupled compositors can be
+// exercised (e.g. panel-2D + 2 submitted tiles). Toggle: 'L' key;
+// DXR_CUBE_PIN_CONTENT=1 starts pinned. Toggle flag is atomic (set on the
+// message-pump thread, consumed on the render thread).
+static std::atomic<bool> g_contentPinTogglePending{false};
+static bool g_contentPinned = false;          // render-thread only
+static uint32_t g_contentPinModeIndex = 0;    // render-thread only
 static UINT g_windowWidth = 1280;
 static UINT g_windowHeight = 720;
 
@@ -228,6 +238,13 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
         }
         if (wParam == VK_F11) {
             ToggleFullscreen(hwnd);
+            return 0;
+        }
+        // #542 content-pin: 'L' freezes the submission-side mode snapshot
+        // (handled on the render thread) while V/0-8 hardware requests still
+        // go out — drives a deliberate hardware/content divergence.
+        if (wParam == 'L') {
+            g_contentPinTogglePending.store(true);
             return 0;
         }
         break;
@@ -590,23 +607,54 @@ static void RenderThreadFunc(
         UpdateScene(*renderer, perfStats.deltaTime, xr->spinSpeed);
         PollEvents(*xr);
 
+        // #542 content-pin: resolve the env start-pin once, then any pending
+        // 'L' toggle. While pinned the render/submit path below derives its
+        // layout from the SNAPSHOT mode, not the live one — mode requests keep
+        // flowing, so hardware and content diverge on purpose.
+        {
+            static bool s_pinEnvChecked = false;
+            if (!s_pinEnvChecked && xr->sessionRunning) {
+                s_pinEnvChecked = true;
+                const char *pin = getenv("DXR_CUBE_PIN_CONTENT");
+                if (pin && pin[0] == '1') {
+                    g_contentPinned = true;
+                    g_contentPinModeIndex = xr->currentModeIndex;
+                    LOG_INFO("[#542] content PINNED at start (mode=%u)", g_contentPinModeIndex);
+                }
+            }
+            if (g_contentPinTogglePending.exchange(false)) {
+                g_contentPinned = !g_contentPinned;
+                if (g_contentPinned) {
+                    g_contentPinModeIndex = xr->currentModeIndex;
+                }
+                LOG_INFO("[#542] content %s (snapshot mode=%u, live mode=%u)",
+                    g_contentPinned ? "PINNED" : "UNPINNED",
+                    g_contentPinModeIndex, xr->currentModeIndex);
+            }
+        }
+
         if (xr->sessionRunning) {
             XrFrameState frameState;
             if (BeginFrame(*xr, frameState)) {
                 bool rendered = false;
                 bool hudSubmitted = false;
 
-                // Get N-view mode info from enumerated rendering modes
-                uint32_t modeViewCount = (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount)
-                    ? xr->renderingModeViewCounts[xr->currentModeIndex] : 2;
-                uint32_t tileColumns = (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount)
-                    ? xr->renderingModeTileColumns[xr->currentModeIndex] : 2;
-                uint32_t tileRows = (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount)
-                    ? xr->renderingModeTileRows[xr->currentModeIndex] : 1;
-                bool monoMode = (xr->renderingModeCount > 0 && !xr->renderingModeDisplay3D[xr->currentModeIndex]);
-                if (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount) {
-                    xr->recommendedViewScaleX = xr->renderingModeScaleX[xr->currentModeIndex];
-                    xr->recommendedViewScaleY = xr->renderingModeScaleY[xr->currentModeIndex];
+                // Get N-view mode info from enumerated rendering modes.
+                // #542 content-pin: the render/submit layout derives from the
+                // pinned snapshot when active, the live mode otherwise.
+                uint32_t contentModeIndex =
+                    (g_contentPinned && g_contentPinModeIndex < xr->renderingModeCount)
+                        ? g_contentPinModeIndex : xr->currentModeIndex;
+                uint32_t modeViewCount = (xr->renderingModeCount > 0 && contentModeIndex < xr->renderingModeCount)
+                    ? xr->renderingModeViewCounts[contentModeIndex] : 2;
+                uint32_t tileColumns = (xr->renderingModeCount > 0 && contentModeIndex < xr->renderingModeCount)
+                    ? xr->renderingModeTileColumns[contentModeIndex] : 2;
+                uint32_t tileRows = (xr->renderingModeCount > 0 && contentModeIndex < xr->renderingModeCount)
+                    ? xr->renderingModeTileRows[contentModeIndex] : 1;
+                bool monoMode = (xr->renderingModeCount > 0 && !xr->renderingModeDisplay3D[contentModeIndex]);
+                if (xr->renderingModeCount > 0 && contentModeIndex < xr->renderingModeCount) {
+                    xr->recommendedViewScaleX = xr->renderingModeScaleX[contentModeIndex];
+                    xr->recommendedViewScaleY = xr->renderingModeScaleY[contentModeIndex];
                 }
                 int eyeCount = monoMode ? 1 : (int)modeViewCount;
                 std::vector<XrCompositionLayerProjectionView> projectionViews(eyeCount, {XR_TYPE_COMPOSITION_LAYER_PROJECTION_VIEW});
@@ -868,6 +916,12 @@ static void RenderThreadFunc(
                                     xr->renderingModeCount,
                                     xr->renderingModeCount > 0 ? xr->renderingModeDisplay3D[xr->currentModeIndex] : true,
                                     xr->renderingModeCount > 0 ? xr->renderingModeIsRequestable[xr->currentModeIndex] : true);
+                                if (g_contentPinned) {
+                                    wchar_t pinBuf[64];
+                                    swprintf(pinBuf, 64, L"\nCONTENT PINNED [L]: %ux%u x%d",
+                                        tileColumns, tileRows, eyeCount);
+                                    dispText += pinBuf;
+                                }
                                 std::wstring eyeText = FormatEyeTrackingInfo(
                                     xr->eyePositions, (uint32_t)eyeCount,
                                     xr->eyeTrackingActive, xr->isEyeTracking,

--- a/test_apps/cube_handle_gl_win/main.cpp
+++ b/test_apps/cube_handle_gl_win/main.cpp
@@ -50,11 +50,19 @@ static XrSessionManager* g_xr = nullptr;
 // snapshot while hardware mode requests (V / 0-8) still go out — drives a
 // deliberate hardware/content divergence so the decoupled compositors can be
 // exercised (e.g. panel-2D + 2 submitted tiles). Toggle: 'L' key;
-// DXR_CUBE_PIN_CONTENT=1 starts pinned. Toggle flag is atomic (set on the
+// DXR_CUBE_PIN_CONTENT=1 starts pinned. Toggle flags are atomic (set on the
 // message-pump thread, consumed on the render thread).
+// On top of the pin, two single-axis keys:
+//   'H' = HARDWARE-only: pin content at its current layout, then request the
+//         opposite-hardware mode — only the panel changes.
+//   'J' = CONTENT-only: flip the pinned submission layout to the opposite-
+//         hardware mode's layout — no runtime request, only content changes.
 static std::atomic<bool> g_contentPinTogglePending{false};
+static std::atomic<bool> g_hwToggleRequested{false};
+static std::atomic<bool> g_contentToggleRequested{false};
 static bool g_contentPinned = false;          // render-thread only
 static uint32_t g_contentPinModeIndex = 0;    // render-thread only
+static uint32_t g_lastLive3DModeIndex = UINT32_MAX; // render-thread only
 static UINT g_windowWidth = 1280;
 static UINT g_windowHeight = 720;
 
@@ -243,8 +251,17 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
         // #542 content-pin: 'L' freezes the submission-side mode snapshot
         // (handled on the render thread) while V/0-8 hardware requests still
         // go out — drives a deliberate hardware/content divergence.
+        // 'H' / 'J' toggle a single axis (hardware-only / content-only).
         if (wParam == 'L') {
             g_contentPinTogglePending.store(true);
+            return 0;
+        }
+        if (wParam == 'H') {
+            g_hwToggleRequested.store(true);
+            return 0;
+        }
+        if (wParam == 'J') {
+            g_contentToggleRequested.store(true);
             return 0;
         }
         break;
@@ -630,6 +647,67 @@ static void RenderThreadFunc(
                 LOG_INFO("[#542] content %s (snapshot mode=%u, live mode=%u)",
                     g_contentPinned ? "PINNED" : "UNPINNED",
                     g_contentPinModeIndex, xr->currentModeIndex);
+            }
+
+            // Track the most recent live 3D mode for the "back to 3D" direction
+            // of the single-axis toggles (mirrors the runtime's V-key restore).
+            if (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount &&
+                xr->renderingModeDisplay3D[xr->currentModeIndex]) {
+                g_lastLive3DModeIndex = xr->currentModeIndex;
+            }
+            // Resolve a mode whose hardware state is the opposite of `from3d`:
+            // prefer the remembered 3D mode when going back to 3D, else the
+            // first mode on the other side of the hardware flag.
+            auto findOppositeMode = [&](bool from3d) -> int {
+                if (from3d == false && g_lastLive3DModeIndex < xr->renderingModeCount &&
+                    xr->renderingModeDisplay3D[g_lastLive3DModeIndex]) {
+                    return (int)g_lastLive3DModeIndex;
+                }
+                for (uint32_t i = 0; i < xr->renderingModeCount; i++) {
+                    if (xr->renderingModeDisplay3D[i] != from3d) {
+                        return (int)i;
+                    }
+                }
+                return -1;
+            };
+
+            // 'H' — HARDWARE-only: pin content where it is (so it won't follow),
+            // then request the opposite-hardware mode. Only the panel changes.
+            if (g_hwToggleRequested.exchange(false)) {
+                if (xr->renderingModeCount > 0 && xr->session != XR_NULL_HANDLE &&
+                    xr->pfnRequestDisplayRenderingModeEXT != nullptr &&
+                    xr->currentModeIndex < xr->renderingModeCount) {
+                    if (!g_contentPinned) {
+                        g_contentPinned = true;
+                        g_contentPinModeIndex = xr->currentModeIndex;
+                    }
+                    bool live3d = xr->renderingModeDisplay3D[xr->currentModeIndex];
+                    int target = findOppositeMode(live3d);
+                    if (target >= 0) {
+                        xr->pfnRequestDisplayRenderingModeEXT(xr->session, (uint32_t)target);
+                        LOG_INFO("[#542] H: hardware-only -> requested mode %d (%s); "
+                            "content stays pinned at mode %u layout",
+                            target, live3d ? "2D" : "3D", g_contentPinModeIndex);
+                    }
+                }
+            }
+
+            // 'J' — CONTENT-only: flip the pinned submission layout to the
+            // opposite-hardware mode's layout. No runtime request goes out.
+            if (g_contentToggleRequested.exchange(false)) {
+                if (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount) {
+                    uint32_t cur = (g_contentPinned && g_contentPinModeIndex < xr->renderingModeCount)
+                        ? g_contentPinModeIndex : xr->currentModeIndex;
+                    bool cur3d = xr->renderingModeDisplay3D[cur];
+                    int target = findOppositeMode(cur3d);
+                    if (target >= 0) {
+                        g_contentPinned = true;
+                        g_contentPinModeIndex = (uint32_t)target;
+                        LOG_INFO("[#542] J: content-only -> pinned at mode %d layout (%s); "
+                            "hardware untouched (live mode=%u)",
+                            target, cur3d ? "2D" : "3D", xr->currentModeIndex);
+                    }
+                }
             }
         }
 

--- a/test_apps/cube_handle_vk_win/main.cpp
+++ b/test_apps/cube_handle_vk_win/main.cpp
@@ -49,23 +49,18 @@ static std::mutex g_inputMutex;
 static std::atomic<bool> g_running{true};
 static XrSessionManager* g_xr = nullptr;
 
-// #542 content-pin (validation affordance): freeze the submission-side mode
-// snapshot while hardware mode requests (V / 0-8) still go out — drives a
-// deliberate hardware/content divergence so the decoupled compositors can be
-// exercised (e.g. panel-2D + 2 submitted tiles). Toggle: 'L' key;
-// DXR_CUBE_PIN_CONTENT=1 starts pinned. Toggle flags are atomic (set on the
+// #542 'H' (validation affordance): toggle the HARDWARE display state alone
+// for the current mode via xrRequestDisplayModeEXT — the mode, the app's
+// content, and the DP's weave/blit processing are untouched. In 3D the panel
+// shows the woven atlas flat (blurry); fading parallax to zero converges
+// back to sharp — the MANUAL tracking-loss transition shape (#522). The
+// runtime auto-clears the override on the next mode request, so the local
+// note resets whenever the mode changes. Toggle flag is atomic (set on the
 // message-pump thread, consumed on the render thread).
-// On top of the pin, two single-axis keys:
-//   'H' = HARDWARE-only: pin content at its current layout, then request the
-//         opposite-hardware mode — only the panel changes.
-//   'J' = CONTENT-only: flip the pinned submission layout to the opposite-
-//         hardware mode's layout — no runtime request, only content changes.
-static std::atomic<bool> g_contentPinTogglePending{false};
 static std::atomic<bool> g_hwToggleRequested{false};
-static std::atomic<bool> g_contentToggleRequested{false};
-static bool g_contentPinned = false;          // render-thread only
-static uint32_t g_contentPinModeIndex = 0;    // render-thread only
-static uint32_t g_lastLive3DModeIndex = UINT32_MAX; // render-thread only
+static bool g_hwOverrideActive = false;       // render-thread only
+static bool g_hwOverride3D = false;           // render-thread only
+static uint32_t g_hwOverrideModeIndex = 0;    // render-thread only
 
 // Set DISPLAYXR_TRANSPARENT_BG=1 in the environment to opt into transparent
 // desktop composition: the HWND is created with WS_EX_NOREDIRECTIONBITMAP +
@@ -267,20 +262,10 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
             ToggleFullscreen(hwnd);
             return 0;
         }
-        // #542 content-pin: 'L' freezes the submission-side mode snapshot
-        // (handled on the render thread) while V/0-8 hardware requests still
-        // go out — drives a deliberate hardware/content divergence.
-        // 'H' / 'J' toggle a single axis (hardware-only / content-only).
-        if (wParam == 'L') {
-            g_contentPinTogglePending.store(true);
-            return 0;
-        }
+        // #542: 'H' toggles the HARDWARE display state alone for the current
+        // mode (xrRequestDisplayModeEXT) — handled on the render thread.
         if (wParam == 'H') {
             g_hwToggleRequested.store(true);
-            return 0;
-        }
-        if (wParam == 'J') {
-            g_contentToggleRequested.store(true);
             return 0;
         }
         break;
@@ -639,89 +624,30 @@ static void RenderThreadFunc(
         UpdateScene(*renderer, perfStats.deltaTime, xr->spinSpeed);
         PollEvents(*xr);
 
-        // #542 content-pin: resolve the env start-pin once, then any pending
-        // 'L' toggle. While pinned the render/submit path below derives its
-        // layout from the SNAPSHOT mode, not the live one — mode requests keep
-        // flowing, so hardware and content diverge on purpose.
+        // #542 'H': hardware-state-only toggle for the current mode.
         {
-            static bool s_pinEnvChecked = false;
-            if (!s_pinEnvChecked && xr->sessionRunning) {
-                s_pinEnvChecked = true;
-                const char *pin = getenv("DXR_CUBE_PIN_CONTENT");
-                if (pin && pin[0] == '1') {
-                    g_contentPinned = true;
-                    g_contentPinModeIndex = xr->currentModeIndex;
-                    LOG_INFO("[#542] content PINNED at start (mode=%u)", g_contentPinModeIndex);
-                }
+            // A mode change resets the hardware to the new mode's default —
+            // drop the local override note so the next H starts from there.
+            if (g_hwOverrideActive && xr->currentModeIndex != g_hwOverrideModeIndex) {
+                g_hwOverrideActive = false;
             }
-            if (g_contentPinTogglePending.exchange(false)) {
-                g_contentPinned = !g_contentPinned;
-                if (g_contentPinned) {
-                    g_contentPinModeIndex = xr->currentModeIndex;
-                }
-                LOG_INFO("[#542] content %s (snapshot mode=%u, live mode=%u)",
-                    g_contentPinned ? "PINNED" : "UNPINNED",
-                    g_contentPinModeIndex, xr->currentModeIndex);
-            }
-
-            // Track the most recent live 3D mode for the "back to 3D" direction
-            // of the single-axis toggles (mirrors the runtime's V-key restore).
-            if (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount &&
-                xr->renderingModeDisplay3D[xr->currentModeIndex]) {
-                g_lastLive3DModeIndex = xr->currentModeIndex;
-            }
-            // Resolve a mode whose hardware state is the opposite of `from3d`:
-            // prefer the remembered 3D mode when going back to 3D, else the
-            // first mode on the other side of the hardware flag.
-            auto findOppositeMode = [&](bool from3d) -> int {
-                if (from3d == false && g_lastLive3DModeIndex < xr->renderingModeCount &&
-                    xr->renderingModeDisplay3D[g_lastLive3DModeIndex]) {
-                    return (int)g_lastLive3DModeIndex;
-                }
-                for (uint32_t i = 0; i < xr->renderingModeCount; i++) {
-                    if (xr->renderingModeDisplay3D[i] != from3d) {
-                        return (int)i;
-                    }
-                }
-                return -1;
-            };
-
-            // 'H' — HARDWARE-only: pin content where it is (so it won't follow),
-            // then request the opposite-hardware mode. Only the panel changes.
             if (g_hwToggleRequested.exchange(false)) {
-                if (xr->renderingModeCount > 0 && xr->session != XR_NULL_HANDLE &&
-                    xr->pfnRequestDisplayRenderingModeEXT != nullptr &&
-                    xr->currentModeIndex < xr->renderingModeCount) {
-                    if (!g_contentPinned) {
-                        g_contentPinned = true;
-                        g_contentPinModeIndex = xr->currentModeIndex;
+                if (xr->pfnRequestDisplayModeEXT != nullptr && xr->session != XR_NULL_HANDLE &&
+                    xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount) {
+                    bool mode_default_3d = xr->renderingModeDisplay3D[xr->currentModeIndex];
+                    bool cur_3d = g_hwOverrideActive ? g_hwOverride3D : mode_default_3d;
+                    bool want_3d = !cur_3d;
+                    XrResult hres = xr->pfnRequestDisplayModeEXT(xr->session,
+                        want_3d ? XR_DISPLAY_MODE_3D_EXT : XR_DISPLAY_MODE_2D_EXT);
+                    if (XR_SUCCEEDED(hres)) {
+                        g_hwOverrideActive = (want_3d != mode_default_3d);
+                        g_hwOverride3D = want_3d;
+                        g_hwOverrideModeIndex = xr->currentModeIndex;
                     }
-                    bool live3d = xr->renderingModeDisplay3D[xr->currentModeIndex];
-                    int target = findOppositeMode(live3d);
-                    if (target >= 0) {
-                        xr->pfnRequestDisplayRenderingModeEXT(xr->session, (uint32_t)target);
-                        LOG_INFO("[#542] H: hardware-only -> requested mode %d (%s); "
-                            "content stays pinned at mode %u layout",
-                            target, live3d ? "2D" : "3D", g_contentPinModeIndex);
-                    }
-                }
-            }
-
-            // 'J' — CONTENT-only: flip the pinned submission layout to the
-            // opposite-hardware mode's layout. No runtime request goes out.
-            if (g_contentToggleRequested.exchange(false)) {
-                if (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount) {
-                    uint32_t cur = (g_contentPinned && g_contentPinModeIndex < xr->renderingModeCount)
-                        ? g_contentPinModeIndex : xr->currentModeIndex;
-                    bool cur3d = xr->renderingModeDisplay3D[cur];
-                    int target = findOppositeMode(cur3d);
-                    if (target >= 0) {
-                        g_contentPinned = true;
-                        g_contentPinModeIndex = (uint32_t)target;
-                        LOG_INFO("[#542] J: content-only -> pinned at mode %d layout (%s); "
-                            "hardware untouched (live mode=%u)",
-                            target, cur3d ? "2D" : "3D", xr->currentModeIndex);
-                    }
+                    LOG_INFO("[#542] H: hardware-only -> %s (mode %u unchanged, rc=0x%x)",
+                        want_3d ? "3D" : "2D", xr->currentModeIndex, (unsigned)hres);
+                } else {
+                    LOG_INFO("[#542] H: xrRequestDisplayModeEXT unavailable");
                 }
             }
         }
@@ -732,23 +658,18 @@ static void RenderThreadFunc(
             if (BeginFrame(*xr, frameState)) {
                 LOG_INFO("[FRAME] BeginFrame OK, shouldRender=%d, displayTime=%lld",
                     frameState.shouldRender, (long long)frameState.predictedDisplayTime);
-                // Get N-view mode info from enumerated rendering modes.
-                // #542 content-pin: the render/submit layout derives from the
-                // pinned snapshot when active, the live mode otherwise.
-                uint32_t contentModeIndex =
-                    (g_contentPinned && g_contentPinModeIndex < xr->renderingModeCount)
-                        ? g_contentPinModeIndex : xr->currentModeIndex;
-                bool monoMode = (xr->renderingModeCount > 0 && !xr->renderingModeDisplay3D[contentModeIndex]);
-                if (xr->renderingModeCount > 0 && contentModeIndex < xr->renderingModeCount) {
-                    xr->recommendedViewScaleX = xr->renderingModeScaleX[contentModeIndex];
-                    xr->recommendedViewScaleY = xr->renderingModeScaleY[contentModeIndex];
+                // Get N-view mode info from enumerated rendering modes
+                bool monoMode = (xr->renderingModeCount > 0 && !xr->renderingModeDisplay3D[xr->currentModeIndex]);
+                if (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount) {
+                    xr->recommendedViewScaleX = xr->renderingModeScaleX[xr->currentModeIndex];
+                    xr->recommendedViewScaleY = xr->renderingModeScaleY[xr->currentModeIndex];
                 }
-                uint32_t modeViewCount = (xr->renderingModeCount > 0 && contentModeIndex < xr->renderingModeCount)
-                    ? xr->renderingModeViewCounts[contentModeIndex] : 2;
-                uint32_t tileColumns = (xr->renderingModeCount > 0 && contentModeIndex < xr->renderingModeCount)
-                    ? xr->renderingModeTileColumns[contentModeIndex] : 2;
-                uint32_t tileRows = (xr->renderingModeCount > 0 && contentModeIndex < xr->renderingModeCount)
-                    ? xr->renderingModeTileRows[contentModeIndex] : 1;
+                uint32_t modeViewCount = (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount)
+                    ? xr->renderingModeViewCounts[xr->currentModeIndex] : 2;
+                uint32_t tileColumns = (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount)
+                    ? xr->renderingModeTileColumns[xr->currentModeIndex] : 2;
+                uint32_t tileRows = (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount)
+                    ? xr->renderingModeTileRows[xr->currentModeIndex] : 1;
                 int eyeCount = monoMode ? 1 : (int)modeViewCount;
 
                 // Dynamic arrays for N-view rendering
@@ -1047,11 +968,10 @@ static void RenderThreadFunc(
                                     xr->renderingModeCount,
                                     xr->renderingModeCount > 0 ? xr->renderingModeDisplay3D[xr->currentModeIndex] : true,
                                     xr->renderingModeCount > 0 ? xr->renderingModeIsRequestable[xr->currentModeIndex] : true);
-                                if (g_contentPinned) {
-                                    wchar_t pinBuf[64];
-                                    swprintf(pinBuf, 64, L"\nCONTENT PINNED [L]: %ux%u x%d",
-                                        tileColumns, tileRows, eyeCount);
-                                    dispText += pinBuf;
+                                if (g_hwOverrideActive) {
+                                    dispText += g_hwOverride3D
+                                        ? L"\nHW OVERRIDE [H]: 3D (mode default 2D)"
+                                        : L"\nHW OVERRIDE [H]: 2D (mode default 3D)";
                                 }
                                 std::wstring eyeText = FormatEyeTrackingInfo(
                                     xr->eyePositions, (uint32_t)eyeCount,
@@ -1162,8 +1082,7 @@ static void RenderThreadFunc(
                 }
 
                 // viewCount: 1 for mono (2D mode), 2 for stereo (3D mode)
-                // (#542: follows the content pin, like the render path)
-                uint32_t submitViewCount = (xr->renderingModeCount > 0 && contentModeIndex < xr->renderingModeCount) ? xr->renderingModeViewCounts[contentModeIndex] : 2;
+                uint32_t submitViewCount = (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount) ? xr->renderingModeViewCounts[xr->currentModeIndex] : 2;
                 // When transparent_bg is on, ask the runtime to honor the cube's
                 // per-pixel alpha when blending the projection layer. Pre-#213
                 // apps default to 0 (no source-alpha blend = treat as opaque).

--- a/test_apps/cube_handle_vk_win/main.cpp
+++ b/test_apps/cube_handle_vk_win/main.cpp
@@ -49,6 +49,16 @@ static std::mutex g_inputMutex;
 static std::atomic<bool> g_running{true};
 static XrSessionManager* g_xr = nullptr;
 
+// #542 content-pin (validation affordance): freeze the submission-side mode
+// snapshot while hardware mode requests (V / 0-8) still go out — drives a
+// deliberate hardware/content divergence so the decoupled compositors can be
+// exercised (e.g. panel-2D + 2 submitted tiles). Toggle: 'L' key;
+// DXR_CUBE_PIN_CONTENT=1 starts pinned. Toggle flag is atomic (set on the
+// message-pump thread, consumed on the render thread).
+static std::atomic<bool> g_contentPinTogglePending{false};
+static bool g_contentPinned = false;          // render-thread only
+static uint32_t g_contentPinModeIndex = 0;    // render-thread only
+
 // Set DISPLAYXR_TRANSPARENT_BG=1 in the environment to opt into transparent
 // desktop composition: the HWND is created with WS_EX_NOREDIRECTIONBITMAP +
 // null background brush, the cube clears RGBA(0,0,0,0), and the win32 window
@@ -247,6 +257,13 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
         }
         if (wParam == VK_F11) {
             ToggleFullscreen(hwnd);
+            return 0;
+        }
+        // #542 content-pin: 'L' freezes the submission-side mode snapshot
+        // (handled on the render thread) while V/0-8 hardware requests still
+        // go out — drives a deliberate hardware/content divergence.
+        if (wParam == 'L') {
+            g_contentPinTogglePending.store(true);
             return 0;
         }
         break;
@@ -605,24 +622,55 @@ static void RenderThreadFunc(
         UpdateScene(*renderer, perfStats.deltaTime, xr->spinSpeed);
         PollEvents(*xr);
 
+        // #542 content-pin: resolve the env start-pin once, then any pending
+        // 'L' toggle. While pinned the render/submit path below derives its
+        // layout from the SNAPSHOT mode, not the live one — mode requests keep
+        // flowing, so hardware and content diverge on purpose.
+        {
+            static bool s_pinEnvChecked = false;
+            if (!s_pinEnvChecked && xr->sessionRunning) {
+                s_pinEnvChecked = true;
+                const char *pin = getenv("DXR_CUBE_PIN_CONTENT");
+                if (pin && pin[0] == '1') {
+                    g_contentPinned = true;
+                    g_contentPinModeIndex = xr->currentModeIndex;
+                    LOG_INFO("[#542] content PINNED at start (mode=%u)", g_contentPinModeIndex);
+                }
+            }
+            if (g_contentPinTogglePending.exchange(false)) {
+                g_contentPinned = !g_contentPinned;
+                if (g_contentPinned) {
+                    g_contentPinModeIndex = xr->currentModeIndex;
+                }
+                LOG_INFO("[#542] content %s (snapshot mode=%u, live mode=%u)",
+                    g_contentPinned ? "PINNED" : "UNPINNED",
+                    g_contentPinModeIndex, xr->currentModeIndex);
+            }
+        }
+
         if (xr->sessionRunning) {
             XrFrameState frameState;
             LOG_INFO("[FRAME] Calling BeginFrame (xrWaitFrame + xrBeginFrame)...");
             if (BeginFrame(*xr, frameState)) {
                 LOG_INFO("[FRAME] BeginFrame OK, shouldRender=%d, displayTime=%lld",
                     frameState.shouldRender, (long long)frameState.predictedDisplayTime);
-                // Get N-view mode info from enumerated rendering modes
-                bool monoMode = (xr->renderingModeCount > 0 && !xr->renderingModeDisplay3D[xr->currentModeIndex]);
-                if (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount) {
-                    xr->recommendedViewScaleX = xr->renderingModeScaleX[xr->currentModeIndex];
-                    xr->recommendedViewScaleY = xr->renderingModeScaleY[xr->currentModeIndex];
+                // Get N-view mode info from enumerated rendering modes.
+                // #542 content-pin: the render/submit layout derives from the
+                // pinned snapshot when active, the live mode otherwise.
+                uint32_t contentModeIndex =
+                    (g_contentPinned && g_contentPinModeIndex < xr->renderingModeCount)
+                        ? g_contentPinModeIndex : xr->currentModeIndex;
+                bool monoMode = (xr->renderingModeCount > 0 && !xr->renderingModeDisplay3D[contentModeIndex]);
+                if (xr->renderingModeCount > 0 && contentModeIndex < xr->renderingModeCount) {
+                    xr->recommendedViewScaleX = xr->renderingModeScaleX[contentModeIndex];
+                    xr->recommendedViewScaleY = xr->renderingModeScaleY[contentModeIndex];
                 }
-                uint32_t modeViewCount = (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount)
-                    ? xr->renderingModeViewCounts[xr->currentModeIndex] : 2;
-                uint32_t tileColumns = (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount)
-                    ? xr->renderingModeTileColumns[xr->currentModeIndex] : 2;
-                uint32_t tileRows = (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount)
-                    ? xr->renderingModeTileRows[xr->currentModeIndex] : 1;
+                uint32_t modeViewCount = (xr->renderingModeCount > 0 && contentModeIndex < xr->renderingModeCount)
+                    ? xr->renderingModeViewCounts[contentModeIndex] : 2;
+                uint32_t tileColumns = (xr->renderingModeCount > 0 && contentModeIndex < xr->renderingModeCount)
+                    ? xr->renderingModeTileColumns[contentModeIndex] : 2;
+                uint32_t tileRows = (xr->renderingModeCount > 0 && contentModeIndex < xr->renderingModeCount)
+                    ? xr->renderingModeTileRows[contentModeIndex] : 1;
                 int eyeCount = monoMode ? 1 : (int)modeViewCount;
 
                 // Dynamic arrays for N-view rendering
@@ -921,6 +969,12 @@ static void RenderThreadFunc(
                                     xr->renderingModeCount,
                                     xr->renderingModeCount > 0 ? xr->renderingModeDisplay3D[xr->currentModeIndex] : true,
                                     xr->renderingModeCount > 0 ? xr->renderingModeIsRequestable[xr->currentModeIndex] : true);
+                                if (g_contentPinned) {
+                                    wchar_t pinBuf[64];
+                                    swprintf(pinBuf, 64, L"\nCONTENT PINNED [L]: %ux%u x%d",
+                                        tileColumns, tileRows, eyeCount);
+                                    dispText += pinBuf;
+                                }
                                 std::wstring eyeText = FormatEyeTrackingInfo(
                                     xr->eyePositions, (uint32_t)eyeCount,
                                     xr->eyeTrackingActive, xr->isEyeTracking,
@@ -1030,7 +1084,8 @@ static void RenderThreadFunc(
                 }
 
                 // viewCount: 1 for mono (2D mode), 2 for stereo (3D mode)
-                uint32_t submitViewCount = (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount) ? xr->renderingModeViewCounts[xr->currentModeIndex] : 2;
+                // (#542: follows the content pin, like the render path)
+                uint32_t submitViewCount = (xr->renderingModeCount > 0 && contentModeIndex < xr->renderingModeCount) ? xr->renderingModeViewCounts[contentModeIndex] : 2;
                 // When transparent_bg is on, ask the runtime to honor the cube's
                 // per-pixel alpha when blending the projection layer. Pre-#213
                 // apps default to 0 (no source-alpha blend = treat as opaque).

--- a/test_apps/cube_handle_vk_win/main.cpp
+++ b/test_apps/cube_handle_vk_win/main.cpp
@@ -53,11 +53,19 @@ static XrSessionManager* g_xr = nullptr;
 // snapshot while hardware mode requests (V / 0-8) still go out — drives a
 // deliberate hardware/content divergence so the decoupled compositors can be
 // exercised (e.g. panel-2D + 2 submitted tiles). Toggle: 'L' key;
-// DXR_CUBE_PIN_CONTENT=1 starts pinned. Toggle flag is atomic (set on the
+// DXR_CUBE_PIN_CONTENT=1 starts pinned. Toggle flags are atomic (set on the
 // message-pump thread, consumed on the render thread).
+// On top of the pin, two single-axis keys:
+//   'H' = HARDWARE-only: pin content at its current layout, then request the
+//         opposite-hardware mode — only the panel changes.
+//   'J' = CONTENT-only: flip the pinned submission layout to the opposite-
+//         hardware mode's layout — no runtime request, only content changes.
 static std::atomic<bool> g_contentPinTogglePending{false};
+static std::atomic<bool> g_hwToggleRequested{false};
+static std::atomic<bool> g_contentToggleRequested{false};
 static bool g_contentPinned = false;          // render-thread only
 static uint32_t g_contentPinModeIndex = 0;    // render-thread only
+static uint32_t g_lastLive3DModeIndex = UINT32_MAX; // render-thread only
 
 // Set DISPLAYXR_TRANSPARENT_BG=1 in the environment to opt into transparent
 // desktop composition: the HWND is created with WS_EX_NOREDIRECTIONBITMAP +
@@ -262,8 +270,17 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
         // #542 content-pin: 'L' freezes the submission-side mode snapshot
         // (handled on the render thread) while V/0-8 hardware requests still
         // go out — drives a deliberate hardware/content divergence.
+        // 'H' / 'J' toggle a single axis (hardware-only / content-only).
         if (wParam == 'L') {
             g_contentPinTogglePending.store(true);
+            return 0;
+        }
+        if (wParam == 'H') {
+            g_hwToggleRequested.store(true);
+            return 0;
+        }
+        if (wParam == 'J') {
+            g_contentToggleRequested.store(true);
             return 0;
         }
         break;
@@ -645,6 +662,67 @@ static void RenderThreadFunc(
                 LOG_INFO("[#542] content %s (snapshot mode=%u, live mode=%u)",
                     g_contentPinned ? "PINNED" : "UNPINNED",
                     g_contentPinModeIndex, xr->currentModeIndex);
+            }
+
+            // Track the most recent live 3D mode for the "back to 3D" direction
+            // of the single-axis toggles (mirrors the runtime's V-key restore).
+            if (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount &&
+                xr->renderingModeDisplay3D[xr->currentModeIndex]) {
+                g_lastLive3DModeIndex = xr->currentModeIndex;
+            }
+            // Resolve a mode whose hardware state is the opposite of `from3d`:
+            // prefer the remembered 3D mode when going back to 3D, else the
+            // first mode on the other side of the hardware flag.
+            auto findOppositeMode = [&](bool from3d) -> int {
+                if (from3d == false && g_lastLive3DModeIndex < xr->renderingModeCount &&
+                    xr->renderingModeDisplay3D[g_lastLive3DModeIndex]) {
+                    return (int)g_lastLive3DModeIndex;
+                }
+                for (uint32_t i = 0; i < xr->renderingModeCount; i++) {
+                    if (xr->renderingModeDisplay3D[i] != from3d) {
+                        return (int)i;
+                    }
+                }
+                return -1;
+            };
+
+            // 'H' — HARDWARE-only: pin content where it is (so it won't follow),
+            // then request the opposite-hardware mode. Only the panel changes.
+            if (g_hwToggleRequested.exchange(false)) {
+                if (xr->renderingModeCount > 0 && xr->session != XR_NULL_HANDLE &&
+                    xr->pfnRequestDisplayRenderingModeEXT != nullptr &&
+                    xr->currentModeIndex < xr->renderingModeCount) {
+                    if (!g_contentPinned) {
+                        g_contentPinned = true;
+                        g_contentPinModeIndex = xr->currentModeIndex;
+                    }
+                    bool live3d = xr->renderingModeDisplay3D[xr->currentModeIndex];
+                    int target = findOppositeMode(live3d);
+                    if (target >= 0) {
+                        xr->pfnRequestDisplayRenderingModeEXT(xr->session, (uint32_t)target);
+                        LOG_INFO("[#542] H: hardware-only -> requested mode %d (%s); "
+                            "content stays pinned at mode %u layout",
+                            target, live3d ? "2D" : "3D", g_contentPinModeIndex);
+                    }
+                }
+            }
+
+            // 'J' — CONTENT-only: flip the pinned submission layout to the
+            // opposite-hardware mode's layout. No runtime request goes out.
+            if (g_contentToggleRequested.exchange(false)) {
+                if (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount) {
+                    uint32_t cur = (g_contentPinned && g_contentPinModeIndex < xr->renderingModeCount)
+                        ? g_contentPinModeIndex : xr->currentModeIndex;
+                    bool cur3d = xr->renderingModeDisplay3D[cur];
+                    int target = findOppositeMode(cur3d);
+                    if (target >= 0) {
+                        g_contentPinned = true;
+                        g_contentPinModeIndex = (uint32_t)target;
+                        LOG_INFO("[#542] J: content-only -> pinned at mode %d layout (%s); "
+                            "hardware untouched (live mode=%u)",
+                            target, cur3d ? "2D" : "3D", xr->currentModeIndex);
+                    }
+                }
             }
         }
 

--- a/test_apps/cube_zones_d3d11_win/main.cpp
+++ b/test_apps/cube_zones_d3d11_win/main.cpp
@@ -965,8 +965,17 @@ static void RenderZonesFrame(RenderState& rs, const XrFrameState& frameState) {
             continue;
         }
 
-        // (parenthesized call — windows.h min/max macros are active in this TU)
-        const uint32_t n = (std::min)(viewCountOutput, z.tileCount);
+        // xrLocateViews always reports the MAX view count (identical centered
+        // views in a mono mode) — a well-behaved extension app submits only
+        // the ACTIVE mode's view count (#542: 1 tile in a 2D mode; the
+        // runtime clamps over-submission to the mode regardless, this is the
+        // proper app-side behavior).
+        // (parenthesized calls — windows.h min/max macros are active in this TU)
+        uint32_t activeViewCount = viewCountOutput;
+        if (xr.renderingModeCount > 0 && xr.currentModeIndex < xr.renderingModeCount) {
+            activeViewCount = xr.renderingModeViewCounts[xr.currentModeIndex];
+        }
+        const uint32_t n = (std::min)((std::min)(viewCountOutput, z.tileCount), activeViewCount);
         submitViewCounts[zi] = n;
         projViews[zi].assign(n, {XR_TYPE_COMPOSITION_LAYER_PROJECTION_VIEW});
 


### PR DESCRIPTION
Closes DisplayXR/displayxr-runtime#542. Two layers of work, per the agreed model: **a rendering mode is a complete recipe — layout, view count, scales, and a default hardware state.** `xrRequestDisplayRenderingModeEXT` requests a mode and the hardware follows automatically (unchanged); the new orthogonal control is a **hardware-state-only override** for the current mode.

## 1. Compositor decouple (d3d11, d3d12, gl, vk_native; Metal landed earlier in 0577df2ae)
The `hardware_3d ? N : 1` clamps and `!hardware_display_3d` full-stretch branches are gone (re-keyed on the effective view count). Per-frame **effective content layout** (`comp_*_eff_layout`): **the content recipe is the active mode's, and submissions clamp down to it** — views = min(submitted, mode tiles); mono → one tile spanning the content region; otherwise the mode grid. The mode clamp is load-bearing, not just tidy: `xrLocateViews` always reports the max view count (identical centered views in a mono mode), so always-stereo apps legitimately submit 2 identical views in 2D forever (the documented compat guarantee), and ZONE_3D layers carry zone-sized imageRects — neither may define atlas geometry (an earlier iteration of this branch did, causing a zones-2D left-shift, the same bug class as Android DisplayXR/displayxr-runtime#533). It also subsumes the legacy-app clamp (mode 0 ⇒ mono). Both DP `process_atlas` handoffs + capture providers report the effective grid. Zero-copy gains a submitted-view_count == mode-view_count guard (fences a latent stale `proj.v[]` read). d3d12 also loses its dead mono dup-to-tile-1 draw and its hardcoded 2-view window-space loop.

## 2. `xrRequestDisplayModeEXT` repurposed as the hardware override (spec v15)
The previously-deprecated thin wrapper (zero callers in the app corpus) now sets the **hardware state alone** for the current mode: active mode, content, and DP processing untouched — only the physical 2D/3D element (switchable lens) changes. Hardware-2D over an active 3D mode shows the **woven atlas flat** (blurry); an app fading parallax to zero converges back to sharp — the MANUAL tracking-loss transition (#522). Override holds until the next mode request; reported via `XrEventDataHardwareDisplayStateChangedEXT`. `XR_EXT_display_info_SPEC_VERSION` 14 → 15, **no struct/ABI change**; spec doc updated.

Test affordance: the cube apps' **`H` key** toggles the override (`HW OVERRIDE [H]` on the HUD). The earlier content-pin (`L`) / content-only (`J`) keys were removed — with the override as a first-class API there is nothing app-side to freeze.

## Two deliberate deltas vs the Metal commit (flagging for the macOS side)
1. **Metal has no legacy gate** — a legacy app V-toggled to 2D renders SBS-flat on Metal. The Windows four gate on `legacy_app_tile_scaling`. Suggest porting the gate to Metal.
2. **Metal still derives the atlas from the submission** (views×1 sized by the imageRect for non-zone layers) — the model this PR's final iteration removed on the Windows four after it caused the zones-2D left-shift: on Metal an always-stereo app submitting 2 identical views in a 2D mode gets a 2×1 strip instead of mono, and matched 1×2/2×2 sim modes change geometry. Recommend porting the mode-clamp model (commit `fix(#542): the atlas content recipe is the MODE's`) to Metal.

## Companion
- DisplayXR/displayxr-leia-plugin#45 — `request_display_mode` becomes **lens-only**; the DP selects weave-vs-blit from the **per-frame atlas grid** (content). Required for the override to mean anything at the panel.

## Validation (Leia SR box, dev runtime + dev plugin deployed, logs + atlas captures)
- Matched identity: all four APIs render 3D 2×1 and V-toggle 2D↔3D cleanly; zero-copy unchanged; legacy compromise-scale session V-toggles cleanly.
- Hardware override (`H`): every press flips only the SR lens (`mode unchanged`, no `RenderingModeChanged` event) while the runtime keeps handing the DP a 2×1 atlas — the weave path stays engaged through a hardware-2D panel.
- Transient divergence (app lagging a mode change): d3d11 atlas capture shows a true 2×1 strip under the new layout logic; no crash/overflow on any API.

## ⚠️ Merge gate — do NOT enable auto-merge yet
Hardware-behavior change: the on-panel eyeball is pending — matched 3D weave quality per API, legacy V→2D mono, and the override visual (blurry weave on a flat panel, converging to sharp as parallax → 0). The dev `DisplayXR-LeiaSR.dll` is deployed (backup at `...\Plugins\LeiaSR\DisplayXR-LeiaSR.dll.pre542.bak`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

