### PR TITLE
feat(macos,#48): composite workspace controller chrome in the generic comp_multi path

### DIFF
--- a/src/xrt/compositor/CMakeLists.txt
+++ b/src/xrt/compositor/CMakeLists.txt
@@ -239,6 +239,7 @@ endif()
 add_library(
 	comp_multi STATIC multi/comp_multi_compositor.c multi/comp_multi_interface.h
 			  multi/comp_multi_private.h multi/comp_multi_system.c
+			  multi/comp_multi_workspace.c multi/comp_multi_workspace.h
 	)
 target_link_libraries(
 	comp_multi

--- a/src/xrt/compositor/client/comp_vk_client.c
+++ b/src/xrt/compositor/client/comp_vk_client.c
@@ -55,6 +55,23 @@ to_native_swapchain(struct xrt_swapchain *xsc)
 }
 
 /*!
+ * Public unwrap for the workspace EXT path (oxr_workspace.c, #48): reach the
+ * inner native (IPC) swapchain from a Vulkan client swapchain so the runtime
+ * can read its IPC swapchain id. Mirrors comp_d3d11_client_get_inner_xrt_swapchain.
+ * A VK session that also acts as a workspace controller (creating chrome/cursor/
+ * overlay swapchains) needs this — its swapchains are client_vk_swapchain-wrapped,
+ * unlike a pure WORKSPACE_CONTROLLER session whose swapchains are already native.
+ */
+struct xrt_swapchain *
+comp_vk_client_get_inner_xrt_swapchain(struct xrt_swapchain *xsc)
+{
+	if (xsc == NULL) {
+		return NULL;
+	}
+	return &client_vk_swapchain(xsc)->xscn->base;
+}
+
+/*!
  * Down-cast helper.
  *
  * @private @memberof client_vk_compositor

--- a/src/xrt/compositor/multi/comp_multi_compositor.c
+++ b/src/xrt/compositor/multi/comp_multi_compositor.c
@@ -34,6 +34,7 @@
 #include "util/u_distortion_mesh.h"
 
 #include "multi/comp_multi_private.h"
+#include "multi/comp_multi_workspace.h"
 #include "main/comp_target.h"
 
 // Vulkan helpers needed for Y-flip SBS cleanup (not Leia-specific)
@@ -1300,6 +1301,10 @@ multi_compositor_destroy(struct xrt_compositor *xc)
 
 	struct multi_compositor *mc = multi_compositor(xc);
 
+	// Drop any workspace chrome registered for this client (#48) so a reused
+	// compositor pointer never inherits a stale entry / dangling swapchain ref.
+	comp_multi_workspace_chrome_clear(xc);
+
 	if (mc->state.session_active) {
 		multi_system_compositor_update_session_status(mc->msc, false);
 		mc->state.session_active = false;
@@ -1406,6 +1411,13 @@ multi_compositor_destroy(struct xrt_compositor *xc)
 			mc->session_render.hud_gpu_initialized = false;
 		}
 		u_hud_destroy(&mc->session_render.hud);
+
+		// Destroy workspace chrome blend (#48) — its own flag, independent of
+		// the HUD (chrome can be present without the FPS HUD being enabled).
+		if (vk != NULL && mc->session_render.chrome_blend_initialized) {
+			vk_hud_blend_fini(&mc->session_render.chrome_blend, vk);
+			mc->session_render.chrome_blend_initialized = false;
+		}
 
 		// Destroy fences (generic Vulkan)
 		if (vk != NULL && mc->session_render.fences != NULL) {

--- a/src/xrt/compositor/multi/comp_multi_private.h
+++ b/src/xrt/compositor/multi/comp_multi_private.h
@@ -394,6 +394,16 @@ struct multi_compositor
 		float hud_smoothed_frame_time_ms;
 		//! @}
 
+		//! @name Workspace chrome overlay (#48)
+		//! Alpha-blend pipeline + a controller-submitted chrome swapchain
+		//! (title pill etc.) composited post-weave over this client's content,
+		//! like the HUD. Looked up from comp_multi_workspace by this mc's
+		//! compositor pointer; sibling of @ref hud_blend.
+		//! @{
+		struct vk_hud_blend chrome_blend;
+		bool chrome_blend_initialized;
+		//! @}
+
 		//! Saved device output mode before 2D switch (-1 = none saved)
 		int saved_output_mode;
 

--- a/src/xrt/compositor/multi/comp_multi_system.c
+++ b/src/xrt/compositor/multi/comp_multi_system.c
@@ -40,6 +40,7 @@
 
 #include "multi/comp_multi_private.h"
 #include "multi/comp_multi_interface.h"
+#include "multi/comp_multi_workspace.h"
 #include "main/comp_target.h"
 
 // Per-session rendering support (Phase 4)
@@ -2176,6 +2177,138 @@ session_render_hud_overlay(struct multi_compositor *mc,
 }
 
 /*!
+ * Composite the workspace controller's chrome (e.g. a title pill) over this
+ * client's woven content, post-weave, as a flat alpha-blended 2D overlay — the
+ * same model as @ref session_render_hud_overlay (#48). The chrome swapchain is
+ * registered by the controller through the workspace IPC handlers and looked up
+ * here by this client's compositor pointer (== @p ics->xc). v1 is axis-aligned
+ * and zero-disparity (flat at the screen plane); per-eye / perspective chrome is
+ * the deferred Tier-2 work the D3D11 monolith does.
+ *
+ * Layout mirrors the HUD: the chrome source goes GENERAL → SHADER_READ_ONLY →
+ * GENERAL (shared cross-process images rest in GENERAL between uses, see
+ * @ref composite_local_2d_layers); the target is taken/left in PRESENT_SRC by
+ * @ref vk_hud_blend_draw.
+ */
+static void
+session_render_chrome_overlay(struct multi_compositor *mc,
+                              struct vk_bundle *vk,
+                              VkCommandBuffer cmd,
+                              VkImage swapchain_image,
+                              VkImageView swapchain_view,
+                              uint32_t fb_width,
+                              uint32_t fb_height)
+{
+	// Look up chrome registered for this client compositor (== ics->xc).
+	struct xrt_swapchain *chrome_xsc = NULL;
+	struct comp_multi_chrome_layout layout;
+	if (!comp_multi_workspace_chrome_get(&mc->base.base, &chrome_xsc, &layout)) {
+		return; // No chrome for this client — the common case.
+	}
+
+	struct comp_swapchain *sc = comp_swapchain(chrome_xsc);
+	if (sc == NULL || sc->vkic.image_count == 0) {
+		return;
+	}
+	// Single-image chrome contract (matches the D3D11 service, which samples
+	// images[0]): the controller renders its chrome once into image 0.
+	VkImage chrome_image = sc->vkic.images[0].handle;
+	uint32_t chrome_w = sc->vkic.info.width;
+	uint32_t chrome_h = sc->vkic.info.height;
+	if (chrome_image == VK_NULL_HANDLE || chrome_w == 0 || chrome_h == 0) {
+		return;
+	}
+
+	// Lazy-init the chrome blend pipeline (sibling of hud_blend).
+	if (!mc->session_render.chrome_blend_initialized) {
+		if (!vk_hud_blend_init(&mc->session_render.chrome_blend, vk, mc->session_render.target->format)) {
+			U_LOG_E("[chrome] Failed to init alpha-blend pipeline");
+			return;
+		}
+		mc->session_render.chrome_blend_initialized = true;
+		U_LOG_W("[chrome] Workspace chrome blend pipeline initialized");
+	}
+
+	// Display dims (meters) → pixels-per-meter on this window. Prefer the DP,
+	// fall back to the system compositor info — exactly like the HUD path.
+	float disp_w_m = 0.0f, disp_h_m = 0.0f;
+	if (mc->session_render.display_processor != NULL) {
+		float dw = 0.0f, dh = 0.0f;
+		if (xrt_display_processor_get_display_dimensions(mc->session_render.display_processor, &dw, &dh)) {
+			disp_w_m = dw;
+			disp_h_m = dh;
+		}
+	}
+	if (disp_w_m <= 0.0f || disp_h_m <= 0.0f) {
+		const struct xrt_system_compositor_info *info = &mc->msc->base.info;
+		disp_w_m = info->display_width_m;
+		disp_h_m = info->display_height_m;
+	}
+	if (disp_w_m <= 0.0f || disp_h_m <= 0.0f) {
+		return; // Can't map meters → pixels.
+	}
+	float px_per_m_x = (float)fb_width / disp_w_m;
+	float px_per_m_y = (float)fb_height / disp_h_m;
+
+	// Chrome extent in meters (fraction-of-window width if the controller asked).
+	float chrome_w_m =
+	    (layout.width_as_fraction_of_window > 0.0f) ? disp_w_m * layout.width_as_fraction_of_window : layout.size_w_m;
+	float chrome_h_m = layout.size_h_m;
+	if (chrome_w_m <= 0.0f || chrome_h_m <= 0.0f) {
+		return;
+	}
+
+	// Center in window-local meters. Top-edge anchor: pose.y is an offset from
+	// the window's top edge (matches the D3D11 service convention).
+	float cx_m = layout.pose_in_client.position.x;
+	float cy_m = layout.anchor_to_window_top_edge ? (disp_h_m * 0.5f + layout.pose_in_client.position.y)
+	                                               : layout.pose_in_client.position.y;
+
+	// Window-local meters → target pixels (origin at center; +y up → -y down).
+	float cx_px = (float)fb_width * 0.5f + cx_m * px_per_m_x;
+	float cy_px = (float)fb_height * 0.5f - cy_m * px_per_m_y;
+	float w_px = chrome_w_m * px_per_m_x;
+	float h_px = chrome_h_m * px_per_m_y;
+
+	int32_t dst_x = (int32_t)(cx_px - w_px * 0.5f);
+	int32_t dst_y = (int32_t)(cy_px - h_px * 0.5f);
+	uint32_t dst_w = (uint32_t)(w_px + 0.5f);
+	uint32_t dst_h = (uint32_t)(h_px + 0.5f);
+	if (dst_w == 0 || dst_h == 0) {
+		return;
+	}
+
+	// Chrome source GENERAL → SHADER_READ_ONLY (the blend samples it).
+	VkImageMemoryBarrier to_src = {
+	    .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+	    .srcAccessMask = 0,
+	    .dstAccessMask = VK_ACCESS_SHADER_READ_BIT,
+	    .oldLayout = VK_IMAGE_LAYOUT_GENERAL,
+	    .newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+	    .image = chrome_image,
+	    .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1},
+	};
+	vk->vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, 0, 0,
+	                         NULL, 0, NULL, 1, &to_src);
+
+	vk_hud_blend_draw(&mc->session_render.chrome_blend, vk, cmd, swapchain_view, swapchain_image, fb_width,
+	                   fb_height, chrome_image, chrome_w, chrome_h, dst_x, dst_y, dst_w, dst_h);
+
+	// Restore chrome source → GENERAL for the controller's next frame.
+	VkImageMemoryBarrier to_general = {
+	    .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+	    .srcAccessMask = VK_ACCESS_SHADER_READ_BIT,
+	    .dstAccessMask = 0,
+	    .oldLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+	    .newLayout = VK_IMAGE_LAYOUT_GENERAL,
+	    .image = chrome_image,
+	    .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1},
+	};
+	vk->vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0, 0,
+	                         NULL, 0, NULL, 1, &to_general);
+}
+
+/*!
  * Render a single per-session client to its own comp_target using display processing.
  *
  * @param mc The multi_compositor with per-session rendering
@@ -2783,6 +2916,13 @@ submit_and_present:
 	session_render_hud_overlay(mc, vk, cmd, ct->images[buffer_index].handle,
 	                           ct->images[buffer_index].view,
 	                           framebufferWidth, framebufferHeight);
+
+	// Workspace chrome (title pill etc.) the controller registered for this
+	// client — composited post-weave over the HUD, flat at the screen plane
+	// (#48). No-op (single map lookup) when no controller decorated this client.
+	session_render_chrome_overlay(mc, vk, cmd, ct->images[buffer_index].handle,
+	                              ct->images[buffer_index].view,
+	                              framebufferWidth, framebufferHeight);
 
 	// End command buffer
 	ret = vk->vkEndCommandBuffer(cmd);

--- a/src/xrt/compositor/multi/comp_multi_workspace.c
+++ b/src/xrt/compositor/multi/comp_multi_workspace.c
@@ -1,0 +1,189 @@
+// Copyright 2026, Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  Generic workspace-controller chrome registry (macOS shell Tier 1, #48).
+ * @ingroup comp_multi
+ */
+
+#include "comp_multi_workspace.h"
+
+#include "xrt/xrt_compositor.h" // xrt_swapchain_reference
+
+#include "os/os_threading.h"
+
+#include <string.h>
+
+// Chrome decorates managed content windows; a handful is plenty for Tier 1.
+#define CHROME_MAX_ENTRIES 16
+
+struct chrome_entry
+{
+	struct xrt_compositor *target_xc; //!< Key: per-client compositor (== ics->xc == multi_compositor). NULL = free.
+	struct xrt_swapchain *xsc;        //!< Strong ref to the controller's chrome swapchain.
+	uint32_t swapchain_id;            //!< Controller-side IPC swapchain id (unregister key).
+	struct comp_multi_chrome_layout layout;
+	bool layout_valid;
+};
+
+// One process-global table; the service is a single process. The mutex is
+// initialized on first use (no global ctor in C) — guarded by g_lock_once.
+static struct os_mutex g_lock;
+static bool g_lock_ready = false;
+static struct chrome_entry g_entries[CHROME_MAX_ENTRIES];
+
+static void
+ensure_lock(void)
+{
+	// Benign race on first call is avoided in practice: the first chrome RPC
+	// arrives long after the single-threaded service start. os_mutex_init is
+	// idempotent enough for our single init; keep it simple.
+	if (!g_lock_ready) {
+		os_mutex_init(&g_lock);
+		g_lock_ready = true;
+	}
+}
+
+// Caller must hold g_lock.
+static struct chrome_entry *
+find_locked(struct xrt_compositor *target_xc)
+{
+	if (target_xc == NULL) {
+		return NULL;
+	}
+	for (int i = 0; i < CHROME_MAX_ENTRIES; i++) {
+		if (g_entries[i].target_xc == target_xc) {
+			return &g_entries[i];
+		}
+	}
+	return NULL;
+}
+
+// Caller must hold g_lock.
+static struct chrome_entry *
+find_or_add_locked(struct xrt_compositor *target_xc)
+{
+	struct chrome_entry *e = find_locked(target_xc);
+	if (e != NULL) {
+		return e;
+	}
+	for (int i = 0; i < CHROME_MAX_ENTRIES; i++) {
+		if (g_entries[i].target_xc == NULL) {
+			g_entries[i].target_xc = target_xc;
+			return &g_entries[i];
+		}
+	}
+	return NULL; // Table full.
+}
+
+// Caller must hold g_lock. Releases the strong ref and zeroes the slot.
+static void
+free_entry_locked(struct chrome_entry *e)
+{
+	if (e->xsc != NULL) {
+		xrt_swapchain_reference(&e->xsc, NULL);
+	}
+	memset(e, 0, sizeof(*e));
+}
+
+void
+comp_multi_workspace_chrome_register(struct xrt_compositor *target_xc,
+                                     uint32_t swapchain_id,
+                                     struct xrt_swapchain *xsc)
+{
+	if (target_xc == NULL || xsc == NULL) {
+		return;
+	}
+	ensure_lock();
+	os_mutex_lock(&g_lock);
+	struct chrome_entry *e = find_or_add_locked(target_xc);
+	if (e != NULL) {
+		// Swap the strong ref (drops a prior chrome swapchain if re-registering).
+		xrt_swapchain_reference(&e->xsc, xsc);
+		e->swapchain_id = swapchain_id;
+	}
+	os_mutex_unlock(&g_lock);
+}
+
+void
+comp_multi_workspace_chrome_unregister_by_id(uint32_t swapchain_id)
+{
+	ensure_lock();
+	os_mutex_lock(&g_lock);
+	for (int i = 0; i < CHROME_MAX_ENTRIES; i++) {
+		if (g_entries[i].target_xc != NULL && g_entries[i].xsc != NULL &&
+		    g_entries[i].swapchain_id == swapchain_id) {
+			free_entry_locked(&g_entries[i]);
+		}
+	}
+	os_mutex_unlock(&g_lock);
+}
+
+void
+comp_multi_workspace_chrome_set_layout(struct xrt_compositor *target_xc,
+                                       const struct comp_multi_chrome_layout *layout)
+{
+	if (target_xc == NULL || layout == NULL) {
+		return;
+	}
+	ensure_lock();
+	os_mutex_lock(&g_lock);
+	struct chrome_entry *e = find_or_add_locked(target_xc);
+	if (e != NULL) {
+		e->layout = *layout;
+		e->layout_valid = true;
+	}
+	os_mutex_unlock(&g_lock);
+}
+
+void
+comp_multi_workspace_chrome_update_pose(struct xrt_compositor *target_xc, const struct xrt_pose *pose_in_client)
+{
+	if (target_xc == NULL || pose_in_client == NULL) {
+		return;
+	}
+	ensure_lock();
+	os_mutex_lock(&g_lock);
+	struct chrome_entry *e = find_locked(target_xc);
+	if (e != NULL && e->layout_valid) {
+		e->layout.pose_in_client = *pose_in_client;
+	}
+	os_mutex_unlock(&g_lock);
+}
+
+bool
+comp_multi_workspace_chrome_get(struct xrt_compositor *target_xc,
+                                struct xrt_swapchain **out_xsc,
+                                struct comp_multi_chrome_layout *out_layout)
+{
+	bool found = false;
+	ensure_lock();
+	os_mutex_lock(&g_lock);
+	struct chrome_entry *e = find_locked(target_xc);
+	if (e != NULL && e->layout_valid && e->xsc != NULL) {
+		if (out_xsc != NULL) {
+			*out_xsc = e->xsc;
+		}
+		if (out_layout != NULL) {
+			*out_layout = e->layout;
+		}
+		found = true;
+	}
+	os_mutex_unlock(&g_lock);
+	return found;
+}
+
+void
+comp_multi_workspace_chrome_clear(struct xrt_compositor *target_xc)
+{
+	if (target_xc == NULL) {
+		return;
+	}
+	ensure_lock();
+	os_mutex_lock(&g_lock);
+	struct chrome_entry *e = find_locked(target_xc);
+	if (e != NULL) {
+		free_entry_locked(e);
+	}
+	os_mutex_unlock(&g_lock);
+}

