### PR TITLE
feat(installer): bundle cJSON for macOS (runtime + .app) instead of Homebrew abs path

### DIFF
--- a/installer/macos/build_installer.sh
+++ b/installer/macos/build_installer.sh
@@ -50,6 +50,18 @@ cp "$ARTIFACT_DIR/lib/libvulkan.1.dylib" "$RUNTIME_ROOT/lib/"
 cp "$ARTIFACT_DIR/lib/libMoltenVK.dylib" "$RUNTIME_ROOT/lib/"
 cp "$ARTIFACT_DIR/share/vulkan/icd.d/MoltenVK_icd.json" "$RUNTIME_ROOT/share/vulkan/icd.d/"
 
+# cJSON is a direct dependency of the runtime + plug-in. build_macos.sh
+# bundles it into the artifact's lib/; fall back to Homebrew for older
+# artifacts built before that change.
+BREW_PREFIX="$(brew --prefix 2>/dev/null || echo /opt/homebrew)"
+if [ -f "$ARTIFACT_DIR/lib/libcjson.1.dylib" ]; then
+    cp -L "$ARTIFACT_DIR/lib/libcjson.1.dylib" "$RUNTIME_ROOT/lib/"
+elif [ -f "$BREW_PREFIX/lib/libcjson.1.dylib" ]; then
+    cp -L "$BREW_PREFIX/lib/libcjson.1.dylib" "$RUNTIME_ROOT/lib/"
+else
+    echo "Warning: libcjson.1.dylib not found; installed runtime may keep an absolute Homebrew dependency"
+fi
+
 # Defensive Vulkan rpath fixup. `scripts/build_macos.sh` already runs
 # the equivalent install_name_tool steps against the artifact dir, but
 # repeat here to be robust against external callers that hand us an
@@ -71,11 +83,23 @@ chmod u+w "$RUNTIME_ROOT/lib/libMoltenVK.dylib"
 install_name_tool -id @rpath/libMoltenVK.dylib "$RUNTIME_ROOT/lib/libMoltenVK.dylib" 2>/dev/null || true
 codesign --force --sign - "$RUNTIME_ROOT/lib/libMoltenVK.dylib" 2>/dev/null || true
 
+if [ -f "$RUNTIME_ROOT/lib/libcjson.1.dylib" ]; then
+  chmod u+w "$RUNTIME_ROOT/lib/libcjson.1.dylib"
+  install_name_tool -id @rpath/libcjson.1.dylib "$RUNTIME_ROOT/lib/libcjson.1.dylib" 2>/dev/null || true
+  codesign --force --sign - "$RUNTIME_ROOT/lib/libcjson.1.dylib" 2>/dev/null || true
+fi
+
+# Retarget the runtime's Vulkan + cJSON deps from the Homebrew absolute
+# path ($BREW_PREFIX is /opt/homebrew on Apple Silicon, /usr/local on
+# Intel) to @rpath.
 chmod u+w "$RUNTIME_ROOT/lib/$RUNTIME_BASENAME"
-install_name_tool -change /opt/homebrew/opt/vulkan-loader/lib/libvulkan.1.dylib \
+install_name_tool -change "$BREW_PREFIX/opt/vulkan-loader/lib/libvulkan.1.dylib" \
                           @rpath/libvulkan.1.dylib \
                           "$RUNTIME_ROOT/lib/$RUNTIME_BASENAME" 2>/dev/null || true
-# Runtime needs @loader_path so it can resolve @rpath/libvulkan.1.dylib
+install_name_tool -change "$BREW_PREFIX/opt/cjson/lib/libcjson.1.dylib" \
+                          @rpath/libcjson.1.dylib \
+                          "$RUNTIME_ROOT/lib/$RUNTIME_BASENAME" 2>/dev/null || true
+# Runtime needs @loader_path so it can resolve @rpath/lib*.dylib
 # from its own directory. Idempotent: install_name_tool warns + exits 0
 # if the rpath is already there.
 install_name_tool -add_rpath @loader_path "$RUNTIME_ROOT/lib/$RUNTIME_BASENAME" 2>/dev/null || true
@@ -108,10 +132,9 @@ cp "$PLUGIN_SRC" "$PLUGIN_PAYLOAD_DIR/"
 # runtime is at @loader_path/../.. (.../lib/).
 PAYLOAD_PLUGIN="$PLUGIN_PAYLOAD_DIR/DisplayXR-SimDisplay.dylib"
 chmod u+w "$PAYLOAD_PLUGIN"
-# Drop every existing rpath that points into a build/_package tree;
-# keep only system rpaths (Homebrew cjson etc. — install_name_tool is
-# a no-op on those). We can't enumerate negatively, so just delete the
-# known dev-iteration rpaths if present and let any survivor warn.
+# Drop every existing rpath that points into a build/_package tree.
+# We can't enumerate negatively, so just delete the known dev-iteration
+# rpaths if present and let any survivor warn.
 for r in $(otool -l "$PAYLOAD_PLUGIN" 2>/dev/null \
            | awk '/LC_RPATH/{f=1} f && /path /{print $2; f=0}' \
            | grep -E '^/.*displayxr-runtime/.*build|@loader_path' || true); do
