### PR TITLE
fix(macos,#59): rounded window corners + TAB focus from cold start (shared surface)

### DIFF
--- a/src/xrt/compositor/CMakeLists.txt
+++ b/src/xrt/compositor/CMakeLists.txt
@@ -240,6 +240,7 @@ add_library(
 	comp_multi STATIC multi/comp_multi_compositor.c multi/comp_multi_interface.h
 			  multi/comp_multi_private.h multi/comp_multi_system.c
 			  multi/comp_multi_workspace.c multi/comp_multi_workspace.h
+			  multi/comp_multi_content_blend.c multi/comp_multi_content_blend.h
 	)
 target_link_libraries(
 	comp_multi

--- a/src/xrt/compositor/multi/comp_multi_content_blend.c
+++ b/src/xrt/compositor/multi/comp_multi_content_blend.c
@@ -1,0 +1,682 @@
+// Copyright 2025, Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  Rounded-corner + edge-feather content composite pipeline (macOS).
+ * @author David Fattal
+ * @ingroup comp_multi
+ */
+
+#include "comp_multi_content_blend.h"
+
+#ifdef XRT_OS_MACOS
+
+#include "util/u_logging.h"
+
+#include <string.h>
+
+/*
+ * Embedded SPIR-V, compiled offline with glslangValidator (no CMake shader
+ * build step — same pattern as vk_hud_blend).
+ *
+ * Vertex (content.vert): fullscreen triangle, no vertex buffer.
+ *   v_uv = vec2((gl_VertexIndex << 1) & 2, gl_VertexIndex & 2);
+ *   gl_Position = vec4(v_uv * 2.0 - 1.0, 0.0, 1.0);
+ *
+ * Fragment (content.frag): sample content over a source sub-rect, modulate
+ * output alpha by rounded-rect SDF coverage x aspect-correct edge feather
+ * (faithful port of d3d11_service_shaders.h:766-832, all-four-corners). See
+ * comp_multi_content_blend.h for the push-constant layout.
+ */
+
+// clang-format off
+static const uint32_t content_vert_spv[] = {
+	0x07230203, 0x00010000, 0x0008000b, 0x0000002b, 0x00000000, 0x00020011, 0x00000001,
+	0x0006000b, 0x00000001, 0x4c534c47, 0x6474732e, 0x3035342e, 0x00000000, 0x0003000e,
+	0x00000000, 0x00000001, 0x0008000f, 0x00000000, 0x00000004, 0x6e69616d, 0x00000000,
+	0x00000009, 0x0000000c, 0x0000001d, 0x00030003, 0x00000002, 0x000001c2, 0x00040005,
+	0x00000004, 0x6e69616d, 0x00000000, 0x00040005, 0x00000009, 0x76755f76, 0x00000000,
+	0x00060005, 0x0000000c, 0x565f6c67, 0x65747265, 0x646e4978, 0x00007865, 0x00060005,
+	0x0000001b, 0x505f6c67, 0x65567265, 0x78657472, 0x00000000, 0x00060006, 0x0000001b,
+	0x00000000, 0x505f6c67, 0x7469736f, 0x006e6f69, 0x00070006, 0x0000001b, 0x00000001,
+	0x505f6c67, 0x746e696f, 0x657a6953, 0x00000000, 0x00070006, 0x0000001b, 0x00000002,
+	0x435f6c67, 0x4470696c, 0x61747369, 0x0065636e, 0x00070006, 0x0000001b, 0x00000003,
+	0x435f6c67, 0x446c6c75, 0x61747369, 0x0065636e, 0x00030005, 0x0000001d, 0x00000000,
+	0x00040047, 0x00000009, 0x0000001e, 0x00000000, 0x00040047, 0x0000000c, 0x0000000b,
+	0x0000002a, 0x00030047, 0x0000001b, 0x00000002, 0x00050048, 0x0000001b, 0x00000000,
+	0x0000000b, 0x00000000, 0x00050048, 0x0000001b, 0x00000001, 0x0000000b, 0x00000001,
+	0x00050048, 0x0000001b, 0x00000002, 0x0000000b, 0x00000003, 0x00050048, 0x0000001b,
+	0x00000003, 0x0000000b, 0x00000004, 0x00020013, 0x00000002, 0x00030021, 0x00000003,
+	0x00000002, 0x00030016, 0x00000006, 0x00000020, 0x00040017, 0x00000007, 0x00000006,
+	0x00000002, 0x00040020, 0x00000008, 0x00000003, 0x00000007, 0x0004003b, 0x00000008,
+	0x00000009, 0x00000003, 0x00040015, 0x0000000a, 0x00000020, 0x00000001, 0x00040020,
+	0x0000000b, 0x00000001, 0x0000000a, 0x0004003b, 0x0000000b, 0x0000000c, 0x00000001,
+	0x0004002b, 0x0000000a, 0x0000000e, 0x00000001, 0x0004002b, 0x0000000a, 0x00000010,
+	0x00000002, 0x00040017, 0x00000017, 0x00000006, 0x00000004, 0x00040015, 0x00000018,
+	0x00000020, 0x00000000, 0x0004002b, 0x00000018, 0x00000019, 0x00000001, 0x0004001c,
+	0x0000001a, 0x00000006, 0x00000019, 0x0006001e, 0x0000001b, 0x00000017, 0x00000006,
+	0x0000001a, 0x0000001a, 0x00040020, 0x0000001c, 0x00000003, 0x0000001b, 0x0004003b,
+	0x0000001c, 0x0000001d, 0x00000003, 0x0004002b, 0x0000000a, 0x0000001e, 0x00000000,
+	0x0004002b, 0x00000006, 0x00000020, 0x40000000, 0x0004002b, 0x00000006, 0x00000022,
+	0x3f800000, 0x0004002b, 0x00000006, 0x00000025, 0x00000000, 0x00040020, 0x00000029,
+	0x00000003, 0x00000017, 0x00050036, 0x00000002, 0x00000004, 0x00000000, 0x00000003,
+	0x000200f8, 0x00000005, 0x0004003d, 0x0000000a, 0x0000000d, 0x0000000c, 0x000500c4,
+	0x0000000a, 0x0000000f, 0x0000000d, 0x0000000e, 0x000500c7, 0x0000000a, 0x00000011,
+	0x0000000f, 0x00000010, 0x0004006f, 0x00000006, 0x00000012, 0x00000011, 0x0004003d,
+	0x0000000a, 0x00000013, 0x0000000c, 0x000500c7, 0x0000000a, 0x00000014, 0x00000013,
+	0x00000010, 0x0004006f, 0x00000006, 0x00000015, 0x00000014, 0x00050050, 0x00000007,
+	0x00000016, 0x00000012, 0x00000015, 0x0003003e, 0x00000009, 0x00000016, 0x0004003d,
+	0x00000007, 0x0000001f, 0x00000009, 0x0005008e, 0x00000007, 0x00000021, 0x0000001f,
+	0x00000020, 0x00050050, 0x00000007, 0x00000023, 0x00000022, 0x00000022, 0x00050083,
+	0x00000007, 0x00000024, 0x00000021, 0x00000023, 0x00050051, 0x00000006, 0x00000026,
+	0x00000024, 0x00000000, 0x00050051, 0x00000006, 0x00000027, 0x00000024, 0x00000001,
+	0x00070050, 0x00000017, 0x00000028, 0x00000026, 0x00000027, 0x00000025, 0x00000022,
+	0x00050041, 0x00000029, 0x0000002a, 0x0000001d, 0x0000001e, 0x0003003e, 0x0000002a,
+	0x00000028, 0x000100fd, 0x00010038,
+};
+
+static const uint32_t content_frag_spv[] = {
+	0x07230203, 0x00010000, 0x0008000b, 0x00000112, 0x00000000, 0x00020011, 0x00000001,
+	0x0006000b, 0x00000001, 0x4c534c47, 0x6474732e, 0x3035342e, 0x00000000, 0x0003000e,
+	0x00000000, 0x00000001, 0x0007000f, 0x00000004, 0x00000004, 0x6e69616d, 0x00000000,
+	0x00000013, 0x00000107, 0x00030010, 0x00000004, 0x00000007, 0x00030003, 0x00000002,
+	0x000001c2, 0x00040005, 0x00000004, 0x6e69616d, 0x00000000, 0x00030005, 0x00000009,
+	0x00767573, 0x00030005, 0x0000000a, 0x00004350, 0x00060006, 0x0000000a, 0x00000000,
+	0x5f637273, 0x6f5f7675, 0x00006666, 0x00070006, 0x0000000a, 0x00000001, 0x5f637273,
+	0x735f7675, 0x656c6163, 0x00000000, 0x00060006, 0x0000000a, 0x00000002, 0x5f6e6977,
+	0x6f5f7675, 0x00006666, 0x00070006, 0x0000000a, 0x00000003, 0x5f6e6977, 0x735f7675,
+	0x656c6163, 0x00000000, 0x00070006, 0x0000000a, 0x00000004, 0x6e726f63, 0x725f7265,
+	0x75696461, 0x00000073, 0x00070006, 0x0000000a, 0x00000005, 0x6e726f63, 0x615f7265,
+	0x63657073, 0x00000074, 0x00070006, 0x0000000a, 0x00000006, 0x65676465, 0x6165665f,
+	0x72656874, 0x00000000, 0x00050006, 0x0000000a, 0x00000007, 0x6461705f, 0x00000000,
+	0x00030005, 0x0000000c, 0x00006370, 0x00040005, 0x00000013, 0x76755f76, 0x00000000,
+	0x00030005, 0x0000001c, 0x00000063, 0x00040005, 0x00000020, 0x65745f75, 0x00000078,
+	0x00030005, 0x00000024, 0x00000077, 0x00030005, 0x0000002f, 0x00007972, 0x00040005,
+	0x00000034, 0x65707361, 0x00007463, 0x00030005, 0x0000003b, 0x00007872, 0x00060005,
+	0x0000003f, 0x6e726f63, 0x615f7265, 0x6168706c, 0x00000000, 0x00050005, 0x00000043,
+	0x635f6e69, 0x656e726f, 0x00000072, 0x00030005, 0x0000004a, 0x00006463, 0x00040005,
+	0x000000d0, 0x646e6162, 0x00000000, 0x00060005, 0x000000e4, 0x74616566, 0x5f726568,
+	0x68706c61, 0x00000061, 0x00030005, 0x000000ef, 0x00007864, 0x00030005, 0x000000f8,
+	0x00007964, 0x00040005, 0x00000107, 0x6f635f6f, 0x0000006c, 0x00030047, 0x0000000a,
+	0x00000002, 0x00050048, 0x0000000a, 0x00000000, 0x00000023, 0x00000000, 0x00050048,
+	0x0000000a, 0x00000001, 0x00000023, 0x00000008, 0x00050048, 0x0000000a, 0x00000002,
+	0x00000023, 0x00000010, 0x00050048, 0x0000000a, 0x00000003, 0x00000023, 0x00000018,
+	0x00050048, 0x0000000a, 0x00000004, 0x00000023, 0x00000020, 0x00050048, 0x0000000a,
+	0x00000005, 0x00000023, 0x00000024, 0x00050048, 0x0000000a, 0x00000006, 0x00000023,
+	0x00000028, 0x00050048, 0x0000000a, 0x00000007, 0x00000023, 0x0000002c, 0x00040047,
+	0x00000013, 0x0000001e, 0x00000000, 0x00040047, 0x00000020, 0x00000021, 0x00000000,
+	0x00040047, 0x00000020, 0x00000022, 0x00000000, 0x00040047, 0x00000107, 0x0000001e,
+	0x00000000, 0x00020013, 0x00000002, 0x00030021, 0x00000003, 0x00000002, 0x00030016,
+	0x00000006, 0x00000020, 0x00040017, 0x00000007, 0x00000006, 0x00000002, 0x00040020,
+	0x00000008, 0x00000007, 0x00000007, 0x000a001e, 0x0000000a, 0x00000007, 0x00000007,
+	0x00000007, 0x00000007, 0x00000006, 0x00000006, 0x00000006, 0x00000006, 0x00040020,
+	0x0000000b, 0x00000009, 0x0000000a, 0x0004003b, 0x0000000b, 0x0000000c, 0x00000009,
+	0x00040015, 0x0000000d, 0x00000020, 0x00000001, 0x0004002b, 0x0000000d, 0x0000000e,
+	0x00000000, 0x00040020, 0x0000000f, 0x00000009, 0x00000007, 0x00040020, 0x00000012,
+	0x00000001, 0x00000007, 0x0004003b, 0x00000012, 0x00000013, 0x00000001, 0x0004002b,
+	0x0000000d, 0x00000015, 0x00000001, 0x00040017, 0x0000001a, 0x00000006, 0x00000004,
+	0x00040020, 0x0000001b, 0x00000007, 0x0000001a, 0x00090019, 0x0000001d, 0x00000006,
+	0x00000001, 0x00000000, 0x00000000, 0x00000000, 0x00000001, 0x00000000, 0x0003001b,
+	0x0000001e, 0x0000001d, 0x00040020, 0x0000001f, 0x00000000, 0x0000001e, 0x0004003b,
+	0x0000001f, 0x00000020, 0x00000000, 0x0004002b, 0x0000000d, 0x00000025, 0x00000002,
+	0x0004002b, 0x0000000d, 0x00000029, 0x00000003, 0x00040020, 0x0000002e, 0x00000007,
+	0x00000006, 0x0004002b, 0x0000000d, 0x00000030, 0x00000004, 0x00040020, 0x00000031,
+	0x00000009, 0x00000006, 0x0004002b, 0x0000000d, 0x00000035, 0x00000005, 0x0004002b,
+	0x00000006, 0x00000039, 0x3a83126f, 0x0004002b, 0x00000006, 0x00000040, 0x3f800000,
+	0x00020014, 0x00000041, 0x00040020, 0x00000042, 0x00000007, 0x00000041, 0x0003002a,
+	0x00000041, 0x00000044, 0x0004002b, 0x00000006, 0x00000046, 0x00000000, 0x0004002b,
+	0x00000006, 0x0000004b, 0xbf800000, 0x00040015, 0x0000004c, 0x00000020, 0x00000000,
+	0x0004002b, 0x0000004c, 0x0000004d, 0x00000000, 0x0004002b, 0x0000004c, 0x00000054,
+	0x00000001, 0x00030029, 0x00000041, 0x000000ca, 0x0004002b, 0x0000000d, 0x000000d1,
+	0x00000006, 0x0004002b, 0x00000006, 0x000000dd, 0x3ca3d70a, 0x00040020, 0x00000106,
+	0x00000003, 0x0000001a, 0x0004003b, 0x00000106, 0x00000107, 0x00000003, 0x00040017,
+	0x00000108, 0x00000006, 0x00000003, 0x00050036, 0x00000002, 0x00000004, 0x00000000,
+	0x00000003, 0x000200f8, 0x00000005, 0x0004003b, 0x00000008, 0x00000009, 0x00000007,
+	0x0004003b, 0x0000001b, 0x0000001c, 0x00000007, 0x0004003b, 0x00000008, 0x00000024,
+	0x00000007, 0x0004003b, 0x0000002e, 0x0000002f, 0x00000007, 0x0004003b, 0x0000002e,
+	0x00000034, 0x00000007, 0x0004003b, 0x0000002e, 0x0000003b, 0x00000007, 0x0004003b,
+	0x0000002e, 0x0000003f, 0x00000007, 0x0004003b, 0x00000042, 0x00000043, 0x00000007,
+	0x0004003b, 0x0000002e, 0x0000004a, 0x00000007, 0x0004003b, 0x0000002e, 0x000000d0,
+	0x00000007, 0x0004003b, 0x0000002e, 0x000000d5, 0x00000007, 0x0004003b, 0x0000002e,
+	0x000000e4, 0x00000007, 0x0004003b, 0x0000002e, 0x000000ef, 0x00000007, 0x0004003b,
+	0x0000002e, 0x000000f8, 0x00000007, 0x00050041, 0x0000000f, 0x00000010, 0x0000000c,
+	0x0000000e, 0x0004003d, 0x00000007, 0x00000011, 0x00000010, 0x0004003d, 0x00000007,
+	0x00000014, 0x00000013, 0x00050041, 0x0000000f, 0x00000016, 0x0000000c, 0x00000015,
+	0x0004003d, 0x00000007, 0x00000017, 0x00000016, 0x00050085, 0x00000007, 0x00000018,
+	0x00000014, 0x00000017, 0x00050081, 0x00000007, 0x00000019, 0x00000011, 0x00000018,
+	0x0003003e, 0x00000009, 0x00000019, 0x0004003d, 0x0000001e, 0x00000021, 0x00000020,
+	0x0004003d, 0x00000007, 0x00000022, 0x00000009, 0x00050057, 0x0000001a, 0x00000023,
+	0x00000021, 0x00000022, 0x0003003e, 0x0000001c, 0x00000023, 0x00050041, 0x0000000f,
+	0x00000026, 0x0000000c, 0x00000025, 0x0004003d, 0x00000007, 0x00000027, 0x00000026,
+	0x0004003d, 0x00000007, 0x00000028, 0x00000013, 0x00050041, 0x0000000f, 0x0000002a,
+	0x0000000c, 0x00000029, 0x0004003d, 0x00000007, 0x0000002b, 0x0000002a, 0x00050085,
+	0x00000007, 0x0000002c, 0x00000028, 0x0000002b, 0x00050081, 0x00000007, 0x0000002d,
+	0x00000027, 0x0000002c, 0x0003003e, 0x00000024, 0x0000002d, 0x00050041, 0x00000031,
+	0x00000032, 0x0000000c, 0x00000030, 0x0004003d, 0x00000006, 0x00000033, 0x00000032,
+	0x0003003e, 0x0000002f, 0x00000033, 0x00050041, 0x00000031, 0x00000036, 0x0000000c,
+	0x00000035, 0x0004003d, 0x00000006, 0x00000037, 0x00000036, 0x0006000c, 0x00000006,
+	0x00000038, 0x00000001, 0x00000004, 0x00000037, 0x0007000c, 0x00000006, 0x0000003a,
+	0x00000001, 0x00000028, 0x00000038, 0x00000039, 0x0003003e, 0x00000034, 0x0000003a,
+	0x0004003d, 0x00000006, 0x0000003c, 0x0000002f, 0x0004003d, 0x00000006, 0x0000003d,
+	0x00000034, 0x00050088, 0x00000006, 0x0000003e, 0x0000003c, 0x0000003d, 0x0003003e,
+	0x0000003b, 0x0000003e, 0x0003003e, 0x0000003f, 0x00000040, 0x0003003e, 0x00000043,
+	0x00000044, 0x0004003d, 0x00000006, 0x00000045, 0x0000002f, 0x000500ba, 0x00000041,
+	0x00000047, 0x00000045, 0x00000046, 0x000300f7, 0x00000049, 0x00000000, 0x000400fa,
+	0x00000047, 0x00000048, 0x00000049, 0x000200f8, 0x00000048, 0x0003003e, 0x0000004a,
+	0x0000004b, 0x00050041, 0x0000002e, 0x0000004e, 0x00000024, 0x0000004d, 0x0004003d,
+	0x00000006, 0x0000004f, 0x0000004e, 0x0004003d, 0x00000006, 0x00000050, 0x0000003b,
+	0x000500b8, 0x00000041, 0x00000051, 0x0000004f, 0x00000050, 0x000300f7, 0x00000053,
+	0x00000000, 0x000400fa, 0x00000051, 0x00000052, 0x00000053, 0x000200f8, 0x00000052,
+	0x00050041, 0x0000002e, 0x00000055, 0x00000024, 0x00000054, 0x0004003d, 0x00000006,
+	0x00000056, 0x00000055, 0x0004003d, 0x00000006, 0x00000057, 0x0000002f, 0x000500b8,
+	0x00000041, 0x00000058, 0x00000056, 0x00000057, 0x000200f9, 0x00000053, 0x000200f8,
+	0x00000053, 0x000700f5, 0x00000041, 0x00000059, 0x00000051, 0x00000048, 0x00000058,
+	0x00000052, 0x000300f7, 0x0000005b, 0x00000000, 0x000400fa, 0x00000059, 0x0000005a,
+	0x0000006a, 0x000200f8, 0x0000005a, 0x0004003d, 0x00000006, 0x0000005c, 0x0000003b,
+	0x00050041, 0x0000002e, 0x0000005d, 0x00000024, 0x0000004d, 0x0004003d, 0x00000006,
+	0x0000005e, 0x0000005d, 0x00050083, 0x00000006, 0x0000005f, 0x0000005c, 0x0000005e,
+	0x0004003d, 0x00000006, 0x00000060, 0x0000003b, 0x00050088, 0x00000006, 0x00000061,
+	0x0000005f, 0x00000060, 0x0004003d, 0x00000006, 0x00000062, 0x0000002f, 0x00050041,
+	0x0000002e, 0x00000063, 0x00000024, 0x00000054, 0x0004003d, 0x00000006, 0x00000064,
+	0x00000063, 0x00050083, 0x00000006, 0x00000065, 0x00000062, 0x00000064, 0x0004003d,
+	0x00000006, 0x00000066, 0x0000002f, 0x00050088, 0x00000006, 0x00000067, 0x00000065,
+	0x00000066, 0x00050050, 0x00000007, 0x00000068, 0x00000061, 0x00000067, 0x0006000c,
+	0x00000006, 0x00000069, 0x00000001, 0x00000042, 0x00000068, 0x0003003e, 0x0000004a,
+	0x00000069, 0x000200f9, 0x0000005b, 0x000200f8, 0x0000006a, 0x00050041, 0x0000002e,
+	0x0000006b, 0x00000024, 0x0000004d, 0x0004003d, 0x00000006, 0x0000006c, 0x0000006b,
+	0x0004003d, 0x00000006, 0x0000006d, 0x0000003b, 0x00050083, 0x00000006, 0x0000006e,
+	0x00000040, 0x0000006d, 0x000500ba, 0x00000041, 0x0000006f, 0x0000006c, 0x0000006e,
+	0x000300f7, 0x00000071, 0x00000000, 0x000400fa, 0x0000006f, 0x00000070, 0x00000071,
+	0x000200f8, 0x00000070, 0x00050041, 0x0000002e, 0x00000072, 0x00000024, 0x00000054,
+	0x0004003d, 0x00000006, 0x00000073, 0x00000072, 0x0004003d, 0x00000006, 0x00000074,
+	0x0000002f, 0x000500b8, 0x00000041, 0x00000075, 0x00000073, 0x00000074, 0x000200f9,
+	0x00000071, 0x000200f8, 0x00000071, 0x000700f5, 0x00000041, 0x00000076, 0x0000006f,
+	0x0000006a, 0x00000075, 0x00000070, 0x000300f7, 0x00000078, 0x00000000, 0x000400fa,
+	0x00000076, 0x00000077, 0x00000088, 0x000200f8, 0x00000077, 0x00050041, 0x0000002e,
+	0x00000079, 0x00000024, 0x0000004d, 0x0004003d, 0x00000006, 0x0000007a, 0x00000079,
+	0x0004003d, 0x00000006, 0x0000007b, 0x0000003b, 0x00050083, 0x00000006, 0x0000007c,
+	0x00000040, 0x0000007b, 0x00050083, 0x00000006, 0x0000007d, 0x0000007a, 0x0000007c,
+	0x0004003d, 0x00000006, 0x0000007e, 0x0000003b, 0x00050088, 0x00000006, 0x0000007f,
+	0x0000007d, 0x0000007e, 0x0004003d, 0x00000006, 0x00000080, 0x0000002f, 0x00050041,
+	0x0000002e, 0x00000081, 0x00000024, 0x00000054, 0x0004003d, 0x00000006, 0x00000082,
+	0x00000081, 0x00050083, 0x00000006, 0x00000083, 0x00000080, 0x00000082, 0x0004003d,
+	0x00000006, 0x00000084, 0x0000002f, 0x00050088, 0x00000006, 0x00000085, 0x00000083,
+	0x00000084, 0x00050050, 0x00000007, 0x00000086, 0x0000007f, 0x00000085, 0x0006000c,
+	0x00000006, 0x00000087, 0x00000001, 0x00000042, 0x00000086, 0x0003003e, 0x0000004a,
+	0x00000087, 0x000200f9, 0x00000078, 0x000200f8, 0x00000088, 0x00050041, 0x0000002e,
+	0x00000089, 0x00000024, 0x0000004d, 0x0004003d, 0x00000006, 0x0000008a, 0x00000089,
+	0x0004003d, 0x00000006, 0x0000008b, 0x0000003b, 0x000500b8, 0x00000041, 0x0000008c,
+	0x0000008a, 0x0000008b, 0x000300f7, 0x0000008e, 0x00000000, 0x000400fa, 0x0000008c,
+	0x0000008d, 0x0000008e, 0x000200f8, 0x0000008d, 0x00050041, 0x0000002e, 0x0000008f,
+	0x00000024, 0x00000054, 0x0004003d, 0x00000006, 0x00000090, 0x0000008f, 0x0004003d,
+	0x00000006, 0x00000091, 0x0000002f, 0x00050083, 0x00000006, 0x00000092, 0x00000040,
+	0x00000091, 0x000500ba, 0x00000041, 0x00000093, 0x00000090, 0x00000092, 0x000200f9,
+	0x0000008e, 0x000200f8, 0x0000008e, 0x000700f5, 0x00000041, 0x00000094, 0x0000008c,
+	0x00000088, 0x00000093, 0x0000008d, 0x000300f7, 0x00000096, 0x00000000, 0x000400fa,
+	0x00000094, 0x00000095, 0x000000a6, 0x000200f8, 0x00000095, 0x0004003d, 0x00000006,
+	0x00000097, 0x0000003b, 0x00050041, 0x0000002e, 0x00000098, 0x00000024, 0x0000004d,
+	0x0004003d, 0x00000006, 0x00000099, 0x00000098, 0x00050083, 0x00000006, 0x0000009a,
+	0x00000097, 0x00000099, 0x0004003d, 0x00000006, 0x0000009b, 0x0000003b, 0x00050088,
+	0x00000006, 0x0000009c, 0x0000009a, 0x0000009b, 0x00050041, 0x0000002e, 0x0000009d,
+	0x00000024, 0x00000054, 0x0004003d, 0x00000006, 0x0000009e, 0x0000009d, 0x0004003d,
+	0x00000006, 0x0000009f, 0x0000002f, 0x00050083, 0x00000006, 0x000000a0, 0x00000040,
+	0x0000009f, 0x00050083, 0x00000006, 0x000000a1, 0x0000009e, 0x000000a0, 0x0004003d,
+	0x00000006, 0x000000a2, 0x0000002f, 0x00050088, 0x00000006, 0x000000a3, 0x000000a1,
+	0x000000a2, 0x00050050, 0x00000007, 0x000000a4, 0x0000009c, 0x000000a3, 0x0006000c,
+	0x00000006, 0x000000a5, 0x00000001, 0x00000042, 0x000000a4, 0x0003003e, 0x0000004a,
+	0x000000a5, 0x000200f9, 0x00000096, 0x000200f8, 0x000000a6, 0x00050041, 0x0000002e,
+	0x000000a7, 0x00000024, 0x0000004d, 0x0004003d, 0x00000006, 0x000000a8, 0x000000a7,
+	0x0004003d, 0x00000006, 0x000000a9, 0x0000003b, 0x00050083, 0x00000006, 0x000000aa,
+	0x00000040, 0x000000a9, 0x000500ba, 0x00000041, 0x000000ab, 0x000000a8, 0x000000aa,
+	0x000300f7, 0x000000ad, 0x00000000, 0x000400fa, 0x000000ab, 0x000000ac, 0x000000ad,
+	0x000200f8, 0x000000ac, 0x00050041, 0x0000002e, 0x000000ae, 0x00000024, 0x00000054,
+	0x0004003d, 0x00000006, 0x000000af, 0x000000ae, 0x0004003d, 0x00000006, 0x000000b0,
+	0x0000002f, 0x00050083, 0x00000006, 0x000000b1, 0x00000040, 0x000000b0, 0x000500ba,
+	0x00000041, 0x000000b2, 0x000000af, 0x000000b1, 0x000200f9, 0x000000ad, 0x000200f8,
+	0x000000ad, 0x000700f5, 0x00000041, 0x000000b3, 0x000000ab, 0x000000a6, 0x000000b2,
+	0x000000ac, 0x000300f7, 0x000000b5, 0x00000000, 0x000400fa, 0x000000b3, 0x000000b4,
+	0x000000b5, 0x000200f8, 0x000000b4, 0x00050041, 0x0000002e, 0x000000b6, 0x00000024,
+	0x0000004d, 0x0004003d, 0x00000006, 0x000000b7, 0x000000b6, 0x0004003d, 0x00000006,
+	0x000000b8, 0x0000003b, 0x00050083, 0x00000006, 0x000000b9, 0x00000040, 0x000000b8,
+	0x00050083, 0x00000006, 0x000000ba, 0x000000b7, 0x000000b9, 0x0004003d, 0x00000006,
+	0x000000bb, 0x0000003b, 0x00050088, 0x00000006, 0x000000bc, 0x000000ba, 0x000000bb,
+	0x00050041, 0x0000002e, 0x000000bd, 0x00000024, 0x00000054, 0x0004003d, 0x00000006,
+	0x000000be, 0x000000bd, 0x0004003d, 0x00000006, 0x000000bf, 0x0000002f, 0x00050083,
+	0x00000006, 0x000000c0, 0x00000040, 0x000000bf, 0x00050083, 0x00000006, 0x000000c1,
+	0x000000be, 0x000000c0, 0x0004003d, 0x00000006, 0x000000c2, 0x0000002f, 0x00050088,
+	0x00000006, 0x000000c3, 0x000000c1, 0x000000c2, 0x00050050, 0x00000007, 0x000000c4,
+	0x000000bc, 0x000000c3, 0x0006000c, 0x00000006, 0x000000c5, 0x00000001, 0x00000042,
+	0x000000c4, 0x0003003e, 0x0000004a, 0x000000c5, 0x000200f9, 0x000000b5, 0x000200f8,
+	0x000000b5, 0x000200f9, 0x00000096, 0x000200f8, 0x00000096, 0x000200f9, 0x00000078,
+	0x000200f8, 0x00000078, 0x000200f9, 0x0000005b, 0x000200f8, 0x0000005b, 0x0004003d,
+	0x00000006, 0x000000c6, 0x0000004a, 0x000500be, 0x00000041, 0x000000c7, 0x000000c6,
+	0x00000046, 0x000300f7, 0x000000c9, 0x00000000, 0x000400fa, 0x000000c7, 0x000000c8,
+	0x000000c9, 0x000200f8, 0x000000c8, 0x0003003e, 0x00000043, 0x000000ca, 0x0004003d,
+	0x00000006, 0x000000cb, 0x0000004a, 0x000500ba, 0x00000041, 0x000000cc, 0x000000cb,
+	0x00000040, 0x000300f7, 0x000000ce, 0x00000000, 0x000400fa, 0x000000cc, 0x000000cd,
+	0x000000ce, 0x000200f8, 0x000000cd, 0x000100fc, 0x000200f8, 0x000000ce, 0x00050041,
+	0x00000031, 0x000000d2, 0x0000000c, 0x000000d1, 0x0004003d, 0x00000006, 0x000000d3,
+	0x000000d2, 0x000500ba, 0x00000041, 0x000000d4, 0x000000d3, 0x00000046, 0x000300f7,
+	0x000000d7, 0x00000000, 0x000400fa, 0x000000d4, 0x000000d6, 0x000000dc, 0x000200f8,
+	0x000000d6, 0x00050041, 0x00000031, 0x000000d8, 0x0000000c, 0x000000d1, 0x0004003d,
+	0x00000006, 0x000000d9, 0x000000d8, 0x0004003d, 0x00000006, 0x000000da, 0x0000002f,
+	0x00050088, 0x00000006, 0x000000db, 0x000000d9, 0x000000da, 0x0003003e, 0x000000d5,
+	0x000000db, 0x000200f9, 0x000000d7, 0x000200f8, 0x000000dc, 0x0003003e, 0x000000d5,
+	0x000000dd, 0x000200f9, 0x000000d7, 0x000200f8, 0x000000d7, 0x0004003d, 0x00000006,
+	0x000000de, 0x000000d5, 0x0003003e, 0x000000d0, 0x000000de, 0x0004003d, 0x00000006,
+	0x000000df, 0x0000004a, 0x00050083, 0x00000006, 0x000000e0, 0x00000040, 0x000000df,
+	0x0004003d, 0x00000006, 0x000000e1, 0x000000d0, 0x00050088, 0x00000006, 0x000000e2,
+	0x000000e0, 0x000000e1, 0x0008000c, 0x00000006, 0x000000e3, 0x00000001, 0x0000002b,
+	0x000000e2, 0x00000046, 0x00000040, 0x0003003e, 0x0000003f, 0x000000e3, 0x000200f9,
+	0x000000c9, 0x000200f8, 0x000000c9, 0x000200f9, 0x00000049, 0x000200f8, 0x00000049,
+	0x0003003e, 0x000000e4, 0x00000040, 0x0004003d, 0x00000041, 0x000000e5, 0x00000043,
+	0x000400a8, 0x00000041, 0x000000e6, 0x000000e5, 0x000300f7, 0x000000e8, 0x00000000,
+	0x000400fa, 0x000000e6, 0x000000e7, 0x000000e8, 0x000200f8, 0x000000e7, 0x00050041,
+	0x00000031, 0x000000e9, 0x0000000c, 0x000000d1, 0x0004003d, 0x00000006, 0x000000ea,
+	0x000000e9, 0x000500ba, 0x00000041, 0x000000eb, 0x000000ea, 0x00000046, 0x000200f9,
+	0x000000e8, 0x000200f8, 0x000000e8, 0x000700f5, 0x00000041, 0x000000ec, 0x000000e6,
+	0x00000049, 0x000000eb, 0x000000e7, 0x000300f7, 0x000000ee, 0x00000000, 0x000400fa,
+	0x000000ec, 0x000000ed, 0x000000ee, 0x000200f8, 0x000000ed, 0x00050041, 0x0000002e,
+	0x000000f0, 0x00000024, 0x0000004d, 0x0004003d, 0x00000006, 0x000000f1, 0x000000f0,
+	0x00050041, 0x0000002e, 0x000000f2, 0x00000024, 0x0000004d, 0x0004003d, 0x00000006,
+	0x000000f3, 0x000000f2, 0x00050083, 0x00000006, 0x000000f4, 0x00000040, 0x000000f3,
+	0x0007000c, 0x00000006, 0x000000f5, 0x00000001, 0x00000025, 0x000000f1, 0x000000f4,
+	0x0004003d, 0x00000006, 0x000000f6, 0x00000034, 0x00050085, 0x00000006, 0x000000f7,
+	0x000000f5, 0x000000f6, 0x0003003e, 0x000000ef, 0x000000f7, 0x00050041, 0x0000002e,
+	0x000000f9, 0x00000024, 0x00000054, 0x0004003d, 0x00000006, 0x000000fa, 0x000000f9,
+	0x00050041, 0x0000002e, 0x000000fb, 0x00000024, 0x00000054, 0x0004003d, 0x00000006,
+	0x000000fc, 0x000000fb, 0x00050083, 0x00000006, 0x000000fd, 0x00000040, 0x000000fc,
+	0x0007000c, 0x00000006, 0x000000fe, 0x00000001, 0x00000025, 0x000000fa, 0x000000fd,
+	0x0003003e, 0x000000f8, 0x000000fe, 0x0004003d, 0x00000006, 0x000000ff, 0x000000ef,
+	0x0004003d, 0x00000006, 0x00000100, 0x000000f8, 0x0007000c, 0x00000006, 0x00000101,
+	0x00000001, 0x00000025, 0x000000ff, 0x00000100, 0x00050041, 0x00000031, 0x00000102,
+	0x0000000c, 0x000000d1, 0x0004003d, 0x00000006, 0x00000103, 0x00000102, 0x00050088,
+	0x00000006, 0x00000104, 0x00000101, 0x00000103, 0x0008000c, 0x00000006, 0x00000105,
+	0x00000001, 0x0000002b, 0x00000104, 0x00000046, 0x00000040, 0x0003003e, 0x000000e4,
+	0x00000105, 0x000200f9, 0x000000ee, 0x000200f8, 0x000000ee, 0x0004003d, 0x0000001a,
+	0x00000109, 0x0000001c, 0x0008004f, 0x00000108, 0x0000010a, 0x00000109, 0x00000109,
+	0x00000000, 0x00000001, 0x00000002, 0x0004003d, 0x00000006, 0x0000010b, 0x0000003f,
+	0x0004003d, 0x00000006, 0x0000010c, 0x000000e4, 0x00050085, 0x00000006, 0x0000010d,
+	0x0000010b, 0x0000010c, 0x00050051, 0x00000006, 0x0000010e, 0x0000010a, 0x00000000,
+	0x00050051, 0x00000006, 0x0000010f, 0x0000010a, 0x00000001, 0x00050051, 0x00000006,
+	0x00000110, 0x0000010a, 0x00000002, 0x00070050, 0x0000001a, 0x00000111, 0x0000010e,
+	0x0000010f, 0x00000110, 0x0000010d, 0x0003003e, 0x00000107, 0x00000111, 0x000100fd,
+	0x00010038,
+};
+// clang-format on
+
+
+bool
+comp_multi_content_blend_init(struct comp_multi_content_blend *blend, struct vk_bundle *vk, VkFormat atlas_fmt)
+{
+	VkResult ret;
+
+	VkShaderModuleCreateInfo vert_ci = {
+	    .sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO,
+	    .codeSize = sizeof(content_vert_spv),
+	    .pCode = content_vert_spv,
+	};
+	ret = vk->vkCreateShaderModule(vk->device, &vert_ci, NULL, &blend->vert_mod);
+	if (ret != VK_SUCCESS) {
+		U_LOG_E("[content blend] Failed to create vert shader: %d", ret);
+		return false;
+	}
+
+	VkShaderModuleCreateInfo frag_ci = {
+	    .sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO,
+	    .codeSize = sizeof(content_frag_spv),
+	    .pCode = content_frag_spv,
+	};
+	ret = vk->vkCreateShaderModule(vk->device, &frag_ci, NULL, &blend->frag_mod);
+	if (ret != VK_SUCCESS) {
+		U_LOG_E("[content blend] Failed to create frag shader: %d", ret);
+		return false;
+	}
+
+	// Linear sampler — source sub-rect rarely aligns to dst pixels.
+	VkSamplerCreateInfo samp_ci = {
+	    .sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO,
+	    .magFilter = VK_FILTER_LINEAR,
+	    .minFilter = VK_FILTER_LINEAR,
+	    .addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE,
+	    .addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE,
+	};
+	ret = vk->vkCreateSampler(vk->device, &samp_ci, NULL, &blend->sampler);
+	if (ret != VK_SUCCESS) {
+		U_LOG_E("[content blend] Failed to create sampler: %d", ret);
+		return false;
+	}
+
+	VkDescriptorSetLayoutBinding binding = {
+	    .binding = 0,
+	    .descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+	    .descriptorCount = 1,
+	    .stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT,
+	};
+	VkDescriptorSetLayoutCreateInfo dsl_ci = {
+	    .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO,
+	    .bindingCount = 1,
+	    .pBindings = &binding,
+	};
+	ret = vk->vkCreateDescriptorSetLayout(vk->device, &dsl_ci, NULL, &blend->desc_layout);
+	if (ret != VK_SUCCESS) {
+		return false;
+	}
+
+	// Pipeline layout with the fragment push-constant block.
+	VkPushConstantRange pc_range = {
+	    .stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT,
+	    .offset = 0,
+	    .size = sizeof(struct comp_multi_content_pc),
+	};
+	VkPipelineLayoutCreateInfo pl_ci = {
+	    .sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO,
+	    .setLayoutCount = 1,
+	    .pSetLayouts = &blend->desc_layout,
+	    .pushConstantRangeCount = 1,
+	    .pPushConstantRanges = &pc_range,
+	};
+	ret = vk->vkCreatePipelineLayout(vk->device, &pl_ci, NULL, &blend->pipe_layout);
+	if (ret != VK_SUCCESS) {
+		return false;
+	}
+
+	VkDescriptorPoolSize pool_size = {
+	    VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+	    COMP_MULTI_CONTENT_BLEND_MAX_IMAGES,
+	};
+	VkDescriptorPoolCreateInfo dp_ci = {
+	    .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO,
+	    .maxSets = COMP_MULTI_CONTENT_BLEND_MAX_IMAGES,
+	    .poolSizeCount = 1,
+	    .pPoolSizes = &pool_size,
+	};
+	ret = vk->vkCreateDescriptorPool(vk->device, &dp_ci, NULL, &blend->desc_pool);
+	if (ret != VK_SUCCESS) {
+		return false;
+	}
+
+	// Render pass: single color attachment, LOAD/STORE, COLOR_ATTACHMENT in/out
+	// (the atlas is already in COLOR_ATTACHMENT_OPTIMAL when content composites).
+	VkAttachmentDescription att = {
+	    .format = atlas_fmt,
+	    .samples = VK_SAMPLE_COUNT_1_BIT,
+	    .loadOp = VK_ATTACHMENT_LOAD_OP_LOAD,
+	    .storeOp = VK_ATTACHMENT_STORE_OP_STORE,
+	    .stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE,
+	    .stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE,
+	    .initialLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+	    .finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+	};
+	VkAttachmentReference ref = {0, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL};
+	VkSubpassDescription sub = {
+	    .pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS,
+	    .colorAttachmentCount = 1,
+	    .pColorAttachments = &ref,
+	};
+	VkRenderPassCreateInfo rp_ci = {
+	    .sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO,
+	    .attachmentCount = 1,
+	    .pAttachments = &att,
+	    .subpassCount = 1,
+	    .pSubpasses = &sub,
+	};
+	ret = vk->vkCreateRenderPass(vk->device, &rp_ci, NULL, &blend->render_pass);
+	if (ret != VK_SUCCESS) {
+		return false;
+	}
+
+	// Graphics pipeline: fullscreen triangle, SrcAlpha/InvSrcAlpha blend (the
+	// fragment shader's coverage drives source alpha), dynamic viewport/scissor.
+	VkPipelineShaderStageCreateInfo stages[2] = {
+	    {
+	        .sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
+	        .stage = VK_SHADER_STAGE_VERTEX_BIT,
+	        .module = blend->vert_mod,
+	        .pName = "main",
+	    },
+	    {
+	        .sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
+	        .stage = VK_SHADER_STAGE_FRAGMENT_BIT,
+	        .module = blend->frag_mod,
+	        .pName = "main",
+	    },
+	};
+
+	VkPipelineVertexInputStateCreateInfo vi = {.sType =
+	                                                VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO};
+	VkPipelineInputAssemblyStateCreateInfo ia = {
+	    .sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO,
+	    .topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST};
+	VkPipelineViewportStateCreateInfo vps = {.sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO,
+	                                         .viewportCount = 1,
+	                                         .scissorCount = 1};
+	VkPipelineRasterizationStateCreateInfo rs = {
+	    .sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO,
+	    .polygonMode = VK_POLYGON_MODE_FILL,
+	    .cullMode = VK_CULL_MODE_NONE,
+	    .frontFace = VK_FRONT_FACE_COUNTER_CLOCKWISE,
+	    .lineWidth = 1.0f};
+	VkPipelineMultisampleStateCreateInfo ms = {.sType =
+	                                               VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO,
+	                                           .rasterizationSamples = VK_SAMPLE_COUNT_1_BIT};
+	VkPipelineColorBlendAttachmentState blend_att = {
+	    .blendEnable = VK_TRUE,
+	    // Leave the atlas alpha untouched (same rationale as vk_hud_blend) — the
+	    // weave/present path may treat alpha as window transparency.
+	    .colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT,
+	    .srcColorBlendFactor = VK_BLEND_FACTOR_SRC_ALPHA,
+	    .dstColorBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA,
+	    .colorBlendOp = VK_BLEND_OP_ADD,
+	    .srcAlphaBlendFactor = VK_BLEND_FACTOR_ZERO,
+	    .dstAlphaBlendFactor = VK_BLEND_FACTOR_ONE,
+	    .alphaBlendOp = VK_BLEND_OP_ADD};
+	VkPipelineColorBlendStateCreateInfo cb = {.sType =
+	                                              VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO,
+	                                          .attachmentCount = 1,
+	                                          .pAttachments = &blend_att};
+	VkPipelineDepthStencilStateCreateInfo ds = {
+	    .sType = VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO};
+	VkDynamicState dyn_states[] = {VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR};
+	VkPipelineDynamicStateCreateInfo dyn = {.sType =
+	                                            VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO,
+	                                        .dynamicStateCount = 2,
+	                                        .pDynamicStates = dyn_states};
+
+	VkGraphicsPipelineCreateInfo pipe_ci = {
+	    .sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO,
+	    .stageCount = 2,
+	    .pStages = stages,
+	    .pVertexInputState = &vi,
+	    .pInputAssemblyState = &ia,
+	    .pViewportState = &vps,
+	    .pRasterizationState = &rs,
+	    .pMultisampleState = &ms,
+	    .pDepthStencilState = &ds,
+	    .pColorBlendState = &cb,
+	    .pDynamicState = &dyn,
+	    .layout = blend->pipe_layout,
+	    .renderPass = blend->render_pass,
+	    .subpass = 0,
+	};
+	ret = vk->vkCreateGraphicsPipelines(vk->device, VK_NULL_HANDLE, 1, &pipe_ci, NULL, &blend->pipeline);
+	if (ret != VK_SUCCESS) {
+		U_LOG_E("[content blend] Failed to create pipeline: %d", ret);
+		return false;
+	}
+
+	blend->initialized = true;
+	return true;
+}
+
+/*!
+ * Cached descriptor set for a (content image, array-layer) source, created (with
+ * a 2D view selecting the layer in the image's native format) on first sight.
+ */
+static VkDescriptorSet
+get_or_create_image_desc(
+    struct comp_multi_content_blend *blend, struct vk_bundle *vk, VkImage src_image, uint32_t array_layer, VkFormat src_fmt)
+{
+	for (uint32_t i = 0; i < blend->image_count; i++) {
+		if (blend->cached_images[i].image == src_image &&
+		    blend->cached_images[i].array_layer == array_layer) {
+			return blend->cached_images[i].desc_set;
+		}
+	}
+
+	if (blend->image_count >= COMP_MULTI_CONTENT_BLEND_MAX_IMAGES) {
+		U_LOG_E("[content blend] image cache exhausted (max=%u)", COMP_MULTI_CONTENT_BLEND_MAX_IMAGES);
+		return VK_NULL_HANDLE;
+	}
+
+	VkImageViewCreateInfo view_ci = {
+	    .sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,
+	    .image = src_image,
+	    .viewType = VK_IMAGE_VIEW_TYPE_2D,
+	    .format = src_fmt,
+	    .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, array_layer, 1},
+	};
+	VkImageView view = VK_NULL_HANDLE;
+	if (vk->vkCreateImageView(vk->device, &view_ci, NULL, &view) != VK_SUCCESS) {
+		U_LOG_E("[content blend] CreateImageView failed");
+		return VK_NULL_HANDLE;
+	}
+
+	VkDescriptorSetAllocateInfo ds_ai = {
+	    .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO,
+	    .descriptorPool = blend->desc_pool,
+	    .descriptorSetCount = 1,
+	    .pSetLayouts = &blend->desc_layout,
+	};
+	VkDescriptorSet desc_set = VK_NULL_HANDLE;
+	if (vk->vkAllocateDescriptorSets(vk->device, &ds_ai, &desc_set) != VK_SUCCESS) {
+		vk->vkDestroyImageView(vk->device, view, NULL);
+		U_LOG_E("[content blend] AllocateDescriptorSets failed");
+		return VK_NULL_HANDLE;
+	}
+
+	VkDescriptorImageInfo img_info = {
+	    .sampler = blend->sampler,
+	    .imageView = view,
+	    .imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+	};
+	VkWriteDescriptorSet write = {
+	    .sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
+	    .dstSet = desc_set,
+	    .dstBinding = 0,
+	    .descriptorCount = 1,
+	    .descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+	    .pImageInfo = &img_info,
+	};
+	vk->vkUpdateDescriptorSets(vk->device, 1, &write, 0, NULL);
+
+	blend->cached_images[blend->image_count].image = src_image;
+	blend->cached_images[blend->image_count].array_layer = array_layer;
+	blend->cached_images[blend->image_count].view = view;
+	blend->cached_images[blend->image_count].desc_set = desc_set;
+	blend->image_count++;
+	return desc_set;
+}
+
+void
+comp_multi_content_blend_begin(
+    struct comp_multi_content_blend *blend, struct vk_bundle *vk, VkCommandBuffer cmd, VkFramebuffer fb, uint32_t fb_w, uint32_t fb_h)
+{
+	if (!blend->initialized || fb == VK_NULL_HANDLE) {
+		return;
+	}
+
+	VkRenderPassBeginInfo rp_bi = {
+	    .sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO,
+	    .renderPass = blend->render_pass,
+	    .framebuffer = fb,
+	    .renderArea = {{0, 0}, {fb_w, fb_h}},
+	};
+	vk->vkCmdBeginRenderPass(cmd, &rp_bi, VK_SUBPASS_CONTENTS_INLINE);
+	vk->vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, blend->pipeline);
+}
+
+void
+comp_multi_content_blend_draw(struct comp_multi_content_blend *blend,
+                              struct vk_bundle *vk,
+                              VkCommandBuffer cmd,
+                              VkImage src_image,
+                              uint32_t array_layer,
+                              VkFormat src_fmt,
+                              const struct comp_multi_content_pc *pc,
+                              int32_t dst_x,
+                              int32_t dst_y,
+                              uint32_t dst_w,
+                              uint32_t dst_h)
+{
+	if (!blend->initialized || src_image == VK_NULL_HANDLE || dst_w == 0 || dst_h == 0) {
+		return;
+	}
+
+	VkDescriptorSet desc_set = get_or_create_image_desc(blend, vk, src_image, array_layer, src_fmt);
+	if (desc_set == VK_NULL_HANDLE) {
+		return;
+	}
+
+	VkViewport vp = {(float)dst_x, (float)dst_y, (float)dst_w, (float)dst_h, 0.0f, 1.0f};
+	vk->vkCmdSetViewport(cmd, 0, 1, &vp);
+	VkRect2D scissor = {{dst_x, dst_y}, {dst_w, dst_h}};
+	vk->vkCmdSetScissor(cmd, 0, 1, &scissor);
+
+	vk->vkCmdPushConstants(cmd, blend->pipe_layout, VK_SHADER_STAGE_FRAGMENT_BIT, 0,
+	                       sizeof(struct comp_multi_content_pc), pc);
+	vk->vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, blend->pipe_layout, 0, 1, &desc_set, 0,
+	                            NULL);
+	vk->vkCmdDraw(cmd, 3, 1, 0, 0);
+}
+
+void
+comp_multi_content_blend_end(struct comp_multi_content_blend *blend, struct vk_bundle *vk, VkCommandBuffer cmd)
+{
+	if (!blend->initialized) {
+		return;
+	}
+	vk->vkCmdEndRenderPass(cmd);
+}
+
+void
+comp_multi_content_blend_fini(struct comp_multi_content_blend *blend, struct vk_bundle *vk)
+{
+	if (!blend->initialized) {
+		return;
+	}
+
+	for (uint32_t i = 0; i < blend->image_count; i++) {
+		vk->vkDestroyImageView(vk->device, blend->cached_images[i].view, NULL);
+		// Descriptor sets freed implicitly with the pool.
+	}
+
+	if (blend->pipeline != VK_NULL_HANDLE) {
+		vk->vkDestroyPipeline(vk->device, blend->pipeline, NULL);
+	}
+	if (blend->render_pass != VK_NULL_HANDLE) {
+		vk->vkDestroyRenderPass(vk->device, blend->render_pass, NULL);
+	}
+	if (blend->pipe_layout != VK_NULL_HANDLE) {
+		vk->vkDestroyPipelineLayout(vk->device, blend->pipe_layout, NULL);
+	}
+	if (blend->desc_pool != VK_NULL_HANDLE) {
+		vk->vkDestroyDescriptorPool(vk->device, blend->desc_pool, NULL);
+	}
+	if (blend->desc_layout != VK_NULL_HANDLE) {
+		vk->vkDestroyDescriptorSetLayout(vk->device, blend->desc_layout, NULL);
+	}
+	if (blend->sampler != VK_NULL_HANDLE) {
+		vk->vkDestroySampler(vk->device, blend->sampler, NULL);
+	}
+	if (blend->vert_mod != VK_NULL_HANDLE) {
+		vk->vkDestroyShaderModule(vk->device, blend->vert_mod, NULL);
+	}
+	if (blend->frag_mod != VK_NULL_HANDLE) {
+		vk->vkDestroyShaderModule(vk->device, blend->frag_mod, NULL);
+	}
+
+	memset(blend, 0, sizeof(*blend));
+}
+
+#endif // XRT_OS_MACOS

