### PR TITLE
fix(d3d11-service): honor layered swapchains in zones/Local-2D composite (ADR-032)

### DIFF
--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -8523,9 +8523,21 @@ zones_resolve_src_srv(struct d3d11_service_system *sys,
 	if (!sys->workspace_mode && is_srgb_format(desc->Format)) {
 		D3D11_SHADER_RESOURCE_VIEW_DESC srv_desc = {};
 		srv_desc.Format = get_srgb_format(desc->Format);
-		srv_desc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
-		srv_desc.Texture2D.MipLevels = 1;
-		srv_desc.Texture2D.MostDetailedMip = 0;
+		// ADR-032 (#225): a LAYERED (arraySize>1) source needs a whole-array
+		// SRGB SRV so the array PS can select the slice — matching the plain
+		// per-image SRV, which create/import already builds as a Texture2DArray
+		// for layered sources. Tiled (arraySize==1) sources keep Texture2D.
+		if (desc->ArraySize > 1) {
+			srv_desc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2DARRAY;
+			srv_desc.Texture2DArray.MostDetailedMip = 0;
+			srv_desc.Texture2DArray.MipLevels = 1;
+			srv_desc.Texture2DArray.FirstArraySlice = 0;
+			srv_desc.Texture2DArray.ArraySize = desc->ArraySize;
+		} else {
+			srv_desc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
+			srv_desc.Texture2D.MipLevels = 1;
+			srv_desc.Texture2D.MostDetailedMip = 0;
+		}
 		if (SUCCEEDED(sys->device->CreateShaderResourceView(
 		        sc->images[img].texture.get(), &srv_desc, srgb_srv_out.put()))) {
 			*out_is_srgb_blit = true;
@@ -8753,6 +8765,16 @@ service_composite_zones_frame(struct d3d11_service_system *sys,
 					src_format_recorded = true;
 					c->atlas_holds_srgb_bytes = is_srgb_format(sd.Format);
 				}
+				// ADR-032 (#225): a LAYERED (arraySize>1) zone source packs
+				// its eyes as array slices — the SPI render path the Unity
+				// provider uses — so each view must sample slice
+				// `sub.array_index`. Tiled sources (arraySize==1, per-view
+				// imageRect, e.g. the native VK avatar demo) keep the
+				// byte-identical Texture2D path. Mirrors the primary
+				// projection blit.
+				bool is_layered = sd.ArraySize > 1;
+				uint32_t src_slice =
+				    static_cast<uint32_t>(layer->data.zone_3d.proj.v[v].sub.array_index);
 				wil::com_ptr<ID3D11ShaderResourceView> srgb_srv;
 				bool srgb_blit = false;
 				ID3D11ShaderResourceView *src_srv =
@@ -8767,7 +8789,9 @@ service_composite_zones_frame(struct d3d11_service_system *sys,
 				    (float)tile_x + (float)zr->offset.w * scale,
 				    (float)tile_y + (float)zr->offset.h * scale,
 				    dst_w, dst_h,
-				    srgb_blit, blend);
+				    srgb_blit, blend,
+				    /*rtv_override=*/nullptr, /*dst_tex_w=*/0.0f, /*dst_tex_h=*/0.0f,
+				    /*is_array=*/is_layered, /*array_slice=*/src_slice);
 				blits_done++;
 			}
 			if (layer->data.flip_y) {
@@ -8797,6 +8821,12 @@ service_composite_zones_frame(struct d3d11_service_system *sys,
 			}
 			D3D11_TEXTURE2D_DESC sd = {};
 			sc->images[img].texture->GetDesc(&sd);
+			// ADR-032 (#225): Local-2D is normally a single 2D image
+			// (arraySize==1) replicated per view, but honor a layered source's
+			// slice for robustness — no-op for the common tiled case.
+			bool is_layered = sd.ArraySize > 1;
+			uint32_t src_slice =
+			    static_cast<uint32_t>(layer->data.local_2d.sub.array_index);
 			wil::com_ptr<ID3D11ShaderResourceView> srgb_srv;
 			bool srgb_blit = false;
 			ID3D11ShaderResourceView *src_srv =
@@ -8816,7 +8846,9 @@ service_composite_zones_frame(struct d3d11_service_system *sys,
 				    (float)tile_x + (float)lr->offset.w * scale,
 				    (float)tile_y + (float)lr->offset.h * scale,
 				    dst_w, dst_h,
-				    srgb_blit, blend);
+				    srgb_blit, blend,
+				    /*rtv_override=*/nullptr, /*dst_tex_w=*/0.0f, /*dst_tex_h=*/0.0f,
+				    /*is_array=*/is_layered, /*array_slice=*/src_slice);
 				blits_done++;
 			}
 			if (layer->data.flip_y) {

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -9085,6 +9085,77 @@ service_update_zone_wish_publish(struct d3d11_service_system *sys, struct d3d11_
 	}
 }
 
