### PR TITLE
feat(#573)!: remove chroma-key everywhere — ABI v4 (runtime half)

### DIFF
--- a/src/external/openxr_includes/openxr/XR_EXT_win32_window_binding.h
+++ b/src/external/openxr_includes/openxr/XR_EXT_win32_window_binding.h
@@ -30,7 +30,7 @@ extern "C" {
 #endif
 
 #define XR_EXT_win32_window_binding 1
-#define XR_EXT_win32_window_binding_SPEC_VERSION 7
+#define XR_EXT_win32_window_binding_SPEC_VERSION 8
 #define XR_EXT_WIN32_WINDOW_BINDING_EXTENSION_NAME "XR_EXT_win32_window_binding"
 
 // Use a value in the vendor extension range (1000000000+)
@@ -87,17 +87,9 @@ typedef struct XrWin32WindowBindingCreateInfoEXT {
     //! The runtime picks the appropriate DXGI / Windows mechanism per graphics API;
     //! apps should not depend on which one. Only honored when windowHandle is non-NULL
     //! and the session is standalone — ignored in workspace/shell mode.
+    //! Transparency is carried by the swapchain's per-pixel alpha and a transparent
+    //! present (SPEC_VERSION 8, #573 removed the legacy chromaKeyColor field).
     XrBool32                    transparentBackgroundEnabled;
-    //! Optional chroma-key color used by the runtime's post-weave alpha-conversion pass
-    //! when transparentBackgroundEnabled = XR_TRUE. Format: 0x00BBGGRR (Win32 COLORREF).
-    //! When non-zero, the runtime samples the post-weave swapchain image and writes
-    //! alpha = 0 for pixels whose RGB exactly matches this color (alpha = 1 otherwise),
-    //! so the bound display processor's weaver — which strips per-pixel alpha during
-    //! interlacing — does not block transparency. The application is responsible for
-    //! clearing eye views to the same color in transparent regions.
-    //! Set to 0 to disable the post-weave pass (relies entirely on the swapchain's
-    //! per-pixel alpha; usable with alpha-respecting display processors only).
-    uint32_t                    chromaKeyColor;
 } XrWin32WindowBindingCreateInfoEXT;
 
 /*!

--- a/src/xrt/compositor/CMakeLists.txt
+++ b/src/xrt/compositor/CMakeLists.txt
@@ -75,6 +75,17 @@ endif()
 if(XRT_HAVE_D3D11 OR XRT_HAVE_D3D12)
 	target_link_libraries(comp_client PRIVATE aux_d3d)
 	target_sources(comp_client PRIVATE client/comp_d3d_common.cpp client/comp_d3d_common.hpp)
+	# Render-API-agnostic transparent DirectComposition present for forced-IPC
+	# transparent clients (ADR-029). The client must own the present because a
+	# process cannot create a DComp target on another process's HWND; this helper
+	# imports the service's shared output texture + fence and presents on the app's
+	# window. Shared by the D3D11, D3D12 and GL (win32) client compositors, so it
+	# (and the d3d11/dxgi/dcomp libs it needs) lives in the shared D3D block.
+	target_sources(
+		comp_client PRIVATE client/comp_d3d_transparent_present.cpp
+				    client/comp_d3d_transparent_present.h
+		)
+	target_link_libraries(comp_client PRIVATE d3d11 dxgi dcomp)
 endif()
 
 if(XRT_HAVE_D3D11)
@@ -82,9 +93,6 @@ if(XRT_HAVE_D3D11)
 		comp_client PRIVATE client/comp_d3d11_client.cpp client/comp_d3d11_client.h
 				    client/comp_d3d11_glue.c
 		)
-	# #551 — the D3D11 client compositor presents a transparent IPC output via
-	# DirectComposition (DCompositionCreateDevice2) on the app's own window.
-	target_link_libraries(comp_client PRIVATE d3d11 dxgi dcomp)
 endif()
 
 if(XRT_HAVE_D3D12)

--- a/src/xrt/compositor/client/comp_d3d11_client.cpp
+++ b/src/xrt/compositor/client/comp_d3d11_client.cpp
@@ -12,6 +12,7 @@
 #include "comp_d3d11_client.h"
 
 #include "comp_d3d_common.hpp"
+#include "comp_d3d_transparent_present.h"
 
 #include "xrt/xrt_compositor.h"
 #include "xrt/xrt_config_os.h"
@@ -34,9 +35,7 @@
 
 #include <d3d11_1.h>
 #include <d3d11_3.h>
-#include <d3d11_4.h> // #551 ID3D11Fence / ID3D11DeviceContext4 for the transparent present
-#include <dxgi1_2.h> // #551 CreateSwapChainForComposition
-#include <dcomp.h>   // #551 DirectComposition transparent present
+#include <d3d11_4.h> // ID3D11Fence / ID3D11DeviceContext4 (workspace_sync_fence)
 #include <wil/resource.h>
 #include <wil/com.h>
 #include <wil/result_macros.h>
@@ -212,24 +211,17 @@ struct client_d3d11_compositor
 	wil::com_ptr<ID3D11Fence> workspace_sync_fence;
 	uint64_t workspace_sync_fence_value = 0;
 
-	//! #551 — transparent compositing output present. For a forced-IPC
+	//! ADR-029 — transparent compositing output present. For a forced-IPC
 	//! transparent client, the service weaves (with alpha-gate holes) into a
-	//! shared texture; this side imports it + the service→client fence and
+	//! shared texture; this presenter imports it + the service→client fence and
 	//! presents it via a transparent DirectComposition swap chain on the app's
-	//! own window, so DWM blends the LIVE desktop into the holes. Inactive
-	//! (transparent_present == false) for opaque clients — the service presents
-	//! its own swap chain as before. Reusable for any IPC app that requests
-	//! transparentBackgroundEnabled.
-	bool transparent_present = false;
-	HWND transparent_hwnd = nullptr;
-	uint32_t transparent_w = 0, transparent_h = 0;
-	wil::com_ptr<ID3D11Texture2D> transparent_output_texture; //!< imported shared service output
-	wil::com_ptr<ID3D11Fence> transparent_output_fence;       //!< imported service→client fence
-	uint64_t transparent_present_value = 0;                   //!< client wait counter (lockstep w/ service)
-	wil::com_ptr<IDXGISwapChain1> transparent_swapchain;      //!< DComp composition swap chain
-	wil::com_ptr<IDCompositionDevice> transparent_dcomp_device;
-	wil::com_ptr<IDCompositionTarget> transparent_dcomp_target;
-	wil::com_ptr<IDCompositionVisual> transparent_dcomp_visual;
+	//! own window, so DWM blends the LIVE desktop into the holes. NULL for opaque
+	//! clients — the service presents its own swap chain as before. The presenter
+	//! is render-API-agnostic (shared with the D3D12/GL clients); the D3D11 client
+	//! reuses its own @ref app_device for the present.
+	struct comp_d3d_transparent_presenter *transparent = nullptr;
+
+	~client_d3d11_compositor() { comp_d3d_transparent_presenter_destroy(&transparent); }
 };
 
 static_assert(std::is_standard_layout<client_d3d11_compositor>::value);
@@ -973,31 +965,15 @@ client_d3d11_compositor_layer_zone_3d(struct xrt_compositor *xc,
 	return xrt_comp_layer_zone_3d(&c->xcn->base, xdev, xscn, data);
 }
 
-// #551 — per-frame transparent present. Called after the layer-commit RPC
-// returns (the service has weaved + signaled). GPU-wait the service→client
-// fence (lockstep counter, no per-frame IPC), copy the woven shared output into
-// the DComp swap-chain back buffer, and present so DWM blends the LIVE desktop
-// into the alpha-gate holes. No-op for opaque clients.
+// ADR-029 — per-frame transparent present. Called after the layer-commit RPC
+// returns (the service has weaved + signaled). The shared presenter GPU-waits the
+// service→client fence (lockstep counter, no per-frame IPC), copies the woven
+// shared output into the DComp swap-chain back buffer, and presents so DWM blends
+// the LIVE desktop into the alpha-gate holes. No-op for opaque clients.
 static void
 client_d3d11_transparent_present(struct client_d3d11_compositor *c)
 {
-	if (!c->transparent_present || !c->transparent_swapchain || !c->transparent_output_fence) {
-		return;
-	}
-	// Lockstep with the service: it bumps + signals once per commit, we bump +
-	// wait once per commit, so this value always matches the frame just weaved.
-	c->transparent_present_value++;
-	c->fence_context->Wait(c->transparent_output_fence.get(), c->transparent_present_value);
-
-	wil::com_ptr<ID3D11Texture2D> back;
-	if (SUCCEEDED(c->transparent_swapchain->GetBuffer(0, IID_PPV_ARGS(back.put()))) && back) {
-		c->fence_context->CopyResource(back.get(), c->transparent_output_texture.get());
-	}
-	c->transparent_swapchain->Present(1, 0);
-	// Publish the new frame to dwm.exe (cheap delta-state IPC, no GPU work).
-	if (c->transparent_dcomp_device) {
-		c->transparent_dcomp_device->Commit();
-	}
+	comp_d3d_transparent_presenter_present(c->transparent);
 }
 
 static xrt_result_t
@@ -1350,12 +1326,14 @@ try {
 		}
 	}
 
-	// #551 — transparent compositing output. If the service created a shared
-	// output texture for this (transparent) client, import it + the
-	// service→client fence and stand up a transparent DirectComposition swap
-	// chain on the app's own window. The per-frame present in layer_commit then
-	// lets DWM blend the LIVE desktop into the DP's alpha-gate holes. Non-fatal:
-	// any failure leaves the service's opaque present path in effect.
+	// ADR-029 — transparent compositing output. If the service created a shared
+	// output texture for this (transparent) client, hand the shared texture +
+	// service→client fence to the render-API-agnostic presenter, which stands up a
+	// transparent DirectComposition swap chain on the app's own window. The
+	// per-frame present in layer_commit then lets DWM blend the LIVE desktop into
+	// the DP's alpha-gate holes. The D3D11 client reuses its own @ref app_device
+	// for the present. Non-fatal: any failure leaves the service's opaque present
+	// path in effect (presenter stays NULL).
 	{
 		bool have_out = false, have_fence = false;
 		uint32_t tw = 0, th = 0;
@@ -1368,87 +1346,9 @@ try {
 		    hwnd_val != 0) {
 			(void)comp_ipc_client_compositor_get_transparent_output_fence(&xcn->base, &have_fence,
 			                                                             &fence_h);
-			HRESULT hr = c->app_device->OpenSharedResource1(
-			    (HANDLE)tex_h, IID_PPV_ARGS(c->transparent_output_texture.put()));
-			CloseHandle((HANDLE)tex_h); // imported; close our duped copy
-			wil::com_ptr<ID3D11Fence> ofence;
-			if (SUCCEEDED(hr) && have_fence && xrt_graphics_sync_handle_is_valid(fence_h)) {
-				try {
-					ofence = import_fence(*(c->app_device), (HANDLE)fence_h);
-				} catch (...) {
-				}
-			}
-			if (fence_h != XRT_GRAPHICS_SYNC_HANDLE_INVALID) {
-				CloseHandle((HANDLE)fence_h);
-			}
-			if (SUCCEEDED(hr) && ofence) {
-				c->transparent_output_fence = std::move(ofence);
-				HWND hwnd = (HWND)(uintptr_t)hwnd_val;
-				wil::com_ptr<IDXGIDevice> dxgiDev;
-				wil::com_ptr<IDXGIAdapter> adapter;
-				wil::com_ptr<IDXGIFactory2> factory;
-				hr = c->app_device->QueryInterface(IID_PPV_ARGS(dxgiDev.put()));
-				if (SUCCEEDED(hr)) {
-					hr = dxgiDev->GetAdapter(adapter.put());
-				}
-				if (SUCCEEDED(hr)) {
-					hr = adapter->GetParent(IID_PPV_ARGS(factory.put()));
-				}
-				DXGI_SWAP_CHAIN_DESC1 sd = {};
-				sd.Width = tw;
-				sd.Height = th;
-				sd.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-				sd.SampleDesc.Count = 1;
-				sd.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-				sd.BufferCount = 2;
-				sd.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-				sd.AlphaMode = DXGI_ALPHA_MODE_PREMULTIPLIED;
-				if (SUCCEEDED(hr)) {
-					hr = factory->CreateSwapChainForComposition(c->app_device.get(), &sd, nullptr,
-					                                            c->transparent_swapchain.put());
-				}
-				if (SUCCEEDED(hr)) {
-					hr = DCompositionCreateDevice2(
-					    nullptr, IID_PPV_ARGS(c->transparent_dcomp_device.put()));
-				}
-				if (SUCCEEDED(hr)) {
-					hr = c->transparent_dcomp_device->CreateTargetForHwnd(
-					    hwnd, TRUE, c->transparent_dcomp_target.put());
-				}
-				if (SUCCEEDED(hr)) {
-					hr = c->transparent_dcomp_device->CreateVisual(c->transparent_dcomp_visual.put());
-				}
-				if (SUCCEEDED(hr)) {
-					hr = c->transparent_dcomp_visual->SetContent(c->transparent_swapchain.get());
-				}
-				if (SUCCEEDED(hr)) {
-					hr = c->transparent_dcomp_target->SetRoot(c->transparent_dcomp_visual.get());
-				}
-				if (SUCCEEDED(hr)) {
-					hr = c->transparent_dcomp_device->Commit();
-				}
-				if (SUCCEEDED(hr)) {
-					c->transparent_hwnd = hwnd;
-					c->transparent_w = tw;
-					c->transparent_h = th;
-					c->transparent_present = true;
-					U_LOG_W("#551 client transparent present ready (hwnd=%p %ux%u) — DWM "
-					        "blends live desktop into the DP alpha-gate holes",
-					        (void *)hwnd, tw, th);
-				} else {
-					U_LOG_E("#551 client transparent present setup failed: 0x%08lx — service "
-					        "opaque present stays in effect",
-					        hr);
-					c->transparent_swapchain.reset();
-					c->transparent_dcomp_visual.reset();
-					c->transparent_dcomp_target.reset();
-					c->transparent_dcomp_device.reset();
-					c->transparent_output_fence.reset();
-					c->transparent_output_texture.reset();
-				}
-			} else {
-				c->transparent_output_texture.reset();
-			}
+			// The presenter consumes (closes) both handles regardless of outcome.
+			c->transparent = comp_d3d_transparent_presenter_create(c->app_device.get(), hwnd_val, tw,
+			                                                       th, tex_h, fence_h);
 		} else if (tex_h != XRT_GRAPHICS_BUFFER_HANDLE_INVALID) {
 			CloseHandle((HANDLE)tex_h);
 		}

--- a/src/xrt/compositor/client/comp_d3d12_client.cpp
+++ b/src/xrt/compositor/client/comp_d3d12_client.cpp
@@ -13,6 +13,7 @@
 #include "comp_d3d12_client.h"
 
 #include "comp_d3d_common.hpp"
+#include "comp_d3d_transparent_present.h"
 #include "xrt/xrt_compositor.h"
 #include "xrt/xrt_config_os.h"
 #include "xrt/xrt_handles.h"
@@ -48,6 +49,21 @@
 
 using namespace std::chrono_literals;
 using namespace std::chrono;
+
+// #573 — transparent compositing output bridges, defined in
+// src/xrt/ipc/client/ipc_client_compositor.c (resolved at link time so this TU
+// does not pull the IPC client headers). Shared with the D3D11/GL clients.
+extern "C" xrt_result_t
+comp_ipc_client_compositor_get_transparent_output(struct xrt_compositor *xc,
+                                                  bool *out_have_output,
+                                                  uint32_t *out_width,
+                                                  uint32_t *out_height,
+                                                  uint64_t *out_hwnd,
+                                                  xrt_graphics_buffer_handle_t *out_handle);
+extern "C" xrt_result_t
+comp_ipc_client_compositor_get_transparent_output_fence(struct xrt_compositor *xc,
+                                                        bool *out_have_fence,
+                                                        xrt_graphics_sync_handle_t *out_handle);
 
 DEBUG_GET_ONCE_LOG_OPTION(log, "D3D_COMPOSITOR_LOG", U_LOGGING_INFO)
 
@@ -158,6 +174,18 @@ struct client_d3d12_compositor
 	 * The value most recently signaled on the timeline semaphore
 	 */
 	uint64_t timeline_semaphore_value = 0;
+
+	//! ADR-029 (#573) — transparent compositing output present. For a forced-IPC
+	//! transparent client, the service weaves (with alpha-gate holes) into a shared
+	//! texture; this render-API-agnostic presenter imports it + the service→client
+	//! fence and presents it via a transparent DirectComposition swap chain on the
+	//! app's own window, so DWM blends the LIVE desktop into the holes. NULL for
+	//! opaque clients. The D3D12 client passes NULL device → the helper creates its
+	//! own small D3D11 device for the present (the present is pure D3D11 + DComp on
+	//! shared handles, independent of the app's render API).
+	struct comp_d3d_transparent_presenter *transparent = nullptr;
+
+	~client_d3d12_compositor() { comp_d3d_transparent_presenter_destroy(&transparent); }
 };
 
 static_assert(std::is_standard_layout<client_d3d12_compositor>::value);
@@ -987,10 +1015,14 @@ client_d3d12_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_syn
 	}
 	if (c->timeline_semaphore) {
 		// We got this from the native compositor, so we can pass it back
-		return xrt_comp_layer_commit_with_semaphore( //
+		xret = xrt_comp_layer_commit_with_semaphore( //
 		    &c->xcn->base,                           //
 		    c->timeline_semaphore.get(),             //
 		    c->timeline_semaphore_value);            //
+		if (xret == XRT_SUCCESS) {
+			comp_d3d_transparent_presenter_present(c->transparent); // #573
+		}
+		return xret;
 	}
 
 	if (c->fence) {
@@ -1011,7 +1043,11 @@ client_d3d12_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_syn
 		}
 	}
 
-	return xrt_comp_layer_commit(&c->xcn->base, XRT_GRAPHICS_SYNC_HANDLE_INVALID);
+	xret = xrt_comp_layer_commit(&c->xcn->base, XRT_GRAPHICS_SYNC_HANDLE_INVALID);
+	if (xret == XRT_SUCCESS) {
+		comp_d3d_transparent_presenter_present(c->transparent); // #573
+	}
+	return xret;
 }
 
 