--- a/src/xrt/compositor/multi/comp_multi_content_blend.h
+++ b/src/xrt/compositor/multi/comp_multi_content_blend.h
@@ -1,0 +1,134 @@
+// Copyright 2025, Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  Rounded-corner + edge-feather content composite pipeline (macOS).
+ * @author David Fattal
+ * @ingroup comp_multi
+ *
+ * macOS-only dedicated Vulkan pipeline that composites each spatial window's
+ * client content into the shared-surface atlas with rounded corners and
+ * feathered edges — the faithful analogue of the Windows D3D11 content-blit
+ * pixel shader (d3d11_service_shaders.h, rounded-rect SDF coverage). It
+ * replaces the hard vkCmdBlitImage content copy in render_shared_surface_locked
+ * so window corners match the shell's rounded focus-glow ring instead of
+ * spilling past it as sharp rectangles.
+ *
+ * Modeled on vk_hud_blend (aux_vk) but with: a rounded-rect/feather fragment
+ * shader, a fragment push-constant block carrying the per-draw source sub-rect,
+ * window-local UV domain and corner/feather parameters, and an array-layer-aware
+ * image/descriptor cache (content projection swapchains can be multiview array
+ * textures). It does NOT extend vk_hud_blend, which is shared by the
+ * chrome/cursor/HUD decorations and uses hand-embedded SPIR-V.
+ *
+ * The whole module is compiled only on macOS (XRT_OS_MACOS); elsewhere it is an
+ * empty translation unit so Windows/Android binaries stay byte-identical.
+ */
+
+#pragma once
+
+#include "xrt/xrt_config_os.h"
+
+#ifdef XRT_OS_MACOS
+
+#include "vk/vk_helpers.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//! Max distinct (image, array-layer) sources cached for descriptor sets.
+#define COMP_MULTI_CONTENT_BLEND_MAX_IMAGES 64
+
+/*!
+ * Per-draw push constants. Layout (std430 push_constant) MUST match
+ * content.frag exactly — offsets 0,8,16,24,32,36,40,44.
+ */
+struct comp_multi_content_pc
+{
+	float src_uv_off[2];   //!< Source sample sub-rect origin (normalized to full image).
+	float src_uv_scale[2]; //!< Source sample sub-rect extent (normalized).
+	float win_uv_off[2];   //!< Window-local UV [0,1] domain origin for the SDF.
+	float win_uv_scale[2]; //!< Window-local UV [0,1] domain extent for the SDF.
+	float corner_radius;   //!< |radius| as a fraction of window HEIGHT (0 = sharp).
+	float corner_aspect;   //!< win_w_m / win_h_m (aspect-correct corners + feather).
+	float edge_feather;    //!< Feather width as a fraction of window HEIGHT (0 = off).
+	float _pad;            //!< Padding to 48 bytes.
+};
+
+struct comp_multi_content_blend
+{
+	VkRenderPass render_pass;
+	VkPipeline pipeline;
+	VkPipelineLayout pipe_layout;
+	VkDescriptorSetLayout desc_layout;
+	VkDescriptorPool desc_pool;
+	VkSampler sampler;
+	VkShaderModule vert_mod;
+	VkShaderModule frag_mod;
+
+	//! Cache of (VkImage, array-layer) → VkImageView + VkDescriptorSet.
+	struct
+	{
+		VkImage image;
+		uint32_t array_layer;
+		VkImageView view;
+		VkDescriptorSet desc_set;
+	} cached_images[COMP_MULTI_CONTENT_BLEND_MAX_IMAGES];
+	uint32_t image_count;
+
+	bool initialized;
+};
+
+/*!
+ * Create the pipeline. @p atlas_fmt is the format of the atlas color attachment
+ * the content is composited into (the render pass uses LOAD/STORE,
+ * COLOR_ATTACHMENT_OPTIMAL in/out, matching vk_hud_blend's atlas pass).
+ */
+bool
+comp_multi_content_blend_init(struct comp_multi_content_blend *blend, struct vk_bundle *vk, VkFormat atlas_fmt);
+
+/*!
+ * Begin ONE render pass over @p fb (the atlas framebuffer) and bind the
+ * pipeline. The framebuffer's attachment must be in COLOR_ATTACHMENT_OPTIMAL on
+ * entry and is left in COLOR_ATTACHMENT_OPTIMAL on exit. All content draws issued
+ * between begin and end share this render pass instance, so overlapping windows
+ * blend in submission (painter, far→near) order.
+ */
+void
+comp_multi_content_blend_begin(
+    struct comp_multi_content_blend *blend, struct vk_bundle *vk, VkCommandBuffer cmd, VkFramebuffer fb, uint32_t fb_w, uint32_t fb_h);
+
+/*!
+ * Composite one (clipped) content rect. @p src_image / @p array_layer / @p
+ * src_fmt identify the content source (sampled via a cached view of that layer);
+ * @p pc carries the source sub-rect, window-local UV domain and corner/feather
+ * params; @p dst_* is the atlas-px destination rect (already tile-clipped).
+ * Must be called between begin and end.
+ */
+void
+comp_multi_content_blend_draw(struct comp_multi_content_blend *blend,
+                              struct vk_bundle *vk,
+                              VkCommandBuffer cmd,
+                              VkImage src_image,
+                              uint32_t array_layer,
+                              VkFormat src_fmt,
+                              const struct comp_multi_content_pc *pc,
+                              int32_t dst_x,
+                              int32_t dst_y,
+                              uint32_t dst_w,
+                              uint32_t dst_h);
+
+//! End the render pass begun by comp_multi_content_blend_begin.
+void
+comp_multi_content_blend_end(struct comp_multi_content_blend *blend, struct vk_bundle *vk, VkCommandBuffer cmd);
+
+//! Destroy all pipeline objects and cached views; zero the struct.
+void
+comp_multi_content_blend_fini(struct comp_multi_content_blend *blend, struct vk_bundle *vk);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // XRT_OS_MACOS

