### PR TITLE
feat(compositor,#681): first-class array (layered) swapchains on D3D11, GL, Metal

### DIFF
--- a/docs/specs/runtime/swapchain-model.md
+++ b/docs/specs/runtime/swapchain-model.md
@@ -11,6 +11,34 @@ Each compositor maintains two distinct, unrelated swapchains. Understanding this
 - **Content**: the app renders a tiled atlas of views into this swapchain
 - **Flow direction**: app → compositor (input)
 
+#### View addressing: tiled vs layered (array) swapchains
+
+`XrSwapchainSubImage` exposes **two** ways to address a per-view image, and the
+runtime honors whichever the app submits on **every** graphics API:
+
+- **Tiled** (`arraySize = 1`): views packed side-by-side in one image; each view
+  is addressed by `imageRect.offset`/`extent`. This is the layout native and
+  tool apps use, and the only layout that can host `view_count > 2` light-field
+  content.
+- **Layered / array** (`arraySize = N`): one texture-array swapchain whose slices
+  hold the per-view images; each view is addressed by `imageArrayIndex` (with
+  `imageRect` selecting a sub-rect *within* the slice). This is what engine
+  single-pass-instanced stereo (Unity SPI, Unreal Instanced Stereo) and every
+  PC-VR runtime produce, and is capped at the engine's efficient multiview count
+  (typically 2).
+
+Both are first-class on D3D11, D3D12, Vulkan, OpenGL, and Metal — the compositor
+selects the array slice at the per-view atlas-blit sampling site (D3D12/D3D11:
+`Texture2DArray` SRV; Vulkan: `baseArrayLayer`; GL: `sampler2DArray` layer; Metal:
+per-slice 2D texture view). The two addressing modes are orthogonal (a layered
+submission may still use `imageRect`). The **display-processor contract is
+unchanged** either way: the DP always receives a single flat tiled atlas (see
+`process_atlas` below) — array resolution happens entirely upstream, in the
+compositor. Consequently a layered submission never satisfies
+`u_tiling_can_zero_copy()` (slices ≠ tiles), so it always takes the crop/blit
+path; one atlas blit per frame is the floor for array content, matching every
+PC-VR runtime.
+
 ### Target Swapchain
 
 - **Allocated by**: the compositor

--- a/src/xrt/compositor/d3d11/comp_d3d11_renderer.cpp
+++ b/src/xrt/compositor/d3d11/comp_d3d11_renderer.cpp
@@ -32,6 +32,7 @@ struct LayerConstants
 	float post_transform[4]; // xy = offset, zw = scale
 	float color_scale[4];    // Color multiplier
 	float color_bias[4];     // Color offset
+	float array_params[4];   // x = array slice (imageArrayIndex) for layered swapchains; yzw pad
 };
 
 /*!
@@ -88,6 +89,10 @@ struct comp_d3d11_renderer
 
 	//! Pixel shader for projection layers.
 	ID3D11PixelShader *projection_ps;
+
+	//! Pixel shader for projection layers from LAYERED (array) swapchains
+	//! (Texture2DArray; selects the view's imageArrayIndex slice).
+	ID3D11PixelShader *projection_ps_array;
 
 	//! Vertex shader for quad layers.
 	ID3D11VertexShader *quad_vs;
@@ -236,6 +241,41 @@ struct VS_OUTPUT
 float4 PSMain(VS_OUTPUT input) : SV_Target
 {
     float4 color = layer_tex.Sample(layer_samp, input.uv);
+    color = color * color_scale + color_bias;
+    return color;
+}
+)";
+
+// Projection pixel shader variant for LAYERED (array) swapchains. Under
+// single-pass-instanced the app submits ONE swapchain with arraySize=2 and two
+// projection views referencing subImage.imageArrayIndex 0 (left) / 1 (right).
+// The whole-array Texture2DArray SRV (FirstArraySlice=0, ArraySize=N) is bound;
+// this shader selects the requested slice via array_params.x. A plain Texture2D
+// shader (above) always views slice 0, so both eyes would sample the left image
+// (flat output) — this is the D3D11 analog of the D3D12 #656 fix. Single-layer
+// swapchains keep the Texture2D path unchanged.
+static const char *projection_ps_array_source = R"(
+cbuffer LayerCB : register(b0)
+{
+    float4x4 mvp;
+    float4 post_transform;
+    float4 color_scale;
+    float4 color_bias;
+    float4 array_params;   // x = array slice
+};
+
+Texture2DArray layer_tex : register(t0);
+SamplerState layer_samp : register(s0);
+
+struct VS_OUTPUT
+{
+    float4 position : SV_Position;
+    float2 uv : TEXCOORD0;
+};
+
+float4 PSMain(VS_OUTPUT input) : SV_Target
+{
+    float4 color = layer_tex.Sample(layer_samp, float3(input.uv, array_params.x));
     color = color * color_scale + color_bias;
     return color;
 }
@@ -521,6 +561,21 @@ create_shaders(struct comp_d3d11_renderer *r)
 	blob->Release();
 	if (FAILED(hr)) {
 		U_LOG_E("Failed to create pixel shader: 0x%08x", hr);
+		return XRT_ERROR_D3D;
+	}
+
+	// Compile layered (array) projection pixel shader variant
+	xret = compile_shader(internals->device, projection_ps_array_source, "PSMain", "ps_5_0", &blob);
+	if (xret != XRT_SUCCESS) {
+		U_LOG_E("Failed to compile array projection pixel shader");
+		return xret;
+	}
+
+	hr = internals->device->CreatePixelShader(blob->GetBufferPointer(), blob->GetBufferSize(), nullptr,
+	                                           &r->projection_ps_array);
+	blob->Release();
+	if (FAILED(hr)) {
+		U_LOG_E("Failed to create array projection pixel shader: 0x%08x", hr);
 		return XRT_ERROR_D3D;
 	}
 
@@ -830,7 +885,9 @@ render_projection_layer(struct comp_d3d11_renderer *r,
 	struct xrt_layer_projection_view_data *view_data = &layer->data.proj.v[view_index];
 	uint32_t image_index = view_data->sub.image_index;
 
-	// Get the D3D11 swapchain's SRV for this image
+	// Get the D3D11 swapchain's SRV for this image. For layered (array)
+	// swapchains this is a whole-array Texture2DArray SRV (all slices);
+	// for single-layer swapchains it is a Texture2D SRV.
 	ID3D11ShaderResourceView *srv = static_cast<ID3D11ShaderResourceView *>(
 	    comp_d3d11_swapchain_get_srv(xsc, image_index));
 	if (srv == nullptr) {
@@ -838,13 +895,27 @@ render_projection_layer(struct comp_d3d11_renderer *r,
 		return;
 	}
 
+	// Honor the projection view's array layer (subImage.imageArrayIndex).
+	// Under single-pass-instanced the app submits ONE arraySize>1 swapchain
+	// with per-view array_index 0/1; a Texture2D sample always views slice 0
+	// (flat output). When the swapchain is layered, use the Texture2DArray
+	// shader variant and select the slice via the constant buffer. This
+	// mirrors the D3D12 #656 fix. Single-layer swapchains (array_index 0)
+	// keep the Texture2D path unchanged.
+	uint32_t array_size = comp_d3d11_swapchain_get_array_size(xsc);
+	bool is_layered = array_size > 1;
+
 	// Set projection shaders explicitly (must be done per-draw because quad layer
 	// rendering switches to quad shaders, and those persist to the next projection layer)
 	internals->context->VSSetShader(r->projection_vs, nullptr, 0);
-	internals->context->PSSetShader(r->projection_ps, nullptr, 0);
+	internals->context->PSSetShader(is_layered ? r->projection_ps_array : r->projection_ps, nullptr, 0);
 
 	// Update constant buffer
 	LayerConstants constants = {};
+
+	// Array slice for the layered (Texture2DArray) shader variant; ignored by
+	// the Texture2D shader. Non-array swapchains report array_index 0.
+	constants.array_params[0] = is_layered ? static_cast<float>(view_data->sub.array_index) : 0.0f;
 
 	// Identity MVP (fullscreen quad)
 	memset(constants.mvp, 0, sizeof(constants.mvp));
@@ -1267,6 +1338,7 @@ comp_d3d11_renderer_destroy(struct comp_d3d11_renderer **renderer_ptr)
 	SAFE_RELEASE(r->composite_vs);
 	SAFE_RELEASE(r->quad_ps);
 	SAFE_RELEASE(r->quad_vs);
+	SAFE_RELEASE(r->projection_ps_array);
 	SAFE_RELEASE(r->projection_ps);
 	SAFE_RELEASE(r->projection_vs);
 	SAFE_RELEASE(r->depth_dsv);

--- a/src/xrt/compositor/d3d11/comp_d3d11_swapchain.cpp
+++ b/src/xrt/compositor/d3d11/comp_d3d11_swapchain.cpp
@@ -574,6 +574,13 @@ comp_d3d11_swapchain_get_dimensions(struct xrt_swapchain *xsc, uint32_t *out_w, 
 	*out_h = sc->info.height;
 }
 
+extern "C" uint32_t
+comp_d3d11_swapchain_get_array_size(struct xrt_swapchain *xsc)
+{
+	struct comp_d3d11_swapchain *sc = d3d11_sc(xsc);
+	return sc->info.array_size > 0 ? sc->info.array_size : 1;
+}
+
 /*!
  * Wait for GPU completion of all commands submitted up to the most recent
  * xrReleaseSwapchainImage for this swapchain.

--- a/src/xrt/compositor/d3d11/comp_d3d11_swapchain.h
+++ b/src/xrt/compositor/d3d11/comp_d3d11_swapchain.h
@@ -87,6 +87,18 @@ void
 comp_d3d11_swapchain_get_dimensions(struct xrt_swapchain *xsc, uint32_t *out_w, uint32_t *out_h);
 
 /*!
+ * Get the array (layer) size of a swapchain (XrSwapchainCreateInfo.arraySize).
+ * Returns 1 for non-layered swapchains.
+ *
+ * @param xsc The swapchain.
+ * @return The number of array layers (>= 1).
+ *
+ * @ingroup comp_d3d11
+ */
+uint32_t
+comp_d3d11_swapchain_get_array_size(struct xrt_swapchain *xsc);
+
+/*!
  * Wait for GPU completion of all commands submitted up to the most recent
  * xrReleaseSwapchainImage for this swapchain.
  *

--- a/src/xrt/compositor/gl/comp_gl_compositor.cpp
+++ b/src/xrt/compositor/gl/comp_gl_compositor.cpp
@@ -138,6 +138,10 @@ struct comp_gl_swapchain
 	uint32_t image_count;
 	struct xrt_swapchain_create_info info;
 
+	//! GL texture target: GL_TEXTURE_2D for single-layer swapchains,
+	//! GL_TEXTURE_2D_ARRAY for layered (arraySize>1) swapchains.
+	GLenum target;
+
 	int32_t acquired_index;
 	int32_t waited_index;
 	uint32_t last_released_index;
@@ -178,6 +182,23 @@ static const char *FS_BLIT =
     "void main() {\n"
     "    vec2 uv = u_src_rect.xy + v_uv * u_src_rect.zw;\n"
     "    fragColor = texture(u_texture, uv);\n"
+    "}\n";
+
+//! Fragment shader: blit one layer of an ARRAY texture to the atlas. Under
+//! single-pass-instanced the app submits ONE arraySize>1 (GL_TEXTURE_2D_ARRAY)
+//! swapchain with per-view imageArrayIndex 0 (left) / 1 (right); u_layer selects
+//! the slice. This is the GL analog of the D3D12 #656 / D3D11 array fix — a plain
+//! sampler2D always views layer 0 (flat output).
+static const char *FS_BLIT_ARRAY =
+    "#version 330 core\n"
+    "in vec2 v_uv;\n"
+    "out vec4 fragColor;\n"
+    "uniform sampler2DArray u_texture;\n"
+    "uniform vec4 u_src_rect;\n" // x, y, w, h in normalized coords
+    "uniform float u_layer;\n"   // array slice (imageArrayIndex)
+    "void main() {\n"
+    "    vec2 uv = u_src_rect.xy + v_uv * u_src_rect.zw;\n"
+    "    fragColor = texture(u_texture, vec3(uv, u_layer));\n"
     "}\n";
 
 //! Vertex shader: positioned quad for window-space layers.
@@ -263,6 +284,7 @@ struct comp_gl_compositor
 
 	// --- GL resources ---
 	GLuint program_blit;      //!< Shader for blitting eye to atlas texture
+	GLuint program_blit_array; //!< Blit shader for LAYERED (array) swapchains (sampler2DArray)
 	GLuint program_window_space; //!< Window-space layer (positioned quad)
 	GLuint vao_empty;         //!< Empty VAO for vertex-shader-generated fullscreen quad
 	GLuint fbo;               //!< Framebuffer for rendering into atlas texture
@@ -1215,19 +1237,31 @@ gl_compositor_create_swapchain(struct xrt_compositor *xc,
 	sc->waited_index = -1;
 	sc->last_released_index = 0;
 
-	// Create GL textures
+	// Create GL textures. Layered (arraySize>1) swapchains allocate a
+	// GL_TEXTURE_2D_ARRAY with `array_size` slices — under single-pass-instanced
+	// the app renders the two eyes into slices 0/1 of one array texture and
+	// submits them as two projection views with imageArrayIndex 0/1. Non-layered
+	// swapchains keep the GL_TEXTURE_2D path unchanged.
 	GLenum internal_format = xrt_format_to_gl_internal(info->format);
+	uint32_t array_size = info->array_size > 0 ? info->array_size : 1;
+	sc->target = array_size > 1 ? GL_TEXTURE_2D_ARRAY : GL_TEXTURE_2D;
 	glGenTextures(image_count, sc->textures);
 
 	for (uint32_t i = 0; i < image_count; i++) {
-		glBindTexture(GL_TEXTURE_2D, sc->textures[i]);
-		glTexImage2D(GL_TEXTURE_2D, 0, internal_format,
-		             info->width, info->height, 0,
-		             GL_RGBA, GL_UNSIGNED_BYTE, NULL);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+		glBindTexture(sc->target, sc->textures[i]);
+		if (sc->target == GL_TEXTURE_2D_ARRAY) {
+			glTexImage3D(GL_TEXTURE_2D_ARRAY, 0, internal_format,
+			             info->width, info->height, array_size, 0,
+			             GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+		} else {
+			glTexImage2D(GL_TEXTURE_2D, 0, internal_format,
+			             info->width, info->height, 0,
+			             GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+		}
+		glTexParameteri(sc->target, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+		glTexParameteri(sc->target, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+		glTexParameteri(sc->target, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+		glTexParameteri(sc->target, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
 		// sRGB passthrough: apps write display-referred bytes into the sRGB
 		// swapchain image (typically with GL_FRAMEBUFFER_SRGB off). When the
@@ -1240,14 +1274,14 @@ gl_compositor_create_swapchain(struct xrt_compositor *xc,
 		// pass through). Only the in-process native GL path samples these
 		// textures, so this never affects app-side rendering.
 		if (internal_format == GL_SRGB8_ALPHA8 && gl_has_srgb_decode_ext()) {
-			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SRGB_DECODE_EXT, GL_SKIP_DECODE_EXT);
+			glTexParameteri(sc->target, GL_TEXTURE_SRGB_DECODE_EXT, GL_SKIP_DECODE_EXT);
 		}
 
 		// Store GL texture name in the swapchain_gl images array
 		// (this is what the state tracker reads via xrt_swapchain_gl)
 		sc->base.images[i] = sc->textures[i];
 	}
-	glBindTexture(GL_TEXTURE_2D, 0);
+	glBindTexture(sc->target, 0);
 
 	// Set up vtable
 	sc->base.base.destroy = gl_swapchain_destroy;
@@ -3022,6 +3056,13 @@ gl_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t
 	GLint loc_flip_atlas = glGetUniformLocation(c->program_blit, "u_flip_y");
 	glUniform1f(loc_flip_atlas, 0.0f);
 
+	// Uniform locations for the LAYERED (array) blit variant, used per-draw when
+	// a swapchain has arraySize>1 (see the per-eye branch below).
+	GLint loc_tex_arr = glGetUniformLocation(c->program_blit_array, "u_texture");
+	GLint loc_rect_arr = glGetUniformLocation(c->program_blit_array, "u_src_rect");
+	GLint loc_layer_arr = glGetUniformLocation(c->program_blit_array, "u_layer");
+	GLint loc_flip_arr = glGetUniformLocation(c->program_blit_array, "u_flip_y");
+
 	for (uint32_t i = 0; i < c->layer_accum.layer_count; i++) {
 		struct comp_layer *layer = &c->layer_accum.layers[i];
 
@@ -3111,10 +3152,26 @@ gl_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t
 				glViewport(tbx, tby, tbw, tbh);
 			}
 
+			// Honor the projection view's array layer (imageArrayIndex).
+			// Layered swapchains sample the requested slice via the
+			// sampler2DArray variant; single-layer swapchains keep the
+			// sampler2D path. Program is selected per-draw (arrays are rare).
+			const bool layered = gsc->target == GL_TEXTURE_2D_ARRAY;
 			glActiveTexture(GL_TEXTURE0);
-			glBindTexture(GL_TEXTURE_2D, gsc->textures[img_idx]);
-			glUniform1i(loc_tex, 0);
-			glUniform4f(loc_rect, nr.x, nr.y, nr.w, nr.h);
+			if (layered) {
+				uint32_t array_index = layer->data.proj.v[eye].sub.array_index;
+				glUseProgram(c->program_blit_array);
+				glUniform1f(loc_flip_arr, 0.0f);
+				glBindTexture(GL_TEXTURE_2D_ARRAY, gsc->textures[img_idx]);
+				glUniform1i(loc_tex_arr, 0);
+				glUniform4f(loc_rect_arr, nr.x, nr.y, nr.w, nr.h);
+				glUniform1f(loc_layer_arr, (float)array_index);
+			} else {
+				glUseProgram(c->program_blit);
+				glBindTexture(GL_TEXTURE_2D, gsc->textures[img_idx]);
+				glUniform1i(loc_tex, 0);
+				glUniform4f(loc_rect, nr.x, nr.y, nr.w, nr.h);
+			}
 
 			// One-shot diagnostic: log blit params for both eyes
 			{
@@ -3654,6 +3711,7 @@ gl_compositor_destroy(struct xrt_compositor *xc)
 	if (c->dp_input_texture) glDeleteTextures(1, &c->dp_input_texture);
 	if (c->dp_crop_fbo) glDeleteFramebuffers(1, &c->dp_crop_fbo);
 	if (c->program_blit) glDeleteProgram(c->program_blit);
+	if (c->program_blit_array) glDeleteProgram(c->program_blit_array);
 	if (c->program_window_space) glDeleteProgram(c->program_window_space);
 	if (c->program_masked_composite) glDeleteProgram(c->program_masked_composite);
 	if (c->vao_empty) glDeleteVertexArrays(1, &c->vao_empty);
@@ -3900,6 +3958,7 @@ gl_init_resources(struct comp_gl_compositor *c, uint32_t width, uint32_t height)
 
 	// Compile shaders
 	c->program_blit = create_program(VS_FULLSCREEN_QUAD, FS_BLIT);
+	c->program_blit_array = create_program(VS_FULLSCREEN_QUAD, FS_BLIT_ARRAY);
 	c->program_window_space = create_program(VS_WINDOW_SPACE, FS_TEXTURED);
 	// #439 Phase 3 — masked 2D-over-3D composite (flatten reuses program_window_space).
 	c->program_masked_composite = create_program(VS_FULLSCREEN_QUAD, FS_MASKED_COMPOSITE);

--- a/src/xrt/compositor/metal/comp_metal_compositor.m
+++ b/src/xrt/compositor/metal/comp_metal_compositor.m
@@ -1185,7 +1185,46 @@ metal_compositor_create_swapchain(struct xrt_compositor *xc,
 	MTLPixelFormat format = xrt_format_to_metal(info->format);
 	uint32_t bpp = metal_format_bytes_per_pixel(format);
 
+	// Layered (arraySize>1) swapchains cannot be backed by a single-plane
+	// IOSurface — a MTLTextureType2DArray needs `array_size` slices and an
+	// IOSurface is a single 2D plane. Under single-pass-instanced the app
+	// renders both eyes into slices 0/1 of one array texture and submits two
+	// projection views with imageArrayIndex 0/1; the compositor samples the
+	// slice (see the compose pass). Cross-API (Vulkan/MoltenVK) import of a
+	// layered swapchain is not a supported path, so array swapchains skip the
+	// IOSurface and allocate a plain array texture — the Metal native app gets
+	// the id<MTLTexture> directly via comp_metal_swapchain_get_texture().
+	const bool layered = info->array_size > 1;
+
 	for (uint32_t i = 0; i < msc->image_count; i++) {
+		MTLTextureDescriptor *desc = [MTLTextureDescriptor
+		    texture2DDescriptorWithPixelFormat:format
+		                                width:info->width
+		                               height:info->height
+		                            mipmapped:(info->mip_count > 1) ? YES : NO];
+		// PixelFormatView lets the compositor sample an sRGB swapchain through a
+		// UNORM view (sRGB passthrough — see the compose pass) without the GPU
+		// auto-decoding sRGB->linear. The app's own render target keeps the sRGB
+		// format, so its encoding (if any) is unchanged.
+		desc.usage = MTLTextureUsageRenderTarget | MTLTextureUsageShaderRead |
+		             MTLTextureUsagePixelFormatView;
+		desc.storageMode = MTLStorageModeShared;
+
+		if (layered) {
+			desc.textureType = MTLTextureType2DArray;
+			desc.arrayLength = info->array_size;
+			msc->iosurfaces[i] = NULL;
+			msc->images[i] = [c->device newTextureWithDescriptor:desc];
+			if (msc->images[i] == nil) {
+				U_LOG_E("Failed to create layered swapchain image %u", i);
+				metal_swapchain_destroy(&msc->base.base);
+				return XRT_ERROR_ALLOCATION;
+			}
+			// No IOSurface native handle for layered swapchains.
+			msc->base.images[i].handle = (xrt_graphics_buffer_handle_t)0;
+			continue;
+		}
+
 		// Create IOSurface backing for cross-API sharing (Vulkan import)
 		NSDictionary *props = @{
 			(id)kIOSurfaceWidth: @(info->width),
@@ -1202,23 +1241,6 @@ metal_compositor_create_swapchain(struct xrt_compositor *xc,
 		msc->iosurfaces[i] = surface;
 
 		// Create MTLTexture from IOSurface (shared storage required)
-		MTLTextureDescriptor *desc = [MTLTextureDescriptor
-		    texture2DDescriptorWithPixelFormat:format
-		                                width:info->width
-		                               height:info->height
-		                            mipmapped:(info->mip_count > 1) ? YES : NO];
-		// PixelFormatView lets the compositor sample an sRGB swapchain through a
-		// UNORM view (sRGB passthrough — see the compose pass) without the GPU
-		// auto-decoding sRGB->linear. The app's own render target keeps the sRGB
-		// format, so its encoding (if any) is unchanged.
-		desc.usage = MTLTextureUsageRenderTarget | MTLTextureUsageShaderRead |
-		             MTLTextureUsagePixelFormatView;
-		desc.storageMode = MTLStorageModeShared;
-		if (info->array_size > 1) {
-			desc.textureType = MTLTextureType2DArray;
-			desc.arrayLength = info->array_size;
-		}
-
 		msc->images[i] = [c->device newTextureWithDescriptor:desc
 		                                           iosurface:surface
 		                                               plane:0];
@@ -2963,13 +2985,29 @@ metal_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 				if (src_tex == nil) {
 					continue;
 				}
-				// sRGB passthrough: sample an app sRGB swapchain through a UNORM
-				// view so the GPU does not auto-decode sRGB->linear; the DP wants
-				// display-referred bytes. No-op for UNORM. Mirrors GL/D3D/VK.
+				// Select the array slice (imageArrayIndex) AND apply sRGB->UNORM
+				// passthrough in one view. Under single-pass-instanced the app
+				// submits an arraySize>1 texture with per-view slice 0/1; a plain
+				// 2D bind samples slice 0 for both eyes (flat output). A 2D view
+				// pinned to the slice binds correctly to the texture2d<float>
+				// shader — the Metal analog of the D3D12 #656 fix (mirrors
+				// D3D11/GL/VK). The sRGB->UNORM sample avoids the GPU
+				// auto-decoding sRGB->linear; the DP wants display-referred bytes
+				// (no-op for UNORM).
 				{
-					MTLPixelFormat unorm_fmt = metal_srgb_to_unorm(src_tex.pixelFormat);
-					if (unorm_fmt != src_tex.pixelFormat) {
-						id<MTLTexture> v = [src_tex newTextureViewWithPixelFormat:unorm_fmt];
+					MTLPixelFormat view_fmt = metal_srgb_to_unorm(src_tex.pixelFormat);
+					if (src_tex.textureType == MTLTextureType2DArray) {
+						uint32_t array_index = layer->data.proj.v[eye].sub.array_index;
+						id<MTLTexture> v = [src_tex
+						    newTextureViewWithPixelFormat:view_fmt
+						                      textureType:MTLTextureType2D
+						                           levels:NSMakeRange(0, src_tex.mipmapLevelCount)
+						                           slices:NSMakeRange(array_index, 1)];
+						if (v != nil) {
+							src_tex = v;
+						}
+					} else if (view_fmt != src_tex.pixelFormat) {
+						id<MTLTexture> v = [src_tex newTextureViewWithPixelFormat:view_fmt];
 						if (v != nil) {
 							src_tex = v;
 						}

--- a/test_apps/cube_zones_d3d11_win/main.cpp
+++ b/test_apps/cube_zones_d3d11_win/main.cpp
@@ -348,6 +348,22 @@ static bool TransparentBackgroundEnabled() {
     return enabled;
 }
 
+// DISPLAYXR_ARRAY_LAYOUT=1 switches each zone from the default horizontally
+// TILED single-slice swapchain (arraySize=1, width=tileW*viewCount, view vi at
+// imageRect x=vi*tileW, imageArrayIndex=0) to the ARRAY / single-pass-instanced
+// layout (arraySize=viewCount, width=tileW, view vi rendered into array slice vi
+// via a TEXTURE2DARRAY RTV, submitted imageArrayIndex=vi, imageRect {0,0}).
+// This exercises the runtime's per-view array-slice sampling (the D3D11 analog
+// of the D3D12 #656 fix) — the same content must weave with disparity in both
+// layouts. Default off (tiled), matching this app's original behavior.
+static bool ArrayLayoutEnabled() {
+    static const bool enabled = []() {
+        const char* v = getenv("DISPLAYXR_ARRAY_LAYOUT");
+        return v != nullptr && *v != '\0' && *v != '0';
+    }();
+    return enabled;
+}
+
 // Create the application window
 static HWND CreateAppWindow(HINSTANCE hInstance, int width, int height) {
     const bool transparent = TransparentBackgroundEnabled();
@@ -550,19 +566,27 @@ static bool CreateZoneResources(XrSessionManager& xr, D3D11Renderer& renderer,
     z.tileCount = viewCount;
     z.format = xr.swapchain.format; // same encoding as the main projection swapchain
 
+    const bool arrayLayout = ArrayLayoutEnabled();
+
     XrSwapchainCreateInfo sci = {XR_TYPE_SWAPCHAIN_CREATE_INFO};
     sci.usageFlags = XR_SWAPCHAIN_USAGE_COLOR_ATTACHMENT_BIT | XR_SWAPCHAIN_USAGE_SAMPLED_BIT;
     sci.format = z.format;
     sci.sampleCount = 1;
-    sci.width = z.tileW * z.tileCount;
+    // ARRAY: one per-view-sized image with `viewCount` slices. TILED: one wide
+    // image holding `viewCount` tiles side by side.
+    sci.width = arrayLayout ? z.tileW : (z.tileW * z.tileCount);
     sci.height = z.tileH;
     sci.faceCount = 1;
-    sci.arraySize = 1;
+    sci.arraySize = arrayLayout ? z.tileCount : 1;
     sci.mipCount = 1;
     if (XR_FAILED(xrCreateSwapchain(xr.session, &sci, &z.swapchain))) {
-        LOG_ERROR("[zones] zone %u: xrCreateSwapchain failed (%ux%u)", z.zoneId, sci.width, sci.height);
+        LOG_ERROR("[zones] zone %u: xrCreateSwapchain failed (%ux%u arraySize=%u)",
+                  z.zoneId, sci.width, sci.height, sci.arraySize);
         return false;
     }
+    LOG_INFO("[zones] zone %u: %s swapchain %ux%u arraySize=%u (tile %ux%u, %u views)",
+             z.zoneId, arrayLayout ? "ARRAY" : "TILED", sci.width, sci.height, sci.arraySize,
+             z.tileW, z.tileH, z.tileCount);
 
     uint32_t n = 0;
     xrEnumerateSwapchainImages(z.swapchain, 0, &n, nullptr);
@@ -573,18 +597,21 @@ static bool CreateZoneResources(XrSessionManager& xr, D3D11Renderer& renderer,
         return false;
     }
 
+    // Depth is per-view-sized in ARRAY layout (each slice rendered full-viewport),
+    // full-width in TILED layout (all tiles share one wide target).
     ID3D11Texture2D* depthTex = nullptr;
     ID3D11DepthStencilView* dsv = nullptr;
-    if (!CreateDepthStencilView(renderer, z.tileW * z.tileCount, z.tileH, &depthTex, &dsv)) {
+    const uint32_t depthW = arrayLayout ? z.tileW : (z.tileW * z.tileCount);
+    if (!CreateDepthStencilView(renderer, depthW, z.tileH, &depthTex, &dsv)) {
         LOG_ERROR("[zones] zone %u: depth buffer creation failed", z.zoneId);
         return false;
     }
     z.depthTex.Attach(depthTex);
     z.depthDSV.Attach(dsv);
 
-    LOG_INFO("[zones] zone %u: rect %d,%d %dx%d -> swapchain %ux%u (%u tiles of %ux%u)",
+    LOG_INFO("[zones] zone %u: rect %d,%d %dx%d -> %s (%u views of %ux%u)",
              z.zoneId, z.rect.offset.x, z.rect.offset.y, z.rect.extent.width, z.rect.extent.height,
-             z.tileW * z.tileCount, z.tileH, z.tileCount, z.tileW, z.tileH);
+             arrayLayout ? "ARRAY layout" : "TILED layout", z.tileCount, z.tileW, z.tileH);
     return true;
 }
 
@@ -1069,14 +1096,17 @@ static void RenderZonesFrame(RenderState& rs, const XrFrameState& frameState) {
         wi.timeout = XR_INFINITE_DURATION;
         xrWaitSwapchainImage(z.swapchain, &wi);
 
-        ID3D11RenderTargetView* rtv = nullptr;
-        CreateRenderTargetView(renderer, z.images[imageIndex].texture,
-                               static_cast<DXGI_FORMAT>(z.format), &rtv);
+        const bool arrayLayout = ArrayLayoutEnabled();
 
-        // Per-zone clear (premultiplied RGBA). Zone A is opaque; zone B's
-        // semi-transparent background demonstrates the alpha-over composite
-        // (the cube geometry itself renders opaque in both).
-        renderer.context->ClearRenderTargetView(rtv, z.clearColor);
+        // TILED: one RTV over the whole wide image (each view drawn at a tile
+        // viewport). ARRAY: one RTV per slice (TEXTURE2DARRAY, FirstArraySlice=vi),
+        // each view drawn full-viewport into its slice. Clear once per RTV.
+        ID3D11RenderTargetView* rtv = nullptr; // TILED shared RTV
+        if (!arrayLayout) {
+            CreateRenderTargetView(renderer, z.images[imageIndex].texture,
+                                   static_cast<DXGI_FORMAT>(z.format), &rtv);
+            renderer.context->ClearRenderTargetView(rtv, z.clearColor);
+        }
         renderer.context->ClearDepthStencilView(z.depthDSV.Get(),
             D3D11_CLEAR_DEPTH | D3D11_CLEAR_STENCIL, 1.0f, 0);
 
@@ -1085,8 +1115,28 @@ static void RenderZonesFrame(RenderState& rs, const XrFrameState& frameState) {
         renderer.cubeRotation += z.spinPhase;
 
         for (uint32_t vi = 0; vi < n; vi++) {
+            // Select the render target + viewport for this view.
+            ID3D11RenderTargetView* viewRtv = rtv; // TILED default
+            ID3D11RenderTargetView* sliceRtv = nullptr;
+            if (arrayLayout) {
+                // Per-slice TEXTURE2DARRAY RTV pinned to slice vi.
+                D3D11_RENDER_TARGET_VIEW_DESC rd = {};
+                rd.Format = static_cast<DXGI_FORMAT>(z.format);
+                rd.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE2DARRAY;
+                rd.Texture2DArray.MipSlice = 0;
+                rd.Texture2DArray.FirstArraySlice = vi;
+                rd.Texture2DArray.ArraySize = 1;
+                if (FAILED(renderer.device->CreateRenderTargetView(
+                        z.images[imageIndex].texture, &rd, &sliceRtv))) {
+                    LOG_ERROR("[zones] zone %u view %u: array RTV creation failed", z.zoneId, vi);
+                    continue;
+                }
+                renderer.context->ClearRenderTargetView(sliceRtv, z.clearColor);
+                viewRtv = sliceRtv;
+            }
+
             D3D11_VIEWPORT vp = {};
-            vp.TopLeftX = (FLOAT)(vi * z.tileW);
+            vp.TopLeftX = arrayLayout ? 0.0f : (FLOAT)(vi * z.tileW);
             vp.TopLeftY = 0.0f;
             vp.Width = (FLOAT)z.tileW;
             vp.Height = (FLOAT)z.tileH;
@@ -1095,15 +1145,18 @@ static void RenderZonesFrame(RenderState& rs, const XrFrameState& frameState) {
 
             const XMMATRIX viewMatrix = ColumnMajorToXMMatrix(rigViews[vi].view_matrix);
             const XMMATRIX projMatrix = ColumnMajorToXMMatrix(rigViews[vi].projection_matrix);
-            RenderScene(renderer, rtv, z.depthDSV.Get(), z.tileW, z.tileH,
+            RenderScene(renderer, viewRtv, z.depthDSV.Get(), z.tileW, z.tileH,
                         viewMatrix, projMatrix, 1.0f, 0.03f);
 
             projViews[zi][vi].subImage.swapchain = z.swapchain;
-            projViews[zi][vi].subImage.imageRect.offset = {(int32_t)(vi * z.tileW), 0};
+            // ARRAY: full image at slice vi. TILED: tile vi within the wide image.
+            projViews[zi][vi].subImage.imageRect.offset = {arrayLayout ? 0 : (int32_t)(vi * z.tileW), 0};
             projViews[zi][vi].subImage.imageRect.extent = {(int32_t)z.tileW, (int32_t)z.tileH};
-            projViews[zi][vi].subImage.imageArrayIndex = 0;
+            projViews[zi][vi].subImage.imageArrayIndex = arrayLayout ? vi : 0;
             projViews[zi][vi].pose = zoneViews[vi].pose;
             projViews[zi][vi].fov = rigViews[vi].fov;
+
+            if (sliceRtv) sliceRtv->Release();
         }
 
         renderer.cubeRotation = savedRotation;
@@ -1122,14 +1175,30 @@ static void RenderZonesFrame(RenderState& rs, const XrFrameState& frameState) {
         // belong to AUTO / Tier-3, whose wish feathers M inward to 0.
         if (g_wishMode != 1) {
             for (uint32_t vi = 0; vi < n; vi++) {
+                ID3D11RenderTargetView* fadeRtv = rtv; // TILED shared RTV
+                ID3D11RenderTargetView* sliceRtv = nullptr;
+                if (arrayLayout) {
+                    D3D11_RENDER_TARGET_VIEW_DESC rd = {};
+                    rd.Format = static_cast<DXGI_FORMAT>(z.format);
+                    rd.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE2DARRAY;
+                    rd.Texture2DArray.MipSlice = 0;
+                    rd.Texture2DArray.FirstArraySlice = vi;
+                    rd.Texture2DArray.ArraySize = 1;
+                    if (FAILED(renderer.device->CreateRenderTargetView(
+                            z.images[imageIndex].texture, &rd, &sliceRtv))) {
+                        continue;
+                    }
+                    fadeRtv = sliceRtv;
+                }
                 D3D11_VIEWPORT vp = {};
-                vp.TopLeftX = (FLOAT)(vi * z.tileW);
+                vp.TopLeftX = arrayLayout ? 0.0f : (FLOAT)(vi * z.tileW);
                 vp.TopLeftY = 0.0f;
                 vp.Width = (FLOAT)z.tileW;
                 vp.Height = (FLOAT)z.tileH;
                 vp.MaxDepth = 1.0f;
                 renderer.context->RSSetViewports(1, &vp);
-                DrawZoneEdgeFade(renderer, rtv, z.tileW, z.tileH);
+                DrawZoneEdgeFade(renderer, fadeRtv, z.tileW, z.tileH);
+                if (sliceRtv) sliceRtv->Release();
             }
         }
 

--- a/test_apps/cube_zones_gl_win/gl_functions.cpp
+++ b/test_apps/cube_zones_gl_win/gl_functions.cpp
@@ -50,6 +50,7 @@ PFNGLUNIFORM1IPROC glUniform1i_ = nullptr;
 PFNGLGENERATEMIPMAPPROC glGenerateMipmap_ = nullptr;
 PFNGLBLENDFUNCSEPARATEPROC glBlendFuncSeparate_ = nullptr;
 PFNGLUNIFORM2FPROC glUniform2f_ = nullptr;
+PFNGLFRAMEBUFFERTEXTURELAYERPROC glFramebufferTextureLayer_ = nullptr;
 
 PFNWGLCREATECONTEXTATTRIBSARBPROC wglCreateContextAttribsARB_ = nullptr;
 
@@ -101,6 +102,7 @@ bool LoadGLFunctions() {
     LOAD_GL(glGenerateMipmap, PFNGLGENERATEMIPMAPPROC);
     LOAD_GL(glBlendFuncSeparate, PFNGLBLENDFUNCSEPARATEPROC);
     LOAD_GL(glUniform2f, PFNGLUNIFORM2FPROC);
+    LOAD_GL(glFramebufferTextureLayer, PFNGLFRAMEBUFFERTEXTURELAYERPROC);
 
     // WGL extensions (optional — may already be loaded for context creation)
     wglCreateContextAttribsARB_ = (PFNWGLCREATECONTEXTATTRIBSARBPROC)wglGetProcAddress("wglCreateContextAttribsARB");

--- a/test_apps/cube_zones_gl_win/gl_functions.h
+++ b/test_apps/cube_zones_gl_win/gl_functions.h
@@ -87,6 +87,7 @@ typedef void (APIENTRY *PFNGLVERTEXATTRIBPOINTERPROC)(GLuint index, GLint size, 
 typedef void (APIENTRY *PFNGLGENFRAMEBUFFERSPROC)(GLsizei n, GLuint* framebuffers);
 typedef void (APIENTRY *PFNGLBINDFRAMEBUFFERPROC)(GLenum target, GLuint framebuffer);
 typedef void (APIENTRY *PFNGLFRAMEBUFFERTEXTURE2DPROC)(GLenum target, GLenum attachment, GLenum textarget, GLuint texture, GLint level);
+typedef void (APIENTRY *PFNGLFRAMEBUFFERTEXTURELAYERPROC)(GLenum target, GLenum attachment, GLuint texture, GLint level, GLint layer);
 typedef GLenum (APIENTRY *PFNGLCHECKFRAMEBUFFERSTATUSPROC)(GLenum target);
 typedef void (APIENTRY *PFNGLDELETEFRAMEBUFFERSPROC)(GLsizei n, const GLuint* framebuffers);
 typedef void (APIENTRY *PFNGLGENRENDERBUFFERSPROC)(GLsizei n, GLuint* renderbuffers);
@@ -148,6 +149,7 @@ extern PFNGLUNIFORM1IPROC glUniform1i_;
 extern PFNGLGENERATEMIPMAPPROC glGenerateMipmap_;
 extern PFNGLBLENDFUNCSEPARATEPROC glBlendFuncSeparate_;
 extern PFNGLUNIFORM2FPROC glUniform2f_;
+extern PFNGLFRAMEBUFFERTEXTURELAYERPROC glFramebufferTextureLayer_;
 
 extern PFNWGLCREATECONTEXTATTRIBSARBPROC wglCreateContextAttribsARB_;
 

--- a/test_apps/cube_zones_gl_win/gl_renderer.cpp
+++ b/test_apps/cube_zones_gl_win/gl_renderer.cpp
@@ -358,14 +358,44 @@ bool CreateSwapchainFBOs(GLRenderer& renderer,
 
 bool CreateZoneFBOs(GLZoneResources& zr,
     const GLuint* images, uint32_t count,
-    uint32_t fullWidth, uint32_t fullHeight)
+    uint32_t fullWidth, uint32_t fullHeight,
+    uint32_t arraySize)
 {
     zr.fullW = fullWidth;
     zr.fullH = fullHeight;
+    zr.arrayLayout = arraySize > 1;
+    zr.arraySize = zr.arrayLayout ? arraySize : 1;
 
+    // Depth is sized to the render extent: the per-view tile (== fullWidth in
+    // ARRAY layout) or the whole wide image (TILED layout).
     glGenRenderbuffers_(1, &zr.depthRBO);
     glBindRenderbuffer_(GL_RENDERBUFFER, zr.depthRBO);
     glRenderbufferStorage_(GL_RENDERBUFFER, GL_DEPTH_COMPONENT24, fullWidth, fullHeight);
+
+    if (zr.arrayLayout) {
+        // One FBO per (image, slice), attaching one array layer as the color
+        // target via glFramebufferTextureLayer (GL_TEXTURE_2D_ARRAY images).
+        zr.fbos.resize((size_t)count * zr.arraySize);
+        glGenFramebuffers_((GLsizei)zr.fbos.size(), zr.fbos.data());
+        for (uint32_t i = 0; i < count; i++) {
+            for (uint32_t s = 0; s < zr.arraySize; s++) {
+                const size_t fi = (size_t)i * zr.arraySize + s;
+                glBindFramebuffer_(GL_FRAMEBUFFER, zr.fbos[fi]);
+                glFramebufferTextureLayer_(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
+                                           images[i], 0, (GLint)s);
+                glFramebufferRenderbuffer_(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
+                                           GL_RENDERBUFFER, zr.depthRBO);
+                if (glCheckFramebufferStatus_(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
+                    LOG_ERROR("[zones] zone ARRAY FBO incomplete for image %u slice %u", i, s);
+                    return false;
+                }
+            }
+        }
+        glBindFramebuffer_(GL_FRAMEBUFFER, 0);
+        LOG_INFO("[zones] created %u ARRAY zone FBOs (%u images x %u slices, %ux%u)",
+                 (unsigned)zr.fbos.size(), count, zr.arraySize, fullWidth, fullHeight);
+        return true;
+    }
 
     zr.fbos.resize(count);
     glGenFramebuffers_(count, zr.fbos.data());
@@ -533,11 +563,15 @@ void RenderZoneTile(
     const float* clearColor,
     float cubeY,
     float cubeZ,
-    float cubeSize
+    float cubeSize,
+    uint32_t slice
 ) {
-    glBindFramebuffer_(GL_FRAMEBUFFER, zr.fbos[imageIndex]);
+    // ARRAY: per-(image,slice) FBO, view drawn full-viewport into slice.
+    // TILED: per-image FBO, view drawn at its tile-column viewport.
+    const size_t fboIdx = zr.arrayLayout ? ((size_t)imageIndex * zr.arraySize + slice) : imageIndex;
+    glBindFramebuffer_(GL_FRAMEBUFFER, zr.fbos[fboIdx]);
 
-    const uint32_t vpX = tileX * tileW;
+    const uint32_t vpX = zr.arrayLayout ? 0 : (tileX * tileW);
     glViewport(vpX, 0, tileW, tileH);
     glScissor(vpX, 0, tileW, tileH);
     glEnable(GL_SCISSOR_TEST);
@@ -589,13 +623,15 @@ void DrawZoneEdgeFade(
     uint32_t imageIndex,
     uint32_t tileX,
     uint32_t tileW, uint32_t tileH,
-    float featherPx
+    float featherPx,
+    uint32_t slice
 ) {
     if (featherPx <= 0.0f) return;          // DXR_ZONES_FADE_PX=0 disables
     if (!EnsureEdgeFadePass(renderer)) return;
 
-    glBindFramebuffer_(GL_FRAMEBUFFER, zr.fbos[imageIndex]);
-    const uint32_t vpX = tileX * tileW;
+    const size_t fboIdx = zr.arrayLayout ? ((size_t)imageIndex * zr.arraySize + slice) : imageIndex;
+    glBindFramebuffer_(GL_FRAMEBUFFER, zr.fbos[fboIdx]);
+    const uint32_t vpX = zr.arrayLayout ? 0 : (tileX * tileW);
     glViewport(vpX, 0, tileW, tileH);
     glScissor(vpX, 0, tileW, tileH);
     glEnable(GL_SCISSOR_TEST);

--- a/test_apps/cube_zones_gl_win/gl_renderer.h
+++ b/test_apps/cube_zones_gl_win/gl_renderer.h
@@ -58,10 +58,16 @@ struct GLRenderer {
 // the per-zone ID3D11DepthStencilView + per-image RTV the D3D11 app builds.
 // ---------------------------------------------------------------------------
 struct GLZoneResources {
-    std::vector<GLuint> fbos;   // one per swapchain image
+    // TILED: one FBO per swapchain image (whole wide GL_TEXTURE_2D image).
+    // ARRAY: one FBO per (image, slice) — index [image*arraySize + slice] —
+    // each attaching one layer of the GL_TEXTURE_2D_ARRAY via
+    // glFramebufferTextureLayer.
+    std::vector<GLuint> fbos;
     GLuint depthRBO = 0;
-    uint32_t fullW = 0;         // tileW * tileCount
+    uint32_t fullW = 0;         // TILED: tileW*tileCount; ARRAY: tileW (per-view)
     uint32_t fullH = 0;
+    bool arrayLayout = false;
+    uint32_t arraySize = 1;     // number of array slices (ARRAY layout)
 };
 
 // Initialize OpenGL renderer (create shaders, geometry)
@@ -72,10 +78,15 @@ bool CreateSwapchainFBOs(GLRenderer& renderer,
     const GLuint* images, uint32_t count,
     uint32_t width, uint32_t height);
 
-// Create per-zone FBOs + depth for a horizontally tiled zone swapchain.
+// Create per-zone FBOs + depth for a zone swapchain. TILED (arraySize<=1):
+// one FBO per image over a horizontally tiled GL_TEXTURE_2D (fullWidth =
+// tileW*tileCount). ARRAY (arraySize>1): fullWidth = tileW (per-view), one FBO
+// per (image, slice) attaching the GL_TEXTURE_2D_ARRAY layer via
+// glFramebufferTextureLayer.
 bool CreateZoneFBOs(GLZoneResources& zr,
     const GLuint* images, uint32_t count,
-    uint32_t fullWidth, uint32_t fullHeight);
+    uint32_t fullWidth, uint32_t fullHeight,
+    uint32_t arraySize = 1);
 
 void DestroyZoneFBOs(GLZoneResources& zr);
 
@@ -106,6 +117,8 @@ void RenderScene(
 //
 // clearColor: pointer to 4 premultiplied RGBA floats, or nullptr to skip the
 //             color clear for this tile (depth still clears).
+// slice: array layer to render into (ARRAY layout). Ignored (tile placed by
+// tileX) in TILED layout.
 void RenderZoneTile(
     GLRenderer& renderer,
     GLZoneResources& zr,
@@ -117,7 +130,8 @@ void RenderZoneTile(
     const float* clearColor,        // nullptr = skip color clear (depth still cleared)
     float cubeY = 0.03f,
     float cubeZ = 0.0f,
-    float cubeSize = 0.06f
+    float cubeSize = 0.06f,
+    uint32_t slice = 0
 );
 
 // Content-alpha edge fade (ADR-027 rule 4): multiply the current tile's dst
@@ -131,7 +145,8 @@ void DrawZoneEdgeFade(
     uint32_t imageIndex,
     uint32_t tileX,
     uint32_t tileW, uint32_t tileH,
-    float featherPx
+    float featherPx,
+    uint32_t slice = 0
 );
 
 // Cleanup

--- a/test_apps/cube_zones_gl_win/main.cpp
+++ b/test_apps/cube_zones_gl_win/main.cpp
@@ -85,6 +85,20 @@ static bool TransparentBackgroundEnabled() {
     return e;
 }
 
+// DISPLAYXR_ARRAY_LAYOUT=1 switches each zone from the default horizontally
+// TILED single-slice swapchain to the ARRAY / single-pass-instanced layout
+// (arraySize=viewCount, per-view size, each view rendered into array slice vi
+// via glFramebufferTextureLayer, submitted imageArrayIndex=vi). Exercises the
+// GL compositor's per-view array-slice sampling — the same content must weave
+// with disparity in both layouts. Default off (tiled).
+static bool ArrayLayoutEnabled() {
+    static const bool e = []() {
+        const char *v = getenv("DISPLAYXR_ARRAY_LAYOUT");
+        return v != nullptr && *v != '\0' && *v != '0';
+    }();
+    return e;
+}
+
 // ---------------------------------------------------------------------------
 // XR_EXT_display_zones state
 // ---------------------------------------------------------------------------
@@ -588,17 +602,21 @@ static bool CreateZoneResources(XrSessionManager& xr, GLRenderer& renderer,
     z.tileCount = viewCount;
     z.format = xr.swapchain.format; // same encoding as the main projection swapchain
 
+    const bool arrayLayout = ArrayLayoutEnabled();
+
     XrSwapchainCreateInfo sci = {XR_TYPE_SWAPCHAIN_CREATE_INFO};
     sci.usageFlags = XR_SWAPCHAIN_USAGE_COLOR_ATTACHMENT_BIT | XR_SWAPCHAIN_USAGE_SAMPLED_BIT;
     sci.format = z.format;
     sci.sampleCount = 1;
-    sci.width = z.tileW * z.tileCount;
+    // ARRAY: one per-view image with `viewCount` slices. TILED: one wide image.
+    sci.width = arrayLayout ? z.tileW : (z.tileW * z.tileCount);
     sci.height = z.tileH;
     sci.faceCount = 1;
-    sci.arraySize = 1;
+    sci.arraySize = arrayLayout ? z.tileCount : 1;
     sci.mipCount = 1;
     if (XR_FAILED(xrCreateSwapchain(xr.session, &sci, &z.swapchain))) {
-        LOG_ERROR("[zones] zone %u: xrCreateSwapchain failed (%ux%u)", z.zoneId, sci.width, sci.height);
+        LOG_ERROR("[zones] zone %u: xrCreateSwapchain failed (%ux%u arraySize=%u)",
+                  z.zoneId, sci.width, sci.height, sci.arraySize);
         return false;
     }
 
@@ -613,14 +631,18 @@ static bool CreateZoneResources(XrSessionManager& xr, GLRenderer& renderer,
 
     std::vector<GLuint> texIds(n);
     for (uint32_t i = 0; i < n; i++) texIds[i] = z.images[i].image;
-    if (!CreateZoneFBOs(z.gl, texIds.data(), n, z.tileW * z.tileCount, z.tileH)) {
+    // ARRAY: per-view-sized FBOs (fullW = tileW, arraySize slices). TILED: wide.
+    const uint32_t fboFullW = arrayLayout ? z.tileW : (z.tileW * z.tileCount);
+    if (!CreateZoneFBOs(z.gl, texIds.data(), n, fboFullW, z.tileH,
+                        arrayLayout ? z.tileCount : 1)) {
         LOG_ERROR("[zones] zone %u: FBO creation failed", z.zoneId);
         return false;
     }
 
-    LOG_INFO("[zones] zone %u: rect %d,%d %dx%d -> swapchain %ux%u (%u tiles of %ux%u)",
+    LOG_INFO("[zones] zone %u: rect %d,%d %dx%d -> %s swapchain %ux%u arraySize=%u (%u views of %ux%u)",
              z.zoneId, z.rect.offset.x, z.rect.offset.y, z.rect.extent.width, z.rect.extent.height,
-             z.tileW * z.tileCount, z.tileH, z.tileCount, z.tileW, z.tileH);
+             arrayLayout ? "ARRAY" : "TILED", sci.width, sci.height, sci.arraySize,
+             z.tileCount, z.tileW, z.tileH);
     return true;
 }
 
@@ -880,6 +902,7 @@ static void RenderZonesFrame(XrSessionManager& xr, GLRenderer& renderer,
         const float savedRotation = renderer.cubeRotation;
         renderer.cubeRotation += z.spinPhase;
 
+        const bool arrayLayout = z.gl.arrayLayout;
         for (uint32_t vi = 0; vi < n; vi++) {
             const XMMATRIX viewMatrix = ColumnMajorToXMMatrix(rigViews[vi].view_matrix);
             const XMMATRIX projMatrix = ColumnMajorToXMMatrix(rigViews[vi].projection_matrix);
@@ -888,15 +911,18 @@ static void RenderZonesFrame(XrSessionManager& xr, GLRenderer& renderer,
             // fully transparent. HARD GOTCHA (#613): depth clears every tile
             // UNCONDITIONALLY inside RenderZoneTile (color clear is the passed
             // clearColor) — the cube would otherwise z-fail into a dark shadow.
+            // ARRAY layout renders view vi into array slice vi (tileX ignored).
             RenderZoneTile(renderer, z.gl, imageIndex,
                            /*tileX*/ vi, z.tileW, z.tileH,
                            viewMatrix, projMatrix,
