### PR TITLE
refactor(#396): unify legacy/hosted (qwerty) rig onto canonical rig + converters

### DIFF
--- a/src/xrt/auxiliary/math/CMakeLists.txt
+++ b/src/xrt/auxiliary/math/CMakeLists.txt
@@ -20,7 +20,7 @@ set(DISPLAYXR_XRT_INCLUDE_DIR "${_dxr_xrt_includes}" CACHE PATH "" FORCE)
 FetchContent_Declare(
 	displayxr_common
 	GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
-	GIT_TAG v1.0.2
+	GIT_TAG v1.0.4
 	GIT_SHALLOW TRUE
 	)
 FetchContent_MakeAvailable(displayxr_common)

--- a/src/xrt/auxiliary/util/u_hud.c
+++ b/src/xrt/auxiliary/util/u_hud.c
@@ -636,26 +636,26 @@ u_hud_update(struct u_hud *hud, const struct u_hud_data *data)
 	{
 		if (data->camera_mode) {
 			snprintf(buf, sizeof(buf), "Camera [P]  IPD/Prlx:%.3f [Sh+Wh]",
-			         data->cam_spread_factor);
+			         data->ipd_factor);
 			draw_string_aa(hud, x, y, buf, COLOR_VALUE);
 			y += lh;
 
-			float vfov_deg = 2.0f * atanf(data->cam_half_tan_vfov) * 180.0f / 3.14159265f;
+			float vfov_deg = 2.0f * atanf(data->half_tan_vfov) * 180.0f / 3.14159265f;
 			float derived_persp = 1.0f;
-			if (data->nominal_viewer_z > 0.0f && data->cam_half_tan_vfov > 0.0f) {
+			if (data->nominal_viewer_z > 0.0f && data->half_tan_vfov > 0.0f) {
 				derived_persp = data->screen_height_m /
-				                (2.0f * data->nominal_viewer_z * data->cam_half_tan_vfov);
+				                (2.0f * data->nominal_viewer_z * data->half_tan_vfov);
 			}
-			snprintf(buf, sizeof(buf), "Conv:%.2f dp [Wh]  vFOV:%.1f  Persp*:%.2f",
-			         data->cam_convergence, vfov_deg, derived_persp);
+			snprintf(buf, sizeof(buf), "Conv:%.2f dp [Wh]  vFOV:%.1f  Persp*:%.2f  m2v:%.2f",
+			         data->inv_convergence_distance, vfov_deg, derived_persp, data->m2v);
 		} else {
 			snprintf(buf, sizeof(buf), "Display [P]  IPD/Prlx:%.3f [Sh+Wh]",
-			         data->disp_spread_factor);
+			         data->ipd_factor);
 			draw_string_aa(hud, x, y, buf, COLOR_VALUE);
 			y += lh;
 
-			snprintf(buf, sizeof(buf), "vH:%.2fm [Wh]",
-			         data->disp_vHeight);
+			snprintf(buf, sizeof(buf), "vH:%.2fm [Wh]  Persp:%.2f",
+			         data->virtual_display_height, data->perspective_factor);
 		}
 		draw_string_aa(hud, x, y, buf, COLOR_VALUE);
 		y += lh;

--- a/src/xrt/auxiliary/util/u_hud.h
+++ b/src/xrt/auxiliary/util/u_hud.h
@@ -71,15 +71,17 @@ struct u_hud_data
 	float vdisp_x, vdisp_y, vdisp_z;               //!< Virtual display position (m)
 	float forward_x, forward_y, forward_z;         //!< Head forward direction
 
-	// Stereo controls (dual camera/display state)
-	bool camera_mode;                //!< true=camera, false=display
-	float cam_spread_factor;            //!< Camera: IPD factor [0.01,1]
-	float cam_parallax_factor;       //!< Camera: parallax factor [0.01,1]
-	float cam_convergence;           //!< Camera: convergence in diopters [0,2]
-	float cam_half_tan_vfov;         //!< Camera: half_tan_vfov (derived)
-	float disp_spread_factor;           //!< Display: IPD factor [0.01,1]
-	float disp_parallax_factor;      //!< Display: parallax factor [0.01,1]
-	float disp_vHeight;              //!< Display: virtual display height (m) [0.1,10]
+	// Single active view rig (unified shape; matches qwerty_view_state). The
+	// dual camera/display carrier set was retired — camera_mode selects which
+	// type-specific fields are meaningful.
+	bool camera_mode;                //!< true=camera rig active, false=display rig active
+	float ipd_factor;                //!< IPD factor [0.01,1] (shared)
+	float parallax_factor;           //!< parallax factor [0.01,1] (shared)
+	float inv_convergence_distance;  //!< Camera: 1/world-units convergence [0,2]
+	float half_tan_vfov;             //!< Camera: tan(vFOV/2) (derived)
+	float m2v;                       //!< Camera: meters→world scale
+	float virtual_display_height;    //!< Display: virtual display height [0.1,10]
+	float perspective_factor;        //!< Display: perspective factor
 	float nominal_viewer_z;          //!< Hardware: nominal viewer distance (m)
 	float screen_height_m;           //!< Hardware: screen height (m)
 

--- a/src/xrt/compositor/d3d11/comp_d3d11_compositor.cpp
+++ b/src/xrt/compositor/d3d11/comp_d3d11_compositor.cpp
@@ -996,13 +996,13 @@ d3d11_render_hud_overlay(struct comp_d3d11_compositor *c, bool weaving_done,
 		struct qwerty_view_state ss;
 		if (qwerty_get_view_state(c->xsysd->xdevs, c->xsysd->xdev_count, &ss)) {
 			data.camera_mode = ss.camera_mode;
-			data.cam_spread_factor = ss.cam_spread_factor;
-			data.cam_parallax_factor = ss.cam_parallax_factor;
-			data.cam_convergence = ss.cam_convergence;
-			data.cam_half_tan_vfov = ss.cam_half_tan_vfov;
-			data.disp_spread_factor = ss.disp_spread_factor;
-			data.disp_parallax_factor = ss.disp_parallax_factor;
-			data.disp_vHeight = ss.disp_vHeight;
+			data.ipd_factor = ss.ipd_factor;
+			data.parallax_factor = ss.parallax_factor;
+			data.inv_convergence_distance = ss.inv_convergence_distance;
+			data.half_tan_vfov = ss.half_tan_vfov;
+			data.m2v = ss.m2v;
+			data.virtual_display_height = ss.virtual_display_height;
+			data.perspective_factor = ss.perspective_factor;
 			data.nominal_viewer_z = ss.nominal_viewer_z;
 			data.screen_height_m = ss.screen_height_m;
 		}

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -4274,13 +4274,13 @@ d3d11_service_render_hud(struct d3d11_service_system *sys,
 		struct qwerty_view_state ss;
 		if (qwerty_get_view_state(sys->xsysd->xdevs, sys->xsysd->xdev_count, &ss)) {
 			data.camera_mode = ss.camera_mode;
-			data.cam_spread_factor = ss.cam_spread_factor;
-			data.cam_parallax_factor = ss.cam_parallax_factor;
-			data.cam_convergence = ss.cam_convergence;
-			data.cam_half_tan_vfov = ss.cam_half_tan_vfov;
-			data.disp_spread_factor = ss.disp_spread_factor;
-			data.disp_parallax_factor = ss.disp_parallax_factor;
-			data.disp_vHeight = ss.disp_vHeight;
+			data.ipd_factor = ss.ipd_factor;
+			data.parallax_factor = ss.parallax_factor;
+			data.inv_convergence_distance = ss.inv_convergence_distance;
+			data.half_tan_vfov = ss.half_tan_vfov;
+			data.m2v = ss.m2v;
+			data.virtual_display_height = ss.virtual_display_height;
+			data.perspective_factor = ss.perspective_factor;
 			data.nominal_viewer_z = ss.nominal_viewer_z;
 			data.screen_height_m = ss.screen_height_m;
 		}

--- a/src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp
+++ b/src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp
@@ -899,13 +899,13 @@ d3d12_render_hud_overlay(struct comp_d3d12_compositor *c,
 		struct qwerty_view_state ss;
 		if (qwerty_get_view_state(c->xsysd->xdevs, c->xsysd->xdev_count, &ss)) {
 			data.camera_mode = ss.camera_mode;
-			data.cam_spread_factor = ss.cam_spread_factor;
-			data.cam_parallax_factor = ss.cam_parallax_factor;
-			data.cam_convergence = ss.cam_convergence;
-			data.cam_half_tan_vfov = ss.cam_half_tan_vfov;
-			data.disp_spread_factor = ss.disp_spread_factor;
-			data.disp_parallax_factor = ss.disp_parallax_factor;
-			data.disp_vHeight = ss.disp_vHeight;
+			data.ipd_factor = ss.ipd_factor;
+			data.parallax_factor = ss.parallax_factor;
+			data.inv_convergence_distance = ss.inv_convergence_distance;
+			data.half_tan_vfov = ss.half_tan_vfov;
+			data.m2v = ss.m2v;
+			data.virtual_display_height = ss.virtual_display_height;
+			data.perspective_factor = ss.perspective_factor;
 			data.nominal_viewer_z = ss.nominal_viewer_z;
 			data.screen_height_m = ss.screen_height_m;
 		}

--- a/src/xrt/compositor/gl/comp_gl_compositor.cpp
+++ b/src/xrt/compositor/gl/comp_gl_compositor.cpp
@@ -1555,13 +1555,13 @@ gl_compositor_render_hud(struct comp_gl_compositor *c, float dt, uint32_t win_w,
 		struct qwerty_view_state ss;
 		if (qwerty_get_view_state(c->xsysd->xdevs, c->xsysd->xdev_count, &ss)) {
 			data.camera_mode = ss.camera_mode;
-			data.cam_spread_factor = ss.cam_spread_factor;
-			data.cam_parallax_factor = ss.cam_parallax_factor;
-			data.cam_convergence = ss.cam_convergence;
-			data.cam_half_tan_vfov = ss.cam_half_tan_vfov;
-			data.disp_spread_factor = ss.disp_spread_factor;
-			data.disp_parallax_factor = ss.disp_parallax_factor;
-			data.disp_vHeight = ss.disp_vHeight;
+			data.ipd_factor = ss.ipd_factor;
+			data.parallax_factor = ss.parallax_factor;
+			data.inv_convergence_distance = ss.inv_convergence_distance;
+			data.half_tan_vfov = ss.half_tan_vfov;
+			data.m2v = ss.m2v;
+			data.virtual_display_height = ss.virtual_display_height;
+			data.perspective_factor = ss.perspective_factor;
 			data.nominal_viewer_z = ss.nominal_viewer_z;
 			data.screen_height_m = ss.screen_height_m;
 		}

--- a/src/xrt/compositor/metal/comp_metal_compositor.m
+++ b/src/xrt/compositor/metal/comp_metal_compositor.m
@@ -1597,13 +1597,13 @@ metal_compositor_render_hud(struct comp_metal_compositor *c, float dt,
 		struct qwerty_view_state ss;
 		if (qwerty_get_view_state(c->xsysd->xdevs, c->xsysd->xdev_count, &ss)) {
 			data.camera_mode = ss.camera_mode;
-			data.cam_spread_factor = ss.cam_spread_factor;
-			data.cam_parallax_factor = ss.cam_parallax_factor;
-			data.cam_convergence = ss.cam_convergence;
-			data.cam_half_tan_vfov = ss.cam_half_tan_vfov;
-			data.disp_spread_factor = ss.disp_spread_factor;
-			data.disp_parallax_factor = ss.disp_parallax_factor;
-			data.disp_vHeight = ss.disp_vHeight;
+			data.ipd_factor = ss.ipd_factor;
+			data.parallax_factor = ss.parallax_factor;
+			data.inv_convergence_distance = ss.inv_convergence_distance;
+			data.half_tan_vfov = ss.half_tan_vfov;
+			data.m2v = ss.m2v;
+			data.virtual_display_height = ss.virtual_display_height;
+			data.perspective_factor = ss.perspective_factor;
 			data.nominal_viewer_z = ss.nominal_viewer_z;
 			data.screen_height_m = ss.screen_height_m;
 		}

--- a/src/xrt/compositor/multi/comp_multi_system.c
+++ b/src/xrt/compositor/multi/comp_multi_system.c
@@ -2086,13 +2086,13 @@ session_render_hud_overlay(struct multi_compositor *mc,
 		struct qwerty_view_state ss;
 		if (qwerty_get_view_state(mc->xsysd->xdevs, mc->xsysd->xdev_count, &ss)) {
 			data.camera_mode = ss.camera_mode;
-			data.cam_spread_factor = ss.cam_spread_factor;
-			data.cam_parallax_factor = ss.cam_parallax_factor;
-			data.cam_convergence = ss.cam_convergence;
-			data.cam_half_tan_vfov = ss.cam_half_tan_vfov;
-			data.disp_spread_factor = ss.disp_spread_factor;
-			data.disp_parallax_factor = ss.disp_parallax_factor;
-			data.disp_vHeight = ss.disp_vHeight;
+			data.ipd_factor = ss.ipd_factor;
+			data.parallax_factor = ss.parallax_factor;
+			data.inv_convergence_distance = ss.inv_convergence_distance;
+			data.half_tan_vfov = ss.half_tan_vfov;
+			data.m2v = ss.m2v;
+			data.virtual_display_height = ss.virtual_display_height;
+			data.perspective_factor = ss.perspective_factor;
 			data.nominal_viewer_z = ss.nominal_viewer_z;
 			data.screen_height_m = ss.screen_height_m;
 		}

--- a/src/xrt/compositor/vk_native/comp_vk_native_compositor.c
+++ b/src/xrt/compositor/vk_native/comp_vk_native_compositor.c
@@ -1460,13 +1460,13 @@ vk_compositor_render_hud(struct comp_vk_native_compositor *c,
 		struct qwerty_view_state ss;
 		if (qwerty_get_view_state(c->xsysd->xdevs, c->xsysd->xdev_count, &ss)) {
 			data.camera_mode = ss.camera_mode;
-			data.cam_spread_factor = ss.cam_spread_factor;
-			data.cam_parallax_factor = ss.cam_parallax_factor;
-			data.cam_convergence = ss.cam_convergence;
-			data.cam_half_tan_vfov = ss.cam_half_tan_vfov;
-			data.disp_spread_factor = ss.disp_spread_factor;
-			data.disp_parallax_factor = ss.disp_parallax_factor;
-			data.disp_vHeight = ss.disp_vHeight;
+			data.ipd_factor = ss.ipd_factor;
+			data.parallax_factor = ss.parallax_factor;
+			data.inv_convergence_distance = ss.inv_convergence_distance;
+			data.half_tan_vfov = ss.half_tan_vfov;
+			data.m2v = ss.m2v;
+			data.virtual_display_height = ss.virtual_display_height;
+			data.perspective_factor = ss.perspective_factor;
 			data.nominal_viewer_z = ss.nominal_viewer_z;
 			data.screen_height_m = ss.screen_height_m;
 		}

--- a/src/xrt/drivers/CMakeLists.txt
+++ b/src/xrt/drivers/CMakeLists.txt
@@ -32,7 +32,10 @@ if(XRT_BUILD_DRIVER_QWERTY)
 	endif()
 
 	add_library(drv_qwerty STATIC ${QWERTY_SOURCES})
-	target_link_libraries(drv_qwerty PRIVATE xrt-interfaces aux_util)
+	# aux_math (PUBLIC displayxr::math_xrt) provides the canonical rig converters
+	# (dxr_view_rig_*) + dxr_view_math.h, used by the qwerty V-toggle to switch
+	# camera<->display with no disturbance.
+	target_link_libraries(drv_qwerty PRIVATE xrt-interfaces aux_util aux_math)
 	if(XRT_HAVE_SDL2)
 		target_link_libraries(drv_qwerty PRIVATE SDL2::SDL2)
 	endif()

--- a/src/xrt/drivers/qwerty/qwerty_device.c
+++ b/src/xrt/drivers/qwerty/qwerty_device.c
@@ -1120,6 +1120,18 @@ qwerty_toggle_camera_mode(struct qwerty_system *qs)
 
 	qs->camera_mode = !qs->camera_mode;
 
+	// The converter above set the NEW mode's params to the disturbance-free
+	// equivalent of the previous rig (so frame 0 matches the current view).
+	// Snapshot that as the animation start; qwerty_advance_rig_anim then lerps
+	// it to the new mode's DEFAULTS over QWERTY_RIG_ANIM_DUR_S (smooth, no pop).
+	qs->anim_from_convergence = qs->cam_convergence;
+	qs->anim_from_half_tan_vfov = qs->cam_half_tan_vfov;
+	qs->anim_from_m2v = qs->cam_m2v;
+	qs->anim_from_spread = qs->camera_mode ? qs->cam_spread_factor : qs->disp_spread_factor;
+	qs->anim_from_vHeight = qs->disp_vHeight;
+	qs->rig_animating = true;
+	qs->rig_anim_start_ns = os_monotonic_get_ns();
+
 	// Reset controllers to mode-appropriate default positions (attached to head)
 	if (qs->lctrl) {
 		reset_controller_for_mode(qs, qs->lctrl, true);
@@ -1128,13 +1140,14 @@ qwerty_toggle_camera_mode(struct qwerty_system *qs)
 		reset_controller_for_mode(qs, qs->rctrl, false);
 	}
 
-	U_LOG_W("Qwerty: view mode -> %s (derived from previous state)",
-	        qs->camera_mode ? "Camera" : "Display");
+	U_LOG_W("Qwerty: view mode -> %s (smooth transition to %s defaults)",
+	        qs->camera_mode ? "Camera" : "Display", qs->camera_mode ? "camera" : "display");
 }
 
 void
 qwerty_adjust_view_factor(struct qwerty_system *qs, float multiplier)
 {
+	qs->rig_animating = false; // manual adjust cancels an in-flight P-toggle transition
 	if (qs->camera_mode) {
 		float v = clampf(qs->cam_spread_factor * multiplier, 0.01f, 1.0f);
 		qs->cam_spread_factor = v;
@@ -1154,6 +1167,7 @@ qwerty_adjust_convergence(struct qwerty_system *qs, float direction)
 	if (!qs->camera_mode) {
 		return; // No-op in display mode
 	}
+	qs->rig_animating = false; // manual adjust cancels an in-flight P-toggle transition
 	qs->cam_convergence = clampf(qs->cam_convergence + direction * 0.05f, 0.0f, 2.0f);
 	U_LOG_I("Qwerty: Convergence = %.2f diopters", qs->cam_convergence);
 }
@@ -1164,6 +1178,7 @@ qwerty_adjust_vheight(struct qwerty_system *qs, float multiplier)
 	if (qs->camera_mode) {
 		return; // No-op in camera mode
 	}
+	qs->rig_animating = false; // manual adjust cancels an in-flight P-toggle transition
 	qs->disp_vHeight = clampf(qs->disp_vHeight * multiplier, 0.1f, 10.0f);
 	U_LOG_I("Qwerty: vHeight = %.2f m", qs->disp_vHeight);
 }
@@ -1183,12 +1198,49 @@ qwerty_reset_view_state(struct qwerty_system *qs)
 	qs->disp_parallax_factor = 1.0f;
 	qs->disp_vHeight = 1.3f;
 
+	qs->rig_animating = false;
+
 	if (qs->hmd != NULL) {
 		qs->hmd->base.pose.position = QWERTY_HMD_CAMERA_POS;
 		qs->hmd->base.pose.orientation = (struct xrt_quat)XRT_QUAT_IDENTITY;
 	}
 
 	U_LOG_W("Qwerty: view state reset to camera defaults");
+}
+
+// Advance the P-toggle smooth transition: lerp the active rig's tunables from
+// the per-toggle start snapshot to the active mode's DEFAULTS (smoothstep over
+// QWERTY_RIG_ANIM_DUR_S). Time-based and idempotent, so it is safe to call from
+// every qwerty_get_view_state reader within a frame.
+#define QWERTY_RIG_ANIM_DUR_S 0.4f
+static void
+qwerty_advance_rig_anim(struct qwerty_system *qs)
+{
+	if (!qs->rig_animating) {
+		return;
+	}
+	float elapsed = (float)((double)(os_monotonic_get_ns() - qs->rig_anim_start_ns) * 1e-9);
+	float t = elapsed / QWERTY_RIG_ANIM_DUR_S;
+	if (t >= 1.0f) {
+		t = 1.0f;
+	}
+	float s = t * t * (3.0f - 2.0f * t); // smoothstep
+	if (qs->camera_mode) {
+		// → camera defaults (0.5 dp convergence, 0.3249 half-tan vFOV, m2v 1, spread 1)
+		qs->cam_convergence = qs->anim_from_convergence + (0.5f - qs->anim_from_convergence) * s;
+		qs->cam_half_tan_vfov = qs->anim_from_half_tan_vfov + (0.3249f - qs->anim_from_half_tan_vfov) * s;
+		qs->cam_m2v = qs->anim_from_m2v + (1.0f - qs->anim_from_m2v) * s;
+		qs->cam_spread_factor = qs->anim_from_spread + (1.0f - qs->anim_from_spread) * s;
+		qs->cam_parallax_factor = qs->cam_spread_factor;
+	} else {
+		// → display defaults (vHeight 1.3 m, spread 1; perspective stays 1)
+		qs->disp_vHeight = qs->anim_from_vHeight + (1.3f - qs->anim_from_vHeight) * s;
+		qs->disp_spread_factor = qs->anim_from_spread + (1.0f - qs->anim_from_spread) * s;
+		qs->disp_parallax_factor = qs->disp_spread_factor;
+	}
+	if (t >= 1.0f) {
+		qs->rig_animating = false;
+	}
 }
 
 bool
@@ -1215,6 +1267,8 @@ qwerty_get_view_state(struct xrt_device **xdevs, size_t xdev_count, struct qwert
 	if (qs == NULL) {
 		return false;
 	}
+
+	qwerty_advance_rig_anim(qs); // step the P-toggle smooth transition (time-based)
 
 	// Emit the single ACTIVE rig (unified shape). Shared ipd/parallax come from
 	// the active mode's spread/parallax; the type-specific fields are carried so

--- a/src/xrt/drivers/qwerty/qwerty_device.c
+++ b/src/xrt/drivers/qwerty/qwerty_device.c
@@ -24,6 +24,8 @@
 #include "qwerty_device.h"
 #include "qwerty_interface.h"
 
+#include "dxr_view_math.h" // canonical display<->camera rig converters
+
 #include <stdio.h>
 #include <assert.h>
 
@@ -646,6 +648,7 @@ qwerty_system_create(struct qwerty_hmd *qhmd,
 	qs->cam_parallax_factor = 1.0f;
 	qs->cam_convergence = 0.5f;      // 0.5 diopters = 2m convergence
 	qs->cam_half_tan_vfov = 0.3249f; // tan(18 deg) -> 36 deg vFOV
+	qs->cam_m2v = 1.0f;              // world unit == meter for the legacy/qwerty camera
 
 	// Display-centric defaults
 	qs->disp_spread_factor = 1.0f;
@@ -1071,43 +1074,48 @@ qwerty_toggle_camera_mode(struct qwerty_system *qs)
 
 	struct xrt_pose *pose = &qs->hmd->base.pose;
 
-	// Compute forward direction from current orientation
-	struct xrt_vec3 fwd_in = {0, 0, -1};
-	struct xrt_vec3 fwd;
-	math_quat_rotate_vec3(&pose->orientation, &fwd_in, &fwd);
+	// Switch rigs through the canonical converters (displayxr::common) so the
+	// toggle is visually disturbance-free in BOTH directions. This replaces the
+	// previous hand-rolled camera->display half-conversion and, crucially, the
+	// display->camera RESET to arbitrary defaults (0.5 diopters / 36 deg vFOV).
+	// aspect is unused by the converters; nominal/screen come from the hardware.
+	dxr_rig_display_info info = {qs->screen_height_m, 1.0f, qs->nominal_viewer_z};
 
 	if (qs->camera_mode) {
-		// Camera -> Display: derive display state from camera state
-		float conv_dist = (qs->cam_convergence > 0.001f) ? (1.0f / qs->cam_convergence) : 1000.0f;
-
-		// Display position = camera position + forward * convergence_distance
-		struct xrt_vec3 disp_pos = {
-		    pose->position.x + fwd.x * conv_dist,
-		    pose->position.y + fwd.y * conv_dist,
-		    pose->position.z + fwd.z * conv_dist,
+		// Camera -> Display.
+		dxr_camera_rig cam = {
+		    .pose = {{pose->orientation.x, pose->orientation.y, pose->orientation.z, pose->orientation.w},
+		             {pose->position.x, pose->position.y, pose->position.z}},
+		    .ipd_factor = qs->cam_spread_factor,
+		    .parallax_factor = qs->cam_parallax_factor,
+		    .inv_convergence_distance = qs->cam_convergence,
+		    .half_tan_vfov = qs->cam_half_tan_vfov,
+		    .m2v = qs->cam_m2v,
 		};
-
-		// Derive vHeight from camera FOV and convergence distance
-		qs->disp_vHeight = clampf(2.0f * qs->cam_half_tan_vfov * conv_dist, 0.1f, 10.0f);
-
-		// IPD/parallax: keep current display values (independent per mode)
-
-		// Move HMD to display position
-		pose->position = disp_pos;
+		dxr_display_rig disp;
+		dxr_view_rig_camera_to_display(&cam, &info, &disp);
+		qs->disp_vHeight = clampf(disp.virtual_display_height, 0.1f, 10.0f);
+		qs->disp_spread_factor = disp.ipd_factor;
+		qs->disp_parallax_factor = disp.parallax_factor;
+		pose->position = (struct xrt_vec3){disp.pose.position.x, disp.pose.position.y, disp.pose.position.z};
 	} else {
-		// Display -> Camera: reset to camera defaults
-		float cam_distance = 2.0f; // 1 / 0.5 diopters
-		qs->cam_convergence = 0.5f;
-		qs->cam_half_tan_vfov = 0.3249f;
-
-		// Move HMD backward by default camera distance
-		struct xrt_vec3 cam_pos = {
-		    pose->position.x - fwd.x * cam_distance,
-		    pose->position.y - fwd.y * cam_distance,
-		    pose->position.z - fwd.z * cam_distance,
+		// Display -> Camera (was a reset; now a faithful conversion).
+		dxr_display_rig disp = {
+		    .pose = {{pose->orientation.x, pose->orientation.y, pose->orientation.z, pose->orientation.w},
+		             {pose->position.x, pose->position.y, pose->position.z}},
+		    .virtual_display_height = qs->disp_vHeight,
+		    .ipd_factor = qs->disp_spread_factor,
+		    .parallax_factor = qs->disp_parallax_factor,
+		    .perspective_factor = 1.0f,
 		};
-
-		pose->position = cam_pos;
+		dxr_camera_rig cam;
+		dxr_view_rig_display_to_camera(&disp, &info, &cam);
+		qs->cam_convergence = clampf(cam.inv_convergence_distance, 0.0f, 2.0f);
+		qs->cam_half_tan_vfov = cam.half_tan_vfov;
+		qs->cam_m2v = cam.m2v;
+		qs->cam_spread_factor = cam.ipd_factor;
+		qs->cam_parallax_factor = cam.parallax_factor;
+		pose->position = (struct xrt_vec3){cam.pose.position.x, cam.pose.position.y, cam.pose.position.z};
 	}
 
 	qs->camera_mode = !qs->camera_mode;
@@ -1169,6 +1177,7 @@ qwerty_reset_view_state(struct qwerty_system *qs)
 	qs->cam_parallax_factor = 1.0f;
 	qs->cam_convergence = 0.5f;
 	qs->cam_half_tan_vfov = 0.3249f;
+	qs->cam_m2v = 1.0f;
 
 	qs->disp_spread_factor = 1.0f;
 	qs->disp_parallax_factor = 1.0f;
@@ -1207,16 +1216,17 @@ qwerty_get_view_state(struct xrt_device **xdevs, size_t xdev_count, struct qwert
 		return false;
 	}
 
+	// Emit the single ACTIVE rig (unified shape). Shared ipd/parallax come from
+	// the active mode's spread/parallax; the type-specific fields are carried so
+	// the consumer can pick the relevant subset by camera_mode.
 	out->camera_mode = qs->camera_mode;
-
-	out->cam_spread_factor = qs->cam_spread_factor;
-	out->cam_parallax_factor = qs->cam_parallax_factor;
-	out->cam_convergence = qs->cam_convergence;
-	out->cam_half_tan_vfov = qs->cam_half_tan_vfov;
-
-	out->disp_spread_factor = qs->disp_spread_factor;
-	out->disp_parallax_factor = qs->disp_parallax_factor;
-	out->disp_vHeight = qs->disp_vHeight;
+	out->ipd_factor = qs->camera_mode ? qs->cam_spread_factor : qs->disp_spread_factor;
+	out->parallax_factor = qs->camera_mode ? qs->cam_parallax_factor : qs->disp_parallax_factor;
+	out->inv_convergence_distance = qs->cam_convergence;
+	out->half_tan_vfov = qs->cam_half_tan_vfov;
+	out->m2v = qs->cam_m2v;
+	out->virtual_display_height = qs->disp_vHeight;
+	out->perspective_factor = 1.0f; // qwerty display rig is always perspective 1
 
 	out->nominal_viewer_z = qs->nominal_viewer_z;
 	out->screen_height_m = qs->screen_height_m;

--- a/src/xrt/drivers/qwerty/qwerty_device.h
+++ b/src/xrt/drivers/qwerty/qwerty_device.h
@@ -62,6 +62,16 @@ struct qwerty_system
 	float disp_parallax_factor; //!< [0.01,1] default 1.0 (= disp_ipd always)
 	float disp_vHeight;         //!< [0.1,10] meters, default 1.3
 
+	// P-toggle smooth transition: on toggle, the active rig starts at the
+	// converter-equivalent of the previous rig (disturbance-free first frame)
+	// and then animates all tunables to the NEW mode's DEFAULTS over a short
+	// duration. These hold the per-toggle start snapshot + timer.
+	bool rig_animating;
+	uint64_t rig_anim_start_ns;
+	float anim_from_convergence, anim_from_half_tan_vfov, anim_from_m2v;
+	float anim_from_spread; //!< = parallax (kept equal)
+	float anim_from_vHeight;
+
 	// Hardware config (set by target builder)
 	float nominal_viewer_z; //!< meters (e.g. 0.6 from sim_display)
 	float screen_height_m;  //!< meters (e.g. 0.194 from sim_display)

--- a/src/xrt/drivers/qwerty/qwerty_device.h
+++ b/src/xrt/drivers/qwerty/qwerty_device.h
@@ -55,6 +55,7 @@ struct qwerty_system
 	float cam_parallax_factor; //!< [0.01,1] default 1.0 (= cam_ipd always)
 	float cam_convergence;     //!< [0,2] diopters, default 0.5
 	float cam_half_tan_vfov;   //!< default 0.3249 — derived only, not user-adjustable
+	float cam_m2v;             //!< meters→world scale, default 1.0 (qwerty perspective is always 1)
 
 	// Display-centric state (user adjusts when camera_mode=false)
 	float disp_spread_factor;      //!< [0.01,1] default 1.0 (= disp_parallax always)

--- a/src/xrt/drivers/qwerty/qwerty_interface.h
+++ b/src/xrt/drivers/qwerty/qwerty_interface.h
@@ -23,26 +23,27 @@ extern "C" {
 struct xrt_pose;
 
 /*!
- * Snapshot of qwerty view tuning state.
- * Each mode (camera/display) has its own independent variable set.
- * Camera mode: ipd_factor, parallax_factor, convergence, half_tan_vfov.
- * Display mode: ipd_factor, parallax_factor, vHeight (perspective always 1.0).
+ * Snapshot of the qwerty controller's SINGLE active view rig (unified shape,
+ * matching the XR_EXT_view_rig tunables). `camera_mode` selects which rig is
+ * active and therefore which type-specific fields the consumer reads:
+ * camera → inv_convergence_distance, half_tan_vfov, m2v; display →
+ * virtual_display_height, perspective_factor. ipd_factor / parallax_factor are
+ * shared. The legacy dual camera/display carrier set was retired in favor of
+ * this single active rig (the V-toggle converts between rigs via the canonical
+ * dxr_view_rig converters).
  * @ingroup drv_qwerty
  */
 struct qwerty_view_state
 {
-	bool camera_mode; //!< true=camera (default), false=display
+	bool camera_mode; //!< true=camera rig active (default), false=display rig active
 
-	// Camera-centric variables
-	float cam_spread_factor;      //!< [0.01,1] default 1.0 (= cam_parallax always)
-	float cam_parallax_factor; //!< [0.01,1] default 1.0 (= cam_ipd always)
-	float cam_convergence;     //!< [0,2] diopters, default 0.5
-	float cam_half_tan_vfov;   //!< default 0.3249 — derived only, not user-adjustable
-
-	// Display-centric variables
-	float disp_spread_factor;      //!< [0.01,1] default 1.0 (= disp_parallax always)
-	float disp_parallax_factor; //!< [0.01,1] default 1.0 (= disp_ipd always)
-	float disp_vHeight;         //!< [0.1,10] meters, default 1.3
+	float ipd_factor;               //!< [0.01,1] shared
+	float parallax_factor;          //!< [0.01,1] shared
+	float inv_convergence_distance; //!< camera: 1/world-units convergence
+	float half_tan_vfov;            //!< camera: tan(vFOV/2)
+	float m2v;                      //!< camera: meters→world scale
+	float virtual_display_height;   //!< display: app units
+	float perspective_factor;       //!< display: qwerty always 1.0
 
 	// Hardware config
 	float nominal_viewer_z; //!< meters (e.g. 0.6 from sim_display)

--- a/src/xrt/ipc/server/ipc_server_handler.c
+++ b/src/xrt/ipc/server/ipc_server_handler.c
@@ -708,10 +708,11 @@ ipc_try_get_sr_view_poses(volatile struct ipc_client_state *ics,
 			};
 		} else {
 			ct = (dxr_camera3d_tunables){
-			    .ipd_factor = stereo_state.cam_spread_factor,
-			    .parallax_factor = stereo_state.cam_parallax_factor,
-			    .inv_convergence_distance = stereo_state.cam_convergence,
-			    .half_tan_vfov = stereo_state.cam_half_tan_vfov,
+			    .ipd_factor = stereo_state.ipd_factor,
+			    .parallax_factor = stereo_state.parallax_factor,
+			    .inv_convergence_distance = stereo_state.inv_convergence_distance,
+			    .half_tan_vfov = stereo_state.half_tan_vfov,
+			    .m2v = stereo_state.m2v,
 			};
 		}
 		struct dxr_xrt_view cam_views[XRT_MAX_VIEWS];
@@ -761,10 +762,10 @@ ipc_try_get_sr_view_poses(volatile struct ipc_client_state *ics,
 			// rather than identity m2v, otherwise the P-key toggle from
 			// camera mode would land on a default-height display and
 			// shift the convergence plane.
-			dt.ipd_factor = stereo_state.disp_spread_factor;
-			dt.parallax_factor = stereo_state.disp_parallax_factor;
-			dt.perspective_factor = 1.0f;
-			dt.virtual_display_height = stereo_state.disp_vHeight;
+			dt.ipd_factor = stereo_state.ipd_factor;
+			dt.parallax_factor = stereo_state.parallax_factor;
+			dt.perspective_factor = stereo_state.perspective_factor;
+			dt.virtual_display_height = stereo_state.virtual_display_height;
 		} else {
 			dt.virtual_display_height = screen_height_m; // identity m2v
 		}

--- a/src/xrt/ipc/server/ipc_server_handler.c
+++ b/src/xrt/ipc/server/ipc_server_handler.c
@@ -548,9 +548,9 @@ ipc_try_get_sr_view_poses(volatile struct ipc_client_state *ics,
 		have_stereo_state = qwerty_get_view_state(xdevs, XRT_SYSTEM_MAX_DEVICES, &stereo_state);
 	}
 #else
-	struct { bool camera_mode; float cam_spread_factor, cam_parallax_factor, cam_convergence,
-	         cam_half_tan_vfov, disp_spread_factor, disp_parallax_factor,
-	         disp_vHeight, nominal_viewer_z, screen_height_m; } stereo_state = {0};
+	struct { bool camera_mode; float ipd_factor, parallax_factor, inv_convergence_distance,
+	         half_tan_vfov, m2v, virtual_display_height, perspective_factor,
+	         nominal_viewer_z, screen_height_m; } stereo_state = {0};
 	bool have_stereo_state = false;
 #endif
 

--- a/src/xrt/state_trackers/oxr/oxr_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_session.c
@@ -1573,8 +1573,8 @@ oxr_session_locate_views(struct oxr_logger *log,
 		        view_state.perspective_factor, view_state.m2v);
 	}
 #else
-	struct { bool camera_mode; float cam_spread_factor, cam_parallax_factor, cam_convergence,
-	         cam_half_tan_vfov, disp_spread_factor, disp_parallax_factor, disp_vHeight,
+	struct { bool camera_mode; float ipd_factor, parallax_factor, inv_convergence_distance,
+	         half_tan_vfov, m2v, virtual_display_height, perspective_factor,
 	         nominal_viewer_z, screen_height_m; } view_state = {0};
 	bool have_view_state = false;
 #endif

--- a/src/xrt/state_trackers/oxr/oxr_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_session.c
@@ -1738,10 +1738,17 @@ oxr_session_locate_views(struct oxr_logger *log,
 			if (sinfo->nominal_viewer_z_m > 0.0f) {
 				float ipd_m = sess->ipd_meters;
 				eye_count = 2;
-				adj_eyes[0] = (struct xrt_eye_position){
-				    -ipd_m / 2.0f, sinfo->nominal_viewer_y_m, sinfo->nominal_viewer_z_m};
-				adj_eyes[1] = (struct xrt_eye_position){
-				    ipd_m / 2.0f, sinfo->nominal_viewer_y_m, sinfo->nominal_viewer_z_m};
+				// Untracked → the eye sits at the REFERENCE: directly in front
+				// of the display centre at the nominal distance, i.e. (0,0,Nz).
+				// nominal_y must NOT leak into the eye: an eye lateral offset
+				// shears the frustum (dy = (eye_y - 0)*invd), so a non-zero
+				// nominal_y would tilt the untracked frustum vertically — a
+				// residual Y shift the display rig (convergence-locked) cannot
+				// reproduce, so the camera/display rigs would disagree.
+				// nominal_y belongs only to the parallax / zero-parallax pivot
+				// (the `nominal` vector below), never to the eye position.
+				adj_eyes[0] = (struct xrt_eye_position){-ipd_m / 2.0f, 0.0f, sinfo->nominal_viewer_z_m};
+				adj_eyes[1] = (struct xrt_eye_position){ipd_m / 2.0f, 0.0f, sinfo->nominal_viewer_z_m};
 				have_eye_positions = true;
 				if (should_log) {
 					U_LOG_I("Nominal eyes: [0]=(%.4f,%.4f,%.4f) [1]=(%.4f,%.4f,%.4f), IPD=%.1fmm",

--- a/src/xrt/state_trackers/oxr/oxr_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_session.c
@@ -1567,10 +1567,10 @@ oxr_session_locate_views(struct oxr_logger *log,
 	bool have_view_state = qwerty_get_view_state(
 	    sess->sys->xsysd->xdevs, sess->sys->xsysd->xdev_count, &view_state);
 	if (should_log) {
-		U_LOG_I("VIEW STATE: have=%d cam=%d spread=%.3f conv=%.2f disp_spread=%.3f disp_vH=%.2f",
-		        have_view_state, view_state.camera_mode,
-		        view_state.cam_spread_factor, view_state.cam_convergence,
-		        view_state.disp_spread_factor, view_state.disp_vHeight);
+		U_LOG_I("VIEW STATE: have=%d cam=%d ipd=%.3f conv=%.2f vH=%.2f persp=%.2f m2v=%.2f",
+		        have_view_state, view_state.camera_mode, view_state.ipd_factor,
+		        view_state.inv_convergence_distance, view_state.virtual_display_height,
+		        view_state.perspective_factor, view_state.m2v);
 	}
 #else
 	struct { bool camera_mode; float cam_spread_factor, cam_parallax_factor, cam_convergence,
@@ -1977,10 +1977,11 @@ oxr_session_locate_views(struct oxr_logger *log,
 						};
 					} else {
 						ct = (dxr_camera3d_tunables){
-						    .ipd_factor = view_state.cam_spread_factor,
-						    .parallax_factor = view_state.cam_parallax_factor,
-						    .inv_convergence_distance = view_state.cam_convergence,
-						    .half_tan_vfov = view_state.cam_half_tan_vfov,
+						    .ipd_factor = view_state.ipd_factor,
+						    .parallax_factor = view_state.parallax_factor,
+						    .inv_convergence_distance = view_state.inv_convergence_distance,
+						    .half_tan_vfov = view_state.half_tan_vfov,
+						    .m2v = view_state.m2v,
 						};
 					}
 					struct dxr_xrt_view cam_views[XRT_MAX_VIEWS];
@@ -2005,10 +2006,10 @@ oxr_session_locate_views(struct oxr_logger *log,
 						dt.perspective_factor = sess->view_rig.perspective_factor;
 						dt.virtual_display_height = sess->view_rig.virtual_display_height;
 					} else if (have_view_state && !sess->has_external_window) {
-						dt.ipd_factor = view_state.disp_spread_factor;
-						dt.parallax_factor = view_state.disp_parallax_factor;
-						dt.perspective_factor = 1.0f;
-						dt.virtual_display_height = view_state.disp_vHeight;
+						dt.ipd_factor = view_state.ipd_factor;
+						dt.parallax_factor = view_state.parallax_factor;
+						dt.perspective_factor = view_state.perspective_factor;
+						dt.virtual_display_height = view_state.virtual_display_height;
 					} else {
 						dt.virtual_display_height = screen_height_m; // identity m2v
 					}


### PR DESCRIPTION
**Draft — needs behavior testing before merge.** Affects runtime-driven (qwerty) camera for **legacy/hosted apps + Chrome WebXR-in-workspace**. NOT the shell/workspace UI itself.

### Where qwerty actually applies (for reviewers)
- **Shell / workspace UI / workspace-controller session: qwerty NOT used** — renders via the DP eye tracker (Kooima), no qwerty offset (`comp_d3d11_service_owns_window` is false across workspace mode; see `ipc_server_handler.c:522`).
- **Legacy/hosted apps (compositor owns window): qwerty IS the camera** (keyboard + cam/display view-tuning).
- **Chrome WebXR inside workspace (appcontainer): qwerty re-enabled per-session** as the player transform (`use_qwerty_head` 2nd clause).
- **Handle/texture (external-window) apps: qwerty disabled** (`qwerty_set_process_keys(false)` + `!has_external_window`); raw eyes passed.

## What
Retires the legacy/qwerty dual `cam_*/disp_*` rig model + its hand-rolled toggle in favor of the canonical rig converters in displayxr-common `v1.0.2`.

- **V/P toggle → canonical converters.** The previous **display→camera RESET to arbitrary defaults (0.5 diopters / 36° vFOV)** is gone — both directions are now disturbance-free. (Those resets were the "arbitrary camera defaults" that started this work.)
- **Legacy camera gains `m2v`** (default 1; qwerty perspective is always 1, but plumbed end-to-end).
- **Dual carriers retired** → single active rig (unified shape matching `XrCameraRigEXT` tunables): `qwerty_view_state`, `u_hud_data` + 7 native-compositor copy sites + HUD renderer, both compute consumers, and the no-qwerty `#else` fallback structs (Android).
- `drv_qwerty` links `aux_math` to reach the converters. Gating (`use_qwerty_head`, `!has_external_window`, `camera_mode`) preserved exactly.

## Testing needed before merge
- A **hosted/legacy app** (e.g. `cube_hosted_*`): WASD + V (2D/3D) + P (cam/display) — confirm **no view pop on the P-toggle in either direction** (this is the headline fix).
- A **Chrome WebXR** session in workspace: rig still drives correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)