### PR TITLE
feat(weave): macOS DP overlay-atlas (v4) + firstChunk (v5) + N-view worst-case atlas (v6) — #759/#768/#774

### DIFF
--- a/src/xrt/compositor/multi/comp_multi_private.h
+++ b/src/xrt/compositor/multi/comp_multi_private.h
@@ -37,6 +37,7 @@
 // (comp_multi always links aux_vk, so Vulkan is always available)
 #include "xrt/xrt_vulkan_includes.h"
 #include "vk/vk_hud_blend.h"
+#include "vk/vk_local2d_composite.h"
 #include "multi/comp_multi_content_blend.h"
 
 #include "render/render_interface.h"
@@ -44,6 +45,7 @@
 // Forward declarations for per-session rendering
 struct comp_target;
 struct xrt_eye_positions;
+struct xrt_weave_atlas_layout;
 struct xrt_window_metrics;
 struct xrt_system_devices;
 
@@ -461,8 +463,22 @@ struct multi_compositor
 		uint32_t in_iosurface_id;
 		VkImage in_image;
 		VkDeviceMemory in_memory;
+		VkImageView in_view; //!< Full-image view (v6 zero-copy DP sample source).
 		uint32_t in_w, in_h;
 		bool in_first_use; //!< First barrier transitions from UNDEFINED.
+		//! @}
+
+		//! @name v6 N-view crop staging (#774)
+		//! When the worst-case-sized input atlas is LARGER than the active
+		//! mode's packed tiles, ONE box copy lands the top-left packed region
+		//! (tiles are contiguous, so it is a single rectangle) into this image,
+		//! which the DP then samples. Zero-copy (packed == input) skips it.
+		//! @{
+		VkImage crop_image;
+		VkDeviceMemory crop_memory;
+		VkImageView crop_view;
+		uint32_t crop_w, crop_h;
+		bool crop_first_use;
 		//! @}
 
 		//! @name Window-sized 2x1 SBS scratch atlas (2*out_w x out_h)
@@ -482,6 +498,24 @@ struct multi_compositor
 		VkFramebuffer out_fb;
 		void *out_iosurface; //!< Retained exported IOSurfaceRef.
 		uint32_t out_w, out_h;
+		//! @}
+
+		//! @name v4 DP-composited 2D overlay atlas (browser#18)
+		//! A caller-supplied window-sized PREMULTIPLIED-alpha BGRA atlas composited
+		//! OVER the woven output with a premul "over" blend (out = overlay +
+		//! (1-overlay.a)*out) AFTER process_atlas. Imported like the SBS input
+		//! (VK_EXT_metal_objects) and cached by IOSurfaceID. The premul-over pass
+		//! reuses aux_vk's vk_local2d_composite flatten_premul pipeline.
+		//! @{
+		void *overlay_iosurface; //!< Retained IOSurfaceRef (adopted from the IPC receive).
+		uint32_t overlay_iosurface_id;
+		VkImage overlay_image;
+		VkDeviceMemory overlay_memory;
+		VkImageView overlay_view; //!< Sampled by the premul-over blend.
+		uint32_t overlay_w, overlay_h;
+		bool overlay_first_use; //!< First barrier transitions from UNDEFINED.
+		struct vk_local2d_composite overlay_blend; //!< premul-over flatten pipeline.
+		bool overlay_blend_initialized;
 		//! @}
 	} weave;
 #endif
