### PR TITLE
fix(build): make build_windows.bat portable to VS-BuildTools-in-(x86) + custom VULKAN_SDK

### DIFF
--- a/scripts/build_windows.bat
+++ b/scripts/build_windows.bat
@@ -18,7 +18,9 @@ setlocal enabledelayedexpansion
 
 set REPO=%~dp0..\
 set OPENXR_VERSION=1.1.43
-set VULKAN_SDK=C:\VulkanSDK\1.4.341.1
+:: Honor a pre-set VULKAN_SDK (the LunarG installer / a build runner exports it,
+:: possibly a different version) before falling back to the dev-box default.
+if not defined VULKAN_SDK set "VULKAN_SDK=C:\VulkanSDK\1.4.341.1"
 set OPENXR_SDK=%REPO%openxr_sdk
 set NINJA_DIR=%LOCALAPPDATA%\Microsoft\WinGet\Packages\Ninja-build.Ninja_Microsoft.Winget.Source_8wekyb3d8bbwe
 

--- a/scripts/build_windows.bat
+++ b/scripts/build_windows.bat
@@ -57,7 +57,7 @@ if not defined VCVARS (
 
 call "%VCVARS%" >nul 2>&1
 if %ERRORLEVEL% NEQ 0 (
-    echo ERROR: vcvars64.bat failed: %VCVARS%
+    echo ERROR: vcvars64.bat failed: !VCVARS!
     exit /b 1
 )
 


### PR DESCRIPTION
Two portability fixes to `scripts/build_windows.bat`, surfaced while running it on a runner where VS is **BuildTools under `C:\Program Files (x86)\...`** and `VULKAN_SDK` is exported to a non-default version:

1. **`!VCVARS!` (delayed) in the error echo** — the unquoted `%VCVARS%` inside the `if %ERRORLEVEL% NEQ 0 ( ... )` block expands at *parse* time, and the `)` in `(x86)` prematurely closes the block, aborting with `\Microsoft was unexpected at this time`. Delayed expansion (the script already has `enabledelayedexpansion`) substitutes at run time, so the parens never affect block parsing. Only bit anyone whose VS lives under `Program Files (x86)` (e.g. BuildTools).
2. **Honor a pre-set `VULKAN_SDK`** before the hardcoded `C:\VulkanSDK\1.4.341.1` dev-box default — mirrors the demos, which already do this. A box with a different Vulkan SDK version exported via `VULKAN_SDK` no longer fails the prereq check.

Both are safe on a normal dev box (VS under `Program Files`, `VULKAN_SDK` unset → default path, unchanged behavior). Verified fix #1 on the (x86) box: MSVC setup now passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)