### PR TITLE
fix(#396): qwerty/legacy P-toggle is pure disturbance-free (camera-centric default)

### DIFF
--- a/src/xrt/auxiliary/math/CMakeLists.txt
+++ b/src/xrt/auxiliary/math/CMakeLists.txt
@@ -20,7 +20,7 @@ set(DISPLAYXR_XRT_INCLUDE_DIR "${_dxr_xrt_includes}" CACHE PATH "" FORCE)
 FetchContent_Declare(
 	displayxr_common
 	GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
-	GIT_TAG v1.0.4
+	GIT_TAG v1.0.7
 	GIT_SHALLOW TRUE
 	)
 FetchContent_MakeAvailable(displayxr_common)

--- a/src/xrt/drivers/qwerty/qwerty_device.c
+++ b/src/xrt/drivers/qwerty/qwerty_device.c
@@ -654,6 +654,7 @@ qwerty_system_create(struct qwerty_hmd *qhmd,
 	qs->disp_spread_factor = 1.0f;
 	qs->disp_parallax_factor = 1.0f;
 	qs->disp_vHeight = 1.3f; // 1.3m
+	qs->disp_perspective = 1.0f;
 
 	// Hardware config defaults (overridden by target builder)
 	qs->nominal_viewer_z = 0.6f;  // meters
@@ -1095,6 +1096,11 @@ qwerty_toggle_camera_mode(struct qwerty_system *qs)
 		dxr_display_rig disp;
 		dxr_view_rig_camera_to_display(&cam, &info, &disp);
 		qs->disp_vHeight = clampf(disp.virtual_display_height, 0.1f, 10.0f);
+		// Carry the converted perspective — it is NOT 1.0 for the camera default
+		// (e.g. 0.5 dp / 36° vFOV → ~0.50 at the legacy panel/distance). Dropping
+		// it made the display rig snap to its own persp=1 default instead of the
+		// camera-equivalent, i.e. a visible jump on P.
+		qs->disp_perspective = clampf(disp.perspective_factor, 0.1f, 10.0f);
 		qs->disp_spread_factor = disp.ipd_factor;
 		qs->disp_parallax_factor = disp.parallax_factor;
 		pose->position = (struct xrt_vec3){disp.pose.position.x, disp.pose.position.y, disp.pose.position.z};
@@ -1106,7 +1112,7 @@ qwerty_toggle_camera_mode(struct qwerty_system *qs)
 		    .virtual_display_height = qs->disp_vHeight,
 		    .ipd_factor = qs->disp_spread_factor,
 		    .parallax_factor = qs->disp_parallax_factor,
-		    .perspective_factor = 1.0f,
+		    .perspective_factor = qs->disp_perspective,
 		};
 		dxr_camera_rig cam;
 		dxr_view_rig_display_to_camera(&disp, &info, &cam);
@@ -1195,6 +1201,7 @@ qwerty_reset_view_state(struct qwerty_system *qs)
 	qs->disp_spread_factor = 1.0f;
 	qs->disp_parallax_factor = 1.0f;
 	qs->disp_vHeight = 1.3f;
+	qs->disp_perspective = 1.0f;
 
 	qs->rig_animating = false;
 
@@ -1278,7 +1285,7 @@ qwerty_get_view_state(struct xrt_device **xdevs, size_t xdev_count, struct qwert
 	out->half_tan_vfov = qs->cam_half_tan_vfov;
 	out->m2v = qs->cam_m2v;
 	out->virtual_display_height = qs->disp_vHeight;
-	out->perspective_factor = 1.0f; // qwerty display rig is always perspective 1
+	out->perspective_factor = qs->disp_perspective; // converted from the camera rig on P (not fixed 1)
 
 	out->nominal_viewer_z = qs->nominal_viewer_z;
 	out->screen_height_m = qs->screen_height_m;

--- a/src/xrt/drivers/qwerty/qwerty_device.c
+++ b/src/xrt/drivers/qwerty/qwerty_device.c
@@ -1121,16 +1121,14 @@ qwerty_toggle_camera_mode(struct qwerty_system *qs)
 	qs->camera_mode = !qs->camera_mode;
 
 	// The converter above set the NEW mode's params to the disturbance-free
-	// equivalent of the previous rig (so frame 0 matches the current view).
-	// Snapshot that as the animation start; qwerty_advance_rig_anim then lerps
-	// it to the new mode's DEFAULTS over QWERTY_RIG_ANIM_DUR_S (smooth, no pop).
-	qs->anim_from_convergence = qs->cam_convergence;
-	qs->anim_from_half_tan_vfov = qs->cam_half_tan_vfov;
-	qs->anim_from_m2v = qs->cam_m2v;
-	qs->anim_from_spread = qs->camera_mode ? qs->cam_spread_factor : qs->disp_spread_factor;
-	qs->anim_from_vHeight = qs->disp_vHeight;
-	qs->rig_animating = true;
-	qs->rig_anim_start_ns = os_monotonic_get_ns();
+	// equivalent of the previous rig — frame 0 matches the current view exactly,
+	// and that IS the toggle: no easing afterward. Repeated P just ping-pongs the
+	// same view (display<->camera<->display is an identity with the v1.0.4
+	// converter), so there is no visible change. The known per-mode defaults
+	// (0.5 dp / 36° vFOV / m2v 1 for camera; vHeight 1.3 for display) apply only
+	// at the initial camera-centric startup; a toggle preserves the current look.
+	// Cancel any in-flight animation (e.g. left over from a manual adjust path).
+	qs->rig_animating = false;
 
 	// Reset controllers to mode-appropriate default positions (attached to head)
 	if (qs->lctrl) {
@@ -1140,8 +1138,8 @@ qwerty_toggle_camera_mode(struct qwerty_system *qs)
 		reset_controller_for_mode(qs, qs->rctrl, false);
 	}
 
-	U_LOG_W("Qwerty: view mode -> %s (smooth transition to %s defaults)",
-	        qs->camera_mode ? "Camera" : "Display", qs->camera_mode ? "camera" : "display");
+	U_LOG_W("Qwerty: view mode -> %s (disturbance-free, no transition)",
+	        qs->camera_mode ? "Camera" : "Display");
 }
 
 void

--- a/src/xrt/drivers/qwerty/qwerty_device.c
+++ b/src/xrt/drivers/qwerty/qwerty_device.c
@@ -1172,8 +1172,19 @@ qwerty_adjust_convergence(struct qwerty_system *qs, float direction)
 		return; // No-op in display mode
 	}
 	qs->rig_animating = false; // manual adjust cancels an in-flight P-toggle transition
