### PR TITLE
fix(linux,macos,#715): open the hosted compositor window on the 3D panel

### DIFF
--- a/docs/roadmap/linux-support.md
+++ b/docs/roadmap/linux-support.md
@@ -156,6 +156,20 @@ first-light is confirmed. The handle-class app now exists —
 **Done when:** a hosted cube renders into a runtime-created XCB window with
 sim_display weaving.
 
+**Window placement on multi-monitor boxes (#715).** The self-owned XCB window
+opens at the 3D panel's desktop position, mirroring the Windows reference
+(`comp_d3d11_window.cpp`): the vendor plug-in reports the panel top-left via
+`xrt_plugin_display_info` → `xsysc->info.display_screen_left/top`, the
+compositor forwards it into `comp_vk_native_window_xcb_create`, and the helper
+asks for it three ways (create-time x/y, `WM_NORMAL_HINTS` US/PPosition, and a
+post-map `ConfigureRequest` — the same move `xdotool windowmove` sends, since
+WMs like Mutter auto-place fresh toplevels otherwise). (0, 0) means primary
+monitor — the sim_display convention and the unknown-panel fallback. Manual
+override, checked **before** the plug-in value (dev boxes, sim_display):
+`DXR_WINDOW_POS=x,y` in top-down desktop pixels, e.g. `DXR_WINDOW_POS=1920,0`.
+The same knob and plug-in plumbing apply to the macOS vk_native self-owned
+window (`comp_vk_native_window_macos.m`).
+
 ### Phase 2 — Service / IPC path
 
 **Phase 2a — build-green on Linux CI ✅ (done).** `displayxr-service` + the

--- a/src/xrt/compositor/vk_native/comp_vk_native_compositor.c
+++ b/src/xrt/compositor/vk_native/comp_vk_native_compositor.c
@@ -77,6 +77,8 @@
 
 #include <string.h>
 #include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
 
 #ifdef XRT_OS_WINDOWS
 #include <windows.h>
@@ -3257,6 +3259,33 @@ dp_vtable_looks_sane(struct xrt_display_processor *dp)
 	return true;
 }
 
+#if defined(XRT_OS_MACOS) || defined(XRT_OS_LINUX_DESKTOP)
+/*!
+ * Manual override for the self-owned window position: DXR_WINDOW_POS="x,y"
+ * (top-down desktop pixels), checked BEFORE the plug-in-reported display
+ * position. For dev boxes and DPs with no real panel position — sim_display
+ * reports (0, 0) = primary by convention. #715.
+ */
+static void
+apply_window_pos_override(int32_t *left, int32_t *top)
+{
+	const char *e = getenv("DXR_WINDOW_POS");
+	if (e == NULL || e[0] == '\0') {
+		return;
+	}
+	int x = 0;
+	int y = 0;
+	if (sscanf(e, "%d,%d", &x, &y) == 2) {
+		U_LOG_W("DXR_WINDOW_POS=%s overrides plug-in display position (%d, %d)", e, (int)*left, (int)*top);
+		*left = (int32_t)x;
+		*top = (int32_t)y;
+	} else {
+		U_LOG_W("DXR_WINDOW_POS='%s' malformed — expected 'x,y'; using plug-in display position", e);
+	}
+}
+#endif
+
+
 /*
  *
  * Exported functions
@@ -3389,9 +3418,14 @@ comp_vk_native_compositor_create(struct xrt_device *xdev,
 			win_w = 1920;
 			win_h = 1080;
 		}
-		U_LOG_I("Creating self-owned macOS window (%ux%u)", win_w, win_h);
+		// Open on the 3D panel at the plug-in-reported position (as the
+		// Windows arm does), with the DXR_WINDOW_POS env override winning. #715.
+		int32_t win_left = display_screen_left;
+		int32_t win_top = display_screen_top;
+		apply_window_pos_override(&win_left, &win_top);
+		U_LOG_I("Creating self-owned macOS window (%ux%u at %d,%d)", win_w, win_h, win_left, win_top);
 		xrt_result_t xret = comp_vk_native_window_macos_create(
-		    win_w, win_h, transparent_background, &c->macos_window);
+		    win_w, win_h, win_left, win_top, transparent_background, &c->macos_window);
 		if (xret != XRT_SUCCESS) {
 			U_LOG_E("Failed to create self-owned macOS window");
 			free(c);
@@ -3438,9 +3472,14 @@ comp_vk_native_compositor_create(struct xrt_device *xdev,
 			win_w = 1920;
 			win_h = 1080;
 		}
-		U_LOG_I("Creating self-owned XCB window (%ux%u)", win_w, win_h);
+		// Open on the 3D panel at the plug-in-reported position (as the
+		// Windows arm does), with the DXR_WINDOW_POS env override winning. #715.
+		int32_t win_left = display_screen_left;
+		int32_t win_top = display_screen_top;
+		apply_window_pos_override(&win_left, &win_top);
+		U_LOG_I("Creating self-owned XCB window (%ux%u at %d,%d)", win_w, win_h, win_left, win_top);
 		xrt_result_t xret = comp_vk_native_window_xcb_create(
-		    win_w, win_h, transparent_background, &c->xcb_window);
+		    win_w, win_h, win_left, win_top, transparent_background, &c->xcb_window);
 		if (xret != XRT_SUCCESS) {
 			U_LOG_E("Failed to create self-owned XCB window");
 			free(c);

--- a/src/xrt/compositor/vk_native/comp_vk_native_window_macos.h
+++ b/src/xrt/compositor/vk_native/comp_vk_native_window_macos.h
@@ -30,6 +30,13 @@ struct comp_vk_native_window_macos;
  *
  * @param width                 Requested window width in points.
  * @param height                Requested window height in points.
+ * @param screen_left           Window left edge in top-down global coordinates
+ *                              (origin = primary screen top-left) — the 3D
+ *                              panel position the vendor plug-in reports via
+ *                              xsysc->info.display_screen_left. (0, 0) means
+ *                              primary screen. Positions outside every
+ *                              NSScreen fall back to the primary. #715.
+ * @param screen_top            Window top edge, same space as @p screen_left.
  * @param transparent_background When true, the NSWindow + CAMetalLayer are
  *                              configured non-opaque (clear background) so the
  *                              desktop shows through alpha < 1 regions.
@@ -40,6 +47,8 @@ struct comp_vk_native_window_macos;
 xrt_result_t
 comp_vk_native_window_macos_create(uint32_t width,
                                     uint32_t height,
+                                    int32_t screen_left,
+                                    int32_t screen_top,
                                     bool transparent_background,
                                     struct comp_vk_native_window_macos **out_win);
 

--- a/src/xrt/compositor/vk_native/comp_vk_native_window_macos.m
+++ b/src/xrt/compositor/vk_native/comp_vk_native_window_macos.m
@@ -66,16 +66,62 @@ ensure_ns_app(void)
 	}
 }
 
+/*!
+ * Compute the AppKit frame origin for a window whose top-left should sit at
+ * (@p screen_left, @p screen_top) in top-down global coordinates — origin at
+ * the top-left of the primary screen, the space the vendor plug-in reports
+ * the 3D panel position in (Windows convention: (0, 0) = primary). AppKit is
+ * bottom-up, so flip against the primary screen height and pick the screen
+ * containing the point for logging/fallback. #715.
+ */
+static NSRect
+frame_for_display_position(int32_t screen_left, int32_t screen_top, uint32_t width, uint32_t height)
+{
+	NSScreen *primary = [NSScreen screens].firstObject; // origin (0,0) in AppKit global space
+	if (primary == nil) {
+		return NSMakeRect(100, 100, width, height);
+	}
+
+	CGFloat primary_h = primary.frame.size.height;
+	NSPoint top_left = NSMakePoint((CGFloat)screen_left, primary_h - (CGFloat)screen_top);
+	NSRect frame = NSMakeRect(top_left.x, top_left.y - (CGFloat)height, width, height);
+
+	// Find the screen containing the requested top-left; if no screen does,
+	// the plug-in value is bogus for this desktop layout — fall back to the
+	// primary screen rather than opening an unreachable off-screen window.
+	NSScreen *target = nil;
+	for (NSScreen *s in [NSScreen screens]) {
+		// NSPointInRect excludes the top edge in a bottom-up rect, so probe
+		// one point inside the window instead of the exact corner.
+		if (NSPointInRect(NSMakePoint(top_left.x, top_left.y - 1), s.frame)) {
+			target = s;
+			break;
+		}
+	}
+	if (target == nil) {
+		U_LOG_W("VK native macOS: display position (%d, %d) is outside every screen — "
+		        "falling back to the primary screen",
+		        (int)screen_left, (int)screen_top);
+		return NSMakeRect(100, 100, width, height);
+	}
+
+	U_LOG_I("VK native macOS: placing window at (%d, %d) on screen '%s'", (int)screen_left, (int)screen_top,
+	        [target.localizedName UTF8String]);
+	return frame;
+}
+
 static void
 create_window_on_main_thread(struct comp_vk_native_window_macos *win,
                               uint32_t width,
                               uint32_t height,
+                              int32_t screen_left,
+                              int32_t screen_top,
                               bool transparent_background,
                               bool *out_success)
 {
 	ensure_ns_app();
 
-	NSRect frame = NSMakeRect(100, 100, width, height);
+	NSRect frame = frame_for_display_position(screen_left, screen_top, width, height);
 	NSWindowStyleMask style = NSWindowStyleMaskTitled |
 	                          NSWindowStyleMaskClosable |
 	                          NSWindowStyleMaskResizable |
@@ -136,6 +182,8 @@ create_window_on_main_thread(struct comp_vk_native_window_macos *win,
 xrt_result_t
 comp_vk_native_window_macos_create(uint32_t width,
                                     uint32_t height,
+                                    int32_t screen_left,
+                                    int32_t screen_top,
                                     bool transparent_background,
                                     struct comp_vk_native_window_macos **out_win)
 {
@@ -146,10 +194,12 @@ comp_vk_native_window_macos_create(uint32_t width,
 
 	__block bool success = false;
 	if ([NSThread isMainThread]) {
-		create_window_on_main_thread(win, width, height, transparent_background, &success);
+		create_window_on_main_thread(win, width, height, screen_left, screen_top, transparent_background,
+		                             &success);
 	} else {
 		dispatch_sync(dispatch_get_main_queue(), ^{
-			create_window_on_main_thread(win, width, height, transparent_background, &success);
+			create_window_on_main_thread(win, width, height, screen_left, screen_top,
+			                             transparent_background, &success);
 		});
 	}
 

--- a/src/xrt/compositor/vk_native/comp_vk_native_window_xcb.c
+++ b/src/xrt/compositor/vk_native/comp_vk_native_window_xcb.c
@@ -49,6 +49,8 @@ intern_atom(xcb_connection_t *conn, const char *name)
 xrt_result_t
 comp_vk_native_window_xcb_create(uint32_t width,
                                  uint32_t height,
+                                 int32_t screen_left,
+                                 int32_t screen_top,
                                  bool transparent_background,
                                  struct comp_vk_native_window_xcb **out_win)
 {
@@ -99,14 +101,31 @@ comp_vk_native_window_xcb_create(uint32_t width,
 	    XCB_EVENT_MASK_STRUCTURE_NOTIFY | XCB_EVENT_MASK_KEY_PRESS,
 	};
 
+	// Position on the 3D display. The vendor plug-in publishes the panel's
+	// top-left in root-window coordinates through
+	// xsysc->info.display_screen_left/top and the compositor forwards it here
+	// (Windows reference: comp_d3d11_window.cpp). (0, 0) means primary
+	// monitor (sim_display default or unknown panel). #715.
 	xcb_create_window(conn,
 	                  XCB_COPY_FROM_PARENT, // depth
 	                  win->window, screen->root,
-	                  0, 0, (uint16_t)width, (uint16_t)height,
+	                  (int16_t)screen_left, (int16_t)screen_top, (uint16_t)width, (uint16_t)height,
 	                  0,                                 // border
 	                  XCB_WINDOW_CLASS_INPUT_OUTPUT,
 	                  screen->root_visual,
 	                  value_mask, value_list);
+
+	// WM_NORMAL_HINTS with USPosition|PPosition, so the window manager treats
+	// the create-time position as intentional instead of auto-placing the
+	// window (ICCCM §4.1.2.3; GNOME/Mutter auto-places without this).
+	{
+		uint32_t hints[18] = {0};
+		hints[0] = 1 | 4; // USPosition | PPosition
+		hints[1] = (uint32_t)screen_left;
+		hints[2] = (uint32_t)screen_top;
+		xcb_change_property(conn, XCB_PROP_MODE_REPLACE, win->window, XCB_ATOM_WM_NORMAL_HINTS,
+		                    XCB_ATOM_WM_SIZE_HINTS, 32, 18, hints);
+	}
 
 	// Title.
 	const char *title = "DisplayXR";
@@ -123,9 +142,18 @@ comp_vk_native_window_xcb_create(uint32_t width,
 	}
 
 	xcb_map_window(conn, win->window);
+
+	// Re-assert the position after mapping — many WMs (Mutter included)
+	// ignore the create-time x/y of a freshly mapped toplevel, but honor a
+	// post-map ConfigureRequest (this is what `xdotool windowmove` sends).
+	{
+		const uint32_t coords[2] = {(uint32_t)screen_left, (uint32_t)screen_top};
+		xcb_configure_window(conn, win->window, XCB_CONFIG_WINDOW_X | XCB_CONFIG_WINDOW_Y, coords);
+	}
 	xcb_flush(conn);
 
-	U_LOG_I("XCB: created %ux%u window 0x%08x", width, height, (unsigned)win->window);
+	U_LOG_I("XCB: created %ux%u window 0x%08x at (%d, %d)", width, height, (unsigned)win->window,
+	        (int)screen_left, (int)screen_top);
 
 	*out_win = win;
 	return XRT_SUCCESS;

--- a/src/xrt/compositor/vk_native/comp_vk_native_window_xcb.h
+++ b/src/xrt/compositor/vk_native/comp_vk_native_window_xcb.h
@@ -94,6 +94,12 @@ comp_vk_native_window_xcb_query_geometry(const struct comp_vk_native_xcb_handle 
  *
  * @param width                  Requested window width in pixels.
  * @param height                 Requested window height in pixels.
+ * @param screen_left            Window left edge in root-window pixels — the
+ *                               3D panel position the vendor plug-in reports
+ *                               via xsysc->info.display_screen_left. (0, 0)
+ *                               means primary monitor (Windows convention,
+ *                               comp_d3d11_window.cpp). #715.
+ * @param screen_top             Window top edge in root-window pixels.
  * @param transparent_background Reserved; X11 ARGB-visual transparency is not
  *                               wired in Phase 1 (desktop WSI usually exposes
  *                               only OPAQUE compositeAlpha). Accepted for API
@@ -105,6 +111,8 @@ comp_vk_native_window_xcb_query_geometry(const struct comp_vk_native_xcb_handle 
 xrt_result_t
 comp_vk_native_window_xcb_create(uint32_t width,
                                  uint32_t height,
+                                 int32_t screen_left,
+                                 int32_t screen_top,
                                  bool transparent_background,
                                  struct comp_vk_native_window_xcb **out_win);
 


### PR DESCRIPTION
Fixes #715.

The self-owned (hosted-class) vk_native window ignored the plug-in-reported display position — the XCB helper hardcoded (0,0) (`comp_vk_native_window_xcb.c`) and the macOS helper `NSMakeRect(100,100)` — so on multi-monitor boxes (George's 22.04 laptop + Acer DS1, and the deployment laptop + Odyssey 3D shape) the window opened on the primary monitor and had to be moved with `xdotool`. Windows is the reference implementation and already consumes `xsysc->info.display_screen_left/top` (`comp_d3d11_window.cpp`); it is untouched here.

## Changes
- **Linux (XCB):** `comp_vk_native_window_xcb_create` gains `screen_left/top` params, forwarded from the values already arriving at `comp_vk_native_compositor_create`. Position is requested three ways: create-time x/y, `WM_NORMAL_HINTS` `USPosition|PPosition` (so the WM treats it as intentional instead of auto-placing), and a post-map `ConfigureRequest` re-assert — the same request `xdotool windowmove` sends, which is known to work on George's GNOME/XWayland box.
- **macOS:** `comp_vk_native_window_macos_create` gains `screen_left/top`; the frame is placed at the top-down global position flipped into AppKit space, on the `NSScreen` containing that point, with a primary-screen fallback (plus WARN) when the point is outside every screen.
- **`DXR_WINDOW_POS=x,y` env override**, checked before the plug-in value — for dev boxes and sim_display (which reports 0,0 = primary by convention). Malformed values WARN and fall through to the plug-in value.
- Docs: placement contract + override documented in `docs/roadmap/linux-support.md` (Phase 1b).

## Validation
- MinGW compile check passed; macOS build green.
- macOS smoke run (hosted legacy VK cube): `DXR_WINDOW_POS=300,120` → `DXR_WINDOW_POS=300,120 overrides plug-in display position (0, 0)` → `placing window at (300, 120) on screen 'Built-in Retina Display'`.
- Linux CI is build-only (no display); on-hardware check is George's DS1 box — test recipe to follow on #715 after merge.

Companion plug-in work (resolving the real panel position from the EDID-probed DRM connector via RandR) lands separately in displayxr-leia-plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)