### PR TITLE
feat(#551): standalone IPC zones + client-owned transparent present (ADR-029)

### DIFF
--- a/docs/adr/ADR-029-client-owned-transparent-ipc-present.md
+++ b/docs/adr/ADR-029-client-owned-transparent-ipc-present.md
@@ -1,0 +1,115 @@
+---
+status: Accepted
+date: 2026-06-12
+issues: [551]
+---
+# ADR-029: The IPC client owns the transparent present; the DP reconstructs alpha, never bakes a background
+
+## Context
+
+A transparent DisplayXR app (`transparentBackgroundEnabled = XR_TRUE`, see
+`XR_EXT_win32_window_binding`) wants `alpha = 0` regions of its content to show
+the **live desktop** behind its window. In-process this is settled (ADR-007's DP
+weaves; the native compositor configures the app HWND for `DirectComposition` +
+`DXGI_ALPHA_MODE_PREMULTIPLIED`). The **IPC/service path** —
+`XRT_FORCE_MODE=ipc`, WebXR/UWP, or any standalone client of
+`displayxr-service.exe` — is different in two ways that this ADR resolves:
+
+1. **Who presents.** The per-client compositor and the display processor run
+   **out-of-process**, inside `displayxr-service.exe`. A process can only create
+   a `DirectComposition` target (`IDCompositionDevice::CreateTargetForHwnd`) —
+   and a windowed swap chain (`CreateSwapChainForHwnd`) — on a window **it owns**.
+   On a client's HWND both calls return `E_ACCESSDENIED`. So the service
+   physically cannot present transparently onto the app's window. (Symmetrically,
+   `SetWindowDisplayAffinity(WDA_EXCLUDEFROMCAPTURE)` is owner-only — see §
+   "Mechanics".)
+
+2. **How the hole is filled.** The Leia DP's preferred see-through is
+   *compose-under-bg*: it captures the desktop region behind the window via
+   Windows Graphics Capture (WGC) and composites it **under** the app's
+   premultiplied atlas before weaving, so the weaver outputs opaque RGB. Over
+   IPC the captured frame is always **at least one frame stale**, and while
+   dragging a window or playing video under the app the lag is obvious.
+
+## Decision
+
+**The IPC client owns the transparent present, and the DP only reconstructs
+alpha — it never bakes a captured background when the client presents.**
+
+### 1. Service renders to a shared texture; the client presents it
+
+When a client is transparent and supplies its own (cross-process) HWND
+(`use_client_transparent`), the service does **not** create a swap chain.
+Instead it creates a **shared NT-handle texture** (`R8G8B8A8_UNORM`,
+premultiplied alpha) plus a **service→client D3D11 fence**. The per-client
+compositor binds that texture's RTV as its back buffer, so the weave + alpha
+reconstruction land directly in it; then it signals the fence.
+
+Two new IPC RPCs (`compositor_get_transparent_output` and
+`…_output_fence`) hand the duplicated NT handles to the client. The client
+(`comp_d3d11_client`) imports the texture and fence, owns a `DirectComposition`
+device/target/visual on **its own** window, and on each `xrEndFrame`:
+GPU-waits the fence → `CopyResource` shared→DComp back buffer → `Present` →
+`Commit`. DWM blends the `alpha = 0` pixels with the live desktop. No per-frame
+IPC (lockstep fence only); ~zero added lag.
+
+This is the reusable template for **any** transparent IPC app — not specific to
+the zones demo that motivated it.
+
+### 2. `set_transparent_background(enabled, client_presents)` — the DP mode signal
+
+The D3D11 DP vtable slot gains a `client_presents` argument (ADR-020 append-only;
+the 2-arg form is retired in the same window since it had no released callers):
+
+- `client_presents = false` (in-process / opaque-present IPC): DP owns
+  see-through — compose-under-bg (WGC), chroma-key fallback if WGC is
+  unavailable.
+- `client_presents = true` (the §1 path): the runtime owns a transparent
+  present and DWM supplies the live desktop, so the DP must **NOT**
+  compose-under-bg (no WGC, no stale frame). It runs **only** the post-weave
+  **alpha-gate**: a fullscreen pass that samples the original premultiplied
+  atlas and, for every pixel where **all** view tiles have `alpha == 0`, writes
+  `float4(0,0,0,0)` to the output so DWM shows the desktop. Pixels where any
+  view is opaque keep the weaver's lenticular blend at `alpha = 1`.
+
+The alpha-gate is decoupled from compose (`alpha_gate_should_run =
+compose_should_run || client_present_mode`) and lazily builds its pipeline so
+it works with no WGC capture ever created.
+
+## Consequences
+
+- **No background lag.** Live-desktop see-through is exactly as current as DWM
+  itself; the only thing crossing IPC is the app's own woven frame.
+- **Chroma-key is now a fallback, not a path.** The clean enable
+  (`set_transparent_background`) never chroma-keys; `set_chroma_key` remains only
+  for a DP too old to advertise the slot. Plan of record is to remove chroma-key
+  once all DPs ship the slot.
+- **One owner of the present per topology.** In-process: native compositor.
+  IPC: the client. The service never presents onto a window it doesn't own —
+  removing a class of `E_ACCESSDENIED` failures and the temptation to work
+  around them.
+
+## Mechanics / gotchas (load-bearing)
+
+- **A fullscreen pass that *replaces* a target's alpha must force blend OFF.**
+  The alpha-gate writes `float4(0,0,0,0)` to punch holes. The service zones
+  composite leaves a **src-over** blend state bound; under it the gate's output
+  blends as `dst*(1-0) = dst` — a **no-op**, so an opaque black weave survives
+  and the desktop never shows. In-process the gate happened to inherit a
+  blend-disabled state, masking the bug. The gate now sets
+  `OMSetBlendState(nullptr, nullptr, 0xffffffff)` (blend-off, write-all-channels)
+  before its draw. Any DP/post pass that reconstructs alpha must do the same.
+- **Capture-exclusion is owner-only.** `WDA_EXCLUDEFROMCAPTURE` (so the WGC
+  fallback doesn't capture the app's own window) must be set from the
+  window-owning **app** process — the runtime requests it client-side via the
+  `transparentBackgroundEnabled` parse in `oxr_session`. The DP (out-of-process)
+  only reads affinity and tolerates a cross-process `ERROR_ACCESS_DENIED`.
+- **App-side HWND requirements are unchanged** (`WS_EX_NOREDIRECTIONBITMAP` +
+  null background brush; see `XR_EXT_win32_window_binding` §3.2). They apply
+  identically whether the runtime or the client owns the present.
+
+## Related
+
+- ADR-007 (compositor never weaves), ADR-020 (plugin ABI append-only),
+  ADR-027 (display zones — the motivating client).
+- `XR_EXT_win32_window_binding` §3.2 (transparent-window contract, per-API matrix).

--- a/docs/roadmap/display-zones.md
+++ b/docs/roadmap/display-zones.md
@@ -200,17 +200,32 @@ appended fields read 0 (caller-zeroed append-only contract observed).
 
 ### Phase 5 — Leia plugin + IPC
 
