### PR TITLE
Linux runtime .deb — zero-env-var install with sim-display fallback (#781 Phase 1)

### DIFF
--- a/docs/specs/runtime/plugin-discovery.md
+++ b/docs/specs/runtime/plugin-discovery.md
@@ -232,9 +232,21 @@ Fields mirror the Windows registry schema:
 | `plugin.uninstall_command` | `UninstallString` | see §5 | Command-line invocation for cascade-uninstall. Required for vendor plug-ins.          |
 
 Discovery roots are searched in priority order — the per-user root
-above first, then any system roots a platform packager adds (e.g.
-`/usr/share/displayxr/DisplayProcessors/` on Linux distributions). Per-user
-entries with the same `<id>` shadow system entries.
+above first, then the packaged system roots below. Per-user entries with
+the same `<id>` shadow system entries.
+
+**System roots (Linux), searched after the per-user root:**
+
+| Root                                       | Who writes it                                                                 |
+| ------------------------------------------ | ----------------------------------------------------------------------------- |
+| `/usr/lib/displayxr/plugins/`              | The **built-in default** for packaged installs. The runtime `.deb` drops the sim-display `.so` + `200-sim-display.json` here; vendor plug-in `.deb`s drop their `.so` + `050-*.json` alongside. This is the POSIX analogue of the Windows `DisplayProcessors` registry root, and it is what makes an installed box need **no `XRT_PLUGIN_SEARCH_PATH`** (#781). |
+| `/usr/local/share/displayxr/DisplayProcessors/` | A distro/local packager convention.                                      |
+| `/usr/share/displayxr/DisplayProcessors/`  | A distro packager convention.                                                 |
+
+When `XRT_PLUGIN_SEARCH_PATH` is set it is prepended (highest priority), so
+a dev build still overrides an installed one; when it is unset, discovery
+falls through to `/usr/lib/displayxr/plugins/` and the install is
+self-sufficient.
 
 ### 3.2 Android: convention-driven discovery
 

--- a/scripts/build_linux.sh
+++ b/scripts/build_linux.sh
@@ -43,7 +43,10 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-BUILD_DIR="$ROOT/build"
+# BUILD_DIR is overridable so the tree can be built out-of-source — e.g. the
+# .deb Docker test (scripts/test_deb_linux.sh) builds into a container-local
+# dir to avoid colliding with a host build/ cache on the bind-mounted repo.
+BUILD_DIR="${BUILD_DIR:-$ROOT/build}"
 
 SERVICE_MODE=OFF
 RUN_TEST=ON

--- a/scripts/package_deb_linux.sh
+++ b/scripts/package_deb_linux.sh
@@ -35,8 +35,13 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-BUILD_DIR="$ROOT/build"
-DIST_DIR="$ROOT/dist"
+# Both overridable (inherited by the build_linux.sh call below): the .deb Docker
+# test points BUILD_DIR at a container-local dir to avoid a stale host build/
+# cache on the bind-mounted repo, while DIST_DIR stays on the mount so the .deb
+# lands back on the host.
+BUILD_DIR="${BUILD_DIR:-$ROOT/build}"
+DIST_DIR="${DIST_DIR:-$ROOT/dist}"
+export BUILD_DIR   # so the build_linux.sh child below uses the same tree
 
 NO_BUILD=0
 for arg in "$@"; do
@@ -83,7 +88,10 @@ case "$VERSION" in
     [0-9]*) : ;;
     *) VERSION="0.0.0+g$VERSION" ;;
 esac
-ARCH="amd64"
+# Derive the Debian arch from the build host so the label matches the binaries:
+# x86 CI / release boxes -> amd64; an arm64 dev box (e.g. Apple-silicon colima)
+# -> arm64. The runtime .deb targets whatever the build produced.
+ARCH="$(dpkg --print-architecture 2>/dev/null || echo amd64)"
 PKG="displayxr-runtime"
 
 STAGE="$DIST_DIR/${PKG}_${VERSION}_${ARCH}"