@@ -1176,6 +1212,35 @@ try {
 	if (!c->fence) {
 		D3D_WARN(c, "No sync mechanism for D3D12 was successful!");
 	}
+
+	// ADR-029 (#573) — transparent compositing output. If the service created a
+	// shared output texture for this (transparent) client, hand the shared texture +
+	// service→client fence to the render-API-agnostic presenter, which stands up a
+	// transparent DirectComposition swap chain on the app's own window. The per-frame
+	// present in layer_commit then lets DWM blend the LIVE desktop into the DP's
+	// alpha-gate holes. D3D12 passes NULL device → the helper makes its own D3D11
+	// device for the (pure D3D11+DComp) present. Non-fatal: any failure leaves the
+	// service's opaque present in effect (presenter stays NULL).
+	{
+		bool have_out = false, have_fence = false;
+		uint32_t tw = 0, th = 0;
+		uint64_t hwnd_val = 0;
+		xrt_graphics_buffer_handle_t tex_h = XRT_GRAPHICS_BUFFER_HANDLE_INVALID;
+		xrt_graphics_sync_handle_t fence_h = XRT_GRAPHICS_SYNC_HANDLE_INVALID;
+		xrt_result_t oret = comp_ipc_client_compositor_get_transparent_output(
+		    &xcn->base, &have_out, &tw, &th, &hwnd_val, &tex_h);
+		if (oret == XRT_SUCCESS && have_out && tex_h != XRT_GRAPHICS_BUFFER_HANDLE_INVALID &&
+		    hwnd_val != 0) {
+			(void)comp_ipc_client_compositor_get_transparent_output_fence(&xcn->base, &have_fence,
+			                                                             &fence_h);
+			// The presenter consumes (closes) both handles regardless of outcome.
+			c->transparent = comp_d3d_transparent_presenter_create(nullptr, hwnd_val, tw, th, tex_h,
+			                                                       fence_h);
+		} else if (tex_h != XRT_GRAPHICS_BUFFER_HANDLE_INVALID) {
+			CloseHandle((HANDLE)tex_h);
+		}
+	}
+
 	c->base.base.get_swapchain_create_properties = client_d3d12_compositor_get_swapchain_create_properties;
 	c->base.base.create_swapchain = client_d3d12_create_swapchain;
 	c->base.base.create_passthrough = client_d3d12_compositor_passthrough_create;

--- a/src/xrt/compositor/client/comp_d3d_transparent_present.cpp
+++ b/src/xrt/compositor/client/comp_d3d_transparent_present.cpp
@@ -1,0 +1,195 @@
+// Copyright 2026, Collabora, Ltd.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  Render-API-agnostic transparent DirectComposition present for IPC clients.
+ * @ingroup comp_client
+ */
+
+#include "comp_d3d_transparent_present.h"
+
+#include "d3d/d3d_d3d11_helpers.hpp"
+
+#include "util/u_logging.h"
+
+#include <d3d11_4.h> // ID3D11Fence / ID3D11DeviceContext4
+#include <dxgi1_2.h> // CreateSwapChainForComposition
+#include <dcomp.h>   // DirectComposition
+
+#include <wil/com.h>
+#include <wil/result_macros.h>
+
+#include <new>
+
+using wil::com_ptr;
+
+struct comp_d3d_transparent_presenter
+{
+	//! Device + context used for the fence wait and the shared→back-buffer copy. Either the
+	//! caller's device (D3D11 client) or one we created (D3D12/GL/VK clients).
+	com_ptr<ID3D11Device5> device;
+	com_ptr<ID3D11DeviceContext4> context;
+	//! Keeps our self-created device's base interfaces alive (NULL when the caller's device is reused).
+	com_ptr<ID3D11Device> owned_device;
+	com_ptr<ID3D11DeviceContext> owned_context;
+
+	com_ptr<ID3D11Texture2D> output_texture; //!< imported shared service output
+	com_ptr<ID3D11Fence> output_fence;       //!< imported service→client fence
+	uint64_t present_value = 0;              //!< client wait counter (lockstep with the service)
+
+	com_ptr<IDXGISwapChain1> swapchain; //!< DComp composition swap chain
+	com_ptr<IDCompositionDevice> dcomp_device;
+	com_ptr<IDCompositionTarget> dcomp_target;
+	com_ptr<IDCompositionVisual> dcomp_visual;
+
+	uint32_t width = 0, height = 0;
+};
+
+extern "C" struct comp_d3d_transparent_presenter *
+comp_d3d_transparent_presenter_create(void *existing_d3d11_device,
+                                      uint64_t hwnd_val,
+                                      uint32_t width,
+                                      uint32_t height,
+                                      xrt_graphics_buffer_handle_t shared_tex,
+                                      xrt_graphics_sync_handle_t shared_fence)
+{
+	// Consume the handles unconditionally: on every early-out below we still close them.
+	HANDLE tex_h = (HANDLE)shared_tex;
+	HANDLE fence_h = (HANDLE)shared_fence;
+
+	auto fail = [&]() -> comp_d3d_transparent_presenter * {
+		if (tex_h != NULL && tex_h != INVALID_HANDLE_VALUE) {
+			CloseHandle(tex_h);
+		}
+		if (fence_h != NULL && fence_h != INVALID_HANDLE_VALUE) {
+			CloseHandle(fence_h);
+		}
+		return nullptr;
+	};
+
+	if (hwnd_val == 0 || tex_h == NULL || tex_h == INVALID_HANDLE_VALUE) {
+		return fail();
+	}
+
+	auto *p = new (std::nothrow) comp_d3d_transparent_presenter();
+	if (p == nullptr) {
+		return fail();
+	}
+	p->width = width;
+	p->height = height;
+
+	HRESULT hr = S_OK;
+	try {
+		// 1. Resolve the D3D11 device used for the present.
+		if (existing_d3d11_device != nullptr) {
+			auto *base = reinterpret_cast<ID3D11Device *>(existing_d3d11_device);
+			p->device = wil::com_query<ID3D11Device5>(base);
+			com_ptr<ID3D11DeviceContext> ctx;
+			base->GetImmediateContext(ctx.put());
+			p->context = ctx.query<ID3D11DeviceContext4>();
+		} else {
+			auto dev = xrt::compositor::client::createDevice();
+			p->owned_device = dev.first;
+			p->owned_context = dev.second;
+			if (!p->owned_device || !p->owned_context) {
+				delete p;
+				return fail();
+			}
+			p->device = p->owned_device.query<ID3D11Device5>();
+			p->context = p->owned_context.query<ID3D11DeviceContext4>();
+		}
+		if (!p->device || !p->context) {
+			delete p;
+			return fail();
+		}
+
+		// 2. Import the shared output texture + service→client fence.
+		THROW_IF_FAILED(p->device->OpenSharedResource1(tex_h, IID_PPV_ARGS(p->output_texture.put())));
+		CloseHandle(tex_h);
+		tex_h = NULL;
+
+		if (fence_h == NULL || fence_h == INVALID_HANDLE_VALUE) {
+			// No fence ⇒ we cannot lockstep with the service; bail (stays opaque).
+			delete p;
+			return fail();
+		}
+		THROW_IF_FAILED(p->device->OpenSharedFence(fence_h, IID_PPV_ARGS(p->output_fence.put())));
+		CloseHandle(fence_h);
+		fence_h = NULL;
+
+		// 3. Composition swap chain on the device's DXGI factory.
+		com_ptr<IDXGIDevice> dxgi_dev;
+		com_ptr<IDXGIAdapter> adapter;
+		com_ptr<IDXGIFactory2> factory;
+		THROW_IF_FAILED(p->device->QueryInterface(IID_PPV_ARGS(dxgi_dev.put())));
+		THROW_IF_FAILED(dxgi_dev->GetAdapter(adapter.put()));
+		THROW_IF_FAILED(adapter->GetParent(IID_PPV_ARGS(factory.put())));
+
+		DXGI_SWAP_CHAIN_DESC1 sd = {};
+		sd.Width = width;
+		sd.Height = height;
+		sd.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+		sd.SampleDesc.Count = 1;
+		sd.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+		sd.BufferCount = 2;
+		sd.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+		sd.AlphaMode = DXGI_ALPHA_MODE_PREMULTIPLIED;
+		THROW_IF_FAILED(
+		    factory->CreateSwapChainForComposition(p->device.get(), &sd, nullptr, p->swapchain.put()));
+
+		// 4. DComp device/target/visual on the app's HWND.
+		THROW_IF_FAILED(DCompositionCreateDevice2(nullptr, IID_PPV_ARGS(p->dcomp_device.put())));
+		THROW_IF_FAILED(
+		    p->dcomp_device->CreateTargetForHwnd((HWND)(uintptr_t)hwnd_val, TRUE, p->dcomp_target.put()));
+		THROW_IF_FAILED(p->dcomp_device->CreateVisual(p->dcomp_visual.put()));
+		THROW_IF_FAILED(p->dcomp_visual->SetContent(p->swapchain.get()));
+		THROW_IF_FAILED(p->dcomp_target->SetRoot(p->dcomp_visual.get()));
+		THROW_IF_FAILED(p->dcomp_device->Commit());
+	} catch (const wil::ResultException &e) {
+		hr = e.GetErrorCode();
+		U_LOG_E("transparent presenter setup failed: 0x%08lx — staying on opaque present", hr);
+		delete p;
+		return fail();
+	} catch (...) {
+		U_LOG_E("transparent presenter setup failed (exception) — staying on opaque present");
+		delete p;
+		return fail();
+	}
+
+	U_LOG_W("transparent presenter ready (hwnd=0x%llx %ux%u) — DWM blends live desktop into the "
+	        "DP alpha-gate holes",
+	        (unsigned long long)hwnd_val, width, height);
+	return p;
+}
+
+extern "C" void
+comp_d3d_transparent_presenter_present(struct comp_d3d_transparent_presenter *p)
+{
+	if (p == nullptr || !p->swapchain || !p->output_fence || !p->context) {
+		return;
+	}
+	// Lockstep with the service: it bumps + signals once per commit, we bump + wait once per
+	// commit, so this value always matches the frame just weaved.
+	p->present_value++;
+	p->context->Wait(p->output_fence.get(), p->present_value);
+
+	com_ptr<ID3D11Texture2D> back;
+	if (SUCCEEDED(p->swapchain->GetBuffer(0, IID_PPV_ARGS(back.put()))) && back) {
+		p->context->CopyResource(back.get(), p->output_texture.get());
+	}
+	p->swapchain->Present(1, 0);
+	// Publish the new frame to dwm.exe (cheap delta-state IPC, no GPU work).
+	if (p->dcomp_device) {
+		p->dcomp_device->Commit();
+	}
+}
+
+extern "C" void
+comp_d3d_transparent_presenter_destroy(struct comp_d3d_transparent_presenter **p_ptr)
+{
+	if (p_ptr == nullptr || *p_ptr == nullptr) {
+		return;
+	}
+	delete *p_ptr;
+	*p_ptr = nullptr;
+}

--- a/src/xrt/compositor/client/comp_d3d_transparent_present.cpp
+++ b/src/xrt/compositor/client/comp_d3d_transparent_present.cpp
@@ -88,7 +88,7 @@ comp_d3d_transparent_presenter_create(void *existing_d3d11_device,
 			base->GetImmediateContext(ctx.put());
 			p->context = ctx.query<ID3D11DeviceContext4>();
 		} else {
-			auto dev = xrt::compositor::client::createDevice();
+			auto dev = xrt::auxiliary::d3d::d3d11::createDevice();
 			p->owned_device = dev.first;
 			p->owned_context = dev.second;
 			if (!p->owned_device || !p->owned_context) {

--- a/src/xrt/compositor/client/comp_d3d_transparent_present.h
+++ b/src/xrt/compositor/client/comp_d3d_transparent_present.h
@@ -28,6 +28,8 @@
 
 #include "xrt/xrt_handles.h"
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/xrt/compositor/client/comp_d3d_transparent_present.h
+++ b/src/xrt/compositor/client/comp_d3d_transparent_present.h
@@ -1,0 +1,84 @@
+// Copyright 2026, Collabora, Ltd.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  Render-API-agnostic transparent DirectComposition present for IPC clients.
+ *
+ * A forced-IPC transparent client wants alpha=0 regions of the woven output to show
+ * the LIVE desktop. The service runs out-of-process and a process can only create a
+ * DirectComposition target / composition swap chain on a window it OWNS
+ * (`E_ACCESSDENIED` on the client's HWND), so the *client* must own the present
+ * (ADR-029). The service hands over a shared D3D11 NT-handle texture (premultiplied
+ * `R8G8B8A8`) plus a service→client `ID3D11Fence`; this helper imports both, stands up
+ * a transparent DComp swap chain on the app's HWND, and per frame waits the fence,
+ * copies the shared output into the back buffer, and `Present` + `Commit` so DWM blends
+ * the live desktop into the holes.
+ *
+ * The present is pure D3D11 + DirectComposition and is **independent of the app's render
+ * API**: the shared handles are openable by any D3D11 device. A D3D11 client can pass its
+ * own `ID3D11Device` to avoid a second device; a D3D12/GL/VK client passes NULL and the
+ * helper creates its own small D3D11 device for the present. This is why the same helper
+ * serves every Windows IPC client.
+ *
+ * Windows-only.
+ *
+ * @ingroup comp_client
+ */
+#pragma once
+
+#include "xrt/xrt_handles.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*!
+ * Opaque transparent-present helper. Owns the imported shared texture + fence, the DComp
+ * device/target/visual, the composition swap chain, and (when no device was supplied) its
+ * own D3D11 device + context.
+ */
+struct comp_d3d_transparent_presenter;
+
+/*!
+ * Stand up the transparent present from the IPC-provided shared handles.
+ *
+ * @param existing_d3d11_device An `ID3D11Device *` to reuse for the present (D3D11 client),
+ *                              or NULL to have the helper create its own D3D11 device
+ *                              (D3D12/GL/VK clients). Passed as `void *` to keep this
+ *                              header C-includable.
+ * @param hwnd                  The app's window handle (as a `uint64_t`).
+ * @param width,height          Dimensions of the shared output texture.
+ * @param shared_tex            Service output texture NT handle. **Consumed** (closed) by
+ *                              this call regardless of success.
+ * @param shared_fence          Service→client fence NT handle. **Consumed** (closed) by
+ *                              this call regardless of success.
+ *
+ * @return A ready presenter, or NULL on any failure (caller stays on the service's opaque
+ *         present — no see-through, but never a crash).
+ */
+struct comp_d3d_transparent_presenter *
+comp_d3d_transparent_presenter_create(void *existing_d3d11_device,
+                                      uint64_t hwnd,
+                                      uint32_t width,
+                                      uint32_t height,
+                                      xrt_graphics_buffer_handle_t shared_tex,
+                                      xrt_graphics_sync_handle_t shared_fence);
+
+/*!
+ * Per-frame present. Call once after the layer-commit RPC returns (the service has weaved
+ * and signaled). GPU-waits the lockstep fence, copies the shared output into the DComp
+ * back buffer, and `Present` + `Commit`. No-op if @p p is NULL.
+ */
+void
+comp_d3d_transparent_presenter_present(struct comp_d3d_transparent_presenter *p);
+
+/*!
+ * Tear down the presenter and release every owned resource. Sets `*p` to NULL. Safe when
+ * `*p` is already NULL.
+ */
+void
+comp_d3d_transparent_presenter_destroy(struct comp_d3d_transparent_presenter **p);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/xrt/compositor/client/comp_gl_win32_client.c
+++ b/src/xrt/compositor/client/comp_gl_win32_client.c
@@ -21,9 +21,25 @@
 #include "client/comp_gl_win32_client.h"
 #include "client/comp_gl_memobj_swapchain.h"
 #include "client/comp_gl_d3d11_swapchain.h"
+#include "client/comp_d3d_transparent_present.h"
 
 #include "ogl/ogl_api.h"
 #include "ogl/wgl_api.h"
+
+// #573 — transparent compositing output bridges, defined in
+// src/xrt/ipc/client/ipc_client_compositor.c (resolved at link time). Shared
+// with the D3D11/D3D12 clients.
+extern xrt_result_t
+comp_ipc_client_compositor_get_transparent_output(struct xrt_compositor *xc,
+                                                  bool *out_have_output,
+                                                  uint32_t *out_width,
+                                                  uint32_t *out_height,
+                                                  uint64_t *out_hwnd,
+                                                  xrt_graphics_buffer_handle_t *out_handle);
+extern xrt_result_t
+comp_ipc_client_compositor_get_transparent_output_fence(struct xrt_compositor *xc,
+                                                        bool *out_have_fence,
+                                                        xrt_graphics_sync_handle_t *out_handle);
 
 /*
  *
@@ -69,12 +85,32 @@ client_gl_win32_compositor_destroy(struct xrt_compositor *xc)
 {
 	struct client_gl_win32_compositor *c = client_gl_win32_compositor(xc);
 
+	comp_d3d_transparent_presenter_destroy(&c->transparent); // #573
+
 	client_gl_compositor_fini(&c->base);
 
 	FreeLibrary(c->opengl);
 	c->opengl = NULL;
 
 	free(c);
+}
+
+// #573 — wraps the parent GL client's layer_commit to drive the per-frame
+// transparent present after the woven frame is committed + signaled. The shared
+// presenter GPU-waits the service→client fence (lockstep counter, no per-frame
+// IPC), copies the woven shared output into the DComp swap-chain back buffer, and
+// presents so DWM blends the LIVE desktop into the alpha-gate holes. No-op (just
+// the base commit) for opaque clients where @ref transparent is NULL.
+static xrt_result_t
+client_gl_win32_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sync_handle)
+{
+	struct client_gl_win32_compositor *c = client_gl_win32_compositor(xc);
+
+	xrt_result_t xret = c->base_layer_commit(xc, sync_handle);
+	if (xret == XRT_SUCCESS) {
+		comp_d3d_transparent_presenter_present(c->transparent);
+	}
+	return xret;
 }
 
 static xrt_result_t
@@ -239,6 +275,38 @@ client_gl_win32_compositor_create(struct xrt_compositor_native *xcn, void *hDC, 
 	}
 
 	c->base.base.base.destroy = client_gl_win32_compositor_destroy;
+
+	// #573 — transparent compositing output. If the service created a shared output
+	// texture for this (transparent) client, hand the shared texture + service→client
+	// fence to the render-API-agnostic presenter, which stands up a transparent
+	// DirectComposition swap chain on the app's own window. GL passes NULL device →
+	// the helper makes its own D3D11 device for the (pure D3D11+DComp) present. We
+	// then wrap the parent's layer_commit so the present runs each frame. Non-fatal:
+	// any failure leaves the service's opaque present in effect (presenter stays NULL).
+	{
+		bool have_out = false, have_fence = false;
+		uint32_t tw = 0, th = 0;
+		uint64_t hwnd_val = 0;
+		xrt_graphics_buffer_handle_t tex_h = XRT_GRAPHICS_BUFFER_HANDLE_INVALID;
+		xrt_graphics_sync_handle_t fence_h = XRT_GRAPHICS_SYNC_HANDLE_INVALID;
+		xrt_result_t oret = comp_ipc_client_compositor_get_transparent_output(
+		    &xcn->base, &have_out, &tw, &th, &hwnd_val, &tex_h);
+		if (oret == XRT_SUCCESS && have_out && tex_h != XRT_GRAPHICS_BUFFER_HANDLE_INVALID &&
+		    hwnd_val != 0) {
+			(void)comp_ipc_client_compositor_get_transparent_output_fence(&xcn->base, &have_fence,
+			                                                             &fence_h);
+			// The presenter consumes (closes) both handles regardless of outcome.
+			c->transparent =
+			    comp_d3d_transparent_presenter_create(NULL, hwnd_val, tw, th, tex_h, fence_h);
+		} else if (tex_h != XRT_GRAPHICS_BUFFER_HANDLE_INVALID) {
+			CloseHandle((HANDLE)tex_h);
+		}
+
+		if (c->transparent != NULL) {
+			c->base_layer_commit = c->base.base.base.layer_commit;
+			c->base.base.base.layer_commit = client_gl_win32_compositor_layer_commit;
+		}
+	}
 
 	return c;
 }

--- a/src/xrt/compositor/client/comp_gl_win32_client.h
+++ b/src/xrt/compositor/client/comp_gl_win32_client.h
@@ -17,6 +17,9 @@
 extern "C" {
 #endif
 
+//! #573 — render-API-agnostic transparent DComp presenter (client/comp_d3d_transparent_present.h).
+struct comp_d3d_transparent_presenter;
+
 struct client_gl_context
 {
 	HDC hDC;
@@ -47,6 +50,20 @@ struct client_gl_win32_compositor
 
 	//! The OpenGL library
 	HMODULE opengl;
+
+	/*!
+	 * #573 — render-API-agnostic transparent DComp presenter. For a forced-IPC
+	 * transparent client the service weaves (with alpha-gate holes) into a shared
+	 * texture; this presenter imports it + the service→client fence and presents it
+	 * via a transparent DirectComposition swap chain on the app's own window so DWM
+	 * blends the LIVE desktop into the holes. NULL for opaque clients. The GL client
+	 * passes NULL device → the helper makes its own D3D11 device (the present is pure
+	 * D3D11 + DComp on shared handles, independent of the app's render API).
+	 */
+	struct comp_d3d_transparent_presenter *transparent;
+
+	//! #573 — saved parent GL layer_commit, wrapped to drive the per-frame present.
+	xrt_result_t (*base_layer_commit)(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sync_handle);
 };
 
 /*!

--- a/src/xrt/compositor/d3d11/comp_d3d11_compositor.cpp
+++ b/src/xrt/compositor/d3d11/comp_d3d11_compositor.cpp
@@ -2022,10 +2022,9 @@ d3d11_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 	// HUD overlay (post-processing, always readable)
 	d3d11_render_hud_overlay(c, weaving_done, &eye_pos);
 
-	// Note: post-weave chroma-key alpha conversion now lives inside the
-	// Leia D3D11 display processor (set_chroma_key + ck_run_post_weave_strip
-	// in leia_display_processor_d3d11.cpp). The compositor is vendor-agnostic
-	// for transparency.
+	// Note: transparency (compose-under-bg / alpha-gate) lives inside the
+	// vendor display processor, enabled via set_transparent_background. The
+	// compositor is vendor-agnostic for transparency.
 
 	// Copy composited output into shared texture if active (dual output: window + shared)
 	if (c->has_shared_texture && c->shared_texture != nullptr) {
@@ -2181,7 +2180,6 @@ comp_d3d11_compositor_create(struct xrt_device *xdev,
                              void *dp_factory_d3d11,
                              void *shared_texture_handle,
                              bool transparent_background,
-                             uint32_t chroma_key_color,
                              int32_t display_screen_left,
                              int32_t display_screen_top,
                              struct xrt_compositor_native **out_xc)
@@ -2431,11 +2429,11 @@ comp_d3d11_compositor_create(struct xrt_device *xdev,
 			c->display_processor = nullptr;
 		} else {
 			U_LOG_W("D3D11 display processor created via factory");
-			// Forward session-level transparency config. The DP runs the
-			// chroma-key fill+strip internally when transparent_background
-			// is set; chroma_key_color=0 means the DP picks its own key.
-			xrt_display_processor_d3d11_set_chroma_key(
-			    c->display_processor, chroma_key_color, transparent_background);
+			// Forward session-level transparency (#573 — chroma-key-free).
+			// client_presents=false: the in-process present is opaque, so the
+			// DP owns see-through (compose-under-bg from the atlas alpha).
+			xrt_display_processor_d3d11_set_transparent_background(
+			    c->display_processor, transparent_background, false);
 		}
 	} else {
 		U_LOG_W("No D3D11 display processor factory provided");

--- a/src/xrt/compositor/d3d11/comp_d3d11_compositor.h
+++ b/src/xrt/compositor/d3d11/comp_d3d11_compositor.h
@@ -37,10 +37,6 @@ extern "C" {
  * @param transparent_background When true (and hwnd != NULL), bind the swapchain via
  *                               DirectComposition with ALPHA_MODE_PREMULTIPLIED for
  *                               desktop transparency. Otherwise opaque (#163 default).
- * @param chroma_key_color When non-zero (and transparent_background is true), enable
- *                         a post-weave shader pass that converts pixels matching this
- *                         RGB (0x00BBGGRR / Win32 COLORREF) to alpha=0. Required when
- *                         the bound display processor strips alpha during weaving.
  * @param display_screen_left Display top-left X in OS screen coords (from xsysc->info,
  *                            populated by the vendor plug-in iface). 0 = primary.
  * @param display_screen_top  Display top-left Y in OS screen coords. 0 = primary.
@@ -57,7 +53,6 @@ comp_d3d11_compositor_create(struct xrt_device *xdev,
                              void *dp_factory_d3d11,
                              void *shared_texture_handle,
                              bool transparent_background,
-                             uint32_t chroma_key_color,
                              int32_t display_screen_left,
                              int32_t display_screen_top,
                              struct xrt_compositor_native **out_xc);

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -235,18 +235,6 @@ struct d3d11_client_render_resources
 	wil::com_ptr<IDCompositionTarget> dcomp_target;
 	wil::com_ptr<IDCompositionVisual> dcomp_visual;
 
-	//! Chroma-key color (0x00BBGGRR / Win32 COLORREF) for the post-weave alpha-conversion
-	//! shader pass. Zero disables. Lazy-initialized resources for that pass below.
-	uint32_t chroma_key_color;
-	wil::com_ptr<ID3D11VertexShader>     ck_vs;
-	wil::com_ptr<ID3D11PixelShader>      ck_ps;
-	wil::com_ptr<ID3D11Texture2D>        ck_intermediate;
-	wil::com_ptr<ID3D11ShaderResourceView> ck_intermediate_srv;
-	wil::com_ptr<ID3D11Buffer>           ck_constants;
-	wil::com_ptr<ID3D11SamplerState>     ck_sampler;
-	UINT                                  ck_intermediate_w;
-	UINT                                  ck_intermediate_h;
-
 	//! #551 — transparent compositing output for a forced-IPC transparent
 	//! client. The service can't present the app's cross-process window with
 	//! per-pixel alpha (DComp CreateTargetForHwnd is owner-only), so the DP
@@ -2665,14 +2653,6 @@ fini_client_render_resources(struct d3d11_client_render_resources *res)
 	res->dcomp_target.reset();
 	res->dcomp_device.reset();
 
-	// Release chroma-key pass resources.
-	res->ck_intermediate_srv.reset();
-	res->ck_intermediate.reset();
-	res->ck_constants.reset();
-	res->ck_sampler.reset();
-	res->ck_ps.reset();
-	res->ck_vs.reset();
-
 	// #551 transparent output: close the source NT handles (DuplicateHandle'd
 	// copies in the client process are unaffected) and release the resources.
 	if (res->transparent_output_texture_handle != nullptr) {
@@ -2709,12 +2689,10 @@ static xrt_result_t
 init_client_render_resources(struct d3d11_service_system *sys,
                               void *external_hwnd,
                               bool transparent_hwnd,
-                              uint32_t chroma_key_color,
                               struct xrt_system_devices *xsysd,
                               struct d3d11_client_render_resources *res)
 {
 	std::memset(res, 0, sizeof(*res));
-	res->chroma_key_color = chroma_key_color;
 
 	HRESULT hr;
 
@@ -3092,8 +3070,7 @@ init_client_render_resources(struct d3d11_service_system *sys,
 			// tells the DP to composite its weave over the captured desktop
 			// (chroma-key-free). The app window's capture-exclusion affinity is
 			// set client-side (window-owning process) so this works even though
-			// the DP runs out-of-process here. Falls back to the legacy
-			// set_chroma_key enable for a DP that predates the new slot.
+			// the DP runs out-of-process here.
 			if (transparent_hwnd) {
 				// #551 — client_presents: when this client's frames reach the
 				// panel via a transparent DComp present (the #551 client-side
@@ -3101,18 +3078,12 @@ init_client_render_resources(struct d3d11_service_system *sys,
 				// path), DWM blends the LIVE desktop into the alpha-gate holes,
 				// so the DP must NOT compose-under-bg (that bakes a stale
 				// captured desktop = a frame of lag) — alpha-gate only. For an
-				// opaque present the DP owns see-through itself. Fall back to
-				// the legacy chroma-key enable for a DP that predates the slot.
+				// opaque present the DP owns see-through itself.
 				bool client_presents = use_client_transparent || use_transparent;
 				bool tp_ok = xrt_display_processor_d3d11_set_transparent_background(
 				    res->display_processor, true, client_presents);
-				U_LOG_W("#551 DP transparency: client_presents=%d slot_present=%d%s",
-				        (int)client_presents, (int)tp_ok,
-				        tp_ok ? "" : " → chroma-key fallback");
-				if (!tp_ok) {
-					xrt_display_processor_d3d11_set_chroma_key(res->display_processor,
-					                                           chroma_key_color, true);
-				}
+				U_LOG_W("#551 DP transparency: client_presents=%d slot_present=%d",
+				        (int)client_presents, (int)tp_ok);
 			}
 
 			// Phase 6.1 (#140): don't call request_display_mode(true)
@@ -4148,190 +4119,6 @@ compositor_layer_passthrough(struct xrt_compositor *xc,
                               const struct xrt_layer_data *data)
 {
 	return XRT_SUCCESS;
-}
-
-/*
- *
- * Chroma-key post-weave alpha-conversion pass (D3D11 service)
- *
- * Same as the D3D11 in-process pass: rewrite back-buffer alpha based on chroma-key
- * RGB so DComp's per-pixel alpha presentation can punch transparent regions through
- * to the desktop. Inserted between HUD overlay and Present.
- *
- */
-
-static const char *kChromaKeySvcVS = R"(
-struct VSOut { float4 pos : SV_Position; float2 uv : TEXCOORD0; };
-VSOut main(uint vid : SV_VertexID) {
-    VSOut o;
-    o.uv = float2((vid << 1) & 2, vid & 2);
-    o.pos = float4(o.uv * float2(2, -2) + float2(-1, 1), 0, 1);
-    return o;
-}
-)";
-
-static const char *kChromaKeySvcPS = R"(
-struct VSOut { float4 pos : SV_Position; float2 uv : TEXCOORD0; };
-Texture2D<float4> src : register(t0);
-SamplerState samp : register(s0);
-cbuffer Constants : register(b0) { float3 chroma_rgb; float pad; };
-float4 main(VSOut i) : SV_Target {
-    float3 c = src.Sample(samp, i.uv).rgb;
-    float3 d = abs(c - chroma_rgb);
-    bool match = max(max(d.r, d.g), d.b) < (1.0/512.0);
-    // Swapchain is DXGI_ALPHA_MODE_PREMULTIPLIED — RGB must already be * alpha.
-    // For transparent (alpha=0) pixels RGB MUST be (0,0,0); otherwise DWM's
-    // src.rgb + (1-alpha)*dst.rgb blend adds the matched chroma color to the
-    // desktop and saturates to white instead of showing through.
-    float a = match ? 0.0 : 1.0;
-    return float4(c * a, a);
-}
-)";
-
-struct ChromaKeySvcConstants {
-	float chroma_rgb[3];
-	float pad;
-};
-
-static bool
-svc_chroma_key_init_pipeline(struct d3d11_service_system *sys,
-                              struct d3d11_client_render_resources *res)
-{
-	if (res->ck_vs.get() != nullptr) return true;
-	HRESULT hr;
-	wil::com_ptr<ID3DBlob> vs_blob, ps_blob, err_blob;
-	hr = D3DCompile(kChromaKeySvcVS, strlen(kChromaKeySvcVS), nullptr, nullptr, nullptr,
-	                "main", "vs_5_0", 0, 0, vs_blob.put(), err_blob.put());
-	if (FAILED(hr)) {
-		U_LOG_E("Chroma-key VS compile failed: 0x%08lx %s", hr,
-		        err_blob ? (const char *)err_blob->GetBufferPointer() : "");
-		return false;
-	}
-	err_blob.reset();
-	hr = D3DCompile(kChromaKeySvcPS, strlen(kChromaKeySvcPS), nullptr, nullptr, nullptr,
-	                "main", "ps_5_0", 0, 0, ps_blob.put(), err_blob.put());
-	if (FAILED(hr)) {
-		U_LOG_E("Chroma-key PS compile failed: 0x%08lx %s", hr,
-		        err_blob ? (const char *)err_blob->GetBufferPointer() : "");
-		return false;
-	}
-
-	hr = sys->device->CreateVertexShader(vs_blob->GetBufferPointer(), vs_blob->GetBufferSize(),
-	                                      nullptr, res->ck_vs.put());
-	if (FAILED(hr)) { U_LOG_E("CreateVertexShader: 0x%08lx", hr); return false; }
-	hr = sys->device->CreatePixelShader(ps_blob->GetBufferPointer(), ps_blob->GetBufferSize(),
-	                                     nullptr, res->ck_ps.put());
-	if (FAILED(hr)) { U_LOG_E("CreatePixelShader: 0x%08lx", hr); return false; }
-
-	D3D11_BUFFER_DESC cb_desc = {};
-	cb_desc.ByteWidth = sizeof(ChromaKeySvcConstants);
-	cb_desc.Usage = D3D11_USAGE_DYNAMIC;
-	cb_desc.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
-	cb_desc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
-	hr = sys->device->CreateBuffer(&cb_desc, nullptr, res->ck_constants.put());
-	if (FAILED(hr)) { U_LOG_E("CB create: 0x%08lx", hr); return false; }
-
-	D3D11_SAMPLER_DESC samp_desc = {};
-	samp_desc.Filter = D3D11_FILTER_MIN_MAG_MIP_POINT;
-	samp_desc.AddressU = D3D11_TEXTURE_ADDRESS_CLAMP;
-	samp_desc.AddressV = D3D11_TEXTURE_ADDRESS_CLAMP;
-	samp_desc.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
-	samp_desc.MaxLOD = D3D11_FLOAT32_MAX;
-	hr = sys->device->CreateSamplerState(&samp_desc, res->ck_sampler.put());
-	if (FAILED(hr)) { U_LOG_E("Sampler create: 0x%08lx", hr); return false; }
-
-	U_LOG_W("Post-weave chroma-key conversion enabled: 0x%08X", res->chroma_key_color);
-	return true;
-}
-
-static bool
-svc_chroma_key_ensure_intermediate(struct d3d11_service_system *sys,
-                                    struct d3d11_client_render_resources *res,
-                                    UINT width, UINT height)
-{
-	if (res->ck_intermediate.get() != nullptr &&
-	    res->ck_intermediate_w == width && res->ck_intermediate_h == height) {
-		return true;
-	}
-	res->ck_intermediate_srv.reset();
-	res->ck_intermediate.reset();
-
-	D3D11_TEXTURE2D_DESC desc = {};
-	desc.Width = width;
-	desc.Height = height;
-	desc.MipLevels = 1;
-	desc.ArraySize = 1;
-	desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-	desc.SampleDesc.Count = 1;
-	desc.Usage = D3D11_USAGE_DEFAULT;
-	desc.BindFlags = D3D11_BIND_SHADER_RESOURCE;
-	HRESULT hr = sys->device->CreateTexture2D(&desc, nullptr, res->ck_intermediate.put());
-	if (FAILED(hr)) { U_LOG_E("Chroma-key intermediate create: 0x%08lx", hr); return false; }
-	hr = sys->device->CreateShaderResourceView(res->ck_intermediate.get(), nullptr,
-	                                            res->ck_intermediate_srv.put());
-	if (FAILED(hr)) { U_LOG_E("Chroma-key intermediate SRV: 0x%08lx", hr); return false; }
-	res->ck_intermediate_w = width;
-	res->ck_intermediate_h = height;
-	return true;
-}
-
-static void
-svc_chroma_key_pass_execute(struct d3d11_service_system *sys,
-                             struct d3d11_client_render_resources *res)
-{
-	if (res->chroma_key_color == 0) return;
-	if (!svc_chroma_key_init_pipeline(sys, res)) return;
-
-	// Get back-buffer dims via the RTV's underlying resource.
-	if (!res->back_buffer_rtv) return;
-	wil::com_ptr<ID3D11Resource> bb_resource;
-	res->back_buffer_rtv->GetResource(bb_resource.put());
-	wil::com_ptr<ID3D11Texture2D> bb_texture;
-	if (FAILED(bb_resource->QueryInterface(IID_PPV_ARGS(bb_texture.put())))) return;
-	D3D11_TEXTURE2D_DESC bb_desc = {};
-	bb_texture->GetDesc(&bb_desc);
-	if (!svc_chroma_key_ensure_intermediate(sys, res, bb_desc.Width, bb_desc.Height)) return;
-
-	// Copy back buffer to intermediate (source for the shader sample).
-	sys->context->CopyResource(res->ck_intermediate.get(), bb_texture.get());
-
-	// Update constant buffer.
-	D3D11_MAPPED_SUBRESOURCE mapped = {};
-	HRESULT hr = sys->context->Map(res->ck_constants.get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped);
-	if (FAILED(hr)) return;
-	uint32_t k = res->chroma_key_color;
-	ChromaKeySvcConstants *cb = reinterpret_cast<ChromaKeySvcConstants *>(mapped.pData);
-	cb->chroma_rgb[0] = ((k >>  0) & 0xFF) / 255.0f;
-	cb->chroma_rgb[1] = ((k >>  8) & 0xFF) / 255.0f;
-	cb->chroma_rgb[2] = ((k >> 16) & 0xFF) / 255.0f;
-	cb->pad = 0.0f;
-	sys->context->Unmap(res->ck_constants.get(), 0);
-
-	// Bind back-buffer RTV + viewport.
-	ID3D11RenderTargetView *rtvs[] = { res->back_buffer_rtv.get() };
-	sys->context->OMSetRenderTargets(1, rtvs, nullptr);
-	D3D11_VIEWPORT vp = { 0.0f, 0.0f, (float)bb_desc.Width, (float)bb_desc.Height, 0.0f, 1.0f };
-	sys->context->RSSetViewports(1, &vp);
-
-	// Set fullscreen-triangle pipeline state.
-	sys->context->IASetInputLayout(nullptr);
-	sys->context->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-	ID3D11Buffer *null_vb = nullptr;
-	UINT zero = 0;
-	sys->context->IASetVertexBuffers(0, 1, &null_vb, &zero, &zero);
-	sys->context->VSSetShader(res->ck_vs.get(), nullptr, 0);
-	sys->context->PSSetShader(res->ck_ps.get(), nullptr, 0);
-	ID3D11ShaderResourceView *srvs[] = { res->ck_intermediate_srv.get() };
-	sys->context->PSSetShaderResources(0, 1, srvs);
-	ID3D11SamplerState *samps[] = { res->ck_sampler.get() };
-	sys->context->PSSetSamplers(0, 1, samps);
-	ID3D11Buffer *cbs[] = { res->ck_constants.get() };
-	sys->context->PSSetConstantBuffers(0, 1, cbs);
-	sys->context->Draw(3, 0);
-
-	// Unbind so subsequent passes don't see this SRV.
-	ID3D11ShaderResourceView *null_srv = nullptr;
-	sys->context->PSSetShaderResources(0, 1, &null_srv);
 }
 
 /*!
@@ -11025,9 +10812,6 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 	// Render HUD overlay (post-weave, pre-present)
 	d3d11_service_render_hud(sys, &c->render, weaving_done, &eye_pos);
 
-	// Post-weave chroma-key alpha conversion (no-op when chroma_key_color == 0).
-	svc_chroma_key_pass_execute(sys, &c->render);
-
 	// Phase 1 diagnostic — same env-gated [PRESENT_NS] used for the
 	// workspace multi-comp swap chain. In standalone mode this fires
 	// per client per frame against THIS client's own swap chain. Tagged
@@ -11399,11 +11183,9 @@ system_create_native_compositor(struct xrt_system_compositor *xsysc,
 	// Get external window handle if app provided one via XR_EXT_win32_window_binding
 	void *external_hwnd = nullptr;
 	bool transparent_hwnd = false;
-	uint32_t chroma_key_color = 0;
 	if (xsi != nullptr) {
 		external_hwnd = xsi->external_window_handle;
 		transparent_hwnd = xsi->transparent_background_enabled;
-		chroma_key_color = xsi->chroma_key_color;
 	}
 
 	if (!is_headless_relay && !is_workspace_controller) {
@@ -11415,7 +11197,7 @@ system_create_native_compositor(struct xrt_system_compositor *xsysc,
 		}
 
 		xrt_result_t res_ret = init_client_render_resources(
-		    sys, external_hwnd, transparent_hwnd, chroma_key_color, sys->xsysd, &c->render);
+		    sys, external_hwnd, transparent_hwnd, sys->xsysd, &c->render);
 		if (res_ret != XRT_SUCCESS) {
 			U_LOG_E("Failed to initialize client render resources");
 			delete c;

--- a/src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp
+++ b/src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp
@@ -2299,7 +2299,6 @@ comp_d3d12_compositor_create(struct xrt_device *xdev,
                              void *d3d12_command_queue,
                              void *dp_factory_d3d12,
                              bool transparent_background,
-                             uint32_t chroma_key_color,
                              int32_t display_screen_left,
                              int32_t display_screen_top,
                              struct xrt_compositor_native **out_xc)
@@ -2541,11 +2540,11 @@ comp_d3d12_compositor_create(struct xrt_device *xdev,
 			U_LOG_W("D3D12 display processor: output format set to %u (target=%p)",
 			        (unsigned)output_fmt, (void *)c->target);
 
-			// Forward session-level transparency config. The DP runs the
-			// chroma-key fill+strip internally when transparent_background
-			// is set; chroma_key_color=0 means the DP picks its own key.
-			xrt_display_processor_d3d12_set_chroma_key(
-			    c->display_processor, chroma_key_color, transparent_background);
+			// Forward session-level transparency (#573 — chroma-key-free).
+			// client_presents=false: the in-process present is opaque, so the
+			// DP owns see-through (compose-under-bg from the atlas alpha).
+			xrt_display_processor_d3d12_set_transparent_background(
+			    c->display_processor, transparent_background, false);
 		}
 	} else {
 		U_LOG_W("No D3D12 display processor factory provided");

--- a/src/xrt/compositor/d3d12/comp_d3d12_compositor.h
+++ b/src/xrt/compositor/d3d12/comp_d3d12_compositor.h
@@ -37,10 +37,6 @@ extern "C" {
  * @param transparent_background When true (and hwnd != NULL), bind the swapchain via
  *                               DirectComposition with ALPHA_MODE_PREMULTIPLIED for
  *                               desktop transparency. Otherwise opaque (#163 default).
- * @param chroma_key_color When non-zero (and transparent_background is true), enable
- *                         a post-weave shader pass that converts pixels matching this
- *                         RGB (0x00BBGGRR / Win32 COLORREF) to alpha=0. Required when
- *                         the bound display processor strips alpha during weaving.
  * @param display_screen_left Display top-left X in OS screen coords (from xsysc->info,
  *                            populated by the vendor plug-in iface). 0 = primary.
  * @param display_screen_top  Display top-left Y in OS screen coords. 0 = primary.
@@ -58,7 +54,6 @@ comp_d3d12_compositor_create(struct xrt_device *xdev,
                              void *d3d12_command_queue,
                              void *dp_factory_d3d12,
                              bool transparent_background,
-                             uint32_t chroma_key_color,
                              int32_t display_screen_left,
                              int32_t display_screen_top,
                              struct xrt_compositor_native **out_xc);

--- a/src/xrt/compositor/gl/comp_gl_compositor.cpp
+++ b/src/xrt/compositor/gl/comp_gl_compositor.cpp
@@ -469,6 +469,23 @@ struct comp_gl_compositor
 	ID3D11PixelShader *dcomp_ps;
 	ID3D11SamplerState *dcomp_samp;
 	uint32_t dcomp_present_w, dcomp_present_h;
+
+	// P0.3 (#573) — no-interop readback fallback. When WGL_NV_DX_interop2 is
+	// unavailable (near-extinct hardware), GL can't share a texture with D3D11, so
+	// the weave goes to the default framebuffer (the opaque path) and per frame we
+	// glReadPixels it → upload to this DYNAMIC (CPU-write) D3D11 texture → reuse the
+	// same blit + DComp Present. Lets chroma-key be deleted everywhere. Shares the
+	// dcomp_dx_device/swapchain/target/blit pipeline with the interop path above.
+	bool dcomp_readback_active;          //!< True once the readback present path is wired up.
+	// Dedicated RGBA GL weave target — NOT FBO 0. The window's default framebuffer
+	// has no usable alpha (glReadPixels returns A=1), which would turn the α=0
+	// see-through holes into opaque black; weaving into a real RGBA texture
+	// preserves the premultiplied alpha the DComp present needs.
+	GLuint dcomp_readback_gl_tex;        //!< RGBA8 GL texture the DP weaves into.
+	GLuint dcomp_readback_gl_fbo;        //!< FBO around dcomp_readback_gl_tex.
+	ID3D11Texture2D *dcomp_readback_tex; //!< DYNAMIC RGBA source uploaded each frame.
+	ID3D11ShaderResourceView *dcomp_readback_srv;
+	uint8_t *dcomp_readback_cpu;         //!< glReadPixels CPU target (w*h*4 bytes).
 #endif
 };
 
@@ -553,6 +570,12 @@ gl_destroy_dcomp_present(struct comp_gl_compositor *c)
 		c->pfn_wglDXCloseDeviceNV(c->dcomp_dx_interop_device);
 		c->dcomp_dx_interop_device = NULL;
 	}
+	// P0.3 (#573) — readback fallback resources.
+	if (c->dcomp_readback_gl_fbo != 0) { glDeleteFramebuffers(1, &c->dcomp_readback_gl_fbo); c->dcomp_readback_gl_fbo = 0; }
+	if (c->dcomp_readback_gl_tex != 0) { glDeleteTextures(1, &c->dcomp_readback_gl_tex);     c->dcomp_readback_gl_tex = 0; }
+	if (c->dcomp_readback_srv) { c->dcomp_readback_srv->Release(); c->dcomp_readback_srv = NULL; }
+	if (c->dcomp_readback_tex) { c->dcomp_readback_tex->Release(); c->dcomp_readback_tex = NULL; }
+	if (c->dcomp_readback_cpu) { free(c->dcomp_readback_cpu);      c->dcomp_readback_cpu = NULL; }
 	if (c->dcomp_samp)         { c->dcomp_samp->Release();         c->dcomp_samp = NULL; }
 	if (c->dcomp_ps)           { c->dcomp_ps->Release();           c->dcomp_ps = NULL; }
 	if (c->dcomp_vs)           { c->dcomp_vs->Release();           c->dcomp_vs = NULL; }
@@ -565,37 +588,19 @@ gl_destroy_dcomp_present(struct comp_gl_compositor *c)
 	if (c->dcomp_dx_context)   { c->dcomp_dx_context->Release();   c->dcomp_dx_context = NULL; }
 	if (c->dcomp_dx_device)    { c->dcomp_dx_device->Release();    c->dcomp_dx_device = NULL; }
 	c->dcomp_active = false;
+	c->dcomp_readback_active = false;
 }
 
-// Initialize the DComp + WGL_NV_DX_interop2 present path. Returns false on any
-// failure (caller stays on the opaque SwapBuffers path); always leaves the
-// struct in a consistent torn-down state on false.
+// Shared D3D11 / DComp / blit setup used by BOTH the interop and the no-interop
+// readback present paths (#573 P0.3): a dedicated D3D11 device, a flip-model
+// PREMULTIPLIED composition swapchain bound to the HWND via DirectComposition, and
+// the fullscreen-triangle blit pipeline. The source texture and per-frame upload
+// differ between the two paths and are set up by the callers. Returns false (left
+// torn down) on any failure.
 static bool
-gl_setup_dcomp_present(struct comp_gl_compositor *c, HWND hwnd, uint32_t w, uint32_t h)
+gl_setup_dcomp_common(struct comp_gl_compositor *c, HWND hwnd, uint32_t w, uint32_t h)
 {
-	if (w == 0 || h == 0) {
-		return false;
-	}
-
-	// 1. WGL_NV_DX_interop2 entry points (may already be loaded by the
-	//    shared-texture path; load defensively).
-	if (c->pfn_wglDXOpenDeviceNV == NULL) {
-		c->pfn_wglDXOpenDeviceNV = (PFN_wglDXOpenDeviceNV)wglGetProcAddress("wglDXOpenDeviceNV");
-		c->pfn_wglDXCloseDeviceNV = (PFN_wglDXCloseDeviceNV)wglGetProcAddress("wglDXCloseDeviceNV");
-		c->pfn_wglDXRegisterObjectNV = (PFN_wglDXRegisterObjectNV)wglGetProcAddress("wglDXRegisterObjectNV");
-		c->pfn_wglDXUnregisterObjectNV = (PFN_wglDXUnregisterObjectNV)wglGetProcAddress("wglDXUnregisterObjectNV");
-		c->pfn_wglDXLockObjectsNV = (PFN_wglDXLockObjectsNV)wglGetProcAddress("wglDXLockObjectsNV");
-		c->pfn_wglDXUnlockObjectsNV = (PFN_wglDXUnlockObjectsNV)wglGetProcAddress("wglDXUnlockObjectsNV");
-	}
-	if (c->pfn_wglDXOpenDeviceNV == NULL || c->pfn_wglDXRegisterObjectNV == NULL ||
-	    c->pfn_wglDXLockObjectsNV == NULL || c->pfn_wglDXUnlockObjectsNV == NULL ||
-	    c->pfn_wglDXCloseDeviceNV == NULL || c->pfn_wglDXUnregisterObjectNV == NULL) {
-		U_LOG_W("Transparent GL: WGL_NV_DX_interop2 unavailable on this GPU/driver — "
-		        "staying opaque");
-		return false;
-	}
-
-	// 2. Dedicated D3D11 device for the present bridge.
+	// 1. Dedicated D3D11 device for the present bridge.
 	HRESULT hr = D3D11CreateDevice(NULL, D3D_DRIVER_TYPE_HARDWARE, NULL, 0, NULL, 0,
 	                               D3D11_SDK_VERSION, &c->dcomp_dx_device, NULL,
 	                               &c->dcomp_dx_context);
@@ -605,62 +610,7 @@ gl_setup_dcomp_present(struct comp_gl_compositor *c, HWND hwnd, uint32_t w, uint
 		return false;
 	}
 
-	// 3. Open the D3D11 device for GL interop.
-	c->dcomp_dx_interop_device = c->pfn_wglDXOpenDeviceNV(c->dcomp_dx_device);
-	if (c->dcomp_dx_interop_device == NULL) {
-		U_LOG_W("Transparent GL: wglDXOpenDeviceNV failed: %lu — staying opaque", GetLastError());
-		gl_destroy_dcomp_present(c);
-		return false;
-	}
-
-	// 4. Off-screen transit texture (RT + SRV) and its GL interop view + FBO.
-	D3D11_TEXTURE2D_DESC td = {};
-	td.Width = w;
-	td.Height = h;
-	td.MipLevels = 1;
-	td.ArraySize = 1;
-	td.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-	td.SampleDesc.Count = 1;
-	td.Usage = D3D11_USAGE_DEFAULT;
-	td.BindFlags = D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE;
-	hr = c->dcomp_dx_device->CreateTexture2D(&td, NULL, &c->dcomp_transit_tex);
-	if (FAILED(hr)) {
-		U_LOG_W("Transparent GL: transit CreateTexture2D failed: 0x%08x", (unsigned)hr);
-		gl_destroy_dcomp_present(c);
-		return false;
-	}
-	hr = c->dcomp_dx_device->CreateShaderResourceView(c->dcomp_transit_tex, NULL,
-	                                                  &c->dcomp_transit_srv);
-	if (FAILED(hr)) {
-		U_LOG_W("Transparent GL: transit SRV failed: 0x%08x", (unsigned)hr);
-		gl_destroy_dcomp_present(c);
-		return false;
-	}
-	glGenTextures(1, &c->dcomp_transit_gl_tex);
-	c->dcomp_transit_iop = c->pfn_wglDXRegisterObjectNV(
-	    c->dcomp_dx_interop_device, c->dcomp_transit_tex, c->dcomp_transit_gl_tex,
-	    GL_TEXTURE_2D, WGL_ACCESS_READ_WRITE_NV);
-	if (c->dcomp_transit_iop == NULL) {
-		U_LOG_W("Transparent GL: wglDXRegisterObjectNV(transit) failed: %lu", GetLastError());
-		gl_destroy_dcomp_present(c);
-		return false;
-	}
-	// Build the FBO around the transit GL texture (lock while attaching).
-	glGenFramebuffers(1, &c->dcomp_transit_fbo);
-	c->pfn_wglDXLockObjectsNV(c->dcomp_dx_interop_device, 1, &c->dcomp_transit_iop);
-	glBindFramebuffer(GL_FRAMEBUFFER, c->dcomp_transit_fbo);
-	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
-	                       c->dcomp_transit_gl_tex, 0);
-	GLenum fbst = glCheckFramebufferStatus(GL_FRAMEBUFFER);
-	glBindFramebuffer(GL_FRAMEBUFFER, 0);
-	c->pfn_wglDXUnlockObjectsNV(c->dcomp_dx_interop_device, 1, &c->dcomp_transit_iop);
-	if (fbst != GL_FRAMEBUFFER_COMPLETE) {
-		U_LOG_W("Transparent GL: transit FBO incomplete: 0x%x", (unsigned)fbst);
-		gl_destroy_dcomp_present(c);
-		return false;
-	}
-
-	// 5. Flip-model composition swapchain (PREMULTIPLIED alpha).
+	// 2. Flip-model composition swapchain (PREMULTIPLIED alpha).
 	IDXGIFactory2 *factory = NULL;
 	hr = CreateDXGIFactory2(0, __uuidof(IDXGIFactory2), (void **)&factory);
 	if (FAILED(hr) || factory == NULL) {
@@ -686,7 +636,7 @@ gl_setup_dcomp_present(struct comp_gl_compositor *c, HWND hwnd, uint32_t w, uint
 		return false;
 	}
 
-	// 6. Bind the swapchain to the HWND through DirectComposition.
+	// 3. Bind the swapchain to the HWND through DirectComposition.
 	hr = DCompositionCreateDevice2(NULL, __uuidof(IDCompositionDevice),
 	                               (void **)&c->dcomp_device);
 	if (SUCCEEDED(hr)) hr = c->dcomp_device->CreateTargetForHwnd(hwnd, TRUE, &c->dcomp_target);
@@ -700,7 +650,7 @@ gl_setup_dcomp_present(struct comp_gl_compositor *c, HWND hwnd, uint32_t w, uint
 		return false;
 	}
 
-	// 7. Compile the fullscreen-triangle blit pipeline.
+	// 4. Compile the fullscreen-triangle blit pipeline.
 	ID3DBlob *vsb = NULL, *psb = NULL, *err = NULL;
 	hr = D3DCompile(kDcompBlitHLSL, strlen(kDcompBlitHLSL), "dcomp_blit", NULL, NULL,
 	                "vs_main", "vs_5_0", 0, 0, &vsb, &err);
@@ -748,16 +698,194 @@ gl_setup_dcomp_present(struct comp_gl_compositor *c, HWND hwnd, uint32_t w, uint
 
 	c->dcomp_present_w = w;
 	c->dcomp_present_h = h;
+	return true;
+}
+
+// No-interop readback present path (#573 P0.3). For near-extinct hardware/drivers
+// without WGL_NV_DX_interop2: GL can't share a texture with D3D11, so the weave
+// stays on the default framebuffer and each frame we glReadPixels it → upload to a
+// DYNAMIC D3D11 texture → reuse the same DComp blit. Slow (a full CPU round-trip),
+// but it closes the last see-through gap so chroma-key can be deleted everywhere.
+static bool
+gl_setup_dcomp_readback_present(struct comp_gl_compositor *c, HWND hwnd, uint32_t w, uint32_t h)
+{
+	if (w == 0 || h == 0) {
+		return false;
+	}
+	if (!gl_setup_dcomp_common(c, hwnd, w, h)) {
+		return false;
+	}
+
+	// DYNAMIC (CPU-write) source texture + SRV. Uploaded from glReadPixels each
+	// frame; row 0 = GL bottom row, matching the interop transit's orientation so
+	// the existing blit shader's V-flip is correct.
+	D3D11_TEXTURE2D_DESC td = {};
+	td.Width = w;
+	td.Height = h;
+	td.MipLevels = 1;
+	td.ArraySize = 1;
+	td.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	td.SampleDesc.Count = 1;
+	td.Usage = D3D11_USAGE_DYNAMIC;
+	td.BindFlags = D3D11_BIND_SHADER_RESOURCE;
+	td.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
+	HRESULT hr = c->dcomp_dx_device->CreateTexture2D(&td, NULL, &c->dcomp_readback_tex);
+	if (FAILED(hr)) {
+		U_LOG_W("Transparent GL: readback CreateTexture2D failed: 0x%08x", (unsigned)hr);
+		gl_destroy_dcomp_present(c);
+		return false;
+	}
+	hr = c->dcomp_dx_device->CreateShaderResourceView(c->dcomp_readback_tex, NULL,
+	                                                  &c->dcomp_readback_srv);
+	if (FAILED(hr)) {
+		U_LOG_W("Transparent GL: readback SRV failed: 0x%08x", (unsigned)hr);
+		gl_destroy_dcomp_present(c);
+		return false;
+	}
+	c->dcomp_readback_cpu = (uint8_t *)malloc((size_t)w * h * 4);
+	if (c->dcomp_readback_cpu == NULL) {
+		U_LOG_W("Transparent GL: readback CPU buffer alloc failed (%ux%u)", w, h);
+		gl_destroy_dcomp_present(c);
+		return false;
+	}
+
+	// Dedicated RGBA8 GL weave target + FBO (alpha-preserving, unlike FBO 0).
+	glGenTextures(1, &c->dcomp_readback_gl_tex);
+	glBindTexture(GL_TEXTURE_2D, c->dcomp_readback_gl_tex);
+	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, (GLsizei)w, (GLsizei)h, 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+	glBindTexture(GL_TEXTURE_2D, 0);
+	glGenFramebuffers(1, &c->dcomp_readback_gl_fbo);
+	glBindFramebuffer(GL_FRAMEBUFFER, c->dcomp_readback_gl_fbo);
+	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
+	                       c->dcomp_readback_gl_tex, 0);
+	GLenum fbst = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+	glBindFramebuffer(GL_FRAMEBUFFER, 0);
+	if (fbst != GL_FRAMEBUFFER_COMPLETE) {
+		U_LOG_W("Transparent GL: readback FBO incomplete: 0x%x", (unsigned)fbst);
+		gl_destroy_dcomp_present(c);
+		return false;
+	}
+
+	c->dcomp_readback_active = true;
+	U_LOG_W("Transparent GL: NO-INTEROP readback present path active (%ux%u) — glReadPixels → "
+	        "D3D11 dynamic upload → DComp blit (slow fallback for hardware without "
+	        "WGL_NV_DX_interop2)", w, h);
+	return true;
+}
+
+// Initialize the DComp + WGL_NV_DX_interop2 present path. Returns false on any
+// failure (caller stays on the opaque SwapBuffers path); always leaves the
+// struct in a consistent torn-down state on false. When WGL_NV_DX_interop2 is
+// unavailable (or DISPLAYXR_GL_FORCE_READBACK is set), falls back to the no-interop
+// glReadPixels readback path (#573 P0.3) instead of staying opaque.
+static bool
+gl_setup_dcomp_present(struct comp_gl_compositor *c, HWND hwnd, uint32_t w, uint32_t h)
+{
+	if (w == 0 || h == 0) {
+		return false;
+	}
+
+	// Debug/verification knob: force the no-interop readback path even on hardware
+	// that has WGL_NV_DX_interop2, so the fallback can be exercised on dev GPUs.
+	const char *force_readback = getenv("DISPLAYXR_GL_FORCE_READBACK");
+	if (force_readback != NULL && *force_readback != '\0' && *force_readback != '0') {
+		U_LOG_W("Transparent GL: DISPLAYXR_GL_FORCE_READBACK set — using no-interop readback path");
+		return gl_setup_dcomp_readback_present(c, hwnd, w, h);
+	}
+
+	// 1. WGL_NV_DX_interop2 entry points (may already be loaded by the
+	//    shared-texture path; load defensively).
+	if (c->pfn_wglDXOpenDeviceNV == NULL) {
+		c->pfn_wglDXOpenDeviceNV = (PFN_wglDXOpenDeviceNV)wglGetProcAddress("wglDXOpenDeviceNV");
+		c->pfn_wglDXCloseDeviceNV = (PFN_wglDXCloseDeviceNV)wglGetProcAddress("wglDXCloseDeviceNV");
+		c->pfn_wglDXRegisterObjectNV = (PFN_wglDXRegisterObjectNV)wglGetProcAddress("wglDXRegisterObjectNV");
+		c->pfn_wglDXUnregisterObjectNV = (PFN_wglDXUnregisterObjectNV)wglGetProcAddress("wglDXUnregisterObjectNV");
+		c->pfn_wglDXLockObjectsNV = (PFN_wglDXLockObjectsNV)wglGetProcAddress("wglDXLockObjectsNV");
+		c->pfn_wglDXUnlockObjectsNV = (PFN_wglDXUnlockObjectsNV)wglGetProcAddress("wglDXUnlockObjectsNV");
+	}
+	if (c->pfn_wglDXOpenDeviceNV == NULL || c->pfn_wglDXRegisterObjectNV == NULL ||
+	    c->pfn_wglDXLockObjectsNV == NULL || c->pfn_wglDXUnlockObjectsNV == NULL ||
+	    c->pfn_wglDXCloseDeviceNV == NULL || c->pfn_wglDXUnregisterObjectNV == NULL) {
+		U_LOG_W("Transparent GL: WGL_NV_DX_interop2 unavailable on this GPU/driver — "
+		        "using no-interop readback present path");
+		return gl_setup_dcomp_readback_present(c, hwnd, w, h);
+	}
+
+	// 2. Dedicated D3D11 device + swapchain + DComp bind + blit pipeline (shared).
+	if (!gl_setup_dcomp_common(c, hwnd, w, h)) {
+		return false;
+	}
+
+	// 3. Open the D3D11 device for GL interop.
+	c->dcomp_dx_interop_device = c->pfn_wglDXOpenDeviceNV(c->dcomp_dx_device);
+	if (c->dcomp_dx_interop_device == NULL) {
+		U_LOG_W("Transparent GL: wglDXOpenDeviceNV failed: %lu — staying opaque", GetLastError());
+		gl_destroy_dcomp_present(c);
+		return false;
+	}
+
+	// 4. Off-screen transit texture (RT + SRV) and its GL interop view + FBO.
+	D3D11_TEXTURE2D_DESC td = {};
+	td.Width = w;
+	td.Height = h;
+	td.MipLevels = 1;
+	td.ArraySize = 1;
+	td.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	td.SampleDesc.Count = 1;
+	td.Usage = D3D11_USAGE_DEFAULT;
+	td.BindFlags = D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE;
+	HRESULT hr = c->dcomp_dx_device->CreateTexture2D(&td, NULL, &c->dcomp_transit_tex);
+	if (FAILED(hr)) {
+		U_LOG_W("Transparent GL: transit CreateTexture2D failed: 0x%08x", (unsigned)hr);
+		gl_destroy_dcomp_present(c);
+		return false;
+	}
+	hr = c->dcomp_dx_device->CreateShaderResourceView(c->dcomp_transit_tex, NULL,
+	                                                  &c->dcomp_transit_srv);
+	if (FAILED(hr)) {
+		U_LOG_W("Transparent GL: transit SRV failed: 0x%08x", (unsigned)hr);
+		gl_destroy_dcomp_present(c);
+		return false;
+	}
+	glGenTextures(1, &c->dcomp_transit_gl_tex);
+	c->dcomp_transit_iop = c->pfn_wglDXRegisterObjectNV(
+	    c->dcomp_dx_interop_device, c->dcomp_transit_tex, c->dcomp_transit_gl_tex,
+	    GL_TEXTURE_2D, WGL_ACCESS_READ_WRITE_NV);
+	if (c->dcomp_transit_iop == NULL) {
+		U_LOG_W("Transparent GL: wglDXRegisterObjectNV(transit) failed: %lu", GetLastError());
+		gl_destroy_dcomp_present(c);
+		return false;
+	}
+	// Build the FBO around the transit GL texture (lock while attaching).
+	glGenFramebuffers(1, &c->dcomp_transit_fbo);
+	c->pfn_wglDXLockObjectsNV(c->dcomp_dx_interop_device, 1, &c->dcomp_transit_iop);
+	glBindFramebuffer(GL_FRAMEBUFFER, c->dcomp_transit_fbo);
+	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
+	                       c->dcomp_transit_gl_tex, 0);
+	GLenum fbst = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+	glBindFramebuffer(GL_FRAMEBUFFER, 0);
+	c->pfn_wglDXUnlockObjectsNV(c->dcomp_dx_interop_device, 1, &c->dcomp_transit_iop);
+	if (fbst != GL_FRAMEBUFFER_COMPLETE) {
+		U_LOG_W("Transparent GL: transit FBO incomplete: 0x%x", (unsigned)fbst);
+		gl_destroy_dcomp_present(c);
+		return false;
+	}
+
 	c->dcomp_active = true;
 	U_LOG_W("Transparent GL: DComp present path active (%ux%u, FLIP_DISCARD + PREMULTIPLIED + "
 	        "off-screen interop transit + D3D11 blit)", w, h);
 	return true;
 }
 
-// Per-frame: blit the (already GL-woven) transit texture into the current DComp
-// back buffer via a D3D11 fullscreen-triangle draw, then Present + Commit.
+// Shared D3D11 blit-and-present: draw @p srv into the current DComp back buffer via
+// the fullscreen-triangle pipeline, then Present + Commit. Used by both the interop
+// (transit SRV) and readback (dynamic SRV) present paths.
 static void
-gl_dcomp_present_frame(struct comp_gl_compositor *c)
+gl_dcomp_blit_srv_present(struct comp_gl_compositor *c, ID3D11ShaderResourceView *srv)
 {
 	ID3D11Texture2D *bb = NULL;
 	HRESULT hr = c->dcomp_swapchain->GetBuffer(0, __uuidof(ID3D11Texture2D), (void **)&bb);
@@ -784,7 +912,7 @@ gl_dcomp_present_frame(struct comp_gl_compositor *c)
 	ctx->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
 	ctx->VSSetShader(c->dcomp_vs, NULL, 0);
 	ctx->PSSetShader(c->dcomp_ps, NULL, 0);
-	ctx->PSSetShaderResources(0, 1, &c->dcomp_transit_srv);
+	ctx->PSSetShaderResources(0, 1, &srv);
 	ctx->PSSetSamplers(0, 1, &c->dcomp_samp);
 	ctx->Draw(3, 0);
 	// Unbind the SRV so the next frame's interop lock isn't held by the context.
@@ -799,6 +927,63 @@ gl_dcomp_present_frame(struct comp_gl_compositor *c)
 		U_LOG_W("Transparent GL: swapchain Present failed: 0x%08x", (unsigned)hr);
 	}
 	c->dcomp_device->Commit();
+}
+
+// Per-frame (interop path): blit the (already GL-woven) transit texture into the
+// current DComp back buffer, then Present + Commit.
+static void
+gl_dcomp_present_frame(struct comp_gl_compositor *c)
+{
+	gl_dcomp_blit_srv_present(c, c->dcomp_transit_srv);
+}
+
+// Per-frame (no-interop readback path): read the woven default framebuffer back to
+// the CPU, upload into the DYNAMIC D3D11 texture, then blit + Present + Commit.
+static void
+gl_dcomp_readback_present_frame(struct comp_gl_compositor *c)
+{
+	const uint32_t w = c->dcomp_present_w, h = c->dcomp_present_h;
+	if (c->dcomp_readback_cpu == NULL || c->dcomp_readback_tex == NULL) {
+		return;
+	}
+
+	// 1. Read the dedicated RGBA weave FBO (bottom-up, alpha preserved — unlike
+	//    FBO 0). Bind it explicitly as the read framebuffer so we don't depend on
+	//    whatever was last bound.
+	glBindFramebuffer(GL_READ_FRAMEBUFFER, c->dcomp_readback_gl_fbo);
+	glReadBuffer(GL_COLOR_ATTACHMENT0);
+	glPixelStorei(GL_PACK_ALIGNMENT, 1);
+	glReadPixels(0, 0, (GLsizei)w, (GLsizei)h, GL_RGBA, GL_UNSIGNED_BYTE, c->dcomp_readback_cpu);
+	glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
+
+	// 2. Upload to the DYNAMIC texture (respect the driver's row pitch). Row 0 =
+	//    glReadPixels bottom row = the interop transit's orientation, so the blit
+	//    shader's V-flip yields the correct image.
+	D3D11_MAPPED_SUBRESOURCE map = {};
+	HRESULT hr = c->dcomp_dx_context->Map(c->dcomp_readback_tex, 0, D3D11_MAP_WRITE_DISCARD, 0, &map);
+	if (FAILED(hr)) {
+		U_LOG_W("Transparent GL: readback Map failed: 0x%08x", (unsigned)hr);
+		return;
+	}
+	const uint8_t *src = c->dcomp_readback_cpu;
+	uint8_t *dst = (uint8_t *)map.pData;
+	const size_t row_bytes = (size_t)w * 4;
+	for (uint32_t y = 0; y < h; ++y) {
+		memcpy(dst + (size_t)y * map.RowPitch, src + (size_t)y * row_bytes, row_bytes);
+	}
+	c->dcomp_dx_context->Unmap(c->dcomp_readback_tex, 0);
+
+	// 3. Blit + Present through DComp.
+	gl_dcomp_blit_srv_present(c, c->dcomp_readback_srv);
+
+	// Log the per-frame readback cost once (it's the whole reason this path is the
+	// last-resort fallback).
+	static int logged = 0;
+	if (!logged) {
+		logged = 1;
+		U_LOG_W("Transparent GL: readback present active — full %ux%u glReadPixels + CPU upload "
+		        "per frame (no-interop fallback cost)", w, h);
+	}
 }
 #endif // XRT_OS_WINDOWS
 
@@ -3185,7 +3370,21 @@ gl_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t
 		} else
 #endif
 		{
-			glBindFramebuffer(GL_FRAMEBUFFER, 0);
+#ifdef XRT_OS_WINDOWS
+			if (c->dcomp_readback_active) {
+				// No-interop readback path: weave into a dedicated RGBA FBO (NOT
+				// FBO 0, whose default framebuffer drops alpha → opaque-black
+				// holes). Source texture is fixed-size, so clamp present dims.
+				if (present_w != c->dcomp_present_w || present_h != c->dcomp_present_h) {
+					present_w = c->dcomp_present_w;
+					present_h = c->dcomp_present_h;
+				}
+				glBindFramebuffer(GL_FRAMEBUFFER, c->dcomp_readback_gl_fbo);
+			} else
+#endif
+			{
+				glBindFramebuffer(GL_FRAMEBUFFER, 0);
+			}
 		}
 
 		if (c->display_processor != NULL) {
@@ -3233,6 +3432,12 @@ gl_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t
 			gl_dcomp_present_frame(c);
 			// Restore default FBO so other paths see what they expect.
 			glBindFramebuffer(GL_FRAMEBUFFER, 0);
+		} else if (c->dcomp_readback_active) {
+			// No-interop transparent path: the weave is in FBO 0; glReadPixels it,
+			// upload to the DYNAMIC texture, then blit + Present through DComp. No
+			// SwapBuffers — DComp owns the (WS_EX_NOREDIRECTIONBITMAP) window.
+			glFlush();
+			gl_dcomp_readback_present_frame(c);
 		} else {
 			SwapBuffers(c->hdc);
 			if (c->owns_window && c->own_window != NULL) {

--- a/src/xrt/compositor/gl/comp_gl_compositor.cpp
+++ b/src/xrt/compositor/gl/comp_gl_compositor.cpp
@@ -442,7 +442,6 @@ struct comp_gl_compositor
 
 	// --- Transparent-background opt-in plumbing ---
 	bool transparent_background;
-	uint32_t chroma_key_color;
 
 	// --- Transparent-background present path (Windows: DComp + WGL_NV_DX_interop2) ---
 	// See the big comment block above gl_setup_dcomp_present() for the architecture
@@ -4346,7 +4345,6 @@ comp_gl_compositor_create(struct xrt_device *xdev,
                           void *dp_factory_gl,
                           void *shared_texture_handle,
                           bool transparent_background,
-                          uint32_t chroma_key_color,
                           int32_t display_screen_left,
                           int32_t display_screen_top,
                           struct xrt_compositor_native **out_xcn)
@@ -4354,7 +4352,6 @@ comp_gl_compositor_create(struct xrt_device *xdev,
 	struct comp_gl_compositor *c = U_TYPED_CALLOC(struct comp_gl_compositor);
 	c->xdev = xdev;
 	c->transparent_background = transparent_background;
-	c->chroma_key_color = chroma_key_color;
 
 	mcp_capture_init(&c->mcp_capture);
 	mcp_capture_install(&c->mcp_capture);
@@ -4539,14 +4536,15 @@ comp_gl_compositor_create(struct xrt_device *xdev,
 		xrt_result_t dp_ret = factory(dp_window, &c->display_processor);
 		if (dp_ret == XRT_SUCCESS && c->display_processor != NULL) {
 			U_LOG_W("GL compositor: display processor created via factory");
-			// Forward session-level transparency config (mirrors the D3D11/
-			// D3D12/VK legs). The Leia GL DP runs its chroma-key fill+strip
-			// internally when transparent_background is set, so per-pixel alpha
-			// survives the weaver and composes through DComp; chroma_key_color=0
-			// means the DP picks its own key. No-op on DPs without the slot
-			// (e.g. sim_display, which preserves alpha natively).
-			xrt_display_processor_gl_set_chroma_key(
-			    c->display_processor, c->chroma_key_color, c->transparent_background);
+			// Forward session-level transparency (#573 — chroma-key-free;
+			// mirrors the D3D11/D3D12/VK legs). client_presents=false: the DP
+			// owns see-through (compose-under-bg from the atlas alpha). The GL
+			// compositor's own DComp transparent present (when interop/readback
+			// is up) is independent and blends the live desktop into the fully
+			// transparent border. No-op on DPs without the slot (e.g.
+			// sim_display, which preserves alpha natively).
+			xrt_display_processor_gl_set_transparent_background(
+			    c->display_processor, c->transparent_background, false);
 		} else {
 			U_LOG_W("GL compositor: display processor factory returned %d, using built-in shaders", dp_ret);
 			c->display_processor = NULL;

--- a/src/xrt/compositor/gl/comp_gl_compositor.h
+++ b/src/xrt/compositor/gl/comp_gl_compositor.h
@@ -39,9 +39,6 @@ struct xrt_rect;
  *                               compositor switches to a DComp + WGL_NV_DX_interop2 present
  *                               path; falls back to opaque WGL SwapBuffers if the GPU/driver
  *                               doesn't expose interop.
- * @param chroma_key_color       0x00BBGGRR. Forwarded to the display processor as the
- *                               chroma-key color used by the post-weave alpha-recovery pass.
- *                               Pass 0 to let the DP pick a default (magenta).
  * @param display_screen_left    Display top-left X in OS screen coords (from xsysc->info,
  *                               populated by the vendor plug-in iface). 0 = primary.
  *                               Used only on Windows for self-owned window positioning.
@@ -59,7 +56,6 @@ comp_gl_compositor_create(struct xrt_device *xdev,
                           void *dp_factory_gl,
                           void *shared_texture_handle,
                           bool transparent_background,
-                          uint32_t chroma_key_color,
                           int32_t display_screen_left,
                           int32_t display_screen_top,
                           struct xrt_compositor_native **out_xcn);

--- a/src/xrt/compositor/vk_native/comp_vk_native_compositor.c
+++ b/src/xrt/compositor/vk_native/comp_vk_native_compositor.c
@@ -23,6 +23,7 @@
 #include "xrt/xrt_vulkan_includes.h"
 #include "xrt/xrt_system.h"
 #include "xrt/xrt_display_processor.h"
+#include "xrt/xrt_display_processor_vk.h"
 
 #include "vk/vk_helpers.h"
 #include "vk/vk_hud_blend.h"
@@ -3115,7 +3116,7 @@ dp_vtable_looks_sane(struct xrt_display_processor *dp)
 	void *fns[] = {
 	    (void *)dp->process_atlas,        (void *)dp->destroy,
 	    (void *)dp->get_display_pixel_info, (void *)dp->get_render_pass,
-	    (void *)dp->get_display_dimensions, (void *)dp->set_chroma_key,
+	    (void *)dp->get_display_dimensions, (void *)dp->set_eye_tracking_mode,
 	};
 	if (dp->process_atlas == NULL || dp->destroy == NULL) {
 		return false; // mandatory slots
@@ -3152,7 +3153,6 @@ comp_vk_native_compositor_create(struct xrt_device *xdev,
                                  void *dp_factory_vk,
                                  void *shared_texture_handle,
                                  bool transparent_background,
-                                 uint32_t chroma_key_color,
                                  int32_t display_screen_left,
                                  int32_t display_screen_top,
                                  struct xrt_compositor_native **out_xc)
@@ -3366,12 +3366,13 @@ comp_vk_native_compositor_create(struct xrt_device *xdev,
 		U_LOG_W("No VK display processor factory provided");
 	}
 
-	// Forward transparent_background + chroma_key_color to the display processor.
-	// The DP owns the chroma-key trick (compositor stays vendor-agnostic).
-	// Safe no-op if the DP doesn't implement set_chroma_key or display_processor is NULL.
+	// Forward transparent_background to the display processor (#573 —
+	// chroma-key-free). client_presents=false: the in-process present is
+	// opaque, so the DP owns see-through (alpha-gate / compose-under-bg). Safe
+	// no-op if the DP lacks the slot (sim_display) or display_processor is NULL.
 	if (c->display_processor != NULL) {
-		xrt_display_processor_set_chroma_key(
-		    c->display_processor, chroma_key_color, transparent_background);
+		xrt_display_processor_vk_set_transparent_background(
+		    (struct xrt_display_processor_vk *)c->display_processor, transparent_background, false);
 	}
 
 	// Create output target (VkSwapchainKHR) for presentation.

--- a/src/xrt/compositor/vk_native/comp_vk_native_compositor.h
+++ b/src/xrt/compositor/vk_native/comp_vk_native_compositor.h
@@ -40,10 +40,7 @@ extern "C" {
  * @param shared_texture_handle Shared texture HANDLE for offscreen mode, or NULL.
  * @param transparent_background Request transparent (PRE_MULTIPLIED) compositeAlpha
  *        on the presented swapchain. Forwarded to the display processor as the
- *        chroma-key gate.
- * @param chroma_key_color 0x00BBGGRR. When @p transparent_background is true the
- *        display processor uses this color in its pre-weave fill / post-weave strip
- *        passes. Pass 0 to let the DP pick a content-safe default (magenta).
+ *        transparency enable (set_transparent_background).
  * @param out_xc Pointer to receive the created compositor.
  *
  * @return XRT_SUCCESS on success, error code otherwise.
@@ -61,7 +58,6 @@ comp_vk_native_compositor_create(struct xrt_device *xdev,
                                  void *dp_factory_vk,
                                  void *shared_texture_handle,
                                  bool transparent_background,
-                                 uint32_t chroma_key_color,
                                  int32_t display_screen_left,
                                  int32_t display_screen_top,
                                  struct xrt_compositor_native **out_xc);

--- a/src/xrt/drivers/sim_display/sim_display_processor.c
+++ b/src/xrt/drivers/sim_display/sim_display_processor.c
@@ -605,18 +605,6 @@ sim_dp_is_alpha_native(struct xrt_display_processor *xdp)
 	return true;
 }
 
-static void
-sim_dp_set_chroma_key(struct xrt_display_processor *xdp,
-                      uint32_t key_color,
-                      bool transparent_bg_enabled)
-{
-	(void)key_color;
-	// Alpha-native — no chroma-key fill/strip required. We do honor the
-	// transparent-background bit so the weave render-pass clears the target
-	// to alpha=0 instead of opaque black (issue #392).
-	sim_display_processor(xdp)->transparent_bg = transparent_bg_enabled;
-}
-
 // #491 part 3 — store the runtime's flattened 2D-under backdrop for the next
 // process_atlas. sim_display is a test double (no captured desktop), so it
 // records the handoff rather than compositing pixels; the one-shot WARN proves
@@ -753,7 +741,6 @@ sim_display_processor_create(enum sim_display_output_mode mode,
 	sdp->base.get_render_pass = sim_dp_get_render_pass;
 	sdp->base.get_predicted_eye_positions = sim_dp_get_predicted_eye_positions;
 	sdp->base.is_alpha_native = sim_dp_is_alpha_native;
-	sdp->base.set_chroma_key = sim_dp_set_chroma_key;
 	sdp->base.set_background_2d = sim_dp_set_background_2d; // #491 part 3
 	sdp->base.get_local_zone_caps = sim_dp_get_local_zone_caps;          // #224 / ADR-027
 	sdp->base.publish_local_zone_mask = sim_dp_publish_local_zone_mask;  // #224 / ADR-027

--- a/src/xrt/drivers/sim_display/sim_display_processor_d3d11.cpp
+++ b/src/xrt/drivers/sim_display/sim_display_processor_d3d11.cpp
@@ -477,17 +477,6 @@ sim_dp_d3d11_is_alpha_native(struct xrt_display_processor_d3d11 *xdp)
 	return true;
 }
 
-static void
-sim_dp_d3d11_set_chroma_key(struct xrt_display_processor_d3d11 *xdp,
-                            uint32_t key_color,
-                            bool transparent_bg_enabled)
-{
-	(void)xdp;
-	(void)key_color;
-	(void)transparent_bg_enabled;
-	// Alpha-native — no chroma-key fill/strip required.
-}
-
 /*
  * ADR-021: this DP samples the atlas and runs the result through out_encode(),
  * which encodes to sRGB when the runtime declares a LINEAR atlas and passes
@@ -753,7 +742,6 @@ sim_display_processor_d3d11_create(enum sim_display_output_mode mode,
 	sdp->base.process_atlas = sim_dp_d3d11_process_atlas;
 	sdp->base.get_predicted_eye_positions = sim_dp_d3d11_get_predicted_eye_positions;
 	sdp->base.is_alpha_native = sim_dp_d3d11_is_alpha_native;
-	sdp->base.set_chroma_key = sim_dp_d3d11_set_chroma_key;
 	sdp->base.get_handoff_color_capability = sim_dp_d3d11_get_handoff_color_capability;
 	sdp->base.set_atlas_encoding = sim_dp_d3d11_set_atlas_encoding;
 	sdp->base.get_local_zone_caps = sim_dp_d3d11_get_local_zone_caps;

--- a/src/xrt/drivers/sim_display/sim_display_processor_d3d12.cpp
+++ b/src/xrt/drivers/sim_display/sim_display_processor_d3d12.cpp
@@ -468,17 +468,6 @@ sim_dp_d3d12_is_alpha_native(struct xrt_display_processor_d3d12 *xdp)
 	return true;
 }
 
-static void
-sim_dp_d3d12_set_chroma_key(struct xrt_display_processor_d3d12 *xdp,
-                            uint32_t key_color,
-                            bool transparent_bg_enabled)
-{
-	(void)xdp;
-	(void)key_color;
-	(void)transparent_bg_enabled;
-	// Alpha-native — no chroma-key fill/strip required.
-}
-
 // #491 part 3 — test double: record the 2D-under backdrop handoff (no captured
 // desktop to composite under). The one-shot WARN proves the runtime → DP
 // set_background_2d wiring works without Leia hardware.
@@ -616,7 +605,6 @@ sim_display_processor_d3d12_create(enum sim_display_output_mode mode,
 	sdp->base.process_atlas = sim_dp_d3d12_process_atlas;
 	sdp->base.get_predicted_eye_positions = sim_dp_d3d12_get_predicted_eye_positions;
 	sdp->base.is_alpha_native = sim_dp_d3d12_is_alpha_native;
-	sdp->base.set_chroma_key = sim_dp_d3d12_set_chroma_key;
 	sdp->base.set_background_2d = sim_dp_d3d12_set_background_2d; // #491 part 3
 	sdp->base.get_local_zone_caps = sim_dp_d3d12_get_local_zone_caps;         // #224 / ADR-027
 	sdp->base.publish_local_zone_mask = sim_dp_d3d12_publish_local_zone_mask; // #224 / ADR-027

--- a/src/xrt/drivers/sim_display/sim_display_processor_gl.c
+++ b/src/xrt/drivers/sim_display/sim_display_processor_gl.c
@@ -405,17 +405,6 @@ sim_dp_gl_is_alpha_native(struct xrt_display_processor_gl *xdp)
 	return true;
 }
 
-static void
-sim_dp_gl_set_chroma_key(struct xrt_display_processor_gl *xdp,
-                         uint32_t key_color,
-                         bool transparent_bg_enabled)
-{
-	(void)xdp;
-	(void)key_color;
-	(void)transparent_bg_enabled;
-	// Alpha-native — no chroma-key fill/strip required.
-}
-
 // #491 part 3 — test double: record the 2D-under backdrop handoff (no captured
 // desktop to composite under). The one-shot WARN proves the runtime → DP
 // set_background_2d wiring works without Leia hardware.
@@ -568,7 +557,6 @@ sim_display_processor_gl_create(enum sim_display_output_mode mode,
 	sdp->base.process_atlas = sim_dp_gl_process_atlas;
 	sdp->base.get_predicted_eye_positions = sim_dp_gl_get_predicted_eye_positions;
 	sdp->base.is_alpha_native = sim_dp_gl_is_alpha_native;
-	sdp->base.set_chroma_key = sim_dp_gl_set_chroma_key;
 	sdp->base.set_background_2d = sim_dp_gl_set_background_2d; // #491 part 3
 	sdp->base.get_local_zone_caps = sim_dp_gl_get_local_zone_caps;         // #224 / ADR-027
 	sdp->base.publish_local_zone_mask = sim_dp_gl_publish_local_zone_mask; // #224 / ADR-027

--- a/src/xrt/drivers/sim_display/sim_display_processor_metal.m
+++ b/src/xrt/drivers/sim_display/sim_display_processor_metal.m
@@ -419,17 +419,6 @@ sim_dp_metal_is_alpha_native(struct xrt_display_processor_metal *xdp)
 	return true;
 }
 
-static void
-sim_dp_metal_set_chroma_key(struct xrt_display_processor_metal *xdp,
-                            uint32_t key_color,
-                            bool transparent_bg_enabled)
-{
-	(void)xdp;
-	(void)key_color;
-	(void)transparent_bg_enabled;
-	// Alpha-native — no chroma-key fill/strip required.
-}
-
 // #491 part 3 — test double: record the 2D-under backdrop handoff (no captured
 // desktop to composite under). The one-shot WARN proves the runtime → DP
 // set_background_2d wiring works without Leia hardware.
@@ -567,7 +556,6 @@ sim_display_processor_metal_create(enum sim_display_output_mode mode,
 	sdp->base.process_atlas = sim_dp_metal_process_atlas;
 	sdp->base.get_predicted_eye_positions = sim_dp_metal_get_predicted_eye_positions;
 	sdp->base.is_alpha_native = sim_dp_metal_is_alpha_native;
-	sdp->base.set_chroma_key = sim_dp_metal_set_chroma_key;
 	sdp->base.set_background_2d = sim_dp_metal_set_background_2d; // #491 part 3
 	sdp->base.get_local_zone_caps = sim_dp_metal_get_local_zone_caps;         // #224 / ADR-027
 	sdp->base.publish_local_zone_mask = sim_dp_metal_publish_local_zone_mask; // #224 / ADR-027

--- a/src/xrt/include/xrt/xrt_compositor.h
+++ b/src/xrt/include/xrt/xrt_compositor.h
@@ -1005,12 +1005,6 @@ struct xrt_session_info
 	//! on other graphics APIs. Set via XrWin32WindowBindingCreateInfoEXT::transparentBackgroundEnabled.
 	bool transparent_background_enabled;
 
-	//! Optional chroma-key color (0x00BBGGRR) used by the runtime's post-weave
-	//! alpha-conversion shader pass when transparent_background_enabled is true.
-	//! Set via XrWin32WindowBindingCreateInfoEXT::chromaKeyColor. Zero disables
-	//! the pass.
-	uint32_t chroma_key_color;
-
 	//! Readback callback for offscreen compositing (called with composited RGBA pixels)
 	void (*readback_callback)(const uint8_t *pixels, uint32_t w, uint32_t h, void *userdata);
 	//! Userdata passed to readback_callback

--- a/src/xrt/include/xrt/xrt_display_processor.h
+++ b/src/xrt/include/xrt/xrt_display_processor.h
@@ -263,30 +263,6 @@ struct xrt_display_processor
 	bool (*is_self_submitting)(struct xrt_display_processor *xdp);
 
 	/*!
-	 * Inform the DP of session-level transparency configuration.
-	 * Called once at session start when @p transparent_bg_enabled is set on
-	 * the corresponding window-binding extension. DPs that need the
-	 * chroma-key trick (Leia) use this to enable an internal pre-weave
-	 * fill (transparent atlas pixels → key color) and post-weave strip
-	 * (key color → alpha=0). DPs that are alpha_native may treat this as
-	 * a no-op.
-	 *
-	 * @p key_color is honored as an app-supplied override when non-zero
-	 * (matches today's XR_EXT_win32_window_binding.chromaKeyColor); when
-	 * zero, the DP picks its own internal color.
-	 *
-	 * Optional — NULL means the DP doesn't respect transparency requests.
-	 *
-	 * @param xdp                     Pointer to self.
-	 * @param key_color                App-supplied chroma key (0x00BBGGRR);
-	 *                                 0 means DP-picks (recommended).
-	 * @param transparent_bg_enabled  True when transparency was requested.
-	 */
-	void (*set_chroma_key)(struct xrt_display_processor *xdp,
-	                       uint32_t key_color,
-	                       bool transparent_bg_enabled);
-
-	/*!
 	 * Notify the display processor that the host activity has paused
 	 * (backgrounded). Vendor SDKs use this to drop face-tracking
 	 * cameras, dim backlights, and otherwise save power.
@@ -525,8 +501,8 @@ struct xrt_display_processor
  * What is STILL breaking (and trips an assert below): reordering an existing
  * slot, removing one, changing a signature, or inserting anywhere but the end.
  * That is exactly what broke standalone-VK weaving — on_pause/on_resume were
- * inserted mid-struct (before destroy) without a version bump, so the runtime's
- * set_chroma_key call hit a plug-in's destroy. See ADR-020.
+ * inserted mid-struct (before destroy) without a version bump, so a runtime
+ * vtable call landed on the wrong slot (a plug-in's destroy). See ADR-020.
  *
  * If you change anything that trips an assert below, you are making a BREAKING
  * ABI change. In the SAME change you MUST:
@@ -575,19 +551,18 @@ XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, get_display_dimensions)
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, get_display_pixel_info)       == XRT_DP_BASE_OFF +  7 * sizeof(void *), XRT_DP_ABI_MSG);
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, is_alpha_native)              == XRT_DP_BASE_OFF +  8 * sizeof(void *), XRT_DP_ABI_MSG);
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, is_self_submitting)           == XRT_DP_BASE_OFF +  9 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, set_chroma_key)               == XRT_DP_BASE_OFF + 10 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, on_pause)                     == XRT_DP_BASE_OFF + 11 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, on_resume)                    == XRT_DP_BASE_OFF + 12 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, destroy)                      == XRT_DP_BASE_OFF + 13 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, get_handoff_color_capability) == XRT_DP_BASE_OFF + 14 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, set_atlas_encoding)            == XRT_DP_BASE_OFF + 15 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, set_target_color_view)        == XRT_DP_BASE_OFF + 16 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, set_background_2d)             == XRT_DP_BASE_OFF + 17 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, set_eye_tracking_mode)         == XRT_DP_BASE_OFF + 18 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, get_local_zone_caps)           == XRT_DP_BASE_OFF + 19 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, publish_local_zone_mask)       == XRT_DP_BASE_OFF + 20 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, clear_local_zone_mask)         == XRT_DP_BASE_OFF + 21 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(sizeof(struct xrt_display_processor)                                 == XRT_DP_BASE_OFF + 22 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, on_pause)                     == XRT_DP_BASE_OFF + 10 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, on_resume)                    == XRT_DP_BASE_OFF + 11 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, destroy)                      == XRT_DP_BASE_OFF + 12 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, get_handoff_color_capability) == XRT_DP_BASE_OFF + 13 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, set_atlas_encoding)            == XRT_DP_BASE_OFF + 14 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, set_target_color_view)        == XRT_DP_BASE_OFF + 15 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, set_background_2d)             == XRT_DP_BASE_OFF + 16 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, set_eye_tracking_mode)         == XRT_DP_BASE_OFF + 17 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, get_local_zone_caps)           == XRT_DP_BASE_OFF + 18 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, publish_local_zone_mask)       == XRT_DP_BASE_OFF + 19 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor, clear_local_zone_mask)         == XRT_DP_BASE_OFF + 20 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(sizeof(struct xrt_display_processor)                                 == XRT_DP_BASE_OFF + 21 * sizeof(void *), XRT_DP_ABI_MSG);
 // clang-format on
 
 /*!
@@ -784,22 +759,6 @@ xrt_display_processor_is_self_submitting(struct xrt_display_processor *xdp)
 		return false;
 	}
 	return xdp->is_self_submitting(xdp);
-}
-
-/*!
- * @copydoc xrt_display_processor::set_chroma_key
- * No-op if not supported (function pointer is NULL).
- * @public @memberof xrt_display_processor
- */
-static inline void
-xrt_display_processor_set_chroma_key(struct xrt_display_processor *xdp,
-                                     uint32_t key_color,
-                                     bool transparent_bg_enabled)
-{
-	if (!XRT_DP_HAS_SLOT(xdp, set_chroma_key) || xdp->set_chroma_key == NULL) {
-		return;
-	}
-	xdp->set_chroma_key(xdp, key_color, transparent_bg_enabled);
 }
 
 /*!

--- a/src/xrt/include/xrt/xrt_display_processor_d3d11.h
+++ b/src/xrt/include/xrt/xrt_display_processor_d3d11.h
@@ -152,22 +152,10 @@ struct xrt_display_processor_d3d11
 	/*!
 	 * Whether this display processor passes per-pixel alpha through to its
 	 * output stage. true for sim_display-style processors; false (or NULL)
-	 * for Leia-style weavers that need the chroma-key trick.
+	 * for Leia-style weavers.
 	 * Optional — NULL means false.
 	 */
 	bool (*is_alpha_native)(struct xrt_display_processor_d3d11 *xdp);
-
-	/*!
-	 * Inform the DP of session-level transparency configuration.
-	 * @p key_color is the app-supplied chroma key (0x00BBGGRR); 0 means
-	 * the DP picks its own internal color. @p transparent_bg_enabled
-	 * tells the DP whether to run its pre-weave fill / post-weave strip
-	 * pass.
-	 * Optional — NULL means the DP doesn't respect transparency requests.
-	 */
-	void (*set_chroma_key)(struct xrt_display_processor_d3d11 *xdp,
-	                       uint32_t key_color,
-	                       bool transparent_bg_enabled);
 
 	/*!
 	 * Destroy this display processor and free all resources.
@@ -318,18 +306,16 @@ struct xrt_display_processor_d3d11
 	 * Enable/disable transparent-background output for this client (#551).
 	 * When enabled, the DP composites its weave OVER the captured desktop
 	 * behind the app window (compose-under-background, from the atlas's
-	 * premultiplied alpha) so transparent atlas regions show the desktop —
-	 * the chroma-key-free path. This is the policy signal; the runtime
-	 * separately guarantees the app window is excluded from the DP's desktop
-	 * capture (SetWindowDisplayAffinity(WDA_EXCLUDEFROMCAPTURE), set from the
+	 * premultiplied alpha) so transparent atlas regions show the desktop.
+	 * This is the policy signal; the runtime separately guarantees the app
+	 * window is excluded from the DP's desktop capture
+	 * (SetWindowDisplayAffinity(WDA_EXCLUDEFROMCAPTURE), set from the
 	 * window-owning process so it works even when the DP runs out-of-process
 	 * in the service for an IPC client).
 	 *
-	 * Supersedes @ref set_chroma_key as the transparency enable: a DP that
-	 * exposes this slot should drive compose-under here and treat
-	 * set_chroma_key purely as the legacy fallback color. Optional — absent
-	 * slot or NULL ⟹ the runtime falls back to set_chroma_key. Appended per
-	 * ADR-020 (append-only within a major).
+	 * This is the sole transparency enable (#573 removed the legacy chroma-key
+	 * path). Optional — absent slot or NULL ⟹ the DP doesn't support
+	 * transparent output.
 	 *
 	 * @param xdp             Pointer to self.
 	 * @param enabled         true to produce transparent output for see-through.
@@ -386,17 +372,16 @@ XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, get_hardware_3d_s
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, get_display_dimensions)      == XRT_DP_D3D11_BASE_OFF + 5 * sizeof(void *), XRT_DP_ABI_MSG);
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, get_display_pixel_info)      == XRT_DP_D3D11_BASE_OFF + 6 * sizeof(void *), XRT_DP_ABI_MSG);
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, is_alpha_native)             == XRT_DP_D3D11_BASE_OFF + 7 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, set_chroma_key)              == XRT_DP_D3D11_BASE_OFF + 8 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, destroy)                     == XRT_DP_D3D11_BASE_OFF + 9 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, get_handoff_color_capability) == XRT_DP_D3D11_BASE_OFF + 10 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, set_atlas_encoding)           == XRT_DP_D3D11_BASE_OFF + 11 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, get_local_zone_caps)          == XRT_DP_D3D11_BASE_OFF + 12 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, publish_local_zone_mask)      == XRT_DP_D3D11_BASE_OFF + 13 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, clear_local_zone_mask)        == XRT_DP_D3D11_BASE_OFF + 14 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, set_background_2d)            == XRT_DP_D3D11_BASE_OFF + 15 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, set_eye_tracking_mode)        == XRT_DP_D3D11_BASE_OFF + 16 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, set_transparent_background)    == XRT_DP_D3D11_BASE_OFF + 17 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(sizeof(struct xrt_display_processor_d3d11)                                == XRT_DP_D3D11_BASE_OFF + 18 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, destroy)                     == XRT_DP_D3D11_BASE_OFF + 8 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, get_handoff_color_capability) == XRT_DP_D3D11_BASE_OFF + 9 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, set_atlas_encoding)           == XRT_DP_D3D11_BASE_OFF + 10 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, get_local_zone_caps)          == XRT_DP_D3D11_BASE_OFF + 11 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, publish_local_zone_mask)      == XRT_DP_D3D11_BASE_OFF + 12 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, clear_local_zone_mask)        == XRT_DP_D3D11_BASE_OFF + 13 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, set_background_2d)            == XRT_DP_D3D11_BASE_OFF + 14 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, set_eye_tracking_mode)        == XRT_DP_D3D11_BASE_OFF + 15 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, set_transparent_background)    == XRT_DP_D3D11_BASE_OFF + 16 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(sizeof(struct xrt_display_processor_d3d11)                                == XRT_DP_D3D11_BASE_OFF + 17 * sizeof(void *), XRT_DP_ABI_MSG);
 // clang-format on
 
 /*!
@@ -535,22 +520,6 @@ xrt_display_processor_d3d11_is_alpha_native(struct xrt_display_processor_d3d11 *
 }
 
 /*!
- * @copydoc xrt_display_processor_d3d11::set_chroma_key
- * No-op if not supported (function pointer is NULL).
- * @public @memberof xrt_display_processor_d3d11
- */
-static inline void
-xrt_display_processor_d3d11_set_chroma_key(struct xrt_display_processor_d3d11 *xdp,
-                                            uint32_t key_color,
-                                            bool transparent_bg_enabled)
-{
-	if (!XRT_DP_HAS_SLOT(xdp, set_chroma_key) || xdp->set_chroma_key == NULL) {
-		return;
-	}
-	xdp->set_chroma_key(xdp, key_color, transparent_bg_enabled);
-}
-
-/*!
  * @copydoc xrt_display_processor_d3d11::get_handoff_color_capability
  * Returns @ref XRT_DP_COLOR_ENCODED if not supported (slot absent or NULL).
  * @public @memberof xrt_display_processor_d3d11
@@ -667,7 +636,7 @@ xrt_display_processor_d3d11_set_eye_tracking_mode(struct xrt_display_processor_d
 /*!
  * @copydoc xrt_display_processor_d3d11::set_transparent_background
  * Returns false if not supported (slot absent or NULL) — the caller then
- * falls back to @ref xrt_display_processor_d3d11_set_chroma_key.
+ * leaves the DP opaque.
  * @public @memberof xrt_display_processor_d3d11
  */
 static inline bool

--- a/src/xrt/include/xrt/xrt_display_processor_d3d12.h
+++ b/src/xrt/include/xrt/xrt_display_processor_d3d12.h
@@ -165,22 +165,10 @@ struct xrt_display_processor_d3d12
 	/*!
 	 * Whether this display processor passes per-pixel alpha through to its
 	 * output stage. true for sim_display-style processors; false (or NULL)
-	 * for Leia-style weavers that need the chroma-key trick.
+	 * for Leia-style weavers.
 	 * Optional — NULL means false.
 	 */
 	bool (*is_alpha_native)(struct xrt_display_processor_d3d12 *xdp);
-
-	/*!
-	 * Inform the DP of session-level transparency configuration.
-	 * @p key_color is the app-supplied chroma key (0x00BBGGRR); 0 means
-	 * the DP picks its own internal color. @p transparent_bg_enabled
-	 * tells the DP whether to run its pre-weave fill / post-weave strip
-	 * pass.
-	 * Optional — NULL means the DP doesn't respect transparency requests.
-	 */
-	void (*set_chroma_key)(struct xrt_display_processor_d3d12 *xdp,
-	                       uint32_t key_color,
-	                       bool transparent_bg_enabled);
 
 	/*!
 	 * Destroy this display processor and free all resources.
@@ -320,6 +308,31 @@ struct xrt_display_processor_d3d12
 	 * @return true if the clear was accepted.
 	 */
 	bool (*clear_local_zone_mask)(struct xrt_display_processor_d3d12 *xdp);
+
+	/*!
+	 * Enable/disable transparent-background output for this client (#573 — the
+	 * D3D12 counterpart of @ref xrt_display_processor_d3d11::set_transparent_background).
+	 * When enabled, the DP composites its weave OVER the captured desktop behind
+	 * the app window (compose-under-background, from the atlas's premultiplied
+	 * alpha) so transparent atlas regions show the desktop. This is the policy
+	 * signal; the runtime separately guarantees the app window is excluded from
+	 * the DP's desktop capture (SetWindowDisplayAffinity(WDA_EXCLUDEFROMCAPTURE),
+	 * set from the window-owning process).
+	 *
+	 * This is the sole transparency enable (#573 removed the legacy chroma-key
+	 * path, which on D3D12 had been overloaded as the enable signal). Optional —
+	 * absent slot or NULL ⟹ the DP doesn't support transparent output. Appended
+	 * per ADR-020.
+	 *
+	 * @param xdp             Pointer to self.
+	 * @param enabled         true to produce transparent output for see-through.
+	 * @param client_presents true ⟹ the runtime owns a transparent present that
+	 *                        DWM-blends the live desktop into alpha=0 holes; the DP
+	 *                        then only reconstructs alpha (the alpha-gate), never
+	 *                        composing its own captured-desktop background. false ⟹
+	 *                        the DP owns see-through itself (compose-under-bg).
+	 */
+	void (*set_transparent_background)(struct xrt_display_processor_d3d12 *xdp, bool enabled, bool client_presents);
 };
 
 /*
@@ -361,15 +374,15 @@ XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d12, get_hardware_3d_s
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d12, get_display_dimensions)      == XRT_DP_D3D12_BASE_OFF +  6 * sizeof(void *), XRT_DP_ABI_MSG);
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d12, get_display_pixel_info)      == XRT_DP_D3D12_BASE_OFF +  7 * sizeof(void *), XRT_DP_ABI_MSG);
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d12, is_alpha_native)             == XRT_DP_D3D12_BASE_OFF +  8 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d12, set_chroma_key)              == XRT_DP_D3D12_BASE_OFF +  9 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d12, destroy)                     == XRT_DP_D3D12_BASE_OFF + 10 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d12, get_handoff_color_capability) == XRT_DP_D3D12_BASE_OFF + 11 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d12, set_atlas_encoding)           == XRT_DP_D3D12_BASE_OFF + 12 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d12, set_background_2d)            == XRT_DP_D3D12_BASE_OFF + 13 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d12, set_eye_tracking_mode)        == XRT_DP_D3D12_BASE_OFF + 14 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d12, get_local_zone_caps)          == XRT_DP_D3D12_BASE_OFF + 15 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d12, publish_local_zone_mask)      == XRT_DP_D3D12_BASE_OFF + 16 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d12, clear_local_zone_mask)        == XRT_DP_D3D12_BASE_OFF + 17 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d12, destroy)                     == XRT_DP_D3D12_BASE_OFF +  9 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d12, get_handoff_color_capability) == XRT_DP_D3D12_BASE_OFF + 10 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d12, set_atlas_encoding)           == XRT_DP_D3D12_BASE_OFF + 11 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d12, set_background_2d)            == XRT_DP_D3D12_BASE_OFF + 12 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d12, set_eye_tracking_mode)        == XRT_DP_D3D12_BASE_OFF + 13 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d12, get_local_zone_caps)          == XRT_DP_D3D12_BASE_OFF + 14 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d12, publish_local_zone_mask)      == XRT_DP_D3D12_BASE_OFF + 15 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d12, clear_local_zone_mask)        == XRT_DP_D3D12_BASE_OFF + 16 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d12, set_transparent_background)   == XRT_DP_D3D12_BASE_OFF + 17 * sizeof(void *), XRT_DP_ABI_MSG);
 XRT_DP_ABI_ASSERT(sizeof(struct xrt_display_processor_d3d12)                                == XRT_DP_D3D12_BASE_OFF + 18 * sizeof(void *), XRT_DP_ABI_MSG);
 // clang-format on
 
@@ -527,19 +540,21 @@ xrt_display_processor_d3d12_is_alpha_native(struct xrt_display_processor_d3d12 *
 }
 
 /*!
- * @copydoc xrt_display_processor_d3d12::set_chroma_key
- * No-op if not supported (function pointer is NULL).
+ * @copydoc xrt_display_processor_d3d12::set_transparent_background
+ * Returns false if not supported (slot absent or NULL) — the caller then
+ * leaves the DP opaque.
  * @public @memberof xrt_display_processor_d3d12
  */
