### PR TITLE
feat(weave): macOS v4 overlay atlas + v5 firstChunk (browser#18/#22)

### DIFF
--- a/src/xrt/compositor/multi/comp_multi_private.h
+++ b/src/xrt/compositor/multi/comp_multi_private.h
@@ -37,6 +37,7 @@
 // (comp_multi always links aux_vk, so Vulkan is always available)
 #include "xrt/xrt_vulkan_includes.h"
 #include "vk/vk_hud_blend.h"
+#include "vk/vk_local2d_composite.h"
 #include "multi/comp_multi_content_blend.h"
 
 #include "render/render_interface.h"
@@ -483,6 +484,24 @@ struct multi_compositor
 		void *out_iosurface; //!< Retained exported IOSurfaceRef.
 		uint32_t out_w, out_h;
 		//! @}
+
+		//! @name v4 DP-composited 2D overlay atlas (browser#18)
+		//! A caller-supplied window-sized PREMULTIPLIED-alpha BGRA atlas composited
+		//! OVER the woven output with a premul "over" blend (out = overlay +
+		//! (1-overlay.a)*out) AFTER process_atlas. Imported like the SBS input
+		//! (VK_EXT_metal_objects) and cached by IOSurfaceID. The premul-over pass
+		//! reuses aux_vk's vk_local2d_composite flatten_premul pipeline.
+		//! @{
+		void *overlay_iosurface; //!< Retained IOSurfaceRef (adopted from the IPC receive).
+		uint32_t overlay_iosurface_id;
+		VkImage overlay_image;
+		VkDeviceMemory overlay_memory;
+		VkImageView overlay_view; //!< Sampled by the premul-over blend.
+		uint32_t overlay_w, overlay_h;
+		bool overlay_first_use; //!< First barrier transitions from UNDEFINED.
+		struct vk_local2d_composite overlay_blend; //!< premul-over flatten pipeline.
+		bool overlay_blend_initialized;
+		//! @}
 	} weave;
 #endif
 };
@@ -810,6 +829,8 @@ comp_multi_weave_submit(struct xrt_compositor *xc,
                         uint32_t rect_h,
                         uint32_t rect_count,
                         const struct xrt_rect *rects,
+                        xrt_graphics_buffer_handle_t overlay_handle,
+                        bool weave_frame_first,
                         uint32_t *out_width,
                         uint32_t *out_height,
                         uint64_t *out_fence_value,

--- a/src/xrt/compositor/multi/comp_multi_weave_macos.c
+++ b/src/xrt/compositor/multi/comp_multi_weave_macos.c
@@ -263,6 +263,192 @@ weave_release_input(struct vk_bundle *vk, struct multi_compositor *mc)
 	mc->weave.in_h = 0;
 }
 
