### PR TITLE
build(windows): register_dev_plugin.bat — make from-source runtimes find a display processor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,6 +202,14 @@ _package\run_cube_handle_d3d11_win.bat
 
 After a rebuild, copy runtime binaries into `C:\Program Files\DisplayXR\Runtime` (registry discovery finds it); only run the installer when the installer itself changed.
 
+**From-source builds need a registered display processor (Windows).** Windows plug-in discovery is **registry-only** (`HKLM\Software\DisplayXR\DisplayProcessors`) — there's no adjacent-dir / `XRT_PLUGIN_SEARCH_PATH` fallback like POSIX has. `build_windows.bat` builds the sim-display plug-in DLL but does **not** register it, so a pure from-source runtime finds no DP and `xrt_instance_create_system` fails (`XRT_ERROR_DEVICE_CREATION_FAILED` / app "Failed to initialize OpenXR"). Register the freshly-built (ABI-matched) plug-in once, from an **elevated** prompt:
+```bat
+scripts\register_dev_plugin.bat            REM dev sim-display (fallback, no hardware)
+scripts\register_dev_plugin.bat leia C:\path\to\DisplayXR-LeiaSR.dll   REM dev Leia plug-in (ProbeOrder 50)
+scripts\register_dev_plugin.bat list       REM displayxr-cli dp list
+```
+A from-source runtime that's **ahead of the released ABI** will ABI-reject an *installed* (released) vendor plug-in — register your **dev-built** plug-in instead. (POSIX dev builds don't need this: the loader finds plug-ins next to the runtime.)
+
 ### Headless diagnostics (`displayxr-cli`)
 `displayxr-cli` runs the runtime **without a compositor/GPU/window** — it exercises the real plug-in discovery + display-processor path in-process (`target_instance_no_comp`), so it's the fastest way to check "did the runtime start, find a DP, and get sane display info?" without launching an app.
 - `displayxr-cli selftest` — asserts a DP-backed head device exists, a vendor plug-in is active (the loader rejects ABI-mismatched plug-ins, so this *is* an ABI check), and display dims are valid. Strict exit code; this is what the CI gate runs.