@@ -124,15 +132,21 @@ chmod 0644 "$STAGE/usr/lib/displayxr/plugins/200-sim-display.json"
 # ubuntu:24.04 base the .deb is installed into). Falls back to a conservative
 # hardcoded set if objdump/dpkg aren't available.
 compute_depends() {
-    local sonames pkgs="" so path
+    local sonames pkgs="" so pkg
     sonames="$(objdump -p "$RUNTIME_SO" "$CLI_BIN" "$PLUGIN_SO" 2>/dev/null \
                 | awk '/NEEDED/{print $2}' | sort -u)"
     [ -n "$sonames" ] || { echo "libc6, libcjson1, libvulkan1, libx11-6, libx11-xcb1, libxcb1, libxcb-randr0"; return; }
     for so in $sonames; do
-        path="$(ldconfig -p 2>/dev/null | awk -v s="$so" '$1==s {print $NF; exit}')"
-        [ -n "$path" ] || continue
-        p="$(dpkg -S "$path" 2>/dev/null | head -1 | cut -d: -f1)"
-        [ -n "$p" ] && pkgs="$pkgs $p"
+        # Resolve the soname to its owning package via dpkg's file DB. Search by
+        # BARE soname (no leading '/': a leading slash makes dpkg-query treat it
+        # as an absolute path and miss) — a substring match that is immune to the
+        # /lib-vs-/usr/lib usr-merge split that broke `dpkg -S <ldconfig-path>`
+        # (which had dropped libcjson1/libvulkan1). Keep only the line whose file
+        # basename is EXACTLY the soname (so libfoo.so.1.2.3 / dev symlinks don't
+        # match), then strip dpkg's ':arch' qualifier off the package name.
+        pkg="$(dpkg -S "$so" 2>/dev/null \
+               | awk -F': ' -v s="$so" '{n=split($2,a,"/"); if (a[n]==s){p=$1; sub(/:.*/,"",p); print p; exit}}')"
+        [ -n "$pkg" ] && pkgs="$pkgs $pkg"
     done
     # Always include libc6; dedupe; comma-join.
     echo "libc6 $pkgs" | tr ' ' '\n' | sed '/^$/d' | sort -u | paste -sd, - | sed 's/,/, /g'

--- a/scripts/package_deb_linux.sh
+++ b/scripts/package_deb_linux.sh
@@ -1,0 +1,250 @@
+#!/bin/bash
+# Package the Linux runtime build as a Debian package (.deb) — issue #781, Phase 1.
+#
+#   ./scripts/package_deb_linux.sh            # build (if needed) + stage + dpkg-deb
+#   ./scripts/package_deb_linux.sh --no-build # fail instead of building
+#
+# Output: dist/displayxr-runtime_<ver>_amd64.deb
+#
+# Payload (installed layout — mirrors the CI-proven tarball's bin/ + sibling
+# lib/ so displayxr-cli's `$ORIGIN/../lib` RUNPATH resolves exactly as it does
+# in package_linux.sh):
+#   /usr/lib/displayxr/bin/displayxr-cli
+#   /usr/lib/displayxr/lib/openxr_displayxr.so           (the in-process runtime)
+#   /usr/lib/displayxr/plugins/DisplayXR-SimDisplay.so   (built-in fallback DP)
+#   /usr/lib/displayxr/plugins/200-sim-display.json      (its discovery manifest)
+#   /usr/bin/displayxr-cli -> ../lib/displayxr/bin/displayxr-cli  (PATH symlink;
+#       exec'd via the symlink, ld.so still takes $ORIGIN from the real target)
+#
+#   postinst writes /etc/xdg/openxr/1/active_runtime.json (the Khronos loader
+#   well-known path — the Linux ActiveRuntime equivalent) pointing at the
+#   installed runtime .so; postrm removes it (and restores any pre-existing
+#   runtime it backed up).
+#
+# Net effect (design in #781): an installed box needs ZERO env vars —
+#   * XR_RUNTIME_JSON        -> active_runtime.json (postinst)
+#   * XRT_PLUGIN_SEARCH_PATH -> the runtime's built-in default plug-in dir
+#                               /usr/lib/displayxr/plugins (loader searches it
+#                               when the env is unset; target_plugin_loader.c)
+#
+# Phase 1 scope: the IN-PROCESS runtime only. displayxr-service is intentionally
+# NOT packaged — Linux out-of-process service render is not ready (#710). So the
+# build is done WITHOUT --service. The vendor (Leia SR) plug-in ships its own
+# .deb in a later phase; this package stays vendor-free (sim-display fallback).
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BUILD_DIR="$ROOT/build"
+DIST_DIR="$ROOT/dist"
+
+NO_BUILD=0
+for arg in "$@"; do
+    case "$arg" in
+    --no-build) NO_BUILD=1 ;;
+    *) echo "Unknown option: $arg (supported: --no-build)" >&2; exit 2 ;;
+    esac
+done
+
+command -v dpkg-deb >/dev/null 2>&1 || {
+    echo "error: dpkg-deb not found — run this on a Debian/Ubuntu host or in the" >&2
+    echo "       ubuntu:24.04 container (see scripts/test_deb_linux.sh)." >&2
+    exit 1
+}
+
+find_runtime() { find "$BUILD_DIR/src/xrt/targets/openxr" -maxdepth 1 -name "openxr_displayxr.so" -type f 2>/dev/null | head -1; }
+
+if [ -z "$(find_runtime)" ]; then
+    if [ "$NO_BUILD" = 1 ]; then
+        echo "error: no build found under $BUILD_DIR (run scripts/build_linux.sh --no-test first)" >&2
+        exit 1
+    fi
+    # Phase 1: IN-PROCESS runtime, no service (#710). --no-test because the dev
+    # selftest wires XRT_PLUGIN_SEARCH_PATH; we validate the packaged, env-free
+    # path separately via scripts/test_deb_linux.sh.
+    echo "==> No existing build — running build_linux.sh --no-test (in-process, no service)"
+    "$ROOT/scripts/build_linux.sh" --no-test
+fi
+
+RUNTIME_SO="$(find_runtime)"
+CLI_BIN="$(find "$BUILD_DIR/src/xrt/targets/cli" -maxdepth 1 -name displayxr-cli -type f | head -1)"
+PLUGIN_SO="$(find "$BUILD_DIR/src/xrt/drivers" -name "DisplayXR-SimDisplay.so" -type f | head -1)"
+
+for f in "$RUNTIME_SO" "$CLI_BIN" "$PLUGIN_SO"; do
+    [ -n "$f" ] || { echo "error: missing build artifact (runtime/cli/plugin)" >&2; exit 1; }
+done
+
+# --- Version: turn `git describe` into a Debian-legal upstream version. -----
+# v2.1.0 -> 2.1.0 ; v2.1.0-3-gabc123 -> 2.1.0+3.gabc123 ; dirty -> +dirty
+RAW="$(git -C "$ROOT" describe --tags --always --dirty 2>/dev/null || echo 0.0.0)"
+VERSION="$(echo "$RAW" | sed -e 's/^v//' -e 's/-dirty$/+dirty/' -e 's/-\([0-9]\+\)-g/+\1.g/')"
+# A Debian upstream version must start with a digit; fall back if we only had a hash.
+case "$VERSION" in
+    [0-9]*) : ;;
+    *) VERSION="0.0.0+g$VERSION" ;;
+esac
+ARCH="amd64"
+PKG="displayxr-runtime"
+
+STAGE="$DIST_DIR/${PKG}_${VERSION}_${ARCH}"
+echo "==> Staging $STAGE"
+rm -rf "$STAGE"
+mkdir -p "$STAGE/DEBIAN" \
+         "$STAGE/usr/bin" \
+         "$STAGE/usr/lib/displayxr/bin" \
+         "$STAGE/usr/lib/displayxr/lib" \
+         "$STAGE/usr/lib/displayxr/plugins"
+
+install -m 0755 "$CLI_BIN"     "$STAGE/usr/lib/displayxr/bin/displayxr-cli"
+install -m 0644 "$RUNTIME_SO"  "$STAGE/usr/lib/displayxr/lib/openxr_displayxr.so"
+install -m 0644 "$PLUGIN_SO"   "$STAGE/usr/lib/displayxr/plugins/DisplayXR-SimDisplay.so"
+# PATH entry — relative symlink so it stays valid regardless of install root.
+ln -s ../lib/displayxr/bin/displayxr-cli "$STAGE/usr/bin/displayxr-cli"
+
+# --- Packaged display-processor discovery manifest -------------------------
+# binary_path is fixed at the installed location, so we ship the manifest as a
+# real dpkg-tracked file (removed on purge) rather than generating it in postinst.
+cat > "$STAGE/usr/lib/displayxr/plugins/200-sim-display.json" <<EOF
+{
+    "file_format_version": "1.0",
+    "plugin": {
+        "id":           "sim-display",
+        "display_name": "DisplayXR Sim Display",
+        "vendor":       "DisplayXR",
+        "version":      "$VERSION",
+        "binary_path":  "/usr/lib/displayxr/plugins/DisplayXR-SimDisplay.so",
+        "probe_order":  200
+    }
+}
+EOF
+chmod 0644 "$STAGE/usr/lib/displayxr/plugins/200-sim-display.json"
+
+# --- Depends: resolve the shared libs the binaries actually NEED to the ----
+# Debian packages that provide them (works because this runs in the same
+# ubuntu:24.04 base the .deb is installed into). Falls back to a conservative
+# hardcoded set if objdump/dpkg aren't available.
+compute_depends() {
+    local sonames pkgs="" so path
+    sonames="$(objdump -p "$RUNTIME_SO" "$CLI_BIN" "$PLUGIN_SO" 2>/dev/null \
+                | awk '/NEEDED/{print $2}' | sort -u)"
+    [ -n "$sonames" ] || { echo "libc6, libcjson1, libvulkan1, libx11-6, libx11-xcb1, libxcb1, libxcb-randr0"; return; }
+    for so in $sonames; do
+        path="$(ldconfig -p 2>/dev/null | awk -v s="$so" '$1==s {print $NF; exit}')"
+        [ -n "$path" ] || continue
+        p="$(dpkg -S "$path" 2>/dev/null | head -1 | cut -d: -f1)"
+        [ -n "$p" ] && pkgs="$pkgs $p"
+    done
+    # Always include libc6; dedupe; comma-join.
+    echo "libc6 $pkgs" | tr ' ' '\n' | sed '/^$/d' | sort -u | paste -sd, - | sed 's/,/, /g'
+}
+DEPENDS="$(compute_depends)"
+echo "==> Depends: $DEPENDS"
+
+INSTALLED_KB="$(du -sk "$STAGE/usr" | cut -f1)"
+
+# --- control ---------------------------------------------------------------
+cat > "$STAGE/DEBIAN/control" <<EOF
+Package: $PKG
+Version: $VERSION
+Section: libs
+Priority: optional
+Architecture: $ARCH
+Depends: $DEPENDS
+Installed-Size: $INSTALLED_KB
+Maintainer: The DisplayXR Project <noreply@displayxr.dev>
+Homepage: https://github.com/DisplayXR/displayxr-runtime
+Description: DisplayXR OpenXR runtime for 3D displays (in-process, sim-display)
+ Lightweight standalone OpenXR runtime purpose-built for 3D displays. This
+ package ships the in-process runtime, the displayxr-cli diagnostic tool, and
+ the vendor-neutral sim-display display processor as the built-in fallback.
+ .
+ After install the box needs no environment variables: the OpenXR ActiveRuntime
+ is registered at /etc/xdg/openxr/1/active_runtime.json and the runtime's
+ built-in plug-in dir (/usr/lib/displayxr/plugins) is searched automatically.
+ .
+ A vendor display plug-in (e.g. Leia SR) installs alongside with a lower
+ probe_order and claims the display automatically when present; otherwise
+ sim-display drives apps. The out-of-process service is not included on Linux
+ yet (see issue #710).
+EOF
+
+# --- maintainer scripts ----------------------------------------------------
+cat > "$STAGE/DEBIAN/postinst" <<'EOF'
+#!/bin/sh
+# Register DisplayXR as the OpenXR ActiveRuntime (the XR_RUNTIME_JSON dev env's
+# installed replacement). Well-known Khronos loader path on Linux.
+set -e
+
+CONF_DIR="/etc/xdg/openxr/1"
+ACTIVE="$CONF_DIR/active_runtime.json"
+BACKUP="$ACTIVE.pre-displayxr.bak"
+LIB="/usr/lib/displayxr/lib/openxr_displayxr.so"
+
+case "$1" in
+configure)
+    mkdir -p "$CONF_DIR"
+    # Preserve a pre-existing non-DisplayXR runtime so uninstall can restore it.
+    if [ -f "$ACTIVE" ] && ! grep -q "openxr_displayxr.so" "$ACTIVE" 2>/dev/null; then
+        cp -a "$ACTIVE" "$BACKUP" || true
+        echo "displayxr-runtime: backed up existing OpenXR active runtime to $BACKUP"
+    fi
+    cat > "$ACTIVE" <<JSON
+{
+    "file_format_version": "1.0.0",
+    "runtime": {
+        "name": "DisplayXR",
+        "library_path": "$LIB"
+    }
+}
+JSON
+    echo "displayxr-runtime: OpenXR ActiveRuntime -> $ACTIVE"
+    echo "displayxr-runtime: verify with  displayxr-cli selftest"
+    ;;
+esac
+
+exit 0
+EOF
+
+cat > "$STAGE/DEBIAN/postrm" <<'EOF'
+#!/bin/sh
+# Undo the ActiveRuntime registration our postinst wrote (only if it still
+# points at us), restoring any runtime we backed up.
+set -e
+
+CONF_DIR="/etc/xdg/openxr/1"
+ACTIVE="$CONF_DIR/active_runtime.json"
+BACKUP="$ACTIVE.pre-displayxr.bak"
+
+case "$1" in
+remove|purge|upgrade|deconfigure)
+    if [ -f "$ACTIVE" ] && grep -q "openxr_displayxr.so" "$ACTIVE" 2>/dev/null; then
+        rm -f "$ACTIVE"
+        if [ -f "$BACKUP" ]; then
+            mv "$BACKUP" "$ACTIVE"
+            echo "displayxr-runtime: restored previous OpenXR active runtime"
+        fi
+    fi
+    ;;
+esac
+
+exit 0
+EOF
+
+chmod 0755 "$STAGE/DEBIAN/postinst" "$STAGE/DEBIAN/postrm"
+
+# --- build the .deb --------------------------------------------------------
+mkdir -p "$DIST_DIR"
+DEB="$DIST_DIR/${PKG}_${VERSION}_${ARCH}.deb"
+# fakeroot so the payload is owned root:root inside the archive even when built
+# unprivileged (dpkg-deb warns otherwise); fall back to plain build if absent.
+if command -v fakeroot >/dev/null 2>&1; then
+    fakeroot dpkg-deb --build --root-owner-group "$STAGE" "$DEB"
+else
+    dpkg-deb --build --root-owner-group "$STAGE" "$DEB"
+fi
+
+echo ""
+echo "==> $DEB"
+dpkg-deb --info "$DEB" | sed 's/^/    /'
+echo "    --- contents ---"
+dpkg-deb --contents "$DEB" | sed 's/^/    /'

