### PR TITLE
feat(#558): Android service-overlay avatar — runtime side

### DIFF
--- a/src/xrt/auxiliary/android/android_custom_surface.cpp
+++ b/src/xrt/auxiliary/android/android_custom_surface.cpp
@@ -127,13 +127,16 @@ android_custom_surface_async_start(
 			Display display = dm.getDisplay(display_id);
 			displayContext = ctx.createDisplayContext(display);
 			type = WindowManager_LayoutParams::TYPE_APPLICATION_OVERLAY();
-			// #558 P3: the service overlay floats over the LIVE launcher and must
-			// pass touches through. We do NOT use FLAG_NOT_TOUCHABLE — Android
-			// clamps such a system overlay to <=0.80 window alpha (anti-tapjacking),
-			// and an 0.80 whole-window blend destroys the LeiaSR per-pixel interlace
-			// → the weave looks 2D. Instead MonadoView sets an empty touchable
-			// REGION (no flag, no alpha clamp): full passthrough, full-opacity 3D
-			// weave. See MonadoView.installPassthroughTouchRegion().
+			// #558: the service overlay floats over the LIVE launcher, so it MUST
+			// pass touches through — otherwise it eats every tap (launcher, system
+			// dialogs like the battery-optimization prompt, everything). The
+			// per-region touchable API that would pass-through-except-the-tiger is
+			// @hide and this ROM blocks the reflection bypass, so use
+			// FLAG_NOT_TOUCHABLE (full passthrough). Android clamps such an overlay
+			// to <=0.80 window alpha (anti-tapjacking) — that only DIMS the weave; it
+			// does NOT flatten the 3D (the earlier "flat" was MANAGED NoFaceMode,
+			// since fixed). Tiger touch comes from a separate small input overlay.
+			flags |= WindowManager_LayoutParams::FLAG_NOT_TOUCHABLE();
 		}
 
 		int32_t width = 0;

--- a/src/xrt/auxiliary/android/android_custom_surface.cpp
+++ b/src/xrt/auxiliary/android/android_custom_surface.cpp
@@ -109,12 +109,11 @@ android_custom_surface_async_start(
 		Context ctx = Context((jobject)context);
 		Context displayContext;
 		int32_t type = 0;
-		// Not focusable. The overlay stays TOUCHABLE on purpose: it sits on top
-		// of the app to present the (weaved) output, and the NativeActivity's own
-		// window gets no touchable frame in this setup — so the overlay is the
-		// only window that can receive touch. MonadoView forwards every touch to
-		// the host Activity's dispatchTouchEvent, letting an in-process app
-		// (e.g. cube_handle_vk_android) drive input from there (#499).
+		// Not focusable. In-process (TYPE_APPLICATION) the overlay stays TOUCHABLE
+		// on purpose: it sits on top of the app's NativeActivity (which gets no
+		// touchable frame), so it's the only window that can receive touch, and
+		// MonadoView forwards every touch to the host Activity's dispatchTouchEvent
+		// (#499, e.g. cube_handle_vk_android).
 		int32_t flags =
 		    WindowManager_LayoutParams::FLAG_FULLSCREEN() | WindowManager_LayoutParams::FLAG_NOT_FOCUSABLE();
 
@@ -122,11 +121,19 @@ android_custom_surface_async_start(
 			displayContext = ctx;
 			type = WindowManager_LayoutParams::TYPE_APPLICATION();
 		} else {
-			// Out of process mode, determine which display should be used.
+			// Out of process mode (service-owned overlay over the live launcher,
+			// #558). Determine which display should be used.
 			DisplayManager dm = DisplayManager(ctx.getSystemService(Context::DISPLAY_SERVICE()));
 			Display display = dm.getDisplay(display_id);
 			displayContext = ctx.createDisplayContext(display);
 			type = WindowManager_LayoutParams::TYPE_APPLICATION_OVERLAY();
+			// #558 P2: the service overlay has no host Activity to forward touch
+			// to, and it floats over the LIVE launcher — so make it pass touches
+			// straight through (FLAG_NOT_TOUCHABLE). The launcher stays fully
+			// interactive (swipe pages, launch apps) and the tiger is visual-only
+			// on top. (P3 will swap this for a per-silhouette touchable region +
+			// service→client touch forwarding so the tiger is touch-controllable.)
+			flags |= WindowManager_LayoutParams::FLAG_NOT_TOUCHABLE();
 		}
 
 		int32_t width = 0;

--- a/src/xrt/auxiliary/android/android_custom_surface.cpp
+++ b/src/xrt/auxiliary/android/android_custom_surface.cpp
@@ -127,13 +127,13 @@ android_custom_surface_async_start(
 			Display display = dm.getDisplay(display_id);
 			displayContext = ctx.createDisplayContext(display);
 			type = WindowManager_LayoutParams::TYPE_APPLICATION_OVERLAY();
-			// #558 P2: the service overlay has no host Activity to forward touch
-			// to, and it floats over the LIVE launcher — so make it pass touches
-			// straight through (FLAG_NOT_TOUCHABLE). The launcher stays fully
-			// interactive (swipe pages, launch apps) and the tiger is visual-only
-			// on top. (P3 will swap this for a per-silhouette touchable region +
-			// service→client touch forwarding so the tiger is touch-controllable.)
-			flags |= WindowManager_LayoutParams::FLAG_NOT_TOUCHABLE();
+			// #558 P3: the service overlay floats over the LIVE launcher and must
+			// pass touches through. We do NOT use FLAG_NOT_TOUCHABLE — Android
+			// clamps such a system overlay to <=0.80 window alpha (anti-tapjacking),
+			// and an 0.80 whole-window blend destroys the LeiaSR per-pixel interlace
+			// → the weave looks 2D. Instead MonadoView sets an empty touchable
+			// REGION (no flag, no alpha clamp): full passthrough, full-opacity 3D
+			// weave. See MonadoView.installPassthroughTouchRegion().
 		}
 
 		int32_t width = 0;

--- a/src/xrt/auxiliary/android/src/main/java/org/freedesktop/monado/auxiliary/MonadoView.java
+++ b/src/xrt/auxiliary/android/src/main/java/org/freedesktop/monado/auxiliary/MonadoView.java
@@ -346,15 +346,29 @@ public class MonadoView extends SurfaceView
      */
     @Keep
     public static void removeFromWindow(@NonNull MonadoView view) {
-        Handler handler = new Handler(Looper.getMainLooper());
-        handler.post(
-                () -> {
-                    Log.d(TAG, "Start removing view from window");
-                    WindowManager wm =
-                            (WindowManager)
-                                    view.getContext().getSystemService(Context.WINDOW_SERVICE);
-                    wm.removeView(view);
-                });
+        // #558: when we're already on the UI thread (e.g. the service's onDestroy →
+        // MonadoImpl.shutdown → nativeDestroyServiceOverlay), use removeViewImmediate:
+        // it detaches the view synchronously. Plain removeView() only *schedules*
+        // the removal for the next looper traversal — which never runs when the
+        // service's MainLooper is shutting down, so the overlay's last frame stays
+        // frozen on the launcher. Off the UI thread, post a normal removeView.
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            Log.d(TAG, "Removing view from window (immediate)");
+            WindowManager wm =
+                    (WindowManager) view.getContext().getSystemService(Context.WINDOW_SERVICE);
+            wm.removeViewImmediate(view);
+        } else {
+            new Handler(Looper.getMainLooper())
+                    .post(
+                            () -> {
+                                Log.d(TAG, "Start removing view from window");
+                                WindowManager wm =
+                                        (WindowManager)
+                                                view.getContext()
+                                                        .getSystemService(Context.WINDOW_SERVICE);
+                                wm.removeView(view);
+                            });
+        }
     }
 
     @NonNull @Keep

--- a/src/xrt/auxiliary/android/src/main/java/org/freedesktop/monado/auxiliary/MonadoView.java
+++ b/src/xrt/auxiliary/android/src/main/java/org/freedesktop/monado/auxiliary/MonadoView.java
@@ -12,7 +12,9 @@ package org.freedesktop.monado.auxiliary;
 import android.app.Activity;
 import android.content.Context;
 import android.graphics.PixelFormat;
+import android.graphics.Region;
 import android.hardware.display.DisplayManager;
+import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.SystemClock;
@@ -21,6 +23,7 @@ import android.util.Log;
 import android.view.Display;
 import android.view.SurfaceHolder;
 import android.view.SurfaceView;
+import android.view.ViewTreeObserver;
 import android.view.WindowManager;
 import androidx.annotation.GuardedBy;
 import androidx.annotation.Keep;
@@ -69,6 +72,20 @@ public class MonadoView extends SurfaceView
     // handle input via Activity.dispatchTouchEvent (#499).
     @Nullable private Activity hostActivity = null;
 
+    // #558 P3: when this is a SERVICE-owned overlay (no host Activity) it floats
+    // over the live launcher and must pass touches through WITHOUT
+    // FLAG_NOT_TOUCHABLE (that flag makes Android clamp the window to <=0.80
+    // alpha, which blends away the LeiaSR interlace → the weave looks 2D).
+    // Instead we declare an explicit touchable Region (empty = full passthrough,
+    // full opacity). Guarded; a non-empty region (the tiger silhouette) can be
+    // set later to make just the tiger touchable.
+    private final Object touchableRegionSync = new Object();
+
+    @GuardedBy("touchableRegionSync")
+    private final Region touchableRegion = new Region(); // empty == pass everything through
+
+    private boolean passthroughInstalled = false;
+
     public MonadoView(Context context) {
         super(context);
 
@@ -113,6 +130,136 @@ public class MonadoView extends SurfaceView
             return true; // claim the gesture so we keep receiving MOVE/UP
         }
         return super.onTouchEvent(event);
+    }
+
+    @Override
+    protected void onAttachedToWindow() {
+        super.onAttachedToWindow();
+        // Service-owned overlay (no host Activity): install the passthrough touch
+        // region so the live launcher below stays interactive. In-process
+        // (host Activity present) keeps the full-touchable forward-to-Activity
+        // behavior (#499) untouched.
+        if (hostActivity == null) {
+            installPassthroughTouchRegion();
+        }
+    }
+
+    /**
+     * #558 P3: make this service-owned overlay declare an explicit touchable Region via the hidden
+     * ViewTreeObserver.addOnComputeInternalInsetsListener API, instead of FLAG_NOT_TOUCHABLE.
+     *
+     * <p>FLAG_NOT_TOUCHABLE would make Android clamp this system overlay to &lt;=0.80 window alpha
+     * (anti-tapjacking), and an 0.80 whole-window blend destroys the LeiaSR per-pixel interlace so
+     * the weave looks 2D. A touchable Region carries no such clamp: an EMPTY region means nothing
+     * here is touchable (everything passes through to the launcher) while the window stays fully
+     * opaque so the 3D weave survives. Reflected because the API is {@code @hide} (this file already
+     * relies on reflection for SystemProperties).
+     */
+    private static boolean sHiddenApiExempted = false;
+
+    /**
+     * Lift Android's non-SDK (hidden-API) blocklist for this process so the touch-region reflection
+     * below can see {@code ViewTreeObserver$InternalInsetsInfo.touchableRegion} (blocklisted on
+     * Android 14 → getField throws NoSuchFieldException). Uses the well-known double-reflection
+     * bootstrap (Class.forName + getDeclaredMethod obtained reflectively bypass the caller check)
+     * to call VMRuntime.setHiddenApiExemptions("L"). Same technique Shizuku/LSPosed use.
+     */
+    private static void exemptHiddenApis() {
+        if (sHiddenApiExempted) {
+            return;
+        }
+        sHiddenApiExempted = true;
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
+            return; // no non-SDK restrictions before Android 9
+        }
+        try {
+            java.lang.reflect.Method forName =
+                    Class.class.getDeclaredMethod("forName", String.class);
+            java.lang.reflect.Method getDeclaredMethod =
+                    Class.class.getDeclaredMethod(
+                            "getDeclaredMethod", String.class, Class[].class);
+            Class<?> vmRuntimeClass = (Class<?>) forName.invoke(null, "dalvik.system.VMRuntime");
+            java.lang.reflect.Method getRuntime =
+                    (java.lang.reflect.Method)
+                            getDeclaredMethod.invoke(vmRuntimeClass, "getRuntime", (Class<?>[]) null);
+            java.lang.reflect.Method setHiddenApiExemptions =
+                    (java.lang.reflect.Method)
+                            getDeclaredMethod.invoke(
+                                    vmRuntimeClass,
+                                    "setHiddenApiExemptions",
+                                    new Class[] {String[].class});
+            Object vmRuntime = getRuntime.invoke(null);
+            setHiddenApiExemptions.invoke(vmRuntime, new Object[] {new String[] {"L"}});
+            Log.i(TAG, "MonadoView: hidden-API exemptions applied (touch-region reflection)");
+        } catch (Throwable t) {
+            Throwable cause = (t instanceof java.lang.reflect.InvocationTargetException
+                            && t.getCause() != null)
+                    ? t.getCause()
+                    : t;
+            Log.w(TAG, "MonadoView: hidden-API exemption failed: " + cause, cause);
+        }
+    }
+
+    private void installPassthroughTouchRegion() {
+        if (passthroughInstalled) {
+            return;
+        }
+        exemptHiddenApis();
+        try {
+            final Class<?> infoCls =
+                    Class.forName("android.view.ViewTreeObserver$InternalInsetsInfo");
+            final Class<?> listenerCls =
+                    Class.forName("android.view.ViewTreeObserver$OnComputeInternalInsetsListener");
+            final java.lang.reflect.Method setTouchableInsets =
+                    infoCls.getMethod("setTouchableInsets", int.class);
+            final java.lang.reflect.Field touchableRegionField =
+                    infoCls.getField("touchableRegion");
+            final int touchableInsetsRegion =
+                    infoCls.getField("TOUCHABLE_INSETS_REGION").getInt(null);
+
+            final Object listener =
+                    java.lang.reflect.Proxy.newProxyInstance(
+                            listenerCls.getClassLoader(),
+                            new Class<?>[] {listenerCls},
+                            (proxy, method, args) -> {
+                                String name = method.getName();
+                                if ("onComputeInternalInsets".equals(name)
+                                        && args != null
+                                        && args.length == 1) {
+                                    Object info = args[0];
+                                    setTouchableInsets.invoke(info, touchableInsetsRegion);
+                                    Region region = (Region) touchableRegionField.get(info);
+                                    if (region != null) {
+                                        synchronized (touchableRegionSync) {
+                                            region.set(touchableRegion);
+                                        }
+                                    }
+                                    return null;
+                                }
+                                if ("hashCode".equals(name)) {
+                                    return System.identityHashCode(proxy);
+                                }
+                                if ("equals".equals(name)) {
+                                    return proxy == (args != null ? args[0] : null);
+                                }
+                                if ("toString".equals(name)) {
+                                    return "MonadoViewPassthroughInsetsListener";
+                                }
+                                return null;
+                            });
+
+            final java.lang.reflect.Method addListener =
+                    ViewTreeObserver.class.getMethod(
+                            "addOnComputeInternalInsetsListener", listenerCls);
+            addListener.invoke(getViewTreeObserver(), listener);
+            passthroughInstalled = true;
+            Log.i(TAG, "MonadoView: passthrough touch region installed (#558 P3)");
+        } catch (Throwable t) {
+            Log.w(
+                    TAG,
+                    "MonadoView: passthrough touch region unavailable; overlay stays fully touchable",
+                    t);
+        }
     }
 
     private MonadoView(Context context, long nativePointer) {

--- a/src/xrt/compositor/main/comp_window_android.c
+++ b/src/xrt/compositor/main/comp_window_android.c
@@ -18,15 +18,6 @@
  * comp_target_factory are intentionally omitted: the runtime service has no
  * Activity, and the null/service compositor creates this target directly via
  * its comp_target_service, not through a factory.
- *
- * #558 also removed the Java-side remains of the overlay mode (SurfaceManager,
- * IMonado.canDrawOverOtherApps + the Client.java gate, the SYSTEM_ALERT_WINDOW
- * permission and its settings UI) — the gate made a *granted* permission skip
- * the client surface publication against a service that never creates an
- * overlay, i.e. a guaranteed black screen. To revive service-owned
- * presentation (e.g. external/secondary displays per ADR-015), revert the
- * #558 overlay-removal commit and port this file's overlay branch back from
- * Monado upstream.
  */
 
 #include "xrt/xrt_compiler.h"