--- a/scripts/register_dev_plugin.bat
+++ b/scripts/register_dev_plugin.bat
@@ -1,0 +1,92 @@
+@echo off
+setlocal
+REM ============================================================
+REM Register a display-processor plug-in for a FROM-SOURCE dev runtime.
+REM
+REM Windows plug-in discovery is registry-only (HKLM\Software\DisplayXR\
+REM DisplayProcessors) — there is no adjacent-dir / env fallback like POSIX.
+REM `build_windows.bat` produces the sim-display plug-in DLL but does NOT
+REM register it, so a from-source runtime finds no display processor and
+REM xrt_instance_create_system fails (XRT_ERROR_DEVICE_CREATION_FAILED /
+REM "Failed to initialize OpenXR"). This registers the freshly-built,
+REM ABI-matched plug-in exactly as CI and the installer do.
+REM
+REM Run from an ELEVATED prompt (writes HKLM).
+REM
+REM Usage:
+REM   scripts\register_dev_plugin.bat                 :: register dev sim-display (fallback, no hardware)
+REM   scripts\register_dev_plugin.bat leia <dll>      :: register a dev-built Leia plug-in (ProbeOrder 50)
+REM   scripts\register_dev_plugin.bat unregister-sim  :: remove the dev sim-display entry
+REM   scripts\register_dev_plugin.bat list            :: show registered DPs (displayxr-cli dp list)
+REM ============================================================
+
+set "REPO=%~dp0.."
+set "MODE=%~1"
+if "%MODE%"=="" set "MODE=sim"
+
+REM --- elevation check (HKLM writes need admin) ---
+net session >nul 2>&1
+if %ERRORLEVEL% NEQ 0 (
+    if /I not "%MODE%"=="list" (
+        echo ERROR: run from an ELEVATED prompt ^(right-click cmd -^> Run as administrator^).
+        exit /b 1
+    )
+)
+
+if /I "%MODE%"=="list" goto :list
+if /I "%MODE%"=="unregister-sim" goto :unregister_sim
+if /I "%MODE%"=="leia" goto :leia
+goto :sim
+
+:sim
+set "DLL=%REPO%\_package\bin\plugins\DisplayXR-SimDisplay.dll"
+if not exist "%DLL%" (
+    echo ERROR: %DLL% not found. Build first: scripts\build_windows.bat build
+    exit /b 1
+)
+set "KEY=HKLM\Software\DisplayXR\DisplayProcessors\sim-display"
+reg add "%KEY%" /v Binary      /t REG_SZ    /d "%DLL%"                 /f >nul || goto :regfail
+reg add "%KEY%" /v ProbeOrder  /t REG_DWORD /d 200                    /f >nul || goto :regfail
+reg add "%KEY%" /v DisplayName /t REG_SZ    /d "Simulated 3D Display" /f >nul || goto :regfail
+echo Registered dev sim-display (ProbeOrder 200, fallback):
+echo   %DLL%
+goto :list
+
+:leia
+set "DLL=%~2"
+if "%DLL%"=="" (
+    echo ERROR: leia mode needs a DLL path:
+    echo   scripts\register_dev_plugin.bat leia C:\path\to\DisplayXR-LeiaSR.dll
+    exit /b 1
+)
+if not exist "%DLL%" (
+    echo ERROR: not found: %DLL%
+    exit /b 1
+)
+set "KEY=HKLM\Software\DisplayXR\DisplayProcessors\leia-sr"
+reg add "%KEY%" /v Binary      /t REG_SZ    /d "%DLL%"        /f >nul || goto :regfail
+reg add "%KEY%" /v ProbeOrder  /t REG_DWORD /d 50             /f >nul || goto :regfail
+reg add "%KEY%" /v DisplayName /t REG_SZ    /d "Leia SR (dev)" /f >nul || goto :regfail
+echo Registered dev Leia plug-in (ProbeOrder 50, wins over sim):
+echo   %DLL%
+echo Note: this OVERWRITES any installed leia-sr entry. Re-run the installer to restore it.
+goto :list
+
+:unregister_sim
+reg delete "HKLM\Software\DisplayXR\DisplayProcessors\sim-display" /f >nul 2>&1
+echo Removed sim-display dev registration.
+goto :list
+
+:list
+echo.
+set "CLI=%REPO%\_package\bin\displayxr-cli.exe"
+if exist "%CLI%" (
+    "%CLI%" dp list
+) else (
+    echo (displayxr-cli not built yet; skipping dp list)
+)
+exit /b 0
+
+:regfail
+echo ERROR: reg add failed (are you elevated?).
+exit /b 1


### PR DESCRIPTION
## Problem
Windows plug-in discovery is **registry-only** (`HKLM\Software\DisplayXR\DisplayProcessors`) — no adjacent-dir / `XRT_PLUGIN_SEARCH_PATH` fallback, unlike POSIX (`target_plugin_loader.c`). `build_windows.bat` builds the sim-display plug-in DLL but never registers it, so a **pure from-source runtime finds no display processor** → `xrt_instance_create_system` fails (`XRT_ERROR_DEVICE_CREATION_FAILED`, or the app reports "Failed to initialize OpenXR"). A contributor doing a from-source build (no installer) was stranded on exactly this.

Also: a from-source runtime that's *ahead of the released ABI* will ABI-reject an installed (released) vendor plug-in, so "install the bundle first" isn't a reliable substitute.

## Fix (stopgap)
`scripts\register_dev_plugin.bat` registers the freshly-built, ABI-matched plug-in exactly as CI (`build-windows.yml`) and the installer do:
- default → dev **sim-display** (ProbeOrder 200, fallback, no hardware)
- `leia <dll>` → dev-built **Leia** plug-in (ProbeOrder 50)
- `list` → `displayxr-cli dp list`

Plus a CLAUDE.md note so the next source-builder isn't stuck. Elevated prompt required (HKLM).

## Not in scope (tracked separately)
The deeper asymmetry — Windows has no adjacent-dir fallback, so sim-display isn't an automatic universal fallback the way it is on POSIX — is a design decision (registry-only is arguably intentional for control/security). Tracked in a follow-up issue.

Windows-only `.bat`; authored on macOS, **needs a Windows smoke test** (CI doesn't exercise it). @cyrusrohani this is your immediate unblock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)