### PR TITLE
feat(linux,#660): opt-in software-GL (llvmpipe) present path — XRT_FEATURE_GL_LINUX_SOFTWARE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,6 +208,10 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
 	if(PKGCONFIG_FOUND)
 		pkg_check_modules(XCB xcb xcb-randr x11-xcb)
 	endif()
+	# X11 (Xlib) for the native GL compositor's GLX present path (Phase 1b-GL).
+	# GLX itself comes from find_package(OpenGL) above (OpenGL::GLX /
+	# OpenGL_GLX_FOUND). Not REQUIRED — a headless/GL-less box still builds.
+	find_package(X11)
 endif()
 
 # This one is named differently because that's what CTest uses
@@ -274,6 +278,13 @@ option_with_deps(XRT_FEATURE_TRACING "Enable debug tracing on supported platform
 option_with_deps(XRT_FEATURE_WINDOW_PEEK "Enable a window that displays the content of the HMD on screen" DEPENDS XRT_HAVE_SDL2)
 option_with_deps(XRT_FEATURE_DEBUG_GUI "Enable debug window to be used" DEPENDS XRT_HAVE_SDL2)
 option_with_deps(XRT_FEATURE_HYBRID_MODE "Enable hybrid in-process/IPC mode (native compositor for normal apps, IPC for sandboxed apps)" DEFAULT OFF DEPENDS "WIN32 OR APPLE" XRT_MODULE_IPC XRT_FEATURE_OPENXR "XRT_HAVE_D3D11 OR APPLE")
+# Opt-in software-GL present path on desktop Linux: a GLX compositor that shares
+# the app's GL context (no external-memory FD interop) so it renders on software
+# GL (llvmpipe) with NO GPU — for CI / headless / WSL. Default OFF: production
+# Linux uses the Vulkan/XCB native compositor (needs a GPU, see #709). No effect
+# on Windows/macOS/Android. When ON, arms XR_USE_PLATFORM_XLIB, builds comp_gl on
+# Linux, and enables the Xlib GL native compositor + XR_EXT_xlib_window_binding.
+option(XRT_FEATURE_GL_LINUX_SOFTWARE "Enable the opt-in software-GL (GLX/llvmpipe) present path on desktop Linux (no-GPU CI/headless); default OFF = Vulkan/XCB" OFF)
 
 if (XRT_FEATURE_SERVICE)
 	# Disable the client debug gui by default for out-of-proc -
@@ -302,7 +313,13 @@ option_with_deps(XRT_INSTALL_SYSTEMD_UNIT_FILES "Install user unit files for sys
 option_with_deps(XRT_INSTALL_ABSOLUTE_SYSTEMD_UNIT_FILES "Use an absolute path to monado-system in installed user unit files for systemd socket activation" DEPENDS XRT_HAVE_SYSTEMD)
 
 # Drivers to build
-option_with_deps(XRT_BUILD_DRIVER_QWERTY "Enable Qwerty driver" DEPENDS "XRT_HAVE_SDL2 OR WIN32 OR APPLE")
+# option_with_deps forbids parens/AND in a DEPENDS item, so precompute the
+# desktop-Linux+X11 case (native GL compositor drives qwerty via qwerty_xlib, #660).
+set(XRT_QWERTY_LINUX_X11 OFF)
+if(XRT_HAVE_LINUX AND X11_FOUND AND NOT ANDROID)
+	set(XRT_QWERTY_LINUX_X11 ON)
+endif()
+option_with_deps(XRT_BUILD_DRIVER_QWERTY "Enable Qwerty driver" DEPENDS "XRT_HAVE_SDL2 OR WIN32 OR APPLE OR XRT_QWERTY_LINUX_X11")
 set(XRT_IPC_MSG_SOCK_FILENAME displayxr_comp_ipc CACHE STRING "Service socket filename")
 set(XRT_IPC_SERVICE_PID_FILENAME displayxr.pid CACHE STRING "Service pidfile filename")
 set(XRT_OXR_RUNTIME_SUFFIX displayxr CACHE STRING "OpenXR client library suffix")

--- a/scripts/build_linux.sh
+++ b/scripts/build_linux.sh
@@ -48,11 +48,18 @@ BUILD_DIR="$ROOT/build"
 SERVICE_MODE=OFF
 RUN_TEST=ON
 BUILD_APPS=OFF
+# Opt-in software-GL (GLX/llvmpipe) present path. Default OFF → the default Linux
+# build is Vulkan/XCB (production, needs a GPU). --gl switches to the GL path
+# (comp_gl on Linux + Xlib GL binding), which runs on software GL for no-GPU
+# CI/headless/WSL. See XRT_FEATURE_GL_LINUX_SOFTWARE in the top-level CMakeLists.
+GL_SOFTWARE=OFF
 for arg in "$@"; do
   case "$arg" in
     --service) SERVICE_MODE=ON ;;
     --no-test) RUN_TEST=OFF ;;
     --apps) BUILD_APPS=ON ;;
+    --gl) GL_SOFTWARE=ON ;;
+    --no-gl) GL_SOFTWARE=OFF ;;
     *) echo "Unknown arg: $arg" >&2; exit 2 ;;
   esac
 done
@@ -68,6 +75,7 @@ OPENXR_VERSION="1.1.43"
 echo "=== Configuring DisplayXR runtime (Linux, SERVICE=$SERVICE_MODE) ==="
 cmake -B "$BUILD_DIR" -S "$ROOT" -G Ninja \
   -DCMAKE_BUILD_TYPE=Debug \
+  -DXRT_FEATURE_GL_LINUX_SOFTWARE=$GL_SOFTWARE \
   -DXRT_FEATURE_SERVICE=$SERVICE_MODE \
   -DXRT_MODULE_CLI=ON \
   -DXRT_BUILD_DRIVER_QWERTY=OFF \
@@ -225,4 +233,46 @@ EOF
     echo "Built $APP. Run on a Linux box with a GPU + display:"
     echo "  $RUN"
   done
+
+  # Software-GL test apps — only under the opt-in GL path (--gl). The VK apps
+  # above always build; these are skipped otherwise since comp_gl + the Xlib GL
+  # binding aren't compiled into the runtime unless XRT_FEATURE_GL_LINUX_SOFTWARE.
+  # The GL compositor shares the app's GL context (no external-memory FD interop)
+  # so it presents on SOFTWARE GL (llvmpipe) — the run scripts default
+  # LIBGL_ALWAYS_SOFTWARE=1 (unset it for a real GPU).
+  if [ "$GL_SOFTWARE" = "ON" ]; then
+    for GLAPP in cube_hosted_legacy_gl_linux cube_handle_gl_linux; do
+      GLAPP_DIR="$ROOT/test_apps/$GLAPP"
+      if [ ! -d "$GLAPP_DIR" ]; then
+        GLAPP_DIR="$(find "$ROOT/test_apps" -type d -name "$GLAPP" | head -1)"
+      fi
+      if [ -z "$GLAPP_DIR" ] || [ ! -f "$GLAPP_DIR/CMakeLists.txt" ]; then
+        echo "ERROR: GL test app '$GLAPP' not found under $ROOT/test_apps" >&2; exit 1
+      fi
+      echo "=== Building $GLAPP (src: $GLAPP_DIR) ==="
+      cmake -B "$GLAPP_DIR/build" -S "$GLAPP_DIR" -G Ninja \
+        -DCMAKE_BUILD_TYPE=Debug \
+        -DCMAKE_PREFIX_PATH="$OPENXR_DIR"
+      cmake --build "$GLAPP_DIR/build"
+
+      GLRUN="$BUILD_DIR/run_${GLAPP}.sh"
+      cat > "$GLRUN" <<EOF
+#!/bin/bash
+# Run $GLAPP against the dev runtime build (software-GL path). Needs a running X
+# server (DISPLAY set). LIBGL_ALWAYS_SOFTWARE=1 forces llvmpipe (unset for a GPU).
+# OXR_ENABLE_GL_NATIVE_COMPOSITOR=1 selects the native GL compositor path.
+export XR_RUNTIME_JSON="$BUILD_DIR/openxr_displayxr-dev.json"
+export LD_LIBRARY_PATH="$OPENXR_DIR/lib:\${LD_LIBRARY_PATH:-}"
+export XRT_PLUGIN_SEARCH_PATH="$PLUGIN_DIR"
+export OXR_ENABLE_GL_NATIVE_COMPOSITOR="\${OXR_ENABLE_GL_NATIVE_COMPOSITOR:-1}"
+export LIBGL_ALWAYS_SOFTWARE="\${LIBGL_ALWAYS_SOFTWARE:-1}"
+export SIM_DISPLAY_OUTPUT="\${SIM_DISPLAY_OUTPUT:-anaglyph}"
+exec "$GLAPP_DIR/build/$GLAPP" "\$@"
+EOF
+      chmod +x "$GLRUN"
+      echo ""
+      echo "Built $GLAPP. Run on a Linux box with an X server (software GL OK):"
+      echo "  $GLRUN"
+    done
+  fi
 fi

--- a/src/xrt/compositor/CMakeLists.txt
+++ b/src/xrt/compositor/CMakeLists.txt
@@ -343,11 +343,12 @@ endif()
 ###
 # Native OpenGL compositor (bypasses Vulkan entirely)
 #
-# Win32 + macOS only: those are the only platforms that link it (st_oxr's
-# XRT_HAVE_GL_NATIVE_COMPOSITOR arms). Linux is Vulkan-only — no GL window
-# backend exists (#709) — and Android uses GLES (XRT_HAVE_OPENGL is never
-# set there).
-if((WIN32 OR APPLE) AND XRT_HAVE_OPENGL)
+# Win32 + macOS always build it (they link it via st_oxr's GL-native arms).
+# Desktop Linux is Vulkan-only by default (#709: no GL window backend in the
+# default build); the opt-in software-GL path (XRT_FEATURE_GL_LINUX_SOFTWARE)
+# adds the GLX backend + comp_gl on Linux for no-GPU CI/headless. Android uses
+# GLES (XRT_HAVE_OPENGL is never set there).
+if(XRT_HAVE_OPENGL AND (WIN32 OR APPLE OR XRT_FEATURE_GL_LINUX_SOFTWARE))
 	add_subdirectory(gl)
 endif()
 

--- a/src/xrt/compositor/gl/CMakeLists.txt
+++ b/src/xrt/compositor/gl/CMakeLists.txt
@@ -37,6 +37,11 @@ target_include_directories(comp_gl PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../aux
 if(APPLE)
 	target_compile_definitions(comp_gl PRIVATE GL_SILENCE_DEPRECATION)
 	target_sources(comp_gl PRIVATE comp_gl_window_macos.h comp_gl_window_macos.m)
+elseif(XRT_HAVE_LINUX AND NOT ANDROID AND X11_FOUND AND OpenGL_GLX_FOUND)
+	# Desktop Linux (X11/GLX) native GL present path — self-created window whose
+	# GLX context shares the app's context (no external-memory FD interop, so it
+	# runs on software/llvmpipe). See docs/roadmap/linux-support.md (Phase 1b-GL).
+	target_sources(comp_gl PRIVATE comp_gl_window_xlib.h comp_gl_window_xlib.c)
 endif()
 
 # Platform-specific linking
@@ -48,6 +53,8 @@ if(WIN32)
 		)
 elseif(APPLE)
 	target_link_libraries(comp_gl PRIVATE "-framework OpenGL" "-framework Cocoa" "-framework IOSurface")
+elseif(XRT_HAVE_LINUX AND NOT ANDROID AND X11_FOUND AND OpenGL_GLX_FOUND)
+	target_link_libraries(comp_gl PRIVATE OpenGL::GL OpenGL::GLX X11::X11)
 endif()
 
 # Qwerty include path for runtime-side 2D/3D toggle polling

