### PR TITLE
chore(deps,#691): bump mcp v0.4.0→v0.4.2, align common on v1.2.0 (item 13)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,7 +125,7 @@ find_package(cJSON MODULE)
 include(FetchContent)
 FetchContent_Declare(displayxr_mcp
     GIT_REPOSITORY https://github.com/DisplayXR/displayxr-mcp.git
-    GIT_TAG v0.4.0)
+    GIT_TAG v0.4.2)
 # Build the stdio↔socket adapter alongside the lib so the Phase A test
 # scripts under tests/mcp/ can find a binary at a known path during dev
 # (build/_deps/displayxr_mcp-build/displayxr-mcp). Production

--- a/src/xrt/auxiliary/math/CMakeLists.txt
+++ b/src/xrt/auxiliary/math/CMakeLists.txt
@@ -20,7 +20,7 @@ set(DISPLAYXR_XRT_INCLUDE_DIR "${_dxr_xrt_includes}" CACHE PATH "" FORCE)
 FetchContent_Declare(
 	displayxr_common
 	GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
-	GIT_TAG v1.1.1
+	GIT_TAG v1.2.0
 	GIT_SHALLOW TRUE
 	)
 FetchContent_MakeAvailable(displayxr_common)

--- a/test_apps/handle/cube_handle_gl_macos/CMakeLists.txt
+++ b/test_apps/handle/cube_handle_gl_macos/CMakeLists.txt
@@ -60,7 +60,7 @@ set(DISPLAYXR_EXTENSIONS_INCLUDE_DIR "${_dxr_ext_includes}" CACHE PATH
 FetchContent_Declare(
     displayxr_common
     GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
-    GIT_TAG v1.1.2
+    GIT_TAG v1.2.0
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(displayxr_common)

--- a/test_apps/handle/cube_handle_metal_macos/CMakeLists.txt
+++ b/test_apps/handle/cube_handle_metal_macos/CMakeLists.txt
@@ -60,7 +60,7 @@ set(DISPLAYXR_EXTENSIONS_INCLUDE_DIR "${_dxr_ext_includes}" CACHE PATH
 FetchContent_Declare(
     displayxr_common
     GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
-    GIT_TAG v1.1.2
+    GIT_TAG v1.2.0
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(displayxr_common)

--- a/test_apps/handle/cube_handle_vk_macos/CMakeLists.txt
+++ b/test_apps/handle/cube_handle_vk_macos/CMakeLists.txt
@@ -64,7 +64,7 @@ set(DISPLAYXR_EXTENSIONS_INCLUDE_DIR "${_dxr_ext_includes}" CACHE PATH
 FetchContent_Declare(
     displayxr_common
     GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
-    GIT_TAG v1.1.2
+    GIT_TAG v1.2.0
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(displayxr_common)

--- a/test_apps/handle/cube_zones_metal_macos/CMakeLists.txt
+++ b/test_apps/handle/cube_zones_metal_macos/CMakeLists.txt
@@ -60,7 +60,7 @@ set(DISPLAYXR_EXTENSIONS_INCLUDE_DIR "${_dxr_ext_includes}" CACHE PATH
 FetchContent_Declare(
     displayxr_common
     GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
-    GIT_TAG v1.1.2
+    GIT_TAG v1.2.0
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(displayxr_common)

--- a/test_apps/handle/cube_zones_vk_macos/CMakeLists.txt
+++ b/test_apps/handle/cube_zones_vk_macos/CMakeLists.txt
@@ -64,7 +64,7 @@ set(DISPLAYXR_EXTENSIONS_INCLUDE_DIR "${_dxr_ext_includes}" CACHE PATH
 FetchContent_Declare(
     displayxr_common
     GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
-    GIT_TAG v1.1.2
+    GIT_TAG v1.2.0
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(displayxr_common)

--- a/test_apps/hosted/cube_hosted_metal_macos/CMakeLists.txt
+++ b/test_apps/hosted/cube_hosted_metal_macos/CMakeLists.txt
@@ -58,7 +58,7 @@ set(DISPLAYXR_EXTENSIONS_INCLUDE_DIR "${_dxr_ext_includes}" CACHE PATH
 FetchContent_Declare(
     displayxr_common
     GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
-    GIT_TAG v1.1.2
+    GIT_TAG v1.2.0
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(displayxr_common)

--- a/test_apps/legacy/cube_hosted_legacy_gl_macos/CMakeLists.txt
+++ b/test_apps/legacy/cube_hosted_legacy_gl_macos/CMakeLists.txt
@@ -58,7 +58,7 @@ set(DISPLAYXR_EXTENSIONS_INCLUDE_DIR "${_dxr_ext_includes}" CACHE PATH
 FetchContent_Declare(
     displayxr_common
     GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
-    GIT_TAG v1.1.2
+    GIT_TAG v1.2.0
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(displayxr_common)

--- a/test_apps/legacy/cube_hosted_legacy_metal_macos/CMakeLists.txt
+++ b/test_apps/legacy/cube_hosted_legacy_metal_macos/CMakeLists.txt
@@ -58,7 +58,7 @@ set(DISPLAYXR_EXTENSIONS_INCLUDE_DIR "${_dxr_ext_includes}" CACHE PATH
 FetchContent_Declare(
     displayxr_common
     GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
-    GIT_TAG v1.1.2
+    GIT_TAG v1.2.0
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(displayxr_common)

--- a/test_apps/legacy/cube_hosted_legacy_vk_linux/CMakeLists.txt
+++ b/test_apps/legacy/cube_hosted_legacy_vk_linux/CMakeLists.txt
@@ -65,7 +65,7 @@ set(DISPLAYXR_EXTENSIONS_INCLUDE_DIR "${_dxr_ext_includes}" CACHE PATH
 FetchContent_Declare(
     displayxr_common
     GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
-    GIT_TAG v1.1.2
+    GIT_TAG v1.2.0
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(displayxr_common)

--- a/test_apps/legacy/cube_hosted_legacy_vk_macos/CMakeLists.txt
+++ b/test_apps/legacy/cube_hosted_legacy_vk_macos/CMakeLists.txt
@@ -62,7 +62,7 @@ set(DISPLAYXR_EXTENSIONS_INCLUDE_DIR "${_dxr_ext_includes}" CACHE PATH
 FetchContent_Declare(
     displayxr_common
     GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
-    GIT_TAG v1.1.2
+    GIT_TAG v1.2.0
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(displayxr_common)

--- a/test_apps/texture/cube_zones_texture_gl_macos/CMakeLists.txt
+++ b/test_apps/texture/cube_zones_texture_gl_macos/CMakeLists.txt
@@ -61,7 +61,7 @@ set(DISPLAYXR_EXTENSIONS_INCLUDE_DIR "${_dxr_ext_includes}" CACHE PATH
 FetchContent_Declare(
     displayxr_common
     GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
-    GIT_TAG v1.1.2
+    GIT_TAG v1.2.0
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(displayxr_common)

--- a/test_apps/texture/cube_zones_texture_metal_macos/CMakeLists.txt
+++ b/test_apps/texture/cube_zones_texture_metal_macos/CMakeLists.txt
@@ -60,7 +60,7 @@ set(DISPLAYXR_EXTENSIONS_INCLUDE_DIR "${_dxr_ext_includes}" CACHE PATH
 FetchContent_Declare(
     displayxr_common
     GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
-    GIT_TAG v1.1.2
+    GIT_TAG v1.2.0
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(displayxr_common)


### PR DESCRIPTION
Part of #691 item 13 — pin drift the drift-audit flags live.

## Changes
| consumer | dep | before | after |
|---|---|---|---|
| `CMakeLists.txt` | displayxr-mcp | v0.4.0 | **v0.4.2** |
| `src/xrt/auxiliary/math/CMakeLists.txt` | displayxr-common | v1.1.1 | **v1.2.0** |
| 12 macOS/Linux test-app `CMakeLists.txt` | displayxr-common | v1.1.2 | **v1.2.0** |
| `test_apps/common/CMakeLists.txt` | displayxr-common | (already v1.2.0) | — |

Aligning the runtime-core common pin (v1.1.1) with `test_apps/common` (v1.2.0)
also closes the folded-scope duplicate-fetch hazard documented at
`CMakeLists.txt:514`.

## Verified (local Windows)
Wiped `build/_deps/displayxr_{mcp,common}-*` to force a clean re-fetch, then:
- `scripts\build_windows.bat build` → `=== ALL DONE ===`, **0 compile errors**.
- FetchContent landed `displayxr_mcp @ v0.4.2` and `displayxr_common @ v1.2.0`
  (confirmed via `git describe` in `build/_deps/*-src`).
- `displayxr-cli selftest` **PASSED** — Leia SR plug-in, ABI v4, valid display info.

## Notes
- `drift_audit.py` reads **remote HEAD** via `gh api`, so its
  `displayxr-runtime [stale-pin] mcp v0.4.0` finding clears once this merges
  (can't be reflected pre-merge from a local branch).
- Shell's identical mcp pin (`displayxr-shell-pvt/src/CMakeLists.txt:61`) is a
  **separate repo/PR**, not in this checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)