### PR TITLE
feat(d3d11-service): honor layered (arraySize>1) swapchains in per-client blit (ADR-032)

### DIFF
--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -593,6 +593,11 @@ struct d3d11_service_system
 	//! Blit shaders for projection layer copy with SRGB conversion
 	wil::com_ptr<ID3D11VertexShader> blit_vs;
 	wil::com_ptr<ID3D11PixelShader> blit_ps;
+	//! ADR-032: Texture2DArray source variant of blit_ps. Bound by
+	//! blit_to_atlas_texture(is_array=true) when a client submits a LAYERED
+	//! (arraySize>1) swapchain — samples the requested eye's array slice.
+	//! Non-fatal if compilation fails (layered clients fall back to slice 0).
+	wil::com_ptr<ID3D11PixelShader> blit_ps_array;
 	//! #308: premultiplied box-blur variant of blit_ps. Used only for the
 	//! empty-state splash logo while it's pushed behind the launcher band, to
 	//! give it depth-of-field. Blur radius (UV) comes from glow_falloff.
@@ -2007,6 +2012,20 @@ create_layer_shaders(struct d3d11_service_system *sys)
 		return false;
 	}
 
+	// ADR-032: Texture2DArray blit variant for LAYERED (arraySize>1) clients
+	// (non-fatal — a layered client falls back to slice 0 if this is missing).
+	hr = compile_shader(blit_ps_array_hlsl, "PSMain", "ps_5_0", &blob);
+	if (SUCCEEDED(hr)) {
+		hr = sys->device->CreatePixelShader(blob->GetBufferPointer(), blob->GetBufferSize(),
+		                                     nullptr, sys->blit_ps_array.put());
+		blob->Release();
+		if (FAILED(hr)) {
+			U_LOG_W("Failed to create layered blit pixel shader: 0x%08lx (layered clients degrade)", hr);
+		}
+	} else {
+		U_LOG_W("Failed to compile layered blit pixel shader (layered clients degrade)");
+	}
+
 	// #308: blur variant for the pushed-back empty-state splash (non-fatal).
 	hr = compile_shader(blit_blur_ps_hlsl, "PSMain", "ps_5_0", &blob);
 	if (SUCCEEDED(hr)) {
@@ -2224,7 +2243,14 @@ blit_to_atlas_texture(struct d3d11_service_system *sys,
                        ID3D11BlendState *blend = nullptr,
                        ID3D11RenderTargetView *rtv_override = nullptr,
                        float dst_tex_w = 0.0f,
-                       float dst_tex_h = 0.0f)
+                       float dst_tex_h = 0.0f,
+                       // ADR-032: when true, `src_srv` is a whole-array
+                       // Texture2DArray SRV and the blit samples slice
+                       // `array_slice`. Defaults keep the single-layer
+                       // (Texture2D) path byte-identical for all existing
+                       // callers.
+                       bool is_array = false,
+                       uint32_t array_slice = 0)
 {
 	// Update blit constant buffer
 	D3D11_MAPPED_SUBRESOURCE mapped;
@@ -2272,12 +2298,19 @@ blit_to_atlas_texture(struct d3d11_service_system *sys,
 	cb->corner_aspect = 0.0f;
 	cb->edge_feather = 0.0f;
 	cb->glow_intensity = 0.0f;
+	// ADR-032: source array slice for the Texture2DArray blit variant. Written
+	// unconditionally (WRITE_DISCARD map) — harmless for the Texture2D path,
+	// which never reads it. `hud_flags.z` in the shared BlitCB layout.
+	cb->array_slice = static_cast<float>(array_slice);
 
 	sys->context->Unmap(sys->blit_constant_buffer.get(), 0);
 
-	// Set up pipeline for blit
+	// Set up pipeline for blit. ADR-032: bind the Texture2DArray variant for
+	// LAYERED sources (falls back to the plain blit_ps if the array shader
+	// failed to compile — degrades to slice 0 rather than crashing).
+	bool use_array_ps = is_array && sys->blit_ps_array;
 	sys->context->VSSetShader(sys->blit_vs.get(), nullptr, 0);
-	sys->context->PSSetShader(sys->blit_ps.get(), nullptr, 0);
+	sys->context->PSSetShader(use_array_ps ? sys->blit_ps_array.get() : sys->blit_ps.get(), nullptr, 0);
 	sys->context->VSSetConstantBuffers(0, 1, sys->blit_constant_buffer.addressof());
 	sys->context->PSSetConstantBuffers(0, 1, sys->blit_constant_buffer.addressof());
 	sys->context->PSSetShaderResources(0, 1, &src_srv);
@@ -3682,11 +3715,22 @@ compositor_create_swapchain(struct xrt_compositor *xc,
 
 		U_LOG_W("Created shared texture [%u]: handle=%p (NT handle)", i, shared_handle);
 
-		// Create SRV for compositor
+		// Create SRV for compositor. ADR-032: a LAYERED (arraySize>1) swapchain
+		// packs its eyes as array slices; a plain Texture2D SRV silently views
+		// slice 0, so create a whole-array Texture2DArray SRV instead (the
+		// blit reads the requested slice via blit_ps_array).
 		D3D11_SHADER_RESOURCE_VIEW_DESC srv_desc = {};
 		srv_desc.Format = dxgi_format;
-		srv_desc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
-		srv_desc.Texture2D.MipLevels = tex_desc.MipLevels;
+		if (tex_desc.ArraySize > 1) {
+			srv_desc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2DARRAY;
+			srv_desc.Texture2DArray.MostDetailedMip = 0;
+			srv_desc.Texture2DArray.MipLevels = tex_desc.MipLevels;
+			srv_desc.Texture2DArray.FirstArraySlice = 0;
+			srv_desc.Texture2DArray.ArraySize = tex_desc.ArraySize;
+		} else {
+			srv_desc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
+			srv_desc.Texture2D.MipLevels = tex_desc.MipLevels;
+		}
 
 		hr = sys->device->CreateShaderResourceView(
 		    sc->images[i].texture.get(), &srv_desc, sc->images[i].srv.put());
@@ -3806,10 +3850,22 @@ compositor_import_swapchain(struct xrt_compositor *xc,
 		D3D11_TEXTURE2D_DESC desc;
 		sc->images[i].texture->GetDesc(&desc);
 
+		// ADR-032: a LAYERED (arraySize>1) swapchain — e.g. a D3D12 IPC client
+		// submitting an SPI/array swapchain with its two eyes as slices 0/1 —
+		// needs a whole-array Texture2DArray SRV. A plain Texture2D SRV views
+		// only slice 0, so both eyes would sample the LEFT image.
 		D3D11_SHADER_RESOURCE_VIEW_DESC srv_desc = {};
 		srv_desc.Format = desc.Format;
-		srv_desc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
-		srv_desc.Texture2D.MipLevels = 1;
+		if (desc.ArraySize > 1) {
+			srv_desc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2DARRAY;
+			srv_desc.Texture2DArray.MostDetailedMip = 0;
+			srv_desc.Texture2DArray.MipLevels = 1;
+			srv_desc.Texture2DArray.FirstArraySlice = 0;
+			srv_desc.Texture2DArray.ArraySize = desc.ArraySize;
+		} else {
+			srv_desc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
+			srv_desc.Texture2D.MipLevels = 1;
+		}
 
 		hr = sys->device->CreateShaderResourceView(
 		    sc->images[i].texture.get(), &srv_desc, sc->images[i].srv.put());
@@ -10382,6 +10438,7 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 			}
 		}
 
+
 		for (uint32_t eye = 0; eye < proj_view_count; eye++) {
 			// Phase 1 Task 1.2 — mutex acquire timed out earlier;
 			// the source texture is unsafe to read. Leave the per-
@@ -10461,6 +10518,14 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 			bool use_srgb_shader = can_shader_blit && view_is_srgb[eye] && !sys->workspace_mode;
 			bool use_scale_shader = can_shader_blit && needs_scale && sys->workspace_mode;
 
+			// ADR-032: a LAYERED (arraySize>1) source packs its eyes as array
+			// slices. Every array-aware path samples slice `sub.array_index`;
+			// single-layer sources (ArraySize==1) keep the byte-identical
+			// Texture2D path. The raw-copy fallback already selects the source
+			// subresource via `sub.array_index`, so it needs no change.
+			bool is_layered = view_descs[eye].ArraySize > 1;
+			uint32_t src_slice = static_cast<uint32_t>(layer->data.proj.v[eye].sub.array_index);
+
 			if (use_srgb_shader) {
 				// Non-workspace SRGB: shader blit with SRGB SRV for linearization.
 				// The GPU auto-linearizes when sampling through an SRGB SRV.
@@ -10468,9 +10533,18 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 				wil::com_ptr<ID3D11ShaderResourceView> srgb_srv;
 				D3D11_SHADER_RESOURCE_VIEW_DESC srv_desc = {};
 				srv_desc.Format = get_srgb_format(view_descs[eye].Format);
-				srv_desc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
-				srv_desc.Texture2D.MipLevels = 1;
-				srv_desc.Texture2D.MostDetailedMip = 0;
+				if (is_layered) {
+					// Whole-array SRGB SRV so the array PS can select the slice.
+					srv_desc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2DARRAY;
+					srv_desc.Texture2DArray.MostDetailedMip = 0;
+					srv_desc.Texture2DArray.MipLevels = 1;
+					srv_desc.Texture2DArray.FirstArraySlice = 0;
+					srv_desc.Texture2DArray.ArraySize = view_descs[eye].ArraySize;
+				} else {
+					srv_desc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
+					srv_desc.Texture2D.MipLevels = 1;
+					srv_desc.Texture2D.MostDetailedMip = 0;
+				}
 				HRESULT blit_hr = sys->device->CreateShaderResourceView(
 				    view_textures[eye], &srv_desc, srgb_srv.put());
 				if (SUCCEEDED(blit_hr)) {
@@ -10478,7 +10552,10 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 					    src_x, src_y, src_w, src_h,
 					    (float)view_descs[eye].Width, (float)view_descs[eye].Height,
 					    (float)tile_x, (float)tile_y,
-					    dst_w, dst_h, true);
+					    dst_w, dst_h, true,
+					    /*blend=*/nullptr, /*rtv_override=*/nullptr,
+					    /*dst_tex_w=*/0.0f, /*dst_tex_h=*/0.0f,
+					    /*is_array=*/is_layered, /*array_slice=*/src_slice);
 				} else {
 					// Fallback to raw copy
 					D3D11_BOX box = {};
@@ -10494,13 +10571,17 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 				// shader using the default (non-SRGB) SRV so sampling reads
 				// raw bytes and writes them unmodified — keeps the per-client
 				// atlas in gamma space, matching the raw-copy path that
-				// multi_compositor_render expects.
+				// multi_compositor_render expects. The per-image SRV is already
+				// a Texture2DArray for layered sources (ADR-032, create/import).
 				blit_to_atlas_texture(sys, &c->render,
 				    view_scs[eye]->images[view_img_indices[eye]].srv.get(),
 				    src_x, src_y, src_w, src_h,
 				    (float)view_descs[eye].Width, (float)view_descs[eye].Height,
 				    (float)tile_x, (float)tile_y,
-				    dst_w, dst_h, false);
+				    dst_w, dst_h, false,
+				    /*blend=*/nullptr, /*rtv_override=*/nullptr,
+				    /*dst_tex_w=*/0.0f, /*dst_tex_h=*/0.0f,
+				    /*is_array=*/is_layered, /*array_slice=*/src_slice);
 			} else {
 				// Non-SRGB, or workspace mode with content already fitting the
 				// tile, or shader unavailable: raw byte copy. Multi-comp
@@ -10521,6 +10602,7 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 				    layer->data.proj.v[eye].sub.array_index,  // src subresource
 				    &box);
 			}
