### PR TITLE
Android: clean 2D/3D backlight transitions on close / focus / unfocus (#563)

### DIFF
--- a/src/xrt/compositor/multi/comp_multi_compositor.c
+++ b/src/xrt/compositor/multi/comp_multi_compositor.c
@@ -619,6 +619,11 @@ multi_compositor_begin_session(struct xrt_compositor *xc, const struct xrt_begin
 		// (comp_window_android) pulls the live surface from android_globals.
 		mc->session_render.use_android_surface = true;
 		U_LOG_I("Android: enabling per-session rendering (surface via android_globals)");
+
+		// Counterpart of end_session's on_pause (#563): the DP is cached
+		// across end→begin (#39), so wake the vendor SDK back up. The
+		// weave loop re-enables the 3D backlight on the first frame.
+		xrt_display_processor_on_resume(mc->session_render.display_processor);
 #endif
 		multi_system_compositor_update_session_status(mc->msc, true);
 		mc->state.session_active = true;
@@ -685,6 +690,13 @@ multi_compositor_end_session(struct xrt_compositor *xc)
 			// xrEndSession (displayxr-leia-plugin#39). init_session_render
 			// reuses the cached pair; the real destroy happens at client
 			// teardown.
+			//
+			// But DO pause it: the panel's switchable backlight is
+			// system-global and whatever is behind us (home screen,
+			// picker) is 2D content — without this the screen stays in
+			// physical 3D after the session ends (#563). begin_session
+			// resumes the cached DP and the weave re-enables 3D.
+			xrt_display_processor_on_pause(mc->session_render.display_processor);
 #else
 			// Destroy display processor (owns any vendor SDK handles)
 			xrt_display_processor_destroy(&mc->session_render.display_processor);

--- a/src/xrt/compositor/multi/comp_multi_compositor.c
+++ b/src/xrt/compositor/multi/comp_multi_compositor.c
@@ -1272,6 +1272,19 @@ multi_compositor_destroy(struct xrt_compositor *xc)
 		mc->state.session_active = false;
 	}
 
+	// The display processor can outlive session_render.initialized: the
+	// Android end_session path deliberately caches it across end->begin
+	// (leia-plugin#39), so a client that ended its session before
+	// disconnecting reaches this destroy with initialized == false and the
+	// DP still alive. Destroy it unconditionally — the vendor destroy also
+	// drops the panel's system-global 3D backlight back to 2D (#563); the
+	// initialized-gated block below destroys it for the still-initialized
+	// case (xrt_display_processor_destroy NULLs the pointer, so at most one
+	// of the two calls acts).
+	if (!mc->session_render.initialized && mc->session_render.display_processor != NULL) {
+		xrt_display_processor_destroy(&mc->session_render.display_processor);
+	}
+
 	// Clean up per-session render resources if still initialized
 	if (mc->session_render.initialized) {
 		// Mark as not initialized AND clear the window handle under

--- a/src/xrt/compositor/multi/comp_multi_private.h
+++ b/src/xrt/compositor/multi/comp_multi_private.h
@@ -585,6 +585,17 @@ struct multi_system_compositor
 
 	//! Service for creating per-session render targets (provided by comp_main)
 	struct comp_target_service *target_service;
+
+#ifdef XRT_OS_ANDROID
+	/*!
+	 * #563: last observed android_globals output-surface validity
+	 * (-1 = unknown). The main loop pauses/resumes the clients' display
+	 * processors on transitions so the panel's system-global 3D backlight
+	 * drops to 2D when the app backgrounds WITHOUT ending its session
+	 * (the #528 surface-lost case) and comes back on resume.
+	 */
+	int android_window_valid_state;
+#endif
 };
 
 /*!

--- a/src/xrt/compositor/multi/comp_multi_system.c
+++ b/src/xrt/compositor/multi/comp_multi_system.c
@@ -60,6 +60,10 @@
 #include "comp_d3d11_window.h"
 #endif
 
+#ifdef XRT_OS_ANDROID
+#include "android/android_globals.h"
+#endif
+
 #ifdef XRT_BUILD_DRIVER_QWERTY
 #include "qwerty/qwerty_interface.h"
 #include "xrt/xrt_system.h"
@@ -3032,6 +3036,51 @@ update_session_state_locked(struct multi_system_compositor *msc)
 	}
 }
 
+#ifdef XRT_OS_ANDROID
+/*!
+ * #563: pause/resume the clients' display processors when the published
+ * output surface goes away / comes back (Client.java clearAppSurface /
+ * passAppSurface, the #528 backgrounding case that does NOT end the
+ * session). The panel's switchable 3D backlight is system-global — if the
+ * weave just stops, the screen stays in physical 3D over the 2D home
+ * screen. Session end/begin and client destroy have their own hooks; this
+ * covers the surface-only transition.
+ */
+static void
+android_window_transition_locked(struct multi_system_compositor *msc)
+{
+	struct _ANativeWindow *window = NULL;
+	uint64_t generation = 0;
+	bool valid = false;
+	android_globals_get_window_state(&window, &generation, &valid);
+
+	int state = (valid && window != NULL) ? 1 : 0;
+	if (state == msc->android_window_valid_state) {
+		return;
+	}
+	bool first = msc->android_window_valid_state < 0;
+	msc->android_window_valid_state = state;
+	if (first && state == 1) {
+		return; // startup with a live surface — nothing to resume
+	}
+
+	for (size_t k = 0; k < ARRAY_SIZE(msc->clients); k++) {
+		struct multi_compositor *mc = msc->clients[k];
+		if (mc == NULL || !mc->session_render.initialized ||
+		    mc->session_render.display_processor == NULL) {
+			continue;
+		}
+		if (state == 0) {
+			U_LOG_W("multi: output surface lost — pausing DP (backlight to 2D, #563)");
+			xrt_display_processor_on_pause(mc->session_render.display_processor);
+		} else {
+			U_LOG_W("multi: output surface back — resuming DP (#563)");
+			xrt_display_processor_on_resume(mc->session_render.display_processor);
+		}
+	}
+}
+#endif // XRT_OS_ANDROID
+
 static int
 multi_main_loop(struct multi_system_compositor *msc)
 {
@@ -3099,6 +3148,9 @@ multi_main_loop(struct multi_system_compositor *msc)
 
 		// Make sure that the clients doesn't go away while we transfer layers.
 		os_mutex_lock(&msc->list_and_timing_lock);
+#ifdef XRT_OS_ANDROID
+		android_window_transition_locked(msc);
+#endif
 		transfer_layers_locked(msc, predicted_display_time_ns, frame_id);
 		os_mutex_unlock(&msc->list_and_timing_lock);
 
@@ -3312,6 +3364,9 @@ comp_multi_create_system_compositor(struct xrt_compositor_native *xcn,
                                     struct xrt_system_compositor **out_xsysc)
 {
 	struct multi_system_compositor *msc = U_TYPED_CALLOC(struct multi_system_compositor);
+#ifdef XRT_OS_ANDROID
+	msc->android_window_valid_state = -1; /* #563: unknown until first loop tick */
+#endif
 	msc->base.create_native_compositor = system_compositor_create_native_compositor;
 	msc->base.destroy = system_compositor_destroy;
 	msc->xmcc.set_state = system_compositor_set_state;


### PR DESCRIPTION
Closes #563. Plugin counterpart: displayxr-leia-plugin PR (fix/backlight-lifecycle).

The panel's switchable 3D backlight is system-global state in the Leia display service — the weave path only ever turned it ON, and the OOP service never drove the DP's `on_pause`/`on_resume` hooks (only the in-process vk_native compositor did). Closing or backgrounding an app left the screen in physical 3D over 2D content.

- `multi_compositor_end_session`: DP `on_pause` (the DP stays cached per leia-plugin#39, but the vendor SDK now drops the backlight); `begin_session`: `on_resume`.
- Main-loop transition check on the #528 surface-lost/back signal (backgrounding without ending the session) → pause/resume the clients' DPs.
- `multi_compositor_destroy`: destroy the cached DP even when `session_render.initialized` is false — the normal Android close ends the session first, so the cached DP leaked and its backlight-dropping destroy never ran. **This was the main stuck-3D-on-close hole.**

## Verified on NP02J (cube_handle_vk_android, OOP)

| transition | result |
|---|---|
| launch | `backlight -> 3D ON (weave)` |
| close (force-stop / swipe) | `backlight -> 2D OFF (destroy)` |
| background (HOME) | `backlight -> 2D OFF (on_pause)` |
| relaunch | `backlight -> 3D ON (weave)` |

Known separate issue: after background→resume (same process), the service's weave/present path never restarts — so 3D doesn't re-engage until the app is relaunched. A/B-verified this stall reproduces on **pure v1.17.0 main without this PR** (tracking + locate resume fine; only the per-session render stays dead) — filed separately as a pre-existing regression. Hard process-kill of the service also remains uncoverable in-process (vendor service would need to reset on binder death).

🤖 Generated with [Claude Code](https://claude.com/claude-code)