### PR TITLE
fix(d3d12,#747): read DRED when the compositor sees the device reset

### DIFF
--- a/src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp
+++ b/src/xrt/compositor/d3d12/comp_d3d12_compositor.cpp
@@ -471,6 +471,34 @@ gpu_wait_idle(struct comp_d3d12_compositor *c)
 		c->fence->SetEventOnCompletion(c->fence_value, c->fence_event);
 		WaitForSingleObject(c->fence_event, INFINITE);
 	}
+
+	// #747: report a device reset the moment WE can see it, and dump DRED.
+	//
+	// This is the earliest point the runtime observes an adapter reset: on
+	// removal the fence jumps to UINT64_MAX, so the compare above passes, the
+	// wait is skipped, and we return as if nothing happened — silently. The
+	// host then hits DXGI_ERROR_DEVICE_REMOVED in ITS present and aborts.
+	//
+	// That ordering is why DRED has produced nothing in the field: the
+	// breadcrumbs live in the faulted process and die with it, and an
+	// aborting host (Unity aborts inside its own Present) never reads them.
+	// If the runtime does not read them here, nobody does.
+	//
+	// Once-only: after a reset every subsequent call fails, and a per-frame
+	// dump would bury the one interesting readout.
+	{
+		static bool s_reported = false;
+		if (!s_reported && c->device != nullptr) {
+			HRESULT rr = c->device->GetDeviceRemovedReason();
+			if (rr != S_OK) {
+				s_reported = true;
+				U_LOG_E("#747 DEVICE REMOVED observed by the compositor at gpu_wait_idle: "
+				        "GetDeviceRemovedReason=0x%08x",
+				        (unsigned)rr);
+				comp_d3d12_log_dred_state(c->device, "gpu_wait_idle/device-removed");
+			}
+		}
+	}
 }
 
 /*

--- a/src/xrt/compositor/d3d12/comp_d3d12_renderer.cpp
+++ b/src/xrt/compositor/d3d12/comp_d3d12_renderer.cpp
@@ -401,9 +401,10 @@ compile_shader(const char *source, const char *entry, const char *target, ID3DBl
 //
 // When DRED isn't enabled, QueryInterface returns DXGI_ERROR_NOT_FOUND and we
 // log that fact (so users know how to turn it on) but don't error.
-static void
-log_dred_state(ID3D12Device *device, const char *context)
+void
+comp_d3d12_log_dred_state(void *device_ptr, const char *context)
 {
+	ID3D12Device *device = static_cast<ID3D12Device *>(device_ptr);
 	if (device == nullptr) return;
 	ID3D12DeviceRemovedExtendedData *dred = nullptr;
 	HRESULT qr = device->QueryInterface(__uuidof(ID3D12DeviceRemovedExtendedData), (void**)&dred);
@@ -485,7 +486,7 @@ create_atlas_texture(struct comp_d3d12_renderer *r, ID3D12Device *device, uint32
 		if (hr == DXGI_ERROR_DEVICE_REMOVED) {
 			HRESULT dr_hr = device->GetDeviceRemovedReason();
 			U_LOG_E("  GetDeviceRemovedReason: 0x%08x", (unsigned)dr_hr);
-			log_dred_state(device, "create_atlas_texture");
+			comp_d3d12_log_dred_state(device, "create_atlas_texture");
 		}
 		return XRT_ERROR_D3D;
 	}

--- a/src/xrt/compositor/d3d12/comp_d3d12_renderer.h
+++ b/src/xrt/compositor/d3d12/comp_d3d12_renderer.h
@@ -336,6 +336,26 @@ comp_d3d12_renderer_resize(struct comp_d3d12_renderer *renderer,
                            uint32_t new_view_height,
                            uint32_t new_target_height);
 
+
+/*!
+ * #747: dump DRED auto-breadcrumbs + page-fault info for @p device.
+ *
+ * Exported so the compositor can call it the moment IT observes a device reset.
+ * DRED data lives in the faulted process and dies with it, so a host that aborts
+ * without reading it (Unity aborts inside its own Present) produces nothing —
+ * the readout has to happen on OUR first sighting.
+ *
+ * Requires DRED to have been enabled BEFORE device creation; see the comment at
+ * the definition for the per-app registry route.
+ *
+ * @param device D3D12 device (void* = ID3D12Device*).
+ * @param context Short label for the log line.
+ *
+ * @ingroup comp_d3d12
+ */
+void
+comp_d3d12_log_dred_state(void *device, const char *context);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/xrt/compositor/d3d12/comp_d3d12_swapchain.cpp
+++ b/src/xrt/compositor/d3d12/comp_d3d12_swapchain.cpp
@@ -310,6 +310,12 @@ comp_d3d12_swapchain_create(struct comp_d3d12_compositor *c,
 	if (is_depth) {
 		initial_state = D3D12_RESOURCE_STATE_DEPTH_WRITE;
 	}
+	U_LOG_W("#747 trace: swapchain create bits=0x%x flags=0x%x initial_state=0x%x (%s) %ux%u n=%u",
+	        (unsigned)info->bits, (unsigned)resource_flags, (unsigned)initial_state,
+	        initial_state == D3D12_RESOURCE_STATE_RENDER_TARGET ? "RENDER_TARGET"
+	        : initial_state == D3D12_RESOURCE_STATE_DEPTH_WRITE ? "DEPTH_WRITE"
+	                                                            : "?",
+	        (unsigned)info->width, (unsigned)info->height, (unsigned)image_count);
 
 	D3D12_CLEAR_VALUE clear_value = {};
 	clear_value.Format = dxgi_format;
@@ -341,9 +347,14 @@ comp_d3d12_swapchain_create(struct comp_d3d12_compositor *c,
 		// APP renders views into and the compositor samples, so they are the
 		// most likely subject of a cross-component barrier complaint — and the
 		// hardest to identify, since neither side "owns" them outright.
+		//
+		// The dims are part of the name on purpose: a session has SEVERAL
+		// swapchains (projection / HUD / Local2D), each with its own img[0], so
+		// an index alone is ambiguous and points at three different resources.
 		{
-			wchar_t nm[64];
-			swprintf_s(nm, L"DXR.xr_swapchain_img[%u]", i);
+			wchar_t nm[96];
+			swprintf_s(nm, L"DXR.xr_swapchain_img[%u] %ux%u%s", i, (unsigned)info->width,
+			           (unsigned)info->height, is_depth ? L" depth" : L"");
 			sc->images[i]->SetName(nm);
 		}
 


### PR DESCRIPTION
## Why

Requested on #747. DRED is **armed** on the test box (AppCompat registry keys set, verified) but produces **nothing** — because nobody reads it.

**The ordering is the bug.** On an adapter reset the fence jumps to `UINT64_MAX`, so `gpu_wait_idle()`'s `GetCompletedValue() < fence_value` compare passes, the wait is skipped, and the runtime returns **as if nothing happened**. The host then hits `DXGI_ERROR_DEVICE_REMOVED` in *its* present and aborts. DRED breadcrumbs live in the faulted process and **die with it** — and an aborting host (Unity aborts inside `Present`, never calls `GetDeviceRemovedData`) never reads them. Our `log_dred_state()` existed but was wired to exactly **one** atlas-creation error path, which a resize-time reset doesn't go through.

Data collected. Never read. **If the runtime doesn't read it here, nobody does.**

## What

`gpu_wait_idle()` — the earliest point the runtime can observe a reset — now checks `GetDeviceRemovedReason()` and, on failure, logs the reason and dumps DRED: **auto-breadcrumbs** (the GPU op that was executing) and **page-fault data** (the offending resource — **by name**, now that D3D12 objects are named via #751).

Once-only: after a reset every later call fails, and a per-frame dump would bury the one interesting readout.

Also exports the reader as `comp_d3d12_log_dred_state(void *device, ...)`, following this header's existing convention for D3D objects (`void*` + a doc note — the header is C-compatible and can't name `ID3D12Device`).

## Why it matters now

#752 worked, and the Unity agent's numbers are unambiguous:

```
DXR.atlas_texture id-527:  9,839 -> 0
live resize gesture:  ~50% fatal  ->  "much better, several resizes survived"
```

But a **residual crash remains with a new signature**: `dwm.exe` dies of `0xC00001AD` (**fatal memory exhaustion**) **~52 s before** Unity's device removal. That's a leak/exhaustion profile, **not barrier UB** — a second, distinct mechanism. It won't be found by reading code; on this pair of issues my grep-derived hypotheses have been wrong three times and measurement was right every time. This hook is how the next one gets **read** instead of argued about.

## Risk

None functional. One `GetDeviceRemovedReason()` per `gpu_wait_idle` (a lightweight query), and the dump only ever runs on a device that is already dead.

**Verified inert on a healthy device**: 0 occurrences across a normal session, app reaches steady state, no behaviour change.

Refs #747