### PR TITLE
fix(d3d12,#747): ingest swapchain images as RENDER_TARGET, per XR_KHR_D3D12_enable

### DIFF
--- a/src/xrt/compositor/d3d12/comp_d3d12_renderer.cpp
+++ b/src/xrt/compositor/d3d12/comp_d3d12_renderer.cpp
@@ -1487,12 +1487,27 @@ comp_d3d12_renderer_draw_projection_pass(struct comp_d3d12_renderer *renderer,
 				        (void *)src_resource, img_index, (void *)xscn);
 			}
 
-			// Transition swapchain image: COMMON → PIXEL_SHADER_RESOURCE
-			// The app leaves the resource in COMMON after rendering.
+			// Transition swapchain image: RENDER_TARGET → PIXEL_SHADER_RESOURCE.
+			//
+			// #747: RENDER_TARGET, not COMMON. XR_KHR_D3D12_enable makes this a
+			// contract, not a guess — on xrReleaseSwapchainImage "the OpenXR
+			// runtime must interpret the image as ... having a resource state
+			// match with D3D12_RESOURCE_STATE_RENDER_TARGET if the image is a
+			// color rendering target" (DEPTH_WRITE for depth). So a released
+			// image IS in RENDER_TARGET, and the ingest must say so.
+			//
+			// The old comment here claimed "the app leaves the resource in
+			// COMMON after rendering". That was never the contract — it
+			// described what apps happened to do when they copied into an image
+			// and let the implicit COMMON->COPY_DEST promotion decay back to
+			// COMMON. Assuming it made this path COMMON-in/COMMON-out, which
+			// (a) contradicted the sibling ingest at the top of this file, which
+			// has always used RENDER_TARGET correctly, and (b) produced ~13k
+			// id-527s per session against a spec-conformant app.
 			D3D12_RESOURCE_BARRIER src_barrier = {};
 			src_barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
 			src_barrier.Transition.pResource = src_resource;
-			src_barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_COMMON;
+			src_barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
 			src_barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
 			src_barrier.Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
 			cmd_list->ResourceBarrier(1, &src_barrier);
@@ -1629,10 +1644,12 @@ comp_d3d12_renderer_draw_projection_pass(struct comp_d3d12_renderer *renderer,
 				vp.Height = static_cast<float>(zr->extent.h) * zsy;
 				if (vp.Width <= 0.0f || vp.Height <= 0.0f) {
 					// Degenerate / off-target zone: restore the
-					// swapchain state and skip the draw.
+					// swapchain state and skip the draw. #747: restore to
+					// RENDER_TARGET — the state the image arrived in and
+					// must be handed back in.
 					src_barrier.Transition.StateBefore =
 					    D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
-					src_barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_COMMON;
+					src_barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_RENDER_TARGET;
 					cmd_list->ResourceBarrier(1, &src_barrier);
 					continue;
 				}
@@ -1681,9 +1698,12 @@ comp_d3d12_renderer_draw_projection_pass(struct comp_d3d12_renderer *renderer,
 				cmd_list->SetPipelineState(renderer->blit_pso);
 			}
 
-			// Transition swapchain image back: PIXEL_SHADER_RESOURCE → COMMON
+			// Transition swapchain image back: PIXEL_SHADER_RESOURCE →
+			// RENDER_TARGET. #747: leave it as we found it, per the
+			// XR_KHR_D3D12_enable contract — the app is entitled to see
+			// RENDER_TARGET on its next acquire/wait.
 			src_barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
-			src_barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_COMMON;
+			src_barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_RENDER_TARGET;
 			cmd_list->ResourceBarrier(1, &src_barrier);
 		}
 	}

