### PR TITLE
feat(test-apps): wire d3d12/gl/vk Windows cube apps to ModeSwitch ramp

### DIFF
--- a/src/xrt/auxiliary/math/CMakeLists.txt
+++ b/src/xrt/auxiliary/math/CMakeLists.txt
@@ -20,7 +20,7 @@ set(DISPLAYXR_XRT_INCLUDE_DIR "${_dxr_xrt_includes}" CACHE PATH "" FORCE)
 FetchContent_Declare(
 	displayxr_common
 	GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
-	GIT_TAG v1.1.0
+	GIT_TAG v1.1.1
 	GIT_SHALLOW TRUE
 	)
 FetchContent_MakeAvailable(displayxr_common)

--- a/test_apps/common/CMakeLists.txt
+++ b/test_apps/common/CMakeLists.txt
@@ -30,7 +30,7 @@ set(DISPLAYXR_EXTENSIONS_INCLUDE_DIR "${_dxr_ext_includes}" CACHE PATH
 FetchContent_Declare(
     displayxr_common
     GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
-    GIT_TAG v1.1.0
+    GIT_TAG v1.1.1
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(displayxr_common)

--- a/test_apps/cube_handle_d3d12_win/main.cpp
+++ b/test_apps/cube_handle_d3d12_win/main.cpp
@@ -547,8 +547,6 @@ static void RenderThreadFunc(
         InputState inputSnapshot;
         bool resetRequested = false;
         uint32_t windowW, windowH;
-        bool cycleModeRequested = false;
-        int32_t absoluteModeRequest = -1;
         {
             std::lock_guard<std::mutex> lock(g_inputMutex);
             inputSnapshot = g_inputState;
@@ -556,26 +554,20 @@ static void RenderThreadFunc(
             g_inputState.resetViewRequested = false;
             g_inputState.fullscreenToggleRequested = false;
             g_inputState.eyeTrackingModeToggleRequested = false;
-            cycleModeRequested = g_inputState.cycleRenderingModeRequested;
+            // ModeSwitch consumes the V/0-8 flags off inputSnapshot (captured
+            // above); clear them on the shared state so they fire exactly once.
             g_inputState.cycleRenderingModeRequested = false;
-            absoluteModeRequest = g_inputState.absoluteRenderingModeRequested;
             g_inputState.absoluteRenderingModeRequested = -1;
             windowW = g_windowWidth;
             windowH = g_windowHeight;
         }
 
-        // Rendering mode requests (V=cycle, 0-8=absolute). Single source of
-        // truth: the runtime owns current mode via xr->currentModeIndex.
-        if (cycleModeRequested && xr->pfnRequestDisplayRenderingModeEXT &&
-            xr->session != XR_NULL_HANDLE && xr->renderingModeCount > 0) {
-            uint32_t next = (xr->currentModeIndex + 1) % xr->renderingModeCount;
-            xr->pfnRequestDisplayRenderingModeEXT(xr->session, next);
-        }
-        if (absoluteModeRequest >= 0 && xr->pfnRequestDisplayRenderingModeEXT &&
-            xr->session != XR_NULL_HANDLE &&
-            (uint32_t)absoluteModeRequest < xr->renderingModeCount) {
-            xr->pfnRequestDisplayRenderingModeEXT(xr->session, (uint32_t)absoluteModeRequest);
-        }
+        // Rendering mode requests (V=cycle, 0-8=absolute) through the shared
+        // ModeSwitch sequencer: eases viewParams.ipdFactor around the switch and
+        // fires xrRequestDisplayRenderingModeEXT on the right frame. The ramped
+        // ipd lands on inputSnapshot.viewParams.ipdFactor, which the render path
+        // reads. The runtime owns current mode via xr->currentModeIndex.
+        XrSessionUpdateModeSwitch(*xr, inputSnapshot, perfStats.deltaTime);
 
         // Handle eye tracking mode toggle (T key)
         if (inputSnapshot.eyeTrackingModeToggleRequested) {

--- a/test_apps/cube_handle_gl_win/main.cpp
+++ b/test_apps/cube_handle_gl_win/main.cpp
@@ -548,8 +548,6 @@ static void RenderThreadFunc(
     while (g_running.load() && !xr->exitRequested) {
         InputState inputSnapshot;
         bool resetRequested = false;
-        bool cycleModeRequested = false;
-        int32_t absoluteModeRequest = -1;
         uint32_t windowW, windowH;
         {
             std::lock_guard<std::mutex> lock(g_inputMutex);
@@ -558,26 +556,20 @@ static void RenderThreadFunc(
             g_inputState.resetViewRequested = false;
             g_inputState.fullscreenToggleRequested = false;
             g_inputState.eyeTrackingModeToggleRequested = false;
-            cycleModeRequested = g_inputState.cycleRenderingModeRequested;
+            // ModeSwitch consumes the V/0-8 flags off inputSnapshot (captured
+            // above); clear them on the shared state so they fire exactly once.
             g_inputState.cycleRenderingModeRequested = false;
-            absoluteModeRequest = g_inputState.absoluteRenderingModeRequested;
             g_inputState.absoluteRenderingModeRequested = -1;
             windowW = g_windowWidth;
             windowH = g_windowHeight;
         }
 
-        // Rendering mode requests (V=cycle, 0-8=absolute). Single source of
-        // truth: the runtime owns current mode via xr->currentModeIndex.
-        if (cycleModeRequested && xr->pfnRequestDisplayRenderingModeEXT &&
-            xr->session != XR_NULL_HANDLE && xr->renderingModeCount > 0) {
-            uint32_t next = (xr->currentModeIndex + 1) % xr->renderingModeCount;
-            xr->pfnRequestDisplayRenderingModeEXT(xr->session, next);
-        }
-        if (absoluteModeRequest >= 0 && xr->pfnRequestDisplayRenderingModeEXT &&
-            xr->session != XR_NULL_HANDLE &&
-            (uint32_t)absoluteModeRequest < xr->renderingModeCount) {
-            xr->pfnRequestDisplayRenderingModeEXT(xr->session, (uint32_t)absoluteModeRequest);
-        }
+        // Rendering mode requests (V=cycle, 0-8=absolute) through the shared
+        // ModeSwitch sequencer: eases viewParams.ipdFactor around the switch and
+        // fires xrRequestDisplayRenderingModeEXT on the right frame. The ramped
+        // ipd lands on inputSnapshot.viewParams.ipdFactor, which the render path
+        // reads. The runtime owns current mode via xr->currentModeIndex.
+        XrSessionUpdateModeSwitch(*xr, inputSnapshot, perfStats.deltaTime);
 
         UpdatePerformanceStats(perfStats);
         UpdateCameraMovement(inputSnapshot, perfStats.deltaTime, xr->displayHeightM);

--- a/test_apps/cube_handle_vk_win/main.cpp
+++ b/test_apps/cube_handle_vk_win/main.cpp
@@ -563,8 +563,6 @@ static void RenderThreadFunc(
     while (g_running.load() && !xr->exitRequested) {
         InputState inputSnapshot;
         bool resetRequested = false;
-        bool cycleModeRequested = false;
-        int32_t absoluteModeRequest = -1;
         uint32_t windowW, windowH;
         {
             std::lock_guard<std::mutex> lock(g_inputMutex);
@@ -573,26 +571,20 @@ static void RenderThreadFunc(
             g_inputState.resetViewRequested = false;
             g_inputState.fullscreenToggleRequested = false;
             g_inputState.eyeTrackingModeToggleRequested = false;
-            cycleModeRequested = g_inputState.cycleRenderingModeRequested;
+            // ModeSwitch consumes the V/0-8 flags off inputSnapshot (captured
+            // above); clear them on the shared state so they fire exactly once.
             g_inputState.cycleRenderingModeRequested = false;
-            absoluteModeRequest = g_inputState.absoluteRenderingModeRequested;
             g_inputState.absoluteRenderingModeRequested = -1;
             windowW = g_windowWidth;
             windowH = g_windowHeight;
         }
 
-        // Rendering mode requests (V=cycle, 0-8=absolute). Single source of
-        // truth: the runtime owns current mode via xr->currentModeIndex.
-        if (cycleModeRequested && xr->pfnRequestDisplayRenderingModeEXT &&
-            xr->session != XR_NULL_HANDLE && xr->renderingModeCount > 0) {
-            uint32_t next = (xr->currentModeIndex + 1) % xr->renderingModeCount;
-            xr->pfnRequestDisplayRenderingModeEXT(xr->session, next);
-        }
-        if (absoluteModeRequest >= 0 && xr->pfnRequestDisplayRenderingModeEXT &&
-            xr->session != XR_NULL_HANDLE &&
-            (uint32_t)absoluteModeRequest < xr->renderingModeCount) {
-            xr->pfnRequestDisplayRenderingModeEXT(xr->session, (uint32_t)absoluteModeRequest);
-        }
+        // Rendering mode requests (V=cycle, 0-8=absolute) through the shared
+        // ModeSwitch sequencer: eases viewParams.ipdFactor around the switch and
+        // fires xrRequestDisplayRenderingModeEXT on the right frame. The ramped
+        // ipd lands on inputSnapshot.viewParams.ipdFactor, which the render path
+        // reads. The runtime owns current mode via xr->currentModeIndex.
+        XrSessionUpdateModeSwitch(*xr, inputSnapshot, perfStats.deltaTime);
         // Handle eye tracking mode toggle (T key)
         if (inputSnapshot.eyeTrackingModeToggleRequested) {
             if (xr->pfnRequestEyeTrackingModeEXT && xr->session != XR_NULL_HANDLE) {


### PR DESCRIPTION
## What

Extends the smooth 2D↔3D disparity ramp (displayxr-common `dxr::ModeSwitch`) to the remaining Windows cube handle apps — **d3d12, gl, vk** — and bumps the shared `displayxr-common` pin to **v1.1.1**.

- Each app's mutex-snapshot consume block collapses to one `XrSessionUpdateModeSwitch(*xr, inputSnapshot, perfStats.deltaTime)` call. `inputSnapshot` captures the V/0-8 flags before the shared `g_inputState` is cleared under the lock; the helper writes the ramped value into `inputSnapshot.viewParams.ipdFactor`, already what each render path reads. Unused `cycleModeRequested`/`absoluteModeRequest` locals removed.
- **v1.1.1 pin** picks up the first-press snap fix (displayxr-common#13). Because all Windows cube apps share `test_apps/common`, this also lifts the already-merged `cube_handle_d3d11_win` (#621) onto the fix.

## Why

Follow-up to the Leia-validated d3d11 reference (#621). The ramp is app-side (`viewParams.ipdFactor` on the view rig), backend-independent.

## Test

- All four apps build clean (Ninja/Release) against v1.1.1.
- **Leia-validated:** d3d11 (full ramp + mash-V), d3d12 (full ramp + the first-press fix — first 3D→2D now eases, no snap). gl/vk share the identical backend-independent logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)