### PR TITLE
diag(#747): name D3D12 objects for debug-layer attribution + full-session info-queue drain

### DIFF
--- a/src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp
+++ b/src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp
@@ -1136,6 +1136,7 @@ d3d12_crop_atlas_for_dp(struct comp_d3d12_compositor *c,
 			        content_w, content_h, hr);
 			return atlas_resource;
 		}
+		c->dp_input_resource->SetName(L"DXR.dp_input_crop"); // #747: debug-layer attribution
 
 		c->dp_input_width = content_w;
 		c->dp_input_height = content_h;
@@ -2615,6 +2616,12 @@ comp_d3d12_compositor_create(struct xrt_device *xdev,
 		d3d12_compositor_destroy(&c->base.base);
 		return XRT_ERROR_D3D;
 	}
+	// #747: name the list, not just the resources. The compositor SHARES the
+	// app's device, so the debug layer's complaints interleave ours with the
+	// app's — and with everything unnamed there is no way to tell whose barrier
+	// is at fault. The list name attributes the barrier; the resource name
+	// identifies the target. Debug-layer-only metadata.
+	c->cmd_list->SetName(L"DXR.compositor_cmd_list");
 	// Command list is created in recording state, close it
 	c->cmd_list->Close();
 
@@ -2648,6 +2655,12 @@ comp_d3d12_compositor_create(struct xrt_device *xdev,
 			return XRT_ERROR_D3D;
 		}
 		c->has_shared_texture = true;
+
+		// #747: name it. The D3D12 debug layer identifies resources by name, and
+		// with none set every barrier complaint reads "Unnamed ID3D12Resource
+		// Object" — which is why the id-527 spam could be seen but not
+		// attributed. Names are debug-layer-only metadata (ignored without it).
+		c->shared_texture->SetName(L"DXR.app_shared_texture");
 
 		// Query shared texture dimensions
 		D3D12_RESOURCE_DESC st_desc = c->shared_texture->GetDesc();
@@ -3395,6 +3408,7 @@ d3d12_ensure_local2d_scratch(struct comp_d3d12_compositor *c, uint32_t w, uint32
 		c->local2d_scratch = nullptr;
 		return false;
 	}
+	c->local2d_scratch->SetName(L"DXR.local2d_scratch"); // #747: debug-layer attribution
 
 	if (c->local2d_scratch_rtv_heap == nullptr) {
 		D3D12_DESCRIPTOR_HEAP_DESC rtv_desc = {};

--- a/src/xrt/compositor/d3d12/comp_d3d12_renderer.cpp
+++ b/src/xrt/compositor/d3d12/comp_d3d12_renderer.cpp
@@ -490,6 +490,9 @@ create_atlas_texture(struct comp_d3d12_renderer *r, ID3D12Device *device, uint32
 		return XRT_ERROR_D3D;
 	}
 
+	// #747: name it so the debug layer can attribute barrier complaints.
+	r->atlas_texture->SetName(L"DXR.atlas_texture");
+
 	// Create RTV for atlas texture
 	D3D12_CPU_DESCRIPTOR_HANDLE rtv_handle = r->rtv_heap->GetCPUDescriptorHandleForHeapStart();
 	device->CreateRenderTargetView(r->atlas_texture, nullptr, rtv_handle);

--- a/test_apps/texture/cube_zones_texture_d3d12_win/d3d12_renderer.cpp
+++ b/test_apps/texture/cube_zones_texture_d3d12_win/d3d12_renderer.cpp
@@ -641,6 +641,7 @@ bool InitializeD3D12WithLUID(D3D12Renderer& renderer, LUID adapterLuid) {
     hr = renderer.device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT,
         renderer.commandAllocator.Get(), nullptr, IID_PPV_ARGS(&renderer.commandList));
     if (FAILED(hr)) return false;
+    renderer.commandList->SetName(L"APP.renderer_cmd_list"); // #747 attribution
     renderer.commandList->Close(); // Start closed; Reset before use
 
     // Create resources

--- a/test_apps/texture/cube_zones_texture_d3d12_win/d3d12_renderer.cpp
+++ b/test_apps/texture/cube_zones_texture_d3d12_win/d3d12_renderer.cpp
@@ -10,6 +10,8 @@
 #include "mip_chain.h"
 #include <d3d12sdklayers.h>
 #include <cmath>
+#include <map>
+#include <vector>
 
 #define STB_IMAGE_IMPLEMENTATION
 #include "stb_image.h"
@@ -824,6 +826,65 @@ void UpdateScene(D3D12Renderer& renderer, float deltaTime) {
     }
 }
 
