### PR TITLE
control_panel: surface the resolved display → DP binding — #793 Phase 1

### DIFF
--- a/src/xrt/targets/control_panel/control_panel_main.c
+++ b/src/xrt/targets/control_panel/control_panel_main.c
@@ -178,6 +178,17 @@ struct disp_row
 	bool primary;
 };
 
+//! One resolved monitor→DP binding (from `displays --claims --json`, #793).
+struct claim_row
+{
+	char monitor_id[24]; // "0x0123456789abcdef"
+	char plugin_id[64];
+	char confidence[16]; // FALLBACK / EDID / VERIFIED
+	char apis[64];       // "vk|d3d11|d3d12"
+	char serial[32];
+	int pw, ph, left, top;
+};
+
 struct panel_state
 {
 	// info
@@ -213,6 +224,11 @@ struct panel_state
 	// connected displays (EDID)
 	int n_displays;
 	struct disp_row displays[MAX_DPS];
+
+	// resolved per-display DP binding (display → DP the compositor weaves with)
+	int n_claims;
+	int claims_monitor_count; // total monitors enumerated (claimed or not)
+	struct claim_row claims[MAX_DPS];
 
 	// last dp use/reset feedback
 	char last_action[512];
@@ -416,12 +432,53 @@ refresh_displays(struct panel_state *s)
 	cJSON_Delete(root);
 }
 
+//! Resolved monitor→DP registry (#793): which DP the compositor binds to each
+//! display. Same `target_plugin_resolve_displays` data the CLI prints; the panel
+//! stays a dumb JSON client (ADR-019) by shelling `displays --claims --json`.
+static void
+refresh_claims(struct panel_state *s)
+{
+	s->n_claims = 0;
+	s->claims_monitor_count = 0;
+	char out[16384];
+	if (!run_cli("displays --claims --json", out, sizeof(out)) || out[0] == '\0') {
+		return;
+	}
+	cJSON *root = cJSON_Parse(out);
+	if (root == NULL) {
+		return;
+	}
+	s->claims_monitor_count = (int)get_num(root, "monitor_count");
+	const cJSON *arr = cJSON_GetObjectItemCaseSensitive(root, "claims");
+	if (cJSON_IsArray(arr)) {
+		const cJSON *c = NULL;
+		cJSON_ArrayForEach(c, arr)
+		{
+			if (s->n_claims >= MAX_DPS) {
+				break;
+			}
+			struct claim_row *r = &s->claims[s->n_claims++];
+			cpy_str(r->monitor_id, sizeof(r->monitor_id), c, "monitor_id");
+			cpy_str(r->plugin_id, sizeof(r->plugin_id), c, "plugin_id");
+			cpy_str(r->confidence, sizeof(r->confidence), c, "confidence");
+			cpy_str(r->apis, sizeof(r->apis), c, "supported_apis");
+			cpy_str(r->serial, sizeof(r->serial), c, "serial");
+			r->pw = (int)get_num(c, "pixel_width");
+			r->ph = (int)get_num(c, "pixel_height");
+			r->left = (int)get_num(c, "screen_left");
+			r->top = (int)get_num(c, "screen_top");
+		}
+	}
+	cJSON_Delete(root);
+}
+
 static void
 refresh_all(struct panel_state *s)
 {
 	refresh_info(s);
 	refresh_dp(s);
 	refresh_displays(s);
+	refresh_claims(s);
 }
 
 static void
@@ -439,6 +496,7 @@ dp_action(struct panel_state *s, const char *args)
 		snprintf(s->last_action, sizeof(s->last_action), "Failed to run: displayxr-cli %s", args);
 	}
 	refresh_dp(s);
+	refresh_claims(s); // the override changed which DP binds each display (#793)
 }
 
 
