### PR TITLE
test(#396): disturbance-free display↔camera rig toggle (C) + absolute SPACE reset across cube apps

### DIFF
--- a/test_apps/common/CMakeLists.txt
+++ b/test_apps/common/CMakeLists.txt
@@ -30,7 +30,7 @@ set(DISPLAYXR_EXTENSIONS_INCLUDE_DIR "${_dxr_ext_includes}" CACHE PATH
 FetchContent_Declare(
     displayxr_common
     GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
-    GIT_TAG v1.0.4
+    GIT_TAG v1.0.5
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(displayxr_common)

--- a/test_apps/common/CMakeLists.txt
+++ b/test_apps/common/CMakeLists.txt
@@ -30,7 +30,7 @@ set(DISPLAYXR_EXTENSIONS_INCLUDE_DIR "${_dxr_ext_includes}" CACHE PATH
 FetchContent_Declare(
     displayxr_common
     GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
-    GIT_TAG v0.3.0
+    GIT_TAG v1.0.4
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(displayxr_common)

--- a/test_apps/cube_handle_d3d11_win/main.cpp
+++ b/test_apps/cube_handle_d3d11_win/main.cpp
@@ -74,6 +74,10 @@ static float g_cameraM2v = 1.0f;
 // (perspective + pose). 0 = not captured yet (falls back to full display size).
 static float g_canvasWidthM = 0.0f;
 static float g_canvasHeightM = 0.0f;
+
+// Initial virtual display height, snapshotted at startup. SPACE resets the rig
+// to exactly this initial display-centric state (see ResetToInitialState).
+static float g_initialVHeight = 0.24f;
 static const float HUD_WIDTH_FRACTION = 0.30f;
 
 // Fullscreen state
@@ -319,12 +323,43 @@ static bool TryRigRoundtripToggle() {
     return true;
 }
 
+// SPACE = hard reset to the app's initial state: display-centric rig, pose at
+// origin (0,0,0) / identity orientation, the original vHeight, and every other
+// tunable at its default. Deliberately dumb and absolute (no conversion, no
+// dependence on the current rig) so there is no room for drift — the cube
+// always snaps back to exactly the launch view. Replaces the shared handler's
+// reset, which left g_cameraM2v / cameraMode stale (skewed-cube bug).
+static void ResetToInitialState() {
+    InputState& st = g_inputState;
+    st.cameraMode = false;                 // display-centric
+    st.cameraPosX = 0.0f;                   // pose at origin
+    st.cameraPosY = 0.0f;
+    st.cameraPosZ = 0.0f;
+    st.yaw = 0.0f;                          // identity orientation
+    st.pitch = 0.0f;
+    st.viewParams = ViewParams{};           // ipd/parallax/perspective/scale=1, conv=0.5, zoom=1
+    st.viewParams.virtualDisplayHeight = g_initialVHeight;
+    g_cameraM2v = 1.0f;                     // app-local camera scale back to identity
+    // Cancel any in-flight pose animation so it can't drive the pose post-reset.
+    st.resetViewRequested = false;
+    st.transitioning = false;
+    st.teleportAnimating = false;
+    st.animateEnabled = false;
+    st.animationActive = false;
+    LOG_INFO("rig RESET (SPACE): display-centric, pose (0,0,0)/identity, vHeight=%.4f", g_initialVHeight);
+}
+
 // Window procedure (runs on main thread — single-threaded, no locking needed)
 LRESULT CALLBACK WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
     // 'C' = disturbance-free rig round-trip (see TryRigRoundtripToggle). Handle
     // it before the shared UpdateInputState, which would otherwise reset the
     // camera params. Falls through to the shared toggle if display info isn't up.
     if (msg == WM_KEYDOWN && wParam == 'C' && TryRigRoundtripToggle()) {
+        return 0;
+    }
+    // SPACE = hard reset to the initial display-centric state (drift-free).
+    if (msg == WM_KEYDOWN && wParam == VK_SPACE) {
+        ResetToInitialState();
         return 0;
     }
     UpdateInputState(g_inputState, msg, wParam, lParam);
@@ -1537,6 +1572,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 
     // Set virtual display height (app units). 0.24 = 4x the 0.06m cube height.
     g_inputState.viewParams.virtualDisplayHeight = 0.24f;
+    g_initialVHeight = g_inputState.viewParams.virtualDisplayHeight; // SPACE-reset target
     g_inputState.nominalViewerZ = xr.nominalViewerZ;
     g_inputState.renderingModeCount = xr.renderingModeCount;
 

--- a/test_apps/cube_handle_d3d11_win/main.cpp
+++ b/test_apps/cube_handle_d3d11_win/main.cpp
@@ -66,6 +66,14 @@ static const float CAMERA_HALF_TAN_VFOV = 0.32491969623f; // tan(18°) → 36° 
 // converter (TryRigRoundtripToggle) derives this from the display rig so the
 // camera rig reproduces the display rig's eye scaling exactly; default 1.0.
 static float g_cameraM2v = 1.0f;
+
+// The runtime's resolved CANVAS size in meters (XrViewDisplayRawEXT::canvasSizeMeters),
+// captured each frame. The Kooima/rig math runs on the canvas (window client area),
+// NOT the full display — so the C-toggle converter must use the canvas height as
+// physical_height_m, else display<->camera diverge in any non-fullscreen window
+// (perspective + pose). 0 = not captured yet (falls back to full display size).
+static float g_canvasWidthM = 0.0f;
+static float g_canvasHeightM = 0.0f;
 static const float HUD_WIDTH_FRACTION = 0.30f;
 
 // Fullscreen state
@@ -234,9 +242,16 @@ static bool TryRigRoundtripToggle() {
     }
     InputState& st = g_inputState;
 
+    // Use the CANVAS size the runtime resolved (window client area in meters),
+    // NOT the full display — the rig math runs on the canvas, so in any
+    // non-fullscreen window the window "is" the display. Fall back to the full
+    // display size until the first raw-channel capture lands.
+    const float physH = (g_canvasHeightM > 0.0f) ? g_canvasHeightM : g_xr->displayHeightM;
+    const float physW = (g_canvasWidthM > 0.0f) ? g_canvasWidthM : g_xr->displayWidthM;
+
     dxr_rig_display_info info;
-    info.physical_height_m = g_xr->displayHeightM;
-    info.aspect = g_xr->displayWidthM / g_xr->displayHeightM;
+    info.physical_height_m = physH;
+    info.aspect = physW / physH;
     info.nominal_distance_m = g_xr->nominalViewerZ;
 
     // Current rig pose — same construction as the per-frame rigPose in the
@@ -858,6 +873,15 @@ static void RenderOneFrame(RenderState& rs) {
                     }
 
                     xrLocateViews(xr.session, &locateInfo, &viewState, 8, &viewCount, rawViews);
+
+                    // Capture the runtime's resolved CANVAS size (the window
+                    // client area in meters) — this is the physical_height_m the
+                    // Kooima/rig math runs on, which the C-toggle converter must
+                    // match. Fullscreen → canvas == display; windowed → smaller.
+                    if (g_hasViewRigExt && rawProbe.canvasSizeMeters.height > 0.0f) {
+                        g_canvasWidthM = rawProbe.canvasSizeMeters.width;
+                        g_canvasHeightM = rawProbe.canvasSizeMeters.height;
+                    }
 
                     // XR_EXT_view_rig raw-channel verification (#396 W7): one-shot
                     // proof the raw channel reports the DP's full per-view set.

--- a/test_apps/cube_handle_d3d11_win/main.cpp
+++ b/test_apps/cube_handle_d3d11_win/main.cpp
@@ -22,6 +22,7 @@
 #include "xr_session.h"
 #include "projection_depth.h"
 #include "atlas_capture.h"
+#include <dxr_view_math.h>  // display<->camera rig converters (disturbance-free C-toggle test)
 
 #include <chrono>
 #include <cmath>
@@ -61,6 +62,10 @@ static bool g_inSizeMove = false;  // True while user is dragging/resizing the w
 static const uint32_t HUD_PIXEL_WIDTH = 380;
 static const uint32_t HUD_PIXEL_HEIGHT = 470;
 static const float CAMERA_HALF_TAN_VFOV = 0.32491969623f; // tan(18°) → 36° vFOV
+// Camera-rig meters→world scale (XrCameraRigEXT::metersToVirtual). The C-toggle
+// converter (TryRigRoundtripToggle) derives this from the display rig so the
+// camera rig reproduces the display rig's eye scaling exactly; default 1.0.
+static float g_cameraM2v = 1.0f;
 static const float HUD_WIDTH_FRACTION = 0.30f;
 
 // Fullscreen state
@@ -206,8 +211,107 @@ static void ToggleFullscreen(HWND hwnd) {
     }
 }
 
+// Disturbance-free rig round-trip test ('C' key).
+//
+// Instead of the shared input handler's behavior (C flips cameraMode and RESETS
+// the camera params to arbitrary defaults — a visible pop), C here converts the
+// CURRENT rig into its exact equivalent in the OTHER parameterization using the
+// shipped displayxr-common converters, then renders through that rig. Because
+// display→camera is always exact and camera→display is exact for the
+// (compatible) camera rig display→camera produces, the rendered view does not
+// change across the toggle — and display→camera→display is an identity, so
+// pressing C repeatedly never moves the cube, for ANY starting display rig
+// (change ipd / parallax / perspective / vHeight / pose first and it still
+// holds). Manually perturbing the camera rig into a non-compatible convergence
+// is the one case that legitimately can't round-trip (the display rig pins
+// convergence to the display plane); the returned residual flags it.
+//
+// Returns false if display info isn't available yet — caller falls back to the
+// plain shared toggle.
+static bool TryRigRoundtripToggle() {
+    if (g_xr == nullptr || g_xr->displayHeightM <= 0.0f || g_xr->nominalViewerZ <= 0.0f) {
+        return false;
+    }
+    InputState& st = g_inputState;
+
+    dxr_rig_display_info info;
+    info.physical_height_m = g_xr->displayHeightM;
+    info.aspect = g_xr->displayWidthM / g_xr->displayHeightM;
+    info.nominal_distance_m = g_xr->nominalViewerZ;
+
+    // Current rig pose — same construction as the per-frame rigPose in the
+    // locate loop (orientation from yaw/pitch, position from cameraPos). The
+    // converters preserve orientation and only translate the pose, so yaw/pitch
+    // stay put and we write back position only.
+    XMFLOAT4 rq;
+    XMStoreFloat4(&rq, XMQuaternionRotationRollPitchYaw(st.pitch, st.yaw, 0.0f));
+    const dxr_quat q = {rq.x, rq.y, rq.z, rq.w};
+    const dxr_vec3 pos = {st.cameraPosX, st.cameraPosY, st.cameraPosZ};
+
+    if (!st.cameraMode) {
+        // Display → camera.
+        dxr_display_rig disp;
+        disp.pose.orientation = q;
+        disp.pose.position = pos;
+        disp.virtual_display_height = st.viewParams.virtualDisplayHeight / st.viewParams.scaleFactor;
+        disp.ipd_factor = st.viewParams.ipdFactor;
+        disp.parallax_factor = st.viewParams.parallaxFactor;
+        disp.perspective_factor = st.viewParams.perspectiveFactor;
+
+        dxr_camera_rig cam;
+        dxr_view_rig_display_to_camera(&disp, &info, &cam);
+
+        st.viewParams.invConvergenceDistance = cam.inv_convergence_distance;
+        st.viewParams.zoomFactor = CAMERA_HALF_TAN_VFOV / cam.half_tan_vfov;
+        g_cameraM2v = cam.m2v;
+        st.viewParams.ipdFactor = cam.ipd_factor;
+        st.viewParams.parallaxFactor = cam.parallax_factor;
+        st.cameraPosX = cam.pose.position.x;
+        st.cameraPosY = cam.pose.position.y;
+        st.cameraPosZ = cam.pose.position.z;
+        st.cameraMode = true;
+        LOG_INFO("rig C-toggle DISPLAY->CAMERA: convergence=%.4f zoom=%.4f m2v=%.4f pos=(%.3f,%.3f,%.3f)",
+                 st.viewParams.invConvergenceDistance, st.viewParams.zoomFactor, g_cameraM2v,
+                 st.cameraPosX, st.cameraPosY, st.cameraPosZ);
+    } else {
+        // Camera → display.
+        dxr_camera_rig cam;
+        cam.pose.orientation = q;
+        cam.pose.position = pos;
+        cam.ipd_factor = st.viewParams.ipdFactor;
+        cam.parallax_factor = st.viewParams.parallaxFactor;
+        cam.inv_convergence_distance = st.viewParams.invConvergenceDistance;
+        cam.half_tan_vfov = CAMERA_HALF_TAN_VFOV / st.viewParams.zoomFactor;
+        cam.m2v = g_cameraM2v;
+
+        dxr_display_rig disp;
+        const float residual = dxr_view_rig_camera_to_display(&cam, &info, &disp);
+
+        // Preserve the user's display-mode scaleFactor: the rig submits
+        // virtualDisplayHeight/scaleFactor, so scale the converter's vH up by it.
+        st.viewParams.virtualDisplayHeight = disp.virtual_display_height * st.viewParams.scaleFactor;
+        st.viewParams.perspectiveFactor = disp.perspective_factor;
+        st.viewParams.ipdFactor = disp.ipd_factor;
+        st.viewParams.parallaxFactor = disp.parallax_factor;
+        st.cameraPosX = disp.pose.position.x;
+        st.cameraPosY = disp.pose.position.y;
+        st.cameraPosZ = disp.pose.position.z;
+        st.cameraMode = false;
+        LOG_INFO("rig C-toggle CAMERA->DISPLAY: vH=%.4f persp=%.4f pos=(%.3f,%.3f,%.3f) residual=%.5f (0=exact)",
+                 st.viewParams.virtualDisplayHeight, st.viewParams.perspectiveFactor,
+                 st.cameraPosX, st.cameraPosY, st.cameraPosZ, residual);
+    }
+    return true;
+}
+
 // Window procedure (runs on main thread — single-threaded, no locking needed)
 LRESULT CALLBACK WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
+    // 'C' = disturbance-free rig round-trip (see TryRigRoundtripToggle). Handle
+    // it before the shared UpdateInputState, which would otherwise reset the
+    // camera params. Falls through to the shared toggle if display info isn't up.
+    if (msg == WM_KEYDOWN && wParam == 'C' && TryRigRoundtripToggle()) {
+        return 0;
+    }
     UpdateInputState(g_inputState, msg, wParam, lParam);
 
     switch (msg) {
@@ -737,6 +841,10 @@ static void RenderOneFrame(RenderState& rs) {
                             cameraRig.convergenceDiopters = g_inputState.viewParams.invConvergenceDistance;
                             cameraRig.verticalFov =
                                 2.0f * atanf(CAMERA_HALF_TAN_VFOV / g_inputState.viewParams.zoomFactor);
+                            // metersToVirtual carries the eye scale the C-toggle
+                            // converter derived from the display rig, so the
+                            // camera rig reproduces the display rig exactly.
+                            cameraRig.metersToVirtual = g_cameraM2v;
                             locateInfo.next = &cameraRig;
                         } else {
                             displayRig.pose = rigPose;
@@ -869,7 +977,7 @@ static void RenderOneFrame(RenderState& rs) {
                                 wchar_t vhBuf[64];
                                 if (g_inputState.cameraMode) {
                                     float tanHFOV = CAMERA_HALF_TAN_VFOV / g_inputState.viewParams.zoomFactor;
-                                    swprintf(vhBuf, 64, L"\ntanHFOV: %.3f", tanHFOV);
+                                    swprintf(vhBuf, 64, L"\ntanHFOV: %.3f  m2v: %.3f", tanHFOV, g_cameraM2v);
                                 } else {
                                     float hudM2v = 1.0f;
                                     if (g_inputState.viewParams.virtualDisplayHeight > 0.0f && xr.displayHeightM > 0.0f)

--- a/test_apps/cube_handle_d3d11_win/main.cpp
+++ b/test_apps/cube_handle_d3d11_win/main.cpp
@@ -22,7 +22,6 @@
 #include "xr_session.h"
 #include "projection_depth.h"
 #include "atlas_capture.h"
-#include <dxr_view_math.h>  // display<->camera rig converters (disturbance-free C-toggle test)
 
 #include <chrono>
 #include <cmath>
@@ -62,22 +61,10 @@ static bool g_inSizeMove = false;  // True while user is dragging/resizing the w
 static const uint32_t HUD_PIXEL_WIDTH = 380;
 static const uint32_t HUD_PIXEL_HEIGHT = 470;
 static const float CAMERA_HALF_TAN_VFOV = 0.32491969623f; // tan(18°) → 36° vFOV
-// Camera-rig meters→world scale (XrCameraRigEXT::metersToVirtual). The C-toggle
-// converter (TryRigRoundtripToggle) derives this from the display rig so the
-// camera rig reproduces the display rig's eye scaling exactly; default 1.0.
-static float g_cameraM2v = 1.0f;
-
-// The runtime's resolved CANVAS size in meters (XrViewDisplayRawEXT::canvasSizeMeters),
-// captured each frame. The Kooima/rig math runs on the canvas (window client area),
-// NOT the full display — so the C-toggle converter must use the canvas height as
-// physical_height_m, else display<->camera diverge in any non-fullscreen window
-// (perspective + pose). 0 = not captured yet (falls back to full display size).
-static float g_canvasWidthM = 0.0f;
-static float g_canvasHeightM = 0.0f;
-
-// Initial virtual display height, snapshotted at startup. SPACE resets the rig
-// to exactly this initial display-centric state (see ResetToInitialState).
-static float g_initialVHeight = 0.24f;
+// Disturbance-free C toggle + absolute SPACE reset live in displayxr-common
+// (common/rig_mode.{h,cpp}, driven by UpdateInputState/UpdateCameraMovement).
+// The app only feeds InputState the canvas size + initial vHeight and submits
+// XrCameraRigEXT::metersToVirtual = viewParams.cameraM2v (see below).
 static const float HUD_WIDTH_FRACTION = 0.30f;
 
 // Fullscreen state
@@ -223,145 +210,12 @@ static void ToggleFullscreen(HWND hwnd) {
     }
 }
 
-// Disturbance-free rig round-trip test ('C' key).
-//
-// Instead of the shared input handler's behavior (C flips cameraMode and RESETS
-// the camera params to arbitrary defaults — a visible pop), C here converts the
-// CURRENT rig into its exact equivalent in the OTHER parameterization using the
-// shipped displayxr-common converters, then renders through that rig. Because
-// display→camera is always exact and camera→display is exact for the
-// (compatible) camera rig display→camera produces, the rendered view does not
-// change across the toggle — and display→camera→display is an identity, so
-// pressing C repeatedly never moves the cube, for ANY starting display rig
-// (change ipd / parallax / perspective / vHeight / pose first and it still
-// holds). Manually perturbing the camera rig into a non-compatible convergence
-// is the one case that legitimately can't round-trip (the display rig pins
-// convergence to the display plane); the returned residual flags it.
-//
-// Returns false if display info isn't available yet — caller falls back to the
-// plain shared toggle.
-static bool TryRigRoundtripToggle() {
-    if (g_xr == nullptr || g_xr->displayHeightM <= 0.0f || g_xr->nominalViewerZ <= 0.0f) {
-        return false;
-    }
-    InputState& st = g_inputState;
-
-    // Use the CANVAS size the runtime resolved (window client area in meters),
-    // NOT the full display — the rig math runs on the canvas, so in any
-    // non-fullscreen window the window "is" the display. Fall back to the full
-    // display size until the first raw-channel capture lands.
-    const float physH = (g_canvasHeightM > 0.0f) ? g_canvasHeightM : g_xr->displayHeightM;
-    const float physW = (g_canvasWidthM > 0.0f) ? g_canvasWidthM : g_xr->displayWidthM;
-
-    dxr_rig_display_info info;
-    info.physical_height_m = physH;
-    info.aspect = physW / physH;
-    info.nominal_distance_m = g_xr->nominalViewerZ;
-
-    // Current rig pose — same construction as the per-frame rigPose in the
-    // locate loop (orientation from yaw/pitch, position from cameraPos). The
-    // converters preserve orientation and only translate the pose, so yaw/pitch
-    // stay put and we write back position only.
-    XMFLOAT4 rq;
-    XMStoreFloat4(&rq, XMQuaternionRotationRollPitchYaw(st.pitch, st.yaw, 0.0f));
-    const dxr_quat q = {rq.x, rq.y, rq.z, rq.w};
-    const dxr_vec3 pos = {st.cameraPosX, st.cameraPosY, st.cameraPosZ};
-
-    if (!st.cameraMode) {
-        // Display → camera.
-        dxr_display_rig disp;
-        disp.pose.orientation = q;
-        disp.pose.position = pos;
-        disp.virtual_display_height = st.viewParams.virtualDisplayHeight / st.viewParams.scaleFactor;
-        disp.ipd_factor = st.viewParams.ipdFactor;
-        disp.parallax_factor = st.viewParams.parallaxFactor;
-        disp.perspective_factor = st.viewParams.perspectiveFactor;
-
-        dxr_camera_rig cam;
-        dxr_view_rig_display_to_camera(&disp, &info, &cam);
-
-        st.viewParams.invConvergenceDistance = cam.inv_convergence_distance;
-        st.viewParams.zoomFactor = CAMERA_HALF_TAN_VFOV / cam.half_tan_vfov;
-        g_cameraM2v = cam.m2v;
-        st.viewParams.ipdFactor = cam.ipd_factor;
-        st.viewParams.parallaxFactor = cam.parallax_factor;
-        st.cameraPosX = cam.pose.position.x;
-        st.cameraPosY = cam.pose.position.y;
-        st.cameraPosZ = cam.pose.position.z;
-        st.cameraMode = true;
-        LOG_INFO("rig C-toggle DISPLAY->CAMERA: convergence=%.4f zoom=%.4f m2v=%.4f pos=(%.3f,%.3f,%.3f)",
-                 st.viewParams.invConvergenceDistance, st.viewParams.zoomFactor, g_cameraM2v,
-                 st.cameraPosX, st.cameraPosY, st.cameraPosZ);
-    } else {
-        // Camera → display.
-        dxr_camera_rig cam;
-        cam.pose.orientation = q;
-        cam.pose.position = pos;
-        cam.ipd_factor = st.viewParams.ipdFactor;
-        cam.parallax_factor = st.viewParams.parallaxFactor;
-        cam.inv_convergence_distance = st.viewParams.invConvergenceDistance;
-        cam.half_tan_vfov = CAMERA_HALF_TAN_VFOV / st.viewParams.zoomFactor;
-        cam.m2v = g_cameraM2v;
-
-        dxr_display_rig disp;
-        const float residual = dxr_view_rig_camera_to_display(&cam, &info, &disp);
-
-        // Preserve the user's display-mode scaleFactor: the rig submits
-        // virtualDisplayHeight/scaleFactor, so scale the converter's vH up by it.
-        st.viewParams.virtualDisplayHeight = disp.virtual_display_height * st.viewParams.scaleFactor;
-        st.viewParams.perspectiveFactor = disp.perspective_factor;
-        st.viewParams.ipdFactor = disp.ipd_factor;
-        st.viewParams.parallaxFactor = disp.parallax_factor;
-        st.cameraPosX = disp.pose.position.x;
-        st.cameraPosY = disp.pose.position.y;
-        st.cameraPosZ = disp.pose.position.z;
-        st.cameraMode = false;
-        LOG_INFO("rig C-toggle CAMERA->DISPLAY: vH=%.4f persp=%.4f pos=(%.3f,%.3f,%.3f) residual=%.5f (0=exact)",
-                 st.viewParams.virtualDisplayHeight, st.viewParams.perspectiveFactor,
-                 st.cameraPosX, st.cameraPosY, st.cameraPosZ, residual);
-    }
-    return true;
-}
-
-// SPACE = hard reset to the app's initial state: display-centric rig, pose at
-// origin (0,0,0) / identity orientation, the original vHeight, and every other
-// tunable at its default. Deliberately dumb and absolute (no conversion, no
-// dependence on the current rig) so there is no room for drift — the cube
-// always snaps back to exactly the launch view. Replaces the shared handler's
-// reset, which left g_cameraM2v / cameraMode stale (skewed-cube bug).
-static void ResetToInitialState() {
-    InputState& st = g_inputState;
-    st.cameraMode = false;                 // display-centric
-    st.cameraPosX = 0.0f;                   // pose at origin
-    st.cameraPosY = 0.0f;
-    st.cameraPosZ = 0.0f;
-    st.yaw = 0.0f;                          // identity orientation
-    st.pitch = 0.0f;
-    st.viewParams = ViewParams{};           // ipd/parallax/perspective/scale=1, conv=0.5, zoom=1
-    st.viewParams.virtualDisplayHeight = g_initialVHeight;
-    g_cameraM2v = 1.0f;                     // app-local camera scale back to identity
-    // Cancel any in-flight pose animation so it can't drive the pose post-reset.
-    st.resetViewRequested = false;
-    st.transitioning = false;
-    st.teleportAnimating = false;
-    st.animateEnabled = false;
-    st.animationActive = false;
-    LOG_INFO("rig RESET (SPACE): display-centric, pose (0,0,0)/identity, vHeight=%.4f", g_initialVHeight);
-}
-
 // Window procedure (runs on main thread — single-threaded, no locking needed)
 LRESULT CALLBACK WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
-    // 'C' = disturbance-free rig round-trip (see TryRigRoundtripToggle). Handle
-    // it before the shared UpdateInputState, which would otherwise reset the
-    // camera params. Falls through to the shared toggle if display info isn't up.
-    if (msg == WM_KEYDOWN && wParam == 'C' && TryRigRoundtripToggle()) {
-        return 0;
-    }
-    // SPACE = hard reset to the initial display-centric state (drift-free).
-    if (msg == WM_KEYDOWN && wParam == VK_SPACE) {
-        ResetToInitialState();
-        return 0;
-    }
+    // C (disturbance-free rig toggle) and SPACE (absolute reset) are handled by
+    // the shared displayxr-common input path: UpdateInputState sets the request,
+    // UpdateCameraMovement runs the rig_mode conversion / reset using the canvas
+    // size + initial vHeight the render loop feeds into InputState.
     UpdateInputState(g_inputState, msg, wParam, lParam);
 
     switch (msg) {
@@ -894,7 +748,7 @@ static void RenderOneFrame(RenderState& rs) {
                             // metersToVirtual carries the eye scale the C-toggle
                             // converter derived from the display rig, so the
                             // camera rig reproduces the display rig exactly.
-                            cameraRig.metersToVirtual = g_cameraM2v;
+                            cameraRig.metersToVirtual = g_inputState.viewParams.cameraM2v;
                             locateInfo.next = &cameraRig;
                         } else {
                             displayRig.pose = rigPose;
@@ -914,8 +768,8 @@ static void RenderOneFrame(RenderState& rs) {
                     // Kooima/rig math runs on, which the C-toggle converter must
                     // match. Fullscreen → canvas == display; windowed → smaller.
                     if (g_hasViewRigExt && rawProbe.canvasSizeMeters.height > 0.0f) {
-                        g_canvasWidthM = rawProbe.canvasSizeMeters.width;
-                        g_canvasHeightM = rawProbe.canvasSizeMeters.height;
+                        g_inputState.canvasWidthM = rawProbe.canvasSizeMeters.width;
+                        g_inputState.canvasHeightM = rawProbe.canvasSizeMeters.height;
                     }
 
                     // XR_EXT_view_rig raw-channel verification (#396 W7): one-shot
@@ -1036,7 +890,7 @@ static void RenderOneFrame(RenderState& rs) {
                                 wchar_t vhBuf[64];
                                 if (g_inputState.cameraMode) {
                                     float tanHFOV = CAMERA_HALF_TAN_VFOV / g_inputState.viewParams.zoomFactor;
-                                    swprintf(vhBuf, 64, L"\ntanHFOV: %.3f  m2v: %.3f", tanHFOV, g_cameraM2v);
+                                    swprintf(vhBuf, 64, L"\ntanHFOV: %.3f  m2v: %.3f", tanHFOV, g_inputState.viewParams.cameraM2v);
                                 } else {
                                     float hudM2v = 1.0f;
                                     if (g_inputState.viewParams.virtualDisplayHeight > 0.0f && xr.displayHeightM > 0.0f)
@@ -1572,7 +1426,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 
     // Set virtual display height (app units). 0.24 = 4x the 0.06m cube height.
     g_inputState.viewParams.virtualDisplayHeight = 0.24f;
-    g_initialVHeight = g_inputState.viewParams.virtualDisplayHeight; // SPACE-reset target
+    g_inputState.initialVirtualDisplayHeight = g_inputState.viewParams.virtualDisplayHeight; // SPACE-reset target
     g_inputState.nominalViewerZ = xr.nominalViewerZ;
     g_inputState.renderingModeCount = xr.renderingModeCount;
 

--- a/test_apps/cube_handle_gl_macos/CMakeLists.txt
+++ b/test_apps/cube_handle_gl_macos/CMakeLists.txt
@@ -60,7 +60,7 @@ set(DISPLAYXR_EXTENSIONS_INCLUDE_DIR "${_dxr_ext_includes}" CACHE PATH
 FetchContent_Declare(
     displayxr_common
     GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
-    GIT_TAG v0.3.0
+    GIT_TAG v1.0.5
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(displayxr_common)

--- a/test_apps/cube_handle_gl_macos/main.mm
+++ b/test_apps/cube_handle_gl_macos/main.mm
@@ -40,6 +40,7 @@
 // stb_image implementation TU lives in displayxr::common (stb_image_impl_macos.cpp) — declarations only here (#396 W4).
 #include "stb_image.h"
 #include "view_params.h"
+#include "rig_mode.h"
 #include "atlas_capture.h"
 #include "xr_window_space_hud.h"
 #include "hud_renderer_macos.h"
@@ -740,6 +741,14 @@ struct InputState {
     int32_t absoluteRenderingModeRequested = -1; // 0-8 keys; -1 = none
     bool cameraMode = false;
     float nominalViewerZ = 0.5f;
+    // Disturbance-free rig round-trip (C) + absolute reset (SPACE) — delegated
+    // to the shared displayxr-common helper (common/rig_mode.{h,cpp}). The C key
+    // sets the request; the conversion runs in UpdateCameraMovement using the
+    // CANVAS size + initial vHeight fed in below.
+    bool rigModeToggleRequested = false;
+    float canvasWidthM = 0.0f;
+    float canvasHeightM = 0.0f;
+    float initialVirtualDisplayHeight = 0.0f;
     // 'I' key: snapshot the **app's projection-layer atlas only** (cols ×
     // rows × renderW × renderH) to ~/Pictures/DisplayXR/<app>-<N>_
     // <cols>x<rows>.png. One projection layer; HUD / window-space layers
@@ -969,20 +978,9 @@ static void PumpMacOSEvents()
                         g_input.captureAtlasRequested = true;
                     }
                     else if (ch == 'c' && !isRepeat) {
-                        g_input.cameraMode = !g_input.cameraMode;
-                        if (g_input.cameraMode) {
-                            g_input.cameraPosX = 0.0f;
-                            g_input.cameraPosY = 0.0f;
-                            g_input.cameraPosZ = g_input.nominalViewerZ;
-                            g_input.yaw = 0.0f;
-                            g_input.pitch = 0.0f;
-                            if (g_input.nominalViewerZ > 0.0f)
-                                g_input.viewParams.invConvergenceDistance = 1.0f / g_input.nominalViewerZ;
-                        } else {
-                            g_input.cameraPosX = g_input.cameraPosY = g_input.cameraPosZ = 0.0f;
-                            g_input.yaw = 0.0f;
-                            g_input.pitch = 0.0f;
-                        }
+                        // Disturbance-free rig round-trip — the conversion runs
+                        // in UpdateCameraMovement (it has the canvas size).
+                        g_input.rigModeToggleRequested = true;
                     }
                     else if (ch >= '0' && ch <= '8' && !isRepeat) {
                         g_input.absoluteRenderingModeRequested = (int32_t)(ch - '0');
@@ -1020,23 +1018,35 @@ static void PumpMacOSEvents()
 // ============================================================================
 
 static void UpdateCameraMovement(InputState& state, float deltaTime, float displayHeightM = 0.0f) {
+    // Absolute SPACE reset — snap back to the initial DISPLAY-centric state via
+    // the shared helper (display rig, pose origin/identity, initial vHeight,
+    // every tunable default incl. cameraM2v=1).
     if (state.resetViewRequested) {
-        state.yaw = state.pitch = 0.0f;
-        float savedVDH = state.viewParams.virtualDisplayHeight;
-        bool savedCameraMode = state.cameraMode;
-        state.viewParams = ViewParams{};
-        state.viewParams.virtualDisplayHeight = savedVDH;
-        state.cameraMode = savedCameraMode;
-        if (state.cameraMode) {
-            state.cameraPosX = 0.0f;
-            state.cameraPosY = 0.0f;
-            state.cameraPosZ = state.nominalViewerZ;
-            if (state.nominalViewerZ > 0.0f)
-                state.viewParams.invConvergenceDistance = 1.0f / state.nominalViewerZ;
-        } else {
-            state.cameraPosX = state.cameraPosY = state.cameraPosZ = 0.0f;
-        }
         state.resetViewRequested = false;
+        float pos[3] = {state.cameraPosX, state.cameraPosY, state.cameraPosZ};
+        dxr::RigResetToInitial(state.viewParams, state.cameraMode, pos, state.yaw, state.pitch,
+                               state.initialVirtualDisplayHeight);
+        state.cameraPosX = pos[0];
+        state.cameraPosY = pos[1];
+        state.cameraPosZ = pos[2];
+        return;
+    }
+
+    // Disturbance-free rig round-trip toggle (C key) — delegate to the shared
+    // converter so macOS and Windows apps behave identically. Pass the same
+    // orientation quaternion the app submits to the runtime, plus the CANVAS
+    // size the runtime renders into (NOT the full display).
+    if (state.rigModeToggleRequested) {
+        state.rigModeToggleRequested = false;
+        XrQuaternionf rq;
+        quat_from_yaw_pitch(state.yaw, state.pitch, &rq);
+        const float quat[4] = {rq.x, rq.y, rq.z, rq.w};
+        float pos[3] = {state.cameraPosX, state.cameraPosY, state.cameraPosZ};
+        dxr::RigToggleMode(state.viewParams, state.cameraMode, pos, quat, state.canvasWidthM,
+                           state.canvasHeightM, state.nominalViewerZ, displayHeightM);
+        state.cameraPosX = pos[0];
+        state.cameraPosY = pos[1];
+        state.cameraPosZ = pos[2];
         return;
     }
 
@@ -1611,6 +1621,7 @@ int main(int argc, char **argv)
     // mode 1 (default of app.currentModeIndex).
 
     g_input.viewParams.virtualDisplayHeight = 0.24f;
+    g_input.initialVirtualDisplayHeight = g_input.viewParams.virtualDisplayHeight;
     g_input.nominalViewerZ = app.nominalViewerZ;
 
     LOG_INFO("Entering main loop... (ESC to quit, drag to rotate, WASD to move, Space to reset)");
@@ -1705,6 +1716,10 @@ int main(int argc, char **argv)
                 cameraRig.convergenceDiopters = g_input.viewParams.invConvergenceDistance;
                 cameraRig.verticalFov =
                     2.0f * atanf(CAMERA_HALF_TAN_VFOV / g_input.viewParams.zoomFactor);
+                // metersToVirtual carries the eye scale the C-toggle converter
+                // derived from the display rig, so the camera rig reproduces the
+                // display rig exactly.
+                cameraRig.metersToVirtual = g_input.viewParams.cameraM2v;
                 locateInfo.next = &cameraRig;
             } else {
                 displayRig.pose = rigPose;
@@ -1720,6 +1735,14 @@ int main(int argc, char **argv)
 
         uint32_t viewCount = 0;
         xrLocateViews(app.session, &locateInfo, &viewState, (uint32_t)views.size(), &viewCount, views.data());
+
+        // Capture the runtime's resolved CANVAS size (the window client area in
+        // meters) — the physical_height_m the Kooima/rig math runs on, which the
+        // C-toggle converter must match (windowed → smaller than the display).
+        if (useRig && viewRigRaw.canvasSizeMeters.height > 0.0f) {
+            g_input.canvasWidthM = viewRigRaw.canvasSizeMeters.width;
+            g_input.canvasHeightM = viewRigRaw.canvasSizeMeters.height;
+        }
 
         // Acquire swapchain image
         XrSwapchainImageAcquireInfo acqInfo = {XR_TYPE_SWAPCHAIN_IMAGE_ACQUIRE_INFO};

--- a/test_apps/cube_handle_metal_macos/CMakeLists.txt
+++ b/test_apps/cube_handle_metal_macos/CMakeLists.txt
@@ -60,7 +60,7 @@ set(DISPLAYXR_EXTENSIONS_INCLUDE_DIR "${_dxr_ext_includes}" CACHE PATH
 FetchContent_Declare(
     displayxr_common
     GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
-    GIT_TAG v0.3.0
+    GIT_TAG v1.0.5
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(displayxr_common)

--- a/test_apps/cube_handle_metal_macos/main.mm
+++ b/test_apps/cube_handle_metal_macos/main.mm
@@ -38,6 +38,7 @@
 // stb_image implementation TU lives in displayxr::common (stb_image_impl_macos.cpp) — declarations only here (#396 W4).
 #include "stb_image.h"
 #include "view_params.h"
+#include "rig_mode.h"
 #include "atlas_capture.h"
 #include "xr_window_space_hud.h"
 #include "hud_renderer_macos.h"
@@ -796,6 +797,14 @@ struct InputState {
     int32_t absoluteRenderingModeRequested = -1; // 0-8 keys; -1 = none
     bool cameraMode = false;
     float nominalViewerZ = 0.5f;
+    // Disturbance-free rig round-trip (C) + absolute reset (SPACE) — delegated
+    // to the shared displayxr-common helper (common/rig_mode.{h,cpp}). The C key
+    // sets the request; the conversion runs in UpdateCameraMovement using the
+    // CANVAS size + initial vHeight fed in below.
+    bool rigModeToggleRequested = false;
+    float canvasWidthM = 0.0f;
+    float canvasHeightM = 0.0f;
+    float initialVirtualDisplayHeight = 0.0f;
     // 'I' key: snapshot the **app's projection-layer atlas only** (cols ×
     // rows × renderW × renderH) to ~/Pictures/DisplayXR/<app>-<N>_
     // <cols>x<rows>.png. One projection layer; HUD / window-space layers
@@ -1037,20 +1046,9 @@ static void PumpMacOSEvents()
                         g_input.captureAtlasRequested = true;
                     }
                     else if (ch == 'c' && !isRepeat) {
-                        g_input.cameraMode = !g_input.cameraMode;
-                        if (g_input.cameraMode) {
-                            g_input.cameraPosX = 0.0f;
-                            g_input.cameraPosY = 0.0f;
-                            g_input.cameraPosZ = g_input.nominalViewerZ;
-                            g_input.yaw = 0.0f;
-                            g_input.pitch = 0.0f;
-                            if (g_input.nominalViewerZ > 0.0f)
-                                g_input.viewParams.invConvergenceDistance = 1.0f / g_input.nominalViewerZ;
-                        } else {
-                            g_input.cameraPosX = g_input.cameraPosY = g_input.cameraPosZ = 0.0f;
-                            g_input.yaw = 0.0f;
-                            g_input.pitch = 0.0f;
-                        }
+                        // Disturbance-free rig round-trip — the conversion runs
+                        // in UpdateCameraMovement (it has the canvas size).
+                        g_input.rigModeToggleRequested = true;
                     }
                     else if (ch >= '0' && ch <= '8' && !isRepeat) {
                         g_input.absoluteRenderingModeRequested = (int32_t)(ch - '0');
@@ -1089,23 +1087,35 @@ static void PumpMacOSEvents()
 // ============================================================================
 
 static void UpdateCameraMovement(InputState& state, float deltaTime, float displayHeightM = 0.0f) {
+    // Absolute SPACE reset — snap back to the initial DISPLAY-centric state via
+    // the shared helper (display rig, pose origin/identity, initial vHeight,
+    // every tunable default incl. cameraM2v=1).
     if (state.resetViewRequested) {
-        state.yaw = state.pitch = 0.0f;
-        float savedVDH = state.viewParams.virtualDisplayHeight;
-        bool savedCameraMode = state.cameraMode;
-        state.viewParams = ViewParams{};
-        state.viewParams.virtualDisplayHeight = savedVDH;
-        state.cameraMode = savedCameraMode;
-        if (state.cameraMode) {
-            state.cameraPosX = 0.0f;
-            state.cameraPosY = 0.0f;
-            state.cameraPosZ = state.nominalViewerZ;
-            if (state.nominalViewerZ > 0.0f)
-                state.viewParams.invConvergenceDistance = 1.0f / state.nominalViewerZ;
-        } else {
-            state.cameraPosX = state.cameraPosY = state.cameraPosZ = 0.0f;
-        }
         state.resetViewRequested = false;
+        float pos[3] = {state.cameraPosX, state.cameraPosY, state.cameraPosZ};
+        dxr::RigResetToInitial(state.viewParams, state.cameraMode, pos, state.yaw, state.pitch,
+                               state.initialVirtualDisplayHeight);
+        state.cameraPosX = pos[0];
+        state.cameraPosY = pos[1];
+        state.cameraPosZ = pos[2];
+        return;
+    }
+
+    // Disturbance-free rig round-trip toggle (C key) — delegate to the shared
+    // converter so macOS and Windows apps behave identically. Pass the same
+    // orientation quaternion the app submits to the runtime, plus the CANVAS
+    // size the runtime renders into (NOT the full display).
+    if (state.rigModeToggleRequested) {
+        state.rigModeToggleRequested = false;
+        XrQuaternionf rq;
+        quat_from_yaw_pitch(state.yaw, state.pitch, &rq);
+        const float quat[4] = {rq.x, rq.y, rq.z, rq.w};
+        float pos[3] = {state.cameraPosX, state.cameraPosY, state.cameraPosZ};
+        dxr::RigToggleMode(state.viewParams, state.cameraMode, pos, quat, state.canvasWidthM,
+                           state.canvasHeightM, state.nominalViewerZ, displayHeightM);
+        state.cameraPosX = pos[0];
+        state.cameraPosY = pos[1];
+        state.cameraPosZ = pos[2];
         return;
     }
 
@@ -1914,6 +1924,7 @@ int main(int argc, char **argv)
     // SIM_DISPLAY_OUTPUT is a runtime-side construct.
 
     g_input.viewParams.virtualDisplayHeight = 0.24f;
+    g_input.initialVirtualDisplayHeight = g_input.viewParams.virtualDisplayHeight;
     g_input.nominalViewerZ = app.nominalViewerZ;
 
     LOG_INFO("Entering main loop... (ESC to quit, drag to rotate, WASD to move, Space to reset)");
@@ -2076,6 +2087,10 @@ int main(int argc, char **argv)
                 cameraRig.convergenceDiopters = g_input.viewParams.invConvergenceDistance;
                 cameraRig.verticalFov =
                     2.0f * atanf(CAMERA_HALF_TAN_VFOV / g_input.viewParams.zoomFactor);
+                // metersToVirtual carries the eye scale the C-toggle converter
+                // derived from the display rig, so the camera rig reproduces the
+                // display rig exactly.
+                cameraRig.metersToVirtual = g_input.viewParams.cameraM2v;
                 locateInfo.next = &cameraRig;
             } else {
                 displayRig.pose = rigPose;
@@ -2091,6 +2106,14 @@ int main(int argc, char **argv)
 
         uint32_t viewCount = 0;
         xrLocateViews(app.session, &locateInfo, &viewState, (uint32_t)views.size(), &viewCount, views.data());
+
+        // Capture the runtime's resolved CANVAS size (the window client area in
+        // meters) — the physical_height_m the Kooima/rig math runs on, which the
+        // C-toggle converter must match (windowed → smaller than the display).
+        if (useRig && viewRigRaw.canvasSizeMeters.height > 0.0f) {
+            g_input.canvasWidthM = viewRigRaw.canvasSizeMeters.width;
+            g_input.canvasHeightM = viewRigRaw.canvasSizeMeters.height;
+        }
 
         // XR_EXT_view_rig raw-channel verification (#396 W7): one-shot proof
         // the raw channel reports the DP's full per-view set.

--- a/test_apps/cube_handle_vk_macos/CMakeLists.txt
+++ b/test_apps/cube_handle_vk_macos/CMakeLists.txt
@@ -64,7 +64,7 @@ set(DISPLAYXR_EXTENSIONS_INCLUDE_DIR "${_dxr_ext_includes}" CACHE PATH
 FetchContent_Declare(
     displayxr_common
     GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
-    GIT_TAG v0.3.0
+    GIT_TAG v1.0.5
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(displayxr_common)

--- a/test_apps/cube_handle_vk_macos/main.mm
+++ b/test_apps/cube_handle_vk_macos/main.mm
@@ -43,6 +43,7 @@
 #include <unistd.h>
 
 #include "view_params.h"
+#include "rig_mode.h"
 #include "projection_depth.h"
 #include "atlas_capture.h"
 #include "xr_window_space_hud.h"
@@ -113,6 +114,10 @@ struct InputState {
     // Camera vs display mode toggle (C key)
     bool cameraMode = false;
     float nominalViewerZ = 0.5f;  // Cached from runtime for camera-mode init
+    bool rigModeToggleRequested = false;
+    float canvasWidthM = 0.0f;
+    float canvasHeightM = 0.0f;
+    float initialVirtualDisplayHeight = 0.0f;
 
     // Eye tracking mode toggle (T key)
     bool eyeTrackingModeToggleRequested = false;
@@ -1792,23 +1797,7 @@ static void PumpMacOSEvents() {
                         g_input.captureAtlasRequested = true;
                     }
                     else if (ch == 'c' && !isRepeat) {
-                        g_input.cameraMode = !g_input.cameraMode;
-                        if (g_input.cameraMode) {
-                            g_input.cameraPosX = 0.0f;
-                            g_input.cameraPosY = 0.0f;
-                            g_input.cameraPosZ = g_input.nominalViewerZ;
-                            g_input.yaw = 0.0f;
-                            g_input.pitch = 0.0f;
-                            if (g_input.nominalViewerZ > 0.0f)
-                                g_input.viewParams.invConvergenceDistance = 1.0f / g_input.nominalViewerZ;
-                            g_input.viewParams.zoomFactor = 1.0f;
-                        } else {
-                            g_input.cameraPosX = 0.0f;
-                            g_input.cameraPosY = 0.0f;
-                            g_input.cameraPosZ = 0.0f;
-                            g_input.yaw = 0.0f;
-                            g_input.pitch = 0.0f;
-                        }
+                        g_input.rigModeToggleRequested = true;
                     }
                     else if (ch >= '0' && ch <= '8' && !isRepeat) {
                         g_input.absoluteRenderingModeRequested = (int32_t)(ch - '0');
@@ -1849,23 +1838,35 @@ static void PumpMacOSEvents() {
 // ============================================================================
 
 static void UpdateCameraMovement(InputState& state, float deltaTime, float displayHeightM = 0.0f) {
+    // Absolute SPACE reset — snap back to the initial DISPLAY-centric state via
+    // the shared helper (display rig, pose origin/identity, initial vHeight,
+    // every tunable default incl. cameraM2v=1).
     if (state.resetViewRequested) {
-        state.yaw = state.pitch = 0.0f;
-        float savedVDH = state.viewParams.virtualDisplayHeight;
-        bool savedCameraMode = state.cameraMode;
-        state.viewParams = ViewParams{};
-        state.viewParams.virtualDisplayHeight = savedVDH;
-        state.cameraMode = savedCameraMode;
-        if (state.cameraMode) {
-            state.cameraPosX = 0.0f;
-            state.cameraPosY = 0.0f;
-            state.cameraPosZ = state.nominalViewerZ;
-            if (state.nominalViewerZ > 0.0f)
-                state.viewParams.invConvergenceDistance = 1.0f / state.nominalViewerZ;
-        } else {
-            state.cameraPosX = state.cameraPosY = state.cameraPosZ = 0.0f;
-        }
         state.resetViewRequested = false;
+        float pos[3] = {state.cameraPosX, state.cameraPosY, state.cameraPosZ};
+        dxr::RigResetToInitial(state.viewParams, state.cameraMode, pos, state.yaw, state.pitch,
+                               state.initialVirtualDisplayHeight);
+        state.cameraPosX = pos[0];
+        state.cameraPosY = pos[1];
+        state.cameraPosZ = pos[2];
+        return;
+    }
+
+    // Disturbance-free rig round-trip toggle (C key) — delegate to the shared
+    // converter so macOS and Windows apps behave identically. Pass the same
+    // orientation quaternion the app submits to the runtime, plus the CANVAS
+    // size the runtime renders into (NOT the full display).
+    if (state.rigModeToggleRequested) {
+        state.rigModeToggleRequested = false;
+        XrQuaternionf rq;
+        quat_from_yaw_pitch(state.yaw, state.pitch, &rq);
+        const float quat[4] = {rq.x, rq.y, rq.z, rq.w};
+        float pos[3] = {state.cameraPosX, state.cameraPosY, state.cameraPosZ};
+        dxr::RigToggleMode(state.viewParams, state.cameraMode, pos, quat, state.canvasWidthM,
+                           state.canvasHeightM, state.nominalViewerZ, displayHeightM);
+        state.cameraPosX = pos[0];
+        state.cameraPosY = pos[1];
+        state.cameraPosZ = pos[2];
         return;
     }
 
@@ -2885,6 +2886,7 @@ int main() {
     }
 
     g_input.viewParams.virtualDisplayHeight = 0.24f;
+    g_input.initialVirtualDisplayHeight = g_input.viewParams.virtualDisplayHeight;
     g_input.nominalViewerZ = xr.nominalViewerZ;
 
     LOG_INFO("=== Entering main loop ===");
@@ -3019,6 +3021,10 @@ int main() {
                             cameraRig.convergenceDiopters = g_input.viewParams.invConvergenceDistance;
                             cameraRig.verticalFov =
                                 2.0f * atanf(CAMERA_HALF_TAN_VFOV / g_input.viewParams.zoomFactor);
+                            // metersToVirtual carries the eye scale the C-toggle
+                            // converter derived from the display rig, so the
+                            // camera rig reproduces the display rig exactly.
+                            cameraRig.metersToVirtual = g_input.viewParams.cameraM2v;
                             locateInfo.next = &cameraRig;
                         } else {
                             displayRig.pose = rigPose;
@@ -3037,6 +3043,15 @@ int main() {
 
                     XrResult locResult = xrLocateViews(xr.session, &locateInfo,
                         &viewState, viewCount, &viewCount, views.data());
+
+                    // Capture the runtime's resolved CANVAS size (the window
+                    // client area in meters) — the physical_height_m the
+                    // Kooima/rig math runs on, which the C-toggle converter must
+                    // match (windowed → smaller than the display).
+                    if (useRig && viewRigRaw.canvasSizeMeters.height > 0.0f) {
+                        g_input.canvasWidthM = viewRigRaw.canvasSizeMeters.width;
+                        g_input.canvasHeightM = viewRigRaw.canvasSizeMeters.height;
+                    }
                     if (XR_SUCCEEDED(locResult) &&
                         (viewState.viewStateFlags & XR_VIEW_STATE_POSITION_VALID_BIT) &&
                         (viewState.viewStateFlags & XR_VIEW_STATE_ORIENTATION_VALID_BIT))

--- a/test_apps/cube_handle_vk_win/main.cpp
+++ b/test_apps/cube_handle_vk_win/main.cpp
@@ -736,6 +736,10 @@ static void RenderThreadFunc(
                                 cameraRig.convergenceDiopters = inputSnapshot.viewParams.invConvergenceDistance;
                                 cameraRig.verticalFov =
                                     2.0f * atanf(CAMERA_HALF_TAN_VFOV / inputSnapshot.viewParams.zoomFactor);
+                                // metersToVirtual carries the eye scale the C-toggle
+                                // converter derived from the display rig, so the
+                                // camera rig reproduces the display rig exactly.
+                                cameraRig.metersToVirtual = inputSnapshot.viewParams.cameraM2v;
                                 locateInfo.next = &cameraRig;
                             } else {
                                 displayRig.pose = rigPose;
@@ -749,6 +753,16 @@ static void RenderThreadFunc(
                         }
                         xrLocateViews(xr->session, &locateInfo, &viewState, 8, &viewCount, rawViews);
                         LOG_INFO("[FRAME] Raw LocateViews done");
+
+                        // Capture the runtime's resolved CANVAS size (the window
+                        // client area in meters) into g_inputState so next frame's
+                        // snapshot feeds the C-toggle / SPACE-reset converter the
+                        // physical_height_m the rig math runs on.
+                        if (g_hasViewRigExt && rawProbe.canvasSizeMeters.height > 0.0f) {
+                            std::lock_guard<std::mutex> lock(g_inputMutex);
+                            g_inputState.canvasWidthM = rawProbe.canvasSizeMeters.width;
+                            g_inputState.canvasHeightM = rawProbe.canvasSizeMeters.height;
+                        }
 
                         // XR_EXT_view_rig raw-channel verification (#396 W7):
                         // one-shot proof the raw channel reports the DP's full
@@ -1597,6 +1611,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 
     // Set virtual display height (app units). 0.24 = 4x the 0.06m cube height.
     g_inputState.viewParams.virtualDisplayHeight = 0.24f;
+    g_inputState.initialVirtualDisplayHeight = g_inputState.viewParams.virtualDisplayHeight; // SPACE-reset target
     g_inputState.renderingModeCount = xr.renderingModeCount;
 
     std::thread renderThread(RenderThreadFunc, hwnd, &xr, &vkRenderer,

--- a/test_apps/cube_texture_d3d11_win/main.cpp
+++ b/test_apps/cube_texture_d3d11_win/main.cpp
@@ -1149,6 +1149,10 @@ static void RenderOneFrame(RenderState& rs) {
                             cameraRig.convergenceDiopters = g_inputState.viewParams.invConvergenceDistance;
                             cameraRig.verticalFov =
                                 2.0f * atanf(CAMERA_HALF_TAN_VFOV / g_inputState.viewParams.zoomFactor);
+                            // metersToVirtual carries the eye scale the C-toggle
+                            // converter derived from the display rig, so the
+                            // camera rig reproduces the display rig exactly.
+                            cameraRig.metersToVirtual = g_inputState.viewParams.cameraM2v;
                             locateInfo.next = &cameraRig;
                         } else {
                             displayRig.pose = rigPose;
@@ -1162,6 +1166,14 @@ static void RenderOneFrame(RenderState& rs) {
                     }
 
                     xrLocateViews(xr.session, &locateInfo, &viewState, 8, &viewCount, rawViews);
+
+                    // Capture the runtime's resolved CANVAS size (the window
+                    // client area in meters) so the C-toggle / SPACE-reset
+                    // converter runs the rig math on the right physical_height_m.
+                    if (g_hasViewRigExt && viewRigRaw.canvasSizeMeters.height > 0.0f) {
+                        g_inputState.canvasWidthM = viewRigRaw.canvasSizeMeters.width;
+                        g_inputState.canvasHeightM = viewRigRaw.canvasSizeMeters.height;
+                    }
 
                     if (g_hasViewRigExt) {
                         // Latch on the first locate with a real canvas rect —
@@ -1749,6 +1761,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
     PerformanceStats perfStats = {};
     perfStats.lastTime = std::chrono::high_resolution_clock::now();
     g_inputState.viewParams.virtualDisplayHeight = 0.24f;
+    g_inputState.initialVirtualDisplayHeight = g_inputState.viewParams.virtualDisplayHeight; // SPACE-reset target
     g_inputState.nominalViewerZ = xr.nominalViewerZ;
     g_inputState.renderingModeCount = xr.renderingModeCount;
 

--- a/test_apps/cube_texture_d3d12_win/main.cpp
+++ b/test_apps/cube_texture_d3d12_win/main.cpp
@@ -1235,6 +1235,10 @@ static void RenderOneFrame(RenderState& rs) {
                             cameraRig.convergenceDiopters = g_inputState.viewParams.invConvergenceDistance;
                             cameraRig.verticalFov =
                                 2.0f * atanf(CAMERA_HALF_TAN_VFOV / g_inputState.viewParams.zoomFactor);
+                            // metersToVirtual carries the eye scale the C-toggle
+                            // converter derived from the display rig, so the
+                            // camera rig reproduces the display rig exactly.
+                            cameraRig.metersToVirtual = g_inputState.viewParams.cameraM2v;
                             locateInfo.next = &cameraRig;
                         } else {
                             displayRig.pose = rigPose;
@@ -1247,6 +1251,14 @@ static void RenderOneFrame(RenderState& rs) {
                         }
                     }
                     xrLocateViews(xr.session, &locateInfo, &viewState, 8, &viewCount, rawViews);
+
+                    // Capture the runtime's resolved CANVAS size (the window
+                    // client area in meters) so the C-toggle / SPACE-reset
+                    // converter runs the rig math on the right physical_height_m.
+                    if (g_hasViewRigExt && viewRigRaw.canvasSizeMeters.height > 0.0f) {
+                        g_inputState.canvasWidthM = viewRigRaw.canvasSizeMeters.width;
+                        g_inputState.canvasHeightM = viewRigRaw.canvasSizeMeters.height;
+                    }
 
                     if (g_hasViewRigExt) {
                         // Latch on the first locate with a real canvas rect —
@@ -1992,6 +2004,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
     PerformanceStats perfStats = {};
     perfStats.lastTime = std::chrono::high_resolution_clock::now();
     g_inputState.viewParams.virtualDisplayHeight = 0.24f;
+    g_inputState.initialVirtualDisplayHeight = g_inputState.viewParams.virtualDisplayHeight; // SPACE-reset target
     g_inputState.nominalViewerZ = xr.nominalViewerZ;
     g_inputState.renderingModeCount = xr.renderingModeCount;
 

--- a/test_apps/cube_texture_metal_macos/CMakeLists.txt
+++ b/test_apps/cube_texture_metal_macos/CMakeLists.txt
@@ -60,7 +60,7 @@ set(DISPLAYXR_EXTENSIONS_INCLUDE_DIR "${_dxr_ext_includes}" CACHE PATH
 FetchContent_Declare(
     displayxr_common
     GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
-    GIT_TAG v0.3.0
+    GIT_TAG v1.0.5
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(displayxr_common)

--- a/test_apps/cube_texture_metal_macos/main.mm
+++ b/test_apps/cube_texture_metal_macos/main.mm
@@ -56,6 +56,7 @@
 // stb_image implementation TU lives in displayxr::common (stb_image_impl_macos.cpp) — declarations only here (#396 W4).
 #include "stb_image.h"
 #include "view_params.h"
+#include "rig_mode.h"
 #include "xr_window_space_hud.h"
 #include "hud_renderer_macos.h"
 #include <openxr/XR_EXT_display_info.h>
@@ -820,6 +821,14 @@ struct InputState {
     int32_t absoluteRenderingModeRequested = -1; // 0-8 keys; -1 = none
     bool cameraMode = false;
     float nominalViewerZ = 0.5f;
+    // Disturbance-free rig round-trip (C) + absolute reset (SPACE) — delegated
+    // to the shared displayxr-common helper (common/rig_mode.{h,cpp}). The C key
+    // sets the request; the conversion runs in UpdateCameraMovement using the
+    // CANVAS size + initial vHeight fed in below.
+    bool rigModeToggleRequested = false;
+    float canvasWidthM = 0.0f;
+    float canvasHeightM = 0.0f;
+    float initialVirtualDisplayHeight = 0.0f;
 };
 static InputState g_input;
 static const float CAMERA_HALF_TAN_VFOV = 0.32491969623f; // tan(18deg) -> 36deg vFOV
@@ -1459,20 +1468,9 @@ static void PumpMacOSEvents()
                         g_input.cycleRenderingModeRequested = true;
                     }
                     else if (ch == 'c' && !isRepeat) {
-                        g_input.cameraMode = !g_input.cameraMode;
-                        if (g_input.cameraMode) {
-                            g_input.cameraPosX = 0.0f;
-                            g_input.cameraPosY = 0.0f;
-                            g_input.cameraPosZ = g_input.nominalViewerZ;
-                            g_input.yaw = 0.0f;
-                            g_input.pitch = 0.0f;
-                            if (g_input.nominalViewerZ > 0.0f)
-                                g_input.viewParams.invConvergenceDistance = 1.0f / g_input.nominalViewerZ;
-                        } else {
-                            g_input.cameraPosX = g_input.cameraPosY = g_input.cameraPosZ = 0.0f;
-                            g_input.yaw = 0.0f;
-                            g_input.pitch = 0.0f;
-                        }
+                        // Disturbance-free rig round-trip — the conversion runs
+                        // in UpdateCameraMovement (it has the canvas size).
+                        g_input.rigModeToggleRequested = true;
                     }
                     else if (ch >= '0' && ch <= '8' && !isRepeat) {
                         g_input.absoluteRenderingModeRequested = (int32_t)(ch - '0');
@@ -1518,23 +1516,35 @@ static void PumpMacOSEvents()
 // ============================================================================
 
 static void UpdateCameraMovement(InputState& state, float deltaTime, float displayHeightM = 0.0f) {
+    // Absolute SPACE reset — snap back to the initial DISPLAY-centric state via
+    // the shared helper (display rig, pose origin/identity, initial vHeight,
+    // every tunable default incl. cameraM2v=1).
     if (state.resetViewRequested) {
-        state.yaw = state.pitch = 0.0f;
-        float savedVDH = state.viewParams.virtualDisplayHeight;
-        bool savedCameraMode = state.cameraMode;
-        state.viewParams = ViewParams{};
-        state.viewParams.virtualDisplayHeight = savedVDH;
-        state.cameraMode = savedCameraMode;
-        if (state.cameraMode) {
-            state.cameraPosX = 0.0f;
-            state.cameraPosY = 0.0f;
-            state.cameraPosZ = state.nominalViewerZ;
-            if (state.nominalViewerZ > 0.0f)
-                state.viewParams.invConvergenceDistance = 1.0f / state.nominalViewerZ;
-        } else {
-            state.cameraPosX = state.cameraPosY = state.cameraPosZ = 0.0f;
-        }
         state.resetViewRequested = false;
+        float pos[3] = {state.cameraPosX, state.cameraPosY, state.cameraPosZ};
+        dxr::RigResetToInitial(state.viewParams, state.cameraMode, pos, state.yaw, state.pitch,
+                               state.initialVirtualDisplayHeight);
+        state.cameraPosX = pos[0];
+        state.cameraPosY = pos[1];
+        state.cameraPosZ = pos[2];
+        return;
+    }
+
+    // Disturbance-free rig round-trip toggle (C key) — delegate to the shared
+    // converter so macOS and Windows apps behave identically. Pass the same
+    // orientation quaternion the app submits to the runtime, plus the CANVAS
+    // size the runtime renders into (NOT the full display).
+    if (state.rigModeToggleRequested) {
+        state.rigModeToggleRequested = false;
+        XrQuaternionf rq;
+        quat_from_yaw_pitch(state.yaw, state.pitch, &rq);
+        const float quat[4] = {rq.x, rq.y, rq.z, rq.w};
+        float pos[3] = {state.cameraPosX, state.cameraPosY, state.cameraPosZ};
+        dxr::RigToggleMode(state.viewParams, state.cameraMode, pos, quat, state.canvasWidthM,
+                           state.canvasHeightM, state.nominalViewerZ, displayHeightM);
+        state.cameraPosX = pos[0];
+        state.cameraPosY = pos[1];
+        state.cameraPosZ = pos[2];
         return;
     }
 
@@ -2187,6 +2197,7 @@ int main(int argc, char **argv)
     // mode 1 (default of app.currentModeIndex).
 
     g_input.viewParams.virtualDisplayHeight = 0.24f;
+    g_input.initialVirtualDisplayHeight = g_input.viewParams.virtualDisplayHeight;
     g_input.nominalViewerZ = app.nominalViewerZ;
 
     LOG_INFO("Entering main loop... (ESC to quit, drag to rotate, WASD to move, Space to reset)");
@@ -2393,6 +2404,10 @@ int main(int argc, char **argv)
                 cameraRig.convergenceDiopters = g_input.viewParams.invConvergenceDistance;
                 cameraRig.verticalFov =
                     2.0f * atanf(CAMERA_HALF_TAN_VFOV / g_input.viewParams.zoomFactor);
+                // metersToVirtual carries the eye scale the C-toggle converter
+                // derived from the display rig, so the camera rig reproduces the
+                // display rig exactly.
+                cameraRig.metersToVirtual = g_input.viewParams.cameraM2v;
                 locateInfo.next = &cameraRig;
             } else {
                 displayRig.pose = rigPose;
@@ -2408,6 +2423,14 @@ int main(int argc, char **argv)
 
         uint32_t viewCount = 0;
         xrLocateViews(app.session, &locateInfo, &viewState, (uint32_t)views.size(), &viewCount, views.data());
+
+        // Capture the runtime's resolved CANVAS size (the window client area in
+        // meters) — the physical_height_m the Kooima/rig math runs on, which the
+        // C-toggle converter must match (windowed → smaller than the display).
+        if (useRig && viewRigRaw.canvasSizeMeters.height > 0.0f) {
+            g_input.canvasWidthM = viewRigRaw.canvasSizeMeters.width;
+            g_input.canvasHeightM = viewRigRaw.canvasSizeMeters.height;
+        }
 
         // XR_EXT_view_rig raw channel (#396 W7): one-shot proof canvasRectPx
         // reports this texture app's canvas SUB-RECT (the output rect), not

--- a/test_apps/cube_zones_d3d11_win/main.cpp
+++ b/test_apps/cube_zones_d3d11_win/main.cpp
@@ -1353,6 +1353,14 @@ static void RenderOneFrame(RenderState& rs) {
             XrView rawViews[8];
             for (uint32_t vi = 0; vi < 8; vi++) rawViews[vi] = {XR_TYPE_VIEW};
 
+            // XR_EXT_view_rig raw channel: chain XrViewDisplayRawEXT so the
+            // runtime reports the resolved canvas size in meters — fed into
+            // InputState below for the C-toggle / SPACE-reset converter.
+            XrViewDisplayRawEXT rawProbe = {XR_TYPE_VIEW_DISPLAY_RAW_EXT};
+            if (g_hasViewRigExt) {
+                viewState.next = &rawProbe;
+            }
+
             // XR_EXT_view_rig: drive the runtime rig matching the app's
             // current mode with the app's tunables — the runtime owns the
             // window/canvas resolve + the Kooima math and returns
@@ -1379,6 +1387,10 @@ static void RenderOneFrame(RenderState& rs) {
                     cameraRig.convergenceDiopters = g_inputState.viewParams.invConvergenceDistance;
                     cameraRig.verticalFov =
                         2.0f * atanf(CAMERA_HALF_TAN_VFOV / g_inputState.viewParams.zoomFactor);
+                    // metersToVirtual carries the eye scale the C-toggle
+                    // converter derived from the display rig, so the camera
+                    // rig reproduces the display rig exactly.
+                    cameraRig.metersToVirtual = g_inputState.viewParams.cameraM2v;
                     locateInfo.next = &cameraRig;
                 } else {
                     displayRig.pose = rigPose;
@@ -1392,6 +1404,14 @@ static void RenderOneFrame(RenderState& rs) {
             }
 
             xrLocateViews(xr.session, &locateInfo, &viewState, 8, &viewCount, rawViews);
+
+            // Capture the runtime's resolved CANVAS size (the window client
+            // area in meters) so the C-toggle / SPACE-reset converter runs the
+            // rig math on the right physical_height_m.
+            if (g_hasViewRigExt && rawProbe.canvasSizeMeters.height > 0.0f) {
+                g_inputState.canvasWidthM = rawProbe.canvasSizeMeters.width;
+                g_inputState.canvasHeightM = rawProbe.canvasSizeMeters.height;
+            }
 
             // Max per-tile capacity from swapchain
             uint32_t maxTileW = tileColumns > 0 ? xr.swapchain.width / tileColumns : xr.swapchain.width;
@@ -1847,6 +1867,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 
     // Set virtual display height (app units) for the fallback rig path.
     g_inputState.viewParams.virtualDisplayHeight = 0.24f;
+    g_inputState.initialVirtualDisplayHeight = g_inputState.viewParams.virtualDisplayHeight; // SPACE-reset target
     g_inputState.nominalViewerZ = xr.nominalViewerZ;
     g_inputState.renderingModeCount = xr.renderingModeCount;
 

--- a/test_apps/cube_zones_metal_macos/CMakeLists.txt
+++ b/test_apps/cube_zones_metal_macos/CMakeLists.txt
@@ -60,7 +60,7 @@ set(DISPLAYXR_EXTENSIONS_INCLUDE_DIR "${_dxr_ext_includes}" CACHE PATH
 FetchContent_Declare(
     displayxr_common
     GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
-    GIT_TAG v0.3.0
+    GIT_TAG v1.0.5
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(displayxr_common)

--- a/test_apps/cube_zones_metal_macos/main.mm
+++ b/test_apps/cube_zones_metal_macos/main.mm
@@ -61,6 +61,7 @@
 // stb_image implementation TU lives in displayxr::common (stb_image_impl_macos.cpp) — declarations only here (#396 W4).
 #include "stb_image.h"
 #include "view_params.h"
+#include "rig_mode.h"
 #include "atlas_capture.h"
 #include "xr_window_space_hud.h"
 #include "hud_renderer_macos.h"
@@ -893,6 +894,14 @@ struct InputState {
     int32_t absoluteRenderingModeRequested = -1; // 0-8 keys; -1 = none
     bool cameraMode = false;
     float nominalViewerZ = 0.5f;
+    // Disturbance-free rig round-trip (C) + absolute reset (SPACE) — delegated
+    // to the shared displayxr-common helper (common/rig_mode.{h,cpp}). The C key
+    // sets the request; the conversion runs in UpdateCameraMovement using the
+    // CANVAS size + initial vHeight fed in below.
+    bool rigModeToggleRequested = false;
+    float canvasWidthM = 0.0f;
+    float canvasHeightM = 0.0f;
+    float initialVirtualDisplayHeight = 0.0f;
     // 'I' key: snapshot the **app's projection-layer atlas only** (cols ×
     // rows × renderW × renderH) to ~/Pictures/DisplayXR/<app>-<N>_
     // <cols>x<rows>.png. One projection layer; HUD / window-space layers
@@ -1211,20 +1220,9 @@ static void PumpMacOSEvents()
                         g_input.captureAtlasRequested = true;
                     }
                     else if (ch == 'c' && !isRepeat) {
-                        g_input.cameraMode = !g_input.cameraMode;
-                        if (g_input.cameraMode) {
-                            g_input.cameraPosX = 0.0f;
-                            g_input.cameraPosY = 0.0f;
-                            g_input.cameraPosZ = g_input.nominalViewerZ;
-                            g_input.yaw = 0.0f;
-                            g_input.pitch = 0.0f;
-                            if (g_input.nominalViewerZ > 0.0f)
-                                g_input.viewParams.invConvergenceDistance = 1.0f / g_input.nominalViewerZ;
-                        } else {
-                            g_input.cameraPosX = g_input.cameraPosY = g_input.cameraPosZ = 0.0f;
-                            g_input.yaw = 0.0f;
-                            g_input.pitch = 0.0f;
-                        }
+                        // Disturbance-free rig round-trip — the conversion runs
+                        // in UpdateCameraMovement (it has the canvas size).
+                        g_input.rigModeToggleRequested = true;
                     }
                     else if (ch >= '0' && ch <= '8' && !isRepeat) {
                         g_input.absoluteRenderingModeRequested = (int32_t)(ch - '0');
@@ -1263,23 +1261,35 @@ static void PumpMacOSEvents()
 // ============================================================================
 
 static void UpdateCameraMovement(InputState& state, float deltaTime, float displayHeightM = 0.0f) {
+    // Absolute SPACE reset — snap back to the initial DISPLAY-centric state via
+    // the shared helper (display rig, pose origin/identity, initial vHeight,
+    // every tunable default incl. cameraM2v=1).
     if (state.resetViewRequested) {
-        state.yaw = state.pitch = 0.0f;
-        float savedVDH = state.viewParams.virtualDisplayHeight;
-        bool savedCameraMode = state.cameraMode;
-        state.viewParams = ViewParams{};
-        state.viewParams.virtualDisplayHeight = savedVDH;
-        state.cameraMode = savedCameraMode;
-        if (state.cameraMode) {
-            state.cameraPosX = 0.0f;
-            state.cameraPosY = 0.0f;
-            state.cameraPosZ = state.nominalViewerZ;
-            if (state.nominalViewerZ > 0.0f)
-                state.viewParams.invConvergenceDistance = 1.0f / state.nominalViewerZ;
-        } else {
-            state.cameraPosX = state.cameraPosY = state.cameraPosZ = 0.0f;
-        }
         state.resetViewRequested = false;
+        float pos[3] = {state.cameraPosX, state.cameraPosY, state.cameraPosZ};
+        dxr::RigResetToInitial(state.viewParams, state.cameraMode, pos, state.yaw, state.pitch,
+                               state.initialVirtualDisplayHeight);
+        state.cameraPosX = pos[0];
+        state.cameraPosY = pos[1];
+        state.cameraPosZ = pos[2];
+        return;
+    }
+
+    // Disturbance-free rig round-trip toggle (C key) — delegate to the shared
+    // converter so macOS and Windows apps behave identically. Pass the same
+    // orientation quaternion the app submits to the runtime, plus the CANVAS
+    // size the runtime renders into (NOT the full display).
+    if (state.rigModeToggleRequested) {
+        state.rigModeToggleRequested = false;
+        XrQuaternionf rq;
+        quat_from_yaw_pitch(state.yaw, state.pitch, &rq);
+        const float quat[4] = {rq.x, rq.y, rq.z, rq.w};
+        float pos[3] = {state.cameraPosX, state.cameraPosY, state.cameraPosZ};
+        dxr::RigToggleMode(state.viewParams, state.cameraMode, pos, quat, state.canvasWidthM,
+                           state.canvasHeightM, state.nominalViewerZ, displayHeightM);
+        state.cameraPosX = pos[0];
+        state.cameraPosY = pos[1];
+        state.cameraPosZ = pos[2];
         return;
     }
 
@@ -2770,6 +2780,7 @@ int main(int argc, char **argv)
     // SIM_DISPLAY_OUTPUT is a runtime-side construct.
 
     g_input.viewParams.virtualDisplayHeight = 0.24f;
+    g_input.initialVirtualDisplayHeight = g_input.viewParams.virtualDisplayHeight;
     g_input.nominalViewerZ = app.nominalViewerZ;
 
     LOG_INFO("Entering main loop... (ESC to quit, drag to rotate, WASD to move, Space to reset)");
@@ -2957,6 +2968,10 @@ int main(int argc, char **argv)
                 cameraRig.convergenceDiopters = g_input.viewParams.invConvergenceDistance;
                 cameraRig.verticalFov =
                     2.0f * atanf(CAMERA_HALF_TAN_VFOV / g_input.viewParams.zoomFactor);
+                // metersToVirtual carries the eye scale the C-toggle converter
+                // derived from the display rig, so the camera rig reproduces the
+                // display rig exactly.
+                cameraRig.metersToVirtual = g_input.viewParams.cameraM2v;
                 locateInfo.next = &cameraRig;
             } else {
                 displayRig.pose = rigPose;
@@ -2972,6 +2987,14 @@ int main(int argc, char **argv)
 
         uint32_t viewCount = 0;
         xrLocateViews(app.session, &locateInfo, &viewState, (uint32_t)views.size(), &viewCount, views.data());
+
+        // Capture the runtime's resolved CANVAS size (the window client area in
+        // meters) — the physical_height_m the Kooima/rig math runs on, which the
+        // C-toggle converter must match (windowed → smaller than the display).
+        if (useRig && viewRigRaw.canvasSizeMeters.height > 0.0f) {
+            g_input.canvasWidthM = viewRigRaw.canvasSizeMeters.width;
+            g_input.canvasHeightM = viewRigRaw.canvasSizeMeters.height;
+        }
 
         // XR_EXT_view_rig raw-channel verification (#396 W7): one-shot proof
         // the raw channel reports the DP's full per-view set.

--- a/test_apps/cube_zones_vk_macos/CMakeLists.txt
+++ b/test_apps/cube_zones_vk_macos/CMakeLists.txt
@@ -64,7 +64,7 @@ set(DISPLAYXR_EXTENSIONS_INCLUDE_DIR "${_dxr_ext_includes}" CACHE PATH
 FetchContent_Declare(
     displayxr_common
     GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
-    GIT_TAG v0.3.0
+    GIT_TAG v1.0.5
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(displayxr_common)

--- a/test_apps/cube_zones_vk_macos/main.mm
+++ b/test_apps/cube_zones_vk_macos/main.mm
@@ -57,6 +57,7 @@
 #include <unistd.h>
 
 #include "view_params.h"
+#include "rig_mode.h"
 #include "projection_depth.h"
 #include "atlas_capture.h"
 #include "xr_window_space_hud.h"
@@ -188,6 +189,10 @@ struct InputState {
     // Camera vs display mode toggle (C key)
     bool cameraMode = false;
     float nominalViewerZ = 0.5f;  // Cached from runtime for camera-mode init
+    bool rigModeToggleRequested = false;
+    float canvasWidthM = 0.0f;
+    float canvasHeightM = 0.0f;
+    float initialVirtualDisplayHeight = 0.0f;
 
     // Eye tracking mode toggle (T key)
     bool eyeTrackingModeToggleRequested = false;
@@ -1912,23 +1917,7 @@ static void PumpMacOSEvents() {
                         g_input.captureAtlasRequested = true;
                     }
                     else if (ch == 'c' && !isRepeat) {
-                        g_input.cameraMode = !g_input.cameraMode;
-                        if (g_input.cameraMode) {
-                            g_input.cameraPosX = 0.0f;
-                            g_input.cameraPosY = 0.0f;
-                            g_input.cameraPosZ = g_input.nominalViewerZ;
-                            g_input.yaw = 0.0f;
-                            g_input.pitch = 0.0f;
-                            if (g_input.nominalViewerZ > 0.0f)
-                                g_input.viewParams.invConvergenceDistance = 1.0f / g_input.nominalViewerZ;
-                            g_input.viewParams.zoomFactor = 1.0f;
-                        } else {
-                            g_input.cameraPosX = 0.0f;
-                            g_input.cameraPosY = 0.0f;
-                            g_input.cameraPosZ = 0.0f;
-                            g_input.yaw = 0.0f;
-                            g_input.pitch = 0.0f;
-                        }
+                        g_input.rigModeToggleRequested = true;
                     }
                     else if (ch >= '0' && ch <= '8' && !isRepeat) {
                         g_input.absoluteRenderingModeRequested = (int32_t)(ch - '0');
@@ -1969,23 +1958,35 @@ static void PumpMacOSEvents() {
 // ============================================================================
 
 static void UpdateCameraMovement(InputState& state, float deltaTime, float displayHeightM = 0.0f) {
+    // Absolute SPACE reset — snap back to the initial DISPLAY-centric state via
+    // the shared helper (display rig, pose origin/identity, initial vHeight,
+    // every tunable default incl. cameraM2v=1).
     if (state.resetViewRequested) {
-        state.yaw = state.pitch = 0.0f;
-        float savedVDH = state.viewParams.virtualDisplayHeight;
-        bool savedCameraMode = state.cameraMode;
-        state.viewParams = ViewParams{};
-        state.viewParams.virtualDisplayHeight = savedVDH;
-        state.cameraMode = savedCameraMode;
-        if (state.cameraMode) {
-            state.cameraPosX = 0.0f;
-            state.cameraPosY = 0.0f;
-            state.cameraPosZ = state.nominalViewerZ;
-            if (state.nominalViewerZ > 0.0f)
-                state.viewParams.invConvergenceDistance = 1.0f / state.nominalViewerZ;
-        } else {
-            state.cameraPosX = state.cameraPosY = state.cameraPosZ = 0.0f;
-        }
         state.resetViewRequested = false;
+        float pos[3] = {state.cameraPosX, state.cameraPosY, state.cameraPosZ};
+        dxr::RigResetToInitial(state.viewParams, state.cameraMode, pos, state.yaw, state.pitch,
+                               state.initialVirtualDisplayHeight);
+        state.cameraPosX = pos[0];
+        state.cameraPosY = pos[1];
+        state.cameraPosZ = pos[2];
+        return;
+    }
+
+    // Disturbance-free rig round-trip toggle (C key) — delegate to the shared
+    // converter so macOS and Windows apps behave identically. Pass the same
+    // orientation quaternion the app submits to the runtime, plus the CANVAS
+    // size the runtime renders into (NOT the full display).
+    if (state.rigModeToggleRequested) {
+        state.rigModeToggleRequested = false;
+        XrQuaternionf rq;
+        quat_from_yaw_pitch(state.yaw, state.pitch, &rq);
+        const float quat[4] = {rq.x, rq.y, rq.z, rq.w};
+        float pos[3] = {state.cameraPosX, state.cameraPosY, state.cameraPosZ};
+        dxr::RigToggleMode(state.viewParams, state.cameraMode, pos, quat, state.canvasWidthM,
+                           state.canvasHeightM, state.nominalViewerZ, displayHeightM);
+        state.cameraPosX = pos[0];
+        state.cameraPosY = pos[1];
+        state.cameraPosZ = pos[2];
         return;
     }
 
@@ -3539,6 +3540,7 @@ int main() {
     }
 
     g_input.viewParams.virtualDisplayHeight = 0.24f;
+    g_input.initialVirtualDisplayHeight = g_input.viewParams.virtualDisplayHeight;
     g_input.nominalViewerZ = xr.nominalViewerZ;
 
     LOG_INFO("=== Entering main loop ===");
@@ -3713,6 +3715,7 @@ int main() {
                             cameraRig.convergenceDiopters = g_input.viewParams.invConvergenceDistance;
                             cameraRig.verticalFov =
                                 2.0f * atanf(CAMERA_HALF_TAN_VFOV / g_input.viewParams.zoomFactor);
+                            cameraRig.metersToVirtual = g_input.viewParams.cameraM2v;
                             locateInfo.next = &cameraRig;
                         } else {
                             displayRig.pose = rigPose;
@@ -3735,6 +3738,14 @@ int main() {
                         (viewState.viewStateFlags & XR_VIEW_STATE_POSITION_VALID_BIT) &&
                         (viewState.viewStateFlags & XR_VIEW_STATE_ORIENTATION_VALID_BIT))
                     {
+                        // Cache the runtime's CANVAS size (meters) from the raw
+                        // probe so the C-key rig round-trip toggle converts
+                        // against what the runtime actually renders into.
+                        if (useRig && viewRigRaw.canvasSizeMeters.height > 0.0f) {
+                            g_input.canvasWidthM = viewRigRaw.canvasSizeMeters.width;
+                            g_input.canvasHeightM = viewRigRaw.canvasSizeMeters.height;
+                        }
+
                         // Save display-space eye positions for the HUD. Under
                         // the rig, views[] carries render-ready world eyes —
                         // the raw channel (XrViewDisplayRawEXT) keeps the HUD


### PR DESCRIPTION
## What

Adds a **disturbance-free `C` rig toggle** and a **drift-free `SPACE` reset** to the cube test apps, exercising the display↔camera rig converters live.

- **C** converts the *current* rig into its exact equivalent in the other parameterization (display↔camera). `display→camera` is always exact and `display→camera→display` is an identity, so pressing **C** repeatedly never moves the scene — for **any** starting display rig (change IPD / parallax / perspective / vHeight / pose first and it still holds). The converter uses the **canvas** size (window client area the runtime renders into), not the full display, so it's seamless windowed *and* fullscreen.
- **SPACE** is an absolute reset to the initial display-centric state (pose origin / identity, initial vHeight, all tunables default incl. `cameraM2v=1`) — dumb and absolute, no room for drift.

## Where the logic lives

Pushed down into **displayxr-common v1.0.5** so every app shares one implementation:
- new platform-neutral `common/rig_mode.{h,cpp}` (`dxr::RigToggleMode` / `dxr::RigResetToInitial`)
- `ViewParams.cameraM2v` (= `XrCameraRigEXT::metersToVirtual`)
- new `InputState` fields; the Windows input handler delegates `C`/`SPACE` to `rig_mode`

This branch bumps `test_apps/common` pin **v1.0.4 → v1.0.5**.

Depends on the converter correctness fixes already on `main` (common v1.0.4: `vHeight = 2·half_tan_vfov/invd`, plane pose `-es·N`).

## Apps wired

| Platform | Apps | Status |
|---|---|---|
| Windows | `cube_handle_d3d11_win` (reference), `cube_handle_vk_win`, `cube_texture_d3d11_win`, `cube_texture_d3d12_win`, `cube_zones_d3d11_win` | edited by analogy — **need a Windows build/run pass** |
| macOS | `cube_handle_metal/gl/vk_macos`, `cube_texture_metal_macos`, `cube_zones_metal/vk_macos` | all 6 **compile + link clean** against local common |

## Offline validation

Frustum diff `dxr_camera3d_compute_view` vs converted `dxr_display3d_compute_view`: view-match Δ=0 + round-trip identity Δ=0 across centred/off-centre eyes, posed/rotated, all-params-off display rigs. `dxr_display3d_selftest` (incl. independent camera ground-truth) → 0 fails.

## ⚠️ Not yet verified on Windows

The 5 Windows apps were edited mechanically (couldn't build on the dev macOS box). **See the testing checklist in the comment below** before merging.