### PR TITLE
oxr,comp: macOS external-window sessions — host-pumped events + private layered swapchains

### DIFF
--- a/src/xrt/compositor/metal/comp_metal_compositor.m
+++ b/src/xrt/compositor/metal/comp_metal_compositor.m
@@ -2663,7 +2663,23 @@ metal_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 	} else {
 		drawable = [c->metal_layer nextDrawable];
 		if (drawable == nil) {
+			// One-shot diagnostic (displayxr-unity#204 bring-up): a permanently
+			// nil drawable means presents never reach the WindowServer.
+			static int s_nil_logged = 0;
+			if (!s_nil_logged) {
+				s_nil_logged = 1;
+				U_LOG_W("layer_commit: nextDrawable nil (layer=%p device=%p size=%.0fx%.0f window=%p onscreen=%d)",
+				        (void *)c->metal_layer, (void *)c->metal_layer.device,
+				        c->metal_layer.drawableSize.width, c->metal_layer.drawableSize.height,
+				        (void *)c->view.window, c->view.window != nil ? (int)[c->view.window isVisible] : -1);
+			}
 			return XRT_SUCCESS; // Non-fatal, skip this frame
+		}
+		static int s_first_drawable_logged = 0;
+		if (!s_first_drawable_logged) {
+			s_first_drawable_logged = 1;
+			U_LOG_W("layer_commit: first drawable OK (size=%.0fx%.0f)",
+			        c->metal_layer.drawableSize.width, c->metal_layer.drawableSize.height);
 		}
 		output_texture = drawable.texture;
 	}

--- a/src/xrt/compositor/metal/comp_metal_compositor.m
+++ b/src/xrt/compositor/metal/comp_metal_compositor.m
@@ -1213,6 +1213,12 @@ metal_compositor_create_swapchain(struct xrt_compositor *xc,
 		if (layered) {
 			desc.textureType = MTLTextureType2DArray;
 			desc.arrayLength = info->array_size;
+			// Layered swapchains have no IOSurface backing (below) and no CPU
+			// access path — keep them GPU-private. Shared-storage render
+			// targets also break Unity's Metal RenderSurface machinery when a
+			// client wraps slice views as XR render targets (the editor SEGVs
+			// creating the surface's main texture — displayxr-unity#204).
+			desc.storageMode = MTLStorageModePrivate;
 			msc->iosurfaces[i] = NULL;
 			msc->images[i] = [c->device newTextureWithDescriptor:desc];
 			if (msc->images[i] == nil) {

--- a/src/xrt/state_trackers/oxr/oxr_macos.m
+++ b/src/xrt/state_trackers/oxr/oxr_macos.m
@@ -69,6 +69,21 @@ oxr_macos_pump_events(struct xrt_device **xdevs, uint32_t xdev_count, struct xrt
 			return;
 		}
 
+		// External-window sessions (the app supplied the NSView, e.g. the Unity
+		// display provider): the HOST APP owns the event loop. Draining NSApp
+		// here dequeues the host's own events and [NSApp sendEvent:] dispatches
+		// them REENTRANTLY from inside the host's frame callback (xrPollEvent is
+		// called from Unity's LateUpdate) — the Unity editor throws and aborts.
+		// Skip the drain, qwerty, and window-close tracking entirely (the host
+		// delivers input and owns window lifetime); keep the CATransaction
+		// flush + CFRunLoop tick below — that is what commits the compositor's
+		// background-thread drawable presents. (displayxr-unity#204 bring-up.)
+		if (external_window && !service_mode) {
+			[CATransaction flush];
+			CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.001, false);
+			return;
+		}
+
 		// When running inside a host app (external_window == true),
 		// collect keyboard/mouse events so we can re-inject them
 		// after processing.  This lets the runtime see all events


### PR DESCRIPTION
Two macOS fixes surfaced by the Unity display provider bring-up ([displayxr-unity#202](https://github.com/DisplayXR/displayxr-unity/issues/202) Phase 2 = [displayxr-unity#204](https://github.com/DisplayXR/displayxr-unity/issues/204)):

## 1. `oxr_macos_pump_events`: don't drain NSApp for external-window sessions

When the app supplies the NSView (`XrCocoaWindowBindingCreateInfoEXT.viewHandle != NULL`), the **host app owns the event loop**. The pump's `nextEventMatchingMask` dequeues the host's own events and `[NSApp sendEvent:]` dispatches them **reentrantly from inside the host's frame callback** (Unity calls `xrPollEvent` from `LateUpdate` on the main thread) — the Unity editor throws `NSInternalInconsistencyException` mid-dispatch and aborts (verified via `.ips` crash report: `objc_exception_rethrow` inside `nextEventMatchingMask` ← `oxr_macos_pump_events`).

External-window sessions now skip the drain, qwerty forwarding, and window-close tracking (the host delivers input and owns window lifetime) but keep the `[CATransaction flush]` + CFRunLoop tick — that's what commits the compositor's background-thread Metal drawable presents.

## 2. Layered (arraySize>1) swapchain images → `MTLStorageModePrivate`

Layered swapchains already skip the IOSurface backing (#681/#682) and have no CPU access path, so `Shared` storage bought nothing. GPU-private is the correct mode for pure render-target/sample images, and Shared-storage render targets also interact badly with Unity's Metal RenderSurface machinery when the client renders into per-slice views.

Both verified against the Unity provider's Metal session bring-up (session create → view_rig locate → frame loop on an M1 Pro, sim_display SBS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)