--- a/src/xrt/compositor/gl/comp_gl_compositor.cpp
+++ b/src/xrt/compositor/gl/comp_gl_compositor.cpp
@@ -88,6 +88,24 @@ static const IID IID_ID3D11Texture2D_local = {
 #include <OpenGL/OpenGL.h>
 #include <OpenGL/gl3.h>
 #include "comp_gl_window_macos.h"
+#elif defined(XRT_OS_LINUX)
+// Desktop Linux (X11/GLX). Android also defines XRT_OS_LINUX but is matched by
+// the earlier XRT_OS_ANDROID arm. GL entry points come via GLAD (exactly like
+// Windows) so ALL GL code in the process — compositor, sim_display DP, u_hud,
+// aux_ogl — shares one consistently-loaded dispatch table (loaded once in the
+// create path via gladLoadGLUserPtr). All GLX/Xlib lives in comp_gl_window_xlib.c
+// so its headers never leak their macros into this large TU; the only GLX symbol
+// referenced directly here is glXGetProcAddressARB, forward-declared for the
+// GLAD loader.
+#include "ogl/ogl_api.h"
+#include "comp_gl_window_xlib.h"
+extern "C" void (*glXGetProcAddressARB(const unsigned char *procName))(void);
+static GLADapiproc
+gl_xlib_glad_loader(void *userptr, const char *name)
+{
+	(void)userptr;
+	return (GLADapiproc)glXGetProcAddressARB((const unsigned char *)name);
+}
 #endif
 
 /*
@@ -326,6 +344,9 @@ struct comp_gl_compositor
 	GLuint iosurface_present_fbo;
 	uint32_t iosurface_width;
 	uint32_t iosurface_height;
+#elif defined(XRT_OS_LINUX)
+	struct comp_gl_window_xlib *xlib_window; //!< X11/GLX window helper (hosted)
+	bool owns_window;
 #endif
 
 	// --- Shared texture (D3D11 interop via WGL_NV_DX_interop2, Windows only) ---
@@ -1223,6 +1244,11 @@ gl_compositor_create_swapchain(struct xrt_compositor *xc,
 #elif defined(__APPLE__)
 	CGLContextObj prev_cgl_ctx = CGLGetCurrentContext();
 	comp_gl_window_macos_make_current(c->macos_window);
+#elif defined(XRT_OS_LINUX)
+	void *prev_glx_dpy = NULL, *prev_glx_ctx = NULL;
+	unsigned long prev_glx_draw = 0;
+	comp_gl_window_xlib_save_current(&prev_glx_dpy, &prev_glx_draw, &prev_glx_ctx);
+	comp_gl_window_xlib_make_current(c->xlib_window);
 #endif
 
 	uint32_t image_count = 3;
@@ -1310,6 +1336,8 @@ gl_compositor_create_swapchain(struct xrt_compositor *xc,
 	if (prev_cgl_ctx != NULL) {
 		CGLSetCurrentContext(prev_cgl_ctx);
 	}
+#elif defined(XRT_OS_LINUX)
+	comp_gl_window_xlib_restore_current(prev_glx_dpy, prev_glx_draw, prev_glx_ctx);
 #endif
 
 	return XRT_SUCCESS;
@@ -2787,10 +2815,30 @@ gl_compute_effective_layout(struct comp_gl_compositor *c)
 	}
 }
 
+#if defined(XRT_OS_LINUX) && defined(XRT_BUILD_DRIVER_QWERTY)
+// Forward one captured X11 input event from the compositor window to the qwerty
+// devices (WASDQE camera + RMB look + V/1/2/3 mode hotkeys). See comp_gl_window_xlib.
+static void
+gl_xlib_input_forward(void *ctx, void *xevent)
+{
+	struct comp_gl_compositor *c = (struct comp_gl_compositor *)ctx;
+	if (c->xsysd != NULL) {
+		qwerty_process_xlib(c->xsysd->xdevs, c->xsysd->xdev_count, xevent);
+	}
+}
+#endif
+
 static xrt_result_t
 gl_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sync_handle)
 {
 	struct comp_gl_compositor *c = gl_comp(xc);
+
+#if defined(XRT_OS_LINUX) && defined(XRT_BUILD_DRIVER_QWERTY)
+	// Drain this frame's keyboard/mouse from the compositor window into qwerty.
+	if (c->xlib_window != NULL && c->xsysd != NULL) {
+		comp_gl_window_xlib_pump_input(c->xlib_window, gl_xlib_input_forward, c);
+	}
+#endif
 
 	// Capture-intent poll — see u_capture_intent.h. Consumed at the
 	// projection-done boundary (PROJECTION_ONLY) or end of frame
@@ -2828,6 +2876,11 @@ gl_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t
 #elif defined(__APPLE__)
 	CGLContextObj prev_cgl_ctx = CGLGetCurrentContext();
 	comp_gl_window_macos_make_current(c->macos_window);
+#elif defined(XRT_OS_LINUX)
+	void *prev_glx_dpy = NULL, *prev_glx_ctx = NULL;
+	unsigned long prev_glx_draw = 0;
+	comp_gl_window_xlib_save_current(&prev_glx_dpy, &prev_glx_draw, &prev_glx_ctx);
+	comp_gl_window_xlib_make_current(c->xlib_window);
 #endif
 
 	// Save and set GL state — the app may have left depth test, blend, etc. on
@@ -3497,6 +3550,8 @@ gl_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t
 		}
 #elif defined(__APPLE__)
 		comp_gl_window_macos_get_dimensions(c->macos_window, &present_w, &present_h);
+#elif defined(XRT_OS_LINUX)
+		comp_gl_window_xlib_get_dimensions(c->xlib_window, &present_w, &present_h);
 #endif
 
 		// Bind the present target. Default WGL path: FBO 0 (window default
@@ -3609,6 +3664,8 @@ gl_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t
 		// eglSwapBuffers(c->egl_display, c->egl_surface);
 #elif defined(__APPLE__)
 		comp_gl_window_macos_swap_buffers(c->macos_window);
+#elif defined(XRT_OS_LINUX)
+		comp_gl_window_xlib_swap_buffers(c->xlib_window);
 #endif
 	}
 
@@ -3668,6 +3725,8 @@ gl_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t
 	if (prev_cgl_ctx != NULL) {
 		CGLSetCurrentContext(prev_cgl_ctx);
 	}
+#elif defined(XRT_OS_LINUX)
+	comp_gl_window_xlib_restore_current(prev_glx_dpy, prev_glx_draw, prev_glx_ctx);
 #endif
 
 	return XRT_SUCCESS;
@@ -3775,6 +3834,10 @@ gl_compositor_destroy(struct xrt_compositor *xc)
 	}
 	if (c->macos_window != NULL) {
 		comp_gl_window_macos_destroy(&c->macos_window);
+	}
+#elif defined(XRT_OS_LINUX)
+	if (c->xlib_window != NULL) {
+		comp_gl_window_xlib_destroy(&c->xlib_window);
 	}
 #endif
 
@@ -4456,6 +4519,60 @@ comp_gl_compositor_get_window_metrics(struct xrt_compositor *xc,
 
 	out_metrics->valid = true;
 	return true;
+#elif defined(XRT_OS_LINUX)
+	if (!c->sys_info_set || c->xlib_window == NULL) {
+		return false;
+	}
+
+	float disp_w_m = c->sys_info.display_width_m;
+	float disp_h_m = c->sys_info.display_height_m;
+	uint32_t disp_px_w = c->sys_info.display_pixel_width;
+	uint32_t disp_px_h = c->sys_info.display_pixel_height;
+	if (disp_px_w == 0 || disp_px_h == 0 || disp_w_m <= 0 || disp_h_m <= 0) {
+		return false;
+	}
+
+	uint32_t win_px_w = 0, win_px_h = 0;
+	comp_gl_window_xlib_get_dimensions(c->xlib_window, &win_px_w, &win_px_h);
+	if (win_px_w == 0 || win_px_h == 0) {
+		return false;
+	}
+
+	float pixel_size_x = disp_w_m / (float)disp_px_w;
+	float pixel_size_y = disp_h_m / (float)disp_px_h;
+
+	out_metrics->display_width_m = disp_w_m;
+	out_metrics->display_height_m = disp_h_m;
+	out_metrics->display_pixel_width = disp_px_w;
+	out_metrics->display_pixel_height = disp_px_h;
+	out_metrics->display_screen_left = 0;
+	out_metrics->display_screen_top = 0;
+
+	out_metrics->window_pixel_width = win_px_w;
+	out_metrics->window_pixel_height = win_px_h;
+
+	out_metrics->window_width_m = (float)win_px_w * pixel_size_x;
+	out_metrics->window_height_m = (float)win_px_h * pixel_size_y;
+
+	// Real on-screen position when available (window-relative 3D tracks window
+	// moves), else centred. Mirrors the VK native / macOS paths (#524).
+	float disp_center_px_x = (float)disp_px_w / 2.0f;
+	float disp_center_px_y = (float)disp_px_h / 2.0f;
+	float win_center_px_x = disp_center_px_x;
+	float win_center_px_y = disp_center_px_y;
+	int32_t win_left = 0, win_top = 0;
+	if (comp_gl_window_xlib_get_screen_position(c->xlib_window, &win_left, &win_top)) {
+		win_center_px_x = (float)win_left + (float)win_px_w / 2.0f;
+		win_center_px_y = (float)win_top + (float)win_px_h / 2.0f;
+	}
+	out_metrics->window_screen_left = win_left;
+	out_metrics->window_screen_top = win_top;
+
+	out_metrics->window_center_offset_x_m = (win_center_px_x - disp_center_px_x) * pixel_size_x;
+	out_metrics->window_center_offset_y_m = -((win_center_px_y - disp_center_px_y) * pixel_size_y);
+
+	out_metrics->valid = true;
+	return true;
 #else
 	(void)c;
 	return false;
@@ -4497,6 +4614,10 @@ comp_gl_compositor_create(struct xrt_device *xdev,
 	HGLRC caller_hglrc = wglGetCurrentContext();
 #elif defined(__APPLE__)
 	CGLContextObj caller_cgl_ctx = CGLGetCurrentContext();
+#elif defined(XRT_OS_LINUX)
+	void *caller_glx_dpy = NULL, *caller_glx_ctx = NULL;
+	unsigned long caller_glx_draw = 0;
+	comp_gl_window_xlib_save_current(&caller_glx_dpy, &caller_glx_draw, &caller_glx_ctx);
 #endif
 
 	// Platform-specific context/window setup
@@ -4629,6 +4750,40 @@ comp_gl_compositor_create(struct xrt_device *xdev,
 		comp_gl_window_macos_make_current(c->macos_window);
 	}
 	(void)gl_display;
+#elif defined(XRT_OS_LINUX)
+	// Desktop Linux: self-create an X11/GLX window (hosted class). The
+	// compositor's GLX context SHARES the app's context (gl_context) on the
+	// app's Display (gl_display), so it samples the app's swapchain textures
+	// directly — no external-memory FD interop (what makes software/llvmpipe
+	// viable where the VK native path needs external_fd support).
+	(void)shared_texture_handle; // no GL shared-texture present path on Linux
+	{
+		// window_handle carries the app's X11 Window (XID) when the app used
+		// XR_EXT_xlib_window_binding (handle class); NULL → self-create (hosted).
+		unsigned long app_window = (unsigned long)(uintptr_t)window_handle;
+		xrt_result_t xret = comp_gl_window_xlib_create(
+		    gl_display, gl_context, app_window, width, height, &c->xlib_window);
+		if (xret != XRT_SUCCESS) {
+			free(c);
+			return XRT_ERROR_OPENGL;
+		}
+		c->owns_window = (app_window == 0);
+		if (!comp_gl_window_xlib_make_current(c->xlib_window)) {
+			U_LOG_E("GL/Xlib: failed to make compositor context current");
+			free(c);
+			return XRT_ERROR_OPENGL;
+		}
+		// Load the process-wide GLAD dispatch NOW (context is current) so the
+		// compositor, sim_display DP, u_hud and aux_ogl all resolve their gl*
+		// pointers. Without this every glad_gl* call is a NULL-pointer crash.
+		if (gladLoadGLUserPtr(gl_xlib_glad_loader, NULL) == 0) {
+			U_LOG_E("GL/Xlib: gladLoadGLUserPtr failed to load GL functions");
+			free(c);
+			return XRT_ERROR_OPENGL;
+		}
+		U_LOG_W("GL/Xlib: compositor context current + GLAD loaded (GL_VERSION=%s)",
+		        (const char *)glGetString(GL_VERSION));
+	}
 #else
 	(void)shared_texture_handle;
 #endif
@@ -4764,6 +4919,10 @@ comp_gl_compositor_create(struct xrt_device *xdev,
 	if (caller_cgl_ctx != NULL) {
 		CGLSetCurrentContext(caller_cgl_ctx);
 	}
+#elif defined(XRT_OS_LINUX)
+	// Restore the caller's context; if none was current, the app's own
+	// glXMakeCurrent on its render thread is authoritative, so leave it be.
+	comp_gl_window_xlib_restore_current(caller_glx_dpy, caller_glx_draw, caller_glx_ctx);
 #endif
 
 	U_LOG_W("Native OpenGL compositor created: %ux%u", width, height);

--- a/src/xrt/compositor/gl/comp_gl_window_xlib.c
+++ b/src/xrt/compositor/gl/comp_gl_window_xlib.c
@@ -1,0 +1,385 @@
+// Copyright 2026, Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  Xlib/GLX window helper for the native GL compositor on desktop Linux.
+ *
+ * @ingroup comp_gl
+ */
+
+#include "comp_gl_window_xlib.h"
+
+#include "util/u_misc.h"
+#include "util/u_logging.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <X11/Xlib.h>
+#include <GL/glx.h>
+
+struct comp_gl_window_xlib
+{
+	//! Borrowed from the app's XrGraphicsBindingOpenGLXlibKHR.xDisplay — NOT
+	//! opened or closed here (GLX context sharing needs one shared Display).
+	Display *dpy;
+	Window window;
+	Window root;
+	GLXContext context; //!< Compositor's own context, shares with the app's.
+	GLXFBConfig fbconfig;
+
+	Atom atom_wm_delete_window;
+
+	uint32_t width;
+	uint32_t height;
+
+	//! true → self-created window (hosted): destroy it on teardown. false →
+	//! app-provided window (handle, XR_EXT_xlib_window_binding): app owns it.
+	bool owns_window;
+
+	//! Cleared when the user/WM closes the window.
+	bool valid;
+};
+
+xrt_result_t
+comp_gl_window_xlib_create(void *app_display,
+                           void *app_glx_context,
+                           unsigned long app_window,
+                           uint32_t width,
+                           uint32_t height,
+                           struct comp_gl_window_xlib **out_win)
+{
+	if (width == 0) {
+		width = 1280;
+	}
+	if (height == 0) {
+		height = 720;
+	}
+
+	Display *dpy = (Display *)app_display;
+	if (dpy == NULL) {
+		U_LOG_E("GL/Xlib: no app Display* — the OpenXR Xlib GL binding must carry xDisplay");
+		return XRT_ERROR_DEVICE_CREATION_FAILED;
+	}
+
+	int screen = DefaultScreen(dpy);
+
+	// Double-buffered RGBA8 + depth FBConfig for the compositor's present window.
+	const int fb_attrs[] = {
+	    GLX_X_RENDERABLE, True,
+	    GLX_DRAWABLE_TYPE, GLX_WINDOW_BIT,
+	    GLX_RENDER_TYPE, GLX_RGBA_BIT,
+	    GLX_X_VISUAL_TYPE, GLX_TRUE_COLOR,
+	    GLX_RED_SIZE, 8,
+	    GLX_GREEN_SIZE, 8,
+	    GLX_BLUE_SIZE, 8,
+	    GLX_ALPHA_SIZE, 8,
+	    GLX_DEPTH_SIZE, 24,
+	    GLX_DOUBLEBUFFER, True,
+	    None};
+
+	int fbcount = 0;
+	GLXFBConfig *fbc = glXChooseFBConfig(dpy, screen, fb_attrs, &fbcount);
+	if (fbc == NULL || fbcount == 0) {
+		U_LOG_E("GL/Xlib: glXChooseFBConfig found no matching config");
+		return XRT_ERROR_OPENGL;
+	}
+
+	const bool use_app_window = (app_window != 0);
+
+	Window win = 0;
+	Window root = 0;
+	GLXFBConfig fbconfig = fbc[0];
+	Atom wm_delete = None;
+
+	if (use_app_window) {
+		// Handle class: render into the app's own Window. glXMakeCurrent requires
+		// the context's FBConfig be compatible with the drawable's visual, so pick
+		// the FBConfig whose visual matches the app window's visual.
+		XWindowAttributes wa;
+		if (XGetWindowAttributes(dpy, app_window, &wa) == 0) {
+			U_LOG_E("GL/Xlib: XGetWindowAttributes failed for app window 0x%08lx", app_window);
+			XFree(fbc);
+			return XRT_ERROR_OPENGL;
+		}
+		VisualID want_vid = XVisualIDFromVisual(wa.visual);
+		bool matched = false;
+		for (int i = 0; i < fbcount; i++) {
+			int vid = 0;
+			if (glXGetFBConfigAttrib(dpy, fbc[i], GLX_VISUAL_ID, &vid) == Success &&
+			    (VisualID)vid == want_vid) {
+				fbconfig = fbc[i];
+				matched = true;
+				break;
+			}
+		}
+		if (!matched) {
+			// No exact match — fall back to fbc[0]. Context/drawable may still be
+			// compatible; if not, glXMakeCurrent will fail loudly downstream.
+			U_LOG_W("GL/Xlib: no FBConfig matched app window visual 0x%lx; using default",
+			        (unsigned long)want_vid);
+		}
+		win = (Window)app_window;
+		root = wa.root;
+		width = (uint32_t)wa.width;
+		height = (uint32_t)wa.height;
+	} else {
+		// Hosted class: self-create the presentation window.
+		XVisualInfo *vi = glXGetVisualFromFBConfig(dpy, fbconfig);
+		if (vi == NULL) {
+			U_LOG_E("GL/Xlib: glXGetVisualFromFBConfig failed");
+			XFree(fbc);
+			return XRT_ERROR_OPENGL;
+		}
+
+		root = RootWindow(dpy, vi->screen);
+		Colormap cmap = XCreateColormap(dpy, root, vi->visual, AllocNone);
+
+		XSetWindowAttributes swa;
+		memset(&swa, 0, sizeof(swa));
+		swa.colormap = cmap;
+		swa.background_pixel = 0;
+		swa.border_pixel = 0;
+		swa.event_mask = StructureNotifyMask | KeyPressMask | KeyReleaseMask |
+		                 ButtonPressMask | ButtonReleaseMask | PointerMotionMask;
+
+		win = XCreateWindow(dpy, root, 0, 0, width, height, 0, vi->depth,
+		                    InputOutput, vi->visual,
+		                    CWColormap | CWEventMask | CWBackPixel | CWBorderPixel, &swa);
+		XFree(vi);
+		if (win == 0) {
+			U_LOG_E("GL/Xlib: XCreateWindow failed");
+			XFree(fbc);
+			return XRT_ERROR_OPENGL;
+		}
+
+		XStoreName(dpy, win, "DisplayXR");
+
+		// WM_DELETE_WINDOW so a user close is a ClientMessage we can detect rather
+		// than a fatal X error.
+		wm_delete = XInternAtom(dpy, "WM_DELETE_WINDOW", False);
+		if (wm_delete != None) {
+			XSetWMProtocols(dpy, win, &wm_delete, 1);
+		}
+
+		XMapWindow(dpy, win);
+	}
+
+	// Compositor context shares the texture namespace with the app's context so
+	// it can sample the app-rendered swapchain textures directly (no external
+	// memory). Direct rendering; falls back to indirect if that fails.
+	GLXContext share = (GLXContext)app_glx_context;
+	GLXContext ctx = glXCreateNewContext(dpy, fbconfig, GLX_RGBA_TYPE, share, True);
+	if (ctx == NULL && share != NULL) {
+		U_LOG_W("GL/Xlib: shared GLX context creation failed; retrying without sharing");
+		ctx = glXCreateNewContext(dpy, fbconfig, GLX_RGBA_TYPE, NULL, True);
+	}
+	XFree(fbc);
+	if (ctx == NULL) {
+		U_LOG_E("GL/Xlib: glXCreateNewContext failed");
+		if (!use_app_window) {
+			XDestroyWindow(dpy, win);
+		}
+		return XRT_ERROR_OPENGL;
+	}
+
+	struct comp_gl_window_xlib *w = U_TYPED_CALLOC(struct comp_gl_window_xlib);
+	w->dpy = dpy;
+	w->window = win;
+	w->root = root;
+	w->context = ctx;
+	w->fbconfig = fbconfig;
+	w->atom_wm_delete_window = wm_delete;
+	w->width = width;
+	w->height = height;
+	w->owns_window = !use_app_window;
+	w->valid = true;
+
+	XFlush(dpy);
+
+	U_LOG_W("GL/Xlib: %s %ux%u window 0x%08lx (shared=%s)",
+	        use_app_window ? "bound app" : "created", width, height,
+	        (unsigned long)win, share != NULL ? "yes" : "no");
+
+	*out_win = w;
+	return XRT_SUCCESS;
+}
+
+void *
+comp_gl_window_xlib_get_glx_context(struct comp_gl_window_xlib *win)
+{
+	return win != NULL ? (void *)win->context : NULL;
+}
+
+bool
+comp_gl_window_xlib_make_current(struct comp_gl_window_xlib *win)
+{
+	if (win == NULL || win->dpy == NULL) {
+		return false;
+	}
+	return glXMakeCurrent(win->dpy, win->window, win->context) == True;
+}
+
+void
+comp_gl_window_xlib_swap_buffers(struct comp_gl_window_xlib *win)
+{
+	if (win == NULL || win->dpy == NULL) {
+		return;
+	}
+	glXSwapBuffers(win->dpy, win->window);
+}
+
+void
+comp_gl_window_xlib_save_current(void **out_dpy, unsigned long *out_drawable, void **out_ctx)
+{
+	if (out_dpy != NULL) {
+		*out_dpy = (void *)glXGetCurrentDisplay();
+	}
+	if (out_drawable != NULL) {
+		*out_drawable = (unsigned long)glXGetCurrentDrawable();
+	}
+	if (out_ctx != NULL) {
+		*out_ctx = (void *)glXGetCurrentContext();
+	}
+}
+
+void
+comp_gl_window_xlib_restore_current(void *dpy, unsigned long drawable, void *ctx)
+{
+	if (dpy != NULL && ctx != NULL) {
+		glXMakeCurrent((Display *)dpy, (GLXDrawable)drawable, (GLXContext)ctx);
+	}
+}
+
+// Pull ONLY this window's events off the (shared with the app) Display, so we
+// track resize/close without consuming the app's events.
+static void
+pump(struct comp_gl_window_xlib *win)
+{
+	if (win == NULL || win->dpy == NULL) {
+		return;
+	}
+	// Handle class: the app owns the window's event stream on this shared
+	// Display. Don't consume its events — just read the current size directly.
+	if (!win->owns_window) {
+		XWindowAttributes wa;
+		if (XGetWindowAttributes(win->dpy, win->window, &wa) != 0) {
+			if (wa.width > 0 && wa.height > 0) {
+				win->width = (uint32_t)wa.width;
+				win->height = (uint32_t)wa.height;
+			}
+		}
+		return;
+	}
+	XEvent ev;
+	while (XCheckWindowEvent(win->dpy, win->window, StructureNotifyMask, &ev)) {
+		if (ev.type == ConfigureNotify) {
+			if (ev.xconfigure.width > 0 && ev.xconfigure.height > 0) {
+				win->width = (uint32_t)ev.xconfigure.width;
+				win->height = (uint32_t)ev.xconfigure.height;
+			}
+		} else if (ev.type == DestroyNotify) {
+			win->valid = false;
+		}
+	}
+	while (XCheckTypedWindowEvent(win->dpy, win->window, ClientMessage, &ev)) {
+		if (win->atom_wm_delete_window != None &&
+		    (Atom)ev.xclient.data.l[0] == win->atom_wm_delete_window) {
+			win->valid = false;
+		}
+	}
+}
+
+void
+comp_gl_window_xlib_get_dimensions(struct comp_gl_window_xlib *win,
+                                   uint32_t *out_width,
+                                   uint32_t *out_height)
+{
+	if (win == NULL) {
+		return;
+	}
+	pump(win);
+	if (out_width != NULL) {
+		*out_width = win->width;
+	}
+	if (out_height != NULL) {
+		*out_height = win->height;
+	}
+}
+
+bool
+comp_gl_window_xlib_get_screen_position(struct comp_gl_window_xlib *win,
+                                        int32_t *out_left_px,
+                                        int32_t *out_top_px)
+{
+	if (win == NULL || win->dpy == NULL) {
+		return false;
+	}
+	int x = 0, y = 0;
+	Window child = 0;
+	if (XTranslateCoordinates(win->dpy, win->window, win->root, 0, 0, &x, &y, &child) == 0) {
+		return false;
+	}
+	if (out_left_px != NULL) {
+		*out_left_px = x;
+	}
+	if (out_top_px != NULL) {
+		*out_top_px = y;
+	}
+	return true;
+}
+
+bool
+comp_gl_window_xlib_is_valid(struct comp_gl_window_xlib *win)
+{
+	if (win == NULL) {
+		return false;
+	}
+	pump(win);
+	return win->valid;
+}
+
+void
+comp_gl_window_xlib_pump_input(struct comp_gl_window_xlib *win,
+                               comp_gl_window_xlib_input_cb cb,
+                               void *ctx)
+{
+	if (win == NULL || win->dpy == NULL || cb == NULL) {
+		return;
+	}
+	// Handle class: the app owns input on its window — don't steal its events.
+	if (!win->owns_window) {
+		return;
+	}
+	const long mask = KeyPressMask | KeyReleaseMask | ButtonPressMask |
+	                  ButtonReleaseMask | PointerMotionMask;
+	XEvent ev;
+	// Only this window's input events — leaves the app's (on the shared Display) alone.
+	while (XCheckWindowEvent(win->dpy, win->window, mask, &ev)) {
+		cb(ctx, &ev);
+	}
+}
+
+void
+comp_gl_window_xlib_destroy(struct comp_gl_window_xlib **win_ptr)
+{
+	if (win_ptr == NULL || *win_ptr == NULL) {
+		return;
+	}
+	struct comp_gl_window_xlib *win = *win_ptr;
+	if (win->dpy != NULL) {
+		glXMakeCurrent(win->dpy, None, NULL);
+		if (win->context != NULL) {
+			glXDestroyContext(win->dpy, win->context);
+		}
+		// Only destroy a window we created (hosted). Handle-class windows are
+		// owned by the app (XR_EXT_xlib_window_binding).
+		if (win->owns_window && win->window != 0) {
+			XDestroyWindow(win->dpy, win->window);
+		}
+		XFlush(win->dpy);
+		// NOTE: do not XCloseDisplay — the Display is borrowed from the app.
+	}
+	free(win);
+	*win_ptr = NULL;
+}

--- a/src/xrt/compositor/gl/comp_gl_window_xlib.h
+++ b/src/xrt/compositor/gl/comp_gl_window_xlib.h
@@ -1,0 +1,147 @@
+// Copyright 2026, Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  Xlib/GLX window helper for the native GL compositor on desktop Linux.
+ *
+ * Mirrors comp_gl_window_macos (CGL/NSOpenGLView) and the VK native
+ * compositor's comp_vk_native_window_xcb pattern, but for OpenGL via GLX. The
+ * runtime self-creates an X11 window and a GLX context that SHARES the app's
+ * GLX context (so the compositor samples the app's swapchain textures directly
+ * — no external-memory FD interop, which is what makes the software (llvmpipe)
+ * path viable where the Vulkan native path needs external_fd support).
+ *
+ * The app's Display* and GLXContext arrive through the OpenXR Xlib GL binding
+ * (XrGraphicsBindingOpenGLXlibKHR); GLX context sharing requires both contexts
+ * live on the SAME Display, so this helper BORROWS the app's Display (it does
+ * not open or close its own connection).
+ *
+ * @ingroup comp_gl
+ */
+
+#pragma once
+
+#include "xrt/xrt_results.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct comp_gl_window_xlib;
+
+/*!
+ * Create the compositor's presentation target: a GLX context that shares
+ * textures with the app's GLX context, presenting into either a self-created
+ * X11 window (hosted class) or the app's own window (handle class).
+ *
+ * @param app_display     The app's Display* (from XrGraphicsBindingOpenGLXlibKHR.xDisplay).
+ * @param app_glx_context The app's GLXContext for share-group texture sharing (may be NULL).
+ * @param app_window      The app's X11 Window (XID) to render into (handle class,
+ *                        XR_EXT_xlib_window_binding). 0 (None) → self-create a
+ *                        window (hosted class). When provided, the window is NOT
+ *                        mapped/renamed here and NOT destroyed on teardown — the
+ *                        app owns its lifecycle.
+ * @param width           Requested window width in pixels (ignored for handle class).
+ * @param height          Requested window height in pixels (ignored for handle class).
+ * @param out_win         Pointer to receive the created window handle.
+ *
+ * @return XRT_SUCCESS on success, error code otherwise.
+ */
+xrt_result_t
+comp_gl_window_xlib_create(void *app_display,
+                           void *app_glx_context,
+                           unsigned long app_window,
+                           uint32_t width,
+                           uint32_t height,
+                           struct comp_gl_window_xlib **out_win);
+
+/*!
+ * Get the compositor's GLXContext (as void*) for making current.
+ */
+void *
+comp_gl_window_xlib_get_glx_context(struct comp_gl_window_xlib *win);
+
+/*!
+ * Make the compositor's GL context current on the compositor's window drawable.
+ *
+ * @return true if the context was made current successfully.
+ */
+bool
+comp_gl_window_xlib_make_current(struct comp_gl_window_xlib *win);
+
+/*!
+ * Swap buffers (present the rendered frame) via glXSwapBuffers.
+ */
+void
+comp_gl_window_xlib_swap_buffers(struct comp_gl_window_xlib *win);
+
+/*!
+ * Snapshot the currently-current GLX context/drawable/display, so the compositor
+ * can restore the app's context after doing its own GL work. Kept here (not in
+ * the compositor TU) so GLX/Xlib headers stay out of comp_gl_compositor.cpp.
+ * Values are opaque: dpy/ctx as void*, drawable as unsigned long (GLXDrawable).
+ */
+void
+comp_gl_window_xlib_save_current(void **out_dpy, unsigned long *out_drawable, void **out_ctx);
+
+/*!
+ * Restore a context snapshot from comp_gl_window_xlib_save_current (no-op if the
+ * snapshot had no current context).
+ */
+void
+comp_gl_window_xlib_restore_current(void *dpy, unsigned long drawable, void *ctx);
+
+/*!
+ * Get the current window pixel dimensions.
+ */
+void
+comp_gl_window_xlib_get_dimensions(struct comp_gl_window_xlib *win,
+                                   uint32_t *out_width,
+                                   uint32_t *out_height);
+
+/*!
+ * Get the window's on-screen position in root (screen) coordinates, for the
+ * display processor's interlace phase (#524 parity with the macOS/VK helpers).
+ *
+ * @return true if the position could be determined.
+ */
+bool
+comp_gl_window_xlib_get_screen_position(struct comp_gl_window_xlib *win,
+                                        int32_t *out_left_px,
+                                        int32_t *out_top_px);
+
+/*!
+ * Check if the window is still valid (not closed by the user / WM).
+ */
+bool
+comp_gl_window_xlib_is_valid(struct comp_gl_window_xlib *win);
+
+//! Callback for a captured input XEvent (passed as void* to avoid Xlib headers
+//! in the caller). @p ctx is the value handed to comp_gl_window_xlib_pump_input.
+typedef void (*comp_gl_window_xlib_input_cb)(void *ctx, void *xevent);
+
+/*!
+ * Drain this window's pending keyboard/mouse events and hand each to @p cb.
+ * Only events for the compositor's own window are pulled (the app's Display is
+ * shared), so the app's own events are never consumed. Call once per frame.
+ */
+void
+comp_gl_window_xlib_pump_input(struct comp_gl_window_xlib *win,
+                               comp_gl_window_xlib_input_cb cb,
+                               void *ctx);
+
+/*!
+ * Destroy the window helper and release resources. Does NOT close the borrowed
+ * app Display connection.
+ *
+ * @param win_ptr Pointer to window handle (set to NULL after destruction).
+ */
+void
+comp_gl_window_xlib_destroy(struct comp_gl_window_xlib **win_ptr);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/xrt/drivers/CMakeLists.txt
+++ b/src/xrt/drivers/CMakeLists.txt
@@ -31,6 +31,12 @@ if(XRT_BUILD_DRIVER_QWERTY)
 		list(APPEND QWERTY_SOURCES qwerty/qwerty_macos.m)
 	endif()
 
+	# On desktop Linux, add the X11 input handler for the native GL compositor
+	# window (WASDQE camera + RMB look + V/1/2/3 mode hotkeys). (#660)
+	if(XRT_HAVE_LINUX AND NOT ANDROID AND X11_FOUND)
+		list(APPEND QWERTY_SOURCES qwerty/qwerty_xlib.c)
+	endif()
+
 	add_library(drv_qwerty STATIC ${QWERTY_SOURCES})
 	# aux_math (PUBLIC displayxr::math_xrt) provides the canonical rig converters
 	# (dxr_view_rig_*) + dxr_view_math.h, used by the qwerty V-toggle to switch
@@ -41,6 +47,9 @@ if(XRT_BUILD_DRIVER_QWERTY)
 	endif()
 	if(APPLE)
 		target_link_libraries(drv_qwerty PRIVATE "-framework Cocoa" "-framework Carbon")
+	endif()
+	if(XRT_HAVE_LINUX AND NOT ANDROID AND X11_FOUND)
+		target_link_libraries(drv_qwerty PRIVATE X11::X11)
 	endif()
 	list(APPEND ENABLED_DRIVERS qwerty)
 
@@ -211,6 +220,13 @@ if(ANDROID OR XRT_HAVE_LINUX)
 		# Non-Android desktop GL build: the GL DP is compiled in, so it needs
 		# aux_ogl. (Headless Linux without GL skips this, matching the static lib.)
 		target_link_libraries(drv_sim_display_plugin PRIVATE aux_ogl)
+		if(NOT APPLE AND X11_FOUND AND OpenGL_GLX_FOUND)
+			# This plug-in .so carries its OWN GLAD dispatch table (aux_ogl is an
+			# INTERFACE lib compiled into every consumer) and is dlopen'd RTLD_LOCAL,
+			# so the runtime's gladLoad can't reach it — the GL DP self-loads GLAD
+			# via glXGetProcAddressARB, which needs GLX at link. (#660, Phase 1b-GL)
+			target_link_libraries(drv_sim_display_plugin PRIVATE OpenGL::GLX)
+		endif()
 	endif()
 else()
 	target_compile_definitions(drv_sim_display_plugin PRIVATE XRT_USING_RUNTIME_DLL)