--- a/src/xrt/compositor/multi/comp_multi_private.h
+++ b/src/xrt/compositor/multi/comp_multi_private.h
@@ -37,6 +37,7 @@
 // (comp_multi always links aux_vk, so Vulkan is always available)
 #include "xrt/xrt_vulkan_includes.h"
 #include "vk/vk_hud_blend.h"
+#include "multi/comp_multi_content_blend.h"
 
 #include "render/render_interface.h"
 
@@ -673,6 +674,13 @@ struct multi_system_compositor
 	bool shared_chrome_blend_initialized;
 	VkFramebuffer shared_atlas_fb;        //!< Color attachment is the combined atlas.
 	VkImageView shared_atlas_fb_view;     //!< The atlas view the fb was built for (recreate key).
+
+	//! Rounded-corner + edge-feather content composite (Task 9): a dedicated
+	//! SDF pipeline that replaces the hard vkCmdBlitImage content copy so window
+	//! corners match the shell's rounded focus ring. Composites into the same
+	//! shared_atlas_fb (render-pass compatible with shared_chrome_blend).
+	struct comp_multi_content_blend shared_content_blend;
+	bool shared_content_blend_initialized;
 	//! @}
 #endif
 };

--- a/src/xrt/compositor/multi/comp_multi_system.c
+++ b/src/xrt/compositor/multi/comp_multi_system.c
@@ -3598,6 +3598,11 @@ shared_surface_fini(struct multi_system_compositor *msc)
 		vk_hud_blend_fini(&msc->shared_chrome_blend, vk);
 		msc->shared_chrome_blend_initialized = false;
 	}