@@ -450,6 +508,7 @@ dp_action(struct panel_state *s, const char *args)
 
 static const ImVec4 COL_GREEN = {0.30f, 0.85f, 0.40f, 1.0f};
 static const ImVec4 COL_RED = {0.95f, 0.35f, 0.35f, 1.0f};
+static const ImVec4 COL_AMBER = {0.98f, 0.75f, 0.25f, 1.0f}; // override-forced binding (#793)
 
 static void
 draw_panel(struct panel_state *s)
@@ -552,6 +611,27 @@ draw_panel(struct panel_state *s)
 		struct disp_row *d = &s->displays[i];
 		igText("[%d] %s %s  %dx%d @ %dHz  pos (%d,%d)%s", i, d->mfr, d->product, d->pw, d->ph, d->hz,
 		       d->left, d->top, d->primary ? "  [primary]" : "");
+	}
+
+	// ---- Resolved display → DP binding (#793) ----
+	igSeparatorText("Display -> DP binding (resolved)");
+	if (igIsItemHovered(0)) {
+		igSetTooltip("Which display processor the runtime bound to each monitor, from the per-monitor "
+		             "registry — by EDID claim confidence, or forced by the PreferredPlugin override "
+		             "below. This is the DP the compositor actually weaves with.");
+	}
+	if (s->n_claims == 0) {
+		igTextDisabled("(no monitor claimed by any plug-in%s)",
+		               s->claims_monitor_count > 0 ? "" : " — Windows-only");
+	}
+	for (int i = 0; i < s->n_claims; i++) {
+		struct claim_row *r = &s->claims[i];
+		bool forced = s->have_preferred && strcmp(r->plugin_id, s->preferred) == 0;
+		igText("%s  %dx%d @ (%d,%d)", r->monitor_id, r->pw, r->ph, r->left, r->top);
+		igTextColored(forced ? COL_AMBER : COL_GREEN, "    -> %s", r->plugin_id);
+		igSameLine(0.0f, -1.0f);
+		igTextDisabled("[%s]  apis=%s%s%s%s", r->confidence, r->apis, r->serial[0] ? "  serial=" : "",
+		               r->serial, forced ? "   (forced by override)" : "");
 	}
 
 	// ---- Self-test ----


### PR DESCRIPTION
Phase 1 of #793. The tray Control Panel showed the *PreferredPlugin override switch* but never the *resolved reality* — which DP the compositor binds to each monitor. This adds that read-only view.

## What

A new **"Display -> DP binding (resolved)"** section that shells `displayxr-cli displays --claims --json` (the same `target_plugin_resolve_displays` data the CLI already prints) and renders, per monitor: id + geometry, bound plug-in, claim confidence (FALLBACK/EDID/VERIFIED), supported APIs, serial.

- The row whose plug-in matches the active `PreferredPlugin` is drawn **amber** with a `(forced by override)` note — so after #792 (where `dp use` now forces the *weaving* DP too) it is obvious when a display's DP is pinned vs auto-selected by EDID confidence.
- `dp_action()` refreshes the binding table after Use/Reset, so it updates live when you switch DPs from the panel.
- The panel stays a **dumb JSON client** (ADR-019) — zero runtime/vendor symbols linked; all resolution stays in the CLI (one source of truth).

## Scope

Read-only overview only. Deferred to the issue:
- **Phase 2** — loud persistent-override banner + optional session-scoped override (the `dp use` HKLM-persistence footgun).
- **Phase 3** — per-display override (needs a new override schema; the registry is already per-monitor but `PreferredPlugin` is a single global id).

## Verification

Built clean; panel launches and renders. CLI feed confirmed on the Leia box:
```
displays --claims --json → monitor 0x8c41…2ce7 → leia-sr (VERIFIED, apis vk|d3d11|d3d12|gl)
```
which the section renders green (no override set). GUI screenshots are unreliable on this box (foreground/scroll automation) — the new section sits below the fold; eyeball by launching `displayxr-control-panel.exe` and scrolling to "Display -> DP binding (resolved)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)