### PR TITLE
fix(linux,#715): place hosted window via _NET_WM_FULLSCREEN_MONITORS (mutter vetoes client geometry)

### DIFF
--- a/src/xrt/compositor/vk_native/comp_vk_native_window_xcb.c
+++ b/src/xrt/compositor/vk_native/comp_vk_native_window_xcb.c
@@ -16,6 +16,8 @@
 #include <string.h>
 
 #include <xcb/xcb.h>
+#include <xcb/randr.h>    // xcb_randr_get_monitors — resolve the target monitor
+                          // INDEX from the plug-in-reported panel position (#715).
 #include <X11/Xlib-xcb.h> // XGetXCBConnection (libX11-xcb) — Xlib→XCB bridge for
                           // app-provided windows (XR_EXT_xlib_window_binding).
 
@@ -44,6 +46,68 @@ intern_atom(xcb_connection_t *conn, const char *name)
 	xcb_atom_t atom = reply ? reply->atom : XCB_ATOM_NONE;
 	free(reply);
 	return atom;
+}
+
+/*!
+ * Resolve the RandR monitor INDEX that owns the panel position
+ * (@p screen_left, @p screen_top), for the _NET_WM_FULLSCREEN_MONITORS request.
+ *
+ * mutter (and other EWMH WMs) discard client-requested window geometry for an
+ * oversized toplevel, so #716's create-x/y + USPosition + ConfigureRequest are
+ * no-ops on GNOME/XWayland — the window lands on whichever monitor happens to
+ * fit it (#715, George's DS1 report). Targeting by monitor index instead is
+ * WM-cooperative and size-independent.
+ *
+ * Prefers a monitor whose origin exactly matches (left, top); falls back to the
+ * monitor CONTAINING the point (so a `DXR_WINDOW_POS` override still resolves to
+ * the right output). @p out_name_atom receives the monitor's RandR name atom for
+ * logging (XCB_ATOM_NONE if unavailable).
+ *
+ * @return the 0-based monitor index, or -1 if RandR is unavailable / no monitor
+ *         resolves (caller then skips fullscreen and keeps windowed placement).
+ */
+static int
+resolve_monitor_index(xcb_connection_t *conn,
+                      xcb_window_t root,
+                      int32_t screen_left,
+                      int32_t screen_top,
+                      xcb_atom_t *out_name_atom)
+{
+	if (out_name_atom != NULL) {
+		*out_name_atom = XCB_ATOM_NONE;
+	}
+
+	xcb_randr_get_monitors_cookie_t cookie = xcb_randr_get_monitors(conn, root, 1 /* active only */);
+	xcb_randr_get_monitors_reply_t *reply = xcb_randr_get_monitors_reply(conn, cookie, NULL);
+	if (reply == NULL) {
+		return -1; // RandR unavailable / too old.
+	}
+
+	int exact_idx = -1;
+	int contains_idx = -1;
+	xcb_atom_t exact_name = XCB_ATOM_NONE;
+	xcb_atom_t contains_name = XCB_ATOM_NONE;
+
+	xcb_randr_monitor_info_iterator_t it = xcb_randr_get_monitors_monitors_iterator(reply);
+	for (int idx = 0; it.rem; xcb_randr_monitor_info_next(&it), idx++) {
+		const xcb_randr_monitor_info_t *m = it.data;
+		if (exact_idx < 0 && m->x == (int16_t)screen_left && m->y == (int16_t)screen_top) {
+			exact_idx = idx;
+			exact_name = m->name;
+		}
+		if (contains_idx < 0 && screen_left >= m->x && screen_left < m->x + (int32_t)m->width &&
+		    screen_top >= m->y && screen_top < m->y + (int32_t)m->height) {
+			contains_idx = idx;
+			contains_name = m->name;
+		}
+	}
+	free(reply);
+
+	int chosen = exact_idx >= 0 ? exact_idx : contains_idx;
+	if (out_name_atom != NULL) {
+		*out_name_atom = exact_idx >= 0 ? exact_name : contains_name;
+	}
+	return chosen;
 }
 
 xrt_result_t
@@ -141,6 +205,32 @@ comp_vk_native_window_xcb_create(uint32_t width,
 		                    XCB_ATOM_ATOM, 32, 1, &win->atom_wm_delete_window);
 	}
 