+
 		}
 		} // !zero_copy
 

--- a/src/xrt/compositor/d3d11_service/d3d11_service_shaders.h
+++ b/src/xrt/compositor/d3d11_service/d3d11_service_shaders.h
@@ -529,7 +529,14 @@ struct BlitConstants
 	float hud_src_rect[4];
 	float hud_present;
 	float hud_premul;
-	float _hud_pad[2];
+	// ADR-032: source array slice for LAYERED (arraySize>1) swapchains. The
+	// blit_ps_array pixel shader samples src_tex as a Texture2DArray at
+	// float3(uv, array_slice). Occupies the first of the two former HUD pad
+	// floats — the float4 `hud_flags` cbuffer register (x=present, y=premul,
+	// z=array_slice, w=pad) is byte-identical, so single-layer blits (which
+	// leave this 0 and bind the plain Texture2D blit_ps) are unaffected.
+	float array_slice;
+	float _hud_pad[1];
 };
 
 //! Vertex shader for projection blit - draws a quad at specified destination
@@ -908,6 +915,188 @@ float4 PSMain(VS_OUTPUT input) : SV_Target
         // contrast (light-gray tint) and pick up a slight blue tone over
         // workspace clients — preserves internal cursor detail (black
         // outline vs white fill) by multiplying instead of replacing.