--- a/scripts/test_deb_linux.sh
+++ b/scripts/test_deb_linux.sh
@@ -53,14 +53,18 @@ fi
 # --- 2. Build the .deb (repo bind-mounted; artifacts land in dist/) --------
 if [ "$VERIFY_ONLY" = 0 ]; then
     echo "==> Building .deb inside $IMAGE"
-    docker run --rm -v "$ROOT":/src -w /src "$IMAGE" bash -c '
+    # BUILD_DIR points at a container-local dir (NOT under the /src bind mount),
+    # so a stale host build/ cache can't collide with the container's /src path
+    # and the build runs on the fast container fs. DIST_DIR defaults to /src/dist
+    # (mounted) so the .deb lands back on the host.
+    docker run --rm -v "$ROOT":/src -w /src -e BUILD_DIR=/root/dxr-build "$IMAGE" bash -c '
         set -e
         git config --global --add safe.directory /src
         ./scripts/package_deb_linux.sh'
 fi
 
-DEB="$(ls -t "$ROOT"/dist/displayxr-runtime_*_amd64.deb 2>/dev/null | head -1 || true)"
-[ -n "$DEB" ] || { echo "error: no dist/displayxr-runtime_*_amd64.deb found" >&2; exit 1; }
+DEB="$(ls -t "$ROOT"/dist/displayxr-runtime_*_*.deb 2>/dev/null | head -1 || true)"
+[ -n "$DEB" ] || { echo "error: no dist/displayxr-runtime_*_*.deb found" >&2; exit 1; }
 echo "==> Testing $(basename "$DEB")"
 
 # --- 3. Clean-install + env-free acceptance run ----------------------------