+	// Task 9 content composite: owns its own render pass + pipeline (no fb).
+	if (vk != NULL && msc->shared_content_blend_initialized) {
+		comp_multi_content_blend_fini(&msc->shared_content_blend, vk);
+		msc->shared_content_blend_initialized = false;
+	}
 
 	// The one combined stereo atlas (view + image + memory).
 	if (vk != NULL && msc->shared_atlas_initialized) {
@@ -3823,6 +3828,29 @@ shared_ensure_chrome_blend(struct multi_system_compositor *msc, struct vk_bundle
 			return false;
 		}
 		msc->shared_atlas_fb_view = msc->shared_atlas_view;
+	}
+	return true;
+}
+
+/*!
+ * Ensure the rounded-corner content-composite pipeline (Task 9) and the
+ * atlas-wide framebuffer it renders into are ready. Reuses shared_ensure_chrome_blend
+ * to (re)build msc->shared_atlas_fb — the content pipeline's render pass is
+ * render-pass-compatible with the chrome blend's (same single color attachment,
+ * format, samples), so the same framebuffer serves both.
+ */
+static bool
+shared_ensure_content_blend(struct multi_system_compositor *msc, struct vk_bundle *vk)
+{
+	if (!shared_ensure_chrome_blend(msc, vk)) {
+		return false;
+	}
+	if (!msc->shared_content_blend_initialized) {
+		if (!comp_multi_content_blend_init(&msc->shared_content_blend, vk, msc->shared_atlas_format)) {
+			U_LOG_E("[#59] failed to init shared content blend");
+			return false;
+		}
+		msc->shared_content_blend_initialized = true;
 	}
 	return true;
 }
