### PR TITLE
feat(test_apps,#715): open app-owned test-app windows on the 3D panel (INV-1.3 rollout)

### DIFF
--- a/test_apps/cube_handle_vk_linux/main.cpp
+++ b/test_apps/cube_handle_vk_linux/main.cpp
@@ -9,8 +9,11 @@
  * and passes it to the runtime via XR_EXT_xlib_window_binding — the Phase 3
  * validation vehicle for app-provided windows on desktop Linux
  * (docs/roadmap/linux-support.md, #660). Adapted from
- * cube_hosted_legacy_vk_linux; the render path (fixed SBS, no
- * XR_EXT_display_info) is unchanged — the delta is the window + binding.
+ * cube_hosted_legacy_vk_linux; the render path (fixed 2-view SBS, no mode
+ * adaptation) is unchanged — the delta is the window + binding.
+ * XR_EXT_display_info is enabled (when present) solely for the INV-1.3 panel
+ * desktop-position query (#715), which also moves view sizing off the
+ * legacy-compromise path.
  *
  * The app owns the X event loop (pumped once per frame) and the window
  * lifecycle; the runtime derives its XCB connection from the app's Display
@@ -18,6 +21,7 @@
  */
 
 #include <X11/Xlib.h> // before the extension header so it sees real Xlib types
+#include <X11/Xutil.h> // XSizeHints for INV-1.3 window placement
 
 #include <vulkan/vulkan.h>
 
@@ -25,6 +29,7 @@
 #include <openxr/openxr.h>
 #include <openxr/openxr_platform.h>
 #include <openxr/XR_EXT_xlib_window_binding.h>
+#include <openxr/XR_EXT_display_info.h>
 
 #include <cmath>
 #include <csignal>
@@ -83,21 +88,37 @@ static Display* g_xDisplay = nullptr;
 static ::Window g_xWindow = 0;
 static Atom g_wmDeleteWindow = 0;
 
-static bool CreateAppWindow(uint32_t width, uint32_t height) {
+static bool CreateAppWindow(uint32_t width, uint32_t height, int32_t screenLeft, int32_t screenTop) {
     g_xDisplay = XOpenDisplay(nullptr);
     if (g_xDisplay == nullptr) {
         LOG_ERROR("XOpenDisplay failed — is DISPLAY set?");
         return false;
     }
 
+    // INV-1.3: open on the 3D panel (#715). (screenLeft, screenTop) is the
+    // panel top-left in virtual-desktop pixels (top-down, origin = primary
+    // top-left, XrDisplayDesktopPositionEXT); (0,0) = primary/unknown is a
+    // safe create position either way.
     int screen = DefaultScreen(g_xDisplay);
     g_xWindow = XCreateSimpleWindow(
         g_xDisplay, RootWindow(g_xDisplay, screen),
-        0, 0, width, height, 0,
+        screenLeft, screenTop, width, height, 0,
         BlackPixel(g_xDisplay, screen), BlackPixel(g_xDisplay, screen));
     if (g_xWindow == 0) {
         LOG_ERROR("XCreateSimpleWindow failed");
         return false;
+    }
+
+    // WM_NORMAL_HINTS with USPosition|PPosition, so the window manager treats
+    // the create-time position as intentional instead of auto-placing the
+    // window (ICCCM §4.1.2.3; GNOME/Mutter auto-places without this). Mirrors
+    // the runtime's own hosted-window placement (comp_vk_native_window_xcb.c).
+    {
+        XSizeHints hints = {};
+        hints.flags = USPosition | PPosition;
+        hints.x = screenLeft;
+        hints.y = screenTop;
+        XSetWMNormalHints(g_xDisplay, g_xWindow, &hints);
     }
 
     XStoreName(g_xDisplay, g_xWindow, "Cube Handle VK (DisplayXR)");
@@ -110,7 +131,14 @@ static bool CreateAppWindow(uint32_t width, uint32_t height) {
     XMapWindow(g_xDisplay, g_xWindow);
     XFlush(g_xDisplay);
 
-    LOG_INFO("Created app-owned X11 window 0x%lx (%ux%u)", g_xWindow, width, height);
+    // Re-assert the position after mapping — many WMs (Mutter included)
+    // ignore the create-time x/y of a freshly mapped toplevel, but honor a
+    // post-map ConfigureRequest (this is what `xdotool windowmove` sends).
+    XMoveWindow(g_xDisplay, g_xWindow, screenLeft, screenTop);
+    XFlush(g_xDisplay);
+
+    LOG_INFO("Created app-owned X11 window 0x%lx (%ux%u) at (%d, %d)",
+             g_xWindow, width, height, screenLeft, screenTop);
     return true;
 }
 
@@ -1775,6 +1803,11 @@ struct AppXrSession {
     // Per-view dimensions from recommendedImageRectWidth/Height (set once at init)
     uint32_t viewWidth = 0;
     uint32_t viewHeight = 0;
+
+    // v16 XrDisplayDesktopPositionEXT — 3D panel top-left in virtual-desktop
+    // pixels (top-down, origin = primary top-left); (0,0) = primary/unknown.
+    int32_t displayScreenLeft = 0;
+    int32_t displayScreenTop = 0;
 };
 
 static bool InitializeOpenXR(AppXrSession& xr) {
@@ -1788,12 +1821,16 @@ static bool InitializeOpenXR(AppXrSession& xr) {
 
     bool hasVulkan = false;
     bool hasXlibBinding = false;
+    bool hasDisplayInfo = false;
     for (const auto& ext : extensions) {
         if (strcmp(ext.extensionName, XR_KHR_VULKAN_ENABLE_EXTENSION_NAME) == 0) {
             hasVulkan = true;
         }
         if (strcmp(ext.extensionName, XR_EXT_XLIB_WINDOW_BINDING_EXTENSION_NAME) == 0) {
             hasXlibBinding = true;
+        }
+        if (strcmp(ext.extensionName, XR_EXT_DISPLAY_INFO_EXTENSION_NAME) == 0) {
+            hasDisplayInfo = true;
         }
     }
 
@@ -1816,6 +1853,15 @@ static bool InitializeOpenXR(AppXrSession& xr) {
     std::vector<const char*> enabledExtensions;
     enabledExtensions.push_back(XR_KHR_VULKAN_ENABLE_EXTENSION_NAME);
     enabledExtensions.push_back(XR_EXT_XLIB_WINDOW_BINDING_EXTENSION_NAME);
+    if (hasDisplayInfo) {
+        // Enabled for the INV-1.3 panel desktop-position query below (#715).
+        // NOTE: enabling XR_EXT_display_info also switches the runtime's view
+        // sizing off the legacy-app compromise path — the app still renders a
+        // fixed 2-view SBS at whatever dimensions xrEnumerateViewConfigurationViews
+        // reports at init, and does not adapt to later mode changes.
+        enabledExtensions.push_back(XR_EXT_DISPLAY_INFO_EXTENSION_NAME);
+        LOG_INFO("XR_EXT_display_info: AVAILABLE (enabled for panel position)");
+    }
 
     XrInstanceCreateInfo createInfo = {XR_TYPE_INSTANCE_CREATE_INFO};
     strncpy(createInfo.applicationInfo.applicationName, "CubeHandleVkLinux",
@@ -1834,6 +1880,23 @@ static bool InitializeOpenXR(AppXrSession& xr) {
     XrSystemGetInfo systemInfo = {XR_TYPE_SYSTEM_GET_INFO};
     systemInfo.formFactor = XR_FORM_FACTOR_HEAD_MOUNTED_DISPLAY;
     XR_CHECK(xrGetSystem(xr.instance, &systemInfo, &xr.systemId));
+
+    // INV-1.3: panel desktop position, so the window opens on the 3D panel
+    // instead of the primary monitor (spec v16, #715). The runtime fills the
+    // chained struct only when XR_EXT_display_info is enabled; the zero-init
+    // (0,0) = primary is the safe fallback either way.
+    if (hasDisplayInfo) {
+        XrSystemProperties sysProps = {XR_TYPE_SYSTEM_PROPERTIES};
+        XrDisplayDesktopPositionEXT desktopPos = {};
+        desktopPos.type = XR_TYPE_DISPLAY_DESKTOP_POSITION_EXT;
+        sysProps.next = &desktopPos;
+        if (XR_SUCCEEDED(xrGetSystemProperties(xr.instance, xr.systemId, &sysProps))) {
+            xr.displayScreenLeft = desktopPos.left;
+            xr.displayScreenTop = desktopPos.top;
+            LOG_INFO("Display desktop position: (%d, %d)",
+                     xr.displayScreenLeft, xr.displayScreenTop);
+        }
+    }
 
     uint32_t viewCount = 0;
     XR_CHECK(xrEnumerateViewConfigurationViews(xr.instance, xr.systemId, xr.viewConfigType, 0, &viewCount, nullptr));
@@ -2300,18 +2363,21 @@ int main() {
 
     LOG_INFO("=== Cube Handle VK Linux (XR_EXT_xlib_window_binding) ===");
 
-    // Create the app-owned X11 window first — it is passed to the runtime at
-    // xrCreateSession via XR_EXT_xlib_window_binding.
-    if (!CreateAppWindow(1600, 900)) {
-        LOG_ERROR("X11 window creation failed");
-        return 1;
-    }
-
-    // Initialize OpenXR
+    // Initialize OpenXR FIRST — xrGetSystemProperties needs only instance +
+    // system id, and returns the panel desktop position the window below is
+    // created at (INV-1.3 ordering: instance → system → properties → window
+    // → session).
     AppXrSession xr = {};
     if (!InitializeOpenXR(xr)) {
         LOG_ERROR("OpenXR initialization failed");
-        DestroyAppWindow();
+        return 1;
+    }
+
+    // Create the app-owned X11 window on the 3D panel — it is passed to the
+    // runtime at xrCreateSession via XR_EXT_xlib_window_binding.
+    if (!CreateAppWindow(1600, 900, xr.displayScreenLeft, xr.displayScreenTop)) {
+        LOG_ERROR("X11 window creation failed");
+        CleanupOpenXR(xr);
         return 1;
     }
 

--- a/test_apps/handle/cube_handle_d3d11_win/main.cpp
+++ b/test_apps/handle/cube_handle_d3d11_win/main.cpp
@@ -1351,6 +1351,14 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         return 1;
     }
 
+    // INV-1.3: open on the 3D panel (#715) — one-shot move to the panel's
+    // desktop position reported by xrGetSystemProperties (virtual-screen
+    // coords, top-down; (0,0) = primary/unknown is safe), BEFORE
+    // xrCreateSession so the display processor tracks the window on the
+    // panel from the start.
+    SetWindowPos(hwnd, nullptr, g_displayScreenLeft, g_displayScreenTop, 0, 0,
+                 SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
+
     // Check for session target extension
     if (!xr.hasWin32WindowBindingExt) {
         LOG_WARN("XR_EXT_win32_window_binding not available - runtime will create its own window");

--- a/test_apps/handle/cube_handle_d3d11_win/xr_session.cpp
+++ b/test_apps/handle/cube_handle_d3d11_win/xr_session.cpp
@@ -15,6 +15,13 @@ bool g_hasViewRigExt = false;
 // #439 Phase 3 — XR_EXT_local_3d_zone harness (see xr_session.h).
 ZoneMaskHarness g_zone;
 
+// INV-1.3 (#715): 3D panel top-left in virtual-desktop pixels (top-down,
+// origin = primary top-left); (0,0) = primary/unknown. Filled from the
+// XrDisplayDesktopPositionEXT chain in InitializeOpenXR; app-local because the
+// shared XrSessionManager (displayxr-common) doesn't carry this field yet.
+int32_t g_displayScreenLeft = 0;
+int32_t g_displayScreenTop = 0;
+
 // Helper macro for XR error checking with logging
 #define XR_CHECK(call) \
     do { \
@@ -193,7 +200,13 @@ bool InitializeOpenXR(XrSessionManager& xr) {
         XrSystemProperties sysProps = {XR_TYPE_SYSTEM_PROPERTIES};
         XrDisplayInfoEXT displayInfo = {(XrStructureType)XR_TYPE_DISPLAY_INFO_EXT};
         XrEyeTrackingModeCapabilitiesEXT eyeCaps = {(XrStructureType)XR_TYPE_EYE_TRACKING_MODE_CAPABILITIES_EXT};
+        // INV-1.3: panel desktop position, so the app window can be moved onto
+        // the 3D panel instead of the primary monitor (spec v16, #715).
+        // Chained at the tail of the existing chain.
+        XrDisplayDesktopPositionEXT desktopPos = {};
+        desktopPos.type = XR_TYPE_DISPLAY_DESKTOP_POSITION_EXT;
         displayInfo.next = &eyeCaps;
+        eyeCaps.next = &desktopPos;
         sysProps.next = &displayInfo;
         XrResult diResult = xrGetSystemProperties(xr.instance, xr.systemId, &sysProps);
         if (XR_SUCCEEDED(diResult)) {
@@ -208,6 +221,9 @@ bool InitializeOpenXR(XrSessionManager& xr) {
             xr.displayPixelHeight = displayInfo.displayPixelHeight;
             xr.supportedEyeTrackingModes = (uint32_t)eyeCaps.supportedModes;
             xr.defaultEyeTrackingMode = (uint32_t)eyeCaps.defaultMode;
+            g_displayScreenLeft = desktopPos.left;
+            g_displayScreenTop = desktopPos.top;
+            LOG_INFO("Display desktop position: (%d, %d)", g_displayScreenLeft, g_displayScreenTop);
             LOG_INFO("Display info: scale=%.3fx%.3f, size=%.3fx%.3fm, pixels=%ux%u, nominal=(%.0f,%.0f,%.0f)mm",
                 xr.recommendedViewScaleX, xr.recommendedViewScaleY,
                 xr.displayWidthM, xr.displayHeightM,

--- a/test_apps/handle/cube_handle_d3d11_win/xr_session.h
+++ b/test_apps/handle/cube_handle_d3d11_win/xr_session.h
@@ -16,6 +16,12 @@
 #include <openxr/XR_EXT_local_3d_zone.h>
 #include <openxr/XR_EXT_view_rig.h>
 
+// INV-1.3 (#715): 3D panel top-left in virtual-desktop pixels (top-down,
+// origin = primary top-left); (0,0) = primary/unknown. Filled by
+// InitializeOpenXR from the XrDisplayDesktopPositionEXT chain (spec v16).
+extern int32_t g_displayScreenLeft;
+extern int32_t g_displayScreenTop;
+
 // XR_EXT_view_rig (#396 W7) available + enabled on the instance. App-local
 // (not on the shared XrSessionManager) — this app is the extension's verify
 // vehicle; promote to xr_session_common when more consumers adopt it.

--- a/test_apps/handle/cube_handle_d3d12_win/main.cpp
+++ b/test_apps/handle/cube_handle_d3d12_win/main.cpp
@@ -1227,6 +1227,14 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         return 1;
     }
 
+    // INV-1.3: open on the 3D panel (#715) — one-shot move to the panel's
+    // desktop position reported by xrGetSystemProperties (virtual-screen
+    // coords, top-down; (0,0) = primary/unknown is safe), BEFORE
+    // xrCreateSession so the display processor tracks the window on the
+    // panel from the start.
+    SetWindowPos(hwnd, nullptr, g_displayScreenLeft, g_displayScreenTop, 0, 0,
+                 SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
+
     // Get D3D12 graphics requirements
     LUID adapterLuid;
     if (!GetD3D12GraphicsRequirements(xr, &adapterLuid)) {

--- a/test_apps/handle/cube_handle_d3d12_win/xr_session.cpp
+++ b/test_apps/handle/cube_handle_d3d12_win/xr_session.cpp
@@ -14,6 +14,13 @@ bool g_hasViewRigExt = false;
 // #439 Phase 3 — XR_EXT_local_3d_zone harness (see xr_session.h).
 ZoneMaskHarness g_zone;
 
+// INV-1.3 (#715): 3D panel top-left in virtual-desktop pixels (top-down,
+// origin = primary top-left); (0,0) = primary/unknown. Filled from the
+// XrDisplayDesktopPositionEXT chain in InitializeOpenXR; app-local because the
+// shared XrSessionManager (displayxr-common) doesn't carry this field yet.
+int32_t g_displayScreenLeft = 0;
+int32_t g_displayScreenTop = 0;
+
 #define XR_CHECK(call) \
     do { \
         XrResult result = (call); \
@@ -168,7 +175,13 @@ bool InitializeOpenXR(XrSessionManager& xr) {
         XrSystemProperties sysProps = {XR_TYPE_SYSTEM_PROPERTIES};
         XrDisplayInfoEXT displayInfo = {(XrStructureType)XR_TYPE_DISPLAY_INFO_EXT};
         XrEyeTrackingModeCapabilitiesEXT eyeCaps = {(XrStructureType)XR_TYPE_EYE_TRACKING_MODE_CAPABILITIES_EXT};
+        // INV-1.3: panel desktop position, so the app window can be moved onto
+        // the 3D panel instead of the primary monitor (spec v16, #715).
+        // Chained at the tail of the existing chain.
+        XrDisplayDesktopPositionEXT desktopPos = {};
+        desktopPos.type = XR_TYPE_DISPLAY_DESKTOP_POSITION_EXT;
         displayInfo.next = &eyeCaps;
+        eyeCaps.next = &desktopPos;
         sysProps.next = &displayInfo;
         XrResult diResult = xrGetSystemProperties(xr.instance, xr.systemId, &sysProps);
         if (XR_SUCCEEDED(diResult)) {
@@ -183,6 +196,9 @@ bool InitializeOpenXR(XrSessionManager& xr) {
             xr.displayPixelHeight = displayInfo.displayPixelHeight;
             xr.supportedEyeTrackingModes = (uint32_t)eyeCaps.supportedModes;
             xr.defaultEyeTrackingMode = (uint32_t)eyeCaps.defaultMode;
+            g_displayScreenLeft = desktopPos.left;
+            g_displayScreenTop = desktopPos.top;
+            LOG_INFO("Display desktop position: (%d, %d)", g_displayScreenLeft, g_displayScreenTop);
             LOG_INFO("Display info: scale=%.3fx%.3f, size=%.3fx%.3fm, pixels=%ux%u, nominal=(%.0f,%.0f,%.0f)mm",
                 xr.recommendedViewScaleX, xr.recommendedViewScaleY,
                 xr.displayWidthM, xr.displayHeightM,

--- a/test_apps/handle/cube_handle_d3d12_win/xr_session.h
+++ b/test_apps/handle/cube_handle_d3d12_win/xr_session.h
@@ -14,6 +14,12 @@
 #include <openxr/XR_EXT_view_rig.h>
 #include <openxr/XR_EXT_local_3d_zone.h>
 
+// INV-1.3 (#715): 3D panel top-left in virtual-desktop pixels (top-down,
+// origin = primary top-left); (0,0) = primary/unknown. Filled by
+// InitializeOpenXR from the XrDisplayDesktopPositionEXT chain (spec v16).
+extern int32_t g_displayScreenLeft;
+extern int32_t g_displayScreenTop;
+
 // XR_EXT_view_rig (#396 W7) available + enabled on the instance. App-local
 // (not on the shared XrSessionManager); promote to xr_session_common when
 // more consumers adopt it.

--- a/test_apps/handle/cube_handle_gl_macos/main.mm
+++ b/test_apps/handle/cube_handle_gl_macos/main.mm
@@ -819,7 +819,7 @@ static void SignalHandler(int)
 static AppDelegate *g_appDelegate = nil;
 static AppWindowDelegate *g_windowDelegate = nil;
 
-static bool CreateMacOSWindow(uint32_t width, uint32_t height)
+static bool CreateMacOSWindow(uint32_t width, uint32_t height, int32_t screenLeft, int32_t screenTop)
 {
     @autoreleasepool {
         [NSApplication sharedApplication];
@@ -828,7 +828,17 @@ static bool CreateMacOSWindow(uint32_t width, uint32_t height)
         g_appDelegate = [[AppDelegate alloc] init];
         [NSApp setDelegate:g_appDelegate];
 
+        // INV-1.3: open on the 3D panel (#715). (screenLeft, screenTop) is the
+        // panel top-left in top-down global coordinates (origin = primary
+        // top-left, XrDisplayDesktopPositionEXT); flip into AppKit's bottom-up
+        // space. (0,0) = primary — the titled window is auto-constrained below
+        // the menu bar, so it is always a safe create position.
         NSRect frame = NSMakeRect(100, 100, width, height);
+        NSScreen *primary = [NSScreen screens].firstObject;
+        if (primary != nil) {
+            CGFloat topY = primary.frame.size.height - (CGFloat)screenTop;
+            frame = NSMakeRect((CGFloat)screenLeft, topY - (CGFloat)height, width, height);
+        }
         NSUInteger style = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable |
                            NSWindowStyleMaskResizable | NSWindowStyleMaskMiniaturizable;
 
@@ -1114,6 +1124,9 @@ struct AppXrSession {
     float nominalViewerX, nominalViewerY, nominalViewerZ;
     uint32_t displayPixelWidth, displayPixelHeight;
     float recommendedViewScaleX, recommendedViewScaleY;
+    // v16 XrDisplayDesktopPositionEXT — 3D panel top-left in virtual-desktop
+    // pixels (top-down, origin = primary top-left); (0,0) = primary/unknown.
+    int32_t displayScreenLeft, displayScreenTop;
     PFN_xrRequestDisplayModeEXT pfnRequestDisplayModeEXT;
     PFN_xrRequestDisplayRenderingModeEXT pfnRequestDisplayRenderingModeEXT;
     PFN_xrEnumerateDisplayRenderingModesEXT pfnEnumerateDisplayRenderingModesEXT;
@@ -1230,8 +1243,13 @@ static bool InitializeOpenXR(AppXrSession &app)
         XrSystemProperties sysProps = {XR_TYPE_SYSTEM_PROPERTIES};
         XrDisplayInfoEXT displayInfo = {};
         displayInfo.type = XR_TYPE_DISPLAY_INFO_EXT;
+        // INV-1.3: panel desktop position, so the window below opens on the
+        // 3D panel instead of the primary monitor (spec v16, #715).
+        XrDisplayDesktopPositionEXT desktopPos = {};
+        desktopPos.type = XR_TYPE_DISPLAY_DESKTOP_POSITION_EXT;
         if (app.hasDisplayInfoExt) {
             sysProps.next = &displayInfo;
+            displayInfo.next = &desktopPos;
         }
         if (XR_SUCCEEDED(xrGetSystemProperties(app.instance, app.systemId, &sysProps))) {
             memcpy(app.systemName, sysProps.systemName, sizeof(app.systemName));
@@ -1246,6 +1264,9 @@ static bool InitializeOpenXR(AppXrSession &app)
                 app.displayPixelHeight = displayInfo.displayPixelHeight;
                 app.recommendedViewScaleX = displayInfo.recommendedViewScaleX;
                 app.recommendedViewScaleY = displayInfo.recommendedViewScaleY;
+                app.displayScreenLeft = desktopPos.left;
+                app.displayScreenTop = desktopPos.top;
+                LOG_INFO("Display desktop position: (%d, %d)", app.displayScreenLeft, app.displayScreenTop);
                 LOG_INFO("Display pixels: %ux%u", app.displayPixelWidth, app.displayPixelHeight);
                 LOG_INFO("Display info: %.3fx%.3f m, scale=%.2fx%.2f, nominal=(%.3f,%.3f,%.3f)",
                     app.displayWidthM, app.displayHeightM,
@@ -1534,8 +1555,18 @@ int main(int argc, char **argv)
 
     LOG_INFO("=== OpenGL Cube OpenXR (External Window, macOS) ===");
 
-    // Create the macOS window with OpenGL context (app-owned)
-    if (!CreateMacOSWindow(1512, 823)) {
+    // Initialize OpenXR FIRST — xrGetSystemProperties needs only instance +
+    // system id, and returns the panel desktop position the window below is
+    // created at (INV-1.3 ordering: instance → system → properties → window
+    // → session).
+    AppXrSession app = {};
+    if (!InitializeOpenXR(app)) {
+        LOG_ERROR("Failed to initialize OpenXR");
+        return 1;
+    }
+
+    // Create the macOS window with OpenGL context (app-owned) on the 3D panel
+    if (!CreateMacOSWindow(1512, 823, app.displayScreenLeft, app.displayScreenTop)) {
         LOG_ERROR("Failed to create macOS window");
         return 1;
     }
@@ -1547,13 +1578,6 @@ int main(int argc, char **argv)
     GLRenderer renderer = {};
     if (!InitRenderer(renderer)) {
         LOG_ERROR("Failed to initialize OpenGL renderer");
-        return 1;
-    }
-
-    // Initialize OpenXR
-    AppXrSession app = {};
-    if (!InitializeOpenXR(app)) {
-        LOG_ERROR("Failed to initialize OpenXR");
         return 1;
     }
 

--- a/test_apps/handle/cube_handle_gl_win/main.cpp
+++ b/test_apps/handle/cube_handle_gl_win/main.cpp
@@ -1253,6 +1253,14 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         return 1;
     }
 
+    // INV-1.3: open on the 3D panel (#715) — one-shot move to the panel's
+    // desktop position reported by xrGetSystemProperties (virtual-screen
+    // coords, top-down; (0,0) = primary/unknown is safe), BEFORE
+    // xrCreateSession so the display processor tracks the window on the
+    // panel from the start.
+    SetWindowPos(hwnd, nullptr, g_displayScreenLeft, g_displayScreenTop, 0, 0,
+                 SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
+
     // Get OpenGL graphics requirements
     if (!GetOpenGLGraphicsRequirements(xr)) {
         LOG_ERROR("Failed to get OpenGL graphics requirements");

--- a/test_apps/handle/cube_handle_gl_win/xr_session.cpp
+++ b/test_apps/handle/cube_handle_gl_win/xr_session.cpp
@@ -14,6 +14,13 @@ bool g_hasViewRigExt = false;
 // #439 Phase 3 — XR_EXT_local_3d_zone harness (see xr_session.h).
 ZoneMaskHarness g_zone;
 
+// INV-1.3 (#715): 3D panel top-left in virtual-desktop pixels (top-down,
+// origin = primary top-left); (0,0) = primary/unknown. Filled from the
+// XrDisplayDesktopPositionEXT chain in InitializeOpenXR; app-local because the
+// shared XrSessionManager (displayxr-common) doesn't carry this field yet.
+int32_t g_displayScreenLeft = 0;
+int32_t g_displayScreenTop = 0;
+
 #define XR_CHECK(call) \
     do { \
         XrResult result = (call); \
@@ -164,7 +171,13 @@ bool InitializeOpenXR(XrSessionManager& xr) {
         XrSystemProperties sysProps = {XR_TYPE_SYSTEM_PROPERTIES};
         XrDisplayInfoEXT displayInfo = {(XrStructureType)XR_TYPE_DISPLAY_INFO_EXT};
         XrEyeTrackingModeCapabilitiesEXT eyeCaps = {(XrStructureType)XR_TYPE_EYE_TRACKING_MODE_CAPABILITIES_EXT};
+        // INV-1.3: panel desktop position, so the app window can be moved onto
+        // the 3D panel instead of the primary monitor (spec v16, #715).
+        // Chained at the tail of the existing chain.
+        XrDisplayDesktopPositionEXT desktopPos = {};
+        desktopPos.type = XR_TYPE_DISPLAY_DESKTOP_POSITION_EXT;
         displayInfo.next = &eyeCaps;
+        eyeCaps.next = &desktopPos;
         sysProps.next = &displayInfo;
         XrResult diResult = xrGetSystemProperties(xr.instance, xr.systemId, &sysProps);
         if (XR_SUCCEEDED(diResult)) {
@@ -179,6 +192,9 @@ bool InitializeOpenXR(XrSessionManager& xr) {
             xr.displayPixelHeight = displayInfo.displayPixelHeight;
             xr.supportedEyeTrackingModes = (uint32_t)eyeCaps.supportedModes;
             xr.defaultEyeTrackingMode = (uint32_t)eyeCaps.defaultMode;
+            g_displayScreenLeft = desktopPos.left;
+            g_displayScreenTop = desktopPos.top;
+            LOG_INFO("Display desktop position: (%d, %d)", g_displayScreenLeft, g_displayScreenTop);
             LOG_INFO("Display info: scale=%.3fx%.3f, size=%.3fx%.3fm, pixels=%ux%u, nominal=(%.0f,%.0f,%.0f)mm",
                 xr.recommendedViewScaleX, xr.recommendedViewScaleY,
                 xr.displayWidthM, xr.displayHeightM,

--- a/test_apps/handle/cube_handle_gl_win/xr_session.h
+++ b/test_apps/handle/cube_handle_gl_win/xr_session.h
@@ -13,6 +13,12 @@
 #include <openxr/XR_EXT_view_rig.h>
 #include <openxr/XR_EXT_local_3d_zone.h>
 
+// INV-1.3 (#715): 3D panel top-left in virtual-desktop pixels (top-down,
+// origin = primary top-left); (0,0) = primary/unknown. Filled by
+// InitializeOpenXR from the XrDisplayDesktopPositionEXT chain (spec v16).
+extern int32_t g_displayScreenLeft;
+extern int32_t g_displayScreenTop;
+
 // XR_EXT_view_rig (#396 W7) available + enabled on the instance. App-local
 // (not on the shared XrSessionManager); promote to xr_session_common when
 // more consumers adopt it.

--- a/test_apps/handle/cube_handle_vk_macos/main.mm
+++ b/test_apps/handle/cube_handle_vk_macos/main.mm
@@ -1713,7 +1713,7 @@ static void CleanupVkRenderer(VkRenderer& renderer) {
 static AppDelegate *g_appDelegate = nil;
 static AppWindowDelegate *g_windowDelegate = nil;
 
-static bool CreateMacOSWindow(uint32_t width, uint32_t height) {
+static bool CreateMacOSWindow(uint32_t width, uint32_t height, int32_t screenLeft, int32_t screenTop) {
     @autoreleasepool {
         [NSApplication sharedApplication];
         [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
@@ -1721,7 +1721,17 @@ static bool CreateMacOSWindow(uint32_t width, uint32_t height) {
         g_appDelegate = [[AppDelegate alloc] init];
         [NSApp setDelegate:g_appDelegate];
 
+        // INV-1.3: open on the 3D panel (#715). (screenLeft, screenTop) is the
+        // panel top-left in top-down global coordinates (origin = primary
+        // top-left, XrDisplayDesktopPositionEXT); flip into AppKit's bottom-up
+        // space. (0,0) = primary — the titled window is auto-constrained below
+        // the menu bar, so it is always a safe create position.
         NSRect frame = NSMakeRect(100, 100, width, height);
+        NSScreen *primary = [NSScreen screens].firstObject;
+        if (primary != nil) {
+            CGFloat topY = primary.frame.size.height - (CGFloat)screenTop;
+            frame = NSMakeRect((CGFloat)screenLeft, topY - (CGFloat)height, width, height);
+        }
         NSUInteger style = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable |
                            NSWindowStyleMaskResizable | NSWindowStyleMaskMiniaturizable;
 
@@ -2022,6 +2032,10 @@ struct AppXrSession {
     bool hasDisplayInfoExt = false;
     float recommendedViewScaleX = 1.0f;
     float recommendedViewScaleY = 1.0f;
+    // v16 XrDisplayDesktopPositionEXT — 3D panel top-left in virtual-desktop
+    // pixels (top-down, origin = primary top-left); (0,0) = primary/unknown.
+    int32_t displayScreenLeft = 0;
+    int32_t displayScreenTop = 0;
     float displayWidthM = 0.0f;
     float displayHeightM = 0.0f;
     float nominalViewerX = 0.0f;
@@ -2161,7 +2175,12 @@ static bool InitializeOpenXR(AppXrSession& xr) {
         displayInfo.type = XR_TYPE_DISPLAY_INFO_EXT;
         XrEyeTrackingModeCapabilitiesEXT eyeCaps = {};
         eyeCaps.type = (XrStructureType)XR_TYPE_EYE_TRACKING_MODE_CAPABILITIES_EXT;
+        // INV-1.3: panel desktop position, so the window opens on the 3D panel
+        // instead of the primary monitor (spec v16, #715). Chained at the tail.
+        XrDisplayDesktopPositionEXT desktopPos = {};
+        desktopPos.type = XR_TYPE_DISPLAY_DESKTOP_POSITION_EXT;
         displayInfo.next = &eyeCaps;
+        eyeCaps.next = &desktopPos;
         sysProps.next = &displayInfo;
         if (XR_SUCCEEDED(xrGetSystemProperties(xr.instance, xr.systemId, &sysProps))) {
             xr.recommendedViewScaleX = displayInfo.recommendedViewScaleX;
@@ -2175,6 +2194,9 @@ static bool InitializeOpenXR(AppXrSession& xr) {
             xr.displayPixelHeight = displayInfo.displayPixelHeight;
             xr.supportedEyeTrackingModes = (uint32_t)eyeCaps.supportedModes;
             xr.defaultEyeTrackingMode = (uint32_t)eyeCaps.defaultMode;
+            xr.displayScreenLeft = desktopPos.left;
+            xr.displayScreenTop = desktopPos.top;
+            LOG_INFO("Display desktop position: (%d, %d)", xr.displayScreenLeft, xr.displayScreenTop);
             LOG_INFO("Display pixels: %ux%u", xr.displayPixelWidth, xr.displayPixelHeight);
             LOG_INFO("Display info: %.3fx%.3f m, scale=%.2fx%.2f, nominal=(%.3f,%.3f,%.3f)",
                 xr.displayWidthM, xr.displayHeightM,
@@ -2923,10 +2945,20 @@ int main() {
     // (set during xrEnumerateDisplayRenderingModesEXT). Fallback is mode 1
     // (default of xr.currentModeIndex).
 
-    // Step 1: Create the macOS window FIRST (app owns it)
+    // Step 1: Initialize OpenXR FIRST — xrGetSystemProperties needs only
+    // instance + system id, and returns the panel desktop position the window
+    // below is created at (INV-1.3 ordering: instance → system → properties
+    // → window → session).
+    AppXrSession xr = {};
+    if (!InitializeOpenXR(xr)) {
+        LOG_ERROR("OpenXR initialization failed");
+        return 1;
+    }
+
+    // Step 2: Create the macOS window (app owns it) on the 3D panel
     g_windowW = 1280;
     g_windowH = 720;
-    if (!CreateMacOSWindow(g_windowW, g_windowH)) {
+    if (!CreateMacOSWindow(g_windowW, g_windowH, xr.displayScreenLeft, xr.displayScreenTop)) {
         LOG_ERROR("Failed to create macOS window");
         return 1;
     }
@@ -2940,13 +2972,6 @@ int main() {
         g_windowH = (uint32_t)(contentSize.height * backingScale);
         LOG_INFO("Window drawable size: %ux%u (points: %.0fx%.0f, scale: %.1f)",
                  g_windowW, g_windowH, contentSize.width, contentSize.height, (float)backingScale);
-    }
-
-    // Step 2: Initialize OpenXR
-    AppXrSession xr = {};
-    if (!InitializeOpenXR(xr)) {
-        LOG_ERROR("OpenXR initialization failed");
-        return 1;
     }
 
     if (!GetVulkanGraphicsRequirements(xr)) {

--- a/test_apps/handle/cube_handle_vk_win/main.cpp
+++ b/test_apps/handle/cube_handle_vk_win/main.cpp
@@ -1367,6 +1367,14 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         return 1;
     }
 
+    // INV-1.3: open on the 3D panel (#715) — one-shot move to the panel's
+    // desktop position reported by xrGetSystemProperties (virtual-screen
+    // coords, top-down; (0,0) = primary/unknown is safe), BEFORE
+    // xrCreateSession so the display processor tracks the window on the
+    // panel from the start.
+    SetWindowPos(hwnd, nullptr, g_displayScreenLeft, g_displayScreenTop, 0, 0,
+                 SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
+
     // Get Vulkan graphics requirements (must be called before creating Vulkan instance per spec)
     if (!GetVulkanGraphicsRequirements(xr)) {
         LOG_ERROR("Failed to get Vulkan graphics requirements");

--- a/test_apps/handle/cube_handle_vk_win/xr_session.cpp
+++ b/test_apps/handle/cube_handle_vk_win/xr_session.cpp
@@ -14,6 +14,13 @@ bool g_hasViewRigExt = false;
 // #439 Phase 3 — XR_EXT_local_3d_zone harness (see xr_session.h).
 ZoneMaskHarness g_zone;
 
+// INV-1.3 (#715): 3D panel top-left in virtual-desktop pixels (top-down,
+// origin = primary top-left); (0,0) = primary/unknown. Filled from the
+// XrDisplayDesktopPositionEXT chain in InitializeOpenXR; app-local because the
+// shared XrSessionManager (displayxr-common) doesn't carry this field yet.
+int32_t g_displayScreenLeft = 0;
+int32_t g_displayScreenTop = 0;
+
 #define XR_CHECK(call) \
     do { \
         XrResult result = (call); \
@@ -133,7 +140,13 @@ bool InitializeOpenXR(XrSessionManager& xr) {
         XrSystemProperties sysProps = {XR_TYPE_SYSTEM_PROPERTIES};
         XrDisplayInfoEXT displayInfo = {(XrStructureType)XR_TYPE_DISPLAY_INFO_EXT};
         XrEyeTrackingModeCapabilitiesEXT eyeCaps = {(XrStructureType)XR_TYPE_EYE_TRACKING_MODE_CAPABILITIES_EXT};
+        // INV-1.3: panel desktop position, so the app window can be moved onto
+        // the 3D panel instead of the primary monitor (spec v16, #715).
+        // Chained at the tail of the existing chain.
+        XrDisplayDesktopPositionEXT desktopPos = {};
+        desktopPos.type = XR_TYPE_DISPLAY_DESKTOP_POSITION_EXT;
         displayInfo.next = &eyeCaps;
+        eyeCaps.next = &desktopPos;
         sysProps.next = &displayInfo;
         XrResult diResult = xrGetSystemProperties(xr.instance, xr.systemId, &sysProps);
         if (XR_SUCCEEDED(diResult)) {
@@ -148,6 +161,9 @@ bool InitializeOpenXR(XrSessionManager& xr) {
             xr.displayPixelHeight = displayInfo.displayPixelHeight;
             xr.supportedEyeTrackingModes = (uint32_t)eyeCaps.supportedModes;
             xr.defaultEyeTrackingMode = (uint32_t)eyeCaps.defaultMode;
+            g_displayScreenLeft = desktopPos.left;
+            g_displayScreenTop = desktopPos.top;
+            LOG_INFO("Display desktop position: (%d, %d)", g_displayScreenLeft, g_displayScreenTop);
             LOG_INFO("Display info: scale=%.3fx%.3f, size=%.3fx%.3fm, pixels=%ux%u, nominal=(%.0f,%.0f,%.0f)mm",
                 xr.recommendedViewScaleX, xr.recommendedViewScaleY,
                 xr.displayWidthM, xr.displayHeightM,

--- a/test_apps/handle/cube_handle_vk_win/xr_session.h
+++ b/test_apps/handle/cube_handle_vk_win/xr_session.h
@@ -14,6 +14,12 @@
 #include <openxr/XR_EXT_view_rig.h>
 #include <openxr/XR_EXT_local_3d_zone.h>
 
+// INV-1.3 (#715): 3D panel top-left in virtual-desktop pixels (top-down,
+// origin = primary top-left); (0,0) = primary/unknown. Filled by
+// InitializeOpenXR from the XrDisplayDesktopPositionEXT chain (spec v16).
+extern int32_t g_displayScreenLeft;
+extern int32_t g_displayScreenTop;
+
 // XR_EXT_view_rig (#396 W7) available + enabled on the instance. App-local
 // (not on the shared XrSessionManager); promote to xr_session_common when
 // more consumers adopt it.

--- a/test_apps/handle/cube_zones_d3d11_win/main.cpp
+++ b/test_apps/handle/cube_zones_d3d11_win/main.cpp
@@ -1814,6 +1814,14 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         return 1;
     }
 
+    // INV-1.3: open on the 3D panel (#715) — one-shot move to the panel's
+    // desktop position reported by xrGetSystemProperties (virtual-screen
+    // coords, top-down; (0,0) = primary/unknown is safe), BEFORE
+    // xrCreateSession so the display processor tracks the window on the
+    // panel from the start.
+    SetWindowPos(hwnd, nullptr, g_displayScreenLeft, g_displayScreenTop, 0, 0,
+                 SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
+
     // Check for session target extension
     if (!xr.hasWin32WindowBindingExt) {
         LOG_WARN("XR_EXT_win32_window_binding not available - runtime will create its own window");

--- a/test_apps/handle/cube_zones_d3d11_win/xr_session.cpp
+++ b/test_apps/handle/cube_zones_d3d11_win/xr_session.cpp
@@ -19,6 +19,13 @@ ZoneMaskHarness g_zone;
 bool g_hasDisplayZonesExt = false;
 DisplayZonesHarness g_zones;
 
+// INV-1.3 (#715): 3D panel top-left in virtual-desktop pixels (top-down,
+// origin = primary top-left); (0,0) = primary/unknown. Filled from the
+// XrDisplayDesktopPositionEXT chain in InitializeOpenXR; app-local because the
+// shared XrSessionManager (displayxr-common) doesn't carry this field yet.
+int32_t g_displayScreenLeft = 0;
+int32_t g_displayScreenTop = 0;
+
 // Helper macro for XR error checking with logging
 #define XR_CHECK(call) \
     do { \
@@ -212,7 +219,13 @@ bool InitializeOpenXR(XrSessionManager& xr) {
         XrSystemProperties sysProps = {XR_TYPE_SYSTEM_PROPERTIES};
         XrDisplayInfoEXT displayInfo = {(XrStructureType)XR_TYPE_DISPLAY_INFO_EXT};
         XrEyeTrackingModeCapabilitiesEXT eyeCaps = {(XrStructureType)XR_TYPE_EYE_TRACKING_MODE_CAPABILITIES_EXT};
+        // INV-1.3: panel desktop position, so the app window can be moved onto
+        // the 3D panel instead of the primary monitor (spec v16, #715).
+        // Chained at the tail of the existing chain.
+        XrDisplayDesktopPositionEXT desktopPos = {};
+        desktopPos.type = XR_TYPE_DISPLAY_DESKTOP_POSITION_EXT;
         displayInfo.next = &eyeCaps;
+        eyeCaps.next = &desktopPos;
         sysProps.next = &displayInfo;
         XrResult diResult = xrGetSystemProperties(xr.instance, xr.systemId, &sysProps);
         if (XR_SUCCEEDED(diResult)) {
@@ -227,6 +240,9 @@ bool InitializeOpenXR(XrSessionManager& xr) {
             xr.displayPixelHeight = displayInfo.displayPixelHeight;
             xr.supportedEyeTrackingModes = (uint32_t)eyeCaps.supportedModes;
             xr.defaultEyeTrackingMode = (uint32_t)eyeCaps.defaultMode;
+            g_displayScreenLeft = desktopPos.left;
+            g_displayScreenTop = desktopPos.top;
+            LOG_INFO("Display desktop position: (%d, %d)", g_displayScreenLeft, g_displayScreenTop);
             LOG_INFO("Display info: scale=%.3fx%.3f, size=%.3fx%.3fm, pixels=%ux%u, nominal=(%.0f,%.0f,%.0f)mm",
                 xr.recommendedViewScaleX, xr.recommendedViewScaleY,
                 xr.displayWidthM, xr.displayHeightM,

--- a/test_apps/handle/cube_zones_d3d11_win/xr_session.h
+++ b/test_apps/handle/cube_zones_d3d11_win/xr_session.h
@@ -20,6 +20,12 @@
 #include <openxr/XR_EXT_display_zones.h>
 #include <openxr/XR_EXT_view_rig.h>
 
+// INV-1.3 (#715): 3D panel top-left in virtual-desktop pixels (top-down,
+// origin = primary top-left); (0,0) = primary/unknown. Filled by
+// InitializeOpenXR from the XrDisplayDesktopPositionEXT chain (spec v16).
+extern int32_t g_displayScreenLeft;
+extern int32_t g_displayScreenTop;
+
 // XR_EXT_view_rig available + enabled on the instance.
 extern bool g_hasViewRigExt;
 

--- a/test_apps/handle/cube_zones_d3d12_win/main.cpp
+++ b/test_apps/handle/cube_zones_d3d12_win/main.cpp
@@ -760,6 +760,14 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         return 1;
     }
 
+    // INV-1.3: open on the 3D panel (#715) — one-shot move to the panel's
+    // desktop position reported by xrGetSystemProperties (virtual-screen
+    // coords, top-down; (0,0) = primary/unknown is safe), BEFORE
+    // xrCreateSession so the display processor tracks the window on the
+    // panel from the start.
+    SetWindowPos(hwnd, nullptr, g_displayScreenLeft, g_displayScreenTop, 0, 0,
+                 SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
+
     LUID adapterLuid;
     if (!GetD3D12GraphicsRequirements(xr, &adapterLuid)) {
         LOG_ERROR("Failed to get D3D12 graphics requirements");

--- a/test_apps/handle/cube_zones_d3d12_win/xr_session.cpp
+++ b/test_apps/handle/cube_zones_d3d12_win/xr_session.cpp
@@ -19,6 +19,13 @@ ZoneMaskHarness g_zone;
 bool g_hasDisplayZonesExt = false;
 DisplayZonesHarness g_zones;
 
+// INV-1.3 (#715): 3D panel top-left in virtual-desktop pixels (top-down,
+// origin = primary top-left); (0,0) = primary/unknown. Filled from the
+// XrDisplayDesktopPositionEXT chain in InitializeOpenXR; app-local because the
+// shared XrSessionManager (displayxr-common) doesn't carry this field yet.
+int32_t g_displayScreenLeft = 0;
+int32_t g_displayScreenTop = 0;
+
 #define XR_CHECK(call) \
     do { \
         XrResult result = (call); \
@@ -195,7 +202,13 @@ bool InitializeOpenXR(XrSessionManager& xr) {
         XrSystemProperties sysProps = {XR_TYPE_SYSTEM_PROPERTIES};
         XrDisplayInfoEXT displayInfo = {(XrStructureType)XR_TYPE_DISPLAY_INFO_EXT};
         XrEyeTrackingModeCapabilitiesEXT eyeCaps = {(XrStructureType)XR_TYPE_EYE_TRACKING_MODE_CAPABILITIES_EXT};
+        // INV-1.3: panel desktop position, so the app window can be moved onto
+        // the 3D panel instead of the primary monitor (spec v16, #715).
+        // Chained at the tail of the existing chain.
+        XrDisplayDesktopPositionEXT desktopPos = {};
+        desktopPos.type = XR_TYPE_DISPLAY_DESKTOP_POSITION_EXT;
         displayInfo.next = &eyeCaps;
+        eyeCaps.next = &desktopPos;
         sysProps.next = &displayInfo;
         XrResult diResult = xrGetSystemProperties(xr.instance, xr.systemId, &sysProps);
         if (XR_SUCCEEDED(diResult)) {
@@ -210,6 +223,9 @@ bool InitializeOpenXR(XrSessionManager& xr) {
             xr.displayPixelHeight = displayInfo.displayPixelHeight;
             xr.supportedEyeTrackingModes = (uint32_t)eyeCaps.supportedModes;
             xr.defaultEyeTrackingMode = (uint32_t)eyeCaps.defaultMode;
+            g_displayScreenLeft = desktopPos.left;
+            g_displayScreenTop = desktopPos.top;
+            LOG_INFO("Display desktop position: (%d, %d)", g_displayScreenLeft, g_displayScreenTop);
             LOG_INFO("Display info: scale=%.3fx%.3f, size=%.3fx%.3fm, pixels=%ux%u, nominal=(%.0f,%.0f,%.0f)mm",
                 xr.recommendedViewScaleX, xr.recommendedViewScaleY,
                 xr.displayWidthM, xr.displayHeightM,

--- a/test_apps/handle/cube_zones_d3d12_win/xr_session.h
+++ b/test_apps/handle/cube_zones_d3d12_win/xr_session.h
@@ -24,6 +24,12 @@
 #include <openxr/XR_EXT_local_3d_zone.h>
 #include <openxr/XR_EXT_display_zones.h>
 
+// INV-1.3 (#715): 3D panel top-left in virtual-desktop pixels (top-down,
+// origin = primary top-left); (0,0) = primary/unknown. Filled by
+// InitializeOpenXR from the XrDisplayDesktopPositionEXT chain (spec v16).
+extern int32_t g_displayScreenLeft;
+extern int32_t g_displayScreenTop;
+
 // XR_EXT_view_rig (#396 W7) available + enabled on the instance. App-local
 // (not on the shared XrSessionManager); promote to xr_session_common when
 // more consumers adopt it.

--- a/test_apps/handle/cube_zones_gl_win/main.cpp
+++ b/test_apps/handle/cube_zones_gl_win/main.cpp
@@ -1356,6 +1356,14 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         return 1;
     }
 
+    // INV-1.3: open on the 3D panel (#715) — one-shot move to the panel's
+    // desktop position reported by xrGetSystemProperties (virtual-screen
+    // coords, top-down; (0,0) = primary/unknown is safe), BEFORE
+    // xrCreateSession so the display processor tracks the window on the
+    // panel from the start.
+    SetWindowPos(hwnd, nullptr, g_displayScreenLeft, g_displayScreenTop, 0, 0,
+                 SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
+
     if (!GetOpenGLGraphicsRequirements(xr)) {
         LOG_ERROR("Failed to get OpenGL graphics requirements");
         CleanupOpenXR(xr);

--- a/test_apps/handle/cube_zones_gl_win/xr_session.cpp
+++ b/test_apps/handle/cube_zones_gl_win/xr_session.cpp
@@ -22,6 +22,13 @@ ZoneMaskHarness g_zone;
 bool g_hasDisplayZonesExt = false;
 DisplayZonesHarness g_zones;
 
+// INV-1.3 (#715): 3D panel top-left in virtual-desktop pixels (top-down,
+// origin = primary top-left); (0,0) = primary/unknown. Filled from the
+// XrDisplayDesktopPositionEXT chain in InitializeOpenXR; app-local because the
+// shared XrSessionManager (displayxr-common) doesn't carry this field yet.
+int32_t g_displayScreenLeft = 0;
+int32_t g_displayScreenTop = 0;
+
 #define XR_CHECK(call) \
     do { \
         XrResult result = (call); \
@@ -199,7 +206,13 @@ bool InitializeOpenXR(XrSessionManager& xr) {
         XrSystemProperties sysProps = {XR_TYPE_SYSTEM_PROPERTIES};
         XrDisplayInfoEXT displayInfo = {(XrStructureType)XR_TYPE_DISPLAY_INFO_EXT};
         XrEyeTrackingModeCapabilitiesEXT eyeCaps = {(XrStructureType)XR_TYPE_EYE_TRACKING_MODE_CAPABILITIES_EXT};
+        // INV-1.3: panel desktop position, so the app window can be moved onto
+        // the 3D panel instead of the primary monitor (spec v16, #715).
+        // Chained at the tail of the existing chain.
+        XrDisplayDesktopPositionEXT desktopPos = {};
+        desktopPos.type = XR_TYPE_DISPLAY_DESKTOP_POSITION_EXT;
         displayInfo.next = &eyeCaps;
+        eyeCaps.next = &desktopPos;
         sysProps.next = &displayInfo;
         XrResult diResult = xrGetSystemProperties(xr.instance, xr.systemId, &sysProps);
         if (XR_SUCCEEDED(diResult)) {
@@ -214,6 +227,9 @@ bool InitializeOpenXR(XrSessionManager& xr) {
             xr.displayPixelHeight = displayInfo.displayPixelHeight;
             xr.supportedEyeTrackingModes = (uint32_t)eyeCaps.supportedModes;
             xr.defaultEyeTrackingMode = (uint32_t)eyeCaps.defaultMode;
+            g_displayScreenLeft = desktopPos.left;
+            g_displayScreenTop = desktopPos.top;
+            LOG_INFO("Display desktop position: (%d, %d)", g_displayScreenLeft, g_displayScreenTop);
             LOG_INFO("Display info: scale=%.3fx%.3f, size=%.3fx%.3fm, pixels=%ux%u, nominal=(%.0f,%.0f,%.0f)mm",
                 xr.recommendedViewScaleX, xr.recommendedViewScaleY,
                 xr.displayWidthM, xr.displayHeightM,

--- a/test_apps/handle/cube_zones_gl_win/xr_session.h
+++ b/test_apps/handle/cube_zones_gl_win/xr_session.h
@@ -20,6 +20,12 @@
 #include <openxr/XR_EXT_display_zones.h>
 #include <openxr/XR_EXT_view_rig.h>
 
+// INV-1.3 (#715): 3D panel top-left in virtual-desktop pixels (top-down,
+// origin = primary top-left); (0,0) = primary/unknown. Filled by
+// InitializeOpenXR from the XrDisplayDesktopPositionEXT chain (spec v16).
+extern int32_t g_displayScreenLeft;
+extern int32_t g_displayScreenTop;
+
 // XR_EXT_view_rig available + enabled on the instance.
 extern bool g_hasViewRigExt;
 

--- a/test_apps/handle/cube_zones_metal_macos/main.mm
+++ b/test_apps/handle/cube_zones_metal_macos/main.mm
@@ -1069,7 +1069,7 @@ static void SignalHandler(int)
 static AppDelegate *g_appDelegate = nil;
 static AppWindowDelegate *g_windowDelegate = nil;
 
-static bool CreateMacOSWindow(uint32_t width, uint32_t height)
+static bool CreateMacOSWindow(uint32_t width, uint32_t height, int32_t screenLeft, int32_t screenTop)
 {
     @autoreleasepool {
         [NSApplication sharedApplication];
@@ -1078,7 +1078,17 @@ static bool CreateMacOSWindow(uint32_t width, uint32_t height)
         g_appDelegate = [[AppDelegate alloc] init];
         [NSApp setDelegate:g_appDelegate];
 
+        // INV-1.3: open on the 3D panel (#715). (screenLeft, screenTop) is the
+        // panel top-left in top-down global coordinates (origin = primary
+        // top-left, XrDisplayDesktopPositionEXT); flip into AppKit's bottom-up
+        // space. (0,0) = primary — the titled window is auto-constrained below
+        // the menu bar, so it is always a safe create position.
         NSRect frame = NSMakeRect(100, 100, width, height);
+        NSScreen *primary = [NSScreen screens].firstObject;
+        if (primary != nil) {
+            CGFloat topY = primary.frame.size.height - (CGFloat)screenTop;
+            frame = NSMakeRect((CGFloat)screenLeft, topY - (CGFloat)height, width, height);
+        }
         NSUInteger style = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable |
                            NSWindowStyleMaskResizable | NSWindowStyleMaskMiniaturizable;
 
@@ -1347,6 +1357,9 @@ struct AppXrSession {
     float nominalViewerX, nominalViewerY, nominalViewerZ;
     uint32_t displayPixelWidth, displayPixelHeight;
     float recommendedViewScaleX, recommendedViewScaleY;
+    // v16 XrDisplayDesktopPositionEXT — 3D panel top-left in virtual-desktop
+    // pixels (top-down, origin = primary top-left); (0,0) = primary/unknown.
+    int32_t displayScreenLeft, displayScreenTop;
     PFN_xrRequestDisplayModeEXT pfnRequestDisplayModeEXT;
     PFN_xrRequestDisplayRenderingModeEXT pfnRequestDisplayRenderingModeEXT;
     PFN_xrEnumerateDisplayRenderingModesEXT pfnEnumerateDisplayRenderingModesEXT;
@@ -1492,8 +1505,13 @@ static bool InitializeOpenXR(AppXrSession &app)
         XrSystemProperties sysProps = {XR_TYPE_SYSTEM_PROPERTIES};
         XrDisplayInfoEXT displayInfo = {};
         displayInfo.type = XR_TYPE_DISPLAY_INFO_EXT;
+        // INV-1.3: panel desktop position, so the window below opens on the
+        // 3D panel instead of the primary monitor (spec v16, #715).
+        XrDisplayDesktopPositionEXT desktopPos = {};
+        desktopPos.type = XR_TYPE_DISPLAY_DESKTOP_POSITION_EXT;
         if (app.hasDisplayInfoExt) {
             sysProps.next = &displayInfo;
+            displayInfo.next = &desktopPos;
         }
         if (XR_SUCCEEDED(xrGetSystemProperties(app.instance, app.systemId, &sysProps))) {
             memcpy(app.systemName, sysProps.systemName, sizeof(app.systemName));
@@ -1508,6 +1526,9 @@ static bool InitializeOpenXR(AppXrSession &app)
                 app.displayPixelHeight = displayInfo.displayPixelHeight;
                 app.recommendedViewScaleX = displayInfo.recommendedViewScaleX;
                 app.recommendedViewScaleY = displayInfo.recommendedViewScaleY;
+                app.displayScreenLeft = desktopPos.left;
+                app.displayScreenTop = desktopPos.top;
+                LOG_INFO("Display desktop position: (%d, %d)", app.displayScreenLeft, app.displayScreenTop);
                 LOG_INFO("Display pixels: %ux%u", app.displayPixelWidth, app.displayPixelHeight);
                 LOG_INFO("Display info: %.3fx%.3f m, scale=%.2fx%.2f, nominal=(%.3f,%.3f,%.3f)",
                     app.displayWidthM, app.displayHeightM,
@@ -2711,16 +2732,19 @@ int main(int argc, char **argv)
         return 1;
     }
 
-    // Create the macOS window (app-owned)
-    if (!CreateMacOSWindow(1512, 823)) {
-        LOG_ERROR("Failed to create macOS window");
-        return 1;
-    }
-
-    // Initialize OpenXR
+    // Initialize OpenXR FIRST — xrGetSystemProperties needs only instance +
+    // system id, and returns the panel desktop position the window below is
+    // created at (INV-1.3 ordering: instance → system → properties → window
+    // → session).
     AppXrSession app = {};
     if (!InitializeOpenXR(app)) {
         LOG_ERROR("Failed to initialize OpenXR");
+        return 1;
+    }
+
+    // Create the macOS window (app-owned) on the 3D panel
+    if (!CreateMacOSWindow(1512, 823, app.displayScreenLeft, app.displayScreenTop)) {
+        LOG_ERROR("Failed to create macOS window");
         return 1;
     }
 

--- a/test_apps/handle/cube_zones_vk_macos/main.mm
+++ b/test_apps/handle/cube_zones_vk_macos/main.mm
@@ -1752,7 +1752,7 @@ static void CleanupVkRenderer(VkRenderer& renderer) {
 static AppDelegate *g_appDelegate = nil;
 static AppWindowDelegate *g_windowDelegate = nil;
 
-static bool CreateMacOSWindow(uint32_t width, uint32_t height) {
+static bool CreateMacOSWindow(uint32_t width, uint32_t height, int32_t screenLeft, int32_t screenTop) {
     @autoreleasepool {
         [NSApplication sharedApplication];
         [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
@@ -1760,7 +1760,17 @@ static bool CreateMacOSWindow(uint32_t width, uint32_t height) {
         g_appDelegate = [[AppDelegate alloc] init];
         [NSApp setDelegate:g_appDelegate];
 
+        // INV-1.3: open on the 3D panel (#715). (screenLeft, screenTop) is the
+        // panel top-left in top-down global coordinates (origin = primary
+        // top-left, XrDisplayDesktopPositionEXT); flip into AppKit's bottom-up
+        // space. (0,0) = primary — the titled window is auto-constrained below
+        // the menu bar, so it is always a safe create position.
         NSRect frame = NSMakeRect(100, 100, width, height);
+        NSScreen *primary = [NSScreen screens].firstObject;
+        if (primary != nil) {
+            CGFloat topY = primary.frame.size.height - (CGFloat)screenTop;
+            frame = NSMakeRect((CGFloat)screenLeft, topY - (CGFloat)height, width, height);
+        }
         NSUInteger style = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable |
                            NSWindowStyleMaskResizable | NSWindowStyleMaskMiniaturizable;
 
@@ -2048,6 +2058,10 @@ struct AppXrSession {
     bool hasDisplayInfoExt = false;
     float recommendedViewScaleX = 1.0f;
     float recommendedViewScaleY = 1.0f;
+    // v16 XrDisplayDesktopPositionEXT — 3D panel top-left in virtual-desktop
+    // pixels (top-down, origin = primary top-left); (0,0) = primary/unknown.
+    int32_t displayScreenLeft = 0;
+    int32_t displayScreenTop = 0;
     float displayWidthM = 0.0f;
     float displayHeightM = 0.0f;
     float nominalViewerX = 0.0f;
@@ -2195,7 +2209,12 @@ static bool InitializeOpenXR(AppXrSession& xr) {
         displayInfo.type = XR_TYPE_DISPLAY_INFO_EXT;
         XrEyeTrackingModeCapabilitiesEXT eyeCaps = {};
         eyeCaps.type = (XrStructureType)XR_TYPE_EYE_TRACKING_MODE_CAPABILITIES_EXT;
+        // INV-1.3: panel desktop position, so the window opens on the 3D panel
+        // instead of the primary monitor (spec v16, #715). Chained at the tail.
+        XrDisplayDesktopPositionEXT desktopPos = {};
+        desktopPos.type = XR_TYPE_DISPLAY_DESKTOP_POSITION_EXT;
         displayInfo.next = &eyeCaps;
+        eyeCaps.next = &desktopPos;
         sysProps.next = &displayInfo;
         if (XR_SUCCEEDED(xrGetSystemProperties(xr.instance, xr.systemId, &sysProps))) {
             xr.recommendedViewScaleX = displayInfo.recommendedViewScaleX;
@@ -2209,6 +2228,9 @@ static bool InitializeOpenXR(AppXrSession& xr) {
             xr.displayPixelHeight = displayInfo.displayPixelHeight;
             xr.supportedEyeTrackingModes = (uint32_t)eyeCaps.supportedModes;
             xr.defaultEyeTrackingMode = (uint32_t)eyeCaps.defaultMode;
+            xr.displayScreenLeft = desktopPos.left;
+            xr.displayScreenTop = desktopPos.top;
+            LOG_INFO("Display desktop position: (%d, %d)", xr.displayScreenLeft, xr.displayScreenTop);
             LOG_INFO("Display pixels: %ux%u", xr.displayPixelWidth, xr.displayPixelHeight);
             LOG_INFO("Display info: %.3fx%.3f m, scale=%.2fx%.2f, nominal=(%.3f,%.3f,%.3f)",
                 xr.displayWidthM, xr.displayHeightM,
@@ -3387,10 +3409,20 @@ int main() {
     // (set during xrEnumerateDisplayRenderingModesEXT). Fallback is mode 1
     // (default of xr.currentModeIndex).
 
-    // Step 1: Create the macOS window FIRST (app owns it)
+    // Step 1: Initialize OpenXR FIRST — xrGetSystemProperties needs only
+    // instance + system id, and returns the panel desktop position the window
+    // below is created at (INV-1.3 ordering: instance → system → properties
+    // → window → session).
+    AppXrSession xr = {};
+    if (!InitializeOpenXR(xr)) {
+        LOG_ERROR("OpenXR initialization failed");
+        return 1;
+    }
+
+    // Step 2: Create the macOS window (app owns it) on the 3D panel
     g_windowW = 1280;
     g_windowH = 720;
-    if (!CreateMacOSWindow(g_windowW, g_windowH)) {
+    if (!CreateMacOSWindow(g_windowW, g_windowH, xr.displayScreenLeft, xr.displayScreenTop)) {
         LOG_ERROR("Failed to create macOS window");
         return 1;
     }
@@ -3404,13 +3436,6 @@ int main() {
         g_windowH = (uint32_t)(contentSize.height * backingScale);
         LOG_INFO("Window drawable size: %ux%u (points: %.0fx%.0f, scale: %.1f)",
                  g_windowW, g_windowH, contentSize.width, contentSize.height, (float)backingScale);
-    }
-
-    // Step 2: Initialize OpenXR
-    AppXrSession xr = {};
-    if (!InitializeOpenXR(xr)) {
-        LOG_ERROR("OpenXR initialization failed");
-        return 1;
     }
 
     if (!GetVulkanGraphicsRequirements(xr)) {

--- a/test_apps/handle/cube_zones_vk_win/main.cpp
+++ b/test_apps/handle/cube_zones_vk_win/main.cpp
@@ -720,6 +720,14 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         return 1;
     }
 
+    // INV-1.3: open on the 3D panel (#715) — one-shot move to the panel's
+    // desktop position reported by xrGetSystemProperties (virtual-screen
+    // coords, top-down; (0,0) = primary/unknown is safe), BEFORE
+    // xrCreateSession so the display processor tracks the window on the
+    // panel from the start.
+    SetWindowPos(hwnd, nullptr, g_displayScreenLeft, g_displayScreenTop, 0, 0,
+                 SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
+
     if (!GetVulkanGraphicsRequirements(xr)) {
         LOG_ERROR("Failed to get Vulkan graphics requirements");
         CleanupOpenXR(xr);

--- a/test_apps/handle/cube_zones_vk_win/xr_session.cpp
+++ b/test_apps/handle/cube_zones_vk_win/xr_session.cpp
@@ -19,6 +19,13 @@ ZoneMaskHarness g_zone;
 bool g_hasDisplayZonesExt = false;
 DisplayZonesHarness g_zones;
 
+// INV-1.3 (#715): 3D panel top-left in virtual-desktop pixels (top-down,
+// origin = primary top-left); (0,0) = primary/unknown. Filled from the
+// XrDisplayDesktopPositionEXT chain in InitializeOpenXR; app-local because the
+// shared XrSessionManager (displayxr-common) doesn't carry this field yet.
+int32_t g_displayScreenLeft = 0;
+int32_t g_displayScreenTop = 0;
+
 #define XR_CHECK(call) \
     do { \
         XrResult result = (call); \
@@ -160,7 +167,13 @@ bool InitializeOpenXR(XrSessionManager& xr) {
         XrSystemProperties sysProps = {XR_TYPE_SYSTEM_PROPERTIES};
         XrDisplayInfoEXT displayInfo = {(XrStructureType)XR_TYPE_DISPLAY_INFO_EXT};
         XrEyeTrackingModeCapabilitiesEXT eyeCaps = {(XrStructureType)XR_TYPE_EYE_TRACKING_MODE_CAPABILITIES_EXT};
+        // INV-1.3: panel desktop position, so the app window can be moved onto
+        // the 3D panel instead of the primary monitor (spec v16, #715).
+        // Chained at the tail of the existing chain.
+        XrDisplayDesktopPositionEXT desktopPos = {};
+        desktopPos.type = XR_TYPE_DISPLAY_DESKTOP_POSITION_EXT;
         displayInfo.next = &eyeCaps;
+        eyeCaps.next = &desktopPos;
         sysProps.next = &displayInfo;
         XrResult diResult = xrGetSystemProperties(xr.instance, xr.systemId, &sysProps);
         if (XR_SUCCEEDED(diResult)) {
@@ -175,6 +188,9 @@ bool InitializeOpenXR(XrSessionManager& xr) {
             xr.displayPixelHeight = displayInfo.displayPixelHeight;
             xr.supportedEyeTrackingModes = (uint32_t)eyeCaps.supportedModes;
             xr.defaultEyeTrackingMode = (uint32_t)eyeCaps.defaultMode;
+            g_displayScreenLeft = desktopPos.left;
+            g_displayScreenTop = desktopPos.top;
+            LOG_INFO("Display desktop position: (%d, %d)", g_displayScreenLeft, g_displayScreenTop);
             LOG_INFO("Display info: scale=%.3fx%.3f, size=%.3fx%.3fm, pixels=%ux%u, nominal=(%.0f,%.0f,%.0f)mm",
                 xr.recommendedViewScaleX, xr.recommendedViewScaleY,
                 xr.displayWidthM, xr.displayHeightM,

--- a/test_apps/handle/cube_zones_vk_win/xr_session.h
+++ b/test_apps/handle/cube_zones_vk_win/xr_session.h
@@ -24,6 +24,12 @@
 #include <openxr/XR_EXT_local_3d_zone.h>
 #include <openxr/XR_EXT_display_zones.h>
 
+// INV-1.3 (#715): 3D panel top-left in virtual-desktop pixels (top-down,
+// origin = primary top-left); (0,0) = primary/unknown. Filled by
+// InitializeOpenXR from the XrDisplayDesktopPositionEXT chain (spec v16).
+extern int32_t g_displayScreenLeft;
+extern int32_t g_displayScreenTop;
+
 // XR_EXT_view_rig (#396 W7) available + enabled on the instance. App-local
 // (not on the shared XrSessionManager); promote to xr_session_common when
 // more consumers adopt it.

--- a/test_apps/texture/cube_zones_texture_d3d11_win/main.cpp
+++ b/test_apps/texture/cube_zones_texture_d3d11_win/main.cpp
@@ -2068,6 +2068,14 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         return 1;
     }
 
+    // INV-1.3: open on the 3D panel (#715) — one-shot move to the panel's
+    // desktop position reported by xrGetSystemProperties (virtual-screen
+    // coords, top-down; (0,0) = primary/unknown is safe), BEFORE
+    // xrCreateSession so the display processor tracks the window on the
+    // panel from the start.
+    SetWindowPos(hwnd, nullptr, g_displayScreenLeft, g_displayScreenTop, 0, 0,
+                 SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
+
     // Check for session target extension (required for texture mode)
     if (!xr.hasWin32WindowBindingExt) {
         LOG_ERROR("XR_EXT_win32_window_binding not available — required for shared texture mode");

--- a/test_apps/texture/cube_zones_texture_d3d11_win/xr_session.cpp
+++ b/test_apps/texture/cube_zones_texture_d3d11_win/xr_session.cpp
@@ -19,6 +19,13 @@ ZoneMaskHarness g_zone;
 bool g_hasDisplayZonesExt = false;
 DisplayZonesHarness g_zones;
 
+// INV-1.3 (#715): 3D panel top-left in virtual-desktop pixels (top-down,
+// origin = primary top-left); (0,0) = primary/unknown. Filled from the
+// XrDisplayDesktopPositionEXT chain in InitializeOpenXR; app-local because the
+// shared XrSessionManager (displayxr-common) doesn't carry this field yet.
+int32_t g_displayScreenLeft = 0;
+int32_t g_displayScreenTop = 0;
+
 // Helper macro for XR error checking with logging
 #define XR_CHECK(call) \
     do { \
@@ -213,7 +220,13 @@ bool InitializeOpenXR(XrSessionManager& xr) {
         XrSystemProperties sysProps = {XR_TYPE_SYSTEM_PROPERTIES};
         XrDisplayInfoEXT displayInfo = {(XrStructureType)XR_TYPE_DISPLAY_INFO_EXT};
         XrEyeTrackingModeCapabilitiesEXT eyeCaps = {(XrStructureType)XR_TYPE_EYE_TRACKING_MODE_CAPABILITIES_EXT};
+        // INV-1.3: panel desktop position, so the app window can be moved onto
+        // the 3D panel instead of the primary monitor (spec v16, #715).
+        // Chained at the tail of the existing chain.
+        XrDisplayDesktopPositionEXT desktopPos = {};
+        desktopPos.type = XR_TYPE_DISPLAY_DESKTOP_POSITION_EXT;
         displayInfo.next = &eyeCaps;
+        eyeCaps.next = &desktopPos;
         sysProps.next = &displayInfo;
         XrResult diResult = xrGetSystemProperties(xr.instance, xr.systemId, &sysProps);
         if (XR_SUCCEEDED(diResult)) {
@@ -228,6 +241,9 @@ bool InitializeOpenXR(XrSessionManager& xr) {
             xr.displayPixelHeight = displayInfo.displayPixelHeight;
             xr.supportedEyeTrackingModes = (uint32_t)eyeCaps.supportedModes;
             xr.defaultEyeTrackingMode = (uint32_t)eyeCaps.defaultMode;
+            g_displayScreenLeft = desktopPos.left;
+            g_displayScreenTop = desktopPos.top;
+            LOG_INFO("Display desktop position: (%d, %d)", g_displayScreenLeft, g_displayScreenTop);
             LOG_INFO("Display info: scale=%.3fx%.3f, size=%.3fx%.3fm, pixels=%ux%u, nominal=(%.0f,%.0f,%.0f)mm",
                 xr.recommendedViewScaleX, xr.recommendedViewScaleY,
                 xr.displayWidthM, xr.displayHeightM,

--- a/test_apps/texture/cube_zones_texture_d3d11_win/xr_session.h
+++ b/test_apps/texture/cube_zones_texture_d3d11_win/xr_session.h
@@ -23,6 +23,12 @@
 #include <openxr/XR_EXT_display_zones.h>
 #include <openxr/XR_EXT_view_rig.h>
 
+// INV-1.3 (#715): 3D panel top-left in virtual-desktop pixels (top-down,
+// origin = primary top-left); (0,0) = primary/unknown. Filled by
+// InitializeOpenXR from the XrDisplayDesktopPositionEXT chain (spec v16).
+extern int32_t g_displayScreenLeft;
+extern int32_t g_displayScreenTop;
+
 // XR_EXT_view_rig available + enabled on the instance.
 extern bool g_hasViewRigExt;
 

--- a/test_apps/texture/cube_zones_texture_d3d12_win/main.cpp
+++ b/test_apps/texture/cube_zones_texture_d3d12_win/main.cpp
@@ -2456,6 +2456,14 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         return 1;
     }
 
+    // INV-1.3: open on the 3D panel (#715) — one-shot move to the panel's
+    // desktop position reported by xrGetSystemProperties (virtual-screen
+    // coords, top-down; (0,0) = primary/unknown is safe), BEFORE
+    // xrCreateSession so the display processor tracks the window on the
+    // panel from the start.
+    SetWindowPos(hwnd, nullptr, g_displayScreenLeft, g_displayScreenTop, 0, 0,
+                 SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
+
     // Check for session target extension (required for texture mode)
     if (!xr.hasWin32WindowBindingExt) {
         LOG_ERROR("XR_EXT_win32_window_binding not available — required for shared texture mode");

--- a/test_apps/texture/cube_zones_texture_d3d12_win/xr_session.cpp
+++ b/test_apps/texture/cube_zones_texture_d3d12_win/xr_session.cpp
@@ -20,6 +20,13 @@ ZoneMaskHarness g_zone;
 bool g_hasDisplayZonesExt = false;
 DisplayZonesHarness g_zones;
 
+// INV-1.3 (#715): 3D panel top-left in virtual-desktop pixels (top-down,
+// origin = primary top-left); (0,0) = primary/unknown. Filled from the
+// XrDisplayDesktopPositionEXT chain in InitializeOpenXR; app-local because the
+// shared XrSessionManager (displayxr-common) doesn't carry this field yet.
+int32_t g_displayScreenLeft = 0;
+int32_t g_displayScreenTop = 0;
+
 // Helper macro for XR error checking with logging
 #define XR_CHECK(call) \
     do { \
@@ -214,7 +221,13 @@ bool InitializeOpenXR(XrSessionManager& xr) {
         XrSystemProperties sysProps = {XR_TYPE_SYSTEM_PROPERTIES};
         XrDisplayInfoEXT displayInfo = {(XrStructureType)XR_TYPE_DISPLAY_INFO_EXT};
         XrEyeTrackingModeCapabilitiesEXT eyeCaps = {(XrStructureType)XR_TYPE_EYE_TRACKING_MODE_CAPABILITIES_EXT};
+        // INV-1.3: panel desktop position, so the app window can be moved onto
+        // the 3D panel instead of the primary monitor (spec v16, #715).
+        // Chained at the tail of the existing chain.
+        XrDisplayDesktopPositionEXT desktopPos = {};
+        desktopPos.type = XR_TYPE_DISPLAY_DESKTOP_POSITION_EXT;
         displayInfo.next = &eyeCaps;
+        eyeCaps.next = &desktopPos;
         sysProps.next = &displayInfo;
         XrResult diResult = xrGetSystemProperties(xr.instance, xr.systemId, &sysProps);
         if (XR_SUCCEEDED(diResult)) {
@@ -229,6 +242,9 @@ bool InitializeOpenXR(XrSessionManager& xr) {
             xr.displayPixelHeight = displayInfo.displayPixelHeight;
             xr.supportedEyeTrackingModes = (uint32_t)eyeCaps.supportedModes;
             xr.defaultEyeTrackingMode = (uint32_t)eyeCaps.defaultMode;
+            g_displayScreenLeft = desktopPos.left;
+            g_displayScreenTop = desktopPos.top;
+            LOG_INFO("Display desktop position: (%d, %d)", g_displayScreenLeft, g_displayScreenTop);
             LOG_INFO("Display info: scale=%.3fx%.3f, size=%.3fx%.3fm, pixels=%ux%u, nominal=(%.0f,%.0f,%.0f)mm",
                 xr.recommendedViewScaleX, xr.recommendedViewScaleY,
                 xr.displayWidthM, xr.displayHeightM,

--- a/test_apps/texture/cube_zones_texture_d3d12_win/xr_session.h
+++ b/test_apps/texture/cube_zones_texture_d3d12_win/xr_session.h
@@ -26,6 +26,12 @@
 #include <openxr/XR_EXT_display_zones.h>
 #include <openxr/XR_EXT_view_rig.h>
 
+// INV-1.3 (#715): 3D panel top-left in virtual-desktop pixels (top-down,
+// origin = primary top-left); (0,0) = primary/unknown. Filled by
+// InitializeOpenXR from the XrDisplayDesktopPositionEXT chain (spec v16).
+extern int32_t g_displayScreenLeft;
+extern int32_t g_displayScreenTop;
+
 // XR_EXT_view_rig available + enabled on the instance.
 extern bool g_hasViewRigExt;
 

--- a/test_apps/texture/cube_zones_texture_gl_macos/main.mm
+++ b/test_apps/texture/cube_zones_texture_gl_macos/main.mm
@@ -1179,7 +1179,7 @@ static void SignalHandler(int)
 static AppDelegate *g_appDelegate = nil;
 static AppWindowDelegate *g_windowDelegate = nil;
 
-static bool CreateMacOSWindow(uint32_t width, uint32_t height)
+static bool CreateMacOSWindow(uint32_t width, uint32_t height, int32_t screenLeft, int32_t screenTop)
 {
     @autoreleasepool {
         [NSApplication sharedApplication];
@@ -1188,7 +1188,17 @@ static bool CreateMacOSWindow(uint32_t width, uint32_t height)
         g_appDelegate = [[AppDelegate alloc] init];
         [NSApp setDelegate:g_appDelegate];
 
+        // INV-1.3: open on the 3D panel (#715). (screenLeft, screenTop) is the
+        // panel top-left in top-down global coordinates (origin = primary
+        // top-left, XrDisplayDesktopPositionEXT); flip into AppKit's bottom-up
+        // space. (0,0) = primary — the titled window is auto-constrained below
+        // the menu bar, so it is always a safe create position.
         NSRect frame = NSMakeRect(100, 100, width, height);
+        NSScreen *primary = [NSScreen screens].firstObject;
+        if (primary != nil) {
+            CGFloat topY = primary.frame.size.height - (CGFloat)screenTop;
+            frame = NSMakeRect((CGFloat)screenLeft, topY - (CGFloat)height, width, height);
+        }
         NSUInteger style = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable |
                            NSWindowStyleMaskResizable | NSWindowStyleMaskMiniaturizable;
 
@@ -1729,6 +1739,9 @@ struct AppXrSession {
     float nominalViewerX, nominalViewerY, nominalViewerZ;
     uint32_t displayPixelWidth, displayPixelHeight;
     float recommendedViewScaleX, recommendedViewScaleY;
+    // v16 XrDisplayDesktopPositionEXT — 3D panel top-left in virtual-desktop
+    // pixels (top-down, origin = primary top-left); (0,0) = primary/unknown.
+    int32_t displayScreenLeft, displayScreenTop;
     PFN_xrRequestDisplayModeEXT pfnRequestDisplayModeEXT;
     PFN_xrRequestDisplayRenderingModeEXT pfnRequestDisplayRenderingModeEXT;
     PFN_xrEnumerateDisplayRenderingModesEXT pfnEnumerateDisplayRenderingModesEXT;
@@ -1880,8 +1893,13 @@ static bool InitializeOpenXR(AppXrSession &app)
         XrSystemProperties sysProps = {XR_TYPE_SYSTEM_PROPERTIES};
         XrDisplayInfoEXT displayInfo = {};
         displayInfo.type = XR_TYPE_DISPLAY_INFO_EXT;
+        // INV-1.3: panel desktop position, so the window below opens on the
+        // 3D panel instead of the primary monitor (spec v16, #715).
+        XrDisplayDesktopPositionEXT desktopPos = {};
+        desktopPos.type = XR_TYPE_DISPLAY_DESKTOP_POSITION_EXT;
         if (app.hasDisplayInfoExt) {
             sysProps.next = &displayInfo;
+            displayInfo.next = &desktopPos;
         }
         if (XR_SUCCEEDED(xrGetSystemProperties(app.instance, app.systemId, &sysProps))) {
             memcpy(app.systemName, sysProps.systemName, sizeof(app.systemName));
@@ -1896,6 +1914,9 @@ static bool InitializeOpenXR(AppXrSession &app)
                 app.displayPixelHeight = displayInfo.displayPixelHeight;
                 app.recommendedViewScaleX = displayInfo.recommendedViewScaleX;
                 app.recommendedViewScaleY = displayInfo.recommendedViewScaleY;
+                app.displayScreenLeft = desktopPos.left;
+                app.displayScreenTop = desktopPos.top;
+                LOG_INFO("Display desktop position: (%d, %d)", app.displayScreenLeft, app.displayScreenTop);
                 LOG_INFO("Display pixels: %ux%u", app.displayPixelWidth, app.displayPixelHeight);
                 LOG_INFO("Display info: %.3fx%.3f m, scale=%.2fx%.2f, nominal=(%.3f,%.3f,%.3f)",
                     app.displayWidthM, app.displayHeightM,
@@ -3137,10 +3158,20 @@ int main(int argc, char **argv)
         }
     }
 
-    // Create the macOS window FIRST (app-owned) — it makes the GL context
-    // current, which the renderer init needs. (Metal inited the renderer first;
-    // GL must reorder so a context exists before any GL call.)
-    if (!CreateMacOSWindow(1512, 823)) {
+    // Initialize OpenXR FIRST — xrGetSystemProperties needs only instance +
+    // system id, and returns the panel desktop position the window below is
+    // created at (INV-1.3 ordering: instance → system → properties → window
+    // → session).
+    AppXrSession app = {};
+    if (!InitializeOpenXR(app)) {
+        LOG_ERROR("Failed to initialize OpenXR");
+        return 1;
+    }
+
+    // Create the macOS window (app-owned) on the 3D panel — it makes the GL
+    // context current, which the renderer init needs. (Metal inited the
+    // renderer first; GL must order so a context exists before any GL call.)
+    if (!CreateMacOSWindow(1512, 823, app.displayScreenLeft, app.displayScreenTop)) {
         LOG_ERROR("Failed to create macOS window");
         return 1;
     }
@@ -3159,13 +3190,6 @@ int main(int argc, char **argv)
     // that backs the IOSurface read texture, so init it before CreateIOSurface).
     if (!InitMetalPresenter(g_present)) {
         LOG_ERROR("Failed to initialize Metal presenter");
-        return 1;
-    }
-
-    // Initialize OpenXR
-    AppXrSession app = {};
-    if (!InitializeOpenXR(app)) {
-        LOG_ERROR("Failed to initialize OpenXR");
         return 1;
     }
 

--- a/test_apps/texture/cube_zones_texture_gl_win/main.cpp
+++ b/test_apps/texture/cube_zones_texture_gl_win/main.cpp
@@ -1663,6 +1663,14 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         ShutdownLogging();
         return 1;
     }
+
+    // INV-1.3: open on the 3D panel (#715) — one-shot move to the panel's
+    // desktop position reported by xrGetSystemProperties (virtual-screen
+    // coords, top-down; (0,0) = primary/unknown is safe), BEFORE
+    // xrCreateSession so the display processor tracks the window on the
+    // panel from the start.
+    SetWindowPos(hwnd, nullptr, g_displayScreenLeft, g_displayScreenTop, 0, 0,
+                 SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
     if (!xr.hasWin32WindowBindingExt) {
         LOG_ERROR("XR_EXT_win32_window_binding not available — required for shared texture mode");
         MessageBox(hwnd, L"XR_EXT_win32_window_binding extension not available.\nRequired for shared texture mode.",

--- a/test_apps/texture/cube_zones_texture_gl_win/xr_session.cpp
+++ b/test_apps/texture/cube_zones_texture_gl_win/xr_session.cpp
@@ -29,6 +29,13 @@ ZoneMaskHarness g_zone;
 bool g_hasDisplayZonesExt = false;
 DisplayZonesHarness g_zones;
 
+// INV-1.3 (#715): 3D panel top-left in virtual-desktop pixels (top-down,
+// origin = primary top-left); (0,0) = primary/unknown. Filled from the
+// XrDisplayDesktopPositionEXT chain in InitializeOpenXR; app-local because the
+// shared XrSessionManager (displayxr-common) doesn't carry this field yet.
+int32_t g_displayScreenLeft = 0;
+int32_t g_displayScreenTop = 0;
+
 #define XR_CHECK(call) \
     do { \
         XrResult result = (call); \
@@ -206,7 +213,13 @@ bool InitializeOpenXR(XrSessionManager& xr) {
         XrSystemProperties sysProps = {XR_TYPE_SYSTEM_PROPERTIES};
         XrDisplayInfoEXT displayInfo = {(XrStructureType)XR_TYPE_DISPLAY_INFO_EXT};
         XrEyeTrackingModeCapabilitiesEXT eyeCaps = {(XrStructureType)XR_TYPE_EYE_TRACKING_MODE_CAPABILITIES_EXT};
+        // INV-1.3: panel desktop position, so the app window can be moved onto
+        // the 3D panel instead of the primary monitor (spec v16, #715).
+        // Chained at the tail of the existing chain.
+        XrDisplayDesktopPositionEXT desktopPos = {};
+        desktopPos.type = XR_TYPE_DISPLAY_DESKTOP_POSITION_EXT;
         displayInfo.next = &eyeCaps;
+        eyeCaps.next = &desktopPos;
         sysProps.next = &displayInfo;
         XrResult diResult = xrGetSystemProperties(xr.instance, xr.systemId, &sysProps);
         if (XR_SUCCEEDED(diResult)) {
@@ -221,6 +234,9 @@ bool InitializeOpenXR(XrSessionManager& xr) {
             xr.displayPixelHeight = displayInfo.displayPixelHeight;
             xr.supportedEyeTrackingModes = (uint32_t)eyeCaps.supportedModes;
             xr.defaultEyeTrackingMode = (uint32_t)eyeCaps.defaultMode;
+            g_displayScreenLeft = desktopPos.left;
+            g_displayScreenTop = desktopPos.top;
+            LOG_INFO("Display desktop position: (%d, %d)", g_displayScreenLeft, g_displayScreenTop);
             LOG_INFO("Display info: scale=%.3fx%.3f, size=%.3fx%.3fm, pixels=%ux%u, nominal=(%.0f,%.0f,%.0f)mm",
                 xr.recommendedViewScaleX, xr.recommendedViewScaleY,
                 xr.displayWidthM, xr.displayHeightM,

--- a/test_apps/texture/cube_zones_texture_gl_win/xr_session.h
+++ b/test_apps/texture/cube_zones_texture_gl_win/xr_session.h
@@ -39,6 +39,12 @@
 #include <openxr/XR_EXT_display_zones.h>
 #include <openxr/XR_EXT_view_rig.h>
 
+// INV-1.3 (#715): 3D panel top-left in virtual-desktop pixels (top-down,
+// origin = primary top-left); (0,0) = primary/unknown. Filled by
+// InitializeOpenXR from the XrDisplayDesktopPositionEXT chain (spec v16).
+extern int32_t g_displayScreenLeft;
+extern int32_t g_displayScreenTop;
+
 // XR_EXT_view_rig available + enabled on the instance.
 extern bool g_hasViewRigExt;
 

--- a/test_apps/texture/cube_zones_texture_metal_macos/main.mm
+++ b/test_apps/texture/cube_zones_texture_metal_macos/main.mm
@@ -1179,7 +1179,7 @@ static void SignalHandler(int)
 static AppDelegate *g_appDelegate = nil;
 static AppWindowDelegate *g_windowDelegate = nil;
 
-static bool CreateMacOSWindow(uint32_t width, uint32_t height)
+static bool CreateMacOSWindow(uint32_t width, uint32_t height, int32_t screenLeft, int32_t screenTop)
 {
     @autoreleasepool {
         [NSApplication sharedApplication];
@@ -1188,7 +1188,17 @@ static bool CreateMacOSWindow(uint32_t width, uint32_t height)
         g_appDelegate = [[AppDelegate alloc] init];
         [NSApp setDelegate:g_appDelegate];
 
+        // INV-1.3: open on the 3D panel (#715). (screenLeft, screenTop) is the
+        // panel top-left in top-down global coordinates (origin = primary
+        // top-left, XrDisplayDesktopPositionEXT); flip into AppKit's bottom-up
+        // space. (0,0) = primary — the titled window is auto-constrained below
+        // the menu bar, so it is always a safe create position.
         NSRect frame = NSMakeRect(100, 100, width, height);
+        NSScreen *primary = [NSScreen screens].firstObject;
+        if (primary != nil) {
+            CGFloat topY = primary.frame.size.height - (CGFloat)screenTop;
+            frame = NSMakeRect((CGFloat)screenLeft, topY - (CGFloat)height, width, height);
+        }
         NSUInteger style = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable |
                            NSWindowStyleMaskResizable | NSWindowStyleMaskMiniaturizable;
 
@@ -1626,6 +1636,9 @@ struct AppXrSession {
     float nominalViewerX, nominalViewerY, nominalViewerZ;
     uint32_t displayPixelWidth, displayPixelHeight;
     float recommendedViewScaleX, recommendedViewScaleY;
+    // v16 XrDisplayDesktopPositionEXT — 3D panel top-left in virtual-desktop
+    // pixels (top-down, origin = primary top-left); (0,0) = primary/unknown.
+    int32_t displayScreenLeft, displayScreenTop;
     PFN_xrRequestDisplayModeEXT pfnRequestDisplayModeEXT;
     PFN_xrRequestDisplayRenderingModeEXT pfnRequestDisplayRenderingModeEXT;
     PFN_xrEnumerateDisplayRenderingModesEXT pfnEnumerateDisplayRenderingModesEXT;
@@ -1771,8 +1784,13 @@ static bool InitializeOpenXR(AppXrSession &app)
         XrSystemProperties sysProps = {XR_TYPE_SYSTEM_PROPERTIES};
         XrDisplayInfoEXT displayInfo = {};
         displayInfo.type = XR_TYPE_DISPLAY_INFO_EXT;
+        // INV-1.3: panel desktop position, so the window below opens on the
+        // 3D panel instead of the primary monitor (spec v16, #715).
+        XrDisplayDesktopPositionEXT desktopPos = {};
+        desktopPos.type = XR_TYPE_DISPLAY_DESKTOP_POSITION_EXT;
         if (app.hasDisplayInfoExt) {
             sysProps.next = &displayInfo;
+            displayInfo.next = &desktopPos;
         }
         if (XR_SUCCEEDED(xrGetSystemProperties(app.instance, app.systemId, &sysProps))) {
             memcpy(app.systemName, sysProps.systemName, sizeof(app.systemName));
@@ -1787,6 +1805,9 @@ static bool InitializeOpenXR(AppXrSession &app)
                 app.displayPixelHeight = displayInfo.displayPixelHeight;
                 app.recommendedViewScaleX = displayInfo.recommendedViewScaleX;
                 app.recommendedViewScaleY = displayInfo.recommendedViewScaleY;
+                app.displayScreenLeft = desktopPos.left;
+                app.displayScreenTop = desktopPos.top;
+                LOG_INFO("Display desktop position: (%d, %d)", app.displayScreenLeft, app.displayScreenTop);
                 LOG_INFO("Display pixels: %ux%u", app.displayPixelWidth, app.displayPixelHeight);
                 LOG_INFO("Display info: %.3fx%.3f m, scale=%.2fx%.2f, nominal=(%.3f,%.3f,%.3f)",
                     app.displayWidthM, app.displayHeightM,
@@ -3015,16 +3036,19 @@ int main(int argc, char **argv)
         return 1;
     }
 
-    // Create the macOS window (app-owned)
-    if (!CreateMacOSWindow(1512, 823)) {
-        LOG_ERROR("Failed to create macOS window");
-        return 1;
-    }
-
-    // Initialize OpenXR
+    // Initialize OpenXR FIRST — xrGetSystemProperties needs only instance +
+    // system id, and returns the panel desktop position the window below is
+    // created at (INV-1.3 ordering: instance → system → properties → window
+    // → session).
     AppXrSession app = {};
     if (!InitializeOpenXR(app)) {
         LOG_ERROR("Failed to initialize OpenXR");
+        return 1;
+    }
+
+    // Create the macOS window (app-owned) on the 3D panel
+    if (!CreateMacOSWindow(1512, 823, app.displayScreenLeft, app.displayScreenTop)) {
+        LOG_ERROR("Failed to create macOS window");
         return 1;
     }
 

--- a/test_apps/texture/cube_zones_texture_vk_win/main.cpp
+++ b/test_apps/texture/cube_zones_texture_vk_win/main.cpp
@@ -1574,6 +1574,14 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         ShutdownLogging();
         return 1;
     }
+
+    // INV-1.3: open on the 3D panel (#715) — one-shot move to the panel's
+    // desktop position reported by xrGetSystemProperties (virtual-screen
+    // coords, top-down; (0,0) = primary/unknown is safe), BEFORE
+    // xrCreateSession so the display processor tracks the window on the
+    // panel from the start.
+    SetWindowPos(hwnd, nullptr, g_displayScreenLeft, g_displayScreenTop, 0, 0,
+                 SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
     if (!xr.hasWin32WindowBindingExt) {
         LOG_ERROR("XR_EXT_win32_window_binding not available — required for shared texture mode");
         MessageBox(hwnd, L"XR_EXT_win32_window_binding extension not available.\nRequired for shared texture mode.",

--- a/test_apps/texture/cube_zones_texture_vk_win/xr_session.cpp
+++ b/test_apps/texture/cube_zones_texture_vk_win/xr_session.cpp
@@ -20,6 +20,13 @@ ZoneMaskHarness g_zone;
 bool g_hasDisplayZonesExt = false;
 DisplayZonesHarness g_zones;
 
+// INV-1.3 (#715): 3D panel top-left in virtual-desktop pixels (top-down,
+// origin = primary top-left); (0,0) = primary/unknown. Filled from the
+// XrDisplayDesktopPositionEXT chain in InitializeOpenXR; app-local because the
+// shared XrSessionManager (displayxr-common) doesn't carry this field yet.
+int32_t g_displayScreenLeft = 0;
+int32_t g_displayScreenTop = 0;
+
 // Helper macro for XR error checking with logging
 #define XR_CHECK(call) \
     do { \
@@ -188,7 +195,13 @@ bool InitializeOpenXR(XrSessionManager& xr) {
         XrSystemProperties sysProps = {XR_TYPE_SYSTEM_PROPERTIES};
         XrDisplayInfoEXT displayInfo = {(XrStructureType)XR_TYPE_DISPLAY_INFO_EXT};
         XrEyeTrackingModeCapabilitiesEXT eyeCaps = {(XrStructureType)XR_TYPE_EYE_TRACKING_MODE_CAPABILITIES_EXT};
+        // INV-1.3: panel desktop position, so the app window can be moved onto
+        // the 3D panel instead of the primary monitor (spec v16, #715).
+        // Chained at the tail of the existing chain.
+        XrDisplayDesktopPositionEXT desktopPos = {};
+        desktopPos.type = XR_TYPE_DISPLAY_DESKTOP_POSITION_EXT;
         displayInfo.next = &eyeCaps;
+        eyeCaps.next = &desktopPos;
         sysProps.next = &displayInfo;
         XrResult diResult = xrGetSystemProperties(xr.instance, xr.systemId, &sysProps);
         if (XR_SUCCEEDED(diResult)) {
@@ -203,6 +216,9 @@ bool InitializeOpenXR(XrSessionManager& xr) {
             xr.displayPixelHeight = displayInfo.displayPixelHeight;
             xr.supportedEyeTrackingModes = (uint32_t)eyeCaps.supportedModes;
             xr.defaultEyeTrackingMode = (uint32_t)eyeCaps.defaultMode;
+            g_displayScreenLeft = desktopPos.left;
+            g_displayScreenTop = desktopPos.top;
+            LOG_INFO("Display desktop position: (%d, %d)", g_displayScreenLeft, g_displayScreenTop);
             LOG_INFO("Display info: scale=%.3fx%.3f, size=%.3fx%.3fm, pixels=%ux%u, nominal=(%.0f,%.0f,%.0f)mm",
                 xr.recommendedViewScaleX, xr.recommendedViewScaleY,
                 xr.displayWidthM, xr.displayHeightM,

--- a/test_apps/texture/cube_zones_texture_vk_win/xr_session.h
+++ b/test_apps/texture/cube_zones_texture_vk_win/xr_session.h
@@ -40,6 +40,12 @@
 #include <string>
 #include <vector>
 
+// INV-1.3 (#715): 3D panel top-left in virtual-desktop pixels (top-down,
+// origin = primary top-left); (0,0) = primary/unknown. Filled by
+// InitializeOpenXR from the XrDisplayDesktopPositionEXT chain (spec v16).
+extern int32_t g_displayScreenLeft;
+extern int32_t g_displayScreenTop;
+
 // XR_EXT_view_rig available + enabled on the instance.
 extern bool g_hasViewRigExt;
 


### PR DESCRIPTION
## What

Rolls the **INV-1.3 window-placement idiom** out to all 19 remaining window-creating test apps (the reference implementation landed in cube_handle_metal_macos via #720): chain a zero-initialized `XrDisplayDesktopPositionEXT` (display_info **spec v16**) onto the `XrSystemProperties` chain at `xrGetSystemProperties`, then place the app-owned window at the reported `(left, top)` so it opens **on the 3D panel** instead of the OS-default primary monitor — on multi-monitor systems (laptop + external 3D panel) a `CW_USEDEFAULT`/`(100,100)`-style window opens where the weave cannot produce 3D.

Refs #715.

## Per-platform pattern

| Platform | Apps | Pattern |
|---|---|---|
| macOS | `cube_handle_gl_macos`, `cube_handle_vk_macos`, `cube_zones_metal_macos`, `cube_zones_vk_macos`, `cube_zones_texture_gl_macos`, `cube_zones_texture_metal_macos` | Full **reorder** to the reference ordering (instance → system → properties → window → session); NSWindow frame flipped into AppKit's bottom-up space exactly as the reference. No `[window center]` calls existed. |
| Windows | `cube_handle_{d3d11,d3d12,gl,vk}_win`, `cube_zones_{d3d11,d3d12,gl,vk}_win`, `cube_zones_texture_{d3d11,d3d12,gl,vk}_win` | `desktopPos` chained at the **tail** (after `XrEyeTrackingModeCapabilitiesEXT`) in each `xr_session.cpp`; **one-shot `SetWindowPos`** to the panel position right after `InitializeOpenXR` and before `xrCreateSession` (the sanctioned move-once variant — these apps create the window first and their error paths + GL context setup depend on that order). |
| Linux | `cube_handle_vk_linux` | Window created at `(left, top)`, `WM_NORMAL_HINTS` with `USPosition\|PPosition` (`XSetWMNormalHints`), and a **post-map `XMoveWindow` re-assert** after `XMapWindow` + `XFlush` (Mutter et al. ignore create-time position), mirroring the runtime's own `comp_vk_native_window_xcb.c`. Note: this app now enables `XR_EXT_display_info` when present (required for the runtime to fill the struct) — commented in-code that this also moves view sizing off the legacy-compromise path; the app still renders fixed 2-view SBS. |

Texture-class apps still pass their real window (DP position/phase anchor) and position it the same way.

## Backward compatibility

The struct is opt-in and zero-initialized: an old runtime that doesn't know the type leaves `(0,0)`, which means primary monitor / unknown — a safe create position on every platform (macOS titled windows are auto-constrained below the menu bar).

## Verification

- `./scripts/build_macos.sh` green — all 6 edited macOS apps rebuilt.
- Smoke-run `cube_handle_vk_macos`: reaches a running session, logs `Display desktop position: (0, 0)` (sim_display), clean exit.
- `scripts/check_displayxr_app.py` on all 19 apps: identical error/warning counts vs `main` (no new findings).
- Windows + Linux apps compile in CI only (TestApps job / build-linux.yml).

🤖 Generated with [Claude Code](https://claude.com/claude-code)