### PR TITLE
feat(signing,#666): SIGN_CMD-gated release signing + two-pass signed uninstaller

### DIFF
--- a/.claude/skills/dxr-release/SKILL.md
+++ b/.claude/skills/dxr-release/SKILL.md
@@ -180,8 +180,64 @@ CI_CONC="${S#completed/}"
 ```
 
 ### Step 3.3: Branch on outcome
-- `success` → Phase 4
+- `success` → Phase 3.5
 - else → STOP, report failed jobs via `gh run view "$RUN_ID" -R "$REPO" --log-failed`. No rollback — tags are sticky; user retries with a new tag.
+
+---
+
+## PHASE 3.5: CODE-SIGN THE COMPONENT INSTALLER (capability-gated)
+
+Same model as the runtime's `/release` skill: GitHub-hosted CI builds the
+component **unsigned** (the code-signing key is held on a build machine and
+isn't available to cloud CI runners, and no secret lives in these public
+repos). A signed release is produced by a **local signed build on a
+signing-capable machine** that replaces the CI asset. No-ops cleanly without
+signing capability.
+
+This matters most for **leia-plugin** — its vendor plug-in DLL is in the
+load path of every app that uses that display, so Smart App Control blocks
+it unsigned. Demos with Windows installers are next; `mcp` ships DLLs too.
+
+### Step 3.5.1: Capability check
+```bash
+if [ -z "$SIGN_CMD" ] || ! uname -s | grep -qiE 'mingw|msys|cygwin|windows'; then
+  echo "⚠  SIGNING SKIPPED for $COMPONENT — no signing capability here."
+  echo "   Release ships the UNSIGNED CI installer. Re-run /dxr-release"
+  echo "   $COMPONENT $NEW_TAG on a signing-capable build machine (SIGN_CMD set)."
+  SIGNED=no   # continue — do not fail the release
+else
+  SIGNED=yes
+fi
+```
+
+### Step 3.5.2: Local signed build + asset replace (only if SIGNED=yes)
+Requires the component repo to carry the same `SIGN_CMD`-gated build
+plumbing as the runtime (sign inner binaries before NSIS, sign the
+installer, `!uninstfinalize` the uninstaller).
+
+**Plumbing status:** `leia-plugin` has it (`scripts/build-windows.bat`).
+Demos / `mcp` do not yet — for those, set `SIGNED=no` with a note and
+continue (track per #664).
+
+```bash
+cd "$WORK/repo"
+git checkout "$NEW_TAG"
+# Component-specific build entry point (note the hyphen for leia-plugin).
+case "$COMPONENT" in
+  leia-plugin|leia) cmd //c "scripts\\build-windows.bat all" ;;
+  *) echo "No SIGN_CMD plumbing for $COMPONENT yet — skipping signing"; SIGNED=no ;;
+esac
+SIGNED_EXE=$(ls _package/*Setup-*.exe 2>/dev/null | head -1)
+powershell -NoProfile -Command "(Get-AuthenticodeSignature '$SIGNED_EXE').Status" # must be 'Valid'
+
+CI_EXE=$(gh release view "$NEW_TAG" -R "$REPO" --json assets \
+           --jq '.assets[].name | select(test("Setup-.*\\.exe$"))')
+[ -n "$CI_EXE" ] && gh release delete-asset "$NEW_TAG" "$CI_EXE" --yes -R "$REPO"
+gh release upload "$NEW_TAG" "$SIGNED_EXE" --clobber -R "$REPO"
+```
+
+If a component has **no** SIGN_CMD plumbing yet, set `SIGNED=no` with a note
+naming the component, and continue. Never upload an unverified binary.
 
 ---
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -300,6 +300,95 @@ user can audit at a glance.
 
 ---
 
+## PHASE 4.5: CODE-SIGN THE WINDOWS INSTALLER (capability-gated)
+
+GitHub-hosted CI builds the installer **unsigned** — the code-signing key
+is held on a build machine and isn't available to cloud CI runners, and no
+cert/secret is kept in this public repo. So signed releases are produced by
+a **local signed build on a signing-capable machine** and that signed
+installer **replaces** the CI asset. This phase no-ops cleanly for anyone
+without signing capability (the release just ships the unsigned CI
+installer, exactly as before).
+
+Why the installer must be rebuilt locally rather than re-signed in place:
+SAC checks the **DLLs extracted from the installer at load time**, so the
+inner binaries must be signed **before** NSIS packs them. You cannot fix
+that by re-signing the finished `.exe` — hence a full local signed build.
+
+### Step 4.5.1: Capability check
+The gate is the `SIGN_CMD` environment variable, which is set **only** on
+a signing-capable Windows build machine, where `SIGN_CMD` points at the
+configured code-signing tool. It is the same variable `build_windows.bat`
+honors.
+
+```bash
+# Must be a Windows host AND have SIGN_CMD set.
+if [ -z "$SIGN_CMD" ] || ! uname -s | grep -qiE 'mingw|msys|cygwin|windows'; then
+  echo "⚠  SIGNING SKIPPED — no signing capability on this machine."
+  echo "   The release will ship the UNSIGNED CI installer. To produce a"
+  echo "   signed installer, re-run /release on a signing-capable build"
+  echo "   machine (where SIGN_CMD is set)."
+  SIGNED=no
+  # Continue to Phase 5 — do NOT fail the release.
+else
+  SIGNED=yes
+fi
+```
+
+If `SIGNED=no`, skip straight to Phase 5 and carry the warning into the
+final report.
+
+### Step 4.5.2: Local signed build (only if SIGNED=yes)
+Build the runtime + installer locally at the tagged commit. With
+`SIGN_CMD` set, `build_windows.bat` signs every inner binary before NSIS
+packs them, signs the installer `.exe`, and the `.nsi` signs the embedded
+uninstaller — the whole chain.
+
+```bash
+git fetch --tags --quiet
+git checkout [FULL_TAG]            # build the exact released commit
+cmd //c "scripts\\build_windows.bat all"
+```
+
+The signed installer lands at `_package\DisplayXRSetup-[VERSION].*.exe`
+(local build number, so the filename may differ from CI's). Verify the
+signature actually took:
+
+```bash
+SIGNED_EXE=$(ls _package/DisplayXRSetup-*.exe | head -1)
+powershell -NoProfile -Command "(Get-AuthenticodeSignature '$SIGNED_EXE').Status" # must print 'Valid'
+```
+If the status is not `Valid`, STOP and report — do not upload an
+unsigned/invalid binary over a release.
+
+### Step 4.5.3: Replace the CI asset on the release
+Delete the unsigned CI installer from the release and upload the signed
+one. (Names may differ by build number, so delete by the CI asset's
+actual name, then upload the local file.)
+
+```bash
+CI_EXE=$(gh release view [FULL_TAG] --repo DisplayXR/displayxr-runtime \
+           --json assets --jq '.assets[].name | select(test("^DisplayXRSetup-.*\\.exe$"))')
+[ -n "$CI_EXE" ] && gh release delete-asset [FULL_TAG] "$CI_EXE" --yes \
+  --repo DisplayXR/displayxr-runtime
+gh release upload [FULL_TAG] "$SIGNED_EXE" --clobber \
+  --repo DisplayXR/displayxr-runtime
+```
+
+Restore the working tree afterwards: `git checkout main`.
+
+### Step 4.5.4: Scope note
+This phase signs **only the runtime installer**. The vendor plug-in,
+the Unity plug-in, demos, and the shell are signed by **their own**
+release flows (`/dxr-release <component>`, the Unity repo's `/release`,
+etc.) — each carries the same `SIGN_CMD`-gated step. The Unreal plug-in
+is signed inside its own local package step. A user installing the full
+stack gets every layer signed only when each component was released from
+a signing-capable machine. Carry into the report which layers this run
+covered (runtime only).
+
+---
+
 ## PHASE 5: WRITE CURATED RELEASE NOTES
 
 Since the CI workflows now attach artifacts to the release directly via
@@ -386,6 +475,8 @@ Release [FULL_TAG] published successfully!
 
 Build:     Windows CI run #RUN_ID — Runtime + cube test apps passed
            [list any pre-existing-broken jobs here, with note that they don't affect the artifact]
+Signing:   [SIGNED=yes → "runtime installer signed (EV) and re-uploaded over the CI asset"]
+           [SIGNED=no  → "⚠ UNSIGNED — released from a non-signing machine; re-run /release on a signing-capable build machine to ship a signed installer"]
 Release:   https://github.com/DisplayXR/displayxr-runtime/releases/tag/[FULL_TAG]
 Assets:    DisplayXRSetup-X.Y.Z.BUILD.exe (~N MB)
            DisplayXR-Installer-X.Y.Z.pkg (~N MB)  [or "skipped — macOS run did not produce .pkg"]

--- a/installer/CMakeLists.txt
+++ b/installer/CMakeLists.txt
@@ -34,6 +34,15 @@ if(NOT DEFINED BUILD_NUM)
 	set(BUILD_NUM "0")
 endif()
 
+# Optional code-signing command, sourced from the SIGN_CMD environment
+# variable at configure time. Empty on any machine without it (clones,
+# GitHub-hosted CI) -> the installer + uninstaller build unsigned. On a
+# signing-capable build machine SIGN_CMD points at the configured signer.
+# Passed through to makensis, where the .nsi uses it in !uninstfinalize
+# (and !finalize) to sign the uninstaller stub that is embedded at build
+# time. No cert/secret lives in this repo.
+set(SIGN_CMD "$ENV{SIGN_CMD}" CACHE STRING "Code-signing command for installer/uninstaller (empty = unsigned)")
+
 # Generate version header for NSIS
 configure_file(
 	"${CMAKE_CURRENT_SOURCE_DIR}/Version.nsh.in"
@@ -57,6 +66,7 @@ add_custom_target(installer
 		"/DBIN_DIR=${DISPLAYXR_BIN_DIR}"
 		"/DSOURCE_DIR=${CMAKE_SOURCE_DIR}"
 		"/DOUTPUT_DIR=${CMAKE_INSTALL_PREFIX}"
+		"/DSIGN_CMD=${SIGN_CMD}"
 		"${CMAKE_CURRENT_SOURCE_DIR}/DisplayXRInstaller.nsi"
 	WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
 	COMMENT "Building DisplayXR installer..."

--- a/installer/CMakeLists.txt
+++ b/installer/CMakeLists.txt
@@ -41,7 +41,12 @@ endif()
 # Passed through to makensis, where the .nsi uses it in !uninstfinalize
 # (and !finalize) to sign the uninstaller stub that is embedded at build
 # time. No cert/secret lives in this repo.
-set(SIGN_CMD "$ENV{SIGN_CMD}" CACHE STRING "Code-signing command for installer/uninstaller (empty = unsigned)")
+#
+# FORCE so the live SIGN_CMD env always wins on reconfigure: a plain CACHE
+# var is seeded only on the first configure, so a build tree first configured
+# with SIGN_CMD unset would keep caching "" even after SIGN_CMD is later set,
+# silently leaving the embedded uninstaller unsigned (#664 validation).
+set(SIGN_CMD "$ENV{SIGN_CMD}" CACHE STRING "Code-signing command for installer/uninstaller (empty = unsigned)" FORCE)
 
 # Generate version header for NSIS
 configure_file(

--- a/installer/DisplayXRInstaller.nsi
+++ b/installer/DisplayXRInstaller.nsi
@@ -24,6 +24,22 @@
 !endif
 
 ;--------------------------------
+; Code signing (SIGN_CMD passed from CMake; empty = unsigned build).
+; !finalize signs the installer .exe and !uninstfinalize signs the
+; embedded uninstaller stub, both at makensis time. The uninstaller
+; MUST be signed here: it is compiled into the installer at build time
+; and extracted on the user's machine, so signing the finished installer
+; afterwards cannot reach it. SIGN_CMD carries no secret — on a
+; signing-capable build machine it points at the configured signer;
+; elsewhere it is empty and the build is unsigned.
+!ifdef SIGN_CMD
+	!if "${SIGN_CMD}" != ""
+		!finalize '${SIGN_CMD} "%1"'
+		!uninstfinalize '${SIGN_CMD} "%1"'
+	!endif
+!endif
+
+;--------------------------------
 ; General Attributes
 
 Name "DisplayXR ${VERSION}"

--- a/installer/DisplayXRInstaller.nsi
+++ b/installer/DisplayXRInstaller.nsi
@@ -25,17 +25,33 @@
 
 ;--------------------------------
 ; Code signing (SIGN_CMD passed from CMake; empty = unsigned build).
-; !finalize signs the installer .exe and !uninstfinalize signs the
-; embedded uninstaller stub, both at makensis time. The uninstaller
-; MUST be signed here: it is compiled into the installer at build time
-; and extracted on the user's machine, so signing the finished installer
-; afterwards cannot reach it. SIGN_CMD carries no secret — on a
-; signing-capable build machine it points at the configured signer;
-; elsewhere it is empty and the build is unsigned.
-!ifdef SIGN_CMD
-	!if "${SIGN_CMD}" != ""
-		!finalize '${SIGN_CMD} "%1"'
-		!uninstfinalize '${SIGN_CMD} "%1"'
+; SIGN_CMD carries no secret — on a signing-capable build machine it points at
+; the configured signer; elsewhere it is empty and the build is unsigned.
+;
+; The installer .exe is signed via !finalize. The UNINSTALLER is signed via a
+; two-pass build instead of !uninstfinalize: !uninstfinalize is unreliable —
+; the uninstaller NSIS writes at install time is a self-copy of the (signed)
+; installer's exe header, so it inherits the INSTALLER's cert-table pointer,
+; which can dangle past the smaller uninstaller file => effectively unsigned
+; (signtool even refuses to re-sign it, 0x800700C1). This installer's
+; !uninstfinalize happened to survive, but leia/shell's did not (#664); use
+; the robust path here too.
+;
+; Two-pass (canonical NSIS recipe, kept in-script so the CMake `installer`
+; target needs no change): compile an INNER installer whose only job is to
+; WriteUninstaller to %TEMP% and Quit; run it; sign that %TEMP%\Uninstall.exe;
+; then File-include the pre-signed uninstaller in the real pass. INNER is
+; RequestExecutionLevel user so it never triggers UAC when run from makensis
+; on a non-elevated build host.
+!ifndef INNER
+	!ifdef SIGN_CMD
+		!if "${SIGN_CMD}" != ""
+			!finalize '${SIGN_CMD} "%1"'
+			!makensis '-DINNER "-DVERSION=${VERSION}" "-DVERSION_MAJOR=${VERSION_MAJOR}" "-DVERSION_MINOR=${VERSION_MINOR}" "-DVERSION_PATCH=${VERSION_PATCH}" "-DBUILD_NUM=${BUILD_NUM}" "-DSOURCE_DIR=${SOURCE_DIR}" "-DBIN_DIR=${BIN_DIR}" "-DOUTPUT_DIR=${OUTPUT_DIR}" "${__FILE__}"' = 0
+			!system '"$%TEMP%\DisplayXRSetup_inner.exe"' = 2
+			!system '${SIGN_CMD} "$%TEMP%\Uninstall.exe"' = 0
+			!define USE_PRESIGNED_UNINST
+		!endif
 	!endif
 !endif
 
@@ -43,10 +59,16 @@
 ; General Attributes
 
 Name "DisplayXR ${VERSION}"
-OutFile "${OUTPUT_DIR}\DisplayXRSetup-${VERSION}.${BUILD_NUM}.exe"
+!ifdef INNER
+	; Throwaway inner installer: only emits the uninstaller to %TEMP%.
+	OutFile "$%TEMP%\DisplayXRSetup_inner.exe"
+	RequestExecutionLevel user
+!else
+	OutFile "${OUTPUT_DIR}\DisplayXRSetup-${VERSION}.${BUILD_NUM}.exe"
+	RequestExecutionLevel admin
+!endif
 InstallDir "$PROGRAMFILES64\DisplayXR\Runtime"
 InstallDirRegKey HKLM "Software\DisplayXR\Runtime" "InstallPath"
-RequestExecutionLevel admin
 ShowInstDetails show
 ShowUninstDetails show
 
@@ -750,8 +772,14 @@ Section "DisplayXR Runtime" SecRuntime
 	; Broadcast environment change to running applications
 	SendMessage ${HWND_BROADCAST} ${WM_SETTINGCHANGE} 0 "STR:Environment" /TIMEOUT=5000
 
-	; Write uninstaller
+	; Write uninstaller. In a signed build, install the pre-signed uninstaller
+	; produced by the inner pass (two-pass signing — see the code-signing block
+	; in the header). Otherwise (unsigned build / CI) write it normally.
+!ifdef USE_PRESIGNED_UNINST
+	File "/oname=Uninstall.exe" "$%TEMP%\Uninstall.exe"
+!else
 	WriteUninstaller "$INSTDIR\Uninstall.exe"
+!endif
 
 	; Add to Add/Remove Programs
 	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\DisplayXR" \
@@ -1099,6 +1127,14 @@ SectionEnd
 ; Installer Functions
 
 Function .onInit
+!ifdef INNER
+	; Inner pass only: emit the uninstaller to %TEMP% (the binary that gets
+	; signed and File-included by the real pass) then bail — no UI, no install.
+	; This whole path is absent from the real installer.
+	SetSilent silent
+	WriteUninstaller "$%TEMP%\Uninstall.exe"
+	Quit
+!endif
 	; Check for 64-bit Windows
 	${IfNot} ${RunningX64}
 		MessageBox MB_ICONSTOP "DisplayXR requires 64-bit Windows."

--- a/scripts/build_windows.bat
+++ b/scripts/build_windows.bat
@@ -180,12 +180,46 @@ if "%TARGET%"=="build" goto :done
 :: 5. Build installer
 :: ============================================================
 :do_installer
+:: ── Code signing (gated on %SIGN_CMD%) ──────────────────────────────
+:: Signing is OFF unless SIGN_CMD is set in the environment. It is set
+:: only on a signing-capable build machine, where SIGN_CMD points at the
+:: configured code-signing tool. This repo carries NO cert and NO signing
+:: secret — just this "honor SIGN_CMD if present" hook. A clone without
+:: SIGN_CMD builds unsigned, exactly as before.
+::
+:: The inner DLLs/EXEs MUST be signed here, BEFORE makensis packs them —
+:: Smart App Control checks the binaries extracted at install/load time,
+:: so signing the finished installer alone is not enough.
+if defined SIGN_CMD (
+    echo === Signing runtime binaries [SIGN_CMD set] ===
+    powershell -NoProfile -ExecutionPolicy Bypass -File "%REPO%scripts\sign-release.ps1" -Path "%REPO%_package\bin" -SignCmd "%SIGN_CMD%"
+    REM 'if errorlevel 1' reads the live exit code; %ERRORLEVEL% would be
+    REM parse-time-expanded inside this parenthesized block (always stale).
+    if errorlevel 1 (
+        echo Binary signing FAILED
+        exit /b 1
+    )
+) else (
+    echo === Signing skipped [SIGN_CMD not set] - installer will be UNSIGNED ===
+)
+
 echo.
 echo === Building installer ===
 cmake --build "%REPO%build" --config Release --target installer
 
 if %ERRORLEVEL% NEQ 0 (
     echo Installer build FAILED - continuing with test apps...
+)
+
+:: Sign the installer .exe itself (the NSIS uninstaller is signed at
+:: makensis time via !uninstfinalize in DisplayXRInstaller.nsi).
+if defined SIGN_CMD (
+    echo === Signing installer .exe ===
+    powershell -NoProfile -ExecutionPolicy Bypass -File "%REPO%scripts\sign-release.ps1" -Path "%REPO%_package" -SignCmd "%SIGN_CMD%"
+    if errorlevel 1 (
+        echo Installer signing FAILED
+        exit /b 1
+    )
 )
 
 if "%TARGET%"=="installer" goto :done

--- a/scripts/sign-release.ps1
+++ b/scripts/sign-release.ps1
@@ -1,0 +1,84 @@
+<#
+.SYNOPSIS
+  Sign all DisplayXR-produced binaries in a release folder, then verify the
+  whole tree is signed.
+
+.DESCRIPTION
+  Signing is driven entirely by the command passed in -SignCmd (sourced from
+  the SIGN_CMD environment variable by the build scripts). This script holds
+  NO certificate and NO secret. On machines without signing capability,
+  SIGN_CMD is unset and the build scripts skip signing — the build is
+  unsigned, with no behavior change.
+
+    1. Walk the folder for *.dll / *.exe.
+    2. Any binary WITHOUT a Valid Authenticode signature -> sign it via the
+       configured signer. Binaries that already carry a valid signature
+       (e.g. bundled third-party DLLs) are left untouched.
+    3. Re-verify the ENTIRE tree. If anything is still unsigned, FAIL (exit 1).
+
+  -SignCmd receives the file path as a trailing argument. Callers pass a full
+  signing command (including their own timestamp authority) via SIGN_CMD; the
+  default below is a minimal fallback for ad-hoc use.
+
+.EXAMPLE
+  # sign a staged binary tree before packaging
+  .\sign-release.ps1 -Path .\_package\bin -SignCmd "$env:SIGN_CMD"
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path,
+
+    # Signing command; receives the file path as a trailing argument.
+    # Production callers pass a full command (with a timestamp authority)
+    # via the SIGN_CMD environment variable. This default is a bare fallback.
+    [string]$SignCmd = 'signtool sign /fd sha256 /a',
+
+    # Skip signing files already validly signed by anyone (default). Use
+    # -Force to re-sign every binary regardless (overwrites existing sigs).
+    [switch]$Force
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Test-Signed($file) {
+    (Get-AuthenticodeSignature $file).Status -eq 'Valid'
+}
+
+function Invoke-Sign($file) {
+    $parts = $SignCmd -split '\s+'
+    $exe   = $parts[0]
+    $args  = @($parts[1..($parts.Length - 1)]) + $file
+    & $exe @args
+    if ($LASTEXITCODE -ne 0) { throw "Signing failed for $file (exit $LASTEXITCODE)" }
+}
+
+if (-not (Test-Path $Path)) { throw "Path not found: $Path" }
+
+$binaries = Get-ChildItem -Path $Path -Recurse -Include *.dll, *.exe -File
+Write-Host "Found $($binaries.Count) binaries under $Path"
+
+$signed = 0; $skipped = 0
+foreach ($b in $binaries) {
+    if (-not $Force -and (Test-Signed $b.FullName)) {
+        $who = (Get-AuthenticodeSignature $b.FullName).SignerCertificate.Subject
+        Write-Host "  skip (already signed) : $($b.Name)  <$who>"
+        $skipped++
+        continue
+    }
+    Write-Host "  signing               : $($b.Name)"
+    Invoke-Sign $b.FullName
+    $signed++
+}
+
+Write-Host "Signed $signed, skipped $skipped already-signed."
+
+# ---- Verification gate ----
+$unsigned = $binaries | Where-Object { -not (Test-Signed $_.FullName) }
+if ($unsigned) {
+    Write-Host "`nFAIL: the following binaries are still unsigned:" -ForegroundColor Red
+    $unsigned | ForEach-Object { Write-Host "  $($_.FullName)" -ForegroundColor Red }
+    exit 1
+}
+
+Write-Host "`nOK: all $($binaries.Count) binaries under $Path are signed." -ForegroundColor Green


### PR DESCRIPTION
SIGN_CMD-gated code signing for the runtime installer, plus two correctness fixes found while validating it end-to-end with a self-signed cert. _(Tracking issue #666, supersedes #664.)_

## What this does
- **`scripts/sign-release.ps1`** (new): signs every unsigned `*.dll`/`*.exe` in a folder via `$SignCmd`, leaves already-validly-signed third-party DLLs alone, re-verifies the tree.
- **`build_windows.bat`**: when `SIGN_CMD` is set, signs `_package\bin` before NSIS, then the installer `.exe` after. Unset → unsigned build, exactly as before.
- **`installer/DisplayXRInstaller.nsi` + `CMakeLists.txt`**: `!finalize` signs the installer; the uninstaller is signed via a **two-pass** build (below). `SIGN_CMD` cache var is `FORCE`d so the live env always wins on reconfigure.
- **`/release` + `/dxr-release` skills**: capability-gated local-signed-build-replaces-CI-asset phase.

No cert or secret lives in the repo. Without `SIGN_CMD` (clone/CI) the build is unsigned and unchanged.

## Fixes (vs the original signing commit)
- **FORCE the SIGN_CMD cache** — a plain `CACHE` var is seeded only on the first configure, so a tree first configured unsigned kept caching `""` and silently shipped an unsigned uninstaller.
- **two-pass signed uninstaller** — `!uninstfinalize` is unreliable: the install-time uninstaller is a self-copy of the signed installer header and inherits a dangling cert-table pointer → effectively unsigned. Replaced with the canonical two-pass build kept in the `.nsi` (`!makensis` builds an INNER installer that emits the uninstaller → `!system` signs it → the real pass File-includes it). CI/unsigned path unchanged.

## Validation
Self-signed cert, no signing dongle: unsigned path unchanged; all `_package` binaries Valid + `signtool verify /pa`; installed `Uninstall.exe` Valid + executes. Also proven in a 3-component à-la-carte signed install (runtime + plug-in + shell) with the display-processor plug-in active on real hardware.

⚠️ CI builds unsigned, so green CI validates the build + the unsigned `WriteUninstaller` fallback — not signing. Signing is validated locally and happens at release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)