@@ -4226,160 +4254,12 @@ render_shared_surface_locked(struct multi_system_compositor *msc, int64_t displa
 	VkClearColorValue backdrop = {.float32 = {0.1f, 0.1f, 0.1f, 1.0f}};
 	vk->vkCmdClearColorImage(cmd, msc->shared_atlas_image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, &backdrop, 1,
 	                         &atlas_range);
-	// Order the clear before the per-client blits (both TRANSFER writes to the atlas).
-	VkImageMemoryBarrier clear_barrier = {
-	    .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
-	    .srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
-	    .dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
-	    .oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-	    .newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-	    .image = msc->shared_atlas_image,
-	    .subresourceRange = atlas_range,
-	};
-	vk->vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, NULL, 0,
-	                         NULL, 1, &clear_barrier);
-
-	// Blit each client's content into its window px-rect, per eye, into the atlas.
-	for (uint32_t c = 0; c < order_count; c++) {
-		struct shared_client_render *e = &order[c];
-		bool flip_y = e->layer->data.flip_y;
-
-		// Resolve the per-view source images for this client.
-		VkImage src_img[XRT_MAX_VIEWS];
-		uint32_t src_arr[XRT_MAX_VIEWS];
-		int src_x[XRT_MAX_VIEWS], src_y[XRT_MAX_VIEWS], src_w[XRT_MAX_VIEWS], src_h[XRT_MAX_VIEWS];
-		bool ok = true;
-		for (uint32_t v = 0; v < e->view_count; v++) {
-			int tw = 0, th = 0;
-			VkFormat fmt = VK_FORMAT_UNDEFINED;
-			VkImageView iv = VK_NULL_HANDLE;
-			VkImage im = VK_NULL_HANDLE;
-			uint32_t ai = 0;
-			if (!get_session_layer_view(e->layer, v, &tw, &th, &fmt, &iv, &im, &ai)) {
-				ok = false;
-				break;
-			}
-			src_img[v] = im;
-			src_arr[v] = ai;
-			src_x[v] = e->layer->data.proj.v[v].sub.rect.offset.w;
-			src_y[v] = e->layer->data.proj.v[v].sub.rect.offset.h;
-			src_w[v] = tw;
-			src_h[v] = th;
-		}
-		if (!ok) {
-			continue;
-		}
-
-		// Pre-barrier the unique source images GENERAL → TRANSFER_SRC.
-		VkImage uniq[XRT_MAX_VIEWS];
-		uint32_t uniq_arr[XRT_MAX_VIEWS];
-		uint32_t uniq_n = 0;
-		for (uint32_t v = 0; v < e->view_count; v++) {
-			bool found = false;
-			for (uint32_t u = 0; u < uniq_n; u++) {
-				if (uniq[u] == src_img[v] && uniq_arr[u] == src_arr[v]) {
-					found = true;
-					break;
-				}
-			}
-			if (!found) {
-				uniq[uniq_n] = src_img[v];
-				uniq_arr[uniq_n] = src_arr[v];
-				uniq_n++;
-			}
-		}
-		VkImageMemoryBarrier pre[XRT_MAX_VIEWS];
-		for (uint32_t u = 0; u < uniq_n; u++) {
-			pre[u] = (VkImageMemoryBarrier){
-			    .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
-			    .srcAccessMask = 0,
-			    .dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT,
-			    .oldLayout = VK_IMAGE_LAYOUT_GENERAL,
-			    .newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-			    .image = uniq[u],
-			    .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, uniq_arr[u], 1},
-			};
-		}
-		vk->vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0,
-		                         0, NULL, 0, NULL, uniq_n, pre);
-
-		// Per eye: blit this client's view into its window rect of that eye's tile.
-		// M2: a placed window projects its center pose through each eye onto the
-		// panel (Z=0), so z>0 windows float in front with crossed disparity. An
-		// unplaced lone app uses the flat full-display px-rect (M1). The client's
-		// own two views still supply its internal stereo.
-		for (uint32_t eye = 0; eye < tile_columns; eye++) {
-			uint32_t v = (eye < e->view_count) ? eye : (e->view_count - 1);
-			int rx = e->win_x, ry = e->win_y, rw = e->win_w, rh = e->win_h;
-			if (e->placed) {
-				uint32_t ei = (eye < eye_pos.count) ? eye : (eye_pos.count - 1);
-				shared_project_rect_for_eye(e->pose_x, e->pose_y, e->pose_z, e->win_w_m,
-				                            e->win_h_m, eye_pos.eyes[ei].x, eye_pos.eyes[ei].y,
-				                            eye_pos.eyes[ei].z, eye_w, eye_h, px_per_m_x,
-				                            px_per_m_y, &rx, &ry, &rw, &rh);
-			}
-			if (rw <= 0 || rh <= 0) {
-				continue;
-			}
-			// Full (unclipped) destination span within this eye's tile.
-			int tile_x0 = (int)eye * eye_w;
-			float fdx0 = (float)(tile_x0 + rx);
-			float fdy0 = (float)ry;
-			float fdx1 = fdx0 + (float)rw;
-			float fdy1 = fdy0 + (float)rh;
-			// Source span (flip_y maps top↔bottom).
-			float fsx0 = (float)src_x[v];
-			float fsx1 = (float)(src_x[v] + src_w[v]);
-			float fsy0 = (float)(src_y[v] + (flip_y ? src_h[v] : 0));
-			float fsy1 = (float)(src_y[v] + (flip_y ? 0 : src_h[v]));
-			// Clip the destination to the tile bounds (a projected/edge window can
-			// overflow its tile or the atlas — an out-of-bounds vkCmdBlitImage dst
-			// is invalid usage). Map the clip back into the source proportionally.
-			float cdx0 = fmaxf(fdx0, (float)tile_x0);
-			float cdx1 = fminf(fdx1, (float)(tile_x0 + eye_w));
-			float cdy0 = fmaxf(fdy0, 0.0f);
-			float cdy1 = fminf(fdy1, (float)eye_h);
-			if (cdx1 - cdx0 < 1.0f || cdy1 - cdy0 < 1.0f) {
-				continue;
-			}
-			float ux0 = (cdx0 - fdx0) / (fdx1 - fdx0), ux1 = (cdx1 - fdx0) / (fdx1 - fdx0);
-			float uy0 = (cdy0 - fdy0) / (fdy1 - fdy0), uy1 = (cdy1 - fdy0) / (fdy1 - fdy0);
-			int nsx0 = (int)(fsx0 + ux0 * (fsx1 - fsx0) + 0.5f);
-			int nsx1 = (int)(fsx0 + ux1 * (fsx1 - fsx0) + 0.5f);
-			int nsy0 = (int)(fsy0 + uy0 * (fsy1 - fsy0) + 0.5f);
-			int nsy1 = (int)(fsy0 + uy1 * (fsy1 - fsy0) + 0.5f);
-			VkImageBlit blit = {
-			    .srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, src_arr[v], 1},
-			    .srcOffsets = {{nsx0, nsy0, 0}, {nsx1, nsy1, 1}},
-			    .dstSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1},
-			    .dstOffsets = {{(int)cdx0, (int)cdy0, 0}, {(int)cdx1, (int)cdy1, 1}},
-			};
-			vk->vkCmdBlitImage(cmd, src_img[v], VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-			                   msc->shared_atlas_image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &blit,
-			                   VK_FILTER_LINEAR);
-		}
-
-		// Post-barrier the unique sources back to GENERAL (shared cross-proc rest).
-		VkImageMemoryBarrier post[XRT_MAX_VIEWS];
-		for (uint32_t u = 0; u < uniq_n; u++) {
-			post[u] = (VkImageMemoryBarrier){
-			    .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
-			    .srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT,
-			    .dstAccessMask = 0,
-			    .oldLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-			    .newLayout = VK_IMAGE_LAYOUT_GENERAL,
-			    .image = uniq[u],
-			    .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, uniq_arr[u], 1},
-			};
-		}
-		vk->vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
-		                         0, 0, NULL, 0, NULL, uniq_n, post);
-	}
-
-	// M3: composite the workspace decorations (chrome/overlays/cursor) into the
-	// atlas BEFORE the weave so they carry 3D depth. The blend renders into the
-	// atlas as a color attachment, so transition TRANSFER_DST → COLOR_ATTACHMENT
-	// first; shared_composite_decorations leaves it in COLOR_ATTACHMENT.
+	// Atlas → COLOR_ATTACHMENT for the content + decoration passes (the backdrop
+	// clear above was the atlas's only TRANSFER write). Content composites with a
+	// rounded-rect + edge-feather shader (Task 9) instead of a hard vkCmdBlitImage,
+	// so each window's corners match the shell's rounded focus ring and its edges
+	// feather into the backdrop. The decorations (chrome/overlays/cursor) follow in
+	// the same COLOR_ATTACHMENT layout.
 	VkImageMemoryBarrier atlas_to_color = {
 	    .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
 	    .srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
@@ -4391,6 +4271,196 @@ render_shared_surface_locked(struct multi_system_compositor *msc, int64_t displa
 	};
 	vk->vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, 0,
 	                         0, NULL, 0, NULL, 1, &atlas_to_color);
