### PR TITLE
fix(oxr,ipc,#739): scope the #48 service-mode T_base_head skip to non-Windows

### DIFF
--- a/src/xrt/state_trackers/oxr/oxr_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_session.c
@@ -2481,9 +2481,23 @@ oxr_session_locate_views(struct oxr_logger *log,
 		// yet still get display-relative server poses, so key on service mode too.
 		// (#48: macOS hosted OOP — Android has no qwerty so T_base_head was already
 		// identity there; this is a no-op for it.)
-		bool server_display_relative =
-		    sess->has_external_window || sess->is_bridge_relay ||
-		    (sess->sys->xsysc != NULL && sess->sys->xsysc->info.is_service_mode);
+		//
+		// #739: the service-mode leg of the skip is scoped to NON-Windows. On
+		// Windows the wire head_relation (T_xdev_head) IS the server's qwerty
+		// rig pose (ipc_try_get_sr_view_poses), and hosted legacy sessions
+		// (Chrome WebXR) need it composed for the fly-camera: the per-view
+		// poses are head-local by construction, so skipping T_base_head
+		// cancels the qwerty motion out of XrView.pose entirely — inputs then
+		// visibly move only the qwerty controllers (children of the qwerty
+		// HMD). The LOCAL reference-space origin absorbs the 1.6 m standing
+		// height (it is the initial head pose), so composing adds only the
+		// motion delta — the pre-#48 behavior. Workspace sessions return an
+		// identity head relation (use_qwerty=0), so this is a no-op there.
+		bool server_display_relative = sess->has_external_window || sess->is_bridge_relay;
+#ifndef XRT_OS_WINDOWS
+		server_display_relative = server_display_relative ||
+		                          (sess->sys->xsysc != NULL && sess->sys->xsysc->info.is_service_mode);
+#endif
 		if (server_display_relative && !have_eyes && !have_eye_override) {
 			// Use server poses directly (display-relative)
 			result.pose = view_pose;


### PR DESCRIPTION
Fixes #739.

## Problem
Since ecd6d6c63 (#48, shipped v1.23.0) every service-mode session used the server's view poses directly and skipped `T_base_head`. On Windows the wire head relation IS the server's qwerty rig pose (`ipc_try_get_sr_view_poses`) and the per-view poses are head-local by construction — so the skip cancelled qwerty motion out of `XrView.pose` for hosted legacy sessions (Chrome WebXR). Inputs visibly moved only the qwerty controllers (children of the qwerty HMD), never the view.

## Fix
Scope the service-mode leg of the skip to non-Windows (the macOS/Android OOP path #48 actually targeted). Windows composes `T_base_head` again — the pre-#48 behavior:
- LOCAL reference-space origin absorbs the 1.6 m standing height → only the motion delta composes.
- Workspace sessions return an identity head relation (`use_qwerty=0`) → no-op.
- Handle/texture apps keep the skip via `has_external_window`; bridge relays via `is_bridge_relay`.

A first attempt routed legacy locates through the rig-reply eye override — wrong contract for legacy clients (world-space eyes broke the display-local Kooima pairing); reverted, not in this PR.

## Verified
On the Leia box (dev deploy `v2.0.1-3-ga502ac27d`): Chrome WebXR hosted session — WASD/RMB-drag flies the head, controllers ride along, Kooima correct. Cube handle + forced IPC and shell/workspace flows unaffected. User-confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)