### PR TITLE
Control Panel: live resize wrap, plug-in version, tray launcher

### DIFF
--- a/src/xrt/targets/cli/cli_query.c
+++ b/src/xrt/targets/cli/cli_query.c
@@ -141,6 +141,39 @@ read_active_runtime(struct cli_query_result *r)
 		r->active_runtime_set = r->active_runtime[0] != '\0';
 	}
 }
+
+//! Fallback for a plug-in that doesn't self-report a version through
+//! xrt_plugin_iface::version: read the installer-written value from
+//! HKLM\Software\DisplayXR\DisplayProcessors\<id>\Version. The discovery
+//! registry is the authoritative install record (the NSI writes Version from
+//! PROJECT_VERSION, and the loader already uses it for skew detection — #461),
+//! so this surfaces a real version even for plug-ins built before adopting the
+//! iface field. Leaves @p out untouched on any miss.
+static void
+read_plugin_version_from_registry(const char *id, char *out, size_t cap)
+{
+	if (id == NULL || id[0] == '\0') {
+		return;
+	}
+	char subkey[256];
+	snprintf(subkey, sizeof(subkey), "Software\\DisplayXR\\DisplayProcessors\\%s", id);
+
+	HKEY key;
+	if (RegOpenKeyExA(HKEY_LOCAL_MACHINE, subkey, 0, KEY_READ | KEY_WOW64_64KEY, &key) != ERROR_SUCCESS) {
+		return;
+	}
+	char buf[128];
+	DWORD len = sizeof(buf);
+	DWORD type = 0;
+	if (RegQueryValueExA(key, "Version", NULL, &type, (LPBYTE)buf, &len) == ERROR_SUCCESS && type == REG_SZ &&
+	    len > 0) {
+		buf[(len < sizeof(buf)) ? len : sizeof(buf) - 1] = '\0'; // RegQueryValueEx may omit the NUL
+		if (buf[0] != '\0') {
+			snprintf(out, cap, "%s", buf);
+		}
+	}
+	RegCloseKey(key);
+}
 #endif
 
 void
@@ -202,6 +235,13 @@ cli_query_run(struct cli_query_result *r)
 	snprintf(r->plugin_name, sizeof(r->plugin_name), "%s", iface->display_name ? iface->display_name : "");
 	snprintf(r->plugin_vendor, sizeof(r->plugin_vendor), "%s", iface->vendor ? iface->vendor : "");
 	snprintf(r->plugin_version, sizeof(r->plugin_version), "%s", iface->version ? iface->version : "");