@@ -810,6 +844,9 @@ comp_multi_weave_submit(struct xrt_compositor *xc,
                         uint32_t rect_h,
                         uint32_t rect_count,
                         const struct xrt_rect *rects,
+                        xrt_graphics_buffer_handle_t overlay_handle,
+                        bool weave_frame_first,
+                        const struct xrt_weave_atlas_layout *layout,
                         uint32_t *out_width,
                         uint32_t *out_height,
                         uint64_t *out_fence_value,

--- a/src/xrt/compositor/multi/comp_multi_weave_macos.c
+++ b/src/xrt/compositor/multi/comp_multi_weave_macos.c
@@ -229,8 +229,30 @@ weave_import_input(struct vk_bundle *vk, struct multi_compositor *mc, IOSurfaceR
 		return false;
 	}
 
+	// Full-image view: the SBS path only blits the input (TRANSFER_SRC) so it
+	// never needed one, but the v6 zero-copy path (#774) samples the input
+	// atlas directly through the DP, which takes an atlas VkImageView.
+	VkImageView view = VK_NULL_HANDLE;
+	{
+		VkImageViewCreateInfo view_ci = {
+		    .sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,
+		    .image = image,
+		    .viewType = VK_IMAGE_VIEW_TYPE_2D,
+		    .format = WEAVE_VK_FORMAT,
+		    .subresourceRange = {.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT, .levelCount = 1, .layerCount = 1},
+		};
+		ret = vk->vkCreateImageView(vk->device, &view_ci, NULL, &view);
+		if (ret != VK_SUCCESS) {
+			U_LOG_E("weave(#759): vkCreateImageView(input) failed: %d", ret);
+			vk->vkFreeMemory(vk->device, memory, NULL);
+			vk->vkDestroyImage(vk->device, image, NULL);
+			return false;
+		}
+	}
+
 	mc->weave.in_image = image;
 	mc->weave.in_memory = memory;
+	mc->weave.in_view = view;
 	mc->weave.in_w = width;
 	mc->weave.in_h = height;
 	mc->weave.in_first_use = true;
@@ -246,6 +268,10 @@ weave_import_input(struct vk_bundle *vk, struct multi_compositor *mc, IOSurfaceR
 static void
 weave_release_input(struct vk_bundle *vk, struct multi_compositor *mc)
 {
+	if (mc->weave.in_view != VK_NULL_HANDLE) {
+		vk->vkDestroyImageView(vk->device, mc->weave.in_view, NULL);
+		mc->weave.in_view = VK_NULL_HANDLE;
+	}
 	if (mc->weave.in_image != VK_NULL_HANDLE) {
 		vk->vkDestroyImage(vk->device, mc->weave.in_image, NULL);
 		mc->weave.in_image = VK_NULL_HANDLE;
@@ -261,6 +287,192 @@ weave_release_input(struct vk_bundle *vk, struct multi_compositor *mc)
 	mc->weave.in_iosurface_id = 0;
 	mc->weave.in_w = 0;
 	mc->weave.in_h = 0;
+}
+
+/*!
+ * Import a caller IOSurface as a sampler-source VkImage (+ view) for the v4
+ * overlay atlas — the same VK_EXT_metal_objects dance as weave_import_input but
+ * into the SEPARATE overlay cache (so it never clobbers the SBS input) and with
+ * a view the premul-over blend samples. The atlas is premultiplied BGRA8.
+ */
+static bool
+weave_import_overlay(struct vk_bundle *vk, struct multi_compositor *mc, IOSurfaceRef surface)
+{
+#if defined(VK_EXT_metal_objects) && defined(VK_EXT_external_memory_metal)
+	if (!vk->has_EXT_metal_objects || !vk->has_EXT_external_memory_metal) {
+		U_LOG_E("weave(#759) v4: VK_EXT_metal_objects / VK_EXT_external_memory_metal unavailable");
+		return false;
+	}
+
+	uint32_t width = (uint32_t)IOSurfaceGetWidth(surface);
+	uint32_t height = (uint32_t)IOSurfaceGetHeight(surface);
+	if (width == 0 || height == 0) {
+		U_LOG_E("weave(#759) v4: overlay IOSurface has zero dimensions");
+		return false;
+	}
+
+	VkExportMetalObjectCreateInfoEXT export_metal_tex_info = {
+	    .sType = VK_STRUCTURE_TYPE_EXPORT_METAL_OBJECT_CREATE_INFO_EXT,
+	    .exportObjectType = VK_EXPORT_METAL_OBJECT_TYPE_METAL_TEXTURE_BIT_EXT,
+	};
+	VkImportMetalIOSurfaceInfoEXT import_iosurface_info = {
+	    .sType = VK_STRUCTURE_TYPE_IMPORT_METAL_IO_SURFACE_INFO_EXT,
+	    .pNext = &export_metal_tex_info,
+	    .ioSurface = surface,
+	};
+	VkImageCreateInfo image_ci = {
+	    .sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
+	    .pNext = &import_iosurface_info,
+	    .imageType = VK_IMAGE_TYPE_2D,
+	    .format = WEAVE_VK_FORMAT,
+	    .extent = {width, height, 1},
+	    .mipLevels = 1,
+	    .arrayLayers = 1,
+	    .samples = VK_SAMPLE_COUNT_1_BIT,
+	    .tiling = VK_IMAGE_TILING_OPTIMAL,
+	    .usage = VK_IMAGE_USAGE_SAMPLED_BIT,
+	    .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
+	    .initialLayout = VK_IMAGE_LAYOUT_UNDEFINED,
+	};
+
+	VkImage image = VK_NULL_HANDLE;
+	VkResult ret = vk->vkCreateImage(vk->device, &image_ci, NULL, &image);
+	if (ret != VK_SUCCESS) {
+		U_LOG_E("weave(#759) v4: vkCreateImage(overlay IOSurface) failed: %d", ret);
+		return false;
+	}
+
+	VkExportMetalTextureInfoEXT export_tex_info = {
+	    .sType = VK_STRUCTURE_TYPE_EXPORT_METAL_TEXTURE_INFO_EXT,
+	    .image = image,
+	    .plane = VK_IMAGE_ASPECT_COLOR_BIT,
+	};
+	VkExportMetalObjectsInfoEXT export_objects_info = {
+	    .sType = VK_STRUCTURE_TYPE_EXPORT_METAL_OBJECTS_INFO_EXT,
+	    .pNext = &export_tex_info,
+	};
+	vk->vkExportMetalObjectsEXT(vk->device, &export_objects_info);
+	if (export_tex_info.mtlTexture == NULL) {
+		U_LOG_E("weave(#759) v4: failed to export MTLTexture from overlay VkImage");
+		vk->vkDestroyImage(vk->device, image, NULL);
+		return false;
+	}
+
+	VkMemoryRequirements requirements = {0};
+	vk->vkGetImageMemoryRequirements(vk->device, image, &requirements);
+
+	VkMemoryMetalHandlePropertiesEXT metal_props = {
+	    .sType = VK_STRUCTURE_TYPE_MEMORY_METAL_HANDLE_PROPERTIES_EXT,
+	};
+	ret = vk->vkGetMemoryMetalHandlePropertiesEXT(vk->device, VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLTEXTURE_BIT_EXT,
+	                                              export_tex_info.mtlTexture, &metal_props);
+	if (ret != VK_SUCCESS) {
+		U_LOG_E("weave(#759) v4: vkGetMemoryMetalHandlePropertiesEXT failed: %d", ret);
+		vk->vkDestroyImage(vk->device, image, NULL);
+		return false;
+	}
+	requirements.memoryTypeBits = metal_props.memoryTypeBits;
+
+	VkImportMemoryMetalHandleInfoEXT import_memory_info = {
+	    .sType = VK_STRUCTURE_TYPE_IMPORT_MEMORY_METAL_HANDLE_INFO_EXT,
+	    .handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLTEXTURE_BIT_EXT,
+	    .handle = export_tex_info.mtlTexture,
+	};
+	VkMemoryDedicatedAllocateInfoKHR dedicated_info = {
+	    .sType = VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO_KHR,
+	    .pNext = &import_memory_info,
+	    .image = image,
+	};
+
+	uint32_t memory_type_index = UINT32_MAX;
+	VkPhysicalDeviceMemoryProperties mem_props;
+	vk->vkGetPhysicalDeviceMemoryProperties(vk->physical_device, &mem_props);
+	for (uint32_t i = 0; i < mem_props.memoryTypeCount; i++) {
+		if ((requirements.memoryTypeBits & (1u << i)) != 0) {
+			memory_type_index = i;
+			break;
+		}
+	}
+	if (memory_type_index == UINT32_MAX) {
+		U_LOG_E("weave(#759) v4: no valid memory type for overlay IOSurface");
+		vk->vkDestroyImage(vk->device, image, NULL);
+		return false;
+	}
+
+	VkMemoryAllocateInfo alloc_info = {
+	    .sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
+	    .pNext = &dedicated_info,
+	    .allocationSize = requirements.size,
+	    .memoryTypeIndex = memory_type_index,
+	};
+	VkDeviceMemory memory = VK_NULL_HANDLE;
+	ret = vk->vkAllocateMemory(vk->device, &alloc_info, NULL, &memory);
+	if (ret != VK_SUCCESS) {
+		U_LOG_E("weave(#759) v4: vkAllocateMemory(overlay IOSurface) failed: %d", ret);
+		vk->vkDestroyImage(vk->device, image, NULL);
+		return false;
+	}
+	ret = vk->vkBindImageMemory(vk->device, image, memory, 0);
+	if (ret != VK_SUCCESS) {
+		U_LOG_E("weave(#759) v4: vkBindImageMemory(overlay IOSurface) failed: %d", ret);
+		vk->vkFreeMemory(vk->device, memory, NULL);
+		vk->vkDestroyImage(vk->device, image, NULL);
+		return false;
+	}
+
+	VkImageViewCreateInfo view_ci = {
+	    .sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,
+	    .image = image,
+	    .viewType = VK_IMAGE_VIEW_TYPE_2D,
+	    .format = WEAVE_VK_FORMAT,
+	    .subresourceRange = {.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT, .levelCount = 1, .layerCount = 1},
+	};
+	VkImageView view = VK_NULL_HANDLE;
+	ret = vk->vkCreateImageView(vk->device, &view_ci, NULL, &view);
+	if (ret != VK_SUCCESS) {
+		U_LOG_E("weave(#759) v4: vkCreateImageView(overlay) failed: %d", ret);
+		vk->vkFreeMemory(vk->device, memory, NULL);
+		vk->vkDestroyImage(vk->device, image, NULL);
+		return false;
+	}
+
+	mc->weave.overlay_image = image;
+	mc->weave.overlay_memory = memory;
+	mc->weave.overlay_view = view;
+	mc->weave.overlay_w = width;
+	mc->weave.overlay_h = height;
+	mc->weave.overlay_first_use = true;
+	return true;
+#else
+	(void)vk;
+	(void)mc;
+	(void)surface;
+	return false;
+#endif
+}
+
+static void
+weave_release_overlay(struct vk_bundle *vk, struct multi_compositor *mc)
+{
+	if (mc->weave.overlay_view != VK_NULL_HANDLE) {
+		vk->vkDestroyImageView(vk->device, mc->weave.overlay_view, NULL);
+		mc->weave.overlay_view = VK_NULL_HANDLE;
+	}
+	if (mc->weave.overlay_image != VK_NULL_HANDLE) {
+		vk->vkDestroyImage(vk->device, mc->weave.overlay_image, NULL);
+		mc->weave.overlay_image = VK_NULL_HANDLE;
+	}
+	if (mc->weave.overlay_memory != VK_NULL_HANDLE) {
+		vk->vkFreeMemory(vk->device, mc->weave.overlay_memory, NULL);
+		mc->weave.overlay_memory = VK_NULL_HANDLE;
+	}
+	if (mc->weave.overlay_iosurface != NULL) {
+		CFRelease((IOSurfaceRef)mc->weave.overlay_iosurface);
+		mc->weave.overlay_iosurface = NULL;
+	}
+	mc->weave.overlay_iosurface_id = 0;
+	mc->weave.overlay_w = 0;
+	mc->weave.overlay_h = 0;
 }
 
 //! Plain device-local image + view (the SBS scratch atlas).
@@ -345,6 +557,93 @@ weave_release_scratch(struct vk_bundle *vk, struct multi_compositor *mc)
 	}
 	mc->weave.sbs_w = 0;
 	mc->weave.sbs_h = 0;
+}
+
+//! v6 crop staging (#774): a device-local image + view holding the top-left
+//! packed region (tile_columns*cvw x tile_rows*cvh) when the input atlas is
+//! larger than the active mode's tiles. Sampled by the DP (SAMPLED) after a
+//! single box copy from the input (TRANSFER_DST). No zero-copy = no crop image.
+static bool
+weave_create_crop(struct vk_bundle *vk, struct multi_compositor *mc, uint32_t w, uint32_t h)
+{
+	VkImageCreateInfo image_ci = {
+	    .sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
+	    .imageType = VK_IMAGE_TYPE_2D,
+	    .format = WEAVE_VK_FORMAT,
+	    .extent = {w, h, 1},
+	    .mipLevels = 1,
+	    .arrayLayers = 1,
+	    .samples = VK_SAMPLE_COUNT_1_BIT,
+	    .tiling = VK_IMAGE_TILING_OPTIMAL,
+	    .usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT,
+	    .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
+	    .initialLayout = VK_IMAGE_LAYOUT_UNDEFINED,
+	};
+	VkResult ret = vk->vkCreateImage(vk->device, &image_ci, NULL, &mc->weave.crop_image);
+	if (ret != VK_SUCCESS) {
+		return false;
+	}
+
+	VkMemoryRequirements reqs;
+	vk->vkGetImageMemoryRequirements(vk->device, mc->weave.crop_image, &reqs);
+	uint32_t mti = UINT32_MAX;
+	if (!vk_get_memory_type(vk, reqs.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &mti)) {
+		vk->vkDestroyImage(vk->device, mc->weave.crop_image, NULL);
+		mc->weave.crop_image = VK_NULL_HANDLE;
+		return false;
+	}
+	VkMemoryAllocateInfo alloc = {
+	    .sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
+	    .allocationSize = reqs.size,
+	    .memoryTypeIndex = mti,
+	};
+	ret = vk->vkAllocateMemory(vk->device, &alloc, NULL, &mc->weave.crop_memory);
+	if (ret != VK_SUCCESS ||
+	    vk->vkBindImageMemory(vk->device, mc->weave.crop_image, mc->weave.crop_memory, 0) != VK_SUCCESS) {
+		vk->vkDestroyImage(vk->device, mc->weave.crop_image, NULL);
+		mc->weave.crop_image = VK_NULL_HANDLE;
+		if (mc->weave.crop_memory != VK_NULL_HANDLE) {
+			vk->vkFreeMemory(vk->device, mc->weave.crop_memory, NULL);
+			mc->weave.crop_memory = VK_NULL_HANDLE;
+		}
+		return false;
+	}
+
+	VkImageViewCreateInfo view_ci = {
+	    .sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,
+	    .image = mc->weave.crop_image,
+	    .viewType = VK_IMAGE_VIEW_TYPE_2D,
+	    .format = WEAVE_VK_FORMAT,
+	    .subresourceRange = {.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT, .levelCount = 1, .layerCount = 1},
+	};
+	ret = vk->vkCreateImageView(vk->device, &view_ci, NULL, &mc->weave.crop_view);
+	if (ret != VK_SUCCESS) {
+		return false;
+	}
+
+	mc->weave.crop_w = w;
+	mc->weave.crop_h = h;
+	mc->weave.crop_first_use = true;
+	return true;
+}
+
+static void
+weave_release_crop(struct vk_bundle *vk, struct multi_compositor *mc)
+{
+	if (mc->weave.crop_view != VK_NULL_HANDLE) {
+		vk->vkDestroyImageView(vk->device, mc->weave.crop_view, NULL);
+		mc->weave.crop_view = VK_NULL_HANDLE;
+	}
+	if (mc->weave.crop_image != VK_NULL_HANDLE) {
+		vk->vkDestroyImage(vk->device, mc->weave.crop_image, NULL);
+		mc->weave.crop_image = VK_NULL_HANDLE;
+	}
+	if (mc->weave.crop_memory != VK_NULL_HANDLE) {
+		vk->vkFreeMemory(vk->device, mc->weave.crop_memory, NULL);
+		mc->weave.crop_memory = VK_NULL_HANDLE;
+	}
+	mc->weave.crop_w = 0;
+	mc->weave.crop_h = 0;
 }
 
 /*!
@@ -617,6 +916,9 @@ comp_multi_weave_submit(struct xrt_compositor *xc,
                         uint32_t rect_h,
                         uint32_t rect_count,
                         const struct xrt_rect *rects,
+                        xrt_graphics_buffer_handle_t overlay_handle,
+                        bool weave_frame_first,
+                        const struct xrt_weave_atlas_layout *layout,
                         uint32_t *out_width,
                         uint32_t *out_height,
                         uint64_t *out_fence_value,
@@ -635,6 +937,12 @@ comp_multi_weave_submit(struct xrt_compositor *xc,
 	// receive looked up; we either adopt it into the cache or release it.
 	IOSurfaceRef surface = (IOSurfaceRef)in_handle;
 	uint32_t surface_id = (uint32_t)IOSurfaceGetID(surface);
+
+	// v4 overlay atlas (browser#18): the handler passes a second retained
+	// IOSurfaceRef when the caller chained XrWeaveSubmitOverlaysDXR. We own it —
+	// adopt into the overlay cache (keyed by IOSurfaceID) or release it below.
+	IOSurfaceRef overlay = (IOSurfaceRef)overlay_handle; // may be NULL
+	uint32_t overlay_id = overlay != NULL ? (uint32_t)IOSurfaceGetID(overlay) : 0;
 
 	weave_ensure_mutex(mc);
 	os_mutex_lock(&mc->weave.mutex);
@@ -656,10 +964,52 @@ comp_multi_weave_submit(struct xrt_compositor *xc,
 			surface = NULL; // ownership transferred
 		}
 
-		// Output dims: batch = the (window-client-sized) input; legacy =
-		// rect offset+extent (the Windows GetClientRect-less fallback).
+		// v4 overlay: (re)import on identity change. On a matching id we keep the
+		// cached import and release the (redundant) per-call ref at the epilogue.
+		if (overlay != NULL &&
+		    (mc->weave.overlay_image == VK_NULL_HANDLE || mc->weave.overlay_iosurface_id != overlay_id)) {
+			weave_release_overlay(vk, mc);
+			if (weave_import_overlay(vk, mc, overlay)) {
+				mc->weave.overlay_iosurface = (void *)overlay; // adopt the retained ref
+				mc->weave.overlay_iosurface_id = overlay_id;
+				overlay = NULL; // ownership transferred
+				U_LOG_W("weave(#759) v4: overlay import cached (%ux%u)", mc->weave.overlay_w,
+				        mc->weave.overlay_h);
+			}
+		}
+
+		// Spec-v6 N-view atlas (#774): a non-NULL layout with view_count > 0
+		// means the caller already packed the atlas the way every DisplayXR app
+		// does — tiles contiguous from the top-left at (content_view_w,
+		// content_view_h) in a worst-case-sized input (ADR-010). No SBS scratch,
+		// no per-rect unpack blits, no firstChunk clear: crop the top-left packed
+		// region if the worst case is bigger (ADR-030 crop-before-DP) and weave
+		// once. The woven output IS one content view (= the whole window); the
+		// present-owner reads back per-element window-regions from it.
+		const bool nview = (layout != NULL && layout->view_count > 0);
+		uint32_t cvw = 0, cvh = 0, packed_w = 0, packed_h = 0;
+		if (nview) {
+			cvw = layout->content_view_w;
+			cvh = layout->content_view_h;
+			packed_w = layout->tile_columns * cvw;
+			packed_h = layout->tile_rows * cvh;
+			if (packed_w > mc->weave.in_w || packed_h > mc->weave.in_h) {
+				U_LOG_E("weave(#759) v6: packed region %ux%u exceeds input atlas %ux%u "
+				        "(views=%u grid=%ux%u content=%ux%u)",
+				        packed_w, packed_h, mc->weave.in_w, mc->weave.in_h, layout->view_count,
+				        layout->tile_columns, layout->tile_rows, cvw, cvh);
+				break;
+			}
+		}
+
+		// Output dims: v6 = one content view (cvw x cvh); batch = the
+		// (window-client-sized) input; legacy = rect offset+extent (the Windows
+		// GetClientRect-less fallback).
 		uint32_t want_w = 0, want_h = 0;
-		if (rect_count > 0) {
+		if (nview) {
+			want_w = cvw;
+			want_h = cvh;
+		} else if (rect_count > 0) {
 			want_w = mc->weave.in_w;
 			want_h = mc->weave.in_h;
 		} else {
@@ -670,16 +1020,34 @@ comp_multi_weave_submit(struct xrt_compositor *xc,
 			break;
 		}
 
-		// (Re)allocate output + scratch on resize. The scratch is the
-		// window-sized 2x1 SBS atlas (2*w x h) — ONE weave per submit.
+		// (Re)allocate output (+ SBS scratch on the non-v6 paths) on resize. The
+		// scratch is the window-sized 2x1 SBS atlas (2*w x h) — ONE weave per
+		// submit. v6 samples the input (or the crop image) directly, so it needs
+		// no scratch.
 		if (mc->weave.out_image == VK_NULL_HANDLE || mc->weave.out_w != want_w ||
 		    mc->weave.out_h != want_h) {
 			// Never yank resources out from under in-flight GPU work.
 			vk->vkQueueWaitIdle(vk->main_queue->queue);
 			weave_release_output(vk, mc);
 			weave_release_scratch(vk, mc);
-			if (!weave_create_output(vk, mc, want_w, want_h) ||
-			    !weave_create_scratch(vk, mc, want_w * 2, want_h)) {
+			if (!weave_create_output(vk, mc, want_w, want_h)) {
+				break;
+			}
+			if (!nview && !weave_create_scratch(vk, mc, want_w * 2, want_h)) {
+				break;
+			}
+		}
+
+		// v6 crop staging: (re)create when the packed region is smaller than the
+		// input (the common ADR-010 case). Zero-copy (packed == input) samples
+		// the input directly and needs no crop image.
+		const bool v6_zero_copy = nview && (packed_w == mc->weave.in_w && packed_h == mc->weave.in_h);
+		if (nview && !v6_zero_copy &&
+		    (mc->weave.crop_image == VK_NULL_HANDLE || mc->weave.crop_w != packed_w ||
+		     mc->weave.crop_h != packed_h)) {
+			vk->vkQueueWaitIdle(vk->main_queue->queue);
+			weave_release_crop(vk, mc);
+			if (!weave_create_crop(vk, mc, packed_w, packed_h)) {
 				break;
 			}
 		}
@@ -697,6 +1065,104 @@ comp_multi_weave_submit(struct xrt_compositor *xc,
 
 		VkImageSubresourceRange range = {
 		    .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT, .levelCount = 1, .layerCount = 1};
+
+		// Atlas source for the DP sample + the atlas grid it describes. Legacy /
+		// batch weaves the window-sized 2x1 SBS scratch; v6 (#774) weaves the
+		// caller's already-packed N-view atlas — the input directly (zero-copy)
+		// or a cropped copy of its top-left packed region.
+		VkImage dp_src_image = mc->weave.sbs_image;
+		VkImageView dp_src_view = mc->weave.sbs_view;
+		uint32_t atlas_view_w = mc->weave.out_w;
+		uint32_t atlas_view_h = mc->weave.out_h;
+		uint32_t grid_cols = 2, grid_rows = 1;
+
+		if (nview) {
+			// v6: no SBS scratch, no per-rect unpack blits, no firstChunk clear.
+			// Transparency between elements is carried by the caller's own atlas
+			// alpha, which reaches the DP untouched.
+			if (v6_zero_copy) {
+				// The packed atlas fills the input exactly — sample it directly.
+				// Kept GENERAL across frames otherwise (UNDEFINED would discard
+				// the caller's pixels); restored to GENERAL after the weave.
+				VkImageMemoryBarrier in_to_read = {
+				    .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+				    .srcAccessMask = VK_ACCESS_MEMORY_WRITE_BIT,
+				    .dstAccessMask = VK_ACCESS_SHADER_READ_BIT,
+				    .oldLayout = mc->weave.in_first_use ? VK_IMAGE_LAYOUT_UNDEFINED
+				                                        : VK_IMAGE_LAYOUT_GENERAL,
+				    .newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+				    .image = mc->weave.in_image,
+				    .subresourceRange = range,
+				};
+				mc->weave.in_first_use = false;
+				vk->vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+				                         VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, 0, 0, NULL, 0, NULL, 1,
+				                         &in_to_read);
+				dp_src_image = mc->weave.in_image;
+				dp_src_view = mc->weave.in_view;
+			} else {
+				// Crop the top-left packed region (tiles are contiguous, so it
+				// is a single rectangle — ONE box copy, not a per-tile gather).
+				VkImageMemoryBarrier in_to_src = {
+				    .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+				    .srcAccessMask = VK_ACCESS_MEMORY_WRITE_BIT,
+				    .dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT,
+				    .oldLayout = mc->weave.in_first_use ? VK_IMAGE_LAYOUT_UNDEFINED
+				                                        : VK_IMAGE_LAYOUT_GENERAL,
+				    .newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+				    .image = mc->weave.in_image,
+				    .subresourceRange = range,
+				};
+				mc->weave.in_first_use = false;
+				vk->vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+				                         VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, NULL, 0, NULL, 1,
+				                         &in_to_src);
+
+				VkImageMemoryBarrier crop_to_dst = {
+				    .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+				    .srcAccessMask = VK_ACCESS_SHADER_READ_BIT,
+				    .dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
+				    .oldLayout = mc->weave.crop_first_use ? VK_IMAGE_LAYOUT_UNDEFINED
+				                                          : VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+				    .newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+				    .image = mc->weave.crop_image,
+				    .subresourceRange = range,
+				};
+				mc->weave.crop_first_use = false;
+				vk->vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+				                         VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, NULL, 0, NULL, 1,
+				                         &crop_to_dst);
+
+				VkImageCopy copy = {
+				    .srcSubresource = {.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT, .layerCount = 1},
+				    .srcOffset = {0, 0, 0},
+				    .dstSubresource = {.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT, .layerCount = 1},
+				    .dstOffset = {0, 0, 0},
+				    .extent = {packed_w, packed_h, 1},
+				};
+				vk->vkCmdCopyImage(cmd, mc->weave.in_image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+				                   mc->weave.crop_image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &copy);
+
+				VkImageMemoryBarrier crop_to_read = {
+				    .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+				    .srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
+				    .dstAccessMask = VK_ACCESS_SHADER_READ_BIT,
+				    .oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+				    .newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+				    .image = mc->weave.crop_image,
+				    .subresourceRange = range,
+				};
+				vk->vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT,
+				                         VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, 0, 0, NULL, 0, NULL, 1,
+				                         &crop_to_read);
+				dp_src_image = mc->weave.crop_image;
+				dp_src_view = mc->weave.crop_view;
+			}
+			atlas_view_w = cvw;
+			atlas_view_h = cvh;
+			grid_cols = layout->tile_columns;
+			grid_rows = layout->tile_rows;
+		} else {
 
 		// Input: keep GENERAL across frames (UNDEFINED would discard the
 		// caller's pixels); the barrier makes external writes visible.
@@ -729,6 +1195,33 @@ comp_multi_weave_submit(struct xrt_compositor *xc,
 		mc->weave.sbs_first_use = false;
 		vk->vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0,
 		                         0, NULL, 0, NULL, 1, &sbs_to_dst);
+
+		// v5 firstChunk (browser#22): clear the SBS scratch to premultiplied
+		// transparent (0,0,0,0) on the first submit of a frame, so regions BETWEEN
+		// the woven tiles come out alpha 0 instead of stale — the present-owner can
+		// then draw the woven output back WHOLE-WINDOW (opaque tiles replace the
+		// page, transparent gaps show it through). The DP is alpha-native (passes
+		// the atlas alpha through the weave), so cleared gaps stay transparent while
+		// blitted tiles keep the page's opaque alpha. Opt-in: legacy present-owners
+		// draw back only their own tiles and skip it (accumulate-across-submits).
+		if (weave_frame_first) {
+			VkClearColorValue sbs_transparent = {.float32 = {0.0f, 0.0f, 0.0f, 0.0f}};
+			vk->vkCmdClearColorImage(cmd, mc->weave.sbs_image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+			                         &sbs_transparent, 1, &range);
+			// Order the whole-image clear before the per-rect blits (both TRANSFER
+			// writes to overlapping regions — no implicit ordering within a stage).
+			VkImageMemoryBarrier clear_to_blit = {
+			    .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+			    .srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
+			    .dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
+			    .oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+			    .newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+			    .image = mc->weave.sbs_image,
+			    .subresourceRange = range,
+			};
+			vk->vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0,
+			                         0, NULL, 0, NULL, 1, &clear_to_blit);
+		}
 
 		// Blit each rect's squeezed-SBS halves into the two atlas tiles:
 		// left half -> left tile at the rect's window position (stretched to
@@ -792,6 +1285,7 @@ comp_multi_weave_submit(struct xrt_compositor *xc,
 		};
 		vk->vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, 0,
 		                         0, NULL, 0, NULL, 1, &sbs_to_read);
+		} // end !nview (legacy/batch SBS record)
 
 		// Output -> COLOR_ATTACHMENT (fully re-rendered every submit, so the
 		// discard from UNDEFINED is fine).
@@ -808,18 +1302,108 @@ comp_multi_weave_submit(struct xrt_compositor *xc,
 		                         VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, 0, 0, NULL, 0, NULL, 1,
 		                         &out_to_attach);
 
-		// ONE process_atlas per submit — 2x1 SBS, per-eye dims = the window.
+		// ONE process_atlas per submit. Legacy/batch: 2x1 SBS, per-eye dims = the
+		// window. v6: the caller's grid at content_view dims — output is one
+		// content view (cvw x cvh = the whole window).
 		xrt_display_processor_set_target_color_view(mc->weave.dp, mc->weave.out_view);
 		xrt_display_processor_process_atlas(mc->weave.dp, cmd,                             //
-		                                    (VkImage_XDP)mc->weave.sbs_image, mc->weave.sbs_view, //
-		                                    mc->weave.out_w, mc->weave.out_h,              //
-		                                    2, 1,                                          //
+		                                    (VkImage_XDP)dp_src_image, dp_src_view,        //
+		                                    atlas_view_w, atlas_view_h,                    //
+		                                    grid_cols, grid_rows,                          //
 		                                    (VkFormat_XDP)WEAVE_VK_FORMAT,                 //
 		                                    mc->weave.out_fb,                              //
 		                                    (VkImage_XDP)mc->weave.out_image,              //
 		                                    mc->weave.out_w, mc->weave.out_h,              //
 		                                    (VkFormat_XDP)WEAVE_VK_FORMAT,                 //
 		                                    0, 0, 0, 0);
+
+		// v6: restore the input atlas to GENERAL so the next frame's barrier
+		// (oldLayout=GENERAL) is correct and the caller's external Metal writes
+		// land into a defined layout. (In the crop path the input's last use was
+		// the box copy; in zero-copy it was the DP sample.)
+		if (nview) {
+			VkImageMemoryBarrier in_restore = {
+			    .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+			    .srcAccessMask = v6_zero_copy ? VK_ACCESS_SHADER_READ_BIT : VK_ACCESS_TRANSFER_READ_BIT,
+			    .dstAccessMask = VK_ACCESS_MEMORY_WRITE_BIT,
+			    .oldLayout = v6_zero_copy ? VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL
+			                              : VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+			    .newLayout = VK_IMAGE_LAYOUT_GENERAL,
+			    .image = mc->weave.in_image,
+			    .subresourceRange = range,
+			};
+			vk->vkCmdPipelineBarrier(cmd,
+			                         v6_zero_copy ? VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT
+			                                      : VK_PIPELINE_STAGE_TRANSFER_BIT,
+			                         VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0, NULL, 0, NULL, 1, &in_restore);
+		}
+
+		// v4 overlay atlas (browser#18): composite the caller's window-sized
+		// premultiplied-alpha 2D atlas OVER the woven output with a premul "over"
+		// blend (out = overlay + (1-overlay.a)*out), so crisp 2D lands on top of
+		// the interlaced 3D at screen depth. The overlay is NOT woven — it is drawn
+		// after process_atlas onto the same output attachment. Reuses aux_vk's
+		// vk_local2d_composite flatten_premul pipeline (One / OneMinusSrcAlpha, all
+		// RGBA). process_atlas leaves out_image in COLOR_ATTACHMENT_OPTIMAL.
+		if (mc->weave.overlay_image != VK_NULL_HANDLE) {
+			bool blend_ready = mc->weave.overlay_blend_initialized;
+			if (!blend_ready) {
+				blend_ready = vk_local2d_composite_init(&mc->weave.overlay_blend, vk,
+				                                        WEAVE_VK_FORMAT, WEAVE_VK_FORMAT);
+				mc->weave.overlay_blend_initialized = blend_ready;
+				if (blend_ready) {
+					U_LOG_W("weave(#759) v4: premul-over blend pipeline ready");
+				} else {
+					U_LOG_E("weave(#759) v4: premul-over blend init failed");
+				}
+			}
+			if (blend_ready) {
+				// Overlay -> SHADER_READ (make the caller's external write visible).
+				VkImageMemoryBarrier ov_to_read = {
+				    .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+				    .srcAccessMask = VK_ACCESS_MEMORY_WRITE_BIT,
+				    .dstAccessMask = VK_ACCESS_SHADER_READ_BIT,
+				    .oldLayout = mc->weave.overlay_first_use
+				                     ? VK_IMAGE_LAYOUT_UNDEFINED
+				                     : VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+				    .newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+				    .image = mc->weave.overlay_image,
+				    .subresourceRange = range,
+				};
+				mc->weave.overlay_first_use = false;
+				vk->vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+				                         VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, 0, 0, NULL, 0, NULL, 1,
+				                         &ov_to_read);
+
+				// Make the weave's color writes available to the blend pass's
+				// LOAD_OP_LOAD + "over" (out stays COLOR_ATTACHMENT_OPTIMAL).
+				VkImageMemoryBarrier out_weave_to_blend = {
+				    .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+				    .srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+				    .dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT |
+				                     VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+				    .oldLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+				    .newLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+				    .image = mc->weave.out_image,
+				    .subresourceRange = range,
+				};
+				vk->vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+				                         VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, 0, 0, NULL, 0,
+				                         NULL, 1, &out_weave_to_blend);
+
+				// One whole-window premul "over": the atlas is transparent
+				// (alpha 0) everywhere except the 2D regions, so a single
+				// full-window composite is correct. out_fb is render-pass
+				// compatible with the flatten pass (same BGRA8 single attachment).
+				vk_local2d_composite_begin_frame(&mc->weave.overlay_blend, vk);
+				vk_local2d_composite_flatten_draw(&mc->weave.overlay_blend, vk, cmd, mc->weave.out_fb,
+				                                  mc->weave.out_w, mc->weave.out_h,
+				                                  mc->weave.overlay_view,       //
+				                                  0, 0, mc->weave.out_w, mc->weave.out_h, // dst = full window
+				                                  0.0f, 0.0f, 1.0f, 1.0f,       // src = whole atlas, no flip
+				                                  /*unpremultiplied*/ false);
+			}
+		}
 
 		// Output -> GENERAL for the caller's cross-API (Metal) read.
 		VkImageMemoryBarrier out_to_general = {
@@ -872,9 +1456,12 @@ comp_multi_weave_submit(struct xrt_compositor *xc,
 
 	os_mutex_unlock(&mc->weave.mutex);
 
-	// Release the per-call ref if it wasn't adopted into the cache.
+	// Release the per-call refs that weren't adopted into a cache.
 	if (surface != NULL) {
 		CFRelease(surface);
+	}
+	if (overlay != NULL) {
+		CFRelease(overlay);
 	}
 	return ok;
 }
@@ -950,8 +1537,14 @@ comp_multi_weave_fini(struct multi_compositor *mc)
 			vk->vkQueueWaitIdle(vk->main_queue->queue);
 		}
 		weave_release_input(vk, mc);