+	// EWMH fullscreen-on-monitor: the WM-cooperative, size-independent way to
+	// place the weave surface on the 3D panel. mutter discards the create-x/y +
+	// USPosition + ConfigureRequest above for an oversized toplevel (#715,
+	// George's DS1 report), so target the panel's RandR monitor INDEX instead.
+	// DXR_WINDOW_FULLSCREEN=0 opts out (debugging on well-behaved WMs).
+	int fullscreen_monitor = -1;
+	xcb_atom_t monitor_name = XCB_ATOM_NONE;
+	const char *fs_env = getenv("DXR_WINDOW_FULLSCREEN");
+	const bool fullscreen_enabled = (fs_env == NULL) || (strcmp(fs_env, "0") != 0);
+	if (fullscreen_enabled) {
+		fullscreen_monitor = resolve_monitor_index(conn, screen->root, screen_left, screen_top, &monitor_name);
+		if (fullscreen_monitor < 0) {
+			U_LOG_W("XCB: no RandR monitor at (%d, %d) — skipping fullscreen, using windowed placement",
+			        (int)screen_left, (int)screen_top);
+		} else {
+			// Mark fullscreen BEFORE map so the WM manages it fullscreen from
+			// the start (EWMH _NET_WM_STATE, set as a property pre-map).
+			xcb_atom_t net_wm_state = intern_atom(conn, "_NET_WM_STATE");
+			xcb_atom_t net_wm_state_fullscreen = intern_atom(conn, "_NET_WM_STATE_FULLSCREEN");
+			if (net_wm_state != XCB_ATOM_NONE && net_wm_state_fullscreen != XCB_ATOM_NONE) {
+				xcb_change_property(conn, XCB_PROP_MODE_REPLACE, win->window, net_wm_state,
+				                    XCB_ATOM_ATOM, 32, 1, &net_wm_state_fullscreen);
+			}
+		}
+	}
+
 	xcb_map_window(conn, win->window);
 
 	// Re-assert the position after mapping — many WMs (Mutter included)
@@ -150,10 +240,56 @@ comp_vk_native_window_xcb_create(uint32_t width,
 		const uint32_t coords[2] = {(uint32_t)screen_left, (uint32_t)screen_top};
 		xcb_configure_window(conn, win->window, XCB_CONFIG_WINDOW_X | XCB_CONFIG_WINDOW_Y, coords);
 	}
+
+	// _NET_WM_FULLSCREEN_MONITORS → root: pin the fullscreen window to the
+	// resolved monitor index. Single-monitor fullscreen ⇒ all four edges = the
+	// target index; data32[4]=1 is source "application" (EWMH). SUBSTRUCTURE_
+	// REDIRECT|NOTIFY is the mask the WM listens on for these root messages.
+	if (fullscreen_monitor >= 0) {
+		xcb_atom_t net_fs_monitors = intern_atom(conn, "_NET_WM_FULLSCREEN_MONITORS");
+		if (net_fs_monitors != XCB_ATOM_NONE) {
+			xcb_client_message_event_t ev = {0};
+			ev.response_type = XCB_CLIENT_MESSAGE;
+			ev.format = 32;
+			ev.window = win->window;
+			ev.type = net_fs_monitors;
+			ev.data.data32[0] = (uint32_t)fullscreen_monitor; // top
+			ev.data.data32[1] = (uint32_t)fullscreen_monitor; // bottom
+			ev.data.data32[2] = (uint32_t)fullscreen_monitor; // left
+			ev.data.data32[3] = (uint32_t)fullscreen_monitor; // right
+			ev.data.data32[4] = 1;                            // source: application
+			xcb_send_event(conn, 0, screen->root,
+			               XCB_EVENT_MASK_SUBSTRUCTURE_REDIRECT | XCB_EVENT_MASK_SUBSTRUCTURE_NOTIFY,
+			               (const char *)&ev);
+		}
+	}
 	xcb_flush(conn);
 
-	U_LOG_I("XCB: created %ux%u window 0x%08x at (%d, %d)", width, height, (unsigned)win->window,
-	        (int)screen_left, (int)screen_top);
+	if (fullscreen_monitor >= 0) {
+		// Resolve the RandR monitor name for a human-readable breadcrumb; WARN
+		// so it's visible without XRT_LOG=info (parity with the plug-in's #92
+		// "RandR panel position overrides backend" line).
+		char name_buf[64] = "?";
+		if (monitor_name != XCB_ATOM_NONE) {
+			xcb_get_atom_name_reply_t *nr =
+			    xcb_get_atom_name_reply(conn, xcb_get_atom_name(conn, monitor_name), NULL);
+			if (nr != NULL) {
+				int n = xcb_get_atom_name_name_length(nr);
+				if (n > (int)sizeof(name_buf) - 1) {
+					n = (int)sizeof(name_buf) - 1;
+				}
+				memcpy(name_buf, xcb_get_atom_name_name(nr), (size_t)n);
+				name_buf[n] = '\0';
+				free(nr);
+			}
+		}
+		U_LOG_W("XCB: created %ux%u window 0x%08x at (%d, %d), fullscreen on RandR monitor #%d (%s)", width,
+		        height, (unsigned)win->window, (int)screen_left, (int)screen_top, fullscreen_monitor,
+		        name_buf);
+	} else {
+		U_LOG_I("XCB: created %ux%u window 0x%08x at (%d, %d)", width, height, (unsigned)win->window,
+		        (int)screen_left, (int)screen_top);
+	}
 
 	*out_win = win;
 	return XRT_SUCCESS;

