### PR TITLE
ipc(client): retry on ERROR_PIPE_BUSY instead of dropping concurrent connects (#603)

### DIFF
--- a/src/xrt/ipc/client/ipc_client_connection.c
+++ b/src/xrt/ipc/client/ipc_client_connection.c
@@ -91,11 +91,67 @@ ipc_client_socket_connect(struct ipc_connection *ipc_c, struct _JavaVM *vm, void
 
 #elif defined(XRT_OS_WINDOWS)
 
+// Total time we are willing to keep retrying a busy pipe before giving up, and
+// the per-attempt WaitNamedPipe timeout used between retries.
+#define IPC_CONNECT_BUSY_TOTAL_MS 5000
+#define IPC_CONNECT_BUSY_WAIT_MS 500
+
+/*!
+ * Open the service comm pipe, retrying on ERROR_PIPE_BUSY.
+ *
+ * The server mainloop only posts the next listening pipe instance *after* it
+ * finishes handling the previous connection, so when several clients connect at
+ * once (e.g. a workspace launching multiple apps) some race into the gap and
+ * get ERROR_PIPE_BUSY (231). The canonical Win32 client dance for that is to
+ * WaitNamedPipe() for an instance to free up and retry, bounded by a deadline,
+ * instead of failing xrCreateInstance outright. See issue #603.
+ *
+ * On failure the original GetLastError() is preserved so callers can still tell
+ * "server not running" (ERROR_FILE_NOT_FOUND, drives the auto-launch fallback)
+ * apart from "server up but saturated" (ERROR_PIPE_BUSY).
+ */
+static HANDLE
+ipc_open_pipe_busy_retry(struct ipc_connection *ipc_c, const char *pipe_name)
+{
+	DWORD waited_ms = 0;
+	for (int attempt = 1;; attempt++) {
+		HANDLE pipe_inst =
+		    CreateFileA(pipe_name, GENERIC_READ | GENERIC_WRITE, 0, NULL, OPEN_EXISTING, 0, NULL);
+		if (pipe_inst != INVALID_HANDLE_VALUE) {
+			if (waited_ms > 0) {
+				// Leave a breadcrumb that the busy-retry path recovered a
+				// concurrent connect that would previously have failed (#603).
+				IPC_INFO(ipc_c, "Pipe %s was busy, connected after ~%u ms (attempt %d)",
+				         pipe_name, waited_ms, attempt);
+			}
+			return pipe_inst;
+		}
+
+		DWORD err = GetLastError();
+		if (err != ERROR_PIPE_BUSY) {
+			// Server-down or a genuine error: hand back with the error intact.
+			SetLastError(err);
+			return INVALID_HANDLE_VALUE;
+		}
+
+		if (waited_ms >= IPC_CONNECT_BUSY_TOTAL_MS) {
+			IPC_ERROR(ipc_c, "Pipe %s still busy after %u ms, giving up", pipe_name, waited_ms);
+			SetLastError(ERROR_PIPE_BUSY);
+			return INVALID_HANDLE_VALUE;
+		}
+
+		// Block until an instance frees up, then retry. WaitNamedPipe returning
+		// FALSE (its own timeout) is fine — we just loop until the deadline.
+		WaitNamedPipeA(pipe_name, IPC_CONNECT_BUSY_WAIT_MS);
+		waited_ms += IPC_CONNECT_BUSY_WAIT_MS;
+	}
+}
+
 #if defined(NO_XRT_SERVICE_LAUNCH) || !defined(XRT_SERVICE_EXECUTABLE)
 static HANDLE
 ipc_connect_pipe(struct ipc_connection *ipc_c, const char *pipe_name)
 {
-	HANDLE pipe_inst = CreateFileA(pipe_name, GENERIC_READ | GENERIC_WRITE, 0, NULL, OPEN_EXISTING, 0, NULL);
+	HANDLE pipe_inst = ipc_open_pipe_busy_retry(ipc_c, pipe_name);
 	if (pipe_inst == INVALID_HANDLE_VALUE) {
 		DWORD err = GetLastError();
 		IPC_ERROR(ipc_c, "Connect to %s failed: %d %s", pipe_name, err, ipc_winerror(err));
@@ -107,7 +163,7 @@ ipc_connect_pipe(struct ipc_connection *ipc_c, const char *pipe_name)
 static HANDLE
 ipc_connect_pipe(struct ipc_connection *ipc_c, const char *pipe_name)
 {
-	HANDLE pipe_inst = CreateFileA(pipe_name, GENERIC_READ | GENERIC_WRITE, 0, NULL, OPEN_EXISTING, 0, NULL);
+	HANDLE pipe_inst = ipc_open_pipe_busy_retry(ipc_c, pipe_name);
 	if (pipe_inst != INVALID_HANDLE_VALUE) {
 		return pipe_inst;
 	}
@@ -192,7 +248,11 @@ ipc_connect_pipe(struct ipc_connection *ipc_c, const char *pipe_name)
 			break;
 		}
 		err = GetLastError();
-		if (err != ERROR_FILE_NOT_FOUND || WaitForSingleObject(pi.hProcess, 100) != WAIT_TIMEOUT) {
+		// Keep waiting while the freshly-launched service is still spinning up
+		// its pipe (FILE_NOT_FOUND) or is momentarily saturated (PIPE_BUSY), as
+		// long as the service process is still alive.
+		if ((err != ERROR_FILE_NOT_FOUND && err != ERROR_PIPE_BUSY) ||
+		    WaitForSingleObject(pi.hProcess, 100) != WAIT_TIMEOUT) {
 			IPC_ERROR(ipc_c, "Connect to %s failed: %d %s", pipe_name, err, ipc_winerror(err));
 			break;
 		}

--- a/src/xrt/ipc/server/ipc_server_mainloop_windows.cpp
+++ b/src/xrt/ipc/server/ipc_server_mainloop_windows.cpp
@@ -91,7 +91,9 @@ get_pipe_server_pid(const char *pipe_name)
 	return pid;
 }
 
-static bool
+// Returns 0 on success, else the Win32 error from CreateNamedPipeA (notably
+// ERROR_PIPE_BUSY when the IPC_MAX_CLIENTS instance ceiling is reached).
+static DWORD
 create_pipe_instance(struct ipc_server_mainloop *ml, bool first)
 {
 	SECURITY_ATTRIBUTES sa{};
@@ -156,13 +158,14 @@ create_pipe_instance(struct ipc_server_mainloop *ml, bool first)
 	}
 
 	if (ml->pipe_handle != INVALID_HANDLE_VALUE) {
-		return true;
+		return 0;
 	}
 
 	DWORD err = GetLastError();
 	if (err == ERROR_PIPE_BUSY) {
-		U_LOG_W("CreateNamedPipeA failed: %d %s An existing client must disconnect first!", err,
-		        ipc_winerror(err));
+		// At the IPC_MAX_CLIENTS instance ceiling. Not fatal here — the caller
+		// (create_another_pipe_instance) defers re-arming and throttles the
+		// log, so we don't spam a warning every poll while at capacity.
 	} else {
 		U_LOG_E("CreateNamedPipeA failed: %d %s", err, ipc_winerror(err));
 		if (err == ERROR_ACCESS_DENIED && first) {
@@ -182,15 +185,43 @@ create_pipe_instance(struct ipc_server_mainloop *ml, bool first)
 		}
 	}
 
-	return false;
+	return err;
 }
 
 static void
 create_another_pipe_instance(struct ipc_server *vs, struct ipc_server_mainloop *ml)
 {
-	if (!create_pipe_instance(ml, false)) {
-		ipc_server_handle_failure(vs);
+	// Single-threaded mainloop, one server per process, so a function-local
+	// static is enough to throttle the at-capacity log to once per transition.
+	static bool at_capacity_logged = false;
+
+	DWORD err = create_pipe_instance(ml, false);
+	if (err == 0) {
+		if (at_capacity_logged) {
+			U_LOG_W("IPC: a client disconnected, listener re-armed (accepting connections again)");
+			at_capacity_logged = false;
+		}
+		return;
 	}
+
+	if (err == ERROR_PIPE_BUSY) {
+		// All IPC_MAX_CLIENTS pipe instances are live (max concurrent clients
+		// reached). This is transient backpressure, not a server failure:
+		// release the listener for now and let a later poll re-arm it once a
+		// client disconnects and frees an instance. Connecting clients retry on
+		// ERROR_PIPE_BUSY (see ipc_client_connection.c), so a connect in this
+		// window waits instead of taking the whole service down with it.
+		ml->pipe_handle = nullptr;
+		if (!at_capacity_logged) {
+			U_LOG_W("IPC at capacity (%d concurrent clients); deferring new listener until one "
+			        "disconnects",
+			        IPC_MAX_CLIENTS);
+			at_capacity_logged = true;
+		}
+		return;
+	}
+
+	ipc_server_handle_failure(vs);
 }
 
 static void
@@ -275,7 +306,7 @@ ipc_server_mainloop_init(struct ipc_server_mainloop *ml)
 		goto err;
 	}
 
-	if (!create_pipe_instance(ml, true)) {
+	if (create_pipe_instance(ml, true) != 0) {
 		U_LOG_E("CreateNamedPipeA \"%s\" first instance failed, see above.", ml->pipe_name);
 		goto err;
 	}


### PR DESCRIPTION
Fixes #603.

Concurrent IPC connect robustness — two complementary changes:

## 1. Client: retry on ERROR_PIPE_BUSY (`ipc_client_connection.c`)

When several clients connect to the service comm pipe at once (a workspace launching multiple apps), some race into the window between the server accepting one connection and re-arming the next listening instance, and `CreateFile` returns `ERROR_PIPE_BUSY` (231). The Windows `ipc_connect_pipe` did a single `CreateFileA` with no recovery, so that client aborted `xrCreateInstance` with `XR_ERROR_RUNTIME_FAILURE` and the app dropped.

Add the canonical Win32 retry: on `ERROR_PIPE_BUSY`, `WaitNamedPipe()` and retry, bounded to 5s (10 × 500ms), in a shared helper used by both `ipc_connect_pipe` variants. `ERROR_FILE_NOT_FOUND` (server not running) is preserved so the auto-launch fallback still fires. A one-shot breadcrumb logs a recovered busy connect.

## 2. Server: capacity is backpressure, not a crash (`ipc_server_mainloop_windows.cpp`)

When all `IPC_MAX_CLIENTS` pipe instances are live, `create_another_pipe_instance` got `ERROR_PIPE_BUSY` and called `ipc_server_handle_failure()` — taking the **whole service down**, so a burst of connects killed it for every client. Now `create_pipe_instance` returns the Win32 error; on capacity the server drops the listener and re-arms on a later poll once a client disconnects. Combined with the client retry, an overflow connect waits instead of crashing the service. At-capacity log throttled to once per transition.

No wire-protocol/ABI change in either; `IPC_MAX_CLIENTS` left at 8.

## Testing (Windows, Leia SR box, runtime built from this branch)

- **Pre-fix:** `displayxr-shell` launching 4 demos → gauss drops with `ERROR_PIPE_BUSY`; an 8-client burst → **service crashes** (`CreateNamedPipeA failed: 231` → `handle_failure`).
- **Post-fix:** 4-demo launch → **4/4** across 4 runs; 6-client burst → 6/6; **8-client burst → service survives** (same PID before/after), logs `IPC at capacity (8 concurrent clients); deferring new listener`, 8/8 clients connect. Single-app and service-launch paths unaffected.

The companion shell-side fix (a second `displayxr-shell.exe <app>` invocation forwarding the app to the running instance instead of dropping it) is in `displayxr-shell-pvt`.
