### PR TITLE
docs(building): clarify from-source DP registration (ABI-stale plug-in case)

### DIFF
--- a/docs/getting-started/building.md
+++ b/docs/getting-started/building.md
@@ -45,6 +45,9 @@ _package\run_cube_handle_d3d11_win.bat REM 3. run a test app
 > ```bat
 > _package\bin\displayxr-cli.exe selftest   REM PASS = DP found & ABI-matched; FAIL dumps the reason
 > ```
+> The runtime also logs the underlying cause (`negotiate returned …`, which
+> plug-in was rejected) to its per-process log at
+> `%LOCALAPPDATA%\DisplayXR\DisplayXR_<exe>.<pid>_<timestamp>.log`.
 
 **macOS:**
 ```bash

--- a/docs/getting-started/building.md
+++ b/docs/getting-started/building.md
@@ -24,13 +24,27 @@ scripts\register_dev_plugin.bat leia C:\path\to\DisplayXR-LeiaSR.dll   REM (opti
 _package\run_cube_handle_d3d11_win.bat REM 3. run a test app
 ```
 
-> **The step everyone misses on Windows:** building from source produces the
-> sim-display plug-in DLL but does **not** register it, and Windows plug-in
-> discovery is **registry-only** (`HKLM\Software\DisplayXR\DisplayProcessors`).
-> Without step 2 the runtime starts but finds no display processor and fails
-> with `XRT_ERROR_DEVICE_CREATION_FAILED` / "Failed to initialize OpenXR".
-> `dev-setup.bat` and `register_dev_plugin.bat` do this for you. (POSIX/macOS
-> needs no registration — the loader finds plug-ins next to the runtime.)
+> **Windows requires an explicit plug-in registration step.** Building from
+> source produces the sim-display plug-in DLL but does **not** register it, and
+> Windows plug-in discovery is **registry-only**
+> (`HKLM\Software\DisplayXR\DisplayProcessors`). Without step 2 the runtime
+> starts but finds no display processor and fails with
+> `XRT_ERROR_DEVICE_CREATION_FAILED` / "Failed to initialize OpenXR".
+> `dev-setup.bat` and `register_dev_plugin.bat` perform this registration for
+> you. (POSIX/macOS needs no registration — the loader finds plug-ins next to
+> the runtime.)
+>
+> **A registered plug-in can still fail this check.** If you previously ran the
+> released installer, an older `sim-display` / `leia-sr` is registered — but a
+> from-source runtime built ahead of that release **ABI-rejects** it
+> (`negotiate returned -17` in the log, "no registered plug-in claimed the
+> system"), producing the *same* `XRT_ERROR_DEVICE_CREATION_FAILED` / "Failed to
+> initialize OpenXR". A registered plug-in is not necessarily an ABI-matched one.
+> The fix is the same — register your freshly-built plug-in (step 2), which
+> overwrites the stale entry. Diagnose headlessly first:
+> ```bat
+> _package\bin\displayxr-cli.exe selftest   REM PASS = DP found & ABI-matched; FAIL dumps the reason
+> ```
 
 **macOS:**
 ```bash

--- a/docs/getting-started/building.md
+++ b/docs/getting-started/building.md
@@ -48,6 +48,22 @@ _package\run_cube_handle_d3d11_win.bat REM 3. run a test app
 > The runtime also logs the underlying cause (`negotiate returned …`, which
 > plug-in was rejected) to its per-process log at
 > `%LOCALAPPDATA%\DisplayXR\DisplayXR_<exe>.<pid>_<timestamp>.log`.
+>
+> **An elevated prompt re-triggers the same failure even after a correct
+> registration.** Registration is machine-wide and permanent
+> (`HKLM\Software\DisplayXR\DisplayProcessors`) — it is *not* per-session. But
+> *which runtime loads* is: `run_*.bat` points `XR_RUNTIME_JSON` at your
+> from-source runtime, and the Khronos loader **silently ignores
+> `XR_RUNTIME_JSON` in an elevated/admin process** (see
+> [Elevated terminal caveat](#elevated-terminal-caveat)), falling back to the
+> *installed* runtime via `HKLM\Software\Khronos\OpenXR\1\ActiveRuntime`. That
+> older runtime then ABI-rejects your freshly-registered plug-in, failing with
+> `XRT_ERROR_DEVICE_CREATION_FAILED` / "Failed to initialize OpenXR" — so it
+> looks like the registration "only applied to the one prompt where you ran it".
+> It didn't.
+> Either **run test apps from a non-elevated prompt** (so `XR_RUNTIME_JSON` is
+> honored), or run `scripts\dev-setup.bat` once so `ActiveRuntime` points at your
+> dev build and *every* app — any prompt, no env var needed — loads it.
 
 **macOS:**
 ```bash


### PR DESCRIPTION
## What

Extends the "from-source build needs a registered display processor" callout in `docs/getting-started/building.md` to cover the case that actually trips people up: a plug-in **is** registered, but it's ABI-stale.

## Why

The existing callout only described a machine with *nothing* registered ("building from source does not register it → no display processor"). But the identical `XRT_ERROR_DEVICE_CREATION_FAILED` / "Failed to initialize OpenXR" failure also occurs when a plug-in **is** registered from a prior installer (e.g. `sim-display`/`leia-sr` from a released bundle) and a from-source runtime built **ahead** of that release ABI-rejects it at negotiate.

This came up debugging a colleague's from-source build: `displayxr-cli selftest` showed
```
sim-display: negotiate returned -17 (iface=0) — skipping.
leia-sr:     negotiate returned -17 (iface=0) — skipping.
no registered plug-in claimed the system — falling back to static drivers.
Result: XRT_ERROR_DEVICE_CREATION_FAILED
```
A new `main` runtime (ABI v4) rejecting the older installer-registered plug-ins. "I have DisplayXR installed and plug-ins registered" was true, yet init still failed — the existing doc gave no hint that an existing registration can be stale, nor a diagnostic.

## Changes

- Add a second paragraph: a registered plug-in is not necessarily an ABI-matched one; the same failure + fix (register the freshly-built plug-in, which overwrites the stale entry) applies.
- Point at `displayxr-cli selftest` as the headless diagnostic.
- Reword the lead from the informal "The step everyone misses on Windows" to "Windows requires an explicit plug-in registration step."

Docs-only — `DetectChanges` short-circuits the build jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)