--- a/scripts/test_deb_linux.sh
+++ b/scripts/test_deb_linux.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# Acceptance test for the Linux runtime .deb (issue #781, Phase 1).
+#
+# Runs entirely in Docker, so it works from a macOS/Linux dev box that has no
+# dpkg toolchain of its own. Two stages:
+#
+#   1. BUILD  — an ubuntu:24.04 builder image (build deps cached) builds the
+#               in-process runtime and packages it via package_deb_linux.sh.
+#   2. VERIFY — a PRISTINE ubuntu:24.04 container `apt-get install`s the .deb
+#               (deps resolved from the archive) and, with NO DisplayXR env
+#               vars set, runs `displayxr-cli selftest` (must PASS on
+#               sim-display) and `displayxr-cli info` (must show the sim modes).
+#
+# This is the CI-adoptable gate: a green run proves an end user gets a working
+# runtime from the .deb alone — zero configuration.
+#
+#   ./scripts/test_deb_linux.sh                 # build + verify
+#   ./scripts/test_deb_linux.sh --verify-only   # reuse dist/*.deb, just verify
+#   ./scripts/test_deb_linux.sh --rebuild-image # force-rebuild the builder image
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+IMAGE="displayxr-deb-builder:ubuntu2404"
+
+VERIFY_ONLY=0
+REBUILD_IMAGE=0
+for arg in "$@"; do
+    case "$arg" in
+    --verify-only) VERIFY_ONLY=1 ;;
+    --rebuild-image) REBUILD_IMAGE=1 ;;
+    *) echo "Unknown option: $arg" >&2; exit 2 ;;
+    esac
+done
+
+command -v docker >/dev/null 2>&1 || { echo "error: docker not found" >&2; exit 1; }
+
+# --- 1. Builder image (deps cached across runs) ----------------------------
+if [ "$REBUILD_IMAGE" = 1 ] || ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+    echo "==> Building builder image $IMAGE"
+    docker build -t "$IMAGE" -f - "$ROOT" <<'DOCKERFILE'
+FROM ubuntu:24.04
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential cmake ninja-build pkg-config git ca-certificates \
+        binutils dpkg-dev fakeroot \
+        libvulkan-dev glslang-tools libeigen3-dev libcjson-dev \
+        libxcb1-dev libxcb-randr0-dev libx11-dev libx11-xcb-dev \
+    && rm -rf /var/lib/apt/lists/*
+DOCKERFILE
+fi
+
+# --- 2. Build the .deb (repo bind-mounted; artifacts land in dist/) --------
+if [ "$VERIFY_ONLY" = 0 ]; then
+    echo "==> Building .deb inside $IMAGE"
+    docker run --rm -v "$ROOT":/src -w /src "$IMAGE" bash -c '
+        set -e
+        git config --global --add safe.directory /src
+        ./scripts/package_deb_linux.sh'
+fi
+
+DEB="$(ls -t "$ROOT"/dist/displayxr-runtime_*_amd64.deb 2>/dev/null | head -1 || true)"
+[ -n "$DEB" ] || { echo "error: no dist/displayxr-runtime_*_amd64.deb found" >&2; exit 1; }
+echo "==> Testing $(basename "$DEB")"
+
+# --- 3. Clean-install + env-free acceptance run ----------------------------
+# A pristine ubuntu:24.04 (NOT the builder) proves the Depends are complete and
+# nothing leaks in from the build environment.
+docker run --rm -v "$ROOT/dist":/deb:ro ubuntu:24.04 bash -c '
+    set -e
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update -qq
+    echo "=== apt-get install ./'"$(basename "$DEB")"' ==="
+    apt-get install -y -qq "/deb/'"$(basename "$DEB")"'"
+
+    echo "=== assert ZERO DisplayXR env vars are set ==="
+    if env | grep -E "^(XR_RUNTIME_JSON|XRT_PLUGIN_SEARCH_PATH)=" ; then
+        echo "FAIL: a DisplayXR env var is set — the test would not prove the env-free path"; exit 1
+    fi
+    echo "ok — no XR_RUNTIME_JSON / XRT_PLUGIN_SEARCH_PATH"
+
+    echo "=== installed files of interest ==="
+    ls -l /etc/xdg/openxr/1/active_runtime.json /usr/lib/displayxr/plugins/
+    echo "--- active_runtime.json ---"; cat /etc/xdg/openxr/1/active_runtime.json
+
+    echo "=== displayxr-cli info (must show sim-display + its modes) ==="
+    displayxr-cli info | tee /tmp/info.txt
+
+    echo "=== displayxr-cli selftest (must PASS on sim-display) ==="
+    displayxr-cli selftest
+
+    # Content assertion: info must name the sim-display plug-in.
+    grep -qi "sim-display\|Sim Display" /tmp/info.txt || {
+        echo "FAIL: displayxr-cli info did not mention sim-display"; exit 1; }
+
+    echo ""
+    echo "ACCEPTANCE PASS — env-free .deb install runs the runtime on sim-display."
+'

--- a/src/xrt/targets/common/target_plugin_loader.c
+++ b/src/xrt/targets/common/target_plugin_loader.c
@@ -1570,6 +1570,14 @@ build_discovery_roots(char roots[][PATH_MAX], int max_roots)
 		snprintf(user_root, sizeof(user_root), "%s/.local/share/DisplayXR/DisplayProcessors", home);
 		append_roots(roots, max_roots, &n_roots, user_root);
 	}
+	/* Built-in default packaged plug-in dir — the Linux `.deb` drops the
+	 * sim-display .so + its `200-sim-display.json` manifest here, so an
+	 * installed box needs NO XRT_PLUGIN_SEARCH_PATH (#781). The env override
+	 * above is appended first, so a dev build still wins when it is set; when
+	 * it is unset this is the discovery root that makes an installed runtime
+	 * self-sufficient. This is the POSIX analogue of the Windows
+	 * DisplayProcessors registry root. */
+	append_roots(roots, max_roots, &n_roots, "/usr/lib/displayxr/plugins");
 	append_roots(roots, max_roots, &n_roots, "/usr/local/share/displayxr/DisplayProcessors");
 	append_roots(roots, max_roots, &n_roots, "/usr/share/displayxr/DisplayProcessors");
 #endif


