### PR TITLE
runtime(zones): raise maxZones3D 8 → 32; make the zone draw budget loud

### DIFF
--- a/docs/adr/ADR-027-display-zones.md
+++ b/docs/adr/ADR-027-display-zones.md
@@ -195,8 +195,16 @@ Type values 1004999150–153. Header-level sketch:
 
 Scope rules: extension-app classes only (like `local_3d_zone`); view count per
 zone = the session's view count (display modes are session-global — zones vary
-in rect/rig/size, never in view count); `maxZones3D` advertised as 8
+in rect/rig/size, never in view count); `maxZones3D` advertised as 32
 (compositor-side assembly makes the budget plugin-independent).
+
+Why 32 and not "unlimited": every zone alpha-overs into the ONE mode-sized
+atlas (§Composition rules), so zone count costs draw calls, never surface
+area — the cap is an API-level ceiling, not a pipeline limit. It is held at or
+below the compositor's own per-frame draw budget (`VK_ZONE_MAX_DRAWS`, sized
+`maxZones3D × XRT_MAX_VIEWS`) so the advertised number is always the one that
+binds first; raising either without the other is a bug. Originally 8, raised
+once the fixed-atlas assembly made a larger number nearly free.
 
 ### Composition rules — overlap and ordering
 

--- a/docs/specs/extensions/XR_DXR_display_zones.md
+++ b/docs/specs/extensions/XR_DXR_display_zones.md
@@ -82,7 +82,7 @@ typedef struct XrDisplayZoneCapabilitiesDXR {
     XrStructureType    type;          // XR_TYPE_DISPLAY_ZONE_CAPABILITIES_DXR
     void* XR_MAY_ALIAS next;
     XrBool32           supported;     // XR_FALSE => only the legacy single-canvas path
-    uint32_t           maxZones3D;    // max zone-chained projection layers per frame (8)
+    uint32_t           maxZones3D;    // max zone-chained projection layers per frame (32)
 } XrDisplayZoneCapabilitiesDXR;
 
 XRAPI_ATTR XrResult XRAPI_CALL xrGetDisplayZoneCapabilitiesDXR(

--- a/src/xrt/compositor/vk_native/comp_vk_native_renderer.c
+++ b/src/xrt/compositor/vk_native/comp_vk_native_renderer.c
@@ -41,8 +41,12 @@
 #include "shaders/zone_blit.frag.h"
 
 //! Upper bound on zone draws (and so descriptor sets) per frame:
-//! layers (16) × views (8).
-#define VK_ZONE_MAX_DRAWS 128
+//! zones (OXR_DISPLAY_ZONES_MAX_ZONES_3D = 32) × views (XRT_MAX_VIEWS = 8).
+//! Deliberately >= the advertised maxZones3D at the worst-case view count, so
+//! this budget can never be the binding constraint before the API-level cap the
+//! app was told about (xrGetDisplayZoneCapabilitiesDXR). If the zone cap is
+//! raised, raise this with it.
+#define VK_ZONE_MAX_DRAWS 256
 
 /*!
  * Vulkan renderer structure.
@@ -832,7 +836,23 @@ draw_zones_pass(struct comp_vk_native_renderer *r,
 					break;
 				}
 			}
-			if (seen || transitioned_count >= VK_ZONE_MAX_DRAWS) {
+			if (transitioned_count >= VK_ZONE_MAX_DRAWS && !seen) {
+				// Budget exhausted: this image never gets its layout
+				// transition, so its zone silently disappears. One-shot
+				// (never per-frame) so an overflowing app is diagnosable
+				// without flooding the log.
+				static bool s_warned_transitions = false;
+				if (!s_warned_transitions) {
+					s_warned_transitions = true;
+					U_LOG_W(
+					    "VK zones: image-transition budget (%d) exhausted — zones beyond it "
+					    "will not render. Raise VK_ZONE_MAX_DRAWS alongside "
+					    "OXR_DISPLAY_ZONES_MAX_ZONES_3D.",
+					    VK_ZONE_MAX_DRAWS);
+				}
+				continue;
+			}
+			if (seen) {
 				continue;
 			}
 			transitioned[transitioned_count++] = img;
@@ -877,7 +897,21 @@ draw_zones_pass(struct comp_vk_native_renderer *r,
 
 		for (uint32_t eye = 0; eye < view_count; eye++) {
 			struct xrt_swapchain *xsc = layer->sc_array[eye];
-			if (xsc == NULL || draw_count >= VK_ZONE_MAX_DRAWS) {
+			if (draw_count >= VK_ZONE_MAX_DRAWS) {
+				// Same silent-drop hazard as the transition loop above:
+				// warn once rather than quietly losing a zone.
+				static bool s_warned_draws = false;
+				if (!s_warned_draws) {
+					s_warned_draws = true;
+					U_LOG_W(
+					    "VK zones: draw budget (%d) exhausted — zones beyond it will not "
+					    "render. Raise VK_ZONE_MAX_DRAWS alongside "
+					    "OXR_DISPLAY_ZONES_MAX_ZONES_3D.",
+					    VK_ZONE_MAX_DRAWS);
+				}
+				continue;
+			}
+			if (xsc == NULL) {
 				continue;
 			}
 			uint32_t sc_index = layer->data.proj.v[eye].sub.image_index;

--- a/src/xrt/state_trackers/oxr/oxr_objects.h
+++ b/src/xrt/state_trackers/oxr/oxr_objects.h
@@ -138,7 +138,13 @@ struct oxr_local_3d_zone_ext;
 
 //! XR_DXR_display_zones: max zone-chained projection layers per frame
 //! (ADR-027 — plugin-independent, compositor-side assembly).
-#define OXR_DISPLAY_ZONES_MAX_ZONES_3D 8
+//!
+//! Zones do NOT each get their own atlas: every zone alpha-overs into the one
+//! mode-sized atlas (draw_zones_pass), so this cap costs draw calls, not
+//! surface area. It is therefore a deliberate API-level ceiling, not a pipeline
+//! limit — the compositor's own budget (VK_ZONE_MAX_DRAWS) is kept at
+//! this value x XRT_MAX_VIEWS so it can never bind first.
+#define OXR_DISPLAY_ZONES_MAX_ZONES_3D 32
 
 struct time_state;
 


### PR DESCRIPTION
## Why

`maxZones3D` was advertised as **8**. That number implied a per-zone cost that does not exist: `draw_zones_pass` alpha-overs **every zone into the one mode-sized atlas** (`c->eff_layout` = window × scaleXY of the active rendering mode). Zone count costs **draw calls, not surface area** — so 8 was an API-level ceiling inherited from an early estimate, not a pipeline limit.

Related design point already in ADR-027 and unchanged here: view count is session-global, so all zones in a frame share one view count. `draw_zones_pass` clamps each layer's `view_count` to `layout->views`, so a mono zone simply draws fewer tiles — no misindexing.

## What

- `OXR_DISPLAY_ZONES_MAX_ZONES_3D` **8 → 32**. Only stack arrays / loop bounds key off it (`located[]`, `zone_ids[]`, `zone_rects[]`).
- `VK_ZONE_MAX_DRAWS` **128 → 256**, deliberately held at `maxZones3D × XRT_MAX_VIEWS` so the compositor's internal budget can never bind *before* the cap the app was told about via `xrGetDisplayZoneCapabilitiesDXR`.
- **Silent-drop fix:** both over-budget paths (image transitions, draws) were a bare `continue` that quietly lost a zone. Each now warns **once** (never per-frame, per the logging convention). Unreachable at the shipped cap — but reachable the moment either constant moves, which is exactly when you want the warning to already exist.
- ADR-027 + `XR_DXR_display_zones.md` updated with the new value **and** the invariant that the two constants move together.

## Testing

- `scripts\build_windows.bat build` — ALL DONE.
- `displayxr-cli selftest` — PASSED, `zone_caps supported=1`.
- No behavioural change at ≤ 8 zones; this only widens a ceiling and adds warnings.

Not load-bearing on hardware yet: no app currently submits more than 2 zones, so the raise is untested above that in practice. The cap being *discoverable* (`maxZones3D`) means apps that care already query it rather than hardcoding 8.