### PR TITLE
feat(macos,#59): shared spatial surface — one window, combined atlas, per-eye parallax, chrome/cursor/overlays (gated)

### DIFF
--- a/src/xrt/compositor/main/comp_window_macos.h
+++ b/src/xrt/compositor/main/comp_window_macos.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -36,6 +38,20 @@ struct comp_target;
  */
 struct comp_target *
 comp_window_macos_create(struct comp_compositor *c);
+
+/*!
+ * Tier-2 window placement (#59): reposition and resize the runtime-owned NSWindow
+ * to a display sub-rect so multiple workspace clients tile instead of stacking
+ * full-screen. @p x,y,w,h are top-left-origin display PIXELS (the same space the
+ * Windows service uses); this converts them to AppKit points (bottom-left origin)
+ * for the NSWindow frame and updates the CAMetalLayer drawableSize to the pixel
+ * size on the main thread. The caller (comp_multi) flags the per-session swapchain
+ * for recreation so the next frame rebuilds at the new surface size.
+ *
+ * @ingroup comp_main
+ */
+void
+comp_window_macos_set_window_rect(struct comp_target *ct, int32_t x, int32_t y, int32_t w, int32_t h);
 
 #ifdef __cplusplus
 }

--- a/src/xrt/compositor/main/comp_window_macos.m
+++ b/src/xrt/compositor/main/comp_window_macos.m
@@ -284,6 +284,60 @@ comp_window_macos_init_swapchain(struct comp_target *ct, uint32_t width, uint32_
 	return true;
 }
 
+//! Reposition + resize the NSWindow on the main thread. @p x,y,w,h are top-left
+//! display pixels; AppKit frames are bottom-left points, so flip Y and divide by
+//! the backing scale. Update the CAMetalLayer drawableSize to the pixel size.
+static void
+set_window_rect_on_main_thread(struct comp_window_macos *cwm, int32_t x, int32_t y, int32_t w, int32_t h)
+{
+	if (cwm->window == nil || w <= 0 || h <= 0) {
+		return;
+	}
+
+	NSScreen *screen = [cwm->window screen];
+	if (screen == nil) {
+		screen = [NSScreen mainScreen];
+	}
+	CGFloat scale = [cwm->window backingScaleFactor];
+	if (scale <= 0.0) {
+		scale = 1.0;
+	}
+
+	CGFloat win_x_pt = (CGFloat)x / scale;
+	CGFloat win_w_pt = (CGFloat)w / scale;
+	CGFloat win_h_pt = (CGFloat)h / scale;
+	// AppKit origin is the window's BOTTOM edge, measured from the display bottom.
+	// The pixel rect's top edge is y px from the display top, so its bottom edge is
+	// (y + h) px from the top → screen_height − (y + h) points from the bottom.
+	CGFloat screen_h_pt = (screen != nil) ? screen.frame.size.height : (win_h_pt);
+	CGFloat screen_y0_pt = (screen != nil) ? screen.frame.origin.y : 0.0;
+	CGFloat win_y_pt = screen_y0_pt + screen_h_pt - ((CGFloat)(y + h) / scale);
+
+	NSRect frame = NSMakeRect(win_x_pt, win_y_pt, win_w_pt, win_h_pt);
+	[cwm->window setFrame:frame display:YES];
+
+	if (cwm->metal_layer != nil) {
+		cwm->metal_layer.contentsScale = scale;
+		cwm->metal_layer.drawableSize = CGSizeMake((CGFloat)w, (CGFloat)h);
+	}
+}
+
+void
+comp_window_macos_set_window_rect(struct comp_target *ct, int32_t x, int32_t y, int32_t w, int32_t h)
+{
+	if (ct == NULL) {
+		return;
+	}
+	struct comp_window_macos *cwm = (struct comp_window_macos *)ct;
+	if ([NSThread isMainThread]) {
+		set_window_rect_on_main_thread(cwm, x, y, w, h);
+	} else {
+		dispatch_sync(dispatch_get_main_queue(), ^{
+			set_window_rect_on_main_thread(cwm, x, y, w, h);
+		});
+	}
+}
+
 static void
 comp_window_macos_flush(struct comp_target *ct)
 {

--- a/src/xrt/compositor/main/comp_window_macos.m
+++ b/src/xrt/compositor/main/comp_window_macos.m
@@ -66,6 +66,26 @@
 @end
 
 /*!
+ * Borderless NSWindow subclass for the full-screen workspace surface (#61). A
+ * plain borderless NSWindow returns canBecomeKeyWindow = NO, so it would never
+ * become key and the AppKit pump would receive no input. Override it so the
+ * title-bar-less full-screen workspace window can focus + forward input.
+ */
+@interface CompWindowMacosWindow : NSWindow
+@end
+
+@implementation CompWindowMacosWindow
+- (BOOL)canBecomeKeyWindow
+{
+	return YES;
+}
+- (BOOL)canBecomeMainWindow
+{
+	return YES;
+}
+@end
+
+/*!
  * A macOS present target.
  *
  * @implements comp_target_swapchain
@@ -121,31 +141,44 @@ create_window_on_main_thread(struct comp_window_macos *cwm, uint32_t width, uint
 	// display (its point aspect == the physical-pixel aspect == the atlas
 	// aspect), so derive the window shape from it. Fit to ~85% of the screen
 	// height so the title bar stays reachable. (#48 aspect fix.)
+	// Full-screen workspace surface (#61): cover the WHOLE main display at native
+	// resolution. The single-app OOP model assumes the client fills the display —
+	// the runtime composites workspace chrome / overlays / cursor display-relative
+	// and the controller's hit-test uses the display dims — so a smaller floating
+	// window made the rendered pill, the hit-test quad, and the cursor-pixel
+	// mapping disagree. A full-display window makes all three consistent and
+	// matches Windows. NSScreen.frame is the full display (point aspect == the
+	// physical-pixel atlas aspect, so no squish).
 	CGFloat win_w = (CGFloat)width;
 	CGFloat win_h = (CGFloat)height;
 	NSScreen *screen = [NSScreen mainScreen];
 	if (screen != nil) {
 		NSRect sf = screen.frame;
 		if (sf.size.width > 0 && sf.size.height > 0) {
-			CGFloat aspect = sf.size.width / sf.size.height;
-			win_h = sf.size.height * 0.85;
-			win_w = win_h * aspect;
+			win_w = sf.size.width;
+			win_h = sf.size.height;
 		}
 	}
 
-	NSRect frame = NSMakeRect(100, 100, win_w, win_h);
-	NSWindowStyleMask style = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | NSWindowStyleMaskResizable |
-	                          NSWindowStyleMaskMiniaturizable;
+	NSRect frame = (screen != nil) ? screen.frame : NSMakeRect(0, 0, win_w, win_h);
+	// Borderless so there is no title bar over the workspace chrome; the subclass
+	// restores key-window eligibility a borderless window loses.
+	NSWindowStyleMask style = NSWindowStyleMaskBorderless;
 
-	cwm->window = [[NSWindow alloc] initWithContentRect:frame
-	                                          styleMask:style
-	                                            backing:NSBackingStoreBuffered
-	                                              defer:NO];
+	cwm->window = [[CompWindowMacosWindow alloc] initWithContentRect:frame
+	                                                       styleMask:style
+	                                                         backing:NSBackingStoreBuffered
+	                                                           defer:NO];
 	if (cwm->window == nil) {
 		U_LOG_E("comp_window_macos: failed to create NSWindow");
 		*out_success = false;
 		return;
 	}
+
+	// Float above the menu bar so the chrome pill (just inside the top edge) is
+	// visible + clickable; hide the menu bar + dock while the workspace is up.
+	[cwm->window setLevel:NSMainMenuWindowLevel + 1];
+	[NSApp setPresentationOptions:NSApplicationPresentationAutoHideMenuBar | NSApplicationPresentationAutoHideDock];
 
 	// NSWindow defaults releasedWhenClosed=YES, but the struct holds the window
 	// as an unretained pointer (retained only by NSApp's window list). If the user
@@ -173,8 +206,17 @@ create_window_on_main_thread(struct comp_window_macos *cwm, uint32_t width, uint
 	cwm->metal_layer.contentsScale = scale;
 	cwm->metal_layer.drawableSize = CGSizeMake(win_w * scale, win_h * scale);
 
+	// Deliver bare mouse-moved events (no button held) so the workspace gets hover
+	// motion, not just clicks/drags (#61).
+	[cwm->window setAcceptsMouseMovedEvents:YES];
+
 	[cwm->window makeKeyAndOrderFront:nil];
 	[NSApp activateIgnoringOtherApps:YES];
+
+	// Hide the OS cursor (#61): the workspace renders its own cursor sprite, so the
+	// system arrow would double up (matches Windows). Mouse position still tracked
+	// via the per-cycle CGEventGetLocation poll in the AppKit pump.
+	CGDisplayHideCursor(kCGDirectMainDisplay);
 
 	*out_success = true;
 }
@@ -272,6 +314,10 @@ comp_window_macos_destroy(struct comp_target *ct)
 	struct comp_window_macos *cwm = (struct comp_window_macos *)ct;
 
 	comp_target_swapchain_cleanup(&cwm->base);
+
+	// Restore the OS cursor + menu bar/dock hidden while the workspace was up (#61).
+	CGDisplayShowCursor(kCGDirectMainDisplay);
+	[NSApp setPresentationOptions:NSApplicationPresentationDefault];
 
 	if (cwm->window != nil) {
 		NSWindow *w = cwm->window;

--- a/src/xrt/compositor/multi/comp_multi_private.h
+++ b/src/xrt/compositor/multi/comp_multi_private.h
@@ -646,6 +646,26 @@ struct multi_system_compositor
 	bool shared_surface_initialized; //!< True once the shared window + resources exist.
 	struct comp_target *shared_target;             //!< The one full-screen NSWindow target.
 	struct xrt_display_processor *shared_dp;       //!< The one DP that weaves the combined atlas.
+
+	//! Per-image render rings for the one shared target (mirrors session_render).
+	VkCommandPool shared_cmd_pool;
+	VkCommandBuffer *shared_cmd_buffers;
+	VkFence *shared_fences;
+	uint32_t shared_buffer_count;
+	int shared_fenced_buffer;
+	VkRenderPass shared_render_pass;
+	VkFramebuffer *shared_framebuffers;
+
+	//! The ONE combined stereo atlas (tile_columns × per-eye-display, tile_rows=1)
+	//! that every client composites into before the single DP weave.
+	VkImage shared_atlas_image;
+	VkDeviceMemory shared_atlas_memory;
+	VkImageView shared_atlas_view;
+	int shared_atlas_w, shared_atlas_h; //!< Full atlas dims (tiles * per-eye).
+	int shared_eye_w, shared_eye_h;     //!< Per-eye tile dims (the display px).
+	VkFormat shared_atlas_format;
+	bool shared_atlas_initialized;
+	bool shared_swapchain_needs_recreate;
 	//! @}
 #endif
 };

--- a/src/xrt/compositor/multi/comp_multi_private.h
+++ b/src/xrt/compositor/multi/comp_multi_private.h
@@ -666,6 +666,14 @@ struct multi_system_compositor
 	VkFormat shared_atlas_format;
 	bool shared_atlas_initialized;
 	bool shared_swapchain_needs_recreate;
+
+	//! Chrome/overlay/cursor alpha-blend into the combined atlas (M3): one blend
+	//! pipeline + an atlas-wide framebuffer, composited per-eye (depth-biased for
+	//! chrome) BEFORE the weave so the decorations float above each window in 3D.
+	struct vk_hud_blend shared_chrome_blend;
+	bool shared_chrome_blend_initialized;
+	VkFramebuffer shared_atlas_fb;        //!< Color attachment is the combined atlas.
+	VkImageView shared_atlas_fb_view;     //!< The atlas view the fb was built for (recreate key).
 	//! @}
 #endif
 };

--- a/src/xrt/compositor/multi/comp_multi_private.h
+++ b/src/xrt/compositor/multi/comp_multi_private.h
@@ -410,6 +410,20 @@ struct multi_compositor
 		//! True if window-close exit request has been pushed (avoids duplicates)
 		bool window_close_exit_sent;
 
+		//! @name Tier-2 deferred window placement (macOS, #59)
+		//! xrSetWorkspaceClientWindowPoseEXT stores the target pixel rect + a
+		//! request timestamp here; the per-session render thread applies it
+		//! (reposition + drawable resize + swapchain recreate) only once the size
+		//! has settled (~150 ms with no newer pose). A layout glide fires set_pose
+		//! every frame, and recreating the MoltenVK swapchain on each one churns
+		//! the surface and destabilizes every session a few seconds later — so the
+		//! glide is coalesced into a single recreate at its end.
+		//! @{
+		bool resize_pending;
+		uint64_t resize_request_ns;
+		int32_t resize_x, resize_y, resize_w, resize_h;
+		//! @}
+
 		//! True if per-session resources are initialized
 		bool initialized;
 	} session_render;
@@ -611,6 +625,28 @@ struct multi_system_compositor
 	 * (the #528 surface-lost case) and comes back on resume.
 	 */
 	int android_window_valid_state;
+#endif
+
+#ifdef XRT_OS_MACOS
+	/*!
+	 * @name Shared spatial surface (#59, the spatial-desktop re-architecture)
+	 *
+	 * The Windows D3D11 service composites every client app into ONE full-screen
+	 * window as a 3D spatial window (`comp_d3d11_service.cpp::multi_compositor_render`).
+	 * macOS originally rendered one NSWindow per client (`render_session_to_own_target`),
+	 * which is not a spatial desktop (windows are independent OS windows that
+	 * overlap). This is the macOS analogue of the D3D11 monolith: ONE service-owned
+	 * full-screen window + ONE combined stereo atlas into which each client's content
+	 * is blitted at its 3D pose (per-eye parallax), then ONE display-processor weave
+	 * and ONE present. Built behind @ref shared_surface_enabled while the legacy
+	 * per-session path stays the default; flip the gate once the merge is verified.
+	 * @{
+	 */
+	bool shared_surface_enabled;     //!< Gate: route rendering through the shared surface.
+	bool shared_surface_initialized; //!< True once the shared window + resources exist.
+	struct comp_target *shared_target;             //!< The one full-screen NSWindow target.
+	struct xrt_display_processor *shared_dp;       //!< The one DP that weaves the combined atlas.
+	//! @}
 #endif
 };
 