+/*!
+ * Import a caller IOSurface as a sampler-source VkImage (+ view) for the v4
+ * overlay atlas — the same VK_EXT_metal_objects dance as weave_import_input but
+ * into the SEPARATE overlay cache (so it never clobbers the SBS input) and with
+ * a view the premul-over blend samples. The atlas is premultiplied BGRA8.
+ */
+static bool
+weave_import_overlay(struct vk_bundle *vk, struct multi_compositor *mc, IOSurfaceRef surface)
+{
+#if defined(VK_EXT_metal_objects) && defined(VK_EXT_external_memory_metal)
+	if (!vk->has_EXT_metal_objects || !vk->has_EXT_external_memory_metal) {
+		U_LOG_E("weave(#759) v4: VK_EXT_metal_objects / VK_EXT_external_memory_metal unavailable");
+		return false;
+	}
+
+	uint32_t width = (uint32_t)IOSurfaceGetWidth(surface);
+	uint32_t height = (uint32_t)IOSurfaceGetHeight(surface);
+	if (width == 0 || height == 0) {
+		U_LOG_E("weave(#759) v4: overlay IOSurface has zero dimensions");
+		return false;
+	}
+
+	VkExportMetalObjectCreateInfoEXT export_metal_tex_info = {
+	    .sType = VK_STRUCTURE_TYPE_EXPORT_METAL_OBJECT_CREATE_INFO_EXT,
+	    .exportObjectType = VK_EXPORT_METAL_OBJECT_TYPE_METAL_TEXTURE_BIT_EXT,
+	};
+	VkImportMetalIOSurfaceInfoEXT import_iosurface_info = {
+	    .sType = VK_STRUCTURE_TYPE_IMPORT_METAL_IO_SURFACE_INFO_EXT,
+	    .pNext = &export_metal_tex_info,
+	    .ioSurface = surface,
+	};
+	VkImageCreateInfo image_ci = {
+	    .sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
+	    .pNext = &import_iosurface_info,
+	    .imageType = VK_IMAGE_TYPE_2D,
+	    .format = WEAVE_VK_FORMAT,
+	    .extent = {width, height, 1},
+	    .mipLevels = 1,
+	    .arrayLayers = 1,
+	    .samples = VK_SAMPLE_COUNT_1_BIT,
+	    .tiling = VK_IMAGE_TILING_OPTIMAL,
+	    .usage = VK_IMAGE_USAGE_SAMPLED_BIT,
+	    .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
+	    .initialLayout = VK_IMAGE_LAYOUT_UNDEFINED,
+	};
+
+	VkImage image = VK_NULL_HANDLE;
+	VkResult ret = vk->vkCreateImage(vk->device, &image_ci, NULL, &image);
+	if (ret != VK_SUCCESS) {
+		U_LOG_E("weave(#759) v4: vkCreateImage(overlay IOSurface) failed: %d", ret);
+		return false;
+	}
+
+	VkExportMetalTextureInfoEXT export_tex_info = {
+	    .sType = VK_STRUCTURE_TYPE_EXPORT_METAL_TEXTURE_INFO_EXT,
+	    .image = image,
+	    .plane = VK_IMAGE_ASPECT_COLOR_BIT,
+	};
+	VkExportMetalObjectsInfoEXT export_objects_info = {
+	    .sType = VK_STRUCTURE_TYPE_EXPORT_METAL_OBJECTS_INFO_EXT,
+	    .pNext = &export_tex_info,
+	};
+	vk->vkExportMetalObjectsEXT(vk->device, &export_objects_info);
+	if (export_tex_info.mtlTexture == NULL) {
+		U_LOG_E("weave(#759) v4: failed to export MTLTexture from overlay VkImage");
+		vk->vkDestroyImage(vk->device, image, NULL);
+		return false;
+	}
+
+	VkMemoryRequirements requirements = {0};
+	vk->vkGetImageMemoryRequirements(vk->device, image, &requirements);
+
+	VkMemoryMetalHandlePropertiesEXT metal_props = {
+	    .sType = VK_STRUCTURE_TYPE_MEMORY_METAL_HANDLE_PROPERTIES_EXT,
+	};
+	ret = vk->vkGetMemoryMetalHandlePropertiesEXT(vk->device, VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLTEXTURE_BIT_EXT,
+	                                              export_tex_info.mtlTexture, &metal_props);
+	if (ret != VK_SUCCESS) {
+		U_LOG_E("weave(#759) v4: vkGetMemoryMetalHandlePropertiesEXT failed: %d", ret);
+		vk->vkDestroyImage(vk->device, image, NULL);
+		return false;
+	}
+	requirements.memoryTypeBits = metal_props.memoryTypeBits;
+
+	VkImportMemoryMetalHandleInfoEXT import_memory_info = {
+	    .sType = VK_STRUCTURE_TYPE_IMPORT_MEMORY_METAL_HANDLE_INFO_EXT,
+	    .handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLTEXTURE_BIT_EXT,
+	    .handle = export_tex_info.mtlTexture,
+	};
+	VkMemoryDedicatedAllocateInfoKHR dedicated_info = {
+	    .sType = VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO_KHR,
+	    .pNext = &import_memory_info,
+	    .image = image,
+	};
+
+	uint32_t memory_type_index = UINT32_MAX;
+	VkPhysicalDeviceMemoryProperties mem_props;
+	vk->vkGetPhysicalDeviceMemoryProperties(vk->physical_device, &mem_props);
+	for (uint32_t i = 0; i < mem_props.memoryTypeCount; i++) {
+		if ((requirements.memoryTypeBits & (1u << i)) != 0) {
+			memory_type_index = i;
+			break;
+		}
+	}
+	if (memory_type_index == UINT32_MAX) {
+		U_LOG_E("weave(#759) v4: no valid memory type for overlay IOSurface");
+		vk->vkDestroyImage(vk->device, image, NULL);
+		return false;
+	}
+
+	VkMemoryAllocateInfo alloc_info = {
+	    .sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
+	    .pNext = &dedicated_info,
+	    .allocationSize = requirements.size,
+	    .memoryTypeIndex = memory_type_index,
+	};
+	VkDeviceMemory memory = VK_NULL_HANDLE;
+	ret = vk->vkAllocateMemory(vk->device, &alloc_info, NULL, &memory);
+	if (ret != VK_SUCCESS) {
+		U_LOG_E("weave(#759) v4: vkAllocateMemory(overlay IOSurface) failed: %d", ret);
+		vk->vkDestroyImage(vk->device, image, NULL);
+		return false;
+	}
+	ret = vk->vkBindImageMemory(vk->device, image, memory, 0);
+	if (ret != VK_SUCCESS) {
+		U_LOG_E("weave(#759) v4: vkBindImageMemory(overlay IOSurface) failed: %d", ret);
+		vk->vkFreeMemory(vk->device, memory, NULL);
+		vk->vkDestroyImage(vk->device, image, NULL);
+		return false;
+	}
+
+	VkImageViewCreateInfo view_ci = {
+	    .sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,
+	    .image = image,
+	    .viewType = VK_IMAGE_VIEW_TYPE_2D,
+	    .format = WEAVE_VK_FORMAT,
+	    .subresourceRange = {.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT, .levelCount = 1, .layerCount = 1},
+	};
+	VkImageView view = VK_NULL_HANDLE;
+	ret = vk->vkCreateImageView(vk->device, &view_ci, NULL, &view);
+	if (ret != VK_SUCCESS) {
+		U_LOG_E("weave(#759) v4: vkCreateImageView(overlay) failed: %d", ret);
+		vk->vkFreeMemory(vk->device, memory, NULL);
+		vk->vkDestroyImage(vk->device, image, NULL);
+		return false;
+	}
+
+	mc->weave.overlay_image = image;
+	mc->weave.overlay_memory = memory;
+	mc->weave.overlay_view = view;
+	mc->weave.overlay_w = width;
+	mc->weave.overlay_h = height;
+	mc->weave.overlay_first_use = true;
+	return true;
+#else
+	(void)vk;
+	(void)mc;
+	(void)surface;
+	return false;
+#endif
+}
+
+static void
+weave_release_overlay(struct vk_bundle *vk, struct multi_compositor *mc)
+{
+	if (mc->weave.overlay_view != VK_NULL_HANDLE) {
+		vk->vkDestroyImageView(vk->device, mc->weave.overlay_view, NULL);
+		mc->weave.overlay_view = VK_NULL_HANDLE;
+	}
+	if (mc->weave.overlay_image != VK_NULL_HANDLE) {
+		vk->vkDestroyImage(vk->device, mc->weave.overlay_image, NULL);
+		mc->weave.overlay_image = VK_NULL_HANDLE;
+	}
+	if (mc->weave.overlay_memory != VK_NULL_HANDLE) {
+		vk->vkFreeMemory(vk->device, mc->weave.overlay_memory, NULL);
+		mc->weave.overlay_memory = VK_NULL_HANDLE;
+	}
+	if (mc->weave.overlay_iosurface != NULL) {
+		CFRelease((IOSurfaceRef)mc->weave.overlay_iosurface);
+		mc->weave.overlay_iosurface = NULL;
+	}
+	mc->weave.overlay_iosurface_id = 0;
+	mc->weave.overlay_w = 0;
+	mc->weave.overlay_h = 0;
+}
+
 //! Plain device-local image + view (the SBS scratch atlas).
 static bool
 weave_create_scratch(struct vk_bundle *vk, struct multi_compositor *mc, uint32_t w, uint32_t h)
