### PR TITLE
fix(extensions,#737): restore pre-rename SPEC_VERSION values on XR_DXR_* headers

### DIFF
--- a/src/external/openxr_includes/openxr/XR_DXR_atlas_capture.h
+++ b/src/external/openxr_includes/openxr/XR_DXR_atlas_capture.h
@@ -6,7 +6,8 @@
 // Khronos OpenXR registry: extension numbers and XrStructureType values sit
 // in a provisional experimental block (1004999xxx) pending official
 // assignment. Extension names are expected to be stable; numeric values are
-// not. SPEC_VERSION restarted at 1 on the XR_EXT_* -> XR_DXR_* rename.
+// not. SPEC_VERSION continues the pre-rename XR_EXT_* numbering (the
+// interface history did not restart with the name).
 // See GOVERNANCE.md.
 //
 /*!
@@ -43,7 +44,7 @@ extern "C" {
 // SPEC_VERSION 2: the runtime appends "_atlas_<viewCount>_<cols>x<rows>.png"
 // (was a flat "_atlas.png" in v1), and the encoded PNG is always opaque
 // (alpha forced to 255). See issue #425.
-#define XR_DXR_atlas_capture_SPEC_VERSION 1
+#define XR_DXR_atlas_capture_SPEC_VERSION 3
 #define XR_DXR_ATLAS_CAPTURE_EXTENSION_NAME "XR_DXR_atlas_capture"
 
 // Reserved 1004999170..171. Final values reconcile with the Khronos registry

--- a/src/external/openxr_includes/openxr/XR_DXR_cocoa_window_binding.h
+++ b/src/external/openxr_includes/openxr/XR_DXR_cocoa_window_binding.h
@@ -6,7 +6,8 @@
 // Khronos OpenXR registry: extension numbers and XrStructureType values sit
 // in a provisional experimental block (1004999xxx) pending official
 // assignment. Extension names are expected to be stable; numeric values are
-// not. SPEC_VERSION restarted at 1 on the XR_EXT_* -> XR_DXR_* rename.
+// not. SPEC_VERSION continues the pre-rename XR_EXT_* numbering (the
+// interface history did not restart with the name).
 // See GOVERNANCE.md.
 //
 /*!
@@ -44,7 +45,7 @@ extern "C" {
 #endif
 
 #define XR_DXR_cocoa_window_binding 1
-#define XR_DXR_cocoa_window_binding_SPEC_VERSION 1
+#define XR_DXR_cocoa_window_binding_SPEC_VERSION 6
 #define XR_DXR_COCOA_WINDOW_BINDING_EXTENSION_NAME "XR_DXR_cocoa_window_binding"
 
 // Use a value in the vendor extension range (1000000000+)

--- a/src/external/openxr_includes/openxr/XR_DXR_display_info.h
+++ b/src/external/openxr_includes/openxr/XR_DXR_display_info.h
@@ -6,7 +6,8 @@
 // Khronos OpenXR registry: extension numbers and XrStructureType values sit
 // in a provisional experimental block (1004999xxx) pending official
 // assignment. Extension names are expected to be stable; numeric values are
-// not. SPEC_VERSION restarted at 1 on the XR_EXT_* -> XR_DXR_* rename.
+// not. SPEC_VERSION continues the pre-rename XR_EXT_* numbering (the
+// interface history did not restart with the name).
 // See GOVERNANCE.md.
 //
 /*!
@@ -31,7 +32,7 @@ extern "C" {
 #endif
 
 #define XR_DXR_display_info 1
-#define XR_DXR_display_info_SPEC_VERSION 1
+#define XR_DXR_display_info_SPEC_VERSION 16
 #define XR_DXR_DISPLAY_INFO_EXTENSION_NAME "XR_DXR_display_info"
 
 // Reuse the type value from the deleted XR_EXT_dynamic_render_resolution

--- a/src/external/openxr_includes/openxr/XR_DXR_display_zones.h
+++ b/src/external/openxr_includes/openxr/XR_DXR_display_zones.h
@@ -6,7 +6,8 @@
 // Khronos OpenXR registry: extension numbers and XrStructureType values sit
 // in a provisional experimental block (1004999xxx) pending official
 // assignment. Extension names are expected to be stable; numeric values are
-// not. SPEC_VERSION restarted at 1 on the XR_EXT_* -> XR_DXR_* rename.
+// not. SPEC_VERSION continues the pre-rename XR_EXT_* numbering (the
+// interface history did not restart with the name).
 // See GOVERNANCE.md.
 //
 /*!

--- a/src/external/openxr_includes/openxr/XR_DXR_local_3d_zone.h
+++ b/src/external/openxr_includes/openxr/XR_DXR_local_3d_zone.h
@@ -6,7 +6,8 @@
 // Khronos OpenXR registry: extension numbers and XrStructureType values sit
 // in a provisional experimental block (1004999xxx) pending official
 // assignment. Extension names are expected to be stable; numeric values are
-// not. SPEC_VERSION restarted at 1 on the XR_EXT_* -> XR_DXR_* rename.
+// not. SPEC_VERSION continues the pre-rename XR_EXT_* numbering (the
+// interface history did not restart with the name).
 // See GOVERNANCE.md.
 //
 /*!
@@ -54,7 +55,7 @@ extern "C" {
 // reserved it first). No struct/field/entry-point changes; consumers only
 // need a header re-sync + rebuild. See README.md (allocation registry) in
 // this directory.
-#define XR_DXR_local_3d_zone_SPEC_VERSION 1
+#define XR_DXR_local_3d_zone_SPEC_VERSION 4
 #define XR_DXR_LOCAL_3D_ZONE_EXTENSION_NAME "XR_DXR_local_3d_zone"
 
 // Extension type-value range (1004999xxx); replace with a Khronos-assigned

--- a/src/external/openxr_includes/openxr/XR_DXR_macos_gl_binding.h
+++ b/src/external/openxr_includes/openxr/XR_DXR_macos_gl_binding.h
@@ -6,7 +6,8 @@
 // Khronos OpenXR registry: extension numbers and XrStructureType values sit
 // in a provisional experimental block (1004999xxx) pending official
 // assignment. Extension names are expected to be stable; numeric values are
-// not. SPEC_VERSION restarted at 1 on the XR_EXT_* -> XR_DXR_* rename.
+// not. SPEC_VERSION continues the pre-rename XR_EXT_* numbering (the
+// interface history did not restart with the name).
 // See GOVERNANCE.md.
 //
 /*!
@@ -36,7 +37,7 @@ extern "C" {
 // (the old value collided with XR_DXR_display_info's
 // XR_TYPE_EVENT_DATA_RENDERING_MODE_CHANGED_DXR). No struct/field changes;
 // consumers only need a header re-sync + rebuild.
-#define XR_DXR_macos_gl_binding_SPEC_VERSION 1
+#define XR_DXR_macos_gl_binding_SPEC_VERSION 2
 #define XR_DXR_MACOS_GL_BINDING_EXTENSION_NAME "XR_DXR_macos_gl_binding"
 
 // Structure type in the extension type-value range. Allocation registry:

--- a/src/external/openxr_includes/openxr/XR_DXR_mcp_tools.h
+++ b/src/external/openxr_includes/openxr/XR_DXR_mcp_tools.h
@@ -6,7 +6,8 @@
 // Khronos OpenXR registry: extension numbers and XrStructureType values sit
 // in a provisional experimental block (1004999xxx) pending official
 // assignment. Extension names are expected to be stable; numeric values are
-// not. SPEC_VERSION restarted at 1 on the XR_EXT_* -> XR_DXR_* rename.
+// not. SPEC_VERSION continues the pre-rename XR_EXT_* numbering (the
+// interface history did not restart with the name).
 // See GOVERNANCE.md.
 //
 /*!

--- a/src/external/openxr_includes/openxr/XR_DXR_spatial_workspace.h
+++ b/src/external/openxr_includes/openxr/XR_DXR_spatial_workspace.h
@@ -6,7 +6,8 @@
 // Khronos OpenXR registry: extension numbers and XrStructureType values sit
 // in a provisional experimental block (1004999xxx) pending official
 // assignment. Extension names are expected to be stable; numeric values are
-// not. SPEC_VERSION restarted at 1 on the XR_EXT_* -> XR_DXR_* rename.
+// not. SPEC_VERSION continues the pre-rename XR_EXT_* numbering (the
+// interface history did not restart with the name).
 // See GOVERNANCE.md.
 //
 /*!
@@ -34,7 +35,7 @@ extern "C" {
 #endif
 
 #define XR_DXR_spatial_workspace 1
-#define XR_DXR_spatial_workspace_SPEC_VERSION 1
+#define XR_DXR_spatial_workspace_SPEC_VERSION 24
 #define XR_DXR_SPATIAL_WORKSPACE_EXTENSION_NAME "XR_DXR_spatial_workspace"
 
 // Provisional XrStructureType values. The 1004999100..110 range is reserved for

--- a/src/external/openxr_includes/openxr/XR_DXR_view_rig.h
+++ b/src/external/openxr_includes/openxr/XR_DXR_view_rig.h
@@ -6,7 +6,8 @@
 // Khronos OpenXR registry: extension numbers and XrStructureType values sit
 // in a provisional experimental block (1004999xxx) pending official
 // assignment. Extension names are expected to be stable; numeric values are
-// not. SPEC_VERSION restarted at 1 on the XR_EXT_* -> XR_DXR_* rename.
+// not. SPEC_VERSION continues the pre-rename XR_EXT_* numbering (the
+// interface history did not restart with the name).
 // See GOVERNANCE.md.
 //
 /*!
@@ -56,7 +57,7 @@ extern "C" {
 #endif
 
 #define XR_DXR_view_rig 1
-#define XR_DXR_view_rig_SPEC_VERSION 1
+#define XR_DXR_view_rig_SPEC_VERSION 3
 #define XR_DXR_VIEW_RIG_EXTENSION_NAME "XR_DXR_view_rig"
 
 // Reserved 1004999xxx range, next free block after mcp_tools (…130-132).

--- a/src/external/openxr_includes/openxr/XR_DXR_weave.h
+++ b/src/external/openxr_includes/openxr/XR_DXR_weave.h
@@ -6,7 +6,8 @@
 // Khronos OpenXR registry: extension numbers and XrStructureType values sit
 // in a provisional experimental block (1004999xxx) pending official
 // assignment. Extension names are expected to be stable; numeric values are
-// not. SPEC_VERSION restarted at 1 on the XR_EXT_* -> XR_DXR_* rename.
+// not. SPEC_VERSION continues the pre-rename XR_EXT_* numbering (the
+// interface history did not restart with the name).
 // See GOVERNANCE.md.
 //
 /*!
@@ -87,7 +88,7 @@ extern "C" {
 #endif
 
 #define XR_DXR_weave 1
-#define XR_DXR_weave_SPEC_VERSION 1
+#define XR_DXR_weave_SPEC_VERSION 2
 #define XR_DXR_WEAVE_EXTENSION_NAME "XR_DXR_weave"
 
 // Reserved 1004999190..191. Final values reconcile with the Khronos registry

--- a/src/external/openxr_includes/openxr/XR_DXR_win32_window_binding.h
+++ b/src/external/openxr_includes/openxr/XR_DXR_win32_window_binding.h
@@ -6,7 +6,8 @@
 // Khronos OpenXR registry: extension numbers and XrStructureType values sit
 // in a provisional experimental block (1004999xxx) pending official
 // assignment. Extension names are expected to be stable; numeric values are
-// not. SPEC_VERSION restarted at 1 on the XR_EXT_* -> XR_DXR_* rename.
+// not. SPEC_VERSION continues the pre-rename XR_EXT_* numbering (the
+// interface history did not restart with the name).
 // See GOVERNANCE.md.
 //
 /*!
@@ -39,7 +40,7 @@ extern "C" {
 #endif
 
 #define XR_DXR_win32_window_binding 1
-#define XR_DXR_win32_window_binding_SPEC_VERSION 1
+#define XR_DXR_win32_window_binding_SPEC_VERSION 8
 #define XR_DXR_WIN32_WINDOW_BINDING_EXTENSION_NAME "XR_DXR_win32_window_binding"
 
 // Use a value in the vendor extension range (1000000000+)

--- a/src/external/openxr_includes/openxr/XR_DXR_workspace_file_dialog.h
+++ b/src/external/openxr_includes/openxr/XR_DXR_workspace_file_dialog.h
@@ -6,7 +6,8 @@
 // Khronos OpenXR registry: extension numbers and XrStructureType values sit
 // in a provisional experimental block (1004999xxx) pending official
 // assignment. Extension names are expected to be stable; numeric values are
-// not. SPEC_VERSION restarted at 1 on the XR_EXT_* -> XR_DXR_* rename.
+// not. SPEC_VERSION continues the pre-rename XR_EXT_* numbering (the
+// interface history did not restart with the name).
 // See GOVERNANCE.md.
 //
 /*!

--- a/src/external/openxr_includes/openxr/XR_DXR_xlib_window_binding.h
+++ b/src/external/openxr_includes/openxr/XR_DXR_xlib_window_binding.h
@@ -6,7 +6,8 @@
 // Khronos OpenXR registry: extension numbers and XrStructureType values sit
 // in a provisional experimental block (1004999xxx) pending official
 // assignment. Extension names are expected to be stable; numeric values are
-// not. SPEC_VERSION restarted at 1 on the XR_EXT_* -> XR_DXR_* rename.
+// not. SPEC_VERSION continues the pre-rename XR_EXT_* numbering (the
+// interface history did not restart with the name).
 // See GOVERNANCE.md.
 //
 /*!


### PR DESCRIPTION
## Problem

Fixes #737 (workspace cursor invisible over 3D windows under the shell on the v2.0.0 pair).

The #734 rename reset every `XR_DXR_*_SPEC_VERSION` to 1, but the spec version tracks interface evolution — which did not restart with the name — and consumers gate on it numerically:

1. **#737 root cause:** shell `main.c:2108` guards the cursor dim push with `#if XR_DXR_spatial_workspace_SPEC_VERSION >= 23`. Built against the reset header this compiled out, so the shell pushes the memset-zeroed `dimFactor = 0.0` every frame. The runtime clamps 0.0 as valid (`oxr_workspace.c:1391`) and renders the over-window cursor at alpha 0 (`comp_d3d11_service.cpp:7888`, `:7949`) → cursor invisible exactly when over a window, visible between windows (user-confirmed symptom split).
2. Shell `main.c:5387` `>= 21` → multi-overlay (#366) compiled out **and** the runtime-side `extensionVersion >= 21` gate false → single-slot overlay arbiter fallback.
3. Shell `shell_openxr.cpp:472` `>= 24` → reserved-keys declaration skipped (tolerated fallback).

## Fix

Restore all 13 headers to their pre-rename (v1.29.0) SPEC_VERSION values (spatial_workspace 24, display_info 16, win32_window_binding 8, cocoa 6, local_3d_zone 4, atlas_capture 3, view_rig 3, weave 2, macos_gl 2; the other four were already 1) and reword the preamble comment: SPEC_VERSION continues the XR_EXT_* numbering.

`xrEnumerateInstanceExtensionProperties` reports these macros directly (`oxr_api_instance.c:52`), so the runtime-side gates heal on rebuild.

## Follow-ups (not in this PR)

- **Shell must be rebuilt** against the synced headers (extensions auto-sync on merge) to re-enable the compiled-out paths → shell v2.0.1 + runtime v2.0.1 pair.
- displayxr-unity v2.5.0 shipped **stale pre-rename native binaries** (source renamed, committed DLL/bundle not rebuilt) — separate issue being filed.

## Verified

- `build_windows.bat build` → ALL DONE; `displayxr-cli selftest` PASSED (Leia plugin, ABI v4).
- Full cursor fix requires the rebuilt shell; end-to-end eyeball on the Leia box after that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)