+
+	// Composite each client's content into its window rect, per eye, with rounded
+	// corners + feathered edges. ONE render pass over the whole atlas so overlapping
+	// windows blend in painter (far→near, already-sorted) submission order; every
+	// content source image must therefore be SHADER_READ before the pass begins.
+	if (shared_ensure_content_blend(msc, vk)) {
+		// Corner radius matches the shell focus ring (fh*0.045) so the content
+		// corners are concentric with it; feather is ~2 px of the window height,
+		// capped at the radius (Windows caps so feather_band = feather/ry ≤ 1).
+		const float CONTENT_CORNER_RADIUS_FRAC = 0.045f;
+		const float CONTENT_FEATHER_PX = 2.0f;
+
+		// Collect the unique (image, array-layer) content sources across all
+		// clients and transition them GENERAL → SHADER_READ in one batch (barriers
+		// can't sit inside the render pass).
+		VkImage uniq[COMP_MULTI_CONTENT_BLEND_MAX_IMAGES];
+		uint32_t uniq_arr[COMP_MULTI_CONTENT_BLEND_MAX_IMAGES];
+		uint32_t uniq_n = 0;
+		for (uint32_t c = 0; c < order_count; c++) {
+			struct shared_client_render *e = &order[c];
+			for (uint32_t v = 0; v < e->view_count; v++) {
+				int tw = 0, th = 0;
+				VkFormat fmt = VK_FORMAT_UNDEFINED;
+				VkImageView iv = VK_NULL_HANDLE;
+				VkImage im = VK_NULL_HANDLE;
+				uint32_t ai = 0;
+				if (!get_session_layer_view(e->layer, v, &tw, &th, &fmt, &iv, &im, &ai)) {
+					continue;
+				}
+				bool found = false;
+				for (uint32_t u = 0; u < uniq_n; u++) {
+					if (uniq[u] == im && uniq_arr[u] == ai) {
+						found = true;
+						break;
+					}
+				}
+				if (!found && uniq_n < COMP_MULTI_CONTENT_BLEND_MAX_IMAGES) {
+					uniq[uniq_n] = im;
+					uniq_arr[uniq_n] = ai;
+					uniq_n++;
+				}
+			}
+		}
+		if (uniq_n > 0) {
+			VkImageMemoryBarrier pre[COMP_MULTI_CONTENT_BLEND_MAX_IMAGES];
+			for (uint32_t u = 0; u < uniq_n; u++) {
+				pre[u] = (VkImageMemoryBarrier){
+				    .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+				    .srcAccessMask = 0,
+				    .dstAccessMask = VK_ACCESS_SHADER_READ_BIT,
+				    .oldLayout = VK_IMAGE_LAYOUT_GENERAL,
+				    .newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+				    .image = uniq[u],
+				    .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, uniq_arr[u], 1},
+				};
+			}
+			vk->vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+			                         VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, 0, 0, NULL, 0, NULL,
+			                         uniq_n, pre);
+		}
+
+		comp_multi_content_blend_begin(&msc->shared_content_blend, vk, cmd, msc->shared_atlas_fb,
+		                               (uint32_t)msc->shared_atlas_w, (uint32_t)msc->shared_atlas_h);
+		// Per client (far→near), per eye: project the window rect, clip it to the
+		// eye tile, remap the source sub-rect, and draw with rounded-rect coverage.
+		// M2: a placed window projects its center pose through each eye onto the
+		// panel (Z=0), so z>0 windows float toward the viewer; an unplaced lone app
+		// uses the flat full-display px-rect (M1). The client's own views supply
+		// its internal stereo.
+		for (uint32_t c = 0; c < order_count; c++) {
+			struct shared_client_render *e = &order[c];
+			bool flip_y = e->layer->data.flip_y;
+			float corner_aspect = (e->win_h_m > 0.0f) ? (e->win_w_m / e->win_h_m) : 1.0f;
+			float win_h_px = (float)(e->win_h > 0 ? e->win_h : eye_h);
+			float edge_feather = CONTENT_FEATHER_PX / win_h_px;
+			if (edge_feather > CONTENT_CORNER_RADIUS_FRAC) {
+				edge_feather = CONTENT_CORNER_RADIUS_FRAC;
+			}
+
+			for (uint32_t eye = 0; eye < tile_columns; eye++) {
+				uint32_t v = (eye < e->view_count) ? eye : (e->view_count - 1);
+				int tw = 0, th = 0;
+				VkFormat fmt = VK_FORMAT_UNDEFINED;
+				VkImageView iv = VK_NULL_HANDLE;
+				VkImage im = VK_NULL_HANDLE;
+				uint32_t ai = 0;
+				if (!get_session_layer_view(e->layer, v, &tw, &th, &fmt, &iv, &im, &ai)) {
+					continue;
+				}
+				int sx = e->layer->data.proj.v[v].sub.rect.offset.w;
+				int sy = e->layer->data.proj.v[v].sub.rect.offset.h;
+				// Full source image dims for UV normalization (the sub-rect is a
+				// tile within the worst-case swapchain image).
+				struct comp_swapchain *sc = comp_swapchain(e->layer->xscs[v]);
+				float img_w = (float)sc->vkic.info.width;
+				float img_h = (float)sc->vkic.info.height;
+				if (img_w <= 0.0f || img_h <= 0.0f) {
+					continue;
+				}
+
+				int rx = e->win_x, ry = e->win_y, rw = e->win_w, rh = e->win_h;
+				if (e->placed) {
+					uint32_t ei = (eye < eye_pos.count) ? eye : (eye_pos.count - 1);
+					shared_project_rect_for_eye(e->pose_x, e->pose_y, e->pose_z, e->win_w_m,
+					                            e->win_h_m, eye_pos.eyes[ei].x,
+					                            eye_pos.eyes[ei].y, eye_pos.eyes[ei].z, eye_w,
+					                            eye_h, px_per_m_x, px_per_m_y, &rx, &ry, &rw, &rh);
+				}
+				if (rw <= 0 || rh <= 0) {
+					continue;
+				}
+				int tile_x0 = (int)eye * eye_w;
+				float fdx0 = (float)(tile_x0 + rx);
+				float fdy0 = (float)ry;
+				float fdx1 = fdx0 + (float)rw;
+				float fdy1 = fdy0 + (float)rh;
+				// Source span (flip_y maps top↔bottom → negative src_uv_scale.y).
+				float fsx0 = (float)sx;
+				float fsx1 = (float)(sx + tw);
+				float fsy0 = (float)(sy + (flip_y ? th : 0));
+				float fsy1 = (float)(sy + (flip_y ? 0 : th));
+				// Clip the destination to the tile bounds; a projected/edge window
+				// can overflow its tile or the atlas. Map the clip back into the
+				// source proportionally; the window-local UV domain (ux/uy) keeps the
+				// rounded corners at the window's real corners even when clipped.
+				float cdx0 = fmaxf(fdx0, (float)tile_x0);
+				float cdx1 = fminf(fdx1, (float)(tile_x0 + eye_w));
+				float cdy0 = fmaxf(fdy0, 0.0f);
+				float cdy1 = fminf(fdy1, (float)eye_h);
+				if (cdx1 - cdx0 < 1.0f || cdy1 - cdy0 < 1.0f) {
+					continue;
+				}
+				float ux0 = (cdx0 - fdx0) / (fdx1 - fdx0), ux1 = (cdx1 - fdx0) / (fdx1 - fdx0);
+				float uy0 = (cdy0 - fdy0) / (fdy1 - fdy0), uy1 = (cdy1 - fdy0) / (fdy1 - fdy0);
+				float nsx0 = fsx0 + ux0 * (fsx1 - fsx0);
+				float nsx1 = fsx0 + ux1 * (fsx1 - fsx0);
+				float nsy0 = fsy0 + uy0 * (fsy1 - fsy0);
+				float nsy1 = fsy0 + uy1 * (fsy1 - fsy0);
+
+				struct comp_multi_content_pc pc = {
+				    .src_uv_off = {nsx0 / img_w, nsy0 / img_h},
+				    .src_uv_scale = {(nsx1 - nsx0) / img_w, (nsy1 - nsy0) / img_h},
+				    .win_uv_off = {ux0, uy0},
+				    .win_uv_scale = {ux1 - ux0, uy1 - uy0},
+				    .corner_radius = CONTENT_CORNER_RADIUS_FRAC,
+				    .corner_aspect = corner_aspect,
+				    .edge_feather = edge_feather,
+				    ._pad = 0.0f,
+				};
+				comp_multi_content_blend_draw(&msc->shared_content_blend, vk, cmd, im, ai, fmt, &pc,
+				                              (int32_t)cdx0, (int32_t)cdy0,
+				                              (uint32_t)(cdx1 - cdx0), (uint32_t)(cdy1 - cdy0));
+			}
+		}
+		comp_multi_content_blend_end(&msc->shared_content_blend, vk, cmd);
+
+		// Restore the cross-process sources to GENERAL (their rest layout).
+		if (uniq_n > 0) {
+			VkImageMemoryBarrier post[COMP_MULTI_CONTENT_BLEND_MAX_IMAGES];
+			for (uint32_t u = 0; u < uniq_n; u++) {
+				post[u] = (VkImageMemoryBarrier){
+				    .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+				    .srcAccessMask = VK_ACCESS_SHADER_READ_BIT,
+				    .dstAccessMask = 0,
+				    .oldLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+				    .newLayout = VK_IMAGE_LAYOUT_GENERAL,
+				    .image = uniq[u],
+				    .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, uniq_arr[u], 1},
+				};
+			}
+			vk->vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+			                         VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0, 0, NULL, 0, NULL,
+			                         uniq_n, post);
+		}
+	}
+
+	// Make content's color-attachment writes visible to the decoration render pass
+	// (both render into the atlas as a color attachment, in separate render passes).
+	VkImageMemoryBarrier atlas_content_to_deco = {
+	    .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+	    .srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+	    .dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT | VK_ACCESS_COLOR_ATTACHMENT_READ_BIT,
+	    .oldLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+	    .newLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+	    .image = msc->shared_atlas_image,
+	    .subresourceRange = atlas_range,
+	};
+	vk->vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+	                         VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, 0, 0, NULL, 0, NULL, 1,
+	                         &atlas_content_to_deco);
 
 	shared_composite_decorations(msc, vk, cmd, order, order_count, &eye_pos, eye_w, eye_h, px_per_m_x, px_per_m_y,
 	                             tile_columns);

