### PR TITLE
runtime(plugin_loader): PreferredPlugin override forces the weaving DP — #791

### DIFF
--- a/src/xrt/targets/common/target_plugin_loader.c
+++ b/src/xrt/targets/common/target_plugin_loader.c
@@ -2206,6 +2206,21 @@ target_plugin_resolve_displays(const struct xrt_display_descriptor *descriptors,
 		    query_source_claims(&g_display_sources[s], descriptors, dn, src_claims[s], XRT_DP_REGISTRY_MAX_ENTRIES);
 	}
 
+	// #791: an explicit PreferredPlugin override (`displayxr-cli dp use <id>`,
+	// or XRT_PREFERRED_PLUGIN_ID off-Windows) must force the WEAVING DP too, not
+	// just the active head-device plug-in. Without this, the per-monitor winner
+	// below is purely EDID confidence / ProbeOrder, so on real vendor hardware
+	// the vendor DP wins the registry even when the user pinned sim_display for
+	// testing — and the compositor then weaves with the vendor DP (exactly how
+	// the #776 "byte-identical sim-vs-Leia" run happened, and why sim N>2 weaving
+	// could not be visually validated on a vendor-hardware box). When the
+	// preferred source claims a monitor, it wins that monitor outright. sim's
+	// probe_displays claims every monitor at FALLBACK confidence, so `dp use
+	// sim-display` forces sim across the board; a pinned vendor that does NOT
+	// claim a given monitor still falls through to confidence for it.
+	char preferred_id[64] = {0};
+	bool have_preferred = target_plugin_get_preferred(preferred_id, sizeof(preferred_id));
+
 	// Resolve per monitor: highest confidence wins; ties → lower ProbeOrder.
 	// Sources are already in ascending ProbeOrder, so a strict `>` keeps the
 	// first (lowest-order) source at any given confidence.
@@ -2213,15 +2228,43 @@ target_plugin_resolve_displays(const struct xrt_display_descriptor *descriptors,
 		const struct xrt_display_descriptor *desc = &descriptors[d];
 		const struct plugin_display_source *best_src = NULL;
 		const struct xrt_display_claim *best_claim = NULL;
-		for (int s = 0; s < g_display_source_count; s++) {
-			for (uint32_t c = 0; c < src_claim_count[s]; c++) {
-				const struct xrt_display_claim *cl = &src_claims[s][c];
-				if (cl->monitor_id != desc->monitor_id) {
+
+		// Preferred-plugin override (#791): if the pinned source claims this
+		// monitor, it wins regardless of confidence / ProbeOrder.
+		if (have_preferred) {
+			for (int s = 0; s < g_display_source_count && best_claim == NULL; s++) {
+				const struct xrt_plugin_iface *sif = g_display_sources[s].iface;
+				const char *sid = (sif != NULL && sif->id != NULL) ? sif->id : NULL;
+				if (sid == NULL || strcmp(sid, preferred_id) != 0) {
 					continue;
 				}
-				if (best_claim == NULL || cl->confidence > best_claim->confidence) {
-					best_claim = cl;
-					best_src = &g_display_sources[s];
+				for (uint32_t c = 0; c < src_claim_count[s]; c++) {
+					if (src_claims[s][c].monitor_id == desc->monitor_id) {
+						best_src = &g_display_sources[s];
+						best_claim = &src_claims[s][c];
+						break;
+					}
+				}
+			}
+			if (best_claim != NULL) {
+				U_LOG_W("plugin loader: monitor 0x%016llx → PreferredPlugin override '%s' "
+				        "(forced over EDID confidence)",
+				        (unsigned long long)desc->monitor_id, preferred_id);
+			}
+		}
+
+		// No preferred claim for this monitor → highest confidence wins.
+		if (best_claim == NULL) {
+			for (int s = 0; s < g_display_source_count; s++) {
+				for (uint32_t c = 0; c < src_claim_count[s]; c++) {
+					const struct xrt_display_claim *cl = &src_claims[s][c];
+					if (cl->monitor_id != desc->monitor_id) {
+						continue;
+					}
+					if (best_claim == NULL || cl->confidence > best_claim->confidence) {
+						best_claim = cl;
+						best_src = &g_display_sources[s];
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Closes #791. Follow-up from #776 — makes `displayxr-cli dp use <id>` (or `XRT_PREFERRED_PLUGIN_ID` off-Windows) force the **weaving** DP, not just the active head-device plug-in, so sim N>2 weaving can be exercised on a vendor-hardware box.

## Root cause

`target_plugin_resolve_displays` built the per-monitor DP registry purely by EDID **claim confidence / ProbeOrder**, ignoring the PreferredPlugin override. The compositor's `info->dp_factory_*` comes from that registry (via `comp_dp_factory_for_window`), so on real vendor hardware the vendor DP won it even under `dp use sim-display` — the runtime kept weaving with the vendor DP while sim was only the *head-device* plug-in. That is the mechanism behind the #776 "byte-identical sim-vs-Leia dump" (Leia wove both times) and `get_predicted_eye_positions` returning `n=2` despite a 4-view atlas.

## Fix

One localized change in the per-monitor resolve loop: when the pinned source claims a monitor, it wins that monitor outright, ahead of the confidence scan. sim's `probe_displays` already claims every monitor at FALLBACK confidence (its comment literally anticipated "a per-display override can force sim"), so `dp use sim-display` forces sim across the board; a pinned vendor that doesn't claim a monitor still falls through to the confidence winner for it. **No behavior change when nothing is pinned** (production ProbeOrder/EDID discovery is untouched). The scalar `dp_factory_*` already followed the active (pinned) plug-in, so registry and scalar now agree — no `comp_dp_factory` drift.

## Hardware-validated (Leia box, `dp use sim-display`, probe `DXR_REQUEST_MODE=4`, no `SIM_DISPLAY_OUTPUT`)

```
service: target_plugin_resolve_displays] monitor ... → PreferredPlugin override 'sim-display' (forced over EDID confidence)
service: sim_display_set_output_mode] Sim display mode changed: Quad
service: #625 weave v6: views=4 grid=2x2 content=640x360 atlas=2560x1440
probe:   eyes(valid=1 track=0 n=4 L.x=-0.0300 R.x=0.0300)      # n=4 (was n=2 = Leia stereo) → SIM is weaving
```
Zero `leia_dp_d3d11_process_atlas` / `leiasr_d3d11_request_display_mode` lines in the service log for the run — Leia is no longer the weaver. Box restored to Leia afterward (verified).

## Note

Applies to every graphics-API `dp_factory_*` (the registry is API-agnostic), so the override is API-wide, not D3D11-only. The `comp_dp_factory_for_window` drift-detector warning stays honest (registry now matches the pinned scalar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)