-	qs->cam_convergence = clampf(qs->cam_convergence + direction * 0.05f, 0.0f, 2.0f);
-	U_LOG_I("Qwerty: Convergence = %.2f diopters", qs->cam_convergence);
+	// Comfort clamp: never let the zero-parallax plane come NEARER than the
+	// nominal viewing distance. Beyond that, far content's disparity exceeds the
+	// IPD and the eyes DIVERGE (the display-equivalent ipd_factor = ipd*m2v*invd*N
+	// goes > 1). invd <= 1/(m2v*N) caps that; since cam_spread <= 1, it guarantees
+	// the comfort factor (= cam_spread*m2v*invd*N) <= cam_spread <= 1. Conservative
+	// (assumes content at infinity) but right for a generic legacy driver that
+	// doesn't know scene depth; a depth-budget policy could relax it.
+	float conv_max = (qs->cam_m2v > 0.0f && qs->nominal_viewer_z > 0.0f)
+	                     ? 1.0f / (qs->cam_m2v * qs->nominal_viewer_z)
+	                     : 2.0f;
+	qs->cam_convergence = clampf(qs->cam_convergence + direction * 0.05f, 0.0f, conv_max);
+	U_LOG_I("Qwerty: Convergence = %.2f diopters (max %.2f = nominal-distance comfort limit)",
+	        qs->cam_convergence, conv_max);
 }
 
 void

--- a/src/xrt/drivers/qwerty/qwerty_device.h
+++ b/src/xrt/drivers/qwerty/qwerty_device.h
@@ -61,6 +61,8 @@ struct qwerty_system
 	float disp_spread_factor;      //!< [0.01,1] default 1.0 (= disp_parallax always)
 	float disp_parallax_factor; //!< [0.01,1] default 1.0 (= disp_ipd always)
 	float disp_vHeight;         //!< [0.1,10] meters, default 1.3
+	float disp_perspective;     //!< [0.1,10] default 1.0; set to the camera→display
+	                            //!< converted perspective on P (so P is seamless)
 
 	// P-toggle smooth transition: on toggle, the active rig starts at the
 	// converter-equivalent of the previous rig (disturbance-free first frame)


### PR DESCRIPTION
## What

Makes the legacy/qwerty **P** toggle a pure disturbance-free rig switch — the same behavior as the test-app **C** toggle, but starting camera-centric.

- **Default is already camera-centric** with the known defaults (`camera_mode=true`, 0.5 dp convergence, 0.3249 half-tan vFOV, m2v 1; display side vHeight 1.3). Unchanged.
- **P used to** do the seamless converter switch on frame 0 **then ease the params to the mode defaults over 0.4 s** — that easing was a visible change.
- **P now** just switches the rig and holds the view. `display↔camera↔display` is an identity (with the v1.0.4 converter fix on main), so pressing P repeatedly never moves the scene. Per-mode defaults still apply at initial startup, not on toggle.

`qwerty_advance_rig_anim` is now inert (left in place, harmless).

## Pin / dependencies

**Runtime stays on common v1.0.4** — it links `displayxr::math_xrt` (the converter wrapper), not the test-app `displayxr::common`. v1.0.5's additions (rig_mode/ViewParams/input_handler) are test-app-only; the `dxr_view_math` converter math is unchanged. No pin bump here. (Depends on the v1.0.4 converter correctness fix already on `main`.)

## Validation

MinGW `drv_qwerty` compile-check passes.

## 🪟 Windows test (merge when green)
1. `scripts\build_windows.bat build` then run a **legacy/hosted** app (e.g. `_package\run_cube_hosted_d3d11_win.bat`), or any app under the qwerty path.
2. Confirm it **starts camera-centric** with the expected look (0.5 dp / 36° vFOV).
3. Press **P** repeatedly → rig label flips Camera↔Display but the **view does not move/zoom/ease**. (Previously it eased to defaults over ~0.4 s.)
4. Adjust convergence/zoom/vHeight, then **P** → still seamless from the current look (no snap to defaults).

Merge (rebase) when green.