### PR TITLE
chore(signing): don't hardcode the signing-provider repo in public skills/docs

### DIFF
--- a/.claude/skills/dxr-release/SKILL.md
+++ b/.claude/skills/dxr-release/SKILL.md
@@ -235,10 +235,11 @@ path of every app that uses that display, so Smart App Control blocks it
 unsigned. Demos with Windows installers are next; `mcp` ships DLLs too.
 
 The per-component build recipe lives in the runner workflow
-(`build-signed-release.yml` on `$DXR_SIGN_REPO`, default `LeiaInc/codesign-runner`)
-— a single source of truth — so this skill only names the component + ref, not
-build commands. Swap signers by setting `DXR_SIGN_REPO`; lose the provider and
-the release ships unsigned. Contract: `docs/specs/runtime/release-signing.md`.
+(`build-signed-release.yml` on the provider repo named by the `DXR_SIGN_REPO`
+**local env var** — this public repo names no provider path) — a single source of
+truth — so this skill only names the component + ref, not build commands. Set
+`DXR_SIGN_REPO` in your env to sign (unset → unsigned); point it elsewhere to swap
+signers. Contract: `docs/specs/runtime/release-signing.md`.
 
 ### Step 3.5.0: Unity — sign the prebuilt DLL via `sign-artifact`, then re-inject
 
@@ -261,7 +262,7 @@ version>`; it detects the existing release and signs it in place.
 
 ```bash
 if [ "$COMPONENT" = unity ]; then
-  SIGN_REPO="${DXR_SIGN_REPO:-LeiaInc/codesign-runner}"
+  SIGN_REPO="${DXR_SIGN_REPO}"   # local env only; unset -> unsigned (public repo names no provider)
   VER="${NEW_TAG#v}"
   TGZ="com.displayxr.unity-${VER}.tgz"
   DLL_REL="Runtime/Plugins/Windows/x64/displayxr_unity.dll"
@@ -332,11 +333,11 @@ The capability is *"can this box dispatch the signing runner?"* — no Windows
 host, no local secret.
 
 ```bash
-SIGN_REPO="${DXR_SIGN_REPO:-LeiaInc/codesign-runner}"
-if gh workflow view build-signed-release.yml -R "$SIGN_REPO" >/dev/null 2>&1; then
+SIGN_REPO="${DXR_SIGN_REPO}"   # local env only; the public repo names no provider
+if [ -n "$SIGN_REPO" ] && gh workflow view build-signed-release.yml -R "$SIGN_REPO" >/dev/null 2>&1; then
   SIGNED=yes
 else
-  echo "⚠  SIGNING SKIPPED for $COMPONENT — no access to the signing runner ($SIGN_REPO)."
+  echo "⚠  SIGNING SKIPPED for $COMPONENT — DXR_SIGN_REPO unset in the env, or the runner is unreachable."
   echo "   Release ships the UNSIGNED CI installer. Re-run /dxr-release $COMPONENT $NEW_TAG"
   echo "   from a box whose gh auth can dispatch that workflow."
   SIGNED=no   # continue — do not fail the release

--- a/.claude/skills/installer-release/SKILL.md
+++ b/.claude/skills/installer-release/SKILL.md
@@ -211,11 +211,11 @@ host** (runs from the Mac). Full contract + how to swap providers:
 
 ### Step 4.5.1: Resolve capability (OS-agnostic)
 ```bash
-SIGN_REPO="${DXR_SIGN_REPO:-LeiaInc/codesign-runner}"
-if gh workflow view sign-artifact -R "$SIGN_REPO" >/dev/null 2>&1; then
+SIGN_REPO="${DXR_SIGN_REPO}"   # local env only; the public repo names no provider
+if [ -n "$SIGN_REPO" ] && gh workflow view sign-artifact -R "$SIGN_REPO" >/dev/null 2>&1; then
   SIGNED=yes
 else
-  echo "⚠  BUNDLE UNSIGNED — no access to the signing provider ($SIGN_REPO)."
+  echo "⚠  BUNDLE UNSIGNED — DXR_SIGN_REPO unset in the env, or the provider is unreachable."
   echo "   The release ships the unsigned CI bundle. Set DXR_SIGN_REPO to a repo"
   echo "   implementing 'sign-artifact', or re-run from a box with provider access."
   SIGNED=no
@@ -311,12 +311,13 @@ STOP.
 - Bundle `.exe` signing is a **post-hoc skill step** (Phase 4.5), not a CI
   step — the signing key can't live on GitHub-hosted CI, and the provider
   runner isn't reachable from `displayxr-installer`'s CI. The skill dispatches
-  the provider's `sign-artifact` workflow (`$DXR_SIGN_REPO`, default
-  `LeiaInc/codesign-runner`) to sign the finished `.exe`, then re-uploads —
+  the provider's `sign-artifact` workflow on the repo named by the
+  `DXR_SIGN_REPO` **local env var** (this public repo hardcodes no provider path)
+  to sign the finished `.exe`, then re-uploads —
   OS-agnostic, no local hook file. The wrapped component installers are already
