### PR TITLE
feat(qwerty): camera-rig IPD ceiling (display-equiv 1) + shared dxr_rig_toggle

### DIFF
--- a/src/xrt/auxiliary/math/CMakeLists.txt
+++ b/src/xrt/auxiliary/math/CMakeLists.txt
@@ -20,7 +20,7 @@ set(DISPLAYXR_XRT_INCLUDE_DIR "${_dxr_xrt_includes}" CACHE PATH "" FORCE)
 FetchContent_Declare(
 	displayxr_common
 	GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
-	GIT_TAG v1.0.8
+	GIT_TAG v1.0.9
 	GIT_SHALLOW TRUE
 	)
 FetchContent_MakeAvailable(displayxr_common)

--- a/src/xrt/drivers/qwerty/qwerty_device.c
+++ b/src/xrt/drivers/qwerty/qwerty_device.c
@@ -1082,9 +1082,14 @@ qwerty_toggle_camera_mode(struct qwerty_system *qs)
 	// aspect is unused by the converters; nominal/screen come from the hardware.
 	dxr_rig_display_info info = {qs->screen_height_m, 1.0f, qs->nominal_viewer_z};
 
+	// Route the conversion through the shared dxr_rig_toggle so qwerty and the
+	// app-side rig_mode wrapper share one toggle definition; only the
+	// qwerty_system<->rig field mapping (and qwerty's display-rig clamps) is local.
+	struct dxr_rig in = {0}, out = {0};
 	if (qs->camera_mode) {
 		// Camera -> Display.
-		dxr_camera_rig cam = {
+		in.type = DXR_RIG_CAMERA;
+		in.u.camera = (dxr_camera_rig){
 		    .pose = {{pose->orientation.x, pose->orientation.y, pose->orientation.z, pose->orientation.w},
 		             {pose->position.x, pose->position.y, pose->position.z}},
 		    .ipd_factor = qs->cam_spread_factor,
@@ -1093,8 +1098,8 @@ qwerty_toggle_camera_mode(struct qwerty_system *qs)
 		    .half_tan_vfov = qs->cam_half_tan_vfov,
 		    .m2v = qs->cam_m2v,
 		};
-		dxr_display_rig disp;
-		dxr_view_rig_camera_to_display(&cam, &info, &disp);
+		dxr_rig_toggle(&in, &info, &out);
+		const dxr_display_rig disp = out.u.display;
 		qs->disp_vHeight = clampf(disp.virtual_display_height, 0.1f, 10.0f);
 		// Carry the converted perspective — it is NOT 1.0 for the camera default
 		// (e.g. 0.5 dp / 36° vFOV → ~0.50 at the legacy panel/distance). Dropping
@@ -1106,7 +1111,8 @@ qwerty_toggle_camera_mode(struct qwerty_system *qs)
 		pose->position = (struct xrt_vec3){disp.pose.position.x, disp.pose.position.y, disp.pose.position.z};
 	} else {
 		// Display -> Camera (was a reset; now a faithful conversion).
-		dxr_display_rig disp = {
+		in.type = DXR_RIG_DISPLAY;
+		in.u.display = (dxr_display_rig){
 		    .pose = {{pose->orientation.x, pose->orientation.y, pose->orientation.z, pose->orientation.w},
 		             {pose->position.x, pose->position.y, pose->position.z}},
 		    .virtual_display_height = qs->disp_vHeight,
@@ -1114,8 +1120,8 @@ qwerty_toggle_camera_mode(struct qwerty_system *qs)
 		    .parallax_factor = qs->disp_parallax_factor,
 		    .perspective_factor = qs->disp_perspective,
 		};
-		dxr_camera_rig cam;
-		dxr_view_rig_display_to_camera(&disp, &info, &cam);
+		dxr_rig_toggle(&in, &info, &out);
+		const dxr_camera_rig cam = out.u.camera;
 		qs->cam_convergence = clampf(cam.inv_convergence_distance, 0.0f, 2.0f);
 		qs->cam_half_tan_vfov = cam.half_tan_vfov;
 		qs->cam_m2v = cam.m2v;
@@ -1150,10 +1156,21 @@ void
 qwerty_adjust_view_factor(struct qwerty_system *qs, float multiplier)
 {
 	if (qs->camera_mode) {
-		float v = clampf(qs->cam_spread_factor * multiplier, 0.01f, 1.0f);
+		// The display rig clamps IPD/parallax to [0,1], but the camera rig's comfort
+		// is defined on its DISPLAY-centric equivalent, not on the camera factor
+		// itself: camera->display rescales by f = m2v*invd*N, so the display
+		// equivalent of cam_spread is cam_spread*f. Clamp to [0.01, M] where M = 1/f
+		// is the camera factor whose display equivalent is exactly 1 — the canonical
+		// dual of qwerty_adjust_convergence's clamp. dxr_rig_max_ipd_factor derives M
+		// from the live cam params (>1 for far convergence, <1 for near, +inf for
+		// convergence→infinity → effectively unbounded; clampf tolerates HUGE_VALF).
+		dxr_rig_display_info info = {qs->screen_height_m, 1.0f, qs->nominal_viewer_z};
+		dxr_camera_rig cam = {.inv_convergence_distance = qs->cam_convergence, .m2v = qs->cam_m2v};
+		float ipd_max = dxr_rig_max_ipd_factor(&cam, &info);
+		float v = clampf(qs->cam_spread_factor * multiplier, 0.01f, ipd_max);
 		qs->cam_spread_factor = v;
 		qs->cam_parallax_factor = v;
-		U_LOG_I("Qwerty: Camera IPD/Parallax = %.3f", v);
+		U_LOG_I("Qwerty: Camera IPD/Parallax = %.3f (max %.3f = display-equiv 1)", v, ipd_max);
 	} else {
 		float v = clampf(qs->disp_spread_factor * multiplier, 0.01f, 1.0f);
 		qs->disp_spread_factor = v;

--- a/test_apps/common/CMakeLists.txt
+++ b/test_apps/common/CMakeLists.txt
@@ -30,7 +30,7 @@ set(DISPLAYXR_EXTENSIONS_INCLUDE_DIR "${_dxr_ext_includes}" CACHE PATH
 FetchContent_Declare(
     displayxr_common
     GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
-    GIT_TAG v1.0.7
+    GIT_TAG v1.0.9
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(displayxr_common)


### PR DESCRIPTION
Depends on **displayxr-common v1.0.9** (published — `dxr_rig_max_ipd_factor` + `dxr_rig_toggle`).

## IPD ceiling
The display rig clamps IPD/parallax to `[0,1]` (correct for it), but the camera rig is comfort-bounded on its **display-centric equivalent**, not the raw camera factor. `camera→display` rescales by `f = m2v·invd·N`, so the largest camera factor whose display equivalent is exactly 1 is `M = 1/f`.

`qwerty_adjust_view_factor` now clamps camera-mode IPD/parallax to `[0.01, M]` via `dxr_rig_max_ipd_factor()`:
- far convergence (`f<1`) → `M>1` (IPD legitimately exceeds the display rig's 1; the converter is exact there)
- near convergence (`f>1`) → `M<1`
- convergence→infinity (`f→0`) → `+∞`, i.e. no ceiling (no arbitrary cap)

Display mode keeps its `[0,1]` clamp. This is the dual of the existing `qwerty_adjust_convergence` clamp — together they hold the comfort product `ipd·f ≤ 1` from either knob.

The same ceiling is wired into displayxr-common's shared input path (`input_handler.cpp`), so the **cube_* test apps** get it too (pin bumped to v1.0.9).

## Shared toggle
`qwerty_toggle_camera_mode` hand-rolled the camera↔display conversion. It now routes through the new `dxr_rig_toggle()` primitive in displayxr-common, so the runtime qwerty driver and the app-side `rig_mode` wrapper share **one** toggle definition. Behaviour-identical (same converters underneath); only the per-struct field mapping stays local (qwerty's state model differs from `ViewParams`).

## Why not share more
`input_handler` itself can't be reused by the runtime — it lives in the app-facing `displayxr_common_lib` (D3D11 renderer + HUD + window manager + OpenXR session boilerplate) and sits on the opposite side of the OpenXR boundary from qwerty. The shareable part is the rig **math/policy**, which is now single-sourced in `math_core` (converters, comfort helpers, toggle).

## Validation
- Blender (qwerty path) + `cube_handle_d3d11_win` (app input path): IPD climbs past 1 at far convergence, re-clamps below 1 near. P/C toggle visually unchanged. common v1.0.9 CI green (self-test asserts `M=1/f` and display-ipd-at-`M`=1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)