--- a/src/xrt/drivers/qwerty/qwerty_interface.h
+++ b/src/xrt/drivers/qwerty/qwerty_interface.h
@@ -125,6 +125,20 @@ qwerty_process_macos(struct xrt_device **xdevs,
                      void *ns_event_ptr);
 #endif
 
+#if defined(__linux__) && !defined(__ANDROID__)
+/*!
+ * Process an X11 XEvent (key/button/motion) from the runtime's compositor
+ * window and drive the qwerty HMD (camera) + display/rendering-mode toggles.
+ * Desktop-Linux equivalent of qwerty_process_win32 / qwerty_process_macos.
+ *
+ * @param xevent_ptr An XEvent* cast to void* (avoids leaking Xlib headers here).
+ *
+ * @ingroup drv_qwerty
+ */
+void
+qwerty_process_xlib(struct xrt_device **xdevs, size_t xdev_count, void *xevent_ptr);
+#endif
+
 /*!
  * Create all qwerty devices.
  *

--- a/src/xrt/drivers/qwerty/qwerty_xlib.c
+++ b/src/xrt/drivers/qwerty/qwerty_xlib.c
@@ -1,0 +1,149 @@
+// Copyright 2026, Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  Xlib/X11 input handler for qwerty devices (desktop-Linux GL compositor).
+ *
+ * The Linux equivalent of qwerty_process_win32 / qwerty_process_macos: it turns
+ * X11 keyboard/mouse events from the runtime's self-created compositor window
+ * into qwerty device motion, so the runtime-hosted cube can be flown with
+ * WASDQE + arrow keys + RMB-drag look, and the display/rendering modes toggled
+ * with V / 1 / 2 / 3 — without the SDL debug GUI.
+ *
+ * Scoped to the HMD (camera) rig; controllers are not driven here (the hosted
+ * test app uses none). Mirrors qwerty_win32.c's structure, trimmed. (#660)
+ *
+ * @ingroup drv_qwerty
+ */
+
+#include "qwerty_device.h"
+#include "util/u_device.h"
+#include "util/u_hud.h"
+#include "util/u_logging.h"
+#include "xrt/xrt_device.h"
+
+#include <X11/Xlib.h>
+#include <X11/keysym.h>
+
+#include <string.h>
+#include <stdbool.h>
+
+// look_speed units per screen-pixel of mouse motion (matches qwerty_win32.c).
+#define SENSITIVITY 0.1f
+
+static struct qwerty_system *
+find_qwerty_system(struct xrt_device **xdevs, size_t xdev_count)
+{
+	struct xrt_device *xdev = NULL;
+	for (size_t i = 0; i < xdev_count; i++) {
+		if (xdevs[i] == NULL) {
+			continue;
+		}
+		const char *tracker_name = xdevs[i]->tracking_origin->name;
+		if (strcmp(tracker_name, QWERTY_HMD_TRACKER_STR) == 0 ||
+		    strcmp(tracker_name, QWERTY_LEFT_TRACKER_STR) == 0 ||
+		    strcmp(tracker_name, QWERTY_RIGHT_TRACKER_STR) == 0) {
+			xdev = xdevs[i];
+			break;
+		}
+	}
+	if (xdev == NULL) {
+		return NULL;
+	}
+	return qwerty_device(xdev)->sys;
+}
+
+void
+qwerty_process_xlib(struct xrt_device **xdevs, size_t xdev_count, void *xevent_ptr)
+{
+	static struct qwerty_system *qsys = NULL;
+	static struct qwerty_device *qd_hmd = NULL;
+	static bool cached = false;
+	static bool mouse_look_active = false;
+	static int last_x = 0, last_y = 0;
+
+	if (xevent_ptr == NULL) {
+		return;
+	}
+
+	if (!cached) {
+		qsys = find_qwerty_system(xdevs, xdev_count);
+		if (qsys == NULL) {
+			return; // No qwerty devices in this session.
+		}
+		qd_hmd = (qsys->hmd != NULL) ? &qsys->hmd->base : NULL;
+		cached = true;
+		U_LOG_W("QWERTY Xlib input ready — WASDQE move, arrows look, RMB-drag look, "
+		        "Shift sprint, +/- speed, V=2D/3D, 1/2/3=mode, P=cam/display, Space=reset, TAB=HUD");
+	}
+	if (qsys == NULL || !qsys->process_keys || qd_hmd == NULL) {
+		return;
+	}
+
+	XEvent *ev = (XEvent *)xevent_ptr;
+
+	switch (ev->type) {
+	case KeyPress:
+	case KeyRelease: {
+		bool down = (ev->type == KeyPress);
+		KeySym ks = XLookupKeysym(&ev->xkey, 0);
+		switch (ks) {
+		// Translation (WASDQE)
+		case XK_w: down ? qwerty_press_forward(qd_hmd)  : qwerty_release_forward(qd_hmd);  break;
+		case XK_s: down ? qwerty_press_backward(qd_hmd) : qwerty_release_backward(qd_hmd); break;
+		case XK_a: down ? qwerty_press_left(qd_hmd)     : qwerty_release_left(qd_hmd);     break;
+		case XK_d: down ? qwerty_press_right(qd_hmd)    : qwerty_release_right(qd_hmd);    break;
+		case XK_q: down ? qwerty_press_down(qd_hmd)     : qwerty_release_down(qd_hmd);     break;
+		case XK_e: down ? qwerty_press_up(qd_hmd)       : qwerty_release_up(qd_hmd);       break;
+		// Rotation (arrow keys)
+		case XK_Left:  down ? qwerty_press_look_left(qd_hmd)  : qwerty_release_look_left(qd_hmd);  break;
+		case XK_Right: down ? qwerty_press_look_right(qd_hmd) : qwerty_release_look_right(qd_hmd); break;
+		case XK_Up:    down ? qwerty_press_look_up(qd_hmd)    : qwerty_release_look_up(qd_hmd);    break;
+		case XK_Down:  down ? qwerty_press_look_down(qd_hmd)  : qwerty_release_look_down(qd_hmd);  break;
+		// Sprint
+		case XK_Shift_L:
+		case XK_Shift_R: down ? qwerty_press_sprint(qd_hmd) : qwerty_release_sprint(qd_hmd); break;
+		// Movement speed (keydown only)
+		case XK_plus:
+		case XK_equal:
+		case XK_KP_Add: if (down) qwerty_change_movement_speed(qd_hmd, 1); break;
+		case XK_minus:
+		case XK_KP_Subtract: if (down) qwerty_change_movement_speed(qd_hmd, -1); break;
+		// Mode hotkeys (keydown only)
+		case XK_v: if (down) qwerty_toggle_display_mode(qsys); break;
+		case XK_1: if (down) qwerty_set_rendering_mode(qsys, 0); break;
+		case XK_2: if (down) qwerty_set_rendering_mode(qsys, 1); break;
+		case XK_3: if (down) qwerty_set_rendering_mode(qsys, 2); break;
+		case XK_p: if (down) qwerty_toggle_camera_mode(qsys); break;
+		case XK_space: if (down) qwerty_reset_view_state(qsys); break;
+		case XK_Tab: if (down) u_hud_toggle(); break;
+		default: break;
+		}
+		break;
+	}
+	case ButtonPress:
+		if (ev->xbutton.button == Button3) { // RMB → mouse-look
+			mouse_look_active = true;
+			last_x = ev->xbutton.x;
+			last_y = ev->xbutton.y;
+		}
+		break;
+	case ButtonRelease:
+		if (ev->xbutton.button == Button3) {
+			mouse_look_active = false;
+		}
+		break;
+	case MotionNotify:
+		if (mouse_look_active) {
+			int dx = ev->xmotion.x - last_x;
+			int dy = ev->xmotion.y - last_y;
+			if (dx != 0 || dy != 0) {
+				qwerty_add_look_delta(qd_hmd, (float)(-dx) * SENSITIVITY, (float)(-dy) * SENSITIVITY);
+			}
+		}
+		last_x = ev->xmotion.x;
+		last_y = ev->xmotion.y;
+		break;
+	default: break;
+	}
+}

--- a/src/xrt/drivers/sim_display/sim_display_processor_gl.c
+++ b/src/xrt/drivers/sim_display/sim_display_processor_gl.c
@@ -33,6 +33,20 @@
 #include <stdlib.h>
 #include <string.h>
 
+#if !defined(XRT_OS_WINDOWS) && !defined(__APPLE__)
+// Desktop Linux: this plug-in .so carries its own copy of the GLAD dispatch
+// table (aux_ogl/xrt-external-glad is an INTERFACE lib compiled into every
+// consumer) and is dlopen'd RTLD_LOCAL, so the runtime's gladLoad never reaches
+// it. Load our copy from the current GLX context before any gl* call. (#660)
+extern void (*glXGetProcAddressARB(const unsigned char *procName))(void);
+static GLADapiproc
+sim_gl_glad_loader(void *userptr, const char *name)
+{
+	(void)userptr;
+	return (GLADapiproc)glXGetProcAddressARB((const unsigned char *)name);
+}
+#endif
+
 DEBUG_GET_ONCE_FLOAT_OPTION(sim_display_nominal_z_m_gl, "SIM_DISPLAY_NOMINAL_Z_M", 0.60f)
 
 
@@ -554,6 +568,16 @@ sim_display_processor_gl_create(enum sim_display_output_mode mode,
 	if (sdp == NULL) {
 		return XRT_ERROR_ALLOCATION;
 	}
+
+#if !defined(XRT_OS_WINDOWS) && !defined(__APPLE__)
+	// Load THIS .so's GLAD dispatch (see note at sim_gl_glad_loader). The caller
+	// (comp_gl compositor) has made a GL context current before invoking us.
+	if (gladLoadGLUserPtr(sim_gl_glad_loader, NULL) == 0) {
+		U_LOG_E("sim_display GL: gladLoadGLUserPtr failed — no current GLX context?");
+		free(sdp);
+		return XRT_ERROR_VULKAN;
+	}
+#endif
 
 	// ADR-020 rule 1: advertise the vtable size (calloc zeroed reserved_0).
 	sdp->base.struct_size = (uint32_t)sizeof(struct xrt_display_processor_gl);

--- a/src/xrt/include/xrt/CMakeLists.txt
+++ b/src/xrt/include/xrt/CMakeLists.txt
@@ -44,7 +44,14 @@ if(XRT_HAVE_OPENGLES)
 	set(XR_USE_GRAPHICS_API_OPENGL_ES ON)
 endif()
 
-if(XRT_HAVE_OPENGL_GLX AND XRT_HAVE_XLIB)
+if((XRT_HAVE_OPENGL_GLX AND XRT_HAVE_XLIB)
+   OR (XRT_HAVE_LINUX AND NOT ANDROID AND X11_FOUND AND OpenGL_GLX_FOUND))
+	# Desktop-Linux native GL compositor uses the Xlib/GLX graphics binding
+	# (XrGraphicsBindingOpenGLXlibKHR). Enabled even though the legacy GLX client
+	# path (XRT_HAVE_OPENGL_GLX) stays removed. See docs/roadmap/linux-support.md.
+	# NOTE: left unconditional (not gated on XRT_FEATURE_GL_LINUX_SOFTWARE) so the
+	# default Vulkan/XCB build's XR_EXT_xlib_window_binding path is unaffected; the
+	# GL compositor is gated separately via comp_gl + XRT_HAVE_GL_NATIVE_COMPOSITOR.
 	set(XR_USE_PLATFORM_XLIB ON)
 endif()
 

--- a/src/xrt/state_trackers/oxr/CMakeLists.txt
+++ b/src/xrt/state_trackers/oxr/CMakeLists.txt
@@ -77,7 +77,11 @@ if(XRT_HAVE_OPENGL OR XRT_HAVE_OPENGLES)
 endif()
 
 if(XRT_HAVE_OPENGL_GLX AND XRT_HAVE_XLIB)
+	# Legacy Monado GLX *client* compositor path (shares images via
+	# GL_EXT_memory_object_fd). Removed on this runtime; the marker lets
+	# oxr_session.c fall back to it only when actually compiled.
 	target_sources(st_oxr PRIVATE oxr_session_gfx_gl_xlib.c)
+	target_compile_definitions(st_oxr PRIVATE XRT_HAVE_GL_XLIB_CLIENT)
 endif()
 
 if(XRT_HAVE_EGL)
@@ -210,6 +214,22 @@ if(WIN32 AND XRT_HAVE_OPENGL)
 		target_sources(st_oxr PRIVATE oxr_session_gfx_gl_native.c)
 		target_link_libraries(st_oxr PRIVATE comp_gl)
 		target_compile_definitions(st_oxr PRIVATE XRT_HAVE_GL_NATIVE_COMPOSITOR)
+	endif()
+endif()
+
+# Desktop-Linux OpenGL apps route through the native GL compositor (Xlib/GLX),
+# bypassing Vulkan — the compositor shares the app's GL context so there's no
+# external-memory FD interop, which is what lets it run on software/llvmpipe
+# (the Vulkan native path needs external_fd support the software driver lacks).
+# See docs/roadmap/linux-support.md (Phase 1b-GL).
+if(XRT_FEATURE_GL_LINUX_SOFTWARE AND XRT_HAVE_LINUX AND NOT ANDROID AND XRT_HAVE_OPENGL AND X11_FOUND AND OpenGL_GLX_FOUND)
+	if(TARGET comp_gl)
+		target_sources(st_oxr PRIVATE oxr_session_gfx_gl_native.c)
+		target_link_libraries(st_oxr PRIVATE comp_gl)
+		target_compile_definitions(st_oxr PRIVATE XRT_HAVE_GL_NATIVE_COMPOSITOR)
+		# oxr_session.c's Xlib GL dispatch needs the Xlib/GLX types.
+		target_include_directories(st_oxr PRIVATE ${X11_INCLUDE_DIR})
+		target_link_libraries(st_oxr PRIVATE OpenGL::GLX X11::X11)
 	endif()
 endif()
 

--- a/src/xrt/state_trackers/oxr/oxr_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_session.c
@@ -3125,8 +3125,60 @@ oxr_session_create_impl(struct oxr_logger *log,
 		}
 
 		OXR_SESSION_ALLOCATE_AND_INIT(log, sys, OXR_SESSION_GRAPHICS_EXT_XLIB_GL, *out_session);
+
+#ifdef XRT_HAVE_GL_NATIVE_COMPOSITOR
+		// Desktop Linux: route GL apps through the native GL compositor (Xlib/GLX,
+		// bypasses Vulkan). The compositor's GLX context shares the app's context
+		// so it samples swapchain textures directly — no external-memory FD interop
+		// (what makes the software/llvmpipe path viable). Mirrors the Win32 path.
+		if (oxr_gl_native_compositor_supported(sys)) {
+			xrt_result_t xret = xrt_system_create_session(sys->xsys, xsi, &(*out_session)->xs, NULL);
+			if (xret == XRT_ERROR_MULTI_SESSION_NOT_IMPLEMENTED) {
+				return oxr_error(log, XR_ERROR_LIMIT_REACHED, "Per instance multi-session not supported.");
+			}
+			if (xret != XRT_SUCCESS) {
+				return oxr_error(log, XR_ERROR_RUNTIME_FAILURE, "Failed to create xrt_session! '%i'", xret);
+			}
+			// Handle class (XR_EXT_xlib_window_binding): the app provides its own
+			// X11 Window and the runtime renders into it. Absent (or window==0),
+			// window_handle stays NULL → the compositor self-creates the X11/GLX
+			// window (hosted class). The Window XID is passed as an opaque void*;
+			// the GL compositor's Linux branch casts it back. gl_context = app's
+			// GLXContext, gl_display = xDisplay (shared for GLX context sharing).
+			void *ext_window_handle = NULL;
+			const XrXlibWindowBindingCreateInfoEXT *xlib_binding = OXR_GET_INPUT_FROM_CHAIN(
+			    createInfo, XR_TYPE_XLIB_WINDOW_BINDING_CREATE_INFO_EXT, XrXlibWindowBindingCreateInfoEXT);
+			if (xlib_binding != NULL && xlib_binding->window != 0) {
+				ext_window_handle = (void *)(uintptr_t)xlib_binding->window;
+			}
+			XrResult ret = oxr_session_populate_gl_native(log, sys, ext_window_handle,
+			                                              (void *)opengl_xlib->glxContext,
+			                                              (void *)opengl_xlib->xDisplay,
+			                                              NULL /*shared_texture*/,
+			                                              xsi->transparent_background_enabled,
+			                                              *out_session);
+			// Handle class: mark the app-owned window so view-locate/eye handling
+			// matches the win32/cocoa window-binding paths (windowed app mode).
+			if (ret == XR_SUCCESS && ext_window_handle != NULL) {
+				(*out_session)->has_external_window = true;
+				struct xrt_device *head = GET_XDEV_BY_ROLE((*out_session)->sys, head);
+				if (head != NULL) {
+					xrt_device_set_property(head, XRT_DEVICE_PROPERTY_EXT_APP_MODE, 1);
+				}
+			}
+			return ret;
+		}
+#endif
+
+#ifdef XRT_HAVE_GL_XLIB_CLIENT
+		// Legacy Monado GLX client path (shares via GL_EXT_memory_object_fd).
 		OXR_CREATE_XRT_SESSION_AND_NATIVE_COMPOSITOR(log, xsi, *out_session);
 		return oxr_session_populate_gl_xlib(log, sys, opengl_xlib, *out_session);
+#else
+		return oxr_error(log, XR_ERROR_INITIALIZATION_FAILED,
+		                 "GL native compositor unavailable (OXR_ENABLE_GL_NATIVE_COMPOSITOR=0) and the "
+		                 "legacy GLX client compositor is not built on this runtime");
+#endif
 	}
 #endif
 
@@ -3706,6 +3758,25 @@ oxr_session_create(struct oxr_logger *log,
 		}
 	} else {
 		U_LOG_W("No cocoa window binding found in session create chain");
+	}
+#endif
+
+// Software-GL path only (XRT_FEATURE_GL_LINUX_SOFTWARE): parse
+// XR_EXT_xlib_window_binding into xsi.external_window_handle so the GL native
+// compositor's handle class gets has_external_window (raw eye positions +
+// qwerty disabled), mirroring the win32/cocoa paths. The default Vulkan/XCB
+// build handles this binding via its own routing (see the Vulkan graphics
+// binding block above), so this is intentionally scoped to GL builds and never
+// alters the default path. MUST also gate on XR_USE_PLATFORM_XLIB: macOS and
+// Windows also define XRT_HAVE_GL_NATIVE_COMPOSITOR, but XrXlibWindowBindingCreateInfoEXT
+// is Linux-only (its header guards the struct on __linux__ && !__ANDROID__).
+#if defined(XRT_HAVE_GL_NATIVE_COMPOSITOR) && defined(XR_USE_PLATFORM_XLIB)
+	{
+		const XrXlibWindowBindingCreateInfoEXT *xlib_target_info = OXR_GET_INPUT_FROM_CHAIN(
+		    createInfo, XR_TYPE_XLIB_WINDOW_BINDING_CREATE_INFO_EXT, XrXlibWindowBindingCreateInfoEXT);
+		if (xlib_target_info != NULL && xlib_target_info->window != 0) {
+			xsi.external_window_handle = (void *)(uintptr_t)xlib_target_info->window;
+		}
 	}
 #endif
 

