### PR TITLE
fix(shell): honor target class style when promoting forwarded double-clicks

### DIFF
--- a/src/xrt/compositor/d3d11/comp_d3d11_window.cpp
+++ b/src/xrt/compositor/d3d11/comp_d3d11_window.cpp
@@ -1202,15 +1202,30 @@ wnd_proc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 						    w->last_click_target == fwd &&
 						    (now - w->last_click_time_ms) <= GetDoubleClickTime() &&
 						    dx >= -cxd && dx <= cxd && dy >= -cyd && dy <= cyd;
+						// Only promote if the target class opted into
+						// double-clicks. Win32 replaces the second DOWN with
+						// WM_*BUTTONDBLCLK for CS_DBLCLKS windows *only*;
+						// everything else legitimately expects a plain second
+						// DOWN and derives its own click count from the DOWN
+						// stream (SDL, and any app with a click-timing
+						// heuristic). Promoting unconditionally made that
+						// second click vanish into DefWindowProc.
+						bool target_wants_dbl =
+						    (GetClassLongPtrW(fwd, GCL_STYLE) & CS_DBLCLKS) != 0;
 						if (is_dbl) {
-							switch (evt_button) {
-							case 1: post_msg = WM_LBUTTONDBLCLK; break;
-							case 2: post_msg = WM_RBUTTONDBLCLK; break;
-							case 3: post_msg = WM_MBUTTONDBLCLK; break;
-							default: break;
+							if (target_wants_dbl) {
+								switch (evt_button) {
+								case 1: post_msg = WM_LBUTTONDBLCLK; break;
+								case 2: post_msg = WM_RBUTTONDBLCLK; break;
+								case 3: post_msg = WM_MBUTTONDBLCLK; break;
+								default: break;
+								}
 							}
 							// Consume the pair so a triple-click's third press
 							// starts a fresh single click (standard behavior).
+							// Done for both targets: a non-CS_DBLCLKS window
+							// still gets a plain DOWN here, it just isn't
+							// promoted.
 							w->last_click_button = 0;
 							w->last_click_target = NULL;
 						} else {


### PR DESCRIPTION
Closes #769.

## Problem

The shell's forwarded-input path promoted the second `WM_*BUTTONDOWN` of a double-click pair to `WM_*BUTTONDBLCLK` **unconditionally** (`comp_d3d11_window.cpp:1200-1232`, from `85c557c37`). Native Win32 promotes only for windows whose class has `CS_DBLCLKS`; everything else gets a plain second DOWN. For any non-`CS_DBLCLKS` target the promoted click fell through to `DefWindowProc` and was silently dropped — the app only ever saw click #1.

Two failure modes, both silent:

1. **Raw-Win32 apps without `CS_DBLCLKS`** — confirmed: the shell file picker (double-click stopped opening folders/committing files while Enter still worked). Fixed app-side in displayxr-shell-pvt#79.
2. **Apps deriving their own click count from the DOWN stream** — SDL, and anything pairing two DOWNs with a timing heuristic. SDL's win32 backend doesn't set `CS_DBLCLKS` and counts clicks itself, so ImGui's `IsMouseDoubleClicked` never fired in-shell.

## Fix

Promote only when the target opted in, exactly as the OS does, and consume the pair either way so a triple-click's third press starts fresh. `GetClassLongPtrW` works cross-process — one call per forwarded DOWN.

This fixes every non-`CS_DBLCLKS` app with **no per-app changes**, and keeps the `CS_DBLCLKS` apps on the exact path they already expect. The original unconditional promotion was right for its motivating case (earthview's double-click-to-orbit, which does set `CS_DBLCLKS`); it just also caught the opposite class of app.

## Testing

Verified on hardware in-shell:
- File-picker double-click (`CS_DBLCLKS` path) — still descends folders and commits files. Regression guard for the apps the original commit was written for.
- MediaPlayer SDL3/ImGui UI double-click — now works.

## Sweep

Full results in #769. Summary: the file picker was the only affected window in shell-pvt; all `cube_*` test apps here already set `CS_DBLCLKS`; the `windowspace_*` probes and `cube_hosted_legacy_gl_win` don't, but none of them want double-click, so no change was made there. earthview already sets it and is unaffected either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VeyYHBY1K7PP9hHSow38zJ