### PR TITLE
perf(android,#663): pipeline the OOP weave (~34→~46 fps) + present-loop instrumentation + ADPF

### DIFF
--- a/src/xrt/auxiliary/android/CMakeLists.txt
+++ b/src/xrt/auxiliary/android/CMakeLists.txt
@@ -27,6 +27,8 @@ add_library(
 	android_looper.h
 	android_main_thread.c
 	android_main_thread.h
+	android_perf_hint.c
+	android_perf_hint.h
 	org.freedesktop.monado.auxiliary.cpp
 	org.freedesktop.monado.auxiliary.hpp
 	org.freedesktop.monado.auxiliary.impl.hpp

--- a/src/xrt/auxiliary/android/android_perf_hint.c
+++ b/src/xrt/auxiliary/android/android_perf_hint.c
@@ -1,0 +1,150 @@
+// Copyright 2026, DisplayXR.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  Implementation of the Android ADPF hint-session wrapper.
+ * @ingroup aux_android
+ *
+ * The NDK @c APerformanceHint symbols are marked @c __INTRODUCED_IN(33), so
+ * referencing them directly is a hard compile error under the project's minSdk 29
+ * (and @c __builtin_available(android 33, *) does not reliably guard them for the
+ * Android target). We therefore resolve them at runtime with @c dlsym from the
+ * already-loaded @c libandroid.so: on an API-33+ device the symbols resolve and
+ * ADPF is used; on anything older they come back NULL and every call no-ops.
+ */
+
+#include "android_perf_hint.h"
+
+#ifdef XRT_OS_ANDROID
+
+#include "util/u_logging.h"
+
+#include <dlfcn.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdlib.h>
+
+#define DEFAULT_TARGET_NS (16666666) // 60 Hz
+
+// Opaque NDK handle types — we only ever hold pointers, never dereference them.
+typedef struct APerformanceHintManager APerformanceHintManager;
+typedef struct APerformanceHintSession APerformanceHintSession;
+
+typedef APerformanceHintManager *(*pfn_get_manager)(void);
+typedef APerformanceHintSession *(*pfn_create_session)(APerformanceHintManager *,
+                                                       const int32_t *,
+                                                       size_t,
+                                                       int64_t);
+typedef int (*pfn_update_target)(APerformanceHintSession *, int64_t);
+typedef int (*pfn_report_actual)(APerformanceHintSession *, int64_t);
+typedef void (*pfn_close_session)(APerformanceHintSession *);
+
+static struct
+{
+	bool resolved;
+	bool ok;
+	pfn_get_manager get_manager;
+	pfn_create_session create_session;
+	pfn_update_target update_target;
+	pfn_report_actual report_actual;
+	pfn_close_session close_session;
+} adpf;
+
+static void
+resolve_adpf(void)
+{
+	if (adpf.resolved) {
+		return;
+	}
+	adpf.resolved = true;
+
+	// libandroid is already linked into the process; dlopen just hands back its
+	// handle (kept open for process lifetime — intentionally not dlclose'd).
+	void *lib = dlopen("libandroid.so", RTLD_NOW | RTLD_LOCAL);
+	if (lib == NULL) {
+		return;
+	}
+
+	adpf.get_manager = (pfn_get_manager)dlsym(lib, "APerformanceHint_getManager");
+	adpf.create_session = (pfn_create_session)dlsym(lib, "APerformanceHint_createSession");
+	adpf.update_target = (pfn_update_target)dlsym(lib, "APerformanceHint_updateTargetWorkDuration");
+	adpf.report_actual = (pfn_report_actual)dlsym(lib, "APerformanceHint_reportActualWorkDuration");
+	adpf.close_session = (pfn_close_session)dlsym(lib, "APerformanceHint_closeSession");
+
+	adpf.ok = adpf.get_manager != NULL && adpf.create_session != NULL && adpf.update_target != NULL &&
+	          adpf.report_actual != NULL && adpf.close_session != NULL;
+}
+
+struct android_perf_hint_session
+{
+	APerformanceHintSession *session;
+};
+
+struct android_perf_hint_session *
+android_perf_hint_session_create(int32_t tid, int64_t target_duration_ns)
+{
+	if (target_duration_ns <= 0) {
+		target_duration_ns = DEFAULT_TARGET_NS;
+	}
+
+	resolve_adpf();
+	if (!adpf.ok) {
+		U_LOG_W("ADPF: APerformanceHint unavailable (device API < 33?); perf hints off");
+		return NULL;
+	}
+
+	APerformanceHintManager *manager = adpf.get_manager();
+	if (manager == NULL) {
+		U_LOG_W("ADPF: no PerformanceHintManager (device opted out); perf hints off");
+		return NULL;
+	}
+
+	int32_t thread_ids[1] = {tid};
+	APerformanceHintSession *ndk_session = adpf.create_session(manager, thread_ids, 1, target_duration_ns);
+	if (ndk_session == NULL) {
+		U_LOG_W("ADPF: createSession failed; perf hints off");
+		return NULL;
+	}
+
+	struct android_perf_hint_session *s = calloc(1, sizeof(*s));
+	if (s == NULL) {
+		adpf.close_session(ndk_session);
+		return NULL;
+	}
+	s->session = ndk_session;
+
+	U_LOG_W("ADPF: perf-hint session created (tid %d, target %.2f ms)", tid, target_duration_ns / 1e6);
+	return s;
+}
+
+void
+android_perf_hint_session_update_target(struct android_perf_hint_session *s, int64_t target_duration_ns)
+{
+	if (s == NULL || s->session == NULL || target_duration_ns <= 0 || !adpf.ok) {
+		return;
+	}
+	adpf.update_target(s->session, target_duration_ns);
+}
+
+void
+android_perf_hint_session_report_actual(struct android_perf_hint_session *s, int64_t actual_duration_ns)
+{
+	if (s == NULL || s->session == NULL || actual_duration_ns <= 0 || !adpf.ok) {
+		return;
+	}
+	adpf.report_actual(s->session, actual_duration_ns);
+}
+
+void
+android_perf_hint_session_destroy(struct android_perf_hint_session *s)
+{
+	if (s == NULL) {
+		return;
+	}
+	if (s->session != NULL && adpf.ok) {
+		adpf.close_session(s->session);
+	}
+	free(s);
+}
+
+#endif // XRT_OS_ANDROID

--- a/src/xrt/auxiliary/android/android_perf_hint.h
+++ b/src/xrt/auxiliary/android/android_perf_hint.h
@@ -1,0 +1,81 @@
+// Copyright 2026, DisplayXR.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  Android Dynamic Performance Framework (ADPF) hint-session wrapper.
+ * @ingroup aux_android
+ *
+ * Thin C wrapper over the NDK @c APerformanceHint API (API 33+). A hint session
+ * tells the scheduler that a set of threads must finish their work within a target
+ * duration each frame, which keeps the big cores from parking at min clock under a
+ * steady, touch-free workload — the ~13 ms "wait" DVFS core-parking stall that the
+ * Android OOP present path hits after #646 fixed the vsync phase (#663).
+ *
+ * All entry points are NULL-safe and degrade gracefully: if the device is below
+ * API 33, has no PerformanceHintManager, or session creation fails,
+ * android_perf_hint_session_create() returns NULL and every other call is a no-op.
+ * Callers therefore never need to branch on availability.
+ */
+
+#pragma once
+
+#include <xrt/xrt_config_os.h>
+
+#include <stdint.h>
+
+#ifdef XRT_OS_ANDROID
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*!
+ * Opaque ADPF hint-session handle. NULL means "unavailable" (see file comment).
+ * @ingroup aux_android
+ */
+struct android_perf_hint_session;
+
+/*!
+ * Create a hint session for @p tid with an initial target work duration.
+ *
+ * @param tid                Kernel thread id (gettid()) of the thread doing the
+ *                           per-frame work — for the OOP service this is the
+ *                           "Multi Client Module" render thread.
+ * @param target_duration_ns Target per-frame work duration in ns (e.g. 16.67 ms for
+ *                           60 Hz). Values <= 0 fall back to 60 Hz.
+ * @return A session handle, or NULL if ADPF is unavailable (always usable with the
+ *         other calls — they no-op on NULL).
+ * @ingroup aux_android
+ */
+struct android_perf_hint_session *
+android_perf_hint_session_create(int32_t tid, int64_t target_duration_ns);
+
+/*!
+ * Update the session's target per-frame work duration (e.g. when the predicted
+ * display period changes). No-op on a NULL session or non-positive duration.
+ * @ingroup aux_android
+ */
+void
+android_perf_hint_session_update_target(struct android_perf_hint_session *s, int64_t target_duration_ns);
+
+/*!
+ * Report the actual work duration measured for the just-finished frame. This is the
+ * closed-loop signal the scheduler uses. No-op on a NULL session or non-positive
+ * duration.
+ * @ingroup aux_android
+ */
+void
+android_perf_hint_session_report_actual(struct android_perf_hint_session *s, int64_t actual_duration_ns);
+
+/*!
+ * Destroy the session and free the handle. No-op on NULL.
+ * @ingroup aux_android
+ */
+void
+android_perf_hint_session_destroy(struct android_perf_hint_session *s);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // XRT_OS_ANDROID

--- a/src/xrt/compositor/main/comp_target_swapchain.c
+++ b/src/xrt/compositor/main/comp_target_swapchain.c
@@ -79,7 +79,17 @@ android_transparent_requested(void)
  * probably want 3, but most compositors on Linux sets the minImageCount
  * to 3 anyways so we get what we want.
  */
+#ifdef XRT_OS_ANDROID
+// Triple-buffer the Android OOP present chain (#663). On Android this swapchain is
+// FIFO (vsync) and the only comp_target_swapchain consumer is the OOP per-session
+// present target (comp_window_android): with just 2 images, missing one vblank
+// blocks the render thread a full period on acquire (the ~2× vblank stall). A 3rd
+// image lets the loop keep a frame in flight. select_image_count() still clamps to
+// the surface's reported max, so this is safe where the surface only allows 2.
+DEBUG_GET_ONCE_NUM_OPTION(preferred_at_least_image_count, "XRT_COMPOSITOR_PREFERRED_IMAGE_COUNT", 3)
+#else
 DEBUG_GET_ONCE_NUM_OPTION(preferred_at_least_image_count, "XRT_COMPOSITOR_PREFERRED_IMAGE_COUNT", 2)
+#endif
 DEBUG_GET_ONCE_BOOL_OPTION(use_present_wait, "XRT_COMPOSITOR_USE_PRESENT_WAIT", false)
 /*
  * Android closed-loop pacing (#510). The fake compositor pacer is open-loop on

--- a/src/xrt/compositor/multi/comp_multi_system.c
+++ b/src/xrt/compositor/multi/comp_multi_system.c
@@ -63,6 +63,8 @@
 
 #ifdef XRT_OS_ANDROID
 #include "android/android_globals.h"
+#include "android/android_perf_hint.h" // ADPF perf-hint session (#663)
+#include <unistd.h>                     // gettid()
 #endif
 
 #ifdef XRT_OS_MACOS
@@ -84,6 +86,43 @@
 
 #ifdef XRT_GRAPHICS_SYNC_HANDLE_IS_FD
 #include <unistd.h>
+#endif
+
+#ifdef XRT_OS_ANDROID
+/*
+ * Android OOP present-loop diagnostics + DVFS hints (#663).
+ *
+ * DXR_ANDROID_PRESENT_TS  — throttled (every 120 frames) "OOP_PRESENT_TS" line that
+ *   splits the per-session present loop into acquire / record(+weave) / submit /
+ *   gpu_wait / present, so the app's "end" phase can be attributed to IPC vs weave
+ *   vs present without guessing. Default on; the log is throttled so it's not
+ *   per-frame log bloat.
+ * DXR_ANDROID_ADPF        — install an Android Dynamic Performance Framework hint
+ *   session on the render thread so the scheduler keeps big cores unparked (the
+ *   ~13 ms "wait" DVFS core-parking stall #646 documents). Default on; set 0 to
+ *   revert, mirroring #646's DXR_ANDROID_VSYNC_PACING.
+ */
+DEBUG_GET_ONCE_BOOL_OPTION(android_present_ts, "DXR_ANDROID_PRESENT_TS", true)
+DEBUG_GET_ONCE_BOOL_OPTION(android_adpf, "DXR_ANDROID_ADPF", true)
+/*
+ * DXR_ANDROID_PIPELINE_WEAVE — pipeline the per-session weave by ONE frame (#663).
+ * The OOP present loop blocks the render thread on a synchronous vkWaitForFences
+ * for the weave's GPU completion before presenting (the cross-device read-completion
+ * guard at the end of render_session_to_own_target). On the NP02J that wait is the
+ * dominant ~13 ms cost and, being on the critical path every frame, leaves the GPU
+ * idle between bursts → it DVFS-downclocks → the weave runs slow → ~34 fps.
+ *
+ * When on (default), the wait is DEFERRED to the top of the next frame via the
+ * existing fenced_buffer machinery: frame N presents immediately (GPU-ordered by the
+ * render_complete semaphore) and frame N's weave overlaps the compositor's pacing
+ * wait_frame sleep, so the GPU stays fed and clocked. Correctness is preserved — the
+ * next frame's command buffer (which reuses the single atlas/intermediate images and
+ * re-reads the app's shared images) is only recorded AFTER the deferred wait confirms
+ * the previous frame's GPU work finished, so no read/write race is introduced; the
+ * pipeline depth stays at exactly 1. Set debug.xrt.DXR_ANDROID_PIPELINE_WEAVE=0 to
+ * restore the synchronous wait.
+ */
+DEBUG_GET_ONCE_BOOL_OPTION(android_pipeline_weave, "DXR_ANDROID_PIPELINE_WEAVE", true)
 #endif
 
 
@@ -2681,6 +2720,16 @@ render_session_to_own_target(struct multi_compositor *mc,
 		return;
 	}
 
+#ifdef XRT_OS_ANDROID
+	// Per-stage present-loop timestamps (#663). Captured every frame (cheap),
+	// reduced into a throttled OOP_PRESENT_TS log at the present stage so the
+	// app's "end" phase can be split into acquire / record(+weave) / submit /
+	// gpu_wait / present. Only the normal (non-early-return) path logs — error
+	// /skip returns don't pollute the steady-state numbers.
+	int64_t ts_entry = os_monotonic_get_ns();
+	int64_t ts_acq0 = 0, ts_acq1 = 0, ts_submit0 = 0, ts_submit1 = 0, ts_gpu1 = 0;
+#endif
+
 	// Recreate swapchain if flagged (from previous frame's VK_SUBOPTIMAL_KHR)
 #ifdef XRT_OS_WINDOWS
 	if (mc->session_render.swapchain_needs_recreate &&
@@ -2926,6 +2975,9 @@ black_canvas:; // force_black (minimized) jumps here, skipping all content/view 
 
 	// Acquire the next swapchain image from the per-session target
 	uint32_t buffer_index = 0;
+#ifdef XRT_OS_ANDROID
+	ts_acq0 = os_monotonic_get_ns();
+#endif
 	VkResult ret = comp_target_acquire(ct, &buffer_index);
 	if (ret == VK_ERROR_OUT_OF_DATE_KHR) {
 		U_LOG_W("[per-session] Swapchain out of date, recreating now");
@@ -2962,6 +3014,10 @@ black_canvas:; // force_black (minimized) jumps here, skipping all content/view 
 		U_LOG_E("[per-session] buffer_index %u out of range (max %u)", buffer_index, mc->session_render.buffer_count);
 		return;
 	}
+
+#ifdef XRT_OS_ANDROID
+	ts_acq1 = os_monotonic_get_ns(); // acquire done; command-buffer recording starts
+#endif
 
 	// Reset fence for current buffer
 	ret = vk->vkResetFences(vk->device, 1, &mc->session_render.fences[buffer_index]);
@@ -3372,24 +3428,58 @@ submit_and_present:
 	    .pSignalSemaphores = (signal_sem != VK_NULL_HANDLE) ? &signal_sem : NULL,
 	};
 
+#ifdef XRT_OS_ANDROID
+	ts_submit0 = os_monotonic_get_ns(); // record (per-tile blit + weave + overlays) done
+#endif
 	ret = vk->vkQueueSubmit(vk->main_queue->queue, 1, &submit_info, mc->session_render.fences[buffer_index]);
 	if (ret != VK_SUCCESS) {
 		U_LOG_E("[per-session] Failed to submit per-session render: %s", vk_result_string(ret));
 		return;
 	}
+#ifdef XRT_OS_ANDROID
+	ts_submit1 = os_monotonic_get_ns(); // submit returned; GPU wait starts
+#endif
 
-	// CRITICAL: Wait for GPU work to complete before returning.
-	// With cross-device external memory sharing (null compositor + VK app),
-	// there is no GPU-level synchronization between Device A (compositor) and
-	// Device B (app). Without this wait, the compositor's GPU read of shared
-	// images may still be in-flight when the app starts writing to the same
-	// images for the next frame, causing VK_ERROR_DEVICE_LOST on Intel.
-	// GL apps don't hit this because GL has implicit driver-level sync.
-	ret = vk->vkWaitForFences(vk->device, 1, &mc->session_render.fences[buffer_index], VK_TRUE, UINT64_MAX);
-	if (ret != VK_SUCCESS) {
-		U_LOG_E("[per-session] Failed to wait for render fence: %s", vk_result_string(ret));
+	// CRITICAL: the compositor's GPU read of the app's shared images (and reuse of
+	// the single atlas/intermediate images) must complete before the next frame
+	// overwrites them. With cross-device external memory sharing (null compositor +
+	// VK app) there is no GPU-level sync between Device A (compositor) and Device B
+	// (app): a still-in-flight read when the app starts writing the same images
+	// causes VK_ERROR_DEVICE_LOST on Intel. GL apps don't hit this (implicit sync).
+	//
+	// Two ways to provide that guarantee:
+	//  - Synchronous (default off Android / all other platforms): block here on the
+	//    fence, so the read is done before this function returns.
+	//  - Deferred-by-one-frame (#663, Android default): present now (GPU-ordered by
+	//    the render_complete semaphore) and wait for THIS fence at the TOP of the
+	//    next frame, before that frame records/submits any work that reuses the
+	//    images. Either way the previous frame's GPU read is guaranteed complete
+	//    before reuse; the deferred form just lets the weave overlap the pacing
+	//    sleep so the GPU stays clocked (see DXR_ANDROID_PIPELINE_WEAVE). Pipeline
+	//    depth is exactly 1, so no extra image buffering is required.
+	bool defer_fence_wait = false;
+#ifdef XRT_OS_ANDROID
+	defer_fence_wait = debug_get_bool_option_android_pipeline_weave();
+#endif
+
+	if (defer_fence_wait) {
+		// Hand the fence to the next frame's top-of-loop deferred wait.
+		mc->session_render.fenced_buffer = (int32_t)buffer_index;
+	} else {
+		ret = vk->vkWaitForFences(vk->device, 1, &mc->session_render.fences[buffer_index], VK_TRUE,
+		                          UINT64_MAX);
+		if (ret != VK_SUCCESS) {
+			U_LOG_E("[per-session] Failed to wait for render fence: %s", vk_result_string(ret));
+		}
+		mc->session_render.fenced_buffer = -1; // Fence already waited, no deferred wait needed
 	}
-	mc->session_render.fenced_buffer = -1; // Fence already waited, no deferred wait needed
+
+#ifdef XRT_OS_ANDROID
+	// With pipelining this marks "submitted + presented" (the GPU weave finishes
+	// asynchronously and is awaited at the next frame's top); without it, the GPU
+	// weave is already complete here. Either way it bounds the synchronous portion.
+	ts_gpu1 = os_monotonic_get_ns();
+#endif
 
 	// Present the image (GPU work is complete, semaphore already signaled)
 	ret = comp_target_present(ct, vk->main_queue->queue, buffer_index, 0, display_time_ns, 0);
@@ -3407,6 +3497,29 @@ submit_and_present:
 	} else if (ret != VK_SUCCESS) {
 		U_LOG_E("[per-session] Failed to present per-session target: %s", vk_result_string(ret));
 	}
+
+#ifdef XRT_OS_ANDROID
+	// Throttled per-stage split of the present loop (#663). One line every 120
+	// frames (never per-frame — see CLAUDE.md debug-logging rules). Lets the app's
+	// ~12–18 ms "end" phase be attributed: acquire (FIFO/double-buffer stall) vs
+	// record(+weave CPU) vs gpu_wait (synchronous weave GPU) vs present.
+	if (debug_get_bool_option_android_present_ts()) {
+		static uint32_t ts_frame_count = 0;
+		if ((ts_frame_count++ % 120) == 0 && ts_acq0 != 0 && ts_gpu1 != 0) {
+			int64_t t_acquire = ts_acq1 - ts_acq0;
+			int64_t t_record = ts_submit0 - ts_acq1;
+			int64_t t_submit = ts_submit1 - ts_submit0;
+			int64_t t_gpu_wait = ts_gpu1 - ts_submit1;
+			int64_t t_present = os_monotonic_get_ns() - ts_gpu1;
+			int64_t t_total = os_monotonic_get_ns() - ts_entry;
+			U_LOG_W("OOP_PRESENT_TS frame %u | acquire %.2f + record %.2f + submit %.2f + "
+			        "gpu_wait %.2f + present %.2f = total %.2f ms",
+			        ts_frame_count - 1, t_acquire / 1e6, t_record / 1e6, t_submit / 1e6,
+			        t_gpu_wait / 1e6, t_present / 1e6, t_total / 1e6);
+		}
+	}
+#endif
+
 #ifdef XRT_OS_WINDOWS
 	// Signal WM_PAINT handler that frame is done
 	if (mc->session_render.owns_window && mc->session_render.own_window != NULL) {
@@ -5590,6 +5703,20 @@ multi_main_loop(struct multi_system_compositor *msc)
 	struct os_precise_sleeper sleeper = {0};
 	os_precise_sleeper_init(&sleeper);
 
+#ifdef XRT_OS_ANDROID
+	// ADPF hint session on THIS render thread (#663). This is the single thread that
+	// does predict → wait → transfer → render → weave → present per frame, so it is
+	// the correct DVFS target: reporting its actual work duration each frame keeps
+	// the big cores unparked under a steady touch-free workload (the ~13 ms "wait"
+	// stall). NULL-safe if ADPF is unavailable (device API < 33), and gated behind
+	// debug.xrt.DXR_ANDROID_ADPF (default on) so it's revertible like #646's pacing.
+	struct android_perf_hint_session *perf_hint = NULL;
+	if (debug_get_bool_option_android_adpf()) {
+		// Initial target = 60 Hz; refined per-frame from predicted_display_period_ns.
+		perf_hint = android_perf_hint_session_create((int32_t)gettid(), 16666666);
+	}
+#endif
+
 	// Protect the thread state and the sessions state.
 	os_thread_helper_lock(&msc->oth);
 
@@ -5633,6 +5760,14 @@ multi_main_loop(struct multi_system_compositor *msc)
 		int64_t now_ns = os_monotonic_get_ns();
 		int64_t diff_ns = predicted_display_time_ns - now_ns;
 
+#ifdef XRT_OS_ANDROID
+		// ADPF: the real per-frame work starts now (after the pacer wait). Track the
+		// scheduler's target to the predicted display period so the hint stays valid
+		// across refresh-rate changes.
+		int64_t adpf_work_start_ns = now_ns;
+		android_perf_hint_session_update_target(perf_hint, predicted_display_period_ns);
+#endif
+
 		// Now we know the diff, broadcast to pacers.
 		broadcast_timings_to_pacers(msc, predicted_display_time_ns, predicted_display_period_ns, diff_ns);
 
@@ -5661,6 +5796,12 @@ multi_main_loop(struct multi_system_compositor *msc)
 #endif
 		os_mutex_unlock(&msc->list_and_timing_lock);
 
+#ifdef XRT_OS_ANDROID
+		// ADPF: close the loop — report how long this frame's work actually took
+		// (wait-return → present complete) so the scheduler can size the clocks.
+		android_perf_hint_session_report_actual(perf_hint, os_monotonic_get_ns() - adpf_work_start_ns);
+#endif
+
 		// Re-lock the thread for check in while statement.
 		os_thread_helper_lock(&msc->oth);
 	}
@@ -5679,6 +5820,10 @@ multi_main_loop(struct multi_system_compositor *msc)
 	os_thread_helper_unlock(&msc->oth);
 
 	os_precise_sleeper_deinit(&sleeper);
+
+#ifdef XRT_OS_ANDROID
+	android_perf_hint_session_destroy(perf_hint);
+#endif
 
 	return 0;
 }


### PR DESCRIPTION
Closes #663 (residual after #646).

## Problem
Android OOP gauss on the **NP02J** was present/weave-bound at **~34 fps** while GPU render was only ~6 ms. #646 fixed the cold-start vsync *phase*, but a residual ceiling remained.

## Profile first
New per-stage timestamps in the per-session present loop (`render_session_to_own_target`, throttled `OOP_PRESENT_TS` line every 120 frames) pinned it: the loop total was ~17 ms but **dominated by one ~13 ms stage — the synchronous `vkWaitForFences` on the weave's GPU completion**. That wait is on the critical path every frame and leaves the GPU idle between bursts → it DVFS-downclocks → the weave runs slow (a feedback loop; some frames showed the weave at ~5 ms when the GPU was clocked up).

| | Pipelining OFF | Pipelining ON |
|---|---|---|
| App frame | ~29 ms (**~34 fps**) | **~21 ms (~46 fps median, 40–54, peak ~56)** |
| Service present total | ~17–20 ms | **~1.5–4 ms** |
| `gpu_wait` (synchronous) | ~11–15 ms | **~0 ms** (deferred, absorbed by pacing sleep) |
| gauss GPU render | ~6.1 ms | **~4.7 ms** (GPU clocked up) |

## Fix — pipeline the weave by one frame (`DXR_ANDROID_PIPELINE_WEAVE`, Android default on)
Defer the fence wait by one frame via the **existing `fenced_buffer` machinery**. Frame N presents immediately (GPU-ordered by the `render_complete` semaphore) and its weave overlaps the compositor's pacing `wait_frame` sleep, keeping the GPU fed and clocked.

**Correctness, with no extra image buffering:** the next frame's command buffer (which reuses the single atlas/intermediate images and re-reads the app's shared images) is only recorded **after** the deferred wait confirms the previous frame's GPU finished — pipeline depth stays exactly 1, so the cross-device read-completion guard the synchronous wait provided still holds. `recreate_session_swapchain` and the teardown path already drain `fenced_buffer`, and fences are created `SIGNALED`, so the recreate / first-frame edges are safe. `=0` restores the synchronous wait.

## Secondary
- **Triple-buffer** the Android OOP swapchain (preferred image count 3; surface gave 4). Confirmed active (`minImageCount: 3`); not the bottleneck here (acquire <2.5 ms) but removes the double-buffer miss-a-vblank stall.
- **ADPF** perf-hint session on the render thread (new `aux_android/android_perf_hint.*`, `dlsym`'d from `libandroid` so it builds under minSdk 29). **Finding:** the NP02J PowerHAL doesn't support hint sessions (`APerformanceHint_createSession` returns NULL) → graceful no-op here. Kept because it helps on devices that do support it (Pixel etc.). Gated by `DXR_ANDROID_ADPF`.

## Validation (NP02J, gauss low-q)
- ~34 → **~46 fps median** (40–54, peak ~56 / 17.9 ms), **stable over 60 s**, both processes alive.
- **Zero** `VK_ERROR` / `DEVICE_LOST` / validation failures over the run.
- Weave **visually confirmed correct** on-device (no tearing/ghosting/flicker) — the only race detector, since the debug APK has no VK validation and the harness can't capture the VK overlay.

All changes are `#ifdef XRT_OS_ANDROID` — no Windows/macOS behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)