--- a/src/xrt/compositor/multi/comp_multi_workspace.h
+++ b/src/xrt/compositor/multi/comp_multi_workspace.h
@@ -1,0 +1,111 @@
+// Copyright 2026, Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  Generic workspace-controller chrome registry (macOS shell Tier 1, #48).
+ *
+ * The Windows D3D11 service compositor stores controller-submitted chrome
+ * swapchains + layouts per client slot inside its monolith
+ * (`comp_d3d11_service.cpp`, `struct d3d11_multi_client_slot`) and composites
+ * them in `multi_compositor_render()`. The macOS null+comp_multi service has no
+ * such monolith — each content client renders out-of-process to its own target
+ * in `render_session_to_own_target()`. This is the vendor-neutral analogue: a
+ * small process-global, thread-safe table of controller-submitted chrome, keyed
+ * by the *target* client's per-session compositor pointer (the `xrt_compositor *`
+ * the IPC server stores as `ics->xc` — which is the very `multi_compositor` the
+ * render path iterates). The chrome IPC handlers (writers) populate it; the
+ * per-session render path (reader, same library) looks up chrome registered for
+ * its own compositor and composites it over the client's content.
+ *
+ * Layering note: this stays free of `ipc_protocol.h` so the compositor never
+ * depends on the IPC layer. The IPC handler translates its wire layout
+ * (`ipc_workspace_chrome_layout`) into @ref comp_multi_chrome_layout when calling.
+ *
+ * @ingroup comp_multi
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "xrt/xrt_defines.h" // struct xrt_pose
+
+struct xrt_compositor;
+struct xrt_swapchain;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*!
+ * Compositor-local mirror of the controller's chrome layout — the subset the
+ * per-session composite path needs, decoupled from the IPC wire form.
+ *
+ * @ingroup comp_multi
+ */
+struct comp_multi_chrome_layout
+{
+	struct xrt_pose pose_in_client;     //!< Chrome quad pose in client-window-local space (meters).
+	float size_w_m;                     //!< Chrome quad width in meters.
+	float size_h_m;                     //!< Chrome quad height in meters.
+	bool follows_window_orient;         //!< If true chrome rotates with window. (v1: ignored — axis-aligned.)
+	float depth_bias_meters;            //!< Bias toward eye. (v1: ignored — flat post-weave overlay.)
+	bool anchor_to_window_top_edge;     //!< pose.y is an offset from the window's top edge.
+	float width_as_fraction_of_window;  //!< 0 = absolute size_w_m; > 0 = window_width * fraction.
+};
+
+/*!
+ * Register (or replace) the chrome swapchain for @p target_xc. Takes a strong
+ * reference to @p xsc (released on replace / unregister / clear). @p swapchain_id
+ * is stored so @ref comp_multi_workspace_chrome_unregister_by_id can match it.
+ * Thread-safe; called from a per-client IPC handler thread.
+ */
+void
+comp_multi_workspace_chrome_register(struct xrt_compositor *target_xc,
+                                     uint32_t swapchain_id,
+                                     struct xrt_swapchain *xsc);
+
+/*!
+ * Drop the chrome entry whose stored swapchain id matches @p swapchain_id
+ * (the controller destroyed the swapchain). Releases the strong reference.
+ */
+void
+comp_multi_workspace_chrome_unregister_by_id(uint32_t swapchain_id);
+
+/*!
+ * Store/replace the layout for @p target_xc and mark its chrome valid. The
+ * controller calls this right after registering the swapchain.
+ */
+void
+comp_multi_workspace_chrome_set_layout(struct xrt_compositor *target_xc,
+                                       const struct comp_multi_chrome_layout *layout);
+
+/*!
+ * Per-frame pose-only update of an existing entry's `pose_in_client`. Does not
+ * toggle validity; no-op if @p target_xc has no entry yet.
+ */
+void
+comp_multi_workspace_chrome_update_pose(struct xrt_compositor *target_xc, const struct xrt_pose *pose_in_client);
+
+/*!
+ * Render-side lookup. If @p target_xc has a valid chrome registration, sets
+ * @p out_xsc to the (registry-owned strong-ref) swapchain and copies the layout
+ * into @p out_layout, returning true. The returned swapchain stays alive for the
+ * frame by virtue of the registry's reference. Returns false otherwise.
+ */
+bool
+comp_multi_workspace_chrome_get(struct xrt_compositor *target_xc,
+                                struct xrt_swapchain **out_xsc,
+                                struct comp_multi_chrome_layout *out_layout);
+
+/*!
+ * Drop all chrome state for @p target_xc (call on client disconnect so a reused
+ * compositor pointer never inherits stale chrome). Releases the strong reference.
+ */
+void
+comp_multi_workspace_chrome_clear(struct xrt_compositor *target_xc);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/xrt/ipc/server/ipc_server_handler.c
+++ b/src/xrt/ipc/server/ipc_server_handler.c
@@ -56,6 +56,10 @@
 // macOS service input forwarding (#48): drain the generic queue fed by the
 // AppKit pump's NSEvent capture (ipc_server_macos_appkit.m).
 #include "ipc_server_input_queue.h"
