### PR TITLE
feat(#568): Android transparency — 3D avatar over the live screen

### DIFF
--- a/src/xrt/auxiliary/android/android_custom_surface.cpp
+++ b/src/xrt/auxiliary/android/android_custom_surface.cpp
@@ -23,6 +23,20 @@
 #include "org.freedesktop.monado.auxiliary.hpp"
 
 #include <android/native_window_jni.h>
+#include <sys/system_properties.h>
+
+// P0 transparency spike (#568): make the OOP overlay window non-opaque so the
+// live screen shows through the weaved content. Layer A replaces this sysprop
+// gate with the per-session transparent_background flag.
+static bool
+android_transparent_requested(void)
+{
+	char value[PROP_VALUE_MAX] = {0};
+	if (__system_property_get("debug.dxr.transparent", value) > 0) {
+		return value[0] == '1' || value[0] == 't' || value[0] == 'T' || value[0] == 'y' || value[0] == 'Y';
+	}
+	return false;
+}
 
 using wrap::android::content::Context;
 using wrap::android::graphics::PixelFormat;
@@ -145,6 +159,12 @@ android_custom_surface_async_start(
 			}
 		}();
 		lp.setTitle(surface_title);
+		if (android_transparent_requested()) {
+			// PixelFormat.TRANSLUCENT == -3; makes the overlay window non-opaque
+			// so SurfaceFlinger blends the SurfaceView's alpha over the screen.
+			lp.object().set("format", (int32_t)-3);
+			U_LOG_W("android_custom_surface: TRANSLUCENT overlay window (#568 transparency spike)");
+		}
 		ret->monadoView = MonadoView::attachToWindow(displayContext, ret.get(), lp);
 		lp.object().set("preferredDisplayModeId", preferred_display_mode_id);
 

--- a/src/xrt/auxiliary/android/src/main/java/org/freedesktop/monado/auxiliary/MonadoView.java
+++ b/src/xrt/auxiliary/android/src/main/java/org/freedesktop/monado/auxiliary/MonadoView.java
@@ -11,6 +11,7 @@ package org.freedesktop.monado.auxiliary;
 
 import android.app.Activity;
 import android.content.Context;
+import android.graphics.PixelFormat;
 import android.hardware.display.DisplayManager;
 import android.os.Handler;
 import android.os.Looper;
@@ -79,6 +80,27 @@ public class MonadoView extends SurfaceView
         }
         SurfaceHolder surfaceHolder = getHolder();
         surfaceHolder.addCallback(this);
+        // P0 transparency spike (#568): a translucent SurfaceView z-ordered as a
+        // media overlay lets SurfaceFlinger composite the weaved content over the
+        // live screen. Gated on `debug.dxr.transparent` so other apps over this
+        // runtime are unaffected. Layer A drives this from the per-session flag.
+        if (isTransparentSpikeEnabled()) {
+            setZOrderMediaOverlay(true);
+            surfaceHolder.setFormat(PixelFormat.TRANSLUCENT);
+            Log.i(TAG, "MonadoView: TRANSLUCENT media-overlay surface (#568 transparency spike)");
+        }
+    }
+
+    /** Reads the `debug.dxr.transparent` sysprop via the hidden SystemProperties API. */
+    private static boolean isTransparentSpikeEnabled() {
+        try {
+            Class<?> sp = Class.forName("android.os.SystemProperties");
+            String v = (String) sp.getMethod("get", String.class).invoke(null, "debug.dxr.transparent");
+            return v != null && (v.startsWith("1") || v.startsWith("t") || v.startsWith("T")
+                    || v.startsWith("y") || v.startsWith("Y"));
+        } catch (Exception e) {
+            return false;
+        }
     }
 
     @Override

--- a/src/xrt/compositor/main/comp_target_swapchain.c
+++ b/src/xrt/compositor/main/comp_target_swapchain.c
@@ -25,10 +25,30 @@
 #include "android/android_globals.h"
 #include "util/u_time.h"
 #include <android/native_window.h>
+#include <sys/system_properties.h>
 #endif
 
 #include <assert.h>
 #include <stdlib.h>
