### PR TITLE
fix(signing): sign-release.ps1 single-token SIGN_CMD arg-split

### DIFF
--- a/scripts/sign-release.ps1
+++ b/scripts/sign-release.ps1
@@ -46,10 +46,13 @@ function Test-Signed($file) {
 }
 
 function Invoke-Sign($file) {
-    $parts = $SignCmd -split '\s+'
+    # Split into exe + fixed args. Guard the single-token case (a bare signer
+    # path with no args): PowerShell's 1..0 is a DESCENDING range, which would
+    # mis-order the args and end up signing the wrong file.
+    $parts = @($SignCmd -split '\s+' | Where-Object { $_ -ne '' })
     $exe   = $parts[0]
-    $args  = @($parts[1..($parts.Length - 1)]) + $file
-    & $exe @args
+    $rest  = if ($parts.Count -gt 1) { $parts[1..($parts.Count - 1)] } else { @() }
+    & $exe @rest $file
     if ($LASTEXITCODE -ne 0) { throw "Signing failed for $file (exit $LASTEXITCODE)" }
 }
 


### PR DESCRIPTION
`Invoke-Sign` built its args with `$parts[1..($parts.Length-1)]`. For a **single-token** `SIGN_CMD` (a bare signer path, no flags), `Length=1` yields `1..0` — a **descending** range in PowerShell — mis-ordering the args so the signer signs the wrong file.

The real signer is a single-token path, so this would break production signed builds. A multi-token `signtool …` string (used in earlier testing) masked it.

Fix guards the single-token case. Verified end-to-end on a self-hosted signing run (a real bundle signed + verified only after this fix).