### PR TITLE
feat(weave,#625): batched weave submit — N rects, one xrWeaveSubmitDXR per frame

### DIFF
--- a/src/external/openxr_includes/openxr/README.md
+++ b/src/external/openxr_includes/openxr/README.md
@@ -37,7 +37,7 @@ Rules:
 | 1004999160–166 | `XR_DXR_local_3d_zone` | relocated from 130–136 (collided with mcp_tools) — spec v4 |
 | 1004999170–171 | `XR_DXR_atlas_capture` | relocated from 120–121 (collided with workspace_file_dialog) — spec v3 |
 | 1004999180 | `XR_DXR_macos_gl_binding` | relocated from 1004999010 (collided with display_info) — spec v2 |
-| 1004999190–191 | `XR_DXR_weave` | 190 = `XR_TYPE_WEAVE_SUBMIT_INFO_DXR`, 191 = `XR_TYPE_WEAVE_OUTPUT_DXR` (#625) |
+| 1004999190–192 | `XR_DXR_weave` | 190 = `XR_TYPE_WEAVE_SUBMIT_INFO_DXR`, 191 = `XR_TYPE_WEAVE_OUTPUT_DXR` (#625), 192 = `XR_TYPE_WEAVE_SUBMIT_RECTS_DXR` (batch, spec v3) |
 | 1004999200–209 | `XR_DXR_xlib_window_binding` | 200 = `XR_TYPE_XLIB_WINDOW_BINDING_CREATE_INFO_DXR` (#660 Phase 3) |
 | 1004999210–219 | `XR_DXR_display_info` (v16+ additions) | 210 = `XR_TYPE_DISPLAY_DESKTOP_POSITION_DXR` (#715); fresh decade rather than reusing the 005/009 gaps in the original block |
 | 1004999220+ | **next free** | |

--- a/src/external/openxr_includes/openxr/XR_DXR_weave.h
+++ b/src/external/openxr_includes/openxr/XR_DXR_weave.h
@@ -76,6 +76,31 @@
  *
  * Only the rect's offset (top-left) is snapped; the extent passes through
  * unchanged. This is a synchronous, GPU-free query — no texture, no fence.
+ *
+ * Batched submit (SPEC_VERSION 3, issue #625). Per-element submits serialize
+ * the per-call fixed cost (IPC round-trip + shared-texture open + keyed-mutex
+ * + fence) N times per frame, which caps a page at ~8-12 visible weaved
+ * elements. Version 3 amortizes that to ONE submit per frame: chain an
+ * XrWeaveSubmitRectsDXR onto XrWeaveSubmitInfoDXR::next carrying up to
+ * XR_WEAVE_SUBMIT_MAX_RECTS_DXR rects. The chained struct SWITCHES the input
+ * layout contract:
+ *
+ *  - Chain absent (v2 behavior, unchanged): @c inputTexture is an
+ *    element-sized 2x1 SBS atlas for the single @c rect; the whole texture is
+ *    the atlas (left view = left half).
+ *  - Chain present (batch): @c inputTexture is sized to the bound window's
+ *    client area, and each rect's pre-weave SBS content sits in it AT THAT
+ *    RECT'S OWN WINDOW POSITION (identity mapping: sample position == weave
+ *    position; each rect region itself holds squeezed SBS, left view in the
+ *    left half of the rect). The base @c rect field is ignored.
+ *
+ * All rects weave into the same window-sized output with ONE fence signal at
+ * the end; eyes are returned once per call. A batch is NOT equivalent to N
+ * single-rect submits of the same texture — the layouts differ (see above).
+ *
+ * Version history: 1 = initial (pre-rename numbering carried over); 2 =
+ * inputIsDxgi legacy-DXGI handle tagging; 3 = XrWeaveSubmitRectsDXR batched
+ * submit.
  */
 #ifndef XR_DXR_WEAVE_H
 #define XR_DXR_WEAVE_H 1
@@ -88,17 +113,23 @@ extern "C" {
 #endif
 
 #define XR_DXR_weave 1
-#define XR_DXR_weave_SPEC_VERSION 2
+#define XR_DXR_weave_SPEC_VERSION 3
 #define XR_DXR_WEAVE_EXTENSION_NAME "XR_DXR_weave"
 
-// Reserved 1004999190..191. Final values reconcile with the Khronos registry
+// Reserved 1004999190..192. Final values reconcile with the Khronos registry
 // before spec freeze. Allocation registry: README.md in this directory.
-#define XR_TYPE_WEAVE_SUBMIT_INFO_DXR ((XrStructureType)1004999190)
-#define XR_TYPE_WEAVE_OUTPUT_DXR      ((XrStructureType)1004999191)
+#define XR_TYPE_WEAVE_SUBMIT_INFO_DXR  ((XrStructureType)1004999190)
+#define XR_TYPE_WEAVE_OUTPUT_DXR       ((XrStructureType)1004999191)
+#define XR_TYPE_WEAVE_SUBMIT_RECTS_DXR ((XrStructureType)1004999192)
 
 //! Upper bound on eye positions carried by XrWeaveSubmitInfoDXR (mirrors the
 //! runtime's XRT_MAX_VIEWS). Phase 1: carried but unused.
 #define XR_WEAVE_MAX_EYES_DXR 8
+
+//! Upper bound on rects carried by one XrWeaveSubmitRectsDXR (sized so the
+//! runtime's IPC message stays within its fixed buffer). Callers with more
+//! visible elements split into multiple batched submits.
+#define XR_WEAVE_SUBMIT_MAX_RECTS_DXR 32
 
 /*!
  * @brief Per-frame weave submission for one window sub-rect.
@@ -121,6 +152,28 @@ typedef struct XrWeaveSubmitInfoDXR {
     XrBool32                 inputIsDxgi;  //!< XR_TRUE for a legacy global DXGI handle (else NT handle)
     XrRect2Di                rect;         //!< window-relative sub-rect, device px (y-down)
 } XrWeaveSubmitInfoDXR;
+
+/*!
+ * @brief Batched weave submission — N window sub-rects in ONE call (spec v3).
+ *
+ * Chain onto XrWeaveSubmitInfoDXR::next. When present it switches the input
+ * layout contract (see the file header): @c inputTexture must be sized to the
+ * bound window's client area with each rect's pre-weave SBS content placed at
+ * that rect's own window position; the base struct's @c rect is ignored. Each
+ * rect region holds squeezed SBS (left view in the rect's left half). The
+ * runtime weaves every rect into the shared window-sized output and signals
+ * the fence ONCE after the last rect.
+ *
+ * @c rectCount must be 1..XR_WEAVE_SUBMIT_MAX_RECTS_DXR; callers with more
+ * visible elements split into multiple batched submits (each with its own
+ * fence value; waiting the last covers all).
+ */
+typedef struct XrWeaveSubmitRectsDXR {
+    XrStructureType          type;      //!< XR_TYPE_WEAVE_SUBMIT_RECTS_DXR
+    const void* XR_MAY_ALIAS next;
+    uint32_t                 rectCount; //!< 1..XR_WEAVE_SUBMIT_MAX_RECTS_DXR
+    const XrRect2Di*         rects;     //!< window-relative sub-rects, device px (y-down)
+} XrWeaveSubmitRectsDXR;
 
 /*!
  * @brief Weaved output handed back to the present-owner.

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -73,6 +73,7 @@
 #include <cmath>
 #include <mutex>
 #include <map>
+#include <vector>
 #include <sddl.h>
 
 
@@ -275,6 +276,21 @@ struct d3d11_client_render_resources
 	uint64_t                              weave_fence_value;   //!< signaled once per submit
 	uint32_t                              weave_output_w;
 	uint32_t                              weave_output_h;
+
+	//! Spec-v3 batched weave (#625): process_atlas samples its whole SRV as
+	//! the atlas (no input-offset param), so each batch rect is first copied
+	//! out of the shared window-sized input into an exact-size scratch tile.
+	//! Cached per rect index; a tile is recreated only when that rect's
+	//! size/format changes (a scrolling wall of uniform tiles allocates once).
+	struct weave_scratch_tile
+	{
+		wil::com_ptr<ID3D11Texture2D> tex;
+		wil::com_ptr<ID3D11ShaderResourceView> srv;
+		uint32_t w = 0;
+		uint32_t h = 0;
+		DXGI_FORMAT format = DXGI_FORMAT_UNKNOWN;
+	};
+	std::vector<weave_scratch_tile> weave_scratch;
 
 	//! Deferred auto-3D for no-zones standalone clients (#140 / no-zones-2D).
 	//! A non-workspace IPC handle app with no zone mask never triggers a 3D
@@ -2712,6 +2728,7 @@ fini_client_render_resources(struct d3d11_client_render_resources *res)
 	res->weave_output_rtv.reset();
 	res->weave_output_texture.reset();
 	res->weave_fence.reset();
+	res->weave_scratch.clear();
 
 	res->swap_chain.reset();
 
@@ -11502,6 +11519,8 @@ comp_d3d11_service_weave_submit(struct xrt_compositor *xc,
                                int32_t rect_y,
                                uint32_t rect_w,
                                uint32_t rect_h,
+                               uint32_t rect_count,
+                               const struct xrt_rect *rects,
                                uint32_t *out_width,
                                uint32_t *out_height,
                                uint64_t *out_fence_value,
@@ -11520,6 +11539,9 @@ comp_d3d11_service_weave_submit(struct xrt_compositor *xc,
 		*out_eyes = {};
 	}
 	if (xc == nullptr || xc->destroy != compositor_destroy) {
+		return false;
+	}
+	if (rect_count > 0 && rects == nullptr) {
 		return false;
 	}
 	struct d3d11_service_compositor *c = d3d11_service_compositor_from_xrt(xc);
@@ -11594,8 +11616,20 @@ comp_d3d11_service_weave_submit(struct xrt_compositor *xc,
 		}
 	}
 	if (win_w == 0 || win_h == 0) {
-		win_w = (rect_x > 0 ? (uint32_t)rect_x : 0) + rect_w;
-		win_h = (rect_y > 0 ? (uint32_t)rect_y : 0) + rect_h;
+		if (rect_count > 0) {
+			// Batch: derive the output extent from the union of the rects.
+			for (uint32_t i = 0; i < rect_count; i++) {
+				uint32_t rr = (rects[i].offset.w > 0 ? (uint32_t)rects[i].offset.w : 0) +
+				              (uint32_t)rects[i].extent.w;
+				uint32_t rb = (rects[i].offset.h > 0 ? (uint32_t)rects[i].offset.h : 0) +
+				              (uint32_t)rects[i].extent.h;
+				win_w = rr > win_w ? rr : win_w;
+				win_h = rb > win_h ? rb : win_h;
+			}
+		} else {
+			win_w = (rect_x > 0 ? (uint32_t)rect_x : 0) + rect_w;
+			win_h = (rect_y > 0 ? (uint32_t)rect_y : 0) + rect_h;
+		}
 	}
 	if (win_w == 0 || win_h == 0) {
 		return false;
@@ -11647,21 +11681,122 @@ comp_d3d11_service_weave_submit(struct xrt_compositor *xc,
 		acquired = true;
 	}
 
-	// Pre-weave content is side-by-side stereo: 2 columns × 1 row, per-view dims
-	// = half width × full height. The DP weaves into the bound RTV, confined to
-	// the sub-rect via canvas_offset/size at the correct absolute phase.
-	uint32_t view_w = idesc.Width / 2;
-	uint32_t view_h = idesc.Height;
-
 	ID3D11RenderTargetView *rtvs[] = {c->render.weave_output_rtv.get()};
-	sys->context->OMSetRenderTargets(1, rtvs, nullptr);
-	xrt_display_processor_d3d11_process_atlas(dp, sys->context.get(), in_srv.get(),
-	                                          view_w, view_h, /*tile_columns*/ 2, /*tile_rows*/ 1,
-	                                          DXGI_FORMAT_R8G8B8A8_UNORM, win_w, win_h, rect_x, rect_y, rect_w,
-	                                          rect_h);
+	if (rect_count == 0) {
+		// Legacy single-rect (spec v2): the whole input IS the element's 2x1
+		// SBS atlas — per-view dims = half width × full height. The DP weaves
+		// into the bound RTV, confined to the sub-rect via canvas_offset/size
+		// at the correct absolute phase.
+		uint32_t view_w = idesc.Width / 2;
+		uint32_t view_h = idesc.Height;
 
-	if (acquired && in_km) {
-		in_km->ReleaseSync(0);
+		sys->context->OMSetRenderTargets(1, rtvs, nullptr);
+		xrt_display_processor_d3d11_process_atlas(dp, sys->context.get(), in_srv.get(),
+		                                          view_w, view_h, /*tile_columns*/ 2, /*tile_rows*/ 1,
+		                                          DXGI_FORMAT_R8G8B8A8_UNORM, win_w, win_h, rect_x, rect_y,
+		                                          rect_w, rect_h);
+
+		if (acquired && in_km) {
+			in_km->ReleaseSync(0);
+		}
+	} else {
+		// Spec-v3 batch: the input is window-sized with each rect's SBS
+		// content at that rect's own window position. process_atlas samples
+		// its whole SRV as the atlas (no input-offset param), so first copy
+		// every rect out of the shared input into an exact-size scratch tile
+		// — then the keyed mutex can be released BEFORE the weave loop, so
+		// the caller can start writing the next frame while the DP weaves.
+		if (c->render.weave_scratch.size() < rect_count) {
+			c->render.weave_scratch.resize(rect_count);
+		}
+		bool copies_ok = true;
+		for (uint32_t i = 0; i < rect_count; i++) {
+			uint32_t rw = (uint32_t)rects[i].extent.w;
+			uint32_t rh = (uint32_t)rects[i].extent.h;
+			int32_t rx = rects[i].offset.w; // xrt_offset fields are named w/h
+			int32_t ry = rects[i].offset.h;
+			if (rw == 0 || rh == 0) {
+				copies_ok = false;
+				break;
+			}
+			auto &tile = c->render.weave_scratch[i];
+			if (!tile.tex || tile.w != rw || tile.h != rh || tile.format != idesc.Format) {
+				tile.srv.reset();
+				tile.tex.reset();
+				D3D11_TEXTURE2D_DESC td = {};
+				td.Width = rw;
+				td.Height = rh;
+				td.MipLevels = 1;
+				td.ArraySize = 1;
+				td.Format = idesc.Format;
+				td.SampleDesc.Count = 1;
+				td.Usage = D3D11_USAGE_DEFAULT;
+				td.BindFlags = D3D11_BIND_SHADER_RESOURCE;
+				hr = sys->device->CreateTexture2D(&td, nullptr, tile.tex.put());
+				if (SUCCEEDED(hr)) {
+					D3D11_SHADER_RESOURCE_VIEW_DESC tsd = {};
+					tsd.Format = idesc.Format;
+					tsd.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
+					tsd.Texture2D.MipLevels = 1;
+					hr = sys->device->CreateShaderResourceView(tile.tex.get(), &tsd,
+					                                           tile.srv.put());
+				}
+				if (FAILED(hr)) {
+					U_LOG_E("#625 weave batch: scratch tile %u (%ux%u) create failed: 0x%08lx",
+					        i, rw, rh, hr);
+					tile.srv.reset();
+					tile.tex.reset();
+					copies_ok = false;
+					break;
+				}
+				tile.w = rw;
+				tile.h = rh;
+				tile.format = idesc.Format;
+			}
+			// Defensive clamp to the input extent (a partially off-window
+			// rect must not fail the whole batch's copy).
+			D3D11_BOX box = {};
+			box.left = rx > 0 ? (UINT)rx : 0;
+			box.top = ry > 0 ? (UINT)ry : 0;
+			box.right = box.left + rw;
+			box.bottom = box.top + rh;
+			box.back = 1;
+			if (box.right > idesc.Width) {
+				box.right = idesc.Width;
+			}
+			if (box.bottom > idesc.Height) {
+				box.bottom = idesc.Height;
+			}
+			if (box.right <= box.left || box.bottom <= box.top) {
+				continue; // fully outside — nothing to weave for this rect
+			}
+			sys->context->CopySubresourceRegion(tile.tex.get(), 0, 0, 0, 0, in_tex.get(), 0, &box);
+		}
+
+		if (acquired && in_km) {
+			in_km->ReleaseSync(0);
+		}
+		if (!copies_ok) {
+			return false;
+		}
+
+		// Weave every rect into the shared window-sized output; ONE fence
+		// signal after the loop (below). Each scratch tile is a 2x1 SBS atlas
+		// exactly like a legacy input.
+		sys->context->OMSetRenderTargets(1, rtvs, nullptr);
+		for (uint32_t i = 0; i < rect_count; i++) {
+			auto &tile = c->render.weave_scratch[i];
+			if (!tile.srv) {
+				continue;
+			}
+			uint32_t rw = (uint32_t)rects[i].extent.w;
+			uint32_t rh = (uint32_t)rects[i].extent.h;
+			xrt_display_processor_d3d11_process_atlas(dp, sys->context.get(), tile.srv.get(),
+			                                          /*view_w*/ rw / 2, /*view_h*/ rh,
+			                                          /*tile_columns*/ 2, /*tile_rows*/ 1,
+			                                          DXGI_FORMAT_R8G8B8A8_UNORM, win_w, win_h,
+			                                          rects[i].offset.w, rects[i].offset.h, rw, rh);
+		}
 	}
 
 	// Signal the fence and flush so the GPU work + signal are submitted (there is

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.h
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.h
@@ -937,6 +937,14 @@ comp_d3d11_service_weave_bind_window(struct xrt_compositor *xc, uint64_t hwnd);
  * current tracked eye positions in @p out_eyes — the interlace is DP-internal
  * (reads the vendor tracker), so eyes flow OUT for the caller's off-axis
  * (look-around) rendering, not in.
+ *
+ * Two input-layout contracts, discriminated by @p rect_count (spec v3 batch):
+ * - @p rect_count == 0 (legacy): the input is an element-sized 2x1 SBS atlas
+ *   for @p rect_x/y/w/h; @p rects is ignored. Byte-equivalent to spec v2.
+ * - @p rect_count >= 1 (batch): the input is bound-window-client-sized with
+ *   each rect's SBS content at that rect's own window position; every rect is
+ *   woven into the shared output and the fence is signaled ONCE after the
+ *   last rect. @p rect_x/y/w/h are ignored.
  */
 bool
 comp_d3d11_service_weave_submit(struct xrt_compositor *xc,
@@ -946,6 +954,8 @@ comp_d3d11_service_weave_submit(struct xrt_compositor *xc,
                                int32_t rect_y,
                                uint32_t rect_w,
                                uint32_t rect_h,
+                               uint32_t rect_count,
+                               const struct xrt_rect *rects,
                                uint32_t *out_width,
                                uint32_t *out_height,
                                uint64_t *out_fence_value,

--- a/src/xrt/ipc/client/ipc_client.h
+++ b/src/xrt/ipc/client/ipc_client.h
@@ -205,8 +205,13 @@ comp_ipc_client_compositor_get_transparent_output_fence(struct xrt_compositor *x
  * path). The DP weaves server-side (ADR-007 / ADR-019).
  *
  * @c weave_bind_window registers the present-owner's HWND for DP phase-snap.
- * @c weave_submit hands a pre-weave SBS texture (in_handle) + a window-relative
- *   rect across per frame and returns the weaved dims + the fence wait value.
+ * @c weave_submit hands a pre-weave SBS texture (in_handle) + window-relative
+ *   rect(s) across per frame and returns the weaved dims + the fence wait
+ *   value. @p rect_count == 0 selects the legacy single-rect layout
+ *   (@p rect_x/y/w/h, element-sized SBS-atlas input, spec v2 wire bytes);
+ *   @p rect_count 1..IPC_WEAVE_SUBMIT_RECTS_MAX selects the spec-v3 batch
+ *   layout (window-sized input, each rect's content at its own window
+ *   position, @p rects used, @p rect_x/y/w/h ignored).
  * @c weave_get_output / @c weave_get_fence fetch the persistent server-allocated
  *   weaved-texture handle + fence handle ONCE (the caller caches them).
  */
@@ -221,6 +226,8 @@ comp_ipc_client_compositor_weave_submit(struct xrt_compositor *xc,
                                         int32_t rect_y,
                                         uint32_t rect_w,
                                         uint32_t rect_h,
+                                        uint32_t rect_count,
+                                        const struct xrt_rect *rects,
                                         bool *out_have_output,
                                         uint32_t *out_width,
                                         uint32_t *out_height,

--- a/src/xrt/ipc/client/ipc_client_compositor.c
+++ b/src/xrt/ipc/client/ipc_client_compositor.c
@@ -494,6 +494,8 @@ comp_ipc_client_compositor_weave_submit(struct xrt_compositor *xc,
                                         int32_t rect_y,
                                         uint32_t rect_w,
                                         uint32_t rect_h,
+                                        uint32_t rect_count,
+                                        const struct xrt_rect *rects,
                                         bool *out_have_output,
                                         uint32_t *out_width,
                                         uint32_t *out_height,
@@ -502,6 +504,9 @@ comp_ipc_client_compositor_weave_submit(struct xrt_compositor *xc,
 {
 	if (xc == NULL || out_have_output == NULL || out_width == NULL || out_height == NULL ||
 	    out_fence_value == NULL || out_eyes == NULL) {
+		return XRT_ERROR_IPC_FAILURE;
+	}
+	if (rect_count > IPC_WEAVE_SUBMIT_RECTS_MAX || (rect_count > 0 && rects == NULL)) {
 		return XRT_ERROR_IPC_FAILURE;
 	}
 	*out_have_output = false;
@@ -520,6 +525,15 @@ comp_ipc_client_compositor_weave_submit(struct xrt_compositor *xc,
 	args.rect_y = rect_y;
 	args.rect_w = rect_w;
 	args.rect_h = rect_h;
+	// rect_count == 0 keeps the legacy single-rect layout (spec v2 wire
+	// bytes); >= 1 selects the batch layout (window-sized input, rects[]).
+	args.rect_count = rect_count;
+	for (uint32_t i = 0; i < rect_count; i++) {
+		args.rects[i].x = rects[i].offset.w; // xrt_offset fields are named w/h
+		args.rects[i].y = rects[i].offset.h;
+		args.rects[i].w = (uint32_t)rects[i].extent.w;
+		args.rects[i].h = (uint32_t)rects[i].extent.h;
+	}
 
 	xrt_graphics_buffer_handle_t handle = in_handle;
 #if defined(XRT_GRAPHICS_BUFFER_HANDLE_IS_WIN32_HANDLE)

--- a/src/xrt/ipc/server/ipc_server_handler.c
+++ b/src/xrt/ipc/server/ipc_server_handler.c
@@ -5615,12 +5615,28 @@ ipc_handle_weave_submit(volatile struct ipc_client_state *ics,
 	}
 #endif
 
+	// rect_count == 0 = legacy single-rect layout; >= 1 = batch layout
+	// (window-sized input, rects[]). See ipc_arg_weave_submit. Converted to
+	// xrt_rect here — the service compositor API stays IPC-type-free.
+	if (args->rect_count > IPC_WEAVE_SUBMIT_RECTS_MAX) {
+		return XRT_ERROR_IPC_FAILURE;
+	}
+	struct xrt_rect rects[IPC_WEAVE_SUBMIT_RECTS_MAX];
+	for (uint32_t i = 0; i < args->rect_count; i++) {
+		rects[i].offset.w = args->rects[i].x; // xrt_offset fields are named w/h
+		rects[i].offset.h = args->rects[i].y;
+		rects[i].extent.w = (int)args->rects[i].w;
+		rects[i].extent.h = (int)args->rects[i].h;
+	}
+
 	uint32_t w = 0, h = 0;
 	uint64_t fv = 0;
 	struct xrt_eye_positions eyes = {0};
-	bool ok = comp_d3d11_service_weave_submit( //
-	    ics->xc, in_handle, in_is_dxgi,        //
-	    args->rect_x, args->rect_y, args->rect_w, args->rect_h, &w, &h, &fv, &eyes);
+	bool ok = comp_d3d11_service_weave_submit(                  //
+	    ics->xc, in_handle, in_is_dxgi,                         //
+	    args->rect_x, args->rect_y, args->rect_w, args->rect_h, //
+	    args->rect_count, args->rect_count > 0 ? rects : NULL,  //
+	    &w, &h, &fv, &eyes);
 	if (!ok) {
 		return XRT_ERROR_IPC_FAILURE;
 	}

--- a/src/xrt/ipc/shared/ipc_protocol.h
+++ b/src/xrt/ipc/shared/ipc_protocol.h
@@ -735,21 +735,50 @@ struct ipc_arg_swapchain_from_native
 };
 
 /*!
+ * Max rects one weave_submit batch carries (spec v3). Mirrors
+ * XR_WEAVE_SUBMIT_MAX_RECTS_DXR; sized so the encompassing IPC message stays
+ * well within IPC_BUF_SIZE (16 B/rect -> 512 B of rects).
+ */
+#define IPC_WEAVE_SUBMIT_RECTS_MAX 32
+
+/*!
+ * One window-relative weave sub-rect on the wire (bound-window client pixels,
+ * y-down).
+ *
+ * @ingroup ipc
+ */
+struct ipc_weave_rect
+{
+	int32_t x;  //!< Sub-rect left
+	int32_t y;  //!< Sub-rect top
+	uint32_t w; //!< Sub-rect width in pixels
+	uint32_t h; //!< Sub-rect height in pixels
+};
+
+/*!
  * XR_DXR_weave over IPC (#625): per-frame weave_submit arguments. The pre-weave
  * input texture rides as an in_handle (xrt_graphics_buffer_handle_t); this POD
- * carries the window-relative output sub-rect. The interlace is DP-internal
+ * carries the window-relative output sub-rect(s). The interlace is DP-internal
  * (reads the vendor's own eye tracker), so nothing eye-related travels in;
  * weave_submit RETURNS the tracked eyes (struct xrt_eye_positions) for the
  * caller's off-axis rendering.
+ *
+ * rect_count discriminates the two input-layout contracts (spec v3):
+ * 0 = legacy single-rect — the input texture is an element-sized 2x1 SBS atlas
+ * for rect_x/y/w/h (byte-equivalent to spec v2; rects[] unused). >= 1 = batch —
+ * the input texture is window-sized with each rect's SBS content at that
+ * rect's own window position; rect_x/y/w/h unused.
  *
  * @ingroup ipc
  */
 struct ipc_arg_weave_submit
 {
-	int32_t rect_x;  //!< Sub-rect left, bound-window client pixels (y-down)
-	int32_t rect_y;  //!< Sub-rect top, bound-window client pixels (y-down)
-	uint32_t rect_w; //!< Sub-rect width in pixels
-	uint32_t rect_h; //!< Sub-rect height in pixels
+	int32_t rect_x;  //!< Legacy sub-rect left, bound-window client pixels (y-down)
+	int32_t rect_y;  //!< Legacy sub-rect top, bound-window client pixels (y-down)
+	uint32_t rect_w; //!< Legacy sub-rect width in pixels
+	uint32_t rect_h; //!< Legacy sub-rect height in pixels
+	uint32_t rect_count; //!< 0 = legacy layout (rect_x/y/w/h); 1..MAX = batch layout (rects[])
+	struct ipc_weave_rect rects[IPC_WEAVE_SUBMIT_RECTS_MAX]; //!< Batch rects (first rect_count valid)
 };
 
 /*!

--- a/src/xrt/state_trackers/oxr/oxr_weave.c
+++ b/src/xrt/state_trackers/oxr/oxr_weave.c
@@ -28,6 +28,7 @@
 
 #include "oxr_api_funcs.h"
 #include "oxr_api_verify.h"
+#include "oxr_chain.h"
 
 #include "xrt/xrt_results.h"
 #include "xrt/xrt_handles.h"
@@ -56,6 +57,8 @@ comp_ipc_client_compositor_weave_submit(struct xrt_compositor *xc,
                                         int32_t rect_y,
                                         uint32_t rect_w,
                                         uint32_t rect_h,
+                                        uint32_t rect_count,
+                                        const struct xrt_rect *rects,
                                         bool *out_have_output,
                                         uint32_t *out_width,
                                         uint32_t *out_height,
@@ -143,6 +146,33 @@ oxr_xrWeaveSubmitDXR(XrSession session, const XrWeaveSubmitInfoDXR *submitInfo, 
 		                 "out-of-process (service) path");
 	}
 
+	// Spec v3 batched submit: a chained XrWeaveSubmitRectsDXR switches the
+	// input-layout contract (window-sized input, content at each rect's own
+	// window position; base rect ignored). Absent chain = legacy single-rect,
+	// byte-equivalent to spec v2.
+	uint32_t rect_count = 0;
+	struct xrt_rect rects[XR_WEAVE_SUBMIT_MAX_RECTS_DXR];
+	const XrWeaveSubmitRectsDXR *batch =
+	    OXR_GET_INPUT_FROM_CHAIN(submitInfo, XR_TYPE_WEAVE_SUBMIT_RECTS_DXR, XrWeaveSubmitRectsDXR);
+	if (batch != NULL) {
+		if (batch->rectCount < 1 || batch->rectCount > XR_WEAVE_SUBMIT_MAX_RECTS_DXR) {
+			return oxr_error(&log, XR_ERROR_VALIDATION_FAILURE,
+			                 "xrWeaveSubmitDXR: XrWeaveSubmitRectsDXR::rectCount (%u) must be "
+			                 "1..XR_WEAVE_SUBMIT_MAX_RECTS_DXR (%u)",
+			                 batch->rectCount, (uint32_t)XR_WEAVE_SUBMIT_MAX_RECTS_DXR);
+		}
+		OXR_VERIFY_ARG_NOT_NULL(&log, batch->rects);
+		rect_count = batch->rectCount;
+		for (uint32_t i = 0; i < rect_count; i++) {
+			// xrt_offset names its fields w/h (see the @todo in xrt_defines.h);
+			// they are x/y here.
+			rects[i].offset.w = batch->rects[i].offset.x;
+			rects[i].offset.h = batch->rects[i].offset.y;
+			rects[i].extent.w = (int)batch->rects[i].extent.width;
+			rects[i].extent.h = (int)batch->rects[i].extent.height;
+		}
+	}
+
 	bool have_out = false;
 	uint32_t w = 0, h = 0;
 	uint64_t fence_value = 0;
@@ -150,8 +180,8 @@ oxr_xrWeaveSubmitDXR(XrSession session, const XrWeaveSubmitInfoDXR *submitInfo, 
 	xrt_result_t xret = comp_ipc_client_compositor_weave_submit(
 	    &sess->xcn->base, (xrt_graphics_buffer_handle_t)submitInfo->inputTexture,
 	    submitInfo->inputIsDxgi == XR_TRUE, submitInfo->rect.offset.x, submitInfo->rect.offset.y,
-	    (uint32_t)submitInfo->rect.extent.width, (uint32_t)submitInfo->rect.extent.height, &have_out, &w, &h,
-	    &fence_value, &eyes);
+	    (uint32_t)submitInfo->rect.extent.width, (uint32_t)submitInfo->rect.extent.height, rect_count,
+	    rect_count > 0 ? rects : NULL, &have_out, &w, &h, &fence_value, &eyes);
 	if (xret != XRT_SUCCESS) {
 		return oxr_error(&log, XR_ERROR_RUNTIME_FAILURE,
 		                 "xrWeaveSubmitDXR: weave failed (xrt_result=%d)", (int)xret);


### PR DESCRIPTION
## Summary
Lifts the ~8-12 visible inline-3d element ceiling: the GPU-process sync weave does one synchronous `xrWeaveSubmitDXR` per element per frame (~1 ms fixed cost each, serialized on Viz's present thread). This PR amortizes that to **ONE submit per frame carrying N rects** — 50 visible tiles ≈ cost of 1 — for the scrolling 3D-picture-wall use case (#625).

- **`XR_DXR_weave` SPEC_VERSION 2 → 3**: new chained `XrWeaveSubmitRectsDXR` (type `1004999192`, cap `XR_WEAVE_SUBMIT_MAX_RECTS_DXR` = 32). `sizeof(XrWeaveSubmitInfoDXR)` unchanged → old consumers need no rebuild.
- **Two input-layout contracts**, discriminated by the chain / `rect_count`:
  - absent / 0 = legacy element-sized 2×1 SBS atlas — byte-equivalent to v2
  - present / ≥1 = window-sized input, each rect's SBS content at its own window position
- **IPC**: `ipc_arg_weave_submit` widened with `rect_count` + fixed `ipc_weave_rect[32]` (pattern: `IPC_WORKSPACE_INPUT_EVENT_BATCH_MAX`); msg well within `IPC_BUF_SIZE`.
- **Service**: `process_atlas` samples its whole SRV as the atlas, so the batch loop copies each rect from the shared input into a cached exact-size scratch tile (keyed mutex released right after the copies), weaves every rect into the shared window-sized output, then signals the fence **once**. No DP/vendor-plugin change → no plugin-ABI gate.

## Validation
- `scripts\build_windows.bat build` green; deployed to Program Files.
- `displayxr-cli selftest` PASSED (Leia SR plugin active).
- Regression gate: existing tag+26 inline-3d browser (spec-v2 single-rect path) against the new service — `SYNC weave live`, **0 `xrWeaveSubmitDXR failed`**, zero-lag scroll intact, user-eyeballed on Leia hardware.
- Batch path exercised next by the Chromium-fork counterpart (displayxr-browser#12 series update).

The header change auto-syncs to `displayxr-extensions` on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)