### PR TITLE
Fix Linux build of the native Vulkan compositor + cube test apps

### DIFF
--- a/scripts/build_linux.sh
+++ b/scripts/build_linux.sh
@@ -190,7 +190,16 @@ if [ "$BUILD_APPS" = "ON" ]; then
   #                                 passes it via XR_EXT_xlib_window_binding.
   for APP in cube_hosted_legacy_vk_linux cube_handle_vk_linux; do
     APP_DIR="$ROOT/test_apps/$APP"
-    echo "=== Building $APP ==="
+    # CANDIDATE PATCH (#706 Linux validation): the apps aren't all flat under
+    # test_apps/ — cube_hosted_legacy_vk_linux lives in test_apps/legacy/. Fall
+    # back to a nested lookup when the flat path is absent.
+    if [ ! -d "$APP_DIR" ]; then
+      APP_DIR="$(find "$ROOT/test_apps" -type d -name "$APP" | head -1)"
+    fi
+    if [ -z "$APP_DIR" ] || [ ! -f "$APP_DIR/CMakeLists.txt" ]; then
+      echo "ERROR: test app source for '$APP' not found under $ROOT/test_apps" >&2; exit 1
+    fi
+    echo "=== Building $APP (src: $APP_DIR) ==="
     cmake -B "$APP_DIR/build" -S "$APP_DIR" -G Ninja \
       -DCMAKE_BUILD_TYPE=Debug \
       -DCMAKE_PREFIX_PATH="$OPENXR_DIR"

