### PR TITLE
One-line dev environment: scripts\dev-setup.bat (builds runtime + plug-ins + VS, from source)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,8 @@ Specs: `docs/specs/extensions/`. Eye-tracking MANAGED vs MANUAL contract: `docs/
 Languages: C11 (core), C++17 (where needed), Python 3.6+ (build scripts).
 
 ### Windows (preferred on a Leia SR machine — iterate locally, not via CI)
+
+**One-line dev environment (from source).** `scripts\dev-setup.bat` (elevated) is the dev mirror of the user bundle installer: it builds the runtime, registers the ABI-matched sim-display (and `--leia` builds+registers the Leia plug-in from source), points the machine's active OpenXR runtime at the dev build, and generates the VS solution — fresh clone to debuggable in one command. `--leia` / `--leia=release` / `--all` / `--no-vs` / `--no-active-runtime` / `--clean`. (Contrast `scripts\setup-displayxr.bat`, which *downloads released* installers instead of building.) The granular `build_windows.bat` targets below are what it orchestrates:
 ```bat
 scripts\build_windows.bat all        REM generate + runtime + installer + test apps
 scripts\build_windows.bat build      REM runtime only (fastest iteration)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,6 +202,14 @@ _package\run_cube_handle_d3d11_win.bat
 
 After a rebuild, copy runtime binaries into `C:\Program Files\DisplayXR\Runtime` (registry discovery finds it); only run the installer when the installer itself changed.
 
+**From-source builds need a registered display processor (Windows).** Windows plug-in discovery is **registry-only** (`HKLM\Software\DisplayXR\DisplayProcessors`) — there's no adjacent-dir / `XRT_PLUGIN_SEARCH_PATH` fallback like POSIX has. `build_windows.bat` builds the sim-display plug-in DLL but does **not** register it, so a pure from-source runtime finds no DP and `xrt_instance_create_system` fails (`XRT_ERROR_DEVICE_CREATION_FAILED` / app "Failed to initialize OpenXR"). Register the freshly-built (ABI-matched) plug-in once, from an **elevated** prompt:
+```bat
+scripts\register_dev_plugin.bat            REM dev sim-display (fallback, no hardware)
+scripts\register_dev_plugin.bat leia C:\path\to\DisplayXR-LeiaSR.dll   REM dev Leia plug-in (ProbeOrder 50)
+scripts\register_dev_plugin.bat list       REM displayxr-cli dp list
+```
+A from-source runtime that's **ahead of the released ABI** will ABI-reject an *installed* (released) vendor plug-in — register your **dev-built** plug-in instead. (POSIX dev builds don't need this: the loader finds plug-ins next to the runtime.)
+
 ### Headless diagnostics (`displayxr-cli`)
 `displayxr-cli` runs the runtime **without a compositor/GPU/window** — it exercises the real plug-in discovery + display-processor path in-process (`target_instance_no_comp`), so it's the fastest way to check "did the runtime start, find a DP, and get sane display info?" without launching an app.
 - `displayxr-cli selftest` — asserts a DP-backed head device exists, a vendor plug-in is active (the loader rejects ABI-mismatched plug-ins, so this *is* an ABI check), and display dims are valid. Strict exit code; this is what the CI gate runs.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -477,6 +477,19 @@ endif()
 # F5 launches the app, which loads this dev runtime + the vendor plug-in + SR
 # SDK, so you can step across all three. The chosen app's CMakeLists must use
 # CMAKE_CURRENT_SOURCE_DIR (not CMAKE_SOURCE_DIR) so it relocates when folded.
+#
+# WIP — folding the full test-app project drags in its standalone-only
+# assumptions. Known gaps to close before turning this on by default:
+#   1. test_apps/common FetchContents displayxr-common; in the folded scope the
+#      `displayxr::common` target doesn't resolve (the runtime build also pins
+#      displayxr-common) → "target was not found". Reconcile the two fetches /
+#      reuse the runtime's displayxr::common.
+#   2. The test app's OpenXR import is single-config; under the multi-config VS
+#      generator it errors "IMPORTED_IMPLIB not set … MinSizeRel". Apply the
+#      same all-configs backfill used in targets/webxr_bridge/CMakeLists.txt.
+#   3. openxr_loader.dll isn't copied next to the folded exe (only
+#      build_windows.bat does that today) → add a POST_BUILD copy, and rely on
+#      VS_DEBUGGER_ENVIRONMENT below for XR_RUNTIME_JSON (so F5, not a bare run).
 set(XRT_VS_LAUNCH_APP "" CACHE STRING
 	"test_apps/<name> to fold in as an IDE launch target (e.g. cube_handle_d3d11_win); empty = none")
 if(XRT_VS_LAUNCH_APP)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -470,6 +470,41 @@ if(WIN32 AND XRT_BUILD_INSTALLER)
 	add_subdirectory(installer)
 endif()
 