--- a/test_apps/cube_handle_gl_linux/CMakeLists.txt
+++ b/test_apps/cube_handle_gl_linux/CMakeLists.txt
@@ -1,0 +1,100 @@
+# Copyright 2026, Leia Inc.
+# SPDX-License-Identifier: BSL-1.0
+#
+# Linux handle-class OpenGL cube — on-screen target for the native GL compositor
+# + GLX present path via XR_EXT_xlib_window_binding (Phase 3, #660). "Handle" =
+# the app creates its OWN X11 window and passes the Window (XID) to the runtime,
+# which renders into it (vs "hosted", where the runtime self-creates the window).
+# The app supplies a GLX context via the core XR_KHR_opengl_enable Xlib binding;
+# the compositor shares that context so it samples the app's swapchain textures
+# directly — no external-memory FD interop, which is what lets it run on software
+# GL (llvmpipe) under WSLg. Adapted from cube_hosted_legacy_gl_linux.
+
+cmake_minimum_required(VERSION 3.21)
+project(cube_handle_gl_linux LANGUAGES C CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(OpenGL REQUIRED COMPONENTS OpenGL GLX)
+find_package(X11 REQUIRED)
+message(STATUS "Found OpenGL: ${OPENGL_gl_LIBRARY}; GLX: ${OpenGL_GLX_FOUND}; X11: ${X11_FOUND}")
+
+# OpenXR headers from the runtime source tree.
+set(OPENXR_INCLUDE_DIR "${CMAKE_SOURCE_DIR}/../../src/external/openxr_includes")
+
+# Find the OpenXR loader: CMake package → system library → parent build tree.
+set(OPENXR_FOUND FALSE)
+
+find_package(OpenXR QUIET CONFIG)
+if(OpenXR_FOUND)
+    set(OPENXR_FOUND TRUE)
+    message(STATUS "Found OpenXR via find_package")
+endif()
+
+if(NOT OPENXR_FOUND)
+    find_library(OPENXR_LOADER_LIB NAMES openxr_loader)
+    if(OPENXR_LOADER_LIB)
+        set(OPENXR_FOUND TRUE)
+        add_library(OpenXR::openxr_loader SHARED IMPORTED)
+        set_target_properties(OpenXR::openxr_loader PROPERTIES
+            IMPORTED_LOCATION "${OPENXR_LOADER_LIB}"
+        )
+        message(STATUS "Found OpenXR loader: ${OPENXR_LOADER_LIB}")
+    endif()
+endif()
+
+if(NOT OPENXR_FOUND)
+    set(PARENT_BUILD_DIR "${CMAKE_SOURCE_DIR}/../../build")
+    if(EXISTS "${PARENT_BUILD_DIR}/src/external/openxr_loader/OpenXRConfig.cmake")
+        list(APPEND CMAKE_PREFIX_PATH "${PARENT_BUILD_DIR}/src/external/openxr_loader")
+        find_package(OpenXR REQUIRED CONFIG)
+        set(OPENXR_FOUND TRUE)
+    endif()
+endif()
+
+if(NOT OPENXR_FOUND)
+    message(FATAL_ERROR "OpenXR not found. Install the OpenXR loader or build it from source.")
+endif()
+
+# Shared scaffolding (stb_image header + impl TU) via displayxr::common, pinned by tag.
+include(FetchContent)
+set(DISPLAYXR_COMMON_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+get_filename_component(_dxr_ext_includes
+    "${CMAKE_SOURCE_DIR}/../../src/external/openxr_includes" ABSOLUTE)
+set(DISPLAYXR_EXTENSIONS_INCLUDE_DIR "${_dxr_ext_includes}" CACHE PATH
+    "DisplayXR OpenXR extension headers for displayxr::common")
+FetchContent_Declare(
+    displayxr_common
+    GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
+    GIT_TAG v1.1.2
+    GIT_SHALLOW TRUE
+)
+FetchContent_MakeAvailable(displayxr_common)
+
+# stb_image_impl.cpp supplies the stb_image definition on Linux (main.cpp is
+# declarations-only). Mirrors the VK Linux peer.
+add_executable(cube_handle_gl_linux main.cpp stb_image_impl.cpp)
+
+target_include_directories(cube_handle_gl_linux PRIVATE
+    ${OPENXR_INCLUDE_DIR}
+    ${CMAKE_SOURCE_DIR}/../common
+)
+
+# Copy texture files next to the built executable.
+file(GLOB TEXTURE_FILES "${CMAKE_SOURCE_DIR}/../common/textures/*.jpg")
+foreach(TEX ${TEXTURE_FILES})
+    get_filename_component(TEX_NAME ${TEX} NAME)
+    add_custom_command(TARGET cube_handle_gl_linux POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E make_directory "$<TARGET_FILE_DIR:cube_handle_gl_linux>/textures"
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${TEX} "$<TARGET_FILE_DIR:cube_handle_gl_linux>/textures/${TEX_NAME}"
+    )
+endforeach()
+
+target_link_libraries(cube_handle_gl_linux PRIVATE
+    displayxr::common
+    OpenXR::openxr_loader
+    OpenGL::GL
+    OpenGL::GLX
+    X11::X11
+)

--- a/test_apps/cube_handle_gl_linux/main.cpp
+++ b/test_apps/cube_handle_gl_linux/main.cpp
@@ -1,0 +1,1135 @@
+// Copyright 2026, Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  OpenGL OpenXR spinning cube test app for desktop Linux (handle class).
+ *
+ * Self-contained single-file app that renders a spinning cube + grid floor via
+ * OpenGL + OpenXR. Adapted from cube_hosted_legacy_gl_linux — same scene, math
+ * and OpenXR flow; the GL context comes from GLX and the runtime is bound via the
+ * core XR_KHR_opengl_enable Xlib binding (XrGraphicsBindingOpenGLXlibKHR).
+ *
+ * Legacy scene setup: does NOT enable XR_EXT_display_info. Relies on runtime
+ * defaults and recommendedImageRectWidth for swapchain sizing.
+ *
+ * "Handle" class: the APP creates its own on-screen X11 window and passes the
+ * Window (XID) to the runtime via XR_EXT_xlib_window_binding
+ * (XrXlibWindowBindingCreateInfoEXT chained into XrSessionCreateInfo). The native
+ * GL compositor renders into the app's window instead of self-creating one, and
+ * shares the app's GLX context so it samples the app's swapchain textures
+ * directly — no external-memory FD interop (viable on software GL / llvmpipe).
+ */
+
+#include <X11/Xlib.h>
+#define GL_GLEXT_PROTOTYPES
+#include <GL/gl.h>
+#include <GL/glext.h>
+#include <GL/glx.h>
+
+#define XR_USE_GRAPHICS_API_OPENGL
+#define XR_USE_PLATFORM_XLIB
+#include <openxr/openxr.h>
+#include <openxr/openxr_platform.h>
+#include <openxr/XR_EXT_xlib_window_binding.h>
+// Legacy app: NO DisplayXR extension types needed. Standard OpenXR APIs only.
+
+// X11/Xlib.h leaks short/all-caps macros that collide with GL enums and local
+// identifiers; drop the ones this TU uses as names.
+#undef None
+#undef Bool
+#undef Status
+#undef Success
+#undef Always
+
+#include <cmath>
+#include <csignal>
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <chrono>
+#include <vector>
+
+#include <unistd.h>
+
+// stb_image implementation TU lives in stb_image_impl.cpp — declarations only here.
+#include "stb_image.h"
+
+// ============================================================================
+// Logging
+// ============================================================================
+
+#define LOG_INFO(fmt, ...) fprintf(stderr, "[INFO] " fmt "\n", ##__VA_ARGS__)
+#define LOG_WARN(fmt, ...) fprintf(stderr, "[WARN] " fmt "\n", ##__VA_ARGS__)
+#define LOG_ERROR(fmt, ...) fprintf(stderr, "[ERROR] " fmt "\n", ##__VA_ARGS__)
+
+#define XR_CHECK(call)                                                         \
+    do {                                                                       \
+        XrResult _r = (call);                                                  \
+        if (XR_FAILED(_r)) {                                                   \
+            LOG_ERROR("OpenXR error %d at %s:%d", _r, __FILE__, __LINE__);     \
+            return false;                                                      \
+        }                                                                      \
+    } while (0)
+
+// ============================================================================
+// Math (column-major 4x4 matrices)
+// ============================================================================
+
+static void mat4_identity(float m[16])
+{
+    memset(m, 0, 16 * sizeof(float));
+    m[0] = m[5] = m[10] = m[15] = 1.0f;
+}
+
+static void mat4_multiply(float out[16], const float a[16], const float b[16])
+{
+    float tmp[16];
+    for (int c = 0; c < 4; c++) {
+        for (int r = 0; r < 4; r++) {
+            tmp[c * 4 + r] = 0;
+            for (int k = 0; k < 4; k++)
+                tmp[c * 4 + r] += a[k * 4 + r] * b[c * 4 + k];
+        }
+    }
+    memcpy(out, tmp, sizeof(tmp));
+}
+
+static void mat4_translation(float m[16], float x, float y, float z)
+{
+    mat4_identity(m);
+    m[12] = x; m[13] = y; m[14] = z;
+}
+
+static void mat4_scaling(float m[16], float s)
+{
+    mat4_identity(m);
+    m[0] = m[5] = m[10] = s;
+}
+
+static void mat4_rotation_y(float m[16], float angle)
+{
+    mat4_identity(m);
+    float c = cosf(angle), s = sinf(angle);
+    m[0] = c; m[2] = -s;
+    m[8] = s; m[10] = c;
+}
+
+static void mat4_from_xr_fov(float m[16], const XrFovf &fov, float nearZ, float farZ)
+{
+    float l = tanf(fov.angleLeft);
+    float r = tanf(fov.angleRight);
+    float u = tanf(fov.angleUp);
+    float d = tanf(fov.angleDown);
+
+    float w = r - l;
+    float h = u - d;
+
+    memset(m, 0, 16 * sizeof(float));
+    m[0]  = 2.0f / w;
+    m[5]  = 2.0f / h;
+    m[8]  = (r + l) / w;
+    m[9]  = (u + d) / h;
+    // OpenGL uses z range [-1, 1]
+    m[10] = -(farZ + nearZ) / (farZ - nearZ);
+    m[11] = -1.0f;
+    m[14] = -(2.0f * farZ * nearZ) / (farZ - nearZ);
+}
+
+static void mat4_view_from_xr_pose(float m[16], const XrPosef &pose)
+{
+    float x = pose.orientation.x, y = pose.orientation.y;
+    float z = pose.orientation.z, w = pose.orientation.w;
+
+    float r00 = 1 - 2*(y*y + z*z), r01 = 2*(x*y + w*z),     r02 = 2*(x*z - w*y);
+    float r10 = 2*(x*y - w*z),     r11 = 1 - 2*(x*x + z*z), r12 = 2*(y*z + w*x);
+    float r20 = 2*(x*z + w*y),     r21 = 2*(y*z - w*x),      r22 = 1 - 2*(x*x + y*y);
+
+    float px = pose.position.x, py = pose.position.y, pz = pose.position.z;
+
+    mat4_identity(m);
+    m[0] = r00; m[1] = r10; m[2]  = r20;
+    m[4] = r01; m[5] = r11; m[6]  = r21;
+    m[8] = r02; m[9] = r12; m[10] = r22;
+    m[12] = -(r00*px + r01*py + r02*pz);
+    m[13] = -(r10*px + r11*py + r12*pz);
+    m[14] = -(r20*px + r21*py + r22*pz);
+}
+
+// ============================================================================
+// Texture path helper (executable dir + /textures/)
+// ============================================================================
+
+static std::string GetTextureDir()
+{
+    char path[4096];
+    ssize_t n = readlink("/proc/self/exe", path, sizeof(path) - 1);
+    if (n > 0) {
+        path[n] = '\0';
+        std::string s(path);
+        size_t pos = s.find_last_of('/');
+        if (pos != std::string::npos)
+            return s.substr(0, pos + 1) + "textures/";
+    }
+    return "textures/";
+}
+
+// ============================================================================
+// GLSL shaders (OpenGL 4.1 core-compatible)
+// ============================================================================
+
+// Cube shaders — the loaded PBR textures are GL_TEXTURE_RECTANGLE (unnormalized
+// UVs), matching the macOS peer. The swapchain render TARGET is GL_TEXTURE_2D on
+// the Linux native GL compositor; the app never samples it, so this is fine.
+static const char *g_cubeVertexShader = R"GLSL(
+#version 410 core
+layout(location = 0) in vec3 aPos;
+layout(location = 1) in vec4 aColor;
+layout(location = 2) in vec2 aUV;
+layout(location = 3) in vec3 aNormal;
+layout(location = 4) in vec3 aTangent;
+
+uniform mat4 uMVP;
+uniform mat4 uModel;
+uniform vec2 uTexSize; // pixel dimensions for TEXTURE_RECTANGLE
+
+out vec2 vUV;
+out vec3 vWorldNormal;
+out vec3 vWorldTangent;
+
+void main() {
+    gl_Position = uMVP * vec4(aPos, 1.0);
+    vUV = aUV * uTexSize;  // scale [0,1] to pixel coords for TEXTURE_RECTANGLE
+    vWorldNormal = (uModel * vec4(aNormal, 0.0)).xyz;
+    vWorldTangent = (uModel * vec4(aTangent, 0.0)).xyz;
+}
+)GLSL";
+
+static const char *g_cubeFragmentShader = R"GLSL(
+#version 410 core
+uniform sampler2DRect uBasecolorTex;
+uniform sampler2DRect uNormalTex;
+uniform sampler2DRect uAOTex;
+
+in vec2 vUV;
+in vec3 vWorldNormal;
+in vec3 vWorldTangent;
+
+out vec4 fragColor;
+
+void main() {
+    vec4 baseColor = texture(uBasecolorTex, vUV);
+    vec3 normalMap = texture(uNormalTex, vUV).xyz * 2.0 - 1.0;
+    float ao = texture(uAOTex, vUV).r;
+
+    vec3 N = normalize(vWorldNormal);
+    vec3 T = normalize(vWorldTangent);
+    vec3 B = cross(N, T);
+    mat3 TBN = mat3(T, B, N);
+    vec3 normal = normalize(TBN * normalMap);
+
+    vec3 lightDir = normalize(vec3(0.3, 0.5, 1.0));
+    float diffuse = max(dot(normal, lightDir), 0.0) * 0.8 * ao;
+    float ambient = 0.3 + 0.15 * ao;
+
+    fragColor = vec4(baseColor.rgb * (diffuse + ambient), 1.0);
+}
+)GLSL";
+
+// Grid shaders
+static const char *g_gridVertexShader = R"GLSL(
+#version 410 core
+layout(location = 0) in vec3 aPos;
+uniform mat4 uMVP;
+void main() {
+    gl_Position = uMVP * vec4(aPos, 1.0);
+}
+)GLSL";
+
+static const char *g_gridFragmentShader = R"GLSL(
+#version 410 core
+uniform vec4 uColor;
+out vec4 fragColor;
+void main() {
+    fragColor = uColor;
+}
+)GLSL";
+
+// ============================================================================
+// Vertex data structures
+// ============================================================================
+
+struct CubeVertex {
+    float pos[3];
+    float color[4];
+    float uv[2];
+    float normal[3];
+    float tangent[3];
+};
+
+struct GridVertex {
+    float pos[3];
+};
+
+struct EyeRenderParams {
+    uint32_t viewportX, viewportY, width, height;
+    float viewMat[16];
+    float projMat[16];
+};
+
+// ============================================================================
+// Cube geometry (24 verts, 36 indices — 6 faces with unique normals)
+// ============================================================================
+
+static const CubeVertex g_cubeVertices[] = {
+    // Front face (Z+)
+    {{-0.5f,-0.5f, 0.5f}, {1,1,1,1}, {0,1}, { 0, 0, 1}, { 1, 0, 0}},
+    {{ 0.5f,-0.5f, 0.5f}, {1,1,1,1}, {1,1}, { 0, 0, 1}, { 1, 0, 0}},
+    {{ 0.5f, 0.5f, 0.5f}, {1,1,1,1}, {1,0}, { 0, 0, 1}, { 1, 0, 0}},
+    {{-0.5f, 0.5f, 0.5f}, {1,1,1,1}, {0,0}, { 0, 0, 1}, { 1, 0, 0}},
+    // Back face (Z-)
+    {{ 0.5f,-0.5f,-0.5f}, {1,1,1,1}, {0,1}, { 0, 0,-1}, {-1, 0, 0}},
+    {{-0.5f,-0.5f,-0.5f}, {1,1,1,1}, {1,1}, { 0, 0,-1}, {-1, 0, 0}},
+    {{-0.5f, 0.5f,-0.5f}, {1,1,1,1}, {1,0}, { 0, 0,-1}, {-1, 0, 0}},
+    {{ 0.5f, 0.5f,-0.5f}, {1,1,1,1}, {0,0}, { 0, 0,-1}, {-1, 0, 0}},
+    // Right face (X+)
+    {{ 0.5f,-0.5f, 0.5f}, {1,1,1,1}, {0,1}, { 1, 0, 0}, { 0, 0,-1}},
+    {{ 0.5f,-0.5f,-0.5f}, {1,1,1,1}, {1,1}, { 1, 0, 0}, { 0, 0,-1}},
+    {{ 0.5f, 0.5f,-0.5f}, {1,1,1,1}, {1,0}, { 1, 0, 0}, { 0, 0,-1}},
+    {{ 0.5f, 0.5f, 0.5f}, {1,1,1,1}, {0,0}, { 1, 0, 0}, { 0, 0,-1}},
+    // Left face (X-)
+    {{-0.5f,-0.5f,-0.5f}, {1,1,1,1}, {0,1}, {-1, 0, 0}, { 0, 0, 1}},
+    {{-0.5f,-0.5f, 0.5f}, {1,1,1,1}, {1,1}, {-1, 0, 0}, { 0, 0, 1}},
+    {{-0.5f, 0.5f, 0.5f}, {1,1,1,1}, {1,0}, {-1, 0, 0}, { 0, 0, 1}},
+    {{-0.5f, 0.5f,-0.5f}, {1,1,1,1}, {0,0}, {-1, 0, 0}, { 0, 0, 1}},
+    // Top face (Y+)
+    {{-0.5f, 0.5f, 0.5f}, {1,1,1,1}, {0,1}, { 0, 1, 0}, { 1, 0, 0}},
+    {{ 0.5f, 0.5f, 0.5f}, {1,1,1,1}, {1,1}, { 0, 1, 0}, { 1, 0, 0}},
+    {{ 0.5f, 0.5f,-0.5f}, {1,1,1,1}, {1,0}, { 0, 1, 0}, { 1, 0, 0}},
+    {{-0.5f, 0.5f,-0.5f}, {1,1,1,1}, {0,0}, { 0, 1, 0}, { 1, 0, 0}},
+    // Bottom face (Y-)
+    {{-0.5f,-0.5f,-0.5f}, {1,1,1,1}, {0,1}, { 0,-1, 0}, { 1, 0, 0}},
+    {{ 0.5f,-0.5f,-0.5f}, {1,1,1,1}, {1,1}, { 0,-1, 0}, { 1, 0, 0}},
+    {{ 0.5f,-0.5f, 0.5f}, {1,1,1,1}, {1,0}, { 0,-1, 0}, { 1, 0, 0}},
+    {{-0.5f,-0.5f, 0.5f}, {1,1,1,1}, {0,0}, { 0,-1, 0}, { 1, 0, 0}},
+};
+
+static const uint16_t g_cubeIndices[] = {
+     0, 1, 2,  2, 3, 0,   // front
+     4, 5, 6,  6, 7, 4,   // back
+     8, 9,10, 10,11, 8,   // right
+    12,13,14, 14,15,12,   // left
+    16,17,18, 18,19,16,   // top
+    20,21,22, 22,23,20,   // bottom
+};
+
+static std::vector<GridVertex> BuildGridVertices()
+{
+    std::vector<GridVertex> verts;
+    const int N = 10;
+    const float S = 1.0f;
+    const float Y = 0.0f;
+    for (int i = -N; i <= N; i++) {
+        float f = i * S;
+        verts.push_back({{f, Y, -N * S}});
+        verts.push_back({{f, Y,  N * S}});
+        verts.push_back({{-N * S, Y, f}});
+        verts.push_back({{ N * S, Y, f}});
+    }
+    return verts;
+}
+
+// ============================================================================
+// GL shader helpers
+// ============================================================================
+
+static GLuint CompileShader(GLenum type, const char *source)
+{
+    GLuint shader = glCreateShader(type);
+    glShaderSource(shader, 1, &source, nullptr);
+    glCompileShader(shader);
+    GLint ok = 0;
+    glGetShaderiv(shader, GL_COMPILE_STATUS, &ok);
+    if (!ok) {
+        char log[1024];
+        glGetShaderInfoLog(shader, sizeof(log), nullptr, log);
+        LOG_ERROR("Shader compile error: %s", log);
+        glDeleteShader(shader);
+        return 0;
+    }
+    return shader;
+}
+
+static GLuint LinkProgram(GLuint vs, GLuint fs)
+{
+    GLuint prog = glCreateProgram();
+    glAttachShader(prog, vs);
+    glAttachShader(prog, fs);
+    glLinkProgram(prog);
+    GLint ok = 0;
+    glGetProgramiv(prog, GL_LINK_STATUS, &ok);
+    if (!ok) {
+        char log[1024];
+        glGetProgramInfoLog(prog, sizeof(log), nullptr, log);
+        LOG_ERROR("Program link error: %s", log);
+        glDeleteProgram(prog);
+        return 0;
+    }
+    return prog;
+}
+
+// ============================================================================
+// OpenGL renderer
+// ============================================================================
+
+struct GLRenderer {
+    GLuint cubeProgram;
+    GLuint gridProgram;
+
+    GLint cubeLocMVP, cubeLocModel, cubeLocTexSize;
+    GLint cubeLocBasecolor, cubeLocNormal, cubeLocAO;
+
+    GLint gridLocMVP, gridLocColor;
+
+    GLuint cubeVAO, cubeVBO, cubeEBO;
+    GLuint gridVAO, gridVBO;
+    int gridVertexCount;
+
+    GLuint textures[3]; // basecolor, normal, AO
+    int texSizes[3][2];
+
+    GLuint depthRBO;
+    GLuint fbo;
+    uint32_t depthWidth, depthHeight;
+
+    float cubeRotation;
+};
+
+static GLuint LoadTextureRect(const char *path, int *outW, int *outH,
+                               uint8_t fallbackR, uint8_t fallbackG, uint8_t fallbackB)
+{
+    GLuint tex;
+    glGenTextures(1, &tex);
+    glBindTexture(GL_TEXTURE_RECTANGLE, tex);
+
+    int w, h, channels;
+    stbi_uc *pixels = stbi_load(path, &w, &h, &channels, 4);
+
+    if (!pixels) {
+        LOG_WARN("Texture not found: %s (using fallback)", path);
+        w = h = 1;
+        uint8_t fallback[4] = {fallbackR, fallbackG, fallbackB, 255};
+        glTexImage2D(GL_TEXTURE_RECTANGLE, 0, GL_RGBA8, 1, 1, 0,
+                     GL_RGBA, GL_UNSIGNED_BYTE, fallback);
+    } else {
+        glTexImage2D(GL_TEXTURE_RECTANGLE, 0, GL_RGBA8, w, h, 0,
+                     GL_RGBA, GL_UNSIGNED_BYTE, pixels);
+        stbi_image_free(pixels);
+        LOG_INFO("Loaded texture: %s (%dx%d)", path, w, h);
+    }
+
+    glTexParameteri(GL_TEXTURE_RECTANGLE, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_RECTANGLE, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glBindTexture(GL_TEXTURE_RECTANGLE, 0);
+
+    *outW = w;
+    *outH = h;
+    return tex;
+}
+
+static bool InitRenderer(GLRenderer &r)
+{
+    LOG_INFO("OpenGL context:");
+    LOG_INFO("  GL_VERSION: %s", glGetString(GL_VERSION));
+    LOG_INFO("  GL_RENDERER: %s", glGetString(GL_RENDERER));
+    LOG_INFO("  GL_VENDOR: %s", glGetString(GL_VENDOR));
+
+    GLuint cubeVS = CompileShader(GL_VERTEX_SHADER, g_cubeVertexShader);
+    GLuint cubeFS = CompileShader(GL_FRAGMENT_SHADER, g_cubeFragmentShader);
+    if (!cubeVS || !cubeFS) return false;
+    r.cubeProgram = LinkProgram(cubeVS, cubeFS);
+    glDeleteShader(cubeVS);
+    glDeleteShader(cubeFS);
+    if (!r.cubeProgram) return false;
+
+    r.cubeLocMVP = glGetUniformLocation(r.cubeProgram, "uMVP");
+    r.cubeLocModel = glGetUniformLocation(r.cubeProgram, "uModel");
+    r.cubeLocTexSize = glGetUniformLocation(r.cubeProgram, "uTexSize");
+    r.cubeLocBasecolor = glGetUniformLocation(r.cubeProgram, "uBasecolorTex");
+    r.cubeLocNormal = glGetUniformLocation(r.cubeProgram, "uNormalTex");
+    r.cubeLocAO = glGetUniformLocation(r.cubeProgram, "uAOTex");
+
+    GLuint gridVS = CompileShader(GL_VERTEX_SHADER, g_gridVertexShader);
+    GLuint gridFS = CompileShader(GL_FRAGMENT_SHADER, g_gridFragmentShader);
+    if (!gridVS || !gridFS) return false;
+    r.gridProgram = LinkProgram(gridVS, gridFS);
+    glDeleteShader(gridVS);
+    glDeleteShader(gridFS);
+    if (!r.gridProgram) return false;
+
+    r.gridLocMVP = glGetUniformLocation(r.gridProgram, "uMVP");
+    r.gridLocColor = glGetUniformLocation(r.gridProgram, "uColor");
+
+    glGenVertexArrays(1, &r.cubeVAO);
+    glBindVertexArray(r.cubeVAO);
+
+    glGenBuffers(1, &r.cubeVBO);
+    glBindBuffer(GL_ARRAY_BUFFER, r.cubeVBO);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(g_cubeVertices), g_cubeVertices, GL_STATIC_DRAW);
+
+    glGenBuffers(1, &r.cubeEBO);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, r.cubeEBO);
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(g_cubeIndices), g_cubeIndices, GL_STATIC_DRAW);
+
+    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(CubeVertex), (void *)offsetof(CubeVertex, pos));
+    glEnableVertexAttribArray(0);
+    glVertexAttribPointer(1, 4, GL_FLOAT, GL_FALSE, sizeof(CubeVertex), (void *)offsetof(CubeVertex, color));
+    glEnableVertexAttribArray(1);
+    glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, sizeof(CubeVertex), (void *)offsetof(CubeVertex, uv));
+    glEnableVertexAttribArray(2);
+    glVertexAttribPointer(3, 3, GL_FLOAT, GL_FALSE, sizeof(CubeVertex), (void *)offsetof(CubeVertex, normal));
+    glEnableVertexAttribArray(3);
+    glVertexAttribPointer(4, 3, GL_FLOAT, GL_FALSE, sizeof(CubeVertex), (void *)offsetof(CubeVertex, tangent));
+    glEnableVertexAttribArray(4);
+
+    glBindVertexArray(0);
+
+    auto gridVerts = BuildGridVertices();
+    r.gridVertexCount = (int)gridVerts.size();
+
+    glGenVertexArrays(1, &r.gridVAO);
+    glBindVertexArray(r.gridVAO);
+
+    glGenBuffers(1, &r.gridVBO);
+    glBindBuffer(GL_ARRAY_BUFFER, r.gridVBO);
+    glBufferData(GL_ARRAY_BUFFER, gridVerts.size() * sizeof(GridVertex), gridVerts.data(), GL_STATIC_DRAW);
+
+    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(GridVertex), (void *)0);
+    glEnableVertexAttribArray(0);
+
+    glBindVertexArray(0);
+
+    std::string texDir = GetTextureDir();
+    r.textures[0] = LoadTextureRect((texDir + "Wood_Crate_001_basecolor.jpg").c_str(),
+                                     &r.texSizes[0][0], &r.texSizes[0][1], 200, 200, 200);
+    r.textures[1] = LoadTextureRect((texDir + "Wood_Crate_001_normal.jpg").c_str(),
+                                     &r.texSizes[1][0], &r.texSizes[1][1], 128, 128, 255);
+    r.textures[2] = LoadTextureRect((texDir + "Wood_Crate_001_ambientOcclusion.jpg").c_str(),
+                                     &r.texSizes[2][0], &r.texSizes[2][1], 255, 255, 255);
+
+    r.cubeRotation = 0.0f;
+    r.depthRBO = 0;
+    r.fbo = 0;
+    r.depthWidth = r.depthHeight = 0;
+
+    LOG_INFO("OpenGL renderer initialized");
+    return true;
+}
+
+static void EnsureFBO(GLRenderer &r, uint32_t w, uint32_t h)
+{
+    if (r.fbo == 0) {
+        glGenFramebuffers(1, &r.fbo);
+    }
+    if (r.depthRBO == 0 || r.depthWidth != w || r.depthHeight != h) {
+        if (r.depthRBO) glDeleteRenderbuffers(1, &r.depthRBO);
+        glGenRenderbuffers(1, &r.depthRBO);
+        glBindRenderbuffer(GL_RENDERBUFFER, r.depthRBO);
+        glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT32F, w, h);
+        glBindRenderbuffer(GL_RENDERBUFFER, 0);
+        r.depthWidth = w;
+        r.depthHeight = h;
+    }
+}
+
+static void RenderScene(GLRenderer &r, GLuint targetTex, uint32_t targetW, uint32_t targetH,
+                         const EyeRenderParams *eyes, int eyeCount)
+{
+    EnsureFBO(r, targetW, targetH);
+
+    glBindFramebuffer(GL_FRAMEBUFFER, r.fbo);
+    // Swapchain textures are GL_TEXTURE_2D on the Linux native GL compositor.
+    // Detect the target type defensively (GL_TEXTURE_2D vs GL_TEXTURE_RECTANGLE).
+    GLint prev_tex2d = 0;
+    glGetIntegerv(GL_TEXTURE_BINDING_2D, &prev_tex2d);
+    glBindTexture(GL_TEXTURE_2D, targetTex);
+    GLint tex_width = 0;
+    glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_WIDTH, &tex_width);
+    glBindTexture(GL_TEXTURE_2D, prev_tex2d);
+    GLenum texTarget = (tex_width > 0) ? GL_TEXTURE_2D : GL_TEXTURE_RECTANGLE;
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, texTarget, targetTex, 0);
+    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, r.depthRBO);
+
+    GLenum fbStatus = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+    if (fbStatus != GL_FRAMEBUFFER_COMPLETE) {
+        LOG_ERROR("Framebuffer incomplete: 0x%x", fbStatus);
+        glBindFramebuffer(GL_FRAMEBUFFER, 0);
+        return;
+    }
+
+    glClearColor(0.05f, 0.05f, 0.08f, 1.0f);
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+    glEnable(GL_DEPTH_TEST);
+    glDepthFunc(GL_LESS);
+
+    for (int e = 0; e < eyeCount; e++) {
+        const EyeRenderParams &eye = eyes[e];
+        glViewport(eye.viewportX, eye.viewportY, eye.width, eye.height);
+        glScissor(eye.viewportX, eye.viewportY, eye.width, eye.height);
+        glEnable(GL_SCISSOR_TEST);
+
+        float vp_mat[16];
+        mat4_multiply(vp_mat, eye.projMat, eye.viewMat);
+
+        // --- Draw cube ---
+        {
+            float model[16], rotation[16], translation[16], scale[16], tmp[16];
+            mat4_scaling(scale, 0.4f);
+            mat4_rotation_y(rotation, r.cubeRotation);
+            // Handle class sets has_external_window → the runtime returns raw eye
+            // positions (no qwerty compose). The sim display's Kooima frustum is
+            // strongly downward-biased (U≈0°, D≈-18°), so center the cube below
+            // eye height and a comfortable distance out for an app that owns its
+            // own window + camera.
+            mat4_translation(translation, 0.0f, -0.25f, -1.9f);
+            mat4_multiply(tmp, rotation, scale);
+            mat4_multiply(model, translation, tmp);
+
+            float mvp[16];
+            mat4_multiply(mvp, vp_mat, model);
+
+            glUseProgram(r.cubeProgram);
+            glUniformMatrix4fv(r.cubeLocMVP, 1, GL_FALSE, mvp);
+            glUniformMatrix4fv(r.cubeLocModel, 1, GL_FALSE, model);
+            glUniform2f(r.cubeLocTexSize, (float)r.texSizes[0][0], (float)r.texSizes[0][1]);
+
+            glActiveTexture(GL_TEXTURE0);
+            glBindTexture(GL_TEXTURE_RECTANGLE, r.textures[0]);
+            glUniform1i(r.cubeLocBasecolor, 0);
+
+            glActiveTexture(GL_TEXTURE1);
+            glBindTexture(GL_TEXTURE_RECTANGLE, r.textures[1]);
+            glUniform1i(r.cubeLocNormal, 1);
+
+            glActiveTexture(GL_TEXTURE2);
+            glBindTexture(GL_TEXTURE_RECTANGLE, r.textures[2]);
+            glUniform1i(r.cubeLocAO, 2);
+
+            glBindVertexArray(r.cubeVAO);
+            glDrawElements(GL_TRIANGLES, 36, GL_UNSIGNED_SHORT, nullptr);
+        }
+
+        // --- Draw grid ---
+        {
+            float ident[16] = {1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1};
+            float gridMvp[16];
+            mat4_multiply(gridMvp, vp_mat, ident);
+
+            glUseProgram(r.gridProgram);
+            glUniformMatrix4fv(r.gridLocMVP, 1, GL_FALSE, gridMvp);
+            glUniform4f(r.gridLocColor, 0.3f, 0.3f, 0.35f, 1.0f);
+
+            glBindVertexArray(r.gridVAO);
+            glDrawArrays(GL_LINES, 0, r.gridVertexCount);
+        }
+    }
+
+    glDisable(GL_SCISSOR_TEST);
+    glBindVertexArray(0);
+    glUseProgram(0);
+    glFlush();
+
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+}
+
+// ============================================================================
+// OpenXR session management
+// ============================================================================
+
+struct SwapchainInfo {
+    XrSwapchain swapchain;
+    int64_t format;
+    uint32_t width, height, imageCount;
+    std::vector<GLuint> images;
+};
+
+struct AppXrSession {
+    XrInstance instance;
+    XrSystemId systemId;
+    XrSession session;
+    XrSpace localSpace;
+    XrSpace viewSpace;
+    SwapchainInfo swapchain;
+    XrViewConfigurationType viewConfigType;
+    std::vector<XrViewConfigurationView> configViews;
+    XrSessionState sessionState;
+    bool sessionRunning;
+    bool exitRequested;
+
+    uint32_t viewWidth = 0;
+    uint32_t viewHeight = 0;
+};
+
+static volatile bool g_running = true;
+
+static void SignalHandler(int) { g_running = false; }
+
+static bool InitializeOpenXR(AppXrSession &app)
+{
+    uint32_t extCount = 0;
+    xrEnumerateInstanceExtensionProperties(nullptr, 0, &extCount, nullptr);
+    std::vector<XrExtensionProperties> exts(extCount, {XR_TYPE_EXTENSION_PROPERTIES, nullptr, "", 0});
+    xrEnumerateInstanceExtensionProperties(nullptr, extCount, &extCount, exts.data());
+
+    bool hasGlEnable = false;
+    bool hasXlibWindowBinding = false;
+    LOG_INFO("Available OpenXR extensions:");
+    for (auto &e : exts) {
+        LOG_INFO("  %s v%u", e.extensionName, e.extensionVersion);
+        if (strcmp(e.extensionName, XR_KHR_OPENGL_ENABLE_EXTENSION_NAME) == 0)
+            hasGlEnable = true;
+        if (strcmp(e.extensionName, XR_EXT_XLIB_WINDOW_BINDING_EXTENSION_NAME) == 0)
+            hasXlibWindowBinding = true;
+    }
+
+    if (!hasGlEnable) {
+        LOG_ERROR("Runtime does not support XR_KHR_opengl_enable");
+        return false;
+    }
+    if (!hasXlibWindowBinding) {
+        LOG_ERROR("Runtime does not support XR_EXT_xlib_window_binding — "
+                  "cannot run the handle class (app-provided window)");
+        return false;
+    }
+
+    std::vector<const char*> enabledExts = {
+        XR_KHR_OPENGL_ENABLE_EXTENSION_NAME,
+        XR_EXT_XLIB_WINDOW_BINDING_EXTENSION_NAME,
+    };
+    XrInstanceCreateInfo createInfo = {XR_TYPE_INSTANCE_CREATE_INFO};
+    strncpy(createInfo.applicationInfo.applicationName, "GLCubeOpenXR", XR_MAX_APPLICATION_NAME_SIZE - 1);
+    createInfo.applicationInfo.applicationVersion = 1;
+    createInfo.applicationInfo.apiVersion = XR_CURRENT_API_VERSION;
+    createInfo.enabledExtensionCount = (uint32_t)enabledExts.size();
+    createInfo.enabledExtensionNames = enabledExts.data();
+
+    XR_CHECK(xrCreateInstance(&createInfo, &app.instance));
+    LOG_INFO("OpenXR instance created");
+
+    XrSystemGetInfo sysInfo = {XR_TYPE_SYSTEM_GET_INFO};
+    sysInfo.formFactor = XR_FORM_FACTOR_HEAD_MOUNTED_DISPLAY;
+    XR_CHECK(xrGetSystem(app.instance, &sysInfo, &app.systemId));
+    LOG_INFO("Got system ID: %llu", (unsigned long long)app.systemId);
+
+    // XR_KHR_opengl_enable REQUIRES calling xrGetOpenGLGraphicsRequirementsKHR
+    // before xrCreateSession (the runtime rejects the session otherwise).
+    PFN_xrGetOpenGLGraphicsRequirementsKHR pfnGetGlReq = nullptr;
+    xrGetInstanceProcAddr(app.instance, "xrGetOpenGLGraphicsRequirementsKHR",
+                          (PFN_xrVoidFunction *)&pfnGetGlReq);
+    if (pfnGetGlReq == nullptr) {
+        LOG_ERROR("xrGetOpenGLGraphicsRequirementsKHR unavailable");
+        return false;
+    }
+    XrGraphicsRequirementsOpenGLKHR glReq = {XR_TYPE_GRAPHICS_REQUIREMENTS_OPENGL_KHR};
+    XR_CHECK(pfnGetGlReq(app.instance, app.systemId, &glReq));
+    LOG_INFO("OpenGL graphics requirements: min %d.%d max %d.%d",
+             XR_VERSION_MAJOR(glReq.minApiVersionSupported),
+             XR_VERSION_MINOR(glReq.minApiVersionSupported),
+             XR_VERSION_MAJOR(glReq.maxApiVersionSupported),
+             XR_VERSION_MINOR(glReq.maxApiVersionSupported));
+
+    app.viewConfigType = XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO;
+    uint32_t viewCount = 0;
+    XR_CHECK(xrEnumerateViewConfigurationViews(app.instance, app.systemId, app.viewConfigType,
+                                                0, &viewCount, nullptr));
+    app.configViews.resize(viewCount);
+    for (uint32_t i = 0; i < viewCount; i++) {
+        app.configViews[i] = {XR_TYPE_VIEW_CONFIGURATION_VIEW};
+    }
+    XR_CHECK(xrEnumerateViewConfigurationViews(app.instance, app.systemId, app.viewConfigType,
+                                                viewCount, &viewCount, app.configViews.data()));
+    LOG_INFO("View configuration: %u views", viewCount);
+    for (uint32_t i = 0; i < viewCount; i++) {
+        LOG_INFO("  View %u: recommended %ux%u", i,
+                 app.configViews[i].recommendedImageRectWidth,
+                 app.configViews[i].recommendedImageRectHeight);
+    }
+
+    app.viewWidth = app.configViews[0].recommendedImageRectWidth;
+    app.viewHeight = app.configViews[0].recommendedImageRectHeight;
+    return true;
+}
+
+static bool CreateSession(AppXrSession &app, Display *dpy, uint32_t visualid,
+                          GLXFBConfig fbconfig, GLXDrawable drawable, GLXContext ctx)
+{
+    XrGraphicsBindingOpenGLXlibKHR binding = {XR_TYPE_GRAPHICS_BINDING_OPENGL_XLIB_KHR};
+    binding.xDisplay = dpy;
+    binding.visualid = visualid;
+    binding.glxFBConfig = fbconfig;
+    binding.glxDrawable = drawable;
+    binding.glxContext = ctx;
+
+    // Handle class: hand the runtime our own on-screen Window so its native GL
+    // compositor renders into it (vs self-creating one). drawable == the app's
+    // Window (XID) here. Chained after the GL binding in the next chain.
+    XrXlibWindowBindingCreateInfoEXT xlibWindow = {XR_TYPE_XLIB_WINDOW_BINDING_CREATE_INFO_EXT};
+    xlibWindow.xDisplay = dpy;                    // David's struct carries both; the GL
+    xlibWindow.window = (Window)drawable;         // native path reads .window, VK path both.
+    binding.next = &xlibWindow;
+
+    XrSessionCreateInfo sessionInfo = {XR_TYPE_SESSION_CREATE_INFO};
+    sessionInfo.next = &binding;
+    sessionInfo.systemId = app.systemId;
+
+    XR_CHECK(xrCreateSession(app.instance, &sessionInfo, &app.session));
+    LOG_INFO("OpenXR session created with Xlib/GLX binding + XR_EXT_xlib_window_binding "
+             "(app window 0x%08lx)", (unsigned long)drawable);
+
+    app.sessionState = XR_SESSION_STATE_UNKNOWN;
+    app.sessionRunning = false;
+    app.exitRequested = false;
+    return true;
+}
+
+static bool CreateSpaces(AppXrSession &app)
+{
+    XrReferenceSpaceCreateInfo spaceInfo = {XR_TYPE_REFERENCE_SPACE_CREATE_INFO};
+    spaceInfo.referenceSpaceType = XR_REFERENCE_SPACE_TYPE_LOCAL;
+    spaceInfo.poseInReferenceSpace = {{0,0,0,1}, {0,0,0}};
+    XR_CHECK(xrCreateReferenceSpace(app.session, &spaceInfo, &app.localSpace));
+
+    spaceInfo.referenceSpaceType = XR_REFERENCE_SPACE_TYPE_VIEW;
+    XR_CHECK(xrCreateReferenceSpace(app.session, &spaceInfo, &app.viewSpace));
+
+    LOG_INFO("Reference spaces created");
+    return true;
+}
+
+static bool CreateSwapchain(AppXrSession &app)
+{
+    uint32_t w = app.configViews[0].recommendedImageRectWidth * 2; // stereo SBS
+    uint32_t h = app.configViews[0].recommendedImageRectHeight;
+
+    uint32_t formatCount = 0;
+    XR_CHECK(xrEnumerateSwapchainFormats(app.session, 0, &formatCount, nullptr));
+    std::vector<int64_t> formats(formatCount);
+    XR_CHECK(xrEnumerateSwapchainFormats(app.session, formatCount, &formatCount, formats.data()));
+
+    int64_t selectedFormat = formats[0];
+    for (auto f : formats) {
+        if (f == GL_RGBA8) selectedFormat = f;
+    }
+    LOG_INFO("Supported swapchain formats:");
+    for (auto f : formats) {
+        LOG_INFO("  format 0x%llx%s", (long long)f, f == selectedFormat ? " (selected)" : "");
+    }
+
+    XrSwapchainCreateInfo sci = {XR_TYPE_SWAPCHAIN_CREATE_INFO};
+    sci.usageFlags = XR_SWAPCHAIN_USAGE_COLOR_ATTACHMENT_BIT | XR_SWAPCHAIN_USAGE_SAMPLED_BIT;
+    sci.format = selectedFormat;
+    sci.sampleCount = 1;
+    sci.width = w;
+    sci.height = h;
+    sci.faceCount = 1;
+    sci.arraySize = 1;
+    sci.mipCount = 1;
+
+    XR_CHECK(xrCreateSwapchain(app.session, &sci, &app.swapchain.swapchain));
+    app.swapchain.format = selectedFormat;
+    app.swapchain.width = w;
+    app.swapchain.height = h;
+
+    uint32_t imageCount = 0;
+    XR_CHECK(xrEnumerateSwapchainImages(app.swapchain.swapchain, 0, &imageCount, nullptr));
+    app.swapchain.imageCount = imageCount;
+
+    std::vector<XrSwapchainImageOpenGLKHR> glImages(imageCount, {XR_TYPE_SWAPCHAIN_IMAGE_OPENGL_KHR});
+    XR_CHECK(xrEnumerateSwapchainImages(app.swapchain.swapchain, imageCount, &imageCount,
+                                         (XrSwapchainImageBaseHeader *)glImages.data()));
+
+    app.swapchain.images.resize(imageCount);
+    for (uint32_t i = 0; i < imageCount; i++) {
+        app.swapchain.images[i] = glImages[i].image;
+        LOG_INFO("Swapchain image %u: GL texture %u", i, glImages[i].image);
+    }
+
+    LOG_INFO("Swapchain created: %ux%u, %u images", w, h, imageCount);
+    return true;
+}
+
+static void PollEvents(AppXrSession &app)
+{
+    XrEventDataBuffer event = {XR_TYPE_EVENT_DATA_BUFFER};
+    while (xrPollEvent(app.instance, &event) == XR_SUCCESS) {
+        switch (event.type) {
+        case XR_TYPE_EVENT_DATA_SESSION_STATE_CHANGED: {
+            auto *ssc = (XrEventDataSessionStateChanged *)&event;
+            app.sessionState = ssc->state;
+            LOG_INFO("Session state changed: %d", ssc->state);
+
+            if (ssc->state == XR_SESSION_STATE_READY) {
+                XrSessionBeginInfo beginInfo = {XR_TYPE_SESSION_BEGIN_INFO};
+                beginInfo.primaryViewConfigurationType = app.viewConfigType;
+                if (XR_SUCCEEDED(xrBeginSession(app.session, &beginInfo))) {
+                    app.sessionRunning = true;
+                    LOG_INFO("Session started");
+                }
+            } else if (ssc->state == XR_SESSION_STATE_STOPPING) {
+                xrEndSession(app.session);
+                app.sessionRunning = false;
+                LOG_INFO("Session stopped");
+            } else if (ssc->state == XR_SESSION_STATE_EXITING ||
+                       ssc->state == XR_SESSION_STATE_LOSS_PENDING) {
+                app.exitRequested = true;
+            }
+            break;
+        }
+        default: break;
+        }
+        event = {XR_TYPE_EVENT_DATA_BUFFER};
+    }
+}
+
+// ============================================================================
+// Main
+// ============================================================================
+
+int main(int argc, char **argv)
+{
+    (void)argc; (void)argv;
+    signal(SIGINT, SignalHandler);
+    signal(SIGTERM, SignalHandler);
+
+    LOG_INFO("=== OpenGL Cube OpenXR Test App (Linux, handle / XR_EXT_xlib_window_binding) ===");
+
+    // Xlib is shared with the in-process runtime GL compositor (which borrows
+    // this Display for its GLX context sharing), so enable Xlib threading.
+    XInitThreads();
+
+    Display *dpy = XOpenDisplay(nullptr);
+    if (dpy == nullptr) {
+        LOG_ERROR("XOpenDisplay failed — is DISPLAY set / an X server running?");
+        return 1;
+    }
+    int screen = DefaultScreen(dpy);
+
+    int fbAttrs[] = {
+        GLX_X_RENDERABLE, True,
+        GLX_DRAWABLE_TYPE, GLX_WINDOW_BIT,
+        GLX_RENDER_TYPE, GLX_RGBA_BIT,
+        GLX_X_VISUAL_TYPE, GLX_TRUE_COLOR,
+        GLX_RED_SIZE, 8, GLX_GREEN_SIZE, 8, GLX_BLUE_SIZE, 8, GLX_ALPHA_SIZE, 8,
+        GLX_DEPTH_SIZE, 24, GLX_DOUBLEBUFFER, True,
+        0 /*None*/
+    };
+    int fbcount = 0;
+    GLXFBConfig *fbc = glXChooseFBConfig(dpy, screen, fbAttrs, &fbcount);
+    if (fbc == nullptr || fbcount == 0) {
+        LOG_ERROR("glXChooseFBConfig found no config");
+        return 1;
+    }
+    GLXFBConfig fbconfig = fbc[0];
+    XVisualInfo *vi = glXGetVisualFromFBConfig(dpy, fbconfig);
+    if (vi == nullptr) {
+        LOG_ERROR("glXGetVisualFromFBConfig failed");
+        return 1;
+    }
+
+    // Handle class: the app creates its OWN real, on-screen window and hands it
+    // to the runtime via XR_EXT_xlib_window_binding. The runtime's GL compositor
+    // renders into this window (no self-created window).
+    const uint32_t kAppWinW = 1280, kAppWinH = 720;
+    XSetWindowAttributes swa;
+    memset(&swa, 0, sizeof(swa));
+    swa.colormap = XCreateColormap(dpy, RootWindow(dpy, vi->screen), vi->visual, AllocNone);
+    swa.background_pixel = 0;
+    swa.border_pixel = 0;
+    swa.event_mask = StructureNotifyMask;
+    Window appWin = XCreateWindow(dpy, RootWindow(dpy, vi->screen), 0, 0, kAppWinW, kAppWinH, 0,
+                                  vi->depth, InputOutput, vi->visual,
+                                  CWColormap | CWEventMask | CWBackPixel | CWBorderPixel, &swa);
+    XStoreName(dpy, appWin, "DisplayXR Cube (handle, GL/Xlib)");
+    XMapWindow(dpy, appWin);
+
+    GLXContext ctx = glXCreateNewContext(dpy, fbconfig, GLX_RGBA_TYPE, nullptr, True);
+    if (ctx == nullptr) {
+        LOG_ERROR("glXCreateNewContext failed");
+        return 1;
+    }
+    if (!glXMakeCurrent(dpy, appWin, ctx)) {
+        LOG_ERROR("glXMakeCurrent failed");
+        return 1;
+    }
+    XFree(fbc);
+    LOG_INFO("App-owned GLX window 0x%08lx created + mapped (%ux%u)",
+             (unsigned long)appWin, kAppWinW, kAppWinH);
+
+    GLRenderer renderer = {};
+    if (!InitRenderer(renderer)) {
+        LOG_ERROR("Failed to initialize OpenGL renderer");
+        return 1;
+    }
+
+    AppXrSession app = {};
+    if (!InitializeOpenXR(app)) {
+        LOG_ERROR("Failed to initialize OpenXR");
+        return 1;
+    }
+
+    if (!CreateSession(app, dpy, (uint32_t)vi->visualid, fbconfig, (GLXDrawable)appWin, ctx)) {
+        LOG_ERROR("Failed to create session");
+        xrDestroyInstance(app.instance);
+        return 1;
+    }
+    XFree(vi);
+
+    if (!CreateSpaces(app)) { LOG_ERROR("Failed to create spaces"); return 1; }
+    if (!CreateSwapchain(app)) { LOG_ERROR("Failed to create swapchain"); return 1; }
+
+    LOG_INFO("Entering main loop...");
+    auto lastTime = std::chrono::high_resolution_clock::now();
+
+    while (g_running && !app.exitRequested) {
+        auto now = std::chrono::high_resolution_clock::now();
+        float dt = std::chrono::duration<float>(now - lastTime).count();
+        lastTime = now;
+
+        PollEvents(app);
+
+        if (!app.sessionRunning) {
+            usleep(10000);
+            continue;
+        }
+
+        // App renders on its own context; the compositor switches to its shared
+        // context during xrEndFrame and restores ours after. Keep ours current.
+        glXMakeCurrent(dpy, appWin, ctx);
+
+        renderer.cubeRotation += dt * 0.5f;
+
+        XrFrameWaitInfo waitInfo = {XR_TYPE_FRAME_WAIT_INFO};
+        XrFrameState frameState = {XR_TYPE_FRAME_STATE};
+        if (XR_FAILED(xrWaitFrame(app.session, &waitInfo, &frameState))) {
+            LOG_WARN("xrWaitFrame failed");
+            continue;
+        }
+
+        XrFrameBeginInfo beginInfo = {XR_TYPE_FRAME_BEGIN_INFO};
+        if (XR_FAILED(xrBeginFrame(app.session, &beginInfo))) {
+            LOG_WARN("xrBeginFrame failed");
+            continue;
+        }
+
+        std::vector<XrView> views(app.configViews.size(), {XR_TYPE_VIEW});
+        XrViewState viewState = {XR_TYPE_VIEW_STATE};
+        XrViewLocateInfo locateInfo = {XR_TYPE_VIEW_LOCATE_INFO};
+        locateInfo.viewConfigurationType = app.viewConfigType;
+        locateInfo.displayTime = frameState.predictedDisplayTime;
+        locateInfo.space = app.localSpace;
+
+        uint32_t viewCount = 0;
+        xrLocateViews(app.session, &locateInfo, &viewState, (uint32_t)views.size(), &viewCount, views.data());
+
+        static int logCounter = 0;
+        if (logCounter % 120 == 0 && viewCount >= 2) {
+            for (uint32_t i = 0; i < viewCount && i < 2; i++) {
+                auto &p = views[i].pose.position;
+                LOG_INFO("View[%u] pos=(%.3f,%.3f,%.3f)", i, p.x, p.y, p.z);
+            }
+            LOG_INFO("shouldRender=%d viewCount=%u", frameState.shouldRender, viewCount);
+        }
+        logCounter++;
+
+        XrSwapchainImageAcquireInfo acqInfo = {XR_TYPE_SWAPCHAIN_IMAGE_ACQUIRE_INFO};
+        uint32_t imageIndex = 0;
+        if (XR_FAILED(xrAcquireSwapchainImage(app.swapchain.swapchain, &acqInfo, &imageIndex))) {
+            LOG_WARN("xrAcquireSwapchainImage failed");
+            XrFrameEndInfo endInfo = {XR_TYPE_FRAME_END_INFO};
+            endInfo.displayTime = frameState.predictedDisplayTime;
+            endInfo.environmentBlendMode = XR_ENVIRONMENT_BLEND_MODE_OPAQUE;
+            xrEndFrame(app.session, &endInfo);
+            continue;
+        }
+
+        XrSwapchainImageWaitInfo waitImgInfo = {XR_TYPE_SWAPCHAIN_IMAGE_WAIT_INFO};
+        waitImgInfo.timeout = XR_INFINITE_DURATION;
+        xrWaitSwapchainImage(app.swapchain.swapchain, &waitImgInfo);
+
+        uint32_t eyeCount = 2;
+        uint32_t eyeW = app.viewWidth;
+        uint32_t eyeH = app.viewHeight;
+        if (frameState.shouldRender && viewCount >= 2) {
+            EyeRenderParams eyeParams[2];
+            for (uint32_t i = 0; i < eyeCount; i++) {
+                eyeParams[i].viewportX = i * eyeW; // SBS
+                eyeParams[i].viewportY = 0;
+                eyeParams[i].width = eyeW;
+                eyeParams[i].height = eyeH;
+                mat4_view_from_xr_pose(eyeParams[i].viewMat, views[i].pose);
+                mat4_from_xr_fov(eyeParams[i].projMat, views[i].fov, 0.05f, 100.0f);
+            }
+            RenderScene(renderer, app.swapchain.images[imageIndex],
+                        app.swapchain.width, app.swapchain.height, eyeParams, (int)eyeCount);
+        }
+
+        XrSwapchainImageReleaseInfo relInfo = {XR_TYPE_SWAPCHAIN_IMAGE_RELEASE_INFO};
+        xrReleaseSwapchainImage(app.swapchain.swapchain, &relInfo);
+
+        XrCompositionLayerProjectionView projViews[2] = {
+            {XR_TYPE_COMPOSITION_LAYER_PROJECTION_VIEW},
+            {XR_TYPE_COMPOSITION_LAYER_PROJECTION_VIEW}
+        };
+        for (uint32_t i = 0; i < eyeCount; i++) {
+            projViews[i].pose = views[i].pose;
+            projViews[i].fov = views[i].fov;
+            projViews[i].subImage.swapchain = app.swapchain.swapchain;
+            projViews[i].subImage.imageRect.offset = {(int32_t)(i * eyeW), 0};
+            projViews[i].subImage.imageRect.extent = {(int32_t)eyeW, (int32_t)eyeH};
+            projViews[i].subImage.imageArrayIndex = 0;
+        }
+
+        XrCompositionLayerProjection projLayer = {XR_TYPE_COMPOSITION_LAYER_PROJECTION};
+        projLayer.space = app.localSpace;
+        projLayer.viewCount = eyeCount;
+        projLayer.views = projViews;
+
+        const XrCompositionLayerBaseHeader *layers[] = {
+            (XrCompositionLayerBaseHeader *)&projLayer
+        };
+
+        XrFrameEndInfo endInfo = {XR_TYPE_FRAME_END_INFO};
+        endInfo.displayTime = frameState.predictedDisplayTime;
+        endInfo.environmentBlendMode = XR_ENVIRONMENT_BLEND_MODE_OPAQUE;
+        endInfo.layerCount = frameState.shouldRender ? 1 : 0;
+        endInfo.layers = layers;
+
+        xrEndFrame(app.session, &endInfo);
+    }
+
+    LOG_INFO("Shutting down...");
+
+    if (app.swapchain.swapchain) xrDestroySwapchain(app.swapchain.swapchain);
+    if (app.localSpace) xrDestroySpace(app.localSpace);
+    if (app.viewSpace) xrDestroySpace(app.viewSpace);
+    if (app.session) xrDestroySession(app.session);
+    if (app.instance) xrDestroyInstance(app.instance);
+
+    if (renderer.fbo) glDeleteFramebuffers(1, &renderer.fbo);
+    if (renderer.depthRBO) glDeleteRenderbuffers(1, &renderer.depthRBO);
+    glDeleteVertexArrays(1, &renderer.cubeVAO);
+    glDeleteBuffers(1, &renderer.cubeVBO);
+    glDeleteBuffers(1, &renderer.cubeEBO);
+    glDeleteVertexArrays(1, &renderer.gridVAO);
+    glDeleteBuffers(1, &renderer.gridVBO);
+    glDeleteTextures(3, renderer.textures);
+    glDeleteProgram(renderer.cubeProgram);
+    glDeleteProgram(renderer.gridProgram);
+
+    glXMakeCurrent(dpy, 0, nullptr);
+    glXDestroyContext(dpy, ctx);
+    XDestroyWindow(dpy, appWin);
+    XCloseDisplay(dpy);
+
+    LOG_INFO("Clean shutdown complete");
+    return 0;
+}

