### PR TITLE
control_panel: loud persistent-override banner — #793 Phase 2

### DIFF
--- a/src/xrt/targets/control_panel/control_panel_main.c
+++ b/src/xrt/targets/control_panel/control_panel_main.c
@@ -540,6 +540,32 @@ draw_panel(struct panel_state *s)
 		}
 	}
 
+	// ---- Persistent-override banner (#793 Phase 2) ----
+	// `dp use` writes HKLM PreferredPlugin and PERSISTS across reboots — a known
+	// footgun: a box left pinned (e.g. to sim_display for a test) keeps using that
+	// DP for every app and every reboot until someone notices. Surface it loudly,
+	// above everything else, whenever an override is active, with one-click reset.
+	// Shown before the have_info early-return so a mis-pinned DP that breaks the
+	// runtime is still self-evidently the cause.
+	if (s->have_preferred) {
+		igSpacing();
+		igTextColored(COL_AMBER,
+		              "[!] DP OVERRIDE ACTIVE - '%s' is forced for every app and persists across "
+		              "reboots until reset.",
+		              s->preferred);
+		const ImVec4 red = {0.60f, 0.12f, 0.12f, 1.0f};
+		const ImVec4 red_hi = {0.78f, 0.18f, 0.18f, 1.0f};
+		igPushStyleColor_Vec4(ImGuiCol_Button, red);
+		igPushStyleColor_Vec4(ImGuiCol_ButtonHovered, red_hi);
+		igPushStyleColor_Vec4(ImGuiCol_ButtonActive, red_hi);
+		if (igButton("Reset DP override now", (ImVec2){0, 0})) {
+			dp_action(s, "dp reset");
+		}
+		igPopStyleColor(3);
+		igSpacing();
+		igSeparator();
+	}
+
 	if (!s->have_info) {
 		igSpacing();
 		igTextColored(COL_RED, "%s", s->info_err[0] ? s->info_err : "No runtime info.");


### PR DESCRIPTION
Phase 2 of #793. Addresses the `dp use` persistence footgun directly.

## Why

`dp use` writes HKLM `PreferredPlugin` and **persists across reboots**. A box left pinned (e.g. to sim_display for a test) keeps using that DP for every app and every reboot until someone notices — and #792 raised the stakes by making the override force the *weaving* DP too.

## What

An unmissable banner at the **very top** of the Control Panel, shown only when an override is active:
- amber `[!] DP OVERRIDE ACTIVE - '<id>' is forced for every app and persists across reboots until reset`
- a red **"Reset DP override now"** button (one-click `dp reset`)

Rendered *before* the `have_info` early-return, so even a mis-pinned DP that breaks runtime startup is still self-evidently the cause. Uses only cimgui symbols already present (`igPushStyleColor_Vec4` / `igPopStyleColor`).

Verified on the Leia box (`dp use sim-display` → panel shows the banner → reset restores auto/Leia):


## Not in scope

A true **session-scoped** override (auto-clear on service restart) needs runtime support — the service reads `PreferredPlugin` from HKLM at startup with no session-scoped mechanism. Left to a follow-up; the loud banner + one-click reset covers the footgun the persistence created. Phase 3 (per-display override) also remains in #793.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