@@ -617,6 +803,8 @@ comp_multi_weave_submit(struct xrt_compositor *xc,
                         uint32_t rect_h,
                         uint32_t rect_count,
                         const struct xrt_rect *rects,
+                        xrt_graphics_buffer_handle_t overlay_handle,
+                        bool weave_frame_first,
                         uint32_t *out_width,
                         uint32_t *out_height,
                         uint64_t *out_fence_value,
@@ -636,6 +824,12 @@ comp_multi_weave_submit(struct xrt_compositor *xc,
 	IOSurfaceRef surface = (IOSurfaceRef)in_handle;
 	uint32_t surface_id = (uint32_t)IOSurfaceGetID(surface);
 
+	// v4 overlay atlas (browser#18): the handler passes a second retained
+	// IOSurfaceRef when the caller chained XrWeaveSubmitOverlaysDXR. We own it —
+	// adopt into the overlay cache (keyed by IOSurfaceID) or release it below.
+	IOSurfaceRef overlay = (IOSurfaceRef)overlay_handle; // may be NULL
+	uint32_t overlay_id = overlay != NULL ? (uint32_t)IOSurfaceGetID(overlay) : 0;
+
 	weave_ensure_mutex(mc);
 	os_mutex_lock(&mc->weave.mutex);
 
@@ -654,6 +848,20 @@ comp_multi_weave_submit(struct xrt_compositor *xc,
 			mc->weave.in_iosurface = (void *)surface; // adopt the retained ref
 			mc->weave.in_iosurface_id = surface_id;
 			surface = NULL; // ownership transferred
+		}
+
+		// v4 overlay: (re)import on identity change. On a matching id we keep the
+		// cached import and release the (redundant) per-call ref at the epilogue.
+		if (overlay != NULL &&
+		    (mc->weave.overlay_image == VK_NULL_HANDLE || mc->weave.overlay_iosurface_id != overlay_id)) {
+			weave_release_overlay(vk, mc);
+			if (weave_import_overlay(vk, mc, overlay)) {
+				mc->weave.overlay_iosurface = (void *)overlay; // adopt the retained ref
+				mc->weave.overlay_iosurface_id = overlay_id;
+				overlay = NULL; // ownership transferred
+				U_LOG_W("weave(#759) v4: overlay import cached (%ux%u)", mc->weave.overlay_w,
+				        mc->weave.overlay_h);
+			}
 		}
 
 		// Output dims: batch = the (window-client-sized) input; legacy =
@@ -729,6 +937,33 @@ comp_multi_weave_submit(struct xrt_compositor *xc,
 		mc->weave.sbs_first_use = false;
 		vk->vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0,
 		                         0, NULL, 0, NULL, 1, &sbs_to_dst);
+
+		// v5 firstChunk (browser#22): clear the SBS scratch to premultiplied
+		// transparent (0,0,0,0) on the first submit of a frame, so regions BETWEEN
+		// the woven tiles come out alpha 0 instead of stale — the present-owner can
+		// then draw the woven output back WHOLE-WINDOW (opaque tiles replace the
+		// page, transparent gaps show it through). The DP is alpha-native (passes
+		// the atlas alpha through the weave), so cleared gaps stay transparent while
+		// blitted tiles keep the page's opaque alpha. Opt-in: legacy present-owners
+		// draw back only their own tiles and skip it (accumulate-across-submits).
+		if (weave_frame_first) {
+			VkClearColorValue sbs_transparent = {.float32 = {0.0f, 0.0f, 0.0f, 0.0f}};
+			vk->vkCmdClearColorImage(cmd, mc->weave.sbs_image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+			                         &sbs_transparent, 1, &range);
+			// Order the whole-image clear before the per-rect blits (both TRANSFER
+			// writes to overlapping regions — no implicit ordering within a stage).
+			VkImageMemoryBarrier clear_to_blit = {
+			    .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+			    .srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
+			    .dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
+			    .oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+			    .newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+			    .image = mc->weave.sbs_image,
+			    .subresourceRange = range,
+			};
+			vk->vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0,
+			                         0, NULL, 0, NULL, 1, &clear_to_blit);
+		}
 
 		// Blit each rect's squeezed-SBS halves into the two atlas tiles:
 		// left half -> left tile at the rect's window position (stretched to
@@ -821,6 +1056,73 @@ comp_multi_weave_submit(struct xrt_compositor *xc,
 		                                    (VkFormat_XDP)WEAVE_VK_FORMAT,                 //
 		                                    0, 0, 0, 0);
 
+		// v4 overlay atlas (browser#18): composite the caller's window-sized
+		// premultiplied-alpha 2D atlas OVER the woven output with a premul "over"
+		// blend (out = overlay + (1-overlay.a)*out), so crisp 2D lands on top of
+		// the interlaced 3D at screen depth. The overlay is NOT woven — it is drawn
+		// after process_atlas onto the same output attachment. Reuses aux_vk's
+		// vk_local2d_composite flatten_premul pipeline (One / OneMinusSrcAlpha, all
+		// RGBA). process_atlas leaves out_image in COLOR_ATTACHMENT_OPTIMAL.
+		if (mc->weave.overlay_image != VK_NULL_HANDLE) {
+			bool blend_ready = mc->weave.overlay_blend_initialized;
+			if (!blend_ready) {
+				blend_ready = vk_local2d_composite_init(&mc->weave.overlay_blend, vk,
+				                                        WEAVE_VK_FORMAT, WEAVE_VK_FORMAT);
+				mc->weave.overlay_blend_initialized = blend_ready;
+				if (blend_ready) {
+					U_LOG_W("weave(#759) v4: premul-over blend pipeline ready");
+				} else {
+					U_LOG_E("weave(#759) v4: premul-over blend init failed");
+				}
+			}
+			if (blend_ready) {
+				// Overlay -> SHADER_READ (make the caller's external write visible).
+				VkImageMemoryBarrier ov_to_read = {
+				    .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+				    .srcAccessMask = VK_ACCESS_MEMORY_WRITE_BIT,
+				    .dstAccessMask = VK_ACCESS_SHADER_READ_BIT,
+				    .oldLayout = mc->weave.overlay_first_use
+				                     ? VK_IMAGE_LAYOUT_UNDEFINED
+				                     : VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+				    .newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+				    .image = mc->weave.overlay_image,
+				    .subresourceRange = range,
+				};
+				mc->weave.overlay_first_use = false;
+				vk->vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+				                         VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, 0, 0, NULL, 0, NULL, 1,
+				                         &ov_to_read);
+
+				// Make the weave's color writes available to the blend pass's
+				// LOAD_OP_LOAD + "over" (out stays COLOR_ATTACHMENT_OPTIMAL).
+				VkImageMemoryBarrier out_weave_to_blend = {
+				    .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+				    .srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+				    .dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT |
+				                     VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+				    .oldLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+				    .newLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+				    .image = mc->weave.out_image,
+				    .subresourceRange = range,
+				};
+				vk->vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+				                         VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, 0, 0, NULL, 0,
+				                         NULL, 1, &out_weave_to_blend);
+
+				// One whole-window premul "over": the atlas is transparent
+				// (alpha 0) everywhere except the 2D regions, so a single
+				// full-window composite is correct. out_fb is render-pass
+				// compatible with the flatten pass (same BGRA8 single attachment).
+				vk_local2d_composite_begin_frame(&mc->weave.overlay_blend, vk);
+				vk_local2d_composite_flatten_draw(&mc->weave.overlay_blend, vk, cmd, mc->weave.out_fb,
+				                                  mc->weave.out_w, mc->weave.out_h,
+				                                  mc->weave.overlay_view,       //
+				                                  0, 0, mc->weave.out_w, mc->weave.out_h, // dst = full window
+				                                  0.0f, 0.0f, 1.0f, 1.0f,       // src = whole atlas, no flip
+				                                  /*unpremultiplied*/ false);
+			}
+		}
+
 		// Output -> GENERAL for the caller's cross-API (Metal) read.
 		VkImageMemoryBarrier out_to_general = {
 		    .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
@@ -872,9 +1174,12 @@ comp_multi_weave_submit(struct xrt_compositor *xc,
 
 	os_mutex_unlock(&mc->weave.mutex);
 
-	// Release the per-call ref if it wasn't adopted into the cache.
+	// Release the per-call refs that weren't adopted into a cache.
 	if (surface != NULL) {
 		CFRelease(surface);
+	}
+	if (overlay != NULL) {
+		CFRelease(overlay);
 	}
 	return ok;
 }
@@ -950,8 +1255,13 @@ comp_multi_weave_fini(struct multi_compositor *mc)
 			vk->vkQueueWaitIdle(vk->main_queue->queue);
 		}
 		weave_release_input(vk, mc);
