### PR TITLE
fix(#575): capture per-client atlas on forced-IPC standalone path

### DIFF
--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -10812,6 +10812,36 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 	// Render HUD overlay (post-weave, pre-present)
 	d3d11_service_render_hud(sys, &c->render, weaving_done, &eye_pos);
 
+	// Standalone forced-IPC atlas capture. The workspace trigger poll lives in
+	// multi_compositor_render() (workspace-only); a standalone client returns
+	// before that branch and never reaches it. Poll the SAME trigger file here
+	// on the per-client render path so a forced-IPC standalone app's per-client
+	// atlas is capturable with the same
+	// %TEMP%\workspace_screenshot_atlas_<vc>_<cols>x<rows>.png filename — the
+	// existing read-the-PNG workflow keeps working unchanged. Gated to
+	// !workspace_mode by code position (past the workspace early-return above),
+	// so it never double-fires with the workspace poll. PROJECTION_ONLY captures
+	// sys->active_compositor (set to this client at the top of the commit),
+	// reading its content-sized crop_texture / per-client atlas_texture — both
+	// freshly written this frame by service_crop_atlas_for_dp() above.
+	{
+		static char ss_trigger[MAX_PATH] = {};
+		static char ss_prefix[MAX_PATH] = {};
+		if (!ss_trigger[0]) {
+			const char *tmp = getenv("TEMP");
+			if (!tmp)
+				tmp = "C:\\Temp";
+			snprintf(ss_trigger, sizeof(ss_trigger), "%s\\workspace_screenshot_trigger", tmp);
+			snprintf(ss_prefix, sizeof(ss_prefix), "%s\\workspace_screenshot", tmp);
+		}
+		if (GetFileAttributesA(ss_trigger) != INVALID_FILE_ATTRIBUTES) {
+			DeleteFileA(ss_trigger);
+			struct ipc_capture_result dummy = {};
+			comp_d3d11_service_capture_frame(&sys->base, ss_prefix, IPC_CAPTURE_FLAG_PROJECTION_ONLY,
+			                                 &dummy);
+		}
+	}
+
 	// Phase 1 diagnostic — same env-gated [PRESENT_NS] used for the
 	// workspace multi-comp swap chain. In standalone mode this fires
 	// per client per frame against THIS client's own swap chain. Tagged


### PR DESCRIPTION
## Problem
The `%TEMP%\workspace_screenshot_trigger` file-trigger atlas capture (drops `%TEMP%\workspace_screenshot_atlas_<vc>_<cols>x<rows>.png`) was polled only in `multi_compositor_render()` — the **workspace** render path. A **standalone forced-IPC** client renders through `compositor_layer_commit()` and returns before that branch, so its composited per-client atlas could not be captured. (The in-app `'I'`-key `XR_EXT_atlas_capture` is separately skipped for 1×1 mono layouts.)

## Fix
Add a second trigger poll in the **standalone** section of `compositor_layer_commit()` (after the HUD render, past the `if (sys->workspace_mode) return` early-return, so it can't double-fire with the workspace poll). It reuses the existing `comp_d3d11_service_capture_frame()` helper with `IPC_CAPTURE_FLAG_PROJECTION_ONLY`, which captures `sys->active_compositor`'s content-sized `crop_texture` / per-client `atlas_texture` and writes the **same** PNG filename — the existing read-the-PNG workflow is unchanged. No header, signature, or dependency changes (+30 lines, one file).

## Verification (hardware: D3D11 service, ABI v4, Leia v1.8.0)
- Build clean (`ALL DONE`, no `error C`/`LNK`); `displayxr-cli selftest` PASS.
- Forced-IPC standalone cube → `workspace_screenshot_atlas_2_2x1.png` shows the correct 2×1 multiview atlas (two crate tiles with expected parallax). Previously: no capture at all.
- Workspace path re-checked: untouched (edit is after the `workspace_mode` early-return) and still fires (`capture_frame: flags=0x1 written=0x1 used=3840x1080`).

### Caveat
`PROJECTION_ONLY`'s source is stale in the zero-copy sub-path (no `crop_texture` refresh) → helper logs `no source atlas`. The cube is non-zero-copy (content < atlas → `service_crop_atlas_for_dp`), so it works; fallback if ever needed is to capture the texture behind `input_srv` at the DP handoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)