+// macOS workspace chrome (#48): the generic comp_multi chrome registry the
+// per-session render path composites from (the cross-platform analogue of the
+// D3D11 monolith's per-slot chrome storage).
+#include "multi/comp_multi_workspace.h"
 #endif
 
 #if defined(XRT_HAVE_D3D11_SERVICE_COMPOSITOR) || defined(XRT_OS_ANDROID) || defined(XRT_OS_MACOS)
@@ -4385,6 +4389,28 @@ ipc_handle_workspace_capture_frame(volatile struct ipc_client_state *_ics,
 // dispatches to comp_d3d11_service. Layout has the same client_id→slot
 // resolution.
 
+#if defined(XRT_OS_MACOS)
+// Resolve a canonical workspace client id to its per-session compositor
+// (== ics->xc == the multi_compositor the render path keys chrome by, #48). The
+// macOS service hands the controller canonical ids from EnumerateWorkspaceClients,
+// so no 1000+slot normalization is needed here (that is the D3D11-only form).
+static struct xrt_compositor *
+macos_workspace_find_client_xc(struct ipc_server *s, uint32_t client_id)
+{
+	struct xrt_compositor *xc = NULL;
+	os_mutex_lock(&s->global_state.lock);
+	for (uint32_t i = 0; i < IPC_MAX_CLIENTS; i++) {
+		volatile struct ipc_client_state *ics = &s->threads[i].ics;
+		if (ics->client_state.id == client_id && ics->server_thread_index >= 0 && ics->xc != NULL) {
+			xc = (struct xrt_compositor *)ics->xc;
+			break;
+		}
+	}
+	os_mutex_unlock(&s->global_state.lock);
+	return xc;
+}
+#endif
+
 xrt_result_t
 ipc_handle_workspace_register_chrome_swapchain(volatile struct ipc_client_state *_ics,
                                                uint32_t client_id,
@@ -4445,6 +4471,28 @@ ipc_handle_workspace_register_chrome_swapchain(volatile struct ipc_client_state 
 	IPC_INFO(s, "Workspace: register_chrome_swapchain client_id=%u swapchain_id=%u → slot=%d",
 	         client_id, swapchain_id, slot);
 	return comp_d3d11_service_workspace_register_chrome_swapchain_by_slot(s->xsysc, slot, client_id, swapchain_id, xsc);
+#elif defined(XRT_OS_MACOS)
+	// Generic comp_multi path (#48): store the controller's chrome swapchain in
+	// the chrome registry, keyed by the *target* client's compositor; the
+	// per-session render path composites it (no D3D11 monolith / slots here).
+	if (swapchain_id >= IPC_MAX_CLIENT_SWAPCHAINS) {
+		return XRT_ERROR_IPC_FAILURE;
+	}
+	struct xrt_swapchain *xsc = (struct xrt_swapchain *)_ics->xscs[swapchain_id];
+	if (xsc == NULL) {
+		IPC_WARN(s, "Workspace: register_chrome_swapchain - swapchain %u not bound", swapchain_id);
+		return XRT_ERROR_IPC_FAILURE;
+	}
+	struct xrt_compositor *target_xc = macos_workspace_find_client_xc(s, client_id);
+	if (target_xc == NULL) {
+		// Client may not be bound yet — controller retries.
+		IPC_WARN(s, "Workspace: register_chrome_swapchain - client %u not bound yet", client_id);
+		return XRT_ERROR_IPC_FAILURE;
+	}
+	IPC_INFO(s, "Workspace: register_chrome_swapchain client_id=%u swapchain_id=%u (macOS comp_multi)",
+	         client_id, swapchain_id);
+	comp_multi_workspace_chrome_register(target_xc, swapchain_id, xsc);
+	return XRT_SUCCESS;
 #else
 	(void)s;
 	(void)client_id;
@@ -4464,6 +4512,10 @@ ipc_handle_workspace_unregister_chrome_swapchain(volatile struct ipc_client_stat
 	}
 	IPC_INFO(s, "Workspace: unregister_chrome_swapchain swapchain_id=%u", swapchain_id);
 	return comp_d3d11_service_workspace_unregister_chrome_swapchain(s->xsysc, swapchain_id);
+#elif defined(XRT_OS_MACOS)
+	IPC_INFO(s, "Workspace: unregister_chrome_swapchain swapchain_id=%u (macOS)", swapchain_id);
+	comp_multi_workspace_chrome_unregister_by_id(swapchain_id);
+	return XRT_SUCCESS;
 #else
 	(void)s;
 	(void)swapchain_id;
@@ -4510,6 +4562,28 @@ ipc_handle_workspace_set_chrome_layout(volatile struct ipc_client_state *_ics,
 	}
 
 	return comp_d3d11_service_workspace_set_chrome_layout_by_slot(s->xsysc, slot, layout);
+#elif defined(XRT_OS_MACOS)
+	if (layout == NULL) {
+		return XRT_ERROR_IPC_FAILURE;
+	}
+	struct xrt_compositor *target_xc = macos_workspace_find_client_xc(s, client_id);
+	if (target_xc == NULL) {
+		IPC_WARN(s, "Workspace: set_chrome_layout - client %u not found", client_id);
+		return XRT_ERROR_IPC_FAILURE;
+	}
+	// Translate the IPC wire layout into the compositor-local form (keeps
+	// comp_multi free of ipc_protocol.h).
+	struct comp_multi_chrome_layout cml = {
+	    .pose_in_client = layout->pose_in_client,
+	    .size_w_m = layout->size_w_m,
+	    .size_h_m = layout->size_h_m,
+	    .follows_window_orient = layout->follows_window_orient != 0,
+	    .depth_bias_meters = layout->depth_bias_meters,
+	    .anchor_to_window_top_edge = layout->anchor_to_window_top_edge != 0,
+	    .width_as_fraction_of_window = layout->width_as_fraction_of_window,
+	};
+	comp_multi_workspace_chrome_set_layout(target_xc, &cml);
+	return XRT_SUCCESS;
 #else
 	(void)s;
 	(void)client_id;
@@ -4640,6 +4714,17 @@ ipc_handle_workspace_update_chrome_layer_pose(volatile struct ipc_client_state *
 	}
 
 	return comp_d3d11_service_workspace_update_chrome_layer_pose_by_slot(s->xsysc, slot, pose_in_client);
+#elif defined(XRT_OS_MACOS)
+	if (pose_in_client == NULL) {
+		return XRT_ERROR_IPC_FAILURE;
+	}
+	struct xrt_compositor *target_xc = macos_workspace_find_client_xc(s, client_id);
+	if (target_xc == NULL) {
+		// Per-frame call — quieter than set_chrome_layout (no warn).
+		return XRT_ERROR_IPC_FAILURE;
+	}
+	comp_multi_workspace_chrome_update_pose(target_xc, pose_in_client);
+	return XRT_SUCCESS;
 #else
 	(void)s;
 	(void)client_id;

--- a/src/xrt/state_trackers/oxr/oxr_workspace.c
+++ b/src/xrt/state_trackers/oxr/oxr_workspace.c
@@ -194,6 +194,42 @@ struct xrt_swapchain *
 comp_d3d11_client_get_inner_xrt_swapchain(struct xrt_swapchain *xsc);
 #endif
 
+// Forward decl from compositor/client/comp_vk_client.c (#48). A Vulkan session
+// that also acts as a workspace controller (creating chrome/cursor/overlay
+// swapchains) wraps them in client_vk_swapchain — unwrap to the inner
+// ipc_client_swapchain so the dispatch reads the right swapchain id.
+struct xrt_swapchain *
+comp_vk_client_get_inner_xrt_swapchain(struct xrt_swapchain *xsc);
+
+/*!
+ * Unwrap a workspace swapchain (chrome/cursor/overlay) to the inner native
+ * (IPC) swapchain whose id the runtime looks up. The client compositor wraps
+ * swapchains per graphics API: D3D11 on Windows, Vulkan on a VK session. A pure
+ * WORKSPACE_CONTROLLER session skips API wrapping (already native) → passthrough.
+ * Metal is added with the macOS shell (Metal binding); a Metal controller would
+ * extend the branch below.
+ */
+static struct xrt_swapchain *
+workspace_unwrap_client_swapchain(struct oxr_session *sess, struct xrt_swapchain *xsc)
+{
+	if (xsc == NULL) {
+		return NULL;
+	}
+#ifdef _WIN32
+	struct xrt_swapchain *d = comp_d3d11_client_get_inner_xrt_swapchain(xsc);
+	if (d != NULL) {
+		return d;
+	}
+#endif
+	if (sess != NULL && sess->gfx_ext == OXR_SESSION_GRAPHICS_EXT_VULKAN) {
+		struct xrt_swapchain *v = comp_vk_client_get_inner_xrt_swapchain(xsc);
+		if (v != NULL) {
+			return v;
+		}
+	}
+	return xsc; // WORKSPACE_CONTROLLER / already-native.
+}
+
 
 /*
  * Helpers
@@ -1076,13 +1112,7 @@ oxr_xrCreateWorkspaceClientChromeSwapchainEXT(XrSession session,
 	// (id 0 IS valid — first slot in the controller's xscs[] table). On
 	// non-Windows there's no D3D11 wrapper to unwrap, so the swapchain is
 	// already the ipc_client form.
-	struct xrt_swapchain *inner = sc->swapchain;
-#ifdef _WIN32
-	struct xrt_swapchain *unwrapped = comp_d3d11_client_get_inner_xrt_swapchain(inner);
-	if (unwrapped != NULL) {
-		inner = unwrapped;
-	}
-#endif
+	struct xrt_swapchain *inner = workspace_unwrap_client_swapchain(sess, sc->swapchain);
 	uint32_t swapchain_id = comp_ipc_client_compositor_get_swapchain_id(inner);
 
 	xrt_result_t xret = comp_ipc_client_compositor_workspace_register_chrome_swapchain(
@@ -1110,13 +1140,7 @@ oxr_xrDestroyWorkspaceClientChromeSwapchainEXT(XrSwapchain swapchain)
 	// swapchain. The runtime is tolerant of a missing entry — if the swapchain
 	// was never registered (e.g. created via xrCreateSwapchain directly), the
 	// unregister is a no-op there. Same _WIN32 gate as the create path.
-	struct xrt_swapchain *inner = sc->swapchain;
-#ifdef _WIN32
-	struct xrt_swapchain *unwrapped = comp_d3d11_client_get_inner_xrt_swapchain(inner);
-	if (unwrapped != NULL) {
-		inner = unwrapped;
-	}
-#endif
+	struct xrt_swapchain *inner = workspace_unwrap_client_swapchain(sc->sess, sc->swapchain);
 	uint32_t swapchain_id = comp_ipc_client_compositor_get_swapchain_id(inner);
 	if (session_is_ipc_client(sc->sess)) {
 		(void)comp_ipc_client_compositor_workspace_unregister_chrome_swapchain(
@@ -1326,13 +1350,7 @@ oxr_xrSetWorkspaceCursorEXT(XrSession session, const XrWorkspaceCursorInfoEXT *i
 	if (info->swapchain != XR_NULL_HANDLE) {
 		struct oxr_swapchain *sc = NULL;
 		OXR_VERIFY_SWAPCHAIN_AND_INIT_LOG(&log, info->swapchain, sc, "xrSetWorkspaceCursorEXT");
-		struct xrt_swapchain *inner = sc->swapchain;
-#ifdef _WIN32
-		struct xrt_swapchain *unwrapped = comp_d3d11_client_get_inner_xrt_swapchain(inner);
-		if (unwrapped != NULL) {
-			inner = unwrapped;
-		}
-#endif
+		struct xrt_swapchain *inner = workspace_unwrap_client_swapchain(sc->sess, sc->swapchain);
 		ipc_info.swapchain_id = comp_ipc_client_compositor_get_swapchain_id(inner);
 	}
 
@@ -1480,13 +1498,7 @@ oxr_xrSetWorkspaceOverlayEXT(XrSession session, const XrWorkspaceOverlayInfoEXT 
 	if (info->swapchain != XR_NULL_HANDLE) {
 		struct oxr_swapchain *sc = NULL;
 		OXR_VERIFY_SWAPCHAIN_AND_INIT_LOG(&log, info->swapchain, sc, "xrSetWorkspaceOverlayEXT");
-		struct xrt_swapchain *inner = sc->swapchain;
-#ifdef _WIN32
-		struct xrt_swapchain *unwrapped = comp_d3d11_client_get_inner_xrt_swapchain(inner);
-		if (unwrapped != NULL) {
-			inner = unwrapped;
-		}
-#endif
+		struct xrt_swapchain *inner = workspace_unwrap_client_swapchain(sc->sess, sc->swapchain);
 		ipc_info.swapchain_id = comp_ipc_client_compositor_get_swapchain_id(inner);
 	}
 

--- a/test_apps/cube_handle_vk_macos/main.mm
+++ b/test_apps/cube_handle_vk_macos/main.mm
@@ -1544,6 +1544,55 @@ static void RenderScene(VkRenderer& renderer, uint32_t imageIndex,
     vkQueueSubmit(renderer.graphicsQueue, 1, &submitInfo, renderer.frameFence);
 }
 
+// Workspace chrome self-test (#48): one-shot clear of a chrome swapchain image
+// to a solid RGBA color, leaving it in VK_IMAGE_LAYOUT_GENERAL — the layout the
+// service's chrome composite expects shared cross-process images to rest in.
+static void ClearVkImageToColor(VkDevice device, VkQueue queue, VkCommandPool pool,
+    VkImage image, float r, float g, float b, float a) {
+    VkCommandBufferAllocateInfo ai = {VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO};
+    ai.commandPool = pool;
+    ai.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+    ai.commandBufferCount = 1;
+    VkCommandBuffer cmd = VK_NULL_HANDLE;
+    if (vkAllocateCommandBuffers(device, &ai, &cmd) != VK_SUCCESS) return;
+
+    VkCommandBufferBeginInfo bi = {VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO};
+    bi.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+    vkBeginCommandBuffer(cmd, &bi);
+
+    VkImageSubresourceRange range = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+    VkImageMemoryBarrier toDst = {VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
+    toDst.srcAccessMask = 0;
+    toDst.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+    toDst.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    toDst.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+    toDst.image = image;
+    toDst.subresourceRange = range;
+    vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT,
+        0, 0, nullptr, 0, nullptr, 1, &toDst);
+
+    VkClearColorValue color = {{r, g, b, a}};
+    vkCmdClearColorImage(cmd, image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, &color, 1, &range);
+
+    VkImageMemoryBarrier toGeneral = {VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
+    toGeneral.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+    toGeneral.dstAccessMask = 0;
+    toGeneral.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+    toGeneral.newLayout = VK_IMAGE_LAYOUT_GENERAL;
+    toGeneral.image = image;
+    toGeneral.subresourceRange = range;
+    vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+        0, 0, nullptr, 0, nullptr, 1, &toGeneral);
+
+    vkEndCommandBuffer(cmd);
+    VkSubmitInfo si = {VK_STRUCTURE_TYPE_SUBMIT_INFO};
+    si.commandBufferCount = 1;
+    si.pCommandBuffers = &cmd;
+    vkQueueSubmit(queue, 1, &si, VK_NULL_HANDLE);
+    vkQueueWaitIdle(queue);
+    vkFreeCommandBuffers(device, pool, 1, &cmd);
+}
+
 static void CleanupVkRenderer(VkRenderer& renderer) {
     if (renderer.device == VK_NULL_HANDLE) return;
     vkDeviceWaitIdle(renderer.device);
@@ -2995,6 +3044,89 @@ int main() {
         }
     } else {
         LOG_WARN("Failed to create HUD swapchain - HUD disabled");
+    }
+
+    // === Workspace chrome self-test (#48) ===
+    // With DXR_WORKSPACE_CHROME=1, act as a minimal workspace controller and
+    // decorate our OWN window with a title bar, to exercise the macOS chrome
+    // composite path (comp_multi_workspace + session_render_chrome_overlay)
+    // end-to-end without a separate controller app. The real shell is a separate
+    // controller; this is the runtime-side verification vehicle.
+    XrSwapchain chromeSwapchain = XR_NULL_HANDLE;
+    if (xr.hasSpatialWorkspaceExt && getenv("DXR_WORKSPACE_CHROME") != nullptr) {
+        PFN_xrActivateSpatialWorkspaceEXT pfnActivate = nullptr;
+        PFN_xrEnumerateWorkspaceClientsEXT pfnEnumClients = nullptr;
+        PFN_xrCreateWorkspaceClientChromeSwapchainEXT pfnCreateChrome = nullptr;
+        PFN_xrSetWorkspaceClientChromeLayoutEXT pfnSetLayout = nullptr;
+        xrGetInstanceProcAddr(xr.instance, "xrActivateSpatialWorkspaceEXT", (PFN_xrVoidFunction*)&pfnActivate);
+        xrGetInstanceProcAddr(xr.instance, "xrEnumerateWorkspaceClientsEXT", (PFN_xrVoidFunction*)&pfnEnumClients);
+        xrGetInstanceProcAddr(xr.instance, "xrCreateWorkspaceClientChromeSwapchainEXT",
+            (PFN_xrVoidFunction*)&pfnCreateChrome);
+        xrGetInstanceProcAddr(xr.instance, "xrSetWorkspaceClientChromeLayoutEXT",
+            (PFN_xrVoidFunction*)&pfnSetLayout);
+
+        if (pfnActivate && pfnEnumClients && pfnCreateChrome && pfnSetLayout) {
+            XrResult wret = pfnActivate(xr.session);
+            LOG_INFO("[chrome-test] activate workspace: %d", (int)wret);
+
+            // Single client → our own id is clients[0].
+            uint32_t cc = 0;
+            pfnEnumClients(xr.session, 0, &cc, nullptr);
+            XrWorkspaceClientId selfId = 0;
+            if (cc > 0) {
+                std::vector<XrWorkspaceClientId> ids(cc);
+                if (XR_SUCCEEDED(pfnEnumClients(xr.session, cc, &cc, ids.data())) && cc > 0) {
+                    selfId = ids[0];
+                }
+            }
+            LOG_INFO("[chrome-test] self client id=%llu (count=%u)", (unsigned long long)selfId, cc);
+
+            const uint32_t CW = 512, CH = 64;
+            XrWorkspaceChromeSwapchainCreateInfoEXT cci = {XR_TYPE_WORKSPACE_CHROME_SWAPCHAIN_CREATE_INFO_EXT};
+            cci.format = (int64_t)VK_FORMAT_R8G8B8A8_UNORM;
+            cci.width = CW;
+            cci.height = CH;
+            cci.sampleCount = 1;
+            cci.mipCount = 1;
+            XrResult cret = pfnCreateChrome(xr.session, selfId, &cci, &chromeSwapchain);
+            LOG_INFO("[chrome-test] create chrome swapchain: %d", (int)cret);
+
+            if (XR_SUCCEEDED(cret) && chromeSwapchain != XR_NULL_HANDLE) {
+                uint32_t n = 0;
+                xrEnumerateSwapchainImages(chromeSwapchain, 0, &n, nullptr);
+                std::vector<XrSwapchainImageVulkanKHR> cimgs(n, {XR_TYPE_SWAPCHAIN_IMAGE_VULKAN_KHR});
+                xrEnumerateSwapchainImages(chromeSwapchain, n, &n, (XrSwapchainImageBaseHeader*)cimgs.data());
+                uint32_t idx = 0;
+                XrSwapchainImageAcquireInfo acq = {XR_TYPE_SWAPCHAIN_IMAGE_ACQUIRE_INFO};
+                if (n > 0 && XR_SUCCEEDED(xrAcquireSwapchainImage(chromeSwapchain, &acq, &idx))) {
+                    XrSwapchainImageWaitInfo wait = {XR_TYPE_SWAPCHAIN_IMAGE_WAIT_INFO};
+                    wait.timeout = XR_INFINITE_DURATION;
+                    xrWaitSwapchainImage(chromeSwapchain, &wait);
+                    // Opaque cyan-ish bar so it reads clearly over the cube.
+                    ClearVkImageToColor(vkDevice, graphicsQueue, vkRenderer.commandPool,
+                        cimgs[idx].image, 0.10f, 0.55f, 0.90f, 0.90f);
+                    XrSwapchainImageReleaseInfo rel = {XR_TYPE_SWAPCHAIN_IMAGE_RELEASE_INFO};
+                    xrReleaseSwapchainImage(chromeSwapchain, &rel);
+                    LOG_INFO("[chrome-test] chrome image %u cleared + released", idx);
+                }
+
+                // A title bar glued to the window's top edge, 80% width.
+                XrWorkspaceChromeLayoutEXT lay = {XR_TYPE_WORKSPACE_CHROME_LAYOUT_EXT};
+                lay.poseInClient.orientation.w = 1.0f;
+                lay.poseInClient.position.x = 0.0f;
+                lay.poseInClient.position.y = -0.02f; // 2 cm below the top edge
+                lay.poseInClient.position.z = 0.0f;
+                lay.sizeMeters.width = 0.20f;
+                lay.sizeMeters.height = 0.03f;
+                lay.followsWindowOrient = XR_FALSE;
+                lay.anchorToWindowTopEdge = XR_TRUE;
+                lay.widthAsFractionOfWindow = 0.8f;
+                XrResult lret = pfnSetLayout(xr.session, selfId, &lay);
+                LOG_INFO("[chrome-test] set chrome layout: %d", (int)lret);
+            }
+        } else {
+            LOG_WARN("[chrome-test] workspace chrome PFNs not all resolved - skipping");
+        }
     }
 
     g_input.viewParams.virtualDisplayHeight = 0.24f;


### PR DESCRIPTION
## Why

The macOS spatial-shell port's North Star is the shell **app** (#61), but it's blocked on the **runtime**: the shell renders its UI (title pill, taskbar, cursor) into controller-owned swapchains and hands them to the runtime to composite. That compositing only existed in the Windows D3D11 service monolith (`comp_d3d11_service.cpp`). On macOS the chrome IPC handlers were fenced behind `XRT_HAVE_D3D11_SERVICE_COMPOSITOR` and their `#else` returned `XRT_ERROR_IPC_FAILURE` — so the first thing a macOS shell does to draw a title bar (`xrCreateWorkspaceClientChromeSwapchainEXT`) hard-failed.

This ports **chrome** compositing into the generic `comp_multi` / MoltenVK per-session path that #616 established, unblocking the shell-app port. (Cursor + overlay are Phase 2; the registry + unwrap below already cover them.)

## What

**Runtime**
- **`comp_multi_workspace.{c,h}`** — process-global, thread-safe chrome registry keyed by the target client's per-session compositor pointer (`ics->xc` == the `multi_compositor` the render path iterates). Vendor-neutral analogue of the D3D11 monolith's per-slot chrome storage; mirrors the `ipc_server_input_queue` pattern. Holds a strong swapchain ref + layout.
- **`comp_multi_system.c`** — `session_render_chrome_overlay()` composites the registered chrome over the client's woven content **post-weave**, flat at the screen plane, reusing the existing `vk_hud_blend` pipeline (no new shader, no native Metal) — the same model as the FPS HUD overlay.
- **`ipc_server_handler.c`** — macOS branches for register / unregister / set_layout / update_chrome_layer_pose that resolve the controller's swapchain + the target client's compositor and drive the registry (replacing the `IPC_FAILURE` `#else`).
- **`comp_multi_compositor.c`** — tear down `chrome_blend`; clear the registry entry on client destroy (no stale chrome on pointer reuse).
- **`oxr_workspace.c` + `comp_vk_client.c`** — bug fix: a VK session acting as a workspace controller wraps its swapchains in `client_vk_swapchain`, but the workspace dispatch only unwrapped the D3D11 wrapper → garbage IPC swapchain id on macOS. Add `comp_vk_client_get_inner_xrt_swapchain` + a `gfx_ext`-aware `workspace_unwrap_client_swapchain()` used at all four chrome/cursor/overlay sites. (Metal unwrap follows with the macOS shell.)

## Scope (v1)
- Chrome is a **flat 2D overlay at the screen plane** (zero-disparity, like the HUD). Per-eye / perspective / focus-glow / depth-tested chrome stays the deferred Tier-2 work the D3D11 monolith does (#59).
- True multi-content-window spatial merge is out of scope (Tier 2).

## Verification
`cube_handle_vk_macos` gains a `DXR_WORKSPACE_CHROME=1` self-chrome mode: the cube activates the workspace and registers a title bar for itself, exercising the full path (register → registry → per-session lookup → `vk_hud_blend`) without a separate controller app. Confirmed end-to-end on macOS (service mode, MoltenVK): activate/create/clear/set-layout all return `XR_SUCCESS`, the macOS register handler runs, the chrome composite fires, **and the cyan title bar renders over the cube on-screen (eyeballed, stable across V-mode cycling)** — no VK validation / present errors. Regression-safe: with no controller, the chrome lookup is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)