--- a/test_apps/cube_handle_gl_linux/stb_image_impl.cpp
+++ b/test_apps/cube_handle_gl_linux/stb_image_impl.cpp
@@ -1,0 +1,8 @@
+// Copyright 2026, Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+//
+// stb_image implementation TU for the Linux GL app. main.cpp only *declares*
+// stb_image (via displayxr::common's header); this TU provides the definition
+// so stbi_load / stbi_image_free resolve at link. Mirrors the VK Linux peer. (#660)
+#define STB_IMAGE_IMPLEMENTATION
+#include "stb_image.h"

--- a/test_apps/cube_hosted_legacy_gl_linux/CMakeLists.txt
+++ b/test_apps/cube_hosted_legacy_gl_linux/CMakeLists.txt
@@ -1,0 +1,100 @@
+# Copyright 2026, Leia Inc.
+# SPDX-License-Identifier: BSL-1.0
+#
+# Linux hosted (legacy) OpenGL cube — on-screen bring-up target for the native
+# GL compositor + GLX present path (Phase 1b-GL, docs/roadmap/linux-support.md).
+# "Hosted" = the app passes no window handle; the runtime self-creates an X11/GLX
+# window. The app supplies a GLX context (on a tiny hidden drawable) via the core
+# XR_KHR_opengl_enable Xlib binding; the compositor shares that context so it
+# samples the app's swapchain textures directly — no external-memory FD interop,
+# which is what lets it run on software GL (llvmpipe) under WSLg. main.cpp is the
+# Linux port of cube_hosted_legacy_gl_macos (CGL swapped for GLX).
+
+cmake_minimum_required(VERSION 3.21)
+project(cube_hosted_legacy_gl_linux LANGUAGES C CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(OpenGL REQUIRED COMPONENTS OpenGL GLX)
+find_package(X11 REQUIRED)
+message(STATUS "Found OpenGL: ${OPENGL_gl_LIBRARY}; GLX: ${OpenGL_GLX_FOUND}; X11: ${X11_FOUND}")
+
+# OpenXR headers from the runtime source tree.
+set(OPENXR_INCLUDE_DIR "${CMAKE_SOURCE_DIR}/../../src/external/openxr_includes")
+
+# Find the OpenXR loader: CMake package → system library → parent build tree.
+set(OPENXR_FOUND FALSE)
+
+find_package(OpenXR QUIET CONFIG)
+if(OpenXR_FOUND)
+    set(OPENXR_FOUND TRUE)
+    message(STATUS "Found OpenXR via find_package")
+endif()
+
+if(NOT OPENXR_FOUND)
+    find_library(OPENXR_LOADER_LIB NAMES openxr_loader)
+    if(OPENXR_LOADER_LIB)
+        set(OPENXR_FOUND TRUE)
+        add_library(OpenXR::openxr_loader SHARED IMPORTED)
+        set_target_properties(OpenXR::openxr_loader PROPERTIES
+            IMPORTED_LOCATION "${OPENXR_LOADER_LIB}"
+        )
+        message(STATUS "Found OpenXR loader: ${OPENXR_LOADER_LIB}")
+    endif()
+endif()
+
+if(NOT OPENXR_FOUND)
+    set(PARENT_BUILD_DIR "${CMAKE_SOURCE_DIR}/../../build")
+    if(EXISTS "${PARENT_BUILD_DIR}/src/external/openxr_loader/OpenXRConfig.cmake")
+        list(APPEND CMAKE_PREFIX_PATH "${PARENT_BUILD_DIR}/src/external/openxr_loader")
+        find_package(OpenXR REQUIRED CONFIG)
+        set(OPENXR_FOUND TRUE)
+    endif()
+endif()
+
+if(NOT OPENXR_FOUND)
+    message(FATAL_ERROR "OpenXR not found. Install the OpenXR loader or build it from source.")
+endif()
+
+# Shared scaffolding (stb_image header + impl TU) via displayxr::common, pinned by tag.
+include(FetchContent)
+set(DISPLAYXR_COMMON_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+get_filename_component(_dxr_ext_includes
+    "${CMAKE_SOURCE_DIR}/../../src/external/openxr_includes" ABSOLUTE)
+set(DISPLAYXR_EXTENSIONS_INCLUDE_DIR "${_dxr_ext_includes}" CACHE PATH
+    "DisplayXR OpenXR extension headers for displayxr::common")
+FetchContent_Declare(
+    displayxr_common
+    GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
+    GIT_TAG v1.1.2
+    GIT_SHALLOW TRUE
+)
+FetchContent_MakeAvailable(displayxr_common)
+
+# stb_image_impl.cpp supplies the stb_image definition on Linux (main.cpp is
+# declarations-only). Mirrors the VK Linux peer.
+add_executable(cube_hosted_legacy_gl_linux main.cpp stb_image_impl.cpp)
+
+target_include_directories(cube_hosted_legacy_gl_linux PRIVATE
+    ${OPENXR_INCLUDE_DIR}
+    ${CMAKE_SOURCE_DIR}/../common
+)
+
+# Copy texture files next to the built executable.
+file(GLOB TEXTURE_FILES "${CMAKE_SOURCE_DIR}/../common/textures/*.jpg")
+foreach(TEX ${TEXTURE_FILES})
+    get_filename_component(TEX_NAME ${TEX} NAME)
+    add_custom_command(TARGET cube_hosted_legacy_gl_linux POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E make_directory "$<TARGET_FILE_DIR:cube_hosted_legacy_gl_linux>/textures"
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${TEX} "$<TARGET_FILE_DIR:cube_hosted_legacy_gl_linux>/textures/${TEX_NAME}"
+    )
+endforeach()
+
+target_link_libraries(cube_hosted_legacy_gl_linux PRIVATE
+    displayxr::common
+    OpenXR::openxr_loader
+    OpenGL::GL
+    OpenGL::GLX
+    X11::X11
+)

--- a/test_apps/cube_hosted_legacy_gl_linux/main.cpp
+++ b/test_apps/cube_hosted_legacy_gl_linux/main.cpp
@@ -1,0 +1,1101 @@
+// Copyright 2026, Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  OpenGL OpenXR spinning cube test app for desktop Linux (legacy variant).
+ *
+ * Self-contained single-file app that renders a spinning cube + grid floor via
+ * OpenGL + OpenXR. The Linux peer of cube_hosted_legacy_gl_macos — same scene,
+ * math and OpenXR flow, but the GL context comes from GLX and the runtime is
+ * bound via the core XR_KHR_opengl_enable Xlib binding (XrGraphicsBindingOpenGLXlibKHR)
+ * instead of XR_EXT_macos_gl_binding.
+ *
+ * Legacy variant: does NOT enable XR_EXT_display_info. Relies on runtime
+ * defaults and recommendedImageRectWidth for swapchain sizing.
+ *
+ * "Hosted": no windowing on the app side — the runtime's native GL compositor
+ * self-creates the on-screen X11/GLX window. The app only needs a GLX context
+ * (on a tiny hidden drawable) that the compositor shares for swapchain textures.
+ */
+
+#include <X11/Xlib.h>
+#define GL_GLEXT_PROTOTYPES
+#include <GL/gl.h>
+#include <GL/glext.h>
+#include <GL/glx.h>
+
+#define XR_USE_GRAPHICS_API_OPENGL
+#define XR_USE_PLATFORM_XLIB
+#include <openxr/openxr.h>
+#include <openxr/openxr_platform.h>
+// Legacy app: NO DisplayXR extension types needed. Standard OpenXR APIs only.
+
+// X11/Xlib.h leaks short/all-caps macros that collide with GL enums and local
+// identifiers; drop the ones this TU uses as names.
+#undef None
+#undef Bool
+#undef Status
+#undef Success
+#undef Always
+
+#include <cmath>
+#include <csignal>
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <chrono>
+#include <vector>
+
+#include <unistd.h>
+
+// stb_image implementation TU lives in stb_image_impl.cpp — declarations only here.
+#include "stb_image.h"
+
+// ============================================================================
+// Logging
+// ============================================================================
+
+#define LOG_INFO(fmt, ...) fprintf(stderr, "[INFO] " fmt "\n", ##__VA_ARGS__)
+#define LOG_WARN(fmt, ...) fprintf(stderr, "[WARN] " fmt "\n", ##__VA_ARGS__)
+#define LOG_ERROR(fmt, ...) fprintf(stderr, "[ERROR] " fmt "\n", ##__VA_ARGS__)
+
+#define XR_CHECK(call)                                                         \
+    do {                                                                       \
+        XrResult _r = (call);                                                  \
+        if (XR_FAILED(_r)) {                                                   \
+            LOG_ERROR("OpenXR error %d at %s:%d", _r, __FILE__, __LINE__);     \
+            return false;                                                      \
+        }                                                                      \
+    } while (0)
+
+// ============================================================================
+// Math (column-major 4x4 matrices)
+// ============================================================================
+
+static void mat4_identity(float m[16])
+{
+    memset(m, 0, 16 * sizeof(float));
+    m[0] = m[5] = m[10] = m[15] = 1.0f;
+}
+
+static void mat4_multiply(float out[16], const float a[16], const float b[16])
+{
+    float tmp[16];
+    for (int c = 0; c < 4; c++) {
+        for (int r = 0; r < 4; r++) {
+            tmp[c * 4 + r] = 0;
+            for (int k = 0; k < 4; k++)
+                tmp[c * 4 + r] += a[k * 4 + r] * b[c * 4 + k];
+        }
+    }
+    memcpy(out, tmp, sizeof(tmp));
+}
+
+static void mat4_translation(float m[16], float x, float y, float z)
+{
+    mat4_identity(m);
+    m[12] = x; m[13] = y; m[14] = z;
+}
+
+static void mat4_scaling(float m[16], float s)
+{
+    mat4_identity(m);
+    m[0] = m[5] = m[10] = s;
+}
+
+static void mat4_rotation_y(float m[16], float angle)
+{
+    mat4_identity(m);
+    float c = cosf(angle), s = sinf(angle);
+    m[0] = c; m[2] = -s;
+    m[8] = s; m[10] = c;
+}
+
+static void mat4_from_xr_fov(float m[16], const XrFovf &fov, float nearZ, float farZ)
+{
+    float l = tanf(fov.angleLeft);
+    float r = tanf(fov.angleRight);
+    float u = tanf(fov.angleUp);
+    float d = tanf(fov.angleDown);
+
+    float w = r - l;
+    float h = u - d;
+
+    memset(m, 0, 16 * sizeof(float));
+    m[0]  = 2.0f / w;
+    m[5]  = 2.0f / h;
+    m[8]  = (r + l) / w;
+    m[9]  = (u + d) / h;
+    // OpenGL uses z range [-1, 1]
+    m[10] = -(farZ + nearZ) / (farZ - nearZ);
+    m[11] = -1.0f;
+    m[14] = -(2.0f * farZ * nearZ) / (farZ - nearZ);
+}
+
+static void mat4_view_from_xr_pose(float m[16], const XrPosef &pose)
+{
+    float x = pose.orientation.x, y = pose.orientation.y;
+    float z = pose.orientation.z, w = pose.orientation.w;
+
+    float r00 = 1 - 2*(y*y + z*z), r01 = 2*(x*y + w*z),     r02 = 2*(x*z - w*y);
+    float r10 = 2*(x*y - w*z),     r11 = 1 - 2*(x*x + z*z), r12 = 2*(y*z + w*x);
+    float r20 = 2*(x*z + w*y),     r21 = 2*(y*z - w*x),      r22 = 1 - 2*(x*x + y*y);
+
+    float px = pose.position.x, py = pose.position.y, pz = pose.position.z;
+
+    mat4_identity(m);
+    m[0] = r00; m[1] = r10; m[2]  = r20;
+    m[4] = r01; m[5] = r11; m[6]  = r21;
+    m[8] = r02; m[9] = r12; m[10] = r22;
+    m[12] = -(r00*px + r01*py + r02*pz);
+    m[13] = -(r10*px + r11*py + r12*pz);
+    m[14] = -(r20*px + r21*py + r22*pz);
+}
+
+// ============================================================================
+// Texture path helper (executable dir + /textures/)
+// ============================================================================
+
+static std::string GetTextureDir()
+{
+    char path[4096];
+    ssize_t n = readlink("/proc/self/exe", path, sizeof(path) - 1);
+    if (n > 0) {
+        path[n] = '\0';
+        std::string s(path);
+        size_t pos = s.find_last_of('/');
+        if (pos != std::string::npos)
+            return s.substr(0, pos + 1) + "textures/";
+    }
+    return "textures/";
+}
+
+// ============================================================================
+// GLSL shaders (OpenGL 4.1 core-compatible)
+// ============================================================================
+
+// Cube shaders — the loaded PBR textures are GL_TEXTURE_RECTANGLE (unnormalized
+// UVs), matching the macOS peer. The swapchain render TARGET is GL_TEXTURE_2D on
+// the Linux native GL compositor; the app never samples it, so this is fine.
+static const char *g_cubeVertexShader = R"GLSL(
+#version 410 core
+layout(location = 0) in vec3 aPos;
+layout(location = 1) in vec4 aColor;
+layout(location = 2) in vec2 aUV;
+layout(location = 3) in vec3 aNormal;
+layout(location = 4) in vec3 aTangent;
+
+uniform mat4 uMVP;
+uniform mat4 uModel;
+uniform vec2 uTexSize; // pixel dimensions for TEXTURE_RECTANGLE
+
+out vec2 vUV;
+out vec3 vWorldNormal;
+out vec3 vWorldTangent;
+
+void main() {
+    gl_Position = uMVP * vec4(aPos, 1.0);
+    vUV = aUV * uTexSize;  // scale [0,1] to pixel coords for TEXTURE_RECTANGLE
+    vWorldNormal = (uModel * vec4(aNormal, 0.0)).xyz;
+    vWorldTangent = (uModel * vec4(aTangent, 0.0)).xyz;
+}
+)GLSL";
+
+static const char *g_cubeFragmentShader = R"GLSL(
+#version 410 core
+uniform sampler2DRect uBasecolorTex;
+uniform sampler2DRect uNormalTex;
+uniform sampler2DRect uAOTex;
+
+in vec2 vUV;
+in vec3 vWorldNormal;
+in vec3 vWorldTangent;
+
+out vec4 fragColor;
+
+void main() {
+    vec4 baseColor = texture(uBasecolorTex, vUV);
+    vec3 normalMap = texture(uNormalTex, vUV).xyz * 2.0 - 1.0;
+    float ao = texture(uAOTex, vUV).r;
+
+    vec3 N = normalize(vWorldNormal);
+    vec3 T = normalize(vWorldTangent);
+    vec3 B = cross(N, T);
+    mat3 TBN = mat3(T, B, N);
+    vec3 normal = normalize(TBN * normalMap);
+
+    vec3 lightDir = normalize(vec3(0.3, 0.5, 1.0));
+    float diffuse = max(dot(normal, lightDir), 0.0) * 0.8 * ao;
+    float ambient = 0.3 + 0.15 * ao;
+
+    fragColor = vec4(baseColor.rgb * (diffuse + ambient), 1.0);
+}
+)GLSL";
+
+// Grid shaders
+static const char *g_gridVertexShader = R"GLSL(
+#version 410 core
+layout(location = 0) in vec3 aPos;
+uniform mat4 uMVP;
+void main() {
+    gl_Position = uMVP * vec4(aPos, 1.0);
+}
+)GLSL";
+
+static const char *g_gridFragmentShader = R"GLSL(
+#version 410 core
+uniform vec4 uColor;
+out vec4 fragColor;
+void main() {
+    fragColor = uColor;
+}
+)GLSL";
+
+// ============================================================================
+// Vertex data structures
+// ============================================================================
+
+struct CubeVertex {
+    float pos[3];
+    float color[4];
+    float uv[2];
+    float normal[3];
+    float tangent[3];
+};
+
+struct GridVertex {
+    float pos[3];
+};
+
+struct EyeRenderParams {
+    uint32_t viewportX, viewportY, width, height;
+    float viewMat[16];
+    float projMat[16];
+};
+
+// ============================================================================
+// Cube geometry (24 verts, 36 indices — 6 faces with unique normals)
+// ============================================================================
+
+static const CubeVertex g_cubeVertices[] = {
+    // Front face (Z+)
+    {{-0.5f,-0.5f, 0.5f}, {1,1,1,1}, {0,1}, { 0, 0, 1}, { 1, 0, 0}},
+    {{ 0.5f,-0.5f, 0.5f}, {1,1,1,1}, {1,1}, { 0, 0, 1}, { 1, 0, 0}},
+    {{ 0.5f, 0.5f, 0.5f}, {1,1,1,1}, {1,0}, { 0, 0, 1}, { 1, 0, 0}},
+    {{-0.5f, 0.5f, 0.5f}, {1,1,1,1}, {0,0}, { 0, 0, 1}, { 1, 0, 0}},
+    // Back face (Z-)
+    {{ 0.5f,-0.5f,-0.5f}, {1,1,1,1}, {0,1}, { 0, 0,-1}, {-1, 0, 0}},
+    {{-0.5f,-0.5f,-0.5f}, {1,1,1,1}, {1,1}, { 0, 0,-1}, {-1, 0, 0}},
+    {{-0.5f, 0.5f,-0.5f}, {1,1,1,1}, {1,0}, { 0, 0,-1}, {-1, 0, 0}},
+    {{ 0.5f, 0.5f,-0.5f}, {1,1,1,1}, {0,0}, { 0, 0,-1}, {-1, 0, 0}},
+    // Right face (X+)
+    {{ 0.5f,-0.5f, 0.5f}, {1,1,1,1}, {0,1}, { 1, 0, 0}, { 0, 0,-1}},
+    {{ 0.5f,-0.5f,-0.5f}, {1,1,1,1}, {1,1}, { 1, 0, 0}, { 0, 0,-1}},
+    {{ 0.5f, 0.5f,-0.5f}, {1,1,1,1}, {1,0}, { 1, 0, 0}, { 0, 0,-1}},
+    {{ 0.5f, 0.5f, 0.5f}, {1,1,1,1}, {0,0}, { 1, 0, 0}, { 0, 0,-1}},
+    // Left face (X-)
+    {{-0.5f,-0.5f,-0.5f}, {1,1,1,1}, {0,1}, {-1, 0, 0}, { 0, 0, 1}},
+    {{-0.5f,-0.5f, 0.5f}, {1,1,1,1}, {1,1}, {-1, 0, 0}, { 0, 0, 1}},
+    {{-0.5f, 0.5f, 0.5f}, {1,1,1,1}, {1,0}, {-1, 0, 0}, { 0, 0, 1}},
+    {{-0.5f, 0.5f,-0.5f}, {1,1,1,1}, {0,0}, {-1, 0, 0}, { 0, 0, 1}},
+    // Top face (Y+)
+    {{-0.5f, 0.5f, 0.5f}, {1,1,1,1}, {0,1}, { 0, 1, 0}, { 1, 0, 0}},
+    {{ 0.5f, 0.5f, 0.5f}, {1,1,1,1}, {1,1}, { 0, 1, 0}, { 1, 0, 0}},
+    {{ 0.5f, 0.5f,-0.5f}, {1,1,1,1}, {1,0}, { 0, 1, 0}, { 1, 0, 0}},
+    {{-0.5f, 0.5f,-0.5f}, {1,1,1,1}, {0,0}, { 0, 1, 0}, { 1, 0, 0}},
+    // Bottom face (Y-)
+    {{-0.5f,-0.5f,-0.5f}, {1,1,1,1}, {0,1}, { 0,-1, 0}, { 1, 0, 0}},
+    {{ 0.5f,-0.5f,-0.5f}, {1,1,1,1}, {1,1}, { 0,-1, 0}, { 1, 0, 0}},
+    {{ 0.5f,-0.5f, 0.5f}, {1,1,1,1}, {1,0}, { 0,-1, 0}, { 1, 0, 0}},
+    {{-0.5f,-0.5f, 0.5f}, {1,1,1,1}, {0,0}, { 0,-1, 0}, { 1, 0, 0}},
+};
+
+static const uint16_t g_cubeIndices[] = {
+     0, 1, 2,  2, 3, 0,   // front
+     4, 5, 6,  6, 7, 4,   // back
+     8, 9,10, 10,11, 8,   // right
+    12,13,14, 14,15,12,   // left
+    16,17,18, 18,19,16,   // top
+    20,21,22, 22,23,20,   // bottom
+};
+
+static std::vector<GridVertex> BuildGridVertices()
+{
+    std::vector<GridVertex> verts;
+    const int N = 10;
+    const float S = 1.0f;
+    const float Y = 0.0f;
+    for (int i = -N; i <= N; i++) {
+        float f = i * S;
+        verts.push_back({{f, Y, -N * S}});
+        verts.push_back({{f, Y,  N * S}});
+        verts.push_back({{-N * S, Y, f}});
+        verts.push_back({{ N * S, Y, f}});
+    }
+    return verts;
+}
+
+// ============================================================================
+// GL shader helpers
+// ============================================================================
+
+static GLuint CompileShader(GLenum type, const char *source)
+{
+    GLuint shader = glCreateShader(type);
+    glShaderSource(shader, 1, &source, nullptr);
+    glCompileShader(shader);
+    GLint ok = 0;
+    glGetShaderiv(shader, GL_COMPILE_STATUS, &ok);
+    if (!ok) {
+        char log[1024];
+        glGetShaderInfoLog(shader, sizeof(log), nullptr, log);
+        LOG_ERROR("Shader compile error: %s", log);
+        glDeleteShader(shader);
+        return 0;
+    }
+    return shader;
+}
+
+static GLuint LinkProgram(GLuint vs, GLuint fs)
+{
+    GLuint prog = glCreateProgram();
+    glAttachShader(prog, vs);
+    glAttachShader(prog, fs);
+    glLinkProgram(prog);
+    GLint ok = 0;
+    glGetProgramiv(prog, GL_LINK_STATUS, &ok);
+    if (!ok) {
+        char log[1024];
+        glGetProgramInfoLog(prog, sizeof(log), nullptr, log);
+        LOG_ERROR("Program link error: %s", log);
+        glDeleteProgram(prog);
+        return 0;
+    }
+    return prog;
+}
+
+// ============================================================================
+// OpenGL renderer
+// ============================================================================
+
+struct GLRenderer {
+    GLuint cubeProgram;
+    GLuint gridProgram;
+
+    GLint cubeLocMVP, cubeLocModel, cubeLocTexSize;
+    GLint cubeLocBasecolor, cubeLocNormal, cubeLocAO;
+
+    GLint gridLocMVP, gridLocColor;
+
+    GLuint cubeVAO, cubeVBO, cubeEBO;
+    GLuint gridVAO, gridVBO;
+    int gridVertexCount;
+
+    GLuint textures[3]; // basecolor, normal, AO
+    int texSizes[3][2];
+
+    GLuint depthRBO;
+    GLuint fbo;
+    uint32_t depthWidth, depthHeight;
+
+    float cubeRotation;
+};
+
+static GLuint LoadTextureRect(const char *path, int *outW, int *outH,
+                               uint8_t fallbackR, uint8_t fallbackG, uint8_t fallbackB)
+{
+    GLuint tex;
+    glGenTextures(1, &tex);
+    glBindTexture(GL_TEXTURE_RECTANGLE, tex);
+
+    int w, h, channels;
+    stbi_uc *pixels = stbi_load(path, &w, &h, &channels, 4);
+
+    if (!pixels) {
+        LOG_WARN("Texture not found: %s (using fallback)", path);
+        w = h = 1;
+        uint8_t fallback[4] = {fallbackR, fallbackG, fallbackB, 255};
+        glTexImage2D(GL_TEXTURE_RECTANGLE, 0, GL_RGBA8, 1, 1, 0,
+                     GL_RGBA, GL_UNSIGNED_BYTE, fallback);
+    } else {
+        glTexImage2D(GL_TEXTURE_RECTANGLE, 0, GL_RGBA8, w, h, 0,
+                     GL_RGBA, GL_UNSIGNED_BYTE, pixels);
+        stbi_image_free(pixels);
+        LOG_INFO("Loaded texture: %s (%dx%d)", path, w, h);
+    }
+
+    glTexParameteri(GL_TEXTURE_RECTANGLE, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_RECTANGLE, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glBindTexture(GL_TEXTURE_RECTANGLE, 0);
+
+    *outW = w;
+    *outH = h;
+    return tex;
+}
+
+static bool InitRenderer(GLRenderer &r)
+{
+    LOG_INFO("OpenGL context:");
+    LOG_INFO("  GL_VERSION: %s", glGetString(GL_VERSION));
+    LOG_INFO("  GL_RENDERER: %s", glGetString(GL_RENDERER));
+    LOG_INFO("  GL_VENDOR: %s", glGetString(GL_VENDOR));
+
+    GLuint cubeVS = CompileShader(GL_VERTEX_SHADER, g_cubeVertexShader);
+    GLuint cubeFS = CompileShader(GL_FRAGMENT_SHADER, g_cubeFragmentShader);
+    if (!cubeVS || !cubeFS) return false;
+    r.cubeProgram = LinkProgram(cubeVS, cubeFS);
+    glDeleteShader(cubeVS);
+    glDeleteShader(cubeFS);
+    if (!r.cubeProgram) return false;
+
+    r.cubeLocMVP = glGetUniformLocation(r.cubeProgram, "uMVP");
+    r.cubeLocModel = glGetUniformLocation(r.cubeProgram, "uModel");
+    r.cubeLocTexSize = glGetUniformLocation(r.cubeProgram, "uTexSize");
+    r.cubeLocBasecolor = glGetUniformLocation(r.cubeProgram, "uBasecolorTex");
+    r.cubeLocNormal = glGetUniformLocation(r.cubeProgram, "uNormalTex");
+    r.cubeLocAO = glGetUniformLocation(r.cubeProgram, "uAOTex");
+
+    GLuint gridVS = CompileShader(GL_VERTEX_SHADER, g_gridVertexShader);
+    GLuint gridFS = CompileShader(GL_FRAGMENT_SHADER, g_gridFragmentShader);
+    if (!gridVS || !gridFS) return false;
+    r.gridProgram = LinkProgram(gridVS, gridFS);
+    glDeleteShader(gridVS);
+    glDeleteShader(gridFS);
+    if (!r.gridProgram) return false;
+
+    r.gridLocMVP = glGetUniformLocation(r.gridProgram, "uMVP");
+    r.gridLocColor = glGetUniformLocation(r.gridProgram, "uColor");
+
+    glGenVertexArrays(1, &r.cubeVAO);
+    glBindVertexArray(r.cubeVAO);
+
+    glGenBuffers(1, &r.cubeVBO);
+    glBindBuffer(GL_ARRAY_BUFFER, r.cubeVBO);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(g_cubeVertices), g_cubeVertices, GL_STATIC_DRAW);
+
+    glGenBuffers(1, &r.cubeEBO);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, r.cubeEBO);
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(g_cubeIndices), g_cubeIndices, GL_STATIC_DRAW);
+
+    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(CubeVertex), (void *)offsetof(CubeVertex, pos));
+    glEnableVertexAttribArray(0);
+    glVertexAttribPointer(1, 4, GL_FLOAT, GL_FALSE, sizeof(CubeVertex), (void *)offsetof(CubeVertex, color));
+    glEnableVertexAttribArray(1);
+    glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, sizeof(CubeVertex), (void *)offsetof(CubeVertex, uv));
+    glEnableVertexAttribArray(2);
+    glVertexAttribPointer(3, 3, GL_FLOAT, GL_FALSE, sizeof(CubeVertex), (void *)offsetof(CubeVertex, normal));
+    glEnableVertexAttribArray(3);
+    glVertexAttribPointer(4, 3, GL_FLOAT, GL_FALSE, sizeof(CubeVertex), (void *)offsetof(CubeVertex, tangent));
+    glEnableVertexAttribArray(4);
+
+    glBindVertexArray(0);
+
+    auto gridVerts = BuildGridVertices();
+    r.gridVertexCount = (int)gridVerts.size();
+
+    glGenVertexArrays(1, &r.gridVAO);
+    glBindVertexArray(r.gridVAO);
+
+    glGenBuffers(1, &r.gridVBO);
+    glBindBuffer(GL_ARRAY_BUFFER, r.gridVBO);
+    glBufferData(GL_ARRAY_BUFFER, gridVerts.size() * sizeof(GridVertex), gridVerts.data(), GL_STATIC_DRAW);
+
+    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(GridVertex), (void *)0);
+    glEnableVertexAttribArray(0);
+
+    glBindVertexArray(0);
+
+    std::string texDir = GetTextureDir();
+    r.textures[0] = LoadTextureRect((texDir + "Wood_Crate_001_basecolor.jpg").c_str(),
+                                     &r.texSizes[0][0], &r.texSizes[0][1], 200, 200, 200);
+    r.textures[1] = LoadTextureRect((texDir + "Wood_Crate_001_normal.jpg").c_str(),
+                                     &r.texSizes[1][0], &r.texSizes[1][1], 128, 128, 255);
+    r.textures[2] = LoadTextureRect((texDir + "Wood_Crate_001_ambientOcclusion.jpg").c_str(),
+                                     &r.texSizes[2][0], &r.texSizes[2][1], 255, 255, 255);
+
+    r.cubeRotation = 0.0f;
+    r.depthRBO = 0;
+    r.fbo = 0;
+    r.depthWidth = r.depthHeight = 0;
+
+    LOG_INFO("OpenGL renderer initialized");
+    return true;
+}
+
+static void EnsureFBO(GLRenderer &r, uint32_t w, uint32_t h)
+{
+    if (r.fbo == 0) {
+        glGenFramebuffers(1, &r.fbo);
+    }
+    if (r.depthRBO == 0 || r.depthWidth != w || r.depthHeight != h) {
+        if (r.depthRBO) glDeleteRenderbuffers(1, &r.depthRBO);
+        glGenRenderbuffers(1, &r.depthRBO);
+        glBindRenderbuffer(GL_RENDERBUFFER, r.depthRBO);
+        glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT32F, w, h);
+        glBindRenderbuffer(GL_RENDERBUFFER, 0);
+        r.depthWidth = w;
+        r.depthHeight = h;
+    }
+}
+
+static void RenderScene(GLRenderer &r, GLuint targetTex, uint32_t targetW, uint32_t targetH,
+                         const EyeRenderParams *eyes, int eyeCount)
+{
+    EnsureFBO(r, targetW, targetH);
+
+    glBindFramebuffer(GL_FRAMEBUFFER, r.fbo);
+    // Swapchain textures are GL_TEXTURE_2D on the Linux native GL compositor.
+    // Detect the target type defensively (GL_TEXTURE_2D vs GL_TEXTURE_RECTANGLE).
+    GLint prev_tex2d = 0;
+    glGetIntegerv(GL_TEXTURE_BINDING_2D, &prev_tex2d);
+    glBindTexture(GL_TEXTURE_2D, targetTex);
+    GLint tex_width = 0;
+    glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_WIDTH, &tex_width);
+    glBindTexture(GL_TEXTURE_2D, prev_tex2d);
+    GLenum texTarget = (tex_width > 0) ? GL_TEXTURE_2D : GL_TEXTURE_RECTANGLE;
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, texTarget, targetTex, 0);
+    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, r.depthRBO);
+
+    GLenum fbStatus = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+    if (fbStatus != GL_FRAMEBUFFER_COMPLETE) {
+        LOG_ERROR("Framebuffer incomplete: 0x%x", fbStatus);
+        glBindFramebuffer(GL_FRAMEBUFFER, 0);
+        return;
+    }
+
+    glClearColor(0.05f, 0.05f, 0.08f, 1.0f);
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+    glEnable(GL_DEPTH_TEST);
+    glDepthFunc(GL_LESS);
+
+    for (int e = 0; e < eyeCount; e++) {
+        const EyeRenderParams &eye = eyes[e];
+        glViewport(eye.viewportX, eye.viewportY, eye.width, eye.height);
+        glScissor(eye.viewportX, eye.viewportY, eye.width, eye.height);
+        glEnable(GL_SCISSOR_TEST);
+
+        float vp_mat[16];
+        mat4_multiply(vp_mat, eye.projMat, eye.viewMat);
+
+        // --- Draw cube ---
+        {
+            float model[16], rotation[16], translation[16], scale[16], tmp[16];
+            mat4_scaling(scale, 0.4f);
+            mat4_rotation_y(rotation, r.cubeRotation);
+            // At the qwerty HMD's default eye height (y=1.6) so it's centered in
+            // view; WASDQE/arrows/RMB then fly the camera around it.
+            mat4_translation(translation, 0.0f, 1.6f, -1.5f);
+            mat4_multiply(tmp, rotation, scale);
+            mat4_multiply(model, translation, tmp);
+
+            float mvp[16];
+            mat4_multiply(mvp, vp_mat, model);
+
+            glUseProgram(r.cubeProgram);
+            glUniformMatrix4fv(r.cubeLocMVP, 1, GL_FALSE, mvp);
+            glUniformMatrix4fv(r.cubeLocModel, 1, GL_FALSE, model);
+            glUniform2f(r.cubeLocTexSize, (float)r.texSizes[0][0], (float)r.texSizes[0][1]);
+
+            glActiveTexture(GL_TEXTURE0);
+            glBindTexture(GL_TEXTURE_RECTANGLE, r.textures[0]);
+            glUniform1i(r.cubeLocBasecolor, 0);
+
+            glActiveTexture(GL_TEXTURE1);
+            glBindTexture(GL_TEXTURE_RECTANGLE, r.textures[1]);
+            glUniform1i(r.cubeLocNormal, 1);
+
+            glActiveTexture(GL_TEXTURE2);
+            glBindTexture(GL_TEXTURE_RECTANGLE, r.textures[2]);
+            glUniform1i(r.cubeLocAO, 2);
+
+            glBindVertexArray(r.cubeVAO);
+            glDrawElements(GL_TRIANGLES, 36, GL_UNSIGNED_SHORT, nullptr);
+        }
+
+        // --- Draw grid ---
+        {
+            float ident[16] = {1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1};
+            float gridMvp[16];
+            mat4_multiply(gridMvp, vp_mat, ident);
+
+            glUseProgram(r.gridProgram);
+            glUniformMatrix4fv(r.gridLocMVP, 1, GL_FALSE, gridMvp);
+            glUniform4f(r.gridLocColor, 0.3f, 0.3f, 0.35f, 1.0f);
+
+            glBindVertexArray(r.gridVAO);
+            glDrawArrays(GL_LINES, 0, r.gridVertexCount);
+        }
+    }
+
+    glDisable(GL_SCISSOR_TEST);
+    glBindVertexArray(0);
+    glUseProgram(0);
+    glFlush();
+
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+}
+
+// ============================================================================
+// OpenXR session management
+// ============================================================================
+
+struct SwapchainInfo {
+    XrSwapchain swapchain;
+    int64_t format;
+    uint32_t width, height, imageCount;
+    std::vector<GLuint> images;
+};
+
+struct AppXrSession {
+    XrInstance instance;
+    XrSystemId systemId;
+    XrSession session;
+    XrSpace localSpace;
+    XrSpace viewSpace;
+    SwapchainInfo swapchain;
+    XrViewConfigurationType viewConfigType;
+    std::vector<XrViewConfigurationView> configViews;
+    XrSessionState sessionState;
+    bool sessionRunning;
+    bool exitRequested;
+
+    uint32_t viewWidth = 0;
+    uint32_t viewHeight = 0;
+};
+
+static volatile bool g_running = true;
+
+static void SignalHandler(int) { g_running = false; }
+
+static bool InitializeOpenXR(AppXrSession &app)
+{
+    uint32_t extCount = 0;
+    xrEnumerateInstanceExtensionProperties(nullptr, 0, &extCount, nullptr);
+    std::vector<XrExtensionProperties> exts(extCount, {XR_TYPE_EXTENSION_PROPERTIES, nullptr, "", 0});
+    xrEnumerateInstanceExtensionProperties(nullptr, extCount, &extCount, exts.data());
+
+    bool hasGlEnable = false;
+    LOG_INFO("Available OpenXR extensions:");
+    for (auto &e : exts) {
+        LOG_INFO("  %s v%u", e.extensionName, e.extensionVersion);
+        if (strcmp(e.extensionName, XR_KHR_OPENGL_ENABLE_EXTENSION_NAME) == 0)
+            hasGlEnable = true;
+    }
+
+    if (!hasGlEnable) {
+        LOG_ERROR("Runtime does not support XR_KHR_opengl_enable");
+        return false;
+    }
+
+    std::vector<const char*> enabledExts = {XR_KHR_OPENGL_ENABLE_EXTENSION_NAME};
+    XrInstanceCreateInfo createInfo = {XR_TYPE_INSTANCE_CREATE_INFO};
+    strncpy(createInfo.applicationInfo.applicationName, "GLCubeOpenXR", XR_MAX_APPLICATION_NAME_SIZE - 1);
+    createInfo.applicationInfo.applicationVersion = 1;
+    createInfo.applicationInfo.apiVersion = XR_CURRENT_API_VERSION;
+    createInfo.enabledExtensionCount = (uint32_t)enabledExts.size();
+    createInfo.enabledExtensionNames = enabledExts.data();
+
+    XR_CHECK(xrCreateInstance(&createInfo, &app.instance));
+    LOG_INFO("OpenXR instance created");
+
+    XrSystemGetInfo sysInfo = {XR_TYPE_SYSTEM_GET_INFO};
+    sysInfo.formFactor = XR_FORM_FACTOR_HEAD_MOUNTED_DISPLAY;
+    XR_CHECK(xrGetSystem(app.instance, &sysInfo, &app.systemId));
+    LOG_INFO("Got system ID: %llu", (unsigned long long)app.systemId);
+
+    // XR_KHR_opengl_enable REQUIRES calling xrGetOpenGLGraphicsRequirementsKHR
+    // before xrCreateSession (the runtime rejects the session otherwise).
+    PFN_xrGetOpenGLGraphicsRequirementsKHR pfnGetGlReq = nullptr;
+    xrGetInstanceProcAddr(app.instance, "xrGetOpenGLGraphicsRequirementsKHR",
+                          (PFN_xrVoidFunction *)&pfnGetGlReq);
+    if (pfnGetGlReq == nullptr) {
+        LOG_ERROR("xrGetOpenGLGraphicsRequirementsKHR unavailable");
+        return false;
+    }
+    XrGraphicsRequirementsOpenGLKHR glReq = {XR_TYPE_GRAPHICS_REQUIREMENTS_OPENGL_KHR};
+    XR_CHECK(pfnGetGlReq(app.instance, app.systemId, &glReq));
+    LOG_INFO("OpenGL graphics requirements: min %d.%d max %d.%d",
+             XR_VERSION_MAJOR(glReq.minApiVersionSupported),
+             XR_VERSION_MINOR(glReq.minApiVersionSupported),
+             XR_VERSION_MAJOR(glReq.maxApiVersionSupported),
+             XR_VERSION_MINOR(glReq.maxApiVersionSupported));
+
+    app.viewConfigType = XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO;
+    uint32_t viewCount = 0;
+    XR_CHECK(xrEnumerateViewConfigurationViews(app.instance, app.systemId, app.viewConfigType,
+                                                0, &viewCount, nullptr));
+    app.configViews.resize(viewCount);
+    for (uint32_t i = 0; i < viewCount; i++) {
+        app.configViews[i] = {XR_TYPE_VIEW_CONFIGURATION_VIEW};
+    }
+    XR_CHECK(xrEnumerateViewConfigurationViews(app.instance, app.systemId, app.viewConfigType,
+                                                viewCount, &viewCount, app.configViews.data()));
+    LOG_INFO("View configuration: %u views", viewCount);
+    for (uint32_t i = 0; i < viewCount; i++) {
+        LOG_INFO("  View %u: recommended %ux%u", i,
+                 app.configViews[i].recommendedImageRectWidth,
+                 app.configViews[i].recommendedImageRectHeight);
+    }
+
+    app.viewWidth = app.configViews[0].recommendedImageRectWidth;
+    app.viewHeight = app.configViews[0].recommendedImageRectHeight;
+    return true;
+}
+
+static bool CreateSession(AppXrSession &app, Display *dpy, uint32_t visualid,
+                          GLXFBConfig fbconfig, GLXDrawable drawable, GLXContext ctx)
+{
+    XrGraphicsBindingOpenGLXlibKHR binding = {XR_TYPE_GRAPHICS_BINDING_OPENGL_XLIB_KHR};
+    binding.xDisplay = dpy;
+    binding.visualid = visualid;
+    binding.glxFBConfig = fbconfig;
+    binding.glxDrawable = drawable;
+    binding.glxContext = ctx;
+
+    XrSessionCreateInfo sessionInfo = {XR_TYPE_SESSION_CREATE_INFO};
+    sessionInfo.next = &binding;
+    sessionInfo.systemId = app.systemId;
+
+    XR_CHECK(xrCreateSession(app.instance, &sessionInfo, &app.session));
+    LOG_INFO("OpenXR session created with Xlib/GLX binding");
+
+    app.sessionState = XR_SESSION_STATE_UNKNOWN;
+    app.sessionRunning = false;
+    app.exitRequested = false;
+    return true;
+}
+
+static bool CreateSpaces(AppXrSession &app)
+{
+    XrReferenceSpaceCreateInfo spaceInfo = {XR_TYPE_REFERENCE_SPACE_CREATE_INFO};
+    spaceInfo.referenceSpaceType = XR_REFERENCE_SPACE_TYPE_LOCAL;
+    spaceInfo.poseInReferenceSpace = {{0,0,0,1}, {0,0,0}};
+    XR_CHECK(xrCreateReferenceSpace(app.session, &spaceInfo, &app.localSpace));
+
+    spaceInfo.referenceSpaceType = XR_REFERENCE_SPACE_TYPE_VIEW;
+    XR_CHECK(xrCreateReferenceSpace(app.session, &spaceInfo, &app.viewSpace));
+
+    LOG_INFO("Reference spaces created");
+    return true;
+}
+
+static bool CreateSwapchain(AppXrSession &app)
+{
+    uint32_t w = app.configViews[0].recommendedImageRectWidth * 2; // stereo SBS
+    uint32_t h = app.configViews[0].recommendedImageRectHeight;
+
+    uint32_t formatCount = 0;
+    XR_CHECK(xrEnumerateSwapchainFormats(app.session, 0, &formatCount, nullptr));
+    std::vector<int64_t> formats(formatCount);
+    XR_CHECK(xrEnumerateSwapchainFormats(app.session, formatCount, &formatCount, formats.data()));
+
+    int64_t selectedFormat = formats[0];
+    for (auto f : formats) {
+        if (f == GL_RGBA8) selectedFormat = f;
+    }
+    LOG_INFO("Supported swapchain formats:");
+    for (auto f : formats) {
+        LOG_INFO("  format 0x%llx%s", (long long)f, f == selectedFormat ? " (selected)" : "");
+    }
+
+    XrSwapchainCreateInfo sci = {XR_TYPE_SWAPCHAIN_CREATE_INFO};
+    sci.usageFlags = XR_SWAPCHAIN_USAGE_COLOR_ATTACHMENT_BIT | XR_SWAPCHAIN_USAGE_SAMPLED_BIT;
+    sci.format = selectedFormat;
+    sci.sampleCount = 1;
+    sci.width = w;
+    sci.height = h;
+    sci.faceCount = 1;
+    sci.arraySize = 1;
+    sci.mipCount = 1;
+
+    XR_CHECK(xrCreateSwapchain(app.session, &sci, &app.swapchain.swapchain));
+    app.swapchain.format = selectedFormat;
+    app.swapchain.width = w;
+    app.swapchain.height = h;
+
+    uint32_t imageCount = 0;
+    XR_CHECK(xrEnumerateSwapchainImages(app.swapchain.swapchain, 0, &imageCount, nullptr));
+    app.swapchain.imageCount = imageCount;
+
+    std::vector<XrSwapchainImageOpenGLKHR> glImages(imageCount, {XR_TYPE_SWAPCHAIN_IMAGE_OPENGL_KHR});
+    XR_CHECK(xrEnumerateSwapchainImages(app.swapchain.swapchain, imageCount, &imageCount,
+                                         (XrSwapchainImageBaseHeader *)glImages.data()));
+
+    app.swapchain.images.resize(imageCount);
+    for (uint32_t i = 0; i < imageCount; i++) {
+        app.swapchain.images[i] = glImages[i].image;
+        LOG_INFO("Swapchain image %u: GL texture %u", i, glImages[i].image);
+    }
+
+    LOG_INFO("Swapchain created: %ux%u, %u images", w, h, imageCount);
+    return true;
+}
+
+static void PollEvents(AppXrSession &app)
+{
+    XrEventDataBuffer event = {XR_TYPE_EVENT_DATA_BUFFER};
+    while (xrPollEvent(app.instance, &event) == XR_SUCCESS) {
+        switch (event.type) {
+        case XR_TYPE_EVENT_DATA_SESSION_STATE_CHANGED: {
+            auto *ssc = (XrEventDataSessionStateChanged *)&event;
+            app.sessionState = ssc->state;
+            LOG_INFO("Session state changed: %d", ssc->state);
+
+            if (ssc->state == XR_SESSION_STATE_READY) {
+                XrSessionBeginInfo beginInfo = {XR_TYPE_SESSION_BEGIN_INFO};
+                beginInfo.primaryViewConfigurationType = app.viewConfigType;
+                if (XR_SUCCEEDED(xrBeginSession(app.session, &beginInfo))) {
+                    app.sessionRunning = true;
+                    LOG_INFO("Session started");
+                }
+            } else if (ssc->state == XR_SESSION_STATE_STOPPING) {
+                xrEndSession(app.session);
+                app.sessionRunning = false;
+                LOG_INFO("Session stopped");
+            } else if (ssc->state == XR_SESSION_STATE_EXITING ||
+                       ssc->state == XR_SESSION_STATE_LOSS_PENDING) {
+                app.exitRequested = true;
+            }
+            break;
+        }
+        default: break;
+        }
+        event = {XR_TYPE_EVENT_DATA_BUFFER};
+    }
+}
+
+// ============================================================================
+// Main
+// ============================================================================
+
+int main(int argc, char **argv)
+{
+    (void)argc; (void)argv;
+    signal(SIGINT, SignalHandler);
+    signal(SIGTERM, SignalHandler);
+
+    LOG_INFO("=== OpenGL Cube OpenXR Test App (Linux, hosted-legacy) ===");
+
+    // Xlib is shared with the in-process runtime GL compositor (which borrows
+    // this Display for its GLX context sharing), so enable Xlib threading.
+    XInitThreads();
+
+    Display *dpy = XOpenDisplay(nullptr);
+    if (dpy == nullptr) {
+        LOG_ERROR("XOpenDisplay failed — is DISPLAY set / an X server running?");
+        return 1;
+    }
+    int screen = DefaultScreen(dpy);
+
+    int fbAttrs[] = {
+        GLX_X_RENDERABLE, True,
+        GLX_DRAWABLE_TYPE, GLX_WINDOW_BIT,
+        GLX_RENDER_TYPE, GLX_RGBA_BIT,
+        GLX_X_VISUAL_TYPE, GLX_TRUE_COLOR,
+        GLX_RED_SIZE, 8, GLX_GREEN_SIZE, 8, GLX_BLUE_SIZE, 8, GLX_ALPHA_SIZE, 8,
+        GLX_DEPTH_SIZE, 24, GLX_DOUBLEBUFFER, True,
+        0 /*None*/
+    };
+    int fbcount = 0;
+    GLXFBConfig *fbc = glXChooseFBConfig(dpy, screen, fbAttrs, &fbcount);
+    if (fbc == nullptr || fbcount == 0) {
+        LOG_ERROR("glXChooseFBConfig found no config");
+        return 1;
+    }
+    GLXFBConfig fbconfig = fbc[0];
+    XVisualInfo *vi = glXGetVisualFromFBConfig(dpy, fbconfig);
+    if (vi == nullptr) {
+        LOG_ERROR("glXGetVisualFromFBConfig failed");
+        return 1;
+    }
+
+    // Tiny hidden window: the app only needs a valid GLXDrawable to make its
+    // context current; the runtime creates the on-screen window. Not mapped.
+    XSetWindowAttributes swa;
+    memset(&swa, 0, sizeof(swa));
+    swa.colormap = XCreateColormap(dpy, RootWindow(dpy, vi->screen), vi->visual, AllocNone);
+    Window appWin = XCreateWindow(dpy, RootWindow(dpy, vi->screen), 0, 0, 16, 16, 0,
+                                  vi->depth, InputOutput, vi->visual,
+                                  CWColormap, &swa);
+
+    GLXContext ctx = glXCreateNewContext(dpy, fbconfig, GLX_RGBA_TYPE, nullptr, True);
+    if (ctx == nullptr) {
+        LOG_ERROR("glXCreateNewContext failed");
+        return 1;
+    }
+    if (!glXMakeCurrent(dpy, appWin, ctx)) {
+        LOG_ERROR("glXMakeCurrent failed");
+        return 1;
+    }
+    XFree(fbc);
+    LOG_INFO("GLX context created (hidden drawable)");
+
+    GLRenderer renderer = {};
+    if (!InitRenderer(renderer)) {
+        LOG_ERROR("Failed to initialize OpenGL renderer");
+        return 1;
+    }
+
+    AppXrSession app = {};
+    if (!InitializeOpenXR(app)) {
+        LOG_ERROR("Failed to initialize OpenXR");
+        return 1;
+    }
+
+    if (!CreateSession(app, dpy, (uint32_t)vi->visualid, fbconfig, (GLXDrawable)appWin, ctx)) {
+        LOG_ERROR("Failed to create session");
+        xrDestroyInstance(app.instance);
+        return 1;
+    }
+    XFree(vi);
+
+    if (!CreateSpaces(app)) { LOG_ERROR("Failed to create spaces"); return 1; }
+    if (!CreateSwapchain(app)) { LOG_ERROR("Failed to create swapchain"); return 1; }
+
+    LOG_INFO("Entering main loop...");
+    auto lastTime = std::chrono::high_resolution_clock::now();
+
+    while (g_running && !app.exitRequested) {
+        auto now = std::chrono::high_resolution_clock::now();
+        float dt = std::chrono::duration<float>(now - lastTime).count();
+        lastTime = now;
+
+        PollEvents(app);
+
+        if (!app.sessionRunning) {
+            usleep(10000);
+            continue;
+        }
+
+        // App renders on its own context; the compositor switches to its shared
+        // context during xrEndFrame and restores ours after. Keep ours current.
+        glXMakeCurrent(dpy, appWin, ctx);
+
+        renderer.cubeRotation += dt * 0.5f;
+
+        XrFrameWaitInfo waitInfo = {XR_TYPE_FRAME_WAIT_INFO};
+        XrFrameState frameState = {XR_TYPE_FRAME_STATE};
+        if (XR_FAILED(xrWaitFrame(app.session, &waitInfo, &frameState))) {
+            LOG_WARN("xrWaitFrame failed");
+            continue;
+        }
+
+        XrFrameBeginInfo beginInfo = {XR_TYPE_FRAME_BEGIN_INFO};
+        if (XR_FAILED(xrBeginFrame(app.session, &beginInfo))) {
+            LOG_WARN("xrBeginFrame failed");
+            continue;
+        }
+
+        std::vector<XrView> views(app.configViews.size(), {XR_TYPE_VIEW});
+        XrViewState viewState = {XR_TYPE_VIEW_STATE};
+        XrViewLocateInfo locateInfo = {XR_TYPE_VIEW_LOCATE_INFO};
+        locateInfo.viewConfigurationType = app.viewConfigType;
+        locateInfo.displayTime = frameState.predictedDisplayTime;
+        locateInfo.space = app.localSpace;
+
+        uint32_t viewCount = 0;
+        xrLocateViews(app.session, &locateInfo, &viewState, (uint32_t)views.size(), &viewCount, views.data());
+
+        static int logCounter = 0;
+        if (logCounter % 120 == 0 && viewCount >= 2) {
+            for (uint32_t i = 0; i < viewCount && i < 2; i++) {
+                auto &p = views[i].pose.position;
+                LOG_INFO("View[%u] pos=(%.3f,%.3f,%.3f)", i, p.x, p.y, p.z);
+            }
+            LOG_INFO("shouldRender=%d viewCount=%u", frameState.shouldRender, viewCount);
+        }
+        logCounter++;
+
+        XrSwapchainImageAcquireInfo acqInfo = {XR_TYPE_SWAPCHAIN_IMAGE_ACQUIRE_INFO};
+        uint32_t imageIndex = 0;
+        if (XR_FAILED(xrAcquireSwapchainImage(app.swapchain.swapchain, &acqInfo, &imageIndex))) {
+            LOG_WARN("xrAcquireSwapchainImage failed");
+            XrFrameEndInfo endInfo = {XR_TYPE_FRAME_END_INFO};
+            endInfo.displayTime = frameState.predictedDisplayTime;
+            endInfo.environmentBlendMode = XR_ENVIRONMENT_BLEND_MODE_OPAQUE;
+            xrEndFrame(app.session, &endInfo);
+            continue;
+        }
+
+        XrSwapchainImageWaitInfo waitImgInfo = {XR_TYPE_SWAPCHAIN_IMAGE_WAIT_INFO};
+        waitImgInfo.timeout = XR_INFINITE_DURATION;
+        xrWaitSwapchainImage(app.swapchain.swapchain, &waitImgInfo);
+
+        uint32_t eyeCount = 2;
+        uint32_t eyeW = app.viewWidth;
+        uint32_t eyeH = app.viewHeight;
+        if (frameState.shouldRender && viewCount >= 2) {
+            EyeRenderParams eyeParams[2];
+            for (uint32_t i = 0; i < eyeCount; i++) {
+                eyeParams[i].viewportX = i * eyeW; // SBS
+                eyeParams[i].viewportY = 0;
+                eyeParams[i].width = eyeW;
+                eyeParams[i].height = eyeH;
+                mat4_view_from_xr_pose(eyeParams[i].viewMat, views[i].pose);
+                mat4_from_xr_fov(eyeParams[i].projMat, views[i].fov, 0.05f, 100.0f);
+            }
+            RenderScene(renderer, app.swapchain.images[imageIndex],
+                        app.swapchain.width, app.swapchain.height, eyeParams, (int)eyeCount);
+        }
+
+        XrSwapchainImageReleaseInfo relInfo = {XR_TYPE_SWAPCHAIN_IMAGE_RELEASE_INFO};
+        xrReleaseSwapchainImage(app.swapchain.swapchain, &relInfo);
+
+        XrCompositionLayerProjectionView projViews[2] = {
+            {XR_TYPE_COMPOSITION_LAYER_PROJECTION_VIEW},
+            {XR_TYPE_COMPOSITION_LAYER_PROJECTION_VIEW}
+        };
+        for (uint32_t i = 0; i < eyeCount; i++) {
+            projViews[i].pose = views[i].pose;
+            projViews[i].fov = views[i].fov;
+            projViews[i].subImage.swapchain = app.swapchain.swapchain;
+            projViews[i].subImage.imageRect.offset = {(int32_t)(i * eyeW), 0};
+            projViews[i].subImage.imageRect.extent = {(int32_t)eyeW, (int32_t)eyeH};
+            projViews[i].subImage.imageArrayIndex = 0;
+        }
+
+        XrCompositionLayerProjection projLayer = {XR_TYPE_COMPOSITION_LAYER_PROJECTION};
+        projLayer.space = app.localSpace;
+        projLayer.viewCount = eyeCount;
+        projLayer.views = projViews;
+
+        const XrCompositionLayerBaseHeader *layers[] = {
+            (XrCompositionLayerBaseHeader *)&projLayer
+        };
+
+        XrFrameEndInfo endInfo = {XR_TYPE_FRAME_END_INFO};
+        endInfo.displayTime = frameState.predictedDisplayTime;
+        endInfo.environmentBlendMode = XR_ENVIRONMENT_BLEND_MODE_OPAQUE;
+        endInfo.layerCount = frameState.shouldRender ? 1 : 0;
+        endInfo.layers = layers;
+
+        xrEndFrame(app.session, &endInfo);
+    }
+
+    LOG_INFO("Shutting down...");
+
+    if (app.swapchain.swapchain) xrDestroySwapchain(app.swapchain.swapchain);
+    if (app.localSpace) xrDestroySpace(app.localSpace);
+    if (app.viewSpace) xrDestroySpace(app.viewSpace);
+    if (app.session) xrDestroySession(app.session);
+    if (app.instance) xrDestroyInstance(app.instance);
+
+    if (renderer.fbo) glDeleteFramebuffers(1, &renderer.fbo);
+    if (renderer.depthRBO) glDeleteRenderbuffers(1, &renderer.depthRBO);
+    glDeleteVertexArrays(1, &renderer.cubeVAO);
+    glDeleteBuffers(1, &renderer.cubeVBO);
+    glDeleteBuffers(1, &renderer.cubeEBO);
+    glDeleteVertexArrays(1, &renderer.gridVAO);
+    glDeleteBuffers(1, &renderer.gridVBO);
+    glDeleteTextures(3, renderer.textures);
+    glDeleteProgram(renderer.cubeProgram);
+    glDeleteProgram(renderer.gridProgram);
+
+    glXMakeCurrent(dpy, 0, nullptr);
+    glXDestroyContext(dpy, ctx);
+    XDestroyWindow(dpy, appWin);
+    XCloseDisplay(dpy);
+
+    LOG_INFO("Clean shutdown complete");
+    return 0;
+}