-- `displayxr-leia-plugin`: report appended caps (`wish_fractional=0`,
-  `switch_granularity` per vendor confirmation — **verify the column-band
-  claim with Leia before pinning values**); zero firmware work required
-  (conformant via the default any-nonzero quantization).
-- IPC: zone rect on the rig-chained locate call (already server-routed since
-  PR #479) + `XRT_LAYER_ZONE_3D` serialization (projection + 16 bytes). The
-  wish-mask cross-process transport is the one genuinely new IPC surface —
-  scoped here, may slip independently (sentinel-paint probe for validation).
-- Validate via `XRT_FORCE_MODE=ipc` with `cube_zones_d3d11_win`, then the
-  workspace path (wish ignored in v1 per ADR-027 — verify it is *inert*, not
-  broken).
+Runtime side **DONE** across #549 (PR #552, workspace composite + zone-scoped
+locate over IPC, Leia-eyeball validated) and the #551 standalone tail:
+
+- IPC: zone rect rides the rig-chained locate call (server-routed since
+  PR #479); `XRT_LAYER_ZONE_3D` serialization shipped with #549. The wish
+  needed **no new cross-process transport**: the service derives the auto
+  wish from the committed zone-3D layers and publishes it screen-anchored to
+  the per-client DP (`service_update_zone_wish_publish`,
+  `comp_d3d11_service.cpp`) — same feathered union raster as in-process. A
+  mask-capable DP demotes the tier-1 global 3D request (the MODE flip stays:
+  the multi-view atlas recipe is the mode's); a DP without the entry keeps
+  tier-1 unchanged.
+- #551 root-cause note (so the wrong framing doesn't persist): the standalone
+  "no eyes / black view-1" was NOT a locate-plumbing gap — the HWND-scoped
+  metrics + zone rebase already worked (`VIEW-RIG IPC: window-scoped via
+  client HWND`, `ZONES IPC: first zone-scoped locate` in the service log).
+  The persistent symptom was `cube_zones_d3d11_win` allocating zone
+  swapchains at the *startup* mode's view count (1-view standalone), pinning
+  every zone submission to one view; fixed by allocating at the max view
+  count across modes and clamping per-frame to the active mode.
+- `displayxr-leia-plugin` (vendor half, PR #44): report appended caps
+  (`wish_fractional=0`, `switch_granularity` per vendor confirmation);
+  zero firmware work required (conformant via the default any-nonzero
+  quantization). Until it lands in the installed plugin, the service publish
+  no-ops and tier-1 covers.
+- Workspace wish verified *inert* (not broken) per ADR-027 v1.
 
 ### Phase 6 — avatar migration (acceptance)
 

--- a/docs/specs/extensions/XR_EXT_win32_window_binding.md
+++ b/docs/specs/extensions/XR_EXT_win32_window_binding.md
@@ -211,11 +211,40 @@ Apps that already use a separate top-level overlay window for transparency (e.g.
 
 The `_handle` and `_texture` modes both apply (any time `windowHandle` is non-NULL with transparency enabled). The `_offscreen` mode is unaffected — there's no HWND.
 
+#### IPC / service path — the **client** owns the transparent present (ADR-029)
+
+Everything above describes **in-process** transparency, where the native
+compositor configures the app's HWND for `DirectComposition`. Under the
+**IPC/service path** (`XRT_FORCE_MODE=ipc`, WebXR/UWP, or any client of
+`displayxr-service.exe`) the compositor and display processor run
+out-of-process, and a process can only create a DComp target / windowed swap
+chain on a window **it owns** — both calls return `E_ACCESSDENIED` on the
+client's HWND. So the *client* owns the transparent present:
+
+1. The service renders the woven, alpha-reconstructed frame into a **shared
+   NT-handle texture** (premultiplied `R8G8B8A8_UNORM`) and signals a
+   **service→client fence**.
+2. The client (in the app's process) imports both, owns a `DirectComposition`
+   device/target/visual on its own HWND, and per `xrEndFrame` GPU-waits the
+   fence, copies the shared texture into its DComp back buffer, and
+   `Present` + `Commit`. DWM blends the `alpha = 0` regions with the **live
+   desktop** — no captured-background lag.
+
+The DP is told the runtime owns the present (`set_transparent_background(…,
+client_presents = true)`) so it runs **only** its post-weave alpha-gate
+(reconstructing `alpha = 0` holes) and does **not** composite a captured desktop
+under the atlas (which would be ≥1 frame stale over IPC). App-side HWND
+requirements are identical to the in-process contract above. **No app code
+changes are needed** to move between in-process and IPC — opting into
+`transparentBackgroundEnabled` is sufficient; the runtime picks the owner of the
+present from the topology.
+
 #### Per-graphics-API support matrix
 
 | Graphics API | Mechanism | Status |
 |---|---|---|
-| D3D11 | `CreateSwapChainForComposition` + `DXGI_ALPHA_MODE_PREMULTIPLIED` + `IDCompositionTarget` bound to the app HWND. The vendor D3D11 DP runs chroma-key fill+strip around its weaving stage. | Shipping (PR #213). |
+| D3D11 (in-process) | `CreateSwapChainForComposition` + `DXGI_ALPHA_MODE_PREMULTIPLIED` + `IDCompositionTarget` bound to the app HWND. The vendor D3D11 DP reconstructs see-through via compose-under-bg (WGC), with chroma-key fill+strip as the fallback. | Shipping (PR #213). |
+| D3D11 (IPC/service) | The **client** owns the DComp present over a shared NT-handle texture + service→client fence; the DP runs `client_presents` mode — post-weave **alpha-gate only**, no captured-background compose, so the live desktop blends with zero lag. See "IPC / service path" above + ADR-029. | Shipping (#551). |
 | D3D12 | Same as D3D11, plus the runtime explicitly passes the back-buffer RTV through to the strip pass (D3D12 has no `OMGetRenderTargets`). | Shipping (PR #213, PR #3a). |
 | Vulkan | Swapchain `compositeAlpha` runtime-selects `VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR` → `INHERIT` → `OPAQUE` based on `caps.supportedCompositeAlpha`. Most Win32 ICDs only expose `OPAQUE`, in which case alpha is dropped at the WSI present and a one-time warning is logged (the chroma-key strip still runs but its alpha output is invisible — the vendor weaver's RGB on a black background is what reaches the screen). The vendor VK DP runs chroma-key fill+strip via SPIR-V shaders compiled offline. | Shipping (PR #3c). |
 | OpenGL | `CreateSwapChainForComposition` + `DXGI_ALPHA_MODE_PREMULTIPLIED` + `IDCompositionTarget`, bridged from GL via `WGL_NV_DX_interop2`. The GL native compositor weaves into an **off-screen interop transit texture** (the proven `_texture`-app interop path), then a **D3D11 fullscreen-triangle shader blit** copies it into the flip-model DComp back buffer (an RTV write) → `Present` + `Commit`. This sidesteps the PR #3b failure, where the DP wove directly into the flip-model back buffer via interop and produced no visible content (the known `WGL_NV_DX_interop2`-into-flip-model incompatibility — `CopyResource` into that back buffer failed too, but RTV writes work). The vendor GL DP runs chroma-key fill+strip around its weaving stage (driven by `set_chroma_key`). Gated on an app-provided HWND with `WS_EX_NOREDIRECTIONBITMAP`; runtime-hosted GL windows are not yet covered. Falls back to opaque `SwapBuffers` if `WGL_NV_DX_interop2`/DComp are unavailable. | Shipping. |

--- a/src/xrt/compositor/CMakeLists.txt
+++ b/src/xrt/compositor/CMakeLists.txt
@@ -82,6 +82,9 @@ if(XRT_HAVE_D3D11)
 		comp_client PRIVATE client/comp_d3d11_client.cpp client/comp_d3d11_client.h
 				    client/comp_d3d11_glue.c
 		)
+	# #551 — the D3D11 client compositor presents a transparent IPC output via
+	# DirectComposition (DCompositionCreateDevice2) on the app's own window.
+	target_link_libraries(comp_client PRIVATE d3d11 dxgi dcomp)
 endif()
 
 if(XRT_HAVE_D3D12)

--- a/src/xrt/compositor/client/comp_d3d11_client.cpp
+++ b/src/xrt/compositor/client/comp_d3d11_client.cpp
@@ -34,6 +34,9 @@
 
 #include <d3d11_1.h>
 #include <d3d11_3.h>
+#include <d3d11_4.h> // #551 ID3D11Fence / ID3D11DeviceContext4 for the transparent present
+#include <dxgi1_2.h> // #551 CreateSwapChainForComposition
+#include <dcomp.h>   // #551 DirectComposition transparent present
 #include <wil/resource.h>
 #include <wil/com.h>
 #include <wil/result_macros.h>
@@ -59,6 +62,18 @@ comp_ipc_client_compositor_get_workspace_sync_fence(struct xrt_compositor *xc,
                                                     xrt_graphics_sync_handle_t *out_handle);
 extern "C" void
 comp_ipc_client_compositor_set_workspace_sync_fence_value(struct xrt_compositor *xc, uint64_t value);
+// #551 — transparent compositing output bridges.
+extern "C" xrt_result_t
+comp_ipc_client_compositor_get_transparent_output(struct xrt_compositor *xc,
+                                                  bool *out_have_output,
+                                                  uint32_t *out_width,
+                                                  uint32_t *out_height,
+                                                  uint64_t *out_hwnd,
+                                                  xrt_graphics_buffer_handle_t *out_handle);
+extern "C" xrt_result_t
+comp_ipc_client_compositor_get_transparent_output_fence(struct xrt_compositor *xc,
+                                                        bool *out_have_fence,
+                                                        xrt_graphics_sync_handle_t *out_handle);
 
 DEBUG_GET_ONCE_LOG_OPTION(log, "D3D_COMPOSITOR_LOG", U_LOGGING_INFO)
 
@@ -196,6 +211,25 @@ struct client_d3d11_compositor
 	 */
 	wil::com_ptr<ID3D11Fence> workspace_sync_fence;
 	uint64_t workspace_sync_fence_value = 0;
+
+	//! #551 — transparent compositing output present. For a forced-IPC
+	//! transparent client, the service weaves (with alpha-gate holes) into a
+	//! shared texture; this side imports it + the service→client fence and
+	//! presents it via a transparent DirectComposition swap chain on the app's
+	//! own window, so DWM blends the LIVE desktop into the holes. Inactive
+	//! (transparent_present == false) for opaque clients — the service presents
+	//! its own swap chain as before. Reusable for any IPC app that requests
+	//! transparentBackgroundEnabled.
+	bool transparent_present = false;
+	HWND transparent_hwnd = nullptr;
+	uint32_t transparent_w = 0, transparent_h = 0;
+	wil::com_ptr<ID3D11Texture2D> transparent_output_texture; //!< imported shared service output
+	wil::com_ptr<ID3D11Fence> transparent_output_fence;       //!< imported service→client fence
+	uint64_t transparent_present_value = 0;                   //!< client wait counter (lockstep w/ service)
+	wil::com_ptr<IDXGISwapChain1> transparent_swapchain;      //!< DComp composition swap chain
+	wil::com_ptr<IDCompositionDevice> transparent_dcomp_device;
+	wil::com_ptr<IDCompositionTarget> transparent_dcomp_target;
+	wil::com_ptr<IDCompositionVisual> transparent_dcomp_visual;
 };
 
 static_assert(std::is_standard_layout<client_d3d11_compositor>::value);
@@ -939,6 +973,33 @@ client_d3d11_compositor_layer_zone_3d(struct xrt_compositor *xc,
 	return xrt_comp_layer_zone_3d(&c->xcn->base, xdev, xscn, data);
 }
 
+// #551 — per-frame transparent present. Called after the layer-commit RPC
+// returns (the service has weaved + signaled). GPU-wait the service→client
+// fence (lockstep counter, no per-frame IPC), copy the woven shared output into
+// the DComp swap-chain back buffer, and present so DWM blends the LIVE desktop
+// into the alpha-gate holes. No-op for opaque clients.
+static void
+client_d3d11_transparent_present(struct client_d3d11_compositor *c)
+{
+	if (!c->transparent_present || !c->transparent_swapchain || !c->transparent_output_fence) {
+		return;
+	}
+	// Lockstep with the service: it bumps + signals once per commit, we bump +
+	// wait once per commit, so this value always matches the frame just weaved.
+	c->transparent_present_value++;
+	c->fence_context->Wait(c->transparent_output_fence.get(), c->transparent_present_value);
+
+	wil::com_ptr<ID3D11Texture2D> back;
+	if (SUCCEEDED(c->transparent_swapchain->GetBuffer(0, IID_PPV_ARGS(back.put()))) && back) {
+		c->fence_context->CopyResource(back.get(), c->transparent_output_texture.get());
+	}
+	c->transparent_swapchain->Present(1, 0);
+	// Publish the new frame to dwm.exe (cheap delta-state IPC, no GPU work).
+	if (c->transparent_dcomp_device) {
+		c->transparent_dcomp_device->Commit();
+	}
+}
+
 static xrt_result_t
 client_d3d11_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sync_handle)
 {
@@ -1031,6 +1092,9 @@ client_d3d11_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_syn
 				        (long long)(profile_t3 - profile_t0));
 			}
 		}
+		if (xret == XRT_SUCCESS) {
+			client_d3d11_transparent_present(c); // #551
+		}
 		return xret;
 	}
 
@@ -1054,6 +1118,9 @@ client_d3d11_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_syn
 	}
 
 	xret = xrt_comp_layer_commit(&c->xcn->base, XRT_GRAPHICS_SYNC_HANDLE_INVALID);
+	if (xret == XRT_SUCCESS) {
+		client_d3d11_transparent_present(c); // #551
+	}
 	return xret;
 }
 
@@ -1282,6 +1349,111 @@ try {
 			        "KeyedMutex path stays in effect.");
 		}
 	}
