### PR TITLE
fix(#568): macOS VK Local2D flat-2D region reveals desktop, not opaque magenta

### DIFF
--- a/docs/guides/displayxr-app-rules.md
+++ b/docs/guides/displayxr-app-rules.md
@@ -294,6 +294,24 @@ re-implementing — see [INV-8.1](#8-app-folder-layout--what-to-include)).
     the broader color-management design is tracked in
     [#409](https://github.com/DisplayXR/displayxr-runtime/issues/409).
 
+- **INV-4.7 — Clear the WHOLE `imageRect` you declare — every pixel the runtime blits must be
+  written.** The compositor copies the *entire* `subImage.imageRect` you report (INV-4.4) into the
+  atlas; it does **not** know which sub-region you actually drew. Any pixel inside that rect you
+  leave unwritten is undefined GPU memory — on MoltenVK that reads as **opaque magenta**, and in
+  transparent-background mode it becomes an opaque fill where you expected the desktop to show.
+  - If you render into only part of a tile (e.g. an avatar confined to the bottom band, the rest
+    meant to be see-through), **clear the full tile to `(0,0,0,0)` first** (a load-op clear, a
+    `vkCmdClearColorImage`, or a full-viewport clear pass) before drawing — exactly as you already
+    clear the rendered region. Don't rely on the runtime to mask it.
+  - Alternatively, **shrink `imageRect` to cover only the pixels you wrote** — then the unwritten
+    area is outside the declared rect and never blitted. (Prefer the clear when the layer's
+    placement/aspect must stay fixed.)
+  - This bites hardest with transparent backgrounds + flat-2D zones (`XR_EXT_local_3d_zone`
+    Local2D): a transparent 2D pixel reveals whatever is woven beneath it, so an unwritten
+    projection band shows through as garbage instead of the desktop. (Runtime hardening for the
+    macOS alpha-native path landed in #568, but clearing the full rect is the portable fix and the
+    app's responsibility.) Ref: `#568`, `#392`.
+
 ---
 
 ## 5. Texture apps: canvas sub-rect + 2D surround
@@ -572,6 +590,7 @@ launcher. The bare runtime ignores manifests — discovery is the workspace laye
 - [ ] `xrLocateViews` into an 8-wide buffer; render/submit `eyeCount` from the active mode, not 2 (INV-3.1)
 - [ ] App swapchain sized once to worst-case atlas (INV-4.2); per-tile = window/canvas × scaleXY, never display (INV-4.3)
 - [ ] Color space: request an **sRGB swapchain** and write a correctly-encoded image (linear render + GPU sRGB-write, or display-referred bytes — not both); linear/UNORM swapchain is not color-managed; data textures always linear (INV-4.6)
+- [ ] Whole declared `imageRect` is written — partial-tile renders clear the full tile to `(0,0,0,0)` first (or shrink the rect); no undefined pixels reach the atlas, esp. transparent-bg (INV-4.7)
 - [ ] (texture) canvas rect set; blit back from `(x,y,w,h)` sub-rect, not origin (INV-5.2); surround cleared on resize (INV-5.6)
 - [ ] (texture) shared surface sized once to worst-case (INV-5.7)
 - [ ] Window-relative Kooima; matrices transposed for DirectX (INV-6.3/6.4)

--- a/scripts/check_displayxr_app.py
+++ b/scripts/check_displayxr_app.py
@@ -49,6 +49,7 @@ RULES = {
     "INV-3.1": "Locate into an XRT_MAX_VIEWS (8)-wide buffer; render/submit the active mode's viewCount, never a hardcoded 2.",
     "INV-4.3": "Per-tile render size = window/canvas x scaleXY, never display size.",
     "INV-4.6": "Request an sRGB swapchain (and store a correctly-encoded image); don't double-encode.",
+    "INV-4.7": "Write every pixel of the imageRect you declare — clear partial-tile renders to (0,0,0,0) first (or shrink the rect); undefined pixels read as opaque magenta on MoltenVK and break transparent-bg.",
     "INV-7.x": "Capture via xrCaptureAtlasEXT — never reintroduce an app-side CaptureAtlasRegion* readback.",
     "INV-7.2": "xrCaptureAtlasEXT pathPrefix takes NO extension; the runtime appends _atlas.png.",
     "INV-9.1": "Ship a <exe>.displayxr.json (schema_version=1, name 1-64, type 2d|3d) or the app won't appear in the workspace launcher.",

--- a/src/xrt/compositor/vk_native/comp_vk_native_compositor.c
+++ b/src/xrt/compositor/vk_native/comp_vk_native_compositor.c
@@ -156,6 +156,12 @@ struct comp_vk_native_compositor
 	//! Generic Vulkan display processor (vendor-agnostic weaving).
 	struct xrt_display_processor *display_processor;
 
+	//! Transparent-background present requested at create (XR_EXT_*_window_binding
+	//! transparentBackgroundEnabled). The atlas/DP clear to alpha=0 and the
+	//! present uses a transparent compositeAlpha. Cached for the macOS Local2D
+	//! flat-2D-over-desktop rule (#568) in vk_composite_local_2d.
+	bool transparent_background;
+
 	//! True when display is in 3D mode (weaver active). False = 2D passthrough.
 	bool hardware_display_3d;
 
@@ -3469,6 +3475,7 @@ comp_vk_native_compositor_create(struct xrt_device *xdev,
 	// transparent background was requested, so app alpha<1 regions survive
 	// to the present (issue #392). Mirrors the DP weave-clear plumbing above.
 	comp_vk_native_renderer_set_transparent(c->renderer, transparent_background);
+	c->transparent_background = transparent_background;
 
 	// Set tile layout from active rendering mode
 	if (c->xdev != NULL && c->xdev->hmd != NULL) {
@@ -4665,7 +4672,30 @@ vk_composite_local_2d(struct comp_vk_native_compositor *c,
 	// XR_EXT_display_zones: zones frames are ALWAYS the hard M-lerp
 	// (final = M·weave + (1−M)·flatten(2D-over)).
 	const bool have_explicit = (emask != NULL && emask->submitted && emask->staged_view != VK_NULL_HANDLE);
-	const bool alpha_over = !zones_frame && !have_explicit;
+	bool alpha_over = !zones_frame && !have_explicit;
+#if defined(XRT_OS_MACOS)
+	// #568 macOS flat-2D-over-desktop: on the alpha-native transparent path the
+	// desktop shows through wherever the final alpha is 0 (the non-opaque
+	// CAMetalLayer composites our premultiplied pixels) — there is NO captured
+	// desktop woven under the 2D (that is the Windows WGC 2D-under path). The
+	// #491 alpha_over composite (frag = twod + (1-twod.a)·weave) reveals the
+	// WEAVE under a transparent flat-2D pixel, so a Local2D zone placed over an
+	// unrendered/transparent-intended projection band instead exposes whatever
+	// the weave holds there (e.g. an app's uninitialized tile) as an opaque
+	// fill — never the desktop. Fall back to the hard M-lerp
+	// (frag = M·weave + (1-M)·twod): the implicit mask is M=1 outside the
+	// Local2D rects (keep the weave) and M=0 inside them, so a flat-2D region
+	// composites 2D-over-transparent — transparent 2D → alpha 0 → desktop,
+	// mirroring how the projection layer's own transparency already reaches the
+	// CAMetalLayer. Gated to the alpha-native + transparent-background case so
+	// opaque presents and chroma-key DPs are untouched; explicit/zones masks
+	// already use the hard lerp. Windows keeps alpha_over (its 2D-under path
+	// supplies the captured desktop), so no cross-platform regression.
+	if (alpha_over && c->transparent_background && c->display_processor != NULL &&
+	    xrt_display_processor_is_alpha_native(c->display_processor)) {
+		alpha_over = false;
+	}
+#endif
 	vk_local2d_composite_draw(&c->local2d, vk, cmd, c->composite_target_fb, dst_w, dst_h,
 	                          c->local2d_scratch_view, mask_view, c->weave_scratch_view, region_w,
 	                          region_h, cx, cy, cw, ch, alpha_over);
@@ -4678,7 +4708,7 @@ vk_composite_local_2d(struct comp_vk_native_compositor *c,
 			logged = true;
 			U_LOG_W("VK Local2D composite: %ux%u region, %u layer(s), %s mask (#491 alpha_over=%d)",
 			        region_w, region_h, rect_count, have_explicit ? "explicit" : "implicit",
-			        !have_explicit);
+			        alpha_over);
 		}
 	}
 


### PR DESCRIPTION
## Problem
On the macOS VK-native + MoltenVK alpha-native transparent path, a flat-2D Local2D region (`XR_EXT_local_3d_zone`, implicit M=0 mask) rendered a **solid opaque magenta fill** instead of revealing the desktop. The 3D projection layer's transparency worked correctly. Repro: `displayxr-demo-avatar` (`feat/macos-avatar-port`) speech-bubble band.

## Root cause
Diagnosed with an alpha-preserving GPU readback (atlas → weave → target):
- The app confines `renderEye` to the bottom band and leaves the projection swapchain's **top band uninitialized** → MoltenVK fills it opaque magenta.
- The runtime blits the full declared projection tile (incl. that band) into the atlas → the DP weaves it → the target band is opaque magenta.
- The implicit Local2D composite uses the #491 `alpha_over` path (`frag = twod + (1-twod.a)·weave`): a transparent bubble pixel (`twod=0`) resolves to `frag = weave` = opaque magenta → desktop never shows. (The projection region works because `renderEye` clears its area to `alpha=0`.)

## Fix
On macOS, when the background is transparent **and** the DP is alpha-native, fall back to the **hard M-lerp** (`frag = M·weave + (1-M)·twod`) for the implicit mask: `M=1` outside the Local2D rects keeps the weave (tiger preserved); `M=0` inside composites 2D-over-transparent, so a transparent flat-2D pixel yields `alpha 0` and the non-opaque CAMetalLayer reveals the desktop — mirroring the projection layer's own transparency.

Tightly gated (`XRT_OS_MACOS` + `transparent_background` + alpha-native DP + implicit mask). Opaque presents, chroma-key DPs, explicit/zones masks, and the Windows D3D11/D3D12 2D-under desktop-capture path are all untouched → no cross-platform regression.

## Also
`INV-4.7` added to the app-authoring rules (+ linter catalog + checklist): apps must write every pixel of the `imageRect` they declare (clear partial-tile renders to `(0,0,0,0)` first). This is the portable, all-platforms fix for the app-side trigger; the companion clear landed in `displayxr-demo-avatar`.

## Verification
macOS, prebuilt avatar: band surround + rounded-corner cut-outs now read `RGBA(0,0,0,0)` (was `255,0,255,255`); pill + tiger weave preserved. `./scripts/build_macos.sh` clean; smoke-run no crash. Confirmed visually on the live display.

Refs #568, #491, #392, ADR-027.

🤖 Generated with [Claude Code](https://claude.com/claude-code)