+		weave_release_overlay(vk, mc);
 		weave_release_scratch(vk, mc);
 		weave_release_output(vk, mc);
+		if (mc->weave.overlay_blend_initialized) {
+			vk_local2d_composite_fini(&mc->weave.overlay_blend, vk);
+			mc->weave.overlay_blend_initialized = false;
+		}
 		if (mc->weave.dp != NULL) {
 			xrt_display_processor_destroy(&mc->weave.dp);
 		}

--- a/src/xrt/ipc/server/ipc_server_handler.c
+++ b/src/xrt/ipc/server/ipc_server_handler.c
@@ -5688,15 +5688,20 @@ ipc_handle_weave_submit(volatile struct ipc_client_state *ics,
 	// handles[0] is the retained IOSurfaceRef the IPC receive looked up; the
 	// weave engine takes ownership (adopts it into its import cache or
 	// releases it). No DXGI low-bit tag exists on POSIX handles.
-	// v4 overlay atlas is Windows-only for now: the macOS weave engine ignores
-	// it, so release any second retained handle here to avoid leaking it.
+	// v4 overlay atlas (browser#18): handles[1] is a second retained IOSurfaceRef
+	// (a window-sized premul-RGBA atlas) when the caller chained
+	// XrWeaveSubmitOverlaysDXR. Pass ownership to the engine (do NOT unref) — it
+	// adopts it into its overlay cache or releases it.
+	xrt_graphics_buffer_handle_t overlay_handle = XRT_GRAPHICS_BUFFER_HANDLE_INVALID;
 	if (args->have_overlay && handle_count >= 2) {
-		xrt_graphics_buffer_handle_t overlay = handles[1];
-		u_graphics_buffer_unref(&overlay);
+		overlay_handle = handles[1];
 	}
 	if (args->rect_count > IPC_WEAVE_SUBMIT_RECTS_MAX) {
 		xrt_graphics_buffer_handle_t reject = handles[0];
 		u_graphics_buffer_unref(&reject); // don't leak the retained IOSurfaceRef
+		if (overlay_handle != XRT_GRAPHICS_BUFFER_HANDLE_INVALID) {
+			u_graphics_buffer_unref(&overlay_handle); // nor the overlay ref
+		}
 		return XRT_ERROR_IPC_FAILURE;
 	}
 	struct xrt_rect rects[IPC_WEAVE_SUBMIT_RECTS_MAX];
@@ -5714,6 +5719,7 @@ ipc_handle_weave_submit(volatile struct ipc_client_state *ics,
 	    ics->xc, handles[0],                                    //
 	    args->rect_x, args->rect_y, args->rect_w, args->rect_h, //
 	    args->rect_count, args->rect_count > 0 ? rects : NULL,  //
+	    overlay_handle, args->weave_frame_first != 0,           //
 	    &w, &h, &fv, &eyes);
 	if (!ok) {
 		return XRT_ERROR_IPC_FAILURE;

--- a/test_apps/probes/weave_probe_vk_macos/main.cpp
+++ b/test_apps/probes/weave_probe_vk_macos/main.cpp
@@ -73,6 +73,10 @@ static const uint32_t kWinW = 1280;
 static const uint32_t kWinH = 720;
 static const XrRect2Di kRectA = {{100, 100}, {320, 180}};
 static const XrRect2Di kRectB = {{700, 400}, {400, 200}};
+// v4 overlay atlas: an opaque magenta bar near the top, in a gap that overlaps
+// neither weaved rect (so the base rects still verify red/cyan) and a background
+// gap (so firstChunk transparency is verifiable outside it).
+static const XrRect2Di kOverlayBar = {{200, 30}, {800, 40}};
 
 //! BGRA pixel write helper.
 static inline void
@@ -114,6 +118,24 @@ sample_px(IOSurfaceRef surf, int x, int y, uint8_t *out_r, uint8_t *out_g, uint8
 	*out_b = p[0];
 	*out_g = p[1];
 	*out_r = p[2];
+	IOSurfaceUnlock(surf, kIOSurfaceLockReadOnly, NULL);
+	return true;
+}
+
+//! BGRA sample including alpha (for the v5 firstChunk transparency assertion).
+static bool
+sample_px4(IOSurfaceRef surf, int x, int y, uint8_t *out_r, uint8_t *out_g, uint8_t *out_b, uint8_t *out_a)
+{
+	if (IOSurfaceLock(surf, kIOSurfaceLockReadOnly, NULL) != kIOReturnSuccess) {
+		return false;
+	}
+	const uint8_t *base = (const uint8_t *)IOSurfaceGetBaseAddress(surf);
+	size_t stride = IOSurfaceGetBytesPerRow(surf);
+	const uint8_t *p = base + (size_t)y * stride + (size_t)x * 4;
+	*out_b = p[0];
+	*out_g = p[1];
+	*out_r = p[2];
+	*out_a = p[3];
 	IOSurfaceUnlock(surf, kIOSurfaceLockReadOnly, NULL);
 	return true;
 }
@@ -167,6 +189,57 @@ create_input_surface(void)
 	for (int i = 0; i < 4; i++) {
 		CFRelease(vals[i]);
 	}
+	return surf;
+}
+
+/*!
+ * v4 overlay atlas (browser#18): a window-sized PREMULTIPLIED-alpha BGRA surface,
+ * transparent (0,0,0,0) everywhere except one opaque magenta bar. Opaque premul ==
+ * straight, so the bar is a plain magenta with alpha 255. Global so the service's
+ * IOSurfaceLookup(id) finds it (the IPC transports the bare IOSurfaceID).
+ */
+static IOSurfaceRef
+create_overlay_surface(void)
+{
+	int32_t w = (int32_t)kWinW, h = (int32_t)kWinH, bpe = 4;
+	uint32_t fmt = 'BGRA';
+	CFStringRef keys[5] = {CFSTR("IOSurfaceWidth"), CFSTR("IOSurfaceHeight"), CFSTR("IOSurfaceBytesPerElement"),
+	                       CFSTR("IOSurfacePixelFormat"), CFSTR("IOSurfaceIsGlobal")};
+	CFNumberRef vals[4] = {
+	    CFNumberCreate(NULL, kCFNumberSInt32Type, &w),
+	    CFNumberCreate(NULL, kCFNumberSInt32Type, &h),
+	    CFNumberCreate(NULL, kCFNumberSInt32Type, &bpe),
+	    CFNumberCreate(NULL, kCFNumberSInt32Type, &fmt),
+	};
+	CFTypeRef values[5] = {vals[0], vals[1], vals[2], vals[3], kCFBooleanTrue};
+	CFDictionaryRef props = CFDictionaryCreate(NULL, (const void **)keys, (const void **)values, 5,
+	                                           &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+	IOSurfaceRef surf = IOSurfaceCreate(props);
+	CFRelease(props);
+	for (int i = 0; i < 4; i++) {
+		CFRelease(vals[i]);
+	}
+	if (surf == NULL) {
+		return NULL;
+	}
+	IOSurfaceLock(surf, 0, NULL);
+	uint8_t *base = (uint8_t *)IOSurfaceGetBaseAddress(surf);
+	size_t stride = IOSurfaceGetBytesPerRow(surf);
+	// Transparent premultiplied field everywhere (all four channels 0).
+	for (uint32_t y = 0; y < kWinH; y++) {
+		memset(base + (size_t)y * stride, 0, (size_t)kWinW * 4);
+	}
+	// Opaque magenta bar (premul == straight when a=255): B=230, G=13, R=230, A=255.
+	for (int y = kOverlayBar.offset.y; y < kOverlayBar.offset.y + kOverlayBar.extent.height; y++) {
+		for (int x = kOverlayBar.offset.x; x < kOverlayBar.offset.x + kOverlayBar.extent.width; x++) {
+			uint8_t *p = base + (size_t)y * stride + (size_t)x * 4;
+			p[0] = 230; // B
+			p[1] = 13;  // G
+			p[2] = 230; // R
+			p[3] = 255; // A (opaque)
+		}
+	}
+	IOSurfaceUnlock(surf, 0, NULL);
 	return surf;
 }
 
@@ -385,15 +458,29 @@ main(int argc, char **argv)
 	fill_sbs_rect(base, stride, kRectB, /*left*/ 0x00, /*right*/ 0xFF); // -> CYAN after anaglyph
 	IOSurfaceUnlock(input, 0, NULL);
 
-	// ---- Batched submits (spec v3).
+	// ---- v4 overlay atlas (premul-RGBA magenta bar), chained on the submit.
+	IOSurfaceRef overlay = create_overlay_surface();
+	if (overlay == NULL) {
+		LOG("overlay IOSurfaceCreate failed");
+		return 1;
+	}
+
+	// ---- Batched submits (spec v3) + v5 firstChunk + v4 overlay (spec v4).
 	XrRect2Di rects[2] = {kRectA, kRectB};
+	XrWeaveSubmitOverlaysDXR ov = {(XrStructureType)XR_TYPE_WEAVE_SUBMIT_OVERLAYS_DXR};
+	ov.overlayTexture = (void *)overlay;
+	ov.overlayIsDxgi = XR_FALSE;
+	ov.rectCount = 0; // whole-atlas composite (premul alpha authoritative)
+	ov.rects = NULL;
 	XrWeaveSubmitRectsDXR batch = {(XrStructureType)XR_TYPE_WEAVE_SUBMIT_RECTS_DXR};
+	batch.next = &ov; // chain overlays after rects
 	batch.rectCount = 2;
 	batch.rects = rects;
 	XrWeaveSubmitInfoDXR submit = {(XrStructureType)XR_TYPE_WEAVE_SUBMIT_INFO_DXR};
 	submit.next = &batch;
 	submit.inputTexture = (void *)input;
 	submit.inputIsDxgi = XR_FALSE;
+	submit.firstChunk = XR_TRUE; // single submit per frame → first → clears woven output transparent (v5)
 
 	IOSurfaceRef output = NULL;
 	uint32_t out_w = 0, out_h = 0;
@@ -450,9 +537,47 @@ main(int argc, char **argv)
 		pass = pass && ok;
 	}
 
+	// ---- v4 overlay: the magenta bar must be composited over the woven output.
+	{
+		int bx = kOverlayBar.offset.x + kOverlayBar.extent.width / 2;
+		int by = kOverlayBar.offset.y + kOverlayBar.extent.height / 2;
+		uint8_t r = 0, g = 0, b = 0, a = 0;
+		if (sample_px4(output, bx, by, &r, &g, &b, &a)) {
+			bool ok = (r > 150 && b > 150 && g < 80 && a > 200);
+			LOG("v4 overlay bar @(%d,%d) = (%u,%u,%u,a=%u) want magenta+opaque -> %s", bx, by, r, g, b, a,
+			    ok ? "OK" : "WRONG");
+			pass = pass && ok;
+		} else {
+			LOG("FAIL: could not sample overlay bar");
+			pass = false;
+		}
+	}
+
+	// ---- v5 firstChunk: a background gap (no rect, no overlay) must be
+	// transparent (alpha ~0); a woven tile centre must be opaque (alpha ~255).
+	{
+		uint8_t r = 0, g = 0, b = 0, a = 0;
+		if (sample_px4(output, 10, 10, &r, &g, &b, &a)) {
+			bool ok = (a < 40);
+			LOG("v5 firstChunk gap @(10,10) alpha=%u want ~0 -> %s", a, ok ? "OK" : "WRONG");
+			pass = pass && ok;
+		} else {
+			LOG("FAIL: could not sample firstChunk gap");
+			pass = false;
+		}
+		int tx = kRectA.offset.x + kRectA.extent.width / 2;
+		int ty = kRectA.offset.y + kRectA.extent.height / 2;
+		if (sample_px4(output, tx, ty, &r, &g, &b, &a)) {
+			bool ok = (a > 200);
+			LOG("v5 firstChunk tile @(%d,%d) alpha=%u want ~255 -> %s", tx, ty, a, ok ? "OK" : "WRONG");
+			pass = pass && ok;
+		}
+	}
+
 	xrDestroySession(session);
 	xrDestroyInstance(instance);
 	CFRelease(input);
+	CFRelease(overlay);
 	CFRelease(output);
 	vkDestroyDevice(device, NULL);
 	vkDestroyInstance(vk_instance, NULL);


### PR DESCRIPTION
Ports the DP-composited 2D overlay atlas (v4, browser#18) and coherent whole-window firstChunk clear (v5, browser#22) from \`comp_d3d11_service.cpp\` into the **macOS Vulkan/MoltenVK weave service** (\`comp_multi_weave_macos.c\`), reaching Windows parity. The oxr/IPC/wire layers already carried \`overlay_handle\` (2nd handle) + \`weave_frame_first\` cross-platform — only the mac compositor was dropping them.

## Changes
- **comp_multi_weave_submit**: +\`overlay_handle\` (IOSurface) +\`weave_frame_first\` params; overlay ownership adopted-or-released like the input IOSurfaceRef.
- **v5 firstChunk**: \`vkCmdClearColorImage\` the SBS scratch → premul-transparent {0,0,0,0} on the frame's first submit (before rect blits, TRANSFER_DST) so inter-tile gaps weave out alpha=0 for whole-window present.
- **v4 overlay**: import the 2nd IOSurface into a separate SAMPLED cache (VK_EXT_metal_objects, keyed by IOSurfaceID), then one whole-window premul-over composite (One/OneMinusSrcAlpha) OVER the woven output after \`process_atlas\`, **reusing \`aux_vk\` \`vk_local2d_composite\`'s flatten_premul pipeline** (no hand-rolled pipeline).
- **ipc_server_handler** mac branch: decode \`overlay_handle = handles[1]\`, pass ownership (no unref) + \`weave_frame_first\`.
- **weave_probe_vk_macos** extended: submits firstChunk + a magenta overlay bar, asserts the composite + transparent gaps.

## Validation
\`build_macos.sh --service\` green. Probe **PASS on real MoltenVK**: overlay bar composited opaque (230,13,230,a=255), firstChunk gap alpha=0, tile alpha=255, base red/cyan rects unchanged.

This is the runtime half of the mac browser pivot (runtime/DP-side 2D-overlay compositing, ADR-007). The browser-side feed (SetBatchOverlayMac) lands in displayxr-browser. Refs #759, #768, browser#18/#22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)