### PR TITLE
chore: purge stale chroma-key rationale from runtime code + win32 spec

### DIFF
--- a/docs/specs/extensions/XR_DXR_win32_window_binding.md
+++ b/docs/specs/extensions/XR_DXR_win32_window_binding.md
@@ -138,7 +138,7 @@ The two concepts are inseparable: window-space layers only make sense when there
 | 5 | `chromaKeyColor` — optional app-supplied chroma-key override. `0` = runtime DP picks its own default. |
 | 6 | `xrSetSharedTextureSurround2DEXT` — register a full-window 2D shared texture for the non-canvas region. Enables apps with a fixed 3D zone (sub-rect canvas) to deliver full-resolution 2D content for the surrounding area. See [§3.6](#36-xrsetsharedtexturesurround2dext). |
 | 7 | `xrSetSharedTextureSurround2DFenceEXT` — D3D12 variant of §3.6 that uses `ID3D12Fence` for producer→consumer sync. D3D12-native shared resources do not reliably expose `IDXGIKeyedMutex`, so the spec-v6 API does not work for D3D12 apps. *(Removed in v8.)* |
-| 8 | Removed `xrSetSharedTextureOutputRectDXR` + `xrSetSharedTextureSurround2DEXT` + `xrSetSharedTextureSurround2DFenceEXT` — superseded by [`XR_DXR_display_zones`](XR_DXR_display_zones.md) (ADR-031). See [`docs/roadmap/surround-zones-deprecation.md`](../../roadmap/surround-zones-deprecation.md). |
+| 8 | Removed `xrSetSharedTextureOutputRectDXR` + `xrSetSharedTextureSurround2DEXT` + `xrSetSharedTextureSurround2DFenceEXT` — superseded by [`XR_DXR_display_zones`](XR_DXR_display_zones.md) (ADR-031). See [`docs/roadmap/surround-zones-deprecation.md`](../../roadmap/surround-zones-deprecation.md). **Also removed `chromaKeyColor`** (#573) — transparency is carried end-to-end by per-pixel alpha and a transparent present; the `set_chroma_key` slot is gone from all five display-processor vtables. |
 
 ### 3.2 XrWin32WindowBindingCreateInfoDXR
 
@@ -151,7 +151,6 @@ typedef struct XrWin32WindowBindingCreateInfoDXR {
     void*                       readbackUserdata;              // Passed to readbackCallback
     void*                       sharedTextureHandle;           // Shared D3D11/D3D12 texture HANDLE, or NULL
     XrBool32                    transparentBackgroundEnabled;  // SPEC v4: transparent desktop composition opt-in
-    uint32_t                    chromaKeyColor;                // SPEC v5: optional chroma-key override (0x00BBGGRR), 0 = DP picks
 } XrWin32WindowBindingCreateInfoDXR;
 ```
 
@@ -168,7 +167,6 @@ typedef struct XrWin32WindowBindingCreateInfoDXR {
 | `readbackUserdata` | Opaque pointer passed to `readbackCallback`. |
 | `sharedTextureHandle` | Shared D3D11/D3D12 texture `HANDLE` for zero-copy GPU texture sharing. If non-NULL, the runtime composites into this shared texture instead of rendering to a window. |
 | `transparentBackgroundEnabled` | (SPEC v4) When `XR_TRUE`, the runtime configures the bound HWND for per-pixel desktop transparency: app pixels written with `alpha = 1` appear opaque, `alpha = 0` regions composite through to the desktop. Per graphics API, the runtime picks the correct DXGI/DComp mechanism (apps shouldn't depend on which one). Only honored when `windowHandle` is non-NULL and the session is standalone (ignored in workspace/shell mode). **App-side HWND requirements** apply — see "Transparent-window contract" below. |
-| `chromaKeyColor` | (SPEC v5) Optional 0x00BBGGRR chroma-key override for the runtime's post-weave alpha-conversion pass. Only meaningful when `transparentBackgroundEnabled = XR_TRUE`. **`0` = the runtime's display processor picks its own default** (currently magenta `0x00FF00FF`). Non-zero overrides the default — useful for apps that need a content-safe key (e.g. v1.2.9 Unity plugin used gray to minimize fringing on dark scenes). The app should clear transparent regions of the swapchain to either `RGBA(0,0,0,0)` (preferred — DP fills with the key color internally) or `RGB = chromaKeyColor` with `alpha = 1` (legacy app-pre-fill flow, also supported). |
 
 **Three Modes:**
 
@@ -208,7 +206,7 @@ HWND hwnd = CreateWindowEx(
 
 Apps that already use a separate top-level overlay window for transparency (e.g. the displayxr-unity plugin's `displayxr_get_app_main_view`) just need to ensure that overlay HWND has `WS_EX_NOREDIRECTIONBITMAP` and a null background brush. Apps with a single-HWND design should add both flags to that HWND when transparent backgrounds are requested.
 
-**This is not optional.** The runtime cannot work around a redirection-surface-backed HWND because DWM compositing happens above the runtime's swapchain — the runtime's chroma-key strip writes correct alpha=0 pixels to the swapchain, but DWM blends them with the redirection surface before reaching the screen.
+**This is not optional.** The runtime cannot work around a redirection-surface-backed HWND because DWM compositing happens above the runtime's swapchain — the runtime writes correct alpha=0 pixels to the swapchain, but DWM blends them with the redirection surface before reaching the screen.
 
 The `_handle` and `_texture` modes both apply (any time `windowHandle` is non-NULL with transparency enabled). The `_offscreen` mode is unaffected — there's no HWND.
 
@@ -244,11 +242,11 @@ present from the topology.
 
 | Graphics API | Mechanism | Status |
 |---|---|---|
-| D3D11 (in-process) | `CreateSwapChainForComposition` + `DXGI_ALPHA_MODE_PREMULTIPLIED` + `IDCompositionTarget` bound to the app HWND. The vendor D3D11 DP reconstructs see-through via compose-under-bg (WGC), with chroma-key fill+strip as the fallback. | Shipping (PR #213). |
+| D3D11 (in-process) | `CreateSwapChainForComposition` + `DXGI_ALPHA_MODE_PREMULTIPLIED` + `IDCompositionTarget` bound to the app HWND. The vendor D3D11 DP reconstructs see-through via compose-under-bg (WGC). | Shipping (PR #213). |
 | D3D11 (IPC/service) | The **client** owns the DComp present over a shared NT-handle texture + service→client fence; the DP runs `client_presents` mode — post-weave **alpha-gate only**, no captured-background compose, so the live desktop blends with zero lag. See "IPC / service path" above + ADR-029. | Shipping (#551). |
 | D3D12 | Same as D3D11, plus the runtime explicitly passes the back-buffer RTV through to the strip pass (D3D12 has no `OMGetRenderTargets`). | Shipping (PR #213, PR #3a). |
-| Vulkan | Swapchain `compositeAlpha` runtime-selects `VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR` → `INHERIT` → `OPAQUE` based on `caps.supportedCompositeAlpha`. Most Win32 ICDs only expose `OPAQUE`, in which case alpha is dropped at the WSI present and a one-time warning is logged (the chroma-key strip still runs but its alpha output is invisible — the vendor weaver's RGB on a black background is what reaches the screen). The vendor VK DP runs chroma-key fill+strip via SPIR-V shaders compiled offline. | Shipping (PR #3c). |
-| OpenGL | `CreateSwapChainForComposition` + `DXGI_ALPHA_MODE_PREMULTIPLIED` + `IDCompositionTarget`, bridged from GL via `WGL_NV_DX_interop2`. The GL native compositor weaves into an **off-screen interop transit texture** (the proven `_texture`-app interop path), then a **D3D11 fullscreen-triangle shader blit** copies it into the flip-model DComp back buffer (an RTV write) → `Present` + `Commit`. This sidesteps the PR #3b failure, where the DP wove directly into the flip-model back buffer via interop and produced no visible content (the known `WGL_NV_DX_interop2`-into-flip-model incompatibility — `CopyResource` into that back buffer failed too, but RTV writes work). The vendor GL DP runs chroma-key fill+strip around its weaving stage (driven by `set_chroma_key`). Gated on an app-provided HWND with `WS_EX_NOREDIRECTIONBITMAP`; runtime-hosted GL windows are not yet covered. Falls back to opaque `SwapBuffers` if `WGL_NV_DX_interop2`/DComp are unavailable. | Shipping. |
+| Vulkan | Swapchain `compositeAlpha` runtime-selects `VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR` → `INHERIT` → `OPAQUE` based on `caps.supportedCompositeAlpha`. Most Win32 ICDs only expose `OPAQUE`, in which case alpha is dropped at the WSI present and a one-time warning is logged — the vendor weaver's RGB on a black background is what reaches the screen. | Shipping (PR #3c). |
+| OpenGL | `CreateSwapChainForComposition` + `DXGI_ALPHA_MODE_PREMULTIPLIED` + `IDCompositionTarget`, bridged from GL via `WGL_NV_DX_interop2`. The GL native compositor weaves into an **off-screen interop transit texture** (the proven `_texture`-app interop path), then a **D3D11 fullscreen-triangle shader blit** copies it into the flip-model DComp back buffer (an RTV write) → `Present` + `Commit`. This sidesteps the PR #3b failure, where the DP wove directly into the flip-model back buffer via interop and produced no visible content (the known `WGL_NV_DX_interop2`-into-flip-model incompatibility — `CopyResource` into that back buffer failed too, but RTV writes work). Gated on an app-provided HWND with `WS_EX_NOREDIRECTIONBITMAP`; runtime-hosted GL windows are not yet covered. Falls back to opaque `SwapBuffers` if `WGL_NV_DX_interop2`/DComp are unavailable. | Shipping. |
 | Metal (macOS) | `CAMetalLayer.isOpaque = NO` + `NSWindow` non-opaque. App is responsible for the `NSWindow.opaque` flag. | Shipping (PR #4). |
 
 ### 3.3 XrCompositionLayerWindowSpaceDXR

--- a/src/external/openxr_includes/openxr/XR_DXR_win32_window_binding.h
+++ b/src/external/openxr_includes/openxr/XR_DXR_win32_window_binding.h
@@ -92,8 +92,8 @@ typedef struct XrWin32WindowBindingCreateInfoDXR {
     void*                       sharedTextureHandle;   //!< Shared D3D11/D3D12 texture HANDLE for zero-copy, or NULL
     //! When XR_TRUE, the runtime configures the bound HWND for transparent desktop
     //! composition: pixels written by the app with full opacity appear opaque on screen,
-    //! and pixels written transparent (alpha = 0, or matching a chroma key set by the
-    //! app via SetLayeredWindowAttributes) compose through to the desktop underneath.
+    //! and pixels written transparent (alpha = 0) compose through to the desktop
+    //! underneath.
     //! The runtime picks the appropriate DXGI / Windows mechanism per graphics API;
     //! apps should not depend on which one. Only honored when windowHandle is non-NULL
     //! and the session is standalone — ignored in workspace/shell mode.

--- a/src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp
+++ b/src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp
@@ -2242,12 +2242,25 @@ d3d12_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handl
 			// HUD overlay
 			d3d12_render_hud_overlay(c, c->cmd_list, back_buffer, tgt_width, tgt_height, &eye_pos);
 
-			// Transition back buffer COPY_DEST -> PRESENT. The chroma-key
-			// post-weave alpha conversion (when needed) runs inside the Leia
-			// D3D12 display processor's process_atlas, which leaves the back
-			// buffer in RENDER_TARGET. The D3D12 weaver however leaves the
-			// back buffer in RENDER_TARGET pre-HUD; the HUD path puts it in
-			// COPY_DEST here. So source state matches the HUD's exit state.
+			// Transition back buffer -> PRESENT, assuming the HUD overlay above
+			// left it in COPY_DEST.
+			//
+			// UNSOUND — tracked as #747. This StateBefore is an ASSUMPTION, not
+			// a tracked state: process_atlas hands the back buffer to the vendor
+			// display processor, which is a plug-in DLL (ADR-019) free to leave
+			// it in any state, and D3D12 offers no way to query it back. The
+			// assumption is unverifiable here and wrong states are undefined
+			// behaviour — a credible mechanism for the DEVICE_HUNG seen during
+			// interactive resize churn.
+			//
+			// The fix belongs in the plug-in contract (xrt_plugin_iface should
+			// SPECIFY the required entry state and the guaranteed exit state for
+			// the atlas and the target), not in more guessing here. Do not
+			// "improve" this by inferring what a particular vendor's DP does
+			// internally — that was the previous comment's mistake, and it
+			// justified this state by describing a chroma-key alpha pass that
+			// #573 deleted (set_chroma_key is gone from all five DP vtables;
+			// see xrt_plugin.h). The reasoning outlived the mechanism.
 			barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_COPY_DEST;
 			barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_PRESENT;
 			c->cmd_list->ResourceBarrier(1, &barrier);

--- a/src/xrt/compositor/gl/comp_gl_compositor.cpp
+++ b/src/xrt/compositor/gl/comp_gl_compositor.cpp
@@ -268,7 +268,7 @@ static const char *FS_MASKED_COMPOSITE =
 // #439 Phase 3 — authored zone mask (XR_DXR_local_3d_zone), GL R8 texture.
 // In-process handle apps author it on the same GL context the composite
 // samples from, frame-serialized, so a single texture (no staged copy) is
-// coherent. Tier-3 acquire_rt is unimplemented on GL (chroma-key-only DP).
+// coherent. Tier-3 acquire_rt is unimplemented on GL.
 struct comp_gl_zone_mask
 {
 	GLuint tex;  //!< R8 mask, M in [0,1] (1 = 3D / keep weave).


### PR DESCRIPTION
## Why

`#573` deleted chroma-key: `set_chroma_key` is gone from all five DP vtables (`xrt_plugin.h`), `chromaKeyColor` is gone from `XrWin32WindowBindingCreateInfoDXR` (SPEC_VERSION 7→8), ABI moved to v4. **The mechanism is gone; the prose wasn't** — and in three places it still described chroma-key as a *live code path*.

Found while investigating #747. **Comment/doc only — no functional change.**

## What was wrong

**1. `comp_d3d12_compositor.cpp` — stale rationale + vendor name in runtime source**

```cpp
// Transition back buffer COPY_DEST -> PRESENT. The chroma-key
// post-weave alpha conversion (when needed) runs inside the Leia
// D3D12 display processor's process_atlas, which leaves the back
// buffer in RENDER_TARGET. ...
```

This is the stated justification for a barrier `StateBefore` that the D3D12 debug layer flags (#747). It reasons from a mechanism deleted in #573, **and** names a vendor in runtime code. Replaced with what's actually true: the state is an **assumption** about what a plug-in DLL (ADR-019) leaves behind — unqueryable in D3D12 and therefore unverifiable here — flagged as #747, and pointed at the real fix (the plug-in contract should *specify* entry/exit states) so the next reader doesn't try to guess harder.

**Barrier states are unchanged.** Correcting them is #747 work and needs hardware validation.

**2. `XR_DXR_win32_window_binding.h` — self-contradicting, and app-facing**

Said pixels compose through when *"matching a chroma key set by the app via `SetLayeredWindowAttributes`"* — six lines above a note saying #573 removed the field. This header ships to app authors via `displayxr-extensions`.

**3. `docs/specs/extensions/XR_DXR_win32_window_binding.md` — worse than the header**

`chromaKeyColor` was still in the **struct listing** and the **field table** as a live field, documenting a field that does not exist. The documented struct now matches the header exactly. Removal recorded in the v8 history row (v5's row stays — it's history, and true). Also dropped chroma-key from the D3D11/VK/GL mechanism table and the redirection-surface note, which described fill+strip as *Shipping*.

**4. `comp_gl_compositor.cpp`** — dropped a stale `(chroma-key-only DP)` rationale.

## Left alone deliberately

Every remaining mention is a **negative or historical** reference — "chroma-key-free", "no chroma-key trick needed", "lets chroma-key be deleted everywhere". Those correctly document its absence and are worth keeping.

## Risk

None functional — only `//` comments, `//!` doc-comments, and markdown. The header edit touches a doc-comment block only; no struct/ABI change (verified: doc struct == header struct, field for field).

Refs #747