### PR TITLE
feat(display-zones): xrGetWorkspaceTileSizeDXR — live per-client tile canvas (spec v2, #225)

### DIFF
--- a/src/external/openxr_includes/openxr/XR_DXR_display_zones.h
+++ b/src/external/openxr_includes/openxr/XR_DXR_display_zones.h
@@ -58,7 +58,11 @@ extern "C" {
 #endif
 
 #define XR_DXR_display_zones 1
-#define XR_DXR_display_zones_SPEC_VERSION 1
+// SPEC_VERSION 2 (#225): + xrGetWorkspaceTileSizeDXR — the client's live target
+// canvas size in pixels (the shell-driven workspace tile this session composites
+// into; follows tile resize). A minimized engine tile (whose OS window/backbuffer
+// can't track the resize) queries this to re-author to the current tile.
+#define XR_DXR_display_zones_SPEC_VERSION 2
 #define XR_DXR_DISPLAY_ZONES_EXTENSION_NAME "XR_DXR_display_zones"
 
 // Extension type-value range (1004999xxx); replace with a Khronos-assigned
@@ -171,6 +175,16 @@ typedef XrResult (XRAPI_PTR *PFN_xrGetDisplayZoneCapabilitiesDXR)(
 typedef XrResult (XRAPI_PTR *PFN_xrGetDisplayZoneRecommendedViewSizeDXR)(
     XrSession session, const XrRect2Di* zoneRect, XrExtent2Di* recommendedViewSize);
 
+//! (spec v2, #225) Live target canvas (workspace-tile) pixel size for this
+//! session — the shell-driven per-client window rect, updated on resize. Zone /
+//! Local2D rects (client-window pixels) should be authored against this so a
+//! minimized engine tile (whose backbuffer can't track the OS resize) can
+//! re-fit each frame. Standalone: the client's own window client-area size.
+//! 0x0 before the slot binds. Re-query per frame (cheap) or on
+//! XrEventDataDisplayZoneMetricsChangedDXR.
+typedef XrResult (XRAPI_PTR *PFN_xrGetWorkspaceTileSizeDXR)(
+    XrSession session, XrExtent2Di* tileSize);
+
 #ifndef XR_NO_PROTOTYPES
 
 //! Query whether the session can consume zone-chained projection layers.
@@ -183,6 +197,11 @@ XRAPI_ATTR XrResult XRAPI_CALL xrGetDisplayZoneCapabilitiesDXR(
 //! (display modes are session-global); only per-view dimensions vary by rect.
 XRAPI_ATTR XrResult XRAPI_CALL xrGetDisplayZoneRecommendedViewSizeDXR(
     XrSession session, const XrRect2Di* zoneRect, XrExtent2Di* recommendedViewSize);
+
+//! (spec v2, #225) Live workspace-tile pixel size for this session.
+//! See PFN_xrGetWorkspaceTileSizeDXR.
+XRAPI_ATTR XrResult XRAPI_CALL xrGetWorkspaceTileSizeDXR(
+    XrSession session, XrExtent2Di* tileSize);
 
 #endif /* !XR_NO_PROTOTYPES */
 

--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -8523,9 +8523,21 @@ zones_resolve_src_srv(struct d3d11_service_system *sys,
 	if (!sys->workspace_mode && is_srgb_format(desc->Format)) {
 		D3D11_SHADER_RESOURCE_VIEW_DESC srv_desc = {};
 		srv_desc.Format = get_srgb_format(desc->Format);
-		srv_desc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
-		srv_desc.Texture2D.MipLevels = 1;
-		srv_desc.Texture2D.MostDetailedMip = 0;
+		// ADR-032 (#225): a LAYERED (arraySize>1) source needs a whole-array
+		// SRGB SRV so the array PS can select the slice — matching the plain
+		// per-image SRV, which create/import already builds as a Texture2DArray
+		// for layered sources. Tiled (arraySize==1) sources keep Texture2D.
+		if (desc->ArraySize > 1) {
+			srv_desc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2DARRAY;
+			srv_desc.Texture2DArray.MostDetailedMip = 0;
+			srv_desc.Texture2DArray.MipLevels = 1;
+			srv_desc.Texture2DArray.FirstArraySlice = 0;
+			srv_desc.Texture2DArray.ArraySize = desc->ArraySize;
+		} else {
+			srv_desc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
+			srv_desc.Texture2D.MipLevels = 1;
+			srv_desc.Texture2D.MostDetailedMip = 0;
+		}
 		if (SUCCEEDED(sys->device->CreateShaderResourceView(
 		        sc->images[img].texture.get(), &srv_desc, srgb_srv_out.put()))) {
 			*out_is_srgb_blit = true;
@@ -8753,6 +8765,16 @@ service_composite_zones_frame(struct d3d11_service_system *sys,
 					src_format_recorded = true;
 					c->atlas_holds_srgb_bytes = is_srgb_format(sd.Format);
 				}
+				// ADR-032 (#225): a LAYERED (arraySize>1) zone source packs
+				// its eyes as array slices — the SPI render path the Unity
+				// provider uses — so each view must sample slice
+				// `sub.array_index`. Tiled sources (arraySize==1, per-view
+				// imageRect, e.g. the native VK avatar demo) keep the
+				// byte-identical Texture2D path. Mirrors the primary
+				// projection blit.
+				bool is_layered = sd.ArraySize > 1;
+				uint32_t src_slice =
+				    static_cast<uint32_t>(layer->data.zone_3d.proj.v[v].sub.array_index);
 				wil::com_ptr<ID3D11ShaderResourceView> srgb_srv;
 				bool srgb_blit = false;
 				ID3D11ShaderResourceView *src_srv =
@@ -8767,7 +8789,9 @@ service_composite_zones_frame(struct d3d11_service_system *sys,
 				    (float)tile_x + (float)zr->offset.w * scale,
 				    (float)tile_y + (float)zr->offset.h * scale,
 				    dst_w, dst_h,
-				    srgb_blit, blend);
+				    srgb_blit, blend,
+				    /*rtv_override=*/nullptr, /*dst_tex_w=*/0.0f, /*dst_tex_h=*/0.0f,
+				    /*is_array=*/is_layered, /*array_slice=*/src_slice);
 				blits_done++;
 			}
 			if (layer->data.flip_y) {
@@ -8797,6 +8821,12 @@ service_composite_zones_frame(struct d3d11_service_system *sys,
 			}
 			D3D11_TEXTURE2D_DESC sd = {};
 			sc->images[img].texture->GetDesc(&sd);
+			// ADR-032 (#225): Local-2D is normally a single 2D image
+			// (arraySize==1) replicated per view, but honor a layered source's
+			// slice for robustness — no-op for the common tiled case.
+			bool is_layered = sd.ArraySize > 1;
+			uint32_t src_slice =
+			    static_cast<uint32_t>(layer->data.local_2d.sub.array_index);
 			wil::com_ptr<ID3D11ShaderResourceView> srgb_srv;
 			bool srgb_blit = false;
 			ID3D11ShaderResourceView *src_srv =
@@ -8816,7 +8846,9 @@ service_composite_zones_frame(struct d3d11_service_system *sys,
 				    (float)tile_x + (float)lr->offset.w * scale,
 				    (float)tile_y + (float)lr->offset.h * scale,
 				    dst_w, dst_h,
-				    srgb_blit, blend);
+				    srgb_blit, blend,
+				    /*rtv_override=*/nullptr, /*dst_tex_w=*/0.0f, /*dst_tex_h=*/0.0f,
+				    /*is_array=*/is_layered, /*array_slice=*/src_slice);
 				blits_done++;
 			}
 			if (layer->data.flip_y) {

--- a/src/xrt/state_trackers/oxr/oxr_api_funcs.h
+++ b/src/xrt/state_trackers/oxr/oxr_api_funcs.h
@@ -1018,6 +1018,10 @@ XRAPI_ATTR XrResult XRAPI_CALL
 oxr_xrGetDisplayZoneRecommendedViewSizeDXR(XrSession session,
                                            const XrRect2Di *zoneRect,
                                            XrExtent2Di *recommendedViewSize);
+
+//! OpenXR API function @ep{xrGetWorkspaceTileSizeDXR}
+XRAPI_ATTR XrResult XRAPI_CALL
+oxr_xrGetWorkspaceTileSizeDXR(XrSession session, XrExtent2Di *tileSize);
 #endif
 
 #ifdef OXR_HAVE_DXR_weave

--- a/src/xrt/state_trackers/oxr/oxr_api_negotiate.c
+++ b/src/xrt/state_trackers/oxr/oxr_api_negotiate.c
@@ -495,6 +495,7 @@ handle_non_null(struct oxr_instance *inst, struct oxr_logger *log, const char *n
 #ifdef OXR_HAVE_DXR_display_zones
 	ENTRY_IF_EXT(xrGetDisplayZoneCapabilitiesDXR, DXR_display_zones);
 	ENTRY_IF_EXT(xrGetDisplayZoneRecommendedViewSizeDXR, DXR_display_zones);
+	ENTRY_IF_EXT(xrGetWorkspaceTileSizeDXR, DXR_display_zones);
 #endif
 
 #ifdef OXR_HAVE_DXR_weave

--- a/src/xrt/state_trackers/oxr/oxr_display_zones.c
+++ b/src/xrt/state_trackers/oxr/oxr_display_zones.c
@@ -13,6 +13,7 @@
  */
 
 #include "xrt/xrt_compiler.h"
+#include "xrt/xrt_display_metrics.h" // struct xrt_window_metrics (tile size, #225)
 
 #include "util/u_misc.h"
 #include "util/u_trace_marker.h"
@@ -81,6 +82,34 @@ oxr_xrGetDisplayZoneRecommendedViewSizeDXR(XrSession session,
 	recommendedViewSize->width = zoneRect->extent.width;
 	recommendedViewSize->height = zoneRect->extent.height;
 
+	return XR_SUCCESS;
+}
+
+XRAPI_ATTR XrResult XRAPI_CALL
+oxr_xrGetWorkspaceTileSizeDXR(XrSession session, XrExtent2Di *tileSize)
+{
+	OXR_TRACE_MARKER();
+
+	struct oxr_session *sess;
+	struct oxr_logger log;
+	OXR_VERIFY_SESSION_AND_INIT_LOG(&log, session, sess, "xrGetWorkspaceTileSizeDXR");
+	OXR_VERIFY_ARG_NOT_NULL(&log, tileSize);
+
+	// The client's live target canvas = the shell-driven per-client window rect
+	// (#225). window_pixel_* is recomputed from the tile pose on every resize
+	// (slot_pose_to_pixel_rect), so this tracks the 3D-window size — which a
+	// minimized engine tile's own backbuffer cannot. 0x0 before the slot binds
+	// → the app keeps its current authoring size and re-queries next frame.
+	struct xrt_window_metrics wm = {0};
+	if (oxr_session_get_window_metrics(sess, &wm) && wm.valid &&
+	    wm.window_pixel_width > 0 && wm.window_pixel_height > 0) {
+		tileSize->width = (int32_t)wm.window_pixel_width;
+		tileSize->height = (int32_t)wm.window_pixel_height;
+		return XR_SUCCESS;
+	}
+
+	tileSize->width = 0;
+	tileSize->height = 0;
 	return XR_SUCCESS;
 }
 

--- a/src/xrt/state_trackers/oxr/oxr_objects.h
+++ b/src/xrt/state_trackers/oxr/oxr_objects.h
@@ -929,6 +929,16 @@ oxr_session_end(struct oxr_logger *log, struct oxr_session *sess);
 XrResult
 oxr_session_request_exit(struct oxr_logger *log, struct oxr_session *sess);
 
+struct xrt_window_metrics;
+/*!
+ * Fill @p out_metrics with this session's live display/window geometry
+ * (per-client; window_pixel_* is the shell-driven tile pixel rect, updated on
+ * resize). Backs xrGetWorkspaceTileSizeDXR (#225). Returns false and leaves
+ * out_metrics->valid = false when unavailable.
+ */
+bool
+oxr_session_get_window_metrics(struct oxr_session *sess, struct xrt_window_metrics *out_metrics);
+
 #ifdef OXR_HAVE_DXR_display_info
 /*!
  * Request display mode switch (2D/3D).

--- a/src/xrt/state_trackers/oxr/oxr_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_session.c
@@ -345,7 +345,7 @@ oxr_session_get_display_dimensions(struct oxr_session *sess, float *out_width_m,
  * Vendor-neutral: works with both SR SDK (via per-session weaver) and
  * sim_display (via generic Win32 APIs in multi compositor).
  */
-static bool
+bool
 oxr_session_get_window_metrics(struct oxr_session *sess,
                                 struct xrt_window_metrics *out_metrics)
 {


### PR DESCRIPTION
## What
Adds `xrGetWorkspaceTileSizeDXR` (bumps `XR_DXR_display_zones` SPEC_VERSION 1→2): exposes the shell-driven per-client window rect (`window_pixel_*`, recomputed from the tile pose on every resize) to the client, so a **minimized engine tile** — whose own OS backbuffer can't track the 3D-window resize — can size/author to the tile and follow resize.

Backed by the existing window-metrics pull: no new IPC opcode, no struct change — de-static `oxr_session_get_window_metrics` + a new entrypoint returning `window_pixel_*`. Standalone returns own-window size; `0×0` before the slot binds.

## Why
Native handle apps read their tile size from `WM_SIZE`, but Unity gates rendering on a shown main window so it runs minimized (0×0 client) — it needs this query instead. Completes the workspace tile-sizing fix.

## HW validation (Leia SR box)
- `desktop-avatar` (Unity) renders tile-sized stereo (tiger 3D zone + Local2D bubble), tracks 3D-window resize live — provider log shows the tile-size poll `1152×648 → 1941×1092` + `arraySize=2` 2-view + `fov0 ≠ fov1`.
- `model_viewer` (native) unaffected (uses `WM_SIZE`), sharp + resize-tracked.

## Pairs with
- displayxr-shell-pvt#80 — per-app show mode (native `SW_HIDE` / engine `SW_SHOWMINNOACTIVE`)
- displayxr-unity#226 — provider consumes the query
- displayxr-unity-samples#6 — `engine_render_gated` flag on the Unity sample manifests

🤖 Generated with [Claude Code](https://claude.com/claude-code)