### PR TITLE
fix(build): normalize OpenXR_ROOT with TO_CMAKE_PATH before install()

### DIFF
--- a/src/xrt/targets/openxr/CMakeLists.txt
+++ b/src/xrt/targets/openxr/CMakeLists.txt
@@ -218,12 +218,20 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
 	# does NOT link openxr_loader (the loader loads US) and (on this
 	# branch) no longer imports pthreadVC3; these install rules exist
 	# only for the downstream-consumer convenience surface.
-	if(DEFINED OpenXR_ROOT AND EXISTS "${OpenXR_ROOT}/x64/bin/openxr_loader.dll")
-		install(
-			FILES "${OpenXR_ROOT}/x64/bin/openxr_loader.dll"
-			DESTINATION ${CMAKE_INSTALL_BINDIR}
-			COMPONENT Runtime
-			)
+	if(DEFINED OpenXR_ROOT)
+		# Normalize backslashes → forward slashes. A native Windows OpenXR_ROOT
+		# (e.g. build_windows.bat's short-path copy C:\dev\openxr_sdk_1.1.43)
+		# otherwise lands verbatim in the generated cmake_install.cmake, where
+		# CMake reads \d, \o … as invalid escape sequences and aborts the install
+		# with "Syntax error in cmake code" (strict on newer CMake).
+		file(TO_CMAKE_PATH "${OpenXR_ROOT}" _oxr_root)
+		if(EXISTS "${_oxr_root}/x64/bin/openxr_loader.dll")
+			install(
+				FILES "${_oxr_root}/x64/bin/openxr_loader.dll"
+				DESTINATION ${CMAKE_INSTALL_BINDIR}
+				COMPONENT Runtime
+				)
+		endif()
 	endif()
 	# pthreadVC3 (C-only, no C++ exception unwind) and cjson are what
 	# displayxr-shell.exe v1.2.5 dynamically imports. Source from the


### PR DESCRIPTION
Building the runtime on a machine where CMake is strict about escape sequences (surfaced on the signing runner, CMake 3.3x) aborted at **install** time:

```
CMake Error at src/xrt/targets/openxr/cmake_install.cmake (file):
  Syntax error in cmake code ...
    C:\dev\openxr_sdk_1.1.43/x64/bin/openxr_loader.dll
```

`build_windows.bat` copies the OpenXR SDK to a short path `C:\dev\openxr_sdk_<ver>` and passes it as `OpenXR_ROOT`. The backslashes land verbatim in the generated `cmake_install.cmake`, where CMake reads `\d`, `\o`… as invalid escapes. `file(TO_CMAKE_PATH)` converts to forward slashes first — a **no-op on the forward-slash paths CI and most dev boxes feed**, so behavior is unchanged there.

Validated: with this fix the runtime builds + installs + signs cleanly end-to-end on the signing runner (all inner binaries + installer signed `Leia, Inc.`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)