### PR TITLE
fix(macos,#61): link comp_window_macos for pure --service builds

### DIFF
--- a/src/xrt/compositor/CMakeLists.txt
+++ b/src/xrt/compositor/CMakeLists.txt
@@ -204,6 +204,37 @@ endif()
 # and null compositor use.
 
 ###
+# Shared macOS window utility (MoltenVK CAMetalLayer NSWindow + the per-session
+# comp_target_swapchain it drives).
+#
+# Parallels comp_win32_window below: both comp_null (per-session present path,
+# #48) and comp_multi (shared-surface visibility toggle via
+# comp_window_macos_set_visible, #61) depend on this helper. A --service
+# openxr_displayxr.dylib links comp_multi WITHOUT comp_null, so the helper can't
+# live only inside comp_null or that link fails with an undefined
+# comp_window_macos_set_visible. Build it once here so every consumer links it.
+# Defined before add_subdirectory(null) so comp_null can link it.
+if(APPLE)
+	add_library(
+		comp_macos_window STATIC
+		main/comp_window_macos.m
+		main/comp_window_macos.h
+		main/comp_target_swapchain.c
+		)
+	target_link_libraries(
+		comp_macos_window
+		PUBLIC xrt-interfaces
+		PRIVATE aux_util
+			aux_os
+			aux_vk
+			"-framework Cocoa"
+			"-framework QuartzCore"
+			"-framework Metal"
+		)
+	target_include_directories(comp_macos_window PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+endif()
+
+###
 # Null compositor
 #
 
@@ -261,6 +292,14 @@ endif()
 # Link comp_multi to shared Win32 window for self-owned window creation
 if(WIN32)
 	target_link_libraries(comp_multi PRIVATE comp_win32_window)
+endif()
+
+# Link comp_multi to the shared macOS window helper for shared-surface
+# visibility toggling (comp_window_macos_set_visible, #61). Without this a
+# --service openxr_displayxr.dylib (which links comp_multi but not comp_null)
+# fails to link with an undefined comp_window_macos_set_visible.
+if(APPLE)
+	target_link_libraries(comp_multi PRIVATE comp_macos_window)
 endif()
 
 ###

--- a/src/xrt/compositor/null/CMakeLists.txt
+++ b/src/xrt/compositor/null/CMakeLists.txt
@@ -33,18 +33,10 @@ endif()
 # macOS out-of-process present path (shell Tier 1, #48): the null compositor is
 # the service's system compositor on macOS, driving a per-session
 # comp_target_swapchain that presents to a runtime-owned NSWindow via a MoltenVK
-# CAMetalLayer surface (comp_window_macos). Same "shared main/ sources not built
-# elsewhere in the lightweight fork" situation as Android, so compile them here.
+# CAMetalLayer surface (comp_window_macos). Those shared sources now live in the
+# comp_macos_window static lib (compositor/CMakeLists.txt) because comp_multi
+# needs them too in a --service build; link it here instead of compiling them
+# directly (the Cocoa/QuartzCore/Metal frameworks come transitively).
 if(APPLE)
-	target_sources(
-		comp_null
-		PRIVATE
-			${CMAKE_CURRENT_SOURCE_DIR}/../main/comp_target_swapchain.c
-			${CMAKE_CURRENT_SOURCE_DIR}/../main/comp_window_macos.m
-			${CMAKE_CURRENT_SOURCE_DIR}/../main/comp_window_macos.h
-		)
-	target_link_libraries(
-		comp_null
-		PRIVATE "-framework Cocoa" "-framework QuartzCore" "-framework Metal"
-		)
+	target_link_libraries(comp_null PRIVATE comp_macos_window)
 endif()


### PR DESCRIPTION
## Problem

A pure `--service` macOS build fails to link `openxr_displayxr.dylib`:

```
Undefined symbols for architecture arm64:
  "_comp_window_macos_set_visible", referenced from:
      _render_shared_surface_locked in libcomp_multi.a[3](comp_multi_system.c.o)
```

`comp_window_macos_set_visible` is defined in `comp_window_macos.m`, which is compiled **only** into `comp_null`'s Apple block. But a pure `--service` `openxr_displayxr.dylib` links `comp_multi` **without** `comp_null`, and `comp_multi_system.c` calls that function for shared-surface visibility toggling (#61) → undefined symbol.

CI's macOS `Build` job runs `SERVICE+HYBRID`, which links **both** `comp_multi` and `comp_null`, so the symbol resolves and CI has stayed green — masking the break in the pure `--service` configuration.

## Fix

Mirror the existing `comp_win32_window` pattern: extract the shared macOS window helper into its own static lib `comp_macos_window` that both `comp_multi` and `comp_null` link.

- The helper also calls `comp_target_swapchain_*`, so `comp_target_swapchain.c` moves into the lib alongside `comp_window_macos.m`. It has no `comp_multi` dependency (no cycle) and is now compiled exactly once (removed from `comp_null`'s Apple sources), so HYBRID — where both libs are linked — gets no duplicate symbol.
- Cocoa/QuartzCore/Metal frameworks move to the lib and reach consumers transitively.

## Verification (local, macOS / Apple Silicon)

- `scripts/build_macos.sh --service` → links clean, **0** undefined symbols.
- `scripts/build_macos.sh` (default `SERVICE=OFF`, the `.pkg`/installer config) → links clean.
- Installed shell (`DisplayXRShell` .pkg, shell #63) summoned against the `--service` runtime now reports `is_service_mode=true` with **0** `requires an IPC-mode session` errors (was **1769**); `shell_taskbar`/`shell_launcher`/`shell_splash` all create their overlays.

## Why it matters

This is the prerequisite for an IPC-capable macOS runtime. Follow-ups (separate): build the macOS runtime `.pkg` with `XRT_FEATURE_SERVICE=ON` + ship `displayxr-service` (+ a LaunchAgent), so an installed shell renders end-to-end without a dev tree.

Refs #61.