### PR TITLE
feat(bundle): wire avatar_demo + earthview_demo into components.sh (#595 release)

### DIFF
--- a/scripts/lib/components.sh
+++ b/scripts/lib/components.sh
@@ -88,7 +88,7 @@ COMPONENT_INSTALL_MARKER_WINDOWS_gauss_demo="HKLM\\Software\\DisplayXR\\Demos\\G
 # Space-separated; add a demo here once it ships a release installer that CI
 # attaches on a v* tag. The `setup-displayxr.bat` mirror keeps its own copy of
 # this list — keep both in sync.
-DEMO_COMPONENTS="gauss_demo modelviewer_demo mediaplayer_demo"
+DEMO_COMPONENTS="gauss_demo modelviewer_demo mediaplayer_demo avatar_demo earthview_demo"
 
 # --- modelviewer_demo ---
 # glTF 2.0 PBR model viewer demo (displayxr-demo-modelviewer). Dual-platform:
@@ -111,6 +111,29 @@ COMPONENT_PKG_MACOS_mediaplayer_demo="DisplayXRMediaPlayer-*.pkg"
 COMPONENT_EXE_WINDOWS_mediaplayer_demo="DisplayXRMediaPlayerSetup-*.exe"
 COMPONENT_INSTALL_MARKER_MACOS_mediaplayer_demo="/Applications/Stereo Media Player.app"
 COMPONENT_INSTALL_MARKER_WINDOWS_mediaplayer_demo="HKLM\\Software\\DisplayXR\\Demos\\MediaPlayer"
+
+# --- avatar_demo ---
+# 3D Avatar demo (displayxr-demo-avatar). See-through avatar over the live
+# screen via the OpenXR extension wire protocol — no vendor SR SDK. Both
+# installers (macOS .pkg + Windows .exe) are built + attached by CI on a v*
+# tag. The macOS app installs to "3D Avatar.app" (note the leading digit and
+# the space — consumers must quote when testing existence).
+COMPONENT_REPO_avatar_demo="DisplayXR/displayxr-demo-avatar"
+COMPONENT_PKG_MACOS_avatar_demo="DisplayXRAvatar-*.pkg"
+COMPONENT_EXE_WINDOWS_avatar_demo="DisplayXRAvatarSetup-*.exe"
+COMPONENT_INSTALL_MARKER_MACOS_avatar_demo="/Applications/3D Avatar.app"
+COMPONENT_INSTALL_MARKER_WINDOWS_avatar_demo="HKLM\\Software\\DisplayXR\\Demos\\Avatar"
+
+# --- earthview_demo ---
+# EarthView demo (displayxr-demo-earthview). 3D Tiles globe renderer on the 3D
+# display via the OpenXR extension wire protocol — no vendor SR SDK. Both
+# installers (macOS .pkg + Windows .exe) are built + attached by CI on a v*
+# tag. The macOS app installs to "EarthView.app".
+COMPONENT_REPO_earthview_demo="DisplayXR/displayxr-demo-earthview"
+COMPONENT_PKG_MACOS_earthview_demo="DisplayXREarthView-*.pkg"
+COMPONENT_EXE_WINDOWS_earthview_demo="DisplayXREarthViewSetup-*.exe"
+COMPONENT_INSTALL_MARKER_MACOS_earthview_demo="/Applications/EarthView.app"
+COMPONENT_INSTALL_MARKER_WINDOWS_earthview_demo="HKLM\\Software\\DisplayXR\\Demos\\EarthView"
 
 # Helper: look up a per-component field for the current platform.
 #   $1 = component name (runtime, shell, leia_plugin, mcp_tools, gauss_demo)

--- a/scripts/setup-displayxr.bat
+++ b/scripts/setup-displayxr.bat
@@ -55,7 +55,7 @@ REM versions.json) — no COMPONENT_PINKEY override needed for the flat schema.
 
 REM Demo components installed by --with-demos (prebuilt release assets only).
 REM Mirrors DEMO_COMPONENTS in scripts\lib\components.sh; keep in sync.
