### PR TITLE
feat(macos,#759): XR_DXR_weave service on the macOS shared-surface path

### DIFF
--- a/docs/specs/extensions/XR_DXR_weave.md
+++ b/docs/specs/extensions/XR_DXR_weave.md
@@ -4,7 +4,7 @@
 |---|---|
 | **Extension Name** | `XR_DXR_weave` |
 | **Spec Version** | 3 |
-| **Extension Type** | Instance extension (Windows / D3D11 service path only) |
+| **Extension Type** | Instance extension (service path only — Windows/D3D11 + macOS/comp_multi-Vulkan, #759) |
 | **Header** | `src/external/openxr_includes/openxr/XR_DXR_weave.h` (canonical; auto-syncs to `displayxr-extensions`) |
 | **Status** | Provisional (`1004999190–192` type block, pending Khronos registry) |
 | **Design history** | `docs/roadmap/webxr-step-b-design.md` §13.6–13.9, issue #625 |
@@ -89,7 +89,27 @@ window-sized output), so ONE submit carrying N rects makes 50 visible tiles cost
   low-bit-tagged with no `OpenProcess` — required for Low-integrity sandboxed callers
   (Chromium's GPU process; see #743). NT handles remain supported for Medium callers.
 
-## 5. Version history
+## 5. macOS platform mapping (#759)
+
+The macOS service (comp_multi + null compositor, Vulkan/MoltenVK) implements the same three entry
+points with these platform substitutions (`comp_multi_weave_macos.c`):
+
+| Contract point | Windows (D3D11 service) | macOS (comp_multi Vulkan) |
+|---|---|---|
+| `windowHandle` | HWND (DP phase snap + `GetClientRect` sizing) | opaque id, stored only (sim/anaglyph has no lattice) |
+| `inputTexture` | D3D11 NT / legacy-DXGI shared HANDLE | **IOSurfaceRef** (crosses IPC as a global IOSurfaceID) |
+| `inputIsDxgi` | selects legacy-DXGI open path | ignored |
+| Input-ready sync | keyed mutex `AcquireSync(0)` | caller completes GPU writes **before** `xrWeaveSubmitDXR` |
+| Output sizing | bound window client rect | batch: **input IOSurface dims** (the v3 input is window-client-sized by contract); legacy: rect offset+extent |
+| `weavedTexture` | shared NT HANDLE (caller `CloseHandle`s) | retained IOSurfaceRef (caller `CFRelease`s) |
+| `fence` / `fenceValue` | shared D3D fence, GPU-wait | **no fence — completion is SYNCHRONOUS**: `xrWeaveSubmitDXR` returns after the weave finished on the GPU. `fence` stays NULL; `fenceValue` is a plain monotonic counter |
+| `xrWeaveSnapWindowRectDXR` | vendor DP lattice snap | identity (no VK DP snap slot yet) |
+
+The batch algorithm is identical (all rects blitted into ONE window-sized 2×1 SBS scratch, ONE
+`process_atlas` per submit). Verification harness: `test_apps/probes/weave_probe_vk_macos`
+(headless; CPU-checks the sim anaglyph weave — left-eye-white → red, right-eye-white → cyan).
+
+## 6. Version history
 
 | Version | Change |
 |---|---|
@@ -97,7 +117,7 @@ window-sized output), so ONE submit carrying N rects makes 50 visible tiles cost
 | 2 | `inputIsDxgi` legacy-DXGI handle tagging (Low-integrity GPU-process callers, #743). |
 | 3 | `XrWeaveSubmitRectsDXR` batched submit — N rects, one call, one fence (#744). |
 
-## 6. Consumers
+## 7. Consumers
 
 | Consumer | Path | Layout used |
 |---|---|---|

--- a/src/xrt/compositor/CMakeLists.txt
+++ b/src/xrt/compositor/CMakeLists.txt
@@ -300,6 +300,10 @@ endif()
 # fails to link with an undefined comp_window_macos_set_visible.
 if(APPLE)
 	target_link_libraries(comp_multi PRIVATE comp_macos_window)
+	# XR_DXR_weave present-owner service (#759): IOSurface in/out + the
+	# Vulkan weave engine.
+	target_sources(comp_multi PRIVATE multi/comp_multi_weave_macos.c)
+	target_link_libraries(comp_multi PRIVATE "-framework IOSurface" "-framework CoreFoundation")
 endif()
 
 ###

--- a/src/xrt/compositor/multi/comp_multi_compositor.c
+++ b/src/xrt/compositor/multi/comp_multi_compositor.c
@@ -1305,6 +1305,11 @@ multi_compositor_destroy(struct xrt_compositor *xc)
 	// compositor pointer never inherits a stale entry / dangling swapchain ref.
 	comp_multi_workspace_chrome_clear(xc);
 
+#ifdef XRT_OS_MACOS
+	// XR_DXR_weave present-owner resources (#759) — no-op if never used.
+	comp_multi_weave_fini(mc);
+#endif
+
 	if (mc->state.session_active) {
 		multi_system_compositor_update_session_status(mc->msc, false);
 		mc->state.session_active = false;

--- a/src/xrt/compositor/multi/comp_multi_private.h
+++ b/src/xrt/compositor/multi/comp_multi_private.h
@@ -428,6 +428,63 @@ struct multi_compositor
 		//! True if per-session resources are initialized
 		bool initialized;
 	} session_render;
+
+#ifdef XRT_OS_MACOS
+	/*!
+	 * XR_DXR_weave present-owner state (#759) — the macOS analogue of the
+	 * per-client weave block in d3d11_client_render_resources
+	 * (comp_d3d11_service.cpp, #625). The caller owns its NSWindow and
+	 * presents itself; we import its IOSurface, blit every submitted rect
+	 * into a window-sized 2x1 SBS scratch atlas, run ONE DP process_atlas
+	 * into an IOSurface-backed output, and wait completion before the IPC
+	 * reply (synchronous contract — no cross-process fence on macOS).
+	 * Implemented in comp_multi_weave_macos.c.
+	 */
+	struct
+	{
+		bool mutex_initialized;
+		struct os_mutex mutex; //!< Serializes submits + teardown for this client.
+
+		bool engine_initialized;
+		VkCommandPool cmd_pool;
+		VkCommandBuffer cmd;
+		VkFence fence;
+		VkRenderPass render_pass; //!< Output fb's pass (DP-compatible, BGRA8).
+		struct xrt_display_processor *dp;
+
+		uint64_t window_id;   //!< Present-owner window id from bind (future phase use).
+		uint64_t fence_value; //!< Monotonic; completion is synchronous on macOS.
+
+		//! @name Cached input import (rebuilt when the IOSurfaceID changes)
+		//! @{
+		void *in_iosurface; //!< Retained IOSurfaceRef (adopted from the IPC receive).
+		uint32_t in_iosurface_id;
+		VkImage in_image;
+		VkDeviceMemory in_memory;
+		uint32_t in_w, in_h;
+		bool in_first_use; //!< First barrier transitions from UNDEFINED.
+		//! @}
+
+		//! @name Window-sized 2x1 SBS scratch atlas (2*out_w x out_h)
+		//! @{
+		VkImage sbs_image;
+		VkDeviceMemory sbs_memory;
+		VkImageView sbs_view;
+		uint32_t sbs_w, sbs_h;
+		bool sbs_first_use;
+		//! @}
+
+		//! @name IOSurface-backed weaved output (exported to the caller)
+		//! @{
+		VkImage out_image;
+		VkDeviceMemory out_memory;
+		VkImageView out_view;
+		VkFramebuffer out_fb;
+		void *out_iosurface; //!< Retained exported IOSurfaceRef.
+		uint32_t out_w, out_h;
+		//! @}
+	} weave;
+#endif
 };
 
 /*!
@@ -731,6 +788,56 @@ multi_system_compositor_update_session_status(struct multi_system_compositor *ms
  */
 bool
 multi_compositor_init_session_render(struct multi_compositor *mc);
+
+#ifdef XRT_OS_MACOS
+/*!
+ * @name XR_DXR_weave on the macOS service path (#759)
+ * Present-owner weave entry points, called from ipc_server_handler.c exactly
+ * where the Windows build calls comp_d3d11_service_weave_* (#625). All are
+ * implemented in comp_multi_weave_macos.c; see that file for the platform
+ * contract (IOSurface transport, synchronous completion, no fence).
+ * @{
+ */
+bool
+comp_multi_weave_bind_window(struct xrt_compositor *xc, uint64_t window_id);
+
+bool
+comp_multi_weave_submit(struct xrt_compositor *xc,
+                        xrt_graphics_buffer_handle_t in_handle,
+                        int32_t rect_x,
+                        int32_t rect_y,
+                        uint32_t rect_w,
+                        uint32_t rect_h,
+                        uint32_t rect_count,
+                        const struct xrt_rect *rects,
+                        uint32_t *out_width,
+                        uint32_t *out_height,
+                        uint64_t *out_fence_value,
+                        struct xrt_eye_positions *out_eyes);
+
+bool
+comp_multi_weave_export_output(struct xrt_compositor *xc,
+                               xrt_graphics_buffer_handle_t *out_handle,
+                               uint32_t *out_width,
+                               uint32_t *out_height);
+
+bool
+comp_multi_weave_export_fence(struct xrt_compositor *xc, xrt_graphics_sync_handle_t *out_handle);
+
+bool
+comp_multi_weave_snap_window_rect(struct xrt_compositor *xc,
+                                  int32_t origin_x,
+                                  int32_t origin_y,
+                                  int32_t target_x,
+                                  int32_t target_y,
+                                  int32_t *out_snapped_x,
+                                  int32_t *out_snapped_y);
+
+//! Teardown (multi_compositor_destroy). Safe to call when never used.
+void
+comp_multi_weave_fini(struct multi_compositor *mc);
+/*! @} */
+#endif // XRT_OS_MACOS
 
 /*!
  * Check if a multi_compositor has per-session rendering enabled.

--- a/src/xrt/compositor/multi/comp_multi_weave_macos.c
+++ b/src/xrt/compositor/multi/comp_multi_weave_macos.c
@@ -1,0 +1,977 @@
+// Copyright 2026, DisplayXR
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  XR_DXR_weave on the macOS service path (#759) — the macOS analogue of
+ *         the D3D11 service weave (#625).
+ * @author David Fattal
+ * @ingroup comp_multi
+ *
+ * A window-bound synchronous weave service for present-owners (a browser GPU
+ * process, a CEF host): the caller owns its NSWindow and presents itself, but
+ * hands the runtime pre-weave side-by-side stereo pixels + window-relative
+ * rect(s) and composites back a weaved shared texture. The caller NEVER weaves
+ * (ADR-007 / ADR-019).
+ *
+ * macOS platform mapping (vs the Windows/D3D11 original in
+ * comp_d3d11_service.cpp):
+ *
+ *  - Input texture   = a caller-allocated IOSurface. It crosses the IPC as a
+ *    global IOSurfaceID (ipc_message_channel_unix.c) and arrives here as a
+ *    retained IOSurfaceRef, imported into a VkImage via VK_EXT_metal_objects +
+ *    VK_EXT_external_memory_metal (same pattern as
+ *    comp_vk_native_compositor.c import_shared_iosurface).
+ *  - Output texture  = a service-allocated IOSurface-backed VkImage (the
+ *    VkExportMetalObjectCreateInfoEXT allocation pattern from
+ *    vk_image_allocator.c), exported back to the caller as an IOSurfaceRef.
+ *  - Input-ready sync: there is no keyed mutex on macOS. The contract is that
+ *    the caller completes its GPU writes into the input IOSurface before
+ *    calling xrWeaveSubmitDXR (mirrors the existing macOS IPC submit_fallback
+ *    model, comp_vk_client.c).
+ *  - Completion sync: SYNCHRONOUS — the service vkWaitForFences before the IPC
+ *    reply returns, so xrWeaveSubmitDXR returning IS the completion signal.
+ *    weave_get_fence reports no fence; XrWeaveOutputDXR::fence stays NULL and
+ *    fenceValue is a plain monotonic counter.
+ *  - Output sizing: batch (v3) submits size the output from the INPUT IOSurface
+ *    dims — the v3 contract makes the input window-client-sized, so no window
+ *    geometry query is needed. Legacy single-rect submits size it from
+ *    rect offset+extent (the Windows fallback rule).
+ *  - Window bind: stored for future phase use only. sim_display has no
+ *    snap_window_rect (anaglyph has no interlace lattice), so
+ *    xrWeaveSnapWindowRectDXR is the well-defined identity snap.
+ *
+ * The weave itself is ONE xrt_display_processor process_atlas per submit over a
+ * window-sized 2x1 SBS scratch atlas that all rects are blitted into — the same
+ * one-weave-per-frame batch strategy as Windows (per-rect weave() calls degrade
+ * a vendor weaver's predictor; see comp_d3d11_service.cpp). The DP instance is
+ * created from the plug-in's Vulkan factory (dp_factory_vk), i.e. exactly the
+ * DP family the macOS shared-surface path already drives — sim_display's
+ * anaglyph SPIR-V pipeline runs on MoltenVK today.
+ */
+
+#include "xrt/xrt_compositor.h"
+#include "xrt/xrt_display_processor.h"
+#include "xrt/xrt_display_metrics.h"
+#include "xrt/xrt_handles.h"
+
+#include "util/u_misc.h"
+#include "util/u_logging.h"
+
+#include "vk/vk_helpers.h"
+
+#include "comp_multi_private.h"
+
+#ifdef XRT_OS_MACOS
+
+#include <IOSurface/IOSurface.h>
+#include <CoreFoundation/CoreFoundation.h>
+
+/*
+ *
+ * Helpers.
+ *
+ */
+
+//! Everything is BGRA8 end-to-end: IOSurfaces are canonically BGRA on macOS and
+//! the DP factory gets the same format so its pipelines/render-pass match.
+#define WEAVE_VK_FORMAT VK_FORMAT_B8G8R8A8_UNORM
+
+static struct vk_bundle *
+weave_get_vk(struct multi_compositor *mc)
+{
+	if (mc == NULL || mc->msc == NULL || mc->msc->target_service == NULL) {
+		return NULL;
+	}
+	return comp_target_service_get_vk(mc->msc->target_service);
+}
+
+//! Lazily create the per-client engine lock (multi_compositor is zero-alloced).
+static void
+weave_ensure_mutex(struct multi_compositor *mc)
+{
+	os_mutex_lock(&mc->msc->list_and_timing_lock);
+	if (!mc->weave.mutex_initialized) {
+		os_mutex_init(&mc->weave.mutex);
+		mc->weave.mutex_initialized = true;
+	}
+	os_mutex_unlock(&mc->msc->list_and_timing_lock);
+}
+
+/*!
+ * Import a caller IOSurface as a VkImage usable as a blit source. Same
+ * VK_EXT_metal_objects + VK_EXT_external_memory_metal dance as
+ * comp_vk_native_compositor.c::import_shared_iosurface.
+ */
+static bool
+weave_import_input(struct vk_bundle *vk, struct multi_compositor *mc, IOSurfaceRef surface)
+{
+#if defined(VK_EXT_metal_objects) && defined(VK_EXT_external_memory_metal)
+	if (!vk->has_EXT_metal_objects || !vk->has_EXT_external_memory_metal) {
+		U_LOG_E("weave(#759): VK_EXT_metal_objects / VK_EXT_external_memory_metal unavailable");
+		return false;
+	}
+
+	uint32_t width = (uint32_t)IOSurfaceGetWidth(surface);
+	uint32_t height = (uint32_t)IOSurfaceGetHeight(surface);
+	if (width == 0 || height == 0) {
+		U_LOG_E("weave(#759): input IOSurface has zero dimensions");
+		return false;
+	}
+
+	VkExportMetalObjectCreateInfoEXT export_metal_tex_info = {
+	    .sType = VK_STRUCTURE_TYPE_EXPORT_METAL_OBJECT_CREATE_INFO_EXT,
+	    .exportObjectType = VK_EXPORT_METAL_OBJECT_TYPE_METAL_TEXTURE_BIT_EXT,
+	};
+	VkImportMetalIOSurfaceInfoEXT import_iosurface_info = {
+	    .sType = VK_STRUCTURE_TYPE_IMPORT_METAL_IO_SURFACE_INFO_EXT,
+	    .pNext = &export_metal_tex_info,
+	    .ioSurface = surface,
+	};
+	VkImageCreateInfo image_ci = {
+	    .sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
+	    .pNext = &import_iosurface_info,
+	    .imageType = VK_IMAGE_TYPE_2D,
+	    .format = WEAVE_VK_FORMAT,
+	    .extent = {width, height, 1},
+	    .mipLevels = 1,
+	    .arrayLayers = 1,
+	    .samples = VK_SAMPLE_COUNT_1_BIT,
+	    .tiling = VK_IMAGE_TILING_OPTIMAL,
+	    .usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_SAMPLED_BIT,
+	    .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
+	    .initialLayout = VK_IMAGE_LAYOUT_UNDEFINED,
+	};
+
+	VkImage image = VK_NULL_HANDLE;
+	VkResult ret = vk->vkCreateImage(vk->device, &image_ci, NULL, &image);
+	if (ret != VK_SUCCESS) {
+		U_LOG_E("weave(#759): vkCreateImage(input IOSurface) failed: %d", ret);
+		return false;
+	}
+
+	// Export the MTLTexture MoltenVK created over the IOSurface — its handle
+	// is what the memory import below is keyed on.
+	VkExportMetalTextureInfoEXT export_tex_info = {
+	    .sType = VK_STRUCTURE_TYPE_EXPORT_METAL_TEXTURE_INFO_EXT,
+	    .image = image,
+	    .plane = VK_IMAGE_ASPECT_COLOR_BIT,
+	};
+	VkExportMetalObjectsInfoEXT export_objects_info = {
+	    .sType = VK_STRUCTURE_TYPE_EXPORT_METAL_OBJECTS_INFO_EXT,
+	    .pNext = &export_tex_info,
+	};
+	vk->vkExportMetalObjectsEXT(vk->device, &export_objects_info);
+	if (export_tex_info.mtlTexture == NULL) {
+		U_LOG_E("weave(#759): failed to export MTLTexture from input VkImage");
+		vk->vkDestroyImage(vk->device, image, NULL);
+		return false;
+	}
+
+	VkMemoryRequirements requirements = {0};
+	vk->vkGetImageMemoryRequirements(vk->device, image, &requirements);
+
+	VkMemoryMetalHandlePropertiesEXT metal_props = {
+	    .sType = VK_STRUCTURE_TYPE_MEMORY_METAL_HANDLE_PROPERTIES_EXT,
+	};
+	ret = vk->vkGetMemoryMetalHandlePropertiesEXT(vk->device, VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLTEXTURE_BIT_EXT,
+	                                              export_tex_info.mtlTexture, &metal_props);
+	if (ret != VK_SUCCESS) {
+		U_LOG_E("weave(#759): vkGetMemoryMetalHandlePropertiesEXT failed: %d", ret);
+		vk->vkDestroyImage(vk->device, image, NULL);
+		return false;
+	}
+	requirements.memoryTypeBits = metal_props.memoryTypeBits;
+
+	VkImportMemoryMetalHandleInfoEXT import_memory_info = {
+	    .sType = VK_STRUCTURE_TYPE_IMPORT_MEMORY_METAL_HANDLE_INFO_EXT,
+	    .handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLTEXTURE_BIT_EXT,
+	    .handle = export_tex_info.mtlTexture,
+	};
+	VkMemoryDedicatedAllocateInfoKHR dedicated_info = {
+	    .sType = VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO_KHR,
+	    .pNext = &import_memory_info,
+	    .image = image,
+	};
+
+	uint32_t memory_type_index = UINT32_MAX;
+	VkPhysicalDeviceMemoryProperties mem_props;
+	vk->vkGetPhysicalDeviceMemoryProperties(vk->physical_device, &mem_props);
+	for (uint32_t i = 0; i < mem_props.memoryTypeCount; i++) {
+		if ((requirements.memoryTypeBits & (1u << i)) != 0) {
+			memory_type_index = i;
+			break;
+		}
+	}
+	if (memory_type_index == UINT32_MAX) {
+		U_LOG_E("weave(#759): no valid memory type for input IOSurface");
+		vk->vkDestroyImage(vk->device, image, NULL);
+		return false;
+	}
+
+	VkMemoryAllocateInfo alloc_info = {
+	    .sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
+	    .pNext = &dedicated_info,
+	    .allocationSize = requirements.size,
+	    .memoryTypeIndex = memory_type_index,
+	};
+	VkDeviceMemory memory = VK_NULL_HANDLE;
+	ret = vk->vkAllocateMemory(vk->device, &alloc_info, NULL, &memory);
+	if (ret != VK_SUCCESS) {
+		U_LOG_E("weave(#759): vkAllocateMemory(input IOSurface) failed: %d", ret);
+		vk->vkDestroyImage(vk->device, image, NULL);
+		return false;
+	}
+	ret = vk->vkBindImageMemory(vk->device, image, memory, 0);
+	if (ret != VK_SUCCESS) {
+		U_LOG_E("weave(#759): vkBindImageMemory(input IOSurface) failed: %d", ret);
+		vk->vkFreeMemory(vk->device, memory, NULL);
+		vk->vkDestroyImage(vk->device, image, NULL);
+		return false;
+	}
+
+	mc->weave.in_image = image;
+	mc->weave.in_memory = memory;
+	mc->weave.in_w = width;
+	mc->weave.in_h = height;
+	mc->weave.in_first_use = true;
+	return true;
+#else
+	(void)vk;
+	(void)mc;
+	(void)surface;
+	return false;
+#endif
+}
+
+static void
+weave_release_input(struct vk_bundle *vk, struct multi_compositor *mc)
+{
+	if (mc->weave.in_image != VK_NULL_HANDLE) {
+		vk->vkDestroyImage(vk->device, mc->weave.in_image, NULL);
+		mc->weave.in_image = VK_NULL_HANDLE;
+	}
+	if (mc->weave.in_memory != VK_NULL_HANDLE) {
+		vk->vkFreeMemory(vk->device, mc->weave.in_memory, NULL);
+		mc->weave.in_memory = VK_NULL_HANDLE;
+	}
+	if (mc->weave.in_iosurface != NULL) {
+		CFRelease((IOSurfaceRef)mc->weave.in_iosurface);
+		mc->weave.in_iosurface = NULL;
+	}
+	mc->weave.in_iosurface_id = 0;
+	mc->weave.in_w = 0;
+	mc->weave.in_h = 0;
+}
+
+//! Plain device-local image + view (the SBS scratch atlas).
+static bool
+weave_create_scratch(struct vk_bundle *vk, struct multi_compositor *mc, uint32_t w, uint32_t h)
+{
+	VkImageCreateInfo image_ci = {
+	    .sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
+	    .imageType = VK_IMAGE_TYPE_2D,
+	    .format = WEAVE_VK_FORMAT,
+	    .extent = {w, h, 1},
+	    .mipLevels = 1,
+	    .arrayLayers = 1,
+	    .samples = VK_SAMPLE_COUNT_1_BIT,
+	    .tiling = VK_IMAGE_TILING_OPTIMAL,
+	    .usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT,
+	    .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
+	    .initialLayout = VK_IMAGE_LAYOUT_UNDEFINED,
+	};
+	VkResult ret = vk->vkCreateImage(vk->device, &image_ci, NULL, &mc->weave.sbs_image);
+	if (ret != VK_SUCCESS) {
+		return false;
+	}
+
+	VkMemoryRequirements reqs;
+	vk->vkGetImageMemoryRequirements(vk->device, mc->weave.sbs_image, &reqs);
+	uint32_t mti = UINT32_MAX;
+	if (!vk_get_memory_type(vk, reqs.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &mti)) {
+		vk->vkDestroyImage(vk->device, mc->weave.sbs_image, NULL);
+		mc->weave.sbs_image = VK_NULL_HANDLE;
+		return false;
+	}
+	VkMemoryAllocateInfo alloc = {
+	    .sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
+	    .allocationSize = reqs.size,
+	    .memoryTypeIndex = mti,
+	};
+	ret = vk->vkAllocateMemory(vk->device, &alloc, NULL, &mc->weave.sbs_memory);
+	if (ret != VK_SUCCESS || vk->vkBindImageMemory(vk->device, mc->weave.sbs_image, mc->weave.sbs_memory, 0) !=
+	                             VK_SUCCESS) {
+		vk->vkDestroyImage(vk->device, mc->weave.sbs_image, NULL);
+		mc->weave.sbs_image = VK_NULL_HANDLE;
+		if (mc->weave.sbs_memory != VK_NULL_HANDLE) {
+			vk->vkFreeMemory(vk->device, mc->weave.sbs_memory, NULL);
+			mc->weave.sbs_memory = VK_NULL_HANDLE;
+		}
+		return false;
+	}
+
+	VkImageViewCreateInfo view_ci = {
+	    .sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,
+	    .image = mc->weave.sbs_image,
+	    .viewType = VK_IMAGE_VIEW_TYPE_2D,
+	    .format = WEAVE_VK_FORMAT,
+	    .subresourceRange = {.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT, .levelCount = 1, .layerCount = 1},
+	};
+	ret = vk->vkCreateImageView(vk->device, &view_ci, NULL, &mc->weave.sbs_view);
+	if (ret != VK_SUCCESS) {
+		return false;
+	}
+
+	mc->weave.sbs_w = w;
+	mc->weave.sbs_h = h;
+	mc->weave.sbs_first_use = true;
+	return true;
+}
+
+static void
+weave_release_scratch(struct vk_bundle *vk, struct multi_compositor *mc)
+{
+	if (mc->weave.sbs_view != VK_NULL_HANDLE) {
+		vk->vkDestroyImageView(vk->device, mc->weave.sbs_view, NULL);
+		mc->weave.sbs_view = VK_NULL_HANDLE;
+	}
+	if (mc->weave.sbs_image != VK_NULL_HANDLE) {
+		vk->vkDestroyImage(vk->device, mc->weave.sbs_image, NULL);
+		mc->weave.sbs_image = VK_NULL_HANDLE;
+	}
+	if (mc->weave.sbs_memory != VK_NULL_HANDLE) {
+		vk->vkFreeMemory(vk->device, mc->weave.sbs_memory, NULL);
+		mc->weave.sbs_memory = VK_NULL_HANDLE;
+	}
+	mc->weave.sbs_w = 0;
+	mc->weave.sbs_h = 0;
+}
+
+/*!
+ * IOSurface-backed output image + view + framebuffer, IOSurfaceRef exported for
+ * the caller (vk_image_allocator.c export pattern).
+ */
+static bool
+weave_create_output(struct vk_bundle *vk, struct multi_compositor *mc, uint32_t w, uint32_t h)
+{
+#if defined(VK_EXT_metal_objects)
+	if (!vk->has_EXT_metal_objects) {
+		U_LOG_E("weave(#759): VK_EXT_metal_objects unavailable for output export");
+		return false;
+	}
+
+	VkExportMetalObjectCreateInfoEXT export_metal_info = {
+	    .sType = VK_STRUCTURE_TYPE_EXPORT_METAL_OBJECT_CREATE_INFO_EXT,
+	    .exportObjectType = VK_EXPORT_METAL_OBJECT_TYPE_METAL_IOSURFACE_BIT_EXT,
+	};
+	VkImageCreateInfo image_ci = {
+	    .sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
+	    .pNext = &export_metal_info,
+	    .imageType = VK_IMAGE_TYPE_2D,
+	    .format = WEAVE_VK_FORMAT,
+	    .extent = {w, h, 1},
+	    .mipLevels = 1,
+	    .arrayLayers = 1,
+	    .samples = VK_SAMPLE_COUNT_1_BIT,
+	    .tiling = VK_IMAGE_TILING_OPTIMAL,
+	    .usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT |
+	             VK_IMAGE_USAGE_TRANSFER_SRC_BIT,
+	    .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
+	    .initialLayout = VK_IMAGE_LAYOUT_UNDEFINED,
+	};
+	VkResult ret = vk->vkCreateImage(vk->device, &image_ci, NULL, &mc->weave.out_image);
+	if (ret != VK_SUCCESS) {
+		U_LOG_E("weave(#759): vkCreateImage(output) failed: %d", ret);
+		return false;
+	}
+
+	VkMemoryRequirements reqs;
+	vk->vkGetImageMemoryRequirements(vk->device, mc->weave.out_image, &reqs);
+	uint32_t mti = UINT32_MAX;
+	if (!vk_get_memory_type(vk, reqs.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &mti)) {
+		vk->vkDestroyImage(vk->device, mc->weave.out_image, NULL);
+		mc->weave.out_image = VK_NULL_HANDLE;
+		return false;
+	}
+	VkMemoryDedicatedAllocateInfoKHR dedicated = {
+	    .sType = VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO_KHR,
+	    .image = mc->weave.out_image,
+	};
+	VkMemoryAllocateInfo alloc = {
+	    .sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
+	    .pNext = &dedicated,
+	    .allocationSize = reqs.size,
+	    .memoryTypeIndex = mti,
+	};
+	ret = vk->vkAllocateMemory(vk->device, &alloc, NULL, &mc->weave.out_memory);
+	if (ret != VK_SUCCESS || vk->vkBindImageMemory(vk->device, mc->weave.out_image, mc->weave.out_memory, 0) !=
+	                             VK_SUCCESS) {
+		U_LOG_E("weave(#759): output memory alloc/bind failed");
+		vk->vkDestroyImage(vk->device, mc->weave.out_image, NULL);
+		mc->weave.out_image = VK_NULL_HANDLE;
+		if (mc->weave.out_memory != VK_NULL_HANDLE) {
+			vk->vkFreeMemory(vk->device, mc->weave.out_memory, NULL);
+			mc->weave.out_memory = VK_NULL_HANDLE;
+		}
+		return false;
+	}
+
+	// Export the backing IOSurface for the caller (retained; released on
+	// resize/teardown — the IPC send only reads its IOSurfaceID).
+	VkExportMetalIOSurfaceInfoEXT export_surface = {
+	    .sType = VK_STRUCTURE_TYPE_EXPORT_METAL_IO_SURFACE_INFO_EXT,
+	    .image = mc->weave.out_image,
+	};
+	VkExportMetalObjectsInfoEXT export_info = {
+	    .sType = VK_STRUCTURE_TYPE_EXPORT_METAL_OBJECTS_INFO_EXT,
+	    .pNext = &export_surface,
+	};
+	vk->vkExportMetalObjectsEXT(vk->device, &export_info);
+	if (export_surface.ioSurface == NULL) {
+		U_LOG_E("weave(#759): failed to export output IOSurface");
+		return false;
+	}
+	CFRetain(export_surface.ioSurface);
+	mc->weave.out_iosurface = (void *)export_surface.ioSurface;
+
+	VkImageViewCreateInfo view_ci = {
+	    .sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,
+	    .image = mc->weave.out_image,
+	    .viewType = VK_IMAGE_VIEW_TYPE_2D,
+	    .format = WEAVE_VK_FORMAT,
+	    .subresourceRange = {.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT, .levelCount = 1, .layerCount = 1},
+	};
+	ret = vk->vkCreateImageView(vk->device, &view_ci, NULL, &mc->weave.out_view);
+	if (ret != VK_SUCCESS) {
+		return false;
+	}
+
+	VkFramebufferCreateInfo fb_ci = {
+	    .sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO,
+	    .renderPass = mc->weave.render_pass,
+	    .attachmentCount = 1,
+	    .pAttachments = &mc->weave.out_view,
+	    .width = w,
+	    .height = h,
+	    .layers = 1,
+	};
+	ret = vk->vkCreateFramebuffer(vk->device, &fb_ci, NULL, &mc->weave.out_fb);
+	if (ret != VK_SUCCESS) {
+		return false;
+	}
+
+	mc->weave.out_w = w;
+	mc->weave.out_h = h;
+	return true;
+#else
+	(void)vk;
+	(void)mc;
+	(void)w;
+	(void)h;
+	return false;
+#endif
+}
+
+static void
+weave_release_output(struct vk_bundle *vk, struct multi_compositor *mc)
+{
+	if (mc->weave.out_fb != VK_NULL_HANDLE) {
+		vk->vkDestroyFramebuffer(vk->device, mc->weave.out_fb, NULL);
+		mc->weave.out_fb = VK_NULL_HANDLE;
+	}
+	if (mc->weave.out_view != VK_NULL_HANDLE) {
+		vk->vkDestroyImageView(vk->device, mc->weave.out_view, NULL);
+		mc->weave.out_view = VK_NULL_HANDLE;
+	}
+	if (mc->weave.out_image != VK_NULL_HANDLE) {
+		vk->vkDestroyImage(vk->device, mc->weave.out_image, NULL);
+		mc->weave.out_image = VK_NULL_HANDLE;
+	}
+	if (mc->weave.out_memory != VK_NULL_HANDLE) {
+		vk->vkFreeMemory(vk->device, mc->weave.out_memory, NULL);
+		mc->weave.out_memory = VK_NULL_HANDLE;
+	}
+	if (mc->weave.out_iosurface != NULL) {
+		CFRelease((IOSurfaceRef)mc->weave.out_iosurface);
+		mc->weave.out_iosurface = NULL;
+	}
+	mc->weave.out_w = 0;
+	mc->weave.out_h = 0;
+}
+
+/*!
+ * One-time engine bring-up: command pool + buffer, fence, render pass
+ * (compatible with the DP's own — same single BGRA8 color attachment), and the
+ * DP instance from the plug-in's Vulkan factory. Mirrors shared_surface_init.
+ */
+static bool
+weave_ensure_engine(struct vk_bundle *vk, struct multi_compositor *mc)
+{
+	if (mc->weave.engine_initialized) {
+		return true;
+	}
+
+	VkCommandPoolCreateInfo pool_info = {
+	    .sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,
+	    .queueFamilyIndex = vk->main_queue->family_index,
+	    .flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT,
+	};
+	if (vk->vkCreateCommandPool(vk->device, &pool_info, NULL, &mc->weave.cmd_pool) != VK_SUCCESS) {
+		return false;
+	}
+	VkCommandBufferAllocateInfo cb_info = {
+	    .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO,
+	    .commandPool = mc->weave.cmd_pool,
+	    .level = VK_COMMAND_BUFFER_LEVEL_PRIMARY,
+	    .commandBufferCount = 1,
+	};
+	if (vk->vkAllocateCommandBuffers(vk->device, &cb_info, &mc->weave.cmd) != VK_SUCCESS) {
+		return false;
+	}
+	VkFenceCreateInfo fence_info = {.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO};
+	if (vk->vkCreateFence(vk->device, &fence_info, NULL, &mc->weave.fence) != VK_SUCCESS) {
+		return false;
+	}
+
+	// Render pass the output framebuffer is created against. Compatibility with
+	// the DP's internal render pass only needs matching attachment count /
+	// format / samples (load-store ops and layouts don't participate).
+	VkAttachmentDescription color_attachment = {
+	    .format = WEAVE_VK_FORMAT,
+	    .samples = VK_SAMPLE_COUNT_1_BIT,
+	    .loadOp = VK_ATTACHMENT_LOAD_OP_LOAD,
+	    .storeOp = VK_ATTACHMENT_STORE_OP_STORE,
+	    .stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE,
+	    .stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE,
+	    .initialLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+	    .finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+	};
+	VkAttachmentReference color_ref = {.attachment = 0, .layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL};
+	VkSubpassDescription subpass = {
+	    .pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS,
+	    .colorAttachmentCount = 1,
+	    .pColorAttachments = &color_ref,
+	};
+	VkRenderPassCreateInfo rp_info = {
+	    .sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO,
+	    .attachmentCount = 1,
+	    .pAttachments = &color_attachment,
+	    .subpassCount = 1,
+	    .pSubpasses = &subpass,
+	};
+	if (vk->vkCreateRenderPass(vk->device, &rp_info, NULL, &mc->weave.render_pass) != VK_SUCCESS) {
+		return false;
+	}
+
+	// The DP that weaves — same Vulkan plug-in factory family the macOS
+	// shared-surface path drives (sim_display anaglyph runs on MoltenVK).
+	xrt_dp_factory_vk_fn_t factory = (xrt_dp_factory_vk_fn_t)mc->msc->base.info.dp_factory_vk;
+	if (factory == NULL) {
+		U_LOG_E("weave(#759): no Vulkan DP factory — cannot weave");
+		return false;
+	}
+	xrt_result_t xret = factory(vk,                                       // vk_bundle
+	                            (void *)(uintptr_t)mc->weave.cmd_pool,    // cmd_pool
+	                            NULL,                                     // window_handle (present-owner's, not ours)
+	                            (int32_t)WEAVE_VK_FORMAT,                 // target_format
+	                            &mc->weave.dp);
+	if (xret != XRT_SUCCESS || mc->weave.dp == NULL) {
+		U_LOG_E("weave(#759): Vulkan DP factory failed: %d", xret);
+		return false;
+	}
+
+	mc->weave.engine_initialized = true;
+	U_LOG_W("weave(#759): macOS weave engine initialized (BGRA8, synchronous)");
+	return true;
+}
+
+/*
+ *
+ * Public entry points (called from ipc_server_handler.c).
+ *
+ */
+
+bool
+comp_multi_weave_bind_window(struct xrt_compositor *xc, uint64_t window_id)
+{
+	struct multi_compositor *mc = multi_compositor(xc);
+	if (mc == NULL || mc->msc == NULL) {
+		return false;
+	}
+	weave_ensure_mutex(mc);
+	os_mutex_lock(&mc->weave.mutex);
+	// Stored for future interlace-phase use only: sim_display (anaglyph) has no
+	// lattice, and macOS window geometry is derived from the input surface.
+	mc->weave.window_id = window_id;
+	os_mutex_unlock(&mc->weave.mutex);
+	U_LOG_W("weave(#759): bound present-owner window id 0x%" PRIx64, window_id);
+	return true;
+}
+
+bool
+comp_multi_weave_submit(struct xrt_compositor *xc,
+                        xrt_graphics_buffer_handle_t in_handle,
+                        int32_t rect_x,
+                        int32_t rect_y,
+                        uint32_t rect_w,
+                        uint32_t rect_h,
+                        uint32_t rect_count,
+                        const struct xrt_rect *rects,
+                        uint32_t *out_width,
+                        uint32_t *out_height,
+                        uint64_t *out_fence_value,
+                        struct xrt_eye_positions *out_eyes)
+{
+	struct multi_compositor *mc = multi_compositor(xc);
+	if (mc == NULL || mc->msc == NULL || in_handle == NULL) {
+		return false;
+	}
+	struct vk_bundle *vk = weave_get_vk(mc);
+	if (vk == NULL) {
+		return false;
+	}
+
+	// The handler hands us ownership of the retained IOSurfaceRef the IPC
+	// receive looked up; we either adopt it into the cache or release it.
+	IOSurfaceRef surface = (IOSurfaceRef)in_handle;
+	uint32_t surface_id = (uint32_t)IOSurfaceGetID(surface);
+
+	weave_ensure_mutex(mc);
+	os_mutex_lock(&mc->weave.mutex);
+
+	bool ok = false;
+	do {
+		if (!weave_ensure_engine(vk, mc)) {
+			break;
+		}
+
+		// (Re)import the input on identity change (new IOSurface = new id).
+		if (mc->weave.in_image == VK_NULL_HANDLE || mc->weave.in_iosurface_id != surface_id) {
+			weave_release_input(vk, mc);
+			if (!weave_import_input(vk, mc, surface)) {
+				break;
+			}
+			mc->weave.in_iosurface = (void *)surface; // adopt the retained ref
+			mc->weave.in_iosurface_id = surface_id;
+			surface = NULL; // ownership transferred
+		}
+
+		// Output dims: batch = the (window-client-sized) input; legacy =
+		// rect offset+extent (the Windows GetClientRect-less fallback).
+		uint32_t want_w = 0, want_h = 0;
+		if (rect_count > 0) {
+			want_w = mc->weave.in_w;
+			want_h = mc->weave.in_h;
+		} else {
+			want_w = (uint32_t)rect_x + rect_w;
+			want_h = (uint32_t)rect_y + rect_h;
+		}
+		if (want_w == 0 || want_h == 0) {
+			break;
+		}
+
+		// (Re)allocate output + scratch on resize. The scratch is the
+		// window-sized 2x1 SBS atlas (2*w x h) — ONE weave per submit.
+		if (mc->weave.out_image == VK_NULL_HANDLE || mc->weave.out_w != want_w ||
+		    mc->weave.out_h != want_h) {
+			// Never yank resources out from under in-flight GPU work.
+			vk->vkQueueWaitIdle(vk->main_queue->queue);
+			weave_release_output(vk, mc);
+			weave_release_scratch(vk, mc);
+			if (!weave_create_output(vk, mc, want_w, want_h) ||
+			    !weave_create_scratch(vk, mc, want_w * 2, want_h)) {
+				break;
+			}
+		}
+
+		// ---- Record ----
+		VkCommandBuffer cmd = mc->weave.cmd;
+		vk->vkResetCommandBuffer(cmd, 0);
+		VkCommandBufferBeginInfo begin = {
+		    .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
+		    .flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT,
+		};
+		if (vk->vkBeginCommandBuffer(cmd, &begin) != VK_SUCCESS) {
+			break;
+		}
+
+		VkImageSubresourceRange range = {
+		    .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT, .levelCount = 1, .layerCount = 1};
+
+		// Input: keep GENERAL across frames (UNDEFINED would discard the
+		// caller's pixels); the barrier makes external writes visible.
+		VkImageMemoryBarrier in_barrier = {
+		    .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+		    .srcAccessMask = VK_ACCESS_MEMORY_WRITE_BIT,
+		    .dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT,
+		    .oldLayout = mc->weave.in_first_use ? VK_IMAGE_LAYOUT_UNDEFINED : VK_IMAGE_LAYOUT_GENERAL,
+		    .newLayout = VK_IMAGE_LAYOUT_GENERAL,
+		    .image = mc->weave.in_image,
+		    .subresourceRange = range,
+		};
+		mc->weave.in_first_use = false;
+		vk->vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0,
+		                         NULL, 0, NULL, 1, &in_barrier);
+
+		// Scratch -> TRANSFER_DST (persists across frames: stale regions from
+		// closed elements re-weave harmlessly; the caller composites back only
+		// its current rects — same contract as the Windows output).
+		VkImageMemoryBarrier sbs_to_dst = {
+		    .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+		    .srcAccessMask = VK_ACCESS_SHADER_READ_BIT,
+		    .dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
+		    .oldLayout = mc->weave.sbs_first_use ? VK_IMAGE_LAYOUT_UNDEFINED
+		                                         : VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+		    .newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+		    .image = mc->weave.sbs_image,
+		    .subresourceRange = range,
+		};
+		mc->weave.sbs_first_use = false;
+		vk->vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0,
+		                         0, NULL, 0, NULL, 1, &sbs_to_dst);
+
+		// Blit each rect's squeezed-SBS halves into the two atlas tiles:
+		// left half -> left tile at the rect's window position (stretched to
+		// full rect width), right half -> right tile offset by out_w.
+		struct xrt_rect legacy_rect = {
+		    .offset = {.w = 0, .h = 0},
+		    .extent = {.w = (int)want_w, .h = (int)want_h},
+		};
+		const struct xrt_rect *blit_rects = rect_count > 0 ? rects : &legacy_rect;
+		uint32_t blit_count = rect_count > 0 ? rect_count : 1;
+
+		for (uint32_t i = 0; i < blit_count; i++) {
+			// xrt_offset names its fields w/h; they hold x/y here.
+			int32_t rx = blit_rects[i].offset.w;
+			int32_t ry = blit_rects[i].offset.h;
+			int32_t rw = blit_rects[i].extent.w;
+			int32_t rh = blit_rects[i].extent.h;
+			if (rw <= 0 || rh <= 0) {
+				continue;
+			}
+			// Clamp to the input.
+			if (rx < 0 || ry < 0 || (uint32_t)(rx + rw) > mc->weave.in_w ||
+			    (uint32_t)(ry + rh) > mc->weave.in_h) {
+				continue;
+			}
+			int32_t half = rw / 2;
+			if (half <= 0) {
+				continue;
+			}
+
+			VkImageBlit blits[2] = {
+			    // Left eye: input rect's left half -> left tile, unsqueezed.
+			    {
+			        .srcSubresource = {.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT, .layerCount = 1},
+			        .srcOffsets = {{rx, ry, 0}, {rx + half, ry + rh, 1}},
+			        .dstSubresource = {.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT, .layerCount = 1},
+			        .dstOffsets = {{rx, ry, 0}, {rx + rw, ry + rh, 1}},
+			    },
+			    // Right eye: input rect's right half -> right tile (+out_w).
+			    {
+			        .srcSubresource = {.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT, .layerCount = 1},
+			        .srcOffsets = {{rx + half, ry, 0}, {rx + rw, ry + rh, 1}},
+			        .dstSubresource = {.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT, .layerCount = 1},
+			        .dstOffsets = {{(int32_t)mc->weave.out_w + rx, ry, 0},
+			                       {(int32_t)mc->weave.out_w + rx + rw, ry + rh, 1}},
+			    },
+			};
+			vk->vkCmdBlitImage(cmd, mc->weave.in_image, VK_IMAGE_LAYOUT_GENERAL, mc->weave.sbs_image,
+			                   VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 2, blits, VK_FILTER_LINEAR);
+		}
+
+		// Scratch -> SHADER_READ for the DP sample.
+		VkImageMemoryBarrier sbs_to_read = {
+		    .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+		    .srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
+		    .dstAccessMask = VK_ACCESS_SHADER_READ_BIT,
+		    .oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+		    .newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+		    .image = mc->weave.sbs_image,
+		    .subresourceRange = range,
+		};
+		vk->vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, 0,
+		                         0, NULL, 0, NULL, 1, &sbs_to_read);
+
+		// Output -> COLOR_ATTACHMENT (fully re-rendered every submit, so the
+		// discard from UNDEFINED is fine).
+		VkImageMemoryBarrier out_to_attach = {
+		    .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+		    .srcAccessMask = 0,
+		    .dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+		    .oldLayout = VK_IMAGE_LAYOUT_UNDEFINED,
+		    .newLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+		    .image = mc->weave.out_image,
+		    .subresourceRange = range,
+		};
+		vk->vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+		                         VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, 0, 0, NULL, 0, NULL, 1,
+		                         &out_to_attach);
+
+		// ONE process_atlas per submit — 2x1 SBS, per-eye dims = the window.
+		xrt_display_processor_set_target_color_view(mc->weave.dp, mc->weave.out_view);
+		xrt_display_processor_process_atlas(mc->weave.dp, cmd,                             //
+		                                    (VkImage_XDP)mc->weave.sbs_image, mc->weave.sbs_view, //
+		                                    mc->weave.out_w, mc->weave.out_h,              //
+		                                    2, 1,                                          //
+		                                    (VkFormat_XDP)WEAVE_VK_FORMAT,                 //
+		                                    mc->weave.out_fb,                              //
+		                                    (VkImage_XDP)mc->weave.out_image,              //
+		                                    mc->weave.out_w, mc->weave.out_h,              //
+		                                    (VkFormat_XDP)WEAVE_VK_FORMAT,                 //
+		                                    0, 0, 0, 0);
+
+		// Output -> GENERAL for the caller's cross-API (Metal) read.
+		VkImageMemoryBarrier out_to_general = {
+		    .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+		    .srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+		    .dstAccessMask = VK_ACCESS_MEMORY_READ_BIT,
+		    .oldLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+		    .newLayout = VK_IMAGE_LAYOUT_GENERAL,
+		    .image = mc->weave.out_image,
+		    .subresourceRange = range,
+		};
+		vk->vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+		                         VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0, NULL, 0, NULL, 1, &out_to_general);
+
+		if (vk->vkEndCommandBuffer(cmd) != VK_SUCCESS) {
+			break;
+		}
+
+		// ---- Submit + synchronous completion (the macOS sync contract). ----
+		VkSubmitInfo submit = {
+		    .sType = VK_STRUCTURE_TYPE_SUBMIT_INFO,
+		    .commandBufferCount = 1,
+		    .pCommandBuffers = &cmd,
+		};
+		vk_queue_lock(vk->main_queue);
+		VkResult ret = vk->vkQueueSubmit(vk->main_queue->queue, 1, &submit, mc->weave.fence);
+		vk_queue_unlock(vk->main_queue);
+		if (ret != VK_SUCCESS) {
+			U_LOG_E("weave(#759): vkQueueSubmit failed: %d", ret);
+			break;
+		}
+		vk->vkWaitForFences(vk->device, 1, &mc->weave.fence, VK_TRUE, UINT64_MAX);
+		vk->vkResetFences(vk->device, 1, &mc->weave.fence);
+
+		mc->weave.fence_value++;
+
+		*out_width = mc->weave.out_w;
+		*out_height = mc->weave.out_h;
+		*out_fence_value = mc->weave.fence_value;
+
+		// Eyes flow OUT (runtime -> caller) for the caller's next off-axis
+		// frame; the weave itself reads the tracker DP-internally.
+		U_ZERO(out_eyes);
+		if (!xrt_display_processor_get_predicted_eye_positions(mc->weave.dp, out_eyes)) {
+			U_ZERO(out_eyes);
+		}
+
+		ok = true;
+	} while (false);
+
+	os_mutex_unlock(&mc->weave.mutex);
+
+	// Release the per-call ref if it wasn't adopted into the cache.
+	if (surface != NULL) {
+		CFRelease(surface);
+	}
+	return ok;
+}
+
+bool
+comp_multi_weave_export_output(struct xrt_compositor *xc,
+                               xrt_graphics_buffer_handle_t *out_handle,
+                               uint32_t *out_width,
+                               uint32_t *out_height)
+{
+	struct multi_compositor *mc = multi_compositor(xc);
+	if (mc == NULL || !mc->weave.mutex_initialized) {
+		return false;
+	}
+	os_mutex_lock(&mc->weave.mutex);
+	bool ok = false;
+	if (mc->weave.out_iosurface != NULL && mc->weave.out_w != 0) {
+		// The IPC send path only reads the IOSurfaceID out of the ref; the
+		// cache keeps ownership (released on resize/teardown).
+		CFRetain((IOSurfaceRef)mc->weave.out_iosurface);
+		*out_handle = (xrt_graphics_buffer_handle_t)mc->weave.out_iosurface;
+		*out_width = mc->weave.out_w;
+		*out_height = mc->weave.out_h;
+		ok = true;
+	}
+	os_mutex_unlock(&mc->weave.mutex);
+	return ok;
+}
+
+bool
+comp_multi_weave_export_fence(struct xrt_compositor *xc, xrt_graphics_sync_handle_t *out_handle)
+{
+	// No cross-process GPU fence on macOS — completion is synchronous
+	// (xrWeaveSubmitDXR returns after the weave finished on the GPU).
+	(void)xc;
+	(void)out_handle;
+	return false;
+}
+
+bool
+comp_multi_weave_snap_window_rect(struct xrt_compositor *xc,
+                                  int32_t origin_x,
+                                  int32_t origin_y,
+                                  int32_t target_x,
+                                  int32_t target_y,
+                                  int32_t *out_snapped_x,
+                                  int32_t *out_snapped_y)
+{
+	// sim_display has no snap_window_rect (anaglyph has no interlace lattice)
+	// and the generic VK DP vtable carries no snap slot yet — identity snap.
+	(void)xc;
+	(void)origin_x;
+	(void)origin_y;
+	(void)target_x;
+	(void)target_y;
+	(void)out_snapped_x;
+	(void)out_snapped_y;
+	return false;
+}
+
+void
+comp_multi_weave_fini(struct multi_compositor *mc)
+{
+	if (mc == NULL || !mc->weave.mutex_initialized) {
+		return;
+	}
+	struct vk_bundle *vk = weave_get_vk(mc);
+	os_mutex_lock(&mc->weave.mutex);
+	if (vk != NULL) {
+		if (mc->weave.engine_initialized) {
+			// Nothing may be in flight (submits are synchronous), but a
+			// belt-and-braces idle keeps teardown safe if that changes.
+			vk->vkQueueWaitIdle(vk->main_queue->queue);
+		}
+		weave_release_input(vk, mc);
+		weave_release_scratch(vk, mc);
+		weave_release_output(vk, mc);
+		if (mc->weave.dp != NULL) {
+			xrt_display_processor_destroy(&mc->weave.dp);
+		}
+		if (mc->weave.render_pass != VK_NULL_HANDLE) {
+			vk->vkDestroyRenderPass(vk->device, mc->weave.render_pass, NULL);
+			mc->weave.render_pass = VK_NULL_HANDLE;
+		}
+		if (mc->weave.fence != VK_NULL_HANDLE) {
+			vk->vkDestroyFence(vk->device, mc->weave.fence, NULL);
+			mc->weave.fence = VK_NULL_HANDLE;
+		}
+		if (mc->weave.cmd_pool != VK_NULL_HANDLE) {
+			vk->vkDestroyCommandPool(vk->device, mc->weave.cmd_pool, NULL);
+			mc->weave.cmd_pool = VK_NULL_HANDLE;
+		}
+	}
+	mc->weave.engine_initialized = false;
+	os_mutex_unlock(&mc->weave.mutex);
+	os_mutex_destroy(&mc->weave.mutex);
+	mc->weave.mutex_initialized = false;
+}
+
+#endif // XRT_OS_MACOS

