### PR TITLE
refactor(compositor,#637): drop the always-full-window c->canvas field; align explicit-mask edge

### DIFF
--- a/src/xrt/auxiliary/util/u_canvas.h
+++ b/src/xrt/auxiliary/util/u_canvas.h
@@ -43,17 +43,17 @@ struct u_canvas_rect
 };
 
 /*!
- * Apply canvas output rect to window metrics.
+ * Reframe window metrics to a sub-rect canvas.
  *
- * When a shared-texture app has set an output rect, the "window" fields in
- * xrt_window_metrics should reflect the canvas (output rect), not the full
- * window client area. This ensures Kooima FOV uses the correct aspect ratio.
+ * Overrides the "window" fields in xrt_window_metrics with the canvas sub-rect
+ * so Kooima FOV/aspect are computed for that rect, not the full client area.
+ * No-op if canvas->valid is false.
  *
- * Call this after populating raw window metrics from the OS, before returning
- * from get_window_metrics(). No-op if canvas->valid is false.
+ * Used by the display-zones locate path (oxr_session / ipc_server_handler) to
+ * frame each 3D zone's off-axis projection to the zone's window-px rect.
  *
  * @param metrics   Window metrics to adjust in-place.
- * @param canvas    Canvas sub-rect (window/zone-derived).
+ * @param canvas    Sub-rect to reframe to (e.g. a zone rect).
  */
 static inline void
 u_canvas_apply_to_metrics(struct xrt_window_metrics *metrics,

--- a/src/xrt/compositor/d3d11/comp_d3d11_compositor.cpp
+++ b/src/xrt/compositor/d3d11/comp_d3d11_compositor.cpp
@@ -137,12 +137,6 @@ struct comp_d3d11_compositor
 	//! True if shared texture mode is active.
 	bool has_shared_texture;
 
-	//! Canvas output rect for shared-texture apps.
-	//! When valid, it flows to the DP as the weave sub-rect via the
-	//! process_atlas canvas params (#85) and drives view dims + Kooima
-	//! metrics. Superseded by an active zone mask (#439 Phase 2) — read
-	//! through d3d11_effective_canvas() on every frame-path site.
-	struct u_canvas_rect canvas;
 
 	//! Active authored zone mask (#439 Phase 1, XR_EXT_local_3d_zone). Set by
 	//! comp_d3d11_compositor_zone_mask_submit (sticky, last-submit-wins),
@@ -370,7 +364,8 @@ d3d11_update_zone_wish_state(struct comp_d3d11_compositor *c);
 // #439 Phase 2: an active zone mask supersedes the canvas output rect —
 // the weave region, view dims, Kooima metrics, and composite region all
 // become the client-window rect (top-left anchored per #464). With no mask
-// this returns c->canvas verbatim, so the no-mask path is unchanged.
+// this returns an invalid rect, so readers fall back to full-window/target
+// dims, leaving the no-mask path unchanged.
 // Returning a *valid* window rect (not just "invalid") matters on the
 // shared-texture path: the texture is display-sized worst-case, so an
 // invalid canvas there would fall back to display dims — the window rect
@@ -387,7 +382,7 @@ d3d11_effective_canvas(struct comp_d3d11_compositor *c)
 	// definition (each zone rect is its own canvas; the output rect is
 	// inert) — same supersede geometry as the mask/Local2D rules below.
 	if (!c->zones_frame && c->active_zone_mask == nullptr && !c->local_2d_last_frame) {
-		return c->canvas;
+		return {};
 	}
 	struct u_canvas_rect win = {};
 	HWND wnd = c->hwnd != nullptr ? c->hwnd : c->app_hwnd;
@@ -1511,7 +1506,8 @@ d3d11_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 
 	// #439 Phase 2: the one canvas authority for this frame. While a zone
 	// mask is active this is the client-window rect (the mask supersedes
-	// the output rect); otherwise it is c->canvas unchanged. Computed once
+	// the output rect); otherwise it is an invalid rect (readers fall back
+	// to full-window/target dims). Computed once
 	// under c->mutex (held for this whole function) so the weave region,
 	// view dims, and composite all see the same rect even if submit/destroy
 	// race the frame.
@@ -2096,7 +2092,6 @@ comp_d3d11_compositor_create(struct xrt_device *xdev,
 	c->own_window = nullptr;
 	c->owns_window = false;
 	c->app_hwnd = nullptr;
-	c->canvas = {};
 	c->hardware_display_3d = true;
 	c->last_3d_mode_index = 1;
 
@@ -3491,7 +3486,7 @@ d3d11_composite_zone_mask(struct comp_d3d11_compositor *c,
 
 	// Resolve the `twod` source + a window-sized weave snapshot scratch.
 	ID3D11ShaderResourceView *twod_srv = nullptr;
-	if (zones_frame || have_local_2d) {
+	if (zones_frame || have_local_2d || have_explicit) {
 		// #439 Phase 3: flatten the Local2D layers into a runtime-owned RT
 		// scratch. The flatten write, the weave snapshot, and the lerp all
 		// operate on plain UNORM bytes (sRGB-passthrough), so both scratches
@@ -3514,9 +3509,8 @@ d3d11_composite_zone_mask(struct comp_d3d11_compositor *c,
 		}
 		twod_srv = c->local2d_scratch_srv;
 	} else {
-		// An explicit submitted mask with no Local2D layers has no 2D pixel
-		// source (the 2D region is expressed via Local2D layers / zones now).
-		// Nothing to composite — leave the weave untouched.
+		// Unreachable: the early-out gate already returns false unless one of
+		// zones_frame / have_local_2d / have_explicit is set. Defensive only.
 		return false;
 	}
 
@@ -3918,8 +3912,7 @@ comp_d3d11_compositor_get_window_metrics(struct xrt_compositor *xc,
 
 	// Shared-texture (texture-app) sessions carry the app's window in
 	// app_hwnd (c->hwnd stays null — no swapchain on it). Their metrics
-	// come from that window, then u_canvas_apply_to_metrics below rewrites
-	// them to the canvas sub-rect — the documented model (swapchain-model.md:
+	// come from that window — the documented model (swapchain-model.md:
 	// view dims + Kooima projection use canvas size, not display size).
 	// Without this, texture sessions had NO window metrics at all and the
 	// runtime-side Kooima (rig path, raw channel, legacy-2D fovs) ran
@@ -4005,14 +3998,6 @@ comp_d3d11_compositor_get_window_metrics(struct xrt_compositor *xc,
 	out_metrics->window_center_offset_y_m = offset_y_m;
 
 	out_metrics->valid = true;
-
-	// #439 Phase 2: the effective canvas, not c->canvas — while a zone mask
-	// is active this is the window rect, so the apply is a no-op by
-	// construction and the Kooima/adaptive-FOV metrics follow the
-	// window-spanning weave region. (Unlocked read, same as the rest of this
-	// function — the pointer check in d3d11_effective_canvas is benign.)
-	const struct u_canvas_rect eff_canvas = d3d11_effective_canvas(c);
-	u_canvas_apply_to_metrics(out_metrics, &eff_canvas);
 
 	return true;
 }

--- a/src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp
+++ b/src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp
@@ -175,9 +175,6 @@ struct comp_d3d12_compositor
 	float legacy_view_scale_x;
 	float legacy_view_scale_y;
 
-	//! Canvas output rect for shared-texture apps.
-	struct u_canvas_rect canvas;
-
 	//! Lazily allocated intermediate resource for cropping atlas to content dims.
 	ID3D12Resource *dp_input_resource;
 
@@ -349,7 +346,8 @@ static void d3d12_sync_zone_mask_to_dp(struct comp_d3d12_compositor *c);
 // #439 Phase 2: an active zone mask supersedes the canvas output rect —
 // the weave region, view dims, Kooima metrics, and composite region all
 // become the client-window rect (top-left anchored per #464). With no mask
-// this returns c->canvas verbatim, so the no-mask path is unchanged.
+// this returns an invalid rect, so readers fall back to full-window/target
+// dims, leaving the no-mask path unchanged.
 // Returning a *valid* window rect (not just "invalid") matters on the
 // shared-texture path: the texture is display-sized worst-case, so an
 // invalid canvas there would fall back to display dims — the window rect
@@ -364,7 +362,7 @@ d3d12_effective_canvas(struct comp_d3d12_compositor *c)
 	// definition (each zone rect is its own canvas; the output rect is
 	// inert) — same supersede geometry as the mask/Local2D rules.
 	if (!c->zones_frame && c->active_zone_mask == nullptr && !c->local_2d_last_frame) {
-		return c->canvas;
+		return {};
 	}
 	struct u_canvas_rect win = {};
 	HWND wnd = c->hwnd != nullptr ? c->hwnd : c->app_hwnd;
@@ -1435,8 +1433,8 @@ d3d12_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 
 	// #439 Phase 2: the one canvas authority for this frame. While a zone
 	// mask is active (or Local2D layers are present) this is the client-window
-	// rect (it supersedes the output rect); otherwise it is c->canvas
-	// unchanged. Computed once under c->mutex (held for this whole function)
+	// rect (it supersedes the output rect); otherwise it is an invalid rect
+	// (readers fall back to full-window/target dims). Computed once under c->mutex (held for this whole function)
 	// so the weave region, view dims, and composite all see the same rect even
 	// if submit/destroy race the frame.
 	const struct u_canvas_rect eff_canvas = d3d12_effective_canvas(c);
@@ -2645,8 +2643,7 @@ comp_d3d12_compositor_get_window_metrics(struct xrt_compositor *xc,
 		memset(out_metrics, 0, sizeof(*out_metrics));
 
 		// Shared-texture (texture-app) sessions carry the app's window in
-		// app_hwnd (c->hwnd stays null); u_canvas_apply_to_metrics below
-		// rewrites the result to the canvas sub-rect.
+		// app_hwnd (c->hwnd stays null); their metrics come from that window.
 		HWND metrics_hwnd = c->hwnd != nullptr ? c->hwnd : c->app_hwnd;
 		if (c->display_processor == nullptr || metrics_hwnd == nullptr) {
 			return false;
@@ -2716,14 +2713,6 @@ comp_d3d12_compositor_get_window_metrics(struct xrt_compositor *xc,
 
 		out_metrics->valid = true;
 	}
-
-	// #439 Phase 2: the active zone mask supersedes the canvas — the
-	// Kooima/adaptive-FOV metrics follow the same authority as the
-	// weave region. (This path doesn't take c->mutex; the canvas/mask
-	// fields are pointer-sized reads updated under the lock in another
-	// function — the pointer check in d3d12_effective_canvas is benign.)
-	const struct u_canvas_rect eff_canvas = d3d12_effective_canvas(c);
-	u_canvas_apply_to_metrics(out_metrics, &eff_canvas);
 
 	return true;
 }

--- a/src/xrt/compositor/gl/comp_gl_compositor.cpp
+++ b/src/xrt/compositor/gl/comp_gl_compositor.cpp
@@ -376,10 +376,6 @@ struct comp_gl_compositor
 	uint32_t last_3d_mode_index;       //!< Last 3D mode index (for V-key toggle restore)
 	bool legacy_app_tile_scaling;      //!< True if app is legacy (gates 1/2/3 key mode selection)
 
-	//! Canvas output rect for shared-texture apps.
-	struct u_canvas_rect canvas;
-
-
 	// --- #439 Phase 3 — Local2D / zone-mask consumer (full net-new GL leg) ---
 	//! Active authored zone mask (XR_EXT_local_3d_zone). Set by zone_mask_submit
 	//! (sticky, last-submit-wins), cleared on that mask's destroy. NOT owned.
@@ -1751,10 +1747,8 @@ gl_crop_and_process_dp(struct comp_gl_compositor *c,
 		dp_tex = c->dp_input_texture;
 	}
 
-	// Pass (possibly cropped) texture to DP.
-	// XR_EXT_display_zones: in a zones frame the output rect is inert —
-	// pass no canvas (0s) so the DP weaves the full client window.
-	const bool use_canvas = c->canvas.valid && !c->zones_frame;
+	// Pass (possibly cropped) texture to DP. Canvas params are always 0 — the
+	// DP weaves the full client window (sub-rects are expressed as 3D zones now).
 	glViewport(0, 0, output_w, output_h);
 	xrt_display_processor_gl_process_atlas(
 	    c->display_processor,
@@ -1766,10 +1760,10 @@ gl_crop_and_process_dp(struct comp_gl_compositor *c,
 	    GL_RGBA8,
 	    output_w,
 	    output_h,
-	    use_canvas ? c->canvas.x : 0,
-	    use_canvas ? c->canvas.y : 0,
-	    use_canvas ? c->canvas.w : 0,
-	    use_canvas ? c->canvas.h : 0);
+	    0,
+	    0,
+	    0,
+	    0);
 }
 
 #ifdef XRT_OS_WINDOWS
@@ -2318,15 +2312,12 @@ gl_dp_weave_to_fbo(struct comp_gl_compositor *c, GLuint atlas_tex, GLuint target
 		dp_tex = c->dp_input_texture;
 	}
 
-	// XR_EXT_display_zones: in a zones frame the output rect is inert —
-	// pass no canvas (0s) so the DP weaves the full client window.
-	const bool use_canvas = c->canvas.valid && !c->zones_frame;
+	// Canvas params are always 0 — the DP weaves the full client window.
 	glBindFramebuffer(GL_FRAMEBUFFER, target_fbo);
 	glViewport(0, 0, output_w, output_h);
 	xrt_display_processor_gl_process_atlas(c->display_processor, dp_tex, eff_tile_w, eff_tile_h,
 	                                       eff_cols, eff_rows, GL_RGBA8, output_w, output_h,
-	                                       use_canvas ? c->canvas.x : 0, use_canvas ? c->canvas.y : 0,
-	                                       use_canvas ? c->canvas.w : 0, use_canvas ? c->canvas.h : 0);
+	                                       0, 0, 0, 0);
 }
 
 // #439 Phase 3 — the post-weave masked composite. Runs INSTEAD of the plain
@@ -2887,15 +2878,8 @@ gl_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t
 			if (!c->legacy_app_tile_scaling && mode->view_width_pixels > 0) {
 				c->view_width = mode->view_width_pixels;
 				c->view_height = mode->view_height_pixels;
-				// XR_EXT_display_zones: a zones frame spans the full
-				// client window (the output rect is inert) — view dims
-				// follow the window branch below.
-				if (c->canvas.valid && !c->zones_frame) {
-					u_tiling_compute_canvas_view(mode, c->canvas.w, c->canvas.h,
-					                             &c->view_width, &c->view_height);
-				}
 #if defined(XRT_OS_WINDOWS) || defined(__APPLE__)
-				else if (!c->owns_window || c->zones_frame) {
+				if (!c->owns_window || c->zones_frame) {
 					// Handle app: window may be smaller than the display,
 					// so scale view dims to the actual window client area
 					// (matches the D3D11/D3D12 path) — keeps the atlas content
@@ -3307,10 +3291,7 @@ gl_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t
 			// otherwise.
 			uint32_t dp_w = c->shared_width;
 			uint32_t dp_h = c->shared_height;
-			if (c->canvas.valid && !c->zones_frame && c->canvas.w > 0 && c->canvas.h > 0) {
-				dp_w = c->canvas.w;
-				dp_h = c->canvas.h;
-			} else if (c->zones_frame) {
+			if (c->zones_frame) {
 				// XR_EXT_display_zones: the zone PLACEMENT (layer_commit)
 				// scales zone rects into the atlas tile by tile/window, so
 				// the weave OUTPUT must be the window client dims too — NOT
@@ -3393,10 +3374,7 @@ gl_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t
 			// otherwise.
 			uint32_t dp_w = c->iosurface_width;
 			uint32_t dp_h = c->iosurface_height;
-			if (c->canvas.valid && !c->zones_frame && c->canvas.w > 0 && c->canvas.h > 0) {
-				dp_w = c->canvas.w;
-				dp_h = c->canvas.h;
-			} else if (c->zones_frame) {
+			if (c->zones_frame) {
 				// XR_EXT_display_zones: the zone PLACEMENT (layer_commit)
 				// scales zone rects into the atlas tile by tile/window, so
 				// the weave OUTPUT must be the window client dims too — NOT
@@ -4363,11 +4341,6 @@ comp_gl_compositor_get_window_metrics(struct xrt_compositor *xc,
 	out_metrics->window_center_offset_y_m = -((win_center_px_y - disp_center_px_y) * pixel_size_y);
 
 	out_metrics->valid = true;
-	// XR_EXT_display_zones: a zones frame supersedes the canvas (the output
-	// rect is inert) — the metrics already describe the window.
-	if (!c->zones_frame) {
-		u_canvas_apply_to_metrics(out_metrics, &c->canvas);
-	}
 	return true;
 #elif defined(__APPLE__)
 	if (!c->sys_info_set || c->macos_window == NULL) {
@@ -4423,11 +4396,6 @@ comp_gl_compositor_get_window_metrics(struct xrt_compositor *xc,
 	out_metrics->window_center_offset_y_m = -((win_center_px_y - disp_center_px_y) * pixel_size_y);
 
 	out_metrics->valid = true;
-	// XR_EXT_display_zones: a zones frame supersedes the canvas (the output
-	// rect is inert) — the metrics already describe the window.
-	if (!c->zones_frame) {
-		u_canvas_apply_to_metrics(out_metrics, &c->canvas);
-	}
 	return true;
 #else
 	(void)c;

--- a/src/xrt/compositor/metal/comp_metal_compositor.m
+++ b/src/xrt/compositor/metal/comp_metal_compositor.m
@@ -258,9 +258,6 @@ struct comp_metal_compositor
 	//! System compositor info (for display dimensions, nominal viewer).
 	const struct xrt_system_compositor_info *sys_info;
 
-	//! Canvas output rect for shared-texture apps.
-	struct u_canvas_rect canvas;
-
 	/*
 	 * XR_EXT_local_3d_zone consumer state (#439 Phase 3).
 	 */
@@ -1801,7 +1798,7 @@ metal_effective_canvas(struct comp_metal_compositor *c,
                        bool mask_active)
 {
 	if (!mask_active) {
-		return c->canvas;
+		return (struct u_canvas_rect){0};
 	}
 
 	struct u_canvas_rect r = {0};
@@ -3434,12 +3431,7 @@ metal_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 	// just whatever the AppKit background draws — i.e. solid grey).
 	// Only relevant when both a shared IOSurface AND an external view are
 	// present (the editor preview / Unity standalone path).
-	//
-	// Skipped once the app declares a canvas rect: a _texture app owns
-	// presentation (it blits the IOSurface into its view itself, per the
-	// Cocoa binding spec's Texture mode) — mirroring here would fight the
-	// app over the layer's nextDrawable.
-	if (c->shared_texture != nil && c->metal_layer != nil && !c->owns_window && !c->canvas.valid) {
+	if (c->shared_texture != nil && c->metal_layer != nil && !c->owns_window) {
 		id<CAMetalDrawable> mirror = [c->metal_layer nextDrawable];
 		if (mirror != nil) {
 			id<MTLBlitCommandEncoder> blit = [cmd_buf blitCommandEncoder];
@@ -4280,20 +4272,12 @@ comp_metal_compositor_get_window_metrics(struct xrt_compositor *xc,
 		out_metrics->window_center_offset_y_m = offset_y_m;
 
 		out_metrics->valid = true;
-		// #439: an active mask supersedes the canvas — the window metrics
-		// already describe the window, so skip the canvas override.
-		if (!metal_mask_is_active(c)) {
-			u_canvas_apply_to_metrics(out_metrics, &c->canvas);
-		}
 		return true;
 	}
 
 	// Fallback: delegate to display processor (ext/shared path)
 	if (c->display_processor != NULL) {
 		bool ok = xrt_display_processor_metal_get_window_metrics(c->display_processor, out_metrics);
-		if (ok && !metal_mask_is_active(c)) {
-			u_canvas_apply_to_metrics(out_metrics, &c->canvas);
-		}
 		return ok;
 	}
 

--- a/src/xrt/compositor/vk_native/comp_vk_native_compositor.c
+++ b/src/xrt/compositor/vk_native/comp_vk_native_compositor.c
@@ -215,9 +215,6 @@ struct comp_vk_native_compositor
 	VkDeviceMemory dp_input_memory;
 	uint32_t dp_input_width, dp_input_height;
 
-	//! Canvas output rect for shared-texture apps.
-	struct u_canvas_rect canvas;
-
 
 	//! Alpha-blend pipeline for window-space (HUD) layers rendered per-tile
 	//! INTO the atlas pre-weave (matches d3d11/d3d12/metal/gl). Lazy-init
@@ -2321,13 +2318,9 @@ vk_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t
 					uint32_t new_vh = mode->view_height_pixels;
 					uint32_t new_aw = mode->atlas_width_pixels;
 					uint32_t new_ah = mode->atlas_height_pixels;
-					if (c->canvas.valid) {
-						u_tiling_compute_canvas_view(mode, c->canvas.w, c->canvas.h,
-						                             &new_vw, &new_vh);
-					}
 #if defined(XRT_OS_WINDOWS) || defined(__APPLE__)
-					else if (!c->owns_window && c->settings.preferred.width > 0 &&
-					         c->settings.preferred.height > 0) {
+					if (!c->owns_window && c->settings.preferred.width > 0 &&
+					    c->settings.preferred.height > 0) {
 						// Handle app: window may be smaller than the display,
 						// so scale view dims to the actual window client area
 						// (matches the D3D11/D3D12 path) — keeps the atlas
@@ -2581,13 +2574,8 @@ vk_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t
 				vk->vkCreateFramebuffer(vk->device, &fb_ci, NULL, &shared_fb);
 			}
 
-			// DP target: use canvas dims for texture apps
 			uint32_t dp_target_w = tgt_width;
 			uint32_t dp_target_h = tgt_height;
-			if (c->canvas.valid && c->canvas.w > 0 && c->canvas.h > 0) {
-				dp_target_w = c->canvas.w;
-				dp_target_h = c->canvas.h;
-			}
 
 			// #491 part 3 — flatten this frame's 2D-under layers PRE-weave (into
 			// backdrop_scratch) and hand them to the DP so it composites
@@ -2634,10 +2622,10 @@ vk_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t
 			    (VkImage_XDP)c->shared_image,
 			    dp_target_w, dp_target_h,
 			    (VkFormat_XDP)view_format,
-			    c->canvas.valid ? c->canvas.x : 0,
-			    c->canvas.valid ? c->canvas.y : 0,
-			    c->canvas.valid ? c->canvas.w : 0,
-			    c->canvas.valid ? c->canvas.h : 0);
+			    0,
+			    0,
+			    0,
+			    0);
 
 			if (dp_self_submits) {
 				// DP owns its own submit — nothing left for us to do this
@@ -2897,10 +2885,10 @@ vk_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t
 				    (VkImage_XDP)(uintptr_t)target_image,
 				    tgt_width, tgt_height,
 				    (VkFormat_XDP)comp_vk_native_target_get_format(c->target),
-				    c->canvas.valid ? c->canvas.x : 0,
-				    c->canvas.valid ? c->canvas.y : 0,
-				    c->canvas.valid ? c->canvas.w : 0,
-				    c->canvas.valid ? c->canvas.h : 0);
+				    0,
+				    0,
+				    0,
+				    0);
 
 				if (dp_self_submits) {
 					// DP owned the post-weave submit. The vendor weave's
@@ -3745,7 +3733,6 @@ comp_vk_native_compositor_get_window_metrics(struct xrt_compositor *xc,
 	out_metrics->window_center_offset_y_m = -((win_center_px_y - disp_center_px_y) * pixel_size_y);
 
 	out_metrics->valid = true;
-	u_canvas_apply_to_metrics(out_metrics, &c->canvas);
 	return true;
 #elif defined(XRT_OS_MACOS)
 	// Compute compositor-side from the live NSView — own window (hosted) or
@@ -3827,7 +3814,6 @@ comp_vk_native_compositor_get_window_metrics(struct xrt_compositor *xc,
 	out_metrics->window_center_offset_y_m = -((win_center_px_y - disp_center_px_y) * pixel_size_y);
 
 	out_metrics->valid = true;
-	u_canvas_apply_to_metrics(out_metrics, &c->canvas);
 	return true;
 #else
 	// Android: report the LIVE (orientation-aware) target surface extent in
@@ -3855,7 +3841,6 @@ comp_vk_native_compositor_get_window_metrics(struct xrt_compositor *xc,
 	out_metrics->window_orientation = (struct xrt_quat){0, 0, 0, 1};
 	// Meters left 0 (see above) — the caller derives them from xsysc->info.
 	out_metrics->valid = true;
-	u_canvas_apply_to_metrics(out_metrics, &c->canvas);
 	return true;
 #endif
 }
@@ -4137,7 +4122,7 @@ vk_effective_canvas(struct comp_vk_native_compositor *c)
 	// definition (each zone rect is its own canvas; the output rect is
 	// inert) — same supersede geometry as the mask/Local2D rules.
 	if (!c->zones_frame && c->active_zone_mask == NULL && !c->local_2d_last_frame) {
-		return c->canvas;
+		return (struct u_canvas_rect){0};
 	}
 	struct u_canvas_rect win = {0};
 #ifdef XRT_OS_WINDOWS


### PR DESCRIPTION
## What

Follow-up to ADR-031 (#634 Step 5). `xrSetSharedTextureOutputRectEXT` — the only app-facing writer of the compositor `c->canvas` (`struct u_canvas_rect`) — was removed in Step 5, so the field has been permanently its zero/invalid default in all 5 native compositors. This removes that dead field and aligns a degenerate composite edge.

**−135 / +46 LOC.**

## Changes

**Drop the dead `c->canvas` field (behavior-preserving):**
- Remove the field from d3d11/d3d12/metal/gl/vk_native structs (+ the d3d11 zero-init). Every `canvas.valid ? X : Y` reader already took the fallback `Y` (the field was always invalid), so this changes no behavior.
- `*_effective_canvas()` keeps computing the window rect from the HWND on mask/zones frames; its inactive path now returns an invalid literal instead of the field. GL/VK direct `c->canvas.valid ? …` readers collapse to their already-taken full-window/target fallback.
- Drop the no-op `u_canvas_apply_to_metrics(&c->canvas)` calls in the compositors' `get_window_metrics`.

**KEPT — `struct u_canvas_rect` + `u_canvas_apply_to_metrics()`** (corrects the issue's scoping): these are **live** in the display-zones LOCATE path — `oxr_session.c` / `ipc_server_handler.c` call `u_canvas_apply_to_metrics(&wm, &zone_canvas)` to reframe window metrics to each 3D zone's rect for per-zone off-axis Kooima. Only the compositor `c->canvas` *field* (output-rect's dead storage) was vestigial. (The linker caught this — see commit notes.)

**Align the explicit-mask-without-Local2D edge:** `d3d11_composite_zone_mask` now flattens (clear-only → transparent) like `d3d12`, instead of returning false (leaving the weave) — a mask marking a region 2D no longer shows 3D weave there. Unreachable by current apps (real zones frames always carry Local2D or zone layers); makes the backends consistent.

## Validation
- Runtime + Windows test apps build clean.
- **Regression-eyeballed on Leia (PASS):** `cube_zones_texture_d3d11_win` (per-zone framing — the path that uses the zone-rect metrics reframe) + `cube_handle_d3d11_win` (full-window weave; single warmup POSE_INVALID, self-heals).
- macOS/Metal builds via the `(struct u_canvas_rect){0}` C path in `.m` (the `.cpp` backends use `{}` value-init) — macOS CI / a Mac eyeball will confirm.

## Not in this PR
- The dead `use_rect_mask` rect-derived-mask shader path (`masked_composite.hlsl`/`.frag` + `canvas_origin/size` CB + `comp_d3d11_renderer`) is also unreachable now, but it's a separate shader/CB cleanup with its own risk — left for a later pass.

Refs #637, ADR-031.
