### PR TITLE
fix(oxr): #615 hold eye-set/mode coherence across rendering-mode switch

### DIFF
--- a/src/xrt/state_trackers/oxr/oxr_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_session.c
@@ -1779,6 +1779,40 @@ oxr_session_locate_views(struct oxr_logger *log,
 
 	bool have_eyes = got_eye_positions && eye_pos.valid;
 
+	// #615 eye-set/mode coherence guard at a rendering-mode switch.
+	//
+	// At a 2D->3D switch the runtime flips the active mode to N views on the
+	// request frame, but the DP's predicted-eye set lags by up to one frame:
+	// it still reports the single centered 2D eye (count=1, sep=0) for one
+	// locate before catching up to N tracked eyes. Consuming that stale set in
+	// an N-view mode leaves the surplus view(s) without a tracked eye, so they
+	// fall back to device-default (full-disparity, off-axis) FOV below — a
+	// one-frame full-disparity snap the app's per-frame IPD ramp can't absorb.
+	// It's a race (DP update vs mode flip), hence intermittent (issue #615).
+	//
+	// Hold coherence: when the DP under-reports for the active mode, duplicate
+	// the last reported eye into the surplus slots so every view renders from
+	// the (centered) mono eye — a flat frame that matches the just-ended 2D
+	// state. The next frame the DP delivers N eyes and the ramp proceeds from
+	// flat. The mode's view count is untouched (atlas recipe = the MODE); only
+	// the eye-set is made consistent with it for the lagging frame.
+	if (have_eyes && eye_pos.count >= 1 && eye_pos.count < active_view_count &&
+	    active_view_count <= XRT_MAX_VIEWS) {
+		uint32_t under = eye_pos.count;
+		for (uint32_t ei = under; ei < active_view_count; ei++) {
+			eye_pos.eyes[ei] = eye_pos.eyes[under - 1];
+		}
+		eye_pos.count = active_view_count;
+		static bool warned_coherence_guard = false;
+		if (!warned_coherence_guard) {
+			warned_coherence_guard = true;
+			U_LOG_W("#615: DP under-reported %u eye(s) for a %u-view mode at a mode "
+			        "switch; duplicating last eye into surplus slot(s) to hold "
+			        "coherence (avoids a one-frame full-disparity snap). Logged once.",
+			        under, active_view_count);
+		}
+	}
+
 	// Kooima FOV computation (vendor-neutral)
 	// Works with either tracked eye positions or nominal viewer position
 	{


### PR DESCRIPTION
## Summary
Fixes the intermittent **full-disparity snap** on a 2D→3D rendering-mode switch (issue #615, Ask 1). An app-side per-frame IPD ramp on the `XR_EXT_view_rig` descriptor was being defeated by a one-frame disparity pop right around `xrRequestDisplayRenderingModeEXT`.

## Root cause (hardware-confirmed)
Per-frame eye-set logging showed it is **not** eye loss (`is_tracking=1` throughout), **not** the runtime view-math dropping the ramp (`eff_ipd` fed to `dxr_*_compute_views` stayed smooth), and **not** a tracker warm-up. It's an **eye-set/mode coherence race**:

- The runtime flips the active mode to N views on the request frame.
- The DP's `get_predicted_eye_positions` lags by up to one locate — it reports 2D as **one** centered eye (`count=1, sep=0`) and 3D as **two** (`count=2, sep≈0.059`), and for one frame still returns the stale 2D set in the new N-view mode.
- The surplus view(s) then have no tracked eye and fall back to **device-default (full-disparity, off-axis) FOV** → a one-frame snap the ramp can't absorb.

It's a race (DP update vs mode flip), hence intermittent — observed snapping on **3 of 4** switches; smooth only when the DP already had N eyes on frame one.

## Fix
In `oxr_session_locate_views`, when the DP under-reports eyes for the active mode, duplicate the last reported eye into the surplus slots so every view renders from the centered mono eye — a flat frame matching the just-ended 2D state. Next frame the DP delivers N eyes and the ramp proceeds from flat. The **mode's view count is untouched** (atlas recipe = the MODE); only the eye-set is made consistent with it for the lagging frame. Runtime-only; no ABI/DP/plugin change.

## Validation
Leia SR hardware, D3D12, display-zones path, `displayxr-unity-test-transparent` (V toggle): all 2D→3D transitions now smooth. Confirmed by reporter.

## Not in scope
Issue #615 **Ask 2** (a mode-engage-complete event / queryable engaged flag) is a separate enhancement and is **not** addressed here — see the issue thread for a follow-up note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)