+
+	// #551 — transparent compositing output. If the service created a shared
+	// output texture for this (transparent) client, import it + the
+	// service→client fence and stand up a transparent DirectComposition swap
+	// chain on the app's own window. The per-frame present in layer_commit then
+	// lets DWM blend the LIVE desktop into the DP's alpha-gate holes. Non-fatal:
+	// any failure leaves the service's opaque present path in effect.
+	{
+		bool have_out = false, have_fence = false;
+		uint32_t tw = 0, th = 0;
+		uint64_t hwnd_val = 0;
+		xrt_graphics_buffer_handle_t tex_h = XRT_GRAPHICS_BUFFER_HANDLE_INVALID;
+		xrt_graphics_sync_handle_t fence_h = XRT_GRAPHICS_SYNC_HANDLE_INVALID;
+		xrt_result_t oret = comp_ipc_client_compositor_get_transparent_output(
+		    &xcn->base, &have_out, &tw, &th, &hwnd_val, &tex_h);
+		if (oret == XRT_SUCCESS && have_out && tex_h != XRT_GRAPHICS_BUFFER_HANDLE_INVALID &&
+		    hwnd_val != 0) {
+			(void)comp_ipc_client_compositor_get_transparent_output_fence(&xcn->base, &have_fence,
+			                                                             &fence_h);
+			HRESULT hr = c->app_device->OpenSharedResource1(
+			    (HANDLE)tex_h, IID_PPV_ARGS(c->transparent_output_texture.put()));
+			CloseHandle((HANDLE)tex_h); // imported; close our duped copy
+			wil::com_ptr<ID3D11Fence> ofence;
+			if (SUCCEEDED(hr) && have_fence && xrt_graphics_sync_handle_is_valid(fence_h)) {
+				try {
+					ofence = import_fence(*(c->app_device), (HANDLE)fence_h);
+				} catch (...) {
+				}
+			}
+			if (fence_h != XRT_GRAPHICS_SYNC_HANDLE_INVALID) {
+				CloseHandle((HANDLE)fence_h);
+			}
+			if (SUCCEEDED(hr) && ofence) {
+				c->transparent_output_fence = std::move(ofence);
+				HWND hwnd = (HWND)(uintptr_t)hwnd_val;
+				wil::com_ptr<IDXGIDevice> dxgiDev;
+				wil::com_ptr<IDXGIAdapter> adapter;
+				wil::com_ptr<IDXGIFactory2> factory;
+				hr = c->app_device->QueryInterface(IID_PPV_ARGS(dxgiDev.put()));
+				if (SUCCEEDED(hr)) {
+					hr = dxgiDev->GetAdapter(adapter.put());
+				}
+				if (SUCCEEDED(hr)) {
+					hr = adapter->GetParent(IID_PPV_ARGS(factory.put()));
+				}
+				DXGI_SWAP_CHAIN_DESC1 sd = {};
+				sd.Width = tw;
+				sd.Height = th;
+				sd.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+				sd.SampleDesc.Count = 1;
+				sd.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+				sd.BufferCount = 2;
+				sd.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+				sd.AlphaMode = DXGI_ALPHA_MODE_PREMULTIPLIED;
+				if (SUCCEEDED(hr)) {
+					hr = factory->CreateSwapChainForComposition(c->app_device.get(), &sd, nullptr,
+					                                            c->transparent_swapchain.put());
+				}
+				if (SUCCEEDED(hr)) {
+					hr = DCompositionCreateDevice2(
+					    nullptr, IID_PPV_ARGS(c->transparent_dcomp_device.put()));
+				}
+				if (SUCCEEDED(hr)) {
+					hr = c->transparent_dcomp_device->CreateTargetForHwnd(
+					    hwnd, TRUE, c->transparent_dcomp_target.put());
+				}
+				if (SUCCEEDED(hr)) {
+					hr = c->transparent_dcomp_device->CreateVisual(c->transparent_dcomp_visual.put());
+				}
+				if (SUCCEEDED(hr)) {
+					hr = c->transparent_dcomp_visual->SetContent(c->transparent_swapchain.get());
+				}
+				if (SUCCEEDED(hr)) {
+					hr = c->transparent_dcomp_target->SetRoot(c->transparent_dcomp_visual.get());
+				}
+				if (SUCCEEDED(hr)) {
+					hr = c->transparent_dcomp_device->Commit();
+				}
+				if (SUCCEEDED(hr)) {
+					c->transparent_hwnd = hwnd;
+					c->transparent_w = tw;
+					c->transparent_h = th;
+					c->transparent_present = true;
+					U_LOG_W("#551 client transparent present ready (hwnd=%p %ux%u) — DWM "
+					        "blends live desktop into the DP alpha-gate holes",
+					        (void *)hwnd, tw, th);
+				} else {
+					U_LOG_E("#551 client transparent present setup failed: 0x%08lx — service "
+					        "opaque present stays in effect",
+					        hr);
+					c->transparent_swapchain.reset();
+					c->transparent_dcomp_visual.reset();
+					c->transparent_dcomp_target.reset();
+					c->transparent_dcomp_device.reset();
+					c->transparent_output_fence.reset();
+					c->transparent_output_texture.reset();
+				}
+			} else {
+				c->transparent_output_texture.reset();
+			}
+		} else if (tex_h != XRT_GRAPHICS_BUFFER_HANDLE_INVALID) {
+			CloseHandle((HANDLE)tex_h);
+		}
+	}
+
 	c->base.base.get_swapchain_create_properties = client_d3d11_compositor_get_swapchain_create_properties;
 	c->base.base.create_swapchain = client_d3d11_create_swapchain;
 	c->base.base.create_passthrough = client_d3d11_compositor_passthrough_create;

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -246,6 +246,27 @@ struct d3d11_client_render_resources
 	wil::com_ptr<ID3D11SamplerState>     ck_sampler;
 	UINT                                  ck_intermediate_w;
 	UINT                                  ck_intermediate_h;
+
+	//! #551 — transparent compositing output for a forced-IPC transparent
+	//! client. The service can't present the app's cross-process window with
+	//! per-pixel alpha (DComp CreateTargetForHwnd is owner-only), so the DP
+	//! weaves into this SHARED NT-handle texture (its RTV reused as
+	//! back_buffer_rtv) instead of a swap chain; the service signals
+	//! transparent_output_fence after the weave; and the CLIENT (which owns the
+	//! window, in the app process) presents it via a transparent
+	//! DirectComposition swap chain so DWM blends the LIVE desktop into the
+	//! alpha-gate holes. Reusable for any IPC app requesting
+	//! transparentBackgroundEnabled (not zones-specific). texture == nullptr ⇒
+	//! ordinary opaque swap-chain present. The fence is the reverse direction
+	//! of workspace_sync_fence (service signals, client waits); both bump once
+	//! per commit, so the value stays in lockstep without per-frame IPC.
+	wil::com_ptr<ID3D11Texture2D>        transparent_output_texture;
+	HANDLE                                transparent_output_texture_handle; //!< NT handle for IPC export
+	wil::com_ptr<ID3D11Fence>            transparent_output_fence;
+	HANDLE                                transparent_output_fence_handle;   //!< NT handle for IPC export
+	uint64_t                              transparent_output_value;          //!< signaled once per commit
+	uint32_t                              transparent_output_w;
+	uint32_t                              transparent_output_h;
 };
 
 
@@ -2632,6 +2653,19 @@ fini_client_render_resources(struct d3d11_client_render_resources *res)
 	res->ck_ps.reset();
 	res->ck_vs.reset();
 
