### PR TITLE
fix(#602): eliminate VK content-fit atlas churn + resize device loss

### DIFF
--- a/src/xrt/compositor/d3d11/comp_d3d11_renderer.cpp
+++ b/src/xrt/compositor/d3d11/comp_d3d11_renderer.cpp
@@ -141,8 +141,15 @@ struct comp_d3d11_renderer
 	uint32_t tile_rows;
 
 	//! Texture height (may be > view_height to accommodate mono/2D mode).
-	//! The atlas texture is tile_columns*view_width x texture_height.
+	//! The atlas texture content region is tile_columns*view_width x texture_height.
 	uint32_t texture_height;
+
+	//! #602: ALLOCATED atlas texture extent (high-water-mark, worst-case). The
+	//! content region (tile_columns*view_width x texture_height) packs top-left
+	//! into this; content-fit zones shrink the content per frame without
+	//! reallocating. d3d11_crop_atlas_for_dp rect-crops the content back out.
+	uint32_t atlas_alloc_width;
+	uint32_t atlas_alloc_height;
 
 	//! When true, view dims are fixed at legacy compromise scale and
 	//! set_tile_layout must not recompute them.
@@ -629,6 +636,8 @@ create_resources(struct comp_d3d11_renderer *r)
 		U_LOG_E("Failed to create atlas texture: 0x%08x", hr);
 		return XRT_ERROR_D3D;
 	}
