### PR TITLE
Add attribution NOTICE crediting Monado/Collabora

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,12 @@
+DisplayXR Runtime
+Copyright (c) 2024-2026 Leia, Inc. and the DisplayXR project contributors
+
+This software is a fork of Monado (https://monado.freedesktop.org/),
+Copyright (c) Collabora, Ltd. and the Monado contributors.
+
+The DisplayXR Runtime, including its Monado-derived portions, is licensed under
+the Boost Software License 1.0 (BSL-1.0); see the LICENSE file and the
+SPDX-License-Identifier header carried by each source file. Individual files may
+bear additional copyright notices and other permissive licenses (Apache-2.0,
+MIT, BSD-2-Clause, BSD-3-Clause, CC0-1.0, Zlib) as indicated in their headers and
+in the LICENSES/ directory.


### PR DESCRIPTION
## Attribution NOTICE (no license change)

Adds a top-level **NOTICE** file crediting the runtime's **Monado (Collabora)** heritage and pointing to the per-file SPDX headers + `LICENSES/` directory.

This is **attribution only — not a license change.** The runtime **stays BSL-1.0**: it remains a Monado-aligned fork so we can keep pulling from / pushing to upstream Monado. No SPDX headers are touched; `LICENSE` is unchanged.

Companion to the Apache-2.0 relicensing of the *wholly-owned* DisplayXR implementation repos (the runtime is intentionally excluded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)