### PR TITLE
ci: bump actions to Node 24 runtimes ahead of the June 16 default flip

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -26,7 +26,7 @@ jobs:
     outputs:
       docs_only: ${{ steps.filter.outputs.docs_only }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           # Full clone — the diff below uses pull_request.base.sha,
           # which can be older than the merge commit's first parent
@@ -73,7 +73,7 @@ jobs:
     steps:
 
       - name: Checkout repository and submodules
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           lfs: true
@@ -96,7 +96,7 @@ jobs:
 
       - name: Set up JDK 17
         if: needs.DetectChanges.outputs.docs_only != 'true'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -111,7 +111,7 @@ jobs:
 
       - name: Cache Gradle dependencies
         if: needs.DetectChanges.outputs.docs_only != 'true'
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.gradle/caches
@@ -161,7 +161,7 @@ jobs:
 
       - name: Upload APK
         if: needs.DetectChanges.outputs.docs_only != 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: DisplayXR-Android-inProcess-debug
           path: src/xrt/targets/openxr_android/build/outputs/apk/inProcess/debug/openxr_android-inProcess-debug.apk

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -42,7 +42,7 @@ jobs:
     outputs:
       docs_only: ${{ steps.filter.outputs.docs_only }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           # Full clone — the diff below uses pull_request.base.sha,
           # which can be older than the merge commit's first parent
@@ -76,7 +76,7 @@ jobs:
     runs-on: macos-14
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -123,7 +123,7 @@ jobs:
       GH_TOKEN: ${{ github.token }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -205,7 +205,7 @@ jobs:
           echo "PASS: .pkg payload contains plug-in + manifest."
 
       - name: Upload installer
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: needs.DetectChanges.outputs.docs_only != 'true' && (github.event_name == 'pull_request' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
         with:
           retention-days: 3
@@ -223,7 +223,7 @@ jobs:
       # per PR #279.
       - name: Attach macOS installer to GitHub release on tag
         if: needs.DetectChanges.outputs.docs_only != 'true' && startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: _package/DisplayXR-Installer-*.pkg
           fail_on_unmatched_files: true

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -37,7 +37,7 @@ jobs:
       test_apps_changed: ${{ steps.filter.outputs.test_apps }}
       docs_only: ${{ steps.filter.outputs.docs_only }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           # Full clone — the diff below uses pull_request.base.sha,
           # which can be older than the merge commit's first parent
@@ -104,7 +104,7 @@ jobs:
     steps:
 
       - name: Checkout repository and submodules
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           lfs: true
@@ -328,7 +328,7 @@ jobs:
         run: cmake --build build --config Release --target installer
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: needs.DetectChanges.outputs.docs_only != 'true' && (github.event_name == 'pull_request' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
         id: artifact-upload-step
         with:
@@ -338,7 +338,7 @@ jobs:
           path: _package
 
       - name: Upload installer
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: needs.DetectChanges.outputs.docs_only != 'true' && (github.event_name == 'pull_request' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
         id: installer-upload-step
         with:
@@ -353,7 +353,7 @@ jobs:
       # DisplayXRSetup-X.Y.Z.BUILD.exe from the NSI's OutFile.
       - name: Attach Windows installer to GitHub release on tag
         if: needs.DetectChanges.outputs.docs_only != 'true' && startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: _package/DisplayXRSetup-*.exe
           fail_on_unmatched_files: true
@@ -377,12 +377,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
       - name: Download runtime artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: DisplayXR
           path: runtime
@@ -467,12 +467,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
       - name: Download runtime artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: DisplayXR
           path: runtime
@@ -557,12 +557,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
       - name: Download runtime artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: DisplayXR
           path: runtime
@@ -607,12 +607,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
       - name: Download runtime artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: DisplayXR
           path: runtime
@@ -657,12 +657,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
       - name: Download runtime artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: DisplayXR
           path: runtime
@@ -707,12 +707,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
       - name: Download runtime artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: DisplayXR
           path: runtime
@@ -763,7 +763,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - uses: ilammy/msvc-dev-cmd@v1
         with:
@@ -805,7 +805,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - uses: ilammy/msvc-dev-cmd@v1
         with:
@@ -847,12 +847,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
       - name: Download runtime artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: DisplayXR
           path: runtime
@@ -897,12 +897,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
       - name: Download runtime artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: DisplayXR
           path: runtime
@@ -943,12 +943,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
       - name: Download runtime artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: DisplayXR
           path: runtime
@@ -995,7 +995,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -1043,7 +1043,7 @@ jobs:
     steps:
       - name: Mint App installation token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.DISPLAYXR_APP_ID }}
           private-key: ${{ secrets.DISPLAYXR_APP_PRIVATE_KEY }}
@@ -1055,7 +1055,7 @@ jobs:
             displayxr-website
 
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
           token: ${{ steps.app-token.outputs.token }}
@@ -1186,7 +1186,7 @@ jobs:
       - name: Notify website to resync
         if: steps.abi.outputs.rc == '0' && hashFiles('.bump-noop') == ''
         continue-on-error: true
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ steps.app-token.outputs.token }}
           repository: DisplayXR/displayxr-website

--- a/.github/workflows/cts.yml
+++ b/.github/workflows/cts.yml
@@ -58,7 +58,7 @@ jobs:
       GH_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout repository and submodules
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           lfs: true
@@ -133,7 +133,7 @@ jobs:
       # layers) pinned to the loader version. Cached on the harness script hash.
       - name: Cache CTS build
         id: cts-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: build-cts
           key: cts-${{ runner.os }}-${{ hashFiles('scripts/fetch_build_cts.bat') }}-1.1.43
@@ -193,7 +193,7 @@ jobs:
 
       - name: Upload CTS results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: cts-${{ steps.params.outputs.scope }}-${{ steps.params.outputs.graphics }}
           path: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,7 +35,7 @@ jobs:
   shell-path-guard:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: No shell source in runtime tree
         run: |
@@ -60,7 +60,7 @@ jobs:
   vendor-docs-guard:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: No vendor internals docs in runtime tree
         run: |

--- a/.github/workflows/no-vendored-math.yml
+++ b/.github/workflows/no-vendored-math.yml
@@ -21,7 +21,7 @@ jobs:
   no-vendored-math:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: No re-vendored displayxr::math sources
         shell: bash

--- a/.github/workflows/publish-extensions.yml
+++ b/.github/workflows/publish-extensions.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Mint App installation token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.DISPLAYXR_APP_ID }}
           private-key: ${{ secrets.DISPLAYXR_APP_PRIVATE_KEY }}
@@ -28,7 +28,7 @@ jobs:
           repositories: displayxr-extensions
 
       - name: Checkout runtime repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
 

--- a/.github/workflows/versions-bump.yml
+++ b/.github/workflows/versions-bump.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Mint App installation token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.DISPLAYXR_APP_ID }}
           private-key: ${{ secrets.DISPLAYXR_APP_PRIVATE_KEY }}