--- a/src/xrt/ipc/server/ipc_server_handler.c
+++ b/src/xrt/ipc/server/ipc_server_handler.c
@@ -4463,6 +4463,24 @@ ipc_handle_workspace_get_client_info(volatile struct ipc_client_state *_ics,
 			}
 		}
 	}
+#elif defined(XRT_OS_MACOS)
+	// macOS shared surface: like the D3D11 path above, report session_visible
+	// from the WORKSPACE minimize state, not the xrSession lifecycle flag. A
+	// freshly-connected OOP client sits in a non-VISIBLE session state until the
+	// compositor promotes it, so its raw session_visible is false even while it
+	// renders on the shared surface. That made the controller's focus
+	// eligibility (isVisible) reject it, so TAB / cold-start auto-focus never
+	// seeded — the user had to click a window first (the click path bypasses the
+	// visibility gate). Report visible = !hidden so a connected, non-minimized
+	// window is focusable; a minimized one (set_window_visibility) still reports
+	// false and TAB skips it. (#59/#61)
+	{
+		struct xrt_compositor *target_xc = NULL;
+		if (ipc_server_get_client_xc(s, client_id, &target_xc) == XRT_SUCCESS &&
+		    target_xc != NULL) {
+			out_state->session_visible = !comp_multi_workspace_is_window_hidden(target_xc);
+		}
+	}
 #endif
 
 	return XRT_SUCCESS;

