### PR TITLE
docs(building): note elevated-prompt ActiveRuntime trap re-triggers the ABI failure

### DIFF
--- a/docs/getting-started/building.md
+++ b/docs/getting-started/building.md
@@ -48,6 +48,22 @@ _package\run_cube_handle_d3d11_win.bat REM 3. run a test app
 > The runtime also logs the underlying cause (`negotiate returned …`, which
 > plug-in was rejected) to its per-process log at
 > `%LOCALAPPDATA%\DisplayXR\DisplayXR_<exe>.<pid>_<timestamp>.log`.
+>
+> **An elevated prompt re-triggers the same failure even after a correct
+> registration.** Registration is machine-wide and permanent
+> (`HKLM\Software\DisplayXR\DisplayProcessors`) — it is *not* per-session. But
+> *which runtime loads* is: `run_*.bat` points `XR_RUNTIME_JSON` at your
+> from-source runtime, and the Khronos loader **silently ignores
+> `XR_RUNTIME_JSON` in an elevated/admin process** (see
+> [Elevated terminal caveat](#elevated-terminal-caveat)), falling back to the
+> *installed* runtime via `HKLM\Software\Khronos\OpenXR\1\ActiveRuntime`. That
+> older runtime then ABI-rejects your freshly-registered plug-in, failing with
+> `XRT_ERROR_DEVICE_CREATION_FAILED` / "Failed to initialize OpenXR" — so it
+> looks like the registration "only applied to the one prompt where you ran it".
+> It didn't.
+> Either **run test apps from a non-elevated prompt** (so `XR_RUNTIME_JSON` is
+> honored), or run `scripts\dev-setup.bat` once so `ActiveRuntime` points at your
+> dev build and *every* app — any prompt, no env var needed — loads it.
 
 **macOS:**
 ```bash


### PR DESCRIPTION
Stacked on #642.

## What this adds
A from-source dev (Cyrus) followed the #642 guidance correctly — `register_dev_plugin.bat` + `displayxr-cli selftest` → **SELF-TEST PASSED** — but launching `cube_hosted_d3d11_win.bat` from a **fresh elevated prompt** still went purple / "Failed to initialize OpenXR". It looked like the registration "only applied to the one prompt where I ran it."

It didn't. Two separate scopes were being conflated:

- **Plug-in registration** (`HKLM\Software\DisplayXR\DisplayProcessors`) is machine-wide and permanent — not per-session.
- **Which runtime loads** is what varies. `run_*.bat` sets `XR_RUNTIME_JSON` to the from-source runtime, but the Khronos loader **silently ignores `XR_RUNTIME_JSON` in an elevated/admin process** and falls back to the *installed* runtime via `ActiveRuntime`. That older runtime then ABI-rejects the freshly-registered plug-in — re-triggering the exact `negotiate returned -17` failure #642 documents.

This is not a runtime bug — the ABI gate, registry-only discovery, and the loader's elevated env-var refusal are all working as designed. It's a docs/ergonomics gap: the existing callout didn't connect the elevated-terminal caveat to the ABI-rejection trap.

## Change
One paragraph appended to the from-source DP-registration callout in `docs/getting-started/building.md`, pointing at the two fixes: run non-elevated (so `XR_RUNTIME_JSON` is honored), or `dev-setup.bat` once (sets `ActiveRuntime` machine-wide so any prompt works with no env var).

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)