--- a/src/xrt/compositor/multi/comp_multi_system.c
+++ b/src/xrt/compositor/multi/comp_multi_system.c
@@ -2482,9 +2482,15 @@ session_render_workspace_cursor(struct multi_compositor *mc,
  * @param mc The multi_compositor with per-session rendering
  * @param vk The Vulkan bundle
  * @param display_time_ns The display timestamp
+ * @param force_black When true the client is workspace-minimized (#61): skip all
+ *        content/view/atlas work and present a black desktop canvas, keeping only
+ *        the session-global overlays/cursor (taskbar) at the submit_and_present pass.
  */
 static void
-render_session_to_own_target(struct multi_compositor *mc, struct vk_bundle *vk, int64_t display_time_ns)
+render_session_to_own_target(struct multi_compositor *mc,
+                             struct vk_bundle *vk,
+                             int64_t display_time_ns,
+                             bool force_black)
 {
 	struct comp_target *ct = mc->session_render.target;
 
@@ -2513,6 +2519,13 @@ render_session_to_own_target(struct multi_compositor *mc, struct vk_bundle *vk, 
 		recreate_session_swapchain(mc, vk);
 		// Re-read ct since create_images updates it in place
 		ct = mc->session_render.target;
+	}
+
+	// Workspace-minimized client (#61): skip all content/view/atlas work and jump
+	// straight to acquiring + clearing the target to black. The overlays/cursor are
+	// composited at submit_and_present so the taskbar remains visible.
+	if (force_black) {
+		goto black_canvas;
 	}
 
 	// Must have at least one layer
@@ -2701,6 +2714,8 @@ render_session_to_own_target(struct multi_compositor *mc, struct vk_bundle *vk, 
 	}
 #endif
 
+black_canvas:; // force_black (minimized) jumps here, skipping all content/view setup
+
 	// Establish frame pacing so the per-session comp_target_swapchain has a
 	// valid current_frame_id before acquire/present. render_session_to_own_target
 	// is the only consumer of this target, so it must drive pacing itself —
@@ -2792,6 +2807,42 @@ render_session_to_own_target(struct multi_compositor *mc, struct vk_bundle *vk, 
 	if (ret != VK_SUCCESS) {
 		U_LOG_E("[per-session] Failed to begin command buffer: %s", vk_result_string(ret));
 		return;
+	}
+
+	// Workspace-minimized desktop canvas (#61): clear the swapchain image to black,
+	// leave it in PRESENT_SRC_KHR (the layout submit_and_present's overlay composite
+	// and present expect), then composite only the session-global overlays/cursor.
+	if (force_black) {
+		VkImageSubresourceRange range = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+		VkImageMemoryBarrier to_dst = {
+		    .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+		    .srcAccessMask = 0,
+		    .dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
+		    .oldLayout = VK_IMAGE_LAYOUT_UNDEFINED,
+		    .newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+		    .image = ct->images[buffer_index].handle,
+		    .subresourceRange = range,
+		};
+		vk->vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT,
+		                         0, 0, NULL, 0, NULL, 1, &to_dst);
+
+		VkClearColorValue black = {.float32 = {0.0f, 0.0f, 0.0f, 1.0f}};
+		vk->vkCmdClearColorImage(cmd, ct->images[buffer_index].handle,
+		                         VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, &black, 1, &range);
+
+		VkImageMemoryBarrier to_present = {
+		    .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+		    .srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
+		    .dstAccessMask = 0,
+		    .oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+		    .newLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
+		    .image = ct->images[buffer_index].handle,
+		    .subresourceRange = range,
+		};
+		vk->vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT,
+		                         VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, 0, 0, NULL, 0, NULL, 1,
+		                         &to_present);
+		goto submit_and_present;
 	}
 
 	// #533: 2D is no longer a special-cased mono blit. Both 2D and 3D flow through
@@ -3081,16 +3132,22 @@ submit_and_present:
 	// HUD overlay (post-weave, always readable).
 	// Render for all per-session windows (self-owned and app-provided),
 	// matching the D3D11 compositor which renders HUD for all sessions.
-	session_render_hud_overlay(mc, vk, cmd, ct->images[buffer_index].handle,
-	                           ct->images[buffer_index].view,
-	                           framebufferWidth, framebufferHeight);
+	// A minimized client (#61) shows neither the app HUD nor its own title pill
+	// over the black desktop canvas — only the session-global overlays/cursor.
+	if (!force_black) {
+		session_render_hud_overlay(mc, vk, cmd, ct->images[buffer_index].handle,
+		                           ct->images[buffer_index].view,
+		                           framebufferWidth, framebufferHeight);
 
-	// Workspace chrome (per-client title pill), then the session-global overlays
-	// (taskbar/launcher z=0) and the cursor (topmost) — all composited post-weave
-	// over the HUD, flat (#48). Each is a no-op when nothing is registered.
-	session_render_chrome_overlay(mc, vk, cmd, ct->images[buffer_index].handle,
-	                              ct->images[buffer_index].view,
-	                              framebufferWidth, framebufferHeight);
+		// Workspace chrome (per-client title pill), composited post-weave over the
+		// HUD, flat (#48). A no-op when no chrome is registered for this client.
+		session_render_chrome_overlay(mc, vk, cmd, ct->images[buffer_index].handle,
+		                              ct->images[buffer_index].view,
+		                              framebufferWidth, framebufferHeight);
+	}
+
+	// Session-global overlays (taskbar/launcher z=0) and the cursor (topmost) —
+	// these stay visible even for a minimized client so the taskbar persists.
 	session_render_workspace_overlays(mc, vk, cmd, ct->images[buffer_index].handle,
 	                                  ct->images[buffer_index].view,
 	                                  framebufferWidth, framebufferHeight);
@@ -3191,8 +3248,14 @@ render_per_session_clients_locked(struct multi_system_compositor *msc, int64_t d
 			continue;
 		}
 
-		// Skip if no active/delivered frame
-		if (!mc->delivered.active || mc->delivered.layer_count == 0) {
+		// A workspace-minimized client (#61) renders a black desktop canvas plus
+		// the session-global overlays/cursor — NOT its content — so the taskbar
+		// stays visible while minimized. The client app doesn't know it's
+		// minimized, so it keeps submitting frames; force the black canvas
+		// regardless of delivered state. A non-hidden client with no delivered
+		// frame is skipped as before.
+		bool hidden = comp_multi_workspace_is_window_hidden(&mc->base.base);
+		if (!hidden && (!mc->delivered.active || mc->delivered.layer_count == 0)) {
 			continue;
 		}
 
@@ -3218,8 +3281,8 @@ render_per_session_clients_locked(struct multi_system_compositor *msc, int64_t d
 		}
 #endif
 
-		// Render this session to its own target
-		render_session_to_own_target(mc, vk, display_time_ns);
+		// Render this session to its own target (black canvas + overlays if hidden)
+		render_session_to_own_target(mc, vk, display_time_ns, hidden);
 
 		// Retire the delivered frame for this session
 		int64_t now_ns = os_monotonic_get_ns();

--- a/src/xrt/compositor/multi/comp_multi_system.c
+++ b/src/xrt/compositor/multi/comp_multi_system.c
@@ -2400,23 +2400,18 @@ comp_multi_workspace_set_client_window_pose(struct xrt_compositor *xc,
 	float w_px_f = width_m * px_per_m_x;
 	float h_px_f = height_m * px_per_m_y;
 
-	// ASPECT CLAMP (#59). These content apps render at a FIXED display aspect (one
-	// worst-case swapchain, Kooima projection for the display) and do not reflow to
-	// the window — so presenting that display-aspect content into a window of a
-	// different aspect stretches it (a 2-column grid makes each window ~half the
-	// display aspect → content squished ~2x horizontally). Fit the window to the
-	// display aspect INSIDE the controller's requested rect (letterbox by shrinking
-	// the window, centered) so content stays undistorted. get_pose echoes these
-	// clamped dims, so chrome/cursor/hit-test all stay coherent with what's drawn.
-	// (Filling the whole tile with content letterboxed INSIDE a full-size window is
-	// a nicer follow-up that needs the DP to target a swapchain sub-rect.)
+	// ASPECT FIT (#59), Windows-parity. These content apps render at a FIXED display
+	// aspect and do not reflow, so the window must match that aspect or content
+	// stretches. The Windows D3D11 service keeps the controller's WIDTH and sets
+	// window_height = window_width / content_aspect (comp_d3d11_service.cpp ~L5924).
+	// Mirror that: ALWAYS preserve the requested width and derive the height. This
+	// is what keeps the rendered window width identical to the width the controller
+	// built its chrome texture for — deriving height never moves the width, so the
+	// chrome can't be squished into a narrower-than-its-texture rect (the old code
+	// shrank the width when the request was "too wide", which diverged the two and
+	// caused the chrome squish + hover drift).
 	float disp_aspect = (float)disp_px_w / (float)disp_px_h;
-	float req_aspect = (h_px_f > 0.0f) ? (w_px_f / h_px_f) : disp_aspect;
-	if (req_aspect > disp_aspect) {
-		w_px_f = h_px_f * disp_aspect; // too wide → shrink width
-	} else {
-		h_px_f = w_px_f / disp_aspect; // too tall → shrink height
-	}
+	h_px_f = w_px_f / disp_aspect;
 
 	int32_t w_px = (int32_t)(w_px_f + 0.5f);
 	int32_t h_px = (int32_t)(h_px_f + 0.5f);
@@ -3702,6 +3697,239 @@ shared_client_sort(const void *a, const void *b)
 	return (ca->slot < cb->slot) ? -1 : (ca->slot > cb->slot) ? 1 : 0;
 }
 
+//! Chrome depth offset (meters, toward the viewer) relative to its window. 0 =
+//! coplanar with the window: the pill carries exactly the window's depth (no
+//! extra disparity of its own), so its detailed text/buttons don't fringe in
+//! front of the flat pill background. A small positive value would float it
+//! slightly ahead, but that reads as odd anaglyph fringing on the chrome detail.
+#define SHARED_CHROME_DEPTH_BIAS_M 0.0f
+
+/*!
+ * Ensure the M3 chrome/overlay/cursor blend pipeline and the atlas-wide
+ * framebuffer exist (the framebuffer is rebuilt when the atlas view changes).
+ */
+static bool
+shared_ensure_chrome_blend(struct multi_system_compositor *msc, struct vk_bundle *vk)
+{
+	if (!msc->shared_chrome_blend_initialized) {
+		if (!vk_hud_blend_init(&msc->shared_chrome_blend, vk, msc->shared_atlas_format)) {
+			U_LOG_E("[#59] failed to init shared chrome blend");
+			return false;
+		}
+		msc->shared_chrome_blend_initialized = true;
+	}
+	if (msc->shared_atlas_fb == VK_NULL_HANDLE || msc->shared_atlas_fb_view != msc->shared_atlas_view) {
+		if (msc->shared_atlas_fb != VK_NULL_HANDLE) {
+			vk->vkDestroyFramebuffer(vk->device, msc->shared_atlas_fb, NULL);
+			msc->shared_atlas_fb = VK_NULL_HANDLE;
+		}
+		VkFramebufferCreateInfo fb_info = {
+		    .sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO,
+		    .renderPass = msc->shared_chrome_blend.render_pass,
+		    .attachmentCount = 1,
+		    .pAttachments = &msc->shared_atlas_view,
+		    .width = (uint32_t)msc->shared_atlas_w,
+		    .height = (uint32_t)msc->shared_atlas_h,
+		    .layers = 1,
+		};
+		if (vk->vkCreateFramebuffer(vk->device, &fb_info, NULL, &msc->shared_atlas_fb) != VK_SUCCESS) {
+			U_LOG_E("[#59] failed to create atlas framebuffer");
+			return false;
+		}
+		msc->shared_atlas_fb_view = msc->shared_atlas_view;
+	}
+	return true;
+}
+
+/*!
+ * Alpha-blend one decoration source image into the combined atlas (atlas must be
+ * COLOR_ATTACHMENT_OPTIMAL on entry/exit). The dst rect is clamped to [clip_x0,
+ * clip_x1) × [clip_y0, clip_y1) — the eye's tile — so a decoration can't bleed
+ * into the other eye or off the atlas. The cross-process source rests in GENERAL.
+ */
+static void
+shared_blend_into_atlas(struct multi_system_compositor *msc,
+                        struct vk_bundle *vk,
+                        VkCommandBuffer cmd,
+                        VkImage src_image,
+                        int dst_x,
+                        int dst_y,
+                        int dst_w,
+                        int dst_h,
+                        int clip_x0,
+                        int clip_x1,
+                        int clip_y0,
+                        int clip_y1)
+{
+	if (src_image == VK_NULL_HANDLE || dst_w <= 0 || dst_h <= 0) {
+		return;
+	}
+	// Clamp the dst rect to the clip (eye tile). vk_hud_blend maps the full source
+	// across the dst rect, so clamping squishes a decoration that overhangs the
+	// tile edge — acceptable; chrome/overlays normally sit well inside the tile.
+	int x0 = dst_x < clip_x0 ? clip_x0 : dst_x;
+	int y0 = dst_y < clip_y0 ? clip_y0 : dst_y;
+	int x1 = dst_x + dst_w > clip_x1 ? clip_x1 : dst_x + dst_w;
+	int y1 = dst_y + dst_h > clip_y1 ? clip_y1 : dst_y + dst_h;
+	if (x1 - x0 < 1 || y1 - y0 < 1) {
+		return;
+	}
+
+	VkImageMemoryBarrier to_src = {
+	    .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+	    .srcAccessMask = 0,
+	    .dstAccessMask = VK_ACCESS_SHADER_READ_BIT,
+	    .oldLayout = VK_IMAGE_LAYOUT_GENERAL,
+	    .newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+	    .image = src_image,
+	    .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1},
+	};
+	vk->vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, 0, 0,
+	                         NULL, 0, NULL, 1, &to_src);
+
+	vk_hud_blend_draw_no_layout(&msc->shared_chrome_blend, vk, cmd, msc->shared_atlas_fb,
+	                            (uint32_t)msc->shared_atlas_w, (uint32_t)msc->shared_atlas_h, src_image, x0, y0,
+	                            (uint32_t)(x1 - x0), (uint32_t)(y1 - y0));
+
+	VkImageMemoryBarrier to_general = {
+	    .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+	    .srcAccessMask = VK_ACCESS_SHADER_READ_BIT,
+	    .dstAccessMask = 0,
+	    .oldLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+	    .newLayout = VK_IMAGE_LAYOUT_GENERAL,
+	    .image = src_image,
+	    .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1},
+	};
+	vk->vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0, 0,
+	                         NULL, 0, NULL, 1, &to_general);
+}
+
+/*!
+ * M3: composite the workspace decorations into the combined atlas, per eye,
+ * BEFORE the weave so they carry 3D depth. Chrome floats above each window (its
+ * window pose + a depth bias, projected per eye); session-global overlays
+ * (taskbar/launcher) and the cursor are flat at the panel (z = 0, identical both
+ * eyes). The atlas must be COLOR_ATTACHMENT_OPTIMAL on entry/exit.
+ */
+static void
+shared_composite_decorations(struct multi_system_compositor *msc,
+                             struct vk_bundle *vk,
+                             VkCommandBuffer cmd,
+                             const struct shared_client_render *order,
+                             uint32_t order_count,
+                             const struct xrt_eye_positions *eye_pos,
+                             int eye_w,
+                             int eye_h,
+                             float px_per_m_x,
+                             float px_per_m_y,
+                             uint32_t tile_columns)
+{
+	if (!shared_ensure_chrome_blend(msc, vk)) {
+		return;
+	}
+
+	// Per-client chrome (the title pill), floating above its window in 3D.
+	for (uint32_t c = 0; c < order_count; c++) {
+		const struct shared_client_render *e = &order[c];
+		if (!e->placed) {
+			continue;
+		}
+		struct xrt_swapchain *chrome_xsc = NULL;
+		struct comp_multi_chrome_layout layout;
+		if (!comp_multi_workspace_chrome_get(&e->mc->base.base, &chrome_xsc, &layout)) {
+			continue;
+		}
+		struct comp_swapchain *sc = comp_swapchain(chrome_xsc);
+		if (sc == NULL || sc->vkic.image_count == 0) {
+			continue;
+		}
+		VkImage chrome_img = sc->vkic.images[0].handle;
+		if (chrome_img == VK_NULL_HANDLE) {
+			continue;
+		}
+
+		// Chrome extent + center in WORLD meters (window pose + window-local offset).
+		float chrome_w_m = (layout.width_as_fraction_of_window > 0.0f)
+		                       ? e->win_w_m * layout.width_as_fraction_of_window
+		                       : layout.size_w_m;
+		float chrome_h_m = layout.size_h_m;
+		if (chrome_w_m <= 0.0f || chrome_h_m <= 0.0f) {
+			continue;
+		}
+		float cx_world = e->pose_x + layout.pose_in_client.position.x;
+		float cy_local = layout.anchor_to_window_top_edge
+		                     ? (e->win_h_m * 0.5f + layout.pose_in_client.position.y)
+		                     : layout.pose_in_client.position.y;
+		float cy_world = e->pose_y + cy_local;
+		float cz_world = e->pose_z + SHARED_CHROME_DEPTH_BIAS_M; // float above the window
+
+		for (uint32_t eye = 0; eye < tile_columns; eye++) {
+			uint32_t ei = (eye < eye_pos->count) ? eye : (eye_pos->count - 1);
+			int rx, ry, rw, rh;
+			shared_project_rect_for_eye(cx_world, cy_world, cz_world, chrome_w_m, chrome_h_m,
+			                            eye_pos->eyes[ei].x, eye_pos->eyes[ei].y, eye_pos->eyes[ei].z,
+			                            eye_w, eye_h, px_per_m_x, px_per_m_y, &rx, &ry, &rw, &rh);
+			int tile_x0 = (int)eye * eye_w;
+			shared_blend_into_atlas(msc, vk, cmd, chrome_img, tile_x0 + rx, ry, rw, rh, tile_x0,
+			                        tile_x0 + eye_w, 0, eye_h);
+		}
+	}
+
+	// Session-global overlays (taskbar/launcher), flat at z = 0 in both eye tiles.
+	{
+		struct comp_multi_overlay_state states[COMP_MULTI_WORKSPACE_MAX_OVERLAYS];
+		struct xrt_swapchain *xscs[COMP_MULTI_WORKSPACE_MAX_OVERLAYS];
+		uint32_t n = comp_multi_workspace_copy_overlays(states, xscs, COMP_MULTI_WORKSPACE_MAX_OVERLAYS);
+		for (uint32_t i = 0; i < n; i++) {
+			struct comp_swapchain *sc = comp_swapchain(xscs[i]);
+			if (sc == NULL || sc->vkic.image_count == 0) {
+				continue;
+			}
+			VkImage img = sc->vkic.images[0].handle;
+			if (img == VK_NULL_HANDLE) {
+				continue;
+			}
+			int ow = (int)(states[i].size_w_m * px_per_m_x + 0.5f);
+			int oh = (int)(states[i].size_h_m * px_per_m_y + 0.5f);
+			if (ow < 1 || oh < 1) {
+				continue;
+			}
+			int base_x = (int)(states[i].anchor_x * (float)eye_w - states[i].pivot_x * (float)ow);
+			int base_y = (int)(states[i].anchor_y * (float)eye_h - states[i].pivot_y * (float)oh);
+			for (uint32_t eye = 0; eye < tile_columns; eye++) {
+				int tile_x0 = (int)eye * eye_w;
+				shared_blend_into_atlas(msc, vk, cmd, img, tile_x0 + base_x, base_y, ow, oh,
+				                        tile_x0, tile_x0 + eye_w, 0, eye_h);
+			}
+		}
+	}
+
+	// Session-global cursor, topmost, at the tracked pointer (flat, z = 0).
+	{
+		struct xrt_swapchain *cur_xsc = NULL;
+		struct comp_multi_cursor_state cur;
+		if (comp_multi_workspace_get_cursor(&cur_xsc, &cur)) {
+			struct comp_swapchain *sc = comp_swapchain(cur_xsc);
+			if (sc != NULL && sc->vkic.image_count > 0) {
+				VkImage img = sc->vkic.images[0].handle;
+				int size_px = (int)(cur.size_meters * px_per_m_x + 0.5f);
+				int32_t pxg = 0, pyg = 0;
+				comp_multi_workspace_get_pointer_px(&pxg, &pyg);
+				if (img != VK_NULL_HANDLE && size_px >= 1 && pxg >= 0 && pxg < eye_w && pyg >= 0 &&
+				    pyg < eye_h) {
+					int dx = pxg - (int)(cur.hot_x * (float)size_px);
+					int dy = pyg - (int)(cur.hot_y * (float)size_px);
+					for (uint32_t eye = 0; eye < tile_columns; eye++) {
+						int tile_x0 = (int)eye * eye_w;
+						shared_blend_into_atlas(msc, vk, cmd, img, tile_x0 + dx, dy, size_px,
+						                        size_px, tile_x0, tile_x0 + eye_w, 0, eye_h);
+					}
+				}
+			}
+		}
+	}
+}
+
 /*!
  * Composite every active client into the one combined atlas, weave once, present
  * once. The macOS shared-surface analogue of render_per_session_clients_locked.
@@ -4062,18 +4290,37 @@ render_shared_surface_locked(struct multi_system_compositor *msc, int64_t displa
 		                         0, 0, NULL, 0, NULL, uniq_n, post);
 	}
 
+	// M3: composite the workspace decorations (chrome/overlays/cursor) into the
+	// atlas BEFORE the weave so they carry 3D depth. The blend renders into the
+	// atlas as a color attachment, so transition TRANSFER_DST → COLOR_ATTACHMENT
+	// first; shared_composite_decorations leaves it in COLOR_ATTACHMENT.
+	VkImageMemoryBarrier atlas_to_color = {
+	    .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+	    .srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
+	    .dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT | VK_ACCESS_COLOR_ATTACHMENT_READ_BIT,
+	    .oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+	    .newLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+	    .image = msc->shared_atlas_image,
+	    .subresourceRange = atlas_range,
+	};
+	vk->vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, 0,
+	                         0, NULL, 0, NULL, 1, &atlas_to_color);
+
+	shared_composite_decorations(msc, vk, cmd, order, order_count, &eye_pos, eye_w, eye_h, px_per_m_x, px_per_m_y,
+	                             tile_columns);
+
 	// Atlas → SHADER_READ for the weave.
 	VkImageMemoryBarrier atlas_to_read = {
 	    .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
-	    .srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
+	    .srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
 	    .dstAccessMask = VK_ACCESS_SHADER_READ_BIT,
-	    .oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+	    .oldLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
 	    .newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
 	    .image = msc->shared_atlas_image,
 	    .subresourceRange = atlas_range,
 	};
-	vk->vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, 0, 0, NULL,
-	                         0, NULL, 1, &atlas_to_read);
+	vk->vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+	                         VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, 0, 0, NULL, 0, NULL, 1, &atlas_to_read);
 
 	// Target → COLOR_ATTACHMENT for the weave.
 	VkImageMemoryBarrier pre_weave = {

--- a/src/xrt/compositor/multi/comp_multi_system.c
+++ b/src/xrt/compositor/multi/comp_multi_system.c
@@ -76,6 +76,11 @@
 
 #include <math.h>
 #include <stdio.h>
+
+#ifdef XRT_OS_MACOS
+// Shared spatial surface gate (#59): one full-screen window for all apps.
+DEBUG_GET_ONCE_BOOL_OPTION(shared_surface, "DISPLAYXR_SHARED_SURFACE", false)
+#endif
 #include <assert.h>
 #include <stdarg.h>
 #include <stdlib.h>
@@ -2356,7 +2361,14 @@ comp_multi_workspace_set_client_window_pose(struct xrt_compositor *xc,
 {
 #ifdef XRT_OS_MACOS
 	struct multi_compositor *mc = multi_compositor(xc);
-	if (mc == NULL || pose == NULL || mc->session_render.target == NULL) {
+	if (mc == NULL || pose == NULL) {
+		return false;
+	}
+	// In the shared-surface model (#59) there is no per-client NSWindow; the stored
+	// px-rect drives WHERE this client composites into the combined atlas. Still
+	// store it below, but skip the per-client NSWindow reposition (no target).
+	bool shared = mc->msc->shared_surface_enabled;
+	if (!shared && mc->session_render.target == NULL) {
 		return false;
 	}
 
@@ -2427,12 +2439,14 @@ comp_multi_workspace_set_client_window_pose(struct xrt_compositor *xc,
 	// (#59). Record the target + timestamp; the render thread applies it once the
 	// size has settled (no newer pose for ~150 ms) — coalescing the glide into a
 	// single recreate, the macOS analogue of the Windows defer-during-size-move.
-	mc->session_render.resize_x = x_px;
-	mc->session_render.resize_y = y_px;
-	mc->session_render.resize_w = w_px;
-	mc->session_render.resize_h = h_px;
-	mc->session_render.resize_request_ns = os_monotonic_get_ns();
-	mc->session_render.resize_pending = true;
+	if (!shared) {
+		mc->session_render.resize_x = x_px;
+		mc->session_render.resize_y = y_px;
+		mc->session_render.resize_w = w_px;
+		mc->session_render.resize_h = h_px;
+		mc->session_render.resize_request_ns = os_monotonic_get_ns();
+		mc->session_render.resize_pending = true;
+	}
 	return true;
 #else
 	(void)xc;
@@ -3403,6 +3417,631 @@ submit_and_present:
 
 }
 
+#ifdef XRT_OS_MACOS
+/*
+ * ============================================================================
+ * Shared spatial surface (#59) — the macOS analogue of the Windows D3D11
+ * monolith (comp_d3d11_service.cpp::multi_compositor_render).
+ *
+ * Instead of one NSWindow per client, the service owns ONE full-screen window
+ * and composites every client app into ONE combined stereo atlas at its 3D
+ * pose, then performs ONE display-processor weave and ONE present. M1: flat
+ * (window at panel depth, each client's internal stereo preserved). M2 adds
+ * per-eye parallax; M3 adds chrome/cursor/overlays floating above each window.
+ * ============================================================================
+ */
+
+/*!
+ * Lazily create the one shared full-screen target, its render rings, and the
+ * one display processor. Mirrors multi_compositor_init_session_render but the
+ * resources live on the multi_system_compositor (not a client).
+ */
+static bool
+shared_surface_init(struct multi_system_compositor *msc, struct vk_bundle *vk)
+{
+	if (msc->shared_surface_initialized) {
+		return true;
+	}
+	if (msc->target_service == NULL) {
+		U_LOG_E("[#59] no target service for shared surface");
+		return false;
+	}
+
+	// macOS: the service creates + owns the full-screen NSWindow; the handle arg
+	// is ignored (null_target_service_create_from_window_macos).
+	xrt_result_t ret = comp_target_service_create(msc->target_service, NULL, &msc->shared_target);
+	if (ret != XRT_SUCCESS || msc->shared_target == NULL) {
+		U_LOG_E("[#59] failed to create shared full-screen target: %d", ret);
+		return false;
+	}
+	struct comp_target *ct = msc->shared_target;
+	U_LOG_W("[#59] created shared full-screen target %ux%u fmt=%d (%u images)", ct->width, ct->height,
+	        ct->format, ct->image_count);
+
+	uint32_t image_count = ct->image_count;
+
+	// Command pool + per-image command buffers + fences (signaled).
+	VkResult vr;
+	VkCommandPoolCreateInfo pool_info = {
+	    .sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,
+	    .queueFamilyIndex = vk->main_queue->family_index,
+	    .flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT,
+	};
+	vr = vk->vkCreateCommandPool(vk->device, &pool_info, NULL, &msc->shared_cmd_pool);
+	if (vr != VK_SUCCESS) {
+		U_LOG_E("[#59] failed to create shared command pool: %d", vr);
+		return false;
+	}
+
+	msc->shared_cmd_buffers = U_TYPED_ARRAY_CALLOC(VkCommandBuffer, image_count);
+	msc->shared_fences = U_TYPED_ARRAY_CALLOC(VkFence, image_count);
+	if (msc->shared_cmd_buffers == NULL || msc->shared_fences == NULL) {
+		U_LOG_E("[#59] failed to allocate shared cmd/fence arrays");
+		return false;
+	}
+
+	VkCommandBufferAllocateInfo cb_alloc_info = {
+	    .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO,
+	    .commandPool = msc->shared_cmd_pool,
+	    .level = VK_COMMAND_BUFFER_LEVEL_PRIMARY,
+	    .commandBufferCount = image_count,
+	};
+	vr = vk->vkAllocateCommandBuffers(vk->device, &cb_alloc_info, msc->shared_cmd_buffers);
+	if (vr != VK_SUCCESS) {
+		U_LOG_E("[#59] failed to allocate shared command buffers: %d", vr);
+		return false;
+	}
+
+	VkFenceCreateInfo fence_info = {
+	    .sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO,
+	    .flags = VK_FENCE_CREATE_SIGNALED_BIT,
+	};
+	for (uint32_t i = 0; i < image_count; i++) {
+		vr = vk->vkCreateFence(vk->device, &fence_info, NULL, &msc->shared_fences[i]);
+		if (vr != VK_SUCCESS) {
+			U_LOG_E("[#59] failed to create shared fence %u: %d", i, vr);
+			return false;
+		}
+	}
+	msc->shared_buffer_count = image_count;
+	msc->shared_fenced_buffer = -1;
+
+	// Render pass (single color attachment) + framebuffers — used by a
+	// self-submitting DP that targets the swapchain image (matches per-session).
+	VkAttachmentDescription color_attachment = {
+	    .format = ct->format,
+	    .samples = VK_SAMPLE_COUNT_1_BIT,
+	    .loadOp = VK_ATTACHMENT_LOAD_OP_LOAD,
+	    .storeOp = VK_ATTACHMENT_STORE_OP_STORE,
+	    .stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE,
+	    .stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE,
+	    .initialLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+	    .finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+	};
+	VkAttachmentReference color_ref = {.attachment = 0, .layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL};
+	VkSubpassDescription subpass = {
+	    .pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS,
+	    .colorAttachmentCount = 1,
+	    .pColorAttachments = &color_ref,
+	};
+	VkRenderPassCreateInfo rp_info = {
+	    .sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO,
+	    .attachmentCount = 1,
+	    .pAttachments = &color_attachment,
+	    .subpassCount = 1,
+	    .pSubpasses = &subpass,
+	};
+	vr = vk->vkCreateRenderPass(vk->device, &rp_info, NULL, &msc->shared_render_pass);
+	if (vr == VK_SUCCESS) {
+		msc->shared_framebuffers = U_TYPED_ARRAY_CALLOC(VkFramebuffer, image_count);
+		if (msc->shared_framebuffers != NULL) {
+			for (uint32_t i = 0; i < image_count; i++) {
+				VkFramebufferCreateInfo fb_info = {
+				    .sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO,
+				    .renderPass = msc->shared_render_pass,
+				    .attachmentCount = 1,
+				    .pAttachments = &ct->images[i].view,
+				    .width = ct->width,
+				    .height = ct->height,
+				    .layers = 1,
+				};
+				if (vk->vkCreateFramebuffer(vk->device, &fb_info, NULL,
+				                            &msc->shared_framebuffers[i]) != VK_SUCCESS) {
+					msc->shared_framebuffers[i] = VK_NULL_HANDLE;
+				}
+			}
+		}
+	}
+
+	// The one display processor that weaves the combined atlas.
+	xrt_dp_factory_vk_fn_t factory = (xrt_dp_factory_vk_fn_t)msc->base.info.dp_factory_vk;
+	if (factory != NULL) {
+		xrt_result_t dp_ret = factory(vk,                                         // vk_bundle
+		                              (void *)(uintptr_t)msc->shared_cmd_pool,    // cmd_pool
+		                              NULL,                                        // window_handle (service-owned)
+		                              (int32_t)ct->format,                         // target_format
+		                              &msc->shared_dp);
+		if (dp_ret != XRT_SUCCESS) {
+			U_LOG_W("[#59] shared DP factory failed: %d (no weave)", dp_ret);
+			msc->shared_dp = NULL;
+		} else {
+			U_LOG_W("[#59] created shared display processor");
+		}
+	}
+
+	msc->shared_surface_initialized = true;
+	U_LOG_W("[#59] shared surface initialized");
+	return true;
+}
+
+/*!
+ * Ensure the one combined stereo atlas exists at (tile_columns*eye_w) × eye_h.
+ */
+static bool
+shared_ensure_atlas(struct multi_system_compositor *msc,
+                    struct vk_bundle *vk,
+                    int eye_w,
+                    int eye_h,
+                    uint32_t tile_columns,
+                    VkFormat format)
+{
+	int atlas_w = (int)tile_columns * eye_w;
+	int atlas_h = eye_h;
+	if (msc->shared_atlas_initialized && msc->shared_atlas_w == atlas_w && msc->shared_atlas_h == atlas_h &&
+	    msc->shared_atlas_format == format) {
+		return true;
+	}
+	if (msc->shared_atlas_initialized) {
+		if (msc->shared_atlas_view != VK_NULL_HANDLE)
+			vk->vkDestroyImageView(vk->device, msc->shared_atlas_view, NULL);
+		if (msc->shared_atlas_image != VK_NULL_HANDLE)
+			vk->vkDestroyImage(vk->device, msc->shared_atlas_image, NULL);
+		if (msc->shared_atlas_memory != VK_NULL_HANDLE)
+			vk->vkFreeMemory(vk->device, msc->shared_atlas_memory, NULL);
+		msc->shared_atlas_initialized = false;
+	}
+
+	VkExtent2D extent = {(uint32_t)atlas_w, (uint32_t)atlas_h};
+	VkImageUsageFlags usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
+	VkResult ret =
+	    vk_create_image_simple(vk, extent, format, usage, &msc->shared_atlas_memory, &msc->shared_atlas_image);
+	if (ret != VK_SUCCESS) {
+		U_LOG_E("[#59] failed to create combined atlas: %s", vk_result_string(ret));
+		return false;
+	}
+	VkImageSubresourceRange range = {.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT, .levelCount = 1, .layerCount = 1};
+	ret = vk_create_view(vk, msc->shared_atlas_image, VK_IMAGE_VIEW_TYPE_2D, format, range, &msc->shared_atlas_view);
+	if (ret != VK_SUCCESS) {
+		U_LOG_E("[#59] failed to create combined atlas view: %s", vk_result_string(ret));
+		return false;
+	}
+	msc->shared_atlas_w = atlas_w;
+	msc->shared_atlas_h = atlas_h;
+	msc->shared_eye_w = eye_w;
+	msc->shared_eye_h = eye_h;
+	msc->shared_atlas_format = format;
+	msc->shared_atlas_initialized = true;
+	U_LOG_W("[#59] combined atlas %dx%d (per-eye %dx%d, %u tiles) fmt=%d", atlas_w, atlas_h, eye_w, eye_h,
+	        tile_columns, format);
+	return true;
+}
+
+//! One client's resolved placement + content for the combined-atlas pass.
+struct shared_client_render
+{
+	struct multi_compositor *mc;
+	struct multi_layer_entry *layer;
+	uint32_t view_count;
+	float pose_z;
+	int slot; // stable tie-break (msc->clients index) so equal-z order is deterministic
+	int win_x, win_y, win_w, win_h; // top-left display px
+};
+
+//! Painter's order: far (larger z) first so nearer windows overwrite. Equal z
+//! tie-breaks on the stable client slot — otherwise qsort can swap two
+//! overlapping same-z windows frame to frame, which reads as a blink.
+static int
+shared_client_sort(const void *a, const void *b)
+{
+	const struct shared_client_render *ca = a;
+	const struct shared_client_render *cb = b;
+	if (ca->pose_z > cb->pose_z)
+		return -1;
+	if (ca->pose_z < cb->pose_z)
+		return 1;
+	return (ca->slot < cb->slot) ? -1 : (ca->slot > cb->slot) ? 1 : 0;
+}
+
+/*!
+ * Composite every active client into the one combined atlas, weave once, present
+ * once. The macOS shared-surface analogue of render_per_session_clients_locked.
+ */
+static void
+render_shared_surface_locked(struct multi_system_compositor *msc, int64_t display_time_ns)
+{
+	COMP_TRACE_MARKER();
+
+	struct vk_bundle *vk = comp_target_service_get_vk(msc->target_service);
+	if (vk == NULL) {
+		return;
+	}
+
+	// Collect the clients to composite this frame (active, visible, with content).
+	struct shared_client_render order[MULTI_MAX_CLIENTS];
+	uint32_t order_count = 0;
+	for (size_t k = 0; k < ARRAY_SIZE(msc->clients); k++) {
+		struct multi_compositor *mc = msc->clients[k];
+		if (mc == NULL) {
+			continue;
+		}
+		// A minimized client (#61) contributes nothing to the surface; the
+		// taskbar/overlays draw at the combined pass below regardless.
+		if (comp_multi_workspace_is_window_hidden(&mc->base.base)) {
+			continue;
+		}
+		if (!mc->delivered.active || mc->delivered.layer_count == 0) {
+			continue;
+		}
+		struct multi_layer_entry *layer = NULL;
+		for (uint32_t i = 0; i < mc->delivered.layer_count; i++) {
+			enum xrt_layer_type t = mc->delivered.layers[i].data.type;
+			if (t == XRT_LAYER_PROJECTION || t == XRT_LAYER_PROJECTION_DEPTH || t == XRT_LAYER_ZONE_3D) {
+				layer = &mc->delivered.layers[i];
+				break;
+			}
+		}
+		if (layer == NULL) {
+			continue;
+		}
+
+		struct shared_client_render *e = &order[order_count++];
+		e->mc = mc;
+		e->layer = layer;
+		e->slot = (int)k;
+		uint32_t vc = layer->data.view_count;
+		if (vc < 1)
+			vc = 1;
+		if (vc > XRT_MAX_VIEWS)
+			vc = XRT_MAX_VIEWS;
+		e->view_count = vc;
+
+		// Placement: stored display px-rect from the controller (set_window_pose),
+		// else fall back to the full display (a lone app fills the surface).
+		struct xrt_pose pose = XRT_POSE_IDENTITY;
+		float wm = 0.0f, hm = 0.0f;
+		if (comp_multi_workspace_load_window_pose(&mc->base.base, &pose, &wm, &hm)) {
+			e->pose_z = pose.position.z;
+		} else {
+			e->pose_z = 0.0f;
+		}
+		int wx = 0, wy = 0, ww = 0, wh = 0;
+		if (!comp_multi_workspace_load_window_px_rect(&mc->base.base, &wx, &wy, &ww, &wh) || ww <= 0 ||
+		    wh <= 0) {
+			wx = 0;
+			wy = 0;
+			ww = msc->base.info.display_pixel_width;
+			wh = msc->base.info.display_pixel_height;
+		}
+		e->win_x = wx;
+		e->win_y = wy;
+		e->win_w = ww;
+		e->win_h = wh;
+	}
+
+	// Lazy-init the shared window/DP once a client is present. Avoids creating a
+	// full-screen window with nothing to show.
+	if (order_count == 0 && !msc->shared_surface_initialized) {
+		return;
+	}
+	if (!shared_surface_init(msc, vk)) {
+		return;
+	}
+
+	// Painter's sort (far first).
+	if (order_count > 1) {
+		qsort(order, order_count, sizeof(order[0]), shared_client_sort);
+	}
+
+	struct comp_target *ct = msc->shared_target;
+
+	// Per-eye tile = the display; combined atlas = 2 tiles (stereo) side by side.
+	int eye_w = (int)msc->base.info.display_pixel_width;
+	int eye_h = (int)msc->base.info.display_pixel_height;
+	if (eye_w <= 0 || eye_h <= 0) {
+		eye_w = (int)ct->width;
+		eye_h = (int)ct->height;
+	}
+	const uint32_t tile_columns = 2; // M1: always stereo
+	const uint32_t tile_rows = 1;
+
+	// Atlas format: a SINGLE stable format (the target's) so the atlas is created
+	// once, never per-frame. Clients can submit different swapchain formats (two
+	// identical cubes can land on SRGB vs UNORM); vkCmdBlitImage converts each into
+	// the atlas. Keying recreation on a per-client format made the atlas thrash
+	// (rebuild every frame → full-screen blink) because the painter order — and
+	// thus which client is order[0] — alternates frame to frame.
+	VkFormat atlas_format = ct->format;
+	if (!shared_ensure_atlas(msc, vk, eye_w, eye_h, tile_columns, atlas_format)) {
+		return;
+	}
+
+	// Wait for the previous frame's fence on whatever buffer we'll reuse.
+	if (msc->shared_fenced_buffer >= 0) {
+		vk->vkWaitForFences(vk->device, 1, &msc->shared_fences[msc->shared_fenced_buffer], VK_TRUE, UINT64_MAX);
+		msc->shared_fenced_buffer = -1;
+	}
+
+	// Frame pacing (the shared target is the only consumer; it must drive pacing).
+	{
+		int64_t frame_id = -1, wake = 0, desired = 0, slop = 0, predicted = 0;
+		comp_target_calc_frame_pacing(ct, &frame_id, &wake, &desired, &slop, &predicted);
+		int64_t now_ns = os_monotonic_get_ns();
+		comp_target_mark_wake_up(ct, frame_id, now_ns);
+		comp_target_mark_begin(ct, frame_id, now_ns);
+	}
+
+	uint32_t buffer_index = 0;
+	VkResult ret = comp_target_acquire(ct, &buffer_index);
+	if (ret == VK_ERROR_OUT_OF_DATE_KHR || ret == VK_ERROR_SURFACE_LOST_KHR) {
+		U_LOG_W("[#59] shared acquire %s, skipping frame", vk_result_string(ret));
+		return;
+	}
+	if (ret != VK_SUCCESS && ret != VK_SUBOPTIMAL_KHR) {
+		U_LOG_E("[#59] shared acquire failed: %s", vk_result_string(ret));
+		return;
+	}
+	if (buffer_index >= msc->shared_buffer_count) {
+		U_LOG_E("[#59] shared buffer_index %u out of range", buffer_index);
+		return;
+	}
+
+	vk->vkResetFences(vk->device, 1, &msc->shared_fences[buffer_index]);
+
+	uint32_t fb_w = ct->width, fb_h = ct->height;
+	VkFormat fb_fmt = ct->format;
+	VkFramebuffer framebuffer =
+	    (msc->shared_framebuffers != NULL) ? msc->shared_framebuffers[buffer_index] : VK_NULL_HANDLE;
+
+	VkCommandBuffer cmd = msc->shared_cmd_buffers[buffer_index];
+	vk->vkResetCommandBuffer(cmd, 0);
+	VkCommandBufferBeginInfo begin_info = {
+	    .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
+	    .flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT,
+	};
+	if (vk->vkBeginCommandBuffer(cmd, &begin_info) != VK_SUCCESS) {
+		return;
+	}
+
+	VkImageSubresourceRange atlas_range = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+
+	// Atlas → TRANSFER_DST, then clear to the spatial-desktop backdrop (#1a1a1a).
+	VkImageMemoryBarrier atlas_to_dst = {
+	    .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+	    .srcAccessMask = 0,
+	    .dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
+	    .oldLayout = VK_IMAGE_LAYOUT_UNDEFINED,
+	    .newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+	    .image = msc->shared_atlas_image,
+	    .subresourceRange = atlas_range,
+	};
+	vk->vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, NULL, 0,
+	                         NULL, 1, &atlas_to_dst);
+
+	VkClearColorValue backdrop = {.float32 = {0.1f, 0.1f, 0.1f, 1.0f}};
+	vk->vkCmdClearColorImage(cmd, msc->shared_atlas_image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, &backdrop, 1,
+	                         &atlas_range);
+	// Order the clear before the per-client blits (both TRANSFER writes to the atlas).
+	VkImageMemoryBarrier clear_barrier = {
+	    .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+	    .srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
+	    .dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
+	    .oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+	    .newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+	    .image = msc->shared_atlas_image,
+	    .subresourceRange = atlas_range,
+	};
+	vk->vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, NULL, 0,
+	                         NULL, 1, &clear_barrier);
+
+	// Blit each client's content into its window px-rect, per eye, into the atlas.
+	for (uint32_t c = 0; c < order_count; c++) {
+		struct shared_client_render *e = &order[c];
+		bool flip_y = e->layer->data.flip_y;
+
+		// Resolve the per-view source images for this client.
+		VkImage src_img[XRT_MAX_VIEWS];
+		uint32_t src_arr[XRT_MAX_VIEWS];
+		int src_x[XRT_MAX_VIEWS], src_y[XRT_MAX_VIEWS], src_w[XRT_MAX_VIEWS], src_h[XRT_MAX_VIEWS];
+		bool ok = true;
+		for (uint32_t v = 0; v < e->view_count; v++) {
+			int tw = 0, th = 0;
+			VkFormat fmt = VK_FORMAT_UNDEFINED;
+			VkImageView iv = VK_NULL_HANDLE;
+			VkImage im = VK_NULL_HANDLE;
+			uint32_t ai = 0;
+			if (!get_session_layer_view(e->layer, v, &tw, &th, &fmt, &iv, &im, &ai)) {
+				ok = false;
+				break;
+			}
+			src_img[v] = im;
+			src_arr[v] = ai;
+			src_x[v] = e->layer->data.proj.v[v].sub.rect.offset.w;
+			src_y[v] = e->layer->data.proj.v[v].sub.rect.offset.h;
+			src_w[v] = tw;
+			src_h[v] = th;
+		}
+		if (!ok) {
+			continue;
+		}
+
+		// Pre-barrier the unique source images GENERAL → TRANSFER_SRC.
+		VkImage uniq[XRT_MAX_VIEWS];
+		uint32_t uniq_arr[XRT_MAX_VIEWS];
+		uint32_t uniq_n = 0;
+		for (uint32_t v = 0; v < e->view_count; v++) {
+			bool found = false;
+			for (uint32_t u = 0; u < uniq_n; u++) {
+				if (uniq[u] == src_img[v] && uniq_arr[u] == src_arr[v]) {
+					found = true;
+					break;
+				}
+			}
+			if (!found) {
+				uniq[uniq_n] = src_img[v];
+				uniq_arr[uniq_n] = src_arr[v];
+				uniq_n++;
+			}
+		}
+		VkImageMemoryBarrier pre[XRT_MAX_VIEWS];
+		for (uint32_t u = 0; u < uniq_n; u++) {
+			pre[u] = (VkImageMemoryBarrier){
+			    .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+			    .srcAccessMask = 0,
+			    .dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT,
+			    .oldLayout = VK_IMAGE_LAYOUT_GENERAL,
+			    .newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+			    .image = uniq[u],
+			    .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, uniq_arr[u], 1},
+			};
+		}
+		vk->vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0,
+		                         0, NULL, 0, NULL, uniq_n, pre);
+
+		// Per eye: blit this client's view into its window rect of that eye's tile.
+		// M1 is flat — same dst rect for both eyes; the client's own two views
+		// preserve its internal stereo (window sits on the panel plane).
+		for (uint32_t eye = 0; eye < tile_columns; eye++) {
+			uint32_t v = (eye < e->view_count) ? eye : (e->view_count - 1);
+			int dst_x0 = (int)eye * eye_w + e->win_x;
+			int dst_y0 = e->win_y;
+			int dst_x1 = dst_x0 + e->win_w;
+			int dst_y1 = dst_y0 + e->win_h;
+			int s_top = src_y[v] + (flip_y ? src_h[v] : 0);
+			int s_bot = src_y[v] + (flip_y ? 0 : src_h[v]);
+			VkImageBlit blit = {
+			    .srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, src_arr[v], 1},
+			    .srcOffsets = {{src_x[v], s_top, 0}, {src_x[v] + src_w[v], s_bot, 1}},
+			    .dstSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1},
+			    .dstOffsets = {{dst_x0, dst_y0, 0}, {dst_x1, dst_y1, 1}},
+			};
+			vk->vkCmdBlitImage(cmd, src_img[v], VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+			                   msc->shared_atlas_image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &blit,
+			                   VK_FILTER_LINEAR);
+		}
+
+		// Post-barrier the unique sources back to GENERAL (shared cross-proc rest).
+		VkImageMemoryBarrier post[XRT_MAX_VIEWS];
+		for (uint32_t u = 0; u < uniq_n; u++) {
+			post[u] = (VkImageMemoryBarrier){
+			    .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+			    .srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT,
+			    .dstAccessMask = 0,
+			    .oldLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+			    .newLayout = VK_IMAGE_LAYOUT_GENERAL,
+			    .image = uniq[u],
+			    .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, uniq_arr[u], 1},
+			};
+		}
+		vk->vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+		                         0, 0, NULL, 0, NULL, uniq_n, post);
+	}
+
+	// Atlas → SHADER_READ for the weave.
+	VkImageMemoryBarrier atlas_to_read = {
+	    .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+	    .srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
+	    .dstAccessMask = VK_ACCESS_SHADER_READ_BIT,
+	    .oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+	    .newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+	    .image = msc->shared_atlas_image,
+	    .subresourceRange = atlas_range,
+	};
+	vk->vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, 0, 0, NULL,
+	                         0, NULL, 1, &atlas_to_read);
+
+	// Target → COLOR_ATTACHMENT for the weave.
+	VkImageMemoryBarrier pre_weave = {
+	    .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+	    .srcAccessMask = 0,
+	    .dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+	    .oldLayout = VK_IMAGE_LAYOUT_UNDEFINED,
+	    .newLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+	    .image = ct->images[buffer_index].handle,
+	    .subresourceRange = atlas_range,
+	};
+	vk->vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+	                         0, 0, NULL, 0, NULL, 1, &pre_weave);
+
+	if (msc->shared_dp != NULL) {
+		xrt_display_processor_set_target_color_view(msc->shared_dp, ct->images[buffer_index].view);
+		xrt_display_processor_process_atlas(msc->shared_dp, cmd,
+		                                    (VkImage_XDP)msc->shared_atlas_image, msc->shared_atlas_view,
+		                                    (uint32_t)eye_w, (uint32_t)eye_h, tile_columns, tile_rows,
+		                                    (VkFormat_XDP)atlas_format, framebuffer,
+		                                    (VkImage_XDP)ct->images[buffer_index].handle, fb_w, fb_h,
+		                                    (VkFormat_XDP)fb_fmt, 0, 0, 0, 0);
+	}
+
+	// Target → PRESENT_SRC.
+	VkImageMemoryBarrier post_weave = {
+	    .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+	    .srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+	    .dstAccessMask = 0,
+	    .oldLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+	    .newLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
+	    .image = ct->images[buffer_index].handle,
+	    .subresourceRange = atlas_range,
+	};
+	vk->vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+	                         VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, 0, 0, NULL, 0, NULL, 1, &post_weave);
+
+	if (vk->vkEndCommandBuffer(cmd) != VK_SUCCESS) {
+		return;
+	}
+
+	VkSemaphore wait_sem = ct->semaphores.present_complete;
+	VkPipelineStageFlags wait_stage = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+	VkSemaphore signal_sem = ct->semaphores.render_complete;
+	VkSubmitInfo submit_info = {
+	    .sType = VK_STRUCTURE_TYPE_SUBMIT_INFO,
+	    .waitSemaphoreCount = (wait_sem != VK_NULL_HANDLE) ? 1 : 0,
+	    .pWaitSemaphores = (wait_sem != VK_NULL_HANDLE) ? &wait_sem : NULL,
+	    .pWaitDstStageMask = (wait_sem != VK_NULL_HANDLE) ? &wait_stage : NULL,
+	    .commandBufferCount = 1,
+	    .pCommandBuffers = &cmd,
+	    .signalSemaphoreCount = (signal_sem != VK_NULL_HANDLE) ? 1 : 0,
+	    .pSignalSemaphores = (signal_sem != VK_NULL_HANDLE) ? &signal_sem : NULL,
+	};
+	ret = vk->vkQueueSubmit(vk->main_queue->queue, 1, &submit_info, msc->shared_fences[buffer_index]);
+	if (ret != VK_SUCCESS) {
+		U_LOG_E("[#59] shared submit failed: %s", vk_result_string(ret));
+		return;
+	}
+
+	// Cross-device shared memory has no GPU-level sync between app and compositor
+	// devices (same rationale as the per-session path) — wait before present.
+	vk->vkWaitForFences(vk->device, 1, &msc->shared_fences[buffer_index], VK_TRUE, UINT64_MAX);
+	msc->shared_fenced_buffer = -1;
+
+	ret = comp_target_present(ct, vk->main_queue->queue, buffer_index, 0, display_time_ns, 0);
+	if (ret == VK_ERROR_OUT_OF_DATE_KHR || ret == VK_ERROR_SURFACE_LOST_KHR) {
+		U_LOG_W("[#59] shared present %s", vk_result_string(ret));
+	} else if (ret != VK_SUCCESS && ret != VK_SUBOPTIMAL_KHR) {
+		U_LOG_E("[#59] shared present failed: %s", vk_result_string(ret));
+	}
+
+	// NOTE: do NOT retire the delivered frames here. Unlike the per-session path
+	// (where each client owns a swapchain that persists its last present), the
+	// shared surface rebuilds ONE atlas every compositor frame. Retiring would
+	// clear `delivered`, so any client that did not submit a brand-new frame this
+	// tick would fall back to backdrop → a per-window blink. Leaving `delivered`
+	// sticky (the native compositor's model — it is overwritten on the next
+	// delivery) means every placed client always has content to composite; a
+	// frozen/slow client simply re-shows its last frame, exactly like a real
+	// desktop window.
+}
+#endif // XRT_OS_MACOS
+
 /*!
  * Render all per-session clients to their own targets.
  * Called after xrt_comp_layer_commit() for sessions with external window handles.
@@ -3527,8 +4166,17 @@ transfer_layers_locked(struct multi_system_compositor *msc, int64_t display_time
 		// old swapchain's BufferQueue connection (VK_ERROR_NATIVE_WINDOW_IN_USE_KHR storm)
 		// and pointlessly rebuilds a target no layers will reach. begin_session flips
 		// session_active back on and the next pass re-inits from the then-current surface.
-		if (mc->state.session_active && multi_compositor_has_session_render(mc) &&
-		    !mc->session_render.initialized && !mc->session_render.window_close_exit_sent) {
+		bool skip_session_render_init = false;
+#ifdef XRT_OS_MACOS
+		// Shared spatial surface (#59): every client composites into ONE
+		// service-owned full-screen window, so the per-client NSWindow/target/DP
+		// is never created. The shared surface reads each client's delivered
+		// frames directly (deliver_any_frames below still runs).
+		skip_session_render_init = mc->msc->shared_surface_enabled;
+#endif
+		if (!skip_session_render_init && mc->state.session_active &&
+		    multi_compositor_has_session_render(mc) && !mc->session_render.initialized &&
+		    !mc->session_render.window_close_exit_sent) {
 			multi_compositor_init_session_render(mc);
 		}
 
@@ -3952,7 +4600,16 @@ multi_main_loop(struct multi_system_compositor *msc)
 		// Render per-session clients to their own targets (Phase 4)
 		// These sessions were skipped in transfer_layers_locked and render separately
 		os_mutex_lock(&msc->list_and_timing_lock);
-		render_per_session_clients_locked(msc, predicted_display_time_ns);
+#ifdef XRT_OS_MACOS
+		if (msc->shared_surface_enabled) {
+			// Shared spatial surface (#59): composite every client into ONE
+			// full-screen window + combined atlas → one weave → one present.
+			render_shared_surface_locked(msc, predicted_display_time_ns);
+		} else
+#endif
+		{
+			render_per_session_clients_locked(msc, predicted_display_time_ns);
+		}
 		os_mutex_unlock(&msc->list_and_timing_lock);
 
 		// Re-lock the thread for check in while statement.
@@ -4175,6 +4832,18 @@ comp_multi_create_system_compositor(struct xrt_compositor_native *xcn,
 
 	// Store the target service for per-session rendering (Phase 3)
 	msc->target_service = target_service;
+
+#ifdef XRT_OS_MACOS
+	// Shared spatial surface (#59): when enabled, every client app composites into
+	// ONE full-screen window as a 3D spatial window (the macOS analogue of the
+	// Windows D3D11 monolith), instead of one NSWindow per app. Off by default
+	// while the merge is verified; flip on with DISPLAYXR_SHARED_SURFACE=1.
+	msc->shared_surface_enabled = debug_get_bool_option_shared_surface();
+	msc->shared_fenced_buffer = -1;
+	if (msc->shared_surface_enabled) {
+		U_LOG_W("[#59] shared spatial surface ENABLED (single full-screen window)");
+	}
+#endif
 
 	msc->sessions.active_count = 0;
 	msc->sessions.state = do_warm_start ? MULTI_SYSTEM_STATE_INIT_WARM_START : MULTI_SYSTEM_STATE_STOPPED;

--- a/src/xrt/compositor/multi/comp_multi_system.c
+++ b/src/xrt/compositor/multi/comp_multi_system.c
@@ -2275,6 +2275,34 @@ session_display_dims_m(struct multi_compositor *mc, float *out_w_m, float *out_h
 }
 
 /*!
+ * Public window-dims query for the workspace IPC layer (macOS get_window_pose).
+ *
+ * In the macOS OOP single-app model the content client fills the display, so
+ * its "window" IS the display — and the chrome composite
+ * (@ref session_render_chrome_overlay) places chrome against the same display
+ * dims. Returning those dims here keeps the controller's pill sizing
+ * (win_w * fraction) consistent with where the runtime composites it. The pose
+ * is identity at the origin (the composite ignores per-client window pose in
+ * the single-app model; true multi-window placement is Tier-2, #59).
+ */
+bool
+comp_multi_workspace_get_client_window_dims(struct xrt_compositor *xc,
+                                            struct xrt_pose *out_pose,
+                                            float *out_w_m,
+                                            float *out_h_m)
+{
+	struct multi_compositor *mc = multi_compositor(xc);
+	if (mc == NULL) {
+		return false;
+	}
+	if (out_pose != NULL) {
+		struct xrt_pose ident = XRT_POSE_IDENTITY;
+		*out_pose = ident;
+	}
+	return session_display_dims_m(mc, out_w_m, out_h_m);
+}
+
+/*!
  * Composite the workspace controller's chrome (e.g. a title pill) over this
  * client's woven content, post-weave, as a flat alpha-blended 2D overlay (#48).
  * The chrome swapchain is registered by the controller through the workspace IPC

--- a/src/xrt/compositor/multi/comp_multi_system.c
+++ b/src/xrt/compositor/multi/comp_multi_system.c
@@ -65,6 +65,10 @@
 #include "android/android_globals.h"
 #endif
 
+#ifdef XRT_OS_MACOS
+#include "main/comp_window_macos.h" // per-session NSWindow reposition/resize (#59)
+#endif
+
 #ifdef XRT_BUILD_DRIVER_QWERTY
 #include "qwerty/qwerty_interface.h"
 #include "xrt/xrt_system.h"
@@ -2275,6 +2279,37 @@ session_display_dims_m(struct multi_compositor *mc, float *out_w_m, float *out_h
 }
 
 /*!
+ * Physical size, in meters, of THIS client's window surface (Tier-2, #59). The
+ * display's pixel density is uniform, so window_meters = window_px ÷ display
+ * px-per-meter. The Tier-1 workspace composites used the full display meters with
+ * the window's framebuffer px, which over-sized chrome/overlays/cursor once a
+ * window tiled to a sub-rect (px_per_m came out as window_px ÷ display_m instead
+ * of the true display density). Falls back to the full display dims when px info
+ * is missing (a full-display Tier-1 window then reads identical to before).
+ */
+static bool
+session_window_dims_m(struct multi_compositor *mc, uint32_t fb_w, uint32_t fb_h, float *out_w_m, float *out_h_m)
+{
+	float disp_w_m = 0.0f, disp_h_m = 0.0f;
+	if (!session_display_dims_m(mc, &disp_w_m, &disp_h_m)) {
+		return false;
+	}
+	const struct xrt_system_compositor_info *info = &mc->msc->base.info;
+	uint32_t disp_px_w = info->display_pixel_width;
+	uint32_t disp_px_h = info->display_pixel_height;
+	if (disp_px_w == 0 || disp_px_h == 0 || fb_w == 0 || fb_h == 0) {
+		*out_w_m = disp_w_m;
+		*out_h_m = disp_h_m;
+		return true;
+	}
+	float px_per_m_x = (float)disp_px_w / disp_w_m;
+	float px_per_m_y = (float)disp_px_h / disp_h_m;
+	*out_w_m = (float)fb_w / px_per_m_x;
+	*out_h_m = (float)fb_h / px_per_m_y;
+	return true;
+}
+
+/*!
  * Public window-dims query for the workspace IPC layer (macOS get_window_pose).
  *
  * In the macOS OOP single-app model the content client fills the display, so
@@ -2295,11 +2330,137 @@ comp_multi_workspace_get_client_window_dims(struct xrt_compositor *xc,
 	if (mc == NULL) {
 		return false;
 	}
+	// Tier-2 (#59): if the controller has placed this client, echo the stored
+	// pose + window meters so its chrome sizing and hit-testing match the actual
+	// tiled NSWindow. Until then, fall back to the Tier-1 full-display window.
+	if (comp_multi_workspace_load_window_pose(xc, out_pose, out_w_m, out_h_m)) {
+		return true;
+	}
 	if (out_pose != NULL) {
 		struct xrt_pose ident = XRT_POSE_IDENTITY;
 		*out_pose = ident;
 	}
 	return session_display_dims_m(mc, out_w_m, out_h_m);
+}
+
+/*!
+ * Tier-2 window placement (#59): reposition + resize this client's NSWindow to a
+ * display sub-rect. See the header for the contract. Lives here (not
+ * comp_multi_workspace.c) because it needs session_render + the macOS comp_target.
+ */
+bool
+comp_multi_workspace_set_client_window_pose(struct xrt_compositor *xc,
+                                            const struct xrt_pose *pose,
+                                            float width_m,
+                                            float height_m)
+{
+#ifdef XRT_OS_MACOS
+	struct multi_compositor *mc = multi_compositor(xc);
+	if (mc == NULL || pose == NULL || mc->session_render.target == NULL) {
+		return false;
+	}
+
+	// Clamp to a sane minimum so a degenerate pose can't make a zero-size window.
+	if (width_m < 0.02f) {
+		width_m = 0.02f;
+	}
+	if (height_m < 0.02f) {
+		height_m = 0.02f;
+	}
+
+	// Display geometry from the system compositor info (same fallback the D3D11
+	// service's slot_pose_to_pixel_rect uses).
+	const struct xrt_system_compositor_info *info = &mc->msc->base.info;
+	float disp_w_m = info->display_width_m;
+	float disp_h_m = info->display_height_m;
+	int32_t disp_px_w = (int32_t)info->display_pixel_width;
+	int32_t disp_px_h = (int32_t)info->display_pixel_height;
+	if (disp_w_m <= 0.0f || disp_h_m <= 0.0f || disp_px_w <= 0 || disp_px_h <= 0) {
+		disp_px_w = 3024;
+		disp_px_h = 1964;
+		disp_w_m = 0.301f;
+		disp_h_m = 0.196f;
+	}
+
+	float px_per_m_x = (float)disp_px_w / disp_w_m;
+	float px_per_m_y = (float)disp_px_h / disp_h_m;
+
+	float w_px_f = width_m * px_per_m_x;
+	float h_px_f = height_m * px_per_m_y;
+
+	// ASPECT CLAMP (#59). These content apps render at a FIXED display aspect (one
+	// worst-case swapchain, Kooima projection for the display) and do not reflow to
+	// the window — so presenting that display-aspect content into a window of a
+	// different aspect stretches it (a 2-column grid makes each window ~half the
+	// display aspect → content squished ~2x horizontally). Fit the window to the
+	// display aspect INSIDE the controller's requested rect (letterbox by shrinking
+	// the window, centered) so content stays undistorted. get_pose echoes these
+	// clamped dims, so chrome/cursor/hit-test all stay coherent with what's drawn.
+	// (Filling the whole tile with content letterboxed INSIDE a full-size window is
+	// a nicer follow-up that needs the DP to target a swapchain sub-rect.)
+	float disp_aspect = (float)disp_px_w / (float)disp_px_h;
+	float req_aspect = (h_px_f > 0.0f) ? (w_px_f / h_px_f) : disp_aspect;
+	if (req_aspect > disp_aspect) {
+		w_px_f = h_px_f * disp_aspect; // too wide → shrink width
+	} else {
+		h_px_f = w_px_f / disp_aspect; // too tall → shrink height
+	}
+
+	int32_t w_px = (int32_t)(w_px_f + 0.5f);
+	int32_t h_px = (int32_t)(h_px_f + 0.5f);
+	// Keep the window centered on the controller's requested center (top-left-origin
+	// display pixels; matches slot_pose_to_pixel_rect, +y up).
+	float center_px_x = (float)disp_px_w * 0.5f + pose->position.x * px_per_m_x;
+	float center_px_y = (float)disp_px_h * 0.5f - pose->position.y * px_per_m_y;
+	int32_t x_px = (int32_t)(center_px_x - (float)w_px * 0.5f + 0.5f);
+	int32_t y_px = (int32_t)(center_px_y - (float)h_px * 0.5f + 0.5f);
+
+	// Store the CLAMPED dims (meters derived back from the clamped px) so the
+	// controller's chrome sizing + hit-test match the actual window.
+	float clamped_w_m = (float)w_px / px_per_m_x;
+	float clamped_h_m = (float)h_px / px_per_m_y;
+	comp_multi_workspace_store_window_pose(xc, pose, clamped_w_m, clamped_h_m, x_px, y_px, w_px, h_px);
+
+	// DEFER the actual reposition + resize. A layout glide / drag sends a fresh
+	// pose every frame; applying (NSWindow resize + MoltenVK swapchain recreate)
+	// on each one churns the surface and destabilizes every session seconds later
+	// (#59). Record the target + timestamp; the render thread applies it once the
+	// size has settled (no newer pose for ~150 ms) — coalescing the glide into a
+	// single recreate, the macOS analogue of the Windows defer-during-size-move.
+	mc->session_render.resize_x = x_px;
+	mc->session_render.resize_y = y_px;
+	mc->session_render.resize_w = w_px;
+	mc->session_render.resize_h = h_px;
+	mc->session_render.resize_request_ns = os_monotonic_get_ns();
+	mc->session_render.resize_pending = true;
+	return true;
+#else
+	(void)xc;
+	(void)pose;
+	(void)width_m;
+	(void)height_m;
+	return false;
+#endif
+}
+
+/*!
+ * Ask a managed content client to exit (#59). Mirrors the macOS window-close path
+ * in multi_compositor_wait_frame: push XRT_SESSION_EVENT_EXIT_REQUEST to the
+ * client's per-session compositor so its xrPollEvent transitions to EXITING and
+ * the app leaves its loop cleanly.
+ */
+bool
+comp_multi_workspace_request_client_exit(struct xrt_compositor *target_xc)
+{
+	struct multi_compositor *mc = multi_compositor(target_xc);
+	if (mc == NULL) {
+		return false;
+	}
+	union xrt_session_event xse = XRT_STRUCT_INIT;
+	xse.type = XRT_SESSION_EVENT_EXIT_REQUEST;
+	xrt_result_t r = multi_compositor_push_event(mc, &xse);
+	U_LOG_W("[#59] request_client_exit → push EXIT_REQUEST (ret=%d)", (int)r);
+	return r == XRT_SUCCESS;
 }
 
 /*!
@@ -2341,8 +2502,11 @@ session_render_chrome_overlay(struct multi_compositor *mc,
 		return;
 	}
 
+	// Window-relative dims (#59): chrome is sized/positioned in window-local meters,
+	// so use THIS window's physical size (derived from its framebuffer px), not the
+	// full display. For a full-display Tier-1 window these are identical.
 	float disp_w_m = 0.0f, disp_h_m = 0.0f;
-	if (!session_display_dims_m(mc, &disp_w_m, &disp_h_m)) {
+	if (!session_window_dims_m(mc, fb_width, fb_height, &disp_w_m, &disp_h_m)) {
 		return;
 	}
 	float px_per_m_x = (float)fb_width / disp_w_m;
@@ -2394,8 +2558,10 @@ session_render_workspace_overlays(struct multi_compositor *mc,
 		return;
 	}
 
+	// Window-relative dims (#59) so overlay sizes use the true display density even
+	// when this window is a tiled sub-rect; docked at the window's normalized anchor.
 	float disp_w_m = 0.0f, disp_h_m = 0.0f;
-	if (!session_display_dims_m(mc, &disp_w_m, &disp_h_m) || !ensure_workspace_blend(mc, vk)) {
+	if (!session_window_dims_m(mc, fb_width, fb_height, &disp_w_m, &disp_h_m) || !ensure_workspace_blend(mc, vk)) {
 		return;
 	}
 	float px_per_m_x = (float)fb_width / disp_w_m;
@@ -2458,7 +2624,7 @@ session_render_workspace_cursor(struct multi_compositor *mc,
 	}
 
 	float disp_w_m = 0.0f, disp_h_m = 0.0f;
-	if (!session_display_dims_m(mc, &disp_w_m, &disp_h_m) || !ensure_workspace_blend(mc, vk)) {
+	if (!session_window_dims_m(mc, fb_width, fb_height, &disp_w_m, &disp_h_m) || !ensure_workspace_blend(mc, vk)) {
 		return;
 	}
 	float px_per_m_x = (float)fb_width / disp_w_m;
@@ -2469,6 +2635,20 @@ session_render_workspace_cursor(struct multi_compositor *mc,
 
 	int32_t px = 0, py = 0;
 	comp_multi_workspace_get_pointer_px(&px, &py);
+	// The pointer is in GLOBAL display px; this window's surface is a sub-rect at
+	// (win_x,win_y) px (#59). Convert to window-local px. No stored rect (Tier-1
+	// full-display) → offset 0, identical to before.
+	int32_t win_x = 0, win_y = 0;
+	(void)comp_multi_workspace_load_window_px_rect(&mc->base.base, &win_x, &win_y, NULL, NULL);
+	px -= win_x;
+	py -= win_y;
+	// CLIP: only the window the pointer is actually over draws the sprite. Without
+	// this every tiled window blits a sprite at its own offset (the blend clamps to
+	// the framebuffer), so each window shows a stray "ghost" cursor — and with the
+	// OS cursor hidden the user ends up aiming at a ghost in the wrong window (#59).
+	if (px < 0 || py < 0 || px >= (int32_t)fb_width || py >= (int32_t)fb_height) {
+		return;
+	}
 	// Hotspot: the sprite's hot point sits at the pointer.
 	int32_t dst_x = px - (int32_t)(cur.hot_x * size_px);
 	int32_t dst_y = py - (int32_t)(cur.hot_y * size_px);
@@ -3247,6 +3427,31 @@ render_per_session_clients_locked(struct multi_system_compositor *msc, int64_t d
 		if (mc == NULL || !mc->session_render.initialized) {
 			continue;
 		}
+
+#ifdef XRT_OS_MACOS
+		// Tier-2 deferred window placement (#59): apply a pending set_window_pose
+		// once its size has settled (no newer pose for ~150 ms). Coalesces a layout
+		// glide's per-frame poses into a single NSWindow resize + swapchain
+		// recreate; recreating on every glide frame churns MoltenVK and tears down
+		// every session a few seconds later. The reposition/resize + drawableSize
+		// happen on the main thread inside comp_window_macos_set_window_rect; the
+		// recreate flag drives the next acquire to rebuild at the new surface size.
+		if (mc->session_render.resize_pending) {
+			uint64_t now_ns = os_monotonic_get_ns();
+			const uint64_t settle_ns = (uint64_t)150 * 1000 * 1000; // 150 ms
+			if (now_ns - mc->session_render.resize_request_ns >= settle_ns) {
+				comp_window_macos_set_window_rect(
+				    mc->session_render.target, mc->session_render.resize_x,
+				    mc->session_render.resize_y, mc->session_render.resize_w,
+				    mc->session_render.resize_h);
+				mc->session_render.swapchain_needs_recreate = true;
+				mc->session_render.resize_pending = false;
+				U_LOG_W("[#59] applied settled window rect (%d,%d %dx%d)",
+				        mc->session_render.resize_x, mc->session_render.resize_y,
+				        mc->session_render.resize_w, mc->session_render.resize_h);
+			}
+		}
+#endif
 
 		// A workspace-minimized client (#61) renders a black desktop canvas plus
 		// the session-global overlays/cursor — NOT its content — so the taskbar

--- a/src/xrt/compositor/multi/comp_multi_system.c
+++ b/src/xrt/compositor/multi/comp_multi_system.c
@@ -3632,10 +3632,60 @@ struct shared_client_render
 	struct multi_compositor *mc;
 	struct multi_layer_entry *layer;
 	uint32_t view_count;
-	float pose_z;
 	int slot; // stable tie-break (msc->clients index) so equal-z order is deterministic
-	int win_x, win_y, win_w, win_h; // top-left display px
+	bool placed;                     // true if the controller has set a window pose
+	float pose_x, pose_y, pose_z;    // window center in meters (display-center origin, +y up, +z toward viewer)
+	float win_w_m, win_h_m;          // window size in meters (aspect-clamped)
+	int win_x, win_y, win_w, win_h;  // M1 / unplaced fallback: top-left display px
 };
+
+/*!
+ * Project a window's center pose (meters, display-center origin) through one eye
+ * onto the display plane (Z=0), returning a top-left display-px rect. M2 port of
+ * the D3D11 slot_pose_to_pixel_rect_for_eye: a window at z>0 (toward the viewer)
+ * scales up and parallax-shifts per eye so it floats in front of the panel; z=0
+ * gives both eyes the same rect (window on the panel). px_per_m_{x,y} convert
+ * meters→display px; disp_px_{w,h} are the per-eye display dims.
+ */
+static void
+shared_project_rect_for_eye(float pose_x,
+                            float pose_y,
+                            float pose_z,
+                            float win_w_m,
+                            float win_h_m,
+                            float eye_x,
+                            float eye_y,
+                            float eye_z,
+                            int disp_px_w,
+                            int disp_px_h,
+                            float px_per_m_x,
+                            float px_per_m_y,
+                            int *out_x,
+                            int *out_y,
+                            int *out_w,
+                            int *out_h)
+{
+	float wx = pose_x, wy = pose_y, w_m = win_w_m, h_m = win_h_m;
+	if (fabsf(pose_z) > 0.0001f && eye_z > 0.01f) {
+		float denom = eye_z - pose_z;
+		if (fabsf(denom) < 0.001f) {
+			denom = (denom >= 0.0f) ? 0.001f : -0.001f;
+		}
+		float scale = eye_z / denom;
+		wx = eye_x + scale * (pose_x - eye_x);
+		wy = eye_y + scale * (pose_y - eye_y);
+		w_m *= scale;
+		h_m *= scale;
+	}
+	int w_px = (int)(w_m * px_per_m_x + 0.5f);
+	int h_px = (int)(h_m * px_per_m_y + 0.5f);
+	float center_px_x = (float)disp_px_w * 0.5f + wx * px_per_m_x;
+	float center_px_y = (float)disp_px_h * 0.5f - wy * px_per_m_y; // +y up → -y down
+	*out_x = (int)(center_px_x - (float)w_px * 0.5f + 0.5f);
+	*out_y = (int)(center_px_y - (float)h_px * 0.5f + 0.5f);
+	*out_w = w_px;
+	*out_h = h_px;
+}
 
 //! Painter's order: far (larger z) first so nearer windows overwrite. Equal z
 //! tie-breaks on the stable client slot — otherwise qsort can swap two
