### PR TITLE
test(#681): array-layout toggle on cube_handle demos + per-slice depth fix

### DIFF
--- a/test_apps/common/CMakeLists.txt
+++ b/test_apps/common/CMakeLists.txt
@@ -30,7 +30,7 @@ set(DISPLAYXR_EXTENSIONS_INCLUDE_DIR "${_dxr_ext_includes}" CACHE PATH
 FetchContent_Declare(
     displayxr_common
     GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
-    GIT_TAG v1.1.2
+    GIT_TAG v1.2.0
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(displayxr_common)

--- a/test_apps/cube_handle_d3d11_win/main.cpp
+++ b/test_apps/cube_handle_d3d11_win/main.cpp
@@ -313,6 +313,22 @@ static bool TransparentBackgroundEnabled() {
     return e;
 }
 
+// DISPLAYXR_ARRAY_LAYOUT=1 submits the projection as a LAYERED / single-pass-
+// instanced swapchain (arraySize=2: each view in array slice imageArrayIndex)
+// instead of the default TILED atlas (views packed side-by-side by imageRect).
+// This exercises the runtime's per-view array-slice sampling — the same content
+// must weave with disparity either way. It only drives view_count<=2 modes (the
+// array has 2 slices), so mode 1/2 (SBS/2D) work; a >2-view mode is capped to 2.
+// Default off (tiled). Mirrors the cube_zones_*_win DISPLAYXR_ARRAY_LAYOUT toggle.
+static bool ArrayLayoutEnabled() {
+    static const bool e = []() {
+        const char *v = getenv("DISPLAYXR_ARRAY_LAYOUT");
+        return v != nullptr && *v != '\0' && *v != '0';
+    }();
+    return e;
+}
+static const uint32_t kArraySlices = 2; // stereo
+
 // Create the application window
 static HWND CreateAppWindow(HINSTANCE hInstance, int width, int height) {
     const bool transparent = TransparentBackgroundEnabled();
@@ -674,6 +690,12 @@ static void RenderOneFrame(RenderState& rs) {
                     xr.recommendedViewScaleY = xr.renderingModeScaleY[xr.currentModeIndex];
                 }
                 int eyeCount = monoMode ? 1 : (int)modeViewCount;
+                // Layered swapchains hold arraySize slices, so array mode can
+                // only submit that many views — cap to it (a >2-view mode is
+                // driven as its first 2 views).
+                if (ArrayLayoutEnabled() && eyeCount > (int)xr.swapchain.arraySize) {
+                    eyeCount = (int)xr.swapchain.arraySize;
+                }
                 std::vector<XrCompositionLayerProjectionView> projectionViews(eyeCount, {XR_TYPE_COMPOSITION_LAYER_PROJECTION_VIEW});
             bool hudSubmitted = false;
 
@@ -961,11 +983,6 @@ static void RenderOneFrame(RenderState& rs) {
                     if (AcquireSwapchainImage(xr, imageIndex)) {
                         ID3D11Texture2D* swapchainTexture = (*rs.swapchainImages)[imageIndex].texture;
 
-                        ID3D11RenderTargetView* rtv = nullptr;
-                        CreateRenderTargetView(renderer, swapchainTexture,
-                            static_cast<DXGI_FORMAT>(xr.swapchain.format), &rtv);
-
-                        // Clear entire color+depth once before eye loop.
                         // Transparent mode (DISPLAYXR_TRANSPARENT_BG=1): clear to
                         // RGBA(0,0,0,0) so the Leia DP's compose-under-bg pass
                         // shows the desktop wherever the cube didn't draw.
@@ -977,7 +994,17 @@ static void RenderOneFrame(RenderState& rs) {
                             clearColor[0] = 0.05f; clearColor[1] = 0.05f;
                             clearColor[2] = 0.25f; clearColor[3] = 1.0f;
                         }
-                        renderer.context->ClearRenderTargetView(rtv, clearColor);
+
+                        // TILED: one shared RTV over the whole atlas image, cleared
+                        // once (each view is drawn at its tile viewport). ARRAY: a
+                        // per-slice RTV is created + cleared inside the eye loop.
+                        const bool arrayLayout = ArrayLayoutEnabled();
+                        ID3D11RenderTargetView* rtv = nullptr;
+                        if (!arrayLayout) {
+                            CreateRenderTargetView(renderer, swapchainTexture,
+                                static_cast<DXGI_FORMAT>(xr.swapchain.format), &rtv);
+                            renderer.context->ClearRenderTargetView(rtv, clearColor);
+                        }
                         renderer.context->ClearDepthStencilView(rs.depthDSV.Get(),
                             D3D11_CLEAR_DEPTH | D3D11_CLEAR_STENCIL, 1.0f, 0);
 
@@ -996,16 +1023,51 @@ static void RenderOneFrame(RenderState& rs) {
                         } else {
                             renderW = (uint32_t)(g_windowWidth * xr.recommendedViewScaleX);
                             renderH = (uint32_t)(g_windowHeight * xr.recommendedViewScaleY);
-                            if (renderW > maxTileW) renderW = maxTileW;
-                            if (renderH > maxTileH) renderH = maxTileH;
+                            // ARRAY: each slice is a full per-view image, so the
+                            // cap is the whole swapchain image, not a sub-tile.
+                            uint32_t capW = arrayLayout ? xr.swapchain.width : maxTileW;
+                            uint32_t capH = arrayLayout ? xr.swapchain.height : maxTileH;
+                            if (renderW > capW) renderW = capW;
+                            if (renderH > capH) renderH = capH;
                         }
 
                         for (int eye = 0; eye < eyeCount; eye++) {
                             uint32_t tileX = monoMode ? 0 : (eye % tileColumns);
                             uint32_t tileY = monoMode ? 0 : (eye / tileColumns);
+
+                            // ARRAY: render into array slice `eye` via a per-slice
+                            // TEXTURE2DARRAY RTV at a full (0,0) viewport. TILED:
+                            // draw into this view's tile of the shared RTV.
+                            ID3D11RenderTargetView* viewRtv = rtv;
+                            ID3D11RenderTargetView* sliceRtv = nullptr;
+                            if (arrayLayout) {
+                                D3D11_RENDER_TARGET_VIEW_DESC rd = {};
+                                rd.Format = static_cast<DXGI_FORMAT>(xr.swapchain.format);
+                                rd.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE2DARRAY;
+                                rd.Texture2DArray.MipSlice = 0;
+                                rd.Texture2DArray.FirstArraySlice = (UINT)eye;
+                                rd.Texture2DArray.ArraySize = 1;
+                                if (FAILED(renderer.device->CreateRenderTargetView(
+                                        swapchainTexture, &rd, &sliceRtv))) {
+                                    LOG_ERROR("array RTV creation failed for slice %d", eye);
+                                    continue;
+                                }
+                                renderer.context->ClearRenderTargetView(sliceRtv, clearColor);
+                                // Each slice is rendered full-viewport into the SAME
+                                // shared depth buffer, so depth MUST be cleared per
+                                // slice — otherwise slice 1 z-tests against slice 0's
+                                // depth and the other eye's cube punches a shadow
+                                // through (the #613 gotcha). TILED views don't need
+                                // this: their tile viewports occupy disjoint depth
+                                // regions, cleared once before the loop.
+                                renderer.context->ClearDepthStencilView(rs.depthDSV.Get(),
+                                    D3D11_CLEAR_DEPTH | D3D11_CLEAR_STENCIL, 1.0f, 0);
+                                viewRtv = sliceRtv;
+                            }
+
                             D3D11_VIEWPORT vp = {};
-                            vp.TopLeftX = (FLOAT)(tileX * renderW);
-                            vp.TopLeftY = (FLOAT)(tileY * renderH);
+                            vp.TopLeftX = arrayLayout ? 0.0f : (FLOAT)(tileX * renderW);
+                            vp.TopLeftY = arrayLayout ? 0.0f : (FLOAT)(tileY * renderH);
                             vp.Width = (FLOAT)renderW;
                             vp.Height = (FLOAT)renderH;
                             vp.MaxDepth = 1.0f;
@@ -1025,7 +1087,7 @@ static void RenderOneFrame(RenderState& rs) {
                                 projMatrix = xr.projMatrices[vi];
                             }
 
-                            RenderScene(renderer, rtv, rs.depthDSV.Get(),
+                            RenderScene(renderer, viewRtv, rs.depthDSV.Get(),
                                 renderW, renderH,
                                 viewMatrix, projMatrix,
                                 useAppProjection ? 1.0f : g_inputState.viewParams.scaleFactor,
@@ -1033,20 +1095,24 @@ static void RenderOneFrame(RenderState& rs) {
 
                             projectionViews[eye].type = XR_TYPE_COMPOSITION_LAYER_PROJECTION_VIEW;
                             projectionViews[eye].subImage.swapchain = xr.swapchain.swapchain;
+                            // ARRAY: full image at slice `eye`. TILED: this view's tile.
                             projectionViews[eye].subImage.imageRect.offset = {
-                                (int32_t)(tileX * renderW), (int32_t)(tileY * renderH)
+                                arrayLayout ? 0 : (int32_t)(tileX * renderW),
+                                arrayLayout ? 0 : (int32_t)(tileY * renderH)
                             };
                             projectionViews[eye].subImage.imageRect.extent = {
                                 (int32_t)renderW,
                                 (int32_t)renderH
                             };
-                            projectionViews[eye].subImage.imageArrayIndex = 0;
+                            projectionViews[eye].subImage.imageArrayIndex = arrayLayout ? (uint32_t)eye : 0;
 
                             int safeIdx = (eye < (int)viewCount) ? eye : 0;
                             projectionViews[eye].pose = monoMode ? monoPose : rawViews[safeIdx].pose;
                             projectionViews[eye].fov = useAppProjection ?
                                 stereoViews[monoMode ? 0 : eye].fov :
                                 (monoMode ? monoFov : rawViews[safeIdx].fov);
+
+                            if (sliceRtv) sliceRtv->Release();
                         }
 
                         if (rtv) rtv->Release();
@@ -1343,8 +1409,9 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         return 1;
     }
 
-    // Create single swapchain at native display resolution
-    if (!CreateSwapchain(xr)) {
+    // Create the projection swapchain — tiled by default, or a layered/array
+    // swapchain (arraySize=2) when DISPLAYXR_ARRAY_LAYOUT=1.
+    if (!CreateSwapchain(xr, ArrayLayoutEnabled() ? kArraySlices : 1)) {
         LOG_ERROR("Swapchain creation failed");
         CleanupOpenXR(xr);
         if (hudOk) CleanupHudRenderer(hudRenderer);

--- a/test_apps/cube_handle_gl_win/gl_functions.cpp
+++ b/test_apps/cube_handle_gl_win/gl_functions.cpp
@@ -37,6 +37,7 @@ PFNGLVERTEXATTRIBPOINTERPROC glVertexAttribPointer_ = nullptr;
 PFNGLGENFRAMEBUFFERSPROC glGenFramebuffers_ = nullptr;
 PFNGLBINDFRAMEBUFFERPROC glBindFramebuffer_ = nullptr;
 PFNGLFRAMEBUFFERTEXTURE2DPROC glFramebufferTexture2D_ = nullptr;
+PFNGLFRAMEBUFFERTEXTURELAYERPROC glFramebufferTextureLayer_ = nullptr;
 PFNGLCHECKFRAMEBUFFERSTATUSPROC glCheckFramebufferStatus_ = nullptr;
 PFNGLDELETEFRAMEBUFFERSPROC glDeleteFramebuffers_ = nullptr;
 PFNGLGENRENDERBUFFERSPROC glGenRenderbuffers_ = nullptr;
@@ -86,6 +87,7 @@ bool LoadGLFunctions() {
     LOAD_GL(glGenFramebuffers, PFNGLGENFRAMEBUFFERSPROC);
     LOAD_GL(glBindFramebuffer, PFNGLBINDFRAMEBUFFERPROC);
     LOAD_GL(glFramebufferTexture2D, PFNGLFRAMEBUFFERTEXTURE2DPROC);
+    LOAD_GL(glFramebufferTextureLayer, PFNGLFRAMEBUFFERTEXTURELAYERPROC);
     LOAD_GL(glCheckFramebufferStatus, PFNGLCHECKFRAMEBUFFERSTATUSPROC);
     LOAD_GL(glDeleteFramebuffers, PFNGLDELETEFRAMEBUFFERSPROC);
     LOAD_GL(glGenRenderbuffers, PFNGLGENRENDERBUFFERSPROC);

--- a/test_apps/cube_handle_gl_win/gl_functions.h
+++ b/test_apps/cube_handle_gl_win/gl_functions.h
@@ -87,6 +87,7 @@ typedef void (APIENTRY *PFNGLVERTEXATTRIBPOINTERPROC)(GLuint index, GLint size, 
 typedef void (APIENTRY *PFNGLGENFRAMEBUFFERSPROC)(GLsizei n, GLuint* framebuffers);
 typedef void (APIENTRY *PFNGLBINDFRAMEBUFFERPROC)(GLenum target, GLuint framebuffer);
 typedef void (APIENTRY *PFNGLFRAMEBUFFERTEXTURE2DPROC)(GLenum target, GLenum attachment, GLenum textarget, GLuint texture, GLint level);
+typedef void (APIENTRY *PFNGLFRAMEBUFFERTEXTURELAYERPROC)(GLenum target, GLenum attachment, GLuint texture, GLint level, GLint layer);
 typedef GLenum (APIENTRY *PFNGLCHECKFRAMEBUFFERSTATUSPROC)(GLenum target);
 typedef void (APIENTRY *PFNGLDELETEFRAMEBUFFERSPROC)(GLsizei n, const GLuint* framebuffers);
 typedef void (APIENTRY *PFNGLGENRENDERBUFFERSPROC)(GLsizei n, GLuint* renderbuffers);
@@ -131,6 +132,7 @@ extern PFNGLVERTEXATTRIBPOINTERPROC glVertexAttribPointer_;
 extern PFNGLGENFRAMEBUFFERSPROC glGenFramebuffers_;
 extern PFNGLBINDFRAMEBUFFERPROC glBindFramebuffer_;
 extern PFNGLFRAMEBUFFERTEXTURE2DPROC glFramebufferTexture2D_;
+extern PFNGLFRAMEBUFFERTEXTURELAYERPROC glFramebufferTextureLayer_;
 extern PFNGLCHECKFRAMEBUFFERSTATUSPROC glCheckFramebufferStatus_;
 extern PFNGLDELETEFRAMEBUFFERSPROC glDeleteFramebuffers_;
 extern PFNGLGENRENDERBUFFERSPROC glGenRenderbuffers_;

--- a/test_apps/cube_handle_gl_win/gl_renderer.cpp
+++ b/test_apps/cube_handle_gl_win/gl_renderer.cpp
@@ -291,12 +291,41 @@ bool InitializeGLRenderer(GLRenderer& renderer) {
 
 bool CreateSwapchainFBOs(GLRenderer& renderer,
     const GLuint* images, uint32_t count,
-    uint32_t width, uint32_t height)
+    uint32_t width, uint32_t height,
+    uint32_t arraySize)
 {
-    // Create depth renderbuffer (single SBS swapchain)
+    renderer.arrayLayout = arraySize > 1;
+    renderer.arraySize = renderer.arrayLayout ? arraySize : 1;
+
+    // Depth renderbuffer sized to the render extent (per-view in ARRAY, whole
+    // atlas in TILED — both equal to the passed width/height).
     glGenRenderbuffers_(1, &renderer.depthRBO);
     glBindRenderbuffer_(GL_RENDERBUFFER, renderer.depthRBO);
     glRenderbufferStorage_(GL_RENDERBUFFER, GL_DEPTH_COMPONENT24, width, height);
+
+    if (renderer.arrayLayout) {
+        // One FBO per (image, slice), attaching one GL_TEXTURE_2D_ARRAY layer.
+        renderer.fbos.resize((size_t)count * renderer.arraySize);
+        glGenFramebuffers_((GLsizei)renderer.fbos.size(), renderer.fbos.data());
+        for (uint32_t i = 0; i < count; i++) {
+            for (uint32_t s = 0; s < renderer.arraySize; s++) {
+                const size_t fi = (size_t)i * renderer.arraySize + s;
+                glBindFramebuffer_(GL_FRAMEBUFFER, renderer.fbos[fi]);
+                glFramebufferTextureLayer_(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
+                                           images[i], 0, (GLint)s);
+                glFramebufferRenderbuffer_(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
+                                           GL_RENDERBUFFER, renderer.depthRBO);
+                if (glCheckFramebufferStatus_(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
+                    LOG_ERROR("ARRAY FBO incomplete for image %u slice %u", i, s);
+                    return false;
+                }
+            }
+        }
+        glBindFramebuffer_(GL_FRAMEBUFFER, 0);
+        LOG_INFO("Created %u ARRAY FBOs (%u images x %u slices, %ux%u)",
+                 (unsigned)renderer.fbos.size(), count, renderer.arraySize, width, height);
+        return true;
+    }
 
     // Create one FBO per swapchain image
     renderer.fbos.resize(count);
@@ -348,9 +377,13 @@ void RenderScene(
     float zoomScale,
     float cubeY,
     float cubeZ,
-    float cubeSize
+    float cubeSize,
+    uint32_t slice
 ) {
-    glBindFramebuffer_(GL_FRAMEBUFFER, renderer.fbos[imageIndex]);
+    const size_t fboIdx = renderer.arrayLayout
+        ? ((size_t)imageIndex * renderer.arraySize + slice)
+        : imageIndex;
+    glBindFramebuffer_(GL_FRAMEBUFFER, renderer.fbos[fboIdx]);
 
     // TODO: If the swapchain format is GL_SRGB8_ALPHA8, we may need
     // glEnable(GL_FRAMEBUFFER_SRGB) here for correct linear-to-sRGB conversion.

--- a/test_apps/cube_handle_gl_win/gl_renderer.h
+++ b/test_apps/cube_handle_gl_win/gl_renderer.h
@@ -30,10 +30,14 @@ struct GLRenderer {
     GLuint textures[3] = {0, 0, 0};
     bool texturesLoaded = false;
 
-    // Single set of FBOs and depth renderbuffer (SBS swapchain)
-    // Indexed as: fbos[imageIndex]
+    // FBOs + depth renderbuffer for the projection swapchain.
+    // TILED: one FBO per image (fbos[imageIndex]).
+    // ARRAY: one FBO per (image, slice) — fbos[imageIndex*arraySize + slice] —
+    // each attaching one GL_TEXTURE_2D_ARRAY layer via glFramebufferTextureLayer.
     std::vector<GLuint> fbos;
     GLuint depthRBO = 0;
+    bool arrayLayout = false;
+    uint32_t arraySize = 1;
 
     // Scene state
     float cubeRotation = 0.0f;
@@ -42,16 +46,21 @@ struct GLRenderer {
 // Initialize OpenGL renderer (create shaders, geometry)
 bool InitializeGLRenderer(GLRenderer& renderer);
 
-// Create FBOs for swapchain images (single SBS swapchain)
+// Create FBOs for the projection swapchain. TILED (arraySize<=1): one FBO per
+// image over a GL_TEXTURE_2D. ARRAY (arraySize>1): one FBO per (image, slice)
+// attaching a GL_TEXTURE_2D_ARRAY layer via glFramebufferTextureLayer; `width`
+// is the per-view width (one slice), not the atlas width.
 bool CreateSwapchainFBOs(GLRenderer& renderer,
     const GLuint* images, uint32_t count,
-    uint32_t width, uint32_t height);
+    uint32_t width, uint32_t height,
+    uint32_t arraySize = 1);
 
 // Update scene. spinSpeed (rad/s) is agent-settable via the set_spin
 // MCP tool (#457).
 void UpdateScene(GLRenderer& renderer, float deltaTime, float spinSpeed = 0.5f);
 
-// Render to a specific FBO with viewport offset (SBS layout)
+// Render to a specific FBO with viewport offset (SBS layout). In ARRAY layout,
+// `slice` selects the array-layer FBO (viewportX/Y should be 0).
 void RenderScene(
     GLRenderer& renderer,
     uint32_t imageIndex,
@@ -62,7 +71,8 @@ void RenderScene(
     float zoomScale = 1.0f,
     float cubeY = 0.03f,     // World Y position of cube center (sits on floor)
     float cubeZ = 0.0f,      // World Z position (0 = origin, negative = in front of camera)
-    float cubeSize = 0.06f   // Cube edge length in meters
+    float cubeSize = 0.06f,  // Cube edge length in meters
+    uint32_t slice = 0       // ARRAY layout: array layer to render into
 );
 
 // Cleanup

--- a/test_apps/cube_handle_gl_win/main.cpp
+++ b/test_apps/cube_handle_gl_win/main.cpp
@@ -74,6 +74,19 @@ static bool TransparentBackgroundEnabled() {
     return e;
 }
 
+// DISPLAYXR_ARRAY_LAYOUT=1 submits the projection as a LAYERED / single-pass-
+// instanced swapchain (arraySize=2, each view in array slice imageArrayIndex)
+// instead of the default TILED atlas. Exercises the runtime's per-view
+// array-slice sampling; only drives view_count<=2 modes. Default off (tiled).
+static bool ArrayLayoutEnabled() {
+    static const bool e = []() {
+        const char *v = getenv("DISPLAYXR_ARRAY_LAYOUT");
+        return v != nullptr && *v != '\0' && *v != '0';
+    }();
+    return e;
+}
+static const uint32_t kArraySlices = 2; // stereo
+
 // #439 Phase 3 — handle + mask + Local2D layer modes (§8 cases 2/3/4), GL leg.
 // DXR_LOCAL2D_PANEL=1 (case 3, implicit mask) / +DXR_LOCAL2D_MASK=1 (case 2,
 // explicit Tier-2 island mask) / +DXR_LOCAL2D_PANEL2=1 (case 4, second
@@ -648,6 +661,10 @@ static void RenderThreadFunc(
                     xr->recommendedViewScaleY = xr->renderingModeScaleY[xr->currentModeIndex];
                 }
                 int eyeCount = monoMode ? 1 : (int)modeViewCount;
+                // Layered swapchains hold arraySize slices — cap the view count.
+                if (ArrayLayoutEnabled() && eyeCount > (int)xr->swapchain.arraySize) {
+                    eyeCount = (int)xr->swapchain.arraySize;
+                }
                 std::vector<XrCompositionLayerProjectionView> projectionViews(eyeCount, {XR_TYPE_COMPOSITION_LAYER_PROJECTION_VIEW});
 
                 if (frameState.shouldRender) {
@@ -724,8 +741,12 @@ static void RenderThreadFunc(
                         }
 
                         // Max per-tile capacity from swapchain
-                        uint32_t maxTileW = tileColumns > 0 ? xr->swapchain.width / tileColumns : xr->swapchain.width;
-                        uint32_t maxTileH = tileRows > 0 ? xr->swapchain.height / tileRows : xr->swapchain.height;
+                        // ARRAY: each slice is a full per-view image, so the cap
+                        // is the whole swapchain image, not a sub-tile of it.
+                        uint32_t maxTileW = renderer->arrayLayout ? xr->swapchain.width
+                            : (tileColumns > 0 ? xr->swapchain.width / tileColumns : xr->swapchain.width);
+                        uint32_t maxTileH = renderer->arrayLayout ? xr->swapchain.height
+                            : (tileRows > 0 ? xr->swapchain.height / tileRows : xr->swapchain.height);
 
                         // Compute render dims: mono uses full swapchain, stereo uses tile size
                         uint32_t renderW, renderH;
@@ -828,17 +849,20 @@ static void RenderThreadFunc(
                                     projMatrix = xr->projMatrices[eye];
                                 }
 
-                                // Tile-aware viewport: place each view in the correct tile position
+                                // TILED: place each view at its tile viewport.
+                                // ARRAY: render into array slice `eye` at (0,0).
+                                const bool arrayLayout = renderer->arrayLayout;
                                 uint32_t tileX = monoMode ? 0 : (eye % tileColumns);
                                 uint32_t tileY = monoMode ? 0 : (eye / tileColumns);
-                                uint32_t vpX = tileX * renderW;
-                                uint32_t vpY = tileY * renderH;
+                                uint32_t vpX = arrayLayout ? 0 : (tileX * renderW);
+                                uint32_t vpY = arrayLayout ? 0 : (tileY * renderH);
 
                                 RenderScene(*renderer, imageIndex,
                                     vpX, vpY,
                                     renderW, renderH,
                                     viewMatrix, projMatrix,
-                                    useAppProjection ? 1.0f : inputSnapshot.viewParams.scaleFactor);
+                                    useAppProjection ? 1.0f : inputSnapshot.viewParams.scaleFactor,
+                                    0.03f, 0.0f, 0.06f, /*slice*/ (uint32_t)eye);
 
                                 projectionViews[eye].type = XR_TYPE_COMPOSITION_LAYER_PROJECTION_VIEW;
                                 projectionViews[eye].subImage.swapchain = xr->swapchain.swapchain;
@@ -849,7 +873,7 @@ static void RenderThreadFunc(
                                     (int32_t)renderW,
                                     (int32_t)renderH
                                 };
-                                projectionViews[eye].subImage.imageArrayIndex = 0;
+                                projectionViews[eye].subImage.imageArrayIndex = arrayLayout ? (uint32_t)eye : 0;
                                 projectionViews[eye].pose = monoMode ? monoPose : rawViews[eye < (int)viewCount ? eye : 0].pose;
                                 projectionViews[eye].fov = useAppProjection ?
                                     stereoViews[monoMode ? 0 : eye].fov :
@@ -1258,7 +1282,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         return 1;
     }
 
-    if (!CreateSwapchain(xr)) {
+    if (!CreateSwapchain(xr, ArrayLayoutEnabled() ? kArraySlices : 1)) {
         LOG_ERROR("Swapchain creation failed");
         CleanupOpenXR(xr);
         wglMakeCurrent(nullptr, nullptr);
@@ -1297,7 +1321,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         }
 
         if (!CreateSwapchainFBOs(glRenderer, textures.data(), count,
-            xr.swapchain.width, xr.swapchain.height)) {
+            xr.swapchain.width, xr.swapchain.height, xr.swapchain.arraySize)) {
             LOG_ERROR("Failed to create FBOs for swapchain");
             CleanupGLRenderer(glRenderer);
             CleanupOpenXR(xr);

--- a/test_apps/cube_zones_d3d11_win/main.cpp
+++ b/test_apps/cube_zones_d3d11_win/main.cpp
@@ -1132,6 +1132,13 @@ static void RenderZonesFrame(RenderState& rs, const XrFrameState& frameState) {
                     continue;
                 }
                 renderer.context->ClearRenderTargetView(sliceRtv, z.clearColor);
+                // Each slice renders full-viewport into the SAME shared depth
+                // buffer, so depth MUST be cleared per slice — otherwise slice 1
+                // z-tests against slice 0's depth and the other eye's cube punches
+                // a shadow through (#613). TILED tiles occupy disjoint depth
+                // regions and share the single pre-loop clear.
+                renderer.context->ClearDepthStencilView(z.depthDSV.Get(),
+                    D3D11_CLEAR_DEPTH | D3D11_CLEAR_STENCIL, 1.0f, 0);
                 viewRtv = sliceRtv;
             }
 


### PR DESCRIPTION
Follow-up to #682. Gives the flagship **cube_handle** demos a `DISPLAYXR_ARRAY_LAYOUT=1` toggle so the runtime's per-view array-slice sampling is exercised by the canonical per-API demos (not only the zones apps), guarding against a future regression to slice sampling.

## What changed

- **displayxr-common pin → v1.2.0** (`test_apps/common/CMakeLists.txt`) for the new `CreateSwapchain(arraySize)` (DisplayXR/displayxr-common#15). Backward compatible.
- **`cube_handle_d3d11_win`, `cube_handle_gl_win`**: `DISPLAYXR_ARRAY_LAYOUT=1` submits a layered swapchain (arraySize=2, each view in slice `imageArrayIndex`) instead of the tiled atlas. Per-slice `Texture2DArray` RTV (D3D11) / `glFramebufferTextureLayer` FBO (GL). Default off = tiled, byte-identical to today. Array mode only drives `view_count<=2` modes (capped to the 2 slices).

## Per-slice depth fix (D3D11)

Testing surfaced a **subtle right-eye shadow** in the D3D11 array path: each array slice renders full-viewport into the *same* shared depth buffer, which was cleared only once before the view loop. Slice 1 then z-tests against slice 0's depth → the left eye's cube silhouette punches a shadow into the right eye. Fixed by clearing depth **per slice** in array mode (`cube_handle_d3d11_win` + the already-merged `cube_zones_d3d11_win`). Tiled views are unaffected — their tile viewports occupy disjoint depth regions.

**Audited every other array path** — all already clear depth per slice:
- GL (`glClear(DEPTH)` per call / per tile)
- D3D12 zones (`ClearDepthStencilView` with the per-slice RTV)
- VK zones (render-pass `loadOp=CLEAR` per per-slice framebuffer)
- Metal has no array test app (compositor-only fix).

## Testing

D3D11 & GL handle, array + tiled, all weave to 3D with no errors; tiled paths regression-clean. Post-fix D3D11 array re-run is clean. **The right-eye shadow being gone needs a panel eyeball** (visual) — please confirm before merge.

## Deferred

VK/Metal cube_handle toggles: VK arrays were never broken (runtime always handled them) and `cube_zones_vk_win` already exercises them; Metal is macOS-deferred.

Refs #681, #682.

🤖 Generated with [Claude Code](https://claude.com/claude-code)