@@ -119,12 +142,15 @@ for r in $(otool -l "$PAYLOAD_PLUGIN" 2>/dev/null \
 done
 install_name_tool -add_rpath "@loader_path/../.." "$PAYLOAD_PLUGIN" 2>/dev/null || true
 
-# Defensive Vulkan -change on the embedded plug-in (same idempotent
-# fixup applied to the runtime above). @loader_path/../.. above doubles
-# as the rpath that resolves @rpath/libvulkan.1.dylib to
-# .../lib/libvulkan.1.dylib at the install location.
-install_name_tool -change /opt/homebrew/opt/vulkan-loader/lib/libvulkan.1.dylib \
+# Defensive Vulkan + cJSON -change on the embedded plug-in (same
+# idempotent fixup applied to the runtime above). @loader_path/../..
+# above doubles as the rpath that resolves @rpath/lib*.dylib to
+# .../lib/lib*.dylib at the install location.
+install_name_tool -change "$BREW_PREFIX/opt/vulkan-loader/lib/libvulkan.1.dylib" \
                           @rpath/libvulkan.1.dylib \
+                          "$PAYLOAD_PLUGIN" 2>/dev/null || true
+install_name_tool -change "$BREW_PREFIX/opt/cjson/lib/libcjson.1.dylib" \
+                          @rpath/libcjson.1.dylib \
                           "$PAYLOAD_PLUGIN" 2>/dev/null || true
 # Re-sign after all install_name_tool ops to avoid SIGKILL at dlopen.
 codesign --force --sign - "$PAYLOAD_PLUGIN" 2>/dev/null || true

--- a/installer/macos/create_app_bundle.sh
+++ b/installer/macos/create_app_bundle.sh
@@ -86,6 +86,18 @@ cp "$RUNTIME_LIB" "$APP_BUNDLE/Contents/Resources/lib/"
 cp "$ARTIFACT_DIR"/lib/libopenxr_loader* "$APP_BUNDLE/Contents/Resources/lib/"
 cp "$ARTIFACT_DIR/lib/libvulkan.1.dylib" "$APP_BUNDLE/Contents/Resources/lib/"
 cp "$ARTIFACT_DIR/lib/libMoltenVK.dylib" "$APP_BUNDLE/Contents/Resources/lib/"
+# cJSON: the runtime dylib carries a @rpath/libcjson.1.dylib dependency
+# (retargeted by build_macos.sh/build_installer.sh), resolved here via the
+# runtime's @loader_path rpath → Resources/lib/. Without bundling it the
+# .app fails to load the runtime on a clean (no-Homebrew) machine.
+if [ -f "$ARTIFACT_DIR/lib/libcjson.1.dylib" ]; then
+    cp -L "$ARTIFACT_DIR/lib/libcjson.1.dylib" "$APP_BUNDLE/Contents/Resources/lib/"
+else
+    BREW_PREFIX="$(brew --prefix 2>/dev/null || echo /opt/homebrew)"
+    [ -f "$BREW_PREFIX/lib/libcjson.1.dylib" ] && \
+        cp -L "$BREW_PREFIX/lib/libcjson.1.dylib" "$APP_BUNDLE/Contents/Resources/lib/" || \
+        echo "Warning: libcjson.1.dylib not found; .app may not load runtime on a clean machine"
+fi
 
 # --- Resources: manifests with paths relative to .app bundle ---
 cat > "$APP_BUNDLE/Contents/Resources/openxr_displayxr.json" <<EOF

--- a/scripts/build_macos.sh
+++ b/scripts/build_macos.sh
@@ -253,9 +253,13 @@ cp "$ROOT/test_apps/common/textures/"*.jpg "$PKG_DIR/bin/textures/" 2>/dev/null 
 # Copy OpenXR loader
 cp "$OPENXR_DIR"/lib/libopenxr_loader*.dylib "$PKG_DIR/lib/"
 
-# Bundle Vulkan loader and MoltenVK from Homebrew
+# Bundle Vulkan loader, MoltenVK, and cJSON from Homebrew. cJSON is a
+# direct dependency of both the runtime and the sim-display plug-in
+# (target_plugin_loader.c parses the JSON manifests with it); without
+# bundling it the .pkg keeps an absolute /opt/homebrew (or /usr/local on
+# Intel) dependency and won't load on a clean machine.
 BREW_PREFIX="$(brew --prefix)"
-for lib in libvulkan.1.dylib libMoltenVK.dylib; do
+for lib in libvulkan.1.dylib libMoltenVK.dylib libcjson.1.dylib; do
   if [ -f "$BREW_PREFIX/lib/$lib" ]; then
     cp -L "$BREW_PREFIX/lib/$lib" "$PKG_DIR/lib/"
   else
@@ -288,21 +292,33 @@ chmod u+w "$PKG_DIR/lib/libMoltenVK.dylib" 2>/dev/null || true
 install_name_tool -id @rpath/libMoltenVK.dylib "$PKG_DIR/lib/libMoltenVK.dylib" 2>/dev/null || true
 codesign --force --sign - "$PKG_DIR/lib/libMoltenVK.dylib" 2>/dev/null || true
 
-# Retarget the runtime + sim-display plug-in's Vulkan dependency from
-# the Homebrew absolute path to @rpath/libvulkan.1.dylib. The @rpath
+chmod u+w "$PKG_DIR/lib/libcjson.1.dylib" 2>/dev/null || true
+install_name_tool -id @rpath/libcjson.1.dylib "$PKG_DIR/lib/libcjson.1.dylib" 2>/dev/null || true
+codesign --force --sign - "$PKG_DIR/lib/libcjson.1.dylib" 2>/dev/null || true
+
+# Retarget the runtime + sim-display plug-in's Vulkan and cJSON
+# dependencies from the Homebrew absolute path to @rpath. The source
+# prefix is $BREW_PREFIX (/opt/homebrew on Apple Silicon, /usr/local on
+# Intel) so the -change matches on both architectures. The @rpath
 # entries below give dyld the right hint:
-#   runtime  → @loader_path        (libvulkan.1.dylib lives next to it)
-#   plug-in  → @loader_path/../..  (libvulkan.1.dylib is two levels up)
+#   runtime  → @loader_path        (the bundled dylibs live next to it)
+#   plug-in  → @loader_path/../..  (the bundled dylibs are two levels up)
 chmod u+w "$PKG_DIR/lib/$RUNTIME_BASENAME" 2>/dev/null || true
-install_name_tool -change /opt/homebrew/opt/vulkan-loader/lib/libvulkan.1.dylib \
+install_name_tool -change "$BREW_PREFIX/opt/vulkan-loader/lib/libvulkan.1.dylib" \
                           @rpath/libvulkan.1.dylib \
+                          "$PKG_DIR/lib/$RUNTIME_BASENAME" 2>/dev/null || true
+install_name_tool -change "$BREW_PREFIX/opt/cjson/lib/libcjson.1.dylib" \
+                          @rpath/libcjson.1.dylib \
                           "$PKG_DIR/lib/$RUNTIME_BASENAME" 2>/dev/null || true
 codesign --force --sign - "$PKG_DIR/lib/$RUNTIME_BASENAME" 2>/dev/null || true
 
 if [ -f "$PKG_DIR/lib/displayxr/plugins/DisplayXR-SimDisplay.dylib" ]; then
   chmod u+w "$PKG_DIR/lib/displayxr/plugins/DisplayXR-SimDisplay.dylib"
-  install_name_tool -change /opt/homebrew/opt/vulkan-loader/lib/libvulkan.1.dylib \
+  install_name_tool -change "$BREW_PREFIX/opt/vulkan-loader/lib/libvulkan.1.dylib" \
                             @rpath/libvulkan.1.dylib \
+                            "$PKG_DIR/lib/displayxr/plugins/DisplayXR-SimDisplay.dylib" 2>/dev/null || true
+  install_name_tool -change "$BREW_PREFIX/opt/cjson/lib/libcjson.1.dylib" \
+                            @rpath/libcjson.1.dylib \
                             "$PKG_DIR/lib/displayxr/plugins/DisplayXR-SimDisplay.dylib" 2>/dev/null || true
   codesign --force --sign - "$PKG_DIR/lib/displayxr/plugins/DisplayXR-SimDisplay.dylib" 2>/dev/null || true
 fi


### PR DESCRIPTION
cJSON is a direct dependency of the macOS runtime and the sim-display plug-in (`target_plugin_loader.c` parses the JSON manifests with it). The build/installer scripts previously left an **absolute Homebrew path** (`/opt/homebrew/opt/cjson/...`) baked into the runtime dylib, so a clean (no-Homebrew) machine failed to load the runtime.

This bundles `libcjson.1.dylib` and retargets the dep to `@rpath`:
- `scripts/build_macos.sh` — bundle cJSON into the artifact `lib/` (alongside Vulkan/MoltenVK).
- `installer/macos/build_installer.sh` — copy + `install_name_tool -id @rpath` + re-sign cJSON; `-change` the Homebrew abs path → `@rpath` on both the runtime and the embedded plug-in. Also generalizes the hard-coded `/opt/homebrew` to `$(brew --prefix)` so Intel (`/usr/local`) works.
- `installer/macos/create_app_bundle.sh` — bundle cJSON into `Contents/Resources/lib/` (resolved via the runtime's `@loader_path` rpath).

All steps fall back to Homebrew for older artifacts and are idempotent/defensive (`|| true`).

Needed before the next release so the macOS `.pkg`/`.app` are self-contained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)