### PR TITLE
feat(linux,#757): X11 ARGB transparent surface, windowed weaving, Wayland backend + compose-under seam

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -104,7 +104,7 @@ jobs:
             build-essential cmake ninja-build pkg-config \
             libvulkan-dev vulkan-validationlayers glslang-tools \
             libeigen3-dev libcjson-dev libudev-dev \
-            libxcb1-dev libxcb-randr0-dev libx11-dev libx11-xcb-dev \
+            libxcb1-dev libxcb-randr0-dev libx11-dev libx11-xcb-dev libwayland-dev \
             libgl1-mesa-dev libegl1-mesa-dev libxrandr-dev libxxf86vm-dev libxcb-glx0-dev
 
       - name: Build + headless selftest + test app
@@ -139,7 +139,7 @@ jobs:
             build-essential cmake ninja-build pkg-config git \
             libvulkan-dev vulkan-validationlayers glslang-tools \
             libeigen3-dev libcjson-dev libudev-dev \
-            libxcb1-dev libxcb-randr0-dev libx11-dev libx11-xcb-dev \
+            libxcb1-dev libxcb-randr0-dev libx11-dev libx11-xcb-dev libwayland-dev \
             libgl1-mesa-dev libegl1-mesa-dev libxrandr-dev libxxf86vm-dev libxcb-glx0-dev
 
       - uses: actions/checkout@v5
@@ -202,7 +202,7 @@ jobs:
             build-essential cmake ninja-build pkg-config \
             libvulkan-dev vulkan-validationlayers glslang-tools \
             libeigen3-dev libcjson-dev libudev-dev \
-            libxcb1-dev libxcb-randr0-dev libx11-dev libx11-xcb-dev \
+            libxcb1-dev libxcb-randr0-dev libx11-dev libx11-xcb-dev libwayland-dev \
             libgl1-mesa-dev libegl1-mesa-dev libxrandr-dev libxxf86vm-dev libxcb-glx0-dev
 
       - name: Build service + IPC-client runtime (headless selftest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -441,6 +441,15 @@ if(XRT_HAVE_SDL2)
 endif()
 
 # Vulkan flags for the shared Vulkan code.
+#
+# These MUST be set here (globally, flowing into xrt_config_vulkan.h) and never
+# as per-target compile definitions: struct vk_bundle (vk_helpers.h) has
+# members conditionally compiled under VK_USE_PLATFORM_*, so a target-local
+# define gives that target a DIFFERENT struct layout than aux_vk, which fills
+# the bundle — every member after the conditional one shifts by a pointer, and
+# the first dispatch call through the skewed bundle lands in the wrong
+# entry point (#757: vkCreateCommandPool slot invoking vkAllocateCommandBuffers
+# with reinterpreted args → SIGSEGV in the ICD on every session-create).
 if(XRT_HAVE_XCB)
 	set(VK_USE_PLATFORM_XCB_KHR TRUE)
 endif()
@@ -450,6 +459,9 @@ endif()
 if(XRT_HAVE_XLIB_XRANDR)
 	set(VK_USE_PLATFORM_DISPLAY_KHR TRUE)
 	set(VK_USE_PLATFORM_XLIB_XRANDR_EXT TRUE)
+endif()
+if(XRT_HAVE_WAYLAND)
+	set(VK_USE_PLATFORM_WAYLAND_KHR TRUE)
 endif()
 if(ANDROID)
 	set(VK_USE_PLATFORM_ANDROID_KHR TRUE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,6 +212,10 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
 		# bypassing Xorg/compositor — ST-5539). Optional; absence just leaves
 		# the compositor on the XCB present path.
 		pkg_check_modules(XLIB_XRANDR x11 xrandr)
+		# Wayland client for the app-provided-surface present path (runtime#757
+		# WS3b, XR_DXR_wayland_surface_binding). Optional — X11/XCB is the
+		# primary desktop path.
+		pkg_check_modules(WAYLAND wayland-client)
 	endif()
 endif()
 
@@ -250,6 +254,7 @@ option_with_deps(XRT_HAVE_XCB "Enable xcb support" DEPENDS XCB_FOUND)
 # VkDisplayKHR (VK_EXT_acquire_xlib_display / VK_KHR_display). Optional — the
 # compositor falls back to the XCB window path when absent. ST-5539.
 option_with_deps(XRT_HAVE_XLIB_XRANDR "Enable Xlib/Xrandr direct-scanout present (Linux)" DEPENDS XLIB_XRANDR_FOUND XRT_HAVE_XCB)
+option_with_deps(XRT_HAVE_WAYLAND "Enable Wayland app-surface present path (XR_DXR_wayland_surface_binding)" DEPENDS WAYLAND_FOUND XRT_HAVE_VULKAN)
 
 # System deps to use (sorted)
 option_with_deps(XRT_HAVE_LIBUDEV "Enable libudev (used for device probing on Linux)" DEPENDS UDEV_FOUND)

--- a/src/external/openxr_includes/openxr/XR_DXR_wayland_surface_binding.h
+++ b/src/external/openxr_includes/openxr/XR_DXR_wayland_surface_binding.h
@@ -1,0 +1,88 @@
+// Copyright 2026, The DisplayXR Project
+// SPDX-License-Identifier: Apache-2.0
+//
+// PROVISIONAL — DXR is DisplayXR's Khronos-registered OpenXR author ID, but
+// the XR_DXR_* extensions in this header are NOT yet registered in the
+// Khronos OpenXR registry: extension numbers and XrStructureType values sit
+// in a provisional experimental block (1004999xxx) pending official
+// assignment. Extension names are expected to be stable; numeric values are
+// not.
+// See GOVERNANCE.md.
+//
+/*!
+ * @file
+ * @brief  Header for XR_DXR_wayland_surface_binding extension
+ * @author David Fattal
+ * @ingroup external_openxr
+ *
+ * This extension lets an OpenXR application provide its own Wayland surface
+ * (wl_display* + wl_surface*) to the runtime on desktop Linux. When provided,
+ * the runtime renders into the application's surface instead of creating its
+ * own window. Sibling of XR_DXR_xlib_window_binding (X11), XR_DXR_win32_window_binding
+ * (HWND), and XR_DXR_cocoa_window_binding (NSView).
+ *
+ * The app owns the surface lifecycle (registry, xdg-shell toplevel, configure
+ * acks, the Wayland event loop); the runtime only builds its VkSurfaceKHR from
+ * the pair via VK_KHR_wayland_surface. Transparency is native on Wayland — a
+ * surface composites its premultiplied alpha over whatever is behind it, so
+ * transparentBackgroundEnabled needs no ARGB-visual dance (unlike X11).
+ */
+#ifndef XR_DXR_WAYLAND_SURFACE_BINDING_H
+#define XR_DXR_WAYLAND_SURFACE_BINDING_H 1
+
+#include <openxr/openxr.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define XR_DXR_wayland_surface_binding 1
+#define XR_DXR_wayland_surface_binding_SPEC_VERSION 1
+#define XR_DXR_WAYLAND_SURFACE_BINDING_EXTENSION_NAME "XR_DXR_wayland_surface_binding"
+
+// Value from the DisplayXR provisional 1004999xxx block — decade 1004999210–219
+// (the xlib sibling claimed 200–209). Replace with an official Khronos-assigned
+// value if the extension is standardized.
+#define XR_TYPE_WAYLAND_SURFACE_BINDING_CREATE_INFO_DXR ((XrStructureType)1004999210)
+
+// Only meaningful on desktop Linux (Android also reports __linux__ but has no
+// Wayland desktop surface path).
+#if defined(__linux__) && !defined(__ANDROID__)
+
+// Opaque stand-ins so the header stays self-contained when <wayland-client.h>
+// was not included first (same trick as the xlib sibling). wl_display/wl_surface
+// are opaque structs on the client side.
+struct wl_display;
+struct wl_surface;
+
+/*!
+ * @brief Structure passed in XrSessionCreateInfo::next chain to provide an
+ *        external Wayland surface for session rendering on desktop Linux.
+ *
+ * Both wlDisplay and wlSurface must be valid; the wl_display connection must
+ * outlive the session (the runtime borrows it for the lifetime of the Vulkan
+ * surface).
+ *
+ * @extends XrSessionCreateInfo
+ */
+typedef struct XrWaylandSurfaceBindingCreateInfoDXR {
+    XrStructureType             type;       //!< Must be XR_TYPE_WAYLAND_SURFACE_BINDING_CREATE_INFO_DXR
+    const void* XR_MAY_ALIAS    next;       //!< Pointer to next structure in chain
+    struct wl_display*          wlDisplay;  //!< Wayland display connection (wl_display_connect)
+    struct wl_surface*          wlSurface;  //!< Wayland surface owned by the app
+    //! When XR_TRUE, the runtime picks a non-opaque swapchain compositeAlpha so
+    //! pixels the app writes transparent (alpha = 0) compose through to whatever
+    //! is behind the surface. Native on Wayland — no ARGB visual needed. Only
+    //! honored when both wlDisplay and wlSurface are valid. Sibling of
+    //! XrXlibWindowBindingCreateInfoDXR::transparentBackgroundEnabled.
+    XrBool32                    transparentBackgroundEnabled;
+} XrWaylandSurfaceBindingCreateInfoDXR;
+
+#endif // defined(__linux__) && !defined(__ANDROID__)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // XR_DXR_WAYLAND_SURFACE_BINDING_H

--- a/src/external/openxr_includes/openxr/XR_DXR_xlib_window_binding.h
+++ b/src/external/openxr_includes/openxr/XR_DXR_xlib_window_binding.h
@@ -48,7 +48,7 @@ extern "C" {
 #endif
 
 #define XR_DXR_xlib_window_binding 1
-#define XR_DXR_xlib_window_binding_SPEC_VERSION 1
+#define XR_DXR_xlib_window_binding_SPEC_VERSION 2
 #define XR_DXR_XLIB_WINDOW_BINDING_EXTENSION_NAME "XR_DXR_xlib_window_binding"
 
 // Value from the DisplayXR provisional 1004999xxx block — decade 1004999200–209
@@ -92,6 +92,16 @@ typedef struct XrXlibWindowBindingCreateInfoDXR {
     const void* XR_MAY_ALIAS    next;      //!< Pointer to next structure in chain
     Display*                    xDisplay;  //!< Xlib display connection (XOpenDisplay)
     XR_XLIB_WINDOW_TYPE_        window;    //!< X11 Window (XID) owned by the app
+    //! When XR_TRUE, the runtime configures the bound window for transparent
+    //! desktop composition: pixels the app writes with full opacity appear
+    //! opaque on screen, and pixels written transparent (alpha = 0) compose
+    //! through to the desktop underneath. On X11 the runtime selects a 32-bit
+    //! ARGB visual and a non-opaque swapchain compositeAlpha; a compositing
+    //! window manager (e.g. GNOME/Mutter, KWin, picom) must be running for the
+    //! desktop to show through. Only honored when both xDisplay and window are
+    //! valid. Sibling of XrWin32WindowBindingCreateInfoDXR::transparentBackgroundEnabled
+    //! (SPEC_VERSION 2).
+    XrBool32                    transparentBackgroundEnabled;
 } XrXlibWindowBindingCreateInfoDXR;
 
 #undef XR_XLIB_WINDOW_TYPE_

--- a/src/xrt/compositor/vk_native/CMakeLists.txt
+++ b/src/xrt/compositor/vk_native/CMakeLists.txt
@@ -99,7 +99,13 @@ if((WIN32 OR APPLE OR ANDROID OR (XRT_HAVE_LINUX AND XRT_HAVE_XCB)) AND XRT_HAVE
 		# VK_KHR_wayland_surface. No self-created window / xdg-shell — the app owns
 		# the surface lifecycle. WAYLAND_{LIBRARIES,INCLUDE_DIRS} come from the
 		# top-level pkg_check_modules(WAYLAND wayland-client).
-		target_compile_definitions(comp_vk_native PRIVATE VK_USE_PLATFORM_WAYLAND_KHR XRT_HAVE_WAYLAND)
+		#
+		# NOTE: VK_USE_PLATFORM_WAYLAND_KHR and XRT_HAVE_WAYLAND deliberately do
+		# NOT appear as target defines here — they flow globally from
+		# xrt_config_vulkan.h / xrt_config_have.h. A target-local
+		# VK_USE_PLATFORM_* skews the struct vk_bundle layout against aux_vk
+		# (conditional members) — see the platform-flags block in the top
+		# CMakeLists.txt for the full failure mode.
 		target_include_directories(comp_vk_native PRIVATE ${WAYLAND_INCLUDE_DIRS})
 		target_link_libraries(comp_vk_native PRIVATE ${WAYLAND_LIBRARIES})
 	endif()

--- a/src/xrt/compositor/vk_native/CMakeLists.txt
+++ b/src/xrt/compositor/vk_native/CMakeLists.txt
@@ -94,6 +94,16 @@ if((WIN32 OR APPLE OR ANDROID OR (XRT_HAVE_LINUX AND XRT_HAVE_XCB)) AND XRT_HAVE
 		target_link_libraries(comp_vk_native PRIVATE ${XLIB_XRANDR_LIBRARIES})
 	endif()
 
+	if(XRT_HAVE_LINUX AND XRT_HAVE_WAYLAND)
+		# Linux Wayland present path (runtime#757 WS3b): app-provided wl_surface +
+		# VK_KHR_wayland_surface. No self-created window / xdg-shell — the app owns
+		# the surface lifecycle. WAYLAND_{LIBRARIES,INCLUDE_DIRS} come from the
+		# top-level pkg_check_modules(WAYLAND wayland-client).
+		target_compile_definitions(comp_vk_native PRIVATE VK_USE_PLATFORM_WAYLAND_KHR XRT_HAVE_WAYLAND)
+		target_include_directories(comp_vk_native PRIVATE ${WAYLAND_INCLUDE_DIRS})
+		target_link_libraries(comp_vk_native PRIVATE ${WAYLAND_LIBRARIES})
+	endif()
+
 	# Qwerty include path for runtime-side 2D/3D toggle polling
 	if(XRT_BUILD_DRIVER_QWERTY)
 		target_link_libraries(comp_vk_native PRIVATE drv_qwerty_includes)

--- a/src/xrt/compositor/vk_native/comp_vk_native_compositor.c
+++ b/src/xrt/compositor/vk_native/comp_vk_native_compositor.c
@@ -176,6 +176,13 @@ struct comp_vk_native_compositor
 	//! acquire succeeded; NULL means we stayed on the XCB path. ST-5539.
 	struct comp_vk_native_window_direct *direct_window;
 #endif
+#ifdef XRT_HAVE_WAYLAND
+	//! True when the app supplied a Wayland surface (XR_DXR_wayland_surface_binding)
+	//! instead of an X11 window — the target builds a VkWaylandSurfaceKHR.
+	bool use_wayland;
+	//! wl_display* + wl_surface* handed to the target as the type-erased hwnd.
+	struct comp_vk_native_wayland_handle wayland_handle;
+#endif
 #endif
 
 	//! Shared texture VkImage (imported from HANDLE).
@@ -3317,6 +3324,7 @@ apply_window_pos_override(int32_t *left, int32_t *top)
 xrt_result_t
 comp_vk_native_compositor_create(struct xrt_device *xdev,
                                  void *hwnd,
+                                 bool window_is_wayland,
                                  void *vk_instance,
                                  void *vk_physical_device,
                                  void *vk_device,
@@ -3333,6 +3341,7 @@ comp_vk_native_compositor_create(struct xrt_device *xdev,
 		U_LOG_E("VkDevice is null");
 		return XRT_ERROR_DEVICE_CREATION_FAILED;
 	}
+	(void)window_is_wayland; // consumed only in the XRT_HAVE_WAYLAND Linux path
 
 	U_LOG_I("Creating VK native compositor");
 
@@ -3465,7 +3474,21 @@ comp_vk_native_compositor_create(struct xrt_device *xdev,
 	// hwnd is a struct comp_vk_native_xlib_handle* when the app supplied its
 	// own X11 window via XR_DXR_xlib_window_binding (handle class, Phase 3);
 	// NULL for hosted (runtime self-creates an XCB window, Phase 1).
-	if (hwnd != NULL) {
+#ifdef XRT_HAVE_WAYLAND
+	if (window_is_wayland && hwnd != NULL) {
+		// App-provided Wayland surface (XR_DXR_wayland_surface_binding, WS3b):
+		// the target builds a VkWaylandSurfaceKHR from the pair directly — no
+		// XCB window, no xdg-shell (the app owns the surface lifecycle).
+		const struct comp_vk_native_wayland_handle *wl =
+		    (const struct comp_vk_native_wayland_handle *)hwnd;
+		c->wayland_handle = *wl;
+		c->use_wayland = true;
+		c->xcb_window = NULL;
+		c->owns_window = false;
+		U_LOG_I("Using app-provided Wayland surface (XR_DXR_wayland_surface_binding)");
+	} else
+#endif
+	    if (hwnd != NULL) {
 		const struct comp_vk_native_xlib_handle *xlib =
 		    (const struct comp_vk_native_xlib_handle *)hwnd;
 		// Convert the Xlib display to its XCB connection (libX11-xcb) and
@@ -3702,13 +3725,21 @@ comp_vk_native_compositor_create(struct xrt_device *xdev,
 #endif
 		{
 			void *target_hwnd = hwnd;
+			bool target_is_wayland = false;
 #ifdef XRT_OS_WINDOWS
 			if (target_hwnd == NULL) target_hwnd = c->hwnd;
 #endif
 #ifdef XRT_OS_LINUX_DESKTOP
 			if (target_hwnd == NULL && c->xcb_window != NULL) target_hwnd = &c->xcb_handle;
 #endif
-			xret = comp_vk_native_target_create(c, target_hwnd, c->settings.preferred.width,
+#ifdef XRT_HAVE_WAYLAND
+			if (c->use_wayland) {
+				target_hwnd = &c->wayland_handle;
+				target_is_wayland = true;
+			}
+#endif
+			xret = comp_vk_native_target_create(c, target_hwnd, target_is_wayland,
+			                                    c->settings.preferred.width,
 			                                    c->settings.preferred.height,
 			                                    transparent_background, &c->target);
 		}

--- a/src/xrt/compositor/vk_native/comp_vk_native_compositor.c
+++ b/src/xrt/compositor/vk_native/comp_vk_native_compositor.c
@@ -2260,6 +2260,10 @@ vk_flatten_backdrop_2d(struct comp_vk_native_compositor *c,
                        uint32_t *out_h);
 static void
 vk_release_local2d_state(struct comp_vk_native_compositor *c);
+// runtime#757 / LeiaSR#85 — push the app window's panel-relative origin to the DP
+// (windowed-weaving phase anchor). Defined below, next to get_window_metrics.
+static void
+vk_update_present_origin(struct comp_vk_native_compositor *c);
 // #224 / ADR-027 hardware-DP zone leg (P4): one-time caps probe + per-frame
 // sideband publish of the wish / sticky mask. Defined with the other zone
 // helpers near the bottom.
@@ -2714,6 +2718,10 @@ vk_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t
 			// background). Must precede process_atlas.
 			xrt_display_processor_set_background_2d(c->display_processor, bd_view, bd_w, bd_h);
 
+			// Windowed weaving (runtime#757 / LeiaSR#85): anchor the lens phase to
+			// the window's panel position. Must precede process_atlas.
+			vk_update_present_origin(c);
+
 			xrt_display_processor_process_atlas(
 			    c->display_processor,
 			    dp_self_submits ? VK_NULL_HANDLE : cmd,
@@ -2975,6 +2983,10 @@ vk_compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t
 				// #491 part 3 — hand the DP this frame's backdrop (NULL ⟹ clears
 				// it → desktop-only background). Must precede process_atlas.
 				xrt_display_processor_set_background_2d(c->display_processor, bd_view, bd_w, bd_h);
+
+				// Windowed weaving (runtime#757 / LeiaSR#85): anchor the lens phase
+				// to the window's panel position. Must precede process_atlas.
+				vk_update_present_origin(c);
 
 				// Call display processor with atlas (or zero-copy swapchain) texture
 				xrt_display_processor_process_atlas(
@@ -4237,6 +4249,36 @@ comp_vk_native_compositor_get_window_metrics(struct xrt_compositor *xc,
 	out_metrics->valid = true;
 	return true;
 #endif
+}
+
+/*!
+ * Windowed weaving (runtime#757 / LeiaSR#85): tell the DP where the app window's
+ * client area sits on the 3D panel so it can anchor the interlacing phase there,
+ * instead of assuming the window covers the panel from its top-left. The panel
+ * origin is the window's client top-left minus the display's screen origin — both
+ * already computed by @ref comp_vk_native_compositor_get_window_metrics (the same
+ * source the Kooima window metrics use, so the framing and the weave phase agree).
+ *
+ * No-op unless the DP exposes the (ADR-020) `set_present_origin` slot; a
+ * full-panel window (hosted, Android) yields origin (0,0) = display-scoped =
+ * today's behavior. Sticky on the DP side, but we refresh it every weave (cheap)
+ * so a dragged/moved window keeps a correct phase.
+ */
+static void
+vk_update_present_origin(struct comp_vk_native_compositor *c)
+{
+	if (c->display_processor == NULL) {
+		return;
+	}
+	struct xrt_window_metrics m;
+	if (!comp_vk_native_compositor_get_window_metrics(&c->base.base, &m) || !m.valid) {
+		// No live window metrics (headless / no window) — leave the DP
+		// display-scoped (its present origin defaults to (0,0)).
+		return;
+	}
+	xrt_display_processor_vk_set_present_origin((struct xrt_display_processor_vk *)c->display_processor,
+	                                            m.window_screen_left - m.display_screen_left,
+	                                            m.window_screen_top - m.display_screen_top);
 }
 
 bool

--- a/src/xrt/compositor/vk_native/comp_vk_native_compositor.c
+++ b/src/xrt/compositor/vk_native/comp_vk_native_compositor.c
@@ -3672,12 +3672,28 @@ comp_vk_native_compositor_create(struct xrt_device *xdev,
 			return XRT_ERROR_VULKAN;
 		}
 
-		xrt_result_t dp_ret = factory(&c->vk, (void *)(uintptr_t)c->cmd_pool,
+		// Window handed to the DP → the SR weaver. It is NOT for swapchain
+		// creation (the Linux/Vulkan weaver makes none — it renders into our
+		// framebuffer); it is the weaver's window-GEOMETRY input for
+		// getDrawRegions() — the per-view interlacing draw-regions AND the
+		// window-anchored eye-tracked steering. Passing NULL selects the srSDK's
+		// windowless/display-scoped path (constructedWithoutWindow=true), which
+		// weaves for the DEFAULT viewpoint with no window geometry (#778: view
+		// swap on Linux). The working srSDK vulkan_weaving_linux example passes
+		// the real X11 window here, which is why it tracks. So on desktop-Linux
+		// pass the XCB window XID (populated for BOTH the self-created/hosted and
+		// the app-provided/handle window via c->xcb_handle above). macOS keeps
+		// NULL — its weave is the IOSurface shared-surface path, no window.
+		void *dp_window_handle = NULL;
 #ifdef XRT_OS_WINDOWS
-		                               c->hwnd,
-#else
-		                               NULL,
+		dp_window_handle = c->hwnd;
+#elif defined(XRT_OS_LINUX_DESKTOP)
+		dp_window_handle = (void *)(uintptr_t)c->xcb_handle.window;
+		U_LOG_W("VK DP factory: passing X11 window XID 0x%lx to the weaver (0 = windowless/display-scoped)",
+		        (unsigned long)c->xcb_handle.window);
 #endif
+		xrt_result_t dp_ret = factory(&c->vk, (void *)(uintptr_t)c->cmd_pool,
+		                               dp_window_handle,
 		                               (int32_t)VK_FORMAT_B8G8R8A8_UNORM,
 		                               &c->display_processor);
 		if (dp_ret != XRT_SUCCESS) {

--- a/src/xrt/compositor/vk_native/comp_vk_native_compositor.h
+++ b/src/xrt/compositor/vk_native/comp_vk_native_compositor.h
@@ -52,6 +52,7 @@ extern "C" {
 xrt_result_t
 comp_vk_native_compositor_create(struct xrt_device *xdev,
                                  void *hwnd,
+                                 bool window_is_wayland,
                                  void *vk_instance,
                                  void *vk_physical_device,
                                  void *vk_device,

--- a/src/xrt/compositor/vk_native/comp_vk_native_target.cpp
+++ b/src/xrt/compositor/vk_native/comp_vk_native_target.cpp
@@ -752,11 +752,13 @@ dcomp_present(struct comp_vk_native_target *target)
 xrt_result_t
 comp_vk_native_target_create(struct comp_vk_native_compositor *c,
                               void *hwnd,
+                              bool is_wayland,
                               uint32_t width,
                               uint32_t height,
                               bool transparent_background,
                               struct comp_vk_native_target **out_target)
 {
+	(void)is_wayland; // used only in the XRT_HAVE_WAYLAND Linux branch below
 	struct vk_bundle *vk = comp_vk_native_compositor_get_vk(c);
 	uint32_t queue_family_index = comp_vk_native_compositor_get_queue_family(c);
 
@@ -906,6 +908,49 @@ comp_vk_native_target_create(struct comp_vk_native_compositor *c,
 		return XRT_ERROR_VULKAN;
 	}
 #elif defined(XRT_OS_LINUX_DESKTOP)
+#ifdef XRT_HAVE_WAYLAND
+	if (is_wayland) {
+		// App-provided Wayland surface (XR_DXR_wayland_surface_binding, WS3b):
+		// build a VkWaylandSurfaceKHR from the wl_display* + wl_surface* pair.
+		if (hwnd == NULL) {
+			U_LOG_E("VK native target: Wayland handle is NULL");
+			free(target);
+			return XRT_ERROR_DEVICE_CREATION_FAILED;
+		}
+		const struct comp_vk_native_wayland_handle *wl_handle =
+		    (const struct comp_vk_native_wayland_handle *)hwnd;
+		PFN_vkCreateWaylandSurfaceKHR pfnCreateWaylandSurface =
+		    (PFN_vkCreateWaylandSurfaceKHR)vk->vkGetInstanceProcAddr(vk->instance, "vkCreateWaylandSurfaceKHR");
+		if (pfnCreateWaylandSurface == NULL) {
+			U_LOG_E("vkCreateWaylandSurfaceKHR not available — VK_KHR_wayland_surface must be enabled");
+			free(target);
+			return XRT_ERROR_VULKAN;
+		}
+		VkWaylandSurfaceCreateInfoKHR wl_surface_ci = {
+		    .sType = VK_STRUCTURE_TYPE_WAYLAND_SURFACE_CREATE_INFO_KHR,
+		    .pNext = NULL,
+		    .flags = 0,
+		    .display = (struct wl_display *)wl_handle->display,
+		    .surface = (struct wl_surface *)wl_handle->surface,
+		};
+		VkResult wl_res = pfnCreateWaylandSurface(vk->instance, &wl_surface_ci, NULL, &target->surface);
+		if (wl_res != VK_SUCCESS) {
+			U_LOG_E("Failed to create Wayland surface: %d", wl_res);
+			free(target);
+			return XRT_ERROR_VULKAN;
+		}
+		VkBool32 wl_present_support = VK_FALSE;
+		vk->vkGetPhysicalDeviceSurfaceSupportKHR(vk->physical_device, queue_family_index, target->surface,
+		                                         &wl_present_support);
+		if (!wl_present_support) {
+			U_LOG_E("Queue family does not support presentation to Wayland surface");
+			vk->vkDestroySurfaceKHR(vk->instance, target->surface, NULL);
+			free(target);
+			return XRT_ERROR_VULKAN;
+		}
+	} else
+#endif
+	{
 	// hwnd is a struct comp_vk_native_xcb_handle* carrying both the
 	// xcb_connection_t* and the xcb_window_t (a single void* can't hold both).
 	if (hwnd == NULL) {
@@ -952,6 +997,7 @@ comp_vk_native_target_create(struct comp_vk_native_compositor *c,
 		free(target);
 		return XRT_ERROR_VULKAN;
 	}
+	} // end XCB (non-Wayland) branch
 #else
 	U_LOG_E("VK native target: no supported surface type on this platform");
 	free(target);

--- a/src/xrt/compositor/vk_native/comp_vk_native_target.h
+++ b/src/xrt/compositor/vk_native/comp_vk_native_target.h
@@ -42,6 +42,7 @@ extern "C" {
 xrt_result_t
 comp_vk_native_target_create(struct comp_vk_native_compositor *c,
                               void *hwnd,
+                              bool is_wayland,
                               uint32_t width,
                               uint32_t height,
                               bool transparent_background,

--- a/src/xrt/compositor/vk_native/comp_vk_native_window_xcb.c
+++ b/src/xrt/compositor/vk_native/comp_vk_native_window_xcb.c
@@ -30,6 +30,10 @@ struct comp_vk_native_window_xcb
 	//! WM_DELETE_WINDOW atom, so a user close is a clean event not an X error.
 	xcb_atom_t atom_wm_delete_window;
 
+	//! Colormap allocated for a 32-bit ARGB visual in transparent-background
+	//! mode; XCB_NONE for the opaque root-visual path. Freed on destroy.
+	xcb_colormap_t colormap;
+
 	//! Live size, seeded at create and updated on ConfigureNotify.
 	uint32_t width;
 	uint32_t height;
@@ -110,6 +114,32 @@ resolve_monitor_index(xcb_connection_t *conn,
 	return chosen;
 }
 
+/*!
+ * Find a 32-bit-depth TrueColor (ARGB) visual on @p screen, for transparent
+ * desktop composition (XR_DXR_xlib_window_binding transparentBackgroundEnabled).
+ * Rendering into an ARGB visual lets the swapchain advertise a non-opaque
+ * compositeAlpha so a compositing window manager blends the surface over the
+ * desktop. Returns XCB_NONE if the screen exposes no depth-32 TrueColor visual
+ * (no ARGB support) — the caller then falls back to the opaque root visual.
+ */
+static xcb_visualid_t
+find_argb_visual(xcb_screen_t *screen)
+{
+	xcb_depth_iterator_t depth_it = xcb_screen_allowed_depths_iterator(screen);
+	for (; depth_it.rem; xcb_depth_next(&depth_it)) {
+		if (depth_it.data->depth != 32) {
+			continue;
+		}
+		xcb_visualtype_iterator_t vis_it = xcb_depth_visuals_iterator(depth_it.data);
+		for (; vis_it.rem; xcb_visualtype_next(&vis_it)) {
+			if (vis_it.data->_class == XCB_VISUAL_CLASS_TRUE_COLOR) {
+				return vis_it.data->visual_id;
+			}
+		}
+	}
+	return XCB_NONE;
+}
+
 xrt_result_t
 comp_vk_native_window_xcb_create(uint32_t width,
                                  uint32_t height,
@@ -118,8 +148,6 @@ comp_vk_native_window_xcb_create(uint32_t width,
                                  bool transparent_background,
                                  struct comp_vk_native_window_xcb **out_win)
 {
-	(void)transparent_background; // X11 ARGB-visual transparency not wired in Phase 1.
-
 	if (width == 0) {
 		width = 1280;
 	}
@@ -159,11 +187,41 @@ comp_vk_native_window_xcb_create(uint32_t width,
 
 	win->window = xcb_generate_id(conn);
 
-	uint32_t value_mask = XCB_CW_BACK_PIXEL | XCB_CW_EVENT_MASK;
-	uint32_t value_list[] = {
-	    screen->black_pixel,
-	    XCB_EVENT_MASK_STRUCTURE_NOTIFY | XCB_EVENT_MASK_KEY_PRESS,
-	};
+	// Transparent-background mode (XR_DXR_xlib_window_binding
+	// transparentBackgroundEnabled): render into a 32-bit ARGB visual so the
+	// swapchain can advertise a non-opaque compositeAlpha and a compositing WM
+	// (GNOME/Mutter, KWin, picom) blends the surface over the desktop. A window
+	// whose depth differs from its parent's must carry its own colormap and an
+	// explicit border-pixel or X raises BadMatch, so both go in the value list.
+	uint8_t depth = XCB_COPY_FROM_PARENT;
+	xcb_visualid_t visual = screen->root_visual;
+	uint32_t value_mask;
+	uint32_t value_list[4];
+
+	xcb_visualid_t argb_visual = transparent_background ? find_argb_visual(screen) : XCB_NONE;
+	if (argb_visual != XCB_NONE) {
+		win->colormap = xcb_generate_id(conn);
+		xcb_create_colormap(conn, XCB_COLORMAP_ALLOC_NONE, win->colormap, screen->root, argb_visual);
+
+		depth = 32;
+		visual = argb_visual;
+		// Values must follow the canonical mask-bit order:
+		// BACK_PIXEL, BORDER_PIXEL, EVENT_MASK, COLORMAP.
+		value_mask = XCB_CW_BACK_PIXEL | XCB_CW_BORDER_PIXEL | XCB_CW_EVENT_MASK | XCB_CW_COLORMAP;
+		value_list[0] = 0; // fully-transparent background fill
+		value_list[1] = 0; // border pixel (required with a non-parent colormap)
+		value_list[2] = XCB_EVENT_MASK_STRUCTURE_NOTIFY | XCB_EVENT_MASK_KEY_PRESS;
+		value_list[3] = win->colormap;
+		U_LOG_I("XCB: transparent-background mode — 32-bit ARGB visual 0x%x", (unsigned)argb_visual);
+	} else {
+		if (transparent_background) {
+			U_LOG_W("XCB: transparentBackgroundEnabled requested but no 32-bit ARGB visual is "
+			        "available — falling back to an opaque window (is a compositing WM running?)");
+		}
+		value_mask = XCB_CW_BACK_PIXEL | XCB_CW_EVENT_MASK;
+		value_list[0] = screen->black_pixel;
+		value_list[1] = XCB_EVENT_MASK_STRUCTURE_NOTIFY | XCB_EVENT_MASK_KEY_PRESS;
+	}
 
 	// Position on the 3D display. The vendor plug-in publishes the panel's
 	// top-left in root-window coordinates through
@@ -171,12 +229,12 @@ comp_vk_native_window_xcb_create(uint32_t width,
 	// (Windows reference: comp_d3d11_window.cpp). (0, 0) means primary
 	// monitor (sim_display default or unknown panel). #715.
 	xcb_create_window(conn,
-	                  XCB_COPY_FROM_PARENT, // depth
+	                  depth,
 	                  win->window, screen->root,
 	                  (int16_t)screen_left, (int16_t)screen_top, (uint16_t)width, (uint16_t)height,
 	                  0,                                 // border
 	                  XCB_WINDOW_CLASS_INPUT_OUTPUT,
-	                  screen->root_visual,
+	                  visual,
 	                  value_mask, value_list);
 
 	// WM_NORMAL_HINTS with USPosition|PPosition, so the window manager treats
@@ -490,6 +548,11 @@ comp_vk_native_window_xcb_destroy(struct comp_vk_native_window_xcb **win_ptr)
 	if (win->connection != NULL) {
 		if (win->window != XCB_NONE) {
 			xcb_destroy_window(win->connection, win->window);
+		}
+		if (win->colormap != XCB_NONE) {
+			xcb_free_colormap(win->connection, win->colormap);
+		}
+		if (win->window != XCB_NONE || win->colormap != XCB_NONE) {
 			xcb_flush(win->connection);
 		}
 		xcb_disconnect(win->connection);

--- a/src/xrt/compositor/vk_native/comp_vk_native_window_xcb.h
+++ b/src/xrt/compositor/vk_native/comp_vk_native_window_xcb.h
@@ -58,6 +58,21 @@ struct comp_vk_native_xlib_handle
 	unsigned long window;
 };
 
+/*!
+ * App-provided Wayland surface (XR_DXR_wayland_surface_binding, runtime#757
+ * WS3b), passed type-erased as the `hwnd` param of comp_vk_native_compositor_create
+ * when `window_is_wayland` is true. The compositor copies the fields
+ * synchronously during create, so the caller may stack-allocate this.
+ *
+ * `display` is a `struct wl_display *` and `surface` a `struct wl_surface *`;
+ * kept as void pointers so includers don't need the Wayland headers.
+ */
+struct comp_vk_native_wayland_handle
+{
+	void *display;
+	void *surface;
+};
+
 struct comp_vk_native_window_xcb;
 
 /*!

--- a/src/xrt/include/xrt/xrt_display_processor_vk.h
+++ b/src/xrt/include/xrt/xrt_display_processor_vk.h
@@ -139,7 +139,49 @@ struct xrt_display_processor_vk
 	 * @param enabled  true ⟹ the app self-presents a shared texture (canvas-only).
 	 */
 	void (*set_shared_texture_present)(struct xrt_display_processor_vk *xdp, bool enabled);
+
+	/*!
+	 * Set the app window's client-area top-left in **panel-relative pixels**
+	 * (origin = the SR display's top-left), so the DP can anchor its interlacing
+	 * phase to where the woven window physically sits on the 3D panel — the
+	 * enabling signal for **windowed weaving** (runtime#757 / LeiaSR#85).
+	 *
+	 * Background: the interlacing phase must align to the drawn region's absolute
+	 * position on the panel. A vendor weaver derives that from the OS window
+	 * position on Windows, but on desktop Linux the window's absolute position is
+	 * not available to the weaver (the SR SDK's screen-rect query returns (0,0),
+	 * and under Wayland a client cannot know its position at all). The compositor
+	 * — which owns window placement and already queries the window's on-screen
+	 * rect for the Kooima window metrics — is the single source of truth, so it
+	 * supplies the origin here. The DP combines it with the per-atlas canvas
+	 * (viewport) offset: phase = present_origin + canvas_offset.
+	 *
+	 * Sticky: applies to every subsequent @ref xrt_display_processor::process_atlas
+	 * until changed. Set (0,0) — or never call — for display-scoped weaving (a
+	 * full-panel window anchored at the panel top-left), which is the default and
+	 * exactly today's behavior. The compositor should call this per frame (cheap)
+	 * or whenever the window moves.
+	 *
+	 * Optional — an absent slot (older plug-in `struct_size`) or NULL ⟹ the DP
+	 * has no windowed-phase support and weaves display-scoped. Appended after
+	 * @ref set_shared_texture_present per ADR-020 (append-only within a major; no
+	 * version bump — gated by the variant's `base.struct_size`).
+	 *
+	 * @param xdp      Pointer to self.
+	 * @param panel_x  Window client-area left edge, panel-relative pixels.
+	 * @param panel_y  Window client-area top edge, panel-relative pixels.
+	 */
+	void (*set_present_origin)(struct xrt_display_processor_vk *xdp, int32_t panel_x, int32_t panel_y);
 };
+
+/*!
+ * Defined when this header carries the @ref xrt_display_processor_vk::set_present_origin
+ * slot, so a plug-in built against an older runtime (which lacks the slot) can
+ * `#ifdef`-guard its implementation and still compile — the coupled-ABI-addition
+ * pattern for a pre-GA feature that lands across the runtime + a vendor plug-in
+ * (runtime#757 / LeiaSR#85).
+ */
+#define XRT_DP_VK_HAS_PRESENT_ORIGIN 1
 
 /*
  * ── Plug-in ABI tripwire (ADR-020) ─────────────────────────────────────────
@@ -166,7 +208,8 @@ XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_vk, base) == 0, XRT_DP_A
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_vk, set_transparent_background) == sizeof(struct xrt_display_processor) + 0 * sizeof(void *), XRT_DP_ABI_MSG);
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_vk, notify_target_recreated)    == sizeof(struct xrt_display_processor) + 1 * sizeof(void *), XRT_DP_ABI_MSG);
 XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_vk, set_shared_texture_present) == sizeof(struct xrt_display_processor) + 2 * sizeof(void *), XRT_DP_ABI_MSG);
-XRT_DP_ABI_ASSERT(sizeof(struct xrt_display_processor_vk) == sizeof(struct xrt_display_processor) + 3 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(offsetof(struct xrt_display_processor_vk, set_present_origin)          == sizeof(struct xrt_display_processor) + 3 * sizeof(void *), XRT_DP_ABI_MSG);
+XRT_DP_ABI_ASSERT(sizeof(struct xrt_display_processor_vk) == sizeof(struct xrt_display_processor) + 4 * sizeof(void *), XRT_DP_ABI_MSG);
 // clang-format on
 
 /*!
@@ -243,6 +286,30 @@ xrt_display_processor_vk_set_shared_texture_present(struct xrt_display_processor
 		return false;
 	}
 	xdp->set_shared_texture_present(xdp, enabled);
+	return true;
+}
+
+/*!
+ * @copydoc xrt_display_processor_vk::set_present_origin
+ *
+ * Returns false if not supported (the plug-in's `base.struct_size` doesn't cover
+ * the slot, or the pointer is NULL) — the caller then leaves the DP weaving
+ * display-scoped (today's behavior). Like the wrappers above, the presence check
+ * reads `xdp->base.struct_size` because the variant embeds the base — see ADR-020.
+ *
+ * @public @memberof xrt_display_processor_vk
+ */
+static inline bool
+xrt_display_processor_vk_set_present_origin(struct xrt_display_processor_vk *xdp, int32_t panel_x, int32_t panel_y)
+{
+	if (xdp == NULL) {
+		return false;
+	}
+	const char *slot_end = (const char *)&xdp->set_present_origin + sizeof(xdp->set_present_origin);
+	if (slot_end > (const char *)xdp + xdp->base.struct_size || xdp->set_present_origin == NULL) {
+		return false;
+	}
+	xdp->set_present_origin(xdp, panel_x, panel_y);
 	return true;
 }
 

--- a/src/xrt/include/xrt/xrt_openxr_includes.h
+++ b/src/xrt/include/xrt/xrt_openxr_includes.h
@@ -73,6 +73,7 @@ typedef __eglMustCastToProperFunctionPointerType (*PFNEGLGETPROCADDRESSPROC)(con
 #include "openxr/XR_DXR_win32_window_binding.h"
 #include "openxr/XR_DXR_cocoa_window_binding.h"
 #include "openxr/XR_DXR_xlib_window_binding.h"
+#include "openxr/XR_DXR_wayland_surface_binding.h"
 #include "openxr/XR_DXR_macos_gl_binding.h"
 #include "openxr/XR_DXR_display_info.h"
 #include "openxr/XR_DXR_spatial_workspace.h"

--- a/src/xrt/state_trackers/oxr/oxr_extension_support.h
+++ b/src/xrt/state_trackers/oxr/oxr_extension_support.h
@@ -18,6 +18,7 @@
 
 #include "xrt/xrt_config_build.h"
 #include "xrt/xrt_config_os.h"
+#include "xrt/xrt_config_have.h" // XRT_HAVE_WAYLAND — gates XR_DXR_wayland_surface_binding
 #include "xrt/xrt_openxr_includes.h"
 
 // beginning of GENERATED defines - do not modify - used by scripts
@@ -563,6 +564,23 @@
     _(DXR_xlib_window_binding, DXR_XLIB_WINDOW_BINDING)
 #else
 #define OXR_EXTENSION_SUPPORT_DXR_xlib_window_binding(_)
+#endif
+
+
+/*
+ * XR_DXR_wayland_surface_binding
+ *
+ * Desktop Linux only (same "Linux AND NOT Android" gate as the xlib sibling),
+ * and additionally gated on XRT_HAVE_WAYLAND — the runtime only advertises it
+ * when the vk_native compositor was built with the Wayland surface path.
+ */
+#if defined(XR_DXR_wayland_surface_binding) && defined(XRT_OS_LINUX) && !defined(XRT_OS_ANDROID) &&                     \
+    defined(XRT_HAVE_WAYLAND)
+#define OXR_HAVE_DXR_wayland_surface_binding
+#define OXR_EXTENSION_SUPPORT_DXR_wayland_surface_binding(_) \
+    _(DXR_wayland_surface_binding, DXR_WAYLAND_SURFACE_BINDING)
+#else
+#define OXR_EXTENSION_SUPPORT_DXR_wayland_surface_binding(_)
 #endif
 
 
@@ -1171,6 +1189,7 @@
     OXR_EXTENSION_SUPPORT_DXR_win32_window_binding(_) \
     OXR_EXTENSION_SUPPORT_DXR_cocoa_window_binding(_) \
     OXR_EXTENSION_SUPPORT_DXR_xlib_window_binding(_) \
+    OXR_EXTENSION_SUPPORT_DXR_wayland_surface_binding(_) \
     OXR_EXTENSION_SUPPORT_DXR_macos_gl_binding(_) \
     OXR_EXTENSION_SUPPORT_DXR_display_info(_) \
     OXR_EXTENSION_SUPPORT_DXR_spatial_workspace(_) \

--- a/src/xrt/state_trackers/oxr/oxr_objects.h
+++ b/src/xrt/state_trackers/oxr/oxr_objects.h
@@ -1612,6 +1612,7 @@ oxr_session_populate_vk_native(struct oxr_logger *log,
                                 struct oxr_system *sys,
                                 XrGraphicsBindingVulkanKHR const *next,
                                 void *window_handle,
+                                bool window_is_wayland,
                                 void *shared_texture_handle,
                                 bool transparent_background,
                                 struct oxr_session *sess);

--- a/src/xrt/state_trackers/oxr/oxr_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_session.c
@@ -3341,6 +3341,7 @@ oxr_session_create_impl(struct oxr_logger *log,
 			// via VK_EXT_metal_objects import.
 #endif
 
+			bool window_is_wayland = false;
 #if defined(OXR_HAVE_DXR_xlib_window_binding)
 			// On desktop Linux, extract from xlib_window_binding.
 			// vkCreateXcbSurfaceKHR needs both the Display-derived connection
@@ -3357,6 +3358,22 @@ oxr_session_create_impl(struct oxr_logger *log,
 			}
 #endif
 
+#if defined(OXR_HAVE_DXR_wayland_surface_binding)
+			// App-provided Wayland surface (WS3b). Packs the wl_display*/wl_surface*
+			// pair; the target builds a VkWaylandSurfaceKHR. Takes precedence over
+			// the xlib binding if (implausibly) both are chained.
+			struct comp_vk_native_wayland_handle wayland_handle = {0};
+			const XrWaylandSurfaceBindingCreateInfoDXR *wayland_binding = OXR_GET_INPUT_FROM_CHAIN(
+			    createInfo, XR_TYPE_WAYLAND_SURFACE_BINDING_CREATE_INFO_DXR, XrWaylandSurfaceBindingCreateInfoDXR);
+			if (wayland_binding != NULL && wayland_binding->wlDisplay != NULL &&
+			    wayland_binding->wlSurface != NULL) {
+				wayland_handle.display = (void *)wayland_binding->wlDisplay;
+				wayland_handle.surface = (void *)wayland_binding->wlSurface;
+				window_handle = &wayland_handle;
+				window_is_wayland = true;
+			}
+#endif
+
 			xrt_result_t xret = xrt_system_create_session(
 			    sys->xsys, xsi, &(*out_session)->xs, NULL);
 			if (xret == XRT_ERROR_MULTI_SESSION_NOT_IMPLEMENTED) {
@@ -3368,7 +3385,7 @@ oxr_session_create_impl(struct oxr_logger *log,
 				                 "Failed to create xrt_session! '%i'", xret);
 			}
 			return oxr_session_populate_vk_native(
-			    log, sys, vulkan, window_handle, shared_texture_handle,
+			    log, sys, vulkan, window_handle, window_is_wayland, shared_texture_handle,
 			    xsi->transparent_background_enabled, *out_session);
 		}
 #endif
@@ -3756,6 +3773,15 @@ oxr_session_create(struct oxr_logger *log,
 	const XrXlibWindowBindingCreateInfoDXR *xlib_target_info = OXR_GET_INPUT_FROM_CHAIN(
 	    createInfo, XR_TYPE_XLIB_WINDOW_BINDING_CREATE_INFO_DXR, XrXlibWindowBindingCreateInfoDXR);
 	if (xlib_target_info != NULL && xlib_target_info->transparentBackgroundEnabled) {
+		xsi.transparent_background_enabled = true;
+	}
+#endif
+
+#if defined(OXR_HAVE_DXR_wayland_surface_binding)
+	// Wayland transparency opt-in (WS3b) — sibling of the xlib block above.
+	const XrWaylandSurfaceBindingCreateInfoDXR *wayland_target_info = OXR_GET_INPUT_FROM_CHAIN(
+	    createInfo, XR_TYPE_WAYLAND_SURFACE_BINDING_CREATE_INFO_DXR, XrWaylandSurfaceBindingCreateInfoDXR);
+	if (wayland_target_info != NULL && wayland_target_info->transparentBackgroundEnabled) {
 		xsi.transparent_background_enabled = true;
 	}
 #endif

--- a/src/xrt/state_trackers/oxr/oxr_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_session.c
@@ -3747,6 +3747,19 @@ oxr_session_create(struct oxr_logger *log,
 	}
 #endif
 
+#if defined(OXR_HAVE_DXR_xlib_window_binding)
+	// Parse XR_DXR_xlib_window_binding extension (desktop Linux) — only the
+	// transparent-background opt-in is read here (upstream, where xsi is
+	// mutable). The Display/Window pair is resolved later, in the vk_native
+	// branch of oxr_session_populate_graphics, and packed into a
+	// comp_vk_native_xlib_handle. Sibling of the win32/cocoa flags above.
+	const XrXlibWindowBindingCreateInfoDXR *xlib_target_info = OXR_GET_INPUT_FROM_CHAIN(
+	    createInfo, XR_TYPE_XLIB_WINDOW_BINDING_CREATE_INFO_DXR, XrXlibWindowBindingCreateInfoDXR);
+	if (xlib_target_info != NULL && xlib_target_info->transparentBackgroundEnabled) {
+		xsi.transparent_background_enabled = true;
+	}
+#endif
+
 	U_LOG_W("xsi after parsing: external_window=%p, readback=%p, shared_tex=%p",
 	        xsi.external_window_handle, (void *)xsi.readback_callback, xsi.shared_texture_handle);
 

--- a/src/xrt/state_trackers/oxr/oxr_session_gfx_vk_native.c
+++ b/src/xrt/state_trackers/oxr/oxr_session_gfx_vk_native.c
@@ -252,6 +252,7 @@ oxr_session_populate_vk_native(struct oxr_logger *log,
                                 struct oxr_system *sys,
                                 XrGraphicsBindingVulkanKHR const *next,
                                 void *window_handle,
+                                bool window_is_wayland,
                                 void *shared_texture_handle,
                                 bool transparent_background,
                                 struct oxr_session *sess)
@@ -312,7 +313,7 @@ oxr_session_populate_vk_native(struct oxr_logger *log,
 
 	// Create the VK native compositor
 	xrt_result_t xret = comp_vk_native_compositor_create(
-	    xdev, window_handle,
+	    xdev, window_handle, window_is_wayland,
 	    (void *)next->instance,
 	    (void *)next->physicalDevice,
 	    (void *)next->device,


### PR DESCRIPTION
Runtime half of the Linux avatar-overlay transparency feature (#757). **Draft — WIP**; opened for Linux tri-LTS CI compile-validation while the rest of the feature lands.

**In this PR (WS3 + WS5):**
- `XR_DXR_xlib_window_binding`: `transparentBackgroundEnabled` (SPEC_VERSION 1→2), parsed in `oxr_session.c`.
- `comp_vk_native_window_xcb.c`: 32-bit ARGB visual + colormap when transparency is requested (opaque fallback + WARN otherwise); frees colormap on destroy. The target's PRE_MULTIPLIED/INHERIT compositeAlpha selection (already non-macOS-gated) engages once the surface advertises it.

Requires a compositing WM (GNOME/Mutter, KWin, picom).

**Not yet in this PR (tracked on #757):** WS3b Wayland surface backend; extension header sync to displayxr-extensions (on merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)