-static inline void
-xrt_display_processor_d3d12_set_chroma_key(struct xrt_display_processor_d3d12 *xdp,
-                                            uint32_t key_color,
-                                            bool transparent_bg_enabled)
+static inline bool
+xrt_display_processor_d3d12_set_transparent_background(struct xrt_display_processor_d3d12 *xdp,
+                                                       bool enabled,
+                                                       bool client_presents)
 {
-	if (!XRT_DP_HAS_SLOT(xdp, set_chroma_key) || xdp->set_chroma_key == NULL) {
-		return;
+	if (!XRT_DP_HAS_SLOT(xdp, set_transparent_background) || xdp->set_transparent_background == NULL) {
+		return false;
 	}
-	xdp->set_chroma_key(xdp, key_color, transparent_bg_enabled);
+	xdp->set_transparent_background(xdp, enabled, client_presents);
+	return true;
 }
 
 /*!

--- a/src/xrt/include/xrt/xrt_display_processor_gl.h
+++ b/src/xrt/include/xrt/xrt_display_processor_gl.h
@@ -146,22 +146,10 @@ struct xrt_display_processor_gl
 	/*!
 	 * Whether this display processor passes per-pixel alpha through to its
 	 * output stage. true for sim_display-style processors; false (or NULL)
-	 * for Leia-style weavers that need the chroma-key trick.
+	 * for Leia-style weavers.
 	 * Optional — NULL means false.
 	 */
 	bool (*is_alpha_native)(struct xrt_display_processor_gl *xdp);
-
-	/*!
-	 * Inform the DP of session-level transparency configuration.
-	 * @p key_color is the app-supplied chroma key (0x00BBGGRR); 0 means
-	 * the DP picks its own internal color. @p transparent_bg_enabled
-	 * tells the DP whether to run its pre-weave fill / post-weave strip
-	 * pass.
-	 * Optional — NULL means the DP doesn't respect transparency requests.
-	 */
-	void (*set_chroma_key)(struct xrt_display_processor_gl *xdp,
-	                       uint32_t key_color,
-	                       bool transparent_bg_enabled);
 
 	/*!
 	 * Destroy this display processor and free all resources.
@@ -302,6 +290,31 @@ struct xrt_display_processor_gl
 	 * @return true if the clear was accepted.
 	 */
 	bool (*clear_local_zone_mask)(struct xrt_display_processor_gl *xdp);
+
+	/*!
+	 * Enable/disable transparent-background output for this client (#573 — the
+	 * GL counterpart of @ref xrt_display_processor_d3d11::set_transparent_background).
+	 * When enabled, the DP composites its weave OVER the captured desktop behind
+	 * the app window (compose-under-background, from the atlas's premultiplied
+	 * alpha) so transparent atlas regions show the desktop. This is the policy
+	 * signal; the runtime separately guarantees the app window is excluded from
+	 * the DP's desktop capture (SetWindowDisplayAffinity(WDA_EXCLUDEFROMCAPTURE),
+	 * set from the window-owning process).
+	 *
+	 * This is the sole transparency enable (#573 removed the legacy chroma-key
+	 * path, which on GL had been overloaded as the enable signal). Optional —
+	 * absent slot or NULL ⟹ the DP doesn't support transparent output. Appended
+	 * per ADR-020.
+	 *
+	 * @param xdp             Pointer to self.
+	 * @param enabled         true to produce transparent output for see-through.
+	 * @param client_presents true ⟹ the runtime owns a transparent present that
+	 *                        DWM-blends the live desktop into alpha=0 holes; the DP
+	 *                        then only reconstructs alpha (the alpha-gate), never
+	 *                        composing its own captured-desktop background. false ⟹
+	 *                        the DP owns see-through itself (compose-under-bg).
+	 */
+	void (*set_transparent_background)(struct xrt_display_processor_gl *xdp, bool enabled, bool client_presents);
 };
 
 /*
@@ -341,15 +354,15 @@ XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_gl, get_hardware_3d_stat
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_gl, get_display_dimensions)      == XRT_DP_GL_BASE_OFF + 5 * sizeof(void *), XRT_DP_ABI_MSG);
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_gl, get_display_pixel_info)      == XRT_DP_GL_BASE_OFF + 6 * sizeof(void *), XRT_DP_ABI_MSG);
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_gl, is_alpha_native)             == XRT_DP_GL_BASE_OFF + 7 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_gl, set_chroma_key)              == XRT_DP_GL_BASE_OFF + 8 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_gl, destroy)                     == XRT_DP_GL_BASE_OFF + 9 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_gl, get_handoff_color_capability) == XRT_DP_GL_BASE_OFF + 10 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_gl, set_atlas_encoding)           == XRT_DP_GL_BASE_OFF + 11 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_gl, set_background_2d)            == XRT_DP_GL_BASE_OFF + 12 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_gl, set_eye_tracking_mode)        == XRT_DP_GL_BASE_OFF + 13 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_gl, get_local_zone_caps)          == XRT_DP_GL_BASE_OFF + 14 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_gl, publish_local_zone_mask)      == XRT_DP_GL_BASE_OFF + 15 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_gl, clear_local_zone_mask)        == XRT_DP_GL_BASE_OFF + 16 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_gl, destroy)                     == XRT_DP_GL_BASE_OFF + 8 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_gl, get_handoff_color_capability) == XRT_DP_GL_BASE_OFF + 9 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_gl, set_atlas_encoding)           == XRT_DP_GL_BASE_OFF + 10 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_gl, set_background_2d)            == XRT_DP_GL_BASE_OFF + 11 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_gl, set_eye_tracking_mode)        == XRT_DP_GL_BASE_OFF + 12 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_gl, get_local_zone_caps)          == XRT_DP_GL_BASE_OFF + 13 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_gl, publish_local_zone_mask)      == XRT_DP_GL_BASE_OFF + 14 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_gl, clear_local_zone_mask)        == XRT_DP_GL_BASE_OFF + 15 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_gl, set_transparent_background)   == XRT_DP_GL_BASE_OFF + 16 * sizeof(void *), XRT_DP_ABI_MSG);
 XRT_DP_ABI_ASSERT(sizeof(struct xrt_display_processor_gl)                                == XRT_DP_GL_BASE_OFF + 17 * sizeof(void *), XRT_DP_ABI_MSG);
 // clang-format on
 
@@ -488,19 +501,21 @@ xrt_display_processor_gl_is_alpha_native(struct xrt_display_processor_gl *xdp)
 }
 
 /*!
- * @copydoc xrt_display_processor_gl::set_chroma_key
- * No-op if not supported (function pointer is NULL).
+ * @copydoc xrt_display_processor_gl::set_transparent_background
+ * Returns false if not supported (slot absent or NULL) — the caller then
+ * leaves the DP opaque.
  * @public @memberof xrt_display_processor_gl
  */