--- a/src/xrt/ipc/CMakeLists.txt
+++ b/src/xrt/ipc/CMakeLists.txt
@@ -163,6 +163,10 @@ if(ANDROID)
 	target_sources(
 		ipc_server PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/server/ipc_server_mainloop_android.c
 		)
+	# ipc_server_per_client_thread.c tears down the #558 service overlay on the
+	# last client disconnect — it calls aux_android directly, so link it here
+	# (ipc_shared links it PRIVATE, which doesn't propagate to ipc_server).
+	target_link_libraries(ipc_server PRIVATE aux_android)
 	target_link_libraries(
 		ipc_shared
 		PUBLIC ${ANDROID_LIBRARY}

--- a/src/xrt/ipc/CMakeLists.txt
+++ b/src/xrt/ipc/CMakeLists.txt
@@ -163,10 +163,6 @@ if(ANDROID)
 	target_sources(
 		ipc_server PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/server/ipc_server_mainloop_android.c
 		)
-	# ipc_server_per_client_thread.c tears down the #558 service overlay on the
-	# last client disconnect — it calls aux_android directly, so link it here
-	# (ipc_shared links it PRIVATE, which doesn't propagate to ipc_server).
-	target_link_libraries(ipc_server PRIVATE aux_android)
 	target_link_libraries(
 		ipc_shared
 		PUBLIC ${ANDROID_LIBRARY}

--- a/src/xrt/ipc/android/src/main/aidl/org/freedesktop/monado/ipc/IMonado.aidl
+++ b/src/xrt/ipc/android/src/main/aidl/org/freedesktop/monado/ipc/IMonado.aidl
@@ -20,12 +20,13 @@ interface IMonado {
 
     /*!
      * Provide the surface we inject into the activity, back to the service.
-     *
-     * The client always owns the surface. The Monado-era canDrawOverOtherApps()
-     * query (service-side SYSTEM_ALERT_WINDOW overlay mode) was removed with
-     * #558 — revert that commit to revive it.
      */
     void passAppSurface(in Surface surface);
+
+    /*!
+     * Asking service whether it has the capbility to draw over other apps or not.
+     */
+    boolean canDrawOverOtherApps();
 
     /*!
      * Tell the service the previously passed app surface was destroyed (e.g. the

--- a/src/xrt/ipc/android/src/main/java/org/freedesktop/monado/ipc/Client.java
+++ b/src/xrt/ipc/android/src/main/java/org/freedesktop/monado/ipc/Client.java
@@ -177,22 +177,19 @@ public class Client implements ServiceConnection {
                                 activity = (Activity) context_;
                             }
 
-                            // The client ALWAYS owns the surface: it attaches a view to its
-                            // own activity and passes the Surface to the service (#510/#528).
-                            // The Monado-era alternative — skip this when the service holds
-                            // SYSTEM_ALERT_WINDOW and draws its own overlay — was removed with
-                            // #558 (comp_window_android never ported the overlay path, so a
-                            // granted permission only produced a black screen). Revert the
-                            // #558 overlay-removal commit to revive it.
-                            if (activity != null) {
-                                Surface surface = attachViewAndGetSurface(activity);
-                                if (surface == null) {
-                                    Log.e(TAG, "Failed to create surface");
-                                    handleFailure();
-                                    return;
-                                }
+                            try {
+                                if (!monado.canDrawOverOtherApps() && activity != null) {
+                                    Surface surface = attachViewAndGetSurface(activity);
+                                    if (surface == null) {
+                                        Log.e(TAG, "Failed to create surface");
+                                        handleFailure();
+                                        return;
+                                    }
 
-                                sendSurfaceIfNew(surface);
+                                    sendSurfaceIfNew(surface);
+                                }
+                            } catch (RemoteException e) {
+                                e.printStackTrace();
                             }
 
                             if (activity != null) {

--- a/src/xrt/ipc/android/src/main/java/org/freedesktop/monado/ipc/MonadoImpl.java
+++ b/src/xrt/ipc/android/src/main/java/org/freedesktop/monado/ipc/MonadoImpl.java
@@ -12,6 +12,7 @@ package org.freedesktop.monado.ipc;
 import android.content.Context;
 import android.os.ParcelFileDescriptor;
 import android.os.RemoteException;
+import android.provider.Settings;
 import android.util.Log;
 import android.view.Surface;
 import androidx.annotation.Keep;
@@ -38,7 +39,10 @@ public class MonadoImpl extends IMonado.Stub {
         System.loadLibrary(BuildConfig.SERVICE_LIB_NAME);
     }
 
+    private final Context context;
+
     public MonadoImpl(@NonNull Context context) {
+        this.context = context.getApplicationContext();
         // #510: hand the native side the *original* context (the Service), not the
         // application context. A vendor display-processor plug-in run out-of-process
         // (Leia CNSDK) calls Context#getApplication() during init — that method exists
@@ -80,6 +84,12 @@ public class MonadoImpl extends IMonado.Stub {
             return;
         }
         nativeAppSurface(surface);
+    }
+
+    @Override
+    public boolean canDrawOverOtherApps() {
+        Log.i(TAG, "canDrawOverOtherApps");
+        return Settings.canDrawOverlays(context);
     }
 
     @Override

--- a/src/xrt/ipc/android/src/main/java/org/freedesktop/monado/ipc/MonadoImpl.java
+++ b/src/xrt/ipc/android/src/main/java/org/freedesktop/monado/ipc/MonadoImpl.java
@@ -56,6 +56,15 @@ public class MonadoImpl extends IMonado.Stub {
     public void connect(@NonNull ParcelFileDescriptor parcelFileDescriptor) throws RemoteException {
         int fd = parcelFileDescriptor.getFd();
         Log.i(TAG, "connect: given fd " + fd);
+        // Service-owned overlay (#558 revival, P1): when we hold the
+        // "display over other apps" permission the client skips publishing its
+        // surface, so create our own TYPE_APPLICATION_OVERLAY before the
+        // compositor (started by nativeAddClient) begins polling for a surface.
+        // Idempotent native-side, so repeated connects are safe.
+        if (Settings.canDrawOverlays(context)) {
+            Log.i(TAG, "connect: overlay permission held — creating service overlay");
+            nativeCreateServiceOverlay();
+        }
         if (nativeAddClient(fd) != 0) {
             Log.e(TAG, "Failed to transfer client fd ownership!");
             try {
@@ -127,6 +136,16 @@ public class MonadoImpl extends IMonado.Stub {
      */
     @SuppressWarnings("JavaJniMissingFunction")
     private native void nativeAppSurface(@NonNull Surface surface);
+
+    /**
+     * Native creation of the service-owned TYPE_APPLICATION_OVERLAY surface (#558 revival). Called
+     * on connect when the runtime holds the "display over other apps" permission, so the weave
+     * floats over the live launcher instead of a full-screen client Activity. Idempotent.
+     *
+     * <p>Implementation in `src/xrt/targets/service-lib/service_target.cpp`.
+     */
+    @SuppressWarnings("JavaJniMissingFunction")
+    private native void nativeCreateServiceOverlay();
 
     /**
      * Native handling of the client's surface being destroyed (background → file picker etc.):

--- a/src/xrt/ipc/android/src/main/java/org/freedesktop/monado/ipc/MonadoImpl.java
+++ b/src/xrt/ipc/android/src/main/java/org/freedesktop/monado/ipc/MonadoImpl.java
@@ -109,6 +109,11 @@ public class MonadoImpl extends IMonado.Stub {
 
     public void shutdown() {
         Log.i(TAG, "shutdown");
+        // #558: authoritatively tear down the service-owned overlay before the
+        // server stops, so its last weaved frame doesn't linger frozen on the
+        // launcher when the service is destroyed. Idempotent + no-op when there's
+        // no overlay (non-overlay sessions).
+        nativeDestroyServiceOverlay();
         nativeShutdownServer();
     }
 
@@ -146,6 +151,14 @@ public class MonadoImpl extends IMonado.Stub {
      */
     @SuppressWarnings("JavaJniMissingFunction")
     private native void nativeCreateServiceOverlay();
+
+    /**
+     * Destroy the service-owned overlay (#558). Called from {@link #shutdown()} when
+     * the runtime service is going away, so the overlay's last frame doesn't linger
+     * frozen on the launcher. Idempotent.
+     */
+    @SuppressWarnings("JavaJniMissingFunction")
+    private native void nativeDestroyServiceOverlay();
 
     /**
      * Native handling of the client's surface being destroyed (background → file picker etc.):

--- a/src/xrt/ipc/android/src/main/java/org/freedesktop/monado/ipc/MonadoService.kt
+++ b/src/xrt/ipc/android/src/main/java/org/freedesktop/monado/ipc/MonadoService.kt
@@ -38,10 +38,9 @@ class MonadoService : Service(), Watchdog.ShutdownListener {
         binder = MonadoImpl(this)
         watchdog =
             Watchdog(
-                // The surface always comes from the client (#558 removed the service-side
-                // overlay mode), so stop the service as soon as the client disconnects —
-                // the surface belongs to the client.
-                0,
+                // If the surface comes from client, just stop the service when client disconnected
+                // because the surface belongs to the client.
+                if (binder.canDrawOverOtherApps()) BuildConfig.WATCHDOG_TIMEOUT_MILLISECONDS else 0,
                 this,
             )
         watchdog.startMonitor()

--- a/src/xrt/ipc/server/ipc_server_per_client_thread.c
+++ b/src/xrt/ipc/server/ipc_server_per_client_thread.c
@@ -22,11 +22,6 @@
 #include "d3d11_service/comp_d3d11_service.h"
 #endif
 
-#ifdef XRT_OS_ANDROID
-#include "android/android_globals.h"
-#include "android/android_custom_surface.h"
-#endif
-
 #ifndef XRT_OS_WINDOWS
 
 #include <unistd.h>
@@ -200,29 +195,11 @@ common_shutdown(volatile struct ipc_client_state *ics)
 #endif
 		}
 	}
-
-#ifdef XRT_OS_ANDROID
-	// #558 service overlay: when the LAST client disconnects (e.g. the avatar's
-	// task is swiped away from recents), tear down the service-owned
-	// TYPE_APPLICATION_OVERLAY so its last weaved frame clears off the launcher
-	// instead of lingering frozen on top. The overlay was kept process-wide for
-	// reuse across client restarts, but that persisted surface also stalls a
-	// reconnecting client (the stale-overlay stall, #558) — destroying it on the
-	// last disconnect fixes both; the next client recreates a fresh overlay.
-	// connected_client_count was decremented above (read here lock-free, like the
-	// exit_when_idle check). Clear the globals BEFORE destroying so a racing
-	// reconnect recreates rather than grabbing a half-torn surface.
-	if (ics->server->global_state.connected_client_count == 0) {
-		struct android_custom_surface *cs =
-		    (struct android_custom_surface *)android_globals_get_custom_surface();
-		if (cs != NULL) {
-			IPC_WARN(ics->server, "Last client disconnected — tearing down service overlay (#558)");
-			android_globals_set_custom_surface(NULL);
-			android_globals_clear_window();
-			android_custom_surface_destroy(&cs);
-		}
-	}
-#endif
+	// #558 service-overlay teardown is NOT done here: tearing it down on the IPC
+	// client thread races the Android service-shutdown lifecycle and posts an
+	// async removeView to a dying MainLooper, leaving a frozen frame. It's handled
+	// authoritatively from MonadoImpl.shutdown() (← MonadoService.onDestroy, on the
+	// main thread) via nativeDestroyServiceOverlay() instead.
 }
 
 

--- a/src/xrt/ipc/server/ipc_server_per_client_thread.c
+++ b/src/xrt/ipc/server/ipc_server_per_client_thread.c
@@ -22,6 +22,11 @@
 #include "d3d11_service/comp_d3d11_service.h"
 #endif
 
+#ifdef XRT_OS_ANDROID
+#include "android/android_globals.h"
+#include "android/android_custom_surface.h"
+#endif
+
 #ifndef XRT_OS_WINDOWS
 
 #include <unistd.h>
@@ -195,6 +200,29 @@ common_shutdown(volatile struct ipc_client_state *ics)
 #endif
 		}
 	}
+
+#ifdef XRT_OS_ANDROID
+	// #558 service overlay: when the LAST client disconnects (e.g. the avatar's
+	// task is swiped away from recents), tear down the service-owned
+	// TYPE_APPLICATION_OVERLAY so its last weaved frame clears off the launcher
+	// instead of lingering frozen on top. The overlay was kept process-wide for
+	// reuse across client restarts, but that persisted surface also stalls a
+	// reconnecting client (the stale-overlay stall, #558) — destroying it on the
+	// last disconnect fixes both; the next client recreates a fresh overlay.
+	// connected_client_count was decremented above (read here lock-free, like the
+	// exit_when_idle check). Clear the globals BEFORE destroying so a racing
+	// reconnect recreates rather than grabbing a half-torn surface.
+	if (ics->server->global_state.connected_client_count == 0) {
+		struct android_custom_surface *cs =
+		    (struct android_custom_surface *)android_globals_get_custom_surface();
+		if (cs != NULL) {
+			IPC_WARN(ics->server, "Last client disconnected — tearing down service overlay (#558)");
+			android_globals_set_custom_surface(NULL);
+			android_globals_clear_window();
+			android_custom_surface_destroy(&cs);
+		}
+	}
+#endif
 }
 
 

--- a/src/xrt/state_trackers/oxr/oxr_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_session.c
@@ -29,6 +29,7 @@
 #ifdef XRT_OS_ANDROID
 #include "android/android_globals.h"
 #include "android/android_custom_surface.h"
+#include <sys/system_properties.h>
 #endif
 
 #include "os/os_time.h"
@@ -1075,8 +1076,23 @@ oxr_session_poll(struct oxr_logger *log, struct oxr_session *sess)
 		}
 	}
 
+	// #558 overlay mode: the avatar intentionally backgrounds its Activity
+	// (moveTaskToBack) so the launcher stays the interactive foreground app while
+	// the runtime weaves the tiger into a service-owned TYPE_APPLICATION_OVERLAY
+	// on top. In that mode the ON_PAUSE lifecycle must NOT stop the session — the
+	// overlay is still on-screen, so the client must keep submitting frames. Read
+	// debug.dxr.overlay once (this runs in the client process, same sysprop the
+	// avatar + comp read). When OFF, the normal pause→stopping behavior stands.
+	static int s_overlay_mode = -1;
+	if (s_overlay_mode < 0) {
+		char prop[PROP_VALUE_MAX] = {0};
+		s_overlay_mode =
+		    (__system_property_get("debug.dxr.overlay", prop) > 0 && prop[0] == '1') ? 1 : 0;
+	}
+
 	// Most recent Android activity lifecycle event was OnPause: move toward stopping
-	if (sess->sys->inst->activity_state == XRT_ANDROID_LIVECYCLE_EVENT_ON_PAUSE) {
+	if (s_overlay_mode == 0 &&
+	    sess->sys->inst->activity_state == XRT_ANDROID_LIVECYCLE_EVENT_ON_PAUSE) {
 		if (sess->state == XR_SESSION_STATE_FOCUSED) {
 			U_LOG_I("Activity paused: changing session state FOCUSED->VISIBLE");
 			oxr_session_change_state(log, sess, XR_SESSION_STATE_VISIBLE, 0);

--- a/src/xrt/targets/android_common/src/main/AndroidManifest.xml
+++ b/src/xrt/targets/android_common/src/main/AndroidManifest.xml
@@ -5,6 +5,9 @@
         SPDX-License-Identifier: BSL-1.0
     -->
 
+    <!-- For display over other apps. -->
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
+
     <!-- We may try to use OpenGL|ES 3.0 -->
     <uses-feature
         android:glEsVersion="0x00030002"

--- a/src/xrt/targets/android_common/src/main/java/org/freedesktop/monado/android_common/AboutActivity.java
+++ b/src/xrt/targets/android_common/src/main/java/org/freedesktop/monado/android_common/AboutActivity.java
@@ -10,6 +10,7 @@ package org.freedesktop.monado.android_common;
 
 import android.os.Bundle;
 import android.text.method.LinkMovementMethod;
+import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
 import androidx.appcompat.app.AppCompatActivity;
@@ -74,8 +75,12 @@ public class AboutActivity extends AppCompatActivity {
         VrModeStatus statusFrag = VrModeStatus.newInstance(status);
         fragmentTransaction.add(R.id.statusFrame, statusFrag, null);
 
-        // (The display-over-other-apps fragment that used to mount here was removed
-        // with #558 — the service-side SYSTEM_ALERT_WINDOW overlay mode is gone.)
+        if (!isInProcess) {
+            findViewById(R.id.drawOverOtherAppsFrame).setVisibility(View.VISIBLE);
+            DisplayOverOtherAppsStatusFragment drawOverFragment =
+                    new DisplayOverOtherAppsStatusFragment();
+            fragmentTransaction.replace(R.id.drawOverOtherAppsFrame, drawOverFragment, null);
+        }
 
         if (noticeFragmentProvider != null) {
             Fragment noticeFragment = noticeFragmentProvider.makeNoticeFragment();

--- a/src/xrt/targets/android_common/src/main/res/layout/activity_about.xml
+++ b/src/xrt/targets/android_common/src/main/res/layout/activity_about.xml
@@ -91,6 +91,18 @@
     </FrameLayout>
 
     <FrameLayout
+        android:id="@+id/drawOverOtherAppsFrame"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="8dp"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/statusFrame"/>
+
+    <FrameLayout
         android:id="@+id/aboutFrame"
         android:layout_width="0dp"
         android:layout_height="0dp"
@@ -100,7 +112,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/statusFrame">
+        app:layout_constraintTop_toBottomOf="@id/drawOverOtherAppsFrame">
 
         <Button
             android:id="@+id/btnAndroid"

--- a/src/xrt/targets/openxr_android/src/main/java/org/freedesktop/monado/openxr_runtime/DashboardActivity.kt
+++ b/src/xrt/targets/openxr_android/src/main/java/org/freedesktop/monado/openxr_runtime/DashboardActivity.kt
@@ -29,6 +29,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
+import org.freedesktop.monado.android_common.DisplayOverOtherAppsStatusFragment
 import org.freedesktop.monado.android_common.VrModeStatus
 import org.freedesktop.monado.auxiliary.NameAndLogoProvider
 import org.json.JSONObject
@@ -107,6 +108,7 @@ class DashboardActivity : AppCompatActivity() {
 
         if (!BuildConfig.inProcess) {
             findViewById<View>(R.id.cardLive).visibility = View.VISIBLE
+            findViewById<View>(R.id.drawOverOtherAppsFrame).visibility = View.VISIBLE
             // The service shares the activity's (default) process, so a
             // self-kill takes the whole runtime down — same behavior as the
             // legacy About screen's shutdown button.
@@ -115,12 +117,15 @@ class DashboardActivity : AppCompatActivity() {
             shutdown.setOnClickListener { Process.killProcess(Process.myPid()) }
         }
 
-        // Android status fragment (VR listener), hosted in a card frame.
-        // (The display-over-other-apps card was removed with #558 along with
-        // the service-side overlay mode it controlled.)
+        // Android status fragments — the existing android_common logic,
+        // hosted in width-constrained card frames (this IS the fix for the
+        // old corner-jammed overlay-permission UI).
         val tx = supportFragmentManager.beginTransaction()
         val status = VrModeStatus.detectStatus(this, applicationContext.applicationInfo.packageName)
         tx.replace(R.id.statusFrame, VrModeStatus.newInstance(status), null)
+        if (!BuildConfig.inProcess) {
+            tx.replace(R.id.drawOverOtherAppsFrame, DisplayOverOtherAppsStatusFragment(), null)
+        }
         tx.commit()
 
         runQuery()

--- a/src/xrt/targets/openxr_android/src/main/res/layout/activity_dashboard.xml
+++ b/src/xrt/targets/openxr_android/src/main/res/layout/activity_dashboard.xml
@@ -233,6 +233,12 @@
                     android:id="@+id/statusFrame"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content" />
+
+                <FrameLayout
+                    android:id="@+id/drawOverOtherAppsFrame"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:visibility="gone" />
             </LinearLayout>
         </com.google.android.material.card.MaterialCardView>
 

--- a/src/xrt/targets/service-lib/service_target.cpp
+++ b/src/xrt/targets/service-lib/service_target.cpp
@@ -202,7 +202,18 @@ Java_org_freedesktop_monado_ipc_MonadoImpl_nativeCreateServiceOverlay(JNIEnv *en
 	// the overlay TRANSLUCENT so the desktop shows through. Idempotent: a second
 	// client connect is a no-op while an overlay already exists.
 	if (android_globals_get_custom_surface() != nullptr) {
-		U_LOG_I("service: overlay already created — skipping");
+		// #558 stale-overlay-stall fix: the service overlay persists across client
+		// (avatar) restarts — its MonadoView + surface stay attached to the service
+		// window — but the PRIOR client's compositor released its ANativeWindow ref
+		// and the published window was left stale/invalid, so a NEW client's
+		// comp_window_android_init_swapchain stalls polling for a valid window
+		// (previously only a runtime reinstall, which kills the service, cleared it).
+		// Re-publish a fresh ANativeWindow ref from the live overlay surface for the
+		// new client instead of skipping.
+		struct android_custom_surface *cs =
+		    (struct android_custom_surface *)android_globals_get_custom_surface();
+		android_custom_surface_refresh_window(cs);
+		U_LOG_I("service: overlay reused — refreshed window for new client (#558)");
 		return;
 	}
 

--- a/src/xrt/targets/service-lib/service_target.cpp
+++ b/src/xrt/targets/service-lib/service_target.cpp
@@ -21,6 +21,7 @@
 #include <android/native_window_jni.h>
 
 #include "android/android_globals.h"
+#include "android/android_custom_surface.h"
 #include "android/android_main_thread.h"
 
 #include <chrono>
@@ -182,6 +183,56 @@ Java_org_freedesktop_monado_ipc_MonadoImpl_nativeAppSurface(JNIEnv *env, jobject
 	ANativeWindow *nativeWindow = ANativeWindow_fromSurface(env, surface);
 	android_globals_store_window((struct _ANativeWindow *)nativeWindow);
 	U_LOG_I("service: app surface published: ANativeWindow %p (#528)", (void *)nativeWindow);
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_org_freedesktop_monado_ipc_MonadoImpl_nativeCreateServiceOverlay(JNIEnv *env, jobject thiz)
+{
+	jni::init(env);
+	jni::Object monadoImpl(thiz);
+
+	// Service-owned overlay (#558 revival, P1): when the runtime holds the
+	// "display over other apps" permission the CLIENT skips publishing its
+	// surface (Client.java gate), so the SERVICE must create the on-screen
+	// surface itself. Reuse the existing C surface machinery with the SERVICE
+	// context (a non-Activity Context) — android_custom_surface picks
+	// TYPE_APPLICATION_OVERLAY for it, so the weave floats over the live
+	// launcher (launcher stays the resumed, interactive top app) rather than a
+	// full-screen client Activity that pauses it. debug.dxr.transparent makes
+	// the overlay TRANSLUCENT so the desktop shows through. Idempotent: a second
+	// client connect is a no-op while an overlay already exists.
+	if (android_globals_get_custom_surface() != nullptr) {
+		U_LOG_I("service: overlay already created — skipping");
+		return;
+	}
+
+	struct _JavaVM *vm = android_globals_get_vm();
+	void *context = android_globals_get_context();
+	if (vm == nullptr || context == nullptr) {
+		U_LOG_E("service: cannot create overlay — vm=%p context=%p", (void *)vm, context);
+		return;
+	}
+
+	struct android_custom_surface *cs =
+	    android_custom_surface_async_start(vm, context, /*display_id*/ 0, "DisplayXR",
+	                                       /*preferred_display_mode_id*/ 0);
+	if (cs == nullptr) {
+		U_LOG_E("service: android_custom_surface_async_start failed (overlay mode)");
+		return;
+	}
+
+	ANativeWindow *win = android_custom_surface_wait_get_surface(cs, /*timeout_ms*/ 5000);
+	if (win == nullptr) {
+		U_LOG_E("service: overlay surfaceCreated never fired within 5 s");
+		android_custom_surface_destroy(&cs);
+		return;
+	}
+
+	android_globals_store_window((struct _ANativeWindow *)win);
+	// Keep the custom surface alive + discoverable (process-scoped, like the
+	// in-process path) so the surface stays published for the compositor.
+	android_globals_set_custom_surface(cs);
+	U_LOG_I("service: TYPE_APPLICATION_OVERLAY created, ANativeWindow %p (#558 P1)", (void *)win);
 }
 
 extern "C" JNIEXPORT void JNICALL

--- a/src/xrt/targets/service-lib/service_target.cpp
+++ b/src/xrt/targets/service-lib/service_target.cpp
@@ -246,6 +246,28 @@ Java_org_freedesktop_monado_ipc_MonadoImpl_nativeCreateServiceOverlay(JNIEnv *en
 	U_LOG_I("service: TYPE_APPLICATION_OVERLAY created, ANativeWindow %p (#558 P1)", (void *)win);
 }
 
+// #558: authoritative teardown of the service-owned overlay, called from
+// MonadoImpl.shutdown() (← MonadoService.onDestroy) when the runtime service is
+// going away. Runs on the service main thread (JNI-attached), so it reliably
+// removes the MonadoView even when the IPC last-client-disconnect teardown races
+// the Android service-shutdown lifecycle (onUnbind/onPrepareShutdown), which on
+// some ROMs orphaned the overlay and left a frozen frame on the launcher.
+// Idempotent: a no-op once the surface is gone (e.g. the IPC path got there first).
+extern "C" JNIEXPORT void JNICALL
+Java_org_freedesktop_monado_ipc_MonadoImpl_nativeDestroyServiceOverlay(JNIEnv *env, jobject thiz)
+{
+	jni::init(env);
+	struct android_custom_surface *cs =
+	    (struct android_custom_surface *)android_globals_get_custom_surface();
+	if (cs == nullptr) {
+		return;
+	}
+	android_globals_set_custom_surface(nullptr);
+	android_globals_clear_window();
+	android_custom_surface_destroy(&cs);
+	U_LOG_I("service: TYPE_APPLICATION_OVERLAY destroyed on shutdown (#558)");
+}
+
 extern "C" JNIEXPORT void JNICALL
 Java_org_freedesktop_monado_ipc_MonadoImpl_nativeClearAppSurface(JNIEnv *env, jobject thiz)
 {


### PR DESCRIPTION
## What

Runtime support for the **#558 service-owned Android overlay**: a 3D, head-tracked
avatar weaved into a service-owned `TYPE_APPLICATION_OVERLAY` that floats over the
**live, interactive launcher** (and over other 3D apps).

Branch history (P0–P3): restore the SYSTEM_ALERT_WINDOW overlay scaffolding, create
the service-owned overlay surface, keep the OOP session running while the client
Activity is backgrounded (`oxr_session.c` ON_PAUSE gate on `debug.dxr.overlay`),
pass touches through (`FLAG_NOT_TOUCHABLE`), and full-opacity weave.

## This PR's final commit — clean teardown on last-client disconnect

When the **last** IPC client disconnects (e.g. the avatar's task is swiped away),
`common_shutdown` now destroys the service overlay so its last weaved frame clears
off the launcher instead of lingering frozen. This **also** fixes the stale-overlay
reconnect stall: the overlay was kept process-wide for reuse, but a reconnecting
client would stall reusing it — destroying it on the last disconnect means the next
client recreates a fresh surface.

- Guarded `XRT_OS_ANDROID` + `connected_client_count == 0`.
- No-op for non-overlay clients (cube etc.) — they create no custom surface.
- `ipc_server` now links `aux_android` (it calls `android_custom_surface_*`).

## Test (NP02J, David-verified)

Tiger renders head-tracked 3D over the live launcher; draggable; bubble follows;
composites over another 3D app; overlay clears cleanly on quit. Pairs with
`displayxr-demo-avatar#…` (avatar side) and `displayxr-leia-plugin` branch
`feat/android-overlay-3d-558` (keep-3D-while-backgrounded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)