+# IDE convenience: optionally fold one test app into this build so it shows up
+# as a launchable startup target (mainly for the Visual Studio solution from
+# `build_windows.bat vs2022`). Empty by default — the Ninja runtime build and
+# build_windows.bat build the test apps as separate projects. With this set,
+# F5 launches the app, which loads this dev runtime + the vendor plug-in + SR
+# SDK, so you can step across all three. The chosen app's CMakeLists must use
+# CMAKE_CURRENT_SOURCE_DIR (not CMAKE_SOURCE_DIR) so it relocates when folded.
+set(XRT_VS_LAUNCH_APP "" CACHE STRING
+	"test_apps/<name> to fold in as an IDE launch target (e.g. cube_handle_d3d11_win); empty = none")
+if(XRT_VS_LAUNCH_APP)
+	if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test_apps/${XRT_VS_LAUNCH_APP}/CMakeLists.txt")
+		message(STATUS "Folding test app as IDE launch target: ${XRT_VS_LAUNCH_APP}")
+		add_subdirectory(
+			test_apps/${XRT_VS_LAUNCH_APP}
+			test_apps_launch/${XRT_VS_LAUNCH_APP}
+			)
+		if(TARGET ${XRT_VS_LAUNCH_APP})
+			# F5 uses the freshly-installed dev runtime manifest. Build the
+			# INSTALL target first so this path exists.
+			set_target_properties(
+				${XRT_VS_LAUNCH_APP}
+				PROPERTIES VS_DEBUGGER_ENVIRONMENT
+					   "XR_RUNTIME_JSON=${CMAKE_INSTALL_PREFIX}/DisplayXR_win64.json"
+				)
+			# Make it the solution's default startup project.
+			set_property(DIRECTORY PROPERTY VS_STARTUP_PROJECT ${XRT_VS_LAUNCH_APP})
+		endif()
+	else()
+		message(
+			WARNING
+			"XRT_VS_LAUNCH_APP=${XRT_VS_LAUNCH_APP} not found under test_apps/ — skipping"
+			)
+	endif()
+endif()
+
 ###
 # Keep these lists sorted
 ###

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -482,6 +482,15 @@ set(XRT_VS_LAUNCH_APP "" CACHE STRING
 if(XRT_VS_LAUNCH_APP)
 	if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test_apps/${XRT_VS_LAUNCH_APP}/CMakeLists.txt")
 		message(STATUS "Folding test app as IDE launch target: ${XRT_VS_LAUNCH_APP}")
+		# The test apps install a workspace manifest via displayxr_install_manifest,
+		# defined by displayxr-common (FetchContent'd by test_apps/common) in the
+		# standalone build. In the folded build that helper isn't defined; the
+		# manifest sidecar is only for shell/workspace discovery and isn't needed
+		# for an IDE launch target, so provide a no-op fallback if it's missing.
+		if(NOT COMMAND displayxr_install_manifest)
+			function(displayxr_install_manifest)
+			endfunction()
+		endif()
 		add_subdirectory(
 			test_apps/${XRT_VS_LAUNCH_APP}
 			test_apps_launch/${XRT_VS_LAUNCH_APP}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -458,6 +458,23 @@ endif()
 # Descend into the source
 ###
 
+# Visual Studio (multi-config) co-location: scatter-free build tree.
+# The VS generator puts each target in its own <target>/<Config>/ dir, so
+# displayxr-service.exe ends up WITHOUT DisplayXRClient.dll next to it and
+# preload_runtime_core_dll() (target_plugin_loader.c) can't pin the runtime
+# core → plug-in import of it fails → no display processor → the service
+# exits with XRT_ERROR_DEVICE_CREATION_FAILED when run from the build tree
+# (F5 in the solution). Co-locate every exe + DLL per-config so the build
+# tree mirrors the installed _package/bin layout and runs as-is. Ninja +
+# install are unaffected (this only triggers for the VS generator).
+if(CMAKE_GENERATOR MATCHES "Visual Studio")
+	foreach(_cfg Debug Release RelWithDebInfo MinSizeRel)
+		string(TOUPPER "${_cfg}" _CFG)
+		set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_${_CFG} "${CMAKE_BINARY_DIR}/bin/${_cfg}")
+		set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_${_CFG} "${CMAKE_BINARY_DIR}/bin/${_cfg}")
+	endforeach()
+endif()
+
 add_subdirectory(src)
 
 if(BUILD_TESTING)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -30,15 +30,14 @@
         {
             "name": "vs2022",
             "displayName": "Visual Studio 2022 solution",
-            "description": "Multi-config VS solution at build_vs2022/. Folds cube_handle_d3d11_win in as the startup target (F5 launches it against this dev runtime). Mirrors `build_windows.bat vs2022`. Needs a prior build_windows.bat run to fetch vcpkg + the OpenXR loader.",
+            "description": "Multi-config VS solution at build_vs2022/. Mirrors `build_windows.bat vs2022`. Needs a prior build_windows.bat run to fetch vcpkg + the OpenXR loader. Set displayxr-service/displayxr-cli as the startup project to debug. (Folding a test app in as a one-click F5 target via XRT_VS_LAUNCH_APP is WIP.)",
             "generator": "Visual Studio 17 2022",
             "architecture": "x64",
             "inherits": ".common",
             "binaryDir": "${sourceDir}/build_vs2022",
             "cacheVariables": {
                 "XRT_FEATURE_SERVICE": "ON",
-                "XRT_FEATURE_HYBRID_MODE": "ON",
-                "XRT_VS_LAUNCH_APP": "cube_handle_d3d11_win"
+                "XRT_FEATURE_HYBRID_MODE": "ON"
             }
         },
         {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -12,10 +12,34 @@
             "displayName": "Default (same as service-debug)"
         },
         {
+            "name": ".common",
+            "hidden": true,
+            "toolchainFile": "${sourceDir}/vcpkg/scripts/buildsystems/vcpkg.cmake",
+            "cacheVariables": {
+                "VCPKG_MANIFEST_FEATURES": "gui",
+                "OpenXR_ROOT": "${sourceDir}/openxr_sdk"
+            }
+        },
+        {
             "name": ".base-ninja",
             "generator": "Ninja",
             "hidden": true,
+            "inherits": ".common",
             "binaryDir": "${sourceDir}/build"
+        },
+        {
+            "name": "vs2022",
+            "displayName": "Visual Studio 2022 solution",
+            "description": "Multi-config VS solution at build_vs2022/. Folds cube_handle_d3d11_win in as the startup target (F5 launches it against this dev runtime). Mirrors `build_windows.bat vs2022`. Needs a prior build_windows.bat run to fetch vcpkg + the OpenXR loader.",
+            "generator": "Visual Studio 17 2022",
+            "architecture": "x64",
+            "inherits": ".common",
+            "binaryDir": "${sourceDir}/build_vs2022",
+            "cacheVariables": {
+                "XRT_FEATURE_SERVICE": "ON",
+                "XRT_FEATURE_HYBRID_MODE": "ON",
+                "XRT_VS_LAUNCH_APP": "cube_handle_d3d11_win"
+            }
         },
         {
             "name": "service-debug",

--- a/scripts/build_windows.bat
+++ b/scripts/build_windows.bat
@@ -4,11 +4,12 @@ setlocal enabledelayedexpansion
 :: ============================================================
 :: DisplayXR Local Build Script
 :: Downloads all dependencies on first run, then builds.
-:: Usage: scripts\build_windows.bat [generate|build|installer|test-apps|all]
-::   generate   - CMake generate only
+:: Usage: scripts\build_windows.bat [generate|build|installer|test-apps|vs2022|all]
+::   generate   - CMake generate only (Ninja Multi-Config)
 ::   build      - Build runtime + install
 ::   installer  - Build runtime installer
 ::   test-apps  - Build all test apps
+::   vs2022     - Generate Visual Studio 2022 solution (build_vs2022\XRT.sln)
 ::   all        - Everything (default)
 ::
 :: The DisplayXR Shell ships from a separate repo. Installer download:
@@ -140,6 +141,7 @@ echo.
 if "%TARGET%"=="build" if exist "%REPO%build\build.ninja" goto :do_build
 if "%TARGET%"=="installer" if exist "%REPO%build\build.ninja" goto :do_installer
 if "%TARGET%"=="test-apps" goto :do_test_apps
+if "%TARGET%"=="vs2022" goto :do_vs2022
 
 echo === CMake Generate ===
 cmake -S "%REPO%." -B "%REPO%build" -G "Ninja Multi-Config" ^
@@ -416,6 +418,30 @@ echo Run scripts generated in %PKG%\
 
 echo.
 echo === Test apps done ===
+goto :done
+
+:do_vs2022
+echo.
+echo === Generating Visual Studio 2022 solution ===
+cmake -S "%REPO%." -B "%REPO%build_vs2022" -G "Visual Studio 17 2022" -A x64 ^
+  -DCMAKE_TOOLCHAIN_FILE="%REPO%vcpkg\scripts\buildsystems\vcpkg.cmake" ^
+  -DVCPKG_MANIFEST_FEATURES=gui ^
+  -DCMAKE_INSTALL_PREFIX="%REPO%_package" ^
+  -DXRT_BUILD_INSTALLER=ON ^
+  -DXRT_FEATURE_SERVICE=ON ^
+  -DXRT_FEATURE_HYBRID_MODE=ON ^
+  -DOpenXR_ROOT="%OPENXR_SDK_SHORT%"
+
+if %ERRORLEVEL% NEQ 0 (
+    echo VS2022 CMake generate FAILED
+    exit /b 1
+)
+
+echo.
+echo === Visual Studio 2022 solution ready ===
+echo   Solution: %REPO%build_vs2022\XRT.sln
+echo   Open it in Visual Studio 2022 and build the ALL_BUILD or INSTALL target.
+goto :done
 
 :done
 echo.

--- a/scripts/build_windows.bat
+++ b/scripts/build_windows.bat
@@ -430,7 +430,6 @@ cmake -S "%REPO%." -B "%REPO%build_vs2022" -G "Visual Studio 17 2022" -A x64 ^
   -DXRT_BUILD_INSTALLER=ON ^
   -DXRT_FEATURE_SERVICE=ON ^
   -DXRT_FEATURE_HYBRID_MODE=ON ^
-  -DXRT_VS_LAUNCH_APP=cube_handle_d3d11_win ^
   -DOpenXR_ROOT="%OPENXR_SDK_SHORT%"
 
 if %ERRORLEVEL% NEQ 0 (
@@ -441,9 +440,14 @@ if %ERRORLEVEL% NEQ 0 (
 echo.
 echo === Visual Studio 2022 solution ready ===
 echo   Solution: %REPO%build_vs2022\XRT.sln
-echo   Startup project: cube_handle_d3d11_win (F5 to launch + debug end-to-end).
-echo   Build the INSTALL target once first so XR_RUNTIME_JSON resolves.
-echo   To fold a different app: -DXRT_VS_LAUNCH_APP=cube_handle_vk_win
+echo   Build the INSTALL target, then set displayxr-service (or displayxr-cli)
+echo   as the startup project to debug the runtime + plug-in + SR SDK.
+echo   To debug a test app: build it with `build_windows.bat test-apps` and
+echo   launch _package\run_cube_handle_d3d11_win.bat (sets XR_RUNTIME_JSON +
+echo   has openxr_loader.dll beside the exe); attach VS, or add a debug profile
+echo   pointing at that exe with the same env.
+echo   (Folding a test app in as a one-click F5 target: WIP, see issue/PR notes
+echo   — set -DXRT_VS_LAUNCH_APP=cube_handle_d3d11_win once that lands.)
 goto :done
 
 :done

--- a/scripts/build_windows.bat
+++ b/scripts/build_windows.bat
@@ -430,6 +430,7 @@ cmake -S "%REPO%." -B "%REPO%build_vs2022" -G "Visual Studio 17 2022" -A x64 ^
   -DXRT_BUILD_INSTALLER=ON ^
   -DXRT_FEATURE_SERVICE=ON ^
   -DXRT_FEATURE_HYBRID_MODE=ON ^
+  -DXRT_VS_LAUNCH_APP=cube_handle_d3d11_win ^
   -DOpenXR_ROOT="%OPENXR_SDK_SHORT%"
 
 if %ERRORLEVEL% NEQ 0 (
@@ -440,7 +441,9 @@ if %ERRORLEVEL% NEQ 0 (
 echo.
 echo === Visual Studio 2022 solution ready ===
 echo   Solution: %REPO%build_vs2022\XRT.sln
-echo   Open it in Visual Studio 2022 and build the ALL_BUILD or INSTALL target.
+echo   Startup project: cube_handle_d3d11_win (F5 to launch + debug end-to-end).
+echo   Build the INSTALL target once first so XR_RUNTIME_JSON resolves.
+echo   To fold a different app: -DXRT_VS_LAUNCH_APP=cube_handle_vk_win
 goto :done
 
 :done

--- a/scripts/dev-setup.bat
+++ b/scripts/dev-setup.bat
@@ -1,0 +1,195 @@
+@echo off
+setlocal enabledelayedexpansion
+REM ============================================================
+REM DisplayXR ONE-LINE DEVELOPER ENVIRONMENT SETUP (from source).
+REM
+REM The dev mirror of the user bundle installer: takes a fresh clone to a
+REM fully working, debuggable dev environment in one command. Builds the
+REM runtime FROM SOURCE, registers ABI-matched display-processor plug-ins,
+REM points the machine's active OpenXR runtime at the dev build, and
+REM generates the Visual Studio solution. No patching, re-runnable.
+REM
+REM Difference vs scripts\setup-displayxr.bat: that one DOWNLOADS released
+REM installers (versions.json pins) for contributors who don't build. THIS
+REM one builds your local checkout for people hacking on the runtime/plugins.
+REM
+REM Usage:
+REM   scripts\dev-setup.bat                  :: runtime + sim-display + VS solution + active runtime
+REM   scripts\dev-setup.bat --leia           :: also build+register the Leia plug-in FROM SOURCE (ABI-matched)
+REM   scripts\dev-setup.bat --leia=release   :: install the latest RELEASED Leia plug-in instead (ABI risk vs a dev runtime)
+REM   scripts\dev-setup.bat --all            :: every known vendor plug-in (currently == --leia source)
+REM   scripts\dev-setup.bat --no-vs          :: skip the Visual Studio solution
+REM   scripts\dev-setup.bat --no-active-runtime
+REM   scripts\dev-setup.bat --clean          :: unregister dev plug-ins + restore the previous active runtime
+REM
+REM Run from an ELEVATED prompt (registers plug-ins + sets ActiveRuntime in HKLM).
+REM Prereqs (same as build_windows.bat): VS 2022 + C++ workload, Ninja, Vulkan SDK,
+REM GitHub CLI. --leia also needs gh auth (fetches the SR SDK) + a Leia repo.
+REM ============================================================
+
+set "SCRIPT_DIR=%~dp0"
+REM Resolve the repo root to a clean absolute path.
+pushd "%SCRIPT_DIR%.." && set "REPO=!CD!" && popd
+
+REM --- defaults ---
+set "WANT_LEIA="
+set "LEIA_MODE=source"
+set "WANT_VS=1"
+set "SET_ACTIVE=1"
+set "DO_CLEAN="
+
+REM --- parse flags ---
+:parse
+if "%~1"=="" goto :parsed
+if /I "%~1"=="--leia"             set "WANT_LEIA=1"
+if /I "%~1"=="--leia=source"      ( set "WANT_LEIA=1" & set "LEIA_MODE=source" )
+if /I "%~1"=="--leia=release"     ( set "WANT_LEIA=1" & set "LEIA_MODE=release" )
+if /I "%~1"=="--all"              ( set "WANT_LEIA=1" & set "LEIA_MODE=source" )
+if /I "%~1"=="--no-vs"            set "WANT_VS="
+if /I "%~1"=="--no-active-runtime" set "SET_ACTIVE="
+if /I "%~1"=="--clean"            set "DO_CLEAN=1"
+shift
+goto :parse
+:parsed
+
+REM --- elevation check (HKLM) ---
+net session >nul 2>&1
+if %ERRORLEVEL% NEQ 0 (
+    echo ERROR: run from an ELEVATED prompt ^(right-click cmd -^> Run as administrator^).
+    echo        Registering plug-ins and setting the active runtime both write HKLM.
+    exit /b 1
+)
+
+if defined DO_CLEAN goto :clean
+
+echo ============================================================
+echo  DisplayXR dev environment setup
+echo    repo:          %REPO%
+echo    leia:          %WANT_LEIA% (%LEIA_MODE%)
+echo    visual studio: %WANT_VS%
+echo    set active:    %SET_ACTIVE%
+echo ============================================================
+
+REM --- 1. Build the runtime from source (fetches vcpkg + OpenXR loader on first run) ---
+echo.
+echo [1/5] Building runtime from source...
+call "%SCRIPT_DIR%build_windows.bat" build
+if %ERRORLEVEL% NEQ 0 ( echo ERROR: runtime build failed. & exit /b 1 )
+
+REM --- 2. Register the freshly-built, ABI-matched sim-display (universal fallback) ---
+echo.
+echo [2/5] Registering dev sim-display plug-in...
+call "%SCRIPT_DIR%register_dev_plugin.bat" sim
+if %ERRORLEVEL% NEQ 0 ( echo ERROR: sim-display registration failed. & exit /b 1 )
+
+REM --- 3. Vendor plug-ins (optional) ---
+echo.
+if not defined WANT_LEIA (
+    echo [3/5] No vendor plug-in requested ^(pass --leia for Leia SR^).
+) else (
+    if /I "%LEIA_MODE%"=="release" (
+        call :leia_release
+    ) else (
+        call :leia_source
+    )
+    if !ERRORLEVEL! NEQ 0 ( echo ERROR: Leia plug-in setup failed. & exit /b 1 )
+)
+
+REM --- 4. Point the machine's active OpenXR runtime at the dev build ---
+echo.
+if defined SET_ACTIVE (
+    echo [4/5] Setting active OpenXR runtime to the dev build...
+    call :set_active_runtime
+) else (
+    echo [4/5] Skipping active-runtime change ^(--no-active-runtime^); use XR_RUNTIME_JSON per run.
+)
+
+REM --- 5. Visual Studio solution ---
+echo.
+if defined WANT_VS (
+    echo [5/5] Generating Visual Studio solution...
+    call "%SCRIPT_DIR%build_windows.bat" vs2022
+    if !ERRORLEVEL! NEQ 0 ( echo WARN: VS solution generation failed ^(runtime + plug-ins are still set up^). )
+) else (
+    echo [5/5] Skipping Visual Studio solution ^(--no-vs^).
+)
+
+echo.
+echo ============================================================
+echo  DONE. Registered display processors:
+echo ============================================================
+"%REPO%\_package\bin\displayxr-cli.exe" dp list 2>nul
+echo.
+echo Next:
+echo   - Verify:  _package\bin\displayxr-cli.exe selftest
+if defined WANT_VS echo   - Debug:   open build_vs2022\XRT.sln, build INSTALL, set displayxr-service as startup, F5
+echo   - Run cube: _package\run_cube_handle_d3d11_win.bat  ^(after: build_windows.bat test-apps^)
+echo   - Undo:    scripts\dev-setup.bat --clean
+exit /b 0
+
+
+REM ===================== subroutines =====================
+
+:leia_source
+echo [3/5] Building Leia plug-in FROM SOURCE ^(ABI-matched to this runtime^)...
+set "LEIA_REPO=%REPO%\..\displayxr-leia-plugin"
+if not exist "%LEIA_REPO%\.git" (
+    echo   cloning displayxr-leia-plugin next to the runtime...
+    git clone https://github.com/DisplayXR/displayxr-leia-plugin.git "%LEIA_REPO%" || exit /b 1
+) else (
+    echo   updating existing displayxr-leia-plugin checkout...
+    git -C "%LEIA_REPO%" pull --ff-only 2>nul
+)
+REM Build against THIS runtime checkout so the plug-in matches the dev ABI.
+REM The Leia build script auto-fetches the SR SDK via gh if LEIASR_SDKROOT is unset.
+set "DXR_RUNTIME_SOURCE_DIR=%REPO%"
+call "%LEIA_REPO%\scripts\build-windows.bat" build
+if %ERRORLEVEL% NEQ 0 ( echo   ERROR: Leia plug-in build failed. & exit /b 1 )
+REM Locate the built DLL and register it (ProbeOrder 50, wins over sim).
+set "LEIA_DLL="
+for /r "%LEIA_REPO%\_package" %%F in (DisplayXR-LeiaSR.dll) do set "LEIA_DLL=%%F"
+if not defined LEIA_DLL ( echo   ERROR: built DisplayXR-LeiaSR.dll not found under %LEIA_REPO%\_package. & exit /b 1 )
+call "%SCRIPT_DIR%register_dev_plugin.bat" leia "!LEIA_DLL!"
+exit /b %ERRORLEVEL%
+
+:leia_release
+echo [3/5] Installing the latest RELEASED Leia plug-in...
+echo   WARNING: a from-source runtime ahead of the released ABI may reject this plug-in.
+where gh >nul 2>&1 || ( echo   ERROR: gh not found ^(needed to download the release^). & exit /b 1 )
+set "DLDIR=%TEMP%\dxr-leia-release"
+if not exist "%DLDIR%" mkdir "%DLDIR%"
+gh release download -R DisplayXR/displayxr-leia-plugin -p "DisplayXRLeiaSRSetup-*.exe" -D "%DLDIR%" --clobber || ( echo   ERROR: download failed. & exit /b 1 )
+for %%F in ("%DLDIR%\DisplayXRLeiaSRSetup-*.exe") do set "LEIA_EXE=%%F"
+if not defined LEIA_EXE ( echo   ERROR: installer not found after download. & exit /b 1 )
+echo   running %LEIA_EXE% /S ...
+"%LEIA_EXE%" /S
+exit /b %ERRORLEVEL%
+
+:set_active_runtime
+set "MANIFEST=%REPO%\_package\DisplayXR_win64.json"
+if not exist "%MANIFEST%" ( echo   WARN: %MANIFEST% missing; skipping active-runtime change. & exit /b 0 )
+REM Back up the current ActiveRuntime once, so --clean can restore it.
+for /f "tokens=2,*" %%A in ('reg query "HKLM\Software\Khronos\OpenXR\1" /v ActiveRuntime 2^>nul ^| find "ActiveRuntime"') do set "PREV=%%B"
+reg query "HKLM\Software\DisplayXR\DevSetup" /v PrevActiveRuntime >nul 2>&1
+if %ERRORLEVEL% NEQ 0 if defined PREV (
+    reg add "HKLM\Software\DisplayXR\DevSetup" /v PrevActiveRuntime /t REG_SZ /d "!PREV!" /f >nul
+)
+reg add "HKLM\Software\Khronos\OpenXR\1" /v ActiveRuntime /t REG_SZ /d "%MANIFEST%" /f >nul
+echo   ActiveRuntime -^> %MANIFEST%
+exit /b 0
+
+:clean
+echo Cleaning up dev registrations...
+call "%SCRIPT_DIR%register_dev_plugin.bat" unregister-sim
+reg delete "HKLM\Software\DisplayXR\DisplayProcessors\leia-sr" /f >nul 2>&1
+REM Restore the previous active runtime if we backed one up.
+for /f "tokens=2,*" %%A in ('reg query "HKLM\Software\DisplayXR\DevSetup" /v PrevActiveRuntime 2^>nul ^| find "PrevActiveRuntime"') do set "PREV=%%B"
+if defined PREV (
+    reg add "HKLM\Software\Khronos\OpenXR\1" /v ActiveRuntime /t REG_SZ /d "!PREV!" /f >nul
+    reg delete "HKLM\Software\DisplayXR\DevSetup" /v PrevActiveRuntime /f >nul 2>&1
+    echo   restored ActiveRuntime -^> !PREV!
+) else (
+    echo   no backed-up ActiveRuntime to restore ^(left as-is^).
+)
+echo Done.
+exit /b 0

--- a/scripts/dev-setup.bat
+++ b/scripts/dev-setup.bat
@@ -28,8 +28,8 @@ REM GitHub CLI. --leia also needs gh auth (fetches the SR SDK) + a Leia repo.
 REM ============================================================
 
 set "SCRIPT_DIR=%~dp0"
-REM Resolve the repo root to a clean absolute path.
-pushd "%SCRIPT_DIR%.." && set "REPO=!CD!" && popd
+REM Resolve the repo root to a clean absolute path (no pushd/!CD! timing deps).
+for %%I in ("%SCRIPT_DIR%..") do set "REPO=%%~fI"
 
 REM --- defaults ---
 set "WANT_LEIA="

--- a/scripts/register_dev_plugin.bat
+++ b/scripts/register_dev_plugin.bat
@@ -1,0 +1,92 @@
+@echo off
+setlocal
+REM ============================================================
+REM Register a display-processor plug-in for a FROM-SOURCE dev runtime.
+REM
+REM Windows plug-in discovery is registry-only (HKLM\Software\DisplayXR\
+REM DisplayProcessors) — there is no adjacent-dir / env fallback like POSIX.
+REM `build_windows.bat` produces the sim-display plug-in DLL but does NOT
+REM register it, so a from-source runtime finds no display processor and
+REM xrt_instance_create_system fails (XRT_ERROR_DEVICE_CREATION_FAILED /
+REM "Failed to initialize OpenXR"). This registers the freshly-built,
+REM ABI-matched plug-in exactly as CI and the installer do.
+REM
+REM Run from an ELEVATED prompt (writes HKLM).
+REM
+REM Usage:
+REM   scripts\register_dev_plugin.bat                 :: register dev sim-display (fallback, no hardware)
+REM   scripts\register_dev_plugin.bat leia <dll>      :: register a dev-built Leia plug-in (ProbeOrder 50)
+REM   scripts\register_dev_plugin.bat unregister-sim  :: remove the dev sim-display entry
+REM   scripts\register_dev_plugin.bat list            :: show registered DPs (displayxr-cli dp list)
+REM ============================================================
+
+set "REPO=%~dp0.."
+set "MODE=%~1"
+if "%MODE%"=="" set "MODE=sim"
+
+REM --- elevation check (HKLM writes need admin) ---
+net session >nul 2>&1
+if %ERRORLEVEL% NEQ 0 (
+    if /I not "%MODE%"=="list" (
+        echo ERROR: run from an ELEVATED prompt ^(right-click cmd -^> Run as administrator^).
+        exit /b 1
+    )
+)
+
+if /I "%MODE%"=="list" goto :list
+if /I "%MODE%"=="unregister-sim" goto :unregister_sim
+if /I "%MODE%"=="leia" goto :leia
+goto :sim
+
+:sim
+set "DLL=%REPO%\_package\bin\plugins\DisplayXR-SimDisplay.dll"
+if not exist "%DLL%" (
+    echo ERROR: %DLL% not found. Build first: scripts\build_windows.bat build
+    exit /b 1
+)
+set "KEY=HKLM\Software\DisplayXR\DisplayProcessors\sim-display"
+reg add "%KEY%" /v Binary      /t REG_SZ    /d "%DLL%"                 /f >nul || goto :regfail
+reg add "%KEY%" /v ProbeOrder  /t REG_DWORD /d 200                    /f >nul || goto :regfail
+reg add "%KEY%" /v DisplayName /t REG_SZ    /d "Simulated 3D Display" /f >nul || goto :regfail
+echo Registered dev sim-display (ProbeOrder 200, fallback):
+echo   %DLL%
+goto :list
+
+:leia
+set "DLL=%~2"
+if "%DLL%"=="" (
+    echo ERROR: leia mode needs a DLL path:
+    echo   scripts\register_dev_plugin.bat leia C:\path\to\DisplayXR-LeiaSR.dll
+    exit /b 1
+)
+if not exist "%DLL%" (
+    echo ERROR: not found: %DLL%
+    exit /b 1
+)
+set "KEY=HKLM\Software\DisplayXR\DisplayProcessors\leia-sr"
+reg add "%KEY%" /v Binary      /t REG_SZ    /d "%DLL%"        /f >nul || goto :regfail
+reg add "%KEY%" /v ProbeOrder  /t REG_DWORD /d 50             /f >nul || goto :regfail
+reg add "%KEY%" /v DisplayName /t REG_SZ    /d "Leia SR (dev)" /f >nul || goto :regfail
+echo Registered dev Leia plug-in (ProbeOrder 50, wins over sim):
+echo   %DLL%
+echo Note: this OVERWRITES any installed leia-sr entry. Re-run the installer to restore it.
+goto :list
+
+:unregister_sim
+reg delete "HKLM\Software\DisplayXR\DisplayProcessors\sim-display" /f >nul 2>&1
+echo Removed sim-display dev registration.
+goto :list
+
+:list
+echo.
+set "CLI=%REPO%\_package\bin\displayxr-cli.exe"
+if exist "%CLI%" (
+    "%CLI%" dp list
+) else (
+    echo (displayxr-cli not built yet; skipping dp list)
+)
+exit /b 0
+
+:regfail
+echo ERROR: reg add failed (are you elevated?).
+exit /b 1

--- a/src/xrt/targets/webxr_bridge/CMakeLists.txt
+++ b/src/xrt/targets/webxr_bridge/CMakeLists.txt
@@ -26,6 +26,41 @@ if(NOT OpenXR_FOUND)
 	endif()
 endif()
 
+# The prebuilt OpenXR SDK's config package declares the loader target for a
+# single configuration (RelWithDebInfo only). Multi-config generators (the
+# Visual Studio one in particular) hard-error when generating any other
+# configuration of a consumer: "IMPORTED_IMPLIB not set for ... MinSizeRel".
+# Backfill every configuration this build generates from whichever implib the
+# package did declare — the loader is a plain prebuilt DLL, so one binary
+# serves all configs.
+if(TARGET OpenXR::openxr_loader)
+	get_target_property(_xr_implib OpenXR::openxr_loader IMPORTED_IMPLIB)
+	get_target_property(_xr_dll OpenXR::openxr_loader IMPORTED_LOCATION)
+	get_target_property(_xr_configs OpenXR::openxr_loader IMPORTED_CONFIGURATIONS)
+	if(NOT _xr_implib AND _xr_configs)
+		list(GET _xr_configs 0 _xr_cfg0)
+		get_target_property(_xr_implib OpenXR::openxr_loader IMPORTED_IMPLIB_${_xr_cfg0})
+		get_target_property(_xr_dll OpenXR::openxr_loader IMPORTED_LOCATION_${_xr_cfg0})
+	endif()
+	if(_xr_implib)
+		foreach(_xr_cfg ${CMAKE_CONFIGURATION_TYPES} ${CMAKE_BUILD_TYPE})
+			string(TOUPPER "${_xr_cfg}" _xr_cfg_uc)
+			get_target_property(_xr_have OpenXR::openxr_loader IMPORTED_IMPLIB_${_xr_cfg_uc})
+			if(NOT _xr_have)
+				set_property(
+					TARGET OpenXR::openxr_loader APPEND
+					PROPERTY IMPORTED_CONFIGURATIONS ${_xr_cfg_uc}
+					)
+				set_target_properties(
+					OpenXR::openxr_loader
+					PROPERTIES IMPORTED_IMPLIB_${_xr_cfg_uc} "${_xr_implib}"
+						   IMPORTED_LOCATION_${_xr_cfg_uc} "${_xr_dll}"
+					)
+			endif()
+		endforeach()
+	endif()
+endif()
+
 if(NOT OpenXR_FOUND)
 	message(STATUS "webxr_bridge: OpenXR loader not found, skipping displayxr-webxr-bridge")
 	return()
@@ -54,8 +89,12 @@ target_link_libraries(displayxr-webxr-bridge PRIVATE
 install(TARGETS displayxr-webxr-bridge RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # Copy the OpenXR loader DLL next to the exe in the build tree so it can
-# be run from _package/bin/ after install.
+# be run from _package/bin/ after install. _xr_dll was resolved above from
+# whichever IMPORTED_LOCATION(_<CONFIG>) the package/fallback declared.
 get_target_property(_loader_dll OpenXR::openxr_loader IMPORTED_LOCATION)
+if(NOT _loader_dll AND _xr_dll)
+	set(_loader_dll "${_xr_dll}")
+endif()
 if(_loader_dll)
 	add_custom_command(TARGET displayxr-webxr-bridge POST_BUILD
 		COMMAND ${CMAKE_COMMAND} -E copy_if_different

--- a/test_apps/cube_handle_d3d11_win/CMakeLists.txt
+++ b/test_apps/cube_handle_d3d11_win/CMakeLists.txt
@@ -12,8 +12,10 @@ if(MSVC)
     set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 endif()
 
-# OpenXR headers location
-set(OPENXR_INCLUDE_DIR "${CMAKE_SOURCE_DIR}/../../src/external/openxr_includes")
+# OpenXR headers location. Use CMAKE_CURRENT_SOURCE_DIR (not CMAKE_SOURCE_DIR)
+# so this resolves correctly both standalone and when folded into the main
+# build as an IDE launch target (XRT_VS_LAUNCH_APP).
+set(OPENXR_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../src/external/openxr_includes")
 
 # Find OpenXR loader - multiple strategies
 set(OPENXR_FOUND FALSE)
@@ -60,7 +62,7 @@ endif()
 
 # Strategy 3: Look in parent build directory
 if(NOT OPENXR_FOUND)
-    set(PARENT_BUILD_DIR "${CMAKE_SOURCE_DIR}/../../build")
+    set(PARENT_BUILD_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../build")
     if(EXISTS "${PARENT_BUILD_DIR}/src/external/openxr_loader/OpenXRConfig.cmake")
         list(APPEND CMAKE_PREFIX_PATH "${PARENT_BUILD_DIR}/src/external/openxr_loader")
         find_package(OpenXR REQUIRED CONFIG)


### PR DESCRIPTION
The dev mirror of the user bundle installer — **fresh clone to a debuggable dev environment in one command**, no patching:

```bat
scripts\dev-setup.bat            REM runtime + sim-display + VS solution + active runtime
scripts\dev-setup.bat --leia     REM also build+register the Leia plug-in FROM SOURCE (ABI-matched)
```

## What it does (elevated, idempotent)
1. Builds the runtime from source (`build_windows.bat build`).
2. Registers the freshly-built, **ABI-matched sim-display** (universal fallback) — the step the from-source pipeline was missing.
3. `--leia` → clones/updates `displayxr-leia-plugin`, builds it against **this** runtime checkout (`DXR_RUNTIME_SOURCE_DIR`, so it's ABI-matched; the plug-in build auto-fetches the SR SDK via `gh`), registers it (ProbeOrder 50). `--leia=release` installs the released plug-in instead (with an ABI-mismatch warning). `--all` == all known vendors (today: Leia).
4. Points the machine's **active OpenXR runtime** at the dev build (backs up the prior value).
5. Generates the **VS solution** (`build_windows.bat vs2022`).
6. Prints `displayxr-cli dp list` + next steps.

Flags: `--leia` / `--leia=release` / `--all` / `--no-vs` / `--no-active-runtime` / `--clean` (tears down + restores ActiveRuntime).

## vs `setup-displayxr.bat`
That one **downloads released** component installers (versions.json pins) for contributors who don't build. This one **builds from source** for people hacking on the runtime/plugins. The user-facing `DisplayXRBundle-*.exe` (displayxr-installer repo) is the third, end-user, path.

## Relationship to other PRs
**Umbrella** — includes the commits from **#557** (vs2022 target + Open-Folder preset fix; fold is opt-in/off) and **#586** (`register_dev_plugin.bat`) so the one-liner works end-to-end. Suggest merging this and closing #557 + #586 as folded-in (or merge those first and I'll rebase).

## Verification
Windows-only `.bat`, authored on macOS — **needs a Windows run-through** (CI doesn't exercise it). @cyrusrohani this is the no-patching one-liner; please try `scripts\dev-setup.bat --leia` from a fresh elevated prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)