### PR TITLE
feat(#558): per-app overlay mode (overlay apps + normal apps coexist)

### DIFF
--- a/src/xrt/auxiliary/android/android_custom_surface.cpp
+++ b/src/xrt/auxiliary/android/android_custom_surface.cpp
@@ -31,6 +31,11 @@
 static bool
 android_transparent_requested(void)
 {
+	// #558 per-app: transparency follows overlay mode (see-through overlay app),
+	// set per-session in android_globals; debug.dxr.transparent is a dev override.
+	if (android_globals_get_overlay_mode()) {
+		return true;
+	}
 	char value[PROP_VALUE_MAX] = {0};
 	if (__system_property_get("debug.dxr.transparent", value) > 0) {
 		return value[0] == '1' || value[0] == 't' || value[0] == 'T' || value[0] == 'y' || value[0] == 'Y';

--- a/src/xrt/auxiliary/android/android_globals.cpp
+++ b/src/xrt/auxiliary/android/android_globals.cpp
@@ -10,7 +10,9 @@
 #include "android_globals.h"
 
 #include <stddef.h>
+#include <atomic>
 #include <mutex>
+#include <jni.h>
 #include <wrap/android.app.h>
 
 /*!
@@ -150,4 +152,73 @@ android_globals_get_context()
 {
 	return android_globals.context.isNull() ? android_globals.activity.getHandle()
 	                                        : android_globals.context.getHandle();
+}
+
+// #558 per-app overlay mode: service-process flag set by MonadoImpl from the
+// connecting client's manifest, read by the vendor DP plug-in.
+static std::atomic<bool> android_overlay_mode{false};
+
+void
+android_globals_set_overlay_mode(bool enabled)
+{
+	android_overlay_mode.store(enabled, std::memory_order_release);
+}
+
+bool
+android_globals_get_overlay_mode(void)
+{
+	return android_overlay_mode.load(std::memory_order_acquire);
+}
+
+bool
+android_globals_self_declares_overlay(void)
+{
+	// Query this process's own package manifest metadata once; cache the result
+	// (-1 uncomputed, 0 no, 1 yes). Used in the APP process where the connecting
+	// app is this process (e.g. oxr_session keep-alive).
+	static std::atomic<int> cached{-1};
+	int c = cached.load(std::memory_order_acquire);
+	if (c >= 0) {
+		return c != 0;
+	}
+	int result = 0; // default false, also on any JNI failure
+	jobject ctx = (jobject)android_globals_get_context();
+	if (android_globals.vm != nullptr && ctx != nullptr) {
+		JNIEnv *env = jni::env();
+		if (env != nullptr) {
+			jclass ctxCls = env->GetObjectClass(ctx);
+			jmethodID mGetPkgName = env->GetMethodID(ctxCls, "getPackageName", "()Ljava/lang/String;");
+			jmethodID mGetPM =
+			    env->GetMethodID(ctxCls, "getPackageManager", "()Landroid/content/pm/PackageManager;");
+			jstring pkg = (jstring)env->CallObjectMethod(ctx, mGetPkgName);
+			jobject pm = env->CallObjectMethod(ctx, mGetPM);
+			if (pkg != nullptr && pm != nullptr) {
+				jclass pmCls = env->GetObjectClass(pm);
+				jmethodID mGetAppInfo = env->GetMethodID(
+				    pmCls, "getApplicationInfo",
+				    "(Ljava/lang/String;I)Landroid/content/pm/ApplicationInfo;");
+				const jint GET_META_DATA = 0x00000080;
+				jobject ai = env->CallObjectMethod(pm, mGetAppInfo, pkg, GET_META_DATA);
+				if (env->ExceptionCheck()) {
+					env->ExceptionClear();
+				} else if (ai != nullptr) {
+					jclass aiCls = env->GetObjectClass(ai);
+					jfieldID fMeta = env->GetFieldID(aiCls, "metaData", "Landroid/os/Bundle;");
+					jobject bundle = env->GetObjectField(ai, fMeta);
+					if (bundle != nullptr) {
+						jclass bCls = env->GetObjectClass(bundle);
+						jmethodID mGetBool =
+						    env->GetMethodID(bCls, "getBoolean", "(Ljava/lang/String;Z)Z");
+						jstring key = env->NewStringUTF("com.displayxr.overlay_mode");
+						result = env->CallBooleanMethod(bundle, mGetBool, key, JNI_FALSE) ? 1 : 0;
+					}
+				}
+			}
+			if (env->ExceptionCheck()) {
+				env->ExceptionClear();
+			}
+		}
+	}
+	cached.store(result, std::memory_order_release);
+	return result != 0;
 }

--- a/src/xrt/auxiliary/android/android_globals.h
+++ b/src/xrt/auxiliary/android/android_globals.h
@@ -128,6 +128,29 @@ android_globals_set_custom_surface(void *custom_surface);
 void *
 android_globals_get_custom_surface(void);
 
+/*!
+ * Per-session overlay mode (#558 per-app). Set by the runtime service
+ * (MonadoImpl, from the connecting client's manifest) in the SERVICE process;
+ * read by the vendor display-processor plug-in to decide keep-3D-while-
+ * backgrounded. Process-local — only meaningful in the service process.
+ * @ingroup aux_android
+ */
+void
+android_globals_set_overlay_mode(bool enabled);
+
+bool
+android_globals_get_overlay_mode(void);
+
+/*!
+ * True if THIS process's own package declares
+ * `<meta-data android:name="com.displayxr.overlay_mode" android:value="true"/>`.
+ * Read in the APP process (the OpenXR client) — e.g. oxr_session keep-alive —
+ * where the connecting app IS this process. Queried once via JNI and cached.
+ * @ingroup aux_android
+ */
+bool
+android_globals_self_declares_overlay(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/xrt/auxiliary/android/src/main/java/org/freedesktop/monado/auxiliary/MonadoView.java
+++ b/src/xrt/auxiliary/android/src/main/java/org/freedesktop/monado/auxiliary/MonadoView.java
@@ -97,14 +97,15 @@ public class MonadoView extends SurfaceView
         }
         SurfaceHolder surfaceHolder = getHolder();
         surfaceHolder.addCallback(this);
-        // P0 transparency spike (#568): a translucent SurfaceView z-ordered as a
-        // media overlay lets SurfaceFlinger composite the weaved content over the
-        // live screen. Gated on `debug.dxr.transparent` so other apps over this
-        // runtime are unaffected. Layer A drives this from the per-session flag.
-        if (isTransparentSpikeEnabled()) {
+        // A translucent SurfaceView z-ordered as a media overlay lets SurfaceFlinger
+        // composite the weaved content over the live screen (#568). This view is only
+        // created as a SERVICE-owned overlay (no host Activity) for a per-app overlay
+        // (see-through) app (#558), so make it translucent in that case; debug.dxr.transparent
+        // stays as a dev force override for the in-Activity path.
+        if (hostActivity == null || isTransparentSpikeEnabled()) {
             setZOrderMediaOverlay(true);
             surfaceHolder.setFormat(PixelFormat.TRANSLUCENT);
-            Log.i(TAG, "MonadoView: TRANSLUCENT media-overlay surface (#568 transparency spike)");
+            Log.i(TAG, "MonadoView: TRANSLUCENT media-overlay surface (#558 overlay / #568)");
         }
     }
 

--- a/src/xrt/compositor/main/comp_target_swapchain.c
+++ b/src/xrt/compositor/main/comp_target_swapchain.c
@@ -42,6 +42,12 @@
 static bool
 android_transparent_requested(void)
 {
+	// #558 per-app: transparency follows overlay mode (an overlay app is see-through;
+	// a normal app is opaque) — set per-session by the runtime in android_globals.
+	// debug.dxr.transparent stays as a dev force override.
+	if (android_globals_get_overlay_mode()) {
+		return true;
+	}
 	char value[PROP_VALUE_MAX] = {0};
 	if (__system_property_get("debug.dxr.transparent", value) > 0) {
 		return value[0] == '1' || value[0] == 't' || value[0] == 'T' || value[0] == 'y' || value[0] == 'Y';

--- a/src/xrt/compositor/multi/comp_multi_compositor.c
+++ b/src/xrt/compositor/multi/comp_multi_compositor.c
@@ -73,6 +73,11 @@
 static bool
 android_transparent_requested(void)
 {
+	// #558 per-app: transparency follows overlay mode (see-through overlay app vs
+	// opaque normal app), set per-session in android_globals; sysprop is a dev override.
+	if (android_globals_get_overlay_mode()) {
+		return true;
+	}
 	char value[PROP_VALUE_MAX] = {0};
 	if (__system_property_get("debug.dxr.transparent", value) > 0) {
 		return value[0] == '1' || value[0] == 't' || value[0] == 'T' || value[0] == 'y' || value[0] == 'Y';

--- a/src/xrt/ipc/android/src/main/java/org/freedesktop/monado/ipc/MonadoImpl.java
+++ b/src/xrt/ipc/android/src/main/java/org/freedesktop/monado/ipc/MonadoImpl.java
@@ -10,7 +10,11 @@
 package org.freedesktop.monado.ipc;
 
 import android.content.Context;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+import android.os.Binder;
 import android.os.ParcelFileDescriptor;
+import android.os.Process;
 import android.os.RemoteException;
 import android.provider.Settings;
 import android.util.Log;
@@ -61,7 +65,12 @@ public class MonadoImpl extends IMonado.Stub {
         // surface, so create our own TYPE_APPLICATION_OVERLAY before the
         // compositor (started by nativeAddClient) begins polling for a surface.
         // Idempotent native-side, so repeated connects are safe.
-        if (canDrawOverOtherApps()) {
+        boolean overlay = canDrawOverOtherApps();
+        // Propagate the per-session decision to the service-process globals so the
+        // compositor + vendor DP plug-in (keep-3D-while-backgrounded) see it without
+        // re-reading a global sysprop (#558 per-app).
+        nativeSetOverlayMode(overlay);
+        if (overlay) {
             Log.i(TAG, "connect: overlay mode — creating service overlay");
             nativeCreateServiceOverlay();
         }
@@ -95,17 +104,61 @@ public class MonadoImpl extends IMonado.Stub {
         nativeAppSurface(surface);
     }
 
+    // Cached overlay decision from the last resolved client connect, returned for
+    // in-process callers (the service watchdog calls canDrawOverOtherApps() from
+    // MonadoService, where Binder.getCallingUid() is our own uid, not the client's).
+    private volatile boolean cachedClientOverlay = false;
+
     @Override
     public boolean canDrawOverOtherApps() {
-        // #558: this means "the SERVICE owns the on-screen surface (overlay mode)",
-        // which both the client (whether to publish its own surface, Client.java)
-        // and the service watchdog (MonadoService) key on. That requires BOTH the
-        // draw-over-apps permission AND overlay mode (debug.dxr.overlay) — the
-        // permission alone is not enough, or a normal app (permission granted but
-        // not overlay mode) would skip its surface and get a blank service overlay.
-        boolean overlay = Settings.canDrawOverlays(context) && nativeOverlayModeEnabled();
+        // #558: "the SERVICE owns the on-screen surface (overlay mode)" — both the
+        // client (whether to publish its own surface, Client.java) and the service
+        // watchdog (MonadoService) key on this. Requires the draw-over-apps
+        // permission AND that the connecting app opted into overlay mode. Overlay
+        // mode is now PER-APP: the app declares
+        //   <meta-data android:name="com.displayxr.overlay_mode" android:value="true"/>
+        // so a normal app (cube) renders in its own window while an overlay app
+        // (avatar) gets the service overlay — without a global toggle. debug.dxr.overlay
+        // stays as a dev FORCE-ALL override.
+        if (!Settings.canDrawOverlays(context)) {
+            return false;
+        }
+        boolean overlay = callerDeclaresOverlay() || nativeOverlayModeEnabled();
         Log.i(TAG, "canDrawOverOtherApps (overlay mode) = " + overlay);
         return overlay;
+    }
+
+    // True if the calling client's package declares the overlay-mode manifest flag.
+    // Resolves the live binder caller; in-process calls (watchdog) reuse the cached
+    // value from the most recent client resolution.
+    private boolean callerDeclaresOverlay() {
+        int uid = Binder.getCallingUid();
+        if (uid == Process.myUid()) {
+            return cachedClientOverlay; // in-process (watchdog) — use the last client's value
+        }
+        boolean wants = packageDeclaresOverlay(uid);
+        cachedClientOverlay = wants;
+        return wants;
+    }
+
+    private boolean packageDeclaresOverlay(int uid) {
+        PackageManager pm = context.getPackageManager();
+        String[] pkgs = pm.getPackagesForUid(uid);
+        if (pkgs == null) {
+            return false;
+        }
+        for (String pkg : pkgs) {
+            try {
+                ApplicationInfo ai = pm.getApplicationInfo(pkg, PackageManager.GET_META_DATA);
+                if (ai.metaData != null
+                        && ai.metaData.getBoolean("com.displayxr.overlay_mode", false)) {
+                    return true;
+                }
+            } catch (PackageManager.NameNotFoundException e) {
+                // try the next package sharing this uid
+            }
+        }
+        return false;
     }
 
     @Override
@@ -167,9 +220,13 @@ public class MonadoImpl extends IMonado.Stub {
     @SuppressWarnings("JavaJniMissingFunction")
     private native void nativeDestroyServiceOverlay();
 
-    /** True when overlay mode (debug.dxr.overlay) is enabled — see canDrawOverOtherApps. */
+    /** True when the debug.dxr.overlay dev force-all override is set — see canDrawOverOtherApps. */
     @SuppressWarnings("JavaJniMissingFunction")
     private native boolean nativeOverlayModeEnabled();
+
+    /** Publish the per-session overlay decision to the service-process globals (#558 per-app). */
+    @SuppressWarnings("JavaJniMissingFunction")
+    private native void nativeSetOverlayMode(boolean enabled);
 
     /**
      * Native handling of the client's surface being destroyed (background → file picker etc.):

--- a/src/xrt/state_trackers/oxr/oxr_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_session.c
@@ -1080,14 +1080,16 @@ oxr_session_poll(struct oxr_logger *log, struct oxr_session *sess)
 	// (moveTaskToBack) so the launcher stays the interactive foreground app while
 	// the runtime weaves the tiger into a service-owned TYPE_APPLICATION_OVERLAY
 	// on top. In that mode the ON_PAUSE lifecycle must NOT stop the session — the
-	// overlay is still on-screen, so the client must keep submitting frames. Read
-	// debug.dxr.overlay once (this runs in the client process, same sysprop the
-	// avatar + comp read). When OFF, the normal pause→stopping behavior stands.
+	// overlay is still on-screen, so the client must keep submitting frames. This
+	// runs in the CLIENT process, so overlay mode is THIS app's own choice: it's
+	// per-app via the app's manifest flag (com.displayxr.overlay_mode), with
+	// debug.dxr.overlay as a dev force-all override. When OFF, the normal
+	// pause→stopping behavior stands. Resolved once.
 	static int s_overlay_mode = -1;
 	if (s_overlay_mode < 0) {
 		char prop[PROP_VALUE_MAX] = {0};
-		s_overlay_mode =
-		    (__system_property_get("debug.dxr.overlay", prop) > 0 && prop[0] == '1') ? 1 : 0;
+		bool force = __system_property_get("debug.dxr.overlay", prop) > 0 && prop[0] == '1';
+		s_overlay_mode = (force || android_globals_self_declares_overlay()) ? 1 : 0;
 	}
 
 	// Most recent Android activity lifecycle event was OnPause: move toward stopping

--- a/src/xrt/targets/service-lib/service_target.cpp
+++ b/src/xrt/targets/service-lib/service_target.cpp
@@ -192,19 +192,10 @@ Java_org_freedesktop_monado_ipc_MonadoImpl_nativeCreateServiceOverlay(JNIEnv *en
 	jni::init(env);
 	jni::Object monadoImpl(thiz);
 
-	// #558: only create a service overlay in OVERLAY MODE (debug.dxr.overlay).
-	// The "display over other apps" permission alone is NOT enough — a normal app
-	// (e.g. cube_handle_vk_android) publishes its own client surface and must
-	// render into its own window; creating a service overlay for it would steal
-	// the screen + eat input + leave a stray overlay flashing on close. Overlay
-	// mode is the avatar's opt-in switch (the same sysprop the client session +
-	// plugin read), so gate creation on it; default (unset) → ordinary windowed app.
-	{
-		char prop[PROP_VALUE_MAX] = {};
-		if (!(__system_property_get("debug.dxr.overlay", prop) > 0 && prop[0] == '1')) {
-			return;
-		}
-	}
+	// The overlay-mode gate now lives in MonadoImpl.canDrawOverOtherApps (per-app,
+	// from the connecting client's manifest); connect() only calls this in overlay
+	// mode, so no sysprop gate here — that would wrongly block a per-app overlay
+	// app whenever debug.dxr.overlay is unset (#558 per-app).
 
 	// Service-owned overlay (#558 revival, P1): when the runtime holds the
 	// "display over other apps" permission the CLIENT skips publishing its
@@ -261,11 +252,9 @@ Java_org_freedesktop_monado_ipc_MonadoImpl_nativeCreateServiceOverlay(JNIEnv *en
 	U_LOG_I("service: TYPE_APPLICATION_OVERLAY created, ANativeWindow %p (#558 P1)", (void *)win);
 }
 
-// #558: true when overlay mode is enabled (debug.dxr.overlay). MonadoImpl gates
-// "the service owns the on-screen surface" on this AND the draw-over-apps
-// permission — so a normal app (permission happens to be granted, but overlay
-// mode off) publishes its own client surface and renders in its own window
-// instead of being handed a service overlay (which left it black + input-dead).
+// #558: the debug.dxr.overlay sysprop is now a DEV FORCE-ALL override (forces
+// every client into overlay mode). The normal per-app decision is in
+// MonadoImpl.canDrawOverOtherApps (the connecting app's manifest flag).
 extern "C" JNIEXPORT jboolean JNICALL
 Java_org_freedesktop_monado_ipc_MonadoImpl_nativeOverlayModeEnabled(JNIEnv * /*env*/,
                                                                     jobject /*thiz*/)
@@ -273,6 +262,16 @@ Java_org_freedesktop_monado_ipc_MonadoImpl_nativeOverlayModeEnabled(JNIEnv * /*e
 	char prop[PROP_VALUE_MAX] = {};
 	return (__system_property_get("debug.dxr.overlay", prop) > 0 && prop[0] == '1') ? JNI_TRUE
 	                                                                                 : JNI_FALSE;
+}
+
+// #558 per-app: publish the per-session overlay decision to the service-process
+// globals so the compositor + vendor DP plug-in see it (keep-3D-while-bg) without
+// re-reading a global sysprop. Set by MonadoImpl.connect from the client's manifest.
+extern "C" JNIEXPORT void JNICALL
+Java_org_freedesktop_monado_ipc_MonadoImpl_nativeSetOverlayMode(JNIEnv * /*env*/, jobject /*thiz*/,
+                                                                jboolean enabled)
+{
+	android_globals_set_overlay_mode(enabled == JNI_TRUE);
 }
 
 // #558: authoritative teardown of the service-owned overlay, called from


### PR DESCRIPTION
## Problem

Overlay mode was a global `debug.dxr.overlay` sysprop, so it was **avatar OR normal
apps, never both**: with it on, a normal app (cube) wrongly got a service overlay;
with it off, the avatar couldn't be a see-through overlay.

## Fix — per-app, declared in the app's manifest

An app opts in:
```xml
<meta-data android:name="com.displayxr.overlay_mode" android:value="true"/>
```
The runtime reads the **connecting client's** manifest flag and gives it a service
overlay (see-through), while normal apps render in their own opaque window — no
global toggle. `debug.dxr.{overlay,transparent}` remain as dev force-all overrides.

- **MonadoImpl.canDrawOverOtherApps** resolves the caller's manifest flag
  (`Binder.getCallingUid` → `PackageManager`), publishes the per-session decision
  to `android_globals` (`nativeSetOverlayMode`) for the compositor + vendor DP.
- **service_target**: drops the sysprop gate on `nativeCreateServiceOverlay` (the
  Java per-app gate is authoritative).
- **oxr_session** keep-alive reads the app's own manifest flag
  (`android_globals_self_declares_overlay`, app process).
- **Transparency follows overlay mode** (comp_target_swapchain, comp_multi_compositor,
  android_custom_surface, MonadoView) so overlay apps are see-through and normal
  apps opaque without `debug.dxr.transparent`.

## Test (NP02J, ZERO sysprops)

- **Avatar** (manifest flag) → service overlay, translucent, alpha-gate see-through,
  3D weave, draggable, not frozen.
- **Cube** (no flag) → `canDrawOverOtherApps = false`, own surface + opaque window,
  `xrBeginSession SUCCESS`.
- Both coexist with no global toggle.

Pairs with `displayxr-leia-plugin` + `displayxr-demo-avatar` `feat/per-app-overlay-mode`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)