### PR TITLE
chore(bundle): drop earthview_demo from this release (defer)

### DIFF
--- a/scripts/lib/components.sh
+++ b/scripts/lib/components.sh
@@ -88,7 +88,7 @@ COMPONENT_INSTALL_MARKER_WINDOWS_gauss_demo="HKLM\\Software\\DisplayXR\\Demos\\G
 # Space-separated; add a demo here once it ships a release installer that CI
 # attaches on a v* tag. The `setup-displayxr.bat` mirror keeps its own copy of
 # this list — keep both in sync.
-DEMO_COMPONENTS="gauss_demo modelviewer_demo mediaplayer_demo avatar_demo earthview_demo"
+DEMO_COMPONENTS="gauss_demo modelviewer_demo mediaplayer_demo avatar_demo"
 
 # --- modelviewer_demo ---
 # glTF 2.0 PBR model viewer demo (displayxr-demo-modelviewer). Dual-platform:
@@ -123,17 +123,6 @@ COMPONENT_PKG_MACOS_avatar_demo="DisplayXRAvatar-*.pkg"
 COMPONENT_EXE_WINDOWS_avatar_demo="DisplayXRAvatarSetup-*.exe"
 COMPONENT_INSTALL_MARKER_MACOS_avatar_demo="/Applications/3D Avatar.app"
 COMPONENT_INSTALL_MARKER_WINDOWS_avatar_demo="HKLM\\Software\\DisplayXR\\Demos\\Avatar"
-
-# --- earthview_demo ---
-# EarthView demo (displayxr-demo-earthview). 3D Tiles globe renderer on the 3D
-# display via the OpenXR extension wire protocol — no vendor SR SDK. Both
-# installers (macOS .pkg + Windows .exe) are built + attached by CI on a v*
-# tag. The macOS app installs to "EarthView.app".
-COMPONENT_REPO_earthview_demo="DisplayXR/displayxr-demo-earthview"
-COMPONENT_PKG_MACOS_earthview_demo="DisplayXREarthView-*.pkg"
-COMPONENT_EXE_WINDOWS_earthview_demo="DisplayXREarthViewSetup-*.exe"
-COMPONENT_INSTALL_MARKER_MACOS_earthview_demo="/Applications/EarthView.app"
-COMPONENT_INSTALL_MARKER_WINDOWS_earthview_demo="HKLM\\Software\\DisplayXR\\Demos\\EarthView"
 
 # Helper: look up a per-component field for the current platform.
 #   $1 = component name (runtime, shell, leia_plugin, mcp_tools, gauss_demo)

--- a/scripts/setup-displayxr.bat
+++ b/scripts/setup-displayxr.bat
@@ -55,7 +55,7 @@ REM versions.json) — no COMPONENT_PINKEY override needed for the flat schema.
 
 REM Demo components installed by --with-demos (prebuilt release assets only).
 REM Mirrors DEMO_COMPONENTS in scripts\lib\components.sh; keep in sync.
-set "DEMO_COMPONENTS=gauss_demo modelviewer_demo mediaplayer_demo avatar_demo earthview_demo"
+set "DEMO_COMPONENTS=gauss_demo modelviewer_demo mediaplayer_demo avatar_demo"
 
 set "COMPONENT_REPO_modelviewer_demo=DisplayXR/displayxr-demo-modelviewer"
 set "COMPONENT_EXE_modelviewer_demo=DisplayXRModelViewerSetup-*.exe"
@@ -68,10 +68,6 @@ set "COMPONENT_MARKER_mediaplayer_demo=HKLM\Software\DisplayXR\Demos\MediaPlayer
 set "COMPONENT_REPO_avatar_demo=DisplayXR/displayxr-demo-avatar"
 set "COMPONENT_EXE_avatar_demo=DisplayXRAvatarSetup-*.exe"
 set "COMPONENT_MARKER_avatar_demo=HKLM\Software\DisplayXR\Demos\Avatar"
-
-set "COMPONENT_REPO_earthview_demo=DisplayXR/displayxr-demo-earthview"
-set "COMPONENT_EXE_earthview_demo=DisplayXREarthViewSetup-*.exe"
-set "COMPONENT_MARKER_earthview_demo=HKLM\Software\DisplayXR\Demos\EarthView"
 
 REM --- Default flag state ---
 set "WITH_MCP=0"

--- a/versions.json
+++ b/versions.json
@@ -7,6 +7,5 @@
   "gauss_demo":  "v1.10.0",
   "modelviewer_demo": "v0.11.0",
   "mediaplayer_demo": "v1.2.1",
-  "avatar_demo": "v0.2.0",
-  "earthview_demo": "v0.1.0"
+  "avatar_demo": "v0.2.0"
 }


### PR DESCRIPTION
We're shipping the DisplayXR bundle now but deferring **earthview_demo** (needs more time). **avatar_demo (v0.2.0) stays.** This surgically removes all earthview_demo wiring added in `2db6badce` ("feat(bundle): wire avatar_demo + earthview_demo into components.sh"), leaving avatar_demo fully intact.

## Changes
- **`versions.json`** — delete the `earthview_demo` field entirely. A present-but-unreleased field re-trips the bundle coverage check, so it is removed (not reverted to v0.0.0). `avatar_demo: v0.2.0` kept.
- **`scripts/lib/components.sh`** — remove `earthview_demo` from `DEMO_COMPONENTS` and delete its `COMPONENT_REPO/PKG_MACOS/EXE_WINDOWS/INSTALL_MARKER` block. All `avatar_demo` entries kept.
- **`scripts/setup-displayxr.bat`** — remove `earthview_demo` from the bat `DEMO_COMPONENTS` mirror + its `COMPONENT_REPO/EXE/MARKER` vars. avatar kept.

Pairs with displayxr-installer PR #18 (same earthview removal in the bundle scripts/NSI).

Do NOT merge yet — coordinating with the installer PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)