### PR TITLE
feat(weave): present-owner learns + drives its mode end to end — #776 blockers 3+4

### DIFF
--- a/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
+++ b/src/xrt/compositor/d3d11_service/comp_d3d11_service.cpp
@@ -9168,6 +9168,18 @@ service_apply_pending_mode(struct d3d11_service_system *sys, struct d3d11_servic
 			head->hmd->active_rendering_mode_index = req_mode;
 			broadcast_rendering_mode_change(sys, head, prev_idx, req_mode);
 		}
+		// #776 blocker 4: drive the head device's OUTPUT_MODE so the DP actually
+		// switches its per-view composition — the CONTENT-mode counterpart to the
+		// hardware 2D/3D DP_REQUEST_DISPLAY_MODE below. The Windows service is
+		// single-process, so this reaches the real head device (mirrors the macOS
+		// bridge in ipc_handle_compositor_request_rendering_mode). For sim_display
+		// this is the ONLY runtime lever that switches its weave view count
+		// (SBS/anaglyph/quad); without it a present-owner requesting mode 4 "Quad"
+		// held the index but the DP kept weaving 2 views unless SIM_DISPLAY_OUTPUT
+		// was set at service start. A real vendor DP that drives its own mode
+		// leaves set_property(OUTPUT_MODE) unimplemented — a harmless no-op, same
+		// as the macOS path assumes.
+		xrt_device_set_property(head, XRT_DEVICE_PROPERTY_OUTPUT_MODE, (int32_t)req_mode);
 	}
 	if (req_hw >= 0) {
 		want_3d = (req_hw != 0);

--- a/src/xrt/state_trackers/oxr/oxr_session.c
+++ b/src/xrt/state_trackers/oxr/oxr_session.c
@@ -1217,6 +1217,18 @@ skip_macos_pump:
 			if (head != NULL && head->hmd != NULL && cur < head->rendering_mode_count) {
 				const struct xrt_rendering_mode *mode = &head->rendering_modes[cur];
 				sess->hardware_display_3d = mode->hardware_display_3d;
+				// #776 blocker 3: refresh the head's active-mode index from the
+				// authoritative event so xrEnumerateDisplayRenderingModesDXR
+				// reports a fresh `isActive`. Over IPC `head` is the client
+				// proxy whose active_rendering_mode_index is otherwise synced
+				// only by ipc_client_hmd_update_inputs — which a submit-only
+				// weave present-owner (browser/CEF/WebXR bridge) never calls,
+				// since it runs no xrWaitFrame. It DOES pump this event via
+				// xrPollEvent, so this keeps its "what mode am I in?" answer
+				// current (needed to size contentViewWidth/Height, #774). Writes
+				// the same value the device already holds in-process, so it is a
+				// harmless idempotent store on the non-IPC path.
+				head->hmd->active_rendering_mode_index = cur;
 				struct xrt_system_compositor *xsysc = sess->sys->xsysc;
 				if (xsysc != NULL) {
 					xsysc->info.recommended_view_scale_x = mode->view_scale_x;

--- a/test_apps/probes/weave_rpc_probe_d3d11_win/main.cpp
+++ b/test_apps/probes/weave_rpc_probe_d3d11_win/main.cpp
@@ -912,6 +912,39 @@ wWinMain(HINSTANCE hInst, HINSTANCE, PWSTR, int)
 			         ms, latSum / latCount, latCount, out.width, out.height, rx, ry, rw, rh,
 			         out.eyesValid, out.eyesTracking, out.eyeCount, g_lastEyeX[0], g_lastEyeX[1]);
 		}
+
+		// #776 blocker 3: once the requested-mode change event has had time to
+		// arrive (pumped by PollEvents above), read back which mode the runtime
+		// reports as active. Before the blocker-3 fix a submit-only present-owner
+		// like this probe never called xrWaitFrame/update_inputs, so its head
+		// proxy's active_rendering_mode_index stayed stale and every mode read
+		// back isActive=FALSE (or pinned to the init value) — it could not answer
+		// "what mode am I in?" to size its content views. One-shot at frame 90.
+		if (frame == 90) {
+			PFN_xrEnumerateDisplayRenderingModesDXR pfnEnum = nullptr;
+			xrGetInstanceProcAddr(xr.instance, "xrEnumerateDisplayRenderingModesDXR",
+			                      (PFN_xrVoidFunction *)&pfnEnum);
+			if (pfnEnum != nullptr) {
+				uint32_t n = 0;
+				if (XR_SUCCEEDED(pfnEnum(xr.session, 0, &n, nullptr)) && n > 0 && n <= 16) {
+					XrDisplayRenderingModeInfoDXR ms16[16] = {};
+					for (uint32_t i = 0; i < n; i++) {
+						ms16[i].type = XR_TYPE_DISPLAY_RENDERING_MODE_INFO_DXR;
+					}
+					if (XR_SUCCEEDED(pfnEnum(xr.session, n, &n, ms16))) {
+						for (uint32_t i = 0; i < n; i++) {
+							LOG_INFO("[mode-readback] idx=%u name=\"%s\" views=%u grid=%ux%u "
+							         "active=%d",
+							         ms16[i].modeIndex, ms16[i].modeName, ms16[i].viewCount,
+							         ms16[i].tileColumns, ms16[i].tileRows,
+							         (int)ms16[i].isActive);
+						}
+					}
+				}
+			} else {
+				LOG_ERROR("xrEnumerateDisplayRenderingModesDXR: NOT RESOLVED");
+			}
+		}
 		frame++;
 	}
 