@@ -97,7 +97,7 @@ jobs:
             displayxr-website
 
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
           token: ${{ steps.app-token.outputs.token }}
@@ -256,7 +256,7 @@ jobs:
       - name: Notify website to resync
         if: hashFiles('.bump-noop') == '' && (steps.inputs.outputs.field != 'leia_plugin' || steps.abi.outputs.rc == '0')
         continue-on-error: true
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ steps.app-token.outputs.token }}
           repository: DisplayXR/displayxr-website


### PR DESCRIPTION
GitHub flips JavaScript actions to a Node 24 default on **June 16** (4 days out). This bumps every action pin in `.github/workflows/` to the lowest major that declares `runs.using: node24` (verified against each tag's `action.yml`):

| Action | From | To |
|---|---|---|
| actions/checkout | v4 | v5 |
| actions/cache | v4 | v5 |
| actions/upload-artifact | v4 | **v6** (v5 still defaulted to node20) |
| actions/download-artifact | v4 | **v7** (v5/v6 still defaulted to node20) |
| actions/setup-java | v4 | v5 |
| actions/create-github-app-token | v1 | v3 |
| peter-evans/repository-dispatch | v3 | v4 |
| softprops/action-gh-release | v2 | v3 |

**No behavior changes for our usage:** download-artifact's v5 breaking path change only affects `artifact-ids:` downloads — all of ours are by `name:`. create-github-app-token v3 keeps `app-id`/`private-key`/`owner`. All new majors need runner ≥ 2.327.1 — GitHub-hosted runners satisfy this.

**Already Node 24, untouched:** `lukka/run-vcpkg@v11`, `nttld/setup-ndk@v1`; `humbletim/install-vulkan-sdk@v1.2` is composite.

**Left as-is:** `ilammy/msvc-dev-cmd@v1` — no Node 24 release exists (upstream [issue #99](https://github.com/ilammy/msvc-dev-cmd/issues/99), PRs open). After June 16 it gets force-run on Node 24; it's a simple env-capture action and is expected to work.

**Not exercised by this PR's CI:** the `create-github-app-token` + `repository-dispatch` legs (versions-bump / publish-extensions / tag jobs) only run on tag/dispatch events — first real validation is the next component release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)