### PR TITLE
feat(manifest): implement min_runtime gate + refresh Unity app-path doc

### DIFF
--- a/docs/architecture/unity-d3d12-app-path.md
+++ b/docs/architecture/unity-d3d12-app-path.md
@@ -1,166 +1,98 @@
 # Unity D3D12 (and other engine) app path
 
-How a **Unity** D3D12 app reaches the runtime. This is **not obvious** because Unity
-is not a DisplayXR-native app — it uses its own OpenXR plugin and never calls
-`XR_DXR_win32_window_binding` itself. The DisplayXR Unity plugin
-(`unity-3d-display`, ships as `displayxr_unity.dll`) bridges the gap by **hooking
-`xrCreateSession` and injecting a window binding pointing at a plugin-created
-overlay window**. The same pattern applies to any general engine integrated via a
-hook layer rather than purpose-built source.
+How a **Unity** app reaches the runtime. This is **not obvious** because Unity is not a
+DisplayXR-native app — it drives OpenXR through its own XR pipeline and never calls
+`XR_DXR_win32_window_binding` itself. The DisplayXR Unity plugin bridges the gap.
 
-> Cross-repo: the plugin source lives in `unity-3d-display/native~`
-> (`displayxr_hooks.cpp`, `displayxr_win32.c`, `displayxr_standalone_d3d12.cpp`).
-> The runtime side is this repo. For the plain in-process vs service split see
+> **Paradigm change (2026, epic #166 / PR #177).** The plugin was rewritten from an
+> **OpenXR API-layer hook** (which intercepted `xrGetInstanceProcAddr`, hooked
+> `xrCreateSession`, and *injected* a window binding pointing at a plugin-created child
+> overlay) to a first-class **`IUnityXRDisplay` display provider** — the same integration
+> route Oculus/Varjo/Cardboard use. The old hook path and its standalone-D3D12 preview were
+> **hard-removed**; this doc describes the provider. If you're reading old notes that mention
+> `displayxr_hooks.cpp` / `hooked_xrCreateSession` / injected `WS_CHILD` overlays, that code
+> is gone.
+
+> Cross-repo: the plugin lives in **`displayxr-unity`** (UPM `com.displayxr.unity`); provider
+> internals are documented there in
+> [`docs~/architecture/xr-display-provider.md`](https://github.com/DisplayXR/displayxr-unity/blob/main/docs~/architecture/xr-display-provider.md).
+> The runtime side is this repo. For the in-process-vs-service split see
 > [in-process-vs-service.md](in-process-vs-service.md); for app classes see
 > [app-classes](../getting-started/app-classes.md).
 
 ## TL;DR
 
-Unity D3D12 (standalone, the default) runs on the **same in-process native D3D12
-compositor** as `cube_handle_d3d12_win`, as a `_handle`-class app — but it is *not*
-a drop-in equivalent. Two things differ:
-1. **Upstream binding:** the HWND handed to the runtime is a **plugin-created child
-   overlay window**, supplied via a **hook-injected** `XR_DXR_win32_window_binding`
-   — not a window the app made for the runtime, and not the IPC/service path.
-2. **Submission model:** Unity is a **fixed-resolution, always-2-view
-   legacy-compromise** app (per-eye swapchains sized once; `scaleXY` not applied per
-   frame), whereas cube renders **adaptive per-mode tiles**. The compositor *code*
-   (atlas blit / crop / DP weave) is shared, but it is fed differently.
+The provider makes a shipping Unity player behave like the native `cube_handle_d3d12_win`
+handle app: **Unity's XR-Management "DisplayXR Display" provider itself calls `xrCreateSession`**
+(no hook), passing Unity's device on a `XrGraphicsBindingD3D12KHR`/`…D3D11KHR` next-chained to
+an `XrWin32WindowBindingCreateInfoDXR`. It is still *not* a drop-in cube equivalent, for one
+reason that survives the rewrite: **submission model.** Unity submits a **fixed-resolution,
+always-2-view** projection layer (per-eye swapchains sized once at session start, or one
+`arraySize=2` swapchain under Single-Pass-Instanced; `scaleXY` not applied per frame), whereas
+cube renders **adaptive per-mode N-view tiles**. The compositor code is shared; it is fed
+differently.
 
-## Two routes, selected by mode
+## Two routes, selected by transport
 
-| | Unity **standalone** (default) | Unity **under shell** |
+| | Unity **standalone** (default) | Unity **under the DisplayXR Shell** |
 |---|---|---|
-| Plugin behavior | creates a **child overlay** window, injects its HWND | passes Unity's **top-level** HWND, no overlay |
-| Runtime route | **in-process native** `comp_d3d12_compositor` | **client → IPC → D3D11 service** |
-| Selector | `oxr_d3d12_native_compositor_supported` → true (not service mode) | `displayxr_is_shell_mode()` in plugin / `is_service_mode` in runtime |
+| Provider window | creates its **own top-level `WS_POPUP`** overlay over Unity's client area, binds the runtime to it | should **not** create the overlay — binds Unity's hidden main HWND (or none) and submits as a client |
+| Runtime route | **in-process native** `comp_d3d12_compositor` (self-weaves) | **client → IPC → D3D11 service** (`client_d3d12_compositor` → `comp_d3d11_service` multi-compositor tile) |
+| Selector | `is_service_mode` false → `oxr_d3d12_native_compositor_supported` true | `DISPLAYXR_WORKSPACE_SESSION=1` (or `XRT_FORCE_MODE=ipc`) → `u_sandbox_should_use_ipc()` → `is_service_mode` true |
 
-The rest of this doc covers the **standalone (in-process native)** route, since
-that is the non-obvious one. The shell route is the ordinary client/IPC path
-(`client_d3d12_compositor` → `comp_d3d11_service`).
+**The transport switch is entirely runtime-side and already correct.** The shell launches 3D
+apps with `XR_RUNTIME_JSON` + `DISPLAYXR_WORKSPACE_SESSION=1`, unelevated, window hidden.
+`u_sandbox_should_use_ipc()` (`src/xrt/auxiliary/util/u_sandbox.c`) reads that env var and forces
+IPC, which sets `is_service_mode=true`; each `oxr_session_gfx_*_native.c` then **refuses the
+in-process native compositor** when `is_service_mode` is set, so the state tracker falls through
+to the IPC client compositor. Only on that path does the app self-register a multi-compositor
+slot (`comp_d3d11_service.cpp`, workspace-mode-gated) and become a shell-composited **tile** —
+an in-process self-weaving app never connects to the service and cannot be a tile.
 
-## Definitive flow (standalone)
+> **Provider-side status.** The provider must cooperate with the under-shell route by **not**
+> creating/showing its `WS_POPUP` overlay and by submitting frames as a client instead of
+> presenting to a window it owns. The runtime routing is done; the provider's workspace mode is
+> being wired in `displayxr-unity` (detect the workspace session via the existing
+> `displayxr_is_shell_mode()`, which already reads `DISPLAYXR_WORKSPACE_SESSION`; skip the
+> overlay; bind Unity's hidden main HWND or `NULL`). Open questions tracked there: whether the
+> per-frame pump needs any atlas reconciliation on the `client_d3d12_compositor` path, and
+> whether a window binding is wanted at all from a 3D-submit client.
 
-### Plugin side (`unity-3d-display/native~`), at `xrCreateSession`
-`displayxr_unity.dll` is an OpenXR API-layer hook — it intercepts
-`xrGetInstanceProcAddr` and hooks `xrCreateSession` (`hooked_xrCreateSession`,
-`displayxr_hooks.cpp`). Unity's own OpenXR plugin drives the session normally;
-DisplayXR's hook sits in the middle and, **before** calling the real
-`xrCreateSession`:
+## Submission model (applies to both routes)
 
-1. Detects `XR_TYPE_GRAPHICS_BINDING_D3D12_KHR` in the next-chain → selects the
-   D3D12 backend.
-2. Calls `displayxr_get_app_main_view()` (`displayxr_win32.c`), which **creates an
-   overlay window** over Unity's main HWND:
-   - **Default (opaque):** `CreateWindowExW(WS_EX_TRANSPARENT, …, WS_CHILD |
-     WS_VISIBLE, owner = Unity's main HWND)` — a child overlay sized to Unity's
-     client rect. **This is the "HWND with a child."**
-   - **Transparent (#57):** a top-level `WS_POPUP | WS_EX_NOREDIRECTIONBITMAP`
-     overlay; Unity is cloaked + moved off-screen; DComp alpha compositing.
-3. **Injects** an `XrWin32WindowBindingCreateInfoDXR` onto the end of the
-   `xrCreateSession` next-chain with `windowHandle = the overlay HWND` (plus a
-   `readbackCallback` and the `transparentBackgroundEnabled` flag).
-4. Calls the real `xrCreateSession`.
+- **View config is `PRIMARY_STEREO` for everyone — that is not the difference.** The runtime
+  only advertises `XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO` (`oxr_system.c`); `xrLocateViews`
+  returns `view_count` = the **max across all modes** (e.g. 4 for `sim_display`'s Quad), and
+  `xrEndFrame` accepts a projection `viewCount` matching *any* mode's `view_count`.
+- A **native handle app (cube)** renders the active mode's **N views as tiles** in one
+  worst-case-sized swapchain (multiview tiling, ADR-010) and submits an N-view projection layer
+  with per-tile `imageRect`.
+- A **built Unity app renders only 2 eyes** (per-eye swapchains, or SPI `arraySize=2`) and
+  submits a **2-view** layer. **There is no view synthesis downstream** — nothing reconstructs
+  additional views from those 2 eyes, so a built Unity app can only drive modes whose
+  `view_count ≤ 2` (fine for typical 3D-display 3D = 2 views; a `sim_display` 2×2 Quad,
+  `view_count = 4`, cannot be filled). The runtime synthesises per-tile **viewer poses** (not
+  pixels), which is what lets native/extension apps render the N views.
+- **SPI:** when Unity uses `arraySize=2`, the eyes are array **layers** 0/1 submitted with
+  `subImage.imageArrayIndex`; the per-view SRV must sample the layer named by `imageArrayIndex`
+  (`FirstArraySlice = view.subImage.array_index`), not a hardcoded layer 0. (SPI is auto-gated
+  by runtime version — it needs runtime ≥ 1.26.1, else the plugin falls back to MultiPass.)
+- The plugin does **not** compute Kooima — it chains an `XR_DXR_view_rig` descriptor onto
+  `xrLocateViews` and consumes the runtime's render-ready views.
 
-### Runtime side (this repo)
-With `xsi->external_window_handle` now set to the overlay HWND:
+## How this differs from a native D3D12 app (`cube_handle_d3d12_win`)
 
-1. `oxr_session.c` (D3D12 binding branch) → `oxr_d3d12_native_compositor_supported`
-   returns true (not service mode) → **`oxr_session_populate_d3d12_native`**
-   (`oxr_session_gfx_d3d12_native.c`).
-2. `comp_d3d12_compositor_create(xdev, hwnd = overlay, …)` is called **directly**:
-   `sess->compositor = &xcn->base`, `is_d3d12_native_compositor = true`. **No
-   client wrapper, no Vulkan, no IPC.**
-3. In `comp_d3d12_compositor_create` it takes the `else if (hwnd != nullptr)`
-   branch → `c->hwnd = overlay`, `owns_window = false`. So it is a
-   **`_handle`-class app** (not hosted/self-created-window).
-4. `comp_d3d12_target_create` runs `CreateSwapChainForHwnd` **on the overlay**.
-   The overlay is a fresh window with no swapchain, so this **succeeds directly**
-   — the runtime's own `E_ACCESSDENIED → WS_CHILD fallback`
-   (`comp_d3d12_target.cpp`, `create_child_window_threaded`) is **not** triggered.
-   The child in play is the *plugin's* overlay, not the runtime fallback.
-
-### Frame loop — same compositor code, **different submission model**
-The compositor *mechanics* are the shared D3D12 path, but Unity **feeds** them very
-differently from a native handle app (see the next section — this is the part that
-is easy to get wrong).
-
-- Swapchain: `oxr_swapchain_d3d12_native_create` → `comp_d3d12_swapchain_create`
-  (compositor-owned `ID3D12Resource` on Unity's device); images surfaced to Unity
-  via `d3d12_native_enumerate_images` as `XrSwapchainImageD3D12KHR.texture`. Unity
-  allocates **per-eye** swapchains **once** at session start (from
-  `xrEnumerateViewConfigurationViews`) — or **one** swapchain with `arraySize=2`
-  under Single-Pass-Instanced — and renders each eye at that **fixed** resolution
-  every frame.
-- `d3d12_compositor_layer_commit`: per-view atlas blit
-  (`comp_d3d12_renderer.cpp:draw_projection_pass`) → **crop to content**
-  (`d3d12_crop_atlas_for_dp`) → **DP weave** (`process_atlas`) into the overlay's
-  back buffer → HUD → `comp_d3d12_target_present`. Composited pixels also flow
-  back to Unity via the injected `readbackCallback`.
-- **View config is `PRIMARY_STEREO` for *everyone* — that is not the difference.**
-  The runtime only ever advertises `XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO`
-  (`oxr_system.c`), and `xrLocateViews` always returns `view_count` = the **MAX
-  across all modes** (e.g. 4 — `sim_display`'s Quad mode), not 2 (`oxr_session.c`;
-  `xrEndFrame` then accepts a projection `viewCount` matching *any* mode's
-  `view_count` — `oxr_session_frame_end.c`).
-  - A **native handle app (cube)** renders the active mode's **N views as tiles
-    into one worst-case-sized swapchain** (multiview tiling, ADR-010) and submits an
-    N-view projection layer with per-tile `imageRect`.
-  - A **built Unity app** renders **only 2 eyes** (per-eye swapchains, or SPI
-    `arraySize=2`) and submits a **2-view** layer. **There is no view synthesis
-    downstream** — nothing reconstructs additional views from those 2 eyes, so a
-    built Unity app can only drive modes whose `view_count ≤ 2`; a mode with more
-    views (e.g. `sim_display`'s 2×2 Quad, `view_count = 4`) requires the app to
-    render all N tiles itself, which Unity cannot. (The runtime *does* synthesise
-    per-tile **viewer poses** — not pixels — so a native/extension app can render
-    the N views; see `sim_display_device.c`. True N-view *rendering* in the Unity
-    stack exists only in the plugin's editor standalone preview, which runs its own
-    hookless OpenXR session.)
-  So a 2D↔3D mode switch does **not** change Unity's render resolution — only the
-  atlas tiling / `imageRect` it's composited into.
-- **SPI:** when Unity uses `arraySize=2`, the eyes are array **layers** 0/1
-  submitted with `subImage.imageArrayIndex`; the per-view SRV must sample the layer
-  named by `imageArrayIndex` (`FirstArraySlice = view.subImage.array_index`), not a
-  hardcoded layer 0.
-
-## How this differs from a native D3D12 app (`cube_handle_d3d12_win`) — and why
-
-| | `cube_handle_d3d12_win` | Unity D3D12 (standalone) |
+| | `cube_handle_d3d12_win` | Unity D3D12 (provider) |
 |---|---|---|
-| Who calls `xrCreateSession` | the app itself | Unity's OpenXR plugin; **DisplayXR hooks it** |
-| `XR_DXR_win32_window_binding` | app fills it with its own HWND | plugin **injects** it |
-| HWND handed to the runtime | a clean window made **for the runtime** | a **child overlay** over Unity's main window |
-| Window ownership | app owns one window; nothing else presents to it | Unity owns + presents to its **main** window; overlay is a *second* window |
-| Readback | none | `readbackCallback` returns composited pixels |
-| View configuration type | `PRIMARY_STEREO` | `PRIMARY_STEREO` (same — *not* the difference) |
-| Views the app renders | the active mode's **N** (e.g. 2, or 4 in Quad) as **tiles in one** worst-case swapchain | **always 2** eyes; **no view synthesis** → limited to `view_count ≤ 2` modes |
-| Per-view render resolution | **adaptive** — each view at `window × scaleXY` of the active mode | **fixed** — per-eye swapchains sized once at session start; `scaleXY` not applied per frame (ADR-006 "legacy compromise") |
+| Who calls `xrCreateSession` | the app itself | Unity's DisplayXR **display provider** (no hook) |
+| `XR_DXR_win32_window_binding` | app fills it with its own HWND | provider fills it (overlay HWND standalone; hidden Unity HWND / none under shell) |
+| Window handed to the runtime | a clean window made **for the runtime** | standalone: a provider-created **top-level `WS_POPUP`** overlay; under shell: Unity's hidden main window (or none) |
+| Views the app renders | the active mode's **N** as tiles in one swapchain | **always 2** eyes; no view synthesis → limited to `view_count ≤ 2` modes |
+| Per-view render resolution | **adaptive** — each view at `window × scaleXY` of the active mode | **fixed** — per-eye swapchains sized once at session start (ADR-006 "legacy compromise") |
 | Compositor code (atlas blit / crop / DP weave) | shared | shared (fed differently) |
 
-Note: the compositor *code path* is shared, but the *submission model* is not.
-A native handle app renders adaptive per-mode tiles; Unity is effectively a
-**fixed-resolution, always-2-view legacy-compromise** app whose per-mode tiling is
-reconciled by the compositor at `layer_commit`/`xrEndFrame`. (On the **D3D11**
-service path Unity reconciles the atlas itself in `displayxr_d3d11_backend.cpp`; on
-**D3D12** the runtime compositor does the per-view blit.) The plugin also no longer
-computes Kooima — it chains an `XR_DXR_view_rig` descriptor onto `xrLocateViews`
-and consumes the runtime's render-ready views.
-
-**Why the overlay is necessary** (all because Unity is a general engine, not a
-bespoke DisplayXR app):
-
-1. **Unity already owns its main HWND and presents its own swapchain to it.**
-   DXGI enforces one swapchain per HWND for D3D12 — handing Unity's main HWND to
-   the runtime would `E_ACCESSDENIED` (the exact case the runtime's child-window
-   fallback exists for). The plugin sidesteps it with a fresh overlay window.
-2. **Visual conflict.** Even if sharing were allowed, Unity continuously presents
-   its flat game frame to its main window; the runtime's interlaced weave output
-   would fight it. A separate overlay **stacked on top** lets the runtime own the
-   screen while Unity's own present stays hidden behind it.
-3. **Unity won't emit the window binding.** Unity's OpenXR plugin knows nothing
-   about `XR_DXR_win32_window_binding` / 3D-display weaving. The only way to get
-   the binding + the right HWND into `xrCreateSession` is the hook + injection.
-
-A cube app has none of these constraints: it's written for DisplayXR, creates one
-clean window expressly for the runtime, fills the binding itself, and never
-presents to that window — no hook, no overlay, no conflict.
+A cube app is written for DisplayXR: it creates one clean window expressly for the runtime,
+fills the binding itself, and never presents to that window. The provider instead adapts Unity's
+general-engine ownership of its own window — standalone it stacks a runtime-owned overlay over
+Unity's frame; under the shell it yields the window entirely and submits as a client so the
+service composites it as a tile alongside every other app.

--- a/docs/specs/runtime/displayxr-app-manifest.md
+++ b/docs/specs/runtime/displayxr-app-manifest.md
@@ -98,13 +98,14 @@ The manifest sits in a system-known discovery directory and points at any execut
 | `icon_3d_layout` | string | `"sbs-lr"` | How the stereo pair is packed in `icon_3d`. One of `"sbs-lr"` (left-right), `"sbs-rl"` (right-left), `"tb"` (top-bottom, left eye on top), `"bt"` (bottom-top). Ignored if `icon_3d` is absent. |
 | `category` | string | `"app"` | Free-form tag used for grouping. Reserved values: `"test"`, `"demo"`, `"app"`, `"tool"`. Unknown values are accepted and displayed as-is. |
 | `display_mode` | string | `"auto"` | Preferred display mode at launch. `"auto"` lets the runtime choose. Other values are forwarded to the runtime's mode selection. |
+| `min_runtime` | string | *none* | Minimum DisplayXR **runtime** version the app requires, as `MAJOR.MINOR.PATCH` — see §3.5. When set and the installed runtime is older, a workspace controller marks the tile **incompatible** (greyed, launch blocked with an explanatory tooltip) rather than dropping it, so the user sees *why*. Additive; controllers predating this field ignore it. |
 | `description` | string | `""` | One-line description shown in tooltips. Max 256 characters. |
 
 ### 3.3 Reserved for future versions
 
 Names a workspace controller may consume in later schema versions — do not use for custom data:
 
-`version`, `publisher`, `homepage`, `min_runtime`, `required_extensions`, `screenshots`, `trailer`, `pose`, `window_size`, `args`, `working_dir`, `mcp`.
+`version`, `publisher`, `homepage`, `required_extensions`, `screenshots`, `trailer`, `pose`, `window_size`, `args`, `working_dir`, `mcp`.
 
 (`mcp` is reserved for the planned declarative tool-discovery block — see [per-app MCP tools](../../roadmap/per-app-mcp-tools.md) §9 P3.)
 
@@ -119,6 +120,18 @@ Rules:
 - **Uniqueness:** ids should be unique across the ecosystem by convention (pick something specific: `mediaplayer`, `gaussiansplat` — not `viewer`). There is no central registry; collisions between *different* apps are a scanner **warning** (both entries survive — dedup remains by `exe_path`), and consumers such as the MCP workspace aggregator disambiguate at runtime with sticky suffixes (`-2`, `-3`).
 - **Cross-check:** an app that registers MCP tools declares the same id at runtime via `xrSetMCPAppInfoDXR`. The runtime-declared value is authoritative; `scripts/check_displayxr_app.py` lints that manifest and code agree.
 - **Fallback:** when `id` is absent (and the app declares none at runtime), consumers derive a fallback from the sanitized exe basename. Fine for Browse-for-app entries; apps shipping manifests should set it explicitly.
+
+### 3.5 Runtime-version floor (`min_runtime`)
+
+`min_runtime` declares the minimum DisplayXR **runtime** version the app needs to run correctly (e.g. an engine plugin that only composites into the workspace on a runtime that ships a given capability). It is a shell-side **compatibility gate**, distinct from installer-time prerequisite checks — an installer may already refuse to install below a floor, but `min_runtime` also protects against the runtime being downgraded or the app being side-loaded after install.
+
+Rules:
+
+- **Format:** `MAJOR.MINOR.PATCH` (e.g. `"2.0.6"`). A malformed value is a **soft failure** (§6): warn and ignore the field — a bad floor must not knock an otherwise-valid app out of the launcher.
+- **Comparison:** the workspace controller reads the installed runtime version and compares numerically, component-by-component. On Windows the reference source is `HKLM\Software\DisplayXR\Runtime` value `Version` (the same key the runtime installer writes and engine installers read). Controllers on other platforms read the equivalent installed-runtime version.
+- **Incompatible behavior:** when installed `< min_runtime`, the controller keeps the tile **visible but disabled** — greyed, launch blocked, with a tooltip naming the required vs. installed version. The manifest is *not* dropped from discovery (contrast a hard validation rejection in §6): the user should see the app exists and learn why it can't launch, then update the runtime.
+- **Absent:** no gate — the controller launches regardless of runtime version (status quo).
+- **Additive:** controllers predating this field simply ignore the key and launch unconditionally, exactly as before.
 
 ## 4. 3D icons
 
@@ -190,6 +203,9 @@ Rejected manifests are logged as warnings. The scanner does not attempt to recov
 
 - `id` is specified but does not match `^[a-z0-9][a-z0-9-]{0,31}$` — the entry behaves as if `id` were absent (fallback per §3.4). A malformed slug must not knock an otherwise-valid app out of the launcher.
 - `id` duplicates another discovered manifest's `id` (different `exe_path`) — both entries survive; consumers disambiguate per §3.4.
+- `min_runtime` is specified but is not a `MAJOR.MINOR.PATCH` string — the field is ignored (no gate), per §3.5. A malformed floor must not drop the app.
+
+Note that `min_runtime` being *satisfiable-but-unmet* (installed runtime older than the floor) is **not** a manifest rejection — the entry is accepted and surfaced as a disabled/incompatible tile per §3.5, not dropped.
 
 ## 7. Example: minimal manifest
 
@@ -234,7 +250,7 @@ A workspace controller does NOT extract icons from the PE for sidecar/registered
 
 ## 10. Versioning
 
-Breaking changes bump `schema_version`. A workspace controller will refuse to parse manifests with a `schema_version` it does not understand, and log the unsupported version. Additive changes (new optional fields) keep `schema_version: 1`. The `exe_path` field added in this revision is additive — older controllers that read a registered manifest will fall back to sidecar resolution (look for sibling exe, fail, skip the entry); they will never crash. Registered-mode manifests therefore require a workspace controller ≥ the version that introduced this field. The `id` field (§3.4) is likewise additive — controllers that predate it simply ignore the key, and every `id`-consuming behavior has a defined fallback.
+Breaking changes bump `schema_version`. A workspace controller will refuse to parse manifests with a `schema_version` it does not understand, and log the unsupported version. Additive changes (new optional fields) keep `schema_version: 1`. The `exe_path` field added in this revision is additive — older controllers that read a registered manifest will fall back to sidecar resolution (look for sibling exe, fail, skip the entry); they will never crash. Registered-mode manifests therefore require a workspace controller ≥ the version that introduced this field. The `id` field (§3.4) and the `min_runtime` field (§3.5) are likewise additive — controllers that predate either simply ignore the key (for `min_runtime`, that means launching unconditionally, exactly as before), and every consuming behavior has a defined fallback.
 
 ## 11. Browse-for-app and registered-apps state cache (DisplayXR Shell reference implementation)
 

--- a/scripts/check_displayxr_app.py
+++ b/scripts/check_displayxr_app.py
@@ -60,6 +60,9 @@ RULES = {
 # Manifest `id` / XrMCPAppInfoDXR appId slug (manifest spec §3.4).
 APP_ID_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,31}$")
 
+# Optional runtime-version floor (manifest spec §3.5) — MAJOR.MINOR.PATCH.
+MIN_RUNTIME_RE = re.compile(r"^\d+\.\d+\.\d+$")
+
 ERROR, WARN, INFO = "ERROR", "WARN", "INFO"
 
 
@@ -256,6 +259,13 @@ def validate_manifest(mpath: Path, root: Path, findings: list):
             findings.append(Finding(WARN, "INV-9.2", rel(ipath, root), 1,
                                     f"{key} is {dims[0]}x{dims[1]}; convention is {want[0]}x{want[1]}.",
                                     f"Re-export {key} at {want[0]}x{want[1]} (PNG)."))
+
+    # Optional runtime-version floor (spec §3.5). Soft failure: warn + ignore if malformed.
+    min_rt = data.get("min_runtime")
+    if min_rt is not None and not (isinstance(min_rt, str) and MIN_RUNTIME_RE.match(min_rt)):
+        findings.append(Finding(WARN, "INV-9.1", rp, 1,
+                                f"min_runtime {min_rt!r} is not a MAJOR.MINOR.PATCH string; it will be ignored.",
+                                'Set "min_runtime": "2.0.6" (or remove it) — a malformed floor is dropped, not gated.'))
 
 
 def check_mcp_pairing(root: Path, findings: list):


### PR DESCRIPTION
Part of the "open Unity apps in the Shell" work.

- **Spec §3.5**: `min_runtime` moves reserved→implemented — a shell-side runtime-version floor. Installed < floor ⇒ tile shown but disabled (not dropped); malformed ⇒ ignored.
- **Linter**: `check_displayxr_app.py` validates MAJOR.MINOR.PATCH (soft-fail). Tested: warns on `"2.0"`, silent on `"2.0.6"`.
- **Doc**: `unity-d3d12-app-path.md` rewritten from the removed hook/overlay paradigm (#166/#177) to the `IUnityXRDisplay` provider + the standalone-native vs under-shell-IPC-tile routes.

Paired with shell-pvt (parses+gates the field) and unity-samples (emits it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVkJcDPR52int8PWLjmo2R