+	r->atlas_alloc_width = texDesc.Width;
+	r->atlas_alloc_height = texDesc.Height;
 
 	U_LOG_W("Created atlas texture: %ux%u (view=%ux%u, tiles=%ux%u, tex_h=%u)",
 	        texDesc.Width, texDesc.Height, r->view_width, r->view_height,
@@ -1677,19 +1686,44 @@ comp_d3d11_renderer_resize(struct comp_d3d11_renderer *renderer,
 	uint32_t min_h = (new_target_height > atlas_h) ? new_target_height : atlas_h;
 	uint32_t new_texture_height = (min_h > new_view_height) ? min_h : new_view_height;
 
-	// Skip if unchanged
-	if (new_view_width == renderer->view_width &&
-	    new_view_height == renderer->view_height &&
-	    new_texture_height == renderer->texture_height) {
+	// #602: decouple the atlas ALLOCATION (high-water-mark, worst-case) from
+	// the per-frame content VIEW dims. Content-fit display zones (ADR-027)
+	// renegotiate view dims ~6x/sec; previously every change Release()'d and
+	// rebuilt the atlas/SRV/RTV/depth (per-frame COM churn). Instead the
+	// content (tile_columns*view_width x texture_height) packs top-left into a
+	// stable, never-shrinking allocation; d3d11_crop_atlas_for_dp rect-crops
+	// it back out, and the draw path places tiles by the effective layout, not
+	// the allocation. While the content fits the current allocation we only
+	// update the view bookkeeping in place — no Release/recreate.
+	uint32_t req_w = renderer->tile_columns * new_view_width;
+	uint32_t req_h = new_texture_height;
+	bool have_atlas = renderer->atlas_texture != nullptr;
+	bool fits = have_atlas && req_w <= renderer->atlas_alloc_width &&
+	            req_h <= renderer->atlas_alloc_height;
+	if (fits) {
+		renderer->view_width = new_view_width;
+		renderer->view_height = new_view_height;
+		renderer->texture_height = new_texture_height;
 		return XRT_SUCCESS;
 	}
 
 	auto internals = get_internals(renderer->c);
 
-	U_LOG_W("Renderer resize: view %ux%u -> %ux%u, tex_h %u -> %u",
-	        renderer->view_width, renderer->view_height,
-	        new_view_width, new_view_height,
-	        renderer->texture_height, new_texture_height);
+	// Genuine grow: first allocation, a display-mode change, or content larger
+	// than any seen before. High-water-mark — never shrink — so this converges
+	// (content-fit is window-bounded) and stops firing after warmup.
+	uint32_t grow_w = req_w;
+	uint32_t grow_h = req_h;
+	if (have_atlas) {
+		if (renderer->atlas_alloc_width > grow_w) grow_w = renderer->atlas_alloc_width;
+		if (renderer->atlas_alloc_height > grow_h) grow_h = renderer->atlas_alloc_height;
+	}
+
+	// TEMP #602 instrumentation — counts genuine atlas (re)allocations; should
+	// stay tiny (≈ startup/warmup) and NOT climb per-frame. Remove before merge.
+	static uint32_t s_realloc_count = 0;
+	U_LOG_W("#602 D3D11 atlas (re)alloc #%u: %ux%u (view %ux%u, tex_h %u)", ++s_realloc_count, grow_w, grow_h,
+	        new_view_width, new_view_height, new_texture_height);
 
 	// Release existing resources
 #define SAFE_RELEASE(x)                                                                                                \
@@ -1711,10 +1745,11 @@ comp_d3d11_renderer_resize(struct comp_d3d11_renderer *renderer,
 	renderer->view_height = new_view_height;
 	renderer->texture_height = new_texture_height;
 
-	// Recreate atlas texture (tile_columns * view_width)
+	// Recreate atlas texture at the grown (worst-case) allocation; content
+	// packs top-left into it.
 	D3D11_TEXTURE2D_DESC texDesc = {};
-	texDesc.Width = renderer->tile_columns * new_view_width;
-	texDesc.Height = new_texture_height;
+	texDesc.Width = grow_w;
+	texDesc.Height = grow_h;
 	texDesc.MipLevels = 1;
 	texDesc.ArraySize = 1;
 	texDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
@@ -1727,6 +1762,8 @@ comp_d3d11_renderer_resize(struct comp_d3d11_renderer *renderer,
 		U_LOG_E("Failed to recreate atlas texture: 0x%08x", hr);
 		return XRT_ERROR_D3D;
 	}
+	renderer->atlas_alloc_width = texDesc.Width;
+	renderer->atlas_alloc_height = texDesc.Height;
 
 	// Recreate SRV
 	D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
@@ -1764,8 +1801,8 @@ comp_d3d11_renderer_resize(struct comp_d3d11_renderer *renderer,
 		return XRT_ERROR_D3D;
 	}
 
-	U_LOG_W("Renderer resized: atlas texture now %ux%u (view=%ux%u, tiles=%ux%u, tex_h=%u)",
-	        renderer->tile_columns * new_view_width, new_texture_height,
+	U_LOG_W("Renderer resized: atlas alloc now %ux%u (view=%ux%u, tiles=%ux%u, tex_h=%u)",
+	        grow_w, grow_h,
 	        new_view_width, new_view_height,
 	        renderer->tile_columns, renderer->tile_rows, new_texture_height);
 

--- a/src/xrt/compositor/d3d12/comp_d3d12_renderer.cpp
+++ b/src/xrt/compositor/d3d12/comp_d3d12_renderer.cpp
@@ -352,8 +352,15 @@ struct comp_d3d12_renderer
 	uint32_t tile_columns;
 	uint32_t tile_rows;
 
-	//! Actual atlas texture height (tile_rows * view_height).
+	//! Actual atlas content height (tile_rows * view_height).
 	uint32_t texture_height;
+
+	//! #602: ALLOCATED atlas resource extent (high-water-mark, worst-case).
+	//! The content region (tile_columns*view_width x tile_rows*view_height)
+	//! packs top-left into this; content-fit zones shrink the content per
+	//! frame without reallocating. d3d12_crop_atlas_for_dp rect-crops it out.
+	uint32_t atlas_alloc_width;
+	uint32_t atlas_alloc_height;
 
 	//! When true, view dims are fixed at legacy compromise scale and
 	//! set_tile_layout must not recompute them.
@@ -442,13 +449,24 @@ log_dred_state(ID3D12Device *device, const char *context)
 static xrt_result_t
 create_atlas_texture(struct comp_d3d12_renderer *r, ID3D12Device *device, uint32_t width, uint32_t height)
 {
+	(void)height; // atlas height derives from r->view_height (set by the caller)
+
+	// #602 high-water-mark: allocate at the worst case seen so far and never
+	// shrink, so content-fit zones that only change the content extent reuse
+	// this resource (the resize() fast-path skips us entirely while it fits).
+	// Content packs top-left; d3d12_crop_atlas_for_dp rect-crops it back out.
+	uint32_t content_w = r->tile_columns * width;       // Atlas: tile_columns views across
+	uint32_t content_h = r->tile_rows * r->view_height; // Atlas: tile_rows views tall
+	uint32_t alloc_w = content_w > r->atlas_alloc_width ? content_w : r->atlas_alloc_width;
+	uint32_t alloc_h = content_h > r->atlas_alloc_height ? content_h : r->atlas_alloc_height;
+
 	D3D12_HEAP_PROPERTIES heap_props = {};
 	heap_props.Type = D3D12_HEAP_TYPE_DEFAULT;
 
 	D3D12_RESOURCE_DESC res_desc = {};
 	res_desc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
-	res_desc.Width = r->tile_columns * width; // Atlas: tile_columns views across
-	res_desc.Height = r->tile_rows * r->view_height; // Atlas: tile_rows views tall
+	res_desc.Width = alloc_w;
+	res_desc.Height = alloc_h;
 	res_desc.DepthOrArraySize = 1;
 	res_desc.MipLevels = 1;
 	res_desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
@@ -485,6 +503,9 @@ create_atlas_texture(struct comp_d3d12_renderer *r, ID3D12Device *device, uint32
 
 	D3D12_CPU_DESCRIPTOR_HANDLE srv_cpu = r->srv_heap->GetCPUDescriptorHandleForHeapStart();
 	device->CreateShaderResourceView(r->atlas_texture, &srv_desc, srv_cpu);
+
+	r->atlas_alloc_width = alloc_w;
+	r->atlas_alloc_height = alloc_h;
 
 	return XRT_SUCCESS;
 }
@@ -1835,18 +1856,35 @@ comp_d3d12_renderer_resize(struct comp_d3d12_renderer *renderer,
 
 	uint32_t new_texture_height = renderer->tile_rows * new_view_height;
 
-	if (new_view_width == renderer->view_width &&
-	    new_view_height == renderer->view_height &&
-	    new_texture_height == renderer->texture_height) {
+	// #602: decouple the atlas ALLOCATION (high-water-mark) from the per-frame
+	// content VIEW dims. Content-fit display zones (ADR-027) renegotiate view
+	// dims ~6x/sec; previously every change Release()'d and rebuilt the atlas
+	// resource (per-frame COM churn). Instead the content packs top-left into a
+	// stable, never-shrinking allocation; d3d12_crop_atlas_for_dp rect-crops it
+	// back out, and the draw places tiles by the effective layout. While the
+	// content fits the current allocation we only update bookkeeping in place.
+	uint32_t req_w = renderer->tile_columns * new_view_width;
+	uint32_t req_h = new_texture_height;
+	bool have_atlas = renderer->atlas_texture != nullptr;
+	bool fits = have_atlas && req_w <= renderer->atlas_alloc_width &&
+	            req_h <= renderer->atlas_alloc_height;
+	if (fits) {
+		renderer->view_width = new_view_width;
+		renderer->view_height = new_view_height;
+		renderer->texture_height = new_texture_height;
 		return XRT_SUCCESS;
 	}
 
-	U_LOG_W("D3D12 renderer resize: view %ux%u -> %ux%u, tex_h %u -> %u",
-	        renderer->view_width, renderer->view_height,
-	        new_view_width, new_view_height,
+	// TEMP #602 instrumentation — counts genuine atlas (re)allocations; should
+	// stay tiny (≈ startup/warmup) and NOT climb per-frame. Remove before merge.
+	static uint32_t s_realloc_count = 0;
+	U_LOG_W("#602 D3D12 atlas (re)alloc #%u: view %ux%u -> %ux%u, tex_h %u -> %u", ++s_realloc_count,
+	        renderer->view_width, renderer->view_height, new_view_width, new_view_height,
 	        renderer->texture_height, new_texture_height);
 
-	// Release existing atlas texture
+	// Genuine grow (first allocation / display-mode change / content larger
+	// than any seen before). Release the old resource and recreate; the
+	// high-water-mark logic in create_atlas_texture never shrinks.
 	if (renderer->atlas_texture != nullptr) {
 		renderer->atlas_texture->Release();
 		renderer->atlas_texture = nullptr;

--- a/src/xrt/compositor/vk_native/comp_vk_native_compositor.c
+++ b/src/xrt/compositor/vk_native/comp_vk_native_compositor.c
@@ -917,16 +917,43 @@ vk_compositor_begin_frame(struct xrt_compositor *xc, int64_t frame_id)
 
 				if (c->target != NULL) {
 					comp_vk_native_target_resize(c->target, new_width, new_height);
+					// #602: drain the GPU after recreating the swapchain. The
+					// steady-state per-frame path no longer calls
+					// vkDeviceWaitIdle (it used to, incidentally, via the
+					// renderer resize), so without this an in-flight frame can
+					// present/sample a just-destroyed swapchain image →
+					// VK_ERROR_DEVICE_LOST. Window resizes are rare, so the
+					// stall here is fine.
+					c->vk.vkDeviceWaitIdle(c->vk.device);
+					// #602: tell the DP its target-handle-keyed caches are
+					// stale — the resize recreated the target images and
+					// Vulkan can recycle the freed handles, so the DP's strip
+					// framebuffer cache could otherwise alias a destroyed
+					// image and fault the device. Safe to destroy DP objects
+					// here: the device was just drained above.
+					if (c->display_processor != NULL) {
+						xrt_display_processor_vk_notify_target_recreated(
+						    (struct xrt_display_processor_vk *)c->display_processor,
+						    comp_vk_native_target_get_generation(c->target));
+					}
 				}
 				c->settings.preferred.width = new_width;
 				c->settings.preferred.height = new_height;
 
-				uint32_t new_vw = new_width / 2;
-				uint32_t new_vh = new_height;
-				uint32_t tc, tr;
-				comp_vk_native_renderer_get_tile_layout(c->renderer, &tc, &tr);
-				comp_vk_native_renderer_resize(c->renderer, new_vw, new_vh,
-				                                tc * new_vw, tr * new_vh);
+				// #602: the atlas is owned by layer_commit for extension apps
+				// (it allocates the stable mode atlas and derives the scaled
+				// content view every frame). Only legacy apps — which skip the
+				// layer_commit view resize — need the window-derived atlas
+				// resize here. Driving it for extension apps fed a raw window
+				// height the high-water then ratcheted on (→ device loss).
+				if (c->legacy_app_tile_scaling) {
+					uint32_t new_vw = new_width / 2;
+					uint32_t new_vh = new_height;
+					uint32_t tc, tr;
+					comp_vk_native_renderer_get_tile_layout(c->renderer, &tc, &tr);
+					comp_vk_native_renderer_resize(c->renderer, new_vw, new_vh,
+					                                tc * new_vw, tr * new_vh);
+				}
 			}
 		}
 	}
@@ -952,16 +979,28 @@ vk_compositor_begin_frame(struct xrt_compositor *xc, int64_t frame_id)
 
 			if (c->target != NULL) {
 				comp_vk_native_target_resize(c->target, new_width, new_height);
+				// #602: drain after swapchain recreate (see Windows branch).
+				c->vk.vkDeviceWaitIdle(c->vk.device);
+				// #602: invalidate DP target-handle-keyed caches (see Windows branch).
+				if (c->display_processor != NULL) {
+					xrt_display_processor_vk_notify_target_recreated(
+					    (struct xrt_display_processor_vk *)c->display_processor,
+					    comp_vk_native_target_get_generation(c->target));
+				}
 			}
 			c->settings.preferred.width = new_width;
 			c->settings.preferred.height = new_height;
 
-			uint32_t new_vw = new_width / 2;
-			uint32_t new_vh = new_height;
-			uint32_t tc, tr;
-			comp_vk_native_renderer_get_tile_layout(c->renderer, &tc, &tr);
-			comp_vk_native_renderer_resize(c->renderer, new_vw, new_vh,
-			                                tc * new_vw, tr * new_vh);
+			// #602: extension apps' atlas is owned by layer_commit; only legacy
+			// apps need the window-derived resize here (see Windows branch).
+			if (c->legacy_app_tile_scaling) {
+				uint32_t new_vw = new_width / 2;
+				uint32_t new_vh = new_height;
+				uint32_t tc, tr;
+				comp_vk_native_renderer_get_tile_layout(c->renderer, &tc, &tr);
+				comp_vk_native_renderer_resize(c->renderer, new_vw, new_vh,
+				                                tc * new_vw, tr * new_vh);
+			}
 		}
 	}
 #endif

--- a/src/xrt/compositor/vk_native/comp_vk_native_renderer.c
+++ b/src/xrt/compositor/vk_native/comp_vk_native_renderer.c
@@ -1366,18 +1366,63 @@ comp_vk_native_renderer_resize(struct comp_vk_native_renderer *r,
 
 	if (new_view_width < 64) new_view_width = 64;
 	if (new_view_height < 64) new_view_height = 64;
+	if (new_atlas_width < 64) new_atlas_width = 64;
+	if (new_atlas_height < 64) new_atlas_height = 64;
 
-	uint32_t cur_atlas_w = r->tile_columns * r->view_width;
-	uint32_t cur_atlas_h = r->tile_rows * r->view_height;
-	if (new_view_width == r->view_width && new_view_height == r->view_height &&
-	    new_atlas_width == cur_atlas_w && new_atlas_height == cur_atlas_h) {
+	// #602: decouple the atlas ALLOCATION (worst-case, stable) from the
+	// per-frame content VIEW dims. Content-fit display zones (ADR-027)
+	// renegotiate view dims ~6x/sec; previously every change tore down and
+	// rebuilt the atlas image behind a full vkDeviceWaitIdle — a per-frame GPU
+	// stall — and the no-op guard never held while a content-fit canvas was
+	// active (it compared the full mode-atlas width against tile_columns *
+	// content view_width). Instead allocate the atlas once at the worst case
+	// (the mode atlas, passed by layer_commit) and let content pack top-left
+	// into a sub-rect; vk_crop_atlas_for_dp rect-crops it back out, and the
+	// draw/zone/capture paths place tiles by the per-frame effective layout,
+	// not the allocation. While the requested allocation FITS the current one
+	// we only update the view bookkeeping in place — no stall, no recreate.
+	//
+	// The allocation request must be the mode atlas (the stable worst case);
+	// the window-resize branch in begin_frame no longer drives a window-derived
+	// atlas (that fed a raw window height the high-water then ratcheted on, →
+	// out-of-bounds tiles → VK_ERROR_DEVICE_LOST). High-water-mark — never
+	// shrink — so it converges and stops firing.
+	bool have_atlas = r->atlas_image != VK_NULL_HANDLE;
+
+	uint32_t grow_w = new_atlas_width;
+	uint32_t grow_h = new_atlas_height;
+	if (have_atlas) {
+		if (r->atlas_alloc_width > grow_w) grow_w = r->atlas_alloc_width;
+		if (r->atlas_alloc_height > grow_h) grow_h = r->atlas_alloc_height;
+	}
+
+	// Defensive: content must fit the allocation — tiles pack into the atlas,
+	// so a view wider/taller than alloc/tiles would draw out of bounds. Clamp
+	// the stored view dims (these drive the effective layout, crop, and DP
+	// handoff). With the mode-atlas allocation this never triggers for normal
+	// content-fit (views stay <= the per-eye texture); it's a safety net.
+	if (r->tile_columns != 0 && new_view_width * r->tile_columns > grow_w)
+		new_view_width = grow_w / r->tile_columns;
+	if (r->tile_rows != 0 && new_view_height * r->tile_rows > grow_h)
+		new_view_height = grow_h / r->tile_rows;
+
+	bool fits = have_atlas && grow_w == r->atlas_alloc_width && grow_h == r->atlas_alloc_height;
+	if (fits) {
+		r->view_width = new_view_width;
+		r->view_height = new_view_height;
+		r->texture_height = new_view_height;
 		return XRT_SUCCESS;
 	}
 
-	vk->vkDeviceWaitIdle(vk->device);
-	destroy_atlas_resources(r);
+	// Genuine grow: first allocation or a display-mode change. Rare, so the
+	// one-time device-idle stall here is fine; the steady-state content-fit
+	// path fits the branch above and never reaches here.
+	if (have_atlas) {
+		vk->vkDeviceWaitIdle(vk->device);
+		destroy_atlas_resources(r);
+	}
 
-	return create_atlas_resources(r, new_view_width, new_view_height, new_atlas_width, new_atlas_height);
+	return create_atlas_resources(r, new_view_width, new_view_height, grow_w, grow_h);
 }
 
 void

--- a/src/xrt/compositor/vk_native/comp_vk_native_target.cpp
+++ b/src/xrt/compositor/vk_native/comp_vk_native_target.cpp
@@ -84,6 +84,14 @@ struct comp_vk_native_target
 	uint32_t width;
 	uint32_t height;
 
+	//! #602: monotonic counter bumped every time the target image set is
+	//! (re)created (window resize → swapchain / DComp-bridge ring rebuild).
+	//! The display processor watches this to invalidate any cache it keeps
+	//! keyed by the target VkImage handle — Vulkan recycles freed image
+	//! handles, so a stale cache entry can otherwise alias a destroyed image
+	//! and fault the device on use.
+	uint32_t generation;
+
 	//! Surface format.
 	VkFormat format;
 
@@ -1336,6 +1344,7 @@ comp_vk_native_target_resize(struct comp_vk_native_target *target,
 		target->height = height;
 		target->dcomp_ring_idx = 0;
 		target->current_index = 0;
+		target->generation++; // #602: image set rebuilt — invalidate DP caches.
 		target->dcomp_dcomp_device->Commit();
 		return XRT_SUCCESS;
 	}
@@ -1356,5 +1365,15 @@ comp_vk_native_target_resize(struct comp_vk_native_target *target,
 	target->width = width;
 	target->height = height;
 
-	return create_swapchain(target);
+	xrt_result_t scres = create_swapchain(target);
+	if (scres == XRT_SUCCESS) {
+		target->generation++; // #602: image set rebuilt — invalidate DP caches.
+	}
+	return scres;
+}
+
+uint32_t
+comp_vk_native_target_get_generation(struct comp_vk_native_target *target)
+{
+	return target->generation;
 }

--- a/src/xrt/compositor/vk_native/comp_vk_native_target.h
+++ b/src/xrt/compositor/vk_native/comp_vk_native_target.h
@@ -113,6 +113,17 @@ VkFormat
 comp_vk_native_target_get_format(struct comp_vk_native_target *target);
 
 /*!
+ * Get the target's image-set generation (#602). Bumped each time the target
+ * image set is (re)created — the compositor forwards it to the display
+ * processor so caches keyed by the target VkImage handle can be invalidated
+ * across a swapchain/DComp-bridge rebuild (Vulkan recycles freed handles).
+ *
+ * @ingroup comp_vk_native
+ */
+uint32_t
+comp_vk_native_target_get_generation(struct comp_vk_native_target *target);
+
+/*!
  * Resize the target swapchain.
  *
  * @param target The target.

--- a/src/xrt/include/xrt/xrt_display_processor_vk.h
+++ b/src/xrt/include/xrt/xrt_display_processor_vk.h
@@ -91,6 +91,32 @@ struct xrt_display_processor_vk
 	 *                        background.
 	 */
 	void (*set_transparent_background)(struct xrt_display_processor_vk *xdp, bool enabled, bool client_presents);
+
+	/*!
+	 * Notify the DP that the compositor's target image set was (re)created
+	 * (#602) — e.g. a window resize rebuilt the swapchain / DComp-bridge ring.
+	 * Any cache the DP keys by the target VkImage handle MUST be invalidated
+	 * here: Vulkan recycles freed image handles, so a cache entry keyed by a
+	 * now-destroyed image can alias a fresh image of the same handle and fault
+	 * the device when rendered through (observed as VK_ERROR_DEVICE_LOST in the
+	 * compositor's next queue submit). Leia's post-weave alpha-gate "strip"
+	 * framebuffer cache is exactly such a cache.
+	 *
+	 * Called on the compositor's frame thread immediately after the resize, with
+	 * the device idle (the compositor `vkDeviceWaitIdle`s as part of the target
+	 * rebuild), so the DP may destroy VkFramebuffer / VkImageView objects
+	 * synchronously inside this call. @p generation is monotonic; a DP that
+	 * already flushed for it can no-op (the call is idempotent).
+	 *
+	 * Optional — an absent slot (older plug-in `struct_size`) or NULL ⟹ the DP
+	 * keeps no target-handle-keyed cache and needs no notification. Appended
+	 * after @ref set_transparent_background per ADR-020 (append-only within a
+	 * major; no version bump — gated by the variant's `base.struct_size`).
+	 *
+	 * @param xdp         Pointer to self.
+	 * @param generation  Monotonic target image-set generation.
+	 */
+	void (*notify_target_recreated)(struct xrt_display_processor_vk *xdp, uint32_t generation);
 };
 
 /*
@@ -115,8 +141,9 @@ struct xrt_display_processor_vk
  */
 // clang-format off
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_vk, base) == 0, XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_vk, set_transparent_background) == sizeof(struct xrt_display_processor), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(sizeof(struct xrt_display_processor_vk) == sizeof(struct xrt_display_processor) + sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_vk, set_transparent_background) == sizeof(struct xrt_display_processor) + 0 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_vk, notify_target_recreated)    == sizeof(struct xrt_display_processor) + 1 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(sizeof(struct xrt_display_processor_vk) == sizeof(struct xrt_display_processor) + 2 * sizeof(void *), XRT_DP_ABI_MSG);
 // clang-format on
 
 /*!
@@ -146,6 +173,29 @@ xrt_display_processor_vk_set_transparent_background(struct xrt_display_processor
 	}
 	xdp->set_transparent_background(xdp, enabled, client_presents);
 	return true;
+}
+
+/*!
+ * @copydoc xrt_display_processor_vk::notify_target_recreated
+ *
+ * No-op if not supported (the plug-in's `base.struct_size` doesn't cover the
+ * slot, or the pointer is NULL). Like @ref
+ * xrt_display_processor_vk_set_transparent_background, the presence check reads
+ * `xdp->base.struct_size` because the variant embeds the base — see ADR-020.
+ *
+ * @public @memberof xrt_display_processor_vk
+ */
+static inline void
+xrt_display_processor_vk_notify_target_recreated(struct xrt_display_processor_vk *xdp, uint32_t generation)
+{
+	if (xdp == NULL) {
+		return;
+	}
+	const char *slot_end = (const char *)&xdp->notify_target_recreated + sizeof(xdp->notify_target_recreated);
+	if (slot_end > (const char *)xdp + xdp->base.struct_size || xdp->notify_target_recreated == NULL) {
+		return;
+	}
+	xdp->notify_target_recreated(xdp, generation);
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
## Summary
Fixes #602. A content-fit display zone (the avatar demo, a VK `_handle` app) renegotiates its view height several times a second on window resize. Two problems:

1. **Steady-state atlas churn** — the atlas reallocated whenever the content view scaled. Now it allocates once at the stable mode atlas (3840×1080); content packs into a rect-cropped sub-rect, and the VK/D3D11/D3D12 resize paths use high-water + in-place view update (no per-frame device-wait + realloc).
2. **Resize `VK_ERROR_DEVICE_LOST`** — a resize rebuilds the VK target image set (swapchain / DComp-bridge ring). Vulkan recycles freed `VkImage` handles, so the Leia DP's post-weave strip framebuffer cache (keyed by target `VkImage` handle) could return a framebuffer built over a destroyed image → device fault (failed submit in `draw_zones_pass`, then every `xrEndFrame` fails, then SR→2D).

## Fix for (2)
`comp_vk_native_target` carries a monotonic image-set **generation**, bumped on every (re)create. A new **VK-DP-variant** vtable slot `notify_target_recreated` (appended after `set_transparent_background` per ADR-020 — no major bump, gated by `base.struct_size`) lets the compositor tell the DP to drop its target-handle-keyed caches. Called right after `target_resize`, where the compositor already `vkDeviceWaitIdle`s, so the DP destroys its framebuffers synchronously and safely.

> Paired with displayxr-leia-plugin (implements the new slot to flush its strip cache). Lockstep: this lands + releases first, then the plugin re-pins.

## Validation
- **A/B localization** (`avatar_handle_vk_win`): opaque sessions (DP strip path off) never lost the device on resize; transparent (strip path on) did. With the fix, **80 transparent resizes survive clean** — zero device loss, stays 3D, flush fires once per generation.
- **Regression**: `cube_handle_vk_win` (opaque, 60 resizes) clean; `cube_handle_d3d11_win` clean smoke.
- **Glass eyeball**: avatar confirmed rendering correctly through resizes on the Leia display.

🤖 Generated with [Claude Code](https://claude.com/claude-code)