### PR TITLE
fix(android): null-compositor frame pacing — lift the 20 FPS xrWaitFrame cap

### DIFF
--- a/src/xrt/include/xrt/xrt_plugin.h
+++ b/src/xrt/include/xrt/xrt_plugin.h
@@ -117,6 +117,15 @@ struct xrt_plugin_display_info
 	/*! Default eye-tracking mode for sessions that don't override.
 	 *  0 = MANAGED, 1 = MANUAL. */
 	uint32_t default_eye_tracking_mode;
+
+	/*! Panel refresh rate in milli-Hz (e.g. 60000 = 60 Hz). Integer so no
+	 *  float crosses the ABI. 0 = unknown → the runtime keeps its own
+	 *  default (the null compositor's frame pacer falls back to 20 FPS).
+	 *  Drives `xrWaitFrame` pacing on the null-compositor (Android OOP)
+	 *  path, where the DP plug-in owns present/weave and there is no
+	 *  swapchain compositor to source vblank from. Append-only (struct_size
+	 *  guards older plug-ins that don't write it). */
+	uint32_t refresh_mhz;
 };
 
 

--- a/src/xrt/targets/common/target_instance.c
+++ b/src/xrt/targets/common/target_instance.c
@@ -204,17 +204,32 @@ t_instance_create_system(struct xrt_instance *xinst,
 
 	bool use_null = debug_get_bool_option_use_null();
 
+	// Source the panel refresh from the active plug-in BEFORE creating the
+	// compositor — the null compositor seeds its frame pacer once at create
+	// (the DP plug-in owns present/weave on this path, so there's no swapchain
+	// vblank to read). 0/unknown from the plug-in (or no plug-in) falls back to
+	// 60 Hz, NOT the null compositor's own 20 FPS placeholder which used to cap
+	// xrWaitFrame far below the panel + the ~10 ms/frame app workload (#263
+	// dropped the old in-proc leia_edid refresh query). get_display_info is
+	// idempotent + cheap; it's called again below to populate the full info.
+	float sr_refresh_rate_hz = 60.0f;
+	{
+		const struct xrt_plugin_iface *rr_plugin = target_plugin_get_active();
+		if (rr_plugin != NULL &&
+		    rr_plugin->struct_size > offsetof(struct xrt_plugin_iface, get_display_info) &&
+		    rr_plugin->get_display_info != NULL) {
+			struct xrt_plugin_display_info rr_pdi = {0};
+			rr_pdi.struct_size = (uint32_t)sizeof(rr_pdi);
+			if (rr_plugin->get_display_info(target_plugin_get_active_instance(), head, &rr_pdi) &&
+			    rr_pdi.refresh_mhz > 0) {
+				sr_refresh_rate_hz = (float)rr_pdi.refresh_mhz / 1000.0f;
+			}
+		}
+	}
+	U_LOG_W("Null-compositor frame pacing: %.2f Hz", (double)sr_refresh_rate_hz);
+
 #ifdef XRT_MODULE_COMPOSITOR_NULL
 	if (use_null) {
-		// Refresh rate sourcing: previously queried via leia_edid + SR SDK
-		// when the in-proc Leia fallback was linked. Post-#263 the SR
-		// path lives entirely in the plug-in DLL. INTERIM: pass a real rate
-		// instead of 0 (which the null compositor maps to a 20 FPS default —
-		// that placeholder was capping xrWaitFrame to 20 Hz on Android, far
-		// below the panel's 60-144 Hz and the ~10 ms/frame app workload).
-		// TODO: source the true panel refresh from xrt_plugin_display_info
-		// (the monitor-descriptor refresh_mhz path is not yet plumbed there).
-		float sr_refresh_rate_hz = 90.0f;
 		xret = null_compositor_create_system_with_dims(head, 0, 0,
 		                                               sr_refresh_rate_hz, &xsysc);
 	}

--- a/src/xrt/targets/common/target_instance.c
+++ b/src/xrt/targets/common/target_instance.c
@@ -208,10 +208,13 @@ t_instance_create_system(struct xrt_instance *xinst,
 	if (use_null) {
 		// Refresh rate sourcing: previously queried via leia_edid + SR SDK
 		// when the in-proc Leia fallback was linked. Post-#263 the SR
-		// path lives entirely in the plug-in DLL; the null compositor
-		// uses the default refresh rate. Add an entry to
-		// xrt_plugin_display_info if this becomes load-bearing.
-		float sr_refresh_rate_hz = 0.0f;
+		// path lives entirely in the plug-in DLL. INTERIM: pass a real rate
+		// instead of 0 (which the null compositor maps to a 20 FPS default —
+		// that placeholder was capping xrWaitFrame to 20 Hz on Android, far
+		// below the panel's 60-144 Hz and the ~10 ms/frame app workload).
+		// TODO: source the true panel refresh from xrt_plugin_display_info
+		// (the monitor-descriptor refresh_mhz path is not yet plumbed there).
+		float sr_refresh_rate_hz = 90.0f;
 		xret = null_compositor_create_system_with_dims(head, 0, 0,
 		                                               sr_refresh_rate_hz, &xsysc);
 	}


### PR DESCRIPTION
## Problem
On the Android OOP path the runtime uses the **null compositor** (the Leia DP plug-in owns present/weave via the Android surface, so there's no swapchain compositor to source vblank from). The null compositor's fake frame pacer **defaults to 20 FPS / 50 ms**, so `xrWaitFrame` blocks ~50 ms regardless of how fast the app renders — a hard 20 fps cap. `target_instance.c` passed `sr_refresh_rate_hz = 0.0f` into `null_compositor_create_system_with_dims`, which the null compositor interprets as "use the 20 FPS placeholder" (a leftover from when the in-proc Leia EDID refresh query was removed in #263).

This caps every Android app at 20 fps even when app + DP can do far more (e.g. the Adreno gauss-splat renderer is ~6 ms/eye but was stuck at 20 fps; the media player's app work is ~10 ms/frame but it was paced to 20 Hz).

## Fix (2 commits)
1. **20 FPS → 60 Hz fallback.** `target_instance.c` now defaults `sr_refresh_rate_hz` to 60 Hz instead of the null compositor's 20 FPS placeholder.
2. **Source the real panel refresh from the plug-in.** Pre-fetch `xrt_plugin_display_info.refresh_mhz` via `get_display_info` *before* `null_compositor_create_system_with_dims` (the fake pacer is seeded once at create) and seed pacing with it; fall back to 60 Hz when the plug-in reports 0/absent. Adds `refresh_mhz` (milli-Hz, integer so no float crosses the ABI) to `xrt_plugin_display_info`, append-only + struct_size-guarded. Logs `Null-compositor frame pacing: X Hz`.

The Leia plug-in already reports `refresh_mhz` (= 60000 on the nubia) — that side merged in plug-in v1.8.1 (#42), so this is the runtime half.

## Measured (nubia NP02J, OOP runtime)
`Null-compositor frame pacing: 60.00 Hz` confirmed; apps now pace at the panel rate instead of 20 Hz. The gauss-splat demo reaches ~30 fps with this in place (capped at 20 fps without it).

## Notes
- Re-files **#545** (closed as stale); this is a fresh rebase on current `main` with a clean cherry-pick, no conflicts.
- ABI: `refresh_mhz` is the last field of `xrt_plugin_display_info`, distinct from the pre-existing `xrt_display_descriptor.refresh_mhz`; reads are struct_size-clamped, so older plug-ins that don't write it are safe.