-static inline void
-xrt_display_processor_gl_set_chroma_key(struct xrt_display_processor_gl *xdp,
-                                         uint32_t key_color,
-                                         bool transparent_bg_enabled)
+static inline bool
+xrt_display_processor_gl_set_transparent_background(struct xrt_display_processor_gl *xdp,
+                                                    bool enabled,
+                                                    bool client_presents)
 {
-	if (!XRT_DP_HAS_SLOT(xdp, set_chroma_key) || xdp->set_chroma_key == NULL) {
-		return;
+	if (!XRT_DP_HAS_SLOT(xdp, set_transparent_background) || xdp->set_transparent_background == NULL) {
+		return false;
 	}
-	xdp->set_chroma_key(xdp, key_color, transparent_bg_enabled);
+	xdp->set_transparent_background(xdp, enabled, client_presents);
+	return true;
 }
 
 /*!

--- a/src/xrt/include/xrt/xrt_display_processor_metal.h
+++ b/src/xrt/include/xrt/xrt_display_processor_metal.h
@@ -146,22 +146,10 @@ struct xrt_display_processor_metal
 	/*!
 	 * Whether this display processor passes per-pixel alpha through to its
 	 * output stage. true for sim_display-style processors; false (or NULL)
-	 * for Leia-style weavers that need the chroma-key trick.
+	 * for Leia-style weavers.
 	 * Optional — NULL means false.
 	 */
 	bool (*is_alpha_native)(struct xrt_display_processor_metal *xdp);
-
-	/*!
-	 * Inform the DP of session-level transparency configuration.
-	 * @p key_color is the app-supplied chroma key (0x00BBGGRR); 0 means
-	 * the DP picks its own internal color. @p transparent_bg_enabled
-	 * tells the DP whether to run its pre-weave fill / post-weave strip
-	 * pass.
-	 * Optional — NULL means the DP doesn't respect transparency requests.
-	 */
-	void (*set_chroma_key)(struct xrt_display_processor_metal *xdp,
-	                       uint32_t key_color,
-	                       bool transparent_bg_enabled);
 
 	/*!
 	 * Destroy this display processor and free all resources.
@@ -339,16 +327,15 @@ XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_metal, get_hardware_3d_s
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_metal, get_display_dimensions)      == XRT_DP_METAL_BASE_OFF + 5 * sizeof(void *), XRT_DP_ABI_MSG);
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_metal, get_display_pixel_info)      == XRT_DP_METAL_BASE_OFF + 6 * sizeof(void *), XRT_DP_ABI_MSG);
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_metal, is_alpha_native)             == XRT_DP_METAL_BASE_OFF + 7 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_metal, set_chroma_key)              == XRT_DP_METAL_BASE_OFF + 8 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_metal, destroy)                     == XRT_DP_METAL_BASE_OFF + 9 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_metal, get_handoff_color_capability) == XRT_DP_METAL_BASE_OFF + 10 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_metal, set_atlas_encoding)           == XRT_DP_METAL_BASE_OFF + 11 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_metal, set_background_2d)            == XRT_DP_METAL_BASE_OFF + 12 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_metal, set_eye_tracking_mode)        == XRT_DP_METAL_BASE_OFF + 13 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_metal, get_local_zone_caps)          == XRT_DP_METAL_BASE_OFF + 14 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_metal, publish_local_zone_mask)      == XRT_DP_METAL_BASE_OFF + 15 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_metal, clear_local_zone_mask)        == XRT_DP_METAL_BASE_OFF + 16 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(sizeof(struct xrt_display_processor_metal)                                == XRT_DP_METAL_BASE_OFF + 17 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_metal, destroy)                     == XRT_DP_METAL_BASE_OFF + 8 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_metal, get_handoff_color_capability) == XRT_DP_METAL_BASE_OFF + 9 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_metal, set_atlas_encoding)           == XRT_DP_METAL_BASE_OFF + 10 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_metal, set_background_2d)            == XRT_DP_METAL_BASE_OFF + 11 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_metal, set_eye_tracking_mode)        == XRT_DP_METAL_BASE_OFF + 12 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_metal, get_local_zone_caps)          == XRT_DP_METAL_BASE_OFF + 13 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_metal, publish_local_zone_mask)      == XRT_DP_METAL_BASE_OFF + 14 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_metal, clear_local_zone_mask)        == XRT_DP_METAL_BASE_OFF + 15 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(sizeof(struct xrt_display_processor_metal)                                == XRT_DP_METAL_BASE_OFF + 16 * sizeof(void *), XRT_DP_ABI_MSG);
 // clang-format on
 
 /*!
@@ -485,22 +472,6 @@ xrt_display_processor_metal_is_alpha_native(struct xrt_display_processor_metal *
 		return false;
 	}
 	return xdp->is_alpha_native(xdp);
-}
-
-/*!
- * @copydoc xrt_display_processor_metal::set_chroma_key
- * No-op if not supported (function pointer is NULL).
- * @public @memberof xrt_display_processor_metal
- */
-static inline void
-xrt_display_processor_metal_set_chroma_key(struct xrt_display_processor_metal *xdp,
-                                            uint32_t key_color,
-                                            bool transparent_bg_enabled)
-{
-	if (!XRT_DP_HAS_SLOT(xdp, set_chroma_key) || xdp->set_chroma_key == NULL) {
-		return;
-	}
-	xdp->set_chroma_key(xdp, key_color, transparent_bg_enabled);
 }
 
 /*!

--- a/src/xrt/include/xrt/xrt_display_processor_vk.h
+++ b/src/xrt/include/xrt/xrt_display_processor_vk.h
@@ -66,9 +66,8 @@ struct xrt_display_processor_vk
 	 * fullscreen alpha-gate pass samples the original premultiplied atlas and
 	 * writes (0,0,0,0) wherever every view tile is α==0 (so the platform
 	 * compositor — SurfaceFlinger on Android — shows the live screen through
-	 * the holes), else the woven RGB at α=1. This supersedes
-	 * @ref xrt_display_processor::set_chroma_key as the transparency enable on
-	 * this path; chroma-key is retired for the Vulkan/Android variant.
+	 * the holes), else the woven RGB at α=1. This is the sole transparency
+	 * enable (#573 removed the legacy chroma-key path everywhere).
 	 *
 	 * @p client_presents mirrors the D3D11 slot for symmetry, but on Android it
 	 * is **always true**: SurfaceFlinger composites the runtime's translucent
@@ -80,9 +79,9 @@ struct xrt_display_processor_vk
 	 * @ref xrt_display_processor_d3d11::set_transparent_background; callers on
 	 * Android pass true.
 	 *
-	 * Optional — an absent slot (older plug-in `struct_size`) or NULL ⟹ the
-	 * runtime falls back to @ref xrt_display_processor::set_chroma_key. Appended
-	 * per ADR-020 (append-only within a major; no version bump).
+	 * Optional — an absent slot (older plug-in `struct_size`) or NULL ⟹ the DP
+	 * doesn't support transparent output. Appended per ADR-020 (append-only
+	 * within a major).
 	 *
 	 * @param xdp             Pointer to self.
 	 * @param enabled         true to produce transparent output for see-through.
@@ -124,8 +123,7 @@ XRT_DP_ABI_ASSERT(sizeof(struct xrt_display_processor_vk) == sizeof(struct xrt_d
  * @copydoc xrt_display_processor_vk::set_transparent_background
  *
  * Returns false if not supported (the plug-in's `base.struct_size` doesn't cover
- * the slot, or the pointer is NULL) — the caller then falls back to
- * @ref xrt_display_processor_set_chroma_key on the base.
+ * the slot, or the pointer is NULL) — the caller then leaves the DP opaque.
  *
  * Unlike @ref XRT_DP_HAS_SLOT (which assumes a direct `struct_size` member), the
  * presence check here reads `xdp->base.struct_size` because the variant embeds

--- a/src/xrt/include/xrt/xrt_plugin.h
+++ b/src/xrt/include/xrt/xrt_plugin.h
@@ -266,10 +266,19 @@ struct xrt_display_claim
  * The flags word + reserved padding exist so future per-mode capabilities are
  * new bits, not new fields — v3 is intended to be the last rendering-mode
  * layout break.
+ *
+ * v3 → v4 history (#573): the chroma-key transparency mechanism was deleted
+ * everywhere. The `set_chroma_key` slot is removed from all five DP vtables (base
+ * + d3d11/d3d12/gl/metal), shifting every slot after it — a layout break. The
+ * D3D12 and GL DP vtables gain `set_transparent_background` (the chroma-key-free
+ * transparency enable the other variants already had), and the extension struct
+ * drops `chromaKeyColor` (XR_EXT_win32_window_binding SPEC_VERSION 7→8). True
+ * transparency (alpha-capable swapchain + transparent present) is the sole path.
  */
 #define XRT_PLUGIN_API_VERSION_1 1
 #define XRT_PLUGIN_API_VERSION_2 2
 #define XRT_PLUGIN_API_VERSION_3 3
+#define XRT_PLUGIN_API_VERSION_4 4
 
 /*!
  * The version the runtime / plug-in is built against at compile time.
@@ -277,7 +286,7 @@ struct xrt_display_claim
  * `*out_plugin_api_version` are rejected by the runtime (ADR-020 rule 3) with a
  * logged error, and the loader falls back to the next plug-in / sim_display.
  */
-#define XRT_PLUGIN_API_VERSION_CURRENT XRT_PLUGIN_API_VERSION_3
+#define XRT_PLUGIN_API_VERSION_CURRENT XRT_PLUGIN_API_VERSION_4
 
 /*!
  * The single exported symbol every plug-in DLL must provide. C linkage,

--- a/src/xrt/state_trackers/oxr/oxr_objects.h
+++ b/src/xrt/state_trackers/oxr/oxr_objects.h
@@ -1491,7 +1491,6 @@ oxr_session_populate_gl_native(struct oxr_logger *log,
                                 void *gl_display,
                                 void *shared_texture_handle,
                                 bool transparent_background,
-                                uint32_t chroma_key_color,
                                 struct oxr_session *sess);
 #endif
 
@@ -1599,7 +1598,6 @@ oxr_session_populate_vk_native(struct oxr_logger *log,
                                 void *window_handle,
                                 void *shared_texture_handle,
                                 bool transparent_background,
-                                uint32_t chroma_key_color,
                                 struct oxr_session *sess);
 #endif
 
@@ -1694,7 +1692,6 @@ oxr_session_populate_d3d11_native(struct oxr_logger *log,
                                    void *window_handle,
                                    void *shared_texture_handle,
                                    bool transparent_background,
-                                   uint32_t chroma_key_color,
                                    struct oxr_session *sess);
 #endif
 
@@ -1720,7 +1717,6 @@ oxr_session_populate_d3d12_native(struct oxr_logger *log,
                                    void *window_handle,
                                    void *shared_texture_handle,
                                    bool transparent_background,
-                                   uint32_t chroma_key_color,
                                    struct oxr_session *sess);
 #endif
 

--- a/src/xrt/state_trackers/oxr/oxr_plugin_stub.c
+++ b/src/xrt/state_trackers/oxr/oxr_plugin_stub.c
@@ -34,10 +34,11 @@
 _Static_assert(sizeof(XRT_PLUGIN_ENTRYPOINT_NAME) == sizeof("xrtPluginNegotiate"),
                "xrt_plugin: entry-point symbol name changed; coordinate with all plug-in builds");
 
-/* Current API version is the v3 line (per-mode mode_flags on
- * xrt_rendering_mode, #441) — bump deliberately, not by accident. */
-_Static_assert(XRT_PLUGIN_API_VERSION_CURRENT == XRT_PLUGIN_API_VERSION_3,
-               "xrt_plugin: API version current/v3 drift");
+/* Current API version is the v4 line (#573 removed set_chroma_key from all DP
+ * vtables + added set_transparent_background to d3d12/gl) — bump deliberately,
+ * not by accident. */
+_Static_assert(XRT_PLUGIN_API_VERSION_CURRENT == XRT_PLUGIN_API_VERSION_4,
+               "xrt_plugin: API version current/v4 drift");
 
 /*
  * Host iface layout. struct_size must be the first field so plug-ins can

--- a/src/xrt/state_trackers/oxr/oxr_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_session.c
@@ -3063,7 +3063,6 @@ oxr_session_create_impl(struct oxr_logger *log,
 			                                       (void *)opengl_win32->hDC,
 			                                       shared_texture_handle,
 			                                       xsi->transparent_background_enabled,
-			                                       xsi->chroma_key_color,
 			                                       *out_session);
 		}
 #endif
@@ -3185,8 +3184,7 @@ oxr_session_create_impl(struct oxr_logger *log,
 			}
 			return oxr_session_populate_vk_native(
 			    log, sys, vulkan, window_handle, shared_texture_handle,
-			    xsi->transparent_background_enabled,
-			    xsi->chroma_key_color, *out_session);
+			    xsi->transparent_background_enabled, *out_session);
 		}
 #endif
 
@@ -3288,7 +3286,7 @@ oxr_session_create_impl(struct oxr_logger *log,
 			return oxr_session_populate_d3d11_native(log, sys, d3d11, xsi->external_window_handle,
 			                                          xsi->shared_texture_handle,
 			                                          xsi->transparent_background_enabled,
-			                                          xsi->chroma_key_color, *out_session);
+			                                          *out_session);
 		}
 #else
 		U_LOG_IFL_I(U_LOGGING_INFO, "D3D11 native compositor NOT compiled in (XRT_HAVE_D3D11_NATIVE_COMPOSITOR not defined)");
@@ -3336,7 +3334,7 @@ oxr_session_create_impl(struct oxr_logger *log,
 			return oxr_session_populate_d3d12_native(log, sys, d3d12, xsi->external_window_handle,
 			                                         xsi->shared_texture_handle,
 			                                         xsi->transparent_background_enabled,
-			                                         xsi->chroma_key_color, *out_session);
+			                                         *out_session);
 		}
 #else
 		U_LOG_IFL_I(U_LOGGING_INFO, "D3D12 native compositor NOT compiled in");
@@ -3528,13 +3526,10 @@ oxr_session_create(struct oxr_logger *log,
 				                              WDA_EXCLUDEFROMCAPTURE)) {
 					U_LOG_W(
 					    "xrCreateSession: SetWindowDisplayAffinity(WDA_EXCLUDEFROMCAPTURE) "
-					    "failed (err=%lu) — DP compose-under-bg may fall back to chroma-key",
+					    "failed (err=%lu) — DP compose-under-bg disabled for this window",
 					    (unsigned long)GetLastError());
 				}
 			}
-		}
-		if (target_info->chromaKeyColor != 0) {
-			xsi.chroma_key_color = target_info->chromaKeyColor;
 		}
 	}
 #endif

--- a/src/xrt/state_trackers/oxr/oxr_session_gfx_d3d11_native.c
+++ b/src/xrt/state_trackers/oxr/oxr_session_gfx_d3d11_native.c
@@ -128,7 +128,6 @@ oxr_session_populate_d3d11_native(struct oxr_logger *log,
                                    void *window_handle,
                                    void *shared_texture_handle,
                                    bool transparent_background,
-                                   uint32_t chroma_key_color,
                                    struct oxr_session *sess)
 {
 	struct xrt_device *xdev = get_role_head(sess->sys);
@@ -147,7 +146,7 @@ oxr_session_populate_d3d11_native(struct oxr_logger *log,
 	// Create the D3D11 native compositor
 	xrt_result_t xret = comp_d3d11_compositor_create(
 	    xdev, window_handle, (void *)next->device, dp_factory_d3d11, shared_texture_handle,
-	    transparent_background, chroma_key_color, display_screen_left, display_screen_top, &xcn);
+	    transparent_background, display_screen_left, display_screen_top, &xcn);
 	if (xret != XRT_SUCCESS) {
 		return oxr_error(log, XR_ERROR_INITIALIZATION_FAILED,
 		                 "Failed to create D3D11 native compositor: %d", xret);

--- a/src/xrt/state_trackers/oxr/oxr_session_gfx_d3d12_native.c
+++ b/src/xrt/state_trackers/oxr/oxr_session_gfx_d3d12_native.c
@@ -93,7 +93,6 @@ oxr_session_populate_d3d12_native(struct oxr_logger *log,
                                    void *window_handle,
                                    void *shared_texture_handle,
                                    bool transparent_background,
-                                   uint32_t chroma_key_color,
                                    struct oxr_session *sess)
 {
 	struct xrt_device *xdev = get_role_head(sess->sys);
@@ -113,7 +112,7 @@ oxr_session_populate_d3d12_native(struct oxr_logger *log,
 	xrt_result_t xret = comp_d3d12_compositor_create(
 	    xdev, window_handle, shared_texture_handle,
 	    (void *)next->device, (void *)next->queue,
-	    dp_factory_d3d12, transparent_background, chroma_key_color,
+	    dp_factory_d3d12, transparent_background,
 	    display_screen_left, display_screen_top, &xcn);
 	if (xret != XRT_SUCCESS) {
 		return oxr_error(log, XR_ERROR_INITIALIZATION_FAILED,

--- a/src/xrt/state_trackers/oxr/oxr_session_gfx_gl_macos.m
+++ b/src/xrt/state_trackers/oxr/oxr_session_gfx_gl_macos.m
@@ -68,7 +68,6 @@ oxr_session_populate_gl_macos(struct oxr_logger *log,
 	        : NULL,
 	    shared_iosurface,     // IOSurfaceRef for shared texture mode (or NULL for windowed)
 	    /*transparent_background*/ false,  // GL transparent present path is deferred (PR #3b §3b)
-	    /*chroma_key_color*/ 0,
 	    /*display_screen_left*/ 0,   // macOS: NSOpenGLView positioning, no D3D11 window
 	    /*display_screen_top*/ 0,
 	    &xcn);

