### PR TITLE
fix(android,#510): closed-loop compositor pacing via AChoreographer vsync

### DIFF
--- a/src/xrt/compositor/main/comp_target_swapchain.c
+++ b/src/xrt/compositor/main/comp_target_swapchain.c
@@ -25,6 +25,8 @@
 #include "android/android_globals.h"
 #include "util/u_time.h"
 #include <android/native_window.h>
+#include <android/choreographer.h>
+#include <android/looper.h>
 #include <sys/system_properties.h>
 #endif
 
@@ -79,6 +81,23 @@ android_transparent_requested(void)
  */
 DEBUG_GET_ONCE_NUM_OPTION(preferred_at_least_image_count, "XRT_COMPOSITOR_PREFERRED_IMAGE_COUNT", 2)
 DEBUG_GET_ONCE_BOOL_OPTION(use_present_wait, "XRT_COMPOSITOR_USE_PRESENT_WAIT", false)
+/*
+ * Android closed-loop pacing (#510). The fake compositor pacer is open-loop on
+ * Android (no VK_EXT_display_control / VK_GOOGLE_display_timing), so its present
+ * phase grid drifts out of alignment with the real display and the compositor
+ * lands just-after vblank every frame → FIFO shows every 2nd vblank = 30 Hz
+ * (measured via SurfaceFlinger --latency: steady 33.4 ms on a 60 Hz panel). A
+ * surface recreate (minimize/maximize) re-aligns the phase, hence the workaround.
+ *
+ * When on (default), an AChoreographer thread feeds real vsync timestamps into
+ * the pacer via the existing u_pc_update_vblank_from_display_control plumbing —
+ * the same closed-loop mechanism direct mode uses — so the present phase tracks
+ * the display and the compositor hits 60 Hz at cold start without a swipe. Set
+ * debug.xrt.DXR_ANDROID_VSYNC_PACING=0 to fall back to the open-loop behavior.
+ */
+#ifdef XRT_OS_ANDROID
+DEBUG_GET_ONCE_BOOL_OPTION(android_vsync_pacing, "DXR_ANDROID_VSYNC_PACING", true)
+#endif
 
 static inline struct vk_bundle *
 get_vk(struct comp_target_swapchain *cts)
@@ -613,6 +632,80 @@ create_vblank_event_thread(struct comp_target *ct)
 }
 #endif
 
