### PR TITLE
feat(test-apps,macos): inline dxr::ModeSwitch disparity ramp

### DIFF
--- a/test_apps/cube_handle_gl_macos/CMakeLists.txt
+++ b/test_apps/cube_handle_gl_macos/CMakeLists.txt
@@ -60,7 +60,7 @@ set(DISPLAYXR_EXTENSIONS_INCLUDE_DIR "${_dxr_ext_includes}" CACHE PATH
 FetchContent_Declare(
     displayxr_common
     GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
-    GIT_TAG v1.0.7
+    GIT_TAG v1.1.1
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(displayxr_common)

--- a/test_apps/cube_handle_gl_macos/main.mm
+++ b/test_apps/cube_handle_gl_macos/main.mm
@@ -40,6 +40,7 @@
 // stb_image implementation TU lives in displayxr::common (stb_image_impl_macos.cpp) — declarations only here (#396 W4).
 #include "stb_image.h"
 #include "view_params.h"
+#include "mode_switch.h" // dxr::ModeSwitch — smooth 2D<->3D disparity ramp (inline on macOS)
 #include "rig_mode.h"
 #include "atlas_capture.h"
 #include "xr_window_space_hud.h"
@@ -758,6 +759,10 @@ struct InputState {
     bool captureAtlasRequested = false;
 };
 static InputState g_input;
+// Smooth 2D<->3D disparity ramp, driven inline (macOS has its own AppXrSession/
+// InputState, not the Windows-only XrSessionManager helper).
+static dxr::ModeSwitch g_modeSwitch;
+static bool g_modeSwitchConfigured = false;
 static const float CAMERA_HALF_TAN_VFOV = 0.32491969623f; // tan(18deg) -> 36deg vFOV
 
 // HUD window-space layer (XR_EXT_window_space_layer): replaces the legacy
@@ -923,9 +928,13 @@ static void PumpMacOSEvents()
                 float factor = (dy > 0) ? 1.1f : (1.0f / 1.1f);
                 NSUInteger scrollMods = [event modifierFlags];
                 if (scrollMods & NSEventModifierFlagShift) {
-                    g_input.viewParams.ipdFactor *= factor;
-                    if (g_input.viewParams.ipdFactor < 0.0f) g_input.viewParams.ipdFactor = 0.0f;
-                    if (g_input.viewParams.ipdFactor > 1.0f) g_input.viewParams.ipdFactor = 1.0f;
+                    // Edit steadyIpdFactor (the ModeSwitch ramp target); seed
+                    // ipdFactor in lockstep for the idle/non-ramp render path.
+                    float v = g_input.viewParams.steadyIpdFactor * factor;
+                    if (v < 0.0f) v = 0.0f;
+                    if (v > 1.0f) v = 1.0f;
+                    g_input.viewParams.steadyIpdFactor = v;
+                    g_input.viewParams.ipdFactor = v;
                 } else if (scrollMods & NSEventModifierFlagControl) {
                     g_input.viewParams.parallaxFactor *= factor;
                     if (g_input.viewParams.parallaxFactor < 0.0f) g_input.viewParams.parallaxFactor = 0.0f;
@@ -1637,25 +1646,47 @@ int main(int argc, char **argv)
         PumpMacOSEvents();
         PollEvents(app);
 
-        // Handle rendering mode requests (V=cycle next, 0-8=jump absolute).
-        // Single source of truth: the runtime owns the current mode. Keypresses
-        // are REQUESTS — we call xrRequestDisplayRenderingModeEXT and let the
-        // XrEventDataRenderingModeChangedEXT event update app.currentModeIndex.
-        // Render paths and HUD read app.currentModeIndex directly.
-        if (g_input.cycleRenderingModeRequested) {
-            g_input.cycleRenderingModeRequested = false;
-            if (app.pfnRequestDisplayRenderingModeEXT && app.session != XR_NULL_HANDLE &&
-                app.renderingModeCount > 0) {
-                uint32_t next = (app.currentModeIndex + 1) % app.renderingModeCount;
-                app.pfnRequestDisplayRenderingModeEXT(app.session, next);
-            }
+        // Rendering mode requests (V=cycle next, 0-8=jump absolute) through the
+        // dxr::ModeSwitch sequencer: it eases g_input.viewParams.ipdFactor around
+        // the switch and fires xrRequestDisplayRenderingModeEXT on the right frame.
+        // The runtime owns the current mode; the XrEventDataRenderingModeChangedEXT
+        // event updates app.currentModeIndex (render paths + HUD read it directly).
+        if (!g_modeSwitchConfigured) {
+            g_modeSwitch.configure(0.18f, dxr::ModeSwitchEasing::SmoothStep);
+            g_modeSwitchConfigured = true;
         }
-        if (g_input.absoluteRenderingModeRequested >= 0) {
-            uint32_t target = (uint32_t)g_input.absoluteRenderingModeRequested;
-            g_input.absoluteRenderingModeRequested = -1;
-            if (app.pfnRequestDisplayRenderingModeEXT && app.session != XR_NULL_HANDLE &&
-                target < app.renderingModeCount) {
-                app.pfnRequestDisplayRenderingModeEXT(app.session, target);
+        {
+            const float steady = g_input.viewParams.steadyIpdFactor;
+            auto vcOf = [&](uint32_t m) -> uint32_t {
+                return (m < app.renderingModeCount && app.renderingModeViewCounts[m] > 0)
+                           ? app.renderingModeViewCounts[m] : 1;
+            };
+            int32_t target = -1;
+            if (g_input.cycleRenderingModeRequested) {
+                g_input.cycleRenderingModeRequested = false;
+                if (app.renderingModeCount > 0)
+                    target = (int32_t)((app.currentModeIndex + 1) % app.renderingModeCount);
+            }
+            if (g_input.absoluteRenderingModeRequested >= 0) {
+                int32_t a = g_input.absoluteRenderingModeRequested;
+                g_input.absoluteRenderingModeRequested = -1;
+                if ((uint32_t)a < app.renderingModeCount) target = a;
+            }
+            if (target >= 0 && app.session != XR_NULL_HANDLE && app.pfnRequestDisplayRenderingModeEXT) {
+                const float curIpd = g_modeSwitch.active() ? g_modeSwitch.ipd() : steady;
+                g_modeSwitch.request((uint32_t)target, vcOf((uint32_t)target),
+                                     app.currentModeIndex, vcOf(app.currentModeIndex),
+                                     curIpd, steady);
+            }
+            if (g_modeSwitch.active()) {
+                float ipd = steady; bool fire = false; uint32_t mode = app.currentModeIndex;
+                g_modeSwitch.update(dt, &ipd, &fire, &mode);
+                g_input.viewParams.ipdFactor = ipd;
+                if (fire && mode != app.currentModeIndex && app.session != XR_NULL_HANDLE &&
+                    app.pfnRequestDisplayRenderingModeEXT)
+                    app.pfnRequestDisplayRenderingModeEXT(app.session, mode);
+            } else {
+                g_input.viewParams.ipdFactor = steady;
             }
         }
 

--- a/test_apps/cube_handle_metal_macos/CMakeLists.txt
+++ b/test_apps/cube_handle_metal_macos/CMakeLists.txt
@@ -60,7 +60,7 @@ set(DISPLAYXR_EXTENSIONS_INCLUDE_DIR "${_dxr_ext_includes}" CACHE PATH
 FetchContent_Declare(
     displayxr_common
     GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
-    GIT_TAG v1.0.7
+    GIT_TAG v1.1.1
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(displayxr_common)

--- a/test_apps/cube_handle_metal_macos/main.mm
+++ b/test_apps/cube_handle_metal_macos/main.mm
@@ -38,6 +38,7 @@
 // stb_image implementation TU lives in displayxr::common (stb_image_impl_macos.cpp) — declarations only here (#396 W4).
 #include "stb_image.h"
 #include "view_params.h"
+#include "mode_switch.h" // dxr::ModeSwitch — smooth 2D<->3D disparity ramp (inline on macOS)
 #include "rig_mode.h"
 #include "atlas_capture.h"
 #include "xr_window_space_hud.h"
@@ -814,6 +815,11 @@ struct InputState {
     bool captureAtlasRequested = false;
 };
 static InputState g_input;
+// Smooth 2D<->3D disparity ramp. macOS has its own AppXrSession/InputState (not
+// the Windows-only XrSessionManager), so the sequencer is driven inline below
+// rather than through common's XrSessionUpdateModeSwitch helper.
+static dxr::ModeSwitch g_modeSwitch;
+static bool g_modeSwitchConfigured = false;
 static const float CAMERA_HALF_TAN_VFOV = 0.32491969623f; // tan(18deg) -> 36deg vFOV
 
 // HUD window-space layer (XR_EXT_window_space_layer): a fractional-window-space
@@ -991,9 +997,13 @@ static void PumpMacOSEvents()
                 float factor = (dy > 0) ? 1.1f : (1.0f / 1.1f);
                 NSUInteger scrollMods = [event modifierFlags];
                 if (scrollMods & NSEventModifierFlagShift) {
-                    g_input.viewParams.ipdFactor *= factor;
-                    if (g_input.viewParams.ipdFactor < 0.0f) g_input.viewParams.ipdFactor = 0.0f;
-                    if (g_input.viewParams.ipdFactor > 1.0f) g_input.viewParams.ipdFactor = 1.0f;
+                    // Edit steadyIpdFactor (the ModeSwitch ramp target); seed
+                    // ipdFactor in lockstep for the idle/non-ramp render path.
+                    float v = g_input.viewParams.steadyIpdFactor * factor;
+                    if (v < 0.0f) v = 0.0f;
+                    if (v > 1.0f) v = 1.0f;
+                    g_input.viewParams.steadyIpdFactor = v;
+                    g_input.viewParams.ipdFactor = v;
                 } else if (scrollMods & NSEventModifierFlagControl) {
                     g_input.viewParams.parallaxFactor *= factor;
                     if (g_input.viewParams.parallaxFactor < 0.0f) g_input.viewParams.parallaxFactor = 0.0f;
@@ -1940,25 +1950,49 @@ int main(int argc, char **argv)
         PumpMacOSEvents();
         PollEvents(app);
 
-        // Handle rendering mode requests (V=cycle next, 0-8=jump absolute).
-        // Single source of truth: the runtime owns the current mode. Keypresses
-        // are REQUESTS — we call xrRequestDisplayRenderingModeEXT and let the
-        // XrEventDataRenderingModeChangedEXT event update app.currentModeIndex.
-        // Render paths and HUD read app.currentModeIndex directly.
-        if (g_input.cycleRenderingModeRequested) {
-            g_input.cycleRenderingModeRequested = false;
-            if (app.pfnRequestDisplayRenderingModeEXT && app.session != XR_NULL_HANDLE &&
-                app.renderingModeCount > 0) {
-                uint32_t next = (app.currentModeIndex + 1) % app.renderingModeCount;
-                app.pfnRequestDisplayRenderingModeEXT(app.session, next);
-            }
+        // Rendering mode requests (V=cycle next, 0-8=jump absolute) through the
+        // dxr::ModeSwitch sequencer: it eases g_input.viewParams.ipdFactor around
+        // the switch and fires xrRequestDisplayRenderingModeEXT on the right frame.
+        // The runtime owns the current mode; the XrEventDataRenderingModeChangedEXT
+        // event updates app.currentModeIndex (render paths + HUD read it directly).
+        if (!g_modeSwitchConfigured) {
+            g_modeSwitch.configure(0.18f, dxr::ModeSwitchEasing::SmoothStep);
+            g_modeSwitchConfigured = true;
         }
-        if (g_input.absoluteRenderingModeRequested >= 0) {
-            uint32_t target = (uint32_t)g_input.absoluteRenderingModeRequested;
-            g_input.absoluteRenderingModeRequested = -1;
-            if (app.pfnRequestDisplayRenderingModeEXT && app.session != XR_NULL_HANDLE &&
-                target < app.renderingModeCount) {
-                app.pfnRequestDisplayRenderingModeEXT(app.session, target);
+        {
+            const float steady = g_input.viewParams.steadyIpdFactor;
+            auto vcOf = [&](uint32_t m) -> uint32_t {
+                return (m < app.renderingModeCount && app.renderingModeViewCounts[m] > 0)
+                           ? app.renderingModeViewCounts[m] : 1;
+            };
+            int32_t target = -1;
+            if (g_input.cycleRenderingModeRequested) {
+                g_input.cycleRenderingModeRequested = false;
+                if (app.renderingModeCount > 0)
+                    target = (int32_t)((app.currentModeIndex + 1) % app.renderingModeCount);
+            }
+            if (g_input.absoluteRenderingModeRequested >= 0) {
+                int32_t a = g_input.absoluteRenderingModeRequested;
+                g_input.absoluteRenderingModeRequested = -1;
+                if ((uint32_t)a < app.renderingModeCount) target = a;
+            }
+            if (target >= 0 && app.session != XR_NULL_HANDLE && app.pfnRequestDisplayRenderingModeEXT) {
+                // currentIpd = on-screen disparity now: last ramp output while a
+                // ramp is in flight, else steady (avoids the first-press snap).
+                const float curIpd = g_modeSwitch.active() ? g_modeSwitch.ipd() : steady;
+                g_modeSwitch.request((uint32_t)target, vcOf((uint32_t)target),
+                                     app.currentModeIndex, vcOf(app.currentModeIndex),
+                                     curIpd, steady);
+            }
+            if (g_modeSwitch.active()) {
+                float ipd = steady; bool fire = false; uint32_t mode = app.currentModeIndex;
+                g_modeSwitch.update(dt, &ipd, &fire, &mode);
+                g_input.viewParams.ipdFactor = ipd;
+                if (fire && mode != app.currentModeIndex && app.session != XR_NULL_HANDLE &&
+                    app.pfnRequestDisplayRenderingModeEXT)
+                    app.pfnRequestDisplayRenderingModeEXT(app.session, mode);
+            } else {
+                g_input.viewParams.ipdFactor = steady;
             }
         }
 

--- a/test_apps/cube_handle_vk_macos/CMakeLists.txt
+++ b/test_apps/cube_handle_vk_macos/CMakeLists.txt
@@ -64,7 +64,7 @@ set(DISPLAYXR_EXTENSIONS_INCLUDE_DIR "${_dxr_ext_includes}" CACHE PATH
 FetchContent_Declare(
     displayxr_common
     GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
-    GIT_TAG v1.0.7
+    GIT_TAG v1.1.1
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(displayxr_common)

--- a/test_apps/cube_handle_vk_macos/main.mm
+++ b/test_apps/cube_handle_vk_macos/main.mm
@@ -44,6 +44,7 @@
 #include <unistd.h>
 
 #include "view_params.h"
+#include "mode_switch.h" // dxr::ModeSwitch — smooth 2D<->3D disparity ramp (inline on macOS)
 #include "rig_mode.h"
 #include "projection_depth.h"
 #include "atlas_capture.h"
@@ -136,6 +137,10 @@ static volatile bool g_running = true;
 static NSWindow *g_window = nil;
 static NSView *g_metalView = nil;
 static InputState g_input;
+// Smooth 2D<->3D disparity ramp, driven inline (macOS has its own session +
+// InputState, not the Windows-only XrSessionManager helper).
+static dxr::ModeSwitch g_modeSwitch;
+static bool g_modeSwitchConfigured = false;
 static const float CAMERA_HALF_TAN_VFOV = 0.32491969623f; // tan(18°) → 36° vFOV
 
 // Borderless fullscreen state
@@ -1776,9 +1781,13 @@ static void ApplyScrollFactor(float dy, uint32_t mods) {
     bool ctrl  = (mods & (1u << 1)) != 0;
     bool alt   = (mods & (1u << 2)) != 0;
     if (shift) {
-        g_input.viewParams.ipdFactor *= factor;
-        if (g_input.viewParams.ipdFactor < 0.0f) g_input.viewParams.ipdFactor = 0.0f;
-        if (g_input.viewParams.ipdFactor > 1.0f) g_input.viewParams.ipdFactor = 1.0f;
+        // Edit steadyIpdFactor (the ModeSwitch ramp target); seed ipdFactor in
+        // lockstep for the idle/non-ramp render path.
+        float v = g_input.viewParams.steadyIpdFactor * factor;
+        if (v < 0.0f) v = 0.0f;
+        if (v > 1.0f) v = 1.0f;
+        g_input.viewParams.steadyIpdFactor = v;
+        g_input.viewParams.ipdFactor = v;
     } else if (ctrl) {
         g_input.viewParams.parallaxFactor *= factor;
         if (g_input.viewParams.parallaxFactor < 0.0f) g_input.viewParams.parallaxFactor = 0.0f;
@@ -3244,25 +3253,47 @@ int main() {
         if (vkRenderer.cubeRotation > 2.0f * 3.14159265f)
             vkRenderer.cubeRotation -= 2.0f * 3.14159265f;
 
-        // Handle rendering mode requests (V=cycle next, 0-8=jump absolute).
-        // Single source of truth: the runtime owns the current mode. Keypresses
-        // are REQUESTS — we call xrRequestDisplayRenderingModeEXT and let the
-        // XrEventDataRenderingModeChangedEXT event update xr.currentModeIndex.
-        // Render paths and HUD read xr.currentModeIndex directly.
-        if (g_input.cycleRenderingModeRequested) {
-            g_input.cycleRenderingModeRequested = false;
-            if (xr.pfnRequestDisplayRenderingModeEXT && xr.session != XR_NULL_HANDLE &&
-                xr.renderingModeCount > 0) {
-                uint32_t next = (xr.currentModeIndex + 1) % xr.renderingModeCount;
-                xr.pfnRequestDisplayRenderingModeEXT(xr.session, next);
-            }
+        // Rendering mode requests (V=cycle next, 0-8=jump absolute) through the
+        // dxr::ModeSwitch sequencer: it eases g_input.viewParams.ipdFactor around
+        // the switch and fires xrRequestDisplayRenderingModeEXT on the right frame.
+        // The runtime owns the current mode; the XrEventDataRenderingModeChangedEXT
+        // event updates xr.currentModeIndex (render paths + HUD read it directly).
+        if (!g_modeSwitchConfigured) {
+            g_modeSwitch.configure(0.18f, dxr::ModeSwitchEasing::SmoothStep);
+            g_modeSwitchConfigured = true;
         }
-        if (g_input.absoluteRenderingModeRequested >= 0) {
-            uint32_t target = (uint32_t)g_input.absoluteRenderingModeRequested;
-            g_input.absoluteRenderingModeRequested = -1;
-            if (xr.pfnRequestDisplayRenderingModeEXT && xr.session != XR_NULL_HANDLE &&
-                target < xr.renderingModeCount) {
-                xr.pfnRequestDisplayRenderingModeEXT(xr.session, target);
+        {
+            const float steady = g_input.viewParams.steadyIpdFactor;
+            auto vcOf = [&](uint32_t m) -> uint32_t {
+                return (m < xr.renderingModeCount && xr.renderingModeViewCounts[m] > 0)
+                           ? xr.renderingModeViewCounts[m] : 1;
+            };
+            int32_t target = -1;
+            if (g_input.cycleRenderingModeRequested) {
+                g_input.cycleRenderingModeRequested = false;
+                if (xr.renderingModeCount > 0)
+                    target = (int32_t)((xr.currentModeIndex + 1) % xr.renderingModeCount);
+            }
+            if (g_input.absoluteRenderingModeRequested >= 0) {
+                int32_t a = g_input.absoluteRenderingModeRequested;
+                g_input.absoluteRenderingModeRequested = -1;
+                if ((uint32_t)a < xr.renderingModeCount) target = a;
+            }
+            if (target >= 0 && xr.session != XR_NULL_HANDLE && xr.pfnRequestDisplayRenderingModeEXT) {
+                const float curIpd = g_modeSwitch.active() ? g_modeSwitch.ipd() : steady;
+                g_modeSwitch.request((uint32_t)target, vcOf((uint32_t)target),
+                                     xr.currentModeIndex, vcOf(xr.currentModeIndex),
+                                     curIpd, steady);
+            }
+            if (g_modeSwitch.active()) {
+                float ipd = steady; bool fire = false; uint32_t mode = xr.currentModeIndex;
+                g_modeSwitch.update(deltaTime, &ipd, &fire, &mode);
+                g_input.viewParams.ipdFactor = ipd;
+                if (fire && mode != xr.currentModeIndex && xr.session != XR_NULL_HANDLE &&
+                    xr.pfnRequestDisplayRenderingModeEXT)
+                    xr.pfnRequestDisplayRenderingModeEXT(xr.session, mode);
+            } else {
+                g_input.viewParams.ipdFactor = steady;
             }
         }
 


### PR DESCRIPTION
## What

Wires the smooth 2D↔3D disparity ramp into the three **macOS** cube handle apps (`cube_handle_{metal,gl,vk}_macos`).

macOS uses its own `AppXrSession` + `InputState` (not the Windows-only `XrSessionManager` helper), so `dxr::ModeSwitch` is driven **inline** in `main.mm`:
- On V/0-8: `request()` the sequencer with `currentIpd = active() ? ipd() : steady` (avoids the first-press snap fixed in common v1.1.1).
- Each frame: `update()` and write `g_input.viewParams.ipdFactor` (what the rig render site reads), firing `xrRequestDisplayRenderingModeEXT` on the right frame.
- The shift+scroll IPD tuner now edits `steadyIpdFactor` (seeding `ipdFactor` in lockstep).
- Common pins bumped v1.0.7 → **v1.1.1**.

## Test

⚠️ Code was written on a Windows box (no local macOS compile). **Relying on this PR's macOS CI to compile-verify**, then a Mac eyeball of the ramp. Logic mirrors the Leia-validated Windows cube apps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)