### PR DESCRIPTION
Implements **Phase 1 of #781** — a Linux runtime `.deb` so an installed box needs **zero env vars**, with sim-display as the built-in fallback DP. Maps every dev-tree env var to an installer-owned file per the design comment on #781:

| Dev env var | Installed replacement |
|---|---|
| `XR_RUNTIME_JSON` | `postinst` writes `/etc/xdg/openxr/1/active_runtime.json` (Khronos loader well-known path) |
| `XRT_PLUGIN_SEARCH_PATH` | runtime searches a built-in default dir `/usr/lib/displayxr/plugins` when the env is unset |

## Changes

**1. Runtime loader** (`src/xrt/targets/common/target_plugin_loader.c`)
POSIX (macOS/Linux) discovery gains `/usr/lib/displayxr/plugins` as a Linux system root — the POSIX analogue of the Windows `DisplayProcessors` registry root. The `XRT_PLUGIN_SEARCH_PATH` override is still prepended (highest priority), so a dev build wins when it's set; when unset, discovery falls through to the packaged default. macOS/Android paths unchanged. Documented in `plugin-discovery.md` §3.1.

**2. `scripts/package_deb_linux.sh`**
Builds the **in-process** runtime (no `--service`; Linux OOP service render is not ready, #710) and produces `displayxr-runtime_<ver>_<arch>.deb`:
- `/usr/lib/displayxr/bin/displayxr-cli` + PATH symlink `/usr/bin/displayxr-cli`
- `/usr/lib/displayxr/lib/openxr_displayxr.so` (in-process runtime)
- `/usr/lib/displayxr/plugins/{DisplayXR-SimDisplay.so,200-sim-display.json}`
- `postinst` writes `active_runtime.json` (backs up any pre-existing runtime); `postrm` removes it and restores the backup.

Layout mirrors the CI-proven tarball (`bin/` + sibling `lib/`) so `displayxr-cli`'s `$ORIGIN/../lib` RUNPATH resolves. `Depends:` is resolved from the binaries' `DT_NEEDED` sonames via `objdump`+`dpkg -S` (basename match — usr-merge-safe). Arch is derived from `dpkg --print-architecture`.

**3. `scripts/test_deb_linux.sh`** — CI-adoptable acceptance gate
An `ubuntu:24.04` builder packages the `.deb`; a **pristine** `ubuntu:24.04` then `apt-get install`s it and, with **no** DisplayXR env vars, runs `displayxr-cli selftest` (must PASS on sim-display) + `displayxr-cli info` (must show sim modes). `build_linux.sh`/`package_deb_linux.sh` gained a `BUILD_DIR` override so the containerized build never collides with a host `build/` cache.

## ✅ Validation

- **Docker acceptance test RAN and PASSED** (Docker/colima, arm64 host → arm64 `.deb`). In a pristine `ubuntu:24.04`, with **zero** DisplayXR env vars: `apt install ./x.deb` resolved all Depends (libcjson1, libvulkan1, libxcb1, …), `postinst` registered the ActiveRuntime, the loader discovered `sim-display` via `/usr/lib/displayxr/plugins` (ABI v4 match), `displayxr-cli info` showed all 5 sim modes, and **`displayxr-cli selftest` PASSED**.
- **This PR's `build-linux.yml` CI** additionally validates the loader change compiles, `selftest`, and the existing env-free tarball install path (x86/amd64).
- Note: the amd64 release `.deb` is produced by x86 builds (CI / release boxes); the local acceptance run above was arm64 (same scripts, arch auto-derived).

## Out of scope (later phases of #781)
- Leia-plugin `.deb` (needs the SR-runtime-presence probe fix)
- Bundle `install.sh` / meta-deb
- CI wiring of `test_deb_linux.sh`
- `#710` out-of-process service on Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)