--- a/test_apps/texture/cube_zones_texture_d3d12_win/d3d12_renderer.cpp
+++ b/test_apps/texture/cube_zones_texture_d3d12_win/d3d12_renderer.cpp
@@ -952,14 +952,15 @@ void RenderScene(
 
     auto cmdList = renderer.commandList.Get();
 
-    // Transition render target to RENDER_TARGET state
-    D3D12_RESOURCE_BARRIER barrier = {};
-    barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
-    barrier.Transition.pResource = renderTarget;
-    barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_COMMON;
-    barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_RENDER_TARGET;
-    barrier.Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
-    cmdList->ResourceBarrier(1, &barrier);
+    // #747: no entry barrier — the image is ALREADY in RENDER_TARGET.
+    //
+    // renderTarget is an acquired XR swapchain image, and XR_KHR_D3D12_enable
+    // guarantees a color image "has a resource state match with
+    // D3D12_RESOURCE_STATE_RENDER_TARGET" once xrWaitSwapchainImage succeeds.
+    // The old COMMON -> RENDER_TARGET barrier claimed a before-state the image
+    // was never in. (There is no exit barrier, which was already correct: the
+    // image must be RELEASED in RENDER_TARGET, and leaving it untouched does
+    // exactly that.)
 
     // Get RTV and DSV handles
     D3D12_CPU_DESCRIPTOR_HANDLE rtvHandle = renderer.rtvHeap->GetCPUDescriptorHandleForHeapStart();
@@ -1079,10 +1080,14 @@ void RenderScene(
         cmdList->DrawInstanced(renderer.gridVertexCount, 1, 0, 0);
     }
 
-    // Transition render target back
-    barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
-    barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_COMMON;
-    cmdList->ResourceBarrier(1, &barrier);
+    // #747: no exit barrier — the image must be RELEASED in RENDER_TARGET.
+    //
+    // The old RENDER_TARGET -> COMMON here is what handed the runtime an image
+    // in COMMON, which is exactly what the compositor's (now spec-correct)
+    // RENDER_TARGET ingest complains about. XR_KHR_D3D12_enable: on
+    // xrReleaseSwapchainImage the runtime "must interpret the image as ...
+    // having a resource state match with D3D12_RESOURCE_STATE_RENDER_TARGET".
+    // We rendered into it as a render target, so leaving it alone is correct.
 
     // Execute
     hr = cmdList->Close();

--- a/test_apps/texture/cube_zones_texture_d3d12_win/main.cpp
+++ b/test_apps/texture/cube_zones_texture_d3d12_win/main.cpp
@@ -1531,21 +1531,24 @@ static void ClearZoneImage(D3D12Renderer& renderer, DisplayZone& z,
     g_zoneCmdAlloc->Reset();
     g_zoneCmdList->Reset(g_zoneCmdAlloc.Get(), nullptr);
 
-    D3D12_RESOURCE_BARRIER barrier = {};
-    barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
-    barrier.Transition.pResource = rt;
-    barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_COMMON;
-    barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_RENDER_TARGET;
-    barrier.Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
-    g_zoneCmdList->ResourceBarrier(1, &barrier);
-
+    // #747: clear directly in RENDER_TARGET — no barriers.
+    //
+    // An acquired XR swapchain image is ALREADY in RENDER_TARGET and must be
+    // released in RENDER_TARGET: XR_KHR_D3D12_enable specifies that on
+    // xrWaitSwapchainImage success the color image "has a resource state match
+    // with D3D12_RESOURCE_STATE_RENDER_TARGET", and that on
+    // xrReleaseSwapchainImage the runtime "must interpret the image as ...
+    // having a resource state match with D3D12_RESOURCE_STATE_RENDER_TARGET".
+    //
+    // The old COMMON -> RENDER_TARGET -> COMMON pair here was wrong at BOTH
+    // ends: it claimed a before-state the image was never in, and then handed
+    // it back in COMMON, breaking the contract for the runtime's next ingest.
+    // That is precisely the app-side half of #747 — same bug the Unity plugin
+    // had (displayxr-unity@bf4c7ac), and the source of the TRANSFER_DST /
+    // COMMON trace on this app.
     D3D12_CPU_DESCRIPTOR_HANDLE rtvHandle = renderer.rtvHeap->GetCPUDescriptorHandleForHeapStart();
     rtvHandle.ptr += (SIZE_T)rtvIndex * renderer.rtvDescriptorSize;
     g_zoneCmdList->ClearRenderTargetView(rtvHandle, z.clearColor, 0, nullptr);
-
-    barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
-    barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_COMMON;
-    g_zoneCmdList->ResourceBarrier(1, &barrier);
 
     ZoneCmdSubmitAndWait(renderer);
 }
@@ -1561,22 +1564,14 @@ static void PaintViewColor(D3D12Renderer& renderer, ID3D12Resource* rt, int rtvI
     g_zoneCmdAlloc->Reset();
     g_zoneCmdList->Reset(g_zoneCmdAlloc.Get(), nullptr);
 
-    D3D12_RESOURCE_BARRIER barrier = {};
-    barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
-    barrier.Transition.pResource = rt;
-    barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_COMMON;
-    barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_RENDER_TARGET;
-    barrier.Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
-    g_zoneCmdList->ResourceBarrier(1, &barrier);
-
+    // #747: clear directly in RENDER_TARGET — no barriers. `rt` is an acquired
+    // XR swapchain image: XR_KHR_D3D12_enable guarantees it arrives in
+    // RENDER_TARGET and requires it be released in RENDER_TARGET. The old
+    // COMMON -> RENDER_TARGET -> COMMON pair was wrong at both ends.
     D3D12_CPU_DESCRIPTOR_HANDLE rtvHandle = renderer.rtvHeap->GetCPUDescriptorHandleForHeapStart();
     rtvHandle.ptr += (SIZE_T)rtvIndex * renderer.rtvDescriptorSize;
     D3D12_RECT rect = {(LONG)vpX, 0, (LONG)(vpX + tileW), (LONG)tileH};
     g_zoneCmdList->ClearRenderTargetView(rtvHandle, color, 1, &rect);
-
-    barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
-    barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_COMMON;
-    g_zoneCmdList->ResourceBarrier(1, &barrier);
 
     ZoneCmdSubmitAndWait(renderer);
 }
@@ -2486,10 +2481,18 @@ static void RenderOneFrame(RenderState& rs) {
                         rs.hudCmdAllocator->Reset();
                         rs.hudCmdList->Reset(rs.hudCmdAllocator, nullptr);
 
+                        // #747: RENDER_TARGET -> COPY_DEST -> RENDER_TARGET.
+                        // hudTex is an ACQUIRED XR swapchain image, so per
+                        // XR_KHR_D3D12_enable it arrives in RENDER_TARGET and
+                        // must be released in RENDER_TARGET. The old
+                        // COMMON->COPY_DEST->COMMON pair was wrong at both ends
+                        // (it relied on the implicit COMMON->COPY_DEST promotion
+                        // that only holds if the image were in COMMON, and then
+                        // handed it back in COMMON).
                         D3D12_RESOURCE_BARRIER barrier = {};
                         barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
                         barrier.Transition.pResource = hudTex;
-                        barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_COMMON;
+                        barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
                         barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_COPY_DEST;
                         barrier.Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
                         rs.hudCmdList->ResourceBarrier(1, &barrier);
@@ -2512,7 +2515,7 @@ static void RenderOneFrame(RenderState& rs) {
                         rs.hudCmdList->CopyTextureRegion(&dstLoc, 0, 0, 0, &srcLoc, nullptr);
 
                         barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_COPY_DEST;
-                        barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_COMMON;
+                        barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_RENDER_TARGET;
                         rs.hudCmdList->ResourceBarrier(1, &barrier);
 
                         rs.hudCmdList->Close();


### PR DESCRIPTION
## The contract (settled — not inferred)

The Unity agent read `XR_KHR_D3D12_enable` from the registry source and quoted it on #747:

> **acquire** — on `xrWaitSwapchainImage` success: *"The color rendering target image has a resource state match with `D3D12_RESOURCE_STATE_RENDER_TARGET`"* (`DEPTH_WRITE` for depth)
>
> **release** — on `xrReleaseSwapchainImage`: *"the OpenXR runtime **must interpret the image as** … Having a resource state match with `D3D12_RESOURCE_STATE_RENDER_TARGET`"*

That answers the question I explicitly refused to guess at. **A released image IS in `RENDER_TARGET`.** It also settles bug #2 *against the app* — and the Unity agent has already fixed their half (`displayxr-unity@bf4c7ac`), which is what exposed ours.

## The runtime bug

`comp_d3d12_renderer_draw_projection_pass` was **COMMON-in / COMMON-out**:

```
ingest    COMMON -> PIXEL_SHADER_RESOURCE                 =>  RENDER_TARGET -> PSR
restore   PSR -> COMMON   (x2, incl. degenerate-zone)     =>  PSR -> RENDER_TARGET
```

Its comment stated the wrong premise out loud — *"the app leaves the resource in COMMON after rendering"*. That was **never the contract**; it described what apps happened to do when they copied into an image and let the implicit `COMMON→COPY_DEST` promotion decay back to `COMMON`. Two consequences:

- it **contradicted the sibling ingest** at `comp_d3d12_renderer.cpp:579`, which has always used `RENDER_TARGET` correctly — *the runtime disagreed with itself*;
- against a spec-conformant app it produces **~13k id-527s/session** (measured by the Unity agent after their fix).

Swapchain images are already **created** in `RENDER_TARGET` (`comp_d3d12_swapchain.cpp:309`), matching the acquire half — so this makes the runtime self-consistent and spec-conformant end to end.

**Audited:** no COMMON assumptions about app-released images remain in the D3D12 compositor.

## Also: the same bug in `cube_zones_texture_d3d12_win`

Our own test app was the app-half of the `TRANSFER_DST`/`COMMON` trace — the **identical** mistake the Unity plugin had:

- main render path: drops **both** its `COMMON→RT` entry and `RT→COMMON` exit (an acquired image is already RT, and must be released RT);
- HUD upload: `RT → COPY_DEST → RT`;
- slice-color probe: clears **directly in RT** (its `COMMON→RT→COMMON` pair was wrong at both ends).

## Verification (hardware, `DXR_D3D12_DEBUG=1` + live resizes)

Every remaining id-527 now originates from an `APP.*` command list on a path this test app hasn't been converted yet — **the compositor no longer asserts a wrong state on any of them**. Remaining app-side paths are test-app cleanup, tracked separately; they don't affect the runtime contract.

## Sequencing

The Unity agent asked for this to land **before** the next seated crash gauntlet — with both halves on the spec, mixed-contract barrier UB would muddy the DRED signal we're trying to read. Agreed.

Refs #747