+		weave_release_overlay(vk, mc);
 		weave_release_scratch(vk, mc);
+		weave_release_crop(vk, mc);
 		weave_release_output(vk, mc);
+		if (mc->weave.overlay_blend_initialized) {
+			vk_local2d_composite_fini(&mc->weave.overlay_blend, vk);
+			mc->weave.overlay_blend_initialized = false;
+		}
 		if (mc->weave.dp != NULL) {
 			xrt_display_processor_destroy(&mc->weave.dp);
 		}

--- a/src/xrt/ipc/server/ipc_server_handler.c
+++ b/src/xrt/ipc/server/ipc_server_handler.c
@@ -5707,15 +5707,20 @@ ipc_handle_weave_submit(volatile struct ipc_client_state *ics,
 	// handles[0] is the retained IOSurfaceRef the IPC receive looked up; the
 	// weave engine takes ownership (adopts it into its import cache or
 	// releases it). No DXGI low-bit tag exists on POSIX handles.
-	// v4 overlay atlas is Windows-only for now: the macOS weave engine ignores
-	// it, so release any second retained handle here to avoid leaking it.
+	// v4 overlay atlas (browser#18): handles[1] is a second retained IOSurfaceRef
+	// (a window-sized premul-RGBA atlas) when the caller chained
+	// XrWeaveSubmitOverlaysDXR. Pass ownership to the engine (do NOT unref) — it
+	// adopts it into its overlay cache or releases it.
+	xrt_graphics_buffer_handle_t overlay_handle = XRT_GRAPHICS_BUFFER_HANDLE_INVALID;
 	if (args->have_overlay && handle_count >= 2) {
-		xrt_graphics_buffer_handle_t overlay = handles[1];
-		u_graphics_buffer_unref(&overlay);
+		overlay_handle = handles[1];
 	}
 	if (args->rect_count > IPC_WEAVE_SUBMIT_RECTS_MAX) {
 		xrt_graphics_buffer_handle_t reject = handles[0];
 		u_graphics_buffer_unref(&reject); // don't leak the retained IOSurfaceRef
+		if (overlay_handle != XRT_GRAPHICS_BUFFER_HANDLE_INVALID) {
+			u_graphics_buffer_unref(&overlay_handle); // nor the overlay ref
+		}
 		return XRT_ERROR_IPC_FAILURE;
 	}
 	struct xrt_rect rects[IPC_WEAVE_SUBMIT_RECTS_MAX];
@@ -5726,6 +5731,29 @@ ipc_handle_weave_submit(volatile struct ipc_client_state *ics,
 		rects[i].extent.h = (int)args->rects[i].h;
 	}
 
+	// v6 (#774): a non-zero view_count means the input is a worst-case-sized
+	// N-view atlas (tiles packed contiguously top-left at content_view_w/h)
+	// rather than per-rect squeezed SBS. Validated client-side in oxr_weave.c;
+	// re-checked here because the wire is not trusted.
+	struct xrt_weave_atlas_layout layout = {0};
+	if (args->view_count > 0) {
+		if (args->tile_columns == 0 || args->tile_rows == 0 || args->content_view_w == 0 ||
+		    args->content_view_h == 0 || args->view_count > XRT_MAX_VIEWS ||
+		    args->view_count != args->tile_columns * args->tile_rows) {
+			xrt_graphics_buffer_handle_t reject = handles[0];
+			u_graphics_buffer_unref(&reject); // don't leak the retained IOSurfaceRef
+			if (overlay_handle != XRT_GRAPHICS_BUFFER_HANDLE_INVALID) {
+				u_graphics_buffer_unref(&overlay_handle); // nor the overlay ref
+			}
+			return XRT_ERROR_IPC_FAILURE;
+		}
+		layout.view_count = args->view_count;
+		layout.tile_columns = args->tile_columns;
+		layout.tile_rows = args->tile_rows;
+		layout.content_view_w = args->content_view_w;
+		layout.content_view_h = args->content_view_h;
+	}
+
 	uint32_t w = 0, h = 0;
 	uint64_t fv = 0;
 	struct xrt_eye_positions eyes = {0};
@@ -5733,6 +5761,8 @@ ipc_handle_weave_submit(volatile struct ipc_client_state *ics,
 	    ics->xc, handles[0],                                    //
 	    args->rect_x, args->rect_y, args->rect_w, args->rect_h, //
 	    args->rect_count, args->rect_count > 0 ? rects : NULL,  //
+	    overlay_handle, args->weave_frame_first != 0,           //
+	    layout.view_count > 0 ? &layout : NULL,                 //
 	    &w, &h, &fv, &eyes);
 	if (!ok) {
 		return XRT_ERROR_IPC_FAILURE;

--- a/test_apps/probes/weave_probe_vk_macos/main.cpp
+++ b/test_apps/probes/weave_probe_vk_macos/main.cpp
@@ -73,6 +73,10 @@ static const uint32_t kWinW = 1280;
 static const uint32_t kWinH = 720;
 static const XrRect2Di kRectA = {{100, 100}, {320, 180}};
 static const XrRect2Di kRectB = {{700, 400}, {400, 200}};
+// v4 overlay atlas: an opaque magenta bar near the top, in a gap that overlaps
+// neither weaved rect (so the base rects still verify red/cyan) and a background
+// gap (so firstChunk transparency is verifiable outside it).
+static const XrRect2Di kOverlayBar = {{200, 30}, {800, 40}};
 
 //! BGRA pixel write helper.
 static inline void
@@ -114,6 +118,24 @@ sample_px(IOSurfaceRef surf, int x, int y, uint8_t *out_r, uint8_t *out_g, uint8
 	*out_b = p[0];
 	*out_g = p[1];
 	*out_r = p[2];
+	IOSurfaceUnlock(surf, kIOSurfaceLockReadOnly, NULL);
+	return true;
+}
+
+//! BGRA sample including alpha (for the v5 firstChunk transparency assertion).
+static bool
+sample_px4(IOSurfaceRef surf, int x, int y, uint8_t *out_r, uint8_t *out_g, uint8_t *out_b, uint8_t *out_a)
+{
+	if (IOSurfaceLock(surf, kIOSurfaceLockReadOnly, NULL) != kIOReturnSuccess) {
+		return false;
+	}
+	const uint8_t *base = (const uint8_t *)IOSurfaceGetBaseAddress(surf);
+	size_t stride = IOSurfaceGetBytesPerRow(surf);
+	const uint8_t *p = base + (size_t)y * stride + (size_t)x * 4;
+	*out_b = p[0];
+	*out_g = p[1];
+	*out_r = p[2];
+	*out_a = p[3];
 	IOSurfaceUnlock(surf, kIOSurfaceLockReadOnly, NULL);
 	return true;
 }
@@ -167,6 +189,107 @@ create_input_surface(void)
 	for (int i = 0; i < 4; i++) {
 		CFRelease(vals[i]);
 	}
+	return surf;
+}
+
+/*!
+ * v4 overlay atlas (browser#18): a window-sized PREMULTIPLIED-alpha BGRA surface,
+ * transparent (0,0,0,0) everywhere except one opaque magenta bar. Opaque premul ==
+ * straight, so the bar is a plain magenta with alpha 255. Global so the service's
+ * IOSurfaceLookup(id) finds it (the IPC transports the bare IOSurfaceID).
+ */
+static IOSurfaceRef
+create_overlay_surface(void)
+{
+	int32_t w = (int32_t)kWinW, h = (int32_t)kWinH, bpe = 4;
+	uint32_t fmt = 'BGRA';
+	CFStringRef keys[5] = {CFSTR("IOSurfaceWidth"), CFSTR("IOSurfaceHeight"), CFSTR("IOSurfaceBytesPerElement"),
+	                       CFSTR("IOSurfacePixelFormat"), CFSTR("IOSurfaceIsGlobal")};
+	CFNumberRef vals[4] = {
+	    CFNumberCreate(NULL, kCFNumberSInt32Type, &w),
+	    CFNumberCreate(NULL, kCFNumberSInt32Type, &h),
+	    CFNumberCreate(NULL, kCFNumberSInt32Type, &bpe),
+	    CFNumberCreate(NULL, kCFNumberSInt32Type, &fmt),
+	};
+	CFTypeRef values[5] = {vals[0], vals[1], vals[2], vals[3], kCFBooleanTrue};
+	CFDictionaryRef props = CFDictionaryCreate(NULL, (const void **)keys, (const void **)values, 5,
+	                                           &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+	IOSurfaceRef surf = IOSurfaceCreate(props);
+	CFRelease(props);
+	for (int i = 0; i < 4; i++) {
+		CFRelease(vals[i]);
+	}
+	if (surf == NULL) {
+		return NULL;
+	}
+	IOSurfaceLock(surf, 0, NULL);
+	uint8_t *base = (uint8_t *)IOSurfaceGetBaseAddress(surf);
+	size_t stride = IOSurfaceGetBytesPerRow(surf);
+	// Transparent premultiplied field everywhere (all four channels 0).
+	for (uint32_t y = 0; y < kWinH; y++) {
+		memset(base + (size_t)y * stride, 0, (size_t)kWinW * 4);
+	}
+	// Opaque magenta bar (premul == straight when a=255): B=230, G=13, R=230, A=255.
+	for (int y = kOverlayBar.offset.y; y < kOverlayBar.offset.y + kOverlayBar.extent.height; y++) {
+		for (int x = kOverlayBar.offset.x; x < kOverlayBar.offset.x + kOverlayBar.extent.width; x++) {
+			uint8_t *p = base + (size_t)y * stride + (size_t)x * 4;
+			p[0] = 230; // B
+			p[1] = 13;  // G
+			p[2] = 230; // R
+			p[3] = 255; // A (opaque)
+		}
+	}
+	IOSurfaceUnlock(surf, 0, NULL);
+	return surf;
+}
+
+//! Generic global BGRA IOSurface (kIOSurfaceIsGlobal so the service-side
+//! IOSurfaceLookup(id) finds it — the IPC transports the bare IOSurfaceID).
+static IOSurfaceRef
+create_bgra_surface(int32_t w, int32_t h)
+{
+	int32_t bpe = 4;
+	uint32_t fmt = 'BGRA';
+	CFStringRef keys[5] = {CFSTR("IOSurfaceWidth"), CFSTR("IOSurfaceHeight"), CFSTR("IOSurfaceBytesPerElement"),
+	                       CFSTR("IOSurfacePixelFormat"), CFSTR("IOSurfaceIsGlobal")};
+	CFNumberRef vals[4] = {
+	    CFNumberCreate(NULL, kCFNumberSInt32Type, &w),
+	    CFNumberCreate(NULL, kCFNumberSInt32Type, &h),
+	    CFNumberCreate(NULL, kCFNumberSInt32Type, &bpe),
+	    CFNumberCreate(NULL, kCFNumberSInt32Type, &fmt),
+	};
+	CFTypeRef values[5] = {vals[0], vals[1], vals[2], vals[3], kCFBooleanTrue};
+	CFDictionaryRef props = CFDictionaryCreate(NULL, (const void **)keys, (const void **)values, 5,
+	                                           &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+	IOSurfaceRef surf = IOSurfaceCreate(props);
+	CFRelease(props);
+	for (int i = 0; i < 4; i++) {
+		CFRelease(vals[i]);
+	}
+	return surf;
+}
+
+//! Spec-v6 N-view atlas (#774): build a 2-view (2x1) atlas of size 2*cvw x cvh,
+//! tile 0 (left eye) solid RED, tile 1 (right eye) solid CYAN. The anaglyph DP
+//! (out = left.r, right.g, right.b) then weaves this to WHITE. Tiles are packed
+//! CONTIGUOUSLY at content-view stride cvw, so 2*cvw == atlas width (zero-copy).
+static IOSurfaceRef
+create_nview_atlas(uint32_t cvw, uint32_t cvh)
+{
+	IOSurfaceRef surf = create_bgra_surface((int32_t)(2 * cvw), (int32_t)cvh);
+	if (surf == NULL) {
+		return NULL;
+	}
+	IOSurfaceLock(surf, 0, NULL);
+	uint8_t *base = (uint8_t *)IOSurfaceGetBaseAddress(surf);
+	size_t stride = IOSurfaceGetBytesPerRow(surf);
+	for (uint32_t y = 0; y < cvh; y++) {
+		for (uint32_t x = 0; x < cvw; x++) {
+			put_px(base, stride, (int)x, (int)y, 0xFF, 0x00, 0x00);       // tile0 left = RED
+			put_px(base, stride, (int)(cvw + x), (int)y, 0x00, 0xFF, 0xFF); // tile1 right = CYAN
+		}
+	}
+	IOSurfaceUnlock(surf, 0, NULL);
 	return surf;
 }
 
@@ -385,15 +508,29 @@ main(int argc, char **argv)
 	fill_sbs_rect(base, stride, kRectB, /*left*/ 0x00, /*right*/ 0xFF); // -> CYAN after anaglyph
 	IOSurfaceUnlock(input, 0, NULL);
 
-	// ---- Batched submits (spec v3).
+	// ---- v4 overlay atlas (premul-RGBA magenta bar), chained on the submit.
+	IOSurfaceRef overlay = create_overlay_surface();
+	if (overlay == NULL) {
+		LOG("overlay IOSurfaceCreate failed");
+		return 1;
+	}
+
+	// ---- Batched submits (spec v3) + v5 firstChunk + v4 overlay (spec v4).
 	XrRect2Di rects[2] = {kRectA, kRectB};
+	XrWeaveSubmitOverlaysDXR ov = {(XrStructureType)XR_TYPE_WEAVE_SUBMIT_OVERLAYS_DXR};
+	ov.overlayTexture = (void *)overlay;
+	ov.overlayIsDxgi = XR_FALSE;
+	ov.rectCount = 0; // whole-atlas composite (premul alpha authoritative)
+	ov.rects = NULL;
 	XrWeaveSubmitRectsDXR batch = {(XrStructureType)XR_TYPE_WEAVE_SUBMIT_RECTS_DXR};
+	batch.next = &ov; // chain overlays after rects
 	batch.rectCount = 2;
 	batch.rects = rects;
 	XrWeaveSubmitInfoDXR submit = {(XrStructureType)XR_TYPE_WEAVE_SUBMIT_INFO_DXR};
 	submit.next = &batch;
 	submit.inputTexture = (void *)input;
 	submit.inputIsDxgi = XR_FALSE;
+	submit.firstChunk = XR_TRUE; // single submit per frame → first → clears woven output transparent (v5)
 
 	IOSurfaceRef output = NULL;
 	uint32_t out_w = 0, out_h = 0;
@@ -450,9 +587,120 @@ main(int argc, char **argv)
 		pass = pass && ok;
 	}
 
+	// ---- v4 overlay: the magenta bar must be composited over the woven output.
+	{
+		int bx = kOverlayBar.offset.x + kOverlayBar.extent.width / 2;
+		int by = kOverlayBar.offset.y + kOverlayBar.extent.height / 2;
+		uint8_t r = 0, g = 0, b = 0, a = 0;
+		if (sample_px4(output, bx, by, &r, &g, &b, &a)) {
+			bool ok = (r > 150 && b > 150 && g < 80 && a > 200);
+			LOG("v4 overlay bar @(%d,%d) = (%u,%u,%u,a=%u) want magenta+opaque -> %s", bx, by, r, g, b, a,
+			    ok ? "OK" : "WRONG");
+			pass = pass && ok;
+		} else {
+			LOG("FAIL: could not sample overlay bar");
+			pass = false;
+		}
+	}
+
+	// ---- v5 firstChunk: a background gap (no rect, no overlay) must be
+	// transparent (alpha ~0); a woven tile centre must be opaque (alpha ~255).
+	{
+		uint8_t r = 0, g = 0, b = 0, a = 0;
+		if (sample_px4(output, 10, 10, &r, &g, &b, &a)) {
+			bool ok = (a < 40);
+			LOG("v5 firstChunk gap @(10,10) alpha=%u want ~0 -> %s", a, ok ? "OK" : "WRONG");
+			pass = pass && ok;
+		} else {
+			LOG("FAIL: could not sample firstChunk gap");
+			pass = false;
+		}
+		int tx = kRectA.offset.x + kRectA.extent.width / 2;
+		int ty = kRectA.offset.y + kRectA.extent.height / 2;
+		if (sample_px4(output, tx, ty, &r, &g, &b, &a)) {
+			bool ok = (a > 200);
+			LOG("v5 firstChunk tile @(%d,%d) alpha=%u want ~255 -> %s", tx, ty, a, ok ? "OK" : "WRONG");
+			pass = pass && ok;
+		}
+	}
+
+	// ---- Spec-v6 N-view atlas (#774): additive path. A submit that chains
+	// XrWeaveSubmitLayoutDXR carries a worst-case-sized packed atlas (tiles
+	// contiguous top-left at content-view size), NOT per-rect squeezed SBS. The
+	// runtime crops the packed region (here it exactly fills the input →
+	// zero-copy) and weaves once; the output is ONE content view (cvw x cvh).
+	{
+		const uint32_t cvw = 640, cvh = 360;
+		IOSurfaceRef nv_input = create_nview_atlas(cvw, cvh); // 2*cvw x cvh, red|cyan
+		if (nv_input == NULL) {
+			LOG("v6 FAIL: N-view atlas IOSurfaceCreate failed");
+			pass = false;
+		} else {
+			XrWeaveSubmitLayoutDXR lay = {(XrStructureType)XR_TYPE_WEAVE_SUBMIT_LAYOUT_DXR};
+			lay.viewCount = 2;
+			lay.tileColumns = 2;
+			lay.tileRows = 1;
+			lay.contentViewWidth = cvw;
+			lay.contentViewHeight = cvh;
+			XrWeaveSubmitInfoDXR v6submit = {(XrStructureType)XR_TYPE_WEAVE_SUBMIT_INFO_DXR};
+			v6submit.next = &lay; // ONLY the layout chained — no rects, no overlay
+			v6submit.inputTexture = (void *)nv_input;
+			v6submit.inputIsDxgi = XR_FALSE;
+			v6submit.firstChunk = XR_TRUE;
+
+			IOSurfaceRef v6out = NULL;
+			uint32_t v6w = 0, v6h = 0;
+			bool v6ok = true;
+			for (int frame = 0; frame < 3; frame++) {
+				XrWeaveOutputDXR out = {(XrStructureType)XR_TYPE_WEAVE_OUTPUT_DXR};
+				XrResult r = pfn_submit(session, &v6submit, &out);
+				if (XR_FAILED(r)) {
+					LOG("v6 FAIL: xrWeaveSubmitDXR frame %d -> %d", frame, (int)r);
+					v6ok = false;
+					break;
+				}
+				if (out.weavedTexture != NULL && v6out == NULL) {
+					v6out = (IOSurfaceRef)out.weavedTexture;
+				}
+				v6w = out.width;
+				v6h = out.height;
+			}
+			if (v6ok && v6out == NULL) {
+				LOG("v6 FAIL: no weaved output handed back");
+				v6ok = false;
+			}
+			if (v6ok && (v6w != cvw || v6h != cvh)) {
+				LOG("v6 FAIL: output dims %ux%u != content view %ux%u", v6w, v6h, cvw, cvh);
+				v6ok = false;
+			}
+			if (v6ok) {
+				dump_ppm(v6out, "/tmp/weave_probe_macos_v6_output.ppm");
+				// anaglyph(red-left | cyan-right) = (left.r, right.g, right.b) = WHITE.
+				uint8_t r = 0, g = 0, b = 0;
+				if (sample_px(v6out, (int)cvw / 2, (int)cvh / 2, &r, &g, &b)) {
+					bool white = (r > 150 && g > 150 && b > 150);
+					bool nonblack = (r + g + b) > 90;
+					LOG("v6 centre @(%u,%u) = (%u,%u,%u) want white/non-black -> %s", cvw / 2,
+					    cvh / 2, r, g, b, white ? "OK(white)" : (nonblack ? "OK(non-black)" : "WRONG"));
+					v6ok = v6ok && nonblack;
+				} else {
+					LOG("v6 FAIL: could not sample output centre");
+					v6ok = false;
+				}
+			}
+			LOG("v6 N-view atlas: %s", v6ok ? "PASS" : "FAIL");
+			pass = pass && v6ok;
+			if (v6out != NULL) {
+				CFRelease(v6out);
+			}
+			CFRelease(nv_input);
+		}
+	}
+
 	xrDestroySession(session);
 	xrDestroyInstance(instance);
 	CFRelease(input);
+	CFRelease(overlay);
 	CFRelease(output);
 	vkDestroyDevice(device, NULL);
 	vkDestroyInstance(vk_instance, NULL);


### PR DESCRIPTION
The **runtime side** of the mac browser inline-3D weave. Supersedes **#773** (v4/v5) — this branch is a clean superset of it (v4/v5 + v6). #775 (v6 N-view atlas *input*) already merged; this adds the mac weave/compose that consumes it.

## Why now — it's a landed dependency
The mac browser **DP overlay-atlas** just merged to `displayxr-browser` main (patch 0053), and it **depends on the runtime v4 overlay-atlas compose** (`comp_multi_weave_macos.c` `weave_import_overlay` + premul-over `final = woven*(1-a)+overlay`), which is **not yet on runtime main**. Until this lands, a runtime built from main can't composite the browser's 2D-overlay atlas → the mac gallery's 2D chrome won't weave. David-verified the full stack end-to-end on his M1 Pro (browser 0053 ↔ this runtime): tiles solid, header + metadata plates crisp with transparency, no Graphite read race.

## What
- **v4 overlay atlas** (browser#18/#22, #759/#768): separate overlay IOSurface import + one whole-window premul-over composite after `process_atlas`.
- **v5 firstChunk**: clear the window-sized woven output to premul-transparent on the frame's first chunk so all rects accumulate into one coherent surface for the overlay composite.
- **v6 N-view worst-case atlas** (#774): N-view atlas input assembly + `XrWeaveSubmitLayoutDXR` layout chain; `XR_DXR_weave.h` bumped to SPEC_VERSION 6.
- Probe coverage: `weave_probe_vk_macos` + the D3D11 RPC probe exercise the v4 overlay + v6 layout.

## Coordination / gates
- **@claude-win's lane** (weave/runtime) — please review, esp. the `XR_DXR_weave.h` protocol + the D3D11 service parity changes.
- Runtime **ABI gate + CI** will run on this PR (it touches the weave wire/`versions.json`); that's the real gate here (browser patches repo had none).
- Mode negotiation (#776) is a **separate** track — open PR #777; not required for this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>