+
+#ifdef XRT_OS_ANDROID
+/*!
+ * P0 transparency spike (#568): the OOP service has no env block we can set, so
+ * a device sysprop is the dev override. `adb shell setprop debug.dxr.transparent 1`
+ * makes the present surface alpha-capable so SurfaceFlinger composites the
+ * weaved content over the live screen. Layer A will OR this with the real
+ * per-session transparent_background flag.
+ */
+static bool
+android_transparent_requested(void)
+{
+	char value[PROP_VALUE_MAX] = {0};
+	if (__system_property_get("debug.dxr.transparent", value) > 0) {
+		return value[0] == '1' || value[0] == 't' || value[0] == 'T' || value[0] == 'y' || value[0] == 'Y';
+	}
+	return false;
+}
+#endif
 
 
 /*
@@ -768,7 +788,35 @@ comp_target_swapchain_create_images(struct comp_target *ct, const struct comp_ta
 	 * VkSurfaceCapabilitiesKHR structure returned by vkGetPhysicalDeviceSurfaceCapabilitiesKHR for the surface.
 	 */
 	VkCompositeAlphaFlagsKHR composite_alpha = 0;
-	if (surface_caps.supportedCompositeAlpha & VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR) {
+	bool want_transparent = false;
+#ifdef XRT_OS_ANDROID
+	want_transparent = android_transparent_requested();
+	// P0/#568: log every advertised bit so we know what the translucent
+	// SurfaceView's VkSurfaceKHR actually exposes on this device. WARN so it
+	// survives the service's default log level.
+	COMP_WARN(ct->c,
+	          "supportedCompositeAlpha: OPAQUE=%d PRE_MULTIPLIED=%d POST_MULTIPLIED=%d INHERIT=%d (transparent requested=%d)",
+	          !!(surface_caps.supportedCompositeAlpha & VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR),
+	          !!(surface_caps.supportedCompositeAlpha & VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR),
+	          !!(surface_caps.supportedCompositeAlpha & VK_COMPOSITE_ALPHA_POST_MULTIPLIED_BIT_KHR),
+	          !!(surface_caps.supportedCompositeAlpha & VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR), want_transparent);
+#endif
+	if (want_transparent) {
+		// Prefer an alpha-preserving mode. Android WSI typically advertises
+		// INHERIT (alpha governed by the SurfaceView's pixel format) and only
+		// rarely PRE_MULTIPLIED; never pick OPAQUE here (it discards alpha).
+		if (surface_caps.supportedCompositeAlpha & VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR) {
+			composite_alpha = VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR;
+		} else if (surface_caps.supportedCompositeAlpha & VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR) {
+			composite_alpha = VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR;
+		} else if (surface_caps.supportedCompositeAlpha & VK_COMPOSITE_ALPHA_POST_MULTIPLIED_BIT_KHR) {
+			composite_alpha = VK_COMPOSITE_ALPHA_POST_MULTIPLIED_BIT_KHR;
+		} else {
+			COMP_WARN(ct->c, "Transparency requested but no alpha-capable composite mode; falling back to OPAQUE");
+			composite_alpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
+		}
+		COMP_WARN(ct->c, "Transparent present: selected compositeAlpha=0x%x", composite_alpha);
+	} else if (surface_caps.supportedCompositeAlpha & VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR) {
 		composite_alpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
 	} else if (surface_caps.supportedCompositeAlpha & VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR) {
 		composite_alpha = VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR;

--- a/src/xrt/compositor/multi/comp_multi_compositor.c
+++ b/src/xrt/compositor/multi/comp_multi_compositor.c
@@ -1142,11 +1142,15 @@ multi_compositor_layer_local_2d(struct xrt_compositor *xc,
                                 struct xrt_swapchain *xsc,
                                 const struct xrt_layer_data *data)
 {
-	static bool warned = false;
-	if (!warned) {
-		warned = true;
-		U_LOG_W("Local-2D layers are not consumed on the IPC/service path yet — dropping (one-time warning)");
-	}
+	struct multi_compositor *mc = multi_compositor(xc);
+
+	// Enqueue like a window-space layer (single swapchain). The per-session
+	// render path (Android OOP, #568) blits it into the target's 2D region;
+	// the shared/downstream path drops it quietly (comp_multi_system switch).
+	size_t index = mc->progress.layer_count++;
+	mc->progress.layers[index].xdev = xdev;
+	xrt_swapchain_reference(&mc->progress.layers[index].xscs[0], xsc);
+	mc->progress.layers[index].data = *data;
 
 	return XRT_SUCCESS;
 }

--- a/src/xrt/compositor/multi/comp_multi_compositor.c
+++ b/src/xrt/compositor/multi/comp_multi_compositor.c
@@ -62,6 +62,23 @@
 #include "android/android_custom_surface.h"
 #include "android/android_globals.h"
 #include "android/android_main_thread.h"
+#include "xrt/xrt_display_processor_vk.h" // #568: transparent-background alpha-gate
+#include <sys/system_properties.h>
+
+//! #568: transparency is requested via the debug.dxr.transparent sysprop for now
+//! (Layer A will carry a per-session XR_EXT_android_surface_binding flag over IPC).
+//! This is the transparent-texture / alpha-gate path (NOT chroma-key, which is
+//! deprecated): the compositor tells the vendor DP to reconstruct alpha post-weave,
+//! exactly as the Windows transparent-present path does.
+static bool
+android_transparent_requested(void)
+{
+	char value[PROP_VALUE_MAX] = {0};
+	if (__system_property_get("debug.dxr.transparent", value) > 0) {
+		return value[0] == '1' || value[0] == 't' || value[0] == 'T' || value[0] == 'y' || value[0] == 'Y';
+	}
+	return false;
+}
 
 //! Context for marshaling the vendor DP factory call onto the service main thread.
 struct dp_factory_call_ctx
@@ -1847,6 +1864,23 @@ multi_compositor_init_session_render(struct multi_compositor *mc)
 			}
 		}
 	}