--- a/src/xrt/state_trackers/oxr/oxr_session_gfx_gl_native.c
+++ b/src/xrt/state_trackers/oxr/oxr_session_gfx_gl_native.c
@@ -80,7 +80,6 @@ oxr_session_populate_gl_native(struct oxr_logger *log,
                                 void *gl_display,
                                 void *shared_texture_handle,
                                 bool transparent_background,
-                                uint32_t chroma_key_color,
                                 struct oxr_session *sess)
 {
 	struct xrt_device *xdev = get_role_head(sess->sys);
@@ -102,7 +101,6 @@ oxr_session_populate_gl_native(struct oxr_logger *log,
 	    dp_factory_gl,
 	    shared_texture_handle,
 	    transparent_background,
-	    chroma_key_color,
 	    display_screen_left,
 	    display_screen_top,
 	    &xcn);

--- a/src/xrt/state_trackers/oxr/oxr_session_gfx_vk_native.c
+++ b/src/xrt/state_trackers/oxr/oxr_session_gfx_vk_native.c
@@ -254,7 +254,6 @@ oxr_session_populate_vk_native(struct oxr_logger *log,
                                 void *window_handle,
                                 void *shared_texture_handle,
                                 bool transparent_background,
-                                uint32_t chroma_key_color,
                                 struct oxr_session *sess)
 {
 	struct xrt_device *xdev = get_role_head(sess->sys);
@@ -320,7 +319,7 @@ oxr_session_populate_vk_native(struct oxr_logger *log,
 	    next->queueFamilyIndex,
 	    next->queueIndex,
 	    dp_factory_vk, shared_texture_handle,
-	    transparent_background, chroma_key_color,
+	    transparent_background,
 	    display_screen_left, display_screen_top,
 	    &xcn);
 	if (xret != XRT_SUCCESS) {

--- a/test_apps/cube_handle_d3d11_win/xr_session.cpp
+++ b/test_apps/cube_handle_d3d11_win/xr_session.cpp
@@ -316,7 +316,6 @@ bool CreateSession(XrSessionManager& xr, ID3D11Device* d3d11Device, HWND hwnd) {
         const char *e = getenv("DISPLAYXR_TRANSPARENT_BG");
         if (e != nullptr && *e != '\0' && *e != '0') {
             sessionTarget.transparentBackgroundEnabled = XR_TRUE;
-            sessionTarget.chromaKeyColor = 0;
             LOG_INFO("Transparent background ENABLED (DISPLAYXR_TRANSPARENT_BG=1)");
         }
     }

--- a/test_apps/cube_handle_d3d12_win/xr_session.cpp
+++ b/test_apps/cube_handle_d3d12_win/xr_session.cpp
@@ -261,7 +261,6 @@ bool CreateSession(XrSessionManager& xr, ID3D12Device* device, ID3D12CommandQueu
         const char *e = getenv("DISPLAYXR_TRANSPARENT_BG");
         if (e != nullptr && *e != '\0' && *e != '0') {
             sessionTarget.transparentBackgroundEnabled = XR_TRUE;
-            sessionTarget.chromaKeyColor = 0;
             LOG_INFO("Transparent background ENABLED (DISPLAYXR_TRANSPARENT_BG=1)");
         }
     }

--- a/test_apps/cube_handle_gl_win/xr_session.cpp
+++ b/test_apps/cube_handle_gl_win/xr_session.cpp
@@ -256,7 +256,6 @@ bool CreateSession(XrSessionManager& xr, HDC hDC, HGLRC hGLRC, HWND hwnd) {
         const char *e = getenv("DISPLAYXR_TRANSPARENT_BG");
         if (e != nullptr && *e != '\0' && *e != '0') {
             sessionTarget.transparentBackgroundEnabled = XR_TRUE;
-            sessionTarget.chromaKeyColor = 0;
             LOG_INFO("Transparent background ENABLED (DISPLAYXR_TRANSPARENT_BG=1)");
         }
     }

--- a/test_apps/cube_handle_vk_win/xr_session.cpp
+++ b/test_apps/cube_handle_vk_win/xr_session.cpp
@@ -450,7 +450,6 @@ bool CreateSession(XrSessionManager& xr, VkInstance vkInstance, VkPhysicalDevice
         const char *e = getenv("DISPLAYXR_TRANSPARENT_BG");
         if (e != nullptr && *e != '\0' && *e != '0') {
             sessionTarget.transparentBackgroundEnabled = XR_TRUE;
-            sessionTarget.chromaKeyColor = 0; // DP default
             LOG_INFO("Transparent background ENABLED (DISPLAYXR_TRANSPARENT_BG=1)");
         }
     }

--- a/test_apps/cube_zones_d3d11_win/xr_session.cpp
+++ b/test_apps/cube_zones_d3d11_win/xr_session.cpp
@@ -347,7 +347,6 @@ bool CreateSession(XrSessionManager& xr, ID3D11Device* d3d11Device, HWND hwnd) {
         const char* e = getenv("DISPLAYXR_TRANSPARENT_BG");
         if (e == nullptr || *e == '\0' || *e != '0') {
             sessionTarget.transparentBackgroundEnabled = XR_TRUE;
-            sessionTarget.chromaKeyColor = 0;
             LOG_INFO("Transparent background ENABLED (zones default; DISPLAYXR_TRANSPARENT_BG=0 to opt out)");
         }
     }

--- a/test_apps/windowspace_handle_d3d11_win/xr_session.cpp
+++ b/test_apps/windowspace_handle_d3d11_win/xr_session.cpp
@@ -258,7 +258,6 @@ bool CreateSession(XrSessionManager& xr, ID3D11Device* d3d11Device, HWND hwnd) {
         const char *e = getenv("DISPLAYXR_TRANSPARENT_BG");
         if (e != nullptr && *e != '\0' && *e != '0') {
             sessionTarget.transparentBackgroundEnabled = XR_TRUE;
-            sessionTarget.chromaKeyColor = 0;
             LOG_INFO("Transparent background ENABLED (DISPLAYXR_TRANSPARENT_BG=1)");
         }
     }

--- a/test_apps/windowspace_handle_d3d12_win/xr_session.cpp
+++ b/test_apps/windowspace_handle_d3d12_win/xr_session.cpp
@@ -222,7 +222,6 @@ bool CreateSession(XrSessionManager& xr, ID3D12Device* device, ID3D12CommandQueu
         const char *e = getenv("DISPLAYXR_TRANSPARENT_BG");
         if (e != nullptr && *e != '\0' && *e != '0') {
             sessionTarget.transparentBackgroundEnabled = XR_TRUE;
-            sessionTarget.chromaKeyColor = 0;
             LOG_INFO("Transparent background ENABLED (DISPLAYXR_TRANSPARENT_BG=1)");
         }
     }

--- a/test_apps/windowspace_handle_vk_win/xr_session.cpp
+++ b/test_apps/windowspace_handle_vk_win/xr_session.cpp
@@ -411,7 +411,6 @@ bool CreateSession(XrSessionManager& xr, VkInstance vkInstance, VkPhysicalDevice
         const char *e = getenv("DISPLAYXR_TRANSPARENT_BG");
         if (e != nullptr && *e != '\0' && *e != '0') {
             sessionTarget.transparentBackgroundEnabled = XR_TRUE;
-            sessionTarget.chromaKeyColor = 0; // DP default
             LOG_INFO("Transparent background ENABLED (DISPLAYXR_TRANSPARENT_BG=1)");
         }
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -91,7 +91,10 @@ if(XRT_HAVE_D3D11)
 endif()
 
 if(XRT_HAVE_D3D12)
-	target_link_libraries(tests_comp_client_d3d12 PRIVATE comp_client comp_mock)
+	# #573 — comp_d3d12_client.cpp now references the
+	# comp_ipc_client_compositor_get_transparent_output{,_fence} bridge symbols
+	# defined in ipc_client_compositor.c. Add ipc_client (same as d3d11 above).
+	target_link_libraries(tests_comp_client_d3d12 PRIVATE comp_client comp_mock ipc_client)
 endif()
 
 if(XRT_HAVE_VULKAN)
@@ -111,9 +114,15 @@ if(XRT_FEATURE_OPENXR)
 		)
 endif()
 if(_have_opengl_test)
+	# #573 — on Windows comp_gl_win32_client.c references the
+	# comp_ipc_client_compositor_get_transparent_output{,_fence} bridge symbols
+	# defined in ipc_client_compositor.c. Add ipc_client (same as d3d11 above).
 	target_link_libraries(
 		tests_comp_client_opengl PRIVATE comp_client comp_mock aux_ogl SDL2::SDL2
 		)
+	if(WIN32)
+		target_link_libraries(tests_comp_client_opengl PRIVATE ipc_client)
+	endif()
 	target_include_directories(tests_comp_client_opengl PRIVATE SDL2::SDL2)
 endif()
 


### PR DESCRIPTION
Runtime half of #573 — the clean-slate removal of chroma-keying. True transparency (alpha swapchain + transparent DComp present + DP compose-under-bg / alpha-gate) fully replaces the chroma-key fallback. **Coordinated ABI v3→v4 break**, lockstep with `displayxr-leia-plugin` PR (feat/remove-chroma-key-573).

## What's in here
- **P0 (gap-closing, no ABI change):** render-API-agnostic transparent DComp presenter; D3D12 + GL IPC clients wired to it; GL in-process no-interop readback transparent present.
- **ABI v4 break:** `set_chroma_key` removed from all 5 DP vtables; `set_transparent_background` added to D3D12 + GL DP vtables (d3d11/vk already had it); `chroma_key_color`/`chromaKeyColor` dropped from `xrt_session_info` + 5 compositor signatures + the oxr gfx chain; `XR_EXT_win32_window_binding` SPEC_VERSION 7→8; D3D11-service chroma pass + sim_display stubs deleted. `XRT_PLUGIN_API_VERSION_CURRENT` 3→4.

## Validation
- Builds clean (the per-vtable struct_size static_asserts catch any slot mistake).
- `displayxr-cli selftest` passes only with a v4 plugin (v3 plugins → `negotiate -17`, ABI reject working).
- Full v4 stack hardware-validated on the Leia box (D3D11/D3D12/GL/**VK**): 3D weave correct + transparent background composites the live desktop, across opaque and transparent modes.

## Lockstep
Do not release the v4 runtime without the v4 Leia plugin — a v4 runtime rejects a v3 plugin. Paired with leia `feat/remove-chroma-key-573`; release together (runtime v1.18.0 + leia v1.8.0).

Closes #573.

🤖 Generated with [Claude Code](https://claude.com/claude-code)