--- a/test_apps/cube_hosted_legacy_gl_linux/stb_image_impl.cpp
+++ b/test_apps/cube_hosted_legacy_gl_linux/stb_image_impl.cpp
@@ -1,0 +1,8 @@
+// Copyright 2026, Leia Inc.
+// SPDX-License-Identifier: BSL-1.0
+//
+// stb_image implementation TU for the Linux GL app. main.cpp only *declares*
+// stb_image (via displayxr::common's header); this TU provides the definition
+// so stbi_load / stbi_image_free resolve at link. Mirrors the VK Linux peer. (#660)
+#define STB_IMAGE_IMPLEMENTATION
+#include "stb_image.h"


### PR DESCRIPTION
## TL;DR — an *opt-in software-GL* present path for Linux, not a competitor to VK/XCB

Since this branch was cut, `main` shipped the full Linux port on **Vulkan + XCB** — including the handle class via David's `XR_EXT_xlib_window_binding` (`19c4e014f`, Phase 3a), hardware-validated on a GPU box, plus the deliberate #709 decision to gate `comp_gl` **off** on Linux. **That is and should remain the production Linux path.**

This PR adds a **complementary, default-OFF** capability the VK/XCB path can't provide: an **on-screen present path that runs on software GL (llvmpipe) with no GPU** — for no-GPU CI / headless dev / WSL. Filing it so @dfattal can decide whether that niche is worth carrying.

