### PR TITLE
macOS out-of-process service compositor (Tier 1): rendering, input, mode switching (#48)

### DIFF
--- a/docs/specs/runtime/workspace-controller-registration.md
+++ b/docs/specs/runtime/workspace-controller-registration.md
@@ -1,7 +1,12 @@
-# Workspace Controller Registration (Windows)
+# Workspace Controller Registration
 
-**Status:** Stable. Implemented in
-`src/xrt/targets/service/service_workspace_registry.{c,h}`.
+**Status:** Stable on Windows (registry-backed). POSIX (macOS / Linux)
+uses a parallel **JSON-manifest** discovery, implemented in the same
+`src/xrt/targets/service/service_workspace_registry.{c,h}` behind the
+`XRT_OS_WINDOWS` split. The *contract semantics* (id, binary, display
+name, capabilities, actions, enumerate + lookup) are identical across
+platforms; only the storage backend differs. See **POSIX discovery**
+below for the macOS/Linux schema and search roots.
 
 This document is the contract between the DisplayXR runtime and any
 **workspace app** that wants to drive the multi-window spatial shell
@@ -206,6 +211,62 @@ active controller's `DisplayName` as the submenu parent. A future
 multi-controller chooser (when more than one is registered) will live
 in the tray and toggle `service.json::workspace_binary` between
 registered ids.
+
+## POSIX discovery (macOS / Linux)
+
+There is no registry on POSIX, so a controller registers by dropping a
+`<id>.json` **manifest** into a well-known directory — exactly the model
+the display-processor plug-in loader uses (`target_plugin_loader.c`).
+`service_workspace_registry_enumerate()` / `_lookup()` scan these dirs,
+parse each `*.json`, and skip any whose `binary` does not exist on disk.
+
+### Manifest schema (`file_format_version` `"1.0"`)
+
+```json
+{
+  "file_format_version": "1.0",
+  "controller": {
+    "id": "shell",
+    "binary": "/Applications/DisplayXR Shell.app/Contents/MacOS/displayxr-shell",
+    "display_name": "DisplayXR Shell",
+    "vendor": "DisplayXR",
+    "version": "1.2.3",
+    "uninstall_string": "",
+    "supports_file_dialog": true,
+    "actions": [
+      { "label": "Enable Workspace", "type": "lifecycle:enable" },
+      { "label": "",                 "type": "separator" },
+      { "label": "Disable Workspace", "type": "lifecycle:disable" }
+    ]
+  }
+}
+```
+
+- `id` is optional; it defaults to the manifest filename minus `.json`
+  (so `shell.json` → id `shell`), mirroring the plug-in loader's
+  `<probe_order>-<id>.json` convention.
+- `binary` is required and must be an absolute path to an existing
+  regular file, or the entry is skipped.
+- `supports_file_dialog` maps to `WORKSPACE_CAPABILITY_FILE_DIALOG`.
+- `actions[]` follows the same keep/skip rules as Windows: a
+  `"separator"` needs no label; every other `type` needs both `label`
+  and `type`. `Type` values are identical to the Windows table above.
+
+### Search roots (priority order; per-user shadows system)
+
+1. `$XRT_WORKSPACE_CONTROLLER_PATH` — dev override, colon-separated list
+   of dirs (like `XRT_PLUGIN_SEARCH_PATH`).
+2. **macOS:** `~/Library/Application Support/DisplayXR/WorkspaceControllers/`
+   **Linux:** `$XDG_DATA_HOME/DisplayXR/WorkspaceControllers/` (or
+   `~/.local/share/DisplayXR/WorkspaceControllers/`).
+3. **macOS:** `/Library/Application Support/DisplayXR/WorkspaceControllers/`
+   **Linux:** `/usr/local/share/displayxr/WorkspaceControllers/`,
+   `/usr/share/displayxr/WorkspaceControllers/`.
+
+The first manifest seen for a given `id` wins, so a per-user install
+shadows a system-wide one. A macOS `.pkg` installer drops its manifest
+into root #3; a dev build can point `XRT_WORKSPACE_CONTROLLER_PATH` at a
+build-tree dir.
 
 ## Reference implementation
 

--- a/src/xrt/compositor/main/comp_window_macos.h
+++ b/src/xrt/compositor/main/comp_window_macos.h
@@ -1,0 +1,42 @@
+// Copyright 2026, Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  macOS present target for the out-of-process service compositor.
+ * @ingroup comp_main
+ *
+ * DisplayXR (macOS shell, Tier 1): a @ref comp_target_swapchain subclass that
+ * presents to a runtime-owned NSWindow inside the service process via a
+ * VK_EXT_metal_surface (MoltenVK) swapchain over a CAMetalLayer. Mirrors
+ * @ref comp_window_android, but — unlike Android, where the app injects its
+ * surface across IPC (android_globals) — macOS cannot pass an NSView across
+ * process boundaries, so for the single-app Tier-1 path the service *creates
+ * its own* NSWindow (the runtime-owned / hosted model). The CAMetalLayer and
+ * VkSurfaceKHR are created lazily in @ref comp_target::init_post_vulkan.
+ */
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct comp_compositor;
+struct comp_target;
+
+/*!
+ * Create a macOS present target. @p c is the owning compositor (in the service
+ * this is a @ref null_compositor up-cast to @ref comp_compositor — both start
+ * with @ref comp_base, so @p c->base.vk is valid). Returns the target's
+ * @ref comp_target base, or NULL on allocation failure. The NSWindow,
+ * CAMetalLayer and VkSurfaceKHR are not created until
+ * @ref comp_target::init_post_vulkan runs (which carries the requested extent).
+ *
+ * @ingroup comp_main
+ */
+struct comp_target *
+comp_window_macos_create(struct comp_compositor *c);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/xrt/compositor/main/comp_window_macos.m
+++ b/src/xrt/compositor/main/comp_window_macos.m
@@ -1,0 +1,286 @@
+// Copyright 2026, Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  macOS present target for the out-of-process service compositor.
+ * @author David Fattal
+ * @ingroup comp_main
+ *
+ * DisplayXR (macOS shell, Tier 1): a @ref comp_target_swapchain subclass that
+ * presents to a runtime-owned NSWindow inside the service process via a
+ * VK_EXT_metal_surface (MoltenVK) swapchain over a CAMetalLayer. Mirrors
+ * @ref comp_window_android (the out-of-process per-session target pattern), but
+ * — unlike Android, where the app injects its ANativeWindow across IPC
+ * (android_globals) — macOS cannot pass an NSView across process boundaries, so
+ * for the single-app Tier-1 path the service creates and owns the NSWindow (the
+ * hosted model). The NSWindow + CAMetalLayer are created on the main thread;
+ * the VkSurfaceKHR is created from the CAMetalLayer in init_post_vulkan.
+ *
+ * The NSWindow/CAMetalLayer creation reuses the proven pattern from the VK
+ * native compositor's @ref comp_vk_native_window_macos.m; the surface creation
+ * mirrors @ref comp_vk_native_target.cpp (vkCreateMetalSurfaceEXT). Note: ARC is
+ * NOT enabled for this file — Cocoa object pointers are held in a plain C struct
+ * (the NSWindow is retained by NSApp's window list) just like the VK native
+ * helper.
+ */
+
+#import <Cocoa/Cocoa.h>
+#import <QuartzCore/CAMetalLayer.h>
+
+#include "xrt/xrt_compiler.h"
+
+#include "util/u_misc.h"
+#include "util/u_logging.h"
+
+#include "vk/vk_helpers.h"
+
+#include "main/comp_compositor.h"
+#include "main/comp_target_swapchain.h"
+#include "main/comp_window_macos.h"
+
+#include <stdlib.h>
+
+
+/*
+ *
+ * NSView subclass + private struct.
+ *
+ */
+
+/*!
+ * NSView subclass whose backing layer is a CAMetalLayer. Same pattern as
+ * CompMetalView (comp_metal_compositor.m) and CompVkNativeView.
+ */
+@interface CompWindowMacosView : NSView
+@end
+
+@implementation CompWindowMacosView
+- (CALayer *)makeBackingLayer
+{
+	return [CAMetalLayer layer];
+}
+- (BOOL)wantsUpdateLayer
+{
+	return YES;
+}
+@end
+
+/*!
+ * A macOS present target.
+ *
+ * @implements comp_target_swapchain
+ */
+struct comp_window_macos
+{
+	struct comp_target_swapchain base;
+
+	//! Runtime-owned window + its CAMetalLayer (created on the main thread).
+	NSWindow *window;
+	NSView *view;
+	CAMetalLayer *metal_layer;
+};
+
+
+/*
+ *
+ * Functions.
+ *
+ */
+
+static inline struct vk_bundle *
+get_vk(struct comp_window_macos *cwm)
+{
+	// cwm->base.base.c is the owning compositor. In the service this is a
+	// null_compositor up-cast to comp_compositor; both begin with comp_base,
+	// so base.vk is the same bundle the system compositor allocates from.
+	return &cwm->base.base.c->base.vk;
+}
+
+static bool
+comp_window_macos_init(struct comp_target *ct)
+{
+	(void)ct;
+	return true;
+}
+
+//! Build the NSWindow + CAMetalLayer. Must run on the main thread (AppKit).
+static void
+create_window_on_main_thread(struct comp_window_macos *cwm, uint32_t width, uint32_t height, bool *out_success)
+{
+	if (NSApp == nil) {
+		[NSApplication sharedApplication];
+		[NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
+	}
+
+	NSRect frame = NSMakeRect(100, 100, width, height);
+	NSWindowStyleMask style = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | NSWindowStyleMaskResizable |
+	                          NSWindowStyleMaskMiniaturizable;
+
+	cwm->window = [[NSWindow alloc] initWithContentRect:frame
+	                                          styleMask:style
+	                                            backing:NSBackingStoreBuffered
+	                                              defer:NO];
+	if (cwm->window == nil) {
+		U_LOG_E("comp_window_macos: failed to create NSWindow");
+		*out_success = false;
+		return;
+	}
+
+	[cwm->window setTitle:@"DisplayXR — Service Compositor"];
+
+	CompWindowMacosView *v = [[CompWindowMacosView alloc] initWithFrame:frame];
+	v.wantsLayer = YES;
+	[cwm->window setContentView:v];
+
+	cwm->view = v;
+	cwm->metal_layer = (CAMetalLayer *)v.layer;
+
+	// Do NOT set layer.device — MoltenVK associates the MTLDevice when the
+	// VkSurfaceKHR is created from the CAMetalLayer.
+	cwm->metal_layer.pixelFormat = MTLPixelFormatBGRA8Unorm;
+	cwm->metal_layer.framebufferOnly = NO;
+
+	CGFloat scale = cwm->window.backingScaleFactor;
+	cwm->metal_layer.contentsScale = scale;
+	cwm->metal_layer.drawableSize = CGSizeMake(width * scale, height * scale);
+
+	[cwm->window makeKeyAndOrderFront:nil];
+	[NSApp activateIgnoringOtherApps:YES];
+
+	*out_success = true;
+}
+
+static VkResult
+comp_window_macos_create_surface(struct comp_window_macos *cwm, VkSurfaceKHR *out_surface)
+{
+	struct vk_bundle *vk = get_vk(cwm);
+
+	PFN_vkCreateMetalSurfaceEXT pfn = vk->vkCreateMetalSurfaceEXT;
+	if (pfn == NULL) {
+		pfn = (PFN_vkCreateMetalSurfaceEXT)vk->vkGetInstanceProcAddr(vk->instance, "vkCreateMetalSurfaceEXT");
+	}
+	if (pfn == NULL) {
+		U_LOG_E("comp_window_macos: vkCreateMetalSurfaceEXT not available — VK_EXT_metal_surface must be enabled");
+		return VK_ERROR_EXTENSION_NOT_PRESENT;
+	}
+
+	VkMetalSurfaceCreateInfoEXT surface_info = {
+	    .sType = VK_STRUCTURE_TYPE_METAL_SURFACE_CREATE_INFO_EXT,
+	    .pLayer = (const CAMetalLayer *)cwm->metal_layer,
+	};
+
+	VkSurfaceKHR surface = VK_NULL_HANDLE;
+	VkResult ret = pfn(vk->instance, &surface_info, NULL, &surface);
+	if (ret != VK_SUCCESS) {
+		U_LOG_E("comp_window_macos: vkCreateMetalSurfaceEXT: %s", vk_result_string(ret));
+		return ret;
+	}
+
+	VK_NAME_SURFACE(vk, surface, "comp_window_macos surface");
+	*out_surface = surface;
+	return VK_SUCCESS;
+}
+
+static bool
+comp_window_macos_init_swapchain(struct comp_target *ct, uint32_t width, uint32_t height)
+{
+	struct comp_window_macos *cwm = (struct comp_window_macos *)ct;
+
+	// AppKit requires NSWindow creation on the main thread. The comp_multi
+	// per-session render thread is not the main thread, so dispatch the
+	// window build to the main queue. (The service main thread must drain the
+	// main dispatch queue / run an NSApp runloop for this to complete — see
+	// the macOS service mainloop.)
+	__block bool ok = false;
+	if ([NSThread isMainThread]) {
+		create_window_on_main_thread(cwm, width, height, &ok);
+	} else {
+		dispatch_sync(dispatch_get_main_queue(), ^{
+			create_window_on_main_thread(cwm, width, height, &ok);
+		});
+	}
+	if (!ok || cwm->metal_layer == nil) {
+		U_LOG_E("comp_window_macos: failed to create NSWindow/CAMetalLayer");
+		return false;
+	}
+
+	VkResult ret = comp_window_macos_create_surface(cwm, &cwm->base.surface.handle);
+	if (ret != VK_SUCCESS) {
+		return false;
+	}
+
+	U_LOG_W("comp_window_macos: VkSurfaceKHR created from CAMetalLayer (%ux%u)", width, height);
+	return true;
+}
+
+static void
+comp_window_macos_flush(struct comp_target *ct)
+{
+	(void)ct;
+}
+
+static void
+comp_window_macos_update_window_title(struct comp_target *ct, const char *title)
+{
+	struct comp_window_macos *cwm = (struct comp_window_macos *)ct;
+	if (cwm->window == nil || title == NULL) {
+		return;
+	}
+	NSString *t = [NSString stringWithUTF8String:title];
+	void (^set_title)(void) = ^{
+		[cwm->window setTitle:t];
+	};
+	if ([NSThread isMainThread]) {
+		set_title();
+	} else {
+		dispatch_async(dispatch_get_main_queue(), set_title);
+	}
+}
+
+static void
+comp_window_macos_destroy(struct comp_target *ct)
+{
+	struct comp_window_macos *cwm = (struct comp_window_macos *)ct;
+
+	comp_target_swapchain_cleanup(&cwm->base);
+
+	if (cwm->window != nil) {
+		NSWindow *w = cwm->window;
+		void (^close_window)(void) = ^{
+			[w close];
+		};
+		if ([NSThread isMainThread]) {
+			close_window();
+		} else {
+			dispatch_sync(dispatch_get_main_queue(), close_window);
+		}
+	}
+	cwm->window = nil;
+	cwm->view = nil;
+	cwm->metal_layer = nil;
+
+	free(ct);
+}
+
+struct comp_target *
+comp_window_macos_create(struct comp_compositor *c)
+{
+	struct comp_window_macos *w = U_TYPED_CALLOC(struct comp_window_macos);
+	if (w == NULL) {
+		return NULL;
+	}
+
+	// Display-timing has not been exercised on the macOS service path; force
+	// fake timing as the Android target does.
+	comp_target_swapchain_init_and_set_fnptrs(&w->base, COMP_TARGET_FORCE_FAKE_DISPLAY_TIMING);
+
+	w->base.base.name = "macOS";
+	w->base.base.destroy = comp_window_macos_destroy;
+	w->base.base.flush = comp_window_macos_flush;
+	w->base.base.init_pre_vulkan = comp_window_macos_init;
+	w->base.base.init_post_vulkan = comp_window_macos_init_swapchain;
+	w->base.base.set_title = comp_window_macos_update_window_title;
+	w->base.base.c = c;
+
+	return &w->base.base;
+}

--- a/src/xrt/compositor/main/comp_window_macos.m
+++ b/src/xrt/compositor/main/comp_window_macos.m
@@ -147,6 +147,14 @@ create_window_on_main_thread(struct comp_window_macos *cwm, uint32_t width, uint
 		return;
 	}
 
+	// NSWindow defaults releasedWhenClosed=YES, but the struct holds the window
+	// as an unretained pointer (retained only by NSApp's window list). If the user
+	// clicks the title-bar close button, AppKit would release the window, leaving
+	// cwm->window dangling → comp_window_macos_destroy's [w close] then crashes in
+	// objc_msgSend (#48). Keep the runtime in control of the lifetime: the window
+	// is torn down explicitly in destroy.
+	[cwm->window setReleasedWhenClosed:NO];
+
 	[cwm->window setTitle:@"DisplayXR — Service Compositor"];
 
 	CompWindowMacosView *v = [[CompWindowMacosView alloc] initWithFrame:frame];

--- a/src/xrt/compositor/main/comp_window_macos.m
+++ b/src/xrt/compositor/main/comp_window_macos.m
@@ -112,7 +112,28 @@ create_window_on_main_thread(struct comp_window_macos *cwm, uint32_t width, uint
 		[NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
 	}
 
-	NSRect frame = NSMakeRect(100, 100, width, height);
+	// Size the window to the MAIN DISPLAY's full aspect ratio, not the passed
+	// dims. The display processor weaves a full-display atlas (physical pixels,
+	// e.g. 3024x1964 = 1.54:1) and presents it into this surface; if the window
+	// aspect differs the content is non-uniformly scaled (vertical squish). The
+	// sim's visible-frame dims (which exclude menu bar / dock) and the
+	// 1920x1080 fallback both have the wrong aspect — NSScreen.frame is the full
+	// display (its point aspect == the physical-pixel aspect == the atlas
+	// aspect), so derive the window shape from it. Fit to ~85% of the screen
+	// height so the title bar stays reachable. (#48 aspect fix.)
+	CGFloat win_w = (CGFloat)width;
+	CGFloat win_h = (CGFloat)height;
+	NSScreen *screen = [NSScreen mainScreen];
+	if (screen != nil) {
+		NSRect sf = screen.frame;
+		if (sf.size.width > 0 && sf.size.height > 0) {
+			CGFloat aspect = sf.size.width / sf.size.height;
+			win_h = sf.size.height * 0.85;
+			win_w = win_h * aspect;
+		}
+	}
+
+	NSRect frame = NSMakeRect(100, 100, win_w, win_h);
 	NSWindowStyleMask style = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | NSWindowStyleMaskResizable |
 	                          NSWindowStyleMaskMiniaturizable;
 
@@ -142,7 +163,7 @@ create_window_on_main_thread(struct comp_window_macos *cwm, uint32_t width, uint
 
 	CGFloat scale = cwm->window.backingScaleFactor;
 	cwm->metal_layer.contentsScale = scale;
-	cwm->metal_layer.drawableSize = CGSizeMake(width * scale, height * scale);
+	cwm->metal_layer.drawableSize = CGSizeMake(win_w * scale, win_h * scale);
 
 	[cwm->window makeKeyAndOrderFront:nil];
 	[NSApp activateIgnoringOtherApps:YES];

--- a/src/xrt/compositor/multi/comp_multi_compositor.c
+++ b/src/xrt/compositor/multi/comp_multi_compositor.c
@@ -623,13 +623,15 @@ multi_compositor_begin_session(struct xrt_compositor *xc, const struct xrt_begin
 			U_LOG_I("Session has shared IOSurface %p, will use zero-copy rendering",
 			        mc->session_render.shared_texture_handle);
 		} else {
-			// No external view — create the runtime's window now.
-			// This runs on the main thread (xrBeginSession), which is
-			// required for NSWindow creation on macOS.
-			xrt_result_t xret = comp_target_service_init_main_target(mc->msc->target_service);
-			if (xret != XRT_SUCCESS) {
-				U_LOG_E("Failed to init macOS main target: %d", xret);
-			}
+			// No external view — the service owns the window (shell Tier 1,
+			// #48). Engage per-session rendering; the macOS comp_target
+			// (comp_window_macos) creates the runtime-owned NSWindow +
+			// CAMetalLayer in init_post_vulkan. Mirrors the Android
+			// use_android_surface signal. (The dead init_main_target vtable
+			// slot — never assigned anywhere — was the old, non-functional
+			// path here.)
+			mc->session_render.use_macos_surface = true;
+			U_LOG_I("macOS: enabling per-session rendering (service-owned NSWindow)");
 		}
 #endif
 
@@ -690,6 +692,11 @@ multi_compositor_end_session(struct xrt_compositor *xc)
 			mc->session_render.external_window_handle = NULL;
 			mc->session_render.readback_callback = NULL;
 			mc->session_render.shared_texture_handle = NULL;
+			// macOS (#48): unlike Android (which keeps use_android_surface true
+			// across end→begin via the session_active gate), the service-owned
+			// window is cheap to recreate, so clear it here like the handle
+			// fields — begin_session re-sets it on the next session.
+			mc->session_render.use_macos_surface = false;
 			os_mutex_unlock(&mc->msc->list_and_timing_lock);
 
 			struct vk_bundle *vk = comp_target_service_get_vk(mc->msc->target_service);
@@ -1587,9 +1594,11 @@ multi_compositor_init_session_render(struct multi_compositor *mc)
 
 	// No external window handle, readback callback, or shared texture - use shared native compositor.
 	// On Android (#510) the surface arrives out-of-band via android_globals, so use_android_surface
-	// is the signal to proceed even though all the handle fields are NULL.
+	// is the signal to proceed even though all the handle fields are NULL. On macOS (#48) the service
+	// owns the NSWindow, so use_macos_surface plays the same role.
 	if (mc->session_render.external_window_handle == NULL && mc->session_render.readback_callback == NULL &&
-	    mc->session_render.shared_texture_handle == NULL && !mc->session_render.use_android_surface) {
+	    mc->session_render.shared_texture_handle == NULL && !mc->session_render.use_android_surface &&
+	    !mc->session_render.use_macos_surface) {
 		U_LOG_I("init_session_render: no window handle, readback callback, or shared texture, using shared "
 		        "compositor");
 		return false;

--- a/src/xrt/compositor/multi/comp_multi_private.h
+++ b/src/xrt/compositor/multi/comp_multi_private.h
@@ -264,6 +264,12 @@ struct multi_compositor
 		//! android_globals. (#510)
 		bool use_android_surface;
 
+		//! macOS out-of-process (shell Tier 1, #48): macOS can't pass an
+		//! NSView across process boundaries, so the service creates + owns
+		//! the NSWindow. When true, per-session rendering engages and the
+		//! macOS comp_target builds its own runtime-owned window.
+		bool use_macos_surface;
+
 		//! Per-session render target (VkSwapchain from external HWND)
 		struct comp_target *target;
 
@@ -646,7 +652,8 @@ static inline bool
 multi_compositor_has_session_render(struct multi_compositor *mc)
 {
 	return mc->session_render.external_window_handle != NULL || mc->session_render.readback_callback != NULL ||
-	       mc->session_render.shared_texture_handle != NULL || mc->session_render.use_android_surface;
+	       mc->session_render.shared_texture_handle != NULL || mc->session_render.use_android_surface ||
+	       mc->session_render.use_macos_surface;
 }
 
 /*!

--- a/src/xrt/compositor/multi/comp_multi_system.c
+++ b/src/xrt/compositor/multi/comp_multi_system.c
@@ -1770,8 +1770,15 @@ static bool
 ensure_session_atlas_image(struct multi_compositor *mc, struct vk_bundle *vk, int per_eye_width, int height,
                          uint32_t tile_columns, uint32_t tile_rows, VkFormat format)
 {
-	if (mc->session_render.flip_initialized && mc->session_render.flip_width == per_eye_width &&
-	    mc->session_render.flip_height == height && mc->session_render.flip_format == format) {
+	// Cache on the ATLAS dimensions, not the per-tile dims: different grids can
+	// share a per-tile size but need a different atlas (e.g. Anaglyph 2x1 →
+	// 2*W x H vs Cropped SBS 1x2 → W x 2*H, both per-tile WxH). Keying on per-tile
+	// W/H alone kept the stale atlas across such a mode switch → mistiled output
+	// after cycling V (#48).
+	uint32_t atlas_width = tile_columns * (uint32_t)per_eye_width;
+	uint32_t atlas_height = tile_rows * (uint32_t)height;
+	if (mc->session_render.flip_initialized && mc->session_render.flip_width == (int)atlas_width &&
+	    mc->session_render.flip_height == (int)atlas_height && mc->session_render.flip_format == format) {
 		return true;
 	}
 
@@ -1786,8 +1793,6 @@ ensure_session_atlas_image(struct multi_compositor *mc, struct vk_bundle *vk, in
 		mc->session_render.flip_initialized = false;
 	}
 
-	uint32_t atlas_width = tile_columns * (uint32_t)per_eye_width;
-	uint32_t atlas_height = tile_rows * (uint32_t)height;
 	VkExtent2D extent = {atlas_width, atlas_height};
 	VkImageUsageFlags usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
 	VkImageSubresourceRange range = {
@@ -1811,8 +1816,8 @@ ensure_session_atlas_image(struct multi_compositor *mc, struct vk_bundle *vk, in
 		return false;
 	}
 
-	mc->session_render.flip_width = per_eye_width;
-	mc->session_render.flip_height = height;
+	mc->session_render.flip_width = (int)atlas_width;
+	mc->session_render.flip_height = (int)atlas_height;
 	mc->session_render.flip_format = format;
 	mc->session_render.flip_initialized = true;
 
@@ -2614,6 +2619,33 @@ render_session_to_own_target(struct multi_compositor *mc, struct vk_bundle *vk, 
 			vk->vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
 			                         VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, NULL, 0, NULL,
 			                         pre_count, pre_barriers);
+
+			// Clear the atlas when the submission doesn't cover every tile (#48):
+			// on a mode switch the grid can grow (e.g. → Quad 2x2) a frame before
+			// the app catches up and submits all N views, leaving the surplus tiles
+			// UNDEFINED → a one-frame magenta flash. Clear to opaque black so the
+			// uncovered tiles are benign until the app fills them. Skipped in the
+			// common fully-covered case to avoid a per-frame clear.
+			if (view_count < tile_columns * tile_rows) {
+				VkClearColorValue clear = {.float32 = {0.0f, 0.0f, 0.0f, 1.0f}};
+				VkImageSubresourceRange clear_range = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+				vk->vkCmdClearColorImage(cmd, mc->session_render.flip_sbs_image,
+				                         VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, &clear, 1, &clear_range);
+				// Order the clear before the per-tile blits (both TRANSFER writes to
+				// the same image, overlapping regions).
+				VkImageMemoryBarrier clear_barrier = {
+				    .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+				    .srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
+				    .dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
+				    .oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+				    .newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+				    .image = mc->session_render.flip_sbs_image,
+				    .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1},
+				};
+				vk->vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT,
+				                         VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, NULL, 0, NULL, 1,
+				                         &clear_barrier);
+			}
 
 			// Blit each view into its tile position in the atlas
 			for (uint32_t v = 0; v < view_count; v++) {

--- a/src/xrt/compositor/null/CMakeLists.txt
+++ b/src/xrt/compositor/null/CMakeLists.txt
@@ -29,3 +29,22 @@ if(ANDROID)
 		)
 	target_link_libraries(comp_null PRIVATE aux_android)
 endif()
+
+# macOS out-of-process present path (shell Tier 1, #48): the null compositor is
+# the service's system compositor on macOS, driving a per-session
+# comp_target_swapchain that presents to a runtime-owned NSWindow via a MoltenVK
+# CAMetalLayer surface (comp_window_macos). Same "shared main/ sources not built
+# elsewhere in the lightweight fork" situation as Android, so compile them here.
+if(APPLE)
+	target_sources(
+		comp_null
+		PRIVATE
+			${CMAKE_CURRENT_SOURCE_DIR}/../main/comp_target_swapchain.c
+			${CMAKE_CURRENT_SOURCE_DIR}/../main/comp_window_macos.m
+			${CMAKE_CURRENT_SOURCE_DIR}/../main/comp_window_macos.h
+		)
+	target_link_libraries(
+		comp_null
+		PRIVATE "-framework Cocoa" "-framework QuartzCore" "-framework Metal"
+		)
+endif()

--- a/src/xrt/compositor/null/null_compositor.c
+++ b/src/xrt/compositor/null/null_compositor.c
@@ -34,6 +34,9 @@
 #ifdef XRT_OS_ANDROID
 #include "main/comp_window_android.h"
 #endif
+#ifdef XRT_OS_MACOS
+#include "main/comp_window_macos.h"
+#endif
 #include "xrt/xrt_compositor.h"
 #include "xrt/xrt_device.h"
 
@@ -87,6 +90,12 @@ static const char *instance_extensions_common[] = {
     // service's system compositor on Android and presents per-session via
     // comp_window_android → vkCreateAndroidSurfaceKHR.
     VK_KHR_ANDROID_SURFACE_EXTENSION_NAME,                  //
+#endif
+#ifdef XRT_OS_MACOS
+    // Out-of-process present path (macOS shell, Tier 1): the null compositor is
+    // the service's system compositor on macOS and presents per-session via
+    // comp_window_macos → vkCreateMetalSurfaceEXT (MoltenVK).
+    VK_EXT_METAL_SURFACE_EXTENSION_NAME,                    //
 #endif
 };
 
@@ -828,6 +837,103 @@ null_target_service_get_vk_android(struct comp_target_service *service)
 
 #endif // XRT_OS_ANDROID
 
+#if defined(XRT_OS_MACOS)
+
+/*!
+ * Service callback (macOS shell, Tier 1): create the per-session present target.
+ *
+ * Unlike Android, macOS cannot pass an NSView across process boundaries, so the
+ * single-app OOP path has the service create + own the NSWindow (the hosted
+ * model). @p external_window_handle is therefore ignored. The macOS comp_target
+ * (@ref comp_window_macos) builds the NSWindow + CAMetalLayer in its
+ * init_post_vulkan and creates a MoltenVK VkSurfaceKHR over it. Mirrors
+ * @ref null_target_service_create_from_window_android otherwise.
+ */
+static xrt_result_t
+null_target_service_create_from_window_macos(struct comp_target_service *service,
+                                             void *external_window_handle,
+                                             struct comp_target **out_target)
+{
+	(void)external_window_handle; // service owns the window on macOS
+	struct null_compositor *nc = (struct null_compositor *)service->context;
+
+	// Up-cast: comp_target_swapchain reads ct->c->base.vk, at offset 0 in both
+	// comp_compositor and null_compositor (shared comp_base).
+	struct comp_compositor *c_alias = (struct comp_compositor *)nc;
+
+	struct comp_target *ct = comp_window_macos_create(c_alias);
+	if (ct == NULL) {
+		NULL_ERROR(nc, "macOS: failed to allocate per-session comp_target");
+		return XRT_ERROR_ALLOCATION;
+	}
+
+	// Pre-create fake pacing BEFORE create_images so comp_target_swapchain does
+	// not read ct->c->frame_interval_ns (wrong offset across the cast above).
+	{
+		struct comp_target_swapchain *cts = (struct comp_target_swapchain *)ct;
+		if (cts->upc == NULL) {
+			int64_t now_ns = os_monotonic_get_ns();
+			u_pc_fake_create(nc->settings.frame_interval_ns, now_ns, &cts->upc);
+		}
+	}
+
+	uint32_t w = nc->sys_info.display_pixel_width;
+	uint32_t h = nc->sys_info.display_pixel_height;
+	if (w == 0 || h == 0) {
+		w = 1920;
+		h = 1080;
+	}
+
+	if (!comp_target_init_post_vulkan(ct, w, h)) {
+		NULL_ERROR(nc, "macOS: failed to init post-vulkan for per-session target");
+		comp_target_destroy(&ct);
+		return XRT_ERROR_VULKAN;
+	}
+
+	struct comp_target_create_images_info info = {
+	    .extent = {.width = w, .height = h},
+	    .image_usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT,
+	    .color_space = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR,
+	    .present_mode = VK_PRESENT_MODE_FIFO_KHR,
+	    .format_count = 4,
+	    .formats =
+	        {
+	            VK_FORMAT_R8G8B8A8_UNORM,
+	            VK_FORMAT_B8G8R8A8_UNORM,
+	            VK_FORMAT_R8G8B8A8_SRGB,
+	            VK_FORMAT_B8G8R8A8_SRGB,
+	        },
+	};
+
+	comp_target_create_images(ct, &info);
+
+	if (!comp_target_has_images(ct)) {
+		NULL_ERROR(nc, "macOS: failed to create swapchain images for per-session target");
+		comp_target_destroy(&ct);
+		return XRT_ERROR_VULKAN;
+	}
+
+	NULL_INFO(nc, "macOS: created per-session present target (%ux%u)", ct->width, ct->height);
+	*out_target = ct;
+	return XRT_SUCCESS;
+}
+
+static void
+null_target_service_destroy_target_macos(struct comp_target_service *service, struct comp_target **target)
+{
+	(void)service;
+	comp_target_destroy(target);
+}
+
+static struct vk_bundle *
+null_target_service_get_vk_macos(struct comp_target_service *service)
+{
+	struct null_compositor *nc = (struct null_compositor *)service->context;
+	return get_vk(nc);
+}
+
+#endif // XRT_OS_MACOS
+
 /*!
  * Initialize the target service on a null compositor.
  * Called during compositor creation after Vulkan init.
@@ -845,6 +951,13 @@ null_compositor_init_target_service(struct null_compositor *nc)
 	nc->target_service.create_from_window = null_target_service_create_from_window_android;
 	nc->target_service.destroy_target = null_target_service_destroy_target_android;
 	nc->target_service.get_vk = null_target_service_get_vk_android;
+	nc->target_service.context = nc;
+#elif defined(XRT_OS_MACOS)
+	// Out-of-process macOS present path (shell Tier 1, #48). Runtime owns the
+	// NSWindow (macOS can't pass an NSView across process boundaries).
+	nc->target_service.create_from_window = null_target_service_create_from_window_macos;
+	nc->target_service.destroy_target = null_target_service_destroy_target_macos;
+	nc->target_service.get_vk = null_target_service_get_vk_macos;
 	nc->target_service.context = nc;
 #endif
 }

--- a/src/xrt/ipc/CMakeLists.txt
+++ b/src/xrt/ipc/CMakeLists.txt
@@ -174,9 +174,14 @@ elseif(XRT_HAVE_LINUX)
 		)
 elseif(APPLE)
 	target_sources(
-		ipc_server PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/server/ipc_server_mainloop_macos.c
+		ipc_server
+		PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/server/ipc_server_mainloop_macos.c
+			# AppKit pump so the macOS service's main thread can service the
+			# compositor's render-thread NSWindow creation (shell Tier 1, #48).
+			${CMAKE_CURRENT_SOURCE_DIR}/server/ipc_server_macos_appkit.m
+			${CMAKE_CURRENT_SOURCE_DIR}/server/ipc_server_macos_appkit.h
 		)
-	target_link_libraries(ipc_server PRIVATE "-framework CoreFoundation")
+	target_link_libraries(ipc_server PRIVATE "-framework CoreFoundation" "-framework Cocoa")
 elseif(WIN32)
 	target_sources(
 		ipc_server

--- a/src/xrt/ipc/CMakeLists.txt
+++ b/src/xrt/ipc/CMakeLists.txt
@@ -182,6 +182,13 @@ elseif(APPLE)
 			${CMAKE_CURRENT_SOURCE_DIR}/server/ipc_server_macos_appkit.h
 		)
 	target_link_libraries(ipc_server PRIVATE "-framework CoreFoundation" "-framework Cocoa")
+	# The macOS handler's DP-sourced server-side Kooima (#48) includes
+	# multi/comp_multi_private.h, which pulls in the Vulkan headers; aux_vk
+	# exposes ${Vulkan_INCLUDE_DIR} publicly. (Android gets these via the NDK
+	# sysroot; Windows uses the D3D11 service compositor instead.)
+	if(XRT_HAVE_VULKAN)
+		target_link_libraries(ipc_server PRIVATE aux_vk)
+	endif()
 elseif(WIN32)
 	target_sources(
 		ipc_server

--- a/src/xrt/ipc/CMakeLists.txt
+++ b/src/xrt/ipc/CMakeLists.txt
@@ -180,6 +180,10 @@ elseif(APPLE)
 			# compositor's render-thread NSWindow creation (shell Tier 1, #48).
 			${CMAKE_CURRENT_SOURCE_DIR}/server/ipc_server_macos_appkit.m
 			${CMAKE_CURRENT_SOURCE_DIR}/server/ipc_server_macos_appkit.h
+			# Generic input-event queue: AppKit pump captures NSEvents → IPC
+			# handler drains → client app polls (keyboard/mouse forwarding, #48).
+			${CMAKE_CURRENT_SOURCE_DIR}/server/ipc_server_input_queue.c
+			${CMAKE_CURRENT_SOURCE_DIR}/server/ipc_server_input_queue.h
 		)
 	target_link_libraries(ipc_server PRIVATE "-framework CoreFoundation" "-framework Cocoa")
 	# The macOS handler's DP-sourced server-side Kooima (#48) includes

--- a/src/xrt/ipc/server/ipc_server_handler.c
+++ b/src/xrt/ipc/server/ipc_server_handler.c
@@ -52,6 +52,12 @@
 #include "xrt/xrt_display_metrics.h" // struct xrt_eye_positions (DP-tracked eyes; Leia M2)
 #endif
 
+#if defined(XRT_OS_MACOS)
+// macOS service input forwarding (#48): drain the generic queue fed by the
+// AppKit pump's NSEvent capture (ipc_server_macos_appkit.m).
+#include "ipc_server_input_queue.h"
+#endif
+
 #if defined(XRT_HAVE_D3D11_SERVICE_COMPOSITOR) || defined(XRT_OS_ANDROID) || defined(XRT_OS_MACOS)
 // Shared Kooima rig math (#396 W7): same displayxr-common core as the
 // in-process oxr_session.c path and every app/engine consumer. Both server-side
@@ -2450,6 +2456,22 @@ ipc_handle_compositor_request_rendering_mode(volatile struct ipc_client_state *i
 	// per-client compositor backend records it (multi_compositor on Android,
 	// comp_d3d11_service on Windows) and clamps its per-session atlas to the grid.
 	xrt_comp_request_rendering_mode((struct xrt_compositor *)ics->xc, mode_index, tile_columns, tile_rows);
+
+#if defined(XRT_OS_MACOS)
+	// macOS single-process service (#48): the per-session render path
+	// (render_session_to_own_target, comp_multi_system.c) syncs the CONTENT grid,
+	// the hardware 2D/3D weave-state, AND the DP's output composition FROM the head
+	// device's active rendering mode — it treats the device as the authority "as
+	// in-process", because unlike Android's OOP runtime the service shares the
+	// process with the real head device (mc->xsysd is non-NULL). So the recorded
+	// grid above is re-derived from the device every frame; drive the device here
+	// (mirroring the in-process oxr_xrRequestDisplayRenderingModeEXT path) so the
+	// requested mode actually reaches the DP. XRT_DEVICE_PROPERTY_OUTPUT_MODE also
+	// switches sim_display's output weave (2D / anaglyph / SBS / quad). (Windows
+	// uses the D3D11 service's own mode path; Android records on mc with no device
+	// sync — both already work, so this is scoped to macOS.)
+	xrt_device_set_property(head, XRT_DEVICE_PROPERTY_OUTPUT_MODE, (int32_t)mode_index);
+#endif
 	return XRT_SUCCESS;
 }
 
@@ -4007,6 +4029,13 @@ ipc_handle_workspace_enumerate_input_events(volatile struct ipc_client_state *_i
 	}
 	bool ok = comp_d3d11_service_workspace_drain_input_events(s->xsysc, capacity, out_batch);
 	return ok ? XRT_SUCCESS : XRT_ERROR_IPC_FAILURE;
+#elif defined(XRT_OS_MACOS)
+	// macOS null+comp_multi service (#48): the AppKit pump captures NSEvents from
+	// the service-owned window into the generic input queue; drain it here so the
+	// client app can poll forwarded keyboard/mouse via xrEnumerateWorkspaceInputEventsEXT.
+	(void)s;
+	ipc_server_input_queue_drain(capacity, out_batch);
+	return XRT_SUCCESS;
 #else
 	(void)s;
 	(void)capacity;

--- a/src/xrt/ipc/server/ipc_server_handler.c
+++ b/src/xrt/ipc/server/ipc_server_handler.c
@@ -1031,21 +1031,37 @@ ipc_try_get_oop_view_poses(volatile struct ipc_client_state *ics,
 		}
 	}
 
+	// The ACTIVE rendering mode's view count (1 = 2D/mono, 2 = stereo, 4 = Quad).
+	// NOT the locate's `view_count` param: an extension app locates against its
+	// stereo view-config (always >=2) and merely *submits* fewer in 2D, so
+	// `view_count` doesn't track the mode. The client forwards the active mode's
+	// view count in rig->render_view_count (OUTPUT_MODE doesn't cross IPC); for
+	// non-rig locates the server head device's active mode is authoritative. Used
+	// below to size the per-view eye set and the 2D mono-collapse.
+	uint32_t active_view_count = view_count;
+	if (rig != NULL && rig->render_view_count > 0) {
+		active_view_count = rig->render_view_count;
+	} else if (head != NULL && head->hmd != NULL && head->rendering_mode_count > 0 &&
+	           head->hmd->active_rendering_mode_index < head->rendering_mode_count) {
+		active_view_count = head->rendering_modes[head->hmd->active_rendering_mode_index].view_count;
+	}
+
 	// Eyes: DP-tracked if available (Leia/M2 plugs in here unchanged), else the
-	// nominal viewer + a default IPD. head_eyes is the head's actual L/R pair
-	// (reported verbatim in the raw block for the app's HUD); raw_eyes is the
-	// render input (collapsed to a centered eye for 2D below).
-	struct xrt_vec3 head_eyes[2];
-	uint32_t head_eye_count = 2;
+	// nominal viewer layout. head_eyes is the head's per-view eye set (N entries —
+	// nothing special about 2 views in DXR: Quad is 4 views with an elevated upper
+	// row); raw_eyes is the render input (collapsed to a centered eye for 2D).
+	// The DP owns the per-view optical layout; the runtime never synthesizes it.
+	struct xrt_vec3 head_eyes[XRT_MAX_VIEWS];
+	uint32_t head_eye_count = 0;
 	bool is_tracking = false;
 	int64_t sample_time_ns = 0;
 	struct xrt_eye_positions eyes = {0};
 	bool have_dp_eyes = multi_compositor_get_predicted_eye_positions(mc, &eyes) && eyes.valid && eyes.count > 0;
 	if (have_dp_eyes) {
-		uint32_t i1 = (eyes.count >= 2) ? 1 : 0;
-		head_eyes[0] = (struct xrt_vec3){eyes.eyes[0].x, eyes.eyes[0].y, eyes.eyes[0].z};
-		head_eyes[1] = (struct xrt_vec3){eyes.eyes[i1].x, eyes.eyes[i1].y, eyes.eyes[i1].z};
-		head_eye_count = (eyes.count >= 2) ? 2 : 1;
+		head_eye_count = (eyes.count < XRT_MAX_VIEWS) ? eyes.count : XRT_MAX_VIEWS;
+		for (uint32_t i = 0; i < head_eye_count; i++) {
+			head_eyes[i] = (struct xrt_vec3){eyes.eyes[i].x, eyes.eyes[i].y, eyes.eyes[i].z};
+		}
 		is_tracking = eyes.is_tracking;
 		sample_time_ns = eyes.timestamp_ns;
 	} else {
@@ -1058,35 +1074,31 @@ ipc_try_get_oop_view_poses(volatile struct ipc_client_state *ics,
 		if (nz <= 0.0f) {
 			nz = 0.6f; // sane default if the DP left it unset
 		}
-		head_eyes[0] = (struct xrt_vec3){nx - ipd * 0.5f, ny, nz};
-		head_eyes[1] = (struct xrt_vec3){nx + ipd * 0.5f, ny, nz};
+		// One nominal eye per active view. The device's per-view eye offsets carry
+		// the optical layout (sim fills N: views 0-1 stereo, 2-3 elevated for Quad;
+		// they're absolute display-space eyes). Fall back to a stereo pair around
+		// the nominal viewer when the device exposes none (or for 2-view modes).
+		head_eye_count = (active_view_count < XRT_MAX_VIEWS) ? active_view_count : XRT_MAX_VIEWS;
+		if (head_eye_count < 2) {
+			head_eye_count = 2; // always keep a head pair for the raw channel
+		}
+		bool have_offsets = head != NULL && head->hmd != NULL &&
+		                    (head->hmd->view_eye_offsets[1].x != 0.0f ||
+		                     head->hmd->view_eye_offsets[1].y != 0.0f);
+		for (uint32_t i = 0; i < head_eye_count; i++) {
+			if (have_offsets) {
+				const struct xrt_vec3 *o = &head->hmd->view_eye_offsets[i];
+				head_eyes[i] = (struct xrt_vec3){nx + o->x, o->y, o->z > 0.0f ? o->z : nz};
+			} else {
+				head_eyes[i] =
+				    (struct xrt_vec3){nx + ((i & 1u) ? ipd * 0.5f : -ipd * 0.5f), ny, nz};
+			}
+		}
 	}
 
 	// Render input. 2D / mono: collapse to a CENTERED eye so the off-axis frustum
 	// is symmetric (no off-center crop / parallax shift). 3D: per-eye off-axis.
 	//
-	// #521: the gate must be the ACTIVE RENDERING MODE's view_count, NOT the
-	// locate's `view_count` param. An extension app locates against its stereo
-	// view-config (always 2 views) and merely *submits* 1 in 2D mode — so
-	// `view_count` stays 2 even in 2D. Gating on it left views[0] as the off-axis
-	// LEFT eye, which the app then presented as its mono 2D image → the cube
-	// rendered shifted. The server head device's active_rendering_mode_index is
-	// NOT reliable in OOP (OUTPUT_MODE doesn't cross IPC), so the client forwards
-	// the active mode's view count in rig->render_view_count. Fall back to the
-	// located view_count when unset (0).
-	uint32_t active_view_count = view_count;
-	if (rig != NULL && rig->render_view_count > 0) {
-		active_view_count = rig->render_view_count;
-	} else if (head != NULL && head->hmd != NULL && head->rendering_mode_count > 0 &&
-	           head->hmd->active_rendering_mode_index < head->rendering_mode_count) {
-		// Legacy / non-rig locates (e.g. device_get_view_poses on macOS) carry no
-		// render_view_count over IPC. The server head device IS the real display
-		// device here (not a proxy), and a legacy app never switches modes over
-		// IPC, so its active rendering mode is authoritative: read the active
-		// mode's view count directly to drive the 2D mono-collapse below.
-		active_view_count = head->rendering_modes[head->hmd->active_rendering_mode_index].view_count;
-	}
-
 	// Re-express the render eyes relative to the zone centre when a zone is
 	// applied (display-zones P5, #570) — display-local shift, BEFORE the Kooima
 	// compute folds in the rig display_pose. zone_eye_offset_* is (0,0,0) for
@@ -1095,20 +1107,30 @@ ipc_try_get_oop_view_poses(volatile struct ipc_client_state *ics,
 	struct xrt_vec3 raw_eyes[XRT_MAX_VIEWS] = {0};
 	uint32_t eye_count;
 	if (active_view_count == 1) {
-		raw_eyes[0] = (struct xrt_vec3){
-		    0.5f * (head_eyes[0].x + head_eyes[1].x) - zone_eye_offset_x,
-		    0.5f * (head_eyes[0].y + head_eyes[1].y) - zone_eye_offset_y,
-		    0.5f * (head_eyes[0].z + head_eyes[1].z) - zone_eye_offset_z,
-		};
+		// 2D / mono: collapse the head pair to a centered eye.
+		uint32_t nc = head_eye_count < 2 ? head_eye_count : 2;
+		struct xrt_vec3 c = {0, 0, 0};
+		for (uint32_t i = 0; i < nc; i++) {
+			c.x += head_eyes[i].x;
+			c.y += head_eyes[i].y;
+			c.z += head_eyes[i].z;
+		}
+		float inv = nc > 0 ? 1.0f / (float)nc : 1.0f;
+		raw_eyes[0] = (struct xrt_vec3){c.x * inv - zone_eye_offset_x, c.y * inv - zone_eye_offset_y,
+		                                c.z * inv - zone_eye_offset_z};
 		eye_count = 1;
 	} else {
-		raw_eyes[0] = (struct xrt_vec3){head_eyes[0].x - zone_eye_offset_x,
-		                                head_eyes[0].y - zone_eye_offset_y,
-		                                head_eyes[0].z - zone_eye_offset_z};
-		raw_eyes[1] = (struct xrt_vec3){head_eyes[1].x - zone_eye_offset_x,
-		                                head_eyes[1].y - zone_eye_offset_y,
-		                                head_eyes[1].z - zone_eye_offset_z};
-		eye_count = 2;
+		// N-view: one render eye per active view (2 stereo, 4 Quad, …). The DP's
+		// per-view layout already encodes the elevated rows; just rebase by the zone.
+		eye_count = active_view_count < head_eye_count ? active_view_count : head_eye_count;
+		if (eye_count > XRT_MAX_VIEWS) {
+			eye_count = XRT_MAX_VIEWS;
+		}
+		for (uint32_t i = 0; i < eye_count; i++) {
+			raw_eyes[i] = (struct xrt_vec3){head_eyes[i].x - zone_eye_offset_x,
+			                                head_eyes[i].y - zone_eye_offset_y,
+			                                head_eyes[i].z - zone_eye_offset_z};
+		}
 	}
 
 	// A chained XR_EXT_view_rig DISPLAY descriptor (the cube's orbit camera)
@@ -1182,9 +1204,14 @@ ipc_try_get_oop_view_poses(volatile struct ipc_client_state *ics,
 	// face-dot the app HUD reads), plus the display plane + canvas. Reported
 	// independent of the 2D render collapse above.
 	if (rig_reply != NULL) {
-		rig_reply->raw.eyes[0] = head_eyes[0];
-		rig_reply->raw.eyes[1] = head_eyes[1];
-		rig_reply->raw.eye_count = head_eye_count;
+		uint32_t raw_n = head_eye_count;
+		if (raw_n > XRT_MAX_VIEWS) {
+			raw_n = XRT_MAX_VIEWS;
+		}
+		for (uint32_t i = 0; i < raw_n; i++) {
+			rig_reply->raw.eyes[i] = head_eyes[i];
+		}
+		rig_reply->raw.eye_count = raw_n;
 		rig_reply->raw.sample_time_ns = sample_time_ns;
 		rig_reply->raw.is_tracking = is_tracking ? 1u : 0u;
 		rig_reply->raw.display_pose = display_pose;

--- a/src/xrt/ipc/server/ipc_server_handler.c
+++ b/src/xrt/ipc/server/ipc_server_handler.c
@@ -43,18 +43,19 @@
 #include "d3d11_service/comp_d3d11_service.h"
 #endif
 
-#ifdef XRT_OS_ANDROID
-// Out-of-process Android (#510): the per-client compositor is a multi_compositor;
-// the server pulls its live present-target extent for the client's Kooima and
-// runs the server-side Kooima for the null+comp_multi path (no D3D11 service).
+#if defined(XRT_OS_ANDROID) || defined(XRT_OS_MACOS)
+// Out-of-process non-D3D11 service path (Android #510, macOS #48): the per-client
+// compositor is a multi_compositor; the server pulls its live present-target
+// extent for the client's Kooima and runs the server-side Kooima for the
+// null+comp_multi path (no D3D11 service).
 #include "multi/comp_multi_private.h"
 #include "xrt/xrt_display_metrics.h" // struct xrt_eye_positions (DP-tracked eyes; Leia M2)
 #endif
 
-#if defined(XRT_HAVE_D3D11_SERVICE_COMPOSITOR) || defined(XRT_OS_ANDROID)
+#if defined(XRT_HAVE_D3D11_SERVICE_COMPOSITOR) || defined(XRT_OS_ANDROID) || defined(XRT_OS_MACOS)
 // Shared Kooima rig math (#396 W7): same displayxr-common core as the
 // in-process oxr_session.c path and every app/engine consumer. Both server-side
-// Kooima paths (D3D11 service on Windows, null+comp_multi on Android) use it.
+// Kooima paths (D3D11 service on Windows, null+comp_multi on Android/macOS) use it.
 #include "displayxr_math_xrt.h"
 #endif
 
@@ -139,7 +140,7 @@ validate_device_id(volatile struct ipc_client_state *ics, int64_t device_id, str
 	} while (0)
 
 
-#if defined(XRT_HAVE_D3D11_SERVICE_COMPOSITOR) || defined(XRT_OS_ANDROID)
+#if defined(XRT_HAVE_D3D11_SERVICE_COMPOSITOR) || defined(XRT_OS_ANDROID) || defined(XRT_OS_MACOS)
 /*!
  * Fill surplus view slots [from, view_count) with valid poses.
  *
@@ -175,7 +176,7 @@ fill_surplus_view_poses(struct xrt_device *xdev,
 		}
 	}
 }
-#endif // D3D11 service || Android — fill_surplus_view_poses
+#endif // D3D11 service || Android || macOS — fill_surplus_view_poses
 
 #if defined(XRT_HAVE_D3D11_SERVICE_COMPOSITOR)
 /*!
@@ -848,18 +849,23 @@ ipc_try_get_sr_view_poses(volatile struct ipc_client_state *ics,
 }
 #endif // XRT_HAVE_D3D11_SERVICE_COMPOSITOR
 
-#ifdef XRT_OS_ANDROID
+#if defined(XRT_OS_ANDROID) || defined(XRT_OS_MACOS)
 /*!
- * Server-side Kooima for the out-of-process Android path (#510).
+ * Server-side Kooima for the out-of-process null+comp_multi path (Android #510,
+ * macOS #48).
  *
- * On Android the runtime service runs the null compositor + comp_multi (NOT the
- * D3D11 service compositor), so ipc_try_get_sr_view_poses above is compiled out.
- * This is its analogue for the null+comp_multi path: it computes orientation-
- * aware, render-ready off-axis FOVs + head-local poses via the SAME shared
- * displayxr-common Kooima core (dxr_xrt_display3d_compute_views) used by the
- * D3D11 server and the in-process oxr_session.c path. Without it,
- * ipc_handle_session_locate_views_rig falls back to xrt_device_get_view_poses →
- * sim_display's FIXED landscape device FOV (portrait stretched, 2D off-center).
+ * On Android and macOS the runtime service runs the null compositor + comp_multi
+ * (NOT the D3D11 service compositor), so ipc_try_get_sr_view_poses above is
+ * compiled out. This is its analogue for the null+comp_multi path: it computes
+ * orientation-aware, render-ready off-axis FOVs + head-local poses via the SAME
+ * shared displayxr-common Kooima core (dxr_xrt_display3d_compute_views) used by
+ * the D3D11 server and the in-process oxr_session.c path — sourcing eye
+ * positions from the generic xrt_display_processor (multi_compositor_get_-
+ * predicted_eye_positions / the system-compositor nominal viewer), NOT the
+ * device get_view_poses. Without it, the locate handlers fall back to
+ * xrt_device_get_view_poses → sim_display's device FOV, which on macOS is
+ * contaminated by the qwerty standing head pose (1.6 m → a steep vertical
+ * sliver) and on Android is the FIXED landscape FOV (portrait stretched).
  *
  * Inputs mirror the in-process block (oxr_session.c:1512-1797):
  *   - screen meters: the head display dims from xrt_system_compositor_info.
@@ -872,7 +878,7 @@ ipc_try_get_sr_view_poses(volatile struct ipc_client_state *ics,
  * Returns true on success; false → caller's legacy device-poses fallback.
  */
 static bool
-ipc_try_get_android_view_poses(volatile struct ipc_client_state *ics,
+ipc_try_get_oop_view_poses(volatile struct ipc_client_state *ics,
                                struct xrt_device *head,
                                const struct xrt_vec3 *fallback_eye_relation,
                                int64_t at_timestamp_ns,
@@ -906,7 +912,7 @@ ipc_try_get_android_view_poses(volatile struct ipc_client_state *ics,
 		static bool logged_no_dims = false;
 		if (!logged_no_dims) {
 			logged_no_dims = true;
-			IPC_WARN(s, "android Kooima: no display dims from xsysc, using legacy poses");
+			IPC_WARN(s, "oop Kooima: no display dims from xsysc, using legacy poses");
 		}
 		return false;
 	}
@@ -1065,6 +1071,14 @@ ipc_try_get_android_view_poses(volatile struct ipc_client_state *ics,
 	uint32_t active_view_count = view_count;
 	if (rig != NULL && rig->render_view_count > 0) {
 		active_view_count = rig->render_view_count;
+	} else if (head != NULL && head->hmd != NULL && head->rendering_mode_count > 0 &&
+	           head->hmd->active_rendering_mode_index < head->rendering_mode_count) {
+		// Legacy / non-rig locates (e.g. device_get_view_poses on macOS) carry no
+		// render_view_count over IPC. The server head device IS the real display
+		// device here (not a proxy), and a legacy app never switches modes over
+		// IPC, so its active rendering mode is authoritative: read the active
+		// mode's view count directly to drive the 2D mono-collapse below.
+		active_view_count = head->rendering_modes[head->hmd->active_rendering_mode_index].view_count;
 	}
 
 	// Re-express the render eyes relative to the zone centre when a zone is
@@ -1191,7 +1205,7 @@ ipc_try_get_android_view_poses(volatile struct ipc_client_state *ics,
 	static bool first_call = true;
 	if (first_call) {
 		first_call = false;
-		IPC_WARN(s, "android Kooima: FIRST CALL view_count=%u dp_eyes=%d screen=%.3fx%.3fm win_px=%ux%u",
+		IPC_WARN(s, "oop Kooima: FIRST CALL view_count=%u dp_eyes=%d screen=%.3fx%.3fm win_px=%ux%u",
 		         view_count, (int)have_dp_eyes, (double)screen_width_m, (double)screen_height_m,
 		         (unsigned)wm.window_pixel_width, (unsigned)wm.window_pixel_height);
 	}
@@ -1202,7 +1216,7 @@ ipc_try_get_android_view_poses(volatile struct ipc_client_state *ics,
 		float v = (out_fovs[0].angle_up - out_fovs[0].angle_down) * 180.0f / 3.14159265f;
 		float fov_aspect = (v != 0.0f) ? (h / v) : 0.0f;
 		IPC_WARN(s,
-		         "android Kooima: views=%u screen=%.3fx%.3fm FOV H=%.1f° V=%.1f° "
+		         "oop Kooima: views=%u screen=%.3fx%.3fm FOV H=%.1f° V=%.1f° "
 		         "fovAspect=%.3f tracking=%d rig=%d zone=%d",
 		         view_count, (double)screen_width_m, (double)screen_height_m, (double)h, (double)v,
 		         (double)fov_aspect, (int)is_tracking, (int)rig_display, (int)zone_applied);
@@ -1210,7 +1224,7 @@ ipc_try_get_android_view_poses(volatile struct ipc_client_state *ics,
 
 	return true;
 }
-#endif // XRT_OS_ANDROID
+#endif // XRT_OS_ANDROID || XRT_OS_MACOS
 
 
 static xrt_result_t
@@ -5268,6 +5282,13 @@ ipc_handle_device_get_view_poses(volatile struct ipc_client_state *ics,
 	                               view_count, NULL, NULL, &reply.head_relation, fovs, poses)) {
 		reply.result = XRT_SUCCESS;
 	} else
+#elif defined(XRT_OS_MACOS)
+	// Out-of-process macOS (#48): DP-sourced server-side Kooima (see
+	// ipc_handle_device_get_view_poses_2 for the rationale).
+	if (ipc_try_get_oop_view_poses(ics, xdev, fallback_eye_relation, at_timestamp_ns, view_count, NULL, NULL,
+	                               &reply.head_relation, fovs, poses)) {
+		reply.result = XRT_SUCCESS;
+	} else
 #endif
 	{
 		// Fall back to device view poses
@@ -5336,6 +5357,17 @@ ipc_handle_device_get_view_poses_2(volatile struct ipc_client_state *ics,
 	                               out_info->poses)) {
 		return XRT_SUCCESS;
 	}
+#elif defined(XRT_OS_MACOS)
+	// Out-of-process macOS (#48): null+comp_multi service path. Legacy apps locate
+	// via the non-rig device_get_view_poses, so route them through the same
+	// DP-sourced server-side Kooima as the rig path — otherwise the fallback below
+	// runs sim_display's device get_view_poses, whose head pose is contaminated by
+	// the qwerty standing height (1.6 m → a steep vertical sliver FOV). (Android
+	// keeps the device fallback here; its OOP apps use the rig locate path.)
+	if (ipc_try_get_oop_view_poses(ics, xdev, default_eye_relation, at_timestamp_ns, view_count, NULL, NULL,
+	                               &out_info->head_relation, out_info->fovs, out_info->poses)) {
+		return XRT_SUCCESS;
+	}
 #endif
 
 	// Fall back to device view poses
@@ -5385,11 +5417,11 @@ ipc_handle_session_locate_views_rig(volatile struct ipc_client_state *ics,
 	                               out_info->fovs, out_info->poses)) {
 		return XRT_SUCCESS;
 	}
-#elif defined(XRT_OS_ANDROID)
-	// Out-of-process Android (#510): the service runs null+comp_multi, not the
-	// D3D11 service compositor, so run the server-side Kooima for that path.
-	if (ipc_try_get_android_view_poses(ics, head, &fallback_eye_relation, at_timestamp_ns, view_count, rig,
-	                                   out_info, &out_info->head_relation, out_info->fovs, out_info->poses)) {
+#elif defined(XRT_OS_ANDROID) || defined(XRT_OS_MACOS)
+	// Out-of-process Android (#510) / macOS (#48): the service runs null+comp_multi,
+	// not the D3D11 service compositor, so run the server-side Kooima for that path.
+	if (ipc_try_get_oop_view_poses(ics, head, &fallback_eye_relation, at_timestamp_ns, view_count, rig,
+	                               out_info, &out_info->head_relation, out_info->fovs, out_info->poses)) {
 		return XRT_SUCCESS;
 	}
 #else

--- a/src/xrt/ipc/server/ipc_server_input_queue.c
+++ b/src/xrt/ipc/server/ipc_server_input_queue.c
@@ -1,0 +1,62 @@
+// Copyright 2026, Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  Generic service-side input-event queue (macOS shell Tier 1, #48).
+ * @ingroup ipc_server
+ */
+
+#include "ipc_server_input_queue.h"
+
+#include <pthread.h>
+#include <string.h>
+
+// Power-of-two ring so head/tail wrap with a mask. Sized well above a frame's
+// worth of events at 60 Hz; on overflow the oldest event is overwritten.
+#define INPUT_QUEUE_CAPACITY 256
+#define INPUT_QUEUE_MASK (INPUT_QUEUE_CAPACITY - 1)
+
+static pthread_mutex_t g_lock = PTHREAD_MUTEX_INITIALIZER;
+static struct ipc_workspace_input_event g_ring[INPUT_QUEUE_CAPACITY];
+static uint32_t g_head; // next slot to write
+static uint32_t g_tail; // next slot to read
+static uint32_t g_count;
+
+void
+ipc_server_input_queue_push(const struct ipc_workspace_input_event *event)
+{
+	if (event == NULL) {
+		return;
+	}
+	pthread_mutex_lock(&g_lock);
+	g_ring[g_head & INPUT_QUEUE_MASK] = *event;
+	g_head++;
+	if (g_count < INPUT_QUEUE_CAPACITY) {
+		g_count++;
+	} else {
+		// Full: the write above clobbered the oldest slot, so advance tail too.
+		g_tail++;
+	}
+	pthread_mutex_unlock(&g_lock);
+}
+
+void
+ipc_server_input_queue_drain(uint32_t capacity, struct ipc_workspace_input_event_batch *out_batch)
+{
+	if (out_batch == NULL) {
+		return;
+	}
+	if (capacity > IPC_WORKSPACE_INPUT_EVENT_BATCH_MAX) {
+		capacity = IPC_WORKSPACE_INPUT_EVENT_BATCH_MAX;
+	}
+
+	pthread_mutex_lock(&g_lock);
+	uint32_t n = (g_count < capacity) ? g_count : capacity;
+	for (uint32_t i = 0; i < n; i++) {
+		out_batch->events[i] = g_ring[g_tail & INPUT_QUEUE_MASK];
+		g_tail++;
+	}
+	g_count -= n;
+	out_batch->count = n;
+	pthread_mutex_unlock(&g_lock);
+}

--- a/src/xrt/ipc/server/ipc_server_input_queue.h
+++ b/src/xrt/ipc/server/ipc_server_input_queue.h
@@ -1,0 +1,46 @@
+// Copyright 2026, Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  Generic service-side input-event queue (macOS shell Tier 1, #48).
+ *
+ * The Windows D3D11 service compositor owns its output window and enqueues
+ * keyboard/mouse events from its WndProc, drained over IPC by the workspace
+ * controller (comp_d3d11_service_workspace_drain_input_events). The macOS
+ * null+comp_multi service has no such monolith: the service main thread owns the
+ * NSWindow and pumps NSEvents (ipc_server_macos_appkit.m), so this is the
+ * vendor-neutral analogue — a small thread-safe ring of @ref
+ * ipc_workspace_input_event that the AppKit pump pushes into and the IPC handler
+ * (ipc_handle_workspace_enumerate_input_events) drains. One process-global queue;
+ * the service is a single process.
+ *
+ * @ingroup ipc_server
+ */
+
+#pragma once
+
+#include "shared/ipc_protocol.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*!
+ * Push one input event onto the global queue. Thread-safe; called from the
+ * service main thread (AppKit pump). Drops the oldest event if the ring is full
+ * — input is latency-sensitive, a stale event is worse than a dropped one.
+ */
+void
+ipc_server_input_queue_push(const struct ipc_workspace_input_event *event);
+
+/*!
+ * Drain up to @p capacity queued events into @p out_batch (FIFO). Thread-safe;
+ * called from a per-client IPC handler thread. @p capacity is clamped to
+ * IPC_WORKSPACE_INPUT_EVENT_BATCH_MAX. Always sets out_batch->count.
+ */
+void
+ipc_server_input_queue_drain(uint32_t capacity, struct ipc_workspace_input_event_batch *out_batch);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/xrt/ipc/server/ipc_server_macos_appkit.h
+++ b/src/xrt/ipc/server/ipc_server_macos_appkit.h
@@ -1,0 +1,33 @@
+// Copyright 2026, Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  macOS AppKit pump for the service main thread (shell Tier 1, #48).
+ * @ingroup ipc_server
+ *
+ * The macOS service compositor (null + comp_multi + comp_window_macos) creates
+ * its NSWindow on the main thread via `dispatch_sync(dispatch_get_main_queue())`
+ * from the comp_multi render thread. The service main thread runs the kqueue IPC
+ * mainloop (@ref ipc_server_mainloop_macos.c), not an NSApp runloop, so without
+ * draining the main dispatch queue that `dispatch_sync` would deadlock. This
+ * pump is called once per (non-blocking) mainloop poll to service the main
+ * dispatch queue + AppKit events.
+ */
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*!
+ * Service the main thread's GCD queue + AppKit event queue, non-blocking.
+ * Lazily bootstraps NSApplication on first call. Safe to call every poll
+ * iteration; cheap when idle. Must be called from the main thread.
+ */
+void
+ipc_server_macos_pump_main_thread(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/xrt/ipc/server/ipc_server_macos_appkit.m
+++ b/src/xrt/ipc/server/ipc_server_macos_appkit.m
@@ -10,8 +10,97 @@
 #import <Cocoa/Cocoa.h>
 
 #include "ipc_server_macos_appkit.h"
+#include "ipc_server_input_queue.h"
+#include "shared/ipc_protocol.h"
 
 #include <stdbool.h>
+#include <ctype.h>
+
+// Translate an NSEvent (service-window input) into a wire input event and queue
+// it for the IPC handler to forward to the client app (#48). Mirrors the Windows
+// D3D11 service WndProc producer. Keyboard is reported as the lowercased Unicode
+// character in key.vk_code — the macOS client maps characters, not VK codes — so
+// the forwarded path drives the same handling the app's in-process NSEvent loop
+// does (mode keys v/0-8, WASD camera). Returns true if the event was a captured
+// input event (so the caller can skip sendEvent: for keys — no responder, no beep).
+static bool
+queue_ns_input_event(NSEvent *event)
+{
+	NSEventType type = [event type];
+	struct ipc_workspace_input_event ev;
+	memset(&ev, 0, sizeof(ev));
+	ev.timestamp_ms = (uint32_t)([event timestamp] * 1000.0);
+
+	NSUInteger flags = [event modifierFlags];
+	uint32_t mods = 0;
+	if (flags & NSEventModifierFlagShift) mods |= 1u << 0;
+	if (flags & NSEventModifierFlagControl) mods |= 1u << 1;
+	if (flags & NSEventModifierFlagOption) mods |= 1u << 2;
+
+	switch (type) {
+	case NSEventTypeKeyDown:
+	case NSEventTypeKeyUp: {
+		// Swallow OS key auto-repeat: the client treats every forwarded keyDown as
+		// a fresh press (one cycle/toggle per press), matching the in-process
+		// !isRepeat gating. Without this, holding a key spams mode cycles. Held
+		// movement (WASD) is unaffected — its g_input flag stays set until keyUp.
+		if (type == NSEventTypeKeyDown && [event isARepeat]) {
+			return true; // swallowed (no beep), not forwarded
+		}
+		NSString *chars = [event charactersIgnoringModifiers];
+		if ([chars length] == 0) {
+			return false; // modifier-only / dead key — nothing to forward
+		}
+		unichar ch = (unichar)tolower([chars characterAtIndex:0]);
+		ev.event_type = IPC_WORKSPACE_INPUT_EVENT_KEY;
+		ev.u.key.vk_code = (uint32_t)ch;
+		ev.u.key.is_down = (type == NSEventTypeKeyDown) ? 1u : 0u;
+		ev.u.key.modifiers = mods;
+		ipc_server_input_queue_push(&ev);
+		return true;
+	}
+	case NSEventTypeLeftMouseDown:
+	case NSEventTypeLeftMouseUp:
+	case NSEventTypeRightMouseDown:
+	case NSEventTypeRightMouseUp: {
+		NSPoint p = [event locationInWindow];
+		ev.event_type = IPC_WORKSPACE_INPUT_EVENT_POINTER;
+		ev.u.pointer.button =
+		    (type == NSEventTypeRightMouseDown || type == NSEventTypeRightMouseUp) ? 2u : 1u;
+		ev.u.pointer.is_down =
+		    (type == NSEventTypeLeftMouseDown || type == NSEventTypeRightMouseDown) ? 1u : 0u;
+		ev.u.pointer.cursor_x = (int64_t)p.x;
+		ev.u.pointer.cursor_y = (int64_t)p.y;
+		ev.u.pointer.modifiers = mods;
+		ipc_server_input_queue_push(&ev);
+		return false; // also let AppKit handle it (window focus/drag)
+	}
+	case NSEventTypeMouseMoved:
+	case NSEventTypeLeftMouseDragged:
+	case NSEventTypeRightMouseDragged: {
+		NSPoint p = [event locationInWindow];
+		uint32_t button_mask = (uint32_t)[NSEvent pressedMouseButtons];
+		ev.event_type = IPC_WORKSPACE_INPUT_EVENT_POINTER_MOTION;
+		ev.u.pointer_motion.cursor_x = (int64_t)p.x;
+		ev.u.pointer_motion.cursor_y = (int64_t)p.y;
+		ev.u.pointer_motion.button_mask = button_mask;
+		ev.u.pointer_motion.modifiers = mods;
+		ipc_server_input_queue_push(&ev);
+		return false;
+	}
+	case NSEventTypeScrollWheel: {
+		NSPoint p = [event locationInWindow];
+		ev.event_type = IPC_WORKSPACE_INPUT_EVENT_SCROLL;
+		ev.u.scroll.delta_y = (float)[event scrollingDeltaY];
+		ev.u.scroll.cursor_x = (int64_t)p.x;
+		ev.u.scroll.cursor_y = (int64_t)p.y;
+		ev.u.scroll.modifiers = mods;
+		ipc_server_input_queue_push(&ev);
+		return false;
+	}
+	default: return false;
+	}
+}
 
 void
 ipc_server_macos_pump_main_thread(void)
@@ -35,13 +124,19 @@ ipc_server_macos_pump_main_thread(void)
 			// keep draining until nothing left this pass
 		}
 
-		// Pump pending UI events so the window appears + stays responsive.
+		// Pump pending UI events so the window appears + stays responsive, and
+		// forward keyboard/mouse to the client app over IPC (#48). Key events are
+		// captured and NOT sent to AppKit (no responder → system beep); mouse
+		// events are both queued and forwarded to AppKit (window focus/move).
 		NSEvent *event;
 		while ((event = [NSApp nextEventMatchingMask:NSEventMaskAny
 		                                   untilDate:nil
 		                                      inMode:NSDefaultRunLoopMode
 		                                     dequeue:YES]) != nil) {
-			[NSApp sendEvent:event];
+			bool swallow = queue_ns_input_event(event);
+			if (!swallow) {
+				[NSApp sendEvent:event];
+			}
 		}
 	}
 }

--- a/src/xrt/ipc/server/ipc_server_macos_appkit.m
+++ b/src/xrt/ipc/server/ipc_server_macos_appkit.m
@@ -1,0 +1,47 @@
+// Copyright 2026, Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  macOS AppKit pump for the service main thread (shell Tier 1, #48).
+ * @author David Fattal
+ * @ingroup ipc_server
+ */
+
+#import <Cocoa/Cocoa.h>
+
+#include "ipc_server_macos_appkit.h"
+
+#include <stdbool.h>
+
+void
+ipc_server_macos_pump_main_thread(void)
+{
+	@autoreleasepool {
+		static bool inited = false;
+		if (!inited) {
+			// A service is a background process by default; promote it to a
+			// regular app so the compositor's NSWindow can become key + front.
+			if (NSApp == nil) {
+				[NSApplication sharedApplication];
+				[NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
+			}
+			inited = true;
+		}
+
+		// Drain the main dispatch queue (this is what unblocks the comp_multi
+		// render thread's dispatch_sync that creates the NSWindow) plus any
+		// AppKit runloop sources, non-blocking.
+		while (CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.0, true) == kCFRunLoopRunHandledSource) {
+			// keep draining until nothing left this pass
+		}
+
+		// Pump pending UI events so the window appears + stays responsive.
+		NSEvent *event;
+		while ((event = [NSApp nextEventMatchingMask:NSEventMaskAny
+		                                   untilDate:nil
+		                                      inMode:NSDefaultRunLoopMode
+		                                     dequeue:YES]) != nil) {
+			[NSApp sendEvent:event];
+		}
+	}
+}

--- a/src/xrt/ipc/server/ipc_server_mainloop_macos.c
+++ b/src/xrt/ipc/server/ipc_server_mainloop_macos.c
@@ -24,6 +24,7 @@
 
 #include "shared/ipc_shmem.h"
 #include "server/ipc_server.h"
+#include "server/ipc_server_macos_appkit.h"
 
 #include <stdlib.h>
 #include <unistd.h>
@@ -207,6 +208,12 @@ ipc_server_mainloop_poll(struct ipc_server *vs, struct ipc_server_mainloop *ml)
 
 	struct kevent events[NUM_POLL_EVENTS];
 	struct timespec timeout = {NO_SLEEP_SEC, NO_SLEEP_NSEC};
+
+	// Service the main-thread GCD queue + AppKit so the compositor's
+	// render-thread NSWindow creation (dispatch_sync to the main queue in
+	// comp_window_macos) can complete instead of deadlocking. Cheap when idle.
+	// (Shell Tier 1, #48 — the macOS service owns the present window.)
+	ipc_server_macos_pump_main_thread();
 
 	// No sleeping, returns immediately.
 	int ret = kevent(ml->kqueue_fd, NULL, 0, events, NUM_POLL_EVENTS, &timeout);

--- a/src/xrt/state_trackers/oxr/oxr_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_session.c
@@ -1750,12 +1750,6 @@ oxr_session_locate_views(struct oxr_logger *log,
 		}
 	}
 
-	// is_service_mode: out-of-process (IPC) session. Used below to apply the
-	// client-computed Kooima FOV on the generic null+comp_multi server path,
-	// where get_view_poses returns the raw device FOV instead of a 3D-adjusted
-	// one (unlike the D3D11 service compositor). See the FOV save/restore gate.
-	bool is_service_mode = sess->sys->xsysc != NULL && sess->sys->xsysc->info.is_service_mode;
-
 	// Get device pose for 3D world-space computation (qwerty = virtual display)
 	// Bridge-relay sessions (headless, XR_EXT_display_info) forward raw
 	// DP-tracked eye positions to a browser app; treat them like handle
@@ -2331,7 +2325,7 @@ oxr_session_locate_views(struct oxr_logger *log,
 	if (!ipc_rig_done) {
 		struct xrt_fov kooima_fovs[XRT_MAX_VIEWS];
 		uint32_t fov_save_count = (active_view_count < view_count) ? active_view_count : view_count;
-		if (have_kooima_fov && (have_view_state || rig_active || is_service_mode)) {
+		if (have_kooima_fov && (have_view_state || rig_active)) {
 			for (uint32_t ei = 0; ei < fov_save_count; ei++) {
 				kooima_fovs[ei] = fovs[ei];
 			}
@@ -2347,16 +2341,11 @@ oxr_session_locate_views(struct oxr_logger *log,
 		    poses);
 		OXR_CHECK_XRET(log, sess, xret, xrt_device_get_view_poses);
 
-		// Restore client-side Kooima FOVs when the client has local 3D state
-		// (non-IPC qwerty), a chained view rig, OR is a service-mode (OOP)
-		// session. The D3D11 *service* compositor computes 3D-adjusted Kooima
-		// FOVs server-side and returns them via get_view_poses (so the original
-		// code trusted IPC blindly), but the generic null+comp_multi server path
-		// (macOS/Android, #48) returns the raw device FOV — degenerate here, e.g.
-		// a ~2° vertical sliver that hides all geometry. The client already
-		// computed a correct Kooima FOV from the same display dims + (tracked or
-		// nominal) eyes, so use it. On D3D11 the two match, so this is safe.
-		if (have_kooima_fov && (have_view_state || rig_active || is_service_mode)) {
+		// Restore client-side Kooima FOVs only when the client has local
+		// 3D state (non-IPC mode) or a chained view rig. In IPC mode, the
+		// server already computes 3D-adjusted Kooima FOVs and returns them
+		// via get_view_poses — don't override those.
+		if (have_kooima_fov && (have_view_state || rig_active)) {
 			for (uint32_t ei = 0; ei < fov_save_count; ei++) {
 				fovs[ei] = kooima_fovs[ei];
 			}

--- a/src/xrt/state_trackers/oxr/oxr_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_session.c
@@ -2429,11 +2429,20 @@ oxr_session_locate_views(struct oxr_logger *log,
 		// Do the magical space relation dance here.
 		struct xrt_space_relation result = {0};
 
-		// Workspace IPC sessions and bridge-relay sessions: the server already
-		// computed display-relative view poses (via display-centric Kooima
-		// with DP eye tracking). Skip the T_base_head transform which adds a
-		// spurious Y offset from the qwerty device's world-space position.
-		if ((sess->has_external_window || sess->is_bridge_relay) && !have_eyes && !have_eye_override) {
+		// Service-mode (OOP) sessions: the server already computed
+		// display-relative view poses (via display-centric Kooima with DP eye
+		// tracking — ipc_try_get_sr_view_poses on Windows, ipc_try_get_oop_view_poses
+		// on Android/macOS). Skip the T_base_head transform, which would re-add a
+		// spurious Y offset from the head device's world-space tracked pose (the
+		// qwerty standing height of 1.6 m). Handle/texture apps matched this via
+		// has_external_window already; hosted apps (no external window) own no HWND
+		// yet still get display-relative server poses, so key on service mode too.
+		// (#48: macOS hosted OOP — Android has no qwerty so T_base_head was already
+		// identity there; this is a no-op for it.)
+		bool server_display_relative =
+		    sess->has_external_window || sess->is_bridge_relay ||
+		    (sess->sys->xsysc != NULL && sess->sys->xsysc->info.is_service_mode);
+		if (server_display_relative && !have_eyes && !have_eye_override) {
 			// Use server poses directly (display-relative)
 			result.pose = view_pose;
 			result.relation_flags = T_base_head.relation_flags;

--- a/src/xrt/state_trackers/oxr/oxr_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_session.c
@@ -1750,6 +1750,12 @@ oxr_session_locate_views(struct oxr_logger *log,
 		}
 	}
 
+	// is_service_mode: out-of-process (IPC) session. Used below to apply the
+	// client-computed Kooima FOV on the generic null+comp_multi server path,
+	// where get_view_poses returns the raw device FOV instead of a 3D-adjusted
+	// one (unlike the D3D11 service compositor). See the FOV save/restore gate.
+	bool is_service_mode = sess->sys->xsysc != NULL && sess->sys->xsysc->info.is_service_mode;
+
 	// Get device pose for 3D world-space computation (qwerty = virtual display)
 	// Bridge-relay sessions (headless, XR_EXT_display_info) forward raw
 	// DP-tracked eye positions to a browser app; treat them like handle
@@ -2325,7 +2331,7 @@ oxr_session_locate_views(struct oxr_logger *log,
 	if (!ipc_rig_done) {
 		struct xrt_fov kooima_fovs[XRT_MAX_VIEWS];
 		uint32_t fov_save_count = (active_view_count < view_count) ? active_view_count : view_count;
-		if (have_kooima_fov && (have_view_state || rig_active)) {
+		if (have_kooima_fov && (have_view_state || rig_active || is_service_mode)) {
 			for (uint32_t ei = 0; ei < fov_save_count; ei++) {
 				kooima_fovs[ei] = fovs[ei];
 			}
@@ -2341,11 +2347,16 @@ oxr_session_locate_views(struct oxr_logger *log,
 		    poses);
 		OXR_CHECK_XRET(log, sess, xret, xrt_device_get_view_poses);
 
-		// Restore client-side Kooima FOVs only when the client has local
-		// 3D state (non-IPC mode) or a chained view rig. In IPC mode, the
-		// server already computes 3D-adjusted Kooima FOVs and returns them
-		// via get_view_poses — don't override those.
-		if (have_kooima_fov && (have_view_state || rig_active)) {
+		// Restore client-side Kooima FOVs when the client has local 3D state
+		// (non-IPC qwerty), a chained view rig, OR is a service-mode (OOP)
+		// session. The D3D11 *service* compositor computes 3D-adjusted Kooima
+		// FOVs server-side and returns them via get_view_poses (so the original
+		// code trusted IPC blindly), but the generic null+comp_multi server path
+		// (macOS/Android, #48) returns the raw device FOV — degenerate here, e.g.
+		// a ~2° vertical sliver that hides all geometry. The client already
+		// computed a correct Kooima FOV from the same display dims + (tracked or
+		// nominal) eyes, so use it. On D3D11 the two match, so this is safe.
+		if (have_kooima_fov && (have_view_state || rig_active || is_service_mode)) {
 			for (uint32_t ei = 0; ei < fov_save_count; ei++) {
 				fovs[ei] = kooima_fovs[ei];
 			}

--- a/src/xrt/targets/service/CMakeLists.txt
+++ b/src/xrt/targets/service/CMakeLists.txt
@@ -15,6 +15,15 @@ target_link_libraries(
 		target_instance
 	)
 
+# Workspace-controller discovery is cross-platform: registry-backed on Windows,
+# JSON-manifest-backed on POSIX (mirrors the plug-in loader). The minimal macOS
+# service orchestration in main.c uses the POSIX path to find + spawn a
+# registered controller (e.g. the macOS shell).
+target_sources(displayxr-service PRIVATE
+	service_workspace_registry.c
+	service_workspace_registry.h
+)
+
 # Delay-load Vulkan so the service can start on systems where it is absent.
 # The D3D11 service compositor path never calls into Vulkan functions, so the
 # delay-loaded DLL is never triggered. This mirrors the same pattern used by
@@ -35,8 +44,6 @@ if(WIN32)
 		service_orchestrator.h
 		service_tray_win.c
 		service_tray_win.h
-		service_workspace_registry.c
-		service_workspace_registry.h
 		service_resources.rc
 	)
 	target_link_libraries(displayxr-service PRIVATE shell32 ws2_32)

--- a/src/xrt/targets/service/service_workspace_registry.c
+++ b/src/xrt/targets/service/service_workspace_registry.c
@@ -242,21 +242,358 @@ service_workspace_registry_lookup(const char *id,
 
 #else // !XRT_OS_WINDOWS
 
-int
-service_workspace_registry_enumerate(struct workspace_controller_entry *out,
-                                     int max_entries)
+// POSIX discovery is JSON-manifest based, mirroring the plug-in loader
+// (`target_plugin_loader.c`): there is no registry, so each controller drops a
+// `<id>.json` manifest into a well-known directory and the runtime scans it.
+// Schema + roots documented in
+// `docs/specs/runtime/workspace-controller-registration.md` (POSIX section).
+
+#include "util/u_json.h"
+
+#include <dirent.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#ifndef PATH_MAX
+#define PATH_MAX 1024
+#endif
+
+//! Dev override: colon-separated list of dirs, like XRT_PLUGIN_SEARCH_PATH.
+#define WORKSPACE_CONTROLLER_PATH_ENV "XRT_WORKSPACE_CONTROLLER_PATH"
+
+//! Subpath under each Application Support / share root.
+#define WORKSPACE_CONTROLLER_SUBDIR "DisplayXR/WorkspaceControllers"
+
+static bool
+regular_file_exists(const char *path)
 {
-	(void)out;
-	(void)max_entries;
-	return 0;
+	struct stat st;
+	return path[0] != '\0' && stat(path, &st) == 0 && S_ISREG(st.st_mode);
+}
+
+//! Walk the optional `controller.actions` array and populate entry->actions[].
+//! Mirrors the Windows populate_actions() keep/skip rules: "separator" needs no
+//! label, every other type needs both a label and a type.
+static void
+populate_actions(const cJSON *controller, struct workspace_controller_entry *entry)
+{
+	const cJSON *actions = u_json_get(controller, "actions");
+	if (actions == NULL || !cJSON_IsArray(actions)) {
+		return; // Optional; tray falls back to hardcoded defaults.
+	}
+
+	const cJSON *node = NULL;
+	cJSON_ArrayForEach(node, actions)
+	{
+		if (entry->n_actions >= WORKSPACE_REGISTRY_MAX_ACTIONS) {
+			U_LOG_W("workspace registry: '%s' has more than %d actions; truncating", entry->id,
+			        WORKSPACE_REGISTRY_MAX_ACTIONS);
+			break;
+		}
+
+		struct workspace_controller_action *action = &entry->actions[entry->n_actions];
+		memset(action, 0, sizeof(*action));
+
+		const cJSON *label = u_json_get(node, "label");
+		if (label != NULL) {
+			(void)u_json_get_string_into_array(label, action->label, sizeof(action->label));
+		}
+		const cJSON *type = u_json_get(node, "type");
+		if (type != NULL) {
+			(void)u_json_get_string_into_array(type, action->type, sizeof(action->type));
+		}
+
+		bool keep = false;
+		if (strcmp(action->type, "separator") == 0) {
+			keep = true;
+		} else if (action->label[0] != '\0' && action->type[0] != '\0') {
+			keep = true;
+		}
+
+		if (keep) {
+			entry->n_actions++;
+		}
+	}
+}
+
+//! Parse one manifest file into @p entry. Returns true if the manifest is valid
+//! and its binary exists on disk. @p fallback_id is the basename minus ".json",
+//! used when the manifest omits an explicit `controller.id`.
+static bool
+parse_manifest(const char *path, const char *fallback_id, struct workspace_controller_entry *entry)
+{
+	FILE *f = fopen(path, "rb");
+	if (f == NULL) {
+		return false;
+	}
+	if (fseek(f, 0, SEEK_END) != 0) {
+		fclose(f);
+		return false;
+	}
+	long len = ftell(f);
+	if (len <= 0 || len > 64 * 1024) {
+		U_LOG_W("workspace registry: %s: implausible manifest size %ld.", path, len);
+		fclose(f);
+		return false;
+	}
+	if (fseek(f, 0, SEEK_SET) != 0) {
+		fclose(f);
+		return false;
+	}
+	char *buf = (char *)malloc((size_t)len + 1);
+	if (buf == NULL) {
+		fclose(f);
+		return false;
+	}
+	size_t got = fread(buf, 1, (size_t)len, f);
+	fclose(f);
+	if (got != (size_t)len) {
+		free(buf);
+		return false;
+	}
+	buf[len] = '\0';
+
+	cJSON *root = cJSON_Parse(buf);
+	free(buf);
+	if (root == NULL) {
+		U_LOG_W("workspace registry: %s: JSON parse failed.", path);
+		return false;
+	}
+
+	char fmt[16] = {0};
+	const cJSON *fmt_node = u_json_get(root, "file_format_version");
+	if (fmt_node != NULL) {
+		(void)u_json_get_string_into_array(fmt_node, fmt, sizeof(fmt));
+	}
+	if (strcmp(fmt, "1.0") != 0) {
+		U_LOG_W("workspace registry: %s: unsupported file_format_version='%s'.", path, fmt);
+		cJSON_Delete(root);
+		return false;
+	}
+
+	const cJSON *controller = u_json_get(root, "controller");
+	if (controller == NULL) {
+		U_LOG_W("workspace registry: %s: missing 'controller' object.", path);
+		cJSON_Delete(root);
+		return false;
+	}
+
+	memset(entry, 0, sizeof(*entry));
+
+	const cJSON *id_node = u_json_get(controller, "id");
+	if (id_node != NULL) {
+		(void)u_json_get_string_into_array(id_node, entry->id, sizeof(entry->id));
+	}
+	if (entry->id[0] == '\0') {
+		snprintf(entry->id, sizeof(entry->id), "%s", fallback_id);
+	}
+
+	const cJSON *binary_node = u_json_get(controller, "binary");
+	if (binary_node != NULL) {
+		(void)u_json_get_string_into_array(binary_node, entry->binary, sizeof(entry->binary));
+	}
+	if (entry->binary[0] == '\0') {
+		U_LOG_W("workspace registry: %s: required field 'controller.binary' missing.", path);
+		cJSON_Delete(root);
+		return false;
+	}
+	if (!regular_file_exists(entry->binary)) {
+		U_LOG_W("workspace registry: '%s' binary='%s' does not exist; skipping", entry->id, entry->binary);
+		cJSON_Delete(root);
+		return false;
+	}
+
+	const cJSON *dn = u_json_get(controller, "display_name");
+	if (dn != NULL) {
+		(void)u_json_get_string_into_array(dn, entry->display_name, sizeof(entry->display_name));
+	}
+	if (entry->display_name[0] == '\0') {
+		snprintf(entry->display_name, sizeof(entry->display_name), "Workspace Controller");
+	}
+
+	const cJSON *vendor = u_json_get(controller, "vendor");
+	if (vendor != NULL) {
+		(void)u_json_get_string_into_array(vendor, entry->vendor, sizeof(entry->vendor));
+	}
+	const cJSON *version = u_json_get(controller, "version");
+	if (version != NULL) {
+		(void)u_json_get_string_into_array(version, entry->version, sizeof(entry->version));
+	}
+	const cJSON *uninstall = u_json_get(controller, "uninstall_string");
+	if (uninstall != NULL) {
+		(void)u_json_get_string_into_array(uninstall, entry->uninstall_string,
+		                                   sizeof(entry->uninstall_string));
+	}
+
+	bool supports_file_dialog = false;
+	const cJSON *sfd = u_json_get(controller, "supports_file_dialog");
+	if (sfd != NULL && u_json_get_bool(sfd, &supports_file_dialog) && supports_file_dialog) {
+		entry->capabilities |= WORKSPACE_CAPABILITY_FILE_DIALOG;
+	}
+
+	populate_actions(controller, entry);
+
+	cJSON_Delete(root);
+	return true;
+}
+
+static bool
+already_have_id(const struct workspace_controller_entry *entries, int n, const char *id)
+{
+	for (int i = 0; i < n; i++) {
+		if (strcmp(entries[i].id, id) == 0) {
+			return true;
+		}
+	}
+	return false;
+}
+
+static void
+append_root(char roots[][PATH_MAX], int max_roots, int *n_roots, const char *path)
+{
+	if (path == NULL || *path == '\0' || *n_roots >= max_roots) {
+		return;
+	}
+	struct stat st;
+	if (stat(path, &st) != 0 || !S_ISDIR(st.st_mode)) {
+		return;
+	}
+	snprintf(roots[(*n_roots)++], PATH_MAX, "%s", path);
+}
+
+//! Assemble discovery roots in priority order (per-user shadows system).
+static int
+build_discovery_roots(char roots[][PATH_MAX], int max_roots)
+{
+	int n_roots = 0;
+
+	const char *override = getenv(WORKSPACE_CONTROLLER_PATH_ENV);
+	if (override != NULL && *override != '\0') {
+		const char *p = override;
+		while (*p && n_roots < max_roots) {
+			const char *colon = strchr(p, ':');
+			size_t len = colon ? (size_t)(colon - p) : strlen(p);
+			if (len > 0 && len < PATH_MAX) {
+				char buf[PATH_MAX];
+				memcpy(buf, p, len);
+				buf[len] = '\0';
+				append_root(roots, max_roots, &n_roots, buf);
+			}
+			if (!colon) {
+				break;
+			}
+			p = colon + 1;
+		}
+	}
+
+	const char *home = getenv("HOME");
+	char user_root[PATH_MAX];
+#ifdef __APPLE__
+	if (home != NULL && *home != '\0') {
+		snprintf(user_root, sizeof(user_root), "%s/Library/Application Support/" WORKSPACE_CONTROLLER_SUBDIR,
+		         home);
+		append_root(roots, max_roots, &n_roots, user_root);
+	}
+	append_root(roots, max_roots, &n_roots, "/Library/Application Support/" WORKSPACE_CONTROLLER_SUBDIR);
+#else
+	const char *xdg = getenv("XDG_DATA_HOME");
+	if (xdg != NULL && *xdg != '\0') {
+		snprintf(user_root, sizeof(user_root), "%s/" WORKSPACE_CONTROLLER_SUBDIR, xdg);
+		append_root(roots, max_roots, &n_roots, user_root);
+	} else if (home != NULL && *home != '\0') {
+		snprintf(user_root, sizeof(user_root), "%s/.local/share/" WORKSPACE_CONTROLLER_SUBDIR, home);
+		append_root(roots, max_roots, &n_roots, user_root);
+	}
+	append_root(roots, max_roots, &n_roots, "/usr/local/share/displayxr/WorkspaceControllers");
+	append_root(roots, max_roots, &n_roots, "/usr/share/displayxr/WorkspaceControllers");
+#endif
+
+	return n_roots;
+}
+
+//! Scan one directory for `*.json` manifests, appending valid+existing
+//! controllers to @p out[start..max). Earlier roots shadow later ones by id.
+static int
+enumerate_dir(const char *root, struct workspace_controller_entry *out, int start, int max)
+{
+	DIR *d = opendir(root);
+	if (d == NULL) {
+		return start;
+	}
+
+	int count = start;
+	struct dirent *de;
+	while ((de = readdir(d)) != NULL) {
+		if (count >= max) {
+			U_LOG_W("workspace registry: more than %d entries — truncating.", max);
+			break;
+		}
+		const char *name = de->d_name;
+		size_t n = strlen(name);
+		if (n < 6 || strcmp(name + n - 5, ".json") != 0) {
+			continue;
+		}
+
+		char manifest_path[PATH_MAX];
+		snprintf(manifest_path, sizeof(manifest_path), "%s/%s", root, name);
+
+		// Fallback id is the basename minus the ".json" suffix.
+		char fallback_id[64];
+		size_t stem = n - 5;
+		if (stem >= sizeof(fallback_id)) {
+			stem = sizeof(fallback_id) - 1;
+		}
+		memcpy(fallback_id, name, stem);
+		fallback_id[stem] = '\0';
+
+		struct workspace_controller_entry e;
+		if (!parse_manifest(manifest_path, fallback_id, &e)) {
+			continue;
+		}
+		if (already_have_id(out, count, e.id)) {
+			continue; // per-user shadows system-wide
+		}
+		out[count++] = e;
+	}
+	closedir(d);
+	return count;
+}
+
+int
+service_workspace_registry_enumerate(struct workspace_controller_entry *out, int max_entries)
+{
+	if (out == NULL || max_entries <= 0) {
+		return 0;
+	}
+
+	char roots[8][PATH_MAX];
+	int n_roots = build_discovery_roots(roots, 8);
+
+	int count = 0;
+	for (int i = 0; i < n_roots && count < max_entries; i++) {
+		count = enumerate_dir(roots[i], out, count, max_entries);
+	}
+	return count;
 }
 
 bool
-service_workspace_registry_lookup(const char *id,
-                                  struct workspace_controller_entry *out)
+service_workspace_registry_lookup(const char *id, struct workspace_controller_entry *out)
 {
-	(void)id;
-	(void)out;
+	if (id == NULL || id[0] == '\0' || out == NULL) {
+		return false;
+	}
+
+	struct workspace_controller_entry entries[WORKSPACE_REGISTRY_MAX_ENTRIES];
+	int count = service_workspace_registry_enumerate(entries, WORKSPACE_REGISTRY_MAX_ENTRIES);
+	for (int i = 0; i < count; i++) {
+		if (strcmp(entries[i].id, id) == 0) {
+			*out = entries[i];
+			return true;
+		}
+	}
 	return false;
 }
 

--- a/test_apps/cube_handle_vk_macos/main.mm
+++ b/test_apps/cube_handle_vk_macos/main.mm
@@ -2774,6 +2774,21 @@ static void PollForwardedInput(AppXrSession& xr) {
     if (XR_FAILED(r)) {
         return;
     }
+
+    // A successful enumerate means this is an IPC/service session (it returns
+    // XR_ERROR_FEATURE_UNSUPPORTED in-process, and fails before the session is
+    // begun). In service mode the service owns the on-screen render window and
+    // ignores the app's cocoa-bound view, so the app's own window is redundant
+    // and stays blank — hide it once (#48). Main thread (called from main loop).
+    static bool hidRedundantWindow = false;
+    if (!hidRedundantWindow) {
+        hidRedundantWindow = true;
+        if (g_window != nil) {
+            [g_window orderOut:nil];
+            [g_window setIsVisible:NO];
+            LOG_INFO("Service mode: hid the app's redundant window (service owns the render window)");
+        }
+    }
     for (uint32_t i = 0; i < count; i++) {
         const XrWorkspaceInputEventEXT& e = events[i];
         switch (e.eventType) {

--- a/test_apps/cube_handle_vk_macos/main.mm
+++ b/test_apps/cube_handle_vk_macos/main.mm
@@ -30,6 +30,7 @@
 #include <openxr/XR_EXT_display_info.h>
 #include <openxr/XR_EXT_atlas_capture.h>
 #include <openxr/XR_EXT_view_rig.h>
+#include <openxr/XR_EXT_spatial_workspace.h>
 
 #include <cmath>
 #include <csignal>
@@ -1697,6 +1698,73 @@ static bool CreateMacOSWindow(uint32_t width, uint32_t height) {
     return true;
 }
 
+// Apply a scroll-wheel tick to the view params. Shared by the in-process NSEvent
+// path and the OOP forwarded-input path (#48). mods bits: 0=SHIFT, 1=CTRL, 2=ALT
+// (the XR_EXT_spatial_workspace wire convention).
+static void ApplyScrollFactor(float dy, uint32_t mods) {
+    float factor = (dy > 0) ? 1.1f : (1.0f / 1.1f);
+    bool shift = (mods & (1u << 0)) != 0;
+    bool ctrl  = (mods & (1u << 1)) != 0;
+    bool alt   = (mods & (1u << 2)) != 0;
+    if (shift) {
+        g_input.viewParams.ipdFactor *= factor;
+        if (g_input.viewParams.ipdFactor < 0.0f) g_input.viewParams.ipdFactor = 0.0f;
+        if (g_input.viewParams.ipdFactor > 1.0f) g_input.viewParams.ipdFactor = 1.0f;
+    } else if (ctrl) {
+        g_input.viewParams.parallaxFactor *= factor;
+        if (g_input.viewParams.parallaxFactor < 0.0f) g_input.viewParams.parallaxFactor = 0.0f;
+        if (g_input.viewParams.parallaxFactor > 1.0f) g_input.viewParams.parallaxFactor = 1.0f;
+    } else if (alt) {
+        if (g_input.cameraMode) {
+            g_input.viewParams.invConvergenceDistance *= factor;
+            if (g_input.viewParams.invConvergenceDistance < 0.1f) g_input.viewParams.invConvergenceDistance = 0.1f;
+            if (g_input.viewParams.invConvergenceDistance > 10.0f) g_input.viewParams.invConvergenceDistance = 10.0f;
+        } else {
+            g_input.viewParams.perspectiveFactor *= factor;
+            if (g_input.viewParams.perspectiveFactor < 0.1f) g_input.viewParams.perspectiveFactor = 0.1f;
+            if (g_input.viewParams.perspectiveFactor > 10.0f) g_input.viewParams.perspectiveFactor = 10.0f;
+        }
+    } else {
+        if (g_input.cameraMode) {
+            g_input.viewParams.zoomFactor *= factor;
+            if (g_input.viewParams.zoomFactor < 0.1f) g_input.viewParams.zoomFactor = 0.1f;
+            if (g_input.viewParams.zoomFactor > 10.0f) g_input.viewParams.zoomFactor = 10.0f;
+        } else {
+            g_input.viewParams.scaleFactor *= factor;
+            if (g_input.viewParams.scaleFactor < 0.1f) g_input.viewParams.scaleFactor = 0.1f;
+            if (g_input.viewParams.scaleFactor > 10.0f) g_input.viewParams.scaleFactor = 10.0f;
+        }
+    }
+}
+
+// Apply a printable-character key to g_input. Shared by the in-process NSEvent
+// path and the OOP forwarded-input path (#48). Mirrors the per-character cases of
+// the NSEvent KeyDown/KeyUp handlers (mode keys v/0-8, WASD/EQ camera, etc.).
+static void ApplyCharKey(unichar ch, bool isDown, bool isRepeat) {
+    if (isDown) {
+        if (ch == 27) { g_running = false; }
+        else if (ch == 'w') { g_input.keyW = true; }
+        else if (ch == 'a') { g_input.keyA = true; }
+        else if (ch == 's') { g_input.keyS = true; }
+        else if (ch == 'd') { g_input.keyD = true; }
+        else if (ch == 'e') { g_input.keyE = true; }
+        else if (ch == 'q') { g_input.keyQ = true; }
+        else if (ch == ' ') { g_input.resetViewRequested = true; }
+        else if (ch == 'v' && !isRepeat) { g_input.cycleRenderingModeRequested = true; }
+        else if (ch == 't' && !isRepeat) { g_input.eyeTrackingModeToggleRequested = true; }
+        else if ((ch == 'i' || ch == 'I') && !isRepeat) { g_input.captureAtlasRequested = true; }
+        else if (ch == 'c' && !isRepeat) { g_input.rigModeToggleRequested = true; }
+        else if (ch >= '0' && ch <= '8' && !isRepeat) { g_input.absoluteRenderingModeRequested = (int32_t)(ch - '0'); }
+    } else {
+        if (ch == 'w') g_input.keyW = false;
+        else if (ch == 'a') g_input.keyA = false;
+        else if (ch == 's') g_input.keyS = false;
+        else if (ch == 'd') g_input.keyD = false;
+        else if (ch == 'e') g_input.keyE = false;
+        else if (ch == 'q') g_input.keyQ = false;
+    }
+}
+
 static void PumpMacOSEvents() {
     // Track whether left-click started in content area vs title bar.
     // Title bar drags should move the window, not rotate the scene.
@@ -1727,38 +1795,12 @@ static void PumpMacOSEvents() {
                     if (g_input.pitch < -1.4f) g_input.pitch = -1.4f;
                 }
             } else if (type == NSEventTypeScrollWheel) {
-                float dy = (float)[event scrollingDeltaY];
-                float factor = (dy > 0) ? 1.1f : (1.0f / 1.1f);
-                NSUInteger scrollMods = [event modifierFlags];
-                if (scrollMods & NSEventModifierFlagShift) {
-                    g_input.viewParams.ipdFactor *= factor;
-                    if (g_input.viewParams.ipdFactor < 0.0f) g_input.viewParams.ipdFactor = 0.0f;
-                    if (g_input.viewParams.ipdFactor > 1.0f) g_input.viewParams.ipdFactor = 1.0f;
-                } else if (scrollMods & NSEventModifierFlagControl) {
-                    g_input.viewParams.parallaxFactor *= factor;
-                    if (g_input.viewParams.parallaxFactor < 0.0f) g_input.viewParams.parallaxFactor = 0.0f;
-                    if (g_input.viewParams.parallaxFactor > 1.0f) g_input.viewParams.parallaxFactor = 1.0f;
-                } else if (scrollMods & NSEventModifierFlagOption) {
-                    if (g_input.cameraMode) {
-                        g_input.viewParams.invConvergenceDistance *= factor;
-                        if (g_input.viewParams.invConvergenceDistance < 0.1f) g_input.viewParams.invConvergenceDistance = 0.1f;
-                        if (g_input.viewParams.invConvergenceDistance > 10.0f) g_input.viewParams.invConvergenceDistance = 10.0f;
-                    } else {
-                        g_input.viewParams.perspectiveFactor *= factor;
-                        if (g_input.viewParams.perspectiveFactor < 0.1f) g_input.viewParams.perspectiveFactor = 0.1f;
-                        if (g_input.viewParams.perspectiveFactor > 10.0f) g_input.viewParams.perspectiveFactor = 10.0f;
-                    }
-                } else {
-                    if (g_input.cameraMode) {
-                        g_input.viewParams.zoomFactor *= factor;
-                        if (g_input.viewParams.zoomFactor < 0.1f) g_input.viewParams.zoomFactor = 0.1f;
-                        if (g_input.viewParams.zoomFactor > 10.0f) g_input.viewParams.zoomFactor = 10.0f;
-                    } else {
-                        g_input.viewParams.scaleFactor *= factor;
-                        if (g_input.viewParams.scaleFactor < 0.1f) g_input.viewParams.scaleFactor = 0.1f;
-                        if (g_input.viewParams.scaleFactor > 10.0f) g_input.viewParams.scaleFactor = 10.0f;
-                    }
-                }
+                NSUInteger sm = [event modifierFlags];
+                uint32_t mods = 0;
+                if (sm & NSEventModifierFlagShift) mods |= 1u << 0;
+                if (sm & NSEventModifierFlagControl) mods |= 1u << 1;
+                if (sm & NSEventModifierFlagOption) mods |= 1u << 2;
+                ApplyScrollFactor((float)[event scrollingDeltaY], mods);
             } else if (type == NSEventTypeKeyDown) {
                 // Cmd+Ctrl+F fullscreen toggle (keyCode 3 = 'f', ignores character remapping)
                 NSUInteger mods = [event modifierFlags];
@@ -1771,47 +1813,21 @@ static void PumpMacOSEvents() {
                 else if ([[event characters] length] > 0) {
                     unichar ch = tolower([[event characters] characterAtIndex:0]);
                     bool isRepeat = [event isARepeat];
-                    if (ch == 27) { g_running = false; }
-                    else if (ch == 'w') { g_input.keyW = true; }
-                    else if (ch == 'a') { g_input.keyA = true; }
-                    else if (ch == 's') { g_input.keyS = true; }
-                    else if (ch == 'd') { g_input.keyD = true; }
-                    else if (ch == 'e') { g_input.keyE = true; }
-                    else if (ch == 'q') { g_input.keyQ = true; }
-                    else if (ch == ' ') { g_input.resetViewRequested = true; }
-                    else if ([event keyCode] == 48 /* kVK_Tab */ && !isRepeat &&
-                             ([event modifierFlags] & NSEventModifierFlagShift)) {
+                    if ([event keyCode] == 48 /* kVK_Tab */ && !isRepeat &&
+                        ([event modifierFlags] & NSEventModifierFlagShift)) {
                         // SHIFT+TAB so bare TAB stays free for the workspace shell's
                         // focus-cycle binding (matches the Windows test apps).
                         // NSEvent.characters returns 0x19 (NSBackTabCharacter) for
                         // SHIFT+TAB, not '\t' — gate on the hardware keyCode.
                         g_input.hudVisible = !g_input.hudVisible;
-                    }
-                    else if (ch == 'v' && !isRepeat) {
-                        g_input.cycleRenderingModeRequested = true;
-                    }
-                    else if (ch == 't' && !isRepeat) {
-                        g_input.eyeTrackingModeToggleRequested = true;
-                    }
-                    else if ((ch == 'i' || ch == 'I') && !isRepeat) {
-                        g_input.captureAtlasRequested = true;
-                    }
-                    else if (ch == 'c' && !isRepeat) {
-                        g_input.rigModeToggleRequested = true;
-                    }
-                    else if (ch >= '0' && ch <= '8' && !isRepeat) {
-                        g_input.absoluteRenderingModeRequested = (int32_t)(ch - '0');
+                    } else {
+                        ApplyCharKey(ch, true, isRepeat);
                     }
                 }
             } else if (type == NSEventTypeKeyUp) {
                 if ([[event characters] length] > 0) {
                     unichar ch = tolower([[event characters] characterAtIndex:0]);
-                    if (ch == 'w') g_input.keyW = false;
-                    else if (ch == 'a') g_input.keyA = false;
-                    else if (ch == 's') g_input.keyS = false;
-                    else if (ch == 'd') g_input.keyD = false;
-                    else if (ch == 'e') g_input.keyE = false;
-                    else if (ch == 'q') g_input.keyQ = false;
+                    ApplyCharKey(ch, false, false);
                 }
             }
 
@@ -1941,6 +1957,12 @@ struct AppXrSession {
     bool hasAtlasCaptureExt = false;
     bool hasViewRigExt = false;  // XR_EXT_view_rig (#396 W7)
     PFN_xrCaptureAtlasEXT pfnCaptureAtlasEXT = nullptr;
+
+    // XR_EXT_spatial_workspace (#48): when running OOP via the service, the
+    // service window owns keyboard/mouse focus, so the app polls forwarded input
+    // events here instead of its own (unfocused) NSWindow.
+    bool hasSpatialWorkspaceExt = false;
+    PFN_xrEnumerateWorkspaceInputEventsEXT pfnEnumerateWorkspaceInputEventsEXT = nullptr;
     // Enumerated rendering mode info. currentModeIndex is initialized to mode 1
     // as a fallback for runtimes that don't expose isActive; v13+ runtimes
     // replace it via the enumerate step (initial-mode-sync, #234/#239).
@@ -1995,6 +2017,9 @@ static bool InitializeOpenXR(AppXrSession& xr) {
         if (strcmp(ext.extensionName, XR_EXT_VIEW_RIG_EXTENSION_NAME) == 0) {
             xr.hasViewRigExt = true;
         }
+        if (strcmp(ext.extensionName, XR_EXT_SPATIAL_WORKSPACE_EXTENSION_NAME) == 0) {
+            xr.hasSpatialWorkspaceExt = true;
+        }
     }
 
     if (!hasVulkan) {
@@ -2022,6 +2047,10 @@ static bool InitializeOpenXR(AppXrSession& xr) {
     if (xr.hasViewRigExt) {
         enabledExtensions.push_back(XR_EXT_VIEW_RIG_EXTENSION_NAME);
     }
+    if (xr.hasSpatialWorkspaceExt) {
+        enabledExtensions.push_back(XR_EXT_SPATIAL_WORKSPACE_EXTENSION_NAME);
+    }
+    LOG_INFO("XR_EXT_spatial_workspace: %s", xr.hasSpatialWorkspaceExt ? "available" : "not available");
 
     XrInstanceCreateInfo createInfo = {XR_TYPE_INSTANCE_CREATE_INFO};
     strncpy(createInfo.applicationInfo.applicationName, "SimCubeExtMacOS", XR_MAX_APPLICATION_NAME_SIZE);
@@ -2090,6 +2119,14 @@ static bool InitializeOpenXR(AppXrSession& xr) {
             xrGetInstanceProcAddr(xr.instance, "xrCaptureAtlasEXT",
                 (PFN_xrVoidFunction*)&xr.pfnCaptureAtlasEXT);
             LOG_INFO("xrCaptureAtlasEXT: %s", xr.pfnCaptureAtlasEXT ? "resolved" : "NULL");
+        }
+
+        // XR_EXT_spatial_workspace (#48): forwarded keyboard/mouse for the OOP route.
+        if (xr.hasSpatialWorkspaceExt) {
+            xrGetInstanceProcAddr(xr.instance, "xrEnumerateWorkspaceInputEventsEXT",
+                (PFN_xrVoidFunction*)&xr.pfnEnumerateWorkspaceInputEventsEXT);
+            LOG_INFO("xrEnumerateWorkspaceInputEventsEXT: %s",
+                xr.pfnEnumerateWorkspaceInputEventsEXT ? "resolved" : "NULL");
         }
 
         // Load eye tracking mode request function pointer
@@ -2719,6 +2756,66 @@ static void SignalHandler(int sig) {
     g_running = false;
 }
 
+// Poll keyboard/mouse forwarded by the service over IPC (#48). When the app runs
+// OOP, the service window owns input focus, so the app's own NSWindow gets no
+// events — these arrive via XR_EXT_spatial_workspace instead and drive the SAME
+// g_input state the in-process NSEvent path does. No-op in-process (the enumerate
+// call requires an IPC-mode session and returns an error otherwise).
+static void PollForwardedInput(AppXrSession& xr) {
+    if (xr.pfnEnumerateWorkspaceInputEventsEXT == nullptr) {
+        return;
+    }
+    // Drag origin for left-button camera rotation; INT32_MIN = not dragging.
+    static int32_t lastDragX = INT32_MIN, lastDragY = INT32_MIN;
+
+    XrWorkspaceInputEventEXT events[16];
+    uint32_t count = 0;
+    XrResult r = xr.pfnEnumerateWorkspaceInputEventsEXT(xr.session, 16, &count, events);
+    if (XR_FAILED(r)) {
+        return;
+    }
+    for (uint32_t i = 0; i < count; i++) {
+        const XrWorkspaceInputEventEXT& e = events[i];
+        switch (e.eventType) {
+        case XR_WORKSPACE_INPUT_EVENT_KEY_EXT:
+            // Producer encodes the lowercased Unicode character in vkCode.
+            ApplyCharKey((unichar)e.key.vkCode, e.key.isDown != 0, false);
+            break;
+        case XR_WORKSPACE_INPUT_EVENT_POINTER_MOTION_EXT: {
+            bool leftHeld = (e.pointerMotion.buttonMask & 1u) != 0;
+            int32_t cx = e.pointerMotion.cursorX, cy = e.pointerMotion.cursorY;
+            if (leftHeld) {
+                if (lastDragX != INT32_MIN) {
+                    // Cursor is window-space (y-up): the y delta is the negation
+                    // of NSEvent.deltaY, so pitch ADDS dy to match the in-process
+                    // sign (yaw matches deltaX directly).
+                    float dx = (float)(cx - lastDragX);
+                    float dy = (float)(cy - lastDragY);
+                    g_input.yaw   -= dx * 0.005f;
+                    g_input.pitch += dy * 0.005f;
+                    if (g_input.pitch > 1.4f) g_input.pitch = 1.4f;
+                    if (g_input.pitch < -1.4f) g_input.pitch = -1.4f;
+                }
+                lastDragX = cx;
+                lastDragY = cy;
+            } else {
+                lastDragX = INT32_MIN; // button released between motion events
+            }
+            break;
+        }
+        case XR_WORKSPACE_INPUT_EVENT_POINTER_EXT:
+            if (e.pointer.button == 1 && e.pointer.isDown == 0) {
+                lastDragX = INT32_MIN; // left mouse up ends the drag
+            }
+            break;
+        case XR_WORKSPACE_INPUT_EVENT_SCROLL_EXT:
+            ApplyScrollFactor(e.scroll.deltaY, e.scroll.modifiers);
+            break;
+        default: break;
+        }
+    }
+}
+
 int main() {
     // Ensure logs appear immediately even when piped
     setvbuf(stdout, NULL, _IONBF, 0);
@@ -2913,6 +3010,7 @@ int main() {
 
     while (g_running && !xr.exitRequested) {
         PumpMacOSEvents();
+        PollForwardedInput(xr); // OOP: keyboard/mouse forwarded by the service (#48)
 
         auto now = std::chrono::high_resolution_clock::now();
         float deltaTime = std::chrono::duration<float>(now - lastTime).count();

--- a/test_apps/cube_hosted_legacy_vk_macos/main.cpp
+++ b/test_apps/cube_hosted_legacy_vk_macos/main.cpp
@@ -1490,7 +1490,12 @@ static void RenderScene(
         // Draw textured cube
         {
             const float cubeSize = 0.3f;
-            const float cubeHeight = 1.6f;
+            // Display-centered: the 3D-display camera sits at the nominal viewer
+            // (eye Y=0 in front of the screen), so content lives near Y=0, not at
+            // VR standing height. cubeSize/2 rests it on the Y=0 grid floor, like
+            // the cube_handle_* apps. (The old 1.6 put it ~38° above an 18.5°
+            // vertical frame → off-screen in service mode.)
+            const float cubeHeight = cubeSize / 2.0f;
 
             float rot[16], scl[16], trans[16], model[16], tmp[16];
             mat4_rotation_y(rot, renderer.cubeRotation);


### PR DESCRIPTION
First working macOS out-of-process (service-mode) compositor for DisplayXR — the Tier‑1 single‑app path from issue #48. An OpenXR app rendering through `displayxr-service` on macOS now gets correct 3D‑display projection, live keyboard/mouse, runtime mode switching, and clean teardown, using the generic `null + comp_multi + comp_window_macos` path (no D3D11‑service monolith).

Validate with the **aware** handle app forced onto the service (it can't pass an NSView across processes, so the service owns the render window):
```
displayxr-service &
XRT_FORCE_MODE=ipc SIM_DISPLAY_OUTPUT=anaglyph cube_handle_vk_macos
```

## What's in here
- **Tier‑1 OOP service compositor** (`comp_window_macos` + null compositor `VK_EXT_metal_surface` branch + comp_multi `use_macos_surface` + the AppKit/GCD main‑thread pump that resolves the kqueue‑vs‑NSApp hazard). POSIX workspace‑controller discovery (JSON manifest).
- **View poses sourced from the DP, not the device** — the hosted null/multi path was running the device `get_view_poses`, contaminated by the qwerty 1.6 m head pose → steep‑sliver FOV. New `ipc_try_get_oop_view_poses` (generalized from the Android helper) sources eyes from the generic `xrt_display_processor` and folds them through the shared Kooima core. Client side: hosted OOP service sessions now skip the `T_base_head` world transform (it re‑added the same 1.6 m).
- **N‑view** — the helper computes one Kooima view per active view from the DP's `view_eye_offsets` (Quad's elevated upper row no longer flattens). Nothing special about 2 views.
- **Keyboard/mouse forwarding + mode switching over IPC** — generic service‑side input‑event queue fed by the AppKit pump's NSEvent capture, drained over `XR_EXT_spatial_workspace`; the app polls and drives the same input handler. `request_rendering_mode` now drives the server head device's `OUTPUT_MODE` so the per‑session render and the DP actually switch modes.
- **All render modes correct across mode cycling** — per‑session atlas now rebuilds on grid change (was keyed on per‑tile dims, blind to 2×1 vs 1×2), fixing Cropped SBS after cycling; uncovered tiles are cleared to kill the one‑frame magenta flash on the Quad switch.
- **Robustness/UX** — closing the service window no longer crashes (`NSWindow.releasedWhenClosed = NO`); the app's redundant binding window is hidden in service mode.

## Verified on macOS (live)
2D, anaglyph, Cropped SBS, squeezed‑SBS, Quad; live keyboard/mouse; mode switching across full V‑cycling; clean service window‑close.

## Scope / safety
macOS‑specific paths are guarded (`XRT_OS_MACOS`); the cross‑platform fixes (atlas‑cache rebuild, uncovered‑tile clear in `comp_multi`) also benefit the Android OOP path. Windows uses the D3D11 service compositor and is unaffected. Includes one revert pair (`efbb8301c` → `bdee4383a`) documenting a false‑start client‑side FOV approach that was replaced by the server‑side DP sourcing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)