--- a/src/xrt/compositor/gl/comp_gl_compositor.cpp
+++ b/src/xrt/compositor/gl/comp_gl_compositor.cpp
@@ -88,6 +88,12 @@ static const IID IID_ID3D11Texture2D_local = {
 #include <OpenGL/OpenGL.h>
 #include <OpenGL/gl3.h>
 #include "comp_gl_window_macos.h"
+#elif defined(XRT_OS_LINUX)
+// Linux desktop: GLAD-provided GL types via the EGL path (mirrors Android).
+// CANDIDATE PATCH (#706 Linux validation) — the original block had no Linux
+// branch, so GL types were undefined and this TU failed to compile.
+#include "ogl/ogl_api.h"
+#include "ogl/egl_api.h"
 #endif
 
 /*
@@ -326,6 +332,14 @@ struct comp_gl_compositor
 	GLuint iosurface_present_fbo;
 	uint32_t iosurface_width;
 	uint32_t iosurface_height;
+#elif defined(XRT_OS_LINUX)
+	// Linux desktop platform context (EGL path, mirrors Android) + owns_window.
+	// CANDIDATE PATCH (#706 Linux validation) — the original struct had no Linux
+	// branch, so owns_window (used unguarded at the HUD-overlay sites) was undeclared.
+	void *egl_display;   //!< EGLDisplay
+	void *egl_context;   //!< EGLContext
+	void *egl_surface;   //!< EGLSurface
+	bool owns_window;
 #endif
 
 	// --- Shared texture (D3D11 interop via WGL_NV_DX_interop2, Windows only) ---

--- a/src/xrt/compositor/util/comp_vulkan.c
+++ b/src/xrt/compositor/util/comp_vulkan.c
@@ -222,9 +222,15 @@ create_instance(struct vk_bundle *vk, const struct comp_vulkan_arguments *vk_arg
 	VkInstanceCreateFlags instance_flags = 0;
 
 	// MoltenVK is a Vulkan portability driver — must opt in to enumerate it.
+	// CANDIDATE PATCH (#706 Linux validation): guard on the macro so this
+	// MoltenVK-only opt-in compiles out on headers that don't define it (e.g.
+	// Ubuntu's Vulkan-Headers v204). Portability enumeration is not needed on
+	// Linux/desktop drivers; it stays active on macOS where MoltenVK defines it.
+#ifdef VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME
 	if (u_string_list_contains(instance_ext_list, VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME)) {
 		instance_flags |= VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
 	}
+#endif
 
 	VkInstanceCreateInfo instance_info = {
 	    .sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO,

--- a/test_apps/cube_handle_vk_linux/main.cpp
+++ b/test_apps/cube_handle_vk_linux/main.cpp
@@ -1908,6 +1908,10 @@ static bool CreateVulkanInstance(AppXrSession& xr, VkInstance& vkInstance) {
     vkEnumerateInstanceExtensionProperties(nullptr, &availExtCount, availExts.data());
 
     bool hasPortabilityEnum = false;
+    // CANDIDATE PATCH (#706 Linux validation): MoltenVK-only portability
+    // enumeration; guard on the macro so it compiles out where Vulkan headers
+    // don't define it (e.g. Ubuntu Vulkan-Headers v204). Not needed on Linux.
+#ifdef VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME
     for (const auto& ext : availExts) {
         if (strcmp(ext.extensionName, VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME) == 0) {
             hasPortabilityEnum = true;
@@ -1918,6 +1922,7 @@ static bool CreateVulkanInstance(AppXrSession& xr, VkInstance& vkInstance) {
         extensionNames.push_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
         LOG_INFO("  Adding VK_KHR_portability_enumeration for MoltenVK");
     }
+#endif
 
     std::vector<const char*> extensionPtrs;
     for (auto& name : extensionNames) {
@@ -1938,9 +1943,11 @@ static bool CreateVulkanInstance(AppXrSession& xr, VkInstance& vkInstance) {
     createInfo.pApplicationInfo = &appInfo;
     createInfo.enabledExtensionCount = (uint32_t)extensionPtrs.size();
     createInfo.ppEnabledExtensionNames = extensionPtrs.data();
+#ifdef VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR
     if (hasPortabilityEnum) {
         createInfo.flags |= VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
     }
+#endif
 
     VK_CHECK(vkCreateInstance(&createInfo, nullptr, &vkInstance));
     LOG_INFO("Vulkan instance created");

--- a/test_apps/legacy/cube_hosted_legacy_vk_linux/main.cpp
+++ b/test_apps/legacy/cube_hosted_legacy_vk_linux/main.cpp
@@ -1820,6 +1820,10 @@ static bool CreateVulkanInstance(AppXrSession& xr, VkInstance& vkInstance) {
     vkEnumerateInstanceExtensionProperties(nullptr, &availExtCount, availExts.data());
 
     bool hasPortabilityEnum = false;
+    // CANDIDATE PATCH (#706 Linux validation): MoltenVK-only portability
+    // enumeration; guard on the macro so it compiles out where Vulkan headers
+    // don't define it (e.g. Ubuntu Vulkan-Headers v204). Not needed on Linux.
+#ifdef VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME
     for (const auto& ext : availExts) {
         if (strcmp(ext.extensionName, VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME) == 0) {
             hasPortabilityEnum = true;
@@ -1830,6 +1834,7 @@ static bool CreateVulkanInstance(AppXrSession& xr, VkInstance& vkInstance) {
         extensionNames.push_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
         LOG_INFO("  Adding VK_KHR_portability_enumeration for MoltenVK");
     }
+#endif
 
     std::vector<const char*> extensionPtrs;
     for (auto& name : extensionNames) {
@@ -1850,9 +1855,11 @@ static bool CreateVulkanInstance(AppXrSession& xr, VkInstance& vkInstance) {
     createInfo.pApplicationInfo = &appInfo;
     createInfo.enabledExtensionCount = (uint32_t)extensionPtrs.size();
     createInfo.ppEnabledExtensionNames = extensionPtrs.data();
+#ifdef VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR
     if (hasPortabilityEnum) {
         createInfo.flags |= VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
     }
+#endif
 
     VK_CHECK(vkCreateInstance(&createInfo, nullptr, &vkInstance));
     LOG_INFO("Vulkan instance created");


### PR DESCRIPTION
## What

Five minimal fixes that let the runtime and the two Linux cube test apps
actually **build on a real Linux desktop**. Found while doing the on-hardware
Linux validation in #706 (runtime #660 / demos #699).

## Why CI is green but a real desktop isn't

The Linux CI gate runs the headless Phase 0 build, on a box without EGL/GL dev
libs and with Vulkan-Headers that don't carry the portability macros. Under
those conditions the native-VK-compositor translation units below are either
not compiled at all or don't reference the missing macros — so CI stays green
while `build_linux.sh --apps` on an actual Vulkan+X desktop fails hard.

## The fixes

| File | Problem | Fix |
|------|---------|-----|
| `src/xrt/compositor/gl/comp_gl_compositor.cpp` | The GLAD include block (comment: *"cross-platform"*) and the compositor struct's *Platform context* section have `XRT_OS_WINDOWS` / `XRT_OS_ANDROID` / `__APPLE__` branches but **none for desktop Linux** and no `#else`. Result on Linux: every `GL*` type undeclared + `owns_window` undeclared → **653 errors**. | Add `XRT_OS_LINUX` branches taking the EGL path (mirrors the Android branch). |
| `src/xrt/compositor/util/comp_vulkan.c` | `VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME` / `VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR` (a MoltenVK-only opt-in) referenced unconditionally; not defined by Ubuntu's Vulkan-Headers v204, not needed on Linux. | `#ifdef`-guard on the macro so it compiles out where undefined; unchanged on macOS/MoltenVK. |
| `test_apps/legacy/cube_hosted_legacy_vk_linux/main.cpp` | Same portability macros, same problem. | Same `#ifdef` guard. |
| `test_apps/cube_handle_vk_linux/main.cpp` | Same portability macros, same problem. | Same `#ifdef` guard. |
| `scripts/build_linux.sh` | `--apps` looks for `test_apps/cube_hosted_legacy_vk_linux`, but that app lives under `test_apps/legacy/` (only `cube_handle_vk_linux` is top-level). | Fall back to a nested `find` when the flat path is absent; error clearly if truly missing. |

Each source hunk is annotated with a `CANDIDATE PATCH (#706 Linux validation)` comment so maintainers can quickly review the intent. The EGL-path choice for the GL compositor's Linux branch mirrors Android and matches the build's `XRT_HAVE_EGL`/`XRT_HAVE_OPENGL`; if the project intends a GLX path instead, that's an easy swap.

## Verified on

- Ubuntu 22.04.5, Vulkan 1.3.204, NVIDIA RTX 3080 (+ AMD Renoir), X11/XWayland.
- Runtime + both cube apps build clean (`build_linux.sh --apps`), and the **hosted** and **handle** (`XR_EXT_xlib_window_binding`) sessions bring up the native VK compositor and render the stereo textured cube (verified via the compositor's atlas readback). `--service` build also green. Full results in #706.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
