### PR TITLE
chore(signing,#666): release skills dispatch a signing provider (OS-agnostic)

### DIFF
--- a/.claude/skills/dxr-release/SKILL.md
+++ b/.claude/skills/dxr-release/SKILL.md
@@ -188,66 +188,96 @@ CI_CONC="${S#completed/}"
 ## PHASE 3.5: CODE-SIGN THE COMPONENT INSTALLER (capability-gated)
 
 Same model as the runtime's `/release` skill: GitHub-hosted CI builds the
-component **unsigned** (no secret lives in these public repos). A signed
-release is produced by building on a Windows host and signing via the
-operator's configured capability, then replacing the CI asset. No-ops
-cleanly when nothing is configured.
+component **unsigned** (contributor PRs/pushes stay unsigned by design; no
+secret lives in these public repos). A signed release is produced by the
+**self-hosted signing runner** — it rebuilds the tagged commit with the
+box-local EV signer (full chain: inner binaries → installer `.exe` → the NSIS
+uninstaller) and returns the signed installer as an artifact this skill uploads
+over the CI asset. **This box needs no Windows toolchain and holds no secret**
+— it only dispatches the runner and re-uploads, so `/dxr-release` runs from any
+OS. If the runner is unreachable, the release ships the unsigned CI installer
+(signing never gates publishing).
 
-This matters most for **leia-plugin** — its vendor plug-in DLL is in the
-load path of every app that uses that display, so Smart App Control blocks
-it unsigned. Demos with Windows installers are next; `mcp` ships DLLs too.
+This matters most for **leia-plugin** — its vendor plug-in DLL is in the load
+path of every app that uses that display, so Smart App Control blocks it
+unsigned. Demos with Windows installers are next; `mcp` ships DLLs too.
 
-### Step 3.5.1: Resolve the signing method
-Two methods (both need a Windows host); neither names a signing endpoint in
-these repos:
-- **Remote** — `$DXR_SIGN_HOOK` (a local executable that signs a folder in place).
-- **Local** — `$SIGN_CMD` (a per-file signer the component's build honors).
+The per-component build recipe lives in the runner workflow
+(`build-signed-release.yml` on `$DXR_SIGN_REPO`, default `LeiaInc/codesign-runner`)
+— a single source of truth — so this skill only names the component + ref, not
+build commands. Swap signers by setting `DXR_SIGN_REPO`; lose the provider and
+the release ships unsigned. Contract: `docs/specs/runtime/release-signing.md`.
+
+### Step 3.5.1: Resolve signing capability (OS-agnostic)
+The capability is *"can this box dispatch the signing runner?"* — no Windows
+host, no local secret.
 
 ```bash
-WINHOST=$(uname -s | grep -qiE 'mingw|msys|cygwin|windows' && echo yes || echo no)
-if [ -n "$DXR_SIGN_HOOK" ] && [ -x "$DXR_SIGN_HOOK" ] && [ "$WINHOST" = yes ]; then
-  SIGN_METHOD=remote; SIGNED=yes
-elif [ -n "$SIGN_CMD" ] && [ "$WINHOST" = yes ]; then
-  SIGN_METHOD=local;  SIGNED=yes
+SIGN_REPO="${DXR_SIGN_REPO:-LeiaInc/codesign-runner}"
+if gh workflow view build-signed-release.yml -R "$SIGN_REPO" >/dev/null 2>&1; then
+  SIGNED=yes
 else
-  echo "⚠  SIGNING SKIPPED for $COMPONENT — no signing capability here."
-  echo "   Release ships the UNSIGNED CI installer. Re-run /dxr-release"
-  echo "   $COMPONENT $NEW_TAG on a Windows build host with DXR_SIGN_HOOK or SIGN_CMD set."
-  SIGN_METHOD=none; SIGNED=no   # continue — do not fail the release
+  echo "⚠  SIGNING SKIPPED for $COMPONENT — no access to the signing runner ($SIGN_REPO)."
+  echo "   Release ships the UNSIGNED CI installer. Re-run /dxr-release $COMPONENT $NEW_TAG"
+  echo "   from a box whose gh auth can dispatch that workflow."
+  SIGNED=no   # continue — do not fail the release
 fi
 ```
 
-### Step 3.5.2: Build + sign + replace asset (only if SIGNED=yes)
-Requires the component repo to carry the `SIGN_CMD`-gated build plumbing
-(sign inner binaries before NSIS, sign the installer, `!uninstfinalize` the
-uninstaller). **Plumbing status:** `leia-plugin` has it
-(`scripts/build-windows.bat`); demos / `mcp` do not yet — for those set
-`SIGNED=no` and continue (track per #664).
+**earthview is macOS-only for signing purposes:** its release asset is a macOS
+`.pkg`, which the Windows EV runner cannot sign (that needs an Apple Developer
+ID + `productsign` on a Mac — a separate flow). Force `SIGNED=no` for it:
+```bash
+case "$COMPONENT" in earthview|demo-earthview)
+  echo "earthview ships a macOS .pkg — Windows EV runner N/A. SIGNED=no."; SIGNED=no ;; esac
+```
+
+### Step 3.5.2: Normalize the component name for the workflow
+The workflow expects canonical names (`runtime|leia-plugin|mcp|gauss|modelviewer|mediaplayer|avatar`).
+Map the skill's aliases:
+```bash
+case "$COMPONENT" in
+  leia|leia-plugin)              COMP=leia-plugin ;;
+  gauss|demo-gaussiansplat)      COMP=gauss ;;
+  modelviewer|demo-modelviewer)  COMP=modelviewer ;;
+  avatar|demo-avatar)            COMP=avatar ;;
+  mediaplayer|demo-mediaplayer)  COMP=mediaplayer ;;
+  mcp)                           COMP=mcp ;;
+  *)                             COMP="$COMPONENT" ;;
+esac
+```
+
+### Step 3.5.3: Dispatch the runner build, wait, fetch + replace the asset (only if SIGNED=yes)
 
 ```bash
-cd "$WORK/repo"
-git checkout "$NEW_TAG"
+if [ "$SIGNED" = yes ]; then
+  SINCE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  gh workflow run build-signed-release.yml -R "$SIGN_REPO" \
+     -f component="$COMP" -f repo="$REPO" -f ref="$NEW_TAG"
 
-# Component-specific build entry point (note the hyphen for leia-plugin).
-case "$COMPONENT" in
-  leia-plugin|leia) SCRIPT="scripts\\build-windows.bat" ;;
-  *) echo "No signing plumbing for $COMPONENT yet — skipping"; SIGNED=no ;;
-esac
-
-if [ "$SIGNED" = yes ] && [ "$SIGN_METHOD" = remote ]; then
-  cmd //c "$SCRIPT build"                        # UNSIGNED (SIGN_CMD unset)
-  "$DXR_SIGN_HOOK" _package/bin                  # sign inner binaries in place, remotely
-  cmd //c "$SCRIPT installer"                    # NSIS packs the now-signed bins
-  mkdir -p _sign && cp _package/*Setup-*.exe _sign/ \
-    && "$DXR_SIGN_HOOK" _sign && cp _sign/*.exe _package/   # sign the installer .exe
-  # remote mode: NSIS uninstaller unsigned — see /release Step 4.5.2b caveat.
-elif [ "$SIGNED" = yes ]; then                   # SIGN_METHOD=local
-  cmd //c "$SCRIPT all"                          # full local signing incl. uninstaller
+  SIGN_RUN=""
+  for _ in $(seq 1 20); do
+    SIGN_RUN=$(gh run list -R "$SIGN_REPO" --workflow build-signed-release.yml \
+                --event workflow_dispatch --limit 8 --json databaseId,createdAt \
+                --jq "[.[]|select(.createdAt>=\"$SINCE\")]|sort_by(.createdAt)|last|.databaseId // empty")
+    [ -n "$SIGN_RUN" ] && break; sleep 5
+  done
+  [ -n "$SIGN_RUN" ] || { echo "Could not locate the signing run — ship unsigned"; SIGNED=no; }
 fi
 
 if [ "$SIGNED" = yes ]; then
-  SIGNED_EXE=$(ls _package/*Setup-*.exe 2>/dev/null | head -1)
-  powershell -NoProfile -Command "(Get-AuthenticodeSignature '$SIGNED_EXE').Status" # must be 'Valid'
+  gh run watch "$SIGN_RUN" -R "$SIGN_REPO" --interval 30 --exit-status \
+    || { echo "Signing run failed — ship unsigned CI asset, flag in report"; SIGNED=no; }
+fi
+
+if [ "$SIGNED" = yes ]; then
+  rm -rf _signed && gh run download "$SIGN_RUN" -R "$SIGN_REPO" -n signed-installer -D _signed
+  SIGNED_EXE=$(ls _signed/*Setup-*.exe 2>/dev/null | head -1)
+  [ -n "$SIGNED_EXE" ] || { echo "No signed installer in the artifact — ship unsigned"; SIGNED=no; }
+fi
+
+if [ "$SIGNED" = yes ]; then
+  # The runner already fail-closed-verified Status=Valid AND signer=Leia.
   CI_EXE=$(gh release view "$NEW_TAG" -R "$REPO" --json assets \
              --jq '.assets[].name | select(test("Setup-.*\\.exe$"))')
   [ -n "$CI_EXE" ] && gh release delete-asset "$NEW_TAG" "$CI_EXE" --yes -R "$REPO"
@@ -255,7 +285,8 @@ if [ "$SIGNED" = yes ]; then
 fi
 ```
 
-Never upload an unverified binary. If verification isn't `Valid`, STOP.
+No local checkout, no local build, no Windows toolchain — the temp clone from
+Phase 1 is only used for the tag; signing happens entirely on the runner.
 
 ---
 
@@ -331,6 +362,8 @@ Release $NEW_TAG published successfully!
 Component:   $COMPONENT  ($REPO)
 CI:          run $RUN_ID — $CI_CONC
 Release:     https://github.com/$REL_REPO/releases/tag/$NEW_TAG
+Signing:     [signed → "installer built + signed on the signing runner (full chain incl. uninstaller, run $SIGN_RUN), re-uploaded over the CI asset"]
+             [none   → "⚠ UNSIGNED — signing runner unreachable / earthview macOS .pkg; ships the unsigned CI asset"]
 
 Auto-bump:
   versions.json[$FIELD] = $NEW_TAG   via $RT_BUMP_SHA on displayxr-runtime/main

--- a/.claude/skills/installer-release/SKILL.md
+++ b/.claude/skills/installer-release/SKILL.md
@@ -200,45 +200,71 @@ Confirm:
 ## PHASE 4.5: CODE-SIGN THE BUNDLE .EXE (capability-gated)
 
 The bundle wraps **already-signed** component installers (each signed at its
-own release), so it only needs its own outer `.exe` signed — a simple post-hoc
+own release), so it only needs its own outer `.exe` signed — a post-hoc
 **single-file** sign, no inner-binary handling and no rebuild. (signtool on a
-finished NSIS `.exe` is safe; that's ordinary. Only *rcedit* corrupts NSIS.)
-CI builds it unsigned; a signed release is produced by signing the `.exe` and
-re-uploading. No signing endpoint is named here.
+finished NSIS `.exe` is safe/ordinary; only *rcedit* corrupts NSIS.) So unlike
+components (which rebuild on the runner), the bundle uses the provider's
+folder-sign workflow **`sign-artifact`** — the same primitive `sign-hook.sh`
+wraps, dispatched inline here so it needs **no local hook file and no Windows
+host** (runs from the Mac). Full contract + how to swap providers:
+`docs/specs/runtime/release-signing.md`.
 
-Resolve the method (a single-file sign needs no build, so **remote works from
-any host** incl. the Mac):
-- **Remote** — `$DXR_SIGN_HOOK` (a local executable that signs a folder in place).
-- **Local** — `$SIGN_CMD` (per-file signer; needs a Windows host for signtool).
-
+### Step 4.5.1: Resolve capability (OS-agnostic)
 ```bash
-if [ -n "$DXR_SIGN_HOOK" ] && [ -x "$DXR_SIGN_HOOK" ]; then
-  SIGN_METHOD=remote; SIGNED=yes
-elif [ -n "$SIGN_CMD" ] && uname -s | grep -qiE 'mingw|msys|cygwin|windows'; then
-  SIGN_METHOD=local;  SIGNED=yes
+SIGN_REPO="${DXR_SIGN_REPO:-LeiaInc/codesign-runner}"
+if gh workflow view sign-artifact -R "$SIGN_REPO" >/dev/null 2>&1; then
+  SIGNED=yes
 else
-  echo "⚠  BUNDLE UNSIGNED — set DXR_SIGN_HOOK (remote) or SIGN_CMD (local, Windows) to sign."
-  SIGN_METHOD=none; SIGNED=no
+  echo "⚠  BUNDLE UNSIGNED — no access to the signing provider ($SIGN_REPO)."
+  echo "   The release ships the unsigned CI bundle. Set DXR_SIGN_REPO to a repo"
+  echo "   implementing 'sign-artifact', or re-run from a box with provider access."
+  SIGNED=no
 fi
+```
 
+### Step 4.5.2: Download → dispatch `sign-artifact` → re-upload
+```bash
 if [ "$SIGNED" = yes ]; then
   D=$(mktemp -d)
   EXE=$(gh release view "$TAG" -R DisplayXR/displayxr-installer --json assets \
          --jq '.assets[].name | select(test("DisplayXRBundle-.*\\.exe$"))')
-  gh release download "$TAG" -R DisplayXR/displayxr-installer -p "$EXE" -D "$D"
-  if [ "$SIGN_METHOD" = remote ]; then
-    "$DXR_SIGN_HOOK" "$D"                      # signs (+verifies) via the runner
+  gh release download "$TAG" -R DisplayXR/displayxr-installer -p "$EXE" -D "$D/in"
+
+  # Zip the finished .exe and hand it to the provider's folder-sign workflow.
+  ( cd "$D/in" && zip -qr "$D/unsigned.zip" . )
+  TMP="sign-bundle-$(date +%s)-$$"
+  gh release create "$TMP" -R "$SIGN_REPO" --prerelease --title "$TMP" \
+     --notes "temp bundle-signing payload (auto-deleted)" "$D/unsigned.zip"
+  SINCE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  gh workflow run sign-artifact -R "$SIGN_REPO" -f release_tag="$TMP"
+
+  RID=""
+  for _ in $(seq 1 20); do
+    RID=$(gh run list -R "$SIGN_REPO" --workflow sign-artifact --event workflow_dispatch \
+            --limit 8 --json databaseId,createdAt \
+            --jq "[.[]|select(.createdAt>=\"$SINCE\")]|sort_by(.createdAt)|last|.databaseId // empty")
+    [ -n "$RID" ] && break; sleep 4
+  done
+  if [ -n "$RID" ] && gh run watch "$RID" -R "$SIGN_REPO" --interval 15 --exit-status; then
+    gh run download "$RID" -R "$SIGN_REPO" -n signed -D "$D/out"
+    ( cd "$D/out" && unzip -qo signed.zip -d "$D/signed" 2>/dev/null || true )
+    SIGNED_EXE=$(ls "$D/signed/$EXE" 2>/dev/null || ls "$D/out"/**/"$EXE" 2>/dev/null | head -1)
+    if [ -n "$SIGNED_EXE" ]; then
+      gh release upload "$TAG" "$SIGNED_EXE" --clobber -R DisplayXR/displayxr-installer
+      echo "Bundle .exe signed on the provider runner and re-uploaded."
+    else
+      echo "⚠ signed .exe not returned — leaving the unsigned CI bundle."; SIGNED=no
+    fi
   else
-    $SIGN_CMD "$D/$EXE"                        # bash word-splits SIGN_CMD; then verify:
-    powershell -NoProfile -Command "if((Get-AuthenticodeSignature '$D\\$EXE').Status -ne 'Valid'){exit 1}"
+    echo "⚠ sign-artifact run failed/absent — leaving the unsigned CI bundle."; SIGNED=no
   fi
-  gh release upload "$TAG" "$D/$EXE" --clobber -R DisplayXR/displayxr-installer
-  echo "Bundle .exe signed and re-uploaded ($SIGN_METHOD)."
+  # Always clean up the temp signing release/tag on the provider.
+  gh release delete "$TMP" -R "$SIGN_REPO" --yes --cleanup-tag >/dev/null 2>&1 || true
 fi
 ```
 
 Only the Windows `.exe` is covered; the macOS `.pkg` uses an Apple Developer ID
-cert + notarization (separate track). Carry `SIGNED`/`SIGN_METHOD` into the report.
+cert + notarization (separate track). Carry `SIGNED` into the report.
 
 ---
 
@@ -259,7 +285,7 @@ Release:    https://github.com/DisplayXR/displayxr-installer/releases/tag/$TAG
 Assets:     DisplayXRBundle-X.Y.Z.pkg (~N MB)
             DisplayXRBundle-X.Y.Z.exe (~N MB)
 Prerelease: true/false
-Signing:    [remote/local → "bundle .exe signed and re-uploaded"] | [none → "⚠ bundle UNSIGNED — set DXR_SIGN_HOOK / SIGN_CMD"]  (macOS .pkg: unsigned, TODO)
+Signing:    [signed → "bundle .exe signed on the provider runner (run $RID) and re-uploaded"] | [none → "⚠ bundle UNSIGNED — provider unreachable; set DXR_SIGN_REPO or ship unsigned"]  (macOS .pkg: unsigned, TODO)
 
 Source of truth verification:
   installer/versions.json == runtime/versions.json    ✓
@@ -283,12 +309,16 @@ STOP.
   bundle release is the punctuation that says "users go install
   this now."
 - Bundle `.exe` signing is a **post-hoc skill step** (Phase 4.5), not a CI
-  step — the signing key can't live on GitHub-hosted CI, and the org runner
-  isn't reachable from `displayxr-installer`'s CI. The skill signs the
-  finished `.exe` via `$DXR_SIGN_HOOK` (remote) or `$SIGN_CMD` (local) and
-  re-uploads. The wrapped component installers are already signed at their
-  own releases, so no inner-binary handling is needed. macOS `.pkg` signing
-  (Apple Developer ID + notarization) is still TODO.
+  step — the signing key can't live on GitHub-hosted CI, and the provider
+  runner isn't reachable from `displayxr-installer`'s CI. The skill dispatches
+  the provider's `sign-artifact` workflow (`$DXR_SIGN_REPO`, default
+  `LeiaInc/codesign-runner`) to sign the finished `.exe`, then re-uploads —
+  OS-agnostic, no local hook file. The wrapped component installers are already
+  signed at their own releases, so no inner-binary handling is needed. Lose the
+  provider → the release ships unsigned (gate fails, flagged in the report);
+  swap providers by setting `DXR_SIGN_REPO`. Full contract:
+  `docs/specs/runtime/release-signing.md`. macOS `.pkg` signing (Apple
+  Developer ID + notarization) is still TODO.
 - Don't bump component pins by hand in installer's versions.json —
   the file is auto-mirrored from runtime. If you find yourself
   wanting to, you're working around the system. Investigate why

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -302,112 +302,105 @@ user can audit at a glance.
 
 ## PHASE 4.5: CODE-SIGN THE WINDOWS INSTALLER (capability-gated)
 
-GitHub-hosted CI builds the installer **unsigned** (no cert/secret is kept in
-this public repo). A signed release is produced by building on a Windows host
-and signing via whatever capability the operator's environment provides, then
-**replacing** the CI asset. This phase no-ops cleanly when no signing is
-configured (the release ships the unsigned CI installer, exactly as before).
+GitHub-hosted CI builds the installer **unsigned** (no cert/secret lives in this
+public repo — contributor PRs and pushes stay unsigned by design). A signed
+release is produced by the **self-hosted signing runner** (the box that holds
+the DigiCert EV cert): it rebuilds the tagged commit with the box-local signer,
+signs the whole chain (inner binaries → installer `.exe` → the NSIS
+uninstaller), and returns the signed installer as an artifact this skill uploads
+over the CI asset. **This box needs no Windows toolchain and holds no secret** —
+it only dispatches the runner workflow and re-uploads the result, so `/release`
+runs from macOS/Linux/Windows alike. If the runner is unreachable, the release
+still ships the unsigned CI installer (signing is never a gate on publishing).
 
-Why the installer is (re)built rather than re-signed in place: SAC checks the
+Why the runner rebuilds (rather than re-signing the CI `.exe`): SAC checks the
 **DLLs extracted from the installer at load time**, so the inner binaries must
-be signed **before** NSIS packs them — you can't fix that by re-signing the
-finished `.exe`.
+be signed **before** NSIS packs them; and the two-pass signed uninstaller needs
+makensis to run on the cert machine. Both are only possible where the cert is.
 
-### Step 4.5.1: Resolve the signing method
-Two methods, resolved in order. **Both require a Windows host** (the installer
-build needs MSVC + NSIS). Neither puts any signing endpoint or secret in this
-repo — the operator's environment supplies it.
-
-- **Remote** — `$DXR_SIGN_HOOK` points at a local, operator-provided executable
-  that signs a *folder of binaries in place*. It encapsulates the signing
-  endpoint (this repo names nothing). Use when the build host has no local
-  signer of its own.
-- **Local** — `$SIGN_CMD` is a per-file signer available on the build host
-  (the variable `build_windows.bat` honors).
+### Step 4.5.1: Resolve signing capability (OS-agnostic)
+The capability is simply *"can this box dispatch the signing runner?"* — no
+Windows host required. The runner workflow (`build-signed-release.yml`) and the
+cert live in the provider repo `$DXR_SIGN_REPO` (default `LeiaInc/codesign-runner`);
+this repo names no endpoint. To swap signers set `DXR_SIGN_REPO` to another repo
+implementing the same workflow; lose the provider and the release ships unsigned.
+Contract + fallbacks: `docs/specs/runtime/release-signing.md`.
 
 ```bash
-WINHOST=$(uname -s | grep -qiE 'mingw|msys|cygwin|windows' && echo yes || echo no)
-if [ -n "$DXR_SIGN_HOOK" ] && [ -x "$DXR_SIGN_HOOK" ] && [ "$WINHOST" = yes ]; then
-  SIGN_METHOD=remote; SIGNED=yes
-elif [ -n "$SIGN_CMD" ] && [ "$WINHOST" = yes ]; then
-  SIGN_METHOD=local;  SIGNED=yes
+SIGN_REPO="${DXR_SIGN_REPO:-LeiaInc/codesign-runner}"
+if gh workflow view build-signed-release.yml -R "$SIGN_REPO" >/dev/null 2>&1; then
+  SIGNED=yes
 else
-  echo "⚠  SIGNING SKIPPED — no signing capability on this machine."
+  echo "⚠  SIGNING SKIPPED — no access to the signing runner ($SIGN_REPO)."
   echo "   The release will ship the UNSIGNED CI installer. To sign, re-run"
-  echo "   /release on a Windows build host with either DXR_SIGN_HOOK (remote)"
-  echo "   or SIGN_CMD (local) configured."
-  SIGN_METHOD=none; SIGNED=no
+  echo "   /release from a box whose gh auth can dispatch that workflow."
+  SIGNED=no
 fi
 ```
 
-If `SIGNED=no`, skip straight to Phase 5 and carry the warning into the
-final report.
+If `SIGNED=no`, skip straight to Phase 5 and carry the warning into the report.
 
-Always build the exact released commit first:
+### Step 4.5.2: Dispatch the runner build, wait, fetch the signed installer
 ```bash
-git fetch --tags --quiet
-git checkout [FULL_TAG]
+SINCE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+gh workflow run build-signed-release.yml -R "$SIGN_REPO" \
+   -f component=runtime -f repo=DisplayXR/displayxr-runtime -f ref=[FULL_TAG]
+
+# Locate the run we just dispatched.
+SIGN_RUN=""
+for _ in $(seq 1 20); do
+  SIGN_RUN=$(gh run list -R "$SIGN_REPO" --workflow build-signed-release.yml \
+              --event workflow_dispatch --limit 8 --json databaseId,createdAt \
+              --jq "[.[]|select(.createdAt>=\"$SINCE\")]|sort_by(.createdAt)|last|.databaseId // empty")
+  [ -n "$SIGN_RUN" ] && break; sleep 5
+done
+[ -n "$SIGN_RUN" ] || { echo "Could not locate the signing run — ship unsigned"; SIGNED=no; }
+
+# Wait for it (runtime build is slow — allow ~30 min).
+[ "$SIGNED" = yes ] && gh run watch "$SIGN_RUN" -R "$SIGN_REPO" --interval 30 --exit-status \
+  || { echo "Signing run failed — ship the unsigned CI asset, flag in report"; SIGNED=no; }
+
+# Download the signed installer.
+if [ "$SIGNED" = yes ]; then
+  rm -rf _signed && gh run download "$SIGN_RUN" -R "$SIGN_REPO" -n signed-installer -D _signed
+  SIGNED_EXE=$(ls _signed/DisplayXRSetup-*.exe 2>/dev/null | head -1)
+  [ -n "$SIGNED_EXE" ] || { echo "No signed installer in the artifact — ship unsigned"; SIGNED=no; }
+fi
 ```
 
-### Step 4.5.2a: Local signed build (SIGN_METHOD=local)
-With `SIGN_CMD` set, `build_windows.bat` signs every inner binary before NSIS
-packs them, signs the installer `.exe`, and the `.nsi` signs the embedded
-uninstaller — the whole chain.
-```bash
-cmd //c "scripts\\build_windows.bat all"
-```
-
-### Step 4.5.2b: Remote signed build via the hook (SIGN_METHOD=remote)
-Build unsigned, sign the inner binaries through the hook (one batch), then let
-NSIS pack the now-signed binaries, and finally sign the installer `.exe`:
-```bash
-cmd //c "scripts\\build_windows.bat build"      # _package\bin, UNSIGNED (SIGN_CMD unset)
-"$DXR_SIGN_HOOK" _package/bin                    # sign inner binaries in place, remotely
-cmd //c "scripts\\build_windows.bat installer"   # NSIS packs the now-signed bins
-mkdir -p _sign && cp _package/DisplayXRSetup-*.exe _sign/ \
-  && "$DXR_SIGN_HOOK" _sign && cp _sign/*.exe _package/   # sign the installer .exe
-```
-**Remote-mode caveat:** the NSIS **uninstaller** is *not* signed in this mode
-(its `!uninstfinalize` needs a local per-file `SIGN_CMD` during makensis; the
-hook is per-folder/out-of-process). The uninstaller isn't in the app load
-path, so this is an accepted interim gap — use the **local** `SIGN_CMD` method
-for full-fidelity signing including the uninstaller. Note it in the report.
-
-### Step 4.5.2c: Verify the installer signature
-The signed installer lands at `_package\DisplayXRSetup-[VERSION].*.exe`
-(local build number, so the filename may differ from CI's). Verify:
-
-```bash
-SIGNED_EXE=$(ls _package/DisplayXRSetup-*.exe | head -1)
-powershell -NoProfile -Command "(Get-AuthenticodeSignature '$SIGNED_EXE').Status" # must print 'Valid'
-```
-If the status is not `Valid`, STOP and report — do not upload an
-unsigned/invalid binary over a release.
+The runner already fail-closed-verifies `Status=Valid` AND signer contains
+`Leia` before uploading the artifact, so a returned installer is trustworthy.
+(On a Windows box you may re-verify locally with `Get-AuthenticodeSignature`;
+elsewhere trust the runner's gate.)
 
 ### Step 4.5.3: Replace the CI asset on the release
-Delete the unsigned CI installer from the release and upload the signed
-one. (Names may differ by build number, so delete by the CI asset's
-actual name, then upload the local file.)
-
 ```bash
-CI_EXE=$(gh release view [FULL_TAG] --repo DisplayXR/displayxr-runtime \
-           --json assets --jq '.assets[].name | select(test("^DisplayXRSetup-.*\\.exe$"))')
-[ -n "$CI_EXE" ] && gh release delete-asset [FULL_TAG] "$CI_EXE" --yes \
-  --repo DisplayXR/displayxr-runtime
-gh release upload [FULL_TAG] "$SIGNED_EXE" --clobber \
-  --repo DisplayXR/displayxr-runtime
+if [ "$SIGNED" = yes ]; then
+  CI_EXE=$(gh release view [FULL_TAG] --repo DisplayXR/displayxr-runtime \
+             --json assets --jq '.assets[].name | select(test("^DisplayXRSetup-.*\\.exe$"))')
+  [ -n "$CI_EXE" ] && gh release delete-asset [FULL_TAG] "$CI_EXE" --yes \
+    --repo DisplayXR/displayxr-runtime
+  gh release upload [FULL_TAG] "$SIGNED_EXE" --clobber \
+    --repo DisplayXR/displayxr-runtime
+fi
 ```
-
-Restore the working tree afterwards: `git checkout main`.
+No local checkout to restore — nothing was built or checked out on this box.
 
 ### Step 4.5.4: Scope note
-This phase signs **only the runtime installer**. The vendor plug-in,
-the Unity plug-in, demos, and the shell are signed by **their own**
-release flows (`/dxr-release <component>`, the Unity repo's `/release`,
-etc.) — each carries the same `DXR_SIGN_HOOK` (remote) / `SIGN_CMD` (local)
-gate. A user installing the full stack gets every layer signed only when
-each component was released with signing configured. Carry into the report
-which layers this run covered (runtime only) and by which method.
+This phase signs **only the runtime installer**. The vendor plug-in, the Unity
+plug-in, demos, and the shell are signed by **their own** release flows
+(`/dxr-release <component>`, the Unity repo's `/release`, etc.) — each dispatches
+the same `build-signed-release.yml` on the signing runner. A user installing the
+full stack gets every layer signed only when each component was released with
+the runner reachable. Report which layers this run covered (runtime only).
+
+### Step 4.5.5: Legacy local-Windows fallback (offline / runner down)
+If the signing runner is unavailable but you're on a Windows build host that has
+the cert locally, the pre-runner path still works: `git checkout [FULL_TAG]`,
+`cmd //c "scripts\\build_windows.bat all"` with `SIGN_CMD` set (full-chain local
+signing incl. uninstaller), verify `Get-AuthenticodeSignature … = Valid`, then
+the Step 4.5.3 asset swap. This is the only path that does **not** need the
+runner — use it only when the runner can't be reached.
 
 ---
 
@@ -497,9 +490,8 @@ Release [FULL_TAG] published successfully!
 
 Build:     Windows CI run #RUN_ID — Runtime + cube test apps passed
            [list any pre-existing-broken jobs here, with note that they don't affect the artifact]
-Signing:   [remote → "runtime installer signed via DXR_SIGN_HOOK and re-uploaded over the CI asset (uninstaller unsigned in remote mode)"]
-           [local  → "runtime installer fully signed (incl. uninstaller) via local SIGN_CMD and re-uploaded"]
-           [none   → "⚠ UNSIGNED — released from a non-signing machine; re-run /release on a Windows build host with DXR_SIGN_HOOK or SIGN_CMD set"]
+Signing:   [signed → "runtime installer built + signed on the signing runner (full chain incl. uninstaller, run $SIGN_RUN), re-uploaded over the CI asset"]
+           [none   → "⚠ UNSIGNED — signing runner unreachable; re-run /release from a box whose gh can dispatch build-signed-release.yml on the signing runner"]
 Release:   https://github.com/DisplayXR/displayxr-runtime/releases/tag/[FULL_TAG]
 Assets:    DisplayXRSetup-X.Y.Z.BUILD.exe (~N MB)
            DisplayXR-Installer-X.Y.Z.pkg (~N MB)  [or "skipped — macOS run did not produce .pkg"]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,6 +182,18 @@ To make them invocable from *any* directory (not just a runtime checkout), `scri
 
 Full spec: `docs/specs/runtime/versions-json-autobump.md`.
 
+### Release code-signing
+CI builds are **unsigned** (contributors need no signing access). Signed
+releases are produced by a **signing provider** — a repo (`$DXR_SIGN_REPO`,
+default private `LeiaInc/codesign-runner`) that owns the EV cert on a self-hosted
+runner and exposes `build-signed-release.yml` (build+sign a component) and
+`sign-artifact` (sign a folder). The `/release`, `/dxr-release`, and
+`/installer-release` skills dispatch it, download the signed artifact, and
+replace the unsigned CI asset — so they run from **any OS** (no local Windows,
+no local secret). Signing never gates publishing: if the provider is unreachable
+the release ships unsigned; swap providers by setting `DXR_SIGN_REPO`. Full
+spec: `docs/specs/runtime/release-signing.md`.
+
 ## Repos & issue routing
 
 | Repo | Visibility | Contents |

--- a/docs/specs/runtime/release-signing.md
+++ b/docs/specs/runtime/release-signing.md
@@ -1,0 +1,92 @@
+# Release code-signing
+
+How DisplayXR releases get Authenticode-signed, and how to keep releasing when
+the signer is unavailable or changes. This is the contract the `/release`,
+`/dxr-release`, and `/installer-release` skills implement.
+
+## Two tiers: unsigned CI, signed release
+
+- **Contributor / CI builds are unsigned, by design.** GitHub-hosted CI holds
+  no certificate and no secret. Every PR, push, and even tag build produces
+  **unsigned** installers. Contributors never need signing access.
+- **Releases are signed by a signing provider** — a repo that owns the code-
+  signing certificate on a self-hosted runner and exposes it through two
+  `workflow_dispatch` workflows (below). The release skills dispatch it,
+  download the signed artifact, and replace the unsigned CI asset on the GitHub
+  Release. **Signing never gates publishing** — if the provider is unreachable
+  the release still ships the unsigned CI installer, with a warning.
+
+The current provider is the private **`LeiaInc/codesign-runner`** (DigiCert EV,
+subject `Leia, Inc.`). Nothing in the public repos names it beyond the default
+below.
+
+## Why signed releases rebuild (not re-sign the CI `.exe`)
+
+Smart App Control checks the **DLLs extracted from the installer at load time**,
+so the inner binaries must be signed **before** NSIS packs them — re-signing the
+finished `.exe` is not enough. And the two-pass signed NSIS uninstaller needs
+`makensis` to run on the machine that holds the cert. Both are only possible
+where the cert lives, so a **component** signed release is produced by rebuilding
+the tagged commit *on the signing runner* with a runner-local `SIGN_CMD`. The
+**bundle** is the exception: it wraps already-signed child installers, so its
+outer `.exe` only needs a single-file sign (no rebuild).
+
+## The provider contract
+
+A signing provider is any repo `$DXR_SIGN_REPO` implementing these two
+`workflow_dispatch` workflows. Point the skills at a different provider by
+setting `DXR_SIGN_REPO=<owner/repo>` in the release box's environment — that is
+the entire "switch signers" operation.
+
+### 1. `build-signed-release.yml` — build + sign a component (used by `/release`, `/dxr-release`)
+
+- **Inputs:** `component` (`runtime|leia-plugin|mcp|gauss|modelviewer|mediaplayer|avatar`),
+  `repo` (`owner/name`), `ref` (the tag, e.g. `v1.6.0`).
+- **Behavior:** checkout `repo@ref` on a Windows runner that has the cert; set
+  `SIGN_CMD` to the runner-local signer; run that component's own signed build
+  (full chain: inner binaries → installer `.exe` → two-pass uninstaller);
+  fail-closed verify `Status=Valid` **and** signer matches the expected subject.
+- **Output:** artifact **`signed-installer`** containing `*Setup-*.exe`.
+- Reference sketch: staged locally at `C:\displayxr-signing\build-signed-release.yml`
+  (gitignored — it is committed only into the provider repo, never here).
+
+### 2. `sign-artifact` — sign a folder of finished files (used by `/installer-release`, ad-hoc)
+
+- **Inputs:** `release_tag` — a temporary prerelease on `$DXR_SIGN_REPO` carrying
+  `unsigned.zip` (the files to sign).
+- **Behavior:** sign every unsigned binary in the zip with the runner-local
+  signer; verify.
+- **Output:** artifact **`signed`** containing `signed.zip` (same layout, signed).
+- This is what `C:\displayxr-signing\sign-hook.sh` wraps for local use.
+
+## Capability gate + fallback (losing the box)
+
+Each skill probes reachability before signing and degrades gracefully:
+
+```bash
+SIGN_REPO="${DXR_SIGN_REPO:-LeiaInc/codesign-runner}"
+if gh workflow view build-signed-release.yml -R "$SIGN_REPO" >/dev/null 2>&1; then
+  SIGNED=yes          # provider reachable → sign
+else
+  SIGNED=no           # provider gone → ship the unsigned CI installer, warn
+fi
+```
+
+So there are three ways to keep releasing:
+1. **Lose the box, ship unsigned** — do nothing; the gate fails and the release
+   publishes with the unsigned CI installer (the report flags it `UNSIGNED`).
+2. **Point at another provider** — stand up the two workflows above on any repo,
+   set `DXR_SIGN_REPO=<that repo>`. No skill edits.
+3. **Local Windows fallback** — on a Windows box that has the cert locally, the
+   pre-runner path still works (`build_windows.bat all` with `SIGN_CMD` set,
+   full-chain including uninstaller). `/release` keeps this as an explicit
+   fallback step; it's the only path that needs no provider at all.
+
+## Runner prerequisites (for whoever hosts the provider)
+
+Runner labelled `[self-hosted, windows, signing]` with: VS 2022 (C++), Ninja,
+NSIS, Vulkan SDK, GitHub CLI; the box-local EV signer exposed as the `SIGN_CMD`
+secret; `SR_PATH` (Simulated Reality SDK) for the leia-plugin build; a
+`COMPONENT_READ_PAT` secret only if signing a **private** component repo. macOS
+`.pkg` signing (Apple Developer ID + notarization) is a separate track, not
+covered by the Windows runner.


### PR DESCRIPTION
## What

Reworks the three release skills so **signed releases are produced by a signing provider** (a self-hosted runner that holds the EV cert), not by a local Windows build. The release-driving box now needs only `gh` — it runs from **any OS**.

- **`/release`, `/dxr-release`** — dispatch `build-signed-release.yml` on `$DXR_SIGN_REPO` (default `LeiaInc/codesign-runner`) to rebuild + sign the tagged commit (full chain incl. the two-pass NSIS uninstaller, which needs `makensis` on the cert box), download the `signed-installer` artifact, and replace the unsigned CI asset. Component recipe lives in the runner workflow (single source of truth).
- **`/installer-release`** — the bundle wraps already-signed child installers, so its outer `.exe` only needs a single-file sign: dispatch the provider's `sign-artifact` folder-sign workflow inline (no local hook file, OS-agnostic).

## Losing the box / swapping signers

- **Capability gate** on all three: if the provider is unreachable, `SIGNED=no` and the release **ships the unsigned CI installer** — signing never gates publishing.
- **Swap providers** by setting `DXR_SIGN_REPO` to any repo implementing the two workflow contracts. No skill edits.
- **`/release`** keeps a local-Windows `SIGN_CMD` fallback for fully-offline signing.

## Docs

New `docs/specs/runtime/release-signing.md` documents the two-tier model (unsigned CI vs signed release), the provider contract (`build-signed-release.yml` + `sign-artifact`), the capability gate, and the three fallback paths. `CLAUDE.md` Releasing section links it.

The runner-side `build-signed-release.yml` is **not** in this repo — it belongs in the private provider repo and is staged locally only (gitignored). No cert, secret, or signing endpoint is committed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)