+// #747 diagnostic — see the call site in RenderScene for why this exists.
+// DXR_D3D12_DEBUG=1 to enable.
+static void DrainD3D12DebugMessages(D3D12Renderer& renderer) {
+    static int enabled = -1;
+    if (enabled < 0) {
+        const char* v = getenv("DXR_D3D12_DEBUG");
+        enabled = (v != nullptr && v[0] != '\0' && v[0] != '0') ? 1 : 0;
+        if (enabled) {
+            LOG_WARN("#747 DXR_D3D12_DEBUG=1 — draining the D3D12 debug layer info queue "
+                     "every frame (this device is shared with the in-process compositor, "
+                     "so runtime barriers are validated too)");
+        }
+    }
+    if (!enabled || renderer.device == nullptr) {
+        return;
+    }
+
+    ComPtr<ID3D12InfoQueue> q;
+    if (FAILED(renderer.device->QueryInterface(IID_PPV_ARGS(&q)))) {
+        return;
+    }
+
+    static std::map<int, uint64_t> seen;  // message ID -> occurrences
+    const UINT64 n = q->GetNumStoredMessages();
+    for (UINT64 i = 0; i < n; i++) {
+        SIZE_T len = 0;
+        q->GetMessage(i, nullptr, &len);
+        if (len == 0) {
+            continue;
+        }
+        std::vector<char> buf(len);
+        auto* m = reinterpret_cast<D3D12_MESSAGE*>(buf.data());
+        if (FAILED(q->GetMessage(i, m, &len))) {
+            continue;
+        }
+        auto it = seen.find((int)m->ID);
+        if (it == seen.end()) {
+            seen.emplace((int)m->ID, 1);
+            // First sighting of each ID prints in full — that is the actionable line.
+            LOG_WARN("#747 D3D12 debug FIRST id=%d sev=%d: %s", (int)m->ID, (int)m->Severity,
+                     m->pDescription != nullptr ? m->pDescription : "(no description)");
+        } else {
+            it->second++;
+        }
+    }
+    q->ClearStoredMessages();
+
+    // Periodic totals — the RATE is the tell (#747 reports ~5/frame).
+    static uint32_t frames = 0;
+    frames++;
+    if (frames % 300 == 0 && !seen.empty()) {
+        for (const auto& kv : seen) {
+            LOG_WARN("#747 D3D12 debug TOTAL id=%d count=%llu over %u frames (%.2f/frame)",
+                     kv.first, (unsigned long long)kv.second, frames,
+                     (double)kv.second / (double)frames);
+        }
+    }
+}
+
 void RenderScene(
     D3D12Renderer& renderer,
     ID3D12Resource* renderTarget,
@@ -1034,6 +1095,23 @@ void RenderScene(
         renderer.fence->SetEventOnCompletion(renderer.fenceValue, renderer.fenceEvent);
         WaitForSingleObject(renderer.fenceEvent, INFINITE);
     }
+
+    // #747: drain the debug layer's info queue for the WHOLE session, not just
+    // the warmup.
+    //
+    // The debug layer is enabled unconditionally in InitializeD3D12WithLUID, and
+    // the in-process compositor REUSES this app's device
+    // (comp_d3d12_compositor.cpp: `c->device = static_cast<ID3D12Device*>(
+    // d3d12_device)`), so validation already covers the RUNTIME's barriers —
+    // which is exactly how #747's id-527 ResourceBarrier before-state spam
+    // surfaced under Unity's -force-d3d12-debug. Nothing needed enabling; the
+    // messages were simply never read. The 3-frame drain below can't see them:
+    // the compositor barriers on xrEndFrame, after this function, and the DP
+    // path isn't live during warmup.
+    //
+    // Env-gated (draining every frame costs) and deduped by message ID, so
+    // per-frame spam logs once with a periodic total instead of flooding.
+    DrainD3D12DebugMessages(renderer);
 
     // Drain D3D12 debug messages (first 3 frames only)
     if (renderDiag) {

--- a/test_apps/texture/cube_zones_texture_d3d12_win/main.cpp
+++ b/test_apps/texture/cube_zones_texture_d3d12_win/main.cpp
@@ -727,6 +727,11 @@ static void CreateSharedTextureSRV(ID3D12Device* device) {
 static bool CreateAppSwapchainRTVs(ID3D12Device* device) {
     for (UINT i = 0; i < APP_BACK_BUFFER_COUNT; i++) {
         HRESULT hr = g_appSwapchain->GetBuffer(i, IID_PPV_ARGS(&g_appBackBuffers[i]));
+        if (SUCCEEDED(hr) && g_appBackBuffers[i]) {
+            wchar_t nm[64];
+            swprintf_s(nm, L"APP.backbuffer[%u]", i);   // #747 attribution
+            g_appBackBuffers[i]->SetName(nm);
+        }
         if (FAILED(hr)) return false;
 
         D3D12_CPU_DESCRIPTOR_HANDLE rtvHandle = g_appRtvHeap->GetCPUDescriptorHandleForHeapStart();
@@ -1427,6 +1432,7 @@ static bool EnsureZoneCmdResources(D3D12Renderer& renderer) {
             IID_PPV_ARGS(&g_zoneCmdAlloc)))) return false;
     if (FAILED(renderer.device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT,
             g_zoneCmdAlloc.Get(), nullptr, IID_PPV_ARGS(&g_zoneCmdList)))) return false;
+    g_zoneCmdList->SetName(L"APP.zone_cmd_list"); // #747 attribution
     g_zoneCmdList->Close();
     if (FAILED(renderer.device->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&g_zoneFence))))
         return false;