@@ -3705,14 +3755,21 @@ render_shared_surface_locked(struct multi_system_compositor *msc, int64_t displa
 			vc = XRT_MAX_VIEWS;
 		e->view_count = vc;
 
-		// Placement: stored display px-rect from the controller (set_window_pose),
-		// else fall back to the full display (a lone app fills the surface).
+		// Placement: the controller's window pose in meters (set_window_pose)
+		// drives per-eye projection (M2). Fall back to the full display px-rect
+		// for an unplaced lone app (M1 behavior, flat at the panel).
 		struct xrt_pose pose = XRT_POSE_IDENTITY;
 		float wm = 0.0f, hm = 0.0f;
-		if (comp_multi_workspace_load_window_pose(&mc->base.base, &pose, &wm, &hm)) {
+		if (comp_multi_workspace_load_window_pose(&mc->base.base, &pose, &wm, &hm) && wm > 0.0f && hm > 0.0f) {
+			e->placed = true;
+			e->pose_x = pose.position.x;
+			e->pose_y = pose.position.y;
 			e->pose_z = pose.position.z;
+			e->win_w_m = wm;
+			e->win_h_m = hm;
 		} else {
-			e->pose_z = 0.0f;
+			e->placed = false;
+			e->pose_x = e->pose_y = e->pose_z = 0.0f;
 		}
 		int wx = 0, wy = 0, ww = 0, wh = 0;
 		if (!comp_multi_workspace_load_window_px_rect(&mc->base.base, &wx, &wy, &ww, &wh) || ww <= 0 ||
@@ -3764,6 +3821,31 @@ render_shared_surface_locked(struct multi_system_compositor *msc, int64_t displa
 	if (!shared_ensure_atlas(msc, vk, eye_w, eye_h, tile_columns, atlas_format)) {
 		return;
 	}
+
+	// Per-eye parallax inputs (M2): the predicted eye positions from the one
+	// display processor, with a nominal 64 mm IPD @ display nominal-z fallback
+	// when no eye tracker has lock (sim has none). px-per-meter converts the
+	// projected window meters into display px.
+	struct xrt_eye_positions eye_pos = {0};
+	if (msc->shared_dp != NULL) {
+		(void)xrt_display_processor_get_predicted_eye_positions(msc->shared_dp, &eye_pos);
+	}
+	if (!eye_pos.valid || eye_pos.count < 2) {
+		float nom_y = (msc->base.info.nominal_viewer_y_m != 0.0f) ? msc->base.info.nominal_viewer_y_m : 0.0f;
+		float nom_z = (msc->base.info.nominal_viewer_z_m > 0.0f) ? msc->base.info.nominal_viewer_z_m : 0.6f;
+		eye_pos.eyes[0] = (struct xrt_eye_position){-0.032f, nom_y, nom_z};
+		eye_pos.eyes[1] = (struct xrt_eye_position){0.032f, nom_y, nom_z};
+		eye_pos.count = 2;
+		eye_pos.valid = true;
+	}
+	float disp_w_m = msc->base.info.display_width_m;
+	float disp_h_m = msc->base.info.display_height_m;
+	if (disp_w_m <= 0.0f || disp_h_m <= 0.0f) {
+		disp_w_m = 0.301f;
+		disp_h_m = 0.196f;
+	}
+	float px_per_m_x = (float)eye_w / disp_w_m;
+	float px_per_m_y = (float)eye_h / disp_h_m;
 
 	// Wait for the previous frame's fence on whatever buffer we'll reuse.
 	if (msc->shared_fenced_buffer >= 0) {
@@ -3908,21 +3990,55 @@ render_shared_surface_locked(struct multi_system_compositor *msc, int64_t displa
 		                         0, NULL, 0, NULL, uniq_n, pre);
 
 		// Per eye: blit this client's view into its window rect of that eye's tile.
-		// M1 is flat — same dst rect for both eyes; the client's own two views
-		// preserve its internal stereo (window sits on the panel plane).
+		// M2: a placed window projects its center pose through each eye onto the
+		// panel (Z=0), so z>0 windows float in front with crossed disparity. An
+		// unplaced lone app uses the flat full-display px-rect (M1). The client's
+		// own two views still supply its internal stereo.
 		for (uint32_t eye = 0; eye < tile_columns; eye++) {
 			uint32_t v = (eye < e->view_count) ? eye : (e->view_count - 1);
-			int dst_x0 = (int)eye * eye_w + e->win_x;
-			int dst_y0 = e->win_y;
-			int dst_x1 = dst_x0 + e->win_w;
-			int dst_y1 = dst_y0 + e->win_h;
-			int s_top = src_y[v] + (flip_y ? src_h[v] : 0);
-			int s_bot = src_y[v] + (flip_y ? 0 : src_h[v]);
+			int rx = e->win_x, ry = e->win_y, rw = e->win_w, rh = e->win_h;
+			if (e->placed) {
+				uint32_t ei = (eye < eye_pos.count) ? eye : (eye_pos.count - 1);
+				shared_project_rect_for_eye(e->pose_x, e->pose_y, e->pose_z, e->win_w_m,
+				                            e->win_h_m, eye_pos.eyes[ei].x, eye_pos.eyes[ei].y,
+				                            eye_pos.eyes[ei].z, eye_w, eye_h, px_per_m_x,
+				                            px_per_m_y, &rx, &ry, &rw, &rh);
+			}
+			if (rw <= 0 || rh <= 0) {
+				continue;
+			}
+			// Full (unclipped) destination span within this eye's tile.
+			int tile_x0 = (int)eye * eye_w;
+			float fdx0 = (float)(tile_x0 + rx);
+			float fdy0 = (float)ry;
+			float fdx1 = fdx0 + (float)rw;
+			float fdy1 = fdy0 + (float)rh;
+			// Source span (flip_y maps top↔bottom).
+			float fsx0 = (float)src_x[v];
+			float fsx1 = (float)(src_x[v] + src_w[v]);
+			float fsy0 = (float)(src_y[v] + (flip_y ? src_h[v] : 0));
+			float fsy1 = (float)(src_y[v] + (flip_y ? 0 : src_h[v]));
+			// Clip the destination to the tile bounds (a projected/edge window can
+			// overflow its tile or the atlas — an out-of-bounds vkCmdBlitImage dst
+			// is invalid usage). Map the clip back into the source proportionally.
+			float cdx0 = fmaxf(fdx0, (float)tile_x0);
+			float cdx1 = fminf(fdx1, (float)(tile_x0 + eye_w));
+			float cdy0 = fmaxf(fdy0, 0.0f);
+			float cdy1 = fminf(fdy1, (float)eye_h);
+			if (cdx1 - cdx0 < 1.0f || cdy1 - cdy0 < 1.0f) {
+				continue;
+			}
+			float ux0 = (cdx0 - fdx0) / (fdx1 - fdx0), ux1 = (cdx1 - fdx0) / (fdx1 - fdx0);
+			float uy0 = (cdy0 - fdy0) / (fdy1 - fdy0), uy1 = (cdy1 - fdy0) / (fdy1 - fdy0);
+			int nsx0 = (int)(fsx0 + ux0 * (fsx1 - fsx0) + 0.5f);
+			int nsx1 = (int)(fsx0 + ux1 * (fsx1 - fsx0) + 0.5f);
+			int nsy0 = (int)(fsy0 + uy0 * (fsy1 - fsy0) + 0.5f);
+			int nsy1 = (int)(fsy0 + uy1 * (fsy1 - fsy0) + 0.5f);
 			VkImageBlit blit = {
 			    .srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, src_arr[v], 1},
-			    .srcOffsets = {{src_x[v], s_top, 0}, {src_x[v] + src_w[v], s_bot, 1}},
+			    .srcOffsets = {{nsx0, nsy0, 0}, {nsx1, nsy1, 1}},
 			    .dstSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1},
-			    .dstOffsets = {{dst_x0, dst_y0, 0}, {dst_x1, dst_y1, 1}},
+			    .dstOffsets = {{(int)cdx0, (int)cdy0, 0}, {(int)cdx1, (int)cdy1, 1}},
 			};
 			vk->vkCmdBlitImage(cmd, src_img[v], VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
 			                   msc->shared_atlas_image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &blit,

--- a/src/xrt/compositor/multi/comp_multi_workspace.c
+++ b/src/xrt/compositor/multi/comp_multi_workspace.c
@@ -24,6 +24,7 @@ struct chrome_entry
 	uint32_t swapchain_id;            //!< Controller-side IPC swapchain id (unregister key).
 	struct comp_multi_chrome_layout layout;
 	bool layout_valid;
+	bool hidden; //!< Client minimized by the workspace controller (#61): render black canvas + overlays.
 };
 
 // One process-global table; the service is a single process. The mutex is
@@ -186,6 +187,38 @@ comp_multi_workspace_chrome_clear(struct xrt_compositor *target_xc)
 		free_entry_locked(e);
 	}
 	os_mutex_unlock(&g_lock);
+}
+
+void
+comp_multi_workspace_set_window_visibility(struct xrt_compositor *target_xc, bool visible)
+{
+	if (target_xc == NULL) {
+		return;
+	}
+	ensure_lock();
+	os_mutex_lock(&g_lock);
+	// find_or_add: a client may be minimized before/without chrome being
+	// registered; the slot then just carries the hidden flag (xsc/layout stay
+	// empty so chrome_get is a no-op).
+	struct chrome_entry *e = find_or_add_locked(target_xc);
+	if (e != NULL) {
+		e->hidden = !visible;
+	}
+	os_mutex_unlock(&g_lock);
+}
+
+bool
+comp_multi_workspace_is_window_hidden(struct xrt_compositor *target_xc)
+{
+	bool hidden = false;
+	ensure_lock();
+	os_mutex_lock(&g_lock);
+	struct chrome_entry *e = find_locked(target_xc);
+	if (e != NULL) {
+		hidden = e->hidden;
+	}
+	os_mutex_unlock(&g_lock);
+	return hidden;
 }
 
 

--- a/src/xrt/compositor/multi/comp_multi_workspace.c
+++ b/src/xrt/compositor/multi/comp_multi_workspace.c
@@ -25,6 +25,19 @@ struct chrome_entry
 	struct comp_multi_chrome_layout layout;
 	bool layout_valid;
 	bool hidden; //!< Client minimized by the workspace controller (#61): render black canvas + overlays.
+
+	//! @name Tier-2 window placement (#59)
+	//! The pose the controller set via xrSetWorkspaceClientWindowPoseEXT plus the
+	//! derived top-left-origin display-pixel rect of the NSWindow. Until the first
+	//! set_window_pose arrives @ref win_pose_valid is false and the client fills the
+	//! whole display (Tier-1 default).
+	//! @{
+	bool win_pose_valid;
+	struct xrt_pose win_pose;
+	float win_w_m;
+	float win_h_m;
+	int32_t win_px_x, win_px_y, win_px_w, win_px_h;
+	//! @}
 };
 
 // One process-global table; the service is a single process. The mutex is
@@ -219,6 +232,91 @@ comp_multi_workspace_is_window_hidden(struct xrt_compositor *target_xc)
 	}
 	os_mutex_unlock(&g_lock);
 	return hidden;
