### PR TITLE
fix(d3d12): honor per-view imageArrayIndex in projection blit (unblocks Unity Single-Pass-Instanced)

### DIFF
--- a/src/xrt/compositor/d3d12/comp_d3d12_renderer.cpp
+++ b/src/xrt/compositor/d3d12/comp_d3d12_renderer.cpp
@@ -1535,9 +1535,27 @@ comp_d3d12_renderer_draw_projection_pass(struct comp_d3d12_renderer *renderer,
 			// UNORM sample (see the other SRV site): no sRGB auto-decode; the
 			// app's display-referred bytes pass through to the DP unchanged.
 			srv_desc.Format = d3d_dxgi_format_to_unorm_sample(src_desc.Format);
-			srv_desc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
-			srv_desc.Texture2D.MipLevels = 1;
 			srv_desc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+			// Honor the projection view's array layer. Under single-pass-instanced
+			// the app submits ONE swapchain with viewCount=2 and per-view
+			// subImage.imageArrayIndex 0 (left) / 1 (right) — both eyes live in
+			// array slices of a 2-layer (DepthOrArraySize>1) texture. A plain
+			// TEXTURE2D SRV always views slice 0, so both eyes would sample the
+			// left image (flat output). View the array and pin the slice to the
+			// view's array_index. Multi-pass (single-layer, array_index 0) takes
+			// the TEXTURE2D path unchanged.
+			uint32_t array_index = layer->data.proj.v[vi].sub.array_index;
+			if (src_desc.DepthOrArraySize > 1) {
+				srv_desc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2DARRAY;
+				srv_desc.Texture2DArray.MostDetailedMip = 0;
+				srv_desc.Texture2DArray.MipLevels = 1;
+				srv_desc.Texture2DArray.FirstArraySlice = array_index;
+				srv_desc.Texture2DArray.ArraySize = 1;
+				srv_desc.Texture2DArray.PlaneSlice = 0;
+			} else {
+				srv_desc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+				srv_desc.Texture2D.MipLevels = 1;
+			}
 
 			D3D12_CPU_DESCRIPTOR_HANDLE srv_cpu = renderer->srv_heap->GetCPUDescriptorHandleForHeapStart();
 			srv_cpu.ptr += renderer->srv_descriptor_size * srv_slot;


### PR DESCRIPTION
## Summary

The D3D12 projection-blit SRV in `comp_d3d12_renderer.cpp` hardcoded
`D3D12_SRV_DIMENSION_TEXTURE2D`, which always views **array slice 0**. Under Unity's
**Single-Pass-Instanced** render mode the app submits **one** 2-layer texture-array
swapchain (`arraySize=2`) and **one** projection layer with two views referencing
`subImage.imageArrayIndex` **0 (left)** and **1 (right)** — the two eyes live in array
layers 0 and 1. Both views created a `TEXTURE2D` SRV → both sampled slice 0 → **both
eyes got the left image → flat (no disparity).** Multi-pass works because each eye is
its own single-layer swapchain (always slice 0).

## Why this is the only change needed

Everything else already handles the array layer correctly:
- `oxr_session_frame_end.c:277` copies `imageArrayIndex` into `xrt_sub_image::array_index`.
- The swapchain resource is created with `DepthOrArraySize = array_size` (`comp_d3d12_swapchain.cpp:301`) — **both slices are allocated**.
- The zero-copy fast path is already gated off when `array_index != 0` (`comp_d3d12_compositor.cpp:1537`), so array submissions funnel through this blit.

Only the SRV dimension ignored the layer.

## Fix

In the projection blit (`comp_d3d12_renderer.cpp`), when `DepthOrArraySize > 1` create a
`TEXTURE2DARRAY` SRV with `FirstArraySlice = view.subImage.array_index`, `ArraySize = 1`.
Single-layer swapchains (multi-pass, `array_index == 0`) keep the `TEXTURE2D` path
unchanged — no behavior change for existing apps.

## How it was found

Diagnosed from the Unity plugin side (`displayxr-unity` branch
`experiment/spi-single-pass`). With an eye-tracking lock, the entire chain is per-eye
**distinct** end-to-end: `GetStereoMatrices projL != projR`, Unity's own
`xr.GetProjMatrix(0) != (1)`, the pushed stereo arrays differ, `xrCreateSwapchain`
reports `arrays=2`, and `xrEndFrame` submits two views with `imageArrayIndex` 0/1 and
distinct poses. The output stayed flat **only** because the compositor read layer 0 for
both eyes — pinpointing this SRV.

Two diagnostic red herrings worth recording: the `tracking=0` nominal-viewer fallback
correctly renders flat 2D (so "SPI looks mono" with no face locked is expected), and the
Unity boot splash truncates `displayxr.log` (diagnose with `DISPLAYXR_NO_SPLASH=1`).

## Verification

Build this runtime, point `XR_RUNTIME_JSON` at the dev JSON, then run the Unity SPI test
build (`displayxr-unity-test-2d-ui` @ `experiment/spi-single-pass`: `DISPLAYXR_SPI_EXPERIMENTAL`
define + OpenXR Render Mode = Single Pass Instanced) with `DISPLAYXR_NO_SPLASH=1`, sit in
front for a tracking lock, and confirm 3D matches the Multi-Pass build. The plugin's
`KooimaProjectionFixFeature` then applies the off-axis (#127) correction on top for
pixel-correct output, at ~half the Multi-Pass CPU draw/cull cost (URP-on-Windows).

## Scope

D3D11 / Vulkan / Metal compositors are untouched; they keep Multi-Pass. SPI is opt-in on
the URP/Windows/D3D12 path only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)