## Why a GL path can do this and VK/XCB can't

The VK native compositor needs `VK_KHR_external_{memory,semaphore,fence}_fd` to share the app's swapchain image across the app/compositor Vulkan devices — which **software Vulkan (llvmpipe) does not expose** (`vkCreateDevice` → `VK_ERROR_EXTENSION_NOT_PRESENT`). So the production path is correctly GPU-only.

This GL compositor instead **shares the app's GLX context** and samples the app's swapchain textures directly — **no external-memory FD interop** — so it runs end-to-end on llvmpipe. Validated on WSL (Ubuntu, llvmpipe, WSLg): a 4-view anaglyph cube presents on-screen with zero GPU, in both the hosted and handle classes.

## The switch: `XRT_FEATURE_GL_LINUX_SOFTWARE` (default OFF)

`76acc33` makes the whole GL-on-Linux path opt-in behind one CMake option, so the **default Linux build is unchanged** (VK/XCB; no `comp_gl`, no XLIB):

| | OFF (default) | ON (`-D…=ON` / `build_linux.sh --gl`) |
|---|---|---|
| `comp_gl` on Linux | not built (mirrors #709 allowlist) | built |
| `XR_USE_PLATFORM_XLIB` | not armed | armed (Xlib GL binding + `XR_EXT_xlib_window_binding`) |
| GL-native compositor arm | compiled out | `XRT_HAVE_GL_NATIVE_COMPOSITOR` |
| GL test apps | skipped | built |

Verified both ways on WSL: OFF → no `libcomp_gl.a`, no `XR_USE_PLATFORM_XLIB`, selftest PASSED; ON → both present, selftest PASSED.

## Commits

1. `a8bd608` — native GL compositor + GLX present (hosted / self-created window)
2. `cb9d6c4` — qwerty input for the GL compositor
3. `0d1e4c8` — handle class: app-owned X11 window + `cube_handle_gl_linux`
4. `76acc33` — `XRT_FEATURE_GL_LINUX_SOFTWARE` opt-in gate (this makes it coexist with VK/XCB)

## Honest status — one reconciliation item left before merge

- [x] **Opt-in gate** so it doesn't touch the default VK/XCB build — done (`76acc33`).
- [ ] **Adopt main's `XR_EXT_xlib_window_binding`, drop mine.** I independently reinvented the extension with a **conflicting** struct-type (`1000999006` vs main's `1000999200`) and a different struct (`window`-only vs David's `Display*`+`window`). The GL path should consume **David's on-main header** unchanged; my duplicate should be deleted and the GL binding read `xDisplay`+`window` from his struct.
- [ ] **Rebase onto `main`** (currently behind, needs the extension reconciliation above first).

I've held the rebase deliberately — it's only worth doing if we want the software-GL niche. @dfattal: is a no-GPU software-GL present path useful for CI/headless, or should we close this and rely on VK/XCB + a GPU runner?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
