### PR TITLE
feat(compositor,#634): flip surround-shim default ON via Capabilities registry gate

### DIFF
--- a/docs/roadmap/surround-zones-deprecation.md
+++ b/docs/roadmap/surround-zones-deprecation.md
@@ -53,20 +53,27 @@ about window/texture ownership, not region expression.
    into the canvas **sub-rect** (the app's atlas is canvas-sized); only the post-weave
    composite is rerouted, spanning the window with the mask M=1 inside the canvas, so the
    result is `M·weave + (1−M)·surround` — the strip-blit result via the canonical path.
-   - **Gate:** `DISPLAYXR_SURROUND_SHIM`, **default OFF** → zero behavioural change; legacy
-     apps keep the bespoke strips. **Opt-in ON** → shim engages (one-time
-     `Surround→zones shim ACTIVE` log). This is the validation switch.
+   - **Gate:** `u_capability_enabled("DISPLAYXR_SURROUND_SHIM", "SurroundShim", true)`,
+     **default ON** (since Step 3) → legacy surround routes through the unified composite
+     (one-time `Surround→zones shim ACTIVE` log). Precedence: env var (dev override) >
+     `HKLM\Software\DisplayXR\Capabilities\SurroundShim\Enabled` REG_DWORD (admin
+     force-OFF kill-switch) > default ON. Set either to `0` to fall back to the bespoke strips.
    - **Status:** Metal done + verified (`cube_texture_metal_macos`, flag-on routes through
      the unified path, flag-off unchanged). **D3D11 + D3D12 validated on real Leia SR
      hardware** (2026-06-21): flag-off renders the bespoke strips, flag-on logs the one-time
      `Surround→zones shim ACTIVE` WARN and routes through the unified mask composite, opaque
      BGRA texture-app content correct in both, feathered canvas edge as expected. All three
      backends with a working bespoke surround path are now shim-validated.
-   - **Product gate follow-up:** promote the env override to a
-     `HKLM\Software\DisplayXR\Capabilities\…` registry gate (per the registry-over-env-var
-     convention) before flipping the default.
-3. **Flip default ON** once the shim is validated on all three backends + real hardware
-   (Leia SR) — the canonical path now serves legacy apps unconditionally.
+   - **Product gate follow-up (done, Step 3):** the env override was promoted to the shared
+     `u_capability_enabled()` helper (`auxiliary/util/u_capability.{c,h}`) reading the
+     `Capabilities\SurroundShim\Enabled` marker, per the registry-over-env-var convention.
+3. **Flip default ON** (code-complete): all three gates default ON via `u_capability_enabled`;
+   the canonical path now serves legacy apps unconditionally unless force-disabled. Precedence
+   matrix validated on real Leia SR hardware 2026-06-21 (D3D11 + D3D12: default→ACTIVE,
+   env=0→bespoke, registry=0→bespoke, registry=1→ACTIVE). No installer change needed — the
+   marker is read-if-present (default is in code). *Pending before merge:* the standard
+   hardware eyeball; Metal default-flip still needs a macOS eyeball (the shim path itself was
+   already verified on Metal).
 4. **Migrate first-party apps** off the surround calls to native zones submission (the
    `cube_texture_*` apps, any editor/host integrations).
 5. **Delete** the bespoke surround code (strip blit, surround shader, keyed-mutex/fence

--- a/src/xrt/auxiliary/util/CMakeLists.txt
+++ b/src/xrt/auxiliary/util/CMakeLists.txt
@@ -23,6 +23,8 @@ add_library(
 	u_bitwise.h
 	u_builders.c
 	u_builders.h
+	u_capability.c
+	u_capability.h
 	u_capture_dims.c
 	u_capture_dims.h
 	u_debug.c

--- a/src/xrt/auxiliary/util/u_capability.c
+++ b/src/xrt/auxiliary/util/u_capability.c
@@ -1,0 +1,115 @@
+// Copyright 2026, DisplayXR contributors
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  Implementation of @ref u_capability_enabled.
+ * @ingroup aux_util
+ */
+
+#include "xrt/xrt_config_os.h"
+
+#include "util/u_capability.h"
+
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#if defined(XRT_OS_WINDOWS) && !defined(XRT_ENV_MINGW)
+#include "xrt/xrt_windows.h"
+#elif defined(XRT_OS_LINUX) || defined(XRT_OS_MACOS)
+#include <fcntl.h>
+#include <unistd.h>
+#endif
+
+/*
+ * Returns true and writes *out_value when @p env_var names a set, non-empty
+ * environment variable; false (leaving *out_value untouched) otherwise.
+ */
+static bool
+env_override(const char *env_var, bool *out_value)
+{
+	if (env_var == NULL) {
+		return false;
+	}
+	const char *e = getenv(env_var);
+	if (e == NULL || e[0] == '\0') {
+		return false;
+	}
+	if (e[0] == '0' || strcmp(e, "false") == 0 || strcmp(e, "off") == 0 || strcmp(e, "no") == 0) {
+		*out_value = false;
+	} else {
+		*out_value = true;
+	}
+	return true;
+}
+
+/*
+ * Returns true and writes *out_value when the machine capability marker for
+ * @p cap_name exists; false otherwise. The marker is registry-backed on Windows
+ * and a file on macOS/Linux; on the MinGW dev-check build (Windows target without
+ * the Win32 registry path) there is no marker support and this always returns false.
+ */
+static bool
+registry_marker(const char *cap_name, bool *out_value)
+{
+	if (cap_name == NULL) {
+		return false;
+	}
+#if defined(XRT_OS_WINDOWS) && !defined(XRT_ENV_MINGW)
+	char subkey[256];
+	int n = snprintf(subkey, sizeof(subkey), "Software\\DisplayXR\\Capabilities\\%s", cap_name);
+	if (n <= 0 || (size_t)n >= sizeof(subkey)) {
+		return false;
+	}
+	HKEY key = NULL;
+	if (RegOpenKeyExA(HKEY_LOCAL_MACHINE, subkey, 0, KEY_READ | KEY_WOW64_64KEY, &key) != ERROR_SUCCESS) {
+		return false;
+	}
+	DWORD value = 0;
+	DWORD value_size = sizeof(value);
+	DWORD value_type = 0;
+	LSTATUS rc = RegQueryValueExA(key, "Enabled", NULL, &value_type, (LPBYTE)&value, &value_size);
+	RegCloseKey(key);
+	if (rc != ERROR_SUCCESS || value_type != REG_DWORD) {
+		return false;
+	}
+	*out_value = (value == 1);
+	return true;
+#elif defined(XRT_OS_LINUX) || defined(XRT_OS_MACOS)
+	char path[256];
+	int n = snprintf(path, sizeof(path),
+	                 "/Library/Application Support/DisplayXR/Capabilities/%s/Enabled", cap_name);
+	if (n <= 0 || (size_t)n >= sizeof(path)) {
+		return false;
+	}
+	int fd = open(path, O_RDONLY);
+	if (fd < 0) {
+		return false;
+	}
+	char b = 0;
+	ssize_t r = read(fd, &b, 1);
+	close(fd);
+	if (r != 1) {
+		return false;
+	}
+	*out_value = (b == '1');
+	return true;
+#else
+	(void)out_value;
+	return false;
+#endif
+}
+
+bool
+u_capability_enabled(const char *env_var, const char *cap_name, bool default_value)
+{
+	bool value = false;
+	if (env_override(env_var, &value)) {
+		return value;
+	}
+	if (registry_marker(cap_name, &value)) {
+		return value;
+	}
+	return default_value;
+}

--- a/src/xrt/auxiliary/util/u_capability.h
+++ b/src/xrt/auxiliary/util/u_capability.h
@@ -1,0 +1,44 @@
+// Copyright 2026, DisplayXR contributors
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  Runtime capability gate: machine marker (HKLM Capabilities) + env override.
+ * @ingroup aux_util
+ */
+
+#pragma once
+
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*!
+ * Resolve a tri-state runtime-capability flag with the precedence:
+ *
+ *   1. environment variable @p env_var, if set and non-empty — the dev override
+ *      ("0" / "false" / "off" / "no" → false, anything else → true);
+ *   2. else the machine capability marker, if present:
+ *      `HKLM\Software\DisplayXR\Capabilities\<cap_name>\Enabled` (REG_DWORD) on
+ *      Windows, or `/Library/Application Support/DisplayXR/Capabilities/<cap_name>/Enabled`
+ *      (first byte '1') on macOS/Linux;
+ *   3. else @p default_value.
+ *
+ * This mirrors the MCP capability convention
+ * (`oxr_mcp_capability_enabled()` + `mcp_check_env_or()`) but is parameterized by
+ * name and lets the caller choose the default — so a feature can default ON while
+ * still honouring an admin force-OFF marker and a dev env override.
+ *
+ * @param env_var       Environment variable name (may be NULL to skip the override).
+ * @param cap_name      Capability marker name under the Capabilities key (may be NULL).
+ * @param default_value Result when neither the env var nor the marker is present.
+ *
+ * @ingroup aux_util
+ */
+bool
+u_capability_enabled(const char *env_var, const char *cap_name, bool default_value);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/xrt/compositor/d3d11/comp_d3d11_compositor.cpp
+++ b/src/xrt/compositor/d3d11/comp_d3d11_compositor.cpp
@@ -20,6 +20,7 @@
 #include "xrt/xrt_limits.h"
 #include "xrt/xrt_display_metrics.h"
 
+#include "util/u_capability.h"
 #include "util/u_logging.h"
 #include "util/u_misc.h"
 #include "util/u_time.h"
@@ -2752,19 +2753,20 @@ d3d11_surround_shader_enabled(void)
 	return cached != 0;
 }
 
-// Surround→zones translation shim gate (DISPLAYXR_SURROUND_SHIM). Default off:
-// legacy surround apps keep the bespoke strip blit (zero behavioural change).
-// Opt-in routes them through the canonical mask composite (d3d11_composite_zone_mask)
-// so the path can be validated before the bespoke surround code is removed. Env
-// override now; a HKLM/Capabilities registry gate is the product follow-up
-// (deprecation doc). Mirror of metal_surround_shim_enabled.
+// Surround→zones translation shim gate. As of #634 Step 3 the shim is the DEFAULT
+// path: a legacy surround + output-rect frame is routed through the canonical mask
+// composite (d3d11_composite_zone_mask) instead of the bespoke strip blit, so the
+// bespoke surround code can be removed once first-party apps migrate to zones.
+// Precedence (u_capability_enabled): DISPLAYXR_SURROUND_SHIM env (dev override) >
+// HKLM\Software\DisplayXR\Capabilities\SurroundShim\Enabled (admin force-OFF
+// kill-switch) > default ON. Set either to 0 to fall back to the bespoke strips.
+// Mirror of metal_surround_shim_enabled / d3d12_surround_shim_enabled.
 static bool
 d3d11_surround_shim_enabled(void)
 {
 	static int cached = -1;
 	if (cached < 0) {
-		const char *e = getenv("DISPLAYXR_SURROUND_SHIM");
-		cached = (e != nullptr && e[0] != '\0' && e[0] != '0') ? 1 : 0;
+		cached = u_capability_enabled("DISPLAYXR_SURROUND_SHIM", "SurroundShim", true) ? 1 : 0;
 	}
 	return cached != 0;
 }

--- a/src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp
+++ b/src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp
@@ -21,6 +21,7 @@
 #include "xrt/xrt_limits.h"
 #include "xrt/xrt_display_metrics.h"
 
+#include "util/u_capability.h"
 #include "util/u_logging.h"
 #include "util/u_misc.h"
 #include "util/u_time.h"
@@ -5274,19 +5275,20 @@ d3d12_capture_resource_to_png(struct comp_d3d12_compositor *c,
 	return ok;
 }
 
-// Surround→zones translation shim gate (DISPLAYXR_SURROUND_SHIM). Default off:
-// legacy surround apps keep the bespoke strip blit (zero behavioural change).
-// Opt-in routes them through the canonical mask composite (d3d12_composite_zone_mask)
-// so the path can be validated before the bespoke surround code is removed. Env
-// override now; a HKLM/Capabilities registry gate is the product follow-up
-// (deprecation doc). Mirror of metal_surround_shim_enabled / d3d11_surround_shim_enabled.
+// Surround→zones translation shim gate. As of #634 Step 3 the shim is the DEFAULT
+// path: a legacy surround + output-rect frame is routed through the canonical mask
+// composite (d3d12_composite_zone_mask) instead of the bespoke strip blit, so the
+// bespoke surround code can be removed once first-party apps migrate to zones.
+// Precedence (u_capability_enabled): DISPLAYXR_SURROUND_SHIM env (dev override) >
+// HKLM\Software\DisplayXR\Capabilities\SurroundShim\Enabled (admin force-OFF
+// kill-switch) > default ON. Set either to 0 to fall back to the bespoke strips.
+// Mirror of metal_surround_shim_enabled / d3d11_surround_shim_enabled.
 static bool
 d3d12_surround_shim_enabled(void)
 {
 	static int cached = -1;
 	if (cached < 0) {
-		const char *e = getenv("DISPLAYXR_SURROUND_SHIM");
-		cached = (e != nullptr && e[0] != '\0' && e[0] != '0') ? 1 : 0;
+		cached = u_capability_enabled("DISPLAYXR_SURROUND_SHIM", "SurroundShim", true) ? 1 : 0;
 	}
 	return cached != 0;
 }

--- a/src/xrt/compositor/metal/comp_metal_compositor.m
+++ b/src/xrt/compositor/metal/comp_metal_compositor.m
@@ -30,6 +30,7 @@
 #include "xrt/xrt_display_processor_metal.h"
 #include "xrt/xrt_system.h"
 
+#include "util/u_capability.h"
 #include "util/u_logging.h"
 #include "util/u_misc.h"
 #include "util/u_time.h"
@@ -1813,18 +1814,19 @@ metal_compositor_dispatch_capture(struct comp_metal_compositor *c,
 // blit. This bespoke path is retained as the default until the shim is
 // validated as the sole composite path, after which it is deleted.
 
-// Surround→zones translation shim gate (DISPLAYXR_SURROUND_SHIM). Default off:
-// legacy surround apps keep the bespoke strip blit (zero behavioural change).
-// Opt-in routes them through the canonical mask composite so the path can be
-// validated before the bespoke surround code is removed. Env override now; a
-// HKLM/Capabilities registry gate is the product follow-up (deprecation doc).
+// Surround→zones translation shim gate. As of #634 Step 3 the shim is the DEFAULT
+// path: a legacy surround + output-rect frame is routed through the canonical mask
+// composite instead of the bespoke strip blit, so the bespoke surround code can be
+// removed once first-party apps migrate to zones. Precedence (u_capability_enabled):
+// DISPLAYXR_SURROUND_SHIM env (dev override) > the Capabilities/SurroundShim/Enabled
+// marker (admin force-OFF kill-switch) > default ON. Set either to 0 to fall back to
+// the bespoke strips. Mirror of d3d11_surround_shim_enabled / d3d12_surround_shim_enabled.
 static bool
 metal_surround_shim_enabled(void)
 {
 	static int enabled = -1;
 	if (enabled < 0) {
-		const char *e = getenv("DISPLAYXR_SURROUND_SHIM");
-		enabled = (e != NULL && e[0] != '\0' && e[0] != '0') ? 1 : 0;
+		enabled = u_capability_enabled("DISPLAYXR_SURROUND_SHIM", "SurroundShim", true) ? 1 : 0;
 	}
 	return enabled == 1;
 }


### PR DESCRIPTION
## What

Step 3 of the surround → `XR_EXT_display_zones` deprecation (#634): **flip the
`DISPLAYXR_SURROUND_SHIM` translation shim ON by default**, behind a registry
kill-switch. A legacy surround + output-rect frame is now routed through the
canonical unified mask composite instead of the bespoke per-API strip blit — so the
bespoke surround code can be deleted once first-party apps migrate to native zones
(Steps 4–5).

## How

- New `auxiliary/util/u_capability.{c,h}` — `u_capability_enabled(env_var, cap_name, default)`
  resolves a tri-state flag with precedence **env override > machine marker > caller default**.
  Marker is `HKLM\Software\DisplayXR\Capabilities\<name>\Enabled` (REG_DWORD) on Windows, a
  POSIX file mirror on macOS/Linux. Mirrors the MCP convention
  (`oxr_mcp_capability_enabled` + `mcp_check_env_or`) but parameterized and with a
  caller-chosen default, so the shim can default ON while still honouring an admin force-OFF
  marker and a dev env override. Win32 registry path guarded `XRT_OS_WINDOWS && !XRT_ENV_MINGW`
  (mirrors `u_file.c`) to keep the MinGW dev-check clean.
- The three gates (`d3d11`/`d3d12`/`metal` `_surround_shim_enabled`) now call
  `u_capability_enabled("DISPLAYXR_SURROUND_SHIM", "SurroundShim", true)`.
- **No installer change**: the default lives in code, so the marker is read-if-present (an
  optional admin kill-switch). `DISPLAYXR_SURROUND_SHIM=0` or marker `Enabled=0` → bespoke strips.

## Validation (real Leia SR hardware, D3D11 + D3D12)

| env var | marker | result |
|---|---|---|
| unset | absent | **shim ACTIVE** (new default) |
| `=0` | (ignored) | bespoke strips, no ACTIVE log |
| unset | `=0` | bespoke strips |
| unset | `=1` | shim ACTIVE |

The rendered "shim ON" output is identical to the Step 2 shim-on case already eyeball-approved
on the panel (cube + surround, feathered canvas edge).

## Pre-merge checklist (hardware-behavior change)

- [ ] Leia eyeball on the default-on window (carries over from the Step 2 approval — confirm).
- [ ] **macOS eyeball** for the Metal default-flip — could not run on this Windows box; the
      Metal shim *path* was verified earlier, only the default baseline changes.

Refs #634. Design: `docs/roadmap/surround-zones-deprecation.md` §3.