+#ifdef XRT_OS_ANDROID
+/*
+ * Closed-loop pacing for Android: an AChoreographer callback delivers real vsync
+ * timestamps (CLOCK_MONOTONIC ns, same clock as os_monotonic_get_ns), which we
+ * stash in cts->vblank.last_vblank_ns. comp_target_swapchain_update_timings()
+ * (called per-frame from the compositor thread) then feeds it to the pacer via
+ * do_update_timings_vblank_thread → u_pc_update_vblank_from_display_control,
+ * exactly like the VK_EXT_display_control path. See DXR_ANDROID_VSYNC_PACING.
+ */
+static void
+android_vsync_frame_cb(int64_t frameTimeNanos, void *data)
+{
+	struct comp_target_swapchain *cts = (struct comp_target_swapchain *)data;
+
+	os_thread_helper_lock(&cts->vblank.event_thread);
+	cts->vblank.last_vblank_ns = frameTimeNanos;
+	bool running = os_thread_helper_is_running_locked(&cts->vblank.event_thread);
+	os_thread_helper_unlock(&cts->vblank.event_thread);
+
+	// Re-arm for the next vsync as long as the thread is alive.
+	if (running) {
+		AChoreographer_postFrameCallback64(AChoreographer_getInstance(), android_vsync_frame_cb, data);
+	}
+}
+
+static void *
+run_android_vsync_thread(void *ptr)
+{
+	struct comp_target *ct = (struct comp_target *)ptr;
+	struct comp_target_swapchain *cts = (struct comp_target_swapchain *)ct;
+
+	os_thread_helper_name(&cts->vblank.event_thread, "Android VSync");
+	U_TRACE_SET_THREAD_NAME("Android VSync");
+
+	// AChoreographer is bound to the calling thread's looper.
+	ALooper *looper = ALooper_prepare(ALOOPER_PREPARE_ALLOW_NON_CALLBACKS);
+	AChoreographer *chor = looper != NULL ? AChoreographer_getInstance() : NULL;
+	if (chor == NULL) {
+		COMP_ERROR(ct->c, "Android VSync: no Choreographer; pacing stays open-loop");
+		return NULL;
+	}
+
+	AChoreographer_postFrameCallback64(chor, android_vsync_frame_cb, cts);
+
+	for (;;) {
+		os_thread_helper_lock(&cts->vblank.event_thread);
+		bool running = os_thread_helper_is_running_locked(&cts->vblank.event_thread);
+		os_thread_helper_unlock(&cts->vblank.event_thread);
+		if (!running) {
+			break;
+		}
+		// Dispatches the frame callbacks; wakes at least every 100 ms to re-check running.
+		ALooper_pollOnce(100, NULL, NULL, NULL);
+	}
+
+	return NULL;
+}
+
+static bool
+create_android_vsync_thread(struct comp_target *ct)
+{
+	struct comp_target_swapchain *cts = (struct comp_target_swapchain *)ct;
+
+	int thread_ret = os_thread_helper_start(&cts->vblank.event_thread, run_android_vsync_thread, ct);
+	if (thread_ret != 0) {
+		COMP_ERROR(ct->c, "Failed to start Android VSync thread");
+		return false;
+	}
+
+	cts->vblank.has_started = true;
+	return true;
+}
+#endif // XRT_OS_ANDROID
+
 static void
 target_fini_semaphores(struct comp_target_swapchain *cts)
 {
@@ -903,6 +996,16 @@ comp_target_swapchain_create_images(struct comp_target *ct, const struct comp_ta
 	} else if (!cts->has_logged_vblank_info) {
 		cts->has_logged_vblank_info = true;
 		COMP_INFO(ct->c, "Not using vblank event thread!");
+	}
+#endif
+
+#ifdef XRT_OS_ANDROID
+	// Closed-loop pacing via AChoreographer (#510). Started once and kept across
+	// swapchain recreations (the vsync source is the display, not the swapchain).
+	if (debug_get_bool_option_android_vsync_pacing() && !cts->vblank.has_started) {
+		if (create_android_vsync_thread(ct)) {
+			COMP_INFO(ct->c, "Started Android VSync (Choreographer) pacing thread!");
+		}
 	}
 #endif
 

--- a/src/xrt/compositor/multi/comp_multi_system.c
+++ b/src/xrt/compositor/multi/comp_multi_system.c
@@ -2904,6 +2904,17 @@ black_canvas:; // force_black (minimized) jumps here, skipping all content/view 
 	// without this, comp_target_swapchain_present asserts current_frame_id > 0.
 	// (#510: first path to actually exercise comp_window_android present.)
 	{
+#ifdef XRT_OS_ANDROID
+		// Feed the target's pacer the AChoreographer vsync timing before
+		// predicting (closed-loop pacing, #510). In-process compositors call
+		// update_timings every frame; this OOP per-session path omitted it, so
+		// the real vblank never reached the fake pacer and its present phase
+		// drifted → 30 Hz lock. Android-only: it exists solely to drive the
+		// Choreographer vblank feed; Windows/macOS self-owned-window targets
+		// have no such source and never called this here before.
+		comp_target_update_timings(ct);
+#endif
+
 		int64_t frame_id = -1;
 		int64_t wake_up_ns = 0, desired_present_ns = 0, present_slop_ns = 0, predicted_display_ns = 0;
 		comp_target_calc_frame_pacing(ct, &frame_id, &wake_up_ns, &desired_present_ns, &present_slop_ns,


### PR DESCRIPTION
## What

Closed-loop compositor frame pacing on Android (OOP), fixing a cold-start
**30 Hz lock** on the gauss-splat / per-session present path (#510).

## Why

Measured at the display with `dumpsys SurfaceFlinger --latency`: the compositor
presented at a **steady 33.4 ms on a 60 Hz panel** — every 2nd vblank, a hard
30 Hz lock. Cause: the **fake compositor pacer is open-loop on Android**. It
re-syncs its present-time phase grid from real vblank only via
`VK_EXT_display_control` (direct-mode only) or `VK_GOOGLE_display_timing`
(absent here) — Android has neither, so the phase is anchored once at cold start
(during the ~1.5 s surface extent-settle flap) and never corrected, landing
just-after each vblank forever. A manual minimize→maximize cures it only because
the surface teardown recreates the pacer with a fresh anchor.

## How

Give the pacer a real vsync signal:
- An **`AChoreographer` thread** (`comp_target_swapchain`, Android-only) feeds
  frame-callback timestamps into `cts->vblank.last_vblank_ns`.
- The OOP per-session path calls `comp_target_update_timings()` each frame so
  `do_update_timings_vblank_thread` → `u_pc_update_vblank_from_display_control`
  feeds the pacer — the **same closed-loop mechanism direct mode uses**.

**Measured result:** present cadence goes from steady 33.4 ms to predominantly
**16.7 ms (60 Hz)** at cold start.

## Scope / risk

- **Android-only.** The Choreographer thread + its start in `create_images`, the
  `DXR_ANDROID_VSYNC_PACING` flag, and the new `comp_target_update_timings()`
  call are all `#ifdef XRT_OS_ANDROID`. Windows/macOS build + behavior unchanged
  (verified: local Windows build clean).
- Behind `DXR_ANDROID_VSYNC_PACING` (default **on**; set `0` to revert to the
  open-loop behavior).
- Pairs with `U_PACING_APP_USE_MIN_FRAME_PERIOD=1`, which separately stops the
  app pacer doubling 16.7→33.3 ms at cold start.

## Known residual (not addressed here)

A periodic cold-start hitch remains when the CPU DVFS governor parks the big
cores at minimum clock (no touch/interaction) — the frame then can't fit in
16.7 ms even with correct phase. Only a fresh client `SurfaceView` (e.g. manual
minimize/maximize) or a sustained-performance hint clears it. Tracked
separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
