### PR TITLE
ci(cts,#726): fix CTS 1.1.51 arg rename (--apiVersion → --minApiVersion), move CTS pin to 1.1.51.0

### DIFF
--- a/.github/workflows/cts.yml
+++ b/.github/workflows/cts.yml
@@ -112,7 +112,7 @@ jobs:
 
       - name: Install OpenXR loader
         run: |
-          $openxrVersion = "1.1.43"
+          $openxrVersion = "1.1.51"
           $openxrUrl = "https://github.com/KhronosGroup/OpenXR-SDK-Source/releases/download/release-$openxrVersion/openxr_loader_windows-$openxrVersion.zip"
           Invoke-WebRequest -Uri $openxrUrl -OutFile openxr_loader.zip
           Expand-Archive -Path openxr_loader.zip -DestinationPath openxr_sdk -Force
@@ -172,7 +172,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: build-cts
-          key: cts-${{ runner.os }}-${{ hashFiles('scripts/fetch_build_cts.bat') }}-1.1.43
+          key: cts-${{ runner.os }}-${{ hashFiles('scripts/fetch_build_cts.bat') }}-1.1.51
 
       - name: Build CTS
         if: steps.cts-cache.outputs.cache-hit != 'true'

--- a/scripts/fetch_build_cts.bat
+++ b/scripts/fetch_build_cts.bat
@@ -10,15 +10,17 @@ setlocal enabledelayedexpansion
 :: a developer/CI harness, not a runtime artifact.
 ::
 :: Usage: scripts\fetch_build_cts.bat
-::   Pin via CTS_TAG below. This tracks the last conformance rev the
-::   runtime passes clean (1.1.43.0) — it lags the *shipped* loader
-::   (1.1.51) on purpose: openxr-cts-1.1.51.0 crashes the runtime
-::   mid-run (runtime#726). Bump only once that's resolved.
+::   Pin via CTS_TAG below. Tracks the shipped loader (1.1.51, #724).
+::   NOTE: openxr-cts-1.1.44+ renamed the CLI arg --apiVersion ->
+::   --minApiVersion (Khronos MR 3576); run_cts.ps1 was updated to
+::   match (#726). The earlier "1.1.51 crashes the runtime mid-run"
+::   was a misdiagnosis — conformance_cli rejected the stale arg and
+::   exited before running any test (no result XML).
 :: Output: build-cts\build\...\conformance_cli.exe (path echoed at end).
 :: ============================================================
 
 set REPO=%~dp0..\
-set CTS_TAG=openxr-cts-1.1.43.0
+set CTS_TAG=openxr-cts-1.1.51.0
 set CTS_ROOT=%REPO%build-cts
 set CTS_SRC=%CTS_ROOT%\OpenXR-CTS
 set CTS_BUILD=%CTS_ROOT%\build

--- a/scripts/run_cts.ps1
+++ b/scripts/run_cts.ps1
@@ -64,7 +64,38 @@ Write-Output "SNAPSHOT $Plugin ProbeOrder = $origProbe"
 # Both CTS layers: the runtime-conformance validation layer (requested via -L)
 # and the conformance_test_layer (== conformance_test.dll; validApiLayer requests
 # it itself). Register both as Explicit so the elevated loader can find them.
-$layerJsons  = @("$base\XrApiLayer_runtime_conformance.json", "$base\XrApiLayer_conformance_test_layer.json")
+#
+# Discover each manifest instead of hardcoding a path: openxr-cts-1.1.44+ moved
+# the layer JSON copy from conformance_cli's binary dir to each layer's own
+# TARGET_FILE_DIR (Khronos MR 3576-era CMake change) — the old
+# .../conformance_cli/XrApiLayer_*.json paths no longer exist, so the loader
+# reported "failed to find layer" -> XR_ERROR_API_LAYER_NOT_PRESENT (#726). The
+# manifest's library_path is "./<dll>" (same-dir relative), so we must register
+# the copy that sits next to the built DLL; pick the one whose sibling DLL exists.
+$ctsBuild = "$wt\build-cts\build"
+function Resolve-LayerManifest {
+  param([string]$JsonName, [string]$DllName)
+  $hits = @(Get-ChildItem -Path $ctsBuild -Recurse -Filter $JsonName -File -ErrorAction SilentlyContinue)
+  foreach ($h in $hits) {
+    if (Test-Path (Join-Path $h.DirectoryName $DllName)) { return $h.FullName }
+  }
+  # Fall back to the first hit (prefer a RelWithDebInfo copy) even if we can't
+  # confirm the sibling DLL, so failures surface as a loader error not a silent skip.
+  $rel = $hits | Where-Object { $_.FullName -match 'RelWithDebInfo' } | Select-Object -First 1
+  if ($rel) { return $rel.FullName }
+  if ($hits.Count) { return $hits[0].FullName }
+  return $null
+}
+$layerJsons = @()
+if ($ConformanceLayer) {
+  $runtimeConf = Resolve-LayerManifest 'XrApiLayer_runtime_conformance.json' 'XrApiLayer_runtime_conformance.dll'
+  $testLayer   = Resolve-LayerManifest 'XrApiLayer_conformance_test_layer.json' 'conformance_test.dll'
+  foreach ($m in @($runtimeConf, $testLayer)) { if ($m) { $layerJsons += $m } }
+  if (-not $runtimeConf) { throw "could not locate XrApiLayer_runtime_conformance.json under $ctsBuild" }
+  if (-not $testLayer)   { throw "could not locate XrApiLayer_conformance_test_layer.json under $ctsBuild" }
+  Write-Output "RESOLVED runtime-conformance layer manifest: $runtimeConf"
+  Write-Output "RESOLVED conformance-test layer manifest:    $testLayer"
+}
 $explicitKey  = "$xrKey\ApiLayers\Explicit"
 $explicitKeyPreexisted = Test-Path $explicitKey
 $preRegistered = @{}
@@ -101,8 +132,13 @@ try {
   # doesn't repeatedly take over the display.
   $env:XRT_COMPOSITOR_START_WINDOWED = "true"
 
+  # OpenXR-CTS renamed the API-version CLI arg `--apiVersion` -> `--minApiVersion`
+  # in openxr-cts-1.1.44+ (Khronos CHANGELOG.CTS.md, internal MR 3576). Under
+  # 1.1.51 the old spelling is rejected as an "Unrecognised token" and
+  # conformance_cli exits (code 2) before running a single test — no result XML,
+  # which surfaced as the bogus "crashed before writing results" in #726.
   $cliArgs = @(
-    $TestSpec, "-G", $Graphics, "--apiVersion", $ApiVersion,
+    $TestSpec, "-G", $Graphics, "--minApiVersion", $ApiVersion,
     "--reporter", "ctsxml::out=$xml",
     "--reporter", "console::out=$console"
   )


### PR DESCRIPTION
## Root cause — not a runtime crash

`openxr-cts-1.1.51.0` does **not** crash the DisplayXR runtime mid-run — the #726 title was a misdiagnosis. The runtime was never at fault. Two **harness** incompatibilities with the newer Khronos CTS made `conformance_cli` exit before writing result XML, which the `Evaluate results` step reported as "CTS produced no result XML — the run likely crashed before writing results."

### 1. CLI argument renamed
`openxr-cts-1.1.44+` renamed the API-version arg `--apiVersion` → `--minApiVersion` (CHANGELOG.CTS.md, internal MR 3576). `run_cts.ps1` still passed `--apiVersion`, so Catch2 rejected it:

```
Error(s) in input:
  Unrecognised token: --apiVersion
Test failure: Command line arguments were invalid or insufficient.
EXITCODE: 2
```

The CLI exited before running a single test → no XML. (This was the failure on PR #725, run [28925950798](https://github.com/DisplayXR/displayxr-runtime/actions/runs/28925950798).)

### 2. Conformance-layer manifests moved
After the arg fix, a **new** 1.1.51 code path (`VersionDependentData::Initialize`) creates a probe instance with the conformance layer enabled and failed with `XR_ERROR_API_LAYER_NOT_PRESENT`. Loader-debug capture showed the loader could not find `XR_APILAYER_KHRONOS_runtime_conformance`: the manifest JSONs are **no longer copied next to `conformance_cli.exe`** — `1.1.44+` copies each to its own layer `TARGET_FILE_DIR`. `run_cts.ps1` registered the stale paths.

## Fix (harness only — no runtime/compositor source changed)

- `run_cts.ps1`: `--apiVersion` → `--minApiVersion`.
- `run_cts.ps1`: discover each layer manifest under `build-cts` and register the copy sitting next to its built DLL (the manifest `library_path` is same-dir relative), instead of a hardcoded `conformance_cli` path.
- `fetch_build_cts.bat`: bump `CTS_TAG` `1.1.43.0` → `1.1.51.0`.
- `cts.yml`: bump the runtime-build loader pin `1.1.43` → `1.1.51` (align with the shipped loader, #724) + cache-key suffix.

## Verification

Smoke CTS (d3d11) green at 1.1.51.0 on this branch — run [28961172675](https://github.com/DisplayXR/displayxr-runtime/actions/runs/28961172675): **375 assertions, 0 failures, 0 skipped, "CTS passed."**

Follow-up to #724. Closes #726.

🤖 Generated with [Claude Code](https://claude.com/claude-code)