### PR TITLE
feat(test-apps): wire cube_handle_d3d11_win to ModeSwitch disparity ramp

### DIFF
--- a/src/xrt/auxiliary/math/CMakeLists.txt
+++ b/src/xrt/auxiliary/math/CMakeLists.txt
@@ -20,7 +20,7 @@ set(DISPLAYXR_XRT_INCLUDE_DIR "${_dxr_xrt_includes}" CACHE PATH "" FORCE)
 FetchContent_Declare(
 	displayxr_common
 	GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
-	GIT_TAG v1.0.9
+	GIT_TAG v1.1.0
 	GIT_SHALLOW TRUE
 	)
 FetchContent_MakeAvailable(displayxr_common)

--- a/test_apps/common/CMakeLists.txt
+++ b/test_apps/common/CMakeLists.txt
@@ -30,7 +30,7 @@ set(DISPLAYXR_EXTENSIONS_INCLUDE_DIR "${_dxr_ext_includes}" CACHE PATH
 FetchContent_Declare(
     displayxr_common
     GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
-    GIT_TAG v1.0.9
+    GIT_TAG v1.1.0
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(displayxr_common)

--- a/test_apps/cube_handle_d3d11_win/main.cpp
+++ b/test_apps/cube_handle_d3d11_win/main.cpp
@@ -535,27 +535,13 @@ static void RenderOneFrame(RenderState& rs) {
         g_inputState.fullscreenToggleRequested = false;
     }
 
-    // Handle rendering mode requests (V=cycle next, 0-8=jump absolute).
-    // Single source of truth: the runtime owns the current mode. Keypresses
-    // are REQUESTS — we call xrRequestDisplayRenderingModeEXT and let the
-    // XrEventDataRenderingModeChangedEXT event update xr.currentModeIndex.
-    // Render paths and HUD read xr.currentModeIndex directly.
-    if (g_inputState.cycleRenderingModeRequested) {
-        g_inputState.cycleRenderingModeRequested = false;
-        if (xr.pfnRequestDisplayRenderingModeEXT && xr.session != XR_NULL_HANDLE &&
-            xr.renderingModeCount > 0) {
-            uint32_t next = (xr.currentModeIndex + 1) % xr.renderingModeCount;
-            xr.pfnRequestDisplayRenderingModeEXT(xr.session, next);
-        }
-    }
-    if (g_inputState.absoluteRenderingModeRequested >= 0) {
-        uint32_t target = (uint32_t)g_inputState.absoluteRenderingModeRequested;
-        g_inputState.absoluteRenderingModeRequested = -1;
-        if (xr.pfnRequestDisplayRenderingModeEXT && xr.session != XR_NULL_HANDLE &&
-            target < xr.renderingModeCount) {
-            xr.pfnRequestDisplayRenderingModeEXT(xr.session, target);
-        }
-    }
+    // Handle rendering mode requests (V=cycle next, 0-8=jump absolute) through
+    // the shared ModeSwitch sequencer: it consumes the request flags, eases the
+    // stereo disparity (viewParams.ipdFactor) around the switch, and issues
+    // xrRequestDisplayRenderingModeEXT on the right frame. The runtime still owns
+    // the current mode; the XrEventDataRenderingModeChangedEXT event updates
+    // xr.currentModeIndex, which render paths and the HUD read directly.
+    XrSessionUpdateModeSwitch(xr, g_inputState, rs.perfStats->deltaTime);
 
     // #228 Tier 1 smoke test: 'B' fires xrRequestFilePickerEXT and prints
     // the immediate return code. The completion event (success/cancel +


### PR DESCRIPTION
## What

Reference-app wiring of the new `dxr::ModeSwitch` sequencer (displayxr-common v1.1.0). V/0-8 rendering-mode switches now **ease** the stereo disparity over ~0.18 s instead of snapping.

- Bump `displayxr-common` pins to **v1.1.0** (`test_apps/common/CMakeLists.txt` + `src/xrt/auxiliary/math/CMakeLists.txt`, kept in lockstep).
- `cube_handle_d3d11_win`: replace the hand-rolled `if (cycleRenderingModeRequested) pfnRequestDisplayRenderingModeEXT(...)` block with one `XrSessionUpdateModeSwitch(xr, g_inputState, rs.perfStats->deltaTime)` call.

## Why

Companion to the merged runtime #615 fix (one-frame eye-set coherence): the runtime stops the *snap*, ModeSwitch is the multi-frame aesthetic *ramp* (separation of concerns). See displayxr-common#12.

## Test

- Builds clean (Ninja/Release).
- **Leia-validated** on hardware: smooth ease both directions, clean mash-V reversal (reversed-before-fire →2D ramps back up, never flips), `+/-` still tunes the steady depth.

## Rollout

First of the staged wiring. The v1.1.0 `steadyIpdFactor` split seeds `ipdFactor` in lockstep, so the other (un-wired) test apps sharing the bumped `test_apps/common` pin keep working unchanged. Follow-ups: other Windows cube apps → macOS cube apps → the 5 demo repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)