### PR TITLE
test(#396): bump cube apps' displayxr-common pin to v1.0.7 (drift-free exact rig toggle)

### DIFF
--- a/test_apps/common/CMakeLists.txt
+++ b/test_apps/common/CMakeLists.txt
@@ -30,7 +30,7 @@ set(DISPLAYXR_EXTENSIONS_INCLUDE_DIR "${_dxr_ext_includes}" CACHE PATH
 FetchContent_Declare(
     displayxr_common
     GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
-    GIT_TAG v1.0.5
+    GIT_TAG v1.0.7
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(displayxr_common)

--- a/test_apps/cube_handle_gl_macos/CMakeLists.txt
+++ b/test_apps/cube_handle_gl_macos/CMakeLists.txt
@@ -60,7 +60,7 @@ set(DISPLAYXR_EXTENSIONS_INCLUDE_DIR "${_dxr_ext_includes}" CACHE PATH
 FetchContent_Declare(
     displayxr_common
     GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
-    GIT_TAG v1.0.5
+    GIT_TAG v1.0.7
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(displayxr_common)

--- a/test_apps/cube_handle_metal_macos/CMakeLists.txt
+++ b/test_apps/cube_handle_metal_macos/CMakeLists.txt
@@ -60,7 +60,7 @@ set(DISPLAYXR_EXTENSIONS_INCLUDE_DIR "${_dxr_ext_includes}" CACHE PATH
 FetchContent_Declare(
     displayxr_common
     GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
-    GIT_TAG v1.0.5
+    GIT_TAG v1.0.7
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(displayxr_common)

--- a/test_apps/cube_handle_vk_macos/CMakeLists.txt
+++ b/test_apps/cube_handle_vk_macos/CMakeLists.txt
@@ -64,7 +64,7 @@ set(DISPLAYXR_EXTENSIONS_INCLUDE_DIR "${_dxr_ext_includes}" CACHE PATH
 FetchContent_Declare(
     displayxr_common
     GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
-    GIT_TAG v1.0.5
+    GIT_TAG v1.0.7
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(displayxr_common)

--- a/test_apps/cube_texture_metal_macos/CMakeLists.txt
+++ b/test_apps/cube_texture_metal_macos/CMakeLists.txt
@@ -60,7 +60,7 @@ set(DISPLAYXR_EXTENSIONS_INCLUDE_DIR "${_dxr_ext_includes}" CACHE PATH
 FetchContent_Declare(
     displayxr_common
     GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
-    GIT_TAG v1.0.5
+    GIT_TAG v1.0.7
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(displayxr_common)

--- a/test_apps/cube_zones_metal_macos/CMakeLists.txt
+++ b/test_apps/cube_zones_metal_macos/CMakeLists.txt
@@ -60,7 +60,7 @@ set(DISPLAYXR_EXTENSIONS_INCLUDE_DIR "${_dxr_ext_includes}" CACHE PATH
 FetchContent_Declare(
     displayxr_common
     GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
-    GIT_TAG v1.0.5
+    GIT_TAG v1.0.7
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(displayxr_common)

--- a/test_apps/cube_zones_vk_macos/CMakeLists.txt
+++ b/test_apps/cube_zones_vk_macos/CMakeLists.txt
@@ -64,7 +64,7 @@ set(DISPLAYXR_EXTENSIONS_INCLUDE_DIR "${_dxr_ext_includes}" CACHE PATH
 FetchContent_Declare(
     displayxr_common
     GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
-    GIT_TAG v1.0.5
+    GIT_TAG v1.0.7
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(displayxr_common)


### PR DESCRIPTION
## What

Bumps the test apps' `displayxr-common` pin to **v1.0.7** so the disturbance-free C toggle is exact after a **reconvergence** (not just the cyclopean framing — the per-eye stereo disparity matches too) and round-trips with **no param drift**.

Follow-up to #590 (which landed at v1.0.5). Covers `test_apps/common` (the Windows apps) plus the 6 macOS apps that carry their own standalone `displayxr-common` pin.

## Why v1.0.7

The converter is now exact in both directions for *any* convergence, by recognizing that the camera rig's `m2v` is mathematically redundant with `ipd`/`parallax` (it only ever scales the modelview eye). `camera→display` folds the disparity factor into ipd/parallax; `display→camera` emits canonical `m2v=1` and folds the eye-scale back into ipd — so a round trip recovers the original params exactly, with no `m2v` drift.

## Validation

Randomized fuzz (≈38k non-degenerate trials × 4 seeds; random display dims, pose orientation+position, all rig tunables, off-depth eyes, random `m2v`): **both directions + both round-trips exact to float precision** (worst image Δ ≈ 3e-5). The only exclusions are degenerate eye-at-convergence-plane frustums (infinite for any rig). `dxr_display3d_selftest` fails=0. Real fetch of v1.0.7 builds + links clean (metal verified).

## Windows test
Same checklist as #590 (build test-apps, C-toggle fullscreen + windowed + after-perturbation, SPACE reset) — plus: in camera mode, **adjust convergence, then C → display and back** should be seamless now (previously a stereo-disparity jump).