+/*!
+ * Apply a standalone client's pending rendering-mode request (#776).
+ *
+ * xrRequestDisplayRenderingModeDXR lands on the IPC thread and only stores
+ * pending_content_mode / pending_hw_3d; this is where the request is actually
+ * applied, on the render thread.
+ *
+ * Factored out of compositor_layer_commit so the XR_DXR_weave path can call it
+ * too. A weave present-owner never runs xrBeginFrame/xrEndFrame, so it never
+ * reached the per-client commit and its mode requests were silently dropped —
+ * which is what pinned every weave client to whatever mode
+ * weave_force_3d_if_needed happened to pick (#776 blocker 1).
+ *
+ * Gated to standalone: workspace uses the controller's acked flip, the bridge
+ * uses the HWND relay.
+ *
+ * @return true if a request was found and applied.
+ */
+static bool
+service_apply_pending_mode(struct d3d11_service_system *sys, struct d3d11_service_compositor *c, bool bridge_live)
+{
+	if (sys->workspace_mode || bridge_live || c->render.display_processor == nullptr || sys->xsysd == NULL) {
+		return false;
+	}
+	uint32_t req_mode = c->pending_content_mode.exchange(0xFFFFFFFFu, std::memory_order_acq_rel);
+	int req_hw = c->pending_hw_3d.exchange(-1, std::memory_order_acq_rel);
+	struct xrt_device *head = sys->xsysd->static_roles.head;
+	if ((req_mode == 0xFFFFFFFFu && req_hw < 0) || head == nullptr || head->hmd == NULL) {
+		return false;
+	}
+
+	// The app has taken explicit control of the mode — suppress the one-shot
+	// deferred-3D warmup kick so it can't fight the request.
+	c->render.deferred_3d_kicked = true;
+
+	uint32_t prev_idx = head->hmd->active_rendering_mode_index;
+	// Resolve the target hardware state: an explicit hardware request wins;
+	// otherwise follow the requested content mode's hardware_display_3d (the
+	// common no-divergence case).
+	bool want_3d = sys->hardware_display_3d;
+	if (req_mode != 0xFFFFFFFFu && req_mode < head->rendering_mode_count) {
+		want_3d = head->rendering_modes[req_mode].hardware_display_3d;
+		if (prev_idx != req_mode) {
+			// Remember the last 3D mode for later restores (vendor poll, etc.).
+			if (prev_idx < head->rendering_mode_count &&
+			    head->rendering_modes[prev_idx].hardware_display_3d) {
+				sys->last_3d_mode_index = prev_idx;
+			}
+			head->hmd->active_rendering_mode_index = req_mode;
+			broadcast_rendering_mode_change(sys, head, prev_idx, req_mode);
+		}
+	}
+	if (req_hw >= 0) {
+		want_3d = (req_hw != 0);
+	}
+
+	DP_REQUEST_DISPLAY_MODE(c->render.display_processor, want_3d);
+	sync_tile_layout(sys);
+	sys->hardware_display_3d = want_3d;
+	// Stamp the post-flip cooldown so the 100 ms vendor 3D-state poll doesn't see
+	// the panel mid-transition and counter-correct (same refresh the deferred-3D
+	// kick / zones fallback do).
+	int64_t flip_ns = os_monotonic_get_ns();
+	sys->cached_3d_state.store(want_3d, std::memory_order_relaxed);
+	sys->last_3d_state_poll_ns.store(flip_ns, std::memory_order_release);
+	sys->last_flip_landed_ns.store(flip_ns, std::memory_order_release);
+	U_LOG_W("[app_mode] standalone IPC client requested mode (content=%u hw_req=%d) -> active=%u 3D=%d",
+	        req_mode, req_hw, head->hmd->active_rendering_mode_index, (int)want_3d);
+	return true;
+}
+
 
 static xrt_result_t
 compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sync_handle)