+#ifdef XRT_OS_WINDOWS
+	// A plug-in that ships no iface version still has an installer-written
+	// Version in its discovery registry key — surface that rather than "?".
+	if (r->plugin_version[0] == '\0') {
+		read_plugin_version_from_registry(r->plugin_id, r->plugin_version, sizeof(r->plugin_version));
+	}
+#endif
 
 	if (iface->get_display_info == NULL) {
 		r->result_code = CLI_SELFTEST_BAD_INFO;

--- a/src/xrt/targets/control_panel/control_panel_main.c
+++ b/src/xrt/targets/control_panel/control_panel_main.c
@@ -24,6 +24,9 @@
 #include <cjson/cJSON.h>
 
 #include <SDL2/SDL.h>
+#ifdef _WIN32
+#include <SDL2/SDL_syswm.h> // real HWND, to size the ImGui window from the client rect
+#endif
 
 #include <stdbool.h>
 #include <stdio.h>
@@ -459,6 +462,12 @@ draw_panel(struct panel_state *s)
 	                         ImGuiWindowFlags_NoSavedSettings;
 	igBegin("DisplayXR Control Panel", NULL, flags);
 
+	// Wrap all text at the window's right edge so long values (device
+	// strings, ActiveRuntime path, self-test details) reflow instead of
+	// clipping. Pos 0.0f tracks the content-region width, so it follows
+	// the window live on resize. Popped before every igEnd() below.
+	igPushTextWrapPos(0.0f);
+
 	if (igButton("Refresh", (ImVec2){0, 0})) {
 		refresh_all(s);
 	}
@@ -475,6 +484,7 @@ draw_panel(struct panel_state *s)
 	if (!s->have_info) {
 		igSpacing();
 		igTextColored(COL_RED, "%s", s->info_err[0] ? s->info_err : "No runtime info.");
+		igPopTextWrapPos();
 		igEnd();
 		return;
 	}
@@ -523,6 +533,11 @@ draw_panel(struct panel_state *s)
 		igText("Physical : %.4f m x %.4f m", s->w_m, s->h_m);
 		igText("Pixels   : %d x %d", s->px, s->py);
 		igText("Viewer   : (%.3f, %.3f, %.3f) m", s->vx, s->vy, s->vz);
+		if (igIsItemHovered(0)) {
+			igSetTooltip("Nominal viewer (eye) position relative to the display centre, "
+			             "in metres (x=right, y=up, z=out toward the user). Drives the "
+			             "Kooima projection default when the app has no head tracking.");
+		}
 		igText("Eye-tracking : %s (0x%x), default %s",
 		       s->et_supported_label[0] ? s->et_supported_label : "?", (unsigned)s->et_modes,
 		       s->et_default_label[0] ? s->et_default_label : "?");
@@ -558,7 +573,12 @@ draw_panel(struct panel_state *s)
 
 	// ---- Tier 1: DP switch ----
 	igSeparatorText("Display-processor switch (PreferredPlugin override)");
-	igText("PreferredPlugin : %s", s->have_preferred ? s->preferred : "<unset>");
+	igText("PreferredPlugin : %s", s->have_preferred ? s->preferred : "<unset> (auto - by probe order)");
+	if (igIsItemHovered(0)) {
+		igSetTooltip("Optional manual override that forces a specific display processor. "
+		             "When unset (the normal state), the runtime auto-selects by probe order; "
+		             "the active plug-in is shown under 'Display processor' above.");
+	}
 	for (int i = 0; i < s->n_dp; i++) {
 		struct dp_row *r = &s->dps[i];
 		igText("%s %s id='%s' (ProbeOrder %d)%s", r->active ? "*" : " ",
@@ -584,6 +604,7 @@ draw_panel(struct panel_state *s)
 		igTextWrapped("%s", s->last_action);
 	}
 
+	igPopTextWrapPos();
 	igEnd();
 }
 
@@ -593,6 +614,64 @@ draw_panel(struct panel_state *s)
  * SDL2 + OpenGL3 host.
  *
  */
+
+//! Everything needed to paint one frame. Passed to the resize event watch so
+//! the panel can repaint *during* Windows' modal move/size loop — that loop
+//! blocks the normal main loop, so without this the content only reflows on
+//! mouse release (it appears to "stretch" mid-drag, then snap-wrap).
+struct frame_ctx
+{
+	SDL_Window *win;
+	ImGuiIO *io;
+	struct panel_state *state;
+	void *hwnd; // HWND on Windows, NULL elsewhere
+};
+
+//! Paint exactly one frame: new ImGui frame (sized from the live client rect on
+//! Windows), the panel, then present.
+static void
+render_frame(struct frame_ctx *c)
+{
+	ImGui_ImplOpenGL3_NewFrame();
+	ImGui_ImplSDL2_NewFrame();
+#ifdef _WIN32
+	// Override the (possibly stale) backend size with the true client rect so
+	// the full-window panel + its wrap edge track live resizes.
+	if (c->hwnd != NULL) {
+		RECT rc;
+		if (GetClientRect((HWND)c->hwnd, &rc) && rc.right > rc.left && rc.bottom > rc.top) {
+			c->io->DisplaySize.x = (float)(rc.right - rc.left);
+			c->io->DisplaySize.y = (float)(rc.bottom - rc.top);
+			c->io->DisplayFramebufferScale.x = 1.0f;
+			c->io->DisplayFramebufferScale.y = 1.0f;
+		}
+	}
+#endif
+	igNewFrame();
+
+	draw_panel(c->state);
+
+	igRender();
+	glViewport(0, 0, (int)c->io->DisplaySize.x, (int)c->io->DisplaySize.y);
+	glClearColor(0.10f, 0.11f, 0.13f, 1.0f);
+	glClear(GL_COLOR_BUFFER_BIT);
+	ImGui_ImplOpenGL3_RenderDrawData(igGetDrawData());
+	SDL_GL_SwapWindow(c->win);
+}
+
+//! SDL event watch: fires synchronously as events are *sent*, including from
+//! inside Windows' modal resize loop (where the main loop is blocked).
+//! Repainting on every size change is what makes the panel reflow live while
+//! the user drags the window edge.
+static int SDLCALL
+resize_event_watch(void *userdata, SDL_Event *e)
+{
+	if (e->type == SDL_WINDOWEVENT &&
+	    (e->window.event == SDL_WINDOWEVENT_SIZE_CHANGED || e->window.event == SDL_WINDOWEVENT_EXPOSED)) {
+		render_frame((struct frame_ctx *)userdata);
+	}
+	return 0;
+}
 
 int
 main(int argc, char *argv[])
@@ -669,6 +748,33 @@ main(int argc, char *argv[])
 	// the window paints immediately instead of freezing black on launch.
 	bool did_initial = false;
 
+#ifdef _WIN32
+	// On this HighDPI Win32 path SDL's cached window size doesn't reliably
+	// follow OS resizes, which pinned the ImGui window — and thus the text
+	// wrap edge — to the launch width (text clipped instead of reflowing).
+	// Drive the window size from the real client rect each frame instead.
+	HWND panel_hwnd = NULL;
+	{
+		SDL_SysWMinfo wmi;
+		SDL_VERSION(&wmi.version);
+		if (SDL_GetWindowWMInfo(win, &wmi)) {
+			panel_hwnd = wmi.info.win.window;
+		}
+	}
+#endif
+
+	struct frame_ctx fctx;
+	fctx.win = win;
+	fctx.io = io;
+	fctx.state = &state;
+#ifdef _WIN32
+	fctx.hwnd = panel_hwnd;
+#else
+	fctx.hwnd = NULL;
+#endif
+	// Repaint during the modal move/size loop (live resize).
+	SDL_AddEventWatch(resize_event_watch, &fctx);
+
 	bool running = true;
 	while (running) {
 		SDL_Event e;
@@ -683,18 +789,7 @@ main(int argc, char *argv[])
 			}
 		}
 
