### PR TITLE
feat(#553): carry the active rendering mode over IPC; mode-clamp the multi-path atlas

### DIFF
--- a/docs/adr/ADR-028-display-mode-recipe-vs-hardware-state.md
+++ b/docs/adr/ADR-028-display-mode-recipe-vs-hardware-state.md
@@ -91,11 +91,10 @@ views lose nothing) but is the compat path, not the recommendation.
 
 ## Known divergences (tracked, not design)
 
-- **Android single-app OOP (`comp_multi_system.c`, #541):** the active mode
-  does not cross IPC (only the hardware bit does, via
-  `compositor_request_display_mode`), so the server's mode copy is stale and
-  the submission is the only honest geometry signal — that path builds a
-  `view_count×1` atlas from the submission. Bounded in practice (no zones on
-  that path; identical-view over-submission weaves to ≈the original image).
-  Retire by plumbing the mode index (or the content grid) over IPC, then
-  adopting the mode clamp there (#553).
+(The Android single-app OOP divergence was retired by #553: the CONTENT mode
+crosses IPC via `compositor_request_rendering_mode` — mirroring #541's
+hardware-bit message — and `comp_multi_system.c` adopts the mode clamp.)
+
+(The Metal divergence was retired by #556: `comp_metal_compositor.m` adopts the
+mode clamp instead of deriving the atlas from the submission, dropping the
+latent always-stereo-in-2D bug.)

--- a/src/xrt/compositor/multi/comp_multi_compositor.c
+++ b/src/xrt/compositor/multi/comp_multi_compositor.c
@@ -2080,6 +2080,27 @@ multi_compositor_request_display_mode(struct multi_compositor *mc, bool enable_3
 }
 
 void
+multi_compositor_set_rendering_mode(struct multi_compositor *mc,
+                                    uint32_t mode_index,
+                                    uint32_t tile_columns,
+                                    uint32_t tile_rows)
+{
+	if (mc == NULL) {
+		return;
+	}
+
+	// #553: the authoritative CONTENT rendering mode (the atlas recipe,
+	// ADR-028) — pure state, deliberately no DP side effects (hardware keeps
+	// its own channel via multi_compositor_request_display_mode). Not gated on
+	// session_render.initialized: the session-begin push may arrive before the
+	// per-session render path spins up, and the value must not be lost.
+	mc->active_mode_index = mode_index;
+	mc->mode_tile_columns = tile_columns > 0 ? tile_columns : 1;
+	mc->mode_tile_rows = tile_rows > 0 ? tile_rows : 1;
+	mc->active_mode_valid = true;
+}
+
+void
 multi_compositor_set_eye_tracking_mode(struct multi_compositor *mc, uint32_t mode)
 {
 	if (mc == NULL || !mc->session_render.initialized) {

--- a/src/xrt/compositor/multi/comp_multi_private.h
+++ b/src/xrt/compositor/multi/comp_multi_private.h
@@ -152,6 +152,19 @@ struct multi_compositor
 	//! Last known 3D rendering mode index (for V-key toggle restore).
 	uint32_t last_3d_mode_index;
 
+	/*!
+	 * Active CONTENT rendering mode — the atlas recipe (ADR-028, #553).
+	 * In-process this is synced from the head device each frame; out-of-process
+	 * it arrives via compositor_request_rendering_mode over IPC (the server's
+	 * head-device copy is otherwise stale). Orthogonal to hardware_display_3d.
+	 * @{
+	 */
+	bool active_mode_valid;
+	uint32_t active_mode_index;
+	uint32_t mode_tile_columns;
+	uint32_t mode_tile_rows;
+	/*! @} */
+
 	//! Used to implement wait frame, only used for in process.
 	struct os_precise_sleeper frame_sleeper;
 
@@ -671,6 +684,27 @@ multi_compositor_get_window_metrics(struct multi_compositor *mc, struct xrt_wind
  */
 bool
 multi_compositor_request_display_mode(struct multi_compositor *mc, bool enable_3d);
+
+/*!
+ * Record the active CONTENT rendering mode — the atlas recipe (ADR-028, #553).
+ * Pure state, no DP side effects: the hardware 2D/3D state keeps its own
+ * channel (@ref multi_compositor_request_display_mode). Called from the IPC
+ * server handler with the grid already resolved against the server's head
+ * device (the per-client mc has no xsysd out-of-process).
+ *
+ * @param mc           The multi_compositor.
+ * @param mode_index   Active rendering mode index.
+ * @param tile_columns The mode's atlas tile columns.
+ * @param tile_rows    The mode's atlas tile rows.
+ *
+ * @ingroup comp_multi
+ * @private @memberof multi_compositor
+ */
+void
+multi_compositor_set_rendering_mode(struct multi_compositor *mc,
+                                    uint32_t mode_index,
+                                    uint32_t tile_columns,
+                                    uint32_t tile_rows);
 
 /*!
  * Select the eye-tracking control mode (MANAGED=0 / MANUAL=1) on the

--- a/src/xrt/compositor/multi/comp_multi_system.c
+++ b/src/xrt/compositor/multi/comp_multi_system.c
@@ -2154,15 +2154,45 @@ render_session_to_own_target(struct multi_compositor *mc, struct vk_bundle *vk, 
 	}
 #endif
 
-	// CONTENT: the atlas holds exactly the tiles the app submitted (1 = 2D, ≥2 = 3D),
-	// independent of the hardware weave-state (#533 decouple). The app submits the
-	// active mode's tile count with per-view imageRects; the DP weaves or shows flat
-	// per mc->hardware_display_3d.
-	uint32_t view_count = layer->data.view_count;
-	if (view_count < 1)
-		view_count = 1;
-	if (view_count > XRT_MAX_VIEWS)
-		view_count = XRT_MAX_VIEWS;
+	// CONTENT: the atlas recipe is the active MODE's (ADR-028, #553) — the
+	// submission clamps DOWN to it, mirroring the in-process compositors
+	// (comp_d3d11_renderer_compute_effective_layout). In-process the head
+	// device is the mode authority, so sync the grid from it here (after the
+	// qwerty block, to pick up same-frame V/1-2-3 changes); out-of-process
+	// head is NULL and the mode arrives via compositor_request_rendering_mode
+	// over IPC. Orthogonal to mc->hardware_display_3d (the DP weave-state).
+	if (xdev_head != NULL && xdev_head->hmd != NULL) {
+		uint32_t idx = xdev_head->hmd->active_rendering_mode_index;
+		if (idx < xdev_head->rendering_mode_count) {
+			multi_compositor_set_rendering_mode(mc, idx,
+			                                    xdev_head->rendering_modes[idx].tile_columns,
+			                                    xdev_head->rendering_modes[idx].tile_rows);
+		}
+	}
+
+	uint32_t submitted_views = layer->data.view_count;
+	if (submitted_views < 1)
+		submitted_views = 1;
+	if (submitted_views > XRT_MAX_VIEWS)
+		submitted_views = XRT_MAX_VIEWS;
+
+	// Fallback (no mode has arrived yet): the legacy submission-derived strip.
+	uint32_t mode_cols = mc->active_mode_valid ? mc->mode_tile_columns : submitted_views;
+	uint32_t mode_rows = mc->active_mode_valid ? mc->mode_tile_rows : 1;
+	uint32_t mode_tiles = mode_cols * mode_rows;
+
+	// Clamp: always-stereo apps submit the xrLocateViews max view count even
+	// in mono modes — without the clamp that builds an oversized atlas (the
+	// recurring left-shift bug class ADR-028 documents). The min() also kills
+	// the old 2D⇄3D transition hazard: during the one-frame skew between the
+	// mode flip and the content adapting, the atlas never exceeds what was
+	// actually submitted.
+	uint32_t view_count = submitted_views < mode_tiles ? submitted_views : mode_tiles;
+
+	// Mono → one tile spanning the full content region; otherwise the MODE
+	// grid (an under-submitting app paints the first view_count tiles).
+	uint32_t tile_columns = (view_count == 1) ? 1 : mode_cols;
+	uint32_t tile_rows = (view_count == 1) ? 1 : mode_rows;
 
 	int imageWidth = 0, imageHeight = 0;
 	VkFormat imageFormat = VK_FORMAT_UNDEFINED;
@@ -2338,16 +2368,8 @@ render_session_to_own_target(struct multi_compositor *mc, struct vk_bundle *vk, 
 		// for stereo).
 		// ================================================================
 		{
-			// #533 decouple: the atlas layout is the CONTENT the app submitted, not
-			// the (out-of-process stale) server rendering mode. The app submits
-			// view_count tiles with per-view imageRects in a horizontal strip — 1
-			// tile (2D) or 2 (3D) — so build a matching view_count×1 atlas. This keeps
-			// the atlas in lockstep with the submission across a 2D⇄3D transition,
-			// even when the hardware flag (flipped on the fast IPC request) briefly
-			// leads the content by a frame — otherwise a stale 2x1 layout × a 2D-sized
-			// tile builds an oversized atlas that overflows the app swapchain.
-			uint32_t tile_columns = view_count > 0 ? view_count : 1;
-			uint32_t tile_rows = 1;
+			// The atlas grid (tile_columns × tile_rows) is the MODE's, clamped
+			// to the submission — computed above (ADR-028, #553).
 
 			// Determine blit sources — either composited overlay images or
 			// direct swapchain sub-regions.

--- a/src/xrt/ipc/client/ipc_client_compositor.c
+++ b/src/xrt/ipc/client/ipc_client_compositor.c
@@ -262,6 +262,31 @@ comp_ipc_client_compositor_request_display_mode(struct xrt_compositor *xc, uint3
 }
 
 /*
+ * Push the active CONTENT rendering mode (the atlas recipe, ADR-028) to the
+ * out-of-process server (#553). Deliberately a SEPARATE channel from the
+ * hardware 2D/3D request above — mode is the content recipe, hardware state
+ * is orthogonal. Without this the server's mode copy is stale and the multi
+ * compositor had to derive the atlas grid from the submission (the recurring
+ * bug class ADR-028 documents). Same gating contract as
+ * comp_ipc_client_compositor_request_display_mode. Best-effort — no-op on
+ * IPC failure.
+ */
+void
+comp_ipc_client_compositor_request_rendering_mode(struct xrt_compositor *xc, uint32_t mode_index)
+{
+	if (xc == NULL) {
+		return;
+	}
+
+	struct ipc_client_compositor *icc = ipc_client_compositor(xc);
+	if (icc == NULL || icc->ipc_c == NULL) {
+		return;
+	}
+
+	(void)ipc_call_compositor_request_rendering_mode(icc->ipc_c, mode_index);
+}
+
+/*
  * Full DP eye-position struct incl. is_tracking, over IPC (#441 Phase 2).
  * Same gating contract as comp_ipc_client_compositor_get_window_metrics:
  * only safe to call when `xc` is an ipc_client_compositor (the OpenXR state

--- a/src/xrt/ipc/server/ipc_server_handler.c
+++ b/src/xrt/ipc/server/ipc_server_handler.c
@@ -2238,6 +2238,48 @@ ipc_handle_compositor_request_display_mode(volatile struct ipc_client_state *ics
 }
 
 xrt_result_t
+ipc_handle_compositor_request_rendering_mode(volatile struct ipc_client_state *ics, uint32_t mode_index)
+{
+	IPC_TRACE_MARKER();
+
+	if (ics->xc == NULL) {
+		return XRT_ERROR_IPC_SESSION_NOT_CREATED;
+	}
+
+	// CONTENT rendering mode (#553) — the atlas recipe (ADR-028), DECOUPLED
+	// from the hardware 2D/3D channel above. Resolve the index against the
+	// server's head device (the mode-list authority; the per-client
+	// multi_compositor has no xsysd out-of-process) and record the resolved
+	// grid on the per-client compositor so the per-session atlas no longer
+	// has to be derived from the submission.
+	struct ipc_server *s = ics->server;
+	struct xrt_device *head = (s != NULL && s->xsysd != NULL) ? s->xsysd->static_roles.head : NULL;
+	if (head == NULL || mode_index >= head->rendering_mode_count) {
+		U_LOG_W("compositor_request_rendering_mode: invalid mode_index %u (count %u) — ignored",
+		        mode_index, head != NULL ? head->rendering_mode_count : 0);
+		return XRT_SUCCESS;
+	}
+
+	uint32_t tile_columns = head->rendering_modes[mode_index].tile_columns;
+	uint32_t tile_rows = head->rendering_modes[mode_index].tile_rows;
+
+	// Rare lifecycle event (mode switch / session begin+end), not per-frame —
+	// and the line Windows forced-IPC validation greps for.
+	U_LOG_W("CONTENT rendering mode %u arrived over IPC (grid %ux%u)", mode_index, tile_columns, tile_rows);
+
+	// The out-of-process per-client compositor is a comp_multi multi_compositor
+	// only on the Android null+comp_multi service — same cast-validity gate as
+	// the hardware handler above.
+#ifdef XRT_OS_ANDROID
+	struct multi_compositor *mc = multi_compositor((struct xrt_compositor *)ics->xc);
+	if (mc != NULL) {
+		multi_compositor_set_rendering_mode(mc, mode_index, tile_columns, tile_rows);
+	}
+#endif
+	return XRT_SUCCESS;
+}
+
+xrt_result_t
 ipc_handle_compositor_set_performance_level(volatile struct ipc_client_state *ics,
                                             enum xrt_perf_domain domain,
                                             enum xrt_perf_set_level level)

--- a/src/xrt/ipc/shared/proto.json
+++ b/src/xrt/ipc/shared/proto.json
@@ -577,6 +577,12 @@
 		]
 	},
 
+	"compositor_request_rendering_mode": {
+		"in": [
+			{"name": "mode_index", "type": "uint32_t"}
+		]
+	},
+
 	"compositor_get_reference_bounds_rect": {
 		"in": [
 			{"name": "reference_space_type", "type": "enum xrt_reference_space_type"}

--- a/src/xrt/state_trackers/oxr/oxr_api_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_api_session.c
@@ -1463,6 +1463,12 @@ oxr_xrRequestDisplayRenderingModeEXT(XrSession session, uint32_t modeIndex)
 	// 3. Update active mode (view_count stays fixed at 2 for STEREO)
 	head->hmd->active_rendering_mode_index = modeIndex;
 
+	// 3b. Out-of-process the head update above is client-local (the proxy
+	// device doesn't cross IPC) — push the CONTENT mode to the server too
+	// (#553), so its multi_compositor can clamp the atlas to the mode grid.
+	// No-op in-process / bridge-relay.
+	oxr_session_push_rendering_mode_ipc(sess, modeIndex);
+
 	// 4. Update recommended view scales
 	struct xrt_system_compositor *xsysc = sess->sys->xsysc;
 	if (xsysc != NULL) {

--- a/src/xrt/state_trackers/oxr/oxr_objects.h
+++ b/src/xrt/state_trackers/oxr/oxr_objects.h
@@ -937,6 +937,16 @@ XrResult
 oxr_session_request_display_mode(struct oxr_logger *log, struct oxr_session *sess, bool enable_3d);
 
 /*!
+ * Push the active CONTENT rendering mode (the atlas recipe, ADR-028) to the
+ * out-of-process server (#553). No-op for in-process sessions (the head device
+ * is the mode authority there) and bridge-relay sessions. Deliberately a
+ * separate channel from @ref oxr_session_request_display_mode — mode and
+ * hardware state are orthogonal.
+ */
+void
+oxr_session_push_rendering_mode_ipc(struct oxr_session *sess, uint32_t mode_index);
+
+/*!
  * Push the session's eye-tracking control mode (MANAGED=0 / MANUAL=1) to the
  * display processor (#522). Best-effort policy hint; the DP enacts whatever the
  * vendor advertised. Routed in-process via the native compositor or

--- a/src/xrt/state_trackers/oxr/oxr_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_session.c
@@ -125,6 +125,12 @@ comp_ipc_client_compositor_set_eye_tracking_mode(struct xrt_compositor *xc, uint
 void
 comp_ipc_client_compositor_request_display_mode(struct xrt_compositor *xc, uint32_t enable_3d);
 
+// IPC-client CONTENT rendering-mode push to the out-of-process server (#553) —
+// same linkage pattern. The atlas recipe (ADR-028), deliberately a separate
+// channel from the hardware bit above.
+void
+comp_ipc_client_compositor_request_rendering_mode(struct xrt_compositor *xc, uint32_t mode_index);
+
 // Same fetch via the SYSTEM compositor (#449) for compositor-less sessions
 // (headless XR_MND_headless clients like the WebXR bridge, which have no
 // xcn). Same linkage pattern as above.
@@ -477,6 +483,59 @@ oxr_session_request_display_mode(struct oxr_logger *log, struct oxr_session *ses
 }
 
 void
+oxr_session_push_rendering_mode_ipc(struct oxr_session *sess, uint32_t mode_index)
+{
+	if (sess == NULL || sess->xcn == NULL) {
+		return;
+	}
+
+	// Out-of-process IPC client only (single-app OOP Android, #553): push the
+	// CONTENT rendering mode (the atlas recipe, ADR-028) to the server, where
+	// the per-client multi_compositor records it and clamps the submission to
+	// the mode grid. In-process the head device IS the mode authority and the
+	// compositors read it directly — nothing to push. Deliberately a separate
+	// channel from the hardware 2D/3D request above (the two are orthogonal).
+	// Mirrors oxr_session_request_display_mode's dispatch gating.
+#ifdef XRT_HAVE_D3D11_NATIVE_COMPOSITOR
+	if (sess->is_d3d11_native_compositor) {
+		return;
+	}
+#endif
+#ifdef XRT_HAVE_D3D12_NATIVE_COMPOSITOR
+	if (sess->is_d3d12_native_compositor) {
+		return;
+	}
+#endif
+#ifdef XRT_HAVE_METAL_NATIVE_COMPOSITOR
+	if (sess->is_metal_native_compositor) {
+		return;
+	}
+#endif
+#ifdef XRT_HAVE_GL_NATIVE_COMPOSITOR
+	if (sess->is_gl_native_compositor) {
+		return;
+	}
+#endif
+#ifdef XRT_HAVE_VK_NATIVE_COMPOSITOR
+	if (sess->is_vk_native_compositor) {
+		return;
+	}
+#endif
+
+	// In-process multi compositor path — head device covers it.
+	if (sess->sys->xsysc != NULL && sess->sys->xsysc->xmcc != NULL) {
+		return;
+	}
+
+	// Bridge-relay sessions forward to the browser and own no server compositor.
+	if (sess->is_bridge_relay) {
+		return;
+	}
+
+	comp_ipc_client_compositor_request_rendering_mode(&sess->xcn->base, mode_index);
+}
+
+void
 oxr_session_set_eye_tracking_mode(struct oxr_session *sess, uint32_t mode)
 {
 	if (sess == NULL || sess->xcn == NULL) {
@@ -798,6 +857,9 @@ oxr_session_begin(struct oxr_logger *log, struct oxr_session *sess, const XrSess
 				struct xrt_rendering_mode *mode = &head->rendering_modes[default_mode];
 				oxr_session_request_display_mode(log, sess, mode->hardware_display_3d);
 				xrt_device_set_property(head, XRT_DEVICE_PROPERTY_OUTPUT_MODE, default_mode);
+				// #553: seed the server's CONTENT mode copy before the
+				// first frame (out-of-process only; no-op in-process).
+				oxr_session_push_rendering_mode_ipc(sess, default_mode);
 			} else {
 				oxr_session_request_display_mode(log, sess, true);
 			}
@@ -842,6 +904,9 @@ oxr_session_end(struct oxr_logger *log, struct oxr_session *sess)
 		    !head->rendering_modes[0].hardware_display_3d) {
 			xrt_device_set_property(head, XRT_DEVICE_PROPERTY_OUTPUT_MODE, 0);
 			head->hmd->active_rendering_mode_index = 0;
+			// #553: mirror the reset on the server's CONTENT mode copy
+			// (out-of-process only; no-op in-process).
+			oxr_session_push_rendering_mode_ipc(sess, 0);
 		}
 		oxr_session_request_display_mode(log, sess, false);
 	}


### PR DESCRIPTION
Closes #553. Follow-up to #542 / ADR-028 (known divergence #1).

## What

The Android single-app OOP path (`render_session_to_own_target` in `comp_multi_system.c`) built a `view_count×1` atlas from the submission because the server's copy of the active rendering mode was stale — #541 carried only the **hardware** 2D/3D bit over IPC, not the mode. This was the last submission-derived atlas in the tree (the recurring bug class ADR-028 documents).

- **New IPC message** `compositor_request_rendering_mode(mode_index)`, mirroring #541's `compositor_request_display_mode`. Fired from `xrRequestDisplayRenderingModeEXT`, the session-begin default-mode auto-switch (seeds the server before the first frame), and the session-end mode-0 reset. No-op in-process / bridge-relay. Option (a) from the issue — the clamp itself neutralizes the one-frame state-race that motivated option (b).
- **Server handler** resolves the index against its head device's mode list and records index + tile grid on the per-client `multi_compositor` (Android-gated store, same cast-validity reason as the #541 handler; the arrival WARN logs on every platform).
- **Mode clamp** in `render_session_to_own_target`: `views = min(submitted, mode tiles)`; mono → one full-content tile; otherwise the MODE grid. The submission-derived block is deleted. In-process the grid syncs from the head device; out-of-process the IPC value stands. The hardware bit keeps its own channel (orthogonal, ADR-028).
- ADR-028 "Known divergences": Android entry retired (Metal remains, tracked for the macOS box).

## Validation

- ✅ **Windows forced-IPC** (`XRT_FORCE_MODE=ipc` + dev service): `CONTENT rendering mode 1 arrived over IPC (grid 2x1)` in the service log at session begin — proto round-trips, server-side grid resolution correct. (Windows service render path doesn't consume the value; this validates plumbing, not the multi clamp.)
- ✅ **In-process regression**: `cube_handle_d3d11_win` native D3D11 unaffected (push helper no-ops for native sessions), weaves 2×1 as before.
- ⬜ **Android device (nubia NP02J, gates the merge)**: the #533 matrix — four tile configs (3D landscape 1920x1200 2×1 / 3D portrait 1200x1920 2×1 / 2D landscape 2560x1600 1×1 / 2D portrait 1600x2560 1×1), 2D⇄3D switch robustness both directions, 2D renders native (no upscale/left-shift), v15 hardware override over IPC (lens flips, content unchanged).

**Do not merge until the Android device validation is in.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)