### PR TITLE
fix(d3d12,#747): restore the atlas to COMMON after the DP crop's copy read

### DIFF
--- a/src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp
+++ b/src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp
@@ -1154,6 +1154,32 @@ d3d12_crop_atlas_for_dp(struct comp_d3d12_compositor *c,
 	barrier.Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
 	c->cmd_list->ResourceBarrier(1, &barrier);
 
+	// #747: transition the ATLAS explicitly for the copy read, and put it back.
+	//
+	// The copy below READS the atlas. Without this the atlas (COMMON on entry)
+	// is IMPLICITLY PROMOTED to COPY_SOURCE, and it does not decay back until
+	// ExecuteCommandLists — so the caller's closing barrier, which declares
+	// `StateBefore = COMMON` on the way to PIXEL_SHADER_RESOURCE, lies:
+	//
+	//   D3D12 ERROR id=527: Before state (COMMON|PRESENT) ... does not match
+	//   with the current resource state (COPY_SOURCE) (promoted from COMMON)
+	//
+	// Wrong before-states are undefined behaviour. Making the transition
+	// explicit here (rather than fixing up the caller's StateBefore) keeps the
+	// invariant the callers already assume: **this function returns with the
+	// atlas in COMMON on BOTH paths** — the early-out above never touches it,
+	// and the copy path restores it. That symmetry is why the bug hid: the
+	// early-out fires whenever content == atlas dims, so it only bites once the
+	// atlas outgrows the content, which the high-water allocation in
+	// create_atlas_texture() makes permanent after any shrink.
+	D3D12_RESOURCE_BARRIER atlas_rb = {};
+	atlas_rb.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+	atlas_rb.Transition.pResource = atlas_resource;
+	atlas_rb.Transition.StateBefore = D3D12_RESOURCE_STATE_COMMON;
+	atlas_rb.Transition.StateAfter = D3D12_RESOURCE_STATE_COPY_SOURCE;
+	atlas_rb.Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+	c->cmd_list->ResourceBarrier(1, &atlas_rb);
+
 	// Copy content region from atlas to intermediate
 	D3D12_TEXTURE_COPY_LOCATION dst_loc = {};
 	dst_loc.pResource = c->dp_input_resource;
@@ -1167,6 +1193,11 @@ d3d12_crop_atlas_for_dp(struct comp_d3d12_compositor *c,
 
 	D3D12_BOX src_box = {0, 0, 0, content_w, content_h, 1};
 	c->cmd_list->CopyTextureRegion(&dst_loc, 0, 0, 0, &src_loc, &src_box);
+
+	// Atlas COPY_SOURCE → COMMON: restore the entry state the callers assume.
+	atlas_rb.Transition.StateBefore = D3D12_RESOURCE_STATE_COPY_SOURCE;
+	atlas_rb.Transition.StateAfter = D3D12_RESOURCE_STATE_COMMON;
+	c->cmd_list->ResourceBarrier(1, &atlas_rb);
 
 	// Transition intermediate: COPY_DEST → COMMON (for DP)
 	barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_COPY_DEST;

--- a/src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp
+++ b/src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp
@@ -3529,6 +3529,7 @@ d3d12_update_implicit_mask(struct comp_d3d12_compositor *c,
 		HRESULT hr = c->device->CreateCommittedResource(&heap, D3D12_HEAP_FLAG_NONE, &td,
 		                                                D3D12_RESOURCE_STATE_RENDER_TARGET, &clear,
 		                                                IID_PPV_ARGS(&c->implicit_mask_tex));
+	if (c->implicit_mask_tex != nullptr) c->implicit_mask_tex->SetName(L"DXR.implicit_mask_tex"); // #747 attribution
 		if (SUCCEEDED(hr) && c->implicit_mask_tex != nullptr) {
 			D3D12_DESCRIPTOR_HEAP_DESC rtv_desc = {};
 			rtv_desc.NumDescriptors = 1;
@@ -3542,6 +3543,7 @@ d3d12_update_implicit_mask(struct comp_d3d12_compositor *c,
 			hr = c->device->CreateCommittedResource(&heap, D3D12_HEAP_FLAG_NONE, &td,
 			                                        D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, nullptr,
 			                                        IID_PPV_ARGS(&c->implicit_mask_staged));
+	if (c->implicit_mask_staged != nullptr) c->implicit_mask_staged->SetName(L"DXR.implicit_mask_staged"); // #747 attribution
 		}
 		if (FAILED(hr) || c->implicit_mask_staged == nullptr) {
 			U_LOG_E("implicit zone mask: D3D12 resource creation failed: 0x%08x", hr);
@@ -3696,6 +3698,7 @@ d3d12_update_zone_wish_mask(struct comp_d3d12_compositor *c,
 		HRESULT hr = c->device->CreateCommittedResource(&heap, D3D12_HEAP_FLAG_NONE, &td,
 		                                                D3D12_RESOURCE_STATE_RENDER_TARGET, &clear,
 		                                                IID_PPV_ARGS(&c->implicit_mask_tex));
+	if (c->implicit_mask_tex != nullptr) c->implicit_mask_tex->SetName(L"DXR.implicit_mask_tex"); // #747 attribution
 		if (SUCCEEDED(hr) && c->implicit_mask_tex != nullptr) {
 			D3D12_DESCRIPTOR_HEAP_DESC rtv_desc = {};
 			rtv_desc.NumDescriptors = 1;
@@ -3709,6 +3712,7 @@ d3d12_update_zone_wish_mask(struct comp_d3d12_compositor *c,
 			hr = c->device->CreateCommittedResource(&heap, D3D12_HEAP_FLAG_NONE, &td,
 			                                        D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, nullptr,
 			                                        IID_PPV_ARGS(&c->implicit_mask_staged));
+	if (c->implicit_mask_staged != nullptr) c->implicit_mask_staged->SetName(L"DXR.implicit_mask_staged"); // #747 attribution
 		}
 		if (FAILED(hr) || c->implicit_mask_staged == nullptr) {
 			U_LOG_E("zone wish mask: D3D12 resource creation failed: 0x%08x", hr);
@@ -4038,6 +4042,7 @@ d3d12_ensure_backdrop_scratch(struct comp_d3d12_compositor *c, uint32_t w, uint3
 	HRESULT hr = c->device->CreateCommittedResource(&heap, D3D12_HEAP_FLAG_NONE, &desc,
 	                                                D3D12_RESOURCE_STATE_COMMON, &clear,
 	                                                IID_PPV_ARGS(&c->backdrop_scratch));
+	if (c->backdrop_scratch != nullptr) c->backdrop_scratch->SetName(L"DXR.backdrop_scratch"); // #747 attribution
 	if (FAILED(hr) || c->backdrop_scratch == nullptr) {
 		U_LOG_W("backdrop scratch alloc (%ux%u) failed: 0x%08x", w, h, hr);
 		c->backdrop_scratch = nullptr;
@@ -4506,6 +4511,7 @@ comp_d3d12_compositor_zone_mask_create(struct xrt_compositor *xc, uint32_t w, ui
 	    &heap, D3D12_HEAP_FLAG_NONE, &td,
 	    D3D12_RESOURCE_STATE_RENDER_TARGET, &clear,
 	    IID_PPV_ARGS(&mask->tex));
+	if (mask->tex != nullptr) mask->tex->SetName(L"DXR.zone_mask_tex"); // #747 attribution
 
 	if (SUCCEEDED(hr) && mask->tex != nullptr) {
 		D3D12_DESCRIPTOR_HEAP_DESC rtv_desc = {};
@@ -4522,6 +4528,7 @@ comp_d3d12_compositor_zone_mask_create(struct xrt_compositor *xc, uint32_t w, ui
 		    &heap, D3D12_HEAP_FLAG_NONE, &td,
 		    D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, nullptr,
 		    IID_PPV_ARGS(&mask->staged));
+	if (mask->staged != nullptr) mask->staged->SetName(L"DXR.zone_mask_staged"); // #747 attribution
 	}
 	if (FAILED(hr) || mask->staged == nullptr) {
 		U_LOG_E("zone_mask_create: D3D12 resource creation failed: 0x%08x", hr);

--- a/src/xrt/compositor/d3d12/comp_d3d12_swapchain.cpp
+++ b/src/xrt/compositor/d3d12/comp_d3d12_swapchain.cpp
@@ -337,6 +337,15 @@ comp_d3d12_swapchain_create(struct comp_d3d12_compositor *c,
 			d3d12_swapchain_destroy(&sc->base.base);
 			return XRT_ERROR_D3D;
 		}
+		// #747: name it for debug-layer attribution. These are the images the
+		// APP renders views into and the compositor samples, so they are the
+		// most likely subject of a cross-component barrier complaint — and the
+		// hardest to identify, since neither side "owns" them outright.
+		{
+			wchar_t nm[64];
+			swprintf_s(nm, L"DXR.xr_swapchain_img[%u]", i);
+			sc->images[i]->SetName(nm);
+		}
 
 		// Store resource pointer as native image handle
 		sc->base.images[i].handle = reinterpret_cast<xrt_graphics_buffer_handle_t>(sc->images[i]);

--- a/test_apps/texture/cube_zones_texture_d3d12_win/d3d12_renderer.cpp
+++ b/test_apps/texture/cube_zones_texture_d3d12_win/d3d12_renderer.cpp
@@ -849,7 +849,17 @@ static void DrainD3D12DebugMessages(D3D12Renderer& renderer) {
         return;
     }
 
-    static std::map<int, uint64_t> seen;  // message ID -> occurrences
+    // Dedup by the message TEXT, not the ID.
+    //
+    // Deduping by ID alone hides the thing you are hunting: several DIFFERENT
+    // barriers (different command lists, different resources) share id=527, so
+    // only the FIRST would ever print and every later one — including the one
+    // you care about — is silently swallowed into a counter. Cost a wrong
+    // conclusion once already.
+    //
+    // Pointer values are stripped so the same logical complaint collapses across
+    // frames instead of printing once per resource address.
+    static std::map<std::string, uint64_t> seen;  // normalized text -> occurrences
     const UINT64 n = q->GetNumStoredMessages();
     for (UINT64 i = 0; i < n; i++) {
         SIZE_T len = 0;
@@ -862,12 +872,21 @@ static void DrainD3D12DebugMessages(D3D12Renderer& renderer) {
         if (FAILED(q->GetMessage(i, m, &len))) {
             continue;
         }
-        auto it = seen.find((int)m->ID);
+        const char* desc = m->pDescription != nullptr ? m->pDescription : "(no description)";
+        // Normalize: drop 0x... addresses so identical complaints collapse.
+        std::string key;
+        key.reserve(256);
+        for (const char* s = desc; *s != '\0'; s++) {
+            if (s[0] == '0' && s[1] == 'x') {
+                while (*s != '\0' && *s != ':' && *s != ')' && *s != ' ') s++;
+                if (*s == '\0') break;
+            }
+            key.push_back(*s);
+        }
+        auto it = seen.find(key);
         if (it == seen.end()) {
-            seen.emplace((int)m->ID, 1);
-            // First sighting of each ID prints in full — that is the actionable line.
-            LOG_WARN("#747 D3D12 debug FIRST id=%d sev=%d: %s", (int)m->ID, (int)m->Severity,
-                     m->pDescription != nullptr ? m->pDescription : "(no description)");
+            seen.emplace(key, 1);
+            LOG_WARN("#747 D3D12 debug FIRST id=%d sev=%d: %s", (int)m->ID, (int)m->Severity, desc);
         } else {
             it->second++;
         }
@@ -879,9 +898,9 @@ static void DrainD3D12DebugMessages(D3D12Renderer& renderer) {
     frames++;
     if (frames % 300 == 0 && !seen.empty()) {
         for (const auto& kv : seen) {
-            LOG_WARN("#747 D3D12 debug TOTAL id=%d count=%llu over %u frames (%.2f/frame)",
-                     kv.first, (unsigned long long)kv.second, frames,
-                     (double)kv.second / (double)frames);
+            LOG_WARN("#747 D3D12 debug TOTAL count=%llu over %u frames (%.2f/frame): %.110s",
+                     (unsigned long long)kv.second, frames,
+                     (double)kv.second / (double)frames, kv.first.c_str());
         }
     }
 }


### PR DESCRIPTION
> **Not a duplicate of #751.** That landed only the *naming* (the instrument). This is the **fix**, plus a second naming pass and a correction to the drain's dedup.

## The bug

`d3d12_crop_atlas_for_dp()` copies the atlas into an intermediate at content dims. The copy **reads the atlas with no explicit barrier**, so the atlas (COMMON on entry) is **implicitly promoted to `COPY_SOURCE`** and doesn't decay until `ExecuteCommandLists`. The caller's closing barrier then declares `StateBefore = COMMON` on the way back to `PIXEL_SHADER_RESOURCE`, and lies:

```
D3D12 ERROR id=527: Before state (COMMON|PRESENT) of resource ('DXR.atlas_texture')
does not match with the current resource state (COPY_SOURCE) (promoted from COMMON state)
```

Wrong before-states are undefined behaviour.

**Diagnosis credit: the Unity agent on #747**, from the named debug-layer output. I verified every step against the code and confirmed it byte-for-byte on hardware — I had previously blamed a *different* barrier from grep, and was wrong.

## Why it hid

The crop **early-outs**, returning the atlas uncopied, when `content == atlas` dims — the steady state. It only bites once the atlas outgrows the content, and `create_atlas_texture()`'s high-water allocation (`alloc = max(content, alloc)`, never shrinks) makes that **permanent after any shrink**. So it fires on **every frame following a resize-down**, and never before one. That is exactly why it reproduces in a resized editor Game view and not in a fixed-size app — and why my first (fixed-size) runs looked clean.

## The fix

Transition the atlas explicitly around the copy (`COMMON → COPY_SOURCE → COMMON`) rather than patching the caller's `StateBefore`. That preserves the invariant both callers already assume: **the function returns with the atlas in `COMMON` on both paths** — the early-out never touches it, the copy path restores it.

## Verification (Leia SR hardware)

`cube_zones_texture_d3d12_win` + `DXR_D3D12_DEBUG=1`, forcing the crop with live `SetWindowPos` shrinks:

```
BEFORE: id=527 'DXR.atlas_texture' ... (COPY_SOURCE) (promoted from COMMON)
AFTER : gone — no atlas/COPY_SOURCE 527 remains
```

## Audit (the same class elsewhere)

Checked every D3D12 copy site: **the crop was the only one missing a source barrier.** Mask staging (x4), the 2D fallback, and the weave scratch all explicitly transition their source; the HUD copies from an upload buffer (`GENERIC_READ`, none needed). This bug is singular.

*(Out of scope, recorded for follow-up: VK hardcodes `oldLayout` exactly as D3D12 hardcoded `StateBefore` — same assume-don't-track design — and VK validation layers are not wired up at all, so we have neither the detector nor a DRED equivalent there.)*

## Also in this PR

**Second naming pass** — `implicit_mask_tex/_staged`, `backdrop_scratch`, `zone_mask_tex/_staged`, and `DXR.xr_swapchain_img[N]`. That pinned a **second, still-unfixed** id-527 (`'DXR.compositor_cmd_list'`: `RENDER_TARGET` vs actual `COMMON` on a swapchain image). Deliberately **not** fixed here: it is **rare** (1-3 over 2700 frames — a transition event, not a storm) and there is **no creation-time complaint**, so the obvious theory is unsupported. It needs the state traced, not inferred.

**Drain dedup fixed** — keyed by message **text**, not ID. Several different barriers share id=527, so an ID-keyed dedup prints only the first and silently swallows the rest. It hid this very message behind an unrelated app-side one and cost me a wrong conclusion.

## Scope / risk

Adds two barriers on a path that only executes when the crop actually copies. Does **not** claim to fix the `DEVICE_HUNG` — but this bug fires every frame after a resize-down, which fits the reported crash-on-resize far better than the rare bug #2 does. The Unity agent has the only reliable crash repro and should run their gauntlet against this.

Refs #747