-  signed at their own releases, so no inner-binary handling is needed. Lose the
-  provider → the release ships unsigned (gate fails, flagged in the report);
-  swap providers by setting `DXR_SIGN_REPO`. Full contract:
+  signed at their own releases, so no inner-binary handling is needed. Unset env
+  → the release ships unsigned (gate fails, flagged in the report);
+  swap providers by pointing `DXR_SIGN_REPO` elsewhere. Full contract:
   `docs/specs/runtime/release-signing.md`. macOS `.pkg` signing (Apple
   Developer ID + notarization) is still TODO.
 - Don't bump component pins by hand in installer's versions.json —

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -321,17 +321,18 @@ makensis to run on the cert machine. Both are only possible where the cert is.
 ### Step 4.5.1: Resolve signing capability (OS-agnostic)
 The capability is simply *"can this box dispatch the signing runner?"* — no
 Windows host required. The runner workflow (`build-signed-release.yml`) and the
-cert live in the provider repo `$DXR_SIGN_REPO` (default `LeiaInc/codesign-runner`);
-this repo names no endpoint. To swap signers set `DXR_SIGN_REPO` to another repo
-implementing the same workflow; lose the provider and the release ships unsigned.
+cert live in the provider repo named by the **`DXR_SIGN_REPO` env var**, which
+you set in your **local environment** (`export DXR_SIGN_REPO=<owner/repo>`) — this
+public repo hardcodes no provider path. Unset → ships unsigned. To swap signers,
+point `DXR_SIGN_REPO` at another repo implementing the same workflow.
 Contract + fallbacks: `docs/specs/runtime/release-signing.md`.
 
 ```bash
-SIGN_REPO="${DXR_SIGN_REPO:-LeiaInc/codesign-runner}"
-if gh workflow view build-signed-release.yml -R "$SIGN_REPO" >/dev/null 2>&1; then
+SIGN_REPO="${DXR_SIGN_REPO}"   # local env only; the public repo names no provider
+if [ -n "$SIGN_REPO" ] && gh workflow view build-signed-release.yml -R "$SIGN_REPO" >/dev/null 2>&1; then
   SIGNED=yes
 else
-  echo "⚠  SIGNING SKIPPED — no access to the signing runner ($SIGN_REPO)."
+  echo "⚠  SIGNING SKIPPED — DXR_SIGN_REPO unset in the env, or the runner is unreachable."
   echo "   The release will ship the UNSIGNED CI installer. To sign, re-run"
   echo "   /release from a box whose gh auth can dispatch that workflow."
   SIGNED=no

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,9 +184,10 @@ Full spec: `docs/specs/runtime/versions-json-autobump.md`.
 
 ### Release code-signing
 CI builds are **unsigned** (contributors need no signing access). Signed
-releases are produced by a **signing provider** — a repo (`$DXR_SIGN_REPO`,
-default private `LeiaInc/codesign-runner`) that owns the EV cert on a self-hosted
-runner and exposes `build-signed-release.yml` (build+sign a component) and
+releases are produced by a **signing provider** — a repo named by the
+`DXR_SIGN_REPO` **local env var** (this public repo hardcodes no provider path;
+`export DXR_SIGN_REPO=<owner/repo>` on the release machine) that owns the EV cert
+on a self-hosted runner and exposes `build-signed-release.yml` (build+sign a component) and
 `sign-artifact` (sign a folder). The `/release`, `/dxr-release`, and
 `/installer-release` skills dispatch it, download the signed artifact, and
 replace the unsigned CI asset — so they run from **any OS** (no local Windows,

--- a/docs/specs/runtime/release-signing.md
+++ b/docs/specs/runtime/release-signing.md
@@ -16,9 +16,10 @@ the signer is unavailable or changes. This is the contract the `/release`,
   Release. **Signing never gates publishing** — if the provider is unreachable
   the release still ships the unsigned CI installer, with a warning.
 
-The current provider is the private **`LeiaInc/codesign-runner`** (DigiCert EV,
-subject `Leia, Inc.`). Nothing in the public repos names it beyond the default
-below.
+The provider repo is supplied **out-of-band** via the `DXR_SIGN_REPO` local env
+var (`export DXR_SIGN_REPO=<owner/repo>` on the release machine). The public
+repos hardcode **no** provider path — unset the env var and releases ship
+unsigned. (The active provider is a private repo owning a DigiCert EV cert.)
 
 ## Why signed releases rebuild (not re-sign the CI `.exe`)
 
@@ -64,8 +65,8 @@ the entire "switch signers" operation.
 Each skill probes reachability before signing and degrades gracefully:
 
 ```bash
-SIGN_REPO="${DXR_SIGN_REPO:-LeiaInc/codesign-runner}"
-if gh workflow view build-signed-release.yml -R "$SIGN_REPO" >/dev/null 2>&1; then
+SIGN_REPO="${DXR_SIGN_REPO}"   # local env only; the public repo names no provider
+if [ -n "$SIGN_REPO" ] && gh workflow view build-signed-release.yml -R "$SIGN_REPO" >/dev/null 2>&1; then
   SIGNED=yes          # provider reachable → sign
 else
   SIGNED=no           # provider gone → ship the unsigned CI installer, warn


### PR DESCRIPTION
The remote-signing skills used `${DXR_SIGN_REPO:-<provider>}` — the default leaked the private signing runner's path into the PUBLIC runtime repo. Now read `DXR_SIGN_REPO` from the local env only (no default); unset → ships unsigned. The release machine sets `export DXR_SIGN_REPO=<owner/repo>` in its own env. Restores the original SIGN_CMD-style local-only indirection. Tested: unset→SIGNED=no, set→provider reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)