### PR TITLE
fix(#575): V→2D left-shift + V-key not blocked in shell

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,7 @@ Full reference: `docs/architecture/extension-vs-legacy.md`. `_handle` and `_text
 ### Key notes
 - Compositor vtable has 56 methods — use the `comp_base` helper for boilerplate.
 - **Two distinct swapchains** and the **canvas concept** (view dims + Kooima projection use canvas size, not display size): `docs/specs/runtime/swapchain-model.md`.
+- **Crop before the DP is the law; zero-copy is the rare exception.** The app swapchain is worst-case-sized across all modes (ADR-010), so the compositor must crop to the active mode's content dims before `process_atlas()` — *unless* the submission exactly fills the swapchain (`u_tiling_can_zero_copy()` is the *sole* gate; no per-call-site proxies like `view_count>1` or hardware-flag coupling). That coincidence only happens full-screen in the worst-case-filling mode (Windows Leia: 2D only; Android: never). ADR-030 + `docs/specs/runtime/multiview-tiling.md#zero-copy-eligibility--the-single-rule`.
 
 ### Vendor plug-in integration
 Vendor display drivers ship as **plug-in DLLs** from their own repos (ADR-019). `DisplayXR-LeiaSR.dll` (from `displayxr-leia-plugin`'s `src/drv_leia/`, entry point `xrtPluginNegotiate`) loads at `xrCreateInstance` via registry-driven discovery on Windows / JSON-manifest discovery on POSIX (`target_plugin_loader.c`). The runtime DLL has zero SR or `sim_display_*` identifiers in its link line (ADR-019 §2.1; CI-asserted in `build-windows.yml`). Eye tracking and display dimensions come through `iface->get_display_info` → `xrt_plugin_display_info` — no direct runtime → vendor call.

--- a/docs/adr/ADR-030-crop-before-dp-zero-copy-only-when-swapchain-equals-atlas.md
+++ b/docs/adr/ADR-030-crop-before-dp-zero-copy-only-when-swapchain-equals-atlas.md
@@ -1,0 +1,100 @@
+# ADR-030: Compositor Crops to Content; Zero-Copy Only When the Swapchain Equals the Mode Atlas
+
+**Status:** Accepted
+**Date:** 2026-06-14
+
+## Context
+
+The app swapchain is allocated **once** at session creation, sized to the **per-dimension
+worst case across all of the DP's rendering modes, assuming a full-screen window** (ADR-010,
+[swapchain-model](../specs/runtime/swapchain-model.md)):
+
+```
+swapchain_width  = max over modes i of ( tile_columns[i] × view_width[i] )
+swapchain_height = max over modes i of ( tile_rows[i]    × view_height[i] )
+view_width[i]    = display_width  × mode[i].view_scale_x      (full-screen assumption)
+view_height[i]   = display_height × mode[i].view_scale_y
+```
+
+The width worst case and the height worst case may come from **different** modes, so the
+swapchain is a bounding box that need not match any single mode's content shape.
+
+Each frame the app renders a **content region** for the *active* mode
+(`tile_columns × view_width` by `tile_rows × view_height`) into the **top-left** of that
+swapchain. The vendor display processor (DP) takes a texture whose dimensions match the
+content exactly (it derives tile stride as `texture_dim / tile_columns` and, for some
+vendors, feeds the texture size straight into the weaver). So the compositor must hand the
+DP a content-sized surface — **never** the oversized swapchain — or the DP samples the
+unused padding and the image shifts / weaves garbage.
+
+This left two operations whose contract was understood by individual authors but never
+written down as a single load-bearing rule, so each compositor call site grew its own
+ad-hoc eligibility test (e.g. `view_count > 1`, coupling to the hardware 2D/3D flag). That
+drift is the root of the forced-IPC 2D left-shift (issue #575).
+
+## Decision
+
+**1. Cropping before the DP is mandatory and is the default path.** Every compositor (native
+in-process and the D3D11 service / multi-compositor) computes
+`content = (tile_columns × view_width, tile_rows × view_height)` for the active mode and
+copies that top-left region into a content-sized intermediate before calling
+`process_atlas()`. Helpers: `d3d11_crop_atlas_for_dp` (in-process),
+`service_crop_atlas_for_dp` (service).
+
+**2. Zero-copy (handing the app's swapchain image straight to the DP, skipping the crop) is a
+pure optimization, valid in exactly one case: the app's submitted layout *equals* the active
+mode's atlas and fills the swapchain.** This is decided **solely** by the shared predicate
+`u_tiling_can_zero_copy()` (`auxiliary/util/u_tiling.h`), which requires **all** of:
+
+- `submitted view_count == mode->view_count` (the #542 divergence guard — a hardware/content
+  mismatch frame must take the crop path; zero-copy cannot re-tile a mismatched submission),
+- `swapchain_w == mode->atlas_width_pixels && swapchain_h == mode->atlas_height_pixels`, and
+- every view's sub-rect matches its expected tile origin and size.
+
+No call site may add its own eligibility proxy (view-count thresholds, hardware-mode
+coupling, mode-index checks). If `u_tiling_can_zero_copy()` is false, **crop.** Cropping is
+always correct; zero-copy is the special case, not the other way around.
+
+## Rationale
+
+Because the swapchain is the worst-case envelope, the per-frame content equals it **only when
+both** hold:
+
+1. the window is **full-screen** (a windowed app renders `view = window × scale`, strictly
+   smaller than the `display × scale` envelope in at least one dim → content < swapchain →
+   must crop), and
+2. the active mode is the one that hits the per-dim worst case in **both** width and height.
+
+So zero-copy is a rare coincidence, and which mode (if any) triggers it is **DP- and
+platform-specific**:
+
+- **Windows Leia DP.** Modes: 2D = `1×1 @ 1.0×1.0`; LeiaSR/3D = `2×1 @ 0.5×0.5` (X may be
+  refined by the SR SDK). Envelope = `max(W, 2·0.5W) × max(H, 0.5H) = W × H` = full display.
+  The only mode that fills it in **both** dims is **2D** (3D is half-height → its content is
+  `W × 0.5H`, always smaller → always crops). ⇒ **zero-copy fires only for full-screen 2D.**
+- **Android Leia DP.** Its modes (e.g. 3D at `0.75×0.75`) never reach the envelope in either
+  dim, so the swapchain never equals the atlas. ⇒ **zero-copy never fires; it always crops.**
+
+These are consequences of the single rule, not separate special cases — which is exactly why
+the rule, its rationale, and these consequences must be documented rather than rediscovered.
+
+## Consequences
+
+- `u_tiling_can_zero_copy()` is the **one** zero-copy gate. Reviewers reject any compositor
+  branch that decides zero-copy by another means, or that hands the DP a surface larger than
+  `tile_columns × view_width × tile_rows × view_height`.
+- The DP keeps its dimension guarantee (texture dims == content dims), so vendor weavers may
+  assume `1/tile_columns`, `1/tile_rows` UV scaling without querying texture size
+  (see [multiview-tiling](../specs/runtime/multiview-tiling.md#dp-side-dimension-guarantee)).
+- A windowed app, or any non-envelope-filling mode, always takes the crop path — including
+  full-screen 3D on Windows Leia (half-height) and everything on Android.
+- The forced-IPC 2D regression (#575) is fixed by aligning the service path's gate to this
+  rule (drop the `view_count > 1` / hardware-flag coupling, gate on `u_tiling_can_zero_copy`).
+
+## Related
+
+- ADR-007 (compositor never weaves), ADR-010 (worst-case swapchain sizing),
+  ADR-005 (multiview atlas layout), ADR-028 (display-mode recipe vs hardware state),
+  ADR-026 (orientation-aware view scaling).
+- [multiview-tiling](../specs/runtime/multiview-tiling.md) — crop-blit algorithm + the
+  coupled atlas-stride invariant.

--- a/docs/specs/runtime/multiview-tiling.md
+++ b/docs/specs/runtime/multiview-tiling.md
@@ -130,7 +130,7 @@ Commit `fc5f82ff1` + follow-up fixes (`febd2fd05`, `c4cd31b1e`, `735e6dfa8`, `91
 - `recommended_view_scale_x = min(scaleX across all modes)` set in `target_instance.c`
 - Apps compute swapchain size as `max(tileColumns[i] * scaleX[i] * displayPixelWidth)` across all modes for width, similar for height
 - Legacy apps (no `XR_EXT_display_info`): max taken over modes 0 and 1 only; special compromise scale logic for `view_count == 2 && scaleX <= 0.5 && scaleY <= 0.5` -> uses 0.5x1.0
-- Zero-copy passthrough: when app's swapchain matches mode's atlas dimensions exactly, compositor skips atlas blit
+- Zero-copy passthrough: gated solely by `u_tiling_can_zero_copy()` — see [Zero-copy eligibility — the single rule](#zero-copy-eligibility--the-single-rule) for the normative contract
 
 ### Phase D: Extended `xrt_rendering_mode` struct
 
@@ -249,15 +249,33 @@ content_height = tile_rows * view_height      (for active mode)
 
 In stereo mode (e.g., 2×1 tiles at half-height views), the content region is smaller than the swapchain. The content occupies the top-left corner of the swapchain image.
 
-### Compositors must crop before passing to the DP
+### Compositors must crop before passing to the DP (crop is the default; zero-copy is the exception)
 
-The display processor (DP) has **no knowledge of swapchain dimensions** — it expects a texture whose dimensions match the content exactly. Every compositor must:
+The display processor (DP) has **no knowledge of swapchain dimensions** — it expects a texture whose dimensions match the content exactly. **Cropping to content is the mandatory default path; zero-copy is a narrow optimization, not the other way around.** Every compositor must:
 
-1. Compute `content_w = tile_columns * view_width` and `content_h = tile_rows * view_height`
-2. If `content_w == atlas_tex_width && content_h == atlas_tex_height`: pass the atlas directly (no copy needed — this is the common case for 2D mode)
-3. If content is smaller than the atlas: **blit/copy** the valid content region `(0, 0, content_w, content_h)` into a correctly-sized intermediate texture, then pass that to the DP
+1. Compute `content_w = tile_columns * view_width` and `content_h = tile_rows * view_height` for the **active** mode.
+2. **Crop** the valid content region `(0, 0, content_w, content_h)` into a correctly-sized intermediate texture and pass that to the DP — **unless** the zero-copy predicate below is true.
 
-This crop step is performed lazily — the intermediate texture is only created when content dims differ from atlas dims, and is recreated when content dims change (e.g., on mode switch).
+This crop step is performed lazily — the intermediate texture is only created when content dims differ from the swapchain dims, and is recreated when content dims change (e.g., on mode switch).
+
+#### Zero-copy eligibility — the single rule
+
+Skipping the crop and handing the app's swapchain image straight to the DP is valid in **exactly one case**: the app's submitted layout equals the active mode's atlas **and** fills the swapchain. This is decided **solely** by the shared predicate `u_tiling_can_zero_copy()` (`auxiliary/util/u_tiling.h`), which requires **all** of:
+
+- `submitted view_count == mode->view_count` (the #542 divergence guard — a hardware/content mismatch frame must crop; zero-copy cannot re-tile a mismatched submission),
+- `swapchain_w == mode->atlas_width_pixels && swapchain_h == mode->atlas_height_pixels`, and
+- every view's sub-rect matches its expected tile origin and size.
+
+**No compositor may add its own zero-copy proxy** — not a view-count threshold, not coupling to the hardware 2D/3D flag, not a mode-index check. If the predicate is false, **crop**. (Historically the D3D11 service path gated zero-copy on `proj_view_count > 1` coupled to `hardware_display_3d`; that ad-hoc proxy is the root of the #575 forced-IPC 2D left-shift and is removed in favour of this rule.)
+
+##### Why it's a rare coincidence, and which mode triggers it
+
+The swapchain is the **per-dimension worst case across all modes, assuming full-screen** (see [Swapchain images are worst-case sized](#swapchain-images-are-worst-case-sized)). So the per-frame content equals it **only when both** (a) the window is full-screen — a windowed app renders `view = window × scale`, strictly smaller than the `display × scale` envelope, so it *always* crops — **and** (b) the active mode hits the per-dim worst case in **both** width and height. Which mode (if any) qualifies is therefore **DP- and platform-specific**:
+
+- **Windows Leia DP:** 2D = `1×1 @ 1.0×1.0`, 3D = `2×1 @ 0.5×0.5`. Envelope = `max(W, 2·0.5W) × max(H, 0.5H) = W × H`. The only mode filling it in both dims is **2D** (3D is half-height ⇒ `W × 0.5H`, always smaller ⇒ always crops). ⇒ zero-copy fires only for **full-screen 2D**.
+- **Android Leia DP:** modes (e.g. 3D `0.75×0.75`) never reach the envelope ⇒ zero-copy **never** fires; it always crops.
+
+See [ADR-030](../../adr/ADR-030-crop-before-dp-zero-copy-only-when-swapchain-equals-atlas.md) for the decision record.
 
 ### DP-side dimension guarantee
 

--- a/docs/specs/runtime/swapchain-model.md
+++ b/docs/specs/runtime/swapchain-model.md
@@ -33,6 +33,16 @@ App Swapchain          Compositor              Display Processor        Target S
 3. **Display processor** receives the cropped atlas + tile layout (`tile_columns`, `tile_rows`), extracts views, and produces the final interlaced/weaved output into the target swapchain
 4. **Compositor** presents the target swapchain to the display
 
+**Crop is the default; zero-copy is the exception.** Because the swapchain is the worst-case
+envelope, the per-frame content normally occupies only its top-left sub-rect, so step 2 must
+**always** crop — *unless* the app's submission exactly fills the swapchain at the active
+mode's tiling, the one case where the compositor may hand the swapchain straight to the DP.
+That case is decided solely by `u_tiling_can_zero_copy()` and, by construction, only occurs
+for a full-screen window in the mode that hits the per-dim worst case in both dimensions
+(on the Windows Leia DP: 2D only; on Android: never). See
+[ADR-030](../../adr/ADR-030-crop-before-dp-zero-copy-only-when-swapchain-equals-atlas.md) and
+[Multiview Tiling — Zero-copy eligibility](multiview-tiling.md#zero-copy-eligibility--the-single-rule).
+
 See [Multiview Tiling — Compositor-Side Contract](multiview-tiling.md) for the full crop-blit algorithm.
 
 ## Canvas Concept

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -362,6 +362,20 @@ struct d3d11_service_compositor
 	//! apples per-app frame-rate comparison.
 	int64_t last_commit_ns;
 
+	//! App-initiated rendering-mode request (#575). The client's
+	//! xrRequestDisplayRenderingModeEXT crosses IPC into the
+	//! request_rendering_mode / request_display_mode vtable methods, which run
+	//! on the IPC thread and only RECORD the request here. compositor_layer_commit
+	//! (render thread) applies it on the standalone path — driving the per-client
+	//! DP so the hardware SR follows the app's render mode. Without this the IPC
+	//! handlers no-op'd on Windows (Android-only), leaving the app rendering 2D
+	//! mono while the SR stayed 3D (left-shifted single view + black right eye).
+	//! Deferred-apply keeps the per-client DP off the cross-process IPC thread.
+	//! `pending_content_mode` is 0xFFFFFFFF when none; `pending_hw_3d` is
+	//! -1 none / 0 = 2D / 1 = 3D.
+	std::atomic<uint32_t> pending_content_mode{0xFFFFFFFFu};
+	std::atomic<int>      pending_hw_3d{-1};
+
 	//! Phase 2 — per-IPC-client shared `ID3D11Fence` that replaces the
 	//! per-view `IDXGIKeyedMutex::AcquireSync` CPU wait with a GPU-side
 	//! `ID3D11DeviceContext4::Wait`. Created at session-create on the
@@ -9119,6 +9133,65 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 		}
 	}
 
+	// App-initiated rendering-mode request over IPC (#575). A standalone
+	// forced-IPC client's xrRequestDisplayRenderingModeEXT crosses IPC into the
+	// request_rendering_mode / request_display_mode vtable methods, which recorded
+	// the request on the IPC thread (pending_content_mode / pending_hw_3d). Apply
+	// it here on the render thread. Without this the per-client DP was never driven
+	// on Windows (the IPC handlers were Android-only), so the app rendered 2D mono
+	// while the SR stayed 3D — the weaver showed a left-shifted single view with a
+	// black right eye (the IPC half of #575). Mirrors the immediate-flip the bridge
+	// relay above does, and what the Android multi_compositor path does via its own
+	// request_display_mode. Gated to standalone: workspace uses the controller's
+	// acked-flip; bridge uses the HWND relay above.
+	if (!sys->workspace_mode && !bridge_live && c->render.display_processor != nullptr &&
+	    sys->xsysd != NULL) {
+		uint32_t req_mode = c->pending_content_mode.exchange(0xFFFFFFFFu, std::memory_order_acq_rel);
+		int req_hw = c->pending_hw_3d.exchange(-1, std::memory_order_acq_rel);
+		struct xrt_device *head = sys->xsysd->static_roles.head;
+
+		if ((req_mode != 0xFFFFFFFFu || req_hw >= 0) && head != nullptr && head->hmd != NULL) {
+			// The app has taken explicit control of the mode — suppress the
+			// one-shot deferred-3D warmup kick so it can't fight the request.
+			c->render.deferred_3d_kicked = true;
+
+			uint32_t prev_idx = head->hmd->active_rendering_mode_index;
+			// Resolve the target hardware state: an explicit hardware request
+			// wins; otherwise follow the requested content mode's hardware_display_3d
+			// (the common no-divergence case).
+			bool want_3d = sys->hardware_display_3d;
+			if (req_mode != 0xFFFFFFFFu && req_mode < head->rendering_mode_count) {
+				want_3d = head->rendering_modes[req_mode].hardware_display_3d;
+				if (prev_idx != req_mode) {
+					// Remember the last 3D mode for later restores (vendor poll, etc.).
+					if (prev_idx < head->rendering_mode_count &&
+					    head->rendering_modes[prev_idx].hardware_display_3d) {
+						sys->last_3d_mode_index = prev_idx;
+					}
+					head->hmd->active_rendering_mode_index = req_mode;
+					broadcast_rendering_mode_change(sys, head, prev_idx, req_mode);
+				}
+			}
+			if (req_hw >= 0) {
+				want_3d = (req_hw != 0);
+			}
+
+			xrt_display_processor_d3d11_request_display_mode(c->render.display_processor, want_3d);
+			sync_tile_layout(sys);
+			sys->hardware_display_3d = want_3d;
+			// Stamp the post-flip cooldown so the 100 ms vendor 3D-state poll
+			// doesn't see the panel mid-transition and counter-correct (same
+			// refresh the deferred-3D kick / zones fallback do).
+			int64_t flip_ns = os_monotonic_get_ns();
+			sys->cached_3d_state.store(want_3d, std::memory_order_relaxed);
+			sys->last_3d_state_poll_ns.store(flip_ns, std::memory_order_release);
+			sys->last_flip_landed_ns.store(flip_ns, std::memory_order_release);
+			U_LOG_W("[app_mode] standalone IPC client requested mode (content=%u hw_req=%d) "
+			        "-> active=%u 3D=%d",
+			        req_mode, req_hw, head->hmd->active_rendering_mode_index, (int)want_3d);
+		}
+	}
+
 	// Runtime-side 2D/3D toggle (V key) + 1/2/3 mode-select — polls qwerty
 	// driver each frame.
 	// Disabled when bridge is active: mode changes go through the HWND
@@ -10883,6 +10956,38 @@ compositor_layer_commit_with_semaphore(struct xrt_compositor *xc,
 	return compositor_layer_commit(xc, XRT_GRAPHICS_SYNC_HANDLE_INVALID);
 }
 
+//! HARDWARE 2D/3D request (#533/#575) — the weave-state signal, decoupled from
+//! the content/atlas mode below. Runs on the IPC thread; only RECORDS the
+//! request. compositor_layer_commit (render thread, standalone path) applies it
+//! to the per-client DP. This is the Windows D3D11-service implementation of the
+//! polymorphic xrt_comp_request_display_mode dispatch that replaces the old
+//! Android-only #ifdef in the IPC handler.
+static xrt_result_t
+compositor_request_display_mode(struct xrt_compositor *xc, bool enable_3d)
+{
+	struct d3d11_service_compositor *c = d3d11_service_compositor_from_xrt(xc);
+	c->pending_hw_3d.store(enable_3d ? 1 : 0, std::memory_order_release);
+	return XRT_SUCCESS;
+}
+
+//! CONTENT rendering-mode request (#553/#575, ADR-028) — the atlas tile grid the
+//! app submits into, decoupled from the hardware 2D/3D state above. Records the
+//! requested mode index; compositor_layer_commit applies it (active mode index +
+//! sync_tile_layout) on the render thread. tile_columns/tile_rows are resolved
+//! server-side from the head device's mode list, so only the index is needed here.
+static xrt_result_t
+compositor_request_rendering_mode(struct xrt_compositor *xc,
+                                  uint32_t mode_index,
+                                  uint32_t tile_columns,
+                                  uint32_t tile_rows)
+{
+	struct d3d11_service_compositor *c = d3d11_service_compositor_from_xrt(xc);
+	(void)tile_columns;
+	(void)tile_rows;
+	c->pending_content_mode.store(mode_index, std::memory_order_release);
+	return XRT_SUCCESS;
+}
+
 static void
 compositor_destroy(struct xrt_compositor *xc)
 {
@@ -11387,6 +11492,8 @@ system_create_native_compositor(struct xrt_system_compositor *xsysc,
 	c->base.base.layer_passthrough = compositor_layer_passthrough;
 	c->base.base.layer_commit = compositor_layer_commit;
 	c->base.base.layer_commit_with_semaphore = compositor_layer_commit_with_semaphore;
+	c->base.base.request_display_mode = compositor_request_display_mode;
+	c->base.base.request_rendering_mode = compositor_request_rendering_mode;
 	c->base.base.destroy = compositor_destroy;
 
 	// Set up supported formats

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -4348,16 +4348,22 @@ d3d11_service_render_hud(struct d3d11_service_system *sys,
  * When content is smaller than atlas (legacy compromise scale), copies
  * each view's content region to a content-sized staging texture.
  * Returns the SRV to pass to process_atlas().
+ *
+ * @param tile_columns,tile_rows  The EFFECTIVE per-frame grid (what was packed
+ *        this frame), NOT sys->tile_columns — see #575 / ADR-030. For a mono
+ *        frame this is 1×1 even when the content rendering mode is still 3D.
  */
 static ID3D11ShaderResourceView *
 service_crop_atlas_for_dp(struct d3d11_service_system *sys,
                           struct d3d11_client_render_resources *res,
                           uint32_t content_view_w,
                           uint32_t content_view_h,
+                          uint32_t tile_columns,
+                          uint32_t tile_rows,
                           bool flip_y)
 {
-	uint32_t expected_w = sys->tile_columns * content_view_w;
-	uint32_t expected_h = sys->tile_rows * content_view_h;
+	uint32_t expected_w = tile_columns * content_view_w;
+	uint32_t expected_h = tile_rows * content_view_h;
 
 	// Content fills the full atlas — pass directly (only when no flip needed)
 	if (!flip_y && expected_w == sys->display_width && expected_h == sys->display_height) {
@@ -4409,7 +4415,7 @@ service_crop_atlas_for_dp(struct d3d11_service_system *sys,
 	uint32_t src_tex_w = atlas_desc.Width;
 	uint32_t src_tex_h = atlas_desc.Height;
 
-	uint32_t num_views = sys->tile_columns * sys->tile_rows;
+	uint32_t num_views = tile_columns * tile_rows;
 
 	// Source tile stride MUST be the atlas-derived slot stride — the same
 	// `atlas / tile_columns` formula the write side (projection blit, zones
@@ -4418,9 +4424,11 @@ service_crop_atlas_for_dp(struct d3d11_service_system *sys,
 	// the per-client atlas is created at native pixels
 	// (`feedback_atlas_stride_invariant`) — cropping view 1 at the scaled
 	// stride reads empty atlas between the tiles (#549: black view-1 on
-	// the standalone forced-IPC path).
-	uint32_t src_stride_w = atlas_desc.Width / (sys->tile_columns > 0 ? sys->tile_columns : 1);
-	uint32_t src_stride_h = atlas_desc.Height / (sys->tile_rows > 0 ? sys->tile_rows : 1);
+	// the standalone forced-IPC path). Uses the EFFECTIVE per-frame grid
+	// (#575): for a mono frame num_views==1, so only tile 0 (the real
+	// content) is read — never the stale tile 1 of a still-3D content mode.
+	uint32_t src_stride_w = atlas_desc.Width / (tile_columns > 0 ? tile_columns : 1);
+	uint32_t src_stride_h = atlas_desc.Height / (tile_rows > 0 ? tile_rows : 1);
 
 	if (flip_y && res->crop_rtv && sys->blit_vs && sys->blit_ps) {
 		// Shader blit path: crop + Y-flip in one pass per view.
@@ -4448,11 +4456,11 @@ service_crop_atlas_for_dp(struct d3d11_service_system *sys,
 
 		for (uint32_t v = 0; v < num_views && v < XRT_MAX_VIEWS; v++) {
 			uint32_t src_tile_x, src_tile_y;
-			u_tiling_view_origin(v, sys->tile_columns,
+			u_tiling_view_origin(v, tile_columns,
 			                     src_stride_w, src_stride_h,
 			                     &src_tile_x, &src_tile_y);
 			uint32_t dst_tile_x, dst_tile_y;
-			u_tiling_view_origin(v, sys->tile_columns,
+			u_tiling_view_origin(v, tile_columns,
 			                     content_view_w, content_view_h,
 			                     &dst_tile_x, &dst_tile_y);
 
@@ -9364,6 +9372,44 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 				}
 				got_state = false; // skip the legacy counter-correction below
 			}
+			// #575 follow-up — STANDALONE re-assert (mirrors the workspace
+			// force_3d above). The SR SDK auto-demotes to 2D on eye-tracking
+			// loss but NEVER auto-promotes back, so FOLLOWING it (the branch
+			// below) leaves a standalone forced-IPC app stuck in 2D after
+			// tracking returns (unfocus→refocus). The shell never sees this
+			// because it re-asserts the controller's desired state here; do the
+			// same for standalone. Gate on sys->hardware_display_3d — the app's
+			// intended hardware mode, set only by its explicit
+			// xrRequestDisplayRenderingModeEXT — so a genuine user V→2D (which
+			// leaves it false) is NOT overridden. Re-assert 3D + skip the follow
+			// so the intent is never corrupted; persisting the request across
+			// polls means the panel returns to 3D the instant the SR can weave
+			// again (tracking regained). Cooldown-refreshed so we don't hammer.
+			if (!sys->workspace_mode && !bridge_live && got_state &&
+			    c->render.display_processor != nullptr && sys->hardware_display_3d &&
+			    !vendor_is_3d && !pending_flip && !in_cooldown) {
+				U_LOG_W("[force_3d] standalone vendor drifted to 2D (app wants 3D) — re-asserting 3D");
+				xrt_display_processor_d3d11_request_display_mode(c->render.display_processor, true);
+				// If the content rendering mode also drifted to 2D (e.g. a prior
+				// demote before this re-assert was reached), restore the app's
+				// last 3D mode so it re-submits a 3D atlas.
+				struct xrt_device *rhead = sys->xsysd ? sys->xsysd->static_roles.head : nullptr;
+				if (rhead != nullptr && rhead->hmd != NULL) {
+					uint32_t cur = rhead->hmd->active_rendering_mode_index;
+					bool cur_is_3d = cur < rhead->rendering_mode_count &&
+					                 rhead->rendering_modes[cur].hardware_display_3d;
+					if (!cur_is_3d && sys->last_3d_mode_index < rhead->rendering_mode_count &&
+					    rhead->rendering_modes[sys->last_3d_mode_index].hardware_display_3d) {
+						rhead->hmd->active_rendering_mode_index = sys->last_3d_mode_index;
+						broadcast_rendering_mode_change(sys, rhead, cur, sys->last_3d_mode_index);
+					}
+				}
+				sync_tile_layout(sys);
+				sys->cached_3d_state.store(true, std::memory_order_relaxed);
+				sys->last_3d_state_poll_ns.store(now_ns, std::memory_order_release);
+				sys->last_flip_landed_ns.store(now_ns, std::memory_order_release);
+				got_state = false; // skip the follow below
+			}
 			if (vendor_is_3d != sys->hardware_display_3d && !pending_flip && !in_cooldown && got_state) {
 				U_LOG_W("Vendor SDK hardware 3D state changed: %s → %s",
 				        sys->hardware_display_3d ? "3D" : "2D",
@@ -9612,6 +9658,19 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 	ID3D11Texture2D *zc_tex = nullptr;
 	uint32_t zc_view_w = 0, zc_view_h = 0;
 
+	// #575 / ADR-030: the number of views ACTUALLY packed into the atlas this
+	// frame (set from the projection layer's proj_view_count below). The atlas
+	// recipe — and therefore the grid handed to the DP — must follow what was
+	// packed, NOT the global sys->tile_columns: that tracks the CONTENT
+	// rendering-mode grid, which is decoupled from the hardware 2D/3D state
+	// (ADR-028) and can lag it. A mono frame (1 view) packed while
+	// sys->tile_columns is still 2 (3D content mode) must be cropped + handed
+	// to the DP as a 1×1 atlas, or the DP weaves mono content → left-shift +
+	// tracking (the IPC half of #575). 0 = no projection layer this frame
+	// (e.g. a pure zones frame) → keep sys->tile_columns. This is the
+	// per-client analogue of the in-process eff_layout.
+	uint32_t eff_view_count = 0;
+
 	// Actual content dimensions from submitted rects - defaults to sys values,
 	// overwritten per projection layer (may differ for legacy compromise-scale apps)
 	uint32_t content_view_w = sys->view_width;
@@ -9691,6 +9750,11 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 			proj_view_count = 1;
 		if (proj_view_count > XRT_MAX_VIEWS)
 			proj_view_count = XRT_MAX_VIEWS;
+
+		// #575: remember what this frame actually packed (see eff_view_count
+		// decl). The handoff/crop below derive their grid from this, not the
+		// possibly-lagging sys->tile_columns.
+		eff_view_count = proj_view_count;
 
 		// Extract per-view swapchains, textures, and image indices
 		struct d3d11_service_swapchain *view_scs[XRT_MAX_VIEWS] = {};
@@ -9990,14 +10054,23 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 		for (uint32_t e = 0; e < proj_view_count; e++) {
 			if (!view_zc_eligible[e]) { all_views_zc_eligible = false; break; }
 		}
-		if (proj_view_count <= 1) zc_reason = "single_view";
-		else if (has_ui_layers) zc_reason = "ui_layers";
+		// ADR-030: zero-copy eligibility is governed SOLELY by
+		// u_tiling_can_zero_copy() below (submission fills the swapchain at the
+		// mode's tiling) — NOT by a view-count proxy. The old `proj_view_count
+		// > 1` gate excluded the one Windows case where zero-copy is legitimate
+		// (full-screen 2D: 1×1 @ 1.0×1.0 fills the worst-case envelope) and
+		// coupled the decision to the hardware 2D/3D flag. These remaining
+		// guards are NOT proxies — they mean "there's extra compositing to do,
+		// so a straight passthrough is impossible": UI/window-space/zones
+		// layers to blend, a view unsafe to read without a mutex, or workspace
+		// mode (Stage 2 composes N clients; per-client passthrough doesn't apply).
+		if (has_ui_layers) zc_reason = "ui_layers";
 		else if (has_window_space_layers) zc_reason = "window_space_layers";
 		else if (zones_frame || has_local_2d) zc_reason = "zones_layers";
 		else if (!all_views_zc_eligible) zc_reason = "view_ineligible";
 		else if (sys->workspace_mode) zc_reason = "workspace_mode";
 
-		if (proj_view_count > 1 && !has_ui_layers && !has_window_space_layers && !zones_frame && !has_local_2d &&
+		if (!has_ui_layers && !has_window_space_layers && !zones_frame && !has_local_2d &&
 		    all_views_zc_eligible && !sys->workspace_mode) {
 			// Check all views reference the same swapchain image
 			bool all_same = true;
@@ -10805,6 +10878,21 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 	}
 
 
+	// #575 / ADR-030: the grid handed to the DP follows what was actually
+	// packed this frame, NOT the global sys->tile_columns. When only one view
+	// was packed (hardware 2D), the atlas is 1×1 regardless of a still-3D
+	// content rendering mode (ADR-028 decouples hardware from content). Without
+	// this, a mono frame with sys->tile_columns==2 is cropped to a 2-tile
+	// atlas (tile 1 = stale) and process_atlas() weaves mono content → the
+	// forced-IPC 2D left-shift + "weird tracking". eff_view_count==0 (no
+	// projection layer, e.g. a pure zones frame) keeps the mode grid.
+	uint32_t eff_tile_columns = sys->tile_columns;
+	uint32_t eff_tile_rows = sys->tile_rows;
+	if (eff_view_count == 1) {
+		eff_tile_columns = 1;
+		eff_tile_rows = 1;
+	}
+
 	// Select display processor input: zero-copy from app's swapchain, or atlas.
 	// The DP expects the atlas texture to be exactly content-sized
 	// (2*view_width x view_height for SBS). When a legacy/compromise-scale app
@@ -10819,8 +10907,10 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 		input_view_w = zc_view_w;
 		input_view_h = zc_view_h;
 	} else {
-		// Crop atlas to content dims (mirrors d3d11_crop_atlas_for_dp in in-process path)
-		input_srv = service_crop_atlas_for_dp(sys, &c->render, content_view_w, content_view_h, c->atlas_flip_y);
+		// Crop atlas to content dims (mirrors d3d11_crop_atlas_for_dp in in-process path).
+		// Pass the EFFECTIVE per-frame grid, not sys->tile_columns (#575).
+		input_srv = service_crop_atlas_for_dp(sys, &c->render, content_view_w, content_view_h,
+		                                      eff_tile_columns, eff_tile_rows, c->atlas_flip_y);
 		input_view_w = content_view_w;
 		input_view_h = content_view_h;
 	}
@@ -10850,18 +10940,27 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 
 		// Canvas = (0,0,0,0): IPC hosted apps always own the full window,
 		// so canvas equals back buffer — no sub-rect needed.
-		static bool logged_dp = false;
-		if (!logged_dp) {
-			logged_dp = true;
-			U_LOG_W("DP HANDOFF: input_view=%ux%u tiles=%ux%u bb=%ux%u content=%ux%u zc=%d flip_y=%d",
-			        input_view_w, input_view_h, sys->tile_columns, sys->tile_rows,
+		// Re-arm the one-shot whenever the effective grid or hardware state
+		// changes, so the toggle frame (3D→2D) reprints instead of staying
+		// silent on the warmup-frame snapshot (#575 debugging).
+		static uint32_t logged_dp_cols = 0, logged_dp_rows = 0;
+		static int logged_dp_hw = -1;
+		if (logged_dp_cols != eff_tile_columns || logged_dp_rows != eff_tile_rows ||
+		    logged_dp_hw != (int)sys->hardware_display_3d) {
+			logged_dp_cols = eff_tile_columns;
+			logged_dp_rows = eff_tile_rows;
+			logged_dp_hw = (int)sys->hardware_display_3d;
+			U_LOG_W("DP HANDOFF: input_view=%ux%u eff_tiles=%ux%u sys_tiles=%ux%u bb=%ux%u "
+			        "content=%ux%u eff_vc=%u hw3d=%d zc=%d flip_y=%d",
+			        input_view_w, input_view_h, eff_tile_columns, eff_tile_rows,
+			        sys->tile_columns, sys->tile_rows,
 			        back_buffer_width, back_buffer_height,
-			        content_view_w, content_view_h,
-			        (int)use_zero_copy, (int)c->atlas_flip_y);
+			        content_view_w, content_view_h, eff_view_count,
+			        (int)sys->hardware_display_3d, (int)use_zero_copy, (int)c->atlas_flip_y);
 		}
 		xrt_display_processor_d3d11_process_atlas(
 		    c->render.display_processor, sys->context.get(), input_srv,
-		    input_view_w, input_view_h, sys->tile_columns, sys->tile_rows,
+		    input_view_w, input_view_h, eff_tile_columns, eff_tile_rows,
 		    // ADR-021: per-client single-layer weave is always Model A passthrough
 		    // (one client → nothing to blend). No set_atlas_encoding call ⟹ the DP
 		    // keeps its ENCODED default. Pass the real atlas format here.
@@ -10873,7 +10972,7 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 		wil::com_ptr<ID3D11Resource> back_buffer;
 		c->render.back_buffer_rtv->GetResource(back_buffer.put());
 		if (use_zero_copy && zc_tex) {
-			D3D11_BOX src_box = {0, 0, 0, sys->tile_columns * input_view_w, sys->tile_rows * input_view_h, 1};
+			D3D11_BOX src_box = {0, 0, 0, eff_tile_columns * input_view_w, eff_tile_rows * input_view_h, 1};
 			sys->context->CopySubresourceRegion(
 			    back_buffer.get(), 0, 0, 0, 0,
 			    zc_tex, 0, &src_box);

--- a/src/xrt/compositor/multi/comp_multi_compositor.c
+++ b/src/xrt/compositor/multi/comp_multi_compositor.c
@@ -2163,6 +2163,31 @@ multi_compositor_set_rendering_mode(struct multi_compositor *mc,
 	mc->active_mode_valid = true;
 }
 
+//! @copydoc xrt_compositor::request_display_mode
+//! Vtable dispatch target (#575): the IPC server handler now calls through the
+//! xrt_compositor vtable instead of an XRT_OS_ANDROID-only direct call, so the
+//! Windows D3D11 service can implement the same contract. Delegates to the
+//! existing hardware-channel helper.
+static xrt_result_t
+multi_compositor_vtable_request_display_mode(struct xrt_compositor *xc, bool enable_3d)
+{
+	struct multi_compositor *mc = multi_compositor(xc);
+	multi_compositor_request_display_mode(mc, enable_3d);
+	return XRT_SUCCESS;
+}
+
+//! @copydoc xrt_compositor::request_rendering_mode
+static xrt_result_t
+multi_compositor_vtable_request_rendering_mode(struct xrt_compositor *xc,
+                                               uint32_t mode_index,
+                                               uint32_t tile_columns,
+                                               uint32_t tile_rows)
+{
+	struct multi_compositor *mc = multi_compositor(xc);
+	multi_compositor_set_rendering_mode(mc, mode_index, tile_columns, tile_rows);
+	return XRT_SUCCESS;
+}
+
 void
 multi_compositor_set_eye_tracking_mode(struct multi_compositor *mc, uint32_t mode)
 {
@@ -2225,6 +2250,8 @@ multi_compositor_create(struct multi_system_compositor *msc,
 	mc->base.base.set_thread_hint = multi_compositor_set_thread_hint;
 	mc->base.base.get_display_refresh_rate = multi_compositor_get_display_refresh_rate;
 	mc->base.base.request_display_refresh_rate = multi_compositor_request_display_refresh_rate;
+	mc->base.base.request_display_mode = multi_compositor_vtable_request_display_mode;
+	mc->base.base.request_rendering_mode = multi_compositor_vtable_request_rendering_mode;
 	mc->msc = msc;
 	mc->xses = xses;
 	mc->xsi = *xsi;

--- a/src/xrt/include/xrt/xrt_compositor.h
+++ b/src/xrt/include/xrt/xrt_compositor.h
@@ -1547,6 +1547,35 @@ struct xrt_compositor
 	 */
 	xrt_result_t (*request_display_refresh_rate)(struct xrt_compositor *xc, float display_refresh_rate_hz);
 
+	/*!
+	 * Request the HARDWARE 2D/3D display state (#533) — the display processor's
+	 * weave-state signal. DECOUPLED from the content/atlas mode below (ADR-028):
+	 * the two channels are orthogonal. Implemented by the server-side per-client
+	 * compositors (multi_compositor, comp_d3d11_service) so an out-of-process
+	 * (IPC) client's xrRequestDisplayRenderingModeEXT drives the DP. May be NULL
+	 * (in-process native compositors drive their DP directly; null compositor).
+	 *
+	 * @param xc         Self pointer
+	 * @param enable_3d  true = 3D weave, false = 2D flat.
+	 */
+	xrt_result_t (*request_display_mode)(struct xrt_compositor *xc, bool enable_3d);
+
+	/*!
+	 * Request the CONTENT rendering mode (the atlas tile grid the app submits
+	 * into, #553/ADR-028) — DECOUPLED from the hardware 2D/3D state above.
+	 * Implemented by the server-side per-client compositors so an IPC client's
+	 * mode selection clamps the per-session atlas to the mode grid. May be NULL.
+	 *
+	 * @param xc            Self pointer
+	 * @param mode_index    Index into the head device's rendering-mode list.
+	 * @param tile_columns  Resolved grid columns for @p mode_index (server-resolved).
+	 * @param tile_rows     Resolved grid rows for @p mode_index.
+	 */
+	xrt_result_t (*request_rendering_mode)(struct xrt_compositor *xc,
+	                                       uint32_t mode_index,
+	                                       uint32_t tile_columns,
+	                                       uint32_t tile_rows);
+
 	/*! @} */
 
 
@@ -2080,6 +2109,43 @@ static inline xrt_result_t
 xrt_comp_request_display_refresh_rate(struct xrt_compositor *xc, float display_refresh_rate_hz)
 {
 	return xc->request_display_refresh_rate(xc, display_refresh_rate_hz);
+}
+
+/*!
+ * @copydoc xrt_compositor::request_display_mode
+ *
+ * Helper for calling through the function pointer. No-op (returns success) when
+ * the compositor doesn't implement it (in-process native, null compositor).
+ *
+ * @public @memberof xrt_compositor
+ */
+static inline xrt_result_t
+xrt_comp_request_display_mode(struct xrt_compositor *xc, bool enable_3d)
+{
+	if (xc->request_display_mode == NULL) {
+		return XRT_SUCCESS;
+	}
+	return xc->request_display_mode(xc, enable_3d);
+}
+
+/*!
+ * @copydoc xrt_compositor::request_rendering_mode
+ *
+ * Helper for calling through the function pointer. No-op (returns success) when
+ * the compositor doesn't implement it.
+ *
+ * @public @memberof xrt_compositor
+ */
+static inline xrt_result_t
+xrt_comp_request_rendering_mode(struct xrt_compositor *xc,
+                                uint32_t mode_index,
+                                uint32_t tile_columns,
+                                uint32_t tile_rows)
+{
+	if (xc->request_rendering_mode == NULL) {
+		return XRT_SUCCESS;
+	}
+	return xc->request_rendering_mode(xc, mode_index, tile_columns, tile_rows);
 }
 
 

--- a/src/xrt/ipc/server/ipc_server_handler.c
+++ b/src/xrt/ipc/server/ipc_server_handler.c
@@ -405,6 +405,31 @@ ipc_try_get_sr_view_poses(volatile struct ipc_client_state *ics,
 		}
 	}
 
+	// #575: render input — 2D / mono collapses to a CENTERED eye so the
+	// off-axis Kooima frustum is symmetric and matches the centered pose oxr
+	// derives for mono (active_view_count==1). The gate is the ACTIVE mode's
+	// view count, forwarded by the client in rig->render_view_count (the
+	// located view_count is the app's stereo view-config — always 2 for Leia —
+	// and does NOT drop in 2D). This is the Windows D3D11-service analogue of
+	// the #521 collapse already in ipc_try_get_android_view_poses; without it
+	// the SR path returned the per-eye (off-axis) fovs[0], oxr centroided the
+	// pose but kept fovs[0] → center origin + left-eye frustum → 2D left-shift.
+	// The raw channel above already reported the verbatim per-eye set, so
+	// collapsing the render pair here doesn't affect the app's HUD face-dots.
+	{
+		uint32_t active_view_count = view_count;
+		if (rig != NULL && rig->render_view_count > 0) {
+			active_view_count = rig->render_view_count;
+		}
+		if (active_view_count == 1 && eye_count > 1) {
+			raw_eyes[0] = (struct xrt_vec3){
+			    0.5f * (raw_eyes[0].x + raw_eyes[1].x),
+			    0.5f * (raw_eyes[0].y + raw_eyes[1].y),
+			    0.5f * (raw_eyes[0].z + raw_eyes[1].z)};
+			eye_count = 1;
+		}
+	}
+
 	// Transform eyes to window-local frame:
 	// 1. Subtract window position (eye relative to window center)
 	// 2. If rotated, apply inverse rotation (eye in window's local space)
@@ -599,6 +624,15 @@ ipc_try_get_sr_view_poses(volatile struct ipc_client_state *ics,
 			    .half_tan_vfov = ws_rig.half_tan_vfov,
 			    .ipd_factor = ws_rig.ipd_factor,
 			    .parallax_factor = ws_rig.parallax_factor,
+			    // #575 (workspace leg): the controller override replaces the app's
+			    // rig GEOMETRY, but the app's active-mode view count is NOT geometry
+			    // — it's the 2D/3D collapse signal ipc_try_get_sr_view_poses needs to
+			    // fold the render eyes to a CENTERED eye in 2D. Dropping it (leaving
+			    // it 0) makes the server fall back to the located view_count (always
+			    // 2) → no collapse → left-eye fov paired with the centroid pose →
+			    // the mild workspace 2D left-shift (same root cause as the standalone
+			    // leg). Carry the app's forwarded value through the override.
+			    .render_view_count = (rig != NULL) ? rig->render_view_count : 0,
 			};
 			rig = &ws_override;
 		}
@@ -773,6 +807,19 @@ ipc_try_get_sr_view_poses(volatile struct ipc_client_state *ics,
 		         compositor_owns_window, workspace_mode, is_workspace_controller_session,
 		         is_appcontainer_app, use_qwerty_head,
 		         (const char *)ics->client_state.info.application_name);
+	}
+
+	// #575/#533: for the 2D collapse (eye_count==1) duplicate the centered eye
+	// into the surplus eye_world entries the client reads up to view_count.
+	// oxr's mono path averages view_eye_world[0..nc) (nc = DP eye count = 2) to
+	// derive XrView.pose; without the duplication the surplus stays 0 and the
+	// centroid is HALF the centered eye → asset ~2x zoomed + shifted. Mirrors
+	// the Android path's duplication. (out_fovs/out_poses are duplicated by
+	// fill_surplus_view_poses below.)
+	if (rig_reply != NULL && eye_count > 0) {
+		for (uint32_t i = eye_count; i < XRT_MAX_VIEWS; i++) {
+			rig_reply->eye_world[i] = rig_reply->eye_world[eye_count - 1];
+		}
 	}
 
 	fill_surplus_view_poses(xdev, eye_count, view_count, out_fovs, out_poses);

--- a/src/xrt/ipc/server/ipc_server_handler.c
+++ b/src/xrt/ipc/server/ipc_server_handler.c
@@ -2325,18 +2325,14 @@ ipc_handle_compositor_request_display_mode(volatile struct ipc_client_state *ics
 	}
 
 	// HARDWARE 2D/3D request (#533) — the weave-state signal, DECOUPLED from the
-	// per-frame content (atlas tile count). The out-of-process per-client
-	// compositor is a multi_compositor; forward to its DP. Only the Android
-	// null+comp_multi service reaches the DP this way.
-#ifdef XRT_OS_ANDROID
-	struct multi_compositor *mc = multi_compositor((struct xrt_compositor *)ics->xc);
-	if (mc != NULL) {
-		multi_compositor_request_display_mode(mc, enable_3d != 0u);
-	}
-#else
-	(void)enable_3d;
-#endif
-	return XRT_SUCCESS;
+	// per-frame content (atlas tile count). Dispatch polymorphically through the
+	// compositor vtable (#575): the per-client compositor drives its display
+	// processor — multi_compositor on the Android null+comp_multi service,
+	// comp_d3d11_service on the Windows D3D11 service. No-op for backends that
+	// don't implement it. This replaces the former Android-only #ifdef, which
+	// left Windows standalone forced-IPC clients with the SR stuck at its last
+	// hardware state while the app rendered the other mode.
+	return xrt_comp_request_display_mode((struct xrt_compositor *)ics->xc, enable_3d != 0u);
 }
 
 xrt_result_t
@@ -2369,15 +2365,10 @@ ipc_handle_compositor_request_rendering_mode(volatile struct ipc_client_state *i
 	// and the line Windows forced-IPC validation greps for.
 	U_LOG_W("CONTENT rendering mode %u arrived over IPC (grid %ux%u)", mode_index, tile_columns, tile_rows);
 
-	// The out-of-process per-client compositor is a comp_multi multi_compositor
-	// only on the Android null+comp_multi service — same cast-validity gate as
-	// the hardware handler above.
-#ifdef XRT_OS_ANDROID
-	struct multi_compositor *mc = multi_compositor((struct xrt_compositor *)ics->xc);
-	if (mc != NULL) {
-		multi_compositor_set_rendering_mode(mc, mode_index, tile_columns, tile_rows);
-	}
-#endif
+	// Dispatch the CONTENT mode through the compositor vtable (#575) so each
+	// per-client compositor backend records it (multi_compositor on Android,
+	// comp_d3d11_service on Windows) and clamps its per-session atlas to the grid.
+	xrt_comp_request_rendering_mode((struct xrt_compositor *)ics->xc, mode_index, tile_columns, tile_rows);
 	return XRT_SUCCESS;
 }
 

--- a/src/xrt/state_trackers/oxr/oxr_api_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_api_session.c
@@ -1305,6 +1305,32 @@ oxr_xrGetPlanePolygonBufferEXT(XrPlaneDetectorEXT planeDetector,
 
 #ifdef OXR_HAVE_EXT_display_info
 
+/*!
+ * "A workspace controller currently owns display policy" — the ADR-014 authority
+ * signal, evaluated so it is valid in the APP's OWN process.
+ *
+ * #575: the original gate read only `inst->workspace_controller_active`, which is
+ * a PER-INSTANCE flag set true ONLY inside oxr_xrActivateSpatialWorkspaceEXT — i.e.
+ * exclusively in the workspace controller's (shell's) own process. A separate-
+ * process IPC app (a cube launched by the shell) has its own instance where that
+ * flag is forever false, so the app-side mode-authority gate never fired and the
+ * app's V key (xrRequestDisplayRenderingModeEXT) fell through to the legacy path,
+ * pushing itself a local XrEventDataRenderingModeChangedEXT and corrupting its own
+ * content under the shell. The fix: also honor the server-synced
+ * `info.workspace_mode` (fetched at IPC compositor creation — the shell activates
+ * the workspace BEFORE launching apps, so it is already true when the app connects),
+ * which DOES cross the process boundary.
+ */
+static bool
+oxr_workspace_owns_display_policy(const struct oxr_session *sess)
+{
+	if (sess->sys->inst->workspace_controller_active) {
+		return true; // controller's own process (in-process / same-instance path)
+	}
+	const struct xrt_system_compositor *xsysc = sess->sys->xsysc;
+	return xsysc != NULL && xsysc->info.is_service_mode && xsysc->info.workspace_mode;
+}
+
 XRAPI_ATTR XrResult XRAPI_CALL
 oxr_xrRequestDisplayModeEXT(XrSession session, XrDisplayModeEXT displayMode)
 {
@@ -1377,7 +1403,7 @@ oxr_xrRequestEyeTrackingModeEXT(XrSession session, XrEyeTrackingModeEXT mode)
 	// (no workspace controller) the lone app owns it; under a workspace only the
 	// active controller does. Mirrors the #518 display-mode authority gate.
 	bool workspace_gated =
-	    sess->sys->inst->workspace_controller_active && !sess->is_active_workspace_controller;
+	    oxr_workspace_owns_display_policy(sess) && !sess->is_active_workspace_controller;
 	if (!workspace_gated) {
 		oxr_session_set_eye_tracking_mode(sess, (uint32_t)mode);
 	}
@@ -1415,7 +1441,7 @@ oxr_xrRequestDisplayRenderingModeEXT(XrSession session, uint32_t modeIndex)
 	// owns its display mode — otherwise nobody could ever switch 2D<->3D in OOP.
 	if (sess->sys->xsysc != NULL && sess->sys->xsysc->info.is_service_mode &&
 	    sess->compositor != NULL &&
-	    sess->sys->inst->workspace_controller_active &&
+	    oxr_workspace_owns_display_policy(sess) &&
 	    !sess->is_active_workspace_controller) {
 		return XR_SUCCESS;
 	}
@@ -1553,7 +1579,7 @@ oxr_xrEnumerateDisplayRenderingModesEXT(XrSession session,
 	XrBool32 session_is_requestable = XR_TRUE;
 	if (sess->sys->xsysc != NULL && sess->sys->xsysc->info.is_service_mode &&
 	    sess->compositor != NULL &&
-	    sess->sys->inst->workspace_controller_active && // #518: only when a workspace is active
+	    oxr_workspace_owns_display_policy(sess) && // #518/#575: only when a workspace owns policy
 	    !sess->is_active_workspace_controller) {
 		session_is_requestable = XR_FALSE;
 	}

--- a/test_apps/cube_handle_d3d11_win/main.cpp
+++ b/test_apps/cube_handle_d3d11_win/main.cpp
@@ -823,8 +823,8 @@ static void RenderOneFrame(RenderState& rs) {
                             bool dispMonoMode = monoMode;
                             uint32_t dispRenderW, dispRenderH;
                             if (dispMonoMode) {
-                                dispRenderW = g_windowWidth;
-                                dispRenderH = g_windowHeight;
+                                dispRenderW = (uint32_t)(g_windowWidth * xr.recommendedViewScaleX);
+                                dispRenderH = (uint32_t)(g_windowHeight * xr.recommendedViewScaleY);
                                 if (dispRenderW > xr.swapchain.width) dispRenderW = xr.swapchain.width;
                                 if (dispRenderH > xr.swapchain.height) dispRenderH = xr.swapchain.height;
                             } else {
@@ -977,8 +977,13 @@ static void RenderOneFrame(RenderState& rs) {
                         // Dynamic render dims based on window size, clamped to swapchain capacity
                         uint32_t renderW, renderH;
                         if (monoMode) {
-                            renderW = g_windowWidth;
-                            renderH = g_windowHeight;
+                            // 2D: the single view fills the full content region —
+                            // window × the active mode's view scale (#575; same
+                            // window×scale recipe the 3D branch uses). Dropping the
+                            // scale here left the view under-filling the 2D tile →
+                            // content shifted left + right eye black.
+                            renderW = (uint32_t)(g_windowWidth * xr.recommendedViewScaleX);
+                            renderH = (uint32_t)(g_windowHeight * xr.recommendedViewScaleY);
                             if (renderW > xr.swapchain.width) renderW = xr.swapchain.width;
                             if (renderH > xr.swapchain.height) renderH = xr.swapchain.height;
                         } else {

--- a/test_apps/cube_handle_vk_win/main.cpp
+++ b/test_apps/cube_handle_vk_win/main.cpp
@@ -773,8 +773,13 @@ static void RenderThreadFunc(
                         // Compute render dims: mono uses full swapchain, stereo uses tile-sized
                         uint32_t renderW, renderH;
                         if (monoMode) {
-                            renderW = windowW;
-                            renderH = windowH;
+                            // 2D: the single view fills the full content region —
+                            // window × the active mode's view scale (#575; same
+                            // window×scale recipe the 3D branch uses). Dropping the
+                            // scale here left the view under-filling the 2D tile →
+                            // content shifted left + right eye black.
+                            renderW = (uint32_t)(windowW * xr->recommendedViewScaleX);
+                            renderH = (uint32_t)(windowH * xr->recommendedViewScaleY);
                             if (renderW > xr->swapchain.width) renderW = xr->swapchain.width;
                             if (renderH > xr->swapchain.height) renderH = xr->swapchain.height;
                         } else {
@@ -947,8 +952,8 @@ static void RenderThreadFunc(
                                     L"XR_EXT_win32_window_binding: NOT AVAILABLE (Vulkan)";
                                 uint32_t dispRenderW, dispRenderH;
                                 if (monoMode) {
-                                    dispRenderW = windowW;
-                                    dispRenderH = windowH;
+                                    dispRenderW = (uint32_t)(windowW * xr->recommendedViewScaleX);
+                                    dispRenderH = (uint32_t)(windowH * xr->recommendedViewScaleY);
                                     if (dispRenderW > xr->swapchain.width) dispRenderW = xr->swapchain.width;
                                     if (dispRenderH > xr->swapchain.height) dispRenderH = xr->swapchain.height;
                                 } else {


### PR DESCRIPTION
Closes the remaining #575 legs: the V→2D left-shift across forced-IPC / workspace, and the V-key-not-blocked-in-shell regression. All hardware-validated on D3D11/VK/D3D12/GL (Metal pending a Mac eyeball).

## Commits
1. **fix(#575): mono extent = window×scale on d3d11+vk cube apps** — app-side: the cube's 2D branch dropped the active mode's view scale, under-filling the tile. *(pre-existing)*
2. **fix(#575): drive per-client DP hardware mode on Windows forced-IPC** — vtable-polymorphic `request_display_mode`/`request_rendering_mode`, replacing the Android-only `#ifdef` that left Windows forced-IPC clients with the SR stuck. *(pre-existing)*
3. **fix(#575): center the 2D SR locate path + per-client DP fixes** — collapse the SR render eyes to a centered eye in 2D (forced-IPC + workspace `ws_override` legs, + #533 eye_world dup); drive the per-client DP crop/handoff from the effective per-frame grid; standalone force-3D re-assert (refocus→3D); ADR-030 zero-copy gate alignment.
4. **fix(#575): reject app rendering-mode requests under an active workspace** — the authority gate keyed on a per-instance flag never set in the app's process, so an app's V leaked a local `RenderingModeChanged` and broke its content under the shell. Gate now honors the server-synced `info.workspace_mode`.
5. **docs(#575): ADR-030 crop-before-DP / zero-copy eligibility** — crop-before-DP is the law; zero-copy only when the submission fills the swapchain (`u_tiling_can_zero_copy` the sole gate).

## Validation
- **Shell (workspace):** app-V is inert (`BLOCKED(workspace)`), content intact, cube centered; controller `Ctrl+V` flips 2D↔3D cleanly, centered both ways. Eyeball-confirmed across D3D11/VK/D3D12/GL.
- **Standalone forced-IPC:** app-V still switches mode (`wsm=0 → allowed`, `1→0`); 2D centered.
- **In-process:** unchanged (the workspace gate never engages); 2D centered via the DP one-eye-per-active-view contract.
- **Metal:** all three cells pending a Mac eyeball.

🤖 Generated with [Claude Code](https://claude.com/claude-code)