### PR TITLE
feat(weave,#625): xrWeaveSnapWindowRectEXT — window-drag phase lock

### DIFF
--- a/src/external/openxr_includes/openxr/XR_EXT_weave.h
+++ b/src/external/openxr_includes/openxr/XR_EXT_weave.h
@@ -47,6 +47,25 @@
  * Availability: this runtime implements the weave service only on the
  * out-of-process (service / IPC) path. An in-process session reports
  * XR_ERROR_FEATURE_UNSUPPORTED.
+ *
+ * Window-drag phase lock (issue #625). A present-owner that moves its own
+ * window must keep the woven interlace phase-locked to the panel as the window
+ * travels, or the lenticular subpixels shift under the lenses and the 3D
+ * collapses into crosstalk jitter. The DP snaps the window to the nearest
+ * phase-aligned screen position; the snap math + lens parameters are the
+ * vendor's (ADR-019), so they never leave the DP. The present-owner intercepts
+ * WM_WINDOWPOSCHANGING, hands the runtime the drag-start origin rect + the
+ * proposed target rect, and applies the returned phase-snapped rect before the
+ * OS commits the move:
+ *
+ *   // on WM_ENTERSIZEMOVE: remember the drag-start window rect (origin).
+ *   // on WM_WINDOWPOSCHANGING (proposed pos = target):
+ *   XrRect2Di snapped = {};
+ *   xrWeaveSnapWindowRectEXT(session, &origin, &target, &snapped);
+ *   pos->x = snapped.offset.x; pos->y = snapped.offset.y;  // apply
+ *
+ * Only the rect's offset (top-left) is snapped; the extent passes through
+ * unchanged. This is a synchronous, GPU-free query — no texture, no fence.
  */
 #ifndef XR_EXT_WEAVE_H
 #define XR_EXT_WEAVE_H 1
@@ -59,7 +78,7 @@ extern "C" {
 #endif
 
 #define XR_EXT_weave 1
-#define XR_EXT_weave_SPEC_VERSION 1
+#define XR_EXT_weave_SPEC_VERSION 2
 #define XR_EXT_WEAVE_EXTENSION_NAME "XR_EXT_weave"
 
 // Reserved 1000999190..191. Final values reconcile with the Khronos registry
@@ -135,6 +154,9 @@ typedef XrResult (XRAPI_PTR *PFN_xrWeaveBindWindowEXT)(
 typedef XrResult (XRAPI_PTR *PFN_xrWeaveSubmitEXT)(
     XrSession session, const XrWeaveSubmitInfoEXT* submitInfo, XrWeaveOutputEXT* output);
 
+typedef XrResult (XRAPI_PTR *PFN_xrWeaveSnapWindowRectEXT)(
+    XrSession session, const XrRect2Di* originRect, const XrRect2Di* targetRect, XrRect2Di* snappedRect);
+
 #ifndef XR_NO_PROTOTYPES
 
 //! Bind the present-owner's window (HWND on Windows) so the DP phase-snaps the
@@ -149,6 +171,19 @@ XRAPI_ATTR XrResult XRAPI_CALL xrWeaveBindWindowEXT(
 //! presenting. Reports XR_ERROR_FEATURE_UNSUPPORTED on an in-process session.
 XRAPI_ATTR XrResult XRAPI_CALL xrWeaveSubmitEXT(
     XrSession session, const XrWeaveSubmitInfoEXT* submitInfo, XrWeaveOutputEXT* output);
+
+//! Snap a proposed window rect to the nearest interlace-phase-aligned screen
+//! position so the woven 3D stays locked while the present-owner drags its
+//! window. @c originRect is the drag-start window rect; @c targetRect is the
+//! proposed (OS-requested) rect; both in absolute screen pixels (the phase is
+//! absolute). On return @c snappedRect->offset is the phase-snapped top-left and
+//! @c snappedRect->extent equals @c targetRect->extent (size is not snapped).
+//! GPU-free and synchronous. If the DP can't snap (no vendor support, panel in
+//! 2D), @c snappedRect is copied from @c targetRect (a no-op snap) and the call
+//! still returns XR_SUCCESS. Reports XR_ERROR_FEATURE_UNSUPPORTED on an
+//! in-process session.
+XRAPI_ATTR XrResult XRAPI_CALL xrWeaveSnapWindowRectEXT(
+    XrSession session, const XrRect2Di* originRect, const XrRect2Di* targetRect, XrRect2Di* snappedRect);
 
 #endif /* !XR_NO_PROTOTYPES */
 

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -11692,6 +11692,44 @@ comp_d3d11_service_weave_export_fence(struct xrt_compositor *xc, xrt_graphics_sy
 	return true;
 }
 
+extern "C" bool
+comp_d3d11_service_weave_snap_window_rect(struct xrt_compositor *xc,
+                                          int32_t origin_x,
+                                          int32_t origin_y,
+                                          int32_t target_x,
+                                          int32_t target_y,
+                                          int32_t *out_x,
+                                          int32_t *out_y)
+{
+	if (out_x == nullptr || out_y == nullptr) {
+		return false;
+	}
+	// Default = no-op snap (caller keeps the proposed target).
+	*out_x = target_x;
+	*out_y = target_y;
+	if (xc == nullptr || xc->destroy != compositor_destroy) {
+		return false;
+	}
+	struct d3d11_service_compositor *c = d3d11_service_compositor_from_xrt(xc);
+	if (c->render.display_processor == nullptr) {
+		return false;
+	}
+
+	// The snap drives the vendor SR weaver's phase math, which reads the same
+	// (non-thread-safe) immediate context as the render thread — serialize with
+	// it just like weave_submit does.
+	std::lock_guard<std::recursive_mutex> lock(c->sys->render_mutex);
+
+	int32_t sx = target_x, sy = target_y;
+	if (!xrt_display_processor_d3d11_snap_window_rect(c->render.display_processor, origin_x, origin_y, target_x,
+	                                                  target_y, &sx, &sy)) {
+		return false; // DP has no snap support — caller uses the target unchanged
+	}
+	*out_x = sx;
+	*out_y = sy;
+	return true;
+}
+
 
 /*
  *

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.h
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.h
@@ -969,6 +969,24 @@ comp_d3d11_service_weave_export_output(struct xrt_compositor *xc,
 bool
 comp_d3d11_service_weave_export_fence(struct xrt_compositor *xc, xrt_graphics_sync_handle_t *out_handle);
 
+/*!
+ * Snap a proposed window rect to the nearest interlace-phase-aligned screen
+ * position (window-drag phase lock, #625). Forwards the drag-start origin
+ * top-left + the proposed target top-left (absolute screen pixels) to the DP's
+ * @ref xrt_display_processor_d3d11::snap_window_rect and returns the snapped
+ * top-left. The snap math + lens params stay vendor-internal (ADR-019). Returns
+ * false when @p xc is not a D3D11 service compositor or the DP has no snap
+ * support — the caller then uses @p target_x/@p target_y unchanged.
+ */
+bool
+comp_d3d11_service_weave_snap_window_rect(struct xrt_compositor *xc,
+                                          int32_t origin_x,
+                                          int32_t origin_y,
+                                          int32_t target_x,
+                                          int32_t target_y,
+                                          int32_t *out_x,
+                                          int32_t *out_y);
+
 /*! @} */
 
 

--- a/src/xrt/include/xrt/xrt_display_processor_d3d11.h
+++ b/src/xrt/include/xrt/xrt_display_processor_d3d11.h
@@ -350,6 +350,40 @@ struct xrt_display_processor_d3d11
 	 * @param enabled  true ⟹ the app self-presents a shared texture (canvas-only).
 	 */
 	void (*set_shared_texture_present)(struct xrt_display_processor_d3d11 *xdp, bool enabled);
+
+	/*!
+	 * Snap a proposed window rect to the nearest interlace-phase-aligned
+	 * screen position (window-drag phase lock, #625 / XR_EXT_weave). A
+	 * present-owner that moves its own window must keep the woven interlace
+	 * locked to the panel phase as the window travels, or the lenticular
+	 * subpixels shift under the lenses and the 3D collapses into crosstalk
+	 * jitter. The vendor owns the snap math + lens parameters (ADR-019), so
+	 * the runtime passes the drag-start origin top-left and the proposed
+	 * target top-left (absolute screen pixels — the phase is absolute) and
+	 * the DP returns the phase-snapped top-left. Only the top-left is
+	 * snapped; the caller keeps the size unchanged.
+	 *
+	 * Optional — absent slot (older plug-in `struct_size`) or NULL ⟹ no
+	 * snap support; the runtime then leaves the window at @p target_x/y.
+	 * Appended per ADR-020 (append-only within a major).
+	 *
+	 * @param      xdp       Pointer to self.
+	 * @param      origin_x  Drag-start window left, absolute screen px.
+	 * @param      origin_y  Drag-start window top, absolute screen px.
+	 * @param      target_x  Proposed window left, absolute screen px.
+	 * @param      target_y  Proposed window top, absolute screen px.
+	 * @param[out] out_x     Phase-snapped window left, absolute screen px.
+	 * @param[out] out_y     Phase-snapped window top, absolute screen px.
+	 * @return true if a snap was produced (out_x/out_y valid); false ⟹ the
+	 *         caller uses target_x/target_y unchanged.
+	 */
+	bool (*snap_window_rect)(struct xrt_display_processor_d3d11 *xdp,
+	                         int32_t origin_x,
+	                         int32_t origin_y,
+	                         int32_t target_x,
+	                         int32_t target_y,
+	                         int32_t *out_x,
+	                         int32_t *out_y);
 };
 
 /*
@@ -401,7 +435,8 @@ XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, set_background_2d
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, set_eye_tracking_mode)        == XRT_DP_D3D11_BASE_OFF + 15 * sizeof(void *), XRT_DP_ABI_MSG);
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, set_transparent_background)    == XRT_DP_D3D11_BASE_OFF + 16 * sizeof(void *), XRT_DP_ABI_MSG);
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, set_shared_texture_present)    == XRT_DP_D3D11_BASE_OFF + 17 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(sizeof(struct xrt_display_processor_d3d11)                                == XRT_DP_D3D11_BASE_OFF + 18 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_d3d11, snap_window_rect)              == XRT_DP_D3D11_BASE_OFF + 18 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(sizeof(struct xrt_display_processor_d3d11)                                == XRT_DP_D3D11_BASE_OFF + 19 * sizeof(void *), XRT_DP_ABI_MSG);
 // clang-format on
 
 /*!
@@ -687,6 +722,30 @@ xrt_display_processor_d3d11_set_shared_texture_present(struct xrt_display_proces
 	}
 	xdp->set_shared_texture_present(xdp, enabled);
 	return true;
+}
+
+/*!
+ * @copydoc xrt_display_processor_d3d11::snap_window_rect
+ *
+ * Helper for calling through the function pointer. Returns false (and leaves
+ * out_x/out_y untouched) if the slot is absent (older plug-in) or NULL — the
+ * caller then keeps target_x/target_y unchanged.
+ *
+ * @public @memberof xrt_display_processor_d3d11
+ */
+static inline bool
+xrt_display_processor_d3d11_snap_window_rect(struct xrt_display_processor_d3d11 *xdp,
+                                             int32_t origin_x,
+                                             int32_t origin_y,
+                                             int32_t target_x,
+                                             int32_t target_y,
+                                             int32_t *out_x,
+                                             int32_t *out_y)
+{
+	if (!XRT_DP_HAS_SLOT(xdp, snap_window_rect) || xdp->snap_window_rect == NULL) {
+		return false;
+	}
+	return xdp->snap_window_rect(xdp, origin_x, origin_y, target_x, target_y, out_x, out_y);
 }
 
 /*!

--- a/src/xrt/ipc/client/ipc_client_compositor.c
+++ b/src/xrt/ipc/client/ipc_client_compositor.c
@@ -612,6 +612,42 @@ comp_ipc_client_compositor_weave_get_fence(struct xrt_compositor *xc,
 	return XRT_SUCCESS;
 }
 
+xrt_result_t
+comp_ipc_client_compositor_weave_snap_window_rect(struct xrt_compositor *xc,
+                                                  int32_t origin_x,
+                                                  int32_t origin_y,
+                                                  int32_t target_x,
+                                                  int32_t target_y,
+                                                  bool *out_snapped,
+                                                  int32_t *out_snapped_x,
+                                                  int32_t *out_snapped_y)
+{
+	if (xc == NULL || out_snapped == NULL || out_snapped_x == NULL || out_snapped_y == NULL) {
+		return XRT_ERROR_IPC_FAILURE;
+	}
+	// Default = no-op snap (caller keeps the proposed target).
+	*out_snapped = false;
+	*out_snapped_x = target_x;
+	*out_snapped_y = target_y;
+
+	struct ipc_client_compositor *icc = ipc_client_compositor(xc);
+	if (icc == NULL || icc->ipc_c == NULL) {
+		return XRT_ERROR_IPC_FAILURE;
+	}
+
+	bool snapped = false;
+	int32_t sx = target_x, sy = target_y;
+	xrt_result_t xret = ipc_call_weave_snap_window_rect(icc->ipc_c, origin_x, origin_y, target_x, target_y,
+	                                                    &snapped, &sx, &sy);
+	if (xret != XRT_SUCCESS) {
+		return xret;
+	}
+	*out_snapped = snapped;
+	*out_snapped_x = sx;
+	*out_snapped_y = sy;
+	return XRT_SUCCESS;
+}
+
 
 /*
  * Workspace controller bridges — thin accessors used by the OpenXR state

--- a/src/xrt/ipc/server/ipc_server_handler.c
+++ b/src/xrt/ipc/server/ipc_server_handler.c
@@ -5451,6 +5451,42 @@ ipc_handle_weave_get_fence(volatile struct ipc_client_state *ics,
 }
 
 xrt_result_t
+ipc_handle_weave_snap_window_rect(volatile struct ipc_client_state *ics,
+                                  int32_t origin_x,
+                                  int32_t origin_y,
+                                  int32_t target_x,
+                                  int32_t target_y,
+                                  bool *out_snapped,
+                                  int32_t *out_snapped_x,
+                                  int32_t *out_snapped_y)
+{
+	IPC_TRACE_MARKER();
+
+	// Default = no-op snap (the caller keeps its proposed target).
+	*out_snapped = false;
+	*out_snapped_x = target_x;
+	*out_snapped_y = target_y;
+
+	if (ics->xc == NULL) {
+		return XRT_ERROR_IPC_SESSION_NOT_CREATED;
+	}
+
+#if defined(XRT_HAVE_D3D11_SERVICE_COMPOSITOR)
+	int32_t sx = target_x, sy = target_y;
+	if (comp_d3d11_service_weave_snap_window_rect(ics->xc, origin_x, origin_y, target_x, target_y, &sx, &sy)) {
+		*out_snapped = true;
+		*out_snapped_x = sx;
+		*out_snapped_y = sy;
+	}
+	return XRT_SUCCESS;
+#else
+	(void)origin_x;
+	(void)origin_y;
+	return XRT_SUCCESS;
+#endif
+}
+
+xrt_result_t
 ipc_handle_compositor_semaphore_destroy(volatile struct ipc_client_state *ics, uint32_t id)
 {
 	if (ics->xc == NULL) {

--- a/src/xrt/ipc/shared/ipcproto/common.py
+++ b/src/xrt/ipc/shared/ipcproto/common.py
@@ -108,6 +108,7 @@ class Arg:
 
     # Keep all these synchronized with the definitions in the JSON Schema.
     SCALAR_TYPES = set(("uint32_t",
+                        "int32_t",
                         "int64_t",
                         "uint64_t",
                         "bool",

--- a/src/xrt/ipc/shared/proto.json
+++ b/src/xrt/ipc/shared/proto.json
@@ -742,6 +742,20 @@
 		"out_handles": {"type": "xrt_graphics_sync_handle_t"}
 	},
 
+	"weave_snap_window_rect": {
+		"in": [
+			{"name": "origin_x", "type": "int32_t"},
+			{"name": "origin_y", "type": "int32_t"},
+			{"name": "target_x", "type": "int32_t"},
+			{"name": "target_y", "type": "int32_t"}
+		],
+		"out": [
+			{"name": "snapped", "type": "bool"},
+			{"name": "snapped_x", "type": "int32_t"},
+			{"name": "snapped_y", "type": "int32_t"}
+		]
+	},
+
 	"compositor_semaphore_destroy": {
 		"in": [
 			{"name": "id", "type": "uint32_t"}

--- a/src/xrt/ipc/shared/proto.schema.json
+++ b/src/xrt/ipc/shared/proto.schema.json
@@ -11,6 +11,7 @@
             "type": "string",
             "enum": [
                 "uint32_t",
+                "int32_t",
                 "int64_t",
                 "uint64_t",
                 "bool",

--- a/src/xrt/state_trackers/oxr/oxr_api_funcs.h
+++ b/src/xrt/state_trackers/oxr/oxr_api_funcs.h
@@ -1057,6 +1057,13 @@ oxr_xrWeaveBindWindowEXT(XrSession session, void *windowHandle);
 //! OpenXR API function @ep{xrWeaveSubmitEXT}
 XRAPI_ATTR XrResult XRAPI_CALL
 oxr_xrWeaveSubmitEXT(XrSession session, const XrWeaveSubmitInfoEXT *submitInfo, XrWeaveOutputEXT *output);
+
+//! OpenXR API function @ep{xrWeaveSnapWindowRectEXT}
+XRAPI_ATTR XrResult XRAPI_CALL
+oxr_xrWeaveSnapWindowRectEXT(XrSession session,
+                            const XrRect2Di *originRect,
+                            const XrRect2Di *targetRect,
+                            XrRect2Di *snappedRect);
 #endif
 
 #ifdef OXR_HAVE_EXT_conformance_automation

--- a/src/xrt/state_trackers/oxr/oxr_api_negotiate.c
+++ b/src/xrt/state_trackers/oxr/oxr_api_negotiate.c
@@ -500,6 +500,7 @@ handle_non_null(struct oxr_instance *inst, struct oxr_logger *log, const char *n
 #ifdef OXR_HAVE_EXT_weave
 	ENTRY_IF_EXT(xrWeaveBindWindowEXT, EXT_weave);
 	ENTRY_IF_EXT(xrWeaveSubmitEXT, EXT_weave);
+	ENTRY_IF_EXT(xrWeaveSnapWindowRectEXT, EXT_weave);
 #endif
 
 #ifdef OXR_HAVE_EXT_workspace_file_dialog

--- a/src/xrt/state_trackers/oxr/oxr_weave.c
+++ b/src/xrt/state_trackers/oxr/oxr_weave.c
@@ -74,6 +74,16 @@ comp_ipc_client_compositor_weave_get_fence(struct xrt_compositor *xc,
                                            bool *out_have_fence,
                                            xrt_graphics_sync_handle_t *out_handle);
 
+xrt_result_t
+comp_ipc_client_compositor_weave_snap_window_rect(struct xrt_compositor *xc,
+                                                  int32_t origin_x,
+                                                  int32_t origin_y,
+                                                  int32_t target_x,
+                                                  int32_t target_y,
+                                                  bool *out_snapped,
+                                                  int32_t *out_snapped_x,
+                                                  int32_t *out_snapped_y);
+
 //! IPC sessions hold a native-compositor handle (the IPC client compositor) but
 //! none of the in-process native-compositor flags are set. Mirrors oxr_capture.c.
 static bool
@@ -195,6 +205,48 @@ oxr_xrWeaveSubmitEXT(XrSession session, const XrWeaveSubmitInfoEXT *submitInfo, 
 		sess->weave.last_h = h;
 	}
 
+	return XR_SUCCESS;
+}
+
+XRAPI_ATTR XrResult XRAPI_CALL
+oxr_xrWeaveSnapWindowRectEXT(XrSession session,
+                             const XrRect2Di *originRect,
+                             const XrRect2Di *targetRect,
+                             XrRect2Di *snappedRect)
+{
+	OXR_TRACE_MARKER();
+
+	struct oxr_session *sess = NULL;
+	struct oxr_logger log;
+	OXR_VERIFY_SESSION_AND_INIT_LOG(&log, session, sess, "xrWeaveSnapWindowRectEXT");
+	OXR_VERIFY_SESSION_NOT_LOST(&log, sess);
+	OXR_VERIFY_EXTENSION(&log, sess->sys->inst, EXT_weave);
+	OXR_VERIFY_ARG_NOT_NULL(&log, originRect);
+	OXR_VERIFY_ARG_NOT_NULL(&log, targetRect);
+	OXR_VERIFY_ARG_NOT_NULL(&log, snappedRect);
+
+	if (!session_is_ipc(sess)) {
+		return oxr_error(&log, XR_ERROR_FEATURE_UNSUPPORTED,
+		                 "xrWeaveSnapWindowRectEXT: the weave service is only available on the "
+		                 "out-of-process (service) path");
+	}
+
+	// Only the top-left is phase-snapped; the size passes through unchanged.
+	// On no DP snap support the bridge returns the target unchanged, so the
+	// result is always a valid rect.
+	bool snapped = false;
+	int32_t sx = targetRect->offset.x, sy = targetRect->offset.y;
+	xrt_result_t xret = comp_ipc_client_compositor_weave_snap_window_rect(
+	    &sess->xcn->base, originRect->offset.x, originRect->offset.y, targetRect->offset.x, targetRect->offset.y,
+	    &snapped, &sx, &sy);
+	if (xret != XRT_SUCCESS) {
+		return oxr_error(&log, XR_ERROR_RUNTIME_FAILURE,
+		                 "xrWeaveSnapWindowRectEXT: snap failed (xrt_result=%d)", (int)xret);
+	}
+
+	snappedRect->offset.x = sx;
+	snappedRect->offset.y = sy;
+	snappedRect->extent = targetRect->extent;
 	return XR_SUCCESS;
 }
 


### PR DESCRIPTION
Adds an additive snap-rect RPC to `XR_EXT_weave` (spec v1→v2) so a cross-process weave present-owner (the CEF host, #625 Step A) keeps the woven inline-3D **phase-locked to the panel while it drags its own window** — closing the last Step-A gap.

The host intercepts `WM_WINDOWPOSCHANGING` and applies a DP-returned phase-snapped rect; the proprietary snap math + lens params **never leave the display processor** (ADR-019).

## Changes
- **`XR_EXT_weave.h`**: `xrWeaveSnapWindowRectEXT(session, origin, target, &snapped)` + PFN typedef. Only the rect offset is snapped; extent passes through. GPU-free, synchronous.
- **DP vtable**: append `snap_window_rect` at **slot 18** (struct_size-gated, **ABI v4 append-only** per ADR-020) + inline helper + ABI tripwire.
- **d3d11 service**: `comp_d3d11_service_weave_snap_window_rect` forwards under `render_mutex`; no-op (target unchanged) when the DP has no snap support.
- **IPC**: `weave_snap_window_rect` call + server/client bridges. `int32_t` wasn't a proto scalar — added to `ipcproto/common.py` + `proto.schema.json`.
- **oxr**: `oxr_xrWeaveSnapWindowRectEXT` entry + negotiate registration.

In-process sessions report `XR_ERROR_FEATURE_UNSUPPORTED` (weave is service-only). The Leia DP half (probe-window snap driving the SDK's real `SnapToPhase`) ships in `displayxr-leia-plugin` and is gated on this landing (coupled release, ADR-020).

## Validation
Built + deployed on the Leia display; `displayxr-cli selftest` PASS (ABI v4). **Live eyeball passed**: the inline-3D stays phase-locked through a window drag (CEF host + Leia DP probe-window snap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)