-		ImGui_ImplOpenGL3_NewFrame();
-		ImGui_ImplSDL2_NewFrame();
-		igNewFrame();
-
-		draw_panel(&state);
-
-		igRender();
-		glViewport(0, 0, (int)io->DisplaySize.x, (int)io->DisplaySize.y);
-		glClearColor(0.10f, 0.11f, 0.13f, 1.0f);
-		glClear(GL_COLOR_BUFFER_BIT);
-		ImGui_ImplOpenGL3_RenderDrawData(igGetDrawData());
-		SDL_GL_SwapWindow(win);
+		render_frame(&fctx);
 
 		if (!did_initial) {
 			refresh_all(&state);
@@ -702,6 +797,7 @@ main(int argc, char *argv[])
 		}
 	}
 
+	SDL_DelEventWatch(resize_event_watch, &fctx);
 	ImGui_ImplOpenGL3_Shutdown();
 	ImGui_ImplSDL2_Shutdown();
 	igDestroyContext(NULL);

--- a/src/xrt/targets/service/service_tray_win.c
+++ b/src/xrt/targets/service/service_tray_win.c
@@ -26,6 +26,7 @@
 #define IDM_BRIDGE_DISABLE  1021
 #define IDM_BRIDGE_AUTO     1022
 #define IDM_START_ON_LOGIN  1030
+#define IDM_CONTROL_PANEL   1002
 #define IDM_EXIT            1001
 
 // Workspace published-action IDs. Range matches
@@ -180,6 +181,52 @@ bridge_mode_to_id(enum service_child_mode m)
 	}
 }
 