-set "DEMO_COMPONENTS=gauss_demo modelviewer_demo mediaplayer_demo"
+set "DEMO_COMPONENTS=gauss_demo modelviewer_demo mediaplayer_demo avatar_demo earthview_demo"
 
 set "COMPONENT_REPO_modelviewer_demo=DisplayXR/displayxr-demo-modelviewer"
 set "COMPONENT_EXE_modelviewer_demo=DisplayXRModelViewerSetup-*.exe"
@@ -64,6 +64,14 @@ set "COMPONENT_MARKER_modelviewer_demo=HKLM\Software\DisplayXR\Demos\ModelViewer
 set "COMPONENT_REPO_mediaplayer_demo=DisplayXR/displayxr-demo-mediaplayer"
 set "COMPONENT_EXE_mediaplayer_demo=DisplayXRMediaPlayerSetup-*.exe"
 set "COMPONENT_MARKER_mediaplayer_demo=HKLM\Software\DisplayXR\Demos\MediaPlayer"
+
+set "COMPONENT_REPO_avatar_demo=DisplayXR/displayxr-demo-avatar"
+set "COMPONENT_EXE_avatar_demo=DisplayXRAvatarSetup-*.exe"
+set "COMPONENT_MARKER_avatar_demo=HKLM\Software\DisplayXR\Demos\Avatar"
+
+set "COMPONENT_REPO_earthview_demo=DisplayXR/displayxr-demo-earthview"
+set "COMPONENT_EXE_earthview_demo=DisplayXREarthViewSetup-*.exe"
+set "COMPONENT_MARKER_earthview_demo=HKLM\Software\DisplayXR\Demos\EarthView"
 
 REM --- Default flag state ---
 set "WITH_MCP=0"

--- a/versions.json
+++ b/versions.json
@@ -7,5 +7,6 @@
   "gauss_demo":  "v1.10.0",
   "modelviewer_demo": "v0.11.0",
   "mediaplayer_demo": "v1.2.1",
-  "earthview_demo": "v0.0.0"
+  "avatar_demo": "v0.2.0",
+  "earthview_demo": "v0.1.0"
 }


### PR DESCRIPTION
Wire two new demos — **avatar_demo** (v0.2.0) and **earthview_demo** (v0.1.0) — into the bundle component table, following the existing `mediaplayer_demo` pattern exactly. Part of the #595 release wave.

## Changes
- **`scripts/lib/components.sh`** — added `COMPONENT_REPO_` / `COMPONENT_PKG_MACOS_` / `COMPONENT_EXE_WINDOWS_` / `COMPONENT_INSTALL_MARKER_{MACOS,WINDOWS}_` blocks for both demos; appended both to `DEMO_COMPONENTS`.
- **`scripts/setup-displayxr.bat`** — mirrored `DEMO_COMPONENTS` + the `COMPONENT_REPO_/EXE_/MARKER_` vars (the bat mirror that drives the actual `--with-demos` install path; the components.sh comment requires keeping both in sync).
- **`versions.json`** — `"avatar_demo": "v0.2.0"`; `"earthview_demo"` bumped `v0.0.0` → `v0.1.0` (was a pinned-but-unwired orphan).

## Asset names (verified against each demo's installer scripts)
| demo | Windows | macOS |
|---|---|---|
| avatar_demo | `DisplayXRAvatarSetup-*.exe` | `DisplayXRAvatar-*.pkg` |
| earthview_demo | `DisplayXREarthViewSetup-*.exe` | `DisplayXREarthView-*.pkg` |

Note: `versions.json` mirrors to `displayxr-installer` automatically on release. This PR pairs with the **displayxr-installer** PR that chains both demo installers into the meta-installer bundle (where `check_bundle_coverage.ps1` proves they're fully wired).