+        color = color * glow_color;
+    }
+
+    return float4(oetf_out(color.rgb), color.a * alpha * a_mul);
+}
+)";
+
+//! ADR-032: LAYERED (array) source variant of blit_ps_hlsl. A D3D12 IPC client
+//! that submits a single arraySize=2 SPI/array swapchain places its two eyes as
+//! array slices (subImage.imageArrayIndex 0/1) rather than side-by-side tiles.
+//! Sampling that shared texture through a plain Texture2D SRV silently views
+//! slice 0 only, so both eyes get the LEFT image. This variant binds a whole-
+//! array Texture2DArray SRV and selects the requested slice via `array_slice`
+//! (the `hud_flags.z` cbuffer slot — byte-identical BlitCB layout to blit_ps).
+//! Bound by blit_to_atlas_texture(is_array=true); single-layer blits keep the
+//! Texture2D blit_ps path. Body is otherwise identical to blit_ps_hlsl.
+static const char *blit_ps_array_hlsl = R"(
+cbuffer BlitCB : register(b0)
+{
+    float4 src_rect;
+    float2 dst_offset;
+    float2 src_size;
+    float2 dst_size;
+    float convert_srgb;
+    float quad_mode;
+    float2 dst_rect_wh;
+    float corner_radius;
+    float corner_aspect;
+    float4 quad_corners_01;
+    float4 quad_corners_23;
+    float4 quad_w;
+    float edge_feather;
+    float glow_intensity;
+    float glow_extent;
+    float glow_falloff;
+    float4 glow_color;
+    float4 corner_depth_ndc;
+    float4 chrome_alpha;
+    float4 hud_dst_rect;
+    float4 hud_src_rect;
+    float2 hud_flags;        // x = present, y = premul
+    float array_slice;       // z: source array slice for layered swapchains
+    float _hud_pad;          // w
+};
+
+cbuffer ColorCB : register(b1)
+{
+    float g_linearize_output;
+    float3 _color_pad;
+};
+
+// Layered source: eyes are array slices, sampled at float3(uv, array_slice).
+Texture2DArray src_tex : register(t0);
+Texture2D hud_tex : register(t1);
+SamplerState src_samp : register(s0);
+
+struct VS_OUTPUT
+{
+    float4 position : SV_Position;
+    float2 uv : TEXCOORD0;
+    float2 quad_uv : TEXCOORD1;
+};
+
+float3 srgb_to_linear(float3 c)
+{
+    return (c <= 0.04045) ? (c / 12.92) : pow((c + 0.055) / 1.055, 2.4);
+}
+float3 oetf_out(float3 c)
+{
+    return (g_linearize_output > 0.5) ? srgb_to_linear(c) : c;
+}
+
+float4 PSMain(VS_OUTPUT input) : SV_Target
+{
+    float2 uv01 = input.quad_uv;
+
+    if (convert_srgb > 3.5) {
+        float ext_x = glow_extent;
+        float ext_y = (edge_feather > 0.001) ? edge_feather : ext_x;
+        if (ext_x < 0.001) discard;
+        float dx = min(uv01.x, 1.0 - uv01.x);
+        float dy = min(uv01.y, 1.0 - uv01.y);
+        float ndx = dx / ext_x;
+        float ndy = dy / ext_y;
+        if (ndx > 1.0 && ndy > 1.0) discard;
+        float dist = min(min(ndx, ndy), 1.0);
+        float falloff = exp(-glow_falloff * dist * dist);
+        float a = glow_intensity * falloff;
+        return float4(oetf_out(glow_color.rgb) * a, a);
+    }
+
+    if (convert_srgb > 2.5) {
+        float ext_x = glow_extent;
+        float ext_y = (edge_feather > 0.001) ? edge_feather : ext_x;
+        if (ext_x < 0.001) discard;
+        float dx = max(ext_x - uv01.x, uv01.x - (1.0 - ext_x));
+        float dy = max(ext_y - uv01.y, uv01.y - (1.0 - ext_y));
+        float ndx = dx / ext_x;
+        float ndy = dy / ext_y;
+        float dist;
+        if (ndx > 0 && ndy > 0)
+            dist = length(float2(ndx, ndy));
+        else
+            dist = max(max(ndx, ndy), 0.0);
+        if (dist <= 0.0) discard;
+        float falloff = exp(-glow_falloff * dist * dist);
+        float a = glow_intensity * falloff;
+        return float4(oetf_out(glow_color.rgb) * a, a);
+    }
+
+    float corner_alpha = 1.0;
+    bool in_corner = false;
+    if (corner_radius != 0) {
+        float ry = abs(corner_radius);
+        float aspect = abs(corner_aspect);
+        if (aspect < 0.001) aspect = 10.0;
+        float rx = ry / aspect;
+        bool all_corners = (corner_radius < 0 && corner_aspect < 0);
+        bool do_top = (corner_radius > 0 || all_corners);
+        bool do_top_left = do_top && (corner_aspect > 0 || all_corners);
+        bool do_top_right = do_top;
+        bool do_bottom_left = (corner_radius < 0);
+        bool do_bottom_right = (corner_radius < 0);
+        float corner_dist = -1.0;
+        if (do_top_left && uv01.x < rx && uv01.y < ry)
+            corner_dist = length(float2((rx - uv01.x) / rx, (ry - uv01.y) / ry));
+        if (do_top_right && uv01.x > 1.0 - rx && uv01.y < ry)
+            corner_dist = length(float2((uv01.x - (1.0 - rx)) / rx, (ry - uv01.y) / ry));
+        if (do_bottom_left && uv01.x < rx && uv01.y > 1.0 - ry)
+            corner_dist = length(float2((rx - uv01.x) / rx, (uv01.y - (1.0 - ry)) / ry));
+        if (do_bottom_right && uv01.x > 1.0 - rx && uv01.y > 1.0 - ry)
+            corner_dist = length(float2((uv01.x - (1.0 - rx)) / rx, (uv01.y - (1.0 - ry)) / ry));
+        if (corner_dist >= 0.0) {
+            in_corner = true;
+            if (corner_dist > 1.0) discard;
+            float feather_band = (edge_feather > 0.0) ? edge_feather / ry : 0.02;
+            corner_alpha = saturate((1.0 - corner_dist) / feather_band);
+        }
+    }
+
+    float feather_alpha = 1.0;
+    if (!in_corner && edge_feather > 0.0) {
+        float aspect_for_feather = abs(corner_aspect);
+        if (aspect_for_feather < 0.001) aspect_for_feather = 1.0;
+        float dx = min(uv01.x, 1.0 - uv01.x) * aspect_for_feather;
+        float dy = min(uv01.y, 1.0 - uv01.y);
+        float d = min(dx, dy);
+        feather_alpha = saturate(d / edge_feather);
+    }
+    float coverage = corner_alpha * feather_alpha;
+    float alpha = coverage;
+
+    float fade = saturate(chrome_alpha.x);
+    float a_mul = 1.0 - fade;
+
+    if (convert_srgb > 1.5)
+        return float4(oetf_out(src_rect.xyz), alpha * a_mul);
+
+    float4 color = src_tex.Sample(src_samp, float3(input.uv, array_slice));
+
+    if (hud_flags.x > 0.5)
+    {
+        float2 hud_q = (input.quad_uv - hud_dst_rect.xy) / max(hud_dst_rect.zw, float2(1e-6, 1e-6));
+        if (hud_q.x >= 0.0 && hud_q.x <= 1.0 && hud_q.y >= 0.0 && hud_q.y <= 1.0)
+        {
+            float2 hud_uv = hud_src_rect.xy + hud_q * hud_src_rect.zw;
+            float4 hud_color = hud_tex.Sample(src_samp, hud_uv);
+            float a = saturate(hud_color.a);
+            float3 hud_rgb_premul = (hud_flags.y > 0.5) ? hud_color.rgb : hud_color.rgb * a;
+            color.rgb = color.rgb * (1.0 - a) + hud_rgb_premul;
+            color.a = saturate(color.a + a * (1.0 - color.a));
+        }
+    }
+
+    if (chrome_alpha.y > 0.5) {
+        return float4(oetf_out(glow_color.rgb), color.a * glow_color.a * alpha * a_mul);
+    }
+
+    if (edge_feather > 0.0 && glow_intensity > 0.0) {
+        float tint_amount = (1.0 - coverage) * glow_intensity * glow_color.a;
+        color.rgb = lerp(color.rgb, glow_color.rgb, saturate(tint_amount));
+    } else if (glow_intensity > 0.0) {
         color = color * glow_color;
     }
 


### PR DESCRIPTION
## What
Ports **ADR-032** layered-swapchain support to the **out-of-process D3D11 _service_** per-client blit. PR #682 did the in-process D3D11 compositor; the service multi-compositor was the remaining gap.

## Why
A D3D12 IPC client that submits a **layered/SPI** swapchain (`arraySize=2`, two eyes as array slices via `subImage.imageArrayIndex` 0/1) had its slices sampled at index 0 by the service's shader-blit paths (`Texture2D` SRV) — flat/wrong output. ADR-032 §Decision: both tiled and layered addressing are first-class on **every** backend.

## How (gated on `array_size > 1`; single-layer path byte-identical)
- `TEXTURE2DARRAY` whole-array SRV for per-client swapchain images
- `blit_ps_array`: `Texture2DArray` variant of `blit_ps` that samples the requested slice from a cbuffer field (`array_slice`, taken from existing `BlitConstants` padding)
- `blit_to_atlas_texture` gains `is_array`/`array_slice`; the layered shader + array SRV are bound at the blit site

## Validated
Builds clean; **hardware-validated on Leia** — the Unity BiRP player renders as a workspace tile through the layered path (DisplayXR/displayxr-unity#223).

Refs ADR-032, #681, #682.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVkJcDPR52int8PWLjmo2R