+}
+
+void
+comp_multi_workspace_store_window_pose(struct xrt_compositor *target_xc,
+                                       const struct xrt_pose *pose,
+                                       float width_m,
+                                       float height_m,
+                                       int32_t px_x,
+                                       int32_t px_y,
+                                       int32_t px_w,
+                                       int32_t px_h)
+{
+	if (target_xc == NULL || pose == NULL) {
+		return;
+	}
+	ensure_lock();
+	os_mutex_lock(&g_lock);
+	struct chrome_entry *e = find_or_add_locked(target_xc);
+	if (e != NULL) {
+		e->win_pose = *pose;
+		e->win_w_m = width_m;
+		e->win_h_m = height_m;
+		e->win_px_x = px_x;
+		e->win_px_y = px_y;
+		e->win_px_w = px_w;
+		e->win_px_h = px_h;
+		e->win_pose_valid = true;
+	}
+	os_mutex_unlock(&g_lock);
+}
+
+bool
+comp_multi_workspace_load_window_pose(struct xrt_compositor *target_xc,
+                                      struct xrt_pose *out_pose,
+                                      float *out_w_m,
+                                      float *out_h_m)
+{
+	bool found = false;
+	ensure_lock();
+	os_mutex_lock(&g_lock);
+	struct chrome_entry *e = find_locked(target_xc);
+	if (e != NULL && e->win_pose_valid) {
+		if (out_pose != NULL) {
+			*out_pose = e->win_pose;
+		}
+		if (out_w_m != NULL) {
+			*out_w_m = e->win_w_m;
+		}
+		if (out_h_m != NULL) {
+			*out_h_m = e->win_h_m;
+		}
+		found = true;
+	}
+	os_mutex_unlock(&g_lock);
+	return found;
+}
+
+bool
+comp_multi_workspace_load_window_px_rect(struct xrt_compositor *target_xc,
+                                         int32_t *out_x,
+                                         int32_t *out_y,
+                                         int32_t *out_w,
+                                         int32_t *out_h)
+{
+	bool found = false;
+	ensure_lock();
+	os_mutex_lock(&g_lock);
+	struct chrome_entry *e = find_locked(target_xc);
+	if (e != NULL && e->win_pose_valid) {
+		if (out_x != NULL) {
+			*out_x = e->win_px_x;
+		}
+		if (out_y != NULL) {
+			*out_y = e->win_px_y;
+		}
+		if (out_w != NULL) {
+			*out_w = e->win_px_w;
+		}
+		if (out_h != NULL) {
+			*out_h = e->win_px_h;
+		}
+		found = true;
+	}
+	os_mutex_unlock(&g_lock);
+	return found;
 }
 
 

