### PR TITLE
feat(vk_native): opt-in Linux direct-scanout present path (ST-5539, #755)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,6 +207,11 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
 	find_package(udev)
 	if(PKGCONFIG_FOUND)
 		pkg_check_modules(XCB xcb xcb-randr x11-xcb)
+		# Xlib + Xrandr: only needed for the direct-scanout present path
+		# (VK_EXT_acquire_xlib_display steals a RandR output as a VkDisplayKHR,
+		# bypassing Xorg/compositor — ST-5539). Optional; absence just leaves
+		# the compositor on the XCB present path.
+		pkg_check_modules(XLIB_XRANDR x11 xrandr)
 	endif()
 endif()
 
@@ -241,6 +246,10 @@ option_with_deps(XRT_HAVE_METAL "Enable Metal Graphics API support" DEPENDS APPL
 option_with_deps(XRT_HAVE_D3D11 "Enable Direct3D 11 Graphics API support" DEPENDS D3D11_LIBRARY XRT_HAVE_VULKAN XRT_HAVE_DXGI XRT_HAVE_WIL)
 option_with_deps(XRT_HAVE_D3D12 "Enable Direct3D 12 Graphics API support" DEPENDS D3D12_LIBRARY XRT_HAVE_D3D11 XRT_HAVE_VULKAN XRT_HAVE_DXGI XRT_HAVE_WIL)
 option_with_deps(XRT_HAVE_XCB "Enable xcb support" DEPENDS XCB_FOUND)
+# Direct-scanout present path (Linux): Xlib+Xrandr to acquire a RandR output as a
+# VkDisplayKHR (VK_EXT_acquire_xlib_display / VK_KHR_display). Optional — the
+# compositor falls back to the XCB window path when absent. ST-5539.
+option_with_deps(XRT_HAVE_XLIB_XRANDR "Enable Xlib/Xrandr direct-scanout present (Linux)" DEPENDS XLIB_XRANDR_FOUND XRT_HAVE_XCB)
 
 # System deps to use (sorted)
 option_with_deps(XRT_HAVE_LIBUDEV "Enable libudev (used for device probing on Linux)" DEPENDS UDEV_FOUND)
@@ -430,6 +439,13 @@ endif()
 if(XRT_HAVE_XCB)
 	set(VK_USE_PLATFORM_XCB_KHR TRUE)
 endif()
+# Activates the aux-layer VkDisplayKHR helpers + acquire-xlib function pointers
+# (dormant otherwise) and the direct-scanout window backend. Drives the
+# #cmakedefine of both macros in xrt_config_vulkan.h.
+if(XRT_HAVE_XLIB_XRANDR)
+	set(VK_USE_PLATFORM_DISPLAY_KHR TRUE)
+	set(VK_USE_PLATFORM_XLIB_XRANDR_EXT TRUE)
+endif()
 if(ANDROID)
 	set(VK_USE_PLATFORM_ANDROID_KHR TRUE)
 endif()
@@ -577,6 +593,7 @@ message(STATUS "#    SYSTEMD:         ${XRT_HAVE_SYSTEMD}")
 message(STATUS "#    TRACY:           ${XRT_HAVE_TRACY}")
 message(STATUS "#    VULKAN:          ${XRT_HAVE_VULKAN}")
 message(STATUS "#    XCB:             ${XRT_HAVE_XCB}")
+message(STATUS "#    XLIB_XRANDR:     ${XRT_HAVE_XLIB_XRANDR}  (direct-scanout present)")
 message(STATUS "#")
 message(STATUS "#    MODULE_COMPOSITOR:           ${XRT_MODULE_COMPOSITOR}")
 message(STATUS "#    MODULE_COMPOSITOR_MAIN:      ${XRT_MODULE_COMPOSITOR_MAIN}")

--- a/scripts/build_linux.sh
+++ b/scripts/build_linux.sh
@@ -17,7 +17,7 @@
 #   sudo apt-get install -y build-essential cmake ninja-build pkg-config \
 #       libvulkan-dev vulkan-validationlayers glslang-tools \
 #       libeigen3-dev libcjson-dev \
-#       libxcb1-dev libxcb-randr0-dev libx11-dev libx11-xcb-dev
+#       libxcb1-dev libxcb-randr0-dev libx11-dev libx11-xcb-dev libxrandr-dev
 #   # glslang-tools provides glslangValidator, required at configure time to
 #   # compile the null compositor's SPIR-V (cmake/SPIR-V.cmake).
 #   # libxcb*-dev enables XRT_HAVE_XCB → the native Vulkan compositor builds on
@@ -26,6 +26,9 @@
 #   # libx11-dev + libx11-xcb-dev supply Xlib + XGetXCBConnection — the runtime
 #   # converts an app-provided Xlib window (XR_DXR_xlib_window_binding, Phase 3)
 #   # to its XCB connection, and the handle-class test app opens an X11 window.
+#   # libx11-dev + libxrandr-dev also enable XRT_HAVE_XLIB_XRANDR → the optional
+#   # direct-scanout present path (DXR_LINUX_DIRECT_SCANOUT=1) that acquires the
+#   # 3D-panel connector as a VkDisplayKHR and bypasses Xorg/compositor (ST-5539).
 #   # optional (enables the legacy udev VR prober — NOT needed for selftest):
 #   sudo apt-get install -y libudev-dev
 #

--- a/src/xrt/auxiliary/vk/CMakeLists.txt
+++ b/src/xrt/auxiliary/vk/CMakeLists.txt
@@ -46,6 +46,10 @@ endif()
 if(XRT_HAVE_XCB)
 	target_include_directories(aux_vk PRIVATE ${XCB_INCLUDE_DIR})
 endif()
-if(XRT_HAVE_XRANDR)
-	target_include_directories(aux_vk PRIVATE ${XRANDR_INCLUDE_DIR} ${X11_INCLUDE_DIR})
+if(XRT_HAVE_XLIB_XRANDR)
+	# With VK_USE_PLATFORM_XLIB_XRANDR_EXT defined, vulkan.h pulls in
+	# vulkan_xlib_xrandr.h (-> X11/Xlib.h, X11/extensions/Xrandr.h), so the aux
+	# VK display helpers need the X11/Xrandr headers on the include path. These
+	# are usually system-global; the dirs are belt-and-suspenders. ST-5539.
+	target_include_directories(aux_vk PRIVATE ${XLIB_XRANDR_INCLUDE_DIRS})
 endif()

--- a/src/xrt/compositor/null/null_compositor.c
+++ b/src/xrt/compositor/null/null_compositor.c
@@ -196,6 +196,16 @@ select_instances_extensions(struct null_compositor *c, struct u_string_list *req
 #ifdef VK_EXT_display_surface_counter
 	u_string_list_append(optional, VK_EXT_DISPLAY_SURFACE_COUNTER_EXTENSION_NAME);
 #endif
+#if defined(VK_USE_PLATFORM_XLIB_XRANDR_EXT) && defined(VK_USE_PLATFORM_DISPLAY_KHR)
+	// Direct-scanout present path (ST-5539). All optional: a box that lacks
+	// them (or has them but no leasable connector) stays on the XCB window
+	// path. Enabling them loads the aux-layer VkDisplayKHR helpers +
+	// acquire-xlib function pointers that comp_vk_native_window_direct needs.
+	// Order/deps: acquire_xlib -> direct_mode -> KHR_display.
+	u_string_list_append(optional, VK_KHR_DISPLAY_EXTENSION_NAME);
+	u_string_list_append(optional, VK_EXT_DIRECT_MODE_DISPLAY_EXTENSION_NAME);
+	u_string_list_append(optional, VK_EXT_ACQUIRE_XLIB_DISPLAY_EXTENSION_NAME);
+#endif
 
 	return VK_SUCCESS;
 }

--- a/src/xrt/compositor/vk_native/CMakeLists.txt
+++ b/src/xrt/compositor/vk_native/CMakeLists.txt
@@ -81,6 +81,19 @@ if((WIN32 OR APPLE OR ANDROID OR (XRT_HAVE_LINUX AND XRT_HAVE_XCB)) AND XRT_HAVE
 		target_link_libraries(comp_vk_native PRIVATE ${XCB_LIBRARIES})
 	endif()
 
+	if(XRT_HAVE_XLIB_XRANDR)
+		# Direct-scanout present path (ST-5539): steal a RandR output as a
+		# VkDisplayKHR and present to it directly, bypassing Xorg/compositor.
+		# Only this TU calls Xlib/Xrandr (XOpenDisplay, XRR*) — the aux VK
+		# display helpers are pure Vulkan. XLIB_XRANDR_{LIBRARIES,INCLUDE_DIRS}
+		# come from the top-level pkg_check_modules(XLIB_XRANDR x11 xrandr).
+		target_sources(comp_vk_native PRIVATE
+			comp_vk_native_window_direct.c
+			comp_vk_native_window_direct.h)
+		target_include_directories(comp_vk_native PRIVATE ${XLIB_XRANDR_INCLUDE_DIRS})
+		target_link_libraries(comp_vk_native PRIVATE ${XLIB_XRANDR_LIBRARIES})
+	endif()
+
 	# Qwerty include path for runtime-side 2D/3D toggle polling
 	if(XRT_BUILD_DRIVER_QWERTY)
 		target_link_libraries(comp_vk_native PRIVATE drv_qwerty_includes)

--- a/src/xrt/compositor/vk_native/comp_vk_native_compositor.c
+++ b/src/xrt/compositor/vk_native/comp_vk_native_compositor.c
@@ -75,6 +75,14 @@
 #include "vk_native/comp_vk_native_window_xcb.h"
 #endif
 
+// Direct-scanout present path (ST-5539). Only compiled when the bundle carries
+// the display + acquire-xlib platform (CMake: XRT_HAVE_XLIB_XRANDR); the whole
+// direct branch below is gated on the same macro so its symbols exist.
+#if defined(VK_USE_PLATFORM_XLIB_XRANDR_EXT) && defined(VK_USE_PLATFORM_DISPLAY_KHR)
+#define DXR_HAVE_DIRECT_SCANOUT
+#include "vk_native/comp_vk_native_window_direct.h"
+#endif
+
 #include <string.h>
 #include <math.h>
 #include <stdio.h>
@@ -161,6 +169,13 @@ struct comp_vk_native_compositor
 
 	//! True if we created the window ourselves.
 	bool owns_window;
+
+#ifdef DXR_HAVE_DIRECT_SCANOUT
+	//! Direct-scanout backend (owns the acquired connector + display-plane
+	//! surface). Non-NULL only when DXR_LINUX_DIRECT_SCANOUT opted in AND the
+	//! acquire succeeded; NULL means we stayed on the XCB path. ST-5539.
+	struct comp_vk_native_window_direct *direct_window;
+#endif
 #endif
 
 	//! Shared texture VkImage (imported from HANDLE).
@@ -3200,6 +3215,13 @@ vk_compositor_destroy(struct xrt_compositor *xc)
 	if (c->xcb_window != NULL) {
 		comp_vk_native_window_xcb_destroy(&c->xcb_window);
 	}
+#ifdef DXR_HAVE_DIRECT_SCANOUT
+	// After the target (swapchain) is gone — the backend owns the surface it
+	// borrowed to it — release the display back to the X server.
+	if (c->direct_window != NULL) {
+		comp_vk_native_window_direct_destroy(&c->direct_window);
+	}
+#endif
 #endif
 
 	// Destroy command pool (we created it for the display processor factory)
@@ -3472,25 +3494,52 @@ comp_vk_native_compositor_create(struct xrt_device *xdev,
 			win_w = 1920;
 			win_h = 1080;
 		}
-		// Open on the 3D panel at the plug-in-reported position (as the
-		// Windows arm does), with the DXR_WINDOW_POS env override winning. #715.
-		int32_t win_left = display_screen_left;
-		int32_t win_top = display_screen_top;
-		apply_window_pos_override(&win_left, &win_top);
-		U_LOG_I("Creating self-owned XCB window (%ux%u at %d,%d)", win_w, win_h, win_left, win_top);
-		xrt_result_t xret = comp_vk_native_window_xcb_create(
-		    win_w, win_h, win_left, win_top, transparent_background, &c->xcb_window);
-		if (xret != XRT_SUCCESS) {
-			U_LOG_E("Failed to create self-owned XCB window");
-			free(c);
-			return xret;
+
+#ifdef DXR_HAVE_DIRECT_SCANOUT
+		// Opt-in direct scanout (ST-5539): fullscreen-only, reclaims the ~44%
+		// Xorg+compositor presentation cost. Acquire the 3D-panel connector and
+		// scan out to it directly. Any failure (exts absent, no leasable
+		// connector) leaves direct_window NULL → fall through to XCB below, so
+		// the default path is untouched.
+		const char *ds_env = getenv("DXR_LINUX_DIRECT_SCANOUT");
+		if (ds_env != NULL && ds_env[0] == '1') {
+			xrt_result_t dret = comp_vk_native_window_direct_create(
+			    &c->vk, display_screen_left, display_screen_top, &c->direct_window);
+			if (dret == XRT_SUCCESS) {
+				c->owns_window = true;
+				// hwnd stays NULL; the target is built from the backend's
+				// display-plane surface after settings init.
+				U_LOG_W("Direct-scanout present path active (bypassing Xorg/compositor)");
+			} else {
+				U_LOG_W("DXR_LINUX_DIRECT_SCANOUT set but direct scanout "
+				        "unavailable (%d) — falling back to XCB present",
+				        (int)dret);
+			}
 		}
-		c->owns_window = true;
-		// Hand the connection + window id to the target via the type-erased
-		// hwnd. c->xcb_handle lives in the compositor, so the connection the
-		// surface borrows stays valid for the target's lifetime.
-		comp_vk_native_window_xcb_get_handle(c->xcb_window, &c->xcb_handle);
-		hwnd = &c->xcb_handle;
+		if (c->direct_window == NULL)
+#endif
+		{
+			// Open on the 3D panel at the plug-in-reported position (as the
+			// Windows arm does), with the DXR_WINDOW_POS env override winning. #715.
+			int32_t win_left = display_screen_left;
+			int32_t win_top = display_screen_top;
+			apply_window_pos_override(&win_left, &win_top);
+			U_LOG_I("Creating self-owned XCB window (%ux%u at %d,%d)", win_w, win_h, win_left,
+			        win_top);
+			xrt_result_t xret = comp_vk_native_window_xcb_create(
+			    win_w, win_h, win_left, win_top, transparent_background, &c->xcb_window);
+			if (xret != XRT_SUCCESS) {
+				U_LOG_E("Failed to create self-owned XCB window");
+				free(c);
+				return xret;
+			}
+			c->owns_window = true;
+			// Hand the connection + window id to the target via the type-erased
+			// hwnd. c->xcb_handle lives in the compositor, so the connection the
+			// surface borrows stays valid for the target's lifetime.
+			comp_vk_native_window_xcb_get_handle(c->xcb_window, &c->xcb_handle);
+			hwnd = &c->xcb_handle;
+		}
 	}
 #endif
 
@@ -3536,7 +3585,18 @@ comp_vk_native_compositor_create(struct xrt_device *xdev,
 #endif
 
 #ifdef XRT_OS_LINUX_DESKTOP
-	if (c->xcb_window != NULL) {
+#ifdef DXR_HAVE_DIRECT_SCANOUT
+	if (c->direct_window != NULL) {
+		// Direct scanout: dimensions are the connector's fixed native mode.
+		uint32_t dw = 0, dh = 0;
+		comp_vk_native_window_direct_get_dimensions(c->direct_window, &dw, &dh);
+		if (dw > 0 && dh > 0) {
+			c->settings.preferred.width = dw;
+			c->settings.preferred.height = dh;
+		}
+	} else
+#endif
+	    if (c->xcb_window != NULL) {
 		uint32_t xw = 0, xh = 0;
 		comp_vk_native_window_xcb_get_dimensions(c->xcb_window, &xw, &xh);
 		if (xw > 0 && xh > 0) {
@@ -3630,18 +3690,28 @@ comp_vk_native_compositor_create(struct xrt_device *xdev,
 	    || c->owns_window
 #endif
 	) {
-		void *target_hwnd = hwnd;
+		xrt_result_t xret;
+#ifdef DXR_HAVE_DIRECT_SCANOUT
+		if (c->direct_window != NULL) {
+			// Direct scanout: the backend already built the display-plane
+			// surface — hand it straight to the target (no hwnd).
+			xret = comp_vk_native_target_create_from_surface(
+			    c, comp_vk_native_window_direct_get_surface(c->direct_window),
+			    c->settings.preferred.width, c->settings.preferred.height, &c->target);
+		} else
+#endif
+		{
+			void *target_hwnd = hwnd;
 #ifdef XRT_OS_WINDOWS
-		if (target_hwnd == NULL) target_hwnd = c->hwnd;
+			if (target_hwnd == NULL) target_hwnd = c->hwnd;
 #endif
 #ifdef XRT_OS_LINUX_DESKTOP
-		if (target_hwnd == NULL && c->xcb_window != NULL) target_hwnd = &c->xcb_handle;
+			if (target_hwnd == NULL && c->xcb_window != NULL) target_hwnd = &c->xcb_handle;
 #endif
-		xrt_result_t xret = comp_vk_native_target_create(c, target_hwnd,
-		                                                  c->settings.preferred.width,
-		                                                  c->settings.preferred.height,
-		                                                  transparent_background,
-		                                                  &c->target);
+			xret = comp_vk_native_target_create(c, target_hwnd, c->settings.preferred.width,
+			                                    c->settings.preferred.height,
+			                                    transparent_background, &c->target);
+		}
 		if (xret != XRT_SUCCESS) {
 			U_LOG_E("Failed to create VK target");
 			vk_compositor_destroy(&c->base.base);

--- a/src/xrt/compositor/vk_native/comp_vk_native_target.cpp
+++ b/src/xrt/compositor/vk_native/comp_vk_native_target.cpp
@@ -113,6 +113,12 @@ struct comp_vk_native_target
 	//! Window handle.
 	void *hwnd;
 
+	//! True when @ref surface was created and is owned by an external backend
+	//! (the direct-scanout window backend builds the display-plane surface
+	//! itself). Teardown then skips vkDestroySurfaceKHR — the backend releases
+	//! it, after the display, on its own destroy. ST-5539.
+	bool external_surface;
+
 #ifdef XRT_OS_ANDROID
 	//! The ANativeWindow the current VkSurfaceKHR was built from (owns one
 	//! reference, released when the surface is torn down). Distinct from @ref
@@ -991,6 +997,79 @@ comp_vk_native_target_create(struct comp_vk_native_compositor *c,
 	return XRT_SUCCESS;
 }
 
+xrt_result_t
+comp_vk_native_target_create_from_surface(struct comp_vk_native_compositor *c,
+                                          VkSurfaceKHR surface,
+                                          uint32_t width,
+                                          uint32_t height,
+                                          struct comp_vk_native_target **out_target)
+{
+	// Direct-scanout path (ST-5539): the window backend already built the
+	// display-plane surface (only it has the display/mode/plane context), so we
+	// skip per-platform surface creation entirely and reuse the shared
+	// semaphore + swapchain tail. The surface is borrowed, not owned — the
+	// backend destroys it on its own teardown (external_surface = true).
+	struct vk_bundle *vk = comp_vk_native_compositor_get_vk(c);
+	uint32_t queue_family_index = comp_vk_native_compositor_get_queue_family(c);
+
+	if (surface == VK_NULL_HANDLE) {
+		U_LOG_E("VK native target: NULL surface handed to create_from_surface");
+		return XRT_ERROR_DEVICE_CREATION_FAILED;
+	}
+
+	struct comp_vk_native_target *target = U_TYPED_CALLOC(struct comp_vk_native_target);
+	if (target == NULL) {
+		return XRT_ERROR_ALLOCATION;
+	}
+
+	target->vk = vk;
+	target->hwnd = NULL;
+	target->width = width;
+	target->height = height;
+	target->queue_family_index = queue_family_index;
+	target->surface = surface;
+	target->external_surface = true;
+
+	VkBool32 present_support = VK_FALSE;
+	vk->vkGetPhysicalDeviceSurfaceSupportKHR(vk->physical_device, queue_family_index, target->surface,
+	                                          &present_support);
+	if (!present_support) {
+		U_LOG_E("Queue family does not support presentation to the direct-scanout surface");
+		free(target);
+		return XRT_ERROR_VULKAN;
+	}
+
+	VkSemaphoreCreateInfo sem_ci = {
+	    .sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO,
+	};
+	VkResult vk_res = vk->vkCreateSemaphore(vk->device, &sem_ci, NULL, &target->image_available);
+	if (vk_res != VK_SUCCESS) {
+		U_LOG_E("Failed to create image_available semaphore");
+		free(target);
+		return XRT_ERROR_VULKAN;
+	}
+	vk_res = vk->vkCreateSemaphore(vk->device, &sem_ci, NULL, &target->render_finished);
+	if (vk_res != VK_SUCCESS) {
+		U_LOG_E("Failed to create render_finished semaphore");
+		vk->vkDestroySemaphore(vk->device, target->image_available, NULL);
+		free(target);
+		return XRT_ERROR_VULKAN;
+	}
+
+	xrt_result_t xret = create_swapchain(target);
+	if (xret != XRT_SUCCESS) {
+		vk->vkDestroySemaphore(vk->device, target->render_finished, NULL);
+		vk->vkDestroySemaphore(vk->device, target->image_available, NULL);
+		free(target);
+		return xret;
+	}
+
+	*out_target = target;
+	U_LOG_I("Created VK native direct-scanout target: %ux%u, %u images, format %d", target->width,
+	        target->height, target->image_count, target->format);
+	return XRT_SUCCESS;
+}
+
 void
 comp_vk_native_target_destroy(struct comp_vk_native_target **target_ptr)
 {
@@ -1024,7 +1103,7 @@ comp_vk_native_target_destroy(struct comp_vk_native_target **target_ptr)
 	if (target->image_available != VK_NULL_HANDLE) {
 		vk->vkDestroySemaphore(vk->device, target->image_available, NULL);
 	}
-	if (target->surface != VK_NULL_HANDLE) {
+	if (target->surface != VK_NULL_HANDLE && !target->external_surface) {
 		vk->vkDestroySurfaceKHR(vk->instance, target->surface, NULL);
 	}
 

--- a/src/xrt/compositor/vk_native/comp_vk_native_target.h
+++ b/src/xrt/compositor/vk_native/comp_vk_native_target.h
@@ -48,6 +48,30 @@ comp_vk_native_target_create(struct comp_vk_native_compositor *c,
                               struct comp_vk_native_target **out_target);
 
 /*!
+ * Create a target from an already-built VkSurfaceKHR (direct-scanout path,
+ * ST-5539). The window backend owns the surface — the target borrows it and
+ * never destroys it. Skips per-platform surface creation; reuses the shared
+ * semaphore + swapchain setup. Dimensions are the connector's fixed scanout
+ * mode (no resize).
+ *
+ * @param c          The Vulkan native compositor.
+ * @param surface    A valid display-plane VkSurfaceKHR owned by the caller.
+ * @param width      Scanout width in pixels.
+ * @param height     Scanout height in pixels.
+ * @param out_target Pointer to receive the created target.
+ *
+ * @return XRT_SUCCESS on success, error code otherwise.
+ *
+ * @ingroup comp_vk_native
+ */
+xrt_result_t
+comp_vk_native_target_create_from_surface(struct comp_vk_native_compositor *c,
+                                          VkSurfaceKHR surface,
+                                          uint32_t width,
+                                          uint32_t height,
+                                          struct comp_vk_native_target **out_target);
+
+/*!
  * Destroy a Vulkan presentation target.
  *
  * @ingroup comp_vk_native

--- a/src/xrt/compositor/vk_native/comp_vk_native_window_direct.c
+++ b/src/xrt/compositor/vk_native/comp_vk_native_window_direct.c
@@ -1,0 +1,322 @@
+// Copyright 2026, The DisplayXR Project
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  Direct-scanout window backend for the VK native compositor on Linux.
+ *
+ * Model: Monado's comp_window_direct_randr — steal a RandR output from the
+ * running X server as a VkDisplayKHR, acquire it, and present to it directly,
+ * bypassing Xorg + the desktop compositor (ST-5539). See the header for the
+ * ownership contract and the fullscreen-only, opt-in constraints.
+ *
+ * @ingroup comp_vk_native
+ */
+
+#include "comp_vk_native_window_direct.h"
+
+// The whole backend is inert unless the bundle was built with the display +
+// acquire-xlib platform macros (CMake: XRT_HAVE_XLIB_XRANDR). CMake only adds
+// this source under that guard; the #if is belt-and-suspenders so a stray build
+// can't break on the missing vk_bundle fields / Vulkan display types.
+#if defined(VK_USE_PLATFORM_XLIB_XRANDR_EXT) && defined(VK_USE_PLATFORM_DISPLAY_KHR)
+
+#include "util/u_misc.h"
+#include "util/u_logging.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <X11/Xlib.h>
+#include <X11/extensions/Xrandr.h>
+
+struct comp_vk_native_window_direct
+{
+	//! Borrowed — the compositor's bundle (instance + physical_device + the
+	//! display/acquire function pointers loaded when the exts are enabled).
+	struct vk_bundle *vk;
+
+	//! X connection we own (opened here purely to acquire the display; the
+	//! surface itself is a Vulkan display-plane surface, not an X window).
+	Display *dpy;
+
+	//! The connector we stole from X and now own until destroy.
+	VkDisplayKHR display;
+
+	//! Display-plane surface built on @ref display — OWNED here (see header).
+	VkSurfaceKHR surface;
+
+	//! Native mode dimensions = the scanout resolution the swapchain matches.
+	uint32_t width;
+	uint32_t height;
+
+	//! Only turns false on teardown; direct scanout has no user-close event.
+	bool valid;
+};
+
+/*!
+ * Find the RandR output whose CRTC origin matches the plug-in-reported panel
+ * position (@p screen_left, @p screen_top). Falls back to the first connected,
+ * CRTC-active output when nothing matches exactly — the common single-panel
+ * demo box still resolves. Returns None on no candidate.
+ */
+static RROutput
+find_target_randr_output(Display *dpy, int32_t screen_left, int32_t screen_top)
+{
+	Window root = DefaultRootWindow(dpy);
+	XRRScreenResources *res = XRRGetScreenResourcesCurrent(dpy, root);
+	if (res == NULL) {
+		U_LOG_E("direct: XRRGetScreenResourcesCurrent failed");
+		return None;
+	}
+
+	RROutput match = None;
+	RROutput first_active = None;
+
+	for (int i = 0; i < res->noutput; i++) {
+		XRROutputInfo *oi = XRRGetOutputInfo(dpy, res, res->outputs[i]);
+		if (oi == NULL) {
+			continue;
+		}
+		if (oi->connection != RR_Connected || oi->crtc == 0) {
+			XRRFreeOutputInfo(oi);
+			continue;
+		}
+
+		XRRCrtcInfo *ci = XRRGetCrtcInfo(dpy, res, oi->crtc);
+		if (ci != NULL) {
+			if (first_active == None) {
+				first_active = res->outputs[i];
+			}
+			if ((int32_t)ci->x == screen_left && (int32_t)ci->y == screen_top) {
+				match = res->outputs[i];
+				U_LOG_I("direct: matched RandR output '%.*s' at (%d,%d)",
+				        oi->nameLen, oi->name, (int)ci->x, (int)ci->y);
+			}
+			XRRFreeCrtcInfo(ci);
+		}
+		XRRFreeOutputInfo(oi);
+
+		if (match != None) {
+			break;
+		}
+	}
+
+	XRRFreeScreenResources(res);
+
+	if (match == None && first_active != None) {
+		U_LOG_W("direct: no RandR output at (%d,%d); using first connected output",
+		        (int)screen_left, (int)screen_top);
+	}
+	return match != None ? match : first_active;
+}
+
+/*!
+ * Pick a display plane usable with @p display: prefer one already bound to it,
+ * else the first unbound plane (currentDisplay == VK_NULL_HANDLE). Avoids the
+ * (unloaded) vkGetDisplayPlaneSupportedDisplaysKHR by reading currentDisplay
+ * from the plane properties directly.
+ */
+static bool
+pick_display_plane(struct vk_bundle *vk,
+                   VkDisplayKHR display,
+                   uint32_t *out_plane_index,
+                   uint32_t *out_stack_index)
+{
+	uint32_t count = 0;
+	VkDisplayPlanePropertiesKHR *props = NULL;
+	VkResult res = vk_enumerate_physical_display_plane_properties(vk, vk->physical_device, &count, &props);
+	if (res != VK_SUCCESS || count == 0 || props == NULL) {
+		U_LOG_E("direct: no display planes (%d)", res);
+		free(props);
+		return false;
+	}
+
+	bool found = false;
+	// First pass: a plane already driving our display.
+	for (uint32_t i = 0; i < count && !found; i++) {
+		if (props[i].currentDisplay == display) {
+			*out_plane_index = i;
+			*out_stack_index = props[i].currentStackIndex;
+			found = true;
+		}
+	}
+	// Second pass: any unbound plane.
+	for (uint32_t i = 0; i < count && !found; i++) {
+		if (props[i].currentDisplay == VK_NULL_HANDLE) {
+			*out_plane_index = i;
+			*out_stack_index = props[i].currentStackIndex;
+			found = true;
+		}
+	}
+
+	free(props);
+	if (!found) {
+		U_LOG_E("direct: no display plane free for the acquired display");
+	}
+	return found;
+}
+
+xrt_result_t
+comp_vk_native_window_direct_create(struct vk_bundle *vk,
+                                    int32_t screen_left,
+                                    int32_t screen_top,
+                                    struct comp_vk_native_window_direct **out_win)
+{
+	*out_win = NULL;
+
+	// Every function pointer below is only non-NULL when its instance
+	// extension was enabled at bundle build (all optional). A NULL here means
+	// this box isn't direct-scanout capable — the caller falls back to XCB.
+	if (vk->vkGetRandROutputDisplayEXT == NULL || vk->vkAcquireXlibDisplayEXT == NULL ||
+	    vk->vkCreateDisplayPlaneSurfaceKHR == NULL || vk->vkGetPhysicalDeviceDisplayPlanePropertiesKHR == NULL) {
+		U_LOG_I("direct: display/acquire-xlib extensions not enabled; XCB fallback");
+		return XRT_ERROR_VULKAN;
+	}
+
+	Display *dpy = XOpenDisplay(NULL);
+	if (dpy == NULL) {
+		U_LOG_E("direct: XOpenDisplay(NULL) failed");
+		return XRT_ERROR_VULKAN;
+	}
+
+	RROutput output = find_target_randr_output(dpy, screen_left, screen_top);
+	if (output == None) {
+		U_LOG_E("direct: no connected RandR output to acquire");
+		XCloseDisplay(dpy);
+		return XRT_ERROR_VULKAN;
+	}
+
+	// RandR output -> VkDisplayKHR. Null means the ICD does not expose this
+	// output as a Vulkan display (e.g. already leased) — bail to XCB.
+	VkDisplayKHR vkdisplay = VK_NULL_HANDLE;
+	VkResult res = vk->vkGetRandROutputDisplayEXT(vk->physical_device, dpy, output, &vkdisplay);
+	if (res != VK_SUCCESS || vkdisplay == VK_NULL_HANDLE) {
+		U_LOG_E("direct: vkGetRandROutputDisplayEXT failed (%d)", res);
+		XCloseDisplay(dpy);
+		return XRT_ERROR_VULKAN;
+	}
+
+	// Evict the output from the X server; we scan out to it exclusively now.
+	res = vk->vkAcquireXlibDisplayEXT(vk->physical_device, dpy, vkdisplay);
+	if (res != VK_SUCCESS) {
+		U_LOG_E("direct: vkAcquireXlibDisplayEXT failed (%d)", res);
+		XCloseDisplay(dpy);
+		return XRT_ERROR_VULKAN;
+	}
+
+	// Native mode (index 0 is the panel's preferred/native timing) gives both
+	// the VkDisplayModeKHR and the scanout extent.
+	uint32_t mode_count = 0;
+	VkDisplayModePropertiesKHR *modes = NULL;
+	res = vk_enumerate_display_mode_properties(vk, vk->physical_device, vkdisplay, &mode_count, &modes);
+	if (res != VK_SUCCESS || mode_count == 0 || modes == NULL) {
+		U_LOG_E("direct: no display modes (%d)", res);
+		free(modes);
+		vk->vkReleaseDisplayEXT(vk->physical_device, vkdisplay);
+		XCloseDisplay(dpy);
+		return XRT_ERROR_VULKAN;
+	}
+	VkDisplayModeKHR mode = modes[0].displayMode;
+	uint32_t width = modes[0].parameters.visibleRegion.width;
+	uint32_t height = modes[0].parameters.visibleRegion.height;
+	free(modes);
+
+	uint32_t plane_index = 0;
+	uint32_t stack_index = 0;
+	if (!pick_display_plane(vk, vkdisplay, &plane_index, &stack_index)) {
+		vk->vkReleaseDisplayEXT(vk->physical_device, vkdisplay);
+		XCloseDisplay(dpy);
+		return XRT_ERROR_VULKAN;
+	}
+
+	VkDisplaySurfaceCreateInfoKHR surface_ci = {
+	    .sType = VK_STRUCTURE_TYPE_DISPLAY_SURFACE_CREATE_INFO_KHR,
+	    .displayMode = mode,
+	    .planeIndex = plane_index,
+	    .planeStackIndex = stack_index,
+	    .transform = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR,
+	    .globalAlpha = 1.0f,
+	    .alphaMode = VK_DISPLAY_PLANE_ALPHA_OPAQUE_BIT_KHR,
+	    .imageExtent = {width, height},
+	};
+
+	VkSurfaceKHR surface = VK_NULL_HANDLE;
+	res = vk->vkCreateDisplayPlaneSurfaceKHR(vk->instance, &surface_ci, NULL, &surface);
+	if (res != VK_SUCCESS) {
+		U_LOG_E("direct: vkCreateDisplayPlaneSurfaceKHR failed (%d)", res);
+		vk->vkReleaseDisplayEXT(vk->physical_device, vkdisplay);
+		XCloseDisplay(dpy);
+		return XRT_ERROR_VULKAN;
+	}
+
+	struct comp_vk_native_window_direct *win = U_TYPED_CALLOC(struct comp_vk_native_window_direct);
+	if (win == NULL) {
+		vk->vkDestroySurfaceKHR(vk->instance, surface, NULL);
+		vk->vkReleaseDisplayEXT(vk->physical_device, vkdisplay);
+		XCloseDisplay(dpy);
+		return XRT_ERROR_ALLOCATION;
+	}
+
+	win->vk = vk;
+	win->dpy = dpy;
+	win->display = vkdisplay;
+	win->surface = surface;
+	win->width = width;
+	win->height = height;
+	win->valid = true;
+
+	U_LOG_W("direct: scanning out directly to %ux%u connector (bypassing Xorg/compositor)", width, height);
+
+	*out_win = win;
+	return XRT_SUCCESS;
+}
+
+VkSurfaceKHR
+comp_vk_native_window_direct_get_surface(struct comp_vk_native_window_direct *win)
+{
+	return win != NULL ? win->surface : VK_NULL_HANDLE;
+}
+
+void
+comp_vk_native_window_direct_get_dimensions(struct comp_vk_native_window_direct *win,
+                                            uint32_t *out_width,
+                                            uint32_t *out_height)
+{
+	if (win == NULL) {
+		return;
+	}
+	*out_width = win->width;
+	*out_height = win->height;
+}
+
+bool
+comp_vk_native_window_direct_is_valid(struct comp_vk_native_window_direct *win)
+{
+	return win != NULL && win->valid;
+}
+
+void
+comp_vk_native_window_direct_destroy(struct comp_vk_native_window_direct **win_ptr)
+{
+	struct comp_vk_native_window_direct *win = *win_ptr;
+	if (win == NULL) {
+		return;
+	}
+
+	struct vk_bundle *vk = win->vk;
+	if (win->surface != VK_NULL_HANDLE) {
+		vk->vkDestroySurfaceKHR(vk->instance, win->surface, NULL);
+	}
+	if (win->display != VK_NULL_HANDLE && vk->vkReleaseDisplayEXT != NULL) {
+		// Hand the connector back to the X server.
+		vk->vkReleaseDisplayEXT(vk->physical_device, win->display);
+	}
+	if (win->dpy != NULL) {
+		XCloseDisplay(win->dpy);
+	}
+
+	free(win);
+	*win_ptr = NULL;
+}
+
+#endif // VK_USE_PLATFORM_XLIB_XRANDR_EXT && VK_USE_PLATFORM_DISPLAY_KHR

--- a/src/xrt/compositor/vk_native/comp_vk_native_window_direct.h
+++ b/src/xrt/compositor/vk_native/comp_vk_native_window_direct.h
@@ -1,0 +1,115 @@
+// Copyright 2026, The DisplayXR Project
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  Direct-scanout window backend for the VK native compositor on Linux.
+ *
+ * Alternative to comp_vk_native_window_xcb: instead of presenting through a
+ * desktop VK_KHR_xcb_surface window (which Xorg + the desktop compositor then
+ * composite — ~44% of the GPU at 4K, see ST-5539), this backend takes exclusive
+ * ownership of the 3D-display connector and scans out to it directly, bypassing
+ * the compositor entirely.
+ *
+ * Acquisition path (Xorg): steal the RandR output from the running X server via
+ * vkGetRandROutputDisplayEXT (RROutput -> VkDisplayKHR) + vkAcquireXlibDisplayEXT
+ * (VK_EXT_acquire_xlib_display / VK_EXT_direct_mode_display), then build a
+ * display-plane VkSurfaceKHR (vkCreateDisplayPlaneSurfaceKHR) the target
+ * consumes exactly like any other surface. The connector goes dark for the
+ * desktop while we own it — this is a FULLSCREEN-ONLY, opt-in path
+ * (DXR_LINUX_DIRECT_SCANOUT=1). The Wayland / DRM-lease acquisition
+ * (VK_EXT_acquire_drm_display) is a documented future path, not built here.
+ *
+ * Unlike the XCB backend — which defers surface creation to the target — this
+ * backend OWNS the VkSurfaceKHR (only it has the display/mode/plane context to
+ * build it) and hands the finished surface to the target; the target must not
+ * destroy an externally-provided surface (see comp_vk_native_target's
+ * external-surface handling). See docs/roadmap/linux-support.md and
+ * ST-5539 (sw-runtime-linux).
+ *
+ * @ingroup comp_vk_native
+ */
+
+#pragma once
+
+#include "xrt/xrt_results.h"
+#include "vk/vk_helpers.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct comp_vk_native_window_direct;
+
+/*!
+ * Acquire the 3D-display connector and build a direct-scanout surface.
+ *
+ * Enumerates the physical device's displays, selects the target connector
+ * (see @p screen_left / @p screen_top and EDID matching below), acquires it
+ * from the X server, picks its native display mode + a compatible plane, and
+ * creates the display-plane VkSurfaceKHR.
+ *
+ * All of the required instance extensions (VK_KHR_display,
+ * VK_EXT_direct_mode_display, VK_EXT_acquire_xlib_display) are OPTIONAL at
+ * bundle-build time, so this call fails cleanly (leaving @p out_win NULL) when
+ * any is missing — the caller then falls back to the XCB path. Failure here is
+ * expected on non-direct-capable boxes and must not be fatal.
+ *
+ * @param vk            The compositor's already-created Vulkan bundle (needs a
+ *                      valid instance + physical_device; the display/acquire
+ *                      function pointers are loaded into it when the exts are
+ *                      enabled).
+ * @param screen_left   Target connector left edge in root-window pixels — the
+ *                      3D-panel origin the vendor plug-in reports via
+ *                      xsysc->info.display_screen_left. Used to disambiguate
+ *                      the RandR output when EDID matching is inconclusive.
+ * @param screen_top    Target connector top edge in root-window pixels.
+ * @param out_win       Receives the created backend on success, NULL on failure.
+ *
+ * @return XRT_SUCCESS on success; an error code (and NULL @p out_win) on any
+ *         failure — extension missing, no matching connector, acquire denied.
+ */
+xrt_result_t
+comp_vk_native_window_direct_create(struct vk_bundle *vk,
+                                    int32_t screen_left,
+                                    int32_t screen_top,
+                                    struct comp_vk_native_window_direct **out_win);
+
+/*!
+ * Get the finished display-plane surface for swapchain creation. The backend
+ * owns this surface; the target borrows it and must NOT destroy it.
+ */
+VkSurfaceKHR
+comp_vk_native_window_direct_get_surface(struct comp_vk_native_window_direct *win);
+
+/*!
+ * Get the acquired connector's native mode dimensions in pixels. These are the
+ * scanout dimensions the swapchain must match (a direct-mode surface has no
+ * "resize" — the mode is fixed for the session).
+ */
+void
+comp_vk_native_window_direct_get_dimensions(struct comp_vk_native_window_direct *win,
+                                            uint32_t *out_width,
+                                            uint32_t *out_height);
+
+/*!
+ * Whether the backend still owns a valid acquired display. Direct scanout has
+ * no user-close event, so this only turns false on teardown; kept for
+ * signature parity with the XCB backend's per-frame validity check.
+ */
+bool
+comp_vk_native_window_direct_is_valid(struct comp_vk_native_window_direct *win);
+
+/*!
+ * Destroy the display-plane surface, release the display back to the X server
+ * (vkReleaseDisplayEXT), close the X connection, and free the backend
+ * (sets *win_ptr to NULL). Call AFTER the target's swapchain is torn down.
+ */
+void
+comp_vk_native_window_direct_destroy(struct comp_vk_native_window_direct **win_ptr);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Closes the presentation-overhead half of **ST-5539** (sw-runtime-linux). Fixes #755.

## What
Opt-in, fullscreen-only **direct-scanout** present path for the Linux Vulkan compositor: acquire the 3D-panel connector as a `VkDisplayKHR` (`VK_EXT_acquire_xlib_display` on Xorg) and scan out to it directly, **bypassing Xorg + gnome-shell** — the ~44% presentation cost Suki measured.

## Why it's runtime-only (re-scope from the report)
The report attributed the present to the Leia plug-in, but on Linux the plug-in weaves into a **caller-provided** target and does **not** own a swapchain or present (contract §3.3). `comp_vk_native` owns the swapchain + present. **No plug-in / srSDK change.**

## Changes
- **`comp_vk_native_window_direct.{c,h}`** — RandR output → `VkDisplayKHR` → acquire → display-plane surface (Monado `comp_window_direct_randr` model).
- **Activated the dormant aux-layer `VK_KHR_display` path** — `VK_USE_PLATFORM_DISPLAY_KHR` / `_XLIB_XRANDR_EXT` were in `xrt_config_vulkan.h.cmake_in` but never `set()`; new `XRT_HAVE_XLIB_XRANDR` (pkg `x11`+`xrandr`) drives them. This is *why* the report saw "VK_KHR_display referenced but not wired."
- **`null_compositor`** — requests the display exts as **optional** → graceful XCB fallback.
- **`comp_vk_native_target`** — `create_from_surface()` consumes a pre-made (borrowed) surface; `external_surface` guards teardown.
- **compositor** — fullscreen hosted path tries direct when `DXR_LINUX_DIRECT_SCANOUT=1`, silently falls back to XCB on any failure. **Default path untouched.**

## Testing
- Compile-checked by this PR's **Linux CI** (CI has `libx11-dev`+`libxrandr-dev` → `XRT_HAVE_XLIB_XRANDR` on).
- ⚠️ **Draft** — needs on-hardware validation on the **P1 + DS1** box (@ handoff to Suki): `DXR_LINUX_DIRECT_SCANOUT=1` + a fullscreen app (model-viewer / gauss), confirm the connector is scanned out directly and `intel_gpu_top` shows the Xorg share drop.

## Notes
- Fullscreen-only by nature (model-viewer, gauss) — matches the in-thread conclusion.
- clang-format not run locally (not installed on the authoring box); style matched by hand — reformat if the linter nits.
- Wayland/DRM-lease (`VK_EXT_acquire_drm_display`) documented as the future path, not built here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)