### PR TITLE
fix(macos,#59): shared-surface window interactions — drag/resize, tall windows, per-window Kooima

### DIFF
--- a/src/xrt/compositor/multi/comp_multi_system.c
+++ b/src/xrt/compositor/multi/comp_multi_system.c
@@ -2408,19 +2408,14 @@ comp_multi_workspace_set_client_window_pose(struct xrt_compositor *xc,
 	float w_px_f = width_m * px_per_m_x;
 	float h_px_f = height_m * px_per_m_y;
 
-	// ASPECT FIT (#59), Windows-parity. These content apps render at a FIXED display
-	// aspect and do not reflow, so the window must match that aspect or content
-	// stretches. The Windows D3D11 service keeps the controller's WIDTH and sets
-	// window_height = window_width / content_aspect (comp_d3d11_service.cpp ~L5924).
-	// Mirror that: ALWAYS preserve the requested width and derive the height. This
-	// is what keeps the rendered window width identical to the width the controller
-	// built its chrome texture for — deriving height never moves the width, so the
-	// chrome can't be squished into a narrower-than-its-texture rect (the old code
-	// shrank the width when the request was "too wide", which diverged the two and
-	// caused the chrome squish + hover drift).
-	float disp_aspect = (float)disp_px_w / (float)disp_px_h;
-	h_px_f = w_px_f / disp_aspect;
-
+	// Honor the controller's requested WIDTH and HEIGHT verbatim. Window sizing and
+	// aspect policy are the workspace controller's look-and-feel job, not the
+	// runtime's (which only provides the infra). The shell sizes windows to fill
+	// most of the display (a 1×2 grid cell is ~0.81×display-height tall); the old
+	// code instead forced height = width / display_aspect, which HALVED that and
+	// made vertical resize a no-op (the requested height was discarded). Width is
+	// still taken as-requested, so the chrome texture (sized to the window width)
+	// is never squished — only the bogus height override is gone.
 	int32_t w_px = (int32_t)(w_px_f + 0.5f);
 	int32_t h_px = (int32_t)(h_px_f + 0.5f);
 	// Keep the window centered on the controller's requested center (top-left-origin

--- a/src/xrt/ipc/server/ipc_server_handler.c
+++ b/src/xrt/ipc/server/ipc_server_handler.c
@@ -4181,6 +4181,17 @@ ipc_handle_workspace_pointer_capture_set(volatile struct ipc_client_state *_ics,
 	}
 	bool ok = comp_d3d11_service_workspace_pointer_capture_set(s->xsysc, enabled, button);
 	return ok ? XRT_SUCCESS : XRT_ERROR_IPC_FAILURE;
+#elif defined(XRT_OS_MACOS)
+	// macOS has no OS-level pointer capture to toggle: the appkit pump already
+	// publishes POINTER_MOTION every cycle from a global CGEventGetLocation poll
+	// (carrying the pressed-button mask), so a gesture's motion flows whether or
+	// not the cursor is over the window — capture is implicit. The controller's
+	// drag/resize/rotate gestures gate their start on this call succeeding, so
+	// accept it as a no-op rather than failing (which would dead-end every drag).
+	(void)s;
+	(void)enabled;
+	(void)button;
+	return XRT_SUCCESS;
 #else
 	(void)s;
 	(void)enabled;
@@ -4954,6 +4965,17 @@ ipc_handle_workspace_set_client_style(volatile struct ipc_client_state *_ics,
 	return comp_d3d11_service_set_client_style_by_slot(s->xsysc, slot, style)
 	           ? XRT_SUCCESS
 	           : XRT_ERROR_IPC_FAILURE;
+#elif defined(XRT_OS_MACOS)
+	// macOS shared surface: per the infra/look-and-feel split, per-client window
+	// styling (focus glow, corner radius, edge feather) is rendered by the
+	// workspace controller itself as its own chrome/overlay layers — the runtime
+	// only composites them. So the runtime stores/renders nothing here; accept the
+	// controller's per-tick style push as a no-op instead of failing it (which
+	// would spam the controller's log every frame).
+	(void)s;
+	(void)client_id;
+	(void)style;
+	return XRT_SUCCESS;
 #else
 	(void)s;
 	(void)client_id;

--- a/src/xrt/ipc/server/ipc_server_handler.c
+++ b/src/xrt/ipc/server/ipc_server_handler.c
@@ -941,6 +941,10 @@ ipc_try_get_oop_view_poses(volatile struct ipc_client_state *ics,
 	// unknown — the Kooima needs a real physical size.
 	float screen_width_m = s->xsysc->info.display_width_m;
 	float screen_height_m = s->xsysc->info.display_height_m;
+	// #59 per-window Kooima: when a workspace window pose is applied (macOS shared
+	// surface), the render eyes are rebased to the window centre so the off-axis
+	// frustum looks THROUGH the tiled window (set below). 0 = display-centric.
+	float win_eye_offset_x = 0.0f, win_eye_offset_y = 0.0f, win_eye_offset_z = 0.0f;
 	if (screen_width_m <= 0.0f || screen_height_m <= 0.0f) {
 		static bool logged_no_dims = false;
 		if (!logged_no_dims) {
@@ -965,6 +969,35 @@ ipc_try_get_oop_view_poses(volatile struct ipc_client_state *ics,
 			screen_height_m = tmp;
 		}
 	}
+
+#ifdef XRT_OS_MACOS
+	// Shared spatial surface (#59) PER-WINDOW Kooima. Each client composites into a
+	// TILED window, not the full display, so the Kooima screen must be the WINDOW's
+	// physical size — otherwise the client renders for the wide display aspect and a
+	// tall window squishes the blit. Use the controller-placed window pose: its
+	// width/height become the screen, and its centre (display-centric metres) rebases
+	// the render eyes below so the off-axis frustum looks THROUGH the window. This is
+	// the macOS analogue of the Windows per-client window-metrics path
+	// (ipc_try_get_sr_view_poses, screen = wm.window_*_m + window_center_offset). The
+	// shared surface's per-eye rect placement (shared_project_rect_for_eye) handles
+	// the window's POSITION parallax separately; the two are complementary (content-
+	// through-window perspective here, window-in-space placement there), exactly like
+	// D3D11's slot_pose_to_pixel_rect_for_eye + window-metrics Kooima. An unplaced
+	// window (no set_window_pose yet) keeps the display-centric fallback above.
+	{
+		struct xrt_pose wpose = XRT_STRUCT_INIT;
+		float ww_m = 0.0f, wh_m = 0.0f;
+		if (comp_multi_workspace_load_window_pose(ics->xc, &wpose, &ww_m, &wh_m) && ww_m > 0.0f &&
+		    wh_m > 0.0f) {
+			screen_width_m = ww_m;
+			screen_height_m = wh_m;
+			win_eye_offset_x = wpose.position.x;
+			win_eye_offset_y = wpose.position.y;
+			win_eye_offset_z = wpose.position.z;
+		}
+	}
+#endif
+
 	// Full-window meters + pixel dims, captured BEFORE the zone rebase below
 	// overwrites screen_*_m AND wm.window_pixel_* with the zone values — the raw
 	// canvas channel must keep reporting the WHOLE window, not the zone.
@@ -1143,8 +1176,9 @@ ipc_try_get_oop_view_poses(volatile struct ipc_client_state *ics,
 			c.z += head_eyes[i].z;
 		}
 		float inv = nc > 0 ? 1.0f / (float)nc : 1.0f;
-		raw_eyes[0] = (struct xrt_vec3){c.x * inv - zone_eye_offset_x, c.y * inv - zone_eye_offset_y,
-		                                c.z * inv - zone_eye_offset_z};
+		raw_eyes[0] = (struct xrt_vec3){c.x * inv - zone_eye_offset_x - win_eye_offset_x,
+		                                c.y * inv - zone_eye_offset_y - win_eye_offset_y,
+		                                c.z * inv - zone_eye_offset_z - win_eye_offset_z};
 		eye_count = 1;
 	} else {
 		// N-view: one render eye per active view (2 stereo, 4 Quad, …). The DP's
@@ -1154,9 +1188,9 @@ ipc_try_get_oop_view_poses(volatile struct ipc_client_state *ics,
 			eye_count = XRT_MAX_VIEWS;
 		}
 		for (uint32_t i = 0; i < eye_count; i++) {
-			raw_eyes[i] = (struct xrt_vec3){head_eyes[i].x - zone_eye_offset_x,
-			                                head_eyes[i].y - zone_eye_offset_y,
-			                                head_eyes[i].z - zone_eye_offset_z};
+			raw_eyes[i] = (struct xrt_vec3){head_eyes[i].x - zone_eye_offset_x - win_eye_offset_x,
+			                                head_eyes[i].y - zone_eye_offset_y - win_eye_offset_y,
+			                                head_eyes[i].z - zone_eye_offset_z - win_eye_offset_z};
 		}
 	}
 


### PR DESCRIPTION
Three macOS-only fixes for real-window interactions in the shared spatial surface (#59), each David-eyeball-confirmed. Builds on the merged PR #635 (gate flip + legacy delete). **Windows/Android untouched** — every change is `#ifdef XRT_OS_MACOS` / `#elif XRT_OS_MACOS`.

## 1. Pointer-capture + client-style no-op (`7da41a819`)
Title-bar drag, edge-resize, and RMB-rotate all gate their START on `xrEnableWorkspacePointerCaptureEXT` succeeding — that handler was D3D11-only (`#else → IPC_FAILURE`), so every gesture dead-ended on macOS (only maximize worked: it's a direct `set_pose`, no capture). macOS has no OS-level pointer capture — the appkit pump already publishes `POINTER_MOTION` from a global `CGEventGetLocation` poll with the pressed-button mask — so the handler now no-op-accepts. Also no-op-accepts `set_client_style` (window styling is controller-side on macOS, so the runtime renders nothing and just stops failing the per-tick push).

## 2. Honor controller-requested window height (`2cfc3bbed`)
`set_client_window_pose` forced `height = width / display_aspect`, discarding the requested height → windows came out half-height and vertical resize was a no-op. The shell already sizes windows (a 1×2 grid cell is ~0.81×display-height). Honor the requested width AND height verbatim — sizing/aspect policy is the controller's job, the runtime provides infra. Width still as-requested, so chrome isn't squished.

## 3. Per-window Kooima (`8129fbc13`)
With tall windows, the client kept rendering its stereo Kooima for the wide display aspect → the blit into the tall window squished the content. `ipc_try_get_oop_view_poses` now derives the Kooima screen from the window's physical size (when a workspace pose is applied) and rebases the render eyes to the window centre — the macOS analogue of the Windows `ipc_try_get_sr_view_poses` window-metrics path. Complementary to the M2 per-eye rect placement (window-position parallax), so no double-count. Content now renders undistorted at the window aspect.

## Verification
`ninja` green, `displayxr-service` links, changed TUs warning-free. Live (service + shell + 2 cubes): drag/resize/maximize, tall windows, vertical resize, and undistorted per-window content all confirmed.

Companion shell-side work (pill-hover-gate, focus glow ring) is on `displayxr-shell-pvt` `feat/macos-shell-vk`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)