+
+#ifdef XRT_OS_ANDROID
+	// #568: enable the transparent-background alpha-gate on the vendor DP so the
+	// weaved avatar floats over the live screen (the DP reconstructs alpha that
+	// the weave destroys — the same transparent-texture path as Windows; NOT
+	// chroma-key). Safe on any DP: the wrapper struct_size-gates and no-ops if
+	// the plug-in didn't advertise the xrt_display_processor_vk variant. Covers
+	// both the freshly-created and the cached (#528) DP. On Android the platform
+	// (SurfaceFlinger) always presents, so client_presents = true.
+	if (mc->session_render.display_processor != NULL && android_transparent_requested()) {
+		xrt_display_processor_vk_set_transparent_background(
+		    (struct xrt_display_processor_vk *)mc->session_render.display_processor,
+		    true,  // enabled
+		    true); // client_presents
+		U_LOG_W("#568: requested transparent-background alpha-gate on the Android DP");
+	}
+#endif
 
 	// Create HUD overlay for runtime-owned windows
 	mc->session_render.hud = NULL;

--- a/src/xrt/compositor/multi/comp_multi_system.c
+++ b/src/xrt/compositor/multi/comp_multi_system.c
@@ -346,6 +346,127 @@ find_active_blend_mode(struct multi_compositor **overlay_sorted_clients, size_t 
  * @param[out] out_image_view The VkImageView for rendering
  * @return true if extraction successful
  */
+/*!
+ * Composite LOCAL_2D layers (XR_EXT_local_3d_zone, e.g. the avatar speech
+ * bubble, #568) into the final per-session target, post-weave, by scale-blitting
+ * each layer image into its destination rect. The target's 2D regions (outside
+ * any 3D zone) were cleared transparent by the DP, and the layer carries its own
+ * alpha, so the blit drops the panel in with transparent margins → the live
+ * screen shows through. Recorded into @p cmd after process_atlas; the target
+ * enters and leaves in COLOR_ATTACHMENT_OPTIMAL so the existing post-weave →
+ * PRESENT barrier is unaffected.
+ *
+ * Layers blit in submission order (alpha-replace, not alpha-over): correct for a
+ * single bubble or non-overlapping 2D layers; overlapping layers would need a
+ * blend pass (deferred — not required by the avatar, which composites its panel
+ * and text into one layer).
+ *
+ * @return true if at least one LOCAL_2D layer was blitted.
+ */
+static bool
+composite_local_2d_layers(struct multi_compositor *mc,
+                          struct vk_bundle *vk,
+                          VkCommandBuffer cmd,
+                          VkImage target_image,
+                          uint32_t fb_width,
+                          uint32_t fb_height)
+{
+	bool any = false;
+	for (uint32_t i = 0; i < mc->delivered.layer_count; i++) {
+		struct multi_layer_entry *layer = &mc->delivered.layers[i];
+		if (layer->data.type != XRT_LAYER_LOCAL_2D) {
+			continue;
+		}
+		const struct xrt_layer_local_2d_data *l2d = &layer->data.local_2d;
+		struct xrt_swapchain *xsc = layer->xscs[0];
+		if (xsc == NULL) {
+			continue;
+		}
+		struct comp_swapchain *sc = comp_swapchain(xsc);
+		uint32_t img_idx = l2d->sub.image_index;
+		VkImage src_image = sc->vkic.images[img_idx].handle;
+		if (src_image == VK_NULL_HANDLE) {
+			continue;
+		}
+
+		// Source sub-rect within the layer image; honor flip_y by swapping
+		// the src Y bounds (same convention as the atlas blit above).
+		int src_x0 = l2d->sub.rect.offset.w;
+		int src_y0 = l2d->sub.rect.offset.h;
+		int src_w = l2d->sub.rect.extent.w;
+		int src_h = l2d->sub.rect.extent.h;
+		int src_top = layer->data.flip_y ? (src_y0 + src_h) : src_y0;
+		int src_bot = layer->data.flip_y ? src_y0 : (src_y0 + src_h);
+
+		// Destination rect — window/canvas px (== panel px on Android OOP),
+		// clamped to the target.
+		int dx0 = l2d->rect.offset.w, dy0 = l2d->rect.offset.h;
+		int dx1 = dx0 + l2d->rect.extent.w, dy1 = dy0 + l2d->rect.extent.h;
+		if (dx0 < 0) dx0 = 0;
+		if (dy0 < 0) dy0 = 0;
+		if (dx1 > (int)fb_width) dx1 = (int)fb_width;
+		if (dy1 > (int)fb_height) dy1 = (int)fb_height;
+		if (dx1 <= dx0 || dy1 <= dy0) {
+			continue;
+		}
+
+		uint32_t arr = l2d->sub.array_index;
+
+		// target COLOR_ATTACHMENT → TRANSFER_DST; src GENERAL → TRANSFER_SRC
+		// (overlay/shared images are kept in GENERAL, matching the window-space path).
+		VkImageMemoryBarrier pre[2] = {
+		    {.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+		     .srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+		     .dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
+		     .oldLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+		     .newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+		     .image = target_image,
+		     .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1}},
+		    {.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+		     .srcAccessMask = 0,
+		     .dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT,
+		     .oldLayout = VK_IMAGE_LAYOUT_GENERAL,
+		     .newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+		     .image = src_image,
+		     .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, arr, 1}},
+		};
+		vk->vkCmdPipelineBarrier(cmd,
+		                         VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT | VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+		                         VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, NULL, 0, NULL, 2, pre);
+
+		VkImageBlit blit = {
+		    .srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, arr, 1},
+		    .srcOffsets = {{src_x0, src_top, 0}, {src_x0 + src_w, src_bot, 1}},
+		    .dstSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1},
+		    .dstOffsets = {{dx0, dy0, 0}, {dx1, dy1, 1}},
+		};
+		vk->vkCmdBlitImage(cmd, src_image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, target_image,
+		                   VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &blit, VK_FILTER_LINEAR);
+
+		// restore: target → COLOR_ATTACHMENT, src → GENERAL
+		VkImageMemoryBarrier post[2] = {
+		    {.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+		     .srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
+		     .dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+		     .oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+		     .newLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+		     .image = target_image,
+		     .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1}},
+		    {.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+		     .srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT,
+		     .dstAccessMask = 0,
+		     .oldLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+		     .newLayout = VK_IMAGE_LAYOUT_GENERAL,
+		     .image = src_image,
+		     .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, arr, 1}},
+		};
+		vk->vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT,
+		                         VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, 0, 0, NULL, 0, NULL, 2, post);
+		any = true;
+	}
+	return any;
+}
+
 static bool
 get_session_layer_view(struct multi_layer_entry *layer,
                        int view_index,
@@ -358,8 +479,12 @@ get_session_layer_view(struct multi_layer_entry *layer,
 {
 	const struct xrt_layer_data *layer_data = &layer->data;
 
-	// Only support projection layers for SR weaving
-	if (layer_data->type != XRT_LAYER_PROJECTION && layer_data->type != XRT_LAYER_PROJECTION_DEPTH) {
+	// Projection layers for SR weaving, plus zone-3D layers (XR_EXT_display_zones,
+	// #568): xrt_layer_zone_3d_data embeds xrt_layer_projection_data as its first
+	// member, and data.proj / data.zone_3d.proj alias the union's first member —
+	// so the per-view proj/sub reads below are byte-identical for ZONE_3D.
+	if (layer_data->type != XRT_LAYER_PROJECTION && layer_data->type != XRT_LAYER_PROJECTION_DEPTH &&
+	    layer_data->type != XRT_LAYER_ZONE_3D) {
 		return false;
 	}
 
@@ -969,11 +1094,14 @@ composite_layers_to_intermediate(struct multi_compositor *mc,
                                  VkImageView *out_left_view,
                                  VkImageView *out_right_view)
 {
-	// Find the projection layer first
+	// Find the projection (or zone-3D) layer first. Zone-3D carries an
+	// embedded projection (XR_EXT_display_zones, #568) and composites the
+	// same way; only the window-space layer path reaches here today.
 	struct multi_layer_entry *proj_layer = NULL;
 	for (uint32_t i = 0; i < mc->delivered.layer_count; i++) {
 		enum xrt_layer_type type = mc->delivered.layers[i].data.type;
-		if (type == XRT_LAYER_PROJECTION || type == XRT_LAYER_PROJECTION_DEPTH) {
+		if (type == XRT_LAYER_PROJECTION || type == XRT_LAYER_PROJECTION_DEPTH ||
+		    type == XRT_LAYER_ZONE_3D) {
 			proj_layer = &mc->delivered.layers[i];
 			break;
 		}
@@ -2087,13 +2215,37 @@ render_session_to_own_target(struct multi_compositor *mc, struct vk_bundle *vk, 
 		return;
 	}
 
-	// Get the first projection layer
+	// Get the first projection (or zone-3D) layer. A zone-3D layer
+	// (XR_EXT_display_zones, #568) carries an embedded projection plus a
+	// placement rect; it renders exactly like a projection here, then the
+	// rect is handed to the DP as the canvas sub-rect (see process_atlas below).
 	struct multi_layer_entry *layer = NULL;
 	for (uint32_t i = 0; i < mc->delivered.layer_count; i++) {
 		enum xrt_layer_type type = mc->delivered.layers[i].data.type;
-		if (type == XRT_LAYER_PROJECTION || type == XRT_LAYER_PROJECTION_DEPTH) {
+		if (type == XRT_LAYER_PROJECTION || type == XRT_LAYER_PROJECTION_DEPTH ||
+		    type == XRT_LAYER_ZONE_3D) {
 			layer = &mc->delivered.layers[i];
 			break;
+		}
+	}
+
+	// One-shot WARN (per layer-type change) naming what the per-session path
+	// selected and, for a zone (XR_EXT_display_zones / #568), its placement
+	// rect — a lifecycle breadcrumb at the same level as the atlas/DP WARNs
+	// below, so zone-on-OOP framing is greppable without the INFO hot path.
+	{
+		static enum xrt_layer_type last_logged = (enum xrt_layer_type)-1;
+		if (layer != NULL && layer->data.type != last_logged) {
+			last_logged = layer->data.type;
+			if (layer->data.type == XRT_LAYER_ZONE_3D) {
+				const struct xrt_rect *zr = &layer->data.zone_3d.rect;
+				U_LOG_W("[per-session] #568 render layer = ZONE_3D id=%u rect=%d,%d %dx%d",
+				        layer->data.zone_3d.zone_id, zr->offset.w, zr->offset.h,
+				        zr->extent.w, zr->extent.h);
+			} else {
+				U_LOG_W("[per-session] #568 render layer = type %d (not a zone)",
+				        (int)layer->data.type);
+			}
 		}
 	}
 
@@ -2535,6 +2687,21 @@ render_session_to_own_target(struct multi_compositor *mc, struct vk_bundle *vk, 
 			xrt_display_processor_set_target_color_view(mc->session_render.display_processor,
 			                                            ct->images[buffer_index].view);
 
+			// Canvas sub-rect: a zone-3D layer (XR_EXT_display_zones, #568)
+			// confines its woven output to a placement rect (e.g. the avatar's
+			// bottom-75% tiger zone); the DP weaves into that band and clears
+			// outside it transparent. A plain projection layer passes 0,0,0,0
+			// → the DP fills the full target (unchanged for every other app).
+			int32_t canvas_x = 0, canvas_y = 0;
+			uint32_t canvas_w = 0, canvas_h = 0;
+			if (layer->data.type == XRT_LAYER_ZONE_3D) {
+				const struct xrt_rect *zr = &layer->data.zone_3d.rect;
+				canvas_x = zr->offset.w;
+				canvas_y = zr->offset.h;
+				canvas_w = (uint32_t)zr->extent.w;
+				canvas_h = (uint32_t)zr->extent.h;
+			}
+
 			// Call display processor with atlas input
 			xrt_display_processor_process_atlas(
 			    mc->session_render.display_processor, cmd,
@@ -2549,7 +2716,14 @@ render_session_to_own_target(struct multi_compositor *mc, struct vk_bundle *vk, 
 			    (VkImage_XDP)ct->images[buffer_index].handle,
 			    framebufferWidth, framebufferHeight,
 			    (VkFormat_XDP)framebufferFormat,
-			    0, 0, 0, 0);
+			    canvas_x, canvas_y, canvas_w, canvas_h);
+
+			// Composite LOCAL_2D layers (e.g. the avatar speech bubble in the
+			// top-25% 2D band, #568) into the woven target. Post-weave so they
+			// land in the 2D regions the DP left transparent; the target stays
+			// in COLOR_ATTACHMENT for the post-weave barrier below.
+			composite_local_2d_layers(mc, vk, cmd, ct->images[buffer_index].handle,
+			                          framebufferWidth, framebufferHeight);
 
 			// Post-weave barrier: target → PRESENT_SRC_KHR (for HUD overlay + present)
 			VkImageMemoryBarrier post_weave = {
@@ -2893,6 +3067,11 @@ transfer_layers_locked(struct multi_system_compositor *msc, int64_t display_time
 			case XRT_LAYER_EQUIRECT1: do_equirect1_layer(xc, mc, layer, i); break;
 			case XRT_LAYER_EQUIRECT2: do_equirect2_layer(xc, mc, layer, i); break;
 			case XRT_LAYER_ZONE_3D: do_zone_3d_layer(xc, mc, layer, i); break;
+			case XRT_LAYER_LOCAL_2D:
+				// 2D overlay consumed only by the per-session render path
+				// (blit into the target's 2D region, #568); the shared/
+				// downstream path has no consumer — drop quietly.
+				break;
 			default: U_LOG_E("Unhandled layer type '%i'!", layer->data.type); break;
 			}
 		}

--- a/src/xrt/include/xrt/xrt_display_processor_vk.h
+++ b/src/xrt/include/xrt/xrt_display_processor_vk.h
@@ -1,0 +1,155 @@
+// Copyright 2026, Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  Header for @ref xrt_display_processor_vk interface.
+ *
+ * Vulkan/Android variant of the display processor abstraction. Unlike the
+ * standalone @ref xrt_display_processor_d3d11 (D3D11 has no shared base vtable),
+ * the *generic* @ref xrt_display_processor IS already the Vulkan interface —
+ * its @ref xrt_display_processor::process_atlas records into a VkCommandBuffer.
+ * So this variant simply **embeds** the generic base at offset 0 and **appends**
+ * one slot: @ref set_transparent_background.
+ *
+ * A plug-in opts into the variant by setting @ref xrt_display_processor::struct_size
+ * (the embedded base's header) to `sizeof(struct xrt_display_processor_vk)`. The
+ * runtime casts a @ref xrt_display_processor* it received from a Vulkan factory
+ * to this type and uses the reported struct_size to decide whether the appended
+ * slot is present (ADR-020 — exactly the per-API struct_size gate used by
+ * @ref xrt_display_processor_d3d11). A DP that reports only
+ * `sizeof(struct xrt_display_processor)` (sim_display, an older Leia plug-in) is
+ * transparently treated as *not* the variant: the appended slot's bytes fall
+ * past struct_size, so the helper below reports it absent.
+ *
+ * @author David Fattal
+ * @ingroup xrt_iface
+ */
+
+#pragma once
+
+#include "xrt/xrt_display_processor.h" // the embedded base + the XRT_DP_ABI_ASSERT/XRT_DP_ABI_MSG macros
+
+#include <stdbool.h>
+#include <stddef.h> // offsetof — used by the ABI tripwire at the end of this header
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*!
+ * @interface xrt_display_processor_vk
+ *
+ * Vulkan/Android display output processor — the generic @ref xrt_display_processor
+ * plus the transparency-enable slot. The compositor calls the base vtable
+ * (process_atlas, …) exactly as for any Vulkan DP; the appended slot is the
+ * policy signal that turns on transparent-background output (the alpha-gate
+ * post-weave pass on Leia).
+ *
+ * @ingroup xrt_iface
+ */
+struct xrt_display_processor_vk
+{
+	/*!
+	 * The generic Vulkan display-processor vtable. MUST be the first member
+	 * (offset 0) so a @ref xrt_display_processor* and a
+	 * @ref xrt_display_processor_vk* are interchangeable. @ref base.struct_size
+	 * is the 8-byte struct_size header that gates this variant's appended slot
+	 * (set it to `sizeof(struct xrt_display_processor_vk)` to advertise the
+	 * variant; see ADR-020 and @ref XRT_DP_HAS_SLOT).
+	 */
+	struct xrt_display_processor base;
+
+	/*!
+	 * Enable/disable transparent-background output for this client (#568, the
+	 * Android port of the D3D11 ADR-029 slot). When enabled, the DP
+	 * reconstructs per-pixel alpha *after* the weave (which destroys alpha): a
+	 * fullscreen alpha-gate pass samples the original premultiplied atlas and
+	 * writes (0,0,0,0) wherever every view tile is α==0 (so the platform
+	 * compositor — SurfaceFlinger on Android — shows the live screen through
+	 * the holes), else the woven RGB at α=1. This supersedes
+	 * @ref xrt_display_processor::set_chroma_key as the transparency enable on
+	 * this path; chroma-key is retired for the Vulkan/Android variant.
+	 *
+	 * @p client_presents mirrors the D3D11 slot for symmetry, but on Android it
+	 * is **always true**: SurfaceFlinger composites the runtime's translucent
+	 * surface over the home screen for free (the in-process model, ADR-025), so
+	 * the final present already blends the live screen into the α=0 holes. The
+	 * DP therefore only reconstructs alpha (the alpha-gate) — it never composes
+	 * its own captured-desktop background (which would bake a stale frame and
+	 * add latency). The 2-arg signature is kept so the variant matches
+	 * @ref xrt_display_processor_d3d11::set_transparent_background; callers on
+	 * Android pass true.
+	 *
+	 * Optional — an absent slot (older plug-in `struct_size`) or NULL ⟹ the
+	 * runtime falls back to @ref xrt_display_processor::set_chroma_key. Appended
+	 * per ADR-020 (append-only within a major; no version bump).
+	 *
+	 * @param xdp             Pointer to self.
+	 * @param enabled         true to produce transparent output for see-through.
+	 * @param client_presents true ⟹ the platform present blends the live screen
+	 *                        into the α=0 holes (always true on Android). The DP
+	 *                        then only reconstructs alpha, never composes its own
+	 *                        background.
+	 */
+	void (*set_transparent_background)(struct xrt_display_processor_vk *xdp, bool enabled, bool client_presents);
+};
+
+/*
+ * ── Plug-in ABI tripwire (ADR-020) ─────────────────────────────────────────
+ *
+ * This variant is part of the same versioned plug-in ABI as the base
+ * @ref xrt_display_processor. Because it embeds the base at offset 0, the base's
+ * own 22-slot tripwire (in xrt_display_processor.h) already pins the embedded
+ * layout — any base reorder fails there. Here we only need to pin that the base
+ * really is at offset 0 and that @ref set_transparent_background is appended
+ * immediately after it (so the struct_size gate discriminates the variant).
+ * Appending a method WITHOUT a major bump means appending after this slot, with
+ * its own assert and a bumped size assert; any other change is breaking and must
+ * bump XRT_PLUGIN_API_VERSION_CURRENT (xrt_plugin.h) + re-pin every plug-in.
+ *
+ * NOTE the appended slot lands at sizeof(struct xrt_display_processor) — i.e.
+ * right after the base's last slot (clear_local_zone_mask). This is NOT the
+ * D3D11 "+17" offset: the Vulkan base carries more slots than the D3D11 vtable.
+ *
+ * XRT_DP_ABI_ASSERT / XRT_DP_ABI_MSG / XRT_DP_HAS_SLOT are defined (guarded) by
+ * xrt_display_processor.h, included above.
+ */
+// clang-format off
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_vk, base) == 0, XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_vk, set_transparent_background) == sizeof(struct xrt_display_processor), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(sizeof(struct xrt_display_processor_vk) == sizeof(struct xrt_display_processor) + sizeof(void *), XRT_DP_ABI_MSG);
+// clang-format on
+
+/*!
+ * @copydoc xrt_display_processor_vk::set_transparent_background
+ *
+ * Returns false if not supported (the plug-in's `base.struct_size` doesn't cover
+ * the slot, or the pointer is NULL) — the caller then falls back to
+ * @ref xrt_display_processor_set_chroma_key on the base.
+ *
+ * Unlike @ref XRT_DP_HAS_SLOT (which assumes a direct `struct_size` member), the
+ * presence check here reads `xdp->base.struct_size` because the variant embeds
+ * the base — see ADR-020.
+ *
+ * @public @memberof xrt_display_processor_vk
+ */
+static inline bool
+xrt_display_processor_vk_set_transparent_background(struct xrt_display_processor_vk *xdp,
+                                                    bool enabled,
+                                                    bool client_presents)
+{
+	if (xdp == NULL) {
+		return false;
+	}
+	const char *slot_end =
+	    (const char *)&xdp->set_transparent_background + sizeof(xdp->set_transparent_background);
+	if (slot_end > (const char *)xdp + xdp->base.struct_size || xdp->set_transparent_background == NULL) {
+		return false;
+	}
+	xdp->set_transparent_background(xdp, enabled, client_presents);
+	return true;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/xrt/state_trackers/oxr/oxr_display_zones.c
+++ b/src/xrt/state_trackers/oxr/oxr_display_zones.c
@@ -38,10 +38,14 @@ oxr_xrGetDisplayZoneCapabilitiesEXT(XrSession session, XrDisplayZoneCapabilities
 	// Never errors on an unsupported session — reports supported = false.
 	// Zones need a window-bound native compositor (the same session class
 	// as local-2D layers); maxZones3D is plugin-independent (zone assembly
-	// is compositor-side, ADR-027 Decision 5).
+	// is compositor-side, ADR-027 Decision 5). Out-of-process sessions
+	// (Android OOP, #568) own no in-process native compositor but still
+	// drive a window-bound per-session compositor via the service — the
+	// is_service_mode flag covers that class (sess->xcn is the IPC proxy).
 	const bool window_bound = (sess->is_d3d11_native_compositor || sess->is_d3d12_native_compositor ||
 	                           sess->is_metal_native_compositor || sess->is_gl_native_compositor ||
-	                           sess->has_external_window) &&
+	                           sess->has_external_window ||
+	                           (sess->sys->xsysc != NULL && sess->sys->xsysc->info.is_service_mode)) &&
 	                          sess->xcn != NULL;
 
 	capabilities->supported = window_bound ? XR_TRUE : XR_FALSE;

--- a/src/xrt/state_trackers/oxr/oxr_session_frame_end.c
+++ b/src/xrt/state_trackers/oxr/oxr_session_frame_end.c
@@ -1298,9 +1298,14 @@ verify_local_2d_layer(struct oxr_session *sess,
 		                 layer_index);
 	}
 
-	// Same session gate as window-space layers: a window-bound native compositor.
+	// Same session gate as window-space layers (verify_window_space_layer): a
+	// window-bound native compositor, an IPC service-mode session (the service
+	// compositor composites server-side — comp_multi on Android OOP, #568), or a
+	// bound external window. Must match the window-space + zones gates.
+	const bool is_ipc_service = sess->sys->xsysc != NULL && sess->sys->xsysc->info.is_service_mode;
 	if (!sess->is_d3d11_native_compositor && !sess->is_d3d12_native_compositor &&
-	    !sess->is_metal_native_compositor && !sess->is_gl_native_compositor && !sess->has_external_window) {
+	    !sess->is_metal_native_compositor && !sess->is_gl_native_compositor && !is_ipc_service &&
+	    !sess->has_external_window) {
 		return oxr_error(log, XR_ERROR_LAYER_INVALID,
 		                 "(frameEndInfo->layers[%u]) local-2D layer requires a session created with a "
 		                 "window binding extension",
@@ -1443,9 +1448,16 @@ verify_zones_frame(struct oxr_session *sess,
 		                 first_unchained, zone_count);
 	}
 
-	// Same session gate as local-2D layers: a window-bound native compositor.
-	if (!sess->is_d3d11_native_compositor && !sess->is_d3d12_native_compositor &&
-	    !sess->is_metal_native_compositor && !sess->is_gl_native_compositor && !sess->has_external_window) {
+	// Same session gate as local-2D layers: a window-bound native compositor,
+	// OR an out-of-process service session (Android OOP, #568) whose per-session
+	// compositor is window-bound via the service. Must match the caps-query gate
+	// in oxr_display_zones.c — both admit is_service_mode or the app activates
+	// zones (caps) then has every zones frame rejected here.
+	const bool zones_window_bound =
+	    sess->is_d3d11_native_compositor || sess->is_d3d12_native_compositor ||
+	    sess->is_metal_native_compositor || sess->is_gl_native_compositor || sess->has_external_window ||
+	    (sess->sys->xsysc != NULL && sess->sys->xsysc->info.is_service_mode);
+	if (!zones_window_bound) {
 		return oxr_error(log, XR_ERROR_VALIDATION_FAILURE,
 		                 "(frameEndInfo->layers) zone-chained projection layers require a session created "
 		                 "with a window binding extension");


### PR DESCRIPTION
Ports the Windows transparent-present (ADR-029) to Android so apps (demo-avatar) float a glasses-free 3D avatar over the live Android screen. Device-verified on the NP02J (NP02J) in both orientations.

**Runtime changes (this branch):**
- `1413f3ba9` translucent overlay surface (MonadoView + android_custom_surface) + alpha-capable INHERIT/RGBA8 swapchain (comp_target_swapchain).
- `3f139924b` new `xrt_display_processor_vk` DP variant (append-only `set_transparent_background`, struct_size-gated per ADR-020).
- `59c556df7` wire the transparent-background enable to the Android vendor DP (transparent-texture/alpha-gate path — NOT chroma-key).
- `089a84a6f` display-zones + Local2D on Android OOP (bottom-75% tiger zone + top-25% speech-bubble band).

Pairs with leia-plugin `feat/android-transparency-568` (CNSDK alpha-gate + de-occlusion/landscape fixes) and demo-avatar's android leg. Dev-gated on `debug.dxr.transparent` (formal XR_EXT_android_surface_binding flag is a follow-up). Android-specific + flag-gated — no effect on other platforms.

Known follow-ups (filed separately): avatar rig vertical centering; 3D-zone weave sub-rect shift (plugin/CNSDK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)