--- a/src/xrt/ipc/server/ipc_server_macos_appkit.m
+++ b/src/xrt/ipc/server/ipc_server_macos_appkit.m
@@ -150,6 +150,26 @@ ipc_server_macos_pump_main_thread(void)
 			inited = true;
 		}
 
+		// Keep the workspace surface as the ACTIVE app so keyboard events reach
+		// it. keyDown is delivered only to the frontmost app's key window, but a
+		// client launched after the service grabs frontmost on its own startup
+		// (every Cocoa app calls activateIgnoringOtherApps), which steals key-window
+		// status from the surface — so TAB (and any controller key) was silently
+		// dropped until the user clicked the surface to re-key it (mouse events,
+		// unlike keyDown, route to the window under the cursor regardless of key
+		// status, which is why click-to-focus worked but TAB did not). The surface
+		// is a borderless full-screen desktop replacement that owns the display
+		// until the Esc/Cmd+Q kill-switch, so reclaim activation whenever we've
+		// lost it; once active this is a no-op. (#59/#48)
+		if (![NSApp isActive]) {
+			[NSApp activateIgnoringOtherApps:YES];
+			NSWindow *kw = [NSApp keyWindow];
+			if (kw == nil) {
+				kw = [[NSApp windows] firstObject];
+			}
+			[kw makeKeyAndOrderFront:nil];
+		}
+
 		// Drain the main dispatch queue (this is what unblocks the comp_multi
 		// render thread's dispatch_sync that creates the NSWindow) plus any
 		// AppKit runloop sources, non-blocking.


### PR DESCRIPTION
macOS shared spatial surface (#59) polish — all three changes are macOS-only (inside `XRT_OS_MACOS` guards / `.m` files / a fully-guarded new TU), so Windows/Android binaries are byte-identical (git-diff audited).

## 1. Rounded corners + edge feathering (`8bb6a8115`)
The shared-surface content was composited with a hard `vkCmdBlitImage`, so window corners were sharp rectangles spilling past the shell's rounded focus-glow ring. New `comp_multi_content_blend.{c,h}` — a dedicated VK pipeline (modeled on `vk_hud_blend`) whose fragment shader samples the client content and modulates output alpha by a rounded-rect SDF × aspect-correct edge feather. Faithful GLSL port of the Windows D3D11 content-blit coverage (`d3d11_service_shaders.h:766-832`), all four corners. `render_shared_surface_locked`'s per-eye blit loop becomes ONE `COLOR_ATTACHMENT` render pass (far→near painter order preserved by subpass submission order). Corner radius 0.045·height (concentric with the focus ring); feather ~2px capped at the radius. SPIR-V embedded (compiled offline with glslangValidator; no CMake shader step). New pipeline rather than extending `vk_hud_blend` (which is shared by chrome/cursor/HUD).

## 2 & 3. TAB focus works from cold start
TAB did nothing on the shared surface until the user first clicked a window. Diagnosis showed the focus *logic* was already correct (TAB cycled focus every time a key was actually delivered) — it was two independent infra bugs:

- **`af5264864` — visibility/eligibility.** The runtime reported `isVisible=false` for freshly-connected OOP clients (the raw xrSession lifecycle flag stays non-VISIBLE until promoted, even while the client renders on the shared surface), so the controller's focus eligibility (ADR-018) rejected every client. Mirror the existing Windows D3D11 override on macOS: `session_visible = !comp_multi_workspace_is_window_hidden(xc)` — a connected, non-minimized window is focusable; a minimized one still reports false so TAB correctly skips it.

- **`c52c5b255` — keyboard input delivery (the decisive fix).** `keyDown` is delivered only to the frontmost app's key window. The surface calls `makeKeyAndOrderFront`/`activate` at creation, but every OOP client launched afterwards calls `activateIgnoringOtherApps` on its own Cocoa startup, stealing frontmost/key — so TAB was silently dropped until a click re-activated the surface (mouse events route to the window under the cursor regardless of key status, which is why click-to-focus worked but TAB didn't). The surface is a borderless full-screen desktop replacement that owns input until the Esc/Cmd+Q kill-switch, so the AppKit pump now reclaims activation whenever it's lost (no-op once active).

## Verification
Built with `./scripts/build_macos.sh --hybrid` tree (incremental ninja, new TU 0 warnings). Live-tested with the service + shell + 2 cubes: rounded corners + feathered edges confirmed; TAB cycles focus between windows from the get-go with no click. David-confirmed both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)