### PR TITLE
feat(ext,#715): XrDisplayDesktopPositionEXT — expose the 3D panel's desktop position to apps (display_info v16)

### DIFF
--- a/docs/guides/displayxr-app-rules.md
+++ b/docs/guides/displayxr-app-rules.md
@@ -118,6 +118,16 @@ re-implementing — see [INV-8.1](#8-app-folder-layout--what-to-include)).
   window** (used by the display processor for position/phase tracking). Don't drop the HWND
   when you go texture-mode. Ref: `test_apps/cube_texture_d3d11_win/xr_session.cpp:193-194`.
 
+- **INV-1.3 (advisory) — Create your window ON the 3D panel, not wherever the OS defaults.**
+  On multi-monitor systems (laptop + external 3D panel — the deployment shape) a
+  `CW_USEDEFAULT` window opens on the primary monitor, where the weave cannot produce 3D.
+  Chain `XrDisplayDesktopPositionEXT` (spec v16) onto `XrSystemProperties` and create your
+  window at the returned `left/top` (virtual-desktop pixels, top-down; `(0,0)` = primary or
+  unknown — either way a safe create position). This refines the INV-1.1 ordering: create
+  instance → get system → `xrGetSystemProperties` → **create window at the reported
+  position** → create session with the binding. Hosted apps need none of this — the runtime
+  places its own window (#715).
+
 ---
 
 ## 2. Display info & rendering modes (`XR_EXT_display_info`)

--- a/docs/specs/extensions/XR_EXT_display_info.md
+++ b/docs/specs/extensions/XR_EXT_display_info.md
@@ -718,6 +718,46 @@ typedef struct XrDisplayInfoEXT {
 - All returned values are static display properties that do not change during the runtime's
   lifetime.
 
+#### XrDisplayDesktopPositionEXT (v16)
+
+Chained to `XrSystemProperties` (typically via `XrDisplayInfoEXT.next`) to return the 3D
+panel's desktop position — its top-left corner in OS virtual-desktop coordinates: top-down
+pixels, origin at the primary monitor's top-left (the Windows virtual-screen / X11
+root-window convention). `(0, 0)` means the panel is the primary monitor or its position is
+unknown.
+
+| Member | Type | Description |
+|---|---|---|
+| `type` | `XrStructureType` | Must be `XR_TYPE_DISPLAY_DESKTOP_POSITION_EXT` (`1000999210`). |
+| `next` | `void*` | Pointer to next structure in the chain, or `NULL`. |
+| `left` | `int32_t` | Panel left edge in virtual-desktop pixels. |
+| `top` | `int32_t` | Panel top edge in virtual-desktop pixels. |
+
+```c
+typedef struct XrDisplayDesktopPositionEXT {
+    XrStructureType             type;
+    void* XR_MAY_ALIAS          next;
+    int32_t                     left;
+    int32_t                     top;
+} XrDisplayDesktopPositionEXT;
+```
+
+**Why it exists:** applications that create their own window (the handle/texture app
+classes) **should** create it at this position so the content opens on the 3D panel rather
+than the primary monitor on multi-monitor systems — the window-relative weave can only
+produce correct 3D on the panel itself. Hosted-class apps need not query it: the runtime
+self-creates its window at this position. The value is available before session creation
+(`xrGetSystemProperties` needs only the instance and system id), so the query slots
+naturally between `xrGetSystem` and native window creation. It is the same value the
+vendor plug-in reports to the runtime for its own hosted-window placement (#715).
+
+**Valid Usage:**
+- `type` **must** be `XR_TYPE_DISPLAY_DESKTOP_POSITION_EXT`.
+- The application **must** have enabled the `XR_EXT_display_info` extension at instance
+  creation.
+- The position is a static property for the lifetime of the runtime instance; display
+  topology changes (monitor hotplug, rearrangement) are not reported dynamically in v16.
+
 ### New Enums
 
 #### XrDisplayModeEXT
@@ -2052,7 +2092,8 @@ the property) silently ignore the call — graceful degradation.
 | 11 | 2026-03-20 | David Fattal | Added per-mode tile layout fields to `XrDisplayRenderingModeInfoEXT`: `tileColumns`, `tileRows`, `viewWidthPixels`, `viewHeightPixels`. Enables runtime to describe atlas layout for multi-view rendering modes (e.g., 2x2 quad). |
 | 12 | 2026-03-28 | David Fattal | Removed `hardwareDisplay3D` from `XrDisplayInfoEXT`. It remains available **per-mode** on `XrDisplayRenderingModeInfoEXT` (via `xrEnumerateDisplayRenderingModesEXT`) and is also reported by the `XrEventDataHardwareDisplayStateChangedEXT` event. Also moved `xrSetSharedTextureOutputRectEXT` to the window-binding extension headers. |
 | 13 | 2026-05-18 | David Fattal | Added per-session `isActive` and `isRequestable` fields to `XrDisplayRenderingModeInfoEXT` (#234). `isActive` lets an app learn the current mode from the first enumerate without waiting for an event; `isRequestable` tells a session whether it may request a mode (false for non-controller sessions under a workspace). |
-| 15 | 2026-06-11 | David Fattal | **Repurposed `xrRequestDisplayModeEXT`** (#542): no longer a deprecated mode-switching wrapper — it now sets the HARDWARE display state alone for the current mode (the mode's layout/content and the DP's atlas processing are untouched; the DP weaves or flat-blits per the atlas it is handed). Override holds until the next mode request. Reported via `XrEventDataHardwareDisplayStateChangedEXT`. No struct/ABI change. **Current header version (`XR_EXT_display_info_SPEC_VERSION == 15`).** |
+| 15 | 2026-06-11 | David Fattal | **Repurposed `xrRequestDisplayModeEXT`** (#542): no longer a deprecated mode-switching wrapper — it now sets the HARDWARE display state alone for the current mode (the mode's layout/content and the DP's atlas processing are untouched; the DP weaves or flat-blits per the atlas it is handed). Override holds until the next mode request. Reported via `XrEventDataHardwareDisplayStateChangedEXT`. No struct/ABI change. |
+| 16 | 2026-07-07 | David Fattal | Added `XrDisplayDesktopPositionEXT` (`1000999210`, new chained struct — additive, no ABI change to existing structs): the 3D panel's top-left in virtual-desktop pixels, chained to `XrSystemProperties`, so handle/texture-class apps can create their window on the panel on multi-monitor systems (#715). **Current header version (`XR_EXT_display_info_SPEC_VERSION == 16`).** |
 
 > The `XR_EXT_display_info_SPEC_VERSION` define in the header is the authoritative current
 > revision. Earlier revision numbers in this table reflect the proposal's editing history and do

--- a/src/external/openxr_includes/openxr/README.md
+++ b/src/external/openxr_includes/openxr/README.md
@@ -39,7 +39,8 @@ Rules:
 | 1000999180 | `XR_EXT_macos_gl_binding` | relocated from 1000999010 (collided with display_info) — spec v2 |
 | 1000999190–191 | `XR_EXT_weave` | 190 = `XR_TYPE_WEAVE_SUBMIT_INFO_EXT`, 191 = `XR_TYPE_WEAVE_OUTPUT_EXT` (#625) |
 | 1000999200–209 | `XR_EXT_xlib_window_binding` | 200 = `XR_TYPE_XLIB_WINDOW_BINDING_CREATE_INFO_EXT` (#660 Phase 3) |
-| 1000999210+ | **next free** | |
+| 1000999210–219 | `XR_EXT_display_info` (v16+ additions) | 210 = `XR_TYPE_DISPLAY_DESKTOP_POSITION_EXT` (#715); fresh decade rather than reusing the 005/009 gaps in the original block |
+| 1000999220+ | **next free** | |
 
 `XR_EXT_android_surface_binding` defines no `1000999xxx` values in this
 directory as of this writing; if it gains any, claim a decade here first.

--- a/src/external/openxr_includes/openxr/XR_EXT_display_info.h
+++ b/src/external/openxr_includes/openxr/XR_EXT_display_info.h
@@ -30,7 +30,7 @@ extern "C" {
 #endif
 
 #define XR_EXT_display_info 1
-#define XR_EXT_display_info_SPEC_VERSION 15
+#define XR_EXT_display_info_SPEC_VERSION 16
 #define XR_EXT_DISPLAY_INFO_EXTENSION_NAME "XR_EXT_display_info"
 
 // Reuse the type value from the deleted XR_EXT_dynamic_render_resolution
@@ -61,6 +61,35 @@ typedef struct XrDisplayInfoEXT {
     uint32_t                    displayPixelWidth;          //!< Native display panel width in pixels (0 if unknown)
     uint32_t                    displayPixelHeight;         //!< Native display panel height in pixels (0 if unknown)
 } XrDisplayInfoEXT;
+
+// ---- v16: Display desktop position ----
+
+#define XR_TYPE_DISPLAY_DESKTOP_POSITION_EXT ((XrStructureType)1000999210)
+
+/*!
+ * @brief Desktop position of the 3D display, returned by xrGetSystemProperties
+ * (v16 addition).
+ *
+ * When chained to XrSystemProperties (typically via XrDisplayInfoEXT's next
+ * pointer), the runtime fills in the 3D panel's top-left corner in OS
+ * virtual-desktop coordinates: top-down pixels with the origin at the primary
+ * monitor's top-left (Windows virtual-screen / X11 root-window convention).
+ * (0, 0) means the panel is the primary monitor or its position is unknown.
+ *
+ * Applications that create their own window (the handle/texture classes)
+ * should create it at this position so the content opens on the 3D panel
+ * rather than the primary monitor — the window-relative weave can only
+ * produce correct 3D on the panel itself. Hosted-class apps need not care:
+ * the runtime self-creates its window there. See runtime issue #715.
+ *
+ * @extends XrSystemProperties
+ */
+typedef struct XrDisplayDesktopPositionEXT {
+    XrStructureType             type;       //!< Must be XR_TYPE_DISPLAY_DESKTOP_POSITION_EXT
+    void* XR_MAY_ALIAS          next;       //!< Pointer to next structure in chain
+    int32_t                     left;       //!< Panel left edge in virtual-desktop pixels
+    int32_t                     top;        //!< Panel top edge in virtual-desktop pixels
+} XrDisplayDesktopPositionEXT;
 
 /*!
  * @brief Hardware display state for xrRequestDisplayModeEXT (v15 repurpose).

--- a/src/xrt/compositor/metal/comp_metal_compositor.m
+++ b/src/xrt/compositor/metal/comp_metal_compositor.m
@@ -2663,7 +2663,23 @@ metal_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 	} else {
 		drawable = [c->metal_layer nextDrawable];
 		if (drawable == nil) {
+			// One-shot diagnostic (displayxr-unity#204 bring-up): a permanently
+			// nil drawable means presents never reach the WindowServer.
+			static int s_nil_logged = 0;
+			if (!s_nil_logged) {
+				s_nil_logged = 1;
+				U_LOG_W("layer_commit: nextDrawable nil (layer=%p device=%p size=%.0fx%.0f window=%p onscreen=%d)",
+				        (void *)c->metal_layer, (void *)c->metal_layer.device,
+				        c->metal_layer.drawableSize.width, c->metal_layer.drawableSize.height,
+				        (void *)c->view.window, c->view.window != nil ? (int)[c->view.window isVisible] : -1);
+			}
 			return XRT_SUCCESS; // Non-fatal, skip this frame
+		}
+		static int s_first_drawable_logged = 0;
+		if (!s_first_drawable_logged) {
+			s_first_drawable_logged = 1;
+			U_LOG_W("layer_commit: first drawable OK (size=%.0fx%.0f)",
+			        c->metal_layer.drawableSize.width, c->metal_layer.drawableSize.height);
 		}
 		output_texture = drawable.texture;
 	}

--- a/src/xrt/compositor/metal/comp_metal_compositor.m
+++ b/src/xrt/compositor/metal/comp_metal_compositor.m
@@ -1213,6 +1213,12 @@ metal_compositor_create_swapchain(struct xrt_compositor *xc,
 		if (layered) {
 			desc.textureType = MTLTextureType2DArray;
 			desc.arrayLength = info->array_size;
+			// Layered swapchains have no IOSurface backing (below) and no CPU
+			// access path — keep them GPU-private. Shared-storage render
+			// targets also break Unity's Metal RenderSurface machinery when a
+			// client wraps slice views as XR render targets (the editor SEGVs
+			// creating the surface's main texture — displayxr-unity#204).
+			desc.storageMode = MTLStorageModePrivate;
 			msc->iosurfaces[i] = NULL;
 			msc->images[i] = [c->device newTextureWithDescriptor:desc];
 			if (msc->images[i] == nil) {

--- a/src/xrt/state_trackers/oxr/oxr_macos.m
+++ b/src/xrt/state_trackers/oxr/oxr_macos.m
@@ -69,6 +69,21 @@ oxr_macos_pump_events(struct xrt_device **xdevs, uint32_t xdev_count, struct xrt
 			return;
 		}
 
+		// External-window sessions (the app supplied the NSView, e.g. the Unity
+		// display provider): the HOST APP owns the event loop. Draining NSApp
+		// here dequeues the host's own events and [NSApp sendEvent:] dispatches
+		// them REENTRANTLY from inside the host's frame callback (xrPollEvent is
+		// called from Unity's LateUpdate) — the Unity editor throws and aborts.
+		// Skip the drain, qwerty, and window-close tracking entirely (the host
+		// delivers input and owns window lifetime); keep the CATransaction
+		// flush + CFRunLoop tick below — that is what commits the compositor's
+		// background-thread drawable presents. (displayxr-unity#204 bring-up.)
+		if (external_window && !service_mode) {
+			[CATransaction flush];
+			CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.001, false);
+			return;
+		}
+
 		// When running inside a host app (external_window == true),
 		// collect keyboard/mouse events so we can re-inject them
 		// after processing.  This lets the runtime see all events

--- a/src/xrt/state_trackers/oxr/oxr_system.c
+++ b/src/xrt/state_trackers/oxr/oxr_system.c
@@ -714,6 +714,20 @@ oxr_system_get_properties(struct oxr_logger *log, struct oxr_system *sys, XrSyst
 		display_info->displayPixelHeight = info ? info->display_pixel_height : 0;
 	}
 
+	// v16: 3D panel desktop position, so handle/texture-class apps can create
+	// their window on the panel instead of the primary monitor (#715). Same
+	// value the runtime uses to place its own hosted window.
+	XrDisplayDesktopPositionEXT *desktop_pos = NULL;
+	if (sys->inst->extensions.EXT_display_info) {
+		desktop_pos = OXR_GET_OUTPUT_FROM_CHAIN(properties, XR_TYPE_DISPLAY_DESKTOP_POSITION_EXT,
+		                                        XrDisplayDesktopPositionEXT);
+	}
+
+	if (desktop_pos) {
+		desktop_pos->left = info ? info->display_screen_left : 0;
+		desktop_pos->top = info ? info->display_screen_top : 0;
+	}
+
 	XrEyeTrackingModeCapabilitiesEXT *eye_caps = OXR_GET_OUTPUT_FROM_CHAIN(
 	    properties, XR_TYPE_EYE_TRACKING_MODE_CAPABILITIES_EXT, XrEyeTrackingModeCapabilitiesEXT);
 	if (eye_caps) {

--- a/test_apps/handle/cube_handle_metal_macos/main.mm
+++ b/test_apps/handle/cube_handle_metal_macos/main.mm
@@ -907,7 +907,7 @@ static void SignalHandler(int)
 static AppDelegate *g_appDelegate = nil;
 static AppWindowDelegate *g_windowDelegate = nil;
 
-static bool CreateMacOSWindow(uint32_t width, uint32_t height)
+static bool CreateMacOSWindow(uint32_t width, uint32_t height, int32_t screenLeft, int32_t screenTop)
 {
     @autoreleasepool {
         [NSApplication sharedApplication];
@@ -916,7 +916,17 @@ static bool CreateMacOSWindow(uint32_t width, uint32_t height)
         g_appDelegate = [[AppDelegate alloc] init];
         [NSApp setDelegate:g_appDelegate];
 
+        // INV-1.3: open on the 3D panel. (screenLeft, screenTop) is the panel
+        // top-left in top-down global coordinates (origin = primary top-left,
+        // XrDisplayDesktopPositionEXT); flip into AppKit's bottom-up space.
+        // (0,0) = primary — the titled window is auto-constrained below the
+        // menu bar, so it is always a safe create position.
         NSRect frame = NSMakeRect(100, 100, width, height);
+        NSScreen *primary = [NSScreen screens].firstObject;
+        if (primary != nil) {
+            CGFloat topY = primary.frame.size.height - (CGFloat)screenTop;
+            frame = NSMakeRect((CGFloat)screenLeft, topY - (CGFloat)height, width, height);
+        }
         NSUInteger style = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable |
                            NSWindowStyleMaskResizable | NSWindowStyleMaskMiniaturizable;
 
@@ -1183,6 +1193,9 @@ struct AppXrSession {
     float nominalViewerX, nominalViewerY, nominalViewerZ;
     uint32_t displayPixelWidth, displayPixelHeight;
     float recommendedViewScaleX, recommendedViewScaleY;
+    // v16 XrDisplayDesktopPositionEXT — 3D panel top-left in virtual-desktop
+    // pixels (top-down, origin = primary top-left); (0,0) = primary/unknown.
+    int32_t displayScreenLeft, displayScreenTop;
     PFN_xrRequestDisplayModeEXT pfnRequestDisplayModeEXT;
     PFN_xrRequestDisplayRenderingModeEXT pfnRequestDisplayRenderingModeEXT;
     PFN_xrEnumerateDisplayRenderingModesEXT pfnEnumerateDisplayRenderingModesEXT;
@@ -1311,8 +1324,13 @@ static bool InitializeOpenXR(AppXrSession &app)
         XrSystemProperties sysProps = {XR_TYPE_SYSTEM_PROPERTIES};
         XrDisplayInfoEXT displayInfo = {};
         displayInfo.type = XR_TYPE_DISPLAY_INFO_EXT;
+        // INV-1.3: panel desktop position, so the window below opens on the
+        // 3D panel instead of the primary monitor (spec v16, #715).
+        XrDisplayDesktopPositionEXT desktopPos = {};
+        desktopPos.type = XR_TYPE_DISPLAY_DESKTOP_POSITION_EXT;
         if (app.hasDisplayInfoExt) {
             sysProps.next = &displayInfo;
+            displayInfo.next = &desktopPos;
         }
         if (XR_SUCCEEDED(xrGetSystemProperties(app.instance, app.systemId, &sysProps))) {
             memcpy(app.systemName, sysProps.systemName, sizeof(app.systemName));
@@ -1327,6 +1345,9 @@ static bool InitializeOpenXR(AppXrSession &app)
                 app.displayPixelHeight = displayInfo.displayPixelHeight;
                 app.recommendedViewScaleX = displayInfo.recommendedViewScaleX;
                 app.recommendedViewScaleY = displayInfo.recommendedViewScaleY;
+                app.displayScreenLeft = desktopPos.left;
+                app.displayScreenTop = desktopPos.top;
+                LOG_INFO("Display desktop position: (%d, %d)", app.displayScreenLeft, app.displayScreenTop);
                 LOG_INFO("Display pixels: %ux%u", app.displayPixelWidth, app.displayPixelHeight);
                 LOG_INFO("Display info: %.3fx%.3f m, scale=%.2fx%.2f, nominal=(%.3f,%.3f,%.3f)",
                     app.displayWidthM, app.displayHeightM,
@@ -1865,16 +1886,19 @@ int main(int argc, char **argv)
         return 1;
     }
 
-    // Create the macOS window (app-owned)
-    if (!CreateMacOSWindow(1512, 823)) {
-        LOG_ERROR("Failed to create macOS window");
-        return 1;
-    }
-
-    // Initialize OpenXR
+    // Initialize OpenXR FIRST — xrGetSystemProperties needs only instance +
+    // system id, and returns the panel desktop position the window below is
+    // created at (INV-1.3 ordering: instance → system → properties → window
+    // → session).
     AppXrSession app = {};
     if (!InitializeOpenXR(app)) {
         LOG_ERROR("Failed to initialize OpenXR");
+        return 1;
+    }
+
+    // Create the macOS window (app-owned) on the 3D panel
+    if (!CreateMacOSWindow(1512, 823, app.displayScreenLeft, app.displayScreenTop)) {
+        LOG_ERROR("Failed to create macOS window");
         return 1;
     }
 


### PR DESCRIPTION
Follow-up to #716 (hosted windows). Handle/texture-class apps create their own window and had no OpenXR way to learn where the 3D panel is — on multi-monitor boxes (even on Windows: the demos use `CW_USEDEFAULT`) they open on the primary monitor, where the window-relative weave cannot produce 3D.

## Changes
- **`XrDisplayDesktopPositionEXT`** (`1000999210` — fresh decade 210–219 claimed in the registry README per its no-gap-reuse rules), chained to `XrSystemProperties`: panel top-left in virtual-desktop pixels (top-down, origin = primary top-left; `(0,0)` = primary/unknown). `XR_EXT_display_info` SPEC_VERSION 15 → 16.
- **Backward compatible both ways:** apps that don't chain it get byte-for-byte today's behavior; a new app on an older runtime has the chain entry ignored and falls back to its zero-initialized `(0,0)` = primary.
- **`oxr_system.c`**: fills from `xsysc->info.display_screen_left/top` — the same plug-in-reported value the runtime uses for hosted-window placement (#716).
- **Docs:** spec v16 struct section + version-history row; new **INV-1.3** app rule in `displayxr-app-rules.md` (query position → create window there → create session).
- **Reference app:** `cube_handle_metal_macos` reordered to the INV-1.3 flow (OpenXR init before window creation — `InitializeOpenXR` has no window dependency) and creates its NSWindow at the reported position.

## Validation
- Live macOS run: app logs `Display desktop position: (0, 0)` (filled by the runtime from sim_display), window created at the panel position, session reaches FOCUSED, clean render.
- `check_displayxr_app.py`: 0 errors (1 pre-existing sRGB warning).
- MinGW compile check passed.

Demo adoption (5 repos) follows as separate PRs. The header auto-syncs to `displayxr-extensions` on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)