+	// #551 transparent output: close the source NT handles (DuplicateHandle'd
+	// copies in the client process are unaffected) and release the resources.
+	if (res->transparent_output_texture_handle != nullptr) {
+		CloseHandle(res->transparent_output_texture_handle);
+		res->transparent_output_texture_handle = nullptr;
+	}
+	if (res->transparent_output_fence_handle != nullptr) {
+		CloseHandle(res->transparent_output_fence_handle);
+		res->transparent_output_fence_handle = nullptr;
+	}
+	res->transparent_output_fence.reset();
+	res->transparent_output_texture.reset();
+
 	res->swap_chain.reset();
 
 	if (res->owns_window && res->window != nullptr) {
@@ -2815,6 +2849,61 @@ init_client_render_resources(struct d3d11_service_system *sys,
 	const bool use_transparent =
 	    transparent_hwnd && external_hwnd == nullptr && res->owns_window && !sys->workspace_mode;
 
+	// #551 — transparent compositing output for a cross-process app HWND: the
+	// service can't DComp-present the app's window (owner-only), so instead of
+	// a swap chain we weave into a SHARED texture and let the CLIENT (app
+	// process) present it transparently. Reusable for any IPC app that requests
+	// transparentBackgroundEnabled.
+	const bool use_client_transparent =
+	    transparent_hwnd && external_hwnd != nullptr && !sys->workspace_mode;
+	if (use_client_transparent) {
+		D3D11_TEXTURE2D_DESC od = {};
+		od.Width = actual_width;
+		od.Height = actual_height;
+		od.MipLevels = 1;
+		od.ArraySize = 1;
+		od.Format = DXGI_FORMAT_R8G8B8A8_UNORM; // premultiplied-alpha output the client presents
+		od.SampleDesc.Count = 1;
+		od.Usage = D3D11_USAGE_DEFAULT;
+		od.BindFlags = D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE;
+		od.MiscFlags = D3D11_RESOURCE_MISC_SHARED_NTHANDLE | D3D11_RESOURCE_MISC_SHARED;
+		hr = sys->device->CreateTexture2D(&od, nullptr, res->transparent_output_texture.put());
+		if (SUCCEEDED(hr)) {
+			hr = sys->device->CreateRenderTargetView(res->transparent_output_texture.get(), nullptr,
+			                                         res->back_buffer_rtv.put());
+		}
+		wil::com_ptr<IDXGIResource1> dxgi_res1;
+		if (SUCCEEDED(hr)) {
+			hr = res->transparent_output_texture->QueryInterface(IID_PPV_ARGS(dxgi_res1.put()));
+		}
+		if (SUCCEEDED(hr)) {
+			hr = dxgi_res1->CreateSharedHandle(nullptr,
+			                                   DXGI_SHARED_RESOURCE_READ | DXGI_SHARED_RESOURCE_WRITE,
+			                                   nullptr, &res->transparent_output_texture_handle);
+		}
+		// Service→client fence: service signals after the weave, client waits
+		// before presenting. Reverse direction of workspace_sync_fence.
+		if (SUCCEEDED(hr)) {
+			hr = sys->device->CreateFence(0, D3D11_FENCE_FLAG_SHARED,
+			                              IID_PPV_ARGS(res->transparent_output_fence.put()));
+		}
+		if (SUCCEEDED(hr)) {
+			hr = res->transparent_output_fence->CreateSharedHandle(
+			    nullptr, GENERIC_ALL, nullptr, &res->transparent_output_fence_handle);
+		}
+		if (FAILED(hr)) {
+			U_LOG_E("#551 transparent output: shared texture/fence create failed: 0x%08lx", hr);
+			fini_client_render_resources(res);
+			return XRT_ERROR_D3D11;
+		}
+		res->transparent_output_w = actual_width;
+		res->transparent_output_h = actual_height;
+		res->transparent_output_value = 0;
+		U_LOG_W("#551 transparent output: shared %ux%u texture + service→client fence ready "
+		        "(client presents via DComp; no service swap chain)",
+		        actual_width, actual_height);
+	} else {
+
 	DXGI_SWAP_CHAIN_DESC1 sc_desc = {};
 	sc_desc.Width = actual_width;
 	sc_desc.Height = actual_height;
@@ -2922,6 +3011,8 @@ init_client_render_resources(struct d3d11_service_system *sys,
 	res->swap_chain->GetBuffer(0, IID_PPV_ARGS(back_buffer.put()));
 	sys->device->CreateRenderTargetView(back_buffer.get(), nullptr, res->back_buffer_rtv.put());
 
+	} // end !use_client_transparent (swap-chain path)
+
 	// Create stereo render target texture (side-by-side views)
 	D3D11_TEXTURE2D_DESC atlas_desc = {};
 	atlas_desc.Width = sys->display_width;
@@ -2984,11 +3075,21 @@ init_client_render_resources(struct d3d11_service_system *sys,
 			// the DP runs out-of-process here. Falls back to the legacy
 			// set_chroma_key enable for a DP that predates the new slot.
 			if (transparent_hwnd) {
-				// Prefer the clean compose-under-bg enable (#551); fall back to
-				// the legacy chroma-key enable only for a DP that predates the
-				// slot. The DP logs the resulting transparency path.
-				if (!xrt_display_processor_d3d11_set_transparent_background(res->display_processor,
-				                                                            true)) {
+				// #551 — client_presents: when this client's frames reach the
+				// panel via a transparent DComp present (the #551 client-side
+				// IPC present for an external HWND, or the owns-window DComp
+				// path), DWM blends the LIVE desktop into the alpha-gate holes,
+				// so the DP must NOT compose-under-bg (that bakes a stale
+				// captured desktop = a frame of lag) — alpha-gate only. For an
+				// opaque present the DP owns see-through itself. Fall back to
+				// the legacy chroma-key enable for a DP that predates the slot.
+				bool client_presents = use_client_transparent || use_transparent;
+				bool tp_ok = xrt_display_processor_d3d11_set_transparent_background(
+				    res->display_processor, true, client_presents);
+				U_LOG_W("#551 DP transparency: client_presents=%d slot_present=%d%s",
+				        (int)client_presents, (int)tp_ok,
+				        tp_ok ? "" : " → chroma-key fallback");
+				if (!tp_ok) {
 					xrt_display_processor_d3d11_set_chroma_key(res->display_processor,
 					                                           chroma_key_color, true);
 				}
@@ -10863,6 +10964,16 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 		}
 	}
 
+	// #551 — transparent compositing output: no service swap chain. The DP has
+	// weaved (with alpha-gate holes) into the shared output texture; signal the
+	// service→client fence so the CLIENT can GPU-wait then present it via a
+	// transparent DComp swap chain on the app's own window. Bumped once per
+	// commit, in lockstep with the client's wait counter (no per-frame IPC).
+	if (c->render.transparent_output_texture != nullptr && c->render.transparent_output_fence != nullptr) {
+		c->render.transparent_output_value++;
+		sys->context->Signal(c->render.transparent_output_fence.get(), c->render.transparent_output_value);
+	}
+
 	// Present to display
 	if (c->render.swap_chain) {
 		c->render.swap_chain->Present(1, 0);  // VSync
@@ -11033,6 +11144,64 @@ comp_d3d11_service_compositor_set_workspace_sync_fence_value(struct xrt_composit
 	}
 	struct d3d11_service_compositor *c = d3d11_service_compositor_from_xrt(xc);
 	c->last_signaled_fence_value.store(value, std::memory_order_release);
+}
+
+// #551 — export the shared transparent-output texture handle (+ its dims) for
+// the IPC client to import and present transparently. The IPC machinery
+// DuplicateHandle's the source NT handle into the client process; the source
+// stays owned here and is closed on teardown.
+extern "C" bool
+comp_d3d11_service_compositor_export_transparent_output(struct xrt_compositor *xc,
+                                                        xrt_graphics_buffer_handle_t *out_handle,
+                                                        uint32_t *out_width,
+                                                        uint32_t *out_height,
+                                                        uint64_t *out_hwnd)
+{
+	if (out_handle == nullptr) {
+		return false;
+	}
+	*out_handle = XRT_GRAPHICS_BUFFER_HANDLE_INVALID;
+	if (xc == nullptr || xc->destroy != compositor_destroy) {
+		return false;
+	}
+	struct d3d11_service_compositor *c = d3d11_service_compositor_from_xrt(xc);
+	if (c->render.transparent_output_texture_handle == nullptr) {
+		return false;
+	}
+	*out_handle = (xrt_graphics_buffer_handle_t)c->render.transparent_output_texture_handle;
+	if (out_width != nullptr) {
+		*out_width = c->render.transparent_output_w;
+	}
+	if (out_height != nullptr) {
+		*out_height = c->render.transparent_output_h;
+	}
+	// The app's own window (process-agnostic HWND value) so the client — which
+	// owns it — can CreateTargetForHwnd for the transparent present.
+	if (out_hwnd != nullptr) {
+		HWND wnd = c->render.hwnd != nullptr ? c->render.hwnd : c->app_hwnd;
+		*out_hwnd = (uint64_t)(uintptr_t)wnd;
+	}
+	return true;
+}
+
+// #551 — export the service→client transparent-output fence handle.
+extern "C" bool
+comp_d3d11_service_compositor_export_transparent_output_fence(struct xrt_compositor *xc,
+                                                              xrt_graphics_sync_handle_t *out_handle)
+{
+	if (out_handle == nullptr) {
+		return false;
+	}
+	*out_handle = XRT_GRAPHICS_SYNC_HANDLE_INVALID;
+	if (xc == nullptr || xc->destroy != compositor_destroy) {
+		return false;
+	}
+	struct d3d11_service_compositor *c = d3d11_service_compositor_from_xrt(xc);
+	if (c->render.transparent_output_fence_handle == nullptr) {
+		return false;
+	}
+	*out_handle = (xrt_graphics_sync_handle_t)c->render.transparent_output_fence_handle;
+	return true;
 }
 
 

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -2801,13 +2801,19 @@ init_client_render_resources(struct d3d11_service_system *sys,
 	//
 	// Default: flip-model + ALPHA_MODE_IGNORE (#163) — opaque present, no DWM bleed-through.
 	// Transparent opt-in: flip-model + ALPHA_MODE_PREMULTIPLIED via
-	// CreateSwapChainForComposition, bound to the app's HWND through
-	// DirectComposition. DWM blends per-pixel (no chroma key, no
-	// disocclusion fringe, no LWA_COLORKEY required on the plugin side).
-	// Only meaningful when the app owns the HWND and we're not in
-	// workspace/shell mode (workspace path uses a service-owned compositor window).
+	// CreateSwapChainForComposition, bound through DirectComposition.
+	//
+	// #551: DComp's CreateTargetForHwnd can only bind a window THIS process
+	// owns. In the service an app-provided HWND is ALWAYS cross-process, so
+	// that call returns E_ACCESSDENIED and the whole session create fails —
+	// the previous `external_hwnd != nullptr` trigger was structurally dead.
+	// See-through for a vendor DP doesn't need DComp: the DP composites its
+	// weave over the captured desktop (compose-under-bg, from the atlas alpha)
+	// and the opaque present shows it. So restrict the DComp route to a
+	// RUNTIME-owned window (hosted/WebXR); an external app HWND presents opaque
+	// and the DP owns transparency (see set_transparent_background below).
 	const bool use_transparent =
-	    transparent_hwnd && external_hwnd != nullptr && !sys->workspace_mode;
+	    transparent_hwnd && external_hwnd == nullptr && res->owns_window && !sys->workspace_mode;
 
 	DXGI_SWAP_CHAIN_DESC1 sc_desc = {};
 	sc_desc.Width = actual_width;
@@ -2824,9 +2830,12 @@ init_client_render_resources(struct d3d11_service_system *sys,
 		sc_desc.AlphaMode = DXGI_ALPHA_MODE_IGNORE;
 	}
 	if (transparent_hwnd && !use_transparent) {
-		U_LOG_W("Transparent HWND requested but ignored "
-		        "(external_hwnd=%p, workspace_mode=%d)",
-		        external_hwnd, (int)sys->workspace_mode);
+		// Not an error for an external app HWND: the opaque present is correct
+		// and see-through comes from the DP compose-under-bg (#551), not DComp.
+		U_LOG_W(
+		    "Transparent HWND requested: DComp present skipped "
+		    "(external_hwnd=%p owns_window=%d workspace=%d) — DP owns see-through",
+		    external_hwnd, (int)res->owns_window, (int)sys->workspace_mode);
 	}
 
 	if (use_transparent) {
@@ -2965,6 +2974,26 @@ init_client_render_resources(struct d3d11_service_system *sys,
 			res->display_processor = nullptr;
 		} else {
 			U_LOG_W("D3D11 display processor created via factory for client");
+
+			// #551: enable the DP's transparent compose-under-bg for a
+			// transparent client. The runtime already hands the DP a
+			// premultiplied-transparent atlas; this is the policy signal that
+			// tells the DP to composite its weave over the captured desktop
+			// (chroma-key-free). The app window's capture-exclusion affinity is
+			// set client-side (window-owning process) so this works even though
+			// the DP runs out-of-process here. Falls back to the legacy
+			// set_chroma_key enable for a DP that predates the new slot.
+			if (transparent_hwnd) {
+				// Prefer the clean compose-under-bg enable (#551); fall back to
+				// the legacy chroma-key enable only for a DP that predates the
+				// slot. The DP logs the resulting transparency path.
+				if (!xrt_display_processor_d3d11_set_transparent_background(res->display_processor,
+				                                                            true)) {
+					xrt_display_processor_d3d11_set_chroma_key(res->display_processor,
+					                                           chroma_key_color, true);
+				}
+			}
+
 			// Phase 6.1 (#140): don't call request_display_mode(true)
 			// here — the SR SDK's recalibration cycle causes a multi-
 			// second stretched-left-eye artifact. Let the DP come up in

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -365,6 +365,24 @@ struct d3d11_service_compositor
 	int64_t fence_window_start_ns;
 	uint32_t fence_waits_queued_in_window;
 	uint32_t fence_stale_views_in_window;
+
+	//! XR_EXT_display_zones (#551) — standalone wish-over-IPC publish state.
+	//! Mirrors the in-process auto-wish raster (comp_d3d11_compositor's
+	//! d3d11_update_zone_wish_mask): an R8_UNORM union-of-zone-rects mask
+	//! with a feathered ring, rasterized at commit on the shared immediate
+	//! context (under sys->render_mutex) and published to this client's DP.
+	//! Workspace mode never touches any of this (wish INERT, ADR-027 v1).
+	wil::com_ptr<ID3D11Texture2D> wish_mask_tex; //!< RENDER_TARGET raster target
+	wil::com_ptr<ID3D11RenderTargetView> wish_mask_rtv;
+	wil::com_ptr<ID3D11Texture2D> wish_mask_staged; //!< SHADER_RESOURCE copy the DP samples
+	wil::com_ptr<ID3D11ShaderResourceView> wish_mask_staged_srv;
+	uint32_t wish_mask_w;
+	uint32_t wish_mask_h;
+	struct xrt_rect wish_rects[XRT_MAX_LAYERS]; //!< last rasterized rects (dirty check)
+	uint32_t wish_rect_count;
+	uint64_t zone_publish_seq;  //!< mask content generation (bumped per re-raster)
+	bool zone_published;        //!< a mask is live at the DP (clear on non-zones frames / teardown)
+	bool zone_mask_dp_rejected; //!< DP rejected the publish — tier-1 hardware request owns the panel
 };
 
 /*!
@@ -8318,9 +8336,9 @@ zones_resolve_src_srv(struct d3d11_service_system *sys,
  * the canvas (window client area) maps onto the slot by a downscale-only
  * factor, and the resulting content dims feed the same slot bookkeeping the
  * projection path uses. The in-process model is comp_d3d11_renderer's
- * XRT_LAYER_ZONE_3D case. The wish stays on the tier-1 global fallback here
- * (workspace wish is INERT in v1 per ADR-027; the standalone wish-over-IPC
- * publish is a scope-split follow-up).
+ * XRT_LAYER_ZONE_3D case. The standalone wish rides
+ * service_update_zone_wish_publish below (#551); workspace wish is INERT in
+ * v1 per ADR-027.
  *
  * Caller MUST hold sys->render_mutex — the shader blits run on the immediate
  * context from the commit thread and would otherwise race the capture-render
@@ -8601,20 +8619,258 @@ service_composite_zones_frame(struct d3d11_service_system *sys,
 		acquired[a].sc->images[acquired[a].img].keyed_mutex->ReleaseSync(0);
 	}
 
-	// One-shot breadcrumb so a bug report shows the composite geometry.
-	static bool composite_logged = false;
-	if (!composite_logged) {
-		composite_logged = true;
-		U_LOG_W("ZONES SVC: first zones-frame composite, canvas=%ux%u scale=%.3f zones=%u local2d=%u "
-		        "slot=%ux%u content=%ux%u blits=%u skipped=%u workspace=%d",
-		        canvas_w, canvas_h, scale, zone_count, local2d_count,
-		        slot_w, slot_h, content_w, content_h, blits_done, views_skipped,
-		        sys->workspace_mode ? 1 : 0);
+	// One-shot-per-shape breadcrumb so a bug report shows the composite
+	// geometry. Re-logs when the blit count changes (e.g. a standalone zones
+	// client starting in a 1-view mode picks up the tier-1 mode flip a frame
+	// later and begins submitting every view, #551) — never per-frame.
+	static uint32_t composite_logged_blits = UINT32_MAX;
+	if (composite_logged_blits != blits_done) {
+		composite_logged_blits = blits_done;
+		U_LOG_W(
+		    "ZONES SVC: zones-frame composite, canvas=%ux%u scale=%.3f zones=%u local2d=%u "
+		    "slot=%ux%u content=%ux%u blits=%u skipped=%u workspace=%d",
+		    canvas_w, canvas_h, scale, zone_count, local2d_count, slot_w, slot_h, content_w, content_h,
+		    blits_done, views_skipped, sys->workspace_mode ? 1 : 0);
 	}
 
 	*out_content_view_w = content_w;
 	*out_content_view_h = content_h;
 	return true;
+}
+
+// XR_EXT_display_zones (#551) — standalone wish-over-IPC publish. Mirrors the
+// in-process auto-wish (comp_d3d11_compositor.cpp): same feather geometry, so
+// a zone weaves identically on both paths.
+#define SVC_ZONE_WISH_FEATHER_STEPS 8
+#define SVC_ZONE_WISH_FEATHER_STEP_PX 2
+
+/*!
+ * Whether this client's DP exposes the local-zone-mask entry (vtable slot
+ * present and filled). Decides tier-1 demotion: a mask-capable DP gets the
+ * published wish instead of the global hardware 3D request.
+ */
+static bool
+service_dp_accepts_zone_mask(struct xrt_display_processor_d3d11 *xdp)
+{
+	return xdp != nullptr && XRT_DP_HAS_SLOT(xdp, publish_local_zone_mask) && xdp->publish_local_zone_mask != NULL;
+}
+
+/*!
+ * (Re)rasterize the union of @p rects into the per-client R8_UNORM wish mask
+ * with an inward feathered ring (M ramps 0→1 over STEPS×STEP_PX), then copy
+ * to the SRV-only staged texture the DP samples. Dirty-tracked: an unchanged
+ * rect set returns the existing staged SRV without GPU work. Port of the
+ * in-process d3d11_update_zone_wish_mask.
+ *
+ * Caller MUST hold sys->render_mutex — ClearView/CopyResource run on the
+ * shared immediate context from the commit thread.
+ *
+ * Returns the staged SRV, or nullptr on failure / empty input.
+ */
+static ID3D11ShaderResourceView *
+service_update_zone_wish_mask(struct d3d11_service_system *sys,
+                              struct d3d11_service_compositor *c,
+                              const struct xrt_rect *rects,
+                              uint32_t rect_count,
+                              uint32_t w,
+                              uint32_t h)
+{
+	if (w == 0 || h == 0 || rect_count == 0) {
+		return nullptr;
+	}
+
+	bool dirty = c->wish_mask_tex == nullptr || c->wish_mask_staged_srv == nullptr || c->wish_mask_w != w ||
+	             c->wish_mask_h != h || c->wish_rect_count != rect_count;
+	for (uint32_t i = 0; !dirty && i < rect_count; i++) {
+		if (memcmp(&c->wish_rects[i], &rects[i], sizeof(rects[i])) != 0) {
+			dirty = true;
+		}
+	}
+	if (!dirty) {
+		return c->wish_mask_staged_srv.get();
+	}
+
+	if (c->wish_mask_tex == nullptr || c->wish_mask_w != w || c->wish_mask_h != h) {
+		c->wish_mask_staged_srv.reset();
+		c->wish_mask_staged.reset();
+		c->wish_mask_rtv.reset();
+		c->wish_mask_tex.reset();
+		c->wish_mask_w = 0;
+		c->wish_mask_h = 0;
+
+		D3D11_TEXTURE2D_DESC td = {};
+		td.Width = w;
+		td.Height = h;
+		td.MipLevels = 1;
+		td.ArraySize = 1;
+		td.Format = DXGI_FORMAT_R8_UNORM;
+		td.SampleDesc.Count = 1;
+		td.Usage = D3D11_USAGE_DEFAULT;
+		td.BindFlags = D3D11_BIND_RENDER_TARGET;
+		HRESULT hr = sys->device->CreateTexture2D(&td, nullptr, c->wish_mask_tex.put());
+		if (SUCCEEDED(hr) && c->wish_mask_tex != nullptr) {
+			hr = sys->device->CreateRenderTargetView(c->wish_mask_tex.get(), nullptr,
+			                                         c->wish_mask_rtv.put());
+		}
+		if (SUCCEEDED(hr) && c->wish_mask_rtv != nullptr) {
+			td.BindFlags = D3D11_BIND_SHADER_RESOURCE;
+			hr = sys->device->CreateTexture2D(&td, nullptr, c->wish_mask_staged.put());
+		}
+		if (SUCCEEDED(hr) && c->wish_mask_staged != nullptr) {
+			hr = sys->device->CreateShaderResourceView(c->wish_mask_staged.get(), nullptr,
+			                                           c->wish_mask_staged_srv.put());
+		}
+		if (FAILED(hr) || c->wish_mask_staged_srv == nullptr) {
+			U_LOG_E("ZONES SVC: wish mask D3D resource creation failed: 0x%08lx", hr);
+			c->wish_mask_staged_srv.reset();
+			c->wish_mask_staged.reset();
+			c->wish_mask_rtv.reset();
+			c->wish_mask_tex.reset();
+			return nullptr;
+		}
+		c->wish_mask_w = w;
+		c->wish_mask_h = h;
+	}
+
+	const float all_off[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+	sys->context->ClearRenderTargetView(c->wish_mask_rtv.get(), all_off);
+
+	wil::com_ptr<ID3D11DeviceContext1> ctx1;
+	HRESULT hr = sys->context->QueryInterface(__uuidof(ID3D11DeviceContext1), ctx1.put_void());
+	if (FAILED(hr) || ctx1 == nullptr) {
+		U_LOG_E("ZONES SVC: wish mask: ID3D11DeviceContext1 unavailable (hr=0x%08lx)", hr);
+		return nullptr;
+	}
+	for (int32_t s = 1; s <= SVC_ZONE_WISH_FEATHER_STEPS; s++) {
+		const float v = (float)s / (float)SVC_ZONE_WISH_FEATHER_STEPS;
+		const float val[4] = {v, 0.0f, 0.0f, 0.0f};
+		for (uint32_t i = 0; i < rect_count; i++) {
+			// Per-zone inset clamp: zones smaller than the feather
+			// collapse the deeper rings onto one core so the center
+			// still reaches M=1.
+			int32_t min_ext = rects[i].extent.w < rects[i].extent.h ? rects[i].extent.w : rects[i].extent.h;
+			int32_t max_inset = (min_ext - 1) / 2;
+			if (max_inset < 0) {
+				max_inset = 0;
+			}
+			int32_t inset = s * SVC_ZONE_WISH_FEATHER_STEP_PX;
+			if (inset > max_inset) {
+				inset = max_inset;
+			}
+			int32_t left = rects[i].offset.w + inset;
+			int32_t top = rects[i].offset.h + inset;
+			int32_t right = rects[i].offset.w + rects[i].extent.w - inset;
+			int32_t bottom = rects[i].offset.h + rects[i].extent.h - inset;
+			if (left < 0) {
+				left = 0;
+			}
+			if (top < 0) {
+				top = 0;
+			}
+			if (right > (int32_t)w) {
+				right = (int32_t)w;
+			}
+			if (bottom > (int32_t)h) {
+				bottom = (int32_t)h;
+			}
+			if (right <= left || bottom <= top) {
+				continue;
+			}
+			D3D11_RECT dr = {left, top, right, bottom};
+			ctx1->ClearView(c->wish_mask_rtv.get(), val, &dr, 1);
+		}
+	}
+
+	sys->context->CopyResource(c->wish_mask_staged.get(), c->wish_mask_tex.get());
+
+	memcpy(c->wish_rects, rects, sizeof(rects[0]) * rect_count);
+	c->wish_rect_count = rect_count;
+	c->zone_publish_seq++; // new wish content generation
+
+	U_LOG_W("ZONES SVC: wish mask (auto): %ux%u, %u zone rect(s), %u-px feather", w, h, rect_count,
+	        SVC_ZONE_WISH_FEATHER_STEPS * SVC_ZONE_WISH_FEATHER_STEP_PX);
+	return c->wish_mask_staged_srv.get();
+}
+
+/*!
+ * Per-commit wish maintenance for the standalone path: on a zones frame,
+ * rasterize the auto wish (union of the frame's zone-3D rects, the same
+ * source the in-process auto path consumes) and publish it screen-anchored
+ * to this client's DP; on a non-zones frame, withdraw a previously published
+ * mask. Workspace mode is fully inert here (ADR-027 v1) — the caller gates.
+ *
+ * If the DP rejects the publish at runtime (slot present but vendor said no),
+ * fall back to the tier-1 global hardware 3D request once — the tier-1 block
+ * skipped it expecting the mask to drive the panel.
+ */
+static void
+service_update_zone_wish_publish(struct d3d11_service_system *sys, struct d3d11_service_compositor *c, bool zones_frame)
+{
+	struct xrt_display_processor_d3d11 *dp = c->render.display_processor;
+
+	if (!zones_frame) {
+		if (c->zone_published && dp != nullptr) {
+			std::lock_guard<std::recursive_mutex> lock(sys->render_mutex);
+			xrt_display_processor_d3d11_clear_local_zone_mask(dp);
+			c->zone_published = false;
+		}
+		return;
+	}
+
+	if (!service_dp_accepts_zone_mask(dp) || c->zone_mask_dp_rejected) {
+		return; // tier-1 global request owns the panel
+	}
+
+	// Screen-anchor: client-area origin in physical screen pixels. No HWND
+	// (hosted/texture client) → nothing to anchor to; skip the publish.
+	HWND wnd = c->render.hwnd != nullptr ? c->render.hwnd : c->app_hwnd;
+	RECT r;
+	POINT origin = {0, 0};
+	if (wnd == nullptr || !IsWindow(wnd) || !GetClientRect(wnd, &r) || r.right <= 0 || r.bottom <= 0 ||
+	    !ClientToScreen(wnd, &origin)) {
+		return;
+	}
+	uint32_t w = (uint32_t)r.right;
+	uint32_t h = (uint32_t)r.bottom;
+
+	struct xrt_rect rects[XRT_MAX_LAYERS];
+	uint32_t rect_count = 0;
+	for (uint32_t i = 0; i < c->layer_accum.layer_count && rect_count < XRT_MAX_LAYERS; i++) {
+		if (c->layer_accum.layers[i].data.type != XRT_LAYER_ZONE_3D) {
+			continue;
+		}
+		rects[rect_count++] = c->layer_accum.layers[i].data.zone_3d.rect;
+	}
+	if (rect_count == 0) {
+		return;
+	}
+
+	std::lock_guard<std::recursive_mutex> lock(sys->render_mutex);
+	ID3D11ShaderResourceView *srv = service_update_zone_wish_mask(sys, c, rects, rect_count, w, h);
+	if (srv == nullptr) {
+		return;
+	}
+
+	// Published every zones commit: the screen anchor follows the window;
+	// seq is the content generation, so a vendor's content evaluation runs
+	// once per re-raster, not once per frame.
+	bool ok = xrt_display_processor_d3d11_publish_local_zone_mask(
+	    dp, sys->context.get(), srv, w, h, (int32_t)origin.x, (int32_t)origin.y, w, h, c->zone_publish_seq);
+	if (ok) {
+		if (!c->zone_published) {
+			U_LOG_W(
+			    "ZONES SVC: wish mask published to the per-client DP "
+			    "(%ux%u @ screen %ld,%ld, %u zone rect(s))",
+			    w, h, origin.x, origin.y, rect_count);
+		}
+		c->zone_published = true;
+	} else if (!c->zone_mask_dp_rejected) {
+		c->zone_mask_dp_rejected = true;
+		U_LOG_W(
+		    "ZONES SVC: DP rejected the wish mask publish — falling back to the "
+		    "tier-1 global 3D request");
+		xrt_display_processor_d3d11_request_display_mode(dp, true);
+	}
 }
 
 
@@ -9037,6 +9293,19 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 			got_state = true;
 		}
 
+		// Suppress vendor-poll counter-correction while this client's
+		// published wish mask drives the panel (#551): under a mask the
+		// vendor's GLOBAL 3D state legitimately reads 2D (the lens is
+		// owned per-zone by the mask), so following it would flip the MODE
+		// back to 2D and the next zones frame would re-arm the zones mode
+		// flip — a 1↔0 flap every cooldown interval. Tracking-loss 2D
+		// fallback inside mask regions is the vendor's per-zone business.
+		// Withdrawing the mask (non-zones frames / teardown) re-enables
+		// the poll on the next window.
+		if (got_state && c->zone_published) {
+			got_state = false;
+		}
+
 		if (got_state) {
 			// Suppress vendor-poll detection while an acked-flip is in progress
 			// (#234). During WAITING_ACK / FLIPPING the workspace has written
@@ -9216,7 +9485,16 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 				uint32_t prev_idx = zhead->hmd->active_rendering_mode_index;
 				zhead->hmd->active_rendering_mode_index = mode_idx;
 				broadcast_rendering_mode_change(sys, zhead, prev_idx, mode_idx);
-				if (c->render.display_processor != nullptr) {
+				// Tier-1 demotion (#551): a mask-capable DP gets the
+				// published per-zone wish instead of the global hardware
+				// 3D request — the mask drives the panel, exactly like
+				// the in-process path. The MODE flip above stays either
+				// way (the multi-view atlas recipe is the mode's). If the
+				// DP later rejects the publish at runtime, the publish
+				// helper issues this request as the fallback.
+				bool mask_capable = service_dp_accepts_zone_mask(c->render.display_processor) &&
+				                    !c->zone_mask_dp_rejected;
+				if (c->render.display_processor != nullptr && !mask_capable) {
 					xrt_display_processor_d3d11_request_display_mode(
 					    c->render.display_processor, true);
 				}
@@ -9233,9 +9511,12 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 				static bool zones_3d_logged = false;
 				if (!zones_3d_logged) {
 					zones_3d_logged = true;
-					U_LOG_W("ZONES SVC: zones frame on the standalone path — tier-1 global 3D "
-					        "(mode %u -> %u)",
-					        prev_idx, mode_idx);
+					U_LOG_W(
+					    "ZONES SVC: zones frame on the standalone path — %s "
+					    "(mode %u -> %u)",
+					    mask_capable ? "mode flip, panel driven by the published wish"
+					                 : "tier-1 global 3D",
+					    prev_idx, mode_idx);
 				}
 			}
 		}
@@ -9999,6 +10280,14 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 		}
 	}
 
+	// XR_EXT_display_zones (#551): standalone wish-over-IPC publish — the
+	// per-zone Tier-2 leg the tier-1 block above is the fallback for. Runs
+	// on EVERY standalone commit (a non-zones frame withdraws a previously
+	// published mask). Workspace clients stay inert per ADR-027 v1.
+	if (!sys->workspace_mode) {
+		service_update_zone_wish_publish(sys, c, zones_frame);
+	}
+
 	// Render UI layers if any exist and shaders are ready
 	if (has_ui_layers && sys->quad_vs) {
 		// Bind per-client stereo render target
@@ -10270,6 +10559,12 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 		c->pending_workspace_reentry = false;
 
 		if (c->render.display_processor != nullptr) {
+			// Withdraw the standalone zone-mask contribution before the
+			// DP goes away (#551) — workspace mode keeps the wish inert.
+			if (c->zone_published) {
+				xrt_display_processor_d3d11_clear_local_zone_mask(c->render.display_processor);
+				c->zone_published = false;
+			}
 			xrt_display_processor_d3d11_request_display_mode(c->render.display_processor, false);
 			xrt_display_processor_d3d11_destroy(&c->render.display_processor);
 		}
@@ -10629,6 +10924,13 @@ compositor_destroy(struct xrt_compositor *xc)
 			}
 		}
 
+		// Withdraw this client's zone-mask contribution while the DP is
+		// still alive (#551) — equivalent to publishing an all-zero mask.
+		if (c->zone_published && c->render.display_processor != nullptr) {
+			xrt_display_processor_d3d11_clear_local_zone_mask(c->render.display_processor);
+			c->zone_published = false;
+		}
+
 		// Tear down per-client render resources (window, swap chain, DP,
 		// atlas textures / SRVs / RTVs) while still holding render_mutex.
 		fini_client_render_resources(&c->render);
@@ -10650,6 +10952,10 @@ compositor_destroy(struct xrt_compositor *xc)
 			if (sys->active_compositor == c) {
 				sys->active_compositor = nullptr;
 			}
+		}
+		if (c->zone_published && c->render.display_processor != nullptr) {
+			xrt_display_processor_d3d11_clear_local_zone_mask(c->render.display_processor);
+			c->zone_published = false;
 		}
 		fini_client_render_resources(&c->render);
 		if (c->workspace_sync_fence_handle != nullptr) {

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.h
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.h
@@ -892,6 +892,27 @@ comp_d3d11_service_compositor_export_workspace_sync_fence(struct xrt_compositor 
 void
 comp_d3d11_service_compositor_set_workspace_sync_fence_value(struct xrt_compositor *xc, uint64_t value);
 
+/*!
+ * #551 — export the per-client SHARED transparent-output texture handle (+ its
+ * pixel dims) for the IPC client to import and present transparently via its
+ * own DirectComposition swap chain. Returns false when @p xc is not a D3D11
+ * service compositor or the client did not request a transparent background.
+ */
+bool
+comp_d3d11_service_compositor_export_transparent_output(struct xrt_compositor *xc,
+                                                        xrt_graphics_buffer_handle_t *out_handle,
+                                                        uint32_t *out_width,
+                                                        uint32_t *out_height,
+                                                        uint64_t *out_hwnd);
+
+/*!
+ * #551 — export the service→client transparent-output fence handle (the service
+ * signals it after each weave; the client GPU-waits before presenting).
+ */
+bool
+comp_d3d11_service_compositor_export_transparent_output_fence(struct xrt_compositor *xc,
+                                                              xrt_graphics_sync_handle_t *out_handle);
+
 /*! @} */
 
 

--- a/src/xrt/include/xrt/xrt_display_processor_d3d11.h
+++ b/src/xrt/include/xrt/xrt_display_processor_d3d11.h
@@ -313,6 +313,28 @@ struct xrt_display_processor_d3d11
 	 * @param mode  0 = MANAGED, 1 = MANUAL.
 	 */
 	void (*set_eye_tracking_mode)(struct xrt_display_processor_d3d11 *xdp, uint32_t mode);
+
+	/*!
+	 * Enable/disable transparent-background output for this client (#551).
+	 * When enabled, the DP composites its weave OVER the captured desktop
+	 * behind the app window (compose-under-background, from the atlas's
+	 * premultiplied alpha) so transparent atlas regions show the desktop —
+	 * the chroma-key-free path. This is the policy signal; the runtime
+	 * separately guarantees the app window is excluded from the DP's desktop
+	 * capture (SetWindowDisplayAffinity(WDA_EXCLUDEFROMCAPTURE), set from the
+	 * window-owning process so it works even when the DP runs out-of-process
+	 * in the service for an IPC client).
+	 *
+	 * Supersedes @ref set_chroma_key as the transparency enable: a DP that
+	 * exposes this slot should drive compose-under here and treat
+	 * set_chroma_key purely as the legacy fallback color. Optional — absent
+	 * slot or NULL ⟹ the runtime falls back to set_chroma_key. Appended per
+	 * ADR-020 (append-only within a major).
+	 *
+	 * @param xdp      Pointer to self.
+	 * @param enabled  true to composite over the captured desktop.
+	 */
+	void (*set_transparent_background)(struct xrt_display_processor_d3d11 *xdp, bool enabled);
 };
 
 /*
@@ -363,7 +385,8 @@ XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, publish_local_zon
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, clear_local_zone_mask)        == XRT_DP_D3D11_BASE_OFF + 14 * sizeof(void *), XRT_DP_ABI_MSG);
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, set_background_2d)            == XRT_DP_D3D11_BASE_OFF + 15 * sizeof(void *), XRT_DP_ABI_MSG);
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, set_eye_tracking_mode)        == XRT_DP_D3D11_BASE_OFF + 16 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(sizeof(struct xrt_display_processor_d3d11)                                == XRT_DP_D3D11_BASE_OFF + 17 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, set_transparent_background)    == XRT_DP_D3D11_BASE_OFF + 17 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(sizeof(struct xrt_display_processor_d3d11)                                == XRT_DP_D3D11_BASE_OFF + 18 * sizeof(void *), XRT_DP_ABI_MSG);
 // clang-format on
 
 /*!
@@ -629,6 +652,22 @@ xrt_display_processor_d3d11_set_eye_tracking_mode(struct xrt_display_processor_d
 		return;
 	}
 	xdp->set_eye_tracking_mode(xdp, mode);
+}
+
+/*!
+ * @copydoc xrt_display_processor_d3d11::set_transparent_background
+ * Returns false if not supported (slot absent or NULL) — the caller then
+ * falls back to @ref xrt_display_processor_d3d11_set_chroma_key.
+ * @public @memberof xrt_display_processor_d3d11
+ */
+static inline bool
+xrt_display_processor_d3d11_set_transparent_background(struct xrt_display_processor_d3d11 *xdp, bool enabled)
+{
+	if (!XRT_DP_HAS_SLOT(xdp, set_transparent_background) || xdp->set_transparent_background == NULL) {
+		return false;
+	}
+	xdp->set_transparent_background(xdp, enabled);
+	return true;
 }
 
 /*!

--- a/src/xrt/include/xrt/xrt_display_processor_d3d11.h
+++ b/src/xrt/include/xrt/xrt_display_processor_d3d11.h
@@ -331,10 +331,20 @@ struct xrt_display_processor_d3d11
 	 * slot or NULL ⟹ the runtime falls back to set_chroma_key. Appended per
 	 * ADR-020 (append-only within a major).
 	 *
-	 * @param xdp      Pointer to self.
-	 * @param enabled  true to composite over the captured desktop.
+	 * @param xdp             Pointer to self.
+	 * @param enabled         true to produce transparent output for see-through.
+	 * @param client_presents true ⟹ the RUNTIME owns a transparent present that
+	 *                        DWM-blends the live desktop into alpha=0 holes (the
+	 *                        in-process transparent swap chain, or the #551
+	 *                        client-side IPC present). The DP must then NOT do
+	 *                        its own compose-under-bg (which would bake a stale
+	 *                        captured desktop and add a frame of lag) — it only
+	 *                        reconstructs alpha (the alpha-gate) so the present
+	 *                        can blend the live desktop. false ⟹ the DP owns
+	 *                        see-through itself (compose-under-bg / chroma-key)
+	 *                        because the final present is opaque.
 	 */
-	void (*set_transparent_background)(struct xrt_display_processor_d3d11 *xdp, bool enabled);
+	void (*set_transparent_background)(struct xrt_display_processor_d3d11 *xdp, bool enabled, bool client_presents);
 };
 
 /*
@@ -661,12 +671,14 @@ xrt_display_processor_d3d11_set_eye_tracking_mode(struct xrt_display_processor_d
  * @public @memberof xrt_display_processor_d3d11
  */
 static inline bool
-xrt_display_processor_d3d11_set_transparent_background(struct xrt_display_processor_d3d11 *xdp, bool enabled)
+xrt_display_processor_d3d11_set_transparent_background(struct xrt_display_processor_d3d11 *xdp,
+                                                       bool enabled,
+                                                       bool client_presents)
 {
 	if (!XRT_DP_HAS_SLOT(xdp, set_transparent_background) || xdp->set_transparent_background == NULL) {
 		return false;
 	}
-	xdp->set_transparent_background(xdp, enabled);
+	xdp->set_transparent_background(xdp, enabled, client_presents);
 	return true;
 }
 

--- a/src/xrt/ipc/client/ipc_client.h
+++ b/src/xrt/ipc/client/ipc_client.h
@@ -174,6 +174,31 @@ void
 comp_ipc_client_compositor_set_workspace_sync_fence_value(struct xrt_compositor *xc, uint64_t value);
 
 /*!
+ * #551 — fetch the per-client SHARED transparent-output texture handle (+ its
+ * pixel dims) the service weaves into, for the client to present transparently
+ * via its own DirectComposition swap chain. `out_have_output` is false unless
+ * the native compositor is the D3D11 service compositor AND the client
+ * requested a transparent background. Same gating contract as the workspace
+ * fence accessors.
+ */
+xrt_result_t
+comp_ipc_client_compositor_get_transparent_output(struct xrt_compositor *xc,
+                                                  bool *out_have_output,
+                                                  uint32_t *out_width,
+                                                  uint32_t *out_height,
+                                                  uint64_t *out_hwnd,
+                                                  xrt_graphics_buffer_handle_t *out_handle);
+
+/*!
+ * #551 — fetch the service→client transparent-output fence handle (service
+ * signals after each weave; client GPU-waits before presenting).
+ */
+xrt_result_t
+comp_ipc_client_compositor_get_transparent_output_fence(struct xrt_compositor *xc,
+                                                        bool *out_have_fence,
+                                                        xrt_graphics_sync_handle_t *out_handle);
+
+/*!
  * Workspace controller bridges (XR_EXT_spatial_workspace).
  *
  * Thin accessors used by the OpenXR state tracker to dispatch workspace

--- a/src/xrt/ipc/client/ipc_client_compositor.c
+++ b/src/xrt/ipc/client/ipc_client_compositor.c
@@ -373,6 +373,73 @@ comp_ipc_client_compositor_set_workspace_sync_fence_value(struct xrt_compositor 
 	icc->workspace_sync_fence_value = value;
 }
 
+xrt_result_t
+comp_ipc_client_compositor_get_transparent_output(struct xrt_compositor *xc,
+                                                  bool *out_have_output,
+                                                  uint32_t *out_width,
+                                                  uint32_t *out_height,
+                                                  uint64_t *out_hwnd,
+                                                  xrt_graphics_buffer_handle_t *out_handle)
+{
+	if (xc == NULL || out_have_output == NULL || out_width == NULL || out_height == NULL ||
+	    out_hwnd == NULL || out_handle == NULL) {
+		return XRT_ERROR_IPC_FAILURE;
+	}
+	*out_have_output = false;
+	*out_width = 0;
+	*out_height = 0;
+	*out_hwnd = 0;
+	*out_handle = XRT_GRAPHICS_BUFFER_HANDLE_INVALID;
+
+	struct ipc_client_compositor *icc = ipc_client_compositor(xc);
+	if (icc == NULL || icc->ipc_c == NULL) {
+		return XRT_ERROR_IPC_FAILURE;
+	}
+
+	bool have = false;
+	uint32_t w = 0, h = 0;
+	uint64_t wnd = 0;
+	xrt_graphics_buffer_handle_t handle = XRT_GRAPHICS_BUFFER_HANDLE_INVALID;
+	xrt_result_t xret =
+	    ipc_call_compositor_get_transparent_output(icc->ipc_c, &have, &w, &h, &wnd, &handle, 1);
+	if (xret != XRT_SUCCESS) {
+		return xret;
+	}
+	*out_have_output = have;
+	*out_width = w;
+	*out_height = h;
+	*out_hwnd = wnd;
+	*out_handle = handle;
+	return XRT_SUCCESS;
+}
+
+xrt_result_t
+comp_ipc_client_compositor_get_transparent_output_fence(struct xrt_compositor *xc,
+                                                        bool *out_have_fence,
+                                                        xrt_graphics_sync_handle_t *out_handle)
+{
+	if (xc == NULL || out_have_fence == NULL || out_handle == NULL) {
+		return XRT_ERROR_IPC_FAILURE;
+	}
+	*out_have_fence = false;
+	*out_handle = XRT_GRAPHICS_SYNC_HANDLE_INVALID;
+
+	struct ipc_client_compositor *icc = ipc_client_compositor(xc);
+	if (icc == NULL || icc->ipc_c == NULL) {
+		return XRT_ERROR_IPC_FAILURE;
+	}
+
+	bool have = false;
+	xrt_graphics_sync_handle_t h = XRT_GRAPHICS_SYNC_HANDLE_INVALID;
+	xrt_result_t xret = ipc_call_compositor_get_transparent_output_fence(icc->ipc_c, &have, &h, 1);
+	if (xret != XRT_SUCCESS) {
+		return xret;
+	}
+	*out_have_fence = have;
+	*out_handle = h;
+	return XRT_SUCCESS;
+}
+
 
 /*
  * Workspace controller bridges — thin accessors used by the OpenXR state

--- a/src/xrt/ipc/server/ipc_server_handler.c
+++ b/src/xrt/ipc/server/ipc_server_handler.c
@@ -4775,6 +4775,80 @@ ipc_handle_compositor_get_workspace_sync_fence(volatile struct ipc_client_state 
 }
 
 xrt_result_t
+ipc_handle_compositor_get_transparent_output(volatile struct ipc_client_state *ics,
+                                             bool *out_have_output,
+                                             uint32_t *out_width,
+                                             uint32_t *out_height,
+                                             uint64_t *out_hwnd,
+                                             uint32_t max_handle_count,
+                                             xrt_graphics_buffer_handle_t *out_handles,
+                                             uint32_t *out_handle_count)
+{
+	IPC_TRACE_MARKER();
+
+	*out_have_output = false;
+	*out_width = 0;
+	*out_height = 0;
+	*out_hwnd = 0;
+	*out_handle_count = 0;
+
+	if (ics->xc == NULL || max_handle_count < 1) {
+		return XRT_SUCCESS;
+	}
+
+#if defined(XRT_HAVE_D3D11_SERVICE_COMPOSITOR)
+	// #551 — only the d3d11_service compositor exposes a transparent-output
+	// shared texture (and only for a client that requested a transparent
+	// background). The IPC machinery DuplicateHandle's it into the client.
+	xrt_graphics_buffer_handle_t h = XRT_GRAPHICS_BUFFER_HANDLE_INVALID;
+	uint32_t w = 0, ht = 0;
+	uint64_t wnd = 0;
+	if (comp_d3d11_service_compositor_export_transparent_output(ics->xc, &h, &w, &ht, &wnd)) {
+		out_handles[0] = h;
+		*out_handle_count = 1;
+		*out_have_output = true;
+		*out_width = w;
+		*out_height = ht;
+		*out_hwnd = wnd;
+	}
+#else
+	(void)out_handles;
+#endif
+
+	return XRT_SUCCESS;
+}
+
+xrt_result_t
+ipc_handle_compositor_get_transparent_output_fence(volatile struct ipc_client_state *ics,
+                                                   bool *out_have_fence,
+                                                   uint32_t max_handle_count,
+                                                   xrt_graphics_sync_handle_t *out_handles,
+                                                   uint32_t *out_handle_count)
+{
+	IPC_TRACE_MARKER();
+
+	*out_have_fence = false;
+	*out_handle_count = 0;
+
+	if (ics->xc == NULL || max_handle_count < 1) {
+		return XRT_SUCCESS;
+	}
+
+#if defined(XRT_HAVE_D3D11_SERVICE_COMPOSITOR)
+	xrt_graphics_sync_handle_t h = XRT_GRAPHICS_SYNC_HANDLE_INVALID;
+	if (comp_d3d11_service_compositor_export_transparent_output_fence(ics->xc, &h)) {
+		out_handles[0] = h;
+		*out_handle_count = 1;
+		*out_have_fence = true;
+	}
+#else
+	(void)out_handles;
+#endif
+
+	return XRT_SUCCESS;
+}
+
+xrt_result_t
 ipc_handle_compositor_semaphore_destroy(volatile struct ipc_client_state *ics, uint32_t id)
 {
 	if (ics->xc == NULL) {

--- a/src/xrt/ipc/shared/proto.json
+++ b/src/xrt/ipc/shared/proto.json
@@ -677,6 +677,23 @@
 		"out_handles": {"type": "xrt_graphics_sync_handle_t"}
 	},
 
+	"compositor_get_transparent_output": {
+		"out": [
+			{"name": "have_output", "type": "bool"},
+			{"name": "width", "type": "uint32_t"},
+			{"name": "height", "type": "uint32_t"},
+			{"name": "hwnd", "type": "uint64_t"}
+		],
+		"out_handles": {"type": "xrt_graphics_buffer_handle_t"}
+	},
+
+	"compositor_get_transparent_output_fence": {
+		"out": [
+			{"name": "have_fence", "type": "bool"}
+		],
+		"out_handles": {"type": "xrt_graphics_sync_handle_t"}
+	},
+
 	"compositor_semaphore_destroy": {
 		"in": [
 			{"name": "id", "type": "uint32_t"}

--- a/src/xrt/state_trackers/oxr/oxr_event.c
+++ b/src/xrt/state_trackers/oxr/oxr_event.c
@@ -418,7 +418,9 @@ oxr_event_push_XrEventDataRenderingModeChanged(struct oxr_logger *log,
 	changed->currentModeIndex = currentModeIndex;
 	event->result = XR_SUCCESS;
 
-	U_LOG_I("OXR EVENT: Rendering mode changed %u -> %u", previousModeIndex, currentModeIndex);
+	// WARN (not INFO): rare lifecycle event, and the file sink drops INFO
+	// past init — this line is the proof a mode flip reached the client.
+	U_LOG_W("OXR EVENT: Rendering mode changed %u -> %u", previousModeIndex, currentModeIndex);
 
 	lock(inst);
 	push(inst, event);

--- a/src/xrt/state_trackers/oxr/oxr_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_session.c
@@ -3445,6 +3445,28 @@ oxr_session_create(struct oxr_logger *log,
 		}
 		if (target_info->transparentBackgroundEnabled) {
 			xsi.transparent_background_enabled = true;
+			// #551: exclude the app window from the vendor DP's WGC desktop
+			// capture so the DP composites its weave over the desktop BEHIND
+			// the window (compose-under-bg), not the window's own content.
+			// SetWindowDisplayAffinity must run in the window-OWNING process —
+			// the OpenXR layer runs in the app's process, so this works even
+			// when the DP runs out-of-process in the service for an IPC client
+			// (there the service-side DP gets ACCESS_DENIED and detects this
+			// pre-set affinity instead of falling back to chroma-key, #551).
+			// WDA_EXCLUDEFROMCAPTURE needs Win10 2004+; on older OS the call
+			// fails and the DP keeps chroma-key — graceful.
+			if (target_info->windowHandle) {
+#ifndef WDA_EXCLUDEFROMCAPTURE
+#define WDA_EXCLUDEFROMCAPTURE 0x00000011
+#endif
+				if (!SetWindowDisplayAffinity((HWND)target_info->windowHandle,
+				                              WDA_EXCLUDEFROMCAPTURE)) {
+					U_LOG_W(
+					    "xrCreateSession: SetWindowDisplayAffinity(WDA_EXCLUDEFROMCAPTURE) "
+					    "failed (err=%lu) — DP compose-under-bg may fall back to chroma-key",
+					    (unsigned long)GetLastError());
+				}
+			}
 		}
 		if (target_info->chromaKeyColor != 0) {
 			xsi.chroma_key_color = target_info->chromaKeyColor;

--- a/src/xrt/state_trackers/oxr/oxr_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_session.c
@@ -2023,10 +2023,10 @@ oxr_session_locate_views(struct oxr_logger *log,
 		// inert — the server's headless fast path returns before window
 		// resolution, matching the rig-descriptor policy.
 		//
-		// @todo P5 tail: the wish-mask cross-process transport does NOT
-		// ride this call (roadmap-sanctioned slip) — service-mode wish
-		// stays on the tier-1 global fallback until the service
-		// compositor consumes zone layers.
+		// The wish mask does NOT ride this call: the service derives the
+		// auto wish from the committed zone-3D layers and publishes it to
+		// the per-client DP itself (#551, service_update_zone_wish_publish)
+		// — no extra cross-process transport needed.
 		if (zone != NULL && rig_route_native) {
 			rig_info.zone_valid = 1;
 			rig_info.zone_x_px = zone->rect.offset.x;
@@ -2128,6 +2128,20 @@ oxr_session_locate_views(struct oxr_logger *log,
 				ipc_rig_logged = true;
 				U_LOG_W("VIEW-RIG IPC client: locate ok, rig_applied=%u raw_valid=%u eyes=%u",
 				        reply.rig_applied, reply.raw.valid, reply.raw.eye_count);
+			}
+			// The first locate often lands during DP tracking warmup (the
+			// server falls back to device poses with an empty reply), so the
+			// one-shot above can permanently show zeros. Log the first
+			// SUCCESSFUL rig locate separately so a warmup-only failure is
+			// not mistaken for a persistently dead rig path (#551).
+			static bool ipc_rig_success_logged = false;
+			if (!ipc_rig_success_logged &&
+			    (reply.rig_applied != IPC_VIEW_RIG_NONE || reply.raw.valid != 0)) {
+				ipc_rig_success_logged = true;
+				U_LOG_W(
+				    "VIEW-RIG IPC client: first successful locate, "
+				    "rig_applied=%u raw_valid=%u eyes=%u",
+				    reply.rig_applied, reply.raw.valid, reply.raw.eye_count);
 			}
 		} else {
 			static bool ipc_rig_fail_logged = false;

--- a/test_apps/cube_zones_d3d11_win/main.cpp
+++ b/test_apps/cube_zones_d3d11_win/main.cpp
@@ -608,11 +608,19 @@ static void TryActivateZones(XrSessionManager& xr, D3D11Renderer& renderer) {
     }
     LOG_INFO("[zones] capabilities: supported=1 maxZones3D=%u", caps.maxZones3D);
 
-    // Zones share the session's view COUNT (display modes are session-global);
-    // only per-view dimensions vary by rect.
+    // Zones share the session's view COUNT (display modes are session-global).
+    // Allocate the zone swapchains at the MAX view count across all modes,
+    // not the currently active mode's: standalone the session can start in a
+    // 1-view mode (the service's tier-1 zones fallback flips to a multi-view
+    // mode only at the first zones frame, AFTER these swapchains exist), and
+    // a 1-tile swapchain would pin every zone to 1 view forever (#551). The
+    // per-frame submit clamp to the ACTIVE mode's view count stays.
     uint32_t viewCount = 2;
-    if (xr.renderingModeCount > 0 && xr.currentModeIndex < xr.renderingModeCount) {
-        viewCount = xr.renderingModeViewCounts[xr.currentModeIndex];
+    if (xr.renderingModeCount > 0) {
+        viewCount = 1;
+        for (uint32_t mi = 0; mi < xr.renderingModeCount; mi++) {
+            viewCount = (std::max)(viewCount, xr.renderingModeViewCounts[mi]);
+        }
     }
     if (viewCount < 1) viewCount = 1;
     if (viewCount > 8) viewCount = 8;
@@ -996,6 +1004,30 @@ static void RenderZonesFrame(RenderState& rs, const XrFrameState& frameState) {
             submitViewCounts[zi] = 0;
             continue;
         }
+        // Don't submit poses the runtime marked invalid (or zero quats from a
+        // not-yet-tracking first frame) — xrEndFrame rejects them with
+        // XR_ERROR_POSE_INVALID. Skipping this zone for the frame is the
+        // correct degradation; the next locate after tracking warmup is valid.
+        const bool orientationValid =
+            (viewState.viewStateFlags & XR_VIEW_STATE_ORIENTATION_VALID_BIT) != 0;
+        bool posesUsable = orientationValid;
+        for (uint32_t vi = 0; posesUsable && vi < viewCountOutput && vi < 8; vi++) {
+            const XrQuaternionf& q = zoneViews[vi].pose.orientation;
+            if (q.x == 0.0f && q.y == 0.0f && q.z == 0.0f && q.w == 0.0f) {
+                posesUsable = false;
+            }
+        }
+        if (!posesUsable) {
+            static bool warnedInvalid = false;
+            if (!warnedInvalid) {
+                warnedInvalid = true;
+                LOG_WARN("[zones] zone %u locate returned invalid poses (flags=0x%llx) — "
+                         "skipping submission until tracking is up",
+                         z.zoneId, (unsigned long long)viewState.viewStateFlags);
+            }
+            submitViewCounts[zi] = 0;
+            continue;
+        }
 
         // xrLocateViews always reports the MAX view count (identical centered
         // views in a mono mode) — a well-behaved extension app submits only
@@ -1299,6 +1331,11 @@ static void RenderOneFrame(RenderState& rs) {
     int eyeCount = monoMode ? 1 : (int)modeViewCount;
     std::vector<XrCompositionLayerProjectionView> projectionViews(eyeCount, {XR_TYPE_COMPOSITION_LAYER_PROJECTION_VIEW});
     bool hudSubmitted = false;
+    // Only submit the projection layer once the locate+render below actually
+    // filled it — a first-frame locate failure (tracking warmup) or a skipped
+    // render otherwise submits default-constructed views whose zero quats the
+    // runtime rejects with XR_ERROR_POSE_INVALID.
+    bool viewsPopulated = false;
 
     if (frameState.shouldRender) {
         if (LocateViews(xr, frameState.predictedDisplayTime,
@@ -1584,6 +1621,7 @@ static void RenderOneFrame(RenderState& rs) {
                         rigViews[monoMode ? 0 : eye].fov :
                         (monoMode ? monoFov : rawViews[safeIdx].fov);
                 }
+                viewsPopulated = true;
 
                 if (rtv) rtv->Release();
 
@@ -1601,6 +1639,15 @@ static void RenderOneFrame(RenderState& rs) {
     }
 
     // Submit frame (fallback path: plain projection, optionally with the HUD).
+    if (!viewsPopulated) {
+        XrFrameEndInfo endInfo = {XR_TYPE_FRAME_END_INFO};
+        endInfo.displayTime = frameState.predictedDisplayTime;
+        endInfo.environmentBlendMode = XR_ENVIRONMENT_BLEND_MODE_OPAQUE;
+        endInfo.layerCount = 0;
+        endInfo.layers = nullptr;
+        xrEndFrame(xr.session, &endInfo);
+        return;
+    }
     if (hudSubmitted) {
         float hudAR = (float)HUD_PIXEL_WIDTH / (float)HUD_PIXEL_HEIGHT;
         float windowAR = (g_windowWidth > 0 && g_windowHeight > 0) ? (float)g_windowWidth / (float)g_windowHeight : 1.0f;

--- a/test_apps/cube_zones_d3d11_win/main.cpp
+++ b/test_apps/cube_zones_d3d11_win/main.cpp
@@ -637,21 +637,20 @@ static void TryActivateZones(XrSessionManager& xr, D3D11Renderer& renderer) {
     g_zonesArr[0].clearColor[3] = 1.0f;
 
     // Zone B: right. Reduced view spread + flattened perspective (visibly
-    // different framing), phase +1.5 rad, SEMI-TRANSPARENT dark-blue clear
-    // (premultiplied, alpha 0.55): zones composite alpha-over in layer-list
-    // order with blends expressed through CONTENT alpha (ADR-027 rule 4) —
-    // an opaque background would make the overlap a plain replacement. The
-    // cube itself stays opaque; the background lets zone A (and the desktop,
-    // when not overlapping) show through.
+    // different framing), phase +1.5 rad, FULLY TRANSPARENT clear (premultiplied
+    // RGBA all-zero): the cube floats over the LIVE desktop — the alpha-gate
+    // punches every all-views-α==0 pixel in this zone through to DWM (#551). The
+    // cube itself stays opaque; everything around it is see-through. (Contrast
+    // zone A's opaque tint, which marks its boundary.)
     g_zonesArr[1].zoneId = 2;
     g_zonesArr[1].rect = g_zoneBOverlap ? kZoneBOverlapRect : kZoneBRect;
     g_zonesArr[1].ipdFactor = 0.6f;
     g_zonesArr[1].perspectiveFactor = 0.5f;
     g_zonesArr[1].spinPhase = 1.5f;
-    g_zonesArr[1].clearColor[0] = 0.03f * 0.55f;
-    g_zonesArr[1].clearColor[1] = 0.03f * 0.55f;
-    g_zonesArr[1].clearColor[2] = 0.15f * 0.55f;
-    g_zonesArr[1].clearColor[3] = 0.55f;
+    g_zonesArr[1].clearColor[0] = 0.0f;
+    g_zonesArr[1].clearColor[1] = 0.0f;
+    g_zonesArr[1].clearColor[2] = 0.0f;
+    g_zonesArr[1].clearColor[3] = 0.0f;
 
     for (uint32_t zi = 0; zi < kNumZones; zi++) {
         if (!CreateZoneResources(xr, renderer, g_zonesArr[zi], viewCount)) {

--- a/test_apps/cube_zones_d3d11_win/xr_session.cpp
+++ b/test_apps/cube_zones_d3d11_win/xr_session.cpp
@@ -337,6 +337,21 @@ bool CreateSession(XrSessionManager& xr, ID3D11Device* d3d11Device, HWND hwnd) {
     XrWin32WindowBindingCreateInfoEXT sessionTarget = {XR_TYPE_WIN32_WINDOW_BINDING_CREATE_INFO_EXT};
     sessionTarget.windowHandle = hwnd;
 
+    // Transparent window output — ON BY DEFAULT for this app (zones
+    // alpha-composite against the desktop by design); DISPLAYXR_TRANSPARENT_BG=0
+    // opts out. The runtime drives the vendor DP's compose-under-background
+    // from the atlas alpha (chroma-key-free) and excludes this window from the
+    // DP's desktop capture — works in-process AND over IPC (#551). The flag
+    // rides xrt_session_info so it reaches both paths identically.
+    {
+        const char* e = getenv("DISPLAYXR_TRANSPARENT_BG");
+        if (e == nullptr || *e == '\0' || *e != '0') {
+            sessionTarget.transparentBackgroundEnabled = XR_TRUE;
+            sessionTarget.chromaKeyColor = 0;
+            LOG_INFO("Transparent background ENABLED (zones default; DISPLAYXR_TRANSPARENT_BG=0 to opt out)");
+        }
+    }
+
     if (xr.hasWin32WindowBindingExt && hwnd) {
         // Chain: sessionInfo -> d3d11Binding -> sessionTarget
         d3d11Binding.next = &sessionTarget;


### PR DESCRIPTION
## #551 — standalone forced-IPC zones + client-owned transparent present

The standalone (`XRT_FORCE_MODE=ipc`, no workspace) tail of the display-zones work, plus a reusable transparent-present path for **any** IPC app.

### What lands
1. **Both eyes for zones standalone** — zone swapchains allocate at the max-mode view count (not the startup mode's), so the 2-view atlas is whole (was a black view-1).
2. **Per-zone wish mask over IPC** — the service publishes the auto-wish mask to the per-client DP (was tier-1 global-3D only).
3. **Client-owned transparent present (ADR-029)** — the see-through headline. The service/DP run out-of-process and can't own the app HWND's DComp target (`E_ACCESSDENIED`), so the **client** owns the present: the service renders into a shared NT-handle texture + service→client fence; the client imports them, owns a DComp visual on its own window, and per-frame copies+presents. DWM blends the **live desktop** into the alpha-gate holes with ~zero lag (no per-frame IPC). The DP gets `set_transparent_background(…, client_presents=true)` → alpha-gate only, no stale WGC compose-under-bg.

### Validated
Leia hardware, 2026-06-12: both zones in both eyes; transparent background shows the live desktop with **no lag**; blue zone's cube floats over the live desktop. Service selftest path unaffected.

### Coupled plugin work
Needs the Leia DP's `client_presents` half (`displayxr-leia-plugin` branch `feat/zones-ipc-bg-affinity-551`). Per ADR-020 the plugin re-pins to the runtime tag cut after this lands.

### Docs
ADR-029 + `XR_EXT_win32_window_binding` transparent-window contract (IPC path + per-API matrix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
