### PR TITLE
fix(installer): DisplayXR tile icon for runtime installer + ARP entry

### DIFF
--- a/installer/DisplayXRInstaller.nsi
+++ b/installer/DisplayXRInstaller.nsi
@@ -95,8 +95,8 @@ ShowUninstDetails show
 
 !define MUI_ABORTWARNING
 ; White icon so the installer .exe is visible in dark mode Explorer/taskbar
-!define MUI_ICON "${SOURCE_DIR}\assets\displayxr_white.ico"
-!define MUI_UNICON "${SOURCE_DIR}\assets\displayxr_white.ico"
+!define MUI_ICON "${SOURCE_DIR}\assets\displayxr_app.ico"
+!define MUI_UNICON "${SOURCE_DIR}\assets\displayxr_app.ico"
 
 ;--------------------------------
 ; Pages
@@ -791,7 +791,7 @@ Section "DisplayXR Runtime" SecRuntime
 	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\DisplayXR" \
 		"InstallLocation" "$INSTDIR"
 	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\DisplayXR" \
-		"DisplayIcon" "$INSTDIR\DisplayXRClient.dll"
+		"DisplayIcon" "$INSTDIR\displayxr-service.exe"
 	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\DisplayXR" \
 		"Publisher" "DisplayXR"
 	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\DisplayXR" \


### PR DESCRIPTION
Runtime installer used `displayxr_white.ico` (white-on-transparent → invisible on the light installer background). Switch `MUI_ICON`/`MUI_UNICON` to the theme-safe `displayxr_app.ico` tile, and point the Add/Remove Programs `DisplayIcon` at `displayxr-service.exe` (has the tile icon) instead of the icon-less `DisplayXRClient.dll`.

Part of the icon polish pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)