-                           z.clearColor, /*cubeY*/ 0.03f);
+                           z.clearColor, /*cubeY*/ 0.03f, /*cubeZ*/ 0.0f,
+                           /*cubeSize*/ 0.06f, /*slice*/ vi);
 
             projViews[zi][vi].subImage.swapchain = z.swapchain;
-            projViews[zi][vi].subImage.imageRect.offset = {(int32_t)(vi * z.tileW), 0};
+            // ARRAY: full image at slice vi. TILED: tile vi in the wide image.
+            projViews[zi][vi].subImage.imageRect.offset = {arrayLayout ? 0 : (int32_t)(vi * z.tileW), 0};
             projViews[zi][vi].subImage.imageRect.extent = {(int32_t)z.tileW, (int32_t)z.tileH};
-            projViews[zi][vi].subImage.imageArrayIndex = 0;
+            projViews[zi][vi].subImage.imageArrayIndex = arrayLayout ? vi : 0;
             projViews[zi][vi].pose = zoneViews[vi].pose;
             projViews[zi][vi].fov = rigViews[vi].fov;
         }
@@ -909,7 +935,8 @@ static void RenderZonesFrame(XrSessionManager& xr, GLRenderer& renderer,
         if (g_wishMode != 1) {
             for (uint32_t vi = 0; vi < n; vi++) {
                 DrawZoneEdgeFade(renderer, z.gl, imageIndex,
-                                 /*tileX*/ vi, z.tileW, z.tileH, ZoneEdgeFadePx());
+                                 /*tileX*/ vi, z.tileW, z.tileH, ZoneEdgeFadePx(),
+                                 /*slice*/ vi);
             }
         }
 


