### PR TITLE
fix(sim_display,#630): GL anaglyph preserves atlas alpha (translucent 3D zones)

### DIFF
--- a/src/xrt/drivers/sim_display/sim_display_processor_gl.c
+++ b/src/xrt/drivers/sim_display/sim_display_processor_gl.c
@@ -98,7 +98,11 @@ static const char *FS_ANAGLYPH =
     "    vec2 uv_right = vec2((v_uv.x + col) * u_tile_cols_inv, (v_uv.y + row) * u_tile_rows_inv);\n"
     "    vec4 left = texture(u_texture, uv_left);\n"
     "    vec4 right = texture(u_texture, uv_right);\n"
-    "    fragColor = vec4(left.r, right.g, right.b, 1.0);\n"
+    // Preserve alpha (max of both eyes) so translucent/transparent-background
+    // regions survive the anaglyph mix — parity with the VK anaglyph.frag and
+    // the Metal anaglyph_fragment (issue #392 / #630). Forcing alpha to 1.0
+    // here turned premultiplied translucent 3D-zone backgrounds opaque.
+    "    fragColor = vec4(left.r, right.g, right.b, max(left.a, right.a));\n"
     "}\n";
 
 //! Squeezed SBS: left tile on left half, right tile on right half, no crop.


### PR DESCRIPTION
## Summary
On macOS GL (`cube_zones_texture_gl_macos`), a 3D zone with a premultiplied translucent clear color rendered **opaque** instead of see-through. Zone B's clear `{0.0165,0.0165,0.0825, 0.55}` should show the desktop ~45% through, as the Metal/D3D11 siblings do.

## Root cause
The GL sim_display anaglyph shader (`FS_ANAGLYPH`) hard-coded output alpha to `1.0`:
```glsl
fragColor = vec4(left.r, right.g, right.b, 1.0);
```
The Metal `anaglyph_fragment` and the VK `anaglyph.frag` already preserve alpha via `max(left.a, right.a)` (issue #392); the GL leg never got that fix. Zone B is a 3D zone (mask M=1, keep weave), so the forced-opaque alpha went straight to the IOSurface.

## Fix
Output `max(left.a, right.a)`, matching the other two backends. One line.

## Verification
- IOSurface readback: zone B background `(4,4,21,140)` — premultiplied dark blue, alpha 0.55 (was `…,255`); zone A stays opaque `(38,8,8,255)`.
- Live-eyeballed in anaglyph: desktop shows through zone B, matching the Metal sibling.
- No IOSurface sizing change (ADR-010 worst-case intact).

Closes #630.

🤖 Generated with [Claude Code](https://claude.com/claude-code)