### PR TITLE
feat(macos,#61): ship service mode + auto-start in the runtime .pkg

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -197,12 +197,24 @@ jobs:
             echo "::error::DisplayXR-SimDisplay.dylib missing from .pkg payload — runtime would have no display processor on a clean install (#274)."
             MISSING=1
           fi
+          # #61: the .pkg must ship the service binary + its auto-start
+          # LaunchAgent, or the installed spatial shell has nothing to attach to
+          # as an IPC client (blank window). build_macos.sh --installer builds
+          # HYBRID, so the service is always expected here.
+          if ! grep -q 'DisplayXR/bin/displayxr-service' "$EXPAND_DIR/files"; then
+            echo "::error::displayxr-service missing from .pkg payload — the installed spatial shell could not attach as an IPC client (#61)."
+            MISSING=1
+          fi
+          if ! grep -q 'LaunchAgents/com.displayxr.service.plist' "$EXPAND_DIR/files"; then
+            echo "::error::com.displayxr.service.plist (service auto-start LaunchAgent) missing from .pkg payload (#61)."
+            MISSING=1
+          fi
           if [ "$MISSING" -ne 0 ]; then
             echo "Payload listing:"
             cat "$EXPAND_DIR/files"
             exit 1
           fi
-          echo "PASS: .pkg payload contains plug-in + manifest."
+          echo "PASS: .pkg payload contains plug-in + manifest + service + LaunchAgent."
 
       - name: Upload installer
         uses: actions/upload-artifact@v6

--- a/installer/macos/build_installer.sh
+++ b/installer/macos/build_installer.sh
@@ -196,6 +196,63 @@ EOF
 cp "$SCRIPT_DIR/uninstall.sh" "$RUNTIME_ROOT/"
 chmod +x "$RUNTIME_ROOT/uninstall.sh"
 
+# --- Service binary + LaunchAgent (macOS spatial shell, #61) ---
+# The installed spatial shell (DisplayXRShell .pkg) attaches to displayxr-service
+# as an IPC client. Ship the service (built HYBRID by build_macos.sh --installer)
+# and a system LaunchAgent that auto-starts it in the user's GUI session at login
+# — the macOS parallel of Windows' HKLM\...\Run autostart. Present only when the
+# artifact came from a SERVICE build; a non-service .pkg ships runtime-only.
+SERVICE_SRC="$ARTIFACT_DIR/bin/displayxr-service"
+if [ -f "$SERVICE_SRC" ]; then
+    mkdir -p "$RUNTIME_ROOT/bin"
+    cp "$SERVICE_SRC" "$RUNTIME_ROOT/bin/displayxr-service"
+    chmod 0755 "$RUNTIME_ROOT/bin/displayxr-service"
+    # Re-sign defensively (a tar round-trip in CI can drop the signature).
+    codesign --force --sign - "$RUNTIME_ROOT/bin/displayxr-service" 2>/dev/null || true
+
+    LAUNCHAGENT_DIR="$WORK_DIR/payload-runtime/Library/LaunchAgents"
+    mkdir -p "$LAUNCHAGENT_DIR"
+    # The service's bundled Vulkan loader needs the runtime's MoltenVK ICD (in a
+    # private path the loader doesn't search), so the agent sets VK_ICD_FILENAMES.
+    # KeepAlive keeps the always-on orchestrator up; ProcessType Interactive +
+    # the gui/<uid> bootstrap (postinstall) put it in the Aqua session so its
+    # menu-bar status item shows.
+    cat > "$LAUNCHAGENT_DIR/com.displayxr.service.plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.displayxr.service</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>$INSTALL_PREFIX/bin/displayxr-service</string>
+    </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>VK_ICD_FILENAMES</key>
+        <string>$INSTALL_PREFIX/share/vulkan/icd.d/MoltenVK_icd.json</string>
+        <key>VK_DRIVER_FILES</key>
+        <string>$INSTALL_PREFIX/share/vulkan/icd.d/MoltenVK_icd.json</string>
+    </dict>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>ProcessType</key>
+    <string>Interactive</string>
+    <key>StandardOutPath</key>
+    <string>/tmp/displayxr-service.out.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/displayxr-service.err.log</string>
+</dict>
+</plist>
+PLIST
+    echo "Staged displayxr-service + LaunchAgent into the runtime payload."
+else
+    echo "Note: displayxr-service not in artifact (non-SERVICE build); .pkg ships runtime only."
+fi
+
 # --- 2. Build runtime component pkg ---
 echo "--- Building runtime component ---"
 pkgbuild --root "$WORK_DIR/payload-runtime" \

--- a/installer/macos/scripts/runtime/postinstall
+++ b/installer/macos/scripts/runtime/postinstall
@@ -27,4 +27,23 @@ register_active_runtime() {
 register_active_runtime /etc/xdg/openxr/1
 register_active_runtime /usr/local/share/openxr/1
 
+# Auto-start the DisplayXR service (macOS spatial shell, #61). The LaunchAgent
+# has RunAtLoad so it starts at the next login regardless; bootstrapping it into
+# the console user's GUI domain here also brings it up immediately after install
+# (no logout needed). postinstall runs as root, so we target gui/<console-uid>.
+# Skipped cleanly on a runtime-only (non-service) .pkg where the agent is absent.
+AGENT="/Library/LaunchAgents/com.displayxr.service.plist"
+if [ -f "$AGENT" ]; then
+    CONSOLE_USER="$(stat -f%Su /dev/console 2>/dev/null || true)"
+    if [ -n "$CONSOLE_USER" ] && [ "$CONSOLE_USER" != "root" ]; then
+        CONSOLE_UID="$(id -u "$CONSOLE_USER" 2>/dev/null || true)"
+        if [ -n "$CONSOLE_UID" ]; then
+            # bootout first so a re-install reloads the new plist (idempotent).
+            launchctl bootout "gui/$CONSOLE_UID" "$AGENT" 2>/dev/null || true
+            launchctl bootstrap "gui/$CONSOLE_UID" "$AGENT" 2>/dev/null || true
+            launchctl enable "gui/$CONSOLE_UID/com.displayxr.service" 2>/dev/null || true
+        fi
+    fi
+fi
+
 exit 0

--- a/installer/macos/uninstall.sh
+++ b/installer/macos/uninstall.sh
@@ -4,6 +4,20 @@ set -e
 
 echo "=== DisplayXR Uninstaller ==="
 
+# Stop + remove the service LaunchAgent (macOS spatial shell, #61) before
+# deleting its binary, so launchd isn't left pointing at a missing program.
+AGENT="/Library/LaunchAgents/com.displayxr.service.plist"
+if [ -f "$AGENT" ]; then
+    echo "Stopping + removing DisplayXR service LaunchAgent..."
+    CONSOLE_USER="$(stat -f%Su /dev/console 2>/dev/null || true)"
+    if [ -n "$CONSOLE_USER" ] && [ "$CONSOLE_USER" != "root" ]; then
+        CONSOLE_UID="$(id -u "$CONSOLE_USER" 2>/dev/null || true)"
+        [ -n "$CONSOLE_UID" ] && launchctl bootout "gui/$CONSOLE_UID" "$AGENT" 2>/dev/null || true
+    fi
+    sudo rm -f "$AGENT"
+fi
+pkill -x displayxr-service 2>/dev/null || true
+
 echo "Removing DisplayXR runtime..."
 # This recursive delete covers the runtime dylib, the
 # DisplayXR-SimDisplay.dylib plug-in under lib/displayxr/plugins/,

--- a/scripts/build_macos.sh
+++ b/scripts/build_macos.sh
@@ -34,6 +34,16 @@ for arg in "$@"; do
   esac
 done
 
+# The macOS .pkg must ship a service-capable runtime so the installed spatial
+# shell can attach as an IPC client (it sets DISPLAYXR_WORKSPACE_SESSION=1).
+# Build HYBRID — in-process by default (standalone apps keep their own window),
+# IPC only for workspace sessions — and stage displayxr-service into the .pkg
+# (a LaunchAgent added by build_installer.sh auto-starts it at login).
+if [ "$BUILD_INSTALLER" = "ON" ]; then
+  SERVICE_MODE=ON
+  HYBRID_MODE=ON
+fi
+
 # Detect macOS SDK (CMake may pick a stale sysroot otherwise)
 MACOS_SDK="$(xcrun --show-sdk-path 2>/dev/null)"
 
@@ -358,6 +368,35 @@ for app in cube_handle_vk_macos cube_handle_metal_macos cube_handle_gl_macos \
            cube_hosted_legacy_vk_macos; do
   [ -f "$PKG_DIR/bin/$app" ] && codesign --force --sign - "$PKG_DIR/bin/$app" 2>/dev/null || true
 done
+
+# Stage the service binary (the always-on server/orchestrator) when this is a
+# SERVICE build. The installed spatial shell attaches to it as an IPC client,
+# and a LaunchAgent (added by installer/macos/build_installer.sh) auto-starts it
+# at login. It links the bundled Vulkan loader + cJSON, so retarget those from
+# Homebrew absolute paths to @rpath, resolved from @executable_path/../lib (next
+# to the runtime dylib). MoltenVK is loaded via the ICD, not linked directly.
+SERVICE_BIN="$BUILD_DIR/src/xrt/targets/service/displayxr-service"
+if [ "$SERVICE_MODE" = "ON" ] && [ -f "$SERVICE_BIN" ]; then
+  cp "$SERVICE_BIN" "$PKG_DIR/bin/displayxr-service"
+  chmod u+w "$PKG_DIR/bin/displayxr-service"
+  install_name_tool -change "$BREW_PREFIX/opt/vulkan-loader/lib/libvulkan.1.dylib" \
+                            @rpath/libvulkan.1.dylib \
+                            "$PKG_DIR/bin/displayxr-service" 2>/dev/null || true
+  install_name_tool -change "$BREW_PREFIX/opt/cjson/lib/libcjson.1.dylib" \
+                            @rpath/libcjson.1.dylib \
+                            "$PKG_DIR/bin/displayxr-service" 2>/dev/null || true
+  # Drop dev-tree rpaths (Homebrew Cellar, /tmp) and add the install-tree one.
+  for r in $(otool -l "$PKG_DIR/bin/displayxr-service" \
+             | awk '/LC_RPATH/{f=1} f && /path /{print $2; f=0}'); do
+    case "$r" in
+      /opt/homebrew/*|/usr/local/*|/tmp/*)
+        install_name_tool -delete_rpath "$r" "$PKG_DIR/bin/displayxr-service" 2>/dev/null || true ;;
+    esac
+  done
+  install_name_tool -add_rpath @executable_path/../lib "$PKG_DIR/bin/displayxr-service" 2>/dev/null || true
+  codesign --force --sign - "$PKG_DIR/bin/displayxr-service" 2>/dev/null || true
+  echo "Staged displayxr-service (SERVICE build) into _package bin/"
+fi
 
 # Create MoltenVK ICD manifest
 cat > "$PKG_DIR/share/vulkan/icd.d/MoltenVK_icd.json" <<EOF


### PR DESCRIPTION
## Why

The macOS runtime `.pkg` shipped an in-process (`SERVICE=OFF`) runtime and **no `displayxr-service`**, so an installed spatial shell (DisplayXRShell `.pkg`, shell #63) could never become the IPC client the workspace extensions require. It rendered a blank window: `is_service_mode=false`, and every `XR_EXT_spatial_workspace` call returned `requires an IPC-mode session` (taskbar/launcher/splash all failed to create overlays).

This is the last runtime-side piece to make the installed macOS spatial desktop run end-to-end. (Prerequisite link fix landed in #657.)

## What

- **`scripts/build_macos.sh`** — `--installer` now builds **HYBRID** (`XRT_FEATURE_SERVICE=ON` + `XRT_FEATURE_HYBRID_MODE=ON`): standalone apps still run in-process (their own window), only workspace sessions (`DISPLAYXR_WORKSPACE_SESSION=1`, set by the orchestrator) go IPC. It also stages `displayxr-service` into `_package/bin` with its Homebrew Vulkan/cJSON deps retargeted to `@rpath` (`@executable_path/../lib`).

- **`installer/macos/build_installer.sh`** — stages `displayxr-service` → `/Library/Application Support/DisplayXR/bin/`, and writes a system **LaunchAgent** (`/Library/LaunchAgents/com.displayxr.service.plist`) that auto-starts it in the user's GUI session at login (`RunAtLoad` + `KeepAlive` + `ProcessType Interactive` for the menu-bar status item), with `VK_ICD_FILENAMES` pointed at the bundled MoltenVK ICD. The macOS parallel of Windows' `HKLM\…\Run` autostart.

- **`postinstall`** — bootstraps the agent into the console user's `gui/<uid>` domain so it comes up immediately after install (no logout); idempotent bootout-then-bootstrap on re-install. **`uninstall.sh`** boots it out + removes it.

- **`build-macos.yml`** — the payload-assert now also requires `displayxr-service` + the LaunchAgent, so they can't silently regress out of the `.pkg`.

## Verification (local, macOS / Apple Silicon)

- `build_macos.sh --installer` → builds `SERVICE=ON HYBRID=ON`; stages the service with `@rpath` deps (no Homebrew/dev paths survive).
- `.pkg` payload contains `bin/displayxr-service` + a `plutil`-valid `com.displayxr.service.plist` (correct `ProgramArguments` + `VK_ICD_FILENAMES`); postinstall contains the `launchctl bootstrap`.
- The **staged service runs from the bundled layout** — no dyld failures, resolves `@rpath` libvulkan/libcjson from `../lib`, loads the `api=4` sim-display plugin, creates the sim 3D display, head device present.

Combined with #657 (already merged) and shell #63 (merged), an installed macOS shell summoned via Ctrl+Space now gets `is_service_mode=true` and renders its chrome.

Refs #61.