@@ -9405,53 +9476,7 @@ compositor_layer_commit(struct xrt_compositor *xc, xrt_graphics_sync_handle_t sy
 	// relay above does, and what the Android multi_compositor path does via its own
 	// request_display_mode. Gated to standalone: workspace uses the controller's
 	// acked-flip; bridge uses the HWND relay above.
-	if (!sys->workspace_mode && !bridge_live && c->render.display_processor != nullptr &&
-	    sys->xsysd != NULL) {
-		uint32_t req_mode = c->pending_content_mode.exchange(0xFFFFFFFFu, std::memory_order_acq_rel);
-		int req_hw = c->pending_hw_3d.exchange(-1, std::memory_order_acq_rel);
-		struct xrt_device *head = sys->xsysd->static_roles.head;
-
-		if ((req_mode != 0xFFFFFFFFu || req_hw >= 0) && head != nullptr && head->hmd != NULL) {
-			// The app has taken explicit control of the mode — suppress the
-			// one-shot deferred-3D warmup kick so it can't fight the request.
-			c->render.deferred_3d_kicked = true;
-
-			uint32_t prev_idx = head->hmd->active_rendering_mode_index;
-			// Resolve the target hardware state: an explicit hardware request
-			// wins; otherwise follow the requested content mode's hardware_display_3d
-			// (the common no-divergence case).
-			bool want_3d = sys->hardware_display_3d;
-			if (req_mode != 0xFFFFFFFFu && req_mode < head->rendering_mode_count) {
-				want_3d = head->rendering_modes[req_mode].hardware_display_3d;
-				if (prev_idx != req_mode) {
-					// Remember the last 3D mode for later restores (vendor poll, etc.).
-					if (prev_idx < head->rendering_mode_count &&
-					    head->rendering_modes[prev_idx].hardware_display_3d) {
-						sys->last_3d_mode_index = prev_idx;
-					}
-					head->hmd->active_rendering_mode_index = req_mode;
-					broadcast_rendering_mode_change(sys, head, prev_idx, req_mode);
-				}
-			}
-			if (req_hw >= 0) {
-				want_3d = (req_hw != 0);
-			}
-
-			DP_REQUEST_DISPLAY_MODE(c->render.display_processor, want_3d);
-			sync_tile_layout(sys);
-			sys->hardware_display_3d = want_3d;
-			// Stamp the post-flip cooldown so the 100 ms vendor 3D-state poll
-			// doesn't see the panel mid-transition and counter-correct (same
-			// refresh the deferred-3D kick / zones fallback do).
-			int64_t flip_ns = os_monotonic_get_ns();
-			sys->cached_3d_state.store(want_3d, std::memory_order_relaxed);
-			sys->last_3d_state_poll_ns.store(flip_ns, std::memory_order_release);
-			sys->last_flip_landed_ns.store(flip_ns, std::memory_order_release);
-			U_LOG_W("[app_mode] standalone IPC client requested mode (content=%u hw_req=%d) "
-			        "-> active=%u 3D=%d",
-			        req_mode, req_hw, head->hmd->active_rendering_mode_index, (int)want_3d);
-		}
-	}
+	(void)service_apply_pending_mode(sys, c, bridge_live);
 
 	// Runtime-side 2D/3D toggle (V key) + 1/2/3 mode-select — polls qwerty
 	// driver each frame.
@@ -11693,10 +11718,21 @@ weave_force_3d_if_needed(struct d3d11_service_system *sys, struct d3d11_service_
 	if (head == nullptr || head->hmd == NULL) {
 		return;
 	}
-	// Prefer the last 3D mode; else the first 3D-capable mode.
+	// Prefer whatever mode is ALREADY active when it is 3D-capable (#776
+	// blocker 2). A present-owner that asked for a specific mode via
+	// xrRequestDisplayRenderingModeDXR has had it applied by
+	// service_apply_pending_mode() just above; without this branch the
+	// last-3D/first-3D fallback below would immediately overwrite it — and
+	// because this helper is self-healing (re-fires every submit while the SR
+	// reads 2D) it would fight the request every frame. On sim_display the
+	// first-3D fallback is mode 1 "Anaglyph" (2 views), so an app asking for
+	// mode 4 "Quad" (4 views) could never hold it.
 	uint32_t mode_idx = head->rendering_mode_count;
-	if (sys->last_3d_mode_index < head->rendering_mode_count &&
-	    head->rendering_modes[sys->last_3d_mode_index].hardware_display_3d) {
+	uint32_t active_idx = head->hmd->active_rendering_mode_index;
+	if (active_idx < head->rendering_mode_count && head->rendering_modes[active_idx].hardware_display_3d) {
+		mode_idx = active_idx;
+	} else if (sys->last_3d_mode_index < head->rendering_mode_count &&
+	           head->rendering_modes[sys->last_3d_mode_index].hardware_display_3d) {
 		mode_idx = sys->last_3d_mode_index;
 	} else {
 		for (uint32_t m = 0; m < head->rendering_mode_count; m++) {
@@ -11836,6 +11872,18 @@ comp_d3d11_service_weave_submit(struct xrt_compositor *xc,
 	// Serialize with the render thread — sys->context is the (non-thread-safe)
 	// immediate context shared with multi_compositor_render.
 	std::lock_guard<std::recursive_mutex> lock(sys->render_mutex);
+
+	// #776 blocker 1: apply any pending xrRequestDisplayRenderingModeDXR. A
+	// present-owner never runs the per-client commit, which used to be the only
+	// site that consumed pending_content_mode / pending_hw_3d — so a weave
+	// client's mode requests were stored and silently dropped. bridge_live is
+	// false here by construction: a weave caller IS the present-owner, so the
+	// bridge's HWND relay does not apply to it.
+	//
+	// Order matters: apply BEFORE the force-3D kick, so the kick sees the
+	// requested mode already active and keeps it (see weave_force_3d_if_needed,
+	// which now prefers the active mode over its first-3D fallback).
+	(void)service_apply_pending_mode(sys, c, /*bridge_live*/ false);
 
 	// Keep the panel in 3D so the vendor eye tracker locks (look-around). A
 	// present-owner never runs the per-client commit that normally does this.

--- a/test_apps/probes/weave_rpc_probe_d3d11_win/main.cpp
+++ b/test_apps/probes/weave_rpc_probe_d3d11_win/main.cpp
@@ -88,6 +88,10 @@ static bool g_useV6 = false;
 // instead; this is a runtime harness, not a model app.
 static uint32_t g_v6Cols = 2, g_v6Rows = 1;
 static bool g_v6Exact = false; //!< DXR_WEAVE_V6_EXACT=1 -> atlas == packed region (zero-copy branch)
+// DXR_REQUEST_MODE=N asks the runtime for rendering mode N via
+// xrRequestDisplayRenderingModeDXR (#776). A present-owner could not do this
+// before — the request was stored and never applied. -1 = don't request.
+static int g_requestMode = -1;
 static float g_v6ScaleX = 0.5f, g_v6ScaleY = 1.0f;
 
 // v4 overlay atlas (browser#18): a window-sized premultiplied-alpha 2D layer the
@@ -654,6 +658,13 @@ wWinMain(HINSTANCE hInst, HINSTANCE, PWSTR, int)
 			g_v6ScaleY = sy;
 		}
 	}
+	{
+		char mb[16] = {0};
+		DWORD mn = GetEnvironmentVariableA("DXR_REQUEST_MODE", mb, (DWORD)sizeof(mb));
+		if (mn > 0 && mn < sizeof(mb)) {
+			g_requestMode = atoi(mb);
+		}
+	}
 	LOG_INFO("Input layout: %s", g_useV6 ? "v6 N-view worst-case atlas (#774)"
 	                                      : "v3/v4/v5 per-rect squeezed SBS");
 	if (g_useV6) {
@@ -705,6 +716,22 @@ wWinMain(HINSTANCE hInst, HINSTANCE, PWSTR, int)
 	LogXrResult("xrWeaveBindWindowDXR", br);
 	if (XR_FAILED(br)) {
 		return 1;
+	}
+
+	// #776: ask for a specific rendering mode. Before the #776 fix a
+	// present-owner's request was stored and never applied (the only consumer
+	// was the per-client commit, which a weave caller never runs), and the
+	// force-3D kick then pinned it to the first 3D-capable mode.
+	if (g_requestMode >= 0) {
+		PFN_xrRequestDisplayRenderingModeDXR pfnReqMode = nullptr;
+		xrGetInstanceProcAddr(xr.instance, "xrRequestDisplayRenderingModeDXR",
+		                      (PFN_xrVoidFunction *)&pfnReqMode);
+		if (pfnReqMode == nullptr) {
+			LOG_ERROR("xrRequestDisplayRenderingModeDXR: NOT RESOLVED");
+		} else {
+			XrResult mr = pfnReqMode(xr.session, (uint32_t)g_requestMode);
+			LOG_INFO("xrRequestDisplayRenderingModeDXR(%d) -> %d", g_requestMode, (int)mr);
+		}
 	}
 
 	LARGE_INTEGER freq;


### PR DESCRIPTION
## Problem — DisplayXR/displayxr-unity#225

With the workspace-tile provider path (displayxr-unity#223), BiRP/URP/HDRP samples render correctly as shell tiles, but **desktop-avatar renders flat/distorted**. It's the only sample using `XR_DXR_display_zones` (a 3D zone) + a Local2D bubble.

## Root cause — the ADR-032 gap #767 left in the zones path

#767 ported the ADR-032 array-slice fix to the service's **primary projection** blit, but `service_composite_zones_frame` — the `XRT_LAYER_ZONE_3D` + `XRT_LAYER_LOCAL_2D` path — was never updated. It sampled a plain `Texture2D` SRV and **never read `sub.array_index`**, so a **layered (arraySize=2 SPI)** zone source (the render path the Unity provider uses for URP/HDRP) had **both eyes sampled at slice 0 → no disparity → flat**, and the zone rendered outside the primary-projection slot handling → distorted.

Confirmed from three angles:
- **Plugin** forwards all layers via `xrEndFrame` unconditionally (the zone chains onto the primary projection's `.next`; `submit_zone_3d_layer` turns it into `XRT_LAYER_ZONE_3D` with per-view `sub.array_index`). No plugin bug.
- **IPC** carries every typed layer with `array_index`. No drop.
- **Service** `service_composite_zones_frame` had no array-slice branch.

The **native VK avatar demo works** because it submits **tiled (arraySize=1, per-view `imageRect`)** swapchains, which this path already handles. The sole difference is tiled-vs-layered swapchain geometry — not layer topology (both submit zone-on-`proj.next` + separate Local2D, 2 layers).

## Fix (mirror of #767 into the zones composite)

- **zone-3D blit:** `is_layered = sd.ArraySize > 1`, `src_slice = proj.v[v].sub.array_index`; pass `is_array`/`array_slice` into `blit_to_atlas_texture`. The per-image SRV is already a `Texture2DArray` for layered sources (create/import), so the workspace path needs no SRV change.
- **Local-2D blit:** same, for robustness (no-op for the common `arraySize=1` band).
- **`zones_resolve_src_srv`:** build a whole-array SRGB SRV for layered sources so the standalone (non-workspace) sRGB path is array-correct too.
- Tiled (`arraySize=1`) sources stay byte-identical.

## Test
- `comp_d3d11_service` compiles clean (Release).
- **HW verify pending:** version-matched shell + service on the Leia box, desktop-avatar as a workspace tile — expect live stereo + correctly-framed zone + bubble (compare to standalone app-overlay). Single-projection tiles (BiRP/URP/HDRP) must stay unaffected.

Refs ADR-032, #767.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Umm4stoD3G9SuNeocafhPn