--- a/src/xrt/compositor/vk_native/comp_vk_native_window_xcb.h
+++ b/src/xrt/compositor/vk_native/comp_vk_native_window_xcb.h
@@ -99,6 +99,18 @@ comp_vk_native_window_xcb_query_geometry(const struct comp_vk_native_xcb_handle 
  *                               via xsysc->info.display_screen_left. (0, 0)
  *                               means primary monitor (Windows convention,
  *                               comp_d3d11_window.cpp). #715.
+ *
+ *                               These coordinates now also resolve the target
+ *                               RandR MONITOR (the monitor whose origin matches,
+ *                               else the one containing the point), and the
+ *                               window is fullscreened onto it via EWMH
+ *                               _NET_WM_FULLSCREEN_MONITORS. That is the
+ *                               WM-cooperative, size-independent placement path:
+ *                               mutter/GNOME discard the create-x/y +
+ *                               USPosition + ConfigureRequest for an oversized
+ *                               toplevel, so raw coordinates alone don't place
+ *                               the window (#715). Set DXR_WINDOW_FULLSCREEN=0
+ *                               to opt out and keep plain windowed placement.
  * @param screen_top             Window top edge in root-window pixels.
  * @param transparent_background Reserved; X11 ARGB-visual transparency is not
  *                               wired in Phase 1 (desktop WSI usually exposes


### PR DESCRIPTION
## Problem (#715)

On a laptop/mini-PC + external 3D panel layout, the hosted-class compositor window must open on the panel. Runtime #716 (create-x/y + `WM_NORMAL_HINTS` USPosition + post-map ConfigureRequest + `DXR_WINDOW_POS`) and leia-plugin #92 (RandR-resolved panel position) shipped to main.

**George's on-hardware run** (#715, Acer SpatialLabs **DS1** on HDMI @ +1920+0, laptop eDP primary @ +0+0, Ubuntu 22.04 GNOME/mutter/XWayland) found the fix is **incidental, not real**: mutter **discards all three placement signals** #716 uses. Every `DXR_WINDOW_POS` value (auto→1920,0 / `0,0` / `2600,400`) landed the window at the *same* spot on the DS1. It lands there only because it is a 3840×2160 window and the DS1 is the sole monitor that fits it — mutter relocates the oversized window to the fitting monitor and ignores the coordinates. So `DXR_WINDOW_POS` is a **no-op** on GNOME/XWayland, and on a both-4K layout placement would fail with no working knob.

## Fix

Switch to the EWMH **`_NET_WM_FULLSCREEN_MONITORS`** path (George's recommendation): WM-cooperative (stays a normal managed window — no `override_redirect` focus/input surprises), targets by **monitor index** not fragile coordinates, and is size-independent.

In `comp_vk_native_window_xcb_create()`:
1. **Resolve the RandR monitor index** owning the plug-in-reported panel position — exact-origin match, else the monitor **containing** the point (so `DXR_WINDOW_POS` still resolves to the right output, e.g. `0,0` → laptop).
2. Mark the window **`_NET_WM_STATE_FULLSCREEN`** before map.
3. Send **`_NET_WM_FULLSCREEN_MONITORS`** to root targeting that index (`SUBSTRUCTURE_REDIRECT|NOTIFY`, source=application).
4. **`DXR_WINDOW_FULLSCREEN=0`** escape hatch → plain windowed placement (debugging on well-behaved WMs).
5. **WARN breadcrumb** reports the resolved monitor index + RandR name.

The three existing #716 mechanisms are kept (harmless, help cooperative WMs). Graceful degradation: if RandR is unavailable or no monitor resolves, it skips fullscreen and keeps windowed placement.

## Scope

- **Linux/XCB only.** macOS/Windows untouched (`comp_vk_native_window_macos.mm` not modified). `xcb-randr` is already in `XCB_LIBRARIES` — no CMake change.
- **Out of scope / follow-up:** handle apps (#721, e.g. `cube_handle_vk_linux`) create their own windows and hit the same mutter veto — the same pattern would port to the test-app window code.

## Verification

CI is build-green only (no display). Real placement proof is George's DS1 box (recipe posted on #715): rebuild from main, relaunch `run_cube_hosted_legacy_vk_linux.sh` with **no xdotool** → expect it on the DS1; `DXR_WINDOW_POS=0,0` → expect it back on the laptop (the case the old fix failed); plus a both-4K layout to confirm size-independence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)