### PR DESCRIPTION
Implements the assessment in #681: make array (layered) swapchains first-class on the three backends that ignored `imageArrayIndex`, generalizing the D3D12 #656 fix. Single-pass-instanced engine content (Unity SPI, Unreal ISR) and PC-VR-shaped apps submit one `arraySize=N` swapchain with per-view `imageArrayIndex` 0/1; D3D11/GL/Metal sampled slice 0 for every view → flat output (a conformance bug independent of any engine integration). VK and D3D12 already worked.

## What changed

Each fix is **one per-view atlas-blit sampling site**, gated on `arraySize>1` so the single-layer path is byte-identical:

- **D3D11** — `Texture2DArray` PS variant selecting the slice via a `LayerConstants` field + `comp_d3d11_swapchain_get_array_size` accessor. The whole-array SRV already existed.
- **GL** — allocate `GL_TEXTURE_2D_ARRAY` (`glTexImage3D`) when `arraySize>1`; `sampler2DArray` blit program selecting the layer per draw. (GL previously didn't even *allocate* the layers.)
- **Metal** — sample the slice via a per-slice 2D texture view (no shader change). Array swapchains allocate a plain `MTLTextureType2DArray` (no IOSurface — a single-plane IOSurface can't back a multi-slice array; the native app gets the `id<MTLTexture>` directly, and cross-API Vulkan import of a layered swapchain isn't a path). **Code-only** — macOS not built/run in this change; needs an on-device pass.

The **display-processor contract is unchanged**: `process_atlas` always receives a flat tiled atlas; array resolution is entirely upstream. Layered submissions never satisfy `u_tiling_can_zero_copy` (slices ≠ tiles), so they always take the crop/blit path.

## Testing

`DISPLAYXR_ARRAY_LAYOUT=1` toggle added to `cube_zones_d3d11_win` and `cube_zones_gl_win` (per-slice RTV / `glFramebufferTextureLayer` FBOs; default off = tiled).

Hardware-validated on Leia SR:
- **D3D11 array / tiled** and **GL array / tiled** all create the expected swapchains and weave to 3D with **no errors**.
- GL FBO-completeness with `glFramebufferTextureLayer` proves the runtime allocates real `GL_TEXTURE_2D_ARRAY` textures.
- Tiled (default) paths are **regression-clean** on both backends.
- Final per-slice disparity is best confirmed by eye on the panel (visual correctness); the array structure is already HW-validated on D3D12/VK.

## Docs

`docs/specs/runtime/swapchain-model.md` documents the tiled-vs-layered addressing contract.

Refs #681. Unblocks the portability half of DisplayXR/displayxr-unity#166 beyond D3D12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)