--- a/src/xrt/compositor/multi/comp_multi_workspace.h
+++ b/src/xrt/compositor/multi/comp_multi_workspace.h
@@ -107,6 +107,23 @@ void
 comp_multi_workspace_chrome_clear(struct xrt_compositor *target_xc);
 
 /*!
+ * Set the minimized/hidden state for a managed content client (#61). When hidden,
+ * the macOS per-session render path renders a black "desktop canvas" plus the
+ * workspace overlays/cursor instead of the client's content, so the taskbar stays
+ * visible while the app is minimized. Uses find-or-add: may be called before chrome
+ * is registered for @p target_xc.
+ */
+void
+comp_multi_workspace_set_window_visibility(struct xrt_compositor *target_xc, bool visible);
+
+/*!
+ * Query whether @p target_xc is currently hidden/minimized (#61). Returns false if
+ * no state is registered for the client.
+ */
+bool
+comp_multi_workspace_is_window_hidden(struct xrt_compositor *target_xc);
+
+/*!
  * Window-dims query for the macOS workspace get_window_pose IPC handler. In the
  * single-app OOP model the client fills the display, so this returns the display
  * dims as the client's window size and an identity pose. Returns false if @p xc

--- a/src/xrt/compositor/multi/comp_multi_workspace.h
+++ b/src/xrt/compositor/multi/comp_multi_workspace.h
@@ -106,6 +106,19 @@ comp_multi_workspace_chrome_get(struct xrt_compositor *target_xc,
 void
 comp_multi_workspace_chrome_clear(struct xrt_compositor *target_xc);
 
+/*!
+ * Window-dims query for the macOS workspace get_window_pose IPC handler. In the
+ * single-app OOP model the client fills the display, so this returns the display
+ * dims as the client's window size and an identity pose. Returns false if @p xc
+ * is not a multi_compositor or display dims are unavailable. Defined in
+ * comp_multi_system.c (alongside the chrome composite that uses the same dims).
+ */
+bool
+comp_multi_workspace_get_client_window_dims(struct xrt_compositor *xc,
+                                            struct xrt_pose *out_pose,
+                                            float *out_w_m,
+                                            float *out_h_m);
+
 
 /*
  *

--- a/src/xrt/compositor/multi/comp_multi_workspace.h
+++ b/src/xrt/compositor/multi/comp_multi_workspace.h
@@ -136,6 +136,72 @@ comp_multi_workspace_get_client_window_dims(struct xrt_compositor *xc,
                                             float *out_w_m,
                                             float *out_h_m);
 
+/*!
+ * Tier-2 window placement (#59). Set the per-client window pose: reposition and
+ * resize the client's runtime-owned NSWindow into a display sub-rect so multiple
+ * apps tile instead of stacking full-screen. Backs the macOS
+ * xrSetWorkspaceClientWindowPoseEXT handler. Computes the pixel rect from @p pose
+ * (display-center origin, meters, +y up) using the display's pixel density,
+ * stores it (so get_window_dims echoes it back to the controller and the cursor
+ * composite can map global cursor px into the window), repositions the NSWindow
+ * on the main thread and flags the per-session swapchain for recreation at the
+ * new size. Defined in comp_multi_system.c (needs session_render + comp_window_macos).
+ * Returns false if @p xc is not a placeable per-session client.
+ */
+bool
+comp_multi_workspace_set_client_window_pose(struct xrt_compositor *xc,
+                                            const struct xrt_pose *pose,
+                                            float width_m,
+                                            float height_m);
+
+/*!
+ * Store the per-client window placement in the registry (pose + meters + the
+ * derived top-left-origin display-pixel rect). Called by
+ * @ref comp_multi_workspace_set_client_window_pose. Find-or-add: a client may be
+ * posed before chrome is registered.
+ */
+void
+comp_multi_workspace_store_window_pose(struct xrt_compositor *target_xc,
+                                       const struct xrt_pose *pose,
+                                       float width_m,
+                                       float height_m,
+                                       int32_t px_x,
+                                       int32_t px_y,
+                                       int32_t px_w,
+                                       int32_t px_h);
+
+/*!
+ * Ask a managed content client to exit (macOS chrome close button / DELETE key,
+ * #59). Pushes XRT_SESSION_EVENT_EXIT_REQUEST to the client's per-session
+ * compositor; its xrPollEvent surfaces XR_SESSION_STATE_EXITING and the app
+ * leaves its frame loop cleanly. Returns false if @p target_xc is not a
+ * placeable per-session client. Defined in comp_multi_system.c.
+ */
+bool
+comp_multi_workspace_request_client_exit(struct xrt_compositor *target_xc);
+
+/*!
+ * Load a previously stored window pose/dims. Returns false if @p target_xc has
+ * not been placed yet (no set_window_pose has arrived).
+ */
+bool
+comp_multi_workspace_load_window_pose(struct xrt_compositor *target_xc,
+                                      struct xrt_pose *out_pose,
+                                      float *out_w_m,
+                                      float *out_h_m);
+
+/*!
+ * Load the stored top-left-origin display-pixel rect for @p target_xc (the
+ * NSWindow's position on the display). The cursor composite uses it to convert
+ * the global cursor px into window-local px. Returns false if not placed.
+ */
+bool
+comp_multi_workspace_load_window_px_rect(struct xrt_compositor *target_xc,
+                                         int32_t *out_x,
+                                         int32_t *out_y,
+                                         int32_t *out_w,
+                                         int32_t *out_h);
+
 
 /*
  *

--- a/src/xrt/drivers/qwerty/qwerty_macos.m
+++ b/src/xrt/drivers/qwerty/qwerty_macos.m
@@ -38,7 +38,11 @@ find_qwerty_system(struct xrt_device **xdevs, size_t xdev_count)
 {
 	struct xrt_device *xdev = NULL;
 	for (size_t i = 0; i < xdev_count; i++) {
-		if (xdevs[i] == NULL) {
+		// Guard tracking_origin: an out-of-process content client's xdevs are IPC
+		// proxies that may have no tracking origin, and during session exit they
+		// can be partially torn down while xrPollEvent still pumps this — derefing
+		// tracking_origin->name then crashes (#59). Skip such devices.
+		if (xdevs[i] == NULL || xdevs[i]->tracking_origin == NULL) {
 			continue;
 		}
 		const char *tracker_name = xdevs[i]->tracking_origin->name;

--- a/src/xrt/ipc/server/ipc_server_handler.c
+++ b/src/xrt/ipc/server/ipc_server_handler.c
@@ -106,6 +106,24 @@ get_orchestrator_workspace_pid(void)
 	return s_workspace_pid_provider ? s_workspace_pid_provider() : 0;
 }
 
+// The effective workspace-controller pid for input/command authorization. The
+// orchestrator only knows a pid for a controller it SPAWNED (Windows Ctrl+Space
+// trampoline). A manually-launched controller — the macOS shell (#61), and any
+// dev/CLI-launched shell — instead registers itself via xrActivateWorkspaceEXT,
+// which sets s->workspace_controller_pid. Prefer that activate-registered pid and
+// fall back to the orchestrator's. On Windows both agree (the orchestrator spawns
+// the shell, which then activates), so this is a no-op there; on macOS it closes
+// the otherwise-open input gate so the controller — not a content app polling
+// xrEnumerateWorkspaceInputEventsEXT — owns the forwarded input stream.
+static unsigned long
+effective_workspace_controller_pid(struct ipc_server *s)
+{
+	if (s != NULL && s->workspace_controller_pid != 0) {
+		return s->workspace_controller_pid;
+	}
+	return get_orchestrator_workspace_pid();
+}
+
 static ipc_server_workspace_supports_file_dialog_fn s_workspace_file_dialog_provider = NULL;
 
 void
@@ -3731,6 +3749,17 @@ ipc_handle_workspace_set_window_visibility(volatile struct ipc_client_state *_ic
 
 	os_mutex_unlock(&s->global_state.lock);
 	return ok ? XRT_SUCCESS : XRT_ERROR_IPC_FAILURE;
+#elif defined(XRT_OS_MACOS)
+	// macOS OOP: record the minimized/hidden state in the workspace registry. The
+	// per-session render path (render_per_session_clients_locked) reads it and
+	// renders a black desktop canvas + overlays for a hidden client instead of
+	// skipping it, so the taskbar stays visible while minimized (#61).
+	struct xrt_compositor *target_xc = macos_workspace_find_client_xc(s, client_id);
+	if (target_xc == NULL) {
+		return XRT_ERROR_IPC_FAILURE;
+	}
+	comp_multi_workspace_set_window_visibility(target_xc, visible);
+	return XRT_SUCCESS;
 #else
 	(void)s;
 	(void)client_id;
@@ -4089,7 +4118,9 @@ ipc_handle_workspace_enumerate_input_events(volatile struct ipc_client_state *_i
 {
 	struct ipc_server *s = _ics->server;
 
-	unsigned long expected_pid = get_orchestrator_workspace_pid();
+	// Use the activate-registered controller pid (macOS shell, #61) so a content
+	// app polling this same global queue can't steal the controller's input.
+	unsigned long expected_pid = effective_workspace_controller_pid(s);
 	unsigned long caller_pid = (unsigned long)_ics->client_state.pid;
 	if (expected_pid != 0 && caller_pid != expected_pid) {
 		return XRT_ERROR_NOT_AUTHORIZED;

--- a/src/xrt/ipc/server/ipc_server_handler.c
+++ b/src/xrt/ipc/server/ipc_server_handler.c
@@ -60,6 +60,11 @@
 // per-session render path composites from (the cross-platform analogue of the
 // D3D11 monolith's per-slot chrome storage).
 #include "multi/comp_multi_workspace.h"
+// Forward decl: the canonical-id → per-session compositor resolver is defined
+// lower in this file (alongside the chrome RPC handlers) but is also used by
+// the earlier get_window_pose handler.
+static struct xrt_compositor *
+macos_workspace_find_client_xc(struct ipc_server *s, uint32_t client_id);
 #endif
 
 #if defined(XRT_HAVE_D3D11_SERVICE_COMPOSITOR) || defined(XRT_OS_ANDROID) || defined(XRT_OS_MACOS)
@@ -3776,6 +3781,18 @@ ipc_handle_workspace_get_window_pose(volatile struct ipc_client_state *_ics,
 	    s->xsysc, (struct xrt_compositor *)target_ics->xc, out_pose, out_width_m, out_height_m);
 
 	os_mutex_unlock(&s->global_state.lock);
+	return ok ? XRT_SUCCESS : XRT_ERROR_IPC_FAILURE;
+#elif defined(XRT_OS_MACOS)
+	// macOS OOP single-app model: the client fills the display, so its window
+	// IS the display. Return the display dims (consistent with where the chrome
+	// composite, session_render_chrome_overlay, places chrome) + an identity
+	// pose. This unblocks the shell's per-client chrome sizing (#61); true
+	// per-client window placement is Tier-2 (#59).
+	struct xrt_compositor *target_xc = macos_workspace_find_client_xc(s, client_id);
+	if (target_xc == NULL) {
+		return XRT_ERROR_IPC_FAILURE;
+	}
+	bool ok = comp_multi_workspace_get_client_window_dims(target_xc, out_pose, out_width_m, out_height_m);
 	return ok ? XRT_SUCCESS : XRT_ERROR_IPC_FAILURE;
 #else
 	(void)s;

--- a/src/xrt/ipc/server/ipc_server_handler.c
+++ b/src/xrt/ipc/server/ipc_server_handler.c
@@ -3693,6 +3693,19 @@ ipc_handle_workspace_set_window_pose(volatile struct ipc_client_state *_ics,
 	os_mutex_unlock(&s->global_state.lock);
 
 	return ok ? XRT_SUCCESS : XRT_ERROR_IPC_FAILURE;
+#elif defined(XRT_OS_MACOS)
+	// Tier-2 (#59): reposition + resize the client's runtime-owned NSWindow into a
+	// display sub-rect so multiple apps tile instead of stacking full-screen. The
+	// shell's grid/drag/resize layout primitives all funnel here through the same
+	// xrSetWorkspaceClientWindowPoseEXT path the Windows monolith uses.
+	IPC_INFO(s, "Workspace: set_window_pose client_id=%u pos=(%.3f,%.3f,%.3f) size=%.3fx%.3f (macOS)",
+	         client_id, pose->position.x, pose->position.y, pose->position.z, width_m, height_m);
+	struct xrt_compositor *target_xc = macos_workspace_find_client_xc(s, client_id);
+	if (target_xc == NULL) {
+		return XRT_ERROR_IPC_FAILURE;
+	}
+	bool ok = comp_multi_workspace_set_client_window_pose(target_xc, pose, width_m, height_m);
+	return ok ? XRT_SUCCESS : XRT_ERROR_IPC_FAILURE;
 #else
 	(void)s;
 	(void)client_id;
@@ -4219,6 +4232,16 @@ ipc_handle_workspace_request_client_exit(volatile struct ipc_client_state *_ics,
 		return XRT_ERROR_IPC_FAILURE;
 	}
 	return comp_d3d11_service_workspace_request_exit_by_slot(s->xsysc, slot);
+#elif defined(XRT_OS_MACOS)
+	// macOS OOP (#59): resolve the canonical client id to its per-session
+	// compositor and push an exit request — the chrome close (X) button / DELETE
+	// key path. The window-close global never fires in this route (the service
+	// pump doesn't track NSWindows), so this is the app-quit mechanism.
+	struct xrt_compositor *target_xc = macos_workspace_find_client_xc(s, client_id);
+	if (target_xc == NULL) {
+		return XRT_ERROR_IPC_FAILURE;
+	}
+	return comp_multi_workspace_request_client_exit(target_xc) ? XRT_SUCCESS : XRT_ERROR_IPC_FAILURE;
 #else
 	(void)s;
 	(void)client_id;

--- a/src/xrt/ipc/server/ipc_server_macos_appkit.m
+++ b/src/xrt/ipc/server/ipc_server_macos_appkit.m
@@ -17,18 +17,32 @@
 #include <stdbool.h>
 #include <ctype.h>
 
-// Publish the latest pointer position in target framebuffer pixels (top-left
-// origin) for the service-side workspace cursor composite (#48). NSEvent's
-// locationInWindow is in points with a bottom-left origin; convert via the
-// window's backing scale + content-view height to pixel / top-left space.
+// Convert an NSEvent locationInWindow (points, bottom-left origin) to target
+// framebuffer pixels (top-left origin) via the window's backing scale +
+// content-view height. This is the coordinate space the workspace controller's
+// hit-test expects (matching the Windows ScreenToClient client-px/top-left
+// contract, #61) — used both for the cursor composite and the queued POINTER
+// events the shell hit-tests against. Single-app OOP: the service window fills
+// the display, so window content px == display px.
 static void
-publish_pointer_px(NSEvent *event, NSPoint p)
+pointer_event_to_target_px(NSEvent *event, NSPoint p, int32_t *out_x, int32_t *out_y)
 {
 	NSWindow *win = [event window];
 	CGFloat scale = (win != nil) ? [win backingScaleFactor] : 1.0;
 	NSView *cv = (win != nil) ? [win contentView] : nil;
 	CGFloat h_pts = (cv != nil) ? cv.bounds.size.height : 0.0;
-	comp_multi_workspace_set_pointer_px((int32_t)(p.x * scale), (int32_t)((h_pts - p.y) * scale));
+	*out_x = (int32_t)(p.x * scale);
+	*out_y = (int32_t)((h_pts - p.y) * scale);
+}
+
+// Publish the latest pointer position in target framebuffer pixels (top-left
+// origin) for the service-side workspace cursor composite (#48).
+static void
+publish_pointer_px(NSEvent *event, NSPoint p)
+{
+	int32_t px = 0, py = 0;
+	pointer_event_to_target_px(event, p, &px, &py);
+	comp_multi_workspace_set_pointer_px(px, py);
 }
 
 // Translate an NSEvent (service-window input) into a wire input event and queue
@@ -79,14 +93,16 @@ queue_ns_input_event(NSEvent *event)
 	case NSEventTypeRightMouseDown:
 	case NSEventTypeRightMouseUp: {
 		NSPoint p = [event locationInWindow];
+		int32_t px = 0, py = 0;
+		pointer_event_to_target_px(event, p, &px, &py);
 		publish_pointer_px(event, p);
 		ev.event_type = IPC_WORKSPACE_INPUT_EVENT_POINTER;
 		ev.u.pointer.button =
 		    (type == NSEventTypeRightMouseDown || type == NSEventTypeRightMouseUp) ? 2u : 1u;
 		ev.u.pointer.is_down =
 		    (type == NSEventTypeLeftMouseDown || type == NSEventTypeRightMouseDown) ? 1u : 0u;
-		ev.u.pointer.cursor_x = (int64_t)p.x;
-		ev.u.pointer.cursor_y = (int64_t)p.y;
+		ev.u.pointer.cursor_x = (int64_t)px;
+		ev.u.pointer.cursor_y = (int64_t)py;
 		ev.u.pointer.modifiers = mods;
 		ipc_server_input_queue_push(&ev);
 		return false; // also let AppKit handle it (window focus/drag)
@@ -94,23 +110,22 @@ queue_ns_input_event(NSEvent *event)
 	case NSEventTypeMouseMoved:
 	case NSEventTypeLeftMouseDragged:
 	case NSEventTypeRightMouseDragged: {
-		NSPoint p = [event locationInWindow];
-		publish_pointer_px(event, p);
-		uint32_t button_mask = (uint32_t)[NSEvent pressedMouseButtons];
-		ev.event_type = IPC_WORKSPACE_INPUT_EVENT_POINTER_MOTION;
-		ev.u.pointer_motion.cursor_x = (int64_t)p.x;
-		ev.u.pointer_motion.cursor_y = (int64_t)p.y;
-		ev.u.pointer_motion.button_mask = button_mask;
-		ev.u.pointer_motion.modifiers = mods;
-		ipc_server_input_queue_push(&ev);
-		return false;
+		// Do NOT enqueue motion from NSEvents (#61). mouseMoved events arrive with
+		// [event window] == nil, so pointer_event_to_target_px falls back to
+		// scale=1 / height=0 and produces garbage (unscaled x, negative y) that
+		// flip-flopped against the correct values from the per-cycle CGEventGetLocation
+		// poll, making hover spotty. The poll is the single source of cursor motion
+		// (window-independent, correct, and carries the pressed-button mask for drags).
+		return false; // let AppKit handle the event for window behavior
 	}
 	case NSEventTypeScrollWheel: {
 		NSPoint p = [event locationInWindow];
+		int32_t px = 0, py = 0;
+		pointer_event_to_target_px(event, p, &px, &py);
 		ev.event_type = IPC_WORKSPACE_INPUT_EVENT_SCROLL;
 		ev.u.scroll.delta_y = (float)[event scrollingDeltaY];
-		ev.u.scroll.cursor_x = (int64_t)p.x;
-		ev.u.scroll.cursor_y = (int64_t)p.y;
+		ev.u.scroll.cursor_x = (int64_t)px;
+		ev.u.scroll.cursor_y = (int64_t)py;
 		ev.u.scroll.modifiers = mods;
 		ipc_server_input_queue_push(&ev);
 		return false;
@@ -144,7 +159,7 @@ ipc_server_macos_pump_main_thread(void)
 		// Pump pending UI events so the window appears + stays responsive, and
 		// forward keyboard/mouse to the client app over IPC (#48). Key events are
 		// captured and NOT sent to AppKit (no responder → system beep); mouse
-		// events are both queued and forwarded to AppKit (window focus/move).
+		// button events are both queued and forwarded to AppKit (window focus).
 		NSEvent *event;
 		while ((event = [NSApp nextEventMatchingMask:NSEventMaskAny
 		                                   untilDate:nil
@@ -153,6 +168,45 @@ ipc_server_macos_pump_main_thread(void)
 			bool swallow = queue_ns_input_event(event);
 			if (!swallow) {
 				[NSApp sendEvent:event];
+			}
+		}
+
+		// Hover/cursor tracking via POLLING, not the event stream (#61). macOS does
+		// not deliver NSEventTypeMouseMoved to this manually-pumped window, so
+		// bare-hover motion never arrives as an event. Instead, each pump cycle reads
+		// the current global cursor position — the macOS analogue of Windows'
+		// per-frame GetCursorPos that feeds FRAME_TICK — converts it to display pixels
+		// (top-left), and, when it changed, publishes it for the cursor sprite and
+		// enqueues a POINTER_MOTION so the controller hit-tests hover. A steady poll
+		// (smooth), independent of whether AppKit emits move events.
+		{
+			NSScreen *screen = [NSScreen mainScreen];
+			if (screen != nil) {
+				CGFloat scale = screen.backingScaleFactor;
+				// CGEventGetLocation reads the LIVE cursor position (global display
+				// points, top-left origin) independent of the event stream — unlike
+				// [NSEvent mouseLocation], which is frozen in this manually-pumped app
+				// (it only advances from processed events, which don't include moves).
+				CGEventRef cge = CGEventCreate(NULL);
+				CGPoint cgp = CGEventGetLocation(cge);
+				if (cge != NULL) {
+					CFRelease(cge);
+				}
+				int32_t px = (int32_t)(cgp.x * scale);
+				int32_t py = (int32_t)(cgp.y * scale);
+				static int32_t s_last_px = INT32_MIN, s_last_py = INT32_MIN;
+				if (px != s_last_px || py != s_last_py) {
+					s_last_px = px;
+					s_last_py = py;
+					comp_multi_workspace_set_pointer_px(px, py);
+					struct ipc_workspace_input_event mev;
+					memset(&mev, 0, sizeof(mev));
+					mev.event_type = IPC_WORKSPACE_INPUT_EVENT_POINTER_MOTION;
+					mev.u.pointer_motion.cursor_x = (int64_t)px;
+					mev.u.pointer_motion.cursor_y = (int64_t)py;
+					mev.u.pointer_motion.button_mask = (uint32_t)[NSEvent pressedMouseButtons];
+					ipc_server_input_queue_push(&mev);
+				}
 			}
 		}
 	}

--- a/src/xrt/ipc/server/ipc_server_macos_appkit.m
+++ b/src/xrt/ipc/server/ipc_server_macos_appkit.m
@@ -13,6 +13,7 @@
 #include "ipc_server_input_queue.h"
 #include "multi/comp_multi_workspace.h" // cursor pointer-position publish (#48 Phase 2)
 #include "shared/ipc_protocol.h"
+#include "util/u_logging.h"
 
 #include <stdbool.h>
 #include <ctype.h>
@@ -165,6 +166,23 @@ ipc_server_macos_pump_main_thread(void)
 		                                   untilDate:nil
 		                                      inMode:NSDefaultRunLoopMode
 		                                     dequeue:YES]) != nil) {
+			// Workspace kill-switch (#59): the service window is a borderless
+			// full-screen surface that hides the menu bar + dock and owns the
+			// display, so there is no OS affordance to escape if something wedges.
+			// Esc here tears the whole workspace down (the service is the root —
+			// exiting drops every client's IPC connection so they shut down too).
+			// This is the macOS dev analogue of the Windows Ctrl+Space shell
+			// toggle until a real global hotkey is ported. Cmd+Q does the same.
+			if ([event type] == NSEventTypeKeyDown) {
+				bool is_escape = ([event keyCode] == 53);
+				bool is_cmd_q = (([event modifierFlags] & NSEventModifierFlagCommand) != 0) &&
+				                [[event charactersIgnoringModifiers] isEqualToString:@"q"];
+				if (is_escape || is_cmd_q) {
+					U_LOG_W("Workspace: %s — terminating service (workspace kill-switch)",
+					        is_escape ? "Escape" : "Cmd+Q");
+					exit(0);
+				}
+			}
 			bool swallow = queue_ns_input_event(event);
 			if (!swallow) {
 				[NSApp sendEvent:event];

--- a/src/xrt/ipc/server/ipc_server_per_client_thread.c
+++ b/src/xrt/ipc/server/ipc_server_per_client_thread.c
@@ -212,16 +212,56 @@ common_shutdown(volatile struct ipc_client_state *ics)
 #ifndef XRT_OS_WINDOWS // Unix (Linux, Android, macOS)
 
 /*!
+ * Read exactly @p size bytes from the client socket into @p buf, looping over
+ * partial reads. SOCK_STREAM has no message boundaries, so a single recv() can
+ * return fewer bytes than requested when a peer's framed message arrives in
+ * fragments under load — the old code treated that short read as a fatal
+ * "invalid packet" and tore the connection down, which surfaced on the client
+ * as a spurious IPC failure. Returns false on EOF or a real error. See #61.
+ */
+static bool
+recv_exact(volatile struct ipc_client_state *ics, void *buf, size_t size, int flags)
+{
+	uint8_t *bytes = (uint8_t *)buf;
+	size_t got = 0;
+
+	while (got < size) {
+		// MSG_PEEK does not consume, so it always restarts from the head of
+		// the buffer: peek the full amount into the front of buf each pass
+		// rather than advancing the offset.
+		void *dst = (flags & MSG_PEEK) ? (void *)bytes : (void *)(bytes + got);
+		size_t want = (flags & MSG_PEEK) ? size : (size - got);
+
+		ssize_t len = recv(ics->imc.ipc_handle, dst, want, flags);
+		if (len < 0) {
+			if (errno == EINTR) {
+				continue;
+			}
+			IPC_ERROR(ics->server, "recv() failed: '%s'.", strerror(errno));
+			return false;
+		}
+		if (len == 0) {
+			// Peer closed the connection.
+			return false;
+		}
+
+		got = (flags & MSG_PEEK) ? (size_t)len : got + (size_t)len;
+	}
+
+	return true;
+}
+
+/*!
  * Common dispatch logic shared by all Unix client loops.
  * Returns true if the loop should continue, false to break.
  */
 static bool
 unix_dispatch_command(volatile struct ipc_client_state *ics)
 {
-	// Peek the first 4 bytes to get the command type
+	// Peek the first 4 bytes to get the command type (looped so a fragmented
+	// header doesn't read as a truncated command).
 	enum ipc_command cmd;
-	ssize_t len = recv(ics->imc.ipc_handle, &cmd, sizeof(cmd), MSG_PEEK);
-	if (len != sizeof(cmd)) {
+	if (!recv_exact(ics, &cmd, sizeof(cmd), MSG_PEEK | MSG_WAITALL)) {
 		IPC_ERROR(ics->server, "Invalid command received.");
 		return false;
 	}
@@ -232,11 +272,11 @@ unix_dispatch_command(volatile struct ipc_client_state *ics)
 		return false;
 	}
 
-	// Read the whole command now that we know its size
+	// Read the whole command now that we know its size (looped over partial
+	// reads — a short read here is mid-message data, not a bad packet).
 	uint8_t buf[IPC_BUF_SIZE] = {0};
 
-	len = recv(ics->imc.ipc_handle, &buf, cmd_size, 0);
-	if (len != (ssize_t)cmd_size) {
+	if (!recv_exact(ics, buf, cmd_size, 0)) {
 		IPC_ERROR(ics->server, "Invalid packet received, disconnecting client.");
 		return false;
 	}

--- a/src/xrt/ipc/shared/ipc_message_channel_unix.c
+++ b/src/xrt/ipc/shared/ipc_message_channel_unix.c
@@ -83,23 +83,43 @@ ipc_message_channel_close(struct ipc_message_channel *imc)
 xrt_result_t
 ipc_send(struct ipc_message_channel *imc, const void *data, size_t size)
 {
-	struct msghdr msg = {0};
-	struct iovec iov = {0};
+	// SOCK_STREAM does not preserve message boundaries and a single sendmsg()
+	// may transfer fewer bytes than requested when the send buffer is under
+	// pressure (e.g. a workspace controller pipelining many small messages per
+	// tick alongside a render thread's swapchain traffic). Loop until the whole
+	// message is on the wire — a short send that we treated as success would
+	// desync the peer's framed reads and tear the connection down. See #61.
+	const uint8_t *bytes = (const uint8_t *)data;
+	size_t sent = 0;
 
-	iov.iov_base = (void *)data;
-	iov.iov_len = size;
+	while (sent < size) {
+		struct iovec iov = {0};
+		struct msghdr msg = {0};
 
-	msg.msg_name = NULL;
-	msg.msg_namelen = 0;
-	msg.msg_iov = &iov;
-	msg.msg_iovlen = 1;
-	msg.msg_flags = 0;
+		iov.iov_base = (void *)(bytes + sent);
+		iov.iov_len = size - sent;
 
-	ssize_t ret = sendmsg(imc->ipc_handle, &msg, MSG_NOSIGNAL);
-	if (ret < 0) {
-		int code = errno;
-		IPC_ERROR(imc, "sendmsg(%i) failed: '%i' '%s'!", imc->ipc_handle, code, strerror(code));
-		return XRT_ERROR_IPC_FAILURE;
+		msg.msg_name = NULL;
+		msg.msg_namelen = 0;
+		msg.msg_iov = &iov;
+		msg.msg_iovlen = 1;
+		msg.msg_flags = 0;
+
+		ssize_t ret = sendmsg(imc->ipc_handle, &msg, MSG_NOSIGNAL);
+		if (ret < 0) {
+			if (errno == EINTR) {
+				continue;
+			}
+			int code = errno;
+			IPC_ERROR(imc, "sendmsg(%i) failed: '%i' '%s'!", imc->ipc_handle, code, strerror(code));
+			return XRT_ERROR_IPC_FAILURE;
+		}
+		if (ret == 0) {
+			IPC_ERROR(imc, "sendmsg(%i) sent 0 bytes (%i of %i)!", imc->ipc_handle, (int)sent, (int)size);
+			return XRT_ERROR_IPC_FAILURE;
+		}
+
+		sent += (size_t)ret;
 	}
 
 	return XRT_SUCCESS;
@@ -108,31 +128,46 @@ ipc_send(struct ipc_message_channel *imc, const void *data, size_t size)
 xrt_result_t
 ipc_receive(struct ipc_message_channel *imc, void *out_data, size_t size)
 {
-	// wait for the response
-	struct iovec iov = {0};
-	struct msghdr msg = {0};
+	// SOCK_STREAM gives no message-boundary guarantee: a single recvmsg() can
+	// return fewer bytes than the framed reply, with the remainder still in
+	// flight. Loop until the whole reply has arrived. Bailing out on the first
+	// short read (as this used to) would leave the unread tail in the socket
+	// and desync every subsequent call on the connection. See #61.
+	uint8_t *bytes = (uint8_t *)out_data;
+	size_t received = 0;
 
-	iov.iov_base = out_data;
-	iov.iov_len = size;
+	while (received < size) {
+		struct iovec iov = {0};
+		struct msghdr msg = {0};
 
-	msg.msg_name = 0;
-	msg.msg_namelen = 0;
-	msg.msg_iov = &iov;
-	msg.msg_iovlen = 1;
-	msg.msg_flags = 0;
+		iov.iov_base = bytes + received;
+		iov.iov_len = size - received;
 
-	ssize_t len = recvmsg(imc->ipc_handle, &msg, MSG_NOSIGNAL);
+		msg.msg_name = 0;
+		msg.msg_namelen = 0;
+		msg.msg_iov = &iov;
+		msg.msg_iovlen = 1;
+		msg.msg_flags = 0;
 
-	if (len < 0) {
-		int code = errno;
-		IPC_ERROR(imc, "recvmsg(%i) failed: '%i' '%s'!", (int)imc->ipc_handle, code, strerror(code));
-		return XRT_ERROR_IPC_FAILURE;
-	}
+		ssize_t len = recvmsg(imc->ipc_handle, &msg, MSG_NOSIGNAL);
 
-	if ((size_t)len != size) {
-		IPC_ERROR(imc, "recvmsg(%i) failed: wrong size '%i', expected '%i'!", (int)imc->ipc_handle, (int)len,
-		          (int)size);
-		return XRT_ERROR_IPC_FAILURE;
+		if (len < 0) {
+			if (errno == EINTR) {
+				continue;
+			}
+			int code = errno;
+			IPC_ERROR(imc, "recvmsg(%i) failed: '%i' '%s'!", (int)imc->ipc_handle, code, strerror(code));
+			return XRT_ERROR_IPC_FAILURE;
+		}
+
+		if (len == 0) {
+			// Orderly shutdown by the peer before the full reply arrived.
+			IPC_ERROR(imc, "recvmsg(%i) failed: connection closed, got '%i' of '%i' bytes!",
+			          (int)imc->ipc_handle, (int)received, (int)size);
+			return XRT_ERROR_IPC_FAILURE;
+		}
+
+		received += (size_t)len;
 	}
 
 	return XRT_SUCCESS;

--- a/src/xrt/state_trackers/oxr/oxr_macos.m
+++ b/src/xrt/state_trackers/oxr/oxr_macos.m
@@ -49,8 +49,21 @@ extern void oxr_macos_set_window_closed(void);
  */
 void
 oxr_macos_pump_events(struct xrt_device **xdevs, uint32_t xdev_count, struct xrt_device *head,
-                      bool legacy_app, bool external_window)
+                      bool legacy_app, bool external_window, bool exiting, bool service_mode)
 {
+	// Skip the qwerty pump (which walks xdevs and derefs tracking_origin) when:
+	//  - the session is exiting: its devices are being torn down (#59 close path); or
+	//  - this is an out-of-process / IPC client: qwerty lives SERVER-side, so the
+	//    client's xdevs are IPC proxies — running qwerty over them does nothing
+	//    useful and races their churn (a server-side resize/event can rebuild the
+	//    proxy list mid-poll, leaving a dangling tracking_origin → SIGSEGV, #59).
+	// Input + mode switching reach an OOP client over IPC, not via local qwerty.
+	// Null the list so both qwerty blocks below no-op; the window pump (event drain,
+	// Escape detect, CATransaction flush) still runs.
+	if (exiting || service_mode) {
+		xdevs = NULL;
+		xdev_count = 0;
+	}
 	@autoreleasepool {
 		if (NSApp == nil) {
 			return;

--- a/src/xrt/state_trackers/oxr/oxr_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_session.c
@@ -1029,11 +1029,12 @@ oxr_session_poll(struct oxr_logger *log, struct oxr_session *sess)
 	// commit rendered content to the screen. This is the only place
 	// where the app's main thread calls into the runtime each frame.
 	extern void oxr_macos_pump_events(struct xrt_device **xdevs, uint32_t xdev_count, struct xrt_device *head,
-	                                  bool legacy_app, bool external_window);
+	                                  bool legacy_app, bool external_window, bool exiting, bool service_mode);
 	struct xrt_device *head_dev = GET_XDEV_BY_ROLE(sess->sys, head);
 	bool legacy = sess->sys->xsysc != NULL && sess->sys->xsysc->info.legacy_app_tile_scaling;
+	bool svc_mode = sess->sys->xsysc != NULL && sess->sys->xsysc->info.is_service_mode;
 	oxr_macos_pump_events(sess->sys->xsysd->xdevs, sess->sys->xsysd->xdev_count, head_dev, legacy,
-	                      sess->has_external_window);
+	                      sess->has_external_window, sess->exiting, svc_mode);
 
 	// Check if macOS window was closed (close button or Escape key).
 	// For the Vulkan multi compositor this is also handled via


### PR DESCRIPTION
## macOS shared spatial surface (#59 / #61)

Re-architects the macOS OOP service from **one NSWindow per app** (independent OS windows that overlap/spill — not a spatial desktop) to the Windows D3D11 monolith model: **ONE service-owned full-screen window** into which every client app is composited as a 3D spatial window, then **ONE display-processor weave** and **ONE present**.

Built entirely behind the **`DISPLAYXR_SHARED_SURFACE=1`** gate (macOS env, **off by default**) — the legacy per-NSWindow path remains the default, so this is a no-op for anyone not setting the env. All changes are inside `#ifdef XRT_OS_MACOS`; Windows/Android unaffected.

### Milestones (all David-eyeball-confirmed on a Leia-less sim setup)
- **M1** — one shared full-screen window + ONE combined stereo atlas + ONE weave + ONE present. Each client blits its content into its rect of the atlas; painter-sorted by pose.z (stable tie-break); `delivered` left sticky (no per-frame retire) so windows don't blink; fixed atlas format; #1a1a1a backdrop.
- **M2** — per-eye parallax: window-center pose projected through each predicted eye onto Z=0 (port of D3D11 `slot_pose_to_pixel_rect_for_eye`), per-eye rect clipped to its tile. z>0 floats toward the viewer, z=0 sits on the panel.
- **M3** — chrome (title pill) / cursor / overlays (taskbar) composited INTO the atlas before the weave (chrome above each window, overlays/cursor flat at z=0), via `vk_hud_blend_draw_no_layout` into an atlas-wide framebuffer. Plus the chrome-aspect fix: coplanar chrome (no depth-bias fringing) and Windows-parity window sizing (preserve requested width, derive height) so the controller's chrome texture, hit-test, and the rendered pill all agree.

### Notes
- Pairs with the shell branch `feat/macos-shell-vk` (chrome float-above + texture re-render on width settle + taskbar/cursor `images[0]` upload fix) which stays on its dev branch.
- Remaining (next session): flip the gate to default + retire the per-session path; add a shared_surface_fini (resources currently leak on destroy); rotated-window chrome; real-Leia interlace-per-subrect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)