### PR DESCRIPTION
Finishes #776. #777 landed blockers 1+2 (a present-owner can *request* a mode and hold it); this pair makes it **learnable** and makes the request actually **switch the DP's view count** on Windows. Hardware-validated on the Leia box with sim-display forced.

## Blocker 3 — `isActive` was stale over IPC (`oxr_session.c`)

`xrEnumerateDisplayRenderingModesDXR` reports `isActive` from `head->hmd->active_rendering_mode_index`. Over IPC that field on the client proxy is refreshed only by `ipc_client_hmd_update_inputs`, which a submit-only weave present-owner (browser / CEF host / WebXR bridge) never calls — it runs no `xrWaitFrame`. So it could never answer "what mode am I in?" to size its content views (#774).

(#777 already corrected the issue's claim that `init_shm` is the sole writer — the server syncs shm to every client at 20 Hz; the real staleness is this client-side proxy.)

A present-owner **does** pump `xrPollEvent`, so refresh the field from the authoritative `XRT_SESSION_EVENT_RENDERING_MODE_CHANGE` handler — the same one that already updates `sess->hardware_display_3d` and the view scales. One line. In-process it writes the value the device already holds (idempotent); over IPC it corrects the proxy with no input round-trip.

## Blocker 4 — the request never switched the DP's view count on Windows (`comp_d3d11_service.cpp`)

`service_apply_pending_mode` applied a content-mode request by updating the index, broadcasting, and toggling the hardware 2D/3D channel — but never drove `XRT_DEVICE_PROPERTY_OUTPUT_MODE`. On sim_display that property is the **only** runtime lever that switches the weave view count (SBS / anaglyph / quad), read back by the DP's `process_atlas` and `get_predicted_eye_positions`. So a present-owner asking for mode 4 "Quad" held the index but the DP kept weaving 2 views unless `SIM_DISPLAY_OUTPUT=quad` was set at service start.

Drive `OUTPUT_MODE` here, mirroring the qwerty 1/2/3-key path (`comp_d3d11_service.cpp:9579`) and the macOS bridge in `ipc_handle_compositor_request_rendering_mode`. The Windows service is single-process so this reaches the real head device. A real vendor DP that drives its own mode leaves `set_property(OUTPUT_MODE)` unimplemented — a harmless no-op, exactly as the macOS path already assumes.

## Test-app instrumentation

`weave_rpc_probe_d3d11_win` gained a one-shot `[mode-readback]` at frame 90 (enumerates modes, logs `isActive`) so both fixes stay testable.

## Hardware validation (sim-display forced, `DXR_REQUEST_MODE=4`, **no** `SIM_DISPLAY_OUTPUT`)

```
probe:   xrRequestDisplayRenderingModeDXR(4) -> 0
service: sim_display_set_output_mode] Sim display mode changed: Quad          # blocker 4: OUTPUT_MODE drove the switch
service: [app_mode] standalone IPC client requested mode (content=4 hw_req=1) -> active=4 3D=1
service: #625 weave v6: views=4 grid=2x2 content=640x360 atlas=2560x1440
probe:   [mode-readback] idx=4 name="Quad" views=4 grid=2x2 active=1          # blocker 3: fresh isActive on a submit-only owner
```

## Note for the N-view visual (out of scope here, filed to memory)

On a box with **real Leia hardware** the D3D11 compositor's weaving DP (`info->dp_factory_d3d11`, via `comp_dp_factory_for_window`) is populated from the plug-in loader independent of the preferred head-device plugin — Leia (ProbeOrder 50, EDID-present) wins the D3D11 factory even under `dp use sim-display`. So the run above was **woven by Leia**, and `get_predicted_eye_positions` returned `n=2` despite the 4-view atlas. This resolves the long-standing "byte-identical sim-vs-Leia dump" anomaly (it was Leia both times) and means sim N>2 **weaving** can't be visually validated on a Leia box via this path — needs a Leia-free box or a compositor-DP override. Mode negotiation itself (this PR) is correct regardless of which DP welds the pixels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)