+//! Resolve a binary that ships next to displayxr-service.exe (same Runtime
+//! dir) into @p out. Returns true and a NUL-terminated path on success.
+static bool
+resolve_sibling_exe(const wchar_t *name, wchar_t *out, size_t cap)
+{
+	wchar_t dir[MAX_PATH];
+	DWORD len = GetModuleFileNameW(NULL, dir, ARRAYSIZE(dir));
+	if (len == 0 || len >= ARRAYSIZE(dir)) {
+		return false;
+	}
+	wchar_t *slash = wcsrchr(dir, L'\\');
+	if (slash == NULL) {
+		return false;
+	}
+	*(slash + 1) = L'\0';
+	// dir now ends in a backslash; append the binary name.
+	if (wcscpy_s(out, cap, dir) != 0 || wcscat_s(out, cap, name) != 0) {
+		return false;
+	}
+	return true;
+}
+
+//! True if the Control Panel GUI is installed alongside the service.
+static bool
+control_panel_available(void)
+{
+	wchar_t path[MAX_PATH];
+	return resolve_sibling_exe(L"displayxr-control-panel.exe", path, ARRAYSIZE(path)) &&
+	       GetFileAttributesW(path) != INVALID_FILE_ATTRIBUTES;
+}
+
+//! Launch the sibling Control Panel GUI (best-effort; runs in the user's
+//! session since the service tray itself does).
+static void
+launch_control_panel(void)
+{
+	wchar_t path[MAX_PATH];
+	if (!resolve_sibling_exe(L"displayxr-control-panel.exe", path, ARRAYSIZE(path))) {
+		return;
+	}
+	// ShellExecute "open" is enough — the panel is a normal GUI exe and we
+	// don't need its handle. If it's already open this just brings up a
+	// second instance; the panel is cheap and stateless, so that's fine.
+	ShellExecuteW(NULL, L"open", path, NULL, NULL, SW_SHOWNORMAL);
+}
+
 //! Build and show the tray context menu at the cursor position.
 static void
 show_context_menu(HWND hwnd)
@@ -203,6 +250,15 @@ show_context_menu(HWND hwnd)
 
 	// Main menu
 	HMENU menu = CreatePopupMenu();
+
+	// Control Panel (runtime diagnostics GUI) — top-level entry, shown only
+	// when the panel exe is installed alongside the service. It's a runtime-
+	// level diagnostic, not a workspace-app action, so it lives on the
+	// always-on service tray rather than a workspace controller's submenu.
+	if (control_panel_available()) {
+		AppendMenuW(menu, MF_STRING, IDM_CONTROL_PANEL, L"DisplayXR Control Panel");
+		AppendMenuW(menu, MF_SEPARATOR, 0, NULL);
+	}
 
 	// Workspace submenu — only built when a controller binary is detected.
 	// Bare runtime (no controller installed) gets just the Bridge entry,
@@ -333,6 +389,11 @@ tray_wnd_proc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 		case IDM_BRIDGE_DISABLE:
 			s_config.bridge = SERVICE_CHILD_DISABLE;
 			config_changed();
+			break;
+
+		// Open the runtime diagnostics Control Panel
+		case IDM_CONTROL_PANEL:
+			launch_control_panel();
 			break;
 
 		// Start on login toggle


### PR DESCRIPTION
Polish for the DisplayXR Control Panel (follow-up to #378/#380).

## Changes
- **CLI** — `info`/`selftest` now fall back to the installer-written discovery-registry `Version` when a plug-in reports no `iface->version` (the current Leia SR DLL ships none), so the panel shows a real version instead of `?`.
- **Control Panel**
  - Text now **wraps at the window edge** instead of clipping.
  - **Live resize**: drive the ImGui window from the true client rect (`GetClientRect`) each frame, and repaint from an SDL event watch so content reflows *during* Windows' modal move/size loop (was only updating on mouse release).
  - Tooltips/labels: explain the **Viewer** field (nominal Kooima viewpoint) and relabel `PreferredPlugin <unset>` as `(auto - by probe order)`.
- **Service tray** — new top-level **"DisplayXR Control Panel"** launcher, gated on the exe being installed alongside the service.

## Test
Built locally (`build_windows.bat build`), deployed, and verified on the Leia SR box: text reflows live while dragging the window edge, version shows, tray item launches the panel. No hardware-rendering behavior touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)