@@ -2909,6 +2915,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
     {
         renderer.device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&g_blitCmdAllocator));
         renderer.device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, g_blitCmdAllocator.Get(), nullptr, IID_PPV_ARGS(&g_blitCmdList));
+        g_blitCmdList->SetName(L"APP.blit_cmd_list"); // #747 attribution
         g_blitCmdList->Close();
         renderer.device->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&g_blitFence));
         g_blitFenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
@@ -3115,6 +3122,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         if (hudOk) {
             renderer.device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&hudCmdAllocator));
             renderer.device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, hudCmdAllocator.Get(), nullptr, IID_PPV_ARGS(&hudCmdList));
+            if (hudCmdList) hudCmdList->SetName(L"APP.hud_cmd_list"); // #747 attribution
             hudCmdList->Close();
             renderer.device->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&hudFence));
             hudFenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);


### PR DESCRIPTION
## Why

The D3D12 debug layer identifies objects **by name**. The runtime set none, so every barrier complaint reads `'Unnamed ID3D12Resource Object'` / `'Unnamed ID3D12GraphicsCommandList Object'` — which is why #747's id-527 spam could be **seen but never attributed**.

This landed a real lesson: I had a grep-derived hypothesis that `c->shared_texture` was left in `RENDER_TARGET` by an unbalanced path (`:1872` `COMMON→RT` vs `:1961` `RT→COMMON` vs `:2020`). With names on, the actual message was:

```
id=527 ... ResourceBarrier on Command List ('APP.hud_cmd_list'):
  Before state (COMMON|PRESENT) of resource ... does not match with the state (RENDER_TARGET)
```

**The test app's own HUD path — not the compositor**, which emitted **zero** id-527 across 1800+ frames of texture-mode zones work. Without names I would have "fixed" a correct runtime barrier while chasing a defect in a different component.

## What

**Runtime** (`SetName`, debug-layer-only metadata — ignored when the layer is off, zero cost):
`DXR.compositor_cmd_list`, `DXR.app_shared_texture`, `DXR.atlas_texture`, `DXR.local2d_scratch`, `DXR.dp_input_crop`

Naming the **command list** is the load-bearing part: the in-process compositor shares the app's **device and queue**, so the layer interleaves our complaints with the app's and a resource name alone can't say whose barrier is at fault.

**Test app** (`cube_zones_texture_d3d12_win`): `APP.*` names + `DXR_D3D12_DEBUG=1`, an env-gated full-session info-queue drain, deduped by message ID (first sighting prints in full, then a periodic per-ID rate).

## Worth knowing

**Nothing needed enabling.** That app already forces the debug layer on unconditionally, and the compositor reuses the app's device (`comp_d3d12_compositor.cpp:2592`) — so runtime barriers have been validated on every run of it all along. The messages were simply never read; the pre-existing drain caps at 3 frames and can't see them (the compositor barriers on `xrEndFrame`, after `RenderScene`, and the DP path isn't live during warmup). #747 never needed Unity to surface — it needed someone to look.

**The reported "~5/frame" is ~85% noise:**

| id | severity | rate | what |
|---|---|---|---|
| 527 | ERROR | ~0.51/frame | the actual barrier bug |
| 820 | WARNING | ~4.46/frame | `ClearRenderTargetView` clear-value mismatch — perf hint, benign |

## Scope

Does **not** fix #747 and does not clear the runtime — my repro is a same-signature bug elsewhere, and it doesn't exercise Unity's paths (interactive resize churn, `xrDestroySwapchain` → recreate). This is the instrument, not the fix. Landing it so the next `-force-d3d12-debug` run attributes the barrier in one line instead of requiring a branch build.

## Risk

None functional. `SetName` is debug-layer metadata; the drain is env-gated and off by default. Verified the names reach the built DLL (UTF-16) and that a dev-runtime run attributes correctly.

Refs #747