--- a/src/xrt/ipc/server/ipc_server_handler.c
+++ b/src/xrt/ipc/server/ipc_server_handler.c
@@ -5572,8 +5572,8 @@ ipc_handle_compositor_get_transparent_output_fence(volatile struct ipc_client_st
 /*
  * XR_DXR_weave (#625) — window-bound synchronous weave service. The DP weaves
  * server-side (ADR-007 / ADR-019); these handlers only marshal the wire to the
- * D3D11 service compositor's additive weave entry points. D3D11-service-only,
- * exactly as the transparent-output path above.
+ * service compositor's additive weave entry points: the D3D11 service on
+ * Windows, the comp_multi Vulkan weave engine on macOS (#759).
  */
 xrt_result_t
 ipc_handle_weave_bind_window(volatile struct ipc_client_state *ics, uint64_t hwnd)
@@ -5586,6 +5586,11 @@ ipc_handle_weave_bind_window(volatile struct ipc_client_state *ics, uint64_t hwn
 
 #if defined(XRT_HAVE_D3D11_SERVICE_COMPOSITOR)
 	if (!comp_d3d11_service_weave_bind_window(ics->xc, hwnd)) {
+		return XRT_ERROR_IPC_FAILURE;
+	}
+	return XRT_SUCCESS;
+#elif defined(XRT_OS_MACOS)
+	if (!comp_multi_weave_bind_window(ics->xc, hwnd)) {
 		return XRT_ERROR_IPC_FAILURE;
 	}
 	return XRT_SUCCESS;
@@ -5660,6 +5665,40 @@ ipc_handle_weave_submit(volatile struct ipc_client_state *ics,
 	*out_fence_value = fv;
 	*out_eyes = eyes;
 	return XRT_SUCCESS;
+#elif defined(XRT_OS_MACOS)
+	// handles[0] is the retained IOSurfaceRef the IPC receive looked up; the
+	// weave engine takes ownership (adopts it into its import cache or
+	// releases it). No DXGI low-bit tag exists on POSIX handles.
+	if (args->rect_count > IPC_WEAVE_SUBMIT_RECTS_MAX) {
+		xrt_graphics_buffer_handle_t reject = handles[0];
+		u_graphics_buffer_unref(&reject); // don't leak the retained IOSurfaceRef
+		return XRT_ERROR_IPC_FAILURE;
+	}
+	struct xrt_rect rects[IPC_WEAVE_SUBMIT_RECTS_MAX];
+	for (uint32_t i = 0; i < args->rect_count; i++) {
+		rects[i].offset.w = args->rects[i].x; // xrt_offset fields are named w/h
+		rects[i].offset.h = args->rects[i].y;
+		rects[i].extent.w = (int)args->rects[i].w;
+		rects[i].extent.h = (int)args->rects[i].h;
+	}
+
+	uint32_t w = 0, h = 0;
+	uint64_t fv = 0;
+	struct xrt_eye_positions eyes = {0};
+	bool ok = comp_multi_weave_submit(                          //
+	    ics->xc, handles[0],                                    //
+	    args->rect_x, args->rect_y, args->rect_w, args->rect_h, //
+	    args->rect_count, args->rect_count > 0 ? rects : NULL,  //
+	    &w, &h, &fv, &eyes);
+	if (!ok) {
+		return XRT_ERROR_IPC_FAILURE;
+	}
+	*out_have_output = true;
+	*out_width = w;
+	*out_height = h;
+	*out_fence_value = fv;
+	*out_eyes = eyes;
+	return XRT_SUCCESS;
 #else
 	(void)args;
 	(void)handles;
@@ -5691,6 +5730,16 @@ ipc_handle_weave_get_output(volatile struct ipc_client_state *ics,
 	xrt_graphics_buffer_handle_t h = XRT_GRAPHICS_BUFFER_HANDLE_INVALID;
 	uint32_t w = 0, ht = 0;
 	if (comp_d3d11_service_weave_export_output(ics->xc, &h, &w, &ht)) {
+		out_handles[0] = h;
+		*out_handle_count = 1;
+		*out_have_output = true;
+		*out_width = w;
+		*out_height = ht;
+	}
+#elif defined(XRT_OS_MACOS)
+	xrt_graphics_buffer_handle_t h = XRT_GRAPHICS_BUFFER_HANDLE_INVALID;
+	uint32_t w = 0, ht = 0;
+	if (comp_multi_weave_export_output(ics->xc, &h, &w, &ht)) {
 		out_handles[0] = h;
 		*out_handle_count = 1;
 		*out_have_output = true;
@@ -5758,6 +5807,16 @@ ipc_handle_weave_snap_window_rect(volatile struct ipc_client_state *ics,
 #if defined(XRT_HAVE_D3D11_SERVICE_COMPOSITOR)
 	int32_t sx = target_x, sy = target_y;
 	if (comp_d3d11_service_weave_snap_window_rect(ics->xc, origin_x, origin_y, target_x, target_y, &sx, &sy)) {
+		*out_snapped = true;
+		*out_snapped_x = sx;
+		*out_snapped_y = sy;
+	}
+	return XRT_SUCCESS;
+#elif defined(XRT_OS_MACOS)
+	// Identity today (sim_display has no interlace lattice); routes to a
+	// future VK DP snap slot in one place (#759).
+	int32_t sx = target_x, sy = target_y;
+	if (comp_multi_weave_snap_window_rect(ics->xc, origin_x, origin_y, target_x, target_y, &sx, &sy)) {
 		*out_snapped = true;
 		*out_snapped_x = sx;
 		*out_snapped_y = sy;

--- a/src/xrt/state_trackers/oxr/oxr_extension_support.h
+++ b/src/xrt/state_trackers/oxr/oxr_extension_support.h
@@ -657,10 +657,12 @@
  * XR_DXR_weave
  *
  * Hand-added DisplayXR extension (generate_oxr_ext_support.py knows nothing of
- * the DisplayXR blocks — keep them when regenerating). Win32-only: the weave
- * service is implemented on the D3D11 service compositor (#625).
+ * the DisplayXR blocks — keep them when regenerating). Windows: the weave
+ * service is implemented on the D3D11 service compositor (#625). macOS: on the
+ * comp_multi Vulkan weave engine, IOSurface transport, synchronous completion
+ * (#759).
  */
-#if defined(XR_DXR_weave) && defined(XR_USE_PLATFORM_WIN32)
+#if defined(XR_DXR_weave) && (defined(XR_USE_PLATFORM_WIN32) || defined(XR_USE_PLATFORM_MACOS))
 #define OXR_HAVE_DXR_weave
 #define OXR_EXTENSION_SUPPORT_DXR_weave(_) \
     _(DXR_weave, DXR_WEAVE)

--- a/src/xrt/state_trackers/oxr/oxr_weave.c
+++ b/src/xrt/state_trackers/oxr/oxr_weave.c
@@ -14,7 +14,9 @@
  * (ADR-007 / ADR-019).
  *
  * Availability: implemented only on the out-of-process (service / IPC) path —
- * the weave runs in the D3D11 service compositor. An in-process session reports
+ * the weave runs in the D3D11 service compositor on Windows and in the
+ * comp_multi Vulkan weave engine on macOS (#759: IOSurface in/out, synchronous
+ * completion, no fence handle). An in-process session reports
  * XR_ERROR_FEATURE_UNSUPPORTED. The entry points forward to thin IPC-client
  * bridges (defined in ipc_client_compositor.c); st_oxr does not pull the
  * ipc_client include path, so the symbols resolve at link time — same pattern
@@ -227,7 +229,10 @@ oxr_xrWeaveSubmitDXR(XrSession session, const XrWeaveSubmitInfoDXR *submitInfo, 
 		if (comp_ipc_client_compositor_weave_get_fence(&sess->xcn->base, &have_fence, &fence_h) ==
 		        XRT_SUCCESS &&
 		    have_fence && fence_h != XRT_GRAPHICS_SYNC_HANDLE_INVALID) {
-			output->fence = (void *)fence_h;
+			// (intptr_t hop: the handle is an fd int on POSIX — macOS never
+			// exports a fence (#759, completion is synchronous), so this
+			// branch fires on Windows HANDLEs only.)
+			output->fence = (void *)(intptr_t)fence_h;
 		}
 
 		sess->weave.exported = true;

--- a/test_apps/probes/weave_probe_vk_macos/CMakeLists.txt
+++ b/test_apps/probes/weave_probe_vk_macos/CMakeLists.txt
@@ -1,0 +1,64 @@
+# Copyright 2026, DisplayXR
+# SPDX-License-Identifier: BSL-1.0
+#
+# XR_DXR_weave macOS probe (#759) — headless present-owner harness; the macOS
+# sibling of probes/weave_rpc_probe_d3d11_win. No window, no displayxr manifest
+# (it is a service-contract verification tool, not a workspace app).
+
+cmake_minimum_required(VERSION 3.21)
+project(weave_probe_vk_macos LANGUAGES C CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Vulkan SDK (MoltenVK) — the only IPC-capable graphics binding on macOS.
+find_package(Vulkan REQUIRED)
+message(STATUS "Found Vulkan: ${Vulkan_LIBRARY}")
+
+# OpenXR headers (incl. the DisplayXR extension headers) from the source tree.
+set(OPENXR_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../src/external/openxr_includes")
+
+# Find OpenXR loader (same strategy ladder as the other macOS test apps).
+set(OPENXR_FOUND FALSE)
+
+find_package(OpenXR QUIET CONFIG)
+if(OpenXR_FOUND)
+    set(OPENXR_FOUND TRUE)
+    message(STATUS "Found OpenXR via find_package")
+endif()
+
+if(NOT OPENXR_FOUND)
+    find_library(OPENXR_LOADER_LIB NAMES openxr_loader)
+    if(OPENXR_LOADER_LIB)
+        set(OPENXR_FOUND TRUE)
+        add_library(OpenXR::openxr_loader SHARED IMPORTED)
+        set_target_properties(OpenXR::openxr_loader PROPERTIES
+            IMPORTED_LOCATION "${OPENXR_LOADER_LIB}"
+        )
+        message(STATUS "Found OpenXR loader: ${OPENXR_LOADER_LIB}")
+    endif()
+endif()
+
+if(NOT OPENXR_FOUND)
+    set(PARENT_BUILD_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../build")
+    if(EXISTS "${PARENT_BUILD_DIR}/src/external/openxr_loader/OpenXRConfig.cmake")
+        list(APPEND CMAKE_PREFIX_PATH "${PARENT_BUILD_DIR}/src/external/openxr_loader")
+        find_package(OpenXR REQUIRED CONFIG)
+        set(OPENXR_FOUND TRUE)
+    endif()
+endif()
+
+if(NOT OPENXR_FOUND)
+    message(FATAL_ERROR "OpenXR not found. Build the parent project first or: brew install openxr-loader")
+endif()
+
+add_executable(weave_probe_vk_macos main.cpp)
+
+target_include_directories(weave_probe_vk_macos PRIVATE ${OPENXR_INCLUDE_DIR})
+
+target_link_libraries(weave_probe_vk_macos PRIVATE
+    OpenXR::openxr_loader
+    Vulkan::Vulkan
+    "-framework IOSurface"
+    "-framework CoreFoundation"
+)

--- a/test_apps/probes/weave_probe_vk_macos/main.cpp
+++ b/test_apps/probes/weave_probe_vk_macos/main.cpp
@@ -1,0 +1,462 @@
+// Copyright 2026, DisplayXR
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  XR_DXR_weave macOS probe (#759) — headless present-owner harness.
+ *
+ * The macOS sibling of weave_rpc_probe_d3d11_win (#625), reduced to the pure
+ * service contract — no window, no presentation, CPU-verifiable:
+ *
+ *   1. Creates a headless Vulkan (MoltenVK) device — the only IPC-capable
+ *      graphics binding on macOS — and a forced-IPC OpenXR session.
+ *   2. xrWeaveBindWindowDXR(fake id) once.
+ *   3. CPU-fills a window-sized BGRA IOSurface with two squeezed-SBS rects:
+ *        rect A: left eye WHITE, right eye BLACK  -> anaglyph weave = RED
+ *        rect B: left eye BLACK, right eye WHITE  -> anaglyph weave = CYAN
+ *      (sim_display anaglyph.frag: out = (left.r, right.g, right.b, ...).)
+ *   4. Batched xrWeaveSubmitDXR (XrWeaveSubmitRectsDXR, spec v3): input is the
+ *      window-sized surface, content at each rect's own window position.
+ *   5. First submit hands back the weaved output IOSurfaceRef; completion is
+ *      SYNCHRONOUS on macOS (no fence handle — submit returning is the signal).
+ *   6. Reads the output back on the CPU, asserts the two rect centres weave to
+ *      red / cyan, dumps /tmp/weave_probe_macos_output.ppm, exits 0/1.
+ *
+ * Run (service already started with the sim display plug-in):
+ *   SIM_DISPLAY_OUTPUT=anaglyph XRT_PLUGIN_SEARCH_PATH=.../plugins displayxr-service &
+ *   XRT_FORCE_MODE=ipc XR_RUNTIME_JSON=build/openxr_displayxr-dev.json \
+ *     ./weave_probe_gl_macos
+ */
+
+#include <IOSurface/IOSurface.h>
+#include <CoreFoundation/CoreFoundation.h>
+
+#include <vulkan/vulkan.h>
+
+#define XR_USE_PLATFORM_MACOS 1
+#define XR_USE_GRAPHICS_API_VULKAN 1
+#include <openxr/openxr.h>
+#include <openxr/openxr_platform.h>
+#include <openxr/XR_DXR_weave.h>
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#define LOG(...)                                                                                                       \
+	do {                                                                                                           \
+		fprintf(stderr, "[weave_probe] " __VA_ARGS__);                                                         \
+		fprintf(stderr, "\n");                                                                                 \
+	} while (0)
+
+#define XR_CHECK(call)                                                                                                 \
+	do {                                                                                                           \
+		XrResult _r = (call);                                                                                  \
+		if (XR_FAILED(_r)) {                                                                                   \
+			LOG("FAILED %s -> %d", #call, (int)_r);                                                        \
+			return 1;                                                                                      \
+		}                                                                                                      \
+	} while (0)
+
+#define VK_CHECK(call)                                                                                                 \
+	do {                                                                                                           \
+		VkResult _v = (call);                                                                                  \
+		if (_v != VK_SUCCESS) {                                                                                \
+			LOG("FAILED %s -> %d", #call, (int)_v);                                                        \
+			return 1;                                                                                      \
+		}                                                                                                      \
+	} while (0)
+
+// Window-client-sized input (the v3 batch contract) + the two weaved rects.
+static const uint32_t kWinW = 1280;
+static const uint32_t kWinH = 720;
+static const XrRect2Di kRectA = {{100, 100}, {320, 180}};
+static const XrRect2Di kRectB = {{700, 400}, {400, 200}};
+
+//! BGRA pixel write helper.
+static inline void
+put_px(uint8_t *base, size_t stride, int x, int y, uint8_t r, uint8_t g, uint8_t b)
+{
+	uint8_t *p = base + (size_t)y * stride + (size_t)x * 4;
+	p[0] = b;
+	p[1] = g;
+	p[2] = r;
+	p[3] = 0xFF;
+}
+
+/*!
+ * Fill one squeezed-SBS rect: the rect's LEFT half holds the left-eye view,
+ * the RIGHT half the right-eye view — each squeezed to half the rect width.
+ */
+static void
+fill_sbs_rect(uint8_t *base, size_t stride, const XrRect2Di &r, uint8_t left_lum, uint8_t right_lum)
+{
+	int half = r.extent.width / 2;
+	for (int y = r.offset.y; y < r.offset.y + r.extent.height; y++) {
+		for (int x = r.offset.x; x < r.offset.x + r.extent.width; x++) {
+			bool is_left = (x - r.offset.x) < half;
+			uint8_t lum = is_left ? left_lum : right_lum;
+			put_px(base, stride, x, y, lum, lum, lum);
+		}
+	}
+}
+
+static bool
+sample_px(IOSurfaceRef surf, int x, int y, uint8_t *out_r, uint8_t *out_g, uint8_t *out_b)
+{
+	if (IOSurfaceLock(surf, kIOSurfaceLockReadOnly, NULL) != kIOReturnSuccess) {
+		return false;
+	}
+	const uint8_t *base = (const uint8_t *)IOSurfaceGetBaseAddress(surf);
+	size_t stride = IOSurfaceGetBytesPerRow(surf);
+	const uint8_t *p = base + (size_t)y * stride + (size_t)x * 4;
+	*out_b = p[0];
+	*out_g = p[1];
+	*out_r = p[2];
+	IOSurfaceUnlock(surf, kIOSurfaceLockReadOnly, NULL);
+	return true;
+}
+
+static void
+dump_ppm(IOSurfaceRef surf, const char *path)
+{
+	if (IOSurfaceLock(surf, kIOSurfaceLockReadOnly, NULL) != kIOReturnSuccess) {
+		return;
+	}
+	uint32_t w = (uint32_t)IOSurfaceGetWidth(surf);
+	uint32_t h = (uint32_t)IOSurfaceGetHeight(surf);
+	const uint8_t *base = (const uint8_t *)IOSurfaceGetBaseAddress(surf);
+	size_t stride = IOSurfaceGetBytesPerRow(surf);
+	FILE *f = fopen(path, "wb");
+	if (f != NULL) {
+		fprintf(f, "P6\n%u %u\n255\n", w, h);
+		for (uint32_t y = 0; y < h; y++) {
+			const uint8_t *row = base + (size_t)y * stride;
+			for (uint32_t x = 0; x < w; x++) {
+				uint8_t rgb[3] = {row[x * 4 + 2], row[x * 4 + 1], row[x * 4 + 0]};
+				fwrite(rgb, 1, 3, f);
+			}
+		}
+		fclose(f);
+		LOG("dumped weaved output -> %s (%ux%u)", path, w, h);
+	}
+	IOSurfaceUnlock(surf, kIOSurfaceLockReadOnly, NULL);
+}
+
+static IOSurfaceRef
+create_input_surface(void)
+{
+	// kIOSurfaceIsGlobal so the service-side IOSurfaceLookup(id) finds it
+	// (the IPC channel transports the bare IOSurfaceID).
+	int32_t w = (int32_t)kWinW, h = (int32_t)kWinH, bpe = 4;
+	uint32_t fmt = 'BGRA';
+	CFStringRef keys[5] = {CFSTR("IOSurfaceWidth"), CFSTR("IOSurfaceHeight"), CFSTR("IOSurfaceBytesPerElement"),
+	                       CFSTR("IOSurfacePixelFormat"), CFSTR("IOSurfaceIsGlobal")};
+	CFNumberRef vals[4] = {
+	    CFNumberCreate(NULL, kCFNumberSInt32Type, &w),
+	    CFNumberCreate(NULL, kCFNumberSInt32Type, &h),
+	    CFNumberCreate(NULL, kCFNumberSInt32Type, &bpe),
+	    CFNumberCreate(NULL, kCFNumberSInt32Type, &fmt),
+	};
+	CFTypeRef values[5] = {vals[0], vals[1], vals[2], vals[3], kCFBooleanTrue};
+	CFDictionaryRef props = CFDictionaryCreate(NULL, (const void **)keys, (const void **)values, 5,
+	                                           &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+	IOSurfaceRef surf = IOSurfaceCreate(props);
+	CFRelease(props);
+	for (int i = 0; i < 4; i++) {
+		CFRelease(vals[i]);
+	}
+	return surf;
+}
+
+//! Split a space-separated extension string into stable storage + pointers.
+static void
+split_exts(const std::string &s, std::vector<std::string> &storage, std::vector<const char *> &ptrs)
+{
+	size_t start = 0;
+	for (size_t i = 0; i <= s.size(); i++) {
+		if (i == s.size() || s[i] == ' ' || s[i] == '\0') {
+			if (i > start) {
+				storage.push_back(s.substr(start, i - start));
+			}
+			start = i + 1;
+		}
+	}
+	for (const auto &e : storage) {
+		ptrs.push_back(e.c_str());
+	}
+}
+
+int
+main(int argc, char **argv)
+{
+	(void)argc;
+	(void)argv;
+
+	// ---- Instance with the weave + vulkan-enable extensions.
+	uint32_t ext_count = 0;
+	XR_CHECK(xrEnumerateInstanceExtensionProperties(NULL, 0, &ext_count, NULL));
+	std::vector<XrExtensionProperties> exts(ext_count, {XR_TYPE_EXTENSION_PROPERTIES});
+	XR_CHECK(xrEnumerateInstanceExtensionProperties(NULL, ext_count, &ext_count, exts.data()));
+	bool has_weave = false, has_vk = false;
+	for (const auto &e : exts) {
+		if (strcmp(e.extensionName, XR_DXR_WEAVE_EXTENSION_NAME) == 0) {
+			has_weave = true;
+		}
+		if (strcmp(e.extensionName, XR_KHR_VULKAN_ENABLE_EXTENSION_NAME) == 0) {
+			has_vk = true;
+		}
+	}
+	LOG("XR_DXR_weave:         %s", has_weave ? "AVAILABLE" : "NOT FOUND");
+	LOG("XR_KHR_vulkan_enable: %s", has_vk ? "AVAILABLE" : "NOT FOUND");
+	if (!has_weave || !has_vk) {
+		return 1;
+	}
+
+	const char *enabled[] = {XR_KHR_VULKAN_ENABLE_EXTENSION_NAME, XR_DXR_WEAVE_EXTENSION_NAME};
+	XrInstanceCreateInfo ici = {XR_TYPE_INSTANCE_CREATE_INFO};
+	snprintf(ici.applicationInfo.applicationName, sizeof(ici.applicationInfo.applicationName), "%s",
+	         "DXRWeaveProbeMacOS");
+	ici.applicationInfo.applicationVersion = 1;
+	snprintf(ici.applicationInfo.engineName, sizeof(ici.applicationInfo.engineName), "%s", "None");
+	ici.applicationInfo.apiVersion = XR_CURRENT_API_VERSION;
+	ici.enabledExtensionCount = 2;
+	ici.enabledExtensionNames = enabled;
+	XrInstance instance = XR_NULL_HANDLE;
+	XR_CHECK(xrCreateInstance(&ici, &instance));
+
+	XrSystemGetInfo sgi = {XR_TYPE_SYSTEM_GET_INFO};
+	sgi.formFactor = XR_FORM_FACTOR_HEAD_MOUNTED_DISPLAY;
+	XrSystemId system_id = XR_NULL_SYSTEM_ID;
+	XR_CHECK(xrGetSystem(instance, &sgi, &system_id));
+
+	// ---- Headless Vulkan (MoltenVK) device per XR_KHR_vulkan_enable.
+	PFN_xrGetVulkanGraphicsRequirementsKHR pfn_req = NULL;
+	PFN_xrGetVulkanInstanceExtensionsKHR pfn_iext = NULL;
+	PFN_xrGetVulkanDeviceExtensionsKHR pfn_dext = NULL;
+	PFN_xrGetVulkanGraphicsDeviceKHR pfn_gdev = NULL;
+	xrGetInstanceProcAddr(instance, "xrGetVulkanGraphicsRequirementsKHR", (PFN_xrVoidFunction *)&pfn_req);
+	xrGetInstanceProcAddr(instance, "xrGetVulkanInstanceExtensionsKHR", (PFN_xrVoidFunction *)&pfn_iext);
+	xrGetInstanceProcAddr(instance, "xrGetVulkanDeviceExtensionsKHR", (PFN_xrVoidFunction *)&pfn_dext);
+	xrGetInstanceProcAddr(instance, "xrGetVulkanGraphicsDeviceKHR", (PFN_xrVoidFunction *)&pfn_gdev);
+	if (pfn_req == NULL || pfn_iext == NULL || pfn_dext == NULL || pfn_gdev == NULL) {
+		LOG("failed to resolve XR_KHR_vulkan_enable entry points");
+		return 1;
+	}
+	XrGraphicsRequirementsVulkanKHR vk_req = {XR_TYPE_GRAPHICS_REQUIREMENTS_VULKAN_KHR};
+	XR_CHECK(pfn_req(instance, system_id, &vk_req));
+
+	uint32_t len = 0;
+	pfn_iext(instance, system_id, 0, &len, NULL);
+	std::string iext_str(len, '\0');
+	pfn_iext(instance, system_id, len, &len, iext_str.data());
+	std::vector<std::string> iext_storage;
+	std::vector<const char *> iexts;
+	split_exts(iext_str, iext_storage, iexts);
+
+	// MoltenVK is a portability implementation — enumerate it.
+	uint32_t avail = 0;
+	vkEnumerateInstanceExtensionProperties(NULL, &avail, NULL);
+	std::vector<VkExtensionProperties> avail_exts(avail);
+	vkEnumerateInstanceExtensionProperties(NULL, &avail, avail_exts.data());
+	bool has_portability = false;
+	for (const auto &e : avail_exts) {
+		if (strcmp(e.extensionName, "VK_KHR_portability_enumeration") == 0) {
+			has_portability = true;
+			iexts.push_back("VK_KHR_portability_enumeration");
+			break;
+		}
+	}
+
+	VkApplicationInfo app_info = {VK_STRUCTURE_TYPE_APPLICATION_INFO};
+	app_info.pApplicationName = "DXRWeaveProbeMacOS";
+	app_info.apiVersion = VK_API_VERSION_1_1;
+	VkInstanceCreateInfo vici = {VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO};
+	vici.pApplicationInfo = &app_info;
+	vici.enabledExtensionCount = (uint32_t)iexts.size();
+	vici.ppEnabledExtensionNames = iexts.data();
+	if (has_portability) {
+		vici.flags |= 0x00000001; // VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR
+	}
+	VkInstance vk_instance = VK_NULL_HANDLE;
+	VK_CHECK(vkCreateInstance(&vici, NULL, &vk_instance));
+
+	VkPhysicalDevice phys = VK_NULL_HANDLE;
+	XR_CHECK(pfn_gdev(instance, system_id, vk_instance, &phys));
+
+	uint32_t qf_count = 0;
+	vkGetPhysicalDeviceQueueFamilyProperties(phys, &qf_count, NULL);
+	std::vector<VkQueueFamilyProperties> qfs(qf_count);
+	vkGetPhysicalDeviceQueueFamilyProperties(phys, &qf_count, qfs.data());
+	uint32_t qfi = UINT32_MAX;
+	for (uint32_t i = 0; i < qf_count; i++) {
+		if (qfs[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) {
+			qfi = i;
+			break;
+		}
+	}
+	if (qfi == UINT32_MAX) {
+		LOG("no graphics queue family");
+		return 1;
+	}
+
+	len = 0;
+	pfn_dext(instance, system_id, 0, &len, NULL);
+	std::string dext_str(len, '\0');
+	pfn_dext(instance, system_id, len, &len, dext_str.data());
+	std::vector<std::string> dext_storage;
+	std::vector<const char *> dexts;
+	split_exts(dext_str, dext_storage, dexts);
+
+	// MoltenVK devices require VK_KHR_portability_subset when advertised.
+	uint32_t dav = 0;
+	vkEnumerateDeviceExtensionProperties(phys, NULL, &dav, NULL);
+	std::vector<VkExtensionProperties> dav_exts(dav);
+	vkEnumerateDeviceExtensionProperties(phys, NULL, &dav, dav_exts.data());
+	for (const auto &e : dav_exts) {
+		if (strcmp(e.extensionName, "VK_KHR_portability_subset") == 0) {
+			bool already = false;
+			for (const char *d : dexts) {
+				if (strcmp(d, "VK_KHR_portability_subset") == 0) {
+					already = true;
+				}
+			}
+			if (!already) {
+				dexts.push_back("VK_KHR_portability_subset");
+			}
+			break;
+		}
+	}
+
+	float prio = 1.0f;
+	VkDeviceQueueCreateInfo qci = {VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO};
+	qci.queueFamilyIndex = qfi;
+	qci.queueCount = 1;
+	qci.pQueuePriorities = &prio;
+	VkDeviceCreateInfo dci = {VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO};
+	dci.queueCreateInfoCount = 1;
+	dci.pQueueCreateInfos = &qci;
+	dci.enabledExtensionCount = (uint32_t)dexts.size();
+	dci.ppEnabledExtensionNames = dexts.data();
+	VkDevice device = VK_NULL_HANDLE;
+	VK_CHECK(vkCreateDevice(phys, &dci, NULL, &device));
+
+	// ---- Forced-IPC session over the headless Vulkan device.
+	XrGraphicsBindingVulkanKHR vk_binding = {XR_TYPE_GRAPHICS_BINDING_VULKAN_KHR};
+	vk_binding.instance = vk_instance;
+	vk_binding.physicalDevice = phys;
+	vk_binding.device = device;
+	vk_binding.queueFamilyIndex = qfi;
+	vk_binding.queueIndex = 0;
+	XrSessionCreateInfo sci = {XR_TYPE_SESSION_CREATE_INFO};
+	sci.next = &vk_binding;
+	sci.systemId = system_id;
+	XrSession session = XR_NULL_HANDLE;
+	XR_CHECK(xrCreateSession(instance, &sci, &session));
+	LOG("session created (IPC, headless Vulkan)");
+
+	PFN_xrWeaveBindWindowDXR pfn_bind = NULL;
+	PFN_xrWeaveSubmitDXR pfn_submit = NULL;
+	xrGetInstanceProcAddr(instance, "xrWeaveBindWindowDXR", (PFN_xrVoidFunction *)&pfn_bind);
+	xrGetInstanceProcAddr(instance, "xrWeaveSubmitDXR", (PFN_xrVoidFunction *)&pfn_submit);
+	if (pfn_bind == NULL || pfn_submit == NULL) {
+		LOG("failed to resolve weave entry points");
+		return 1;
+	}
+
+	XR_CHECK(pfn_bind(session, (void *)(uintptr_t)0x1)); // fake window id (phase-anchor only)
+
+	// ---- Build the window-sized squeezed-SBS input.
+	IOSurfaceRef input = create_input_surface();
+	if (input == NULL) {
+		LOG("IOSurfaceCreate failed");
+		return 1;
+	}
+	IOSurfaceLock(input, 0, NULL);
+	uint8_t *base = (uint8_t *)IOSurfaceGetBaseAddress(input);
+	size_t stride = IOSurfaceGetBytesPerRow(input);
+	for (uint32_t y = 0; y < kWinH; y++) { // dark-gray background
+		for (uint32_t x = 0; x < kWinW; x++) {
+			put_px(base, stride, (int)x, (int)y, 32, 32, 32);
+		}
+	}
+	fill_sbs_rect(base, stride, kRectA, /*left*/ 0xFF, /*right*/ 0x00); // -> RED after anaglyph
+	fill_sbs_rect(base, stride, kRectB, /*left*/ 0x00, /*right*/ 0xFF); // -> CYAN after anaglyph
+	IOSurfaceUnlock(input, 0, NULL);
+
+	// ---- Batched submits (spec v3).
+	XrRect2Di rects[2] = {kRectA, kRectB};
+	XrWeaveSubmitRectsDXR batch = {(XrStructureType)XR_TYPE_WEAVE_SUBMIT_RECTS_DXR};
+	batch.rectCount = 2;
+	batch.rects = rects;
+	XrWeaveSubmitInfoDXR submit = {(XrStructureType)XR_TYPE_WEAVE_SUBMIT_INFO_DXR};
+	submit.next = &batch;
+	submit.inputTexture = (void *)input;
+	submit.inputIsDxgi = XR_FALSE;
+
+	IOSurfaceRef output = NULL;
+	uint32_t out_w = 0, out_h = 0;
+	for (int frame = 0; frame < 5; frame++) {
+		XrWeaveOutputDXR out = {(XrStructureType)XR_TYPE_WEAVE_OUTPUT_DXR};
+		XrResult r = pfn_submit(session, &submit, &out);
+		if (XR_FAILED(r)) {
+			LOG("xrWeaveSubmitDXR frame %d FAILED: %d", frame, (int)r);
+			return 1;
+		}
+		if (out.weavedTexture != NULL && output == NULL) {
+			output = (IOSurfaceRef)out.weavedTexture; // retained handback
+		}
+		out_w = out.width;
+		out_h = out.height;
+		if (frame == 0) {
+			LOG("frame 0: weaved %ux%u, fence=%p fenceValue=%llu, eyes=%u (valid=%d tracking=%d)",
+			    out.width, out.height, out.fence, (unsigned long long)out.fenceValue, out.eyeCount,
+			    (int)out.eyesValid, (int)out.eyesTracking);
+		}
+	}
+	if (output == NULL) {
+		LOG("FAIL: no weaved output IOSurface was handed back");
+		return 1;
+	}
+	if (out_w != kWinW || out_h != kWinH) {
+		LOG("FAIL: output dims %ux%u != input (window) dims %ux%u", out_w, out_h, kWinW, kWinH);
+		return 1;
+	}
+
+	// ---- Verify the anaglyph weave on the CPU.
+	dump_ppm(output, "/tmp/weave_probe_macos_output.ppm");
+
+	struct Check
+	{
+		const char *name;
+		int x, y;
+		bool want_red; // else cyan
+	} checks[] = {
+	    {"rectA(red)", kRectA.offset.x + kRectA.extent.width / 2, kRectA.offset.y + kRectA.extent.height / 2, true},
+	    {"rectB(cyan)", kRectB.offset.x + kRectB.extent.width / 2, kRectB.offset.y + kRectB.extent.height / 2,
+	     false},
+	};
+	bool pass = true;
+	for (const auto &c : checks) {
+		uint8_t r = 0, g = 0, b = 0;
+		if (!sample_px(output, c.x, c.y, &r, &g, &b)) {
+			LOG("FAIL: could not sample %s", c.name);
+			pass = false;
+			continue;
+		}
+		bool ok = c.want_red ? (r > 150 && g < 80 && b < 80) : (r < 80 && g > 150 && b > 150);
+		LOG("%s @(%d,%d) = (%u,%u,%u) -> %s", c.name, c.x, c.y, r, g, b, ok ? "OK" : "WRONG");
+		pass = pass && ok;
+	}
+
+	xrDestroySession(session);
+	xrDestroyInstance(instance);
+	CFRelease(input);
+	CFRelease(output);
+	vkDestroyDevice(device, NULL);
+	vkDestroyInstance(vk_instance, NULL);
+
+	LOG("%s", pass ? "PASS" : "FAIL");
+	return pass ? 0 : 1;
+}


### PR DESCRIPTION
Closes #759. Ports the window-bound synchronous weave service (#625, spec v3 batch #744) to the macOS OOP service, so present-owner callers (the future mac DisplayXR Browser GPU process, CEF-style hosts) can have the runtime weave sub-rects of their window. This is the runtime prerequisite for the mac browser port (#733 downstream).

## Architecture

The macOS service is Vulkan/MoltenVK end-to-end (null compositor → comp_multi shared surface), and sim_display's anaglyph SPIR-V pipeline already runs on it — so the weave engine is a small Vulkan module in comp_multi reusing the existing `vk_bundle` + `dp_factory_vk`. Callers see pure **IOSurface-in / IOSurface-out** (a Metal caller never touches Vulkan).

| Contract point | Windows (D3D11 service) | macOS (this PR) |
|---|---|---|
| `inputTexture` | NT/DXGI shared HANDLE | IOSurfaceRef (rides the existing IOSurfaceID IPC transport) |
| Input-ready sync | keyed mutex | caller completes GPU writes before submit |
| Output | shared-handle export | IOSurface-backed VkImage, exported via `VkExportMetalObjectCreateInfoEXT` |
| Completion | shared D3D fence | **synchronous** — `vkWaitForFences` before the IPC reply; no fence handle |
| Output sizing | `GetClientRect(hwnd)` | batch: input IOSurface dims (v3 input is window-client-sized by contract); legacy: rect offset+extent |
| Snap | vendor DP lattice | identity (no VK DP snap slot yet) |

The batch algorithm is byte-for-byte the Windows strategy: every rect double-blitted (un-squeezed) into ONE window-sized 2×1 SBS scratch atlas, then ONE `process_atlas` per submit.

## Changes

- **New** `compositor/multi/comp_multi_weave_macos.c` + per-client `multi_compositor::weave` state — import cache (keyed by IOSurfaceID), scratch, output+framebuffer, private DP instance, engine lifecycle (fini wired into `multi_compositor_destroy`).
- `ipc_server_handler.c`: `XRT_OS_MACOS` branches in the weave handlers (bind/submit/get_output/snap; get_fence keeps the benign no-fence fallback, which *is* the macOS contract). Handles the retained-IOSurfaceRef ownership incl. the malformed-rect_count early-return path.
- `oxr_extension_support.h`: `OXR_HAVE_DXR_weave` gate widened to `XR_USE_PLATFORM_MACOS`. `oxr_weave.c`: fd-typed sync-handle cast + doc update (no logic change; the client bridge + wire were already portable).
- `docs/specs/extensions/XR_DXR_weave.md`: new §5 macOS platform mapping.
- **New probe** `test_apps/probes/weave_probe_vk_macos`: headless present-owner harness — forced-IPC MoltenVK session (GL has no IPC client on macOS), CPU-filled squeezed-SBS IOSurface, batched 2-rect submit, CPU-verifies the anaglyph weave and dumps a PPM.

## Verification

Ran end-to-end on this Mac against `displayxr-service` + sim_display (`SIM_DISPLAY_OUTPUT=anaglyph`):

```
[weave_probe] frame 0: weaved 1280x720, fence=0x0 fenceValue=1, eyes=2 (valid=1 tracking=0)
[weave_probe] rectA(red)  @(260,190) = (255,0,0) -> OK
[weave_probe] rectB(cyan) @(900,500) = (0,255,255) -> OK
[weave_probe] PASS
```

Pixel-exact: left-eye-white rect weaves to pure red, right-eye-white to pure cyan (matching `anaglyph.frag`'s `(left.r, right.g, right.b)`), un-woven regions untouched, output dims == input (window) dims, eyes flow back. Windows path untouched (handler branches are `#elif`; D3D11 code byte-identical).

## Deferred (tracked in #759)

- `MTLSharedEvent` async completion (profile first; synchronous matches the existing macOS IPC sync model)
- VK DP `snap_window_rect` slot (ADR-020 append) for a future vendor mac weaver
- Chromium-side mac port (IOSurface-from-SharedImage + weave-under-CoreAnimation) — blocked on the mac build box

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BV3PGjuDGdX3wSfVgZHhsW