### PR TITLE
fix(ipc,#625): admit Chromium's Low-integrity GPU process as a weave IPC client

### DIFF
--- a/src/xrt/ipc/server/ipc_server_mainloop_windows.cpp
+++ b/src/xrt/ipc/server/ipc_server_mainloop_windows.cpp
@@ -107,13 +107,26 @@ create_pipe_instance(struct ipc_server_mainloop *ml, bool first)
 	 * https://learn.microsoft.com/en-us/windows/win32/secbp/creating-a-dacl
 	 * https://learn.microsoft.com/en-us/windows/win32/secauthz/sid-strings
 	 */
+	// #625: the DisplayXR Browser's inline-3D weave session runs inside Chromium's
+	// GPU process, which is LOW integrity with a restricted token even before the
+	// sandbox lowers it. A named pipe has no mandatory label by default (implicit
+	// Medium), so the no-write-up policy blocks a Low client from opening it for
+	// GENERIC_WRITE → CreateFile fails ERROR_ACCESS_DENIED. Add a Low integrity
+	// label (SACL) so Low-integrity clients can connect, and grant the RESTRICTED
+	// SID so a restricted token's restricting-SID access pass also succeeds. This
+	// is local-only (PIPE_REJECT_REMOTE_CLIENTS) and only widens integrity, not
+	// identity (Guest/Anonymous stay denied). Same intent as the AppContainer
+	// (AC) grant already here for the WebXR bridge.
 	const TCHAR *str =               //
 	    TEXT("D:")                   // Discretionary ACL
 	    TEXT("(D;OICI;GA;;;BG)")     // Guest: deny
 	    TEXT("(D;OICI;GA;;;AN)")     // Anonymous: deny
 	    TEXT("(A;OICI;GRGWGX;;;AC)") // UWP/AppContainer packages: read/write/execute
 	    TEXT("(A;OICI;GRGWGX;;;AU)") // Authenticated user: read/write/execute
-	    TEXT("(A;OICI;GA;;;BA)");    // Administrator: full control
+	    TEXT("(A;OICI;GRGWGX;;;RC)") // Restricted code (sandboxed GPU proc): r/w/x
+	    TEXT("(A;OICI;GA;;;BA)")     // Administrator: full control
+	    TEXT("S:")                   // System ACL (mandatory label)
+	    TEXT("(ML;;NW;;;LW)");       // Low integrity object, no-write-up
 
 	BOOL bret = ConvertStringSecurityDescriptorToSecurityDescriptor( //
 	    str,                                                         // StringSecurityDescriptor
@@ -280,6 +293,20 @@ ipc_server_mainloop_poll(struct ipc_server *vs, struct ipc_server_mainloop *ml)
 	switch (DWORD err = GetLastError()) {
 	case ERROR_PIPE_LISTENING: return;
 	case ERROR_PIPE_CONNECTED: handle_connected_client(vs, ml); return;
+	case ERROR_NO_DATA:      // 232: client opened the pipe then closed it before
+	case ERROR_BROKEN_PIPE:  // 109: we accepted — it aborted mid-connect.
+		// A client aborted before the handshake completed (e.g. #625: the
+		// DisplayXR Browser's GPU-process weave client connecting pre-sandbox
+		// may open-and-drop on a retry, or a port scanner probes the pipe).
+		// The current instance is now in a closing state, but that must NOT take
+		// the whole service down — recycle this instance and re-arm the listener
+		// so other clients keep working.
+		U_LOG_W("ConnectNamedPipe: client aborted before handshake (%d %s); re-arming listener", err,
+		        ipc_winerror(err));
+		CloseHandle(ml->pipe_handle);
+		ml->pipe_handle = INVALID_HANDLE_VALUE;
+		create_another_pipe_instance(vs, ml);
+		return;
 	default:
 		U_LOG_E("ConnectNamedPipe failed: %d %s", err, ipc_winerror(err));
 		ipc_server_handle_failure(vs);

--- a/src/xrt/ipc/shared/ipc_message_channel_windows.cpp
+++ b/src/xrt/ipc/shared/ipc_message_channel_windows.cpp
@@ -158,11 +158,28 @@ ipc_send_handles(
 		return ipc_send(imc, nullptr, 0);
 	}
 
-	HANDLE target_process = open_target_process_dup_handle(imc);
-	if (!target_process) {
-		DWORD err = GetLastError();
-		IPC_ERROR(imc, "open_target_process_dup_handle failed: %d %s", err, ipc_winerror(err));
-		return XRT_ERROR_IPC_FAILURE;
+	// #625: low-bit-tagged handles (legacy DXGI shared handles) are process-
+	// independent identifiers that cross the wire raw — they are never
+	// DuplicateHandle'd into the peer. Only open the peer process when some
+	// handle actually needs duplication: a sandboxed low-integrity sender (the
+	// inline-3D browser's GPU process) cannot OpenProcess(PROCESS_DUP_HANDLE)
+	// the medium-integrity service, and it doesn't need to for tagged handles.
+	bool needs_dup = false;
+	for (uint32_t i = 0; i < handle_count; i++) {
+		if (((size_t)handles[i] & 1) == 0) {
+			needs_dup = true;
+			break;
+		}
+	}
+
+	HANDLE target_process = NULL;
+	if (needs_dup) {
+		target_process = open_target_process_dup_handle(imc);
+		if (!target_process) {
+			DWORD err = GetLastError();
+			IPC_ERROR(imc, "open_target_process_dup_handle failed: %d %s", err, ipc_winerror(err));
+			return XRT_ERROR_IPC_FAILURE;
+		}
 	}
 
 	HANDLE current_process = GetCurrentProcess();
@@ -182,7 +199,9 @@ ipc_send_handles(
 		}
 		v.push_back(handle);
 	}
-	CloseHandle(target_process);
+	if (target_process != NULL) {
+		CloseHandle(target_process);
+	}
 	return ipc_send(imc, v.data(), v.size() * sizeof(*v.data()));
 }
 


### PR DESCRIPTION
## Summary
Enables the DisplayXR Browser's inline-3D **zero-lag** weave path, which runs the OpenXR present-owner weave session **inside Chromium's GPU process**. That process is **LOW integrity with a restricted token even before the sandbox lowers it**, so three IPC-layer fixes are needed for it to connect and drive `xrWeaveSubmitDXR` synchronously.

Validated end-to-end this session: a post-`LowerToken()` **synchronous** weave from the GPU main thread returns a woven handle + fence + tracked eyes in **~965 µs** (no deadlock, no `sync_call_restrictions` FATAL, no OpenProcess denial) — proving zero-lag browser-owned weave is achievable.

## Changes
- **Pipe security** (`ipc_server_mainloop_windows.cpp`): the named pipe had no mandatory label (implicit Medium) → a Low client's `CreateFile` for `GENERIC_WRITE` was blocked by no-write-up → `ERROR_ACCESS_DENIED`. Add a **Low integrity label** (`S:(ML;;NW;;;LW)`) and grant the **RESTRICTED** SID (`RC`) for the restricted token's second access pass. Local-only pipe (`PIPE_REJECT_REMOTE_CLIENTS`); widens integrity only — Guest/Anonymous stay denied. Same intent as the existing AppContainer (`AC`) grant for the WebXR bridge.
- **Mainloop robustness** (`ipc_server_mainloop_windows.cpp`): a client that opened the pipe then aborted before the handshake (`ConnectNamedPipe` → `ERROR_NO_DATA` 232 / `ERROR_BROKEN_PIPE` 109) hit the `default` case and took the **whole service down** (`Server exiting`). Recycle the aborted instance and re-arm instead.
- **Handle transfer** (`ipc_message_channel_windows.cpp`): `ipc_send_handles` is sender-initiated (`OpenProcess(PROCESS_DUP_HANDLE, peer)`), which a Low sender can't do to the Medium service. Skip the OpenProcess/dup when **every** handle is low-bit-tagged (legacy DXGI shared handles — process-independent, opened via `OpenSharedResource`). The weave input rides as a tagged handle, so per-frame submits need no peer-process open.

## No regression to existing IPC clients
- **Legacy/handle/texture + workspace apps** use **NT (untagged)** handles for swapchain + shm handoff → the `needs_dup=true` OpenProcess+DuplicateHandle path is **unchanged**. Verified live: a forced-IPC `cube_handle_d3d11_win` connected and created its native compositor + NT-handle swapchains (`Created shared texture … (NT handle)`) with no errors.
- The Low pipe label only **widens** access (write-down from Medium/High is always allowed); tagged handles were already passed raw (never dup'd), so the wire bytes are identical.
- The mainloop change is a strict robustness win — a flaky connector no longer kills the service for everyone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)