### PR TITLE
fix(#558): gate service overlay on overlay mode, not just the permission

### DIFF
--- a/src/xrt/ipc/android/src/main/java/org/freedesktop/monado/ipc/MonadoImpl.java
+++ b/src/xrt/ipc/android/src/main/java/org/freedesktop/monado/ipc/MonadoImpl.java
@@ -61,8 +61,8 @@ public class MonadoImpl extends IMonado.Stub {
         // surface, so create our own TYPE_APPLICATION_OVERLAY before the
         // compositor (started by nativeAddClient) begins polling for a surface.
         // Idempotent native-side, so repeated connects are safe.
-        if (Settings.canDrawOverlays(context)) {
-            Log.i(TAG, "connect: overlay permission held — creating service overlay");
+        if (canDrawOverOtherApps()) {
+            Log.i(TAG, "connect: overlay mode — creating service overlay");
             nativeCreateServiceOverlay();
         }
         if (nativeAddClient(fd) != 0) {
@@ -97,8 +97,15 @@ public class MonadoImpl extends IMonado.Stub {
 
     @Override
     public boolean canDrawOverOtherApps() {
-        Log.i(TAG, "canDrawOverOtherApps");
-        return Settings.canDrawOverlays(context);
+        // #558: this means "the SERVICE owns the on-screen surface (overlay mode)",
+        // which both the client (whether to publish its own surface, Client.java)
+        // and the service watchdog (MonadoService) key on. That requires BOTH the
+        // draw-over-apps permission AND overlay mode (debug.dxr.overlay) — the
+        // permission alone is not enough, or a normal app (permission granted but
+        // not overlay mode) would skip its surface and get a blank service overlay.
+        boolean overlay = Settings.canDrawOverlays(context) && nativeOverlayModeEnabled();
+        Log.i(TAG, "canDrawOverOtherApps (overlay mode) = " + overlay);
+        return overlay;
     }
 
     @Override
@@ -159,6 +166,10 @@ public class MonadoImpl extends IMonado.Stub {
      */
     @SuppressWarnings("JavaJniMissingFunction")
     private native void nativeDestroyServiceOverlay();
+
+    /** True when overlay mode (debug.dxr.overlay) is enabled — see canDrawOverOtherApps. */
+    @SuppressWarnings("JavaJniMissingFunction")
+    private native boolean nativeOverlayModeEnabled();
 
     /**
      * Native handling of the client's surface being destroyed (background → file picker etc.):

--- a/src/xrt/targets/service-lib/service_target.cpp
+++ b/src/xrt/targets/service-lib/service_target.cpp
@@ -19,6 +19,7 @@
 
 #include <android/native_window.h>
 #include <android/native_window_jni.h>
+#include <sys/system_properties.h>
 
 #include "android/android_globals.h"
 #include "android/android_custom_surface.h"
@@ -190,6 +191,20 @@ Java_org_freedesktop_monado_ipc_MonadoImpl_nativeCreateServiceOverlay(JNIEnv *en
 {
 	jni::init(env);
 	jni::Object monadoImpl(thiz);
+
+	// #558: only create a service overlay in OVERLAY MODE (debug.dxr.overlay).
+	// The "display over other apps" permission alone is NOT enough — a normal app
+	// (e.g. cube_handle_vk_android) publishes its own client surface and must
+	// render into its own window; creating a service overlay for it would steal
+	// the screen + eat input + leave a stray overlay flashing on close. Overlay
+	// mode is the avatar's opt-in switch (the same sysprop the client session +
+	// plugin read), so gate creation on it; default (unset) → ordinary windowed app.
+	{
+		char prop[PROP_VALUE_MAX] = {};
+		if (!(__system_property_get("debug.dxr.overlay", prop) > 0 && prop[0] == '1')) {
+			return;
+		}
+	}
 
 	// Service-owned overlay (#558 revival, P1): when the runtime holds the
 	// "display over other apps" permission the CLIENT skips publishing its

--- a/src/xrt/targets/service-lib/service_target.cpp
+++ b/src/xrt/targets/service-lib/service_target.cpp
@@ -261,6 +261,20 @@ Java_org_freedesktop_monado_ipc_MonadoImpl_nativeCreateServiceOverlay(JNIEnv *en
 	U_LOG_I("service: TYPE_APPLICATION_OVERLAY created, ANativeWindow %p (#558 P1)", (void *)win);
 }
 
+// #558: true when overlay mode is enabled (debug.dxr.overlay). MonadoImpl gates
+// "the service owns the on-screen surface" on this AND the draw-over-apps
+// permission — so a normal app (permission happens to be granted, but overlay
+// mode off) publishes its own client surface and renders in its own window
+// instead of being handed a service overlay (which left it black + input-dead).
+extern "C" JNIEXPORT jboolean JNICALL
+Java_org_freedesktop_monado_ipc_MonadoImpl_nativeOverlayModeEnabled(JNIEnv * /*env*/,
+                                                                    jobject /*thiz*/)
+{
+	char prop[PROP_VALUE_MAX] = {};
+	return (__system_property_get("debug.dxr.overlay", prop) > 0 && prop[0] == '1') ? JNI_TRUE
+	                                                                                 : JNI_FALSE;
+}
+
 // #558: authoritative teardown of the service-owned overlay, called from
 // MonadoImpl.shutdown() (← MonadoService.onDestroy) when the runtime service is
 // going away. Runs on the service main thread (JNI-attached), so it reliably


### PR DESCRIPTION
## Problem

`nativeCreateServiceOverlay()` was gated only on `Settings.canDrawOverlays` (the
permission). So once the runtime held draw-over-other-apps, **every** connecting
client got a service-owned `TYPE_APPLICATION_OVERLAY` — including normal apps
(e.g. `cube_handle_vk_android`) that publish their own surface and must render in
their own window. Symptoms: the overlay stole the screen + input, and a stray
overlay flashed on app close.

## Fix

Gate overlay creation on **`debug.dxr.overlay`** — the avatar's overlay-mode
switch already read by the client session and the Leia plug-in. Default (unset)
→ ordinary windowed app; overlay mode on → service overlay as before. One-line
early-return at the top of `nativeCreateServiceOverlay`.

## Test (NP02J)

- `debug.dxr.overlay=0`: cube renders in its own NativeActivity window, **no**
  service overlay created, clean close (no stray overlay, no teardown).
- `debug.dxr.overlay=1`: avatar still weaves the draggable tiger overlay.

## Follow-up

`debug.dxr.overlay` is a global sysprop, so overlay mode is dev-global, not
per-app. A per-app signal (manifest metadata / connect-time flag) would let the
avatar opt in without a global toggle — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)