### PR TITLE
fix(shell): synthesize WM_*BUTTONDBLCLK for forwarded clicks

### DIFF
--- a/src/xrt/compositor/d3d11/comp_d3d11_window.cpp
+++ b/src/xrt/compositor/d3d11/comp_d3d11_window.cpp
@@ -184,6 +184,19 @@ struct comp_d3d11_window
 	//! Set on button-down inside rect, cleared on button-up.
 	bool mouse_press_in_content;
 
+	//! Software double-click synthesis (WndProc thread only — no atomics).
+	//! The runtime re-injects every forwarded click via SendInput (for Raw-Input
+	//! apps), and those synthetic events poison the OS's per-window double-click
+	//! tracker, so CS_DBLCLKS on the workspace window never yields a reliable
+	//! WM_*BUTTONDBLCLK. Instead we detect the double-click ourselves from the
+	//! real (non-injected) forwarded click stream and post a synthetic
+	//! WM_*BUTTONDBLCLK to the focused app. Tracks the previous forwarded DOWN.
+	DWORD last_click_time_ms; //!< GetMessageTime() of the previous forwarded DOWN.
+	int last_click_x;         //!< Workspace-client X of that DOWN.
+	int last_click_y;         //!< Workspace-client Y of that DOWN.
+	uint32_t last_click_button; //!< 1=L,2=R,3=M of that DOWN (0 = none yet).
+	HWND last_click_target;   //!< HWND that DOWN was forwarded to.
+
 	//! The HWND the most recent button-DOWN was forwarded to, or NULL if it
 	//! was not forwarded (cursor outside the focused window's rect — i.e. a
 	//! click on an unfocused window). Captured at WndProc time, BEFORE the
@@ -972,8 +985,47 @@ wnd_proc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 						app_x = rel_x;
 						app_y = rel_y;
 					}
+					// Software double-click synthesis. The OS can't pair our
+					// double-clicks (SendInput re-injection poisons its per-window
+					// dblclk tracker), so we detect the second click ourselves from
+					// the real forwarded DOWN stream and promote its message to
+					// WM_*BUTTONDBLCLK — matching the down/up/dblclk/up sequence a
+					// CS_DBLCLKS window delivers. Apps reading WM_LBUTTONDBLCLK
+					// (e.g. earthview's double-click-to-orbit) then work in-shell.
+					UINT post_msg = message;
+					if (is_button_down) {
+						DWORD now = (DWORD)GetMessageTime();
+						int cxd = GetSystemMetrics(SM_CXDOUBLECLK) / 2;
+						int cyd = GetSystemMetrics(SM_CYDOUBLECLK) / 2;
+						int dx = workspace_x - w->last_click_x;
+						int dy = workspace_y - w->last_click_y;
+						bool is_dbl =
+						    w->last_click_button == evt_button &&
+						    w->last_click_target == fwd &&
+						    (now - w->last_click_time_ms) <= GetDoubleClickTime() &&
+						    dx >= -cxd && dx <= cxd && dy >= -cyd && dy <= cyd;
+						if (is_dbl) {
+							switch (evt_button) {
+							case 1: post_msg = WM_LBUTTONDBLCLK; break;
+							case 2: post_msg = WM_RBUTTONDBLCLK; break;
+							case 3: post_msg = WM_MBUTTONDBLCLK; break;
+							default: break;
+							}
+							// Consume the pair so a triple-click's third press
+							// starts a fresh single click (standard behavior).
+							w->last_click_button = 0;
+							w->last_click_target = NULL;
+						} else {
+							w->last_click_time_ms = now;
+							w->last_click_x = workspace_x;
+							w->last_click_y = workspace_y;
+							w->last_click_button = evt_button;
+							w->last_click_target = fwd;
+						}
+					}
+
 					// PostMessage: works for classic Win32 apps (test apps)
-					PostMessage(fwd, message, wParam, MAKELPARAM(app_x, app_y));
+					PostMessage(fwd, post_msg, wParam, MAKELPARAM(app_x, app_y));
 
 					// Record where a button-DOWN was actually forwarded so
 					// the render-loop click handler can tell whether the hit


### PR DESCRIPTION
## Problem

Double-click never reached apps under the shell — e.g. earthview's **double-click-to-orbit** did nothing. The runtime forwards mouse input by re-posting Win32 messages to the focused app's HWND, but it only produced `down`/`up`; no double-click ever flowed through.

## Root cause (diagnosed live)

`CS_DBLCLKS` on the workspace window doesn't fix it. The runtime also re-injects every forwarded click via `SendInput` (so Raw-Input apps like Unity see buttons), and those synthetic events poison the OS's per-window double-click tracker. Diagnostic logging of the live click stream showed:

```
LDOWN   marker=0   ← real click-1 down
LDBLCLK marker=1   ← our SendInput injection, reclassified as DBLCLK, then skipped
LUP     marker=0
LDOWN   marker=0   ← real click-2 — arrives as a plain DOWN, never a DBLCLK
```

So the OS's dblclk slot is consumed by our own injected noise, and the app only ever sees `down/up/down/up`.

## Fix

Detect the double-click in **software** at the forward site: when a real button-DOWN lands on the same target + button within `GetDoubleClickTime()` and the `SM_C{X,Y}DOUBLECLK` rect of the previous DOWN, promote the posted message to `WM_*BUTTONDBLCLK`. This reproduces the `down/up/dblclk/up` sequence a `CS_DBLCLKS` window delivers — immune to the `SendInput` interleaving — so apps reading `WM_LBUTTONDBLCLK` (earthview via the shared `input_handler.cpp`) work in-shell.

Tracking state is WndProc-thread-only (no atomics) and zero-inits via the existing `U_TYPED_CALLOC`. No shell-pvt change needed — the controller's own double-click detection reads the unchanged POINTER down/up stream.

## Test

Leia-validated in-shell: launched the shell with `earthview_handle_vk_win.exe`, double-clicked the globe → orbit-to-pick fires. Single-click/drag unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)