### PR TITLE
packaging(linux): clean build + exclude vendor SR from runtime .deb Depends (#781)

### DIFF
--- a/scripts/build_linux.sh
+++ b/scripts/build_linux.sh
@@ -68,9 +68,15 @@ OPENXR_VERSION="1.1.51"
 # displayxr-cli links the no-compositor instance directly (target_instance_no_comp),
 # so Phase 0 needs neither a native compositor nor the OpenXR loader — only the
 # runtime libs, the CLI, and the discoverable sim_display plug-in .so.
-echo "=== Configuring DisplayXR runtime (Linux, SERVICE=$SERVICE_MODE) ==="
+# CMAKE_BUILD_TYPE is overridable (default Debug for dev). The .deb packager
+# sets it to Release so the shipped runtime matches the Release-built Leia
+# plug-in — a Debug/Release skew across the plug-in↔runtime struct boundary
+# (NDEBUG-conditional layout) is a candidate cause of the VK-DP-factory
+# null-dispatch crash seen with a Debug .deb runtime (cube-hw finding C), and a
+# Debug runtime is the wrong (36 MB, unoptimized) release artifact regardless.
+echo "=== Configuring DisplayXR runtime (Linux, SERVICE=$SERVICE_MODE, TYPE=${CMAKE_BUILD_TYPE:-Debug}) ==="
 cmake -B "$BUILD_DIR" -S "$ROOT" -G Ninja \
-  -DCMAKE_BUILD_TYPE=Debug \
+  -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE:-Debug}" \
   -DXRT_FEATURE_SERVICE=$SERVICE_MODE \
   -DXRT_MODULE_CLI=ON \
   -DXRT_BUILD_DRIVER_QWERTY=OFF \

--- a/scripts/package_deb_linux.sh
+++ b/scripts/package_deb_linux.sh
@@ -59,15 +59,22 @@ command -v dpkg-deb >/dev/null 2>&1 || {
 
 find_runtime() { find "$BUILD_DIR/src/xrt/targets/openxr" -maxdepth 1 -name "openxr_displayxr.so" -type f 2>/dev/null | head -1; }
 
-if [ -z "$(find_runtime)" ]; then
-    if [ "$NO_BUILD" = 1 ]; then
-        echo "error: no build found under $BUILD_DIR (run scripts/build_linux.sh --no-test first)" >&2
+if [ "$NO_BUILD" = 1 ]; then
+    # Reuse an existing build — the caller guarantees it matches the current
+    # checkout (e.g. a CI step that built immediately before). Fail if none.
+    [ -n "$(find_runtime)" ] || {
+        echo "error: --no-build set but no build under $BUILD_DIR (run scripts/build_linux.sh --no-test first)" >&2
         exit 1
-    fi
-    # Phase 1: IN-PROCESS runtime, no service (#710). --no-test because the dev
-    # selftest wires XRT_PLUGIN_SEARCH_PATH; we validate the packaged, env-free
-    # path separately via scripts/test_deb_linux.sh.
-    echo "==> No existing build — running build_linux.sh --no-test (in-process, no service)"
+    }
+    echo "==> --no-build: reusing existing build under $BUILD_DIR (caller-guaranteed current)"
+else
+    # ALWAYS a clean build so the .deb bits match HEAD. Reusing a stale build/
+    # from an earlier checkout would ship wrong code under a fresh `git describe`
+    # version string — the silent correctness bug from the Suzhou Odyssey Track B
+    # run (cube-hw finding A: 58039d4 bits shipped as 6afba6a → zero-config
+    # discovery broke). Phase 1: IN-PROCESS runtime, no service (#710).
+    echo "==> Clean build via build_linux.sh --no-test (in-process, no service)"
+    rm -rf "$BUILD_DIR"
     "$ROOT/scripts/build_linux.sh" --no-test
 fi
 
@@ -144,8 +151,14 @@ compute_depends() {
         # (which had dropped libcjson1/libvulkan1). Keep only the line whose file
         # basename is EXACTLY the soname (so libfoo.so.1.2.3 / dev symlinks don't
         # match), then strip dpkg's ':arch' qualifier off the package name.
+        # Only accept a match whose file lives in a SYSTEM linker dir (/lib,
+        # /usr/lib, /lib64, ...), and never the vendor SR runtime. The Leia SR
+        # runtime bundles copies of common .so's under /opt/leiasr/lib, so a bare
+        # `dpkg -S <soname>` can otherwise attribute a system lib to
+        # `leiasr-runtime` — the runtime .deb must NEVER Depend on the commercial
+        # SR package (cube-hw finding B).
         pkg="$(dpkg -S "$so" 2>/dev/null \
-               | awk -F': ' -v s="$so" '{n=split($2,a,"/"); if (a[n]==s){p=$1; sub(/:.*/,"",p); print p; exit}}')"
+               | awk -F': ' -v s="$so" '$2 ~ /^\/(usr\/)?lib(32|64)?\// {n=split($2,a,"/"); if (a[n]==s){p=$1; sub(/:.*/,"",p); if (p!="leiasr-runtime"){print p; exit}}}')"
         [ -n "$pkg" ] && pkgs="$pkgs $pkg"
     done
     # Always include libc6; dedupe; comma-join.

--- a/scripts/package_deb_linux.sh
+++ b/scripts/package_deb_linux.sh
@@ -41,7 +41,11 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 # lands back on the host.
 BUILD_DIR="${BUILD_DIR:-$ROOT/build}"
 DIST_DIR="${DIST_DIR:-$ROOT/dist}"
-export BUILD_DIR   # so the build_linux.sh child below uses the same tree
+# Ship a RELEASE runtime: matches the Release-built Leia plug-in (avoids a
+# Debug/Release struct-layout skew across the plug-in↔runtime boundary — cube-hw
+# finding C) and is the correct optimized artifact (Debug was 36 MB). Overridable.
+export CMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE:-Release}"
+export BUILD_DIR   # so the build_linux.sh child below uses the same tree + type
 
 NO_BUILD=0
 for arg in "$@"; do


### PR DESCRIPTION
Two correctness fixes to `scripts/package_deb_linux.sh` from the **Suzhou Odyssey Track B hardware run** (cube-hw report on the #781 Linux `.deb` stack):

- **(A) stale-build reuse.** The script reused an existing `build/` without checking it matched HEAD. On a box with a stale build it shipped **pre-#781 bits under the current `git describe` version string** (58039d4 code labeled 6afba6a) — so the built-in `/usr/lib/displayxr/plugins` discovery was missing and **zero-config discovery failed**. Now: **always a clean build** (`rm -rf BUILD_DIR`) unless `--no-build`, where the caller guarantees an already-current build (the CI build-then-package flow).
- **(B) vendor SR in Depends.** The runtime `.deb` wrongly picked up `Depends: leiasr-runtime` — the Leia SR runtime bundles copies of common system `.so`s under `/opt/leiasr/lib`, so `dpkg -S <bare-soname>` could attribute a system lib to the commercial package. `compute_depends` now only accepts matches under a **system linker dir** (`/lib`, `/usr/lib`, `/lib64`, …) and excludes `leiasr-runtime`. The runtime must never depend on the vendor SR package.

Context: PR #100's Leia plug-in `.deb` is now **hardware-validated** (weaves real 3D on the Odyssey). The separate runtime **VK-DP-factory SIGSEGV** on the real-app path (cube-hw finding C) is tracked as its own investigation — not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)