### PR TITLE
fix(vk,#757): Linux desktop-capture dma-buf enable + vk_bundle ABI-parity layout (plugin ABI v5)

### DIFF
--- a/src/xrt/auxiliary/vk/vk_bundle_init.c
+++ b/src/xrt/auxiliary/vk/vk_bundle_init.c
@@ -19,6 +19,8 @@
  * @ingroup aux_vk
  */
 
+#include "xrt/xrt_config_os.h"
+
 #include "util/u_pretty_print.h"
 #include "vk/vk_helpers.h"
 
@@ -1814,6 +1816,45 @@ vk_init_from_given(struct vk_bundle *vk,
 		vk->has_EXT_external_memory_metal = true;
 	}
 #endif
+
+#if defined(XRT_OS_LINUX) && !defined(XRT_OS_ANDROID)
+	/*
+	 * Desktop-background capture (runtime#757): the display processor imports
+	 * PipeWire dma-bufs on this externally-created device, gated on
+	 * has_KHR_external_memory / has_EXT_external_memory_dma_buf /
+	 * has_EXT_image_drm_format_modifier. Vulkan does not let us read what
+	 * extensions the app enabled, and VK_EXT_external_memory_dma_buf carries
+	 * no entry points to probe — but the runtime's
+	 * xrGetVulkanDeviceExtensionsKHR / xrCreateVulkanDeviceKHR contract lists
+	 * the dma-buf import set on desktop Linux, so a conforming app has enabled
+	 * them. Gate on physical-device support so we never claim what the driver
+	 * lacks.
+	 */
+	{
+		uint32_t prop_count = 0;
+		ret = vk->vkEnumerateDeviceExtensionProperties(vk->physical_device, NULL, &prop_count, NULL);
+		if (ret == VK_SUCCESS && prop_count > 0) {
+			VkExtensionProperties *props = U_TYPED_ARRAY_CALLOC(VkExtensionProperties, prop_count);
+			if (props != NULL &&
+			    vk->vkEnumerateDeviceExtensionProperties(vk->physical_device, NULL, &prop_count,
+			                                             props) == VK_SUCCESS) {
+				for (uint32_t i = 0; i < prop_count; i++) {
+					const char *name = props[i].extensionName;
+					if (strcmp(name, VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME) == 0) {
+						vk->has_KHR_external_memory = true;
+					}
+					if (strcmp(name, VK_EXT_EXTERNAL_MEMORY_DMA_BUF_EXTENSION_NAME) == 0) {
+						vk->has_EXT_external_memory_dma_buf = true;
+					}
+					if (strcmp(name, VK_EXT_IMAGE_DRM_FORMAT_MODIFIER_EXTENSION_NAME) == 0) {
+						vk->has_EXT_image_drm_format_modifier = true;
+					}
+				}
+			}
+			free(props);
+		}
+	}
+#endif // XRT_OS_LINUX && !XRT_OS_ANDROID
 
 	return VK_SUCCESS;
 

--- a/src/xrt/auxiliary/vk/vk_helpers.h
+++ b/src/xrt/auxiliary/vk/vk_helpers.h
@@ -273,6 +273,17 @@ struct vk_bundle
 
 #endif // defined(VK_EXT_calibrated_timestamps)
 
+	// ABI NOTE (config-skew guard): every VK_USE_PLATFORM_*-conditional member
+	// below keeps an identically-named PFN_vkVoidFunction placeholder in the
+	// #else branch, so sizeof(struct vk_bundle) and all member offsets are
+	// IDENTICAL no matter which platform macros a given translation unit (or a
+	// separately-configured consumer, e.g. a display-processor plug-in built
+	// against these headers) was compiled with. A raw vk_bundle * crosses the
+	// runtime -> plug-in DP-factory boundary, so a layout that varies with
+	// feature *detection* (pkg-config finding wayland-client, etc.) is an ABI
+	// landmine: one missing -dev package skews every member after the gap and
+	// the first vk-> call dereferences the wrong slot (SIGSEGV with PC=0).
+	// Do NOT add a conditional member here without the parity #else.
 #if defined(VK_USE_PLATFORM_DISPLAY_KHR)
 	PFN_vkCreateDisplayPlaneSurfaceKHR vkCreateDisplayPlaneSurfaceKHR;
 	PFN_vkGetDisplayPlaneCapabilitiesKHR vkGetDisplayPlaneCapabilitiesKHR;
@@ -280,44 +291,59 @@ struct vk_bundle
 	PFN_vkGetPhysicalDeviceDisplayPlanePropertiesKHR vkGetPhysicalDeviceDisplayPlanePropertiesKHR;
 	PFN_vkGetDisplayModePropertiesKHR vkGetDisplayModePropertiesKHR;
 	PFN_vkReleaseDisplayEXT vkReleaseDisplayEXT;
-
+#else
+	PFN_vkVoidFunction vkCreateDisplayPlaneSurfaceKHR;
+	PFN_vkVoidFunction vkGetDisplayPlaneCapabilitiesKHR;
+	PFN_vkVoidFunction vkGetPhysicalDeviceDisplayPropertiesKHR;
+	PFN_vkVoidFunction vkGetPhysicalDeviceDisplayPlanePropertiesKHR;
+	PFN_vkVoidFunction vkGetDisplayModePropertiesKHR;
+	PFN_vkVoidFunction vkReleaseDisplayEXT;
 #endif // defined(VK_USE_PLATFORM_DISPLAY_KHR)
 
 #if defined(VK_USE_PLATFORM_XCB_KHR)
 	PFN_vkCreateXcbSurfaceKHR vkCreateXcbSurfaceKHR;
-
+#else
+	PFN_vkVoidFunction vkCreateXcbSurfaceKHR;
 #endif // defined(VK_USE_PLATFORM_XCB_KHR)
 
 #if defined(VK_USE_PLATFORM_WAYLAND_KHR)
 	PFN_vkCreateWaylandSurfaceKHR vkCreateWaylandSurfaceKHR;
-
+#else
+	PFN_vkVoidFunction vkCreateWaylandSurfaceKHR;
 #endif // defined(VK_USE_PLATFORM_WAYLAND_KHR)
 
 #if defined(VK_USE_PLATFORM_WAYLAND_KHR) && defined(VK_EXT_acquire_drm_display)
 	PFN_vkAcquireDrmDisplayEXT vkAcquireDrmDisplayEXT;
 	PFN_vkGetDrmDisplayEXT vkGetDrmDisplayEXT;
-
+#else
+	PFN_vkVoidFunction vkAcquireDrmDisplayEXT;
+	PFN_vkVoidFunction vkGetDrmDisplayEXT;
 #endif // defined(VK_USE_PLATFORM_WAYLAND_KHR) && defined(VK_EXT_acquire_drm_display)
 
 #if defined(VK_USE_PLATFORM_XLIB_XRANDR_EXT)
 	PFN_vkGetRandROutputDisplayEXT vkGetRandROutputDisplayEXT;
 	PFN_vkAcquireXlibDisplayEXT vkAcquireXlibDisplayEXT;
-
+#else
+	PFN_vkVoidFunction vkGetRandROutputDisplayEXT;
+	PFN_vkVoidFunction vkAcquireXlibDisplayEXT;
 #endif // defined(VK_USE_PLATFORM_XLIB_XRANDR_EXT)
 
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
 	PFN_vkCreateAndroidSurfaceKHR vkCreateAndroidSurfaceKHR;
-
+#else
+	PFN_vkVoidFunction vkCreateAndroidSurfaceKHR;
 #endif // defined(VK_USE_PLATFORM_ANDROID_KHR)
 
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
 	PFN_vkCreateWin32SurfaceKHR vkCreateWin32SurfaceKHR;
-
+#else
+	PFN_vkVoidFunction vkCreateWin32SurfaceKHR;
 #endif // defined(VK_USE_PLATFORM_WIN32_KHR)
 
 #if defined(VK_USE_PLATFORM_METAL_EXT)
 	PFN_vkCreateMetalSurfaceEXT vkCreateMetalSurfaceEXT;
-
+#else
+	PFN_vkVoidFunction vkCreateMetalSurfaceEXT;
 #endif // defined(VK_USE_PLATFORM_METAL_EXT)
 
 #if defined(VK_EXT_display_surface_counter)
@@ -454,13 +480,19 @@ struct vk_bundle
 	PFN_vkAcquireNextImageKHR vkAcquireNextImageKHR;
 	PFN_vkQueuePresentKHR vkQueuePresentKHR;
 
+	// ABI parity #else branches — see the config-skew guard note above.
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
 	PFN_vkGetMemoryWin32HandleKHR vkGetMemoryWin32HandleKHR;
 	PFN_vkGetFenceWin32HandleKHR vkGetFenceWin32HandleKHR;
 	PFN_vkGetSemaphoreWin32HandleKHR vkGetSemaphoreWin32HandleKHR;
 	PFN_vkImportFenceWin32HandleKHR vkImportFenceWin32HandleKHR;
 	PFN_vkImportSemaphoreWin32HandleKHR vkImportSemaphoreWin32HandleKHR;
-
+#else
+	PFN_vkVoidFunction vkGetMemoryWin32HandleKHR;
+	PFN_vkVoidFunction vkGetFenceWin32HandleKHR;
+	PFN_vkVoidFunction vkGetSemaphoreWin32HandleKHR;
+	PFN_vkVoidFunction vkImportFenceWin32HandleKHR;
+	PFN_vkVoidFunction vkImportSemaphoreWin32HandleKHR;
 #endif // defined(VK_USE_PLATFORM_WIN32_KHR)
 
 #if !defined(VK_USE_PLATFORM_WIN32_KHR)
@@ -469,13 +501,20 @@ struct vk_bundle
 	PFN_vkGetSemaphoreFdKHR vkGetSemaphoreFdKHR;
 	PFN_vkImportFenceFdKHR vkImportFenceFdKHR;
 	PFN_vkImportSemaphoreFdKHR vkImportSemaphoreFdKHR;
-
+#else
+	PFN_vkVoidFunction vkGetMemoryFdKHR;
+	PFN_vkVoidFunction vkGetFenceFdKHR;
+	PFN_vkVoidFunction vkGetSemaphoreFdKHR;
+	PFN_vkVoidFunction vkImportFenceFdKHR;
+	PFN_vkVoidFunction vkImportSemaphoreFdKHR;
 #endif // !defined(VK_USE_PLATFORM_WIN32_KHR)
 
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
 	PFN_vkGetMemoryAndroidHardwareBufferANDROID vkGetMemoryAndroidHardwareBufferANDROID;
 	PFN_vkGetAndroidHardwareBufferPropertiesANDROID vkGetAndroidHardwareBufferPropertiesANDROID;
-
+#else
+	PFN_vkVoidFunction vkGetMemoryAndroidHardwareBufferANDROID;
+	PFN_vkVoidFunction vkGetAndroidHardwareBufferPropertiesANDROID;
 #endif // defined(VK_USE_PLATFORM_ANDROID_KHR)
 
 #if defined(VK_EXT_external_memory_host)

--- a/src/xrt/compositor/client/comp_vk_glue.c
+++ b/src/xrt/compositor/client/comp_vk_glue.c
@@ -56,6 +56,13 @@ const char *xrt_gfx_vk_device_extensions = VK_KHR_DEDICATED_ALLOCATION_EXTENSION
     // VK native compositor on desktop Linux presents on the app's VkDevice via a
     // swapchain over the XCB surface (comp_vk_native_target)
     " " VK_KHR_SWAPCHAIN_EXTENSION_NAME
+    // Desktop-background capture (runtime#757): the display processor imports
+    // PipeWire dma-bufs on the app's VkDevice (the same vk_bundle the DP
+    // weaves with), so the device needs the dma-buf import set. Universally
+    // supported by Mesa and the NVIDIA driver on the desktop-Linux targets we
+    // ship (Preview).
+    " " VK_EXT_EXTERNAL_MEMORY_DMA_BUF_EXTENSION_NAME
+    " " VK_EXT_IMAGE_DRM_FORMAT_MODIFIER_EXTENSION_NAME
 #endif
 
 #elif defined(XRT_GRAPHICS_BUFFER_HANDLE_IS_AHARDWAREBUFFER)

--- a/src/xrt/include/xrt/xrt_plugin.h
+++ b/src/xrt/include/xrt/xrt_plugin.h
@@ -283,11 +283,24 @@ struct xrt_display_claim
  * transparency enable the other variants already had), and the extension struct
  * drops `chromaKeyColor` (XR_DXR_win32_window_binding SPEC_VERSION 7→8). True
  * transparency (alpha-capable swapchain + transparent present) is the sole path.
+ *
+ * v4 → v5 history (#757): `struct vk_bundle` — whose raw pointer crosses the
+ * runtime → plug-in boundary via the VK DP factory — gained ABI-parity #else
+ * placeholder members for every `VK_USE_PLATFORM_*`-conditional PFN slot, so
+ * its layout no longer varies with feature *detection* at configure time
+ * (pkg-config finding wayland-client etc.). For any config that previously
+ * compiled without one of those platform macros this inserts members — a
+ * layout break versus v4 binaries — but it is the LAST such break: the layout
+ * is now identical across configs by construction. The Linux VK DP contract
+ * also newly guarantees the dma-buf import extension set on the app device
+ * (VK_EXT_external_memory_dma_buf + VK_EXT_image_drm_format_modifier,
+ * desktop-background capture).
  */
 #define XRT_PLUGIN_API_VERSION_1 1
 #define XRT_PLUGIN_API_VERSION_2 2
 #define XRT_PLUGIN_API_VERSION_3 3
 #define XRT_PLUGIN_API_VERSION_4 4
+#define XRT_PLUGIN_API_VERSION_5 5
 
 /*!
  * The version the runtime / plug-in is built against at compile time.
@@ -295,7 +308,7 @@ struct xrt_display_claim
  * `*out_plugin_api_version` are rejected by the runtime (ADR-020 rule 3) with a
  * logged error, and the loader falls back to the next plug-in / sim_display.
  */
-#define XRT_PLUGIN_API_VERSION_CURRENT XRT_PLUGIN_API_VERSION_4
+#define XRT_PLUGIN_API_VERSION_CURRENT XRT_PLUGIN_API_VERSION_5
 
 /*!
  * The single exported symbol every plug-in DLL must provide. C linkage,

--- a/src/xrt/state_trackers/oxr/oxr_plugin_stub.c
+++ b/src/xrt/state_trackers/oxr/oxr_plugin_stub.c
@@ -34,11 +34,11 @@
 _Static_assert(sizeof(XRT_PLUGIN_ENTRYPOINT_NAME) == sizeof("xrtPluginNegotiate"),
                "xrt_plugin: entry-point symbol name changed; coordinate with all plug-in builds");
 
-/* Current API version is the v4 line (#573 removed set_chroma_key from all DP
- * vtables + added set_transparent_background to d3d12/gl) — bump deliberately,
- * not by accident. */
-_Static_assert(XRT_PLUGIN_API_VERSION_CURRENT == XRT_PLUGIN_API_VERSION_4,
-               "xrt_plugin: API version current/v4 drift");
+/* Current API version is the v5 line (#757 vk_bundle ABI-parity layout +
+ * Linux dma-buf device-extension guarantee) — bump deliberately, not by
+ * accident. */
+_Static_assert(XRT_PLUGIN_API_VERSION_CURRENT == XRT_PLUGIN_API_VERSION_5,
+               "xrt_plugin: API version current/v5 drift");
 
 /*
  * Host iface layout. struct_size must be the first field so plug-ins can

--- a/src/xrt/state_trackers/oxr/oxr_vulkan.c
+++ b/src/xrt/state_trackers/oxr/oxr_vulkan.c
@@ -210,6 +210,15 @@ static const char *optional_device_extensions[] = {
 #else
     NULL, // avoid zero sized array with UB
 #endif
+
+#if defined(XRT_OS_LINUX) && !defined(XRT_OS_ANDROID) && defined(XRT_GRAPHICS_BUFFER_HANDLE_IS_FD)
+    // Desktop-background capture (runtime#757): dma-buf import on the app's
+    // VkDevice so the display processor can consume PipeWire screencast
+    // buffers. Optional here (checked against the physical device); the
+    // enable1 string in comp_vk_glue.c lists them unconditionally.
+    VK_EXT_EXTERNAL_MEMORY_DMA_BUF_EXTENSION_NAME,
+    VK_EXT_IMAGE_DRM_FORMAT_MODIFIER_EXTENSION_NAME,
+#endif
 };
 
 static bool


### PR DESCRIPTION
## What

Three coupled changes that make **live desktop background capture** (compose-under-bg transparency, #757) work on an installed Linux box, and permanently close the ABI-landmine class it exposed:

1. **dma-buf import set on the app's VkDevice.** The Linux VK DP imports PipeWire screencast dma-bufs on the same device the app created (`vk_init_from_given` wraps it). The device-extension contract now includes `VK_EXT_external_memory_dma_buf` + `VK_EXT_image_drm_format_modifier`:
   - enable1: static `xrt_gfx_vk_device_extensions` string (desktop-Linux FD block)
   - enable2: `optional_device_extensions` (per-device checked)
   - `vk_init_from_given` fills the three `has_*` gates via a physical-device support probe (Vulkan can't read back enabled extensions; dma_buf has no entry points to probe)

2. **`vk_bundle` ABI-parity guard.** Every `VK_USE_PLATFORM_*`-conditional member keeps an identically-named `PFN_vkVoidFunction` placeholder in the `#else` branch → sizeof/offsets are identical regardless of configure-time feature detection. This kills the class of crash where a plug-in built on a box *with* wayland-client skewed one pointer against a CI runtime built *without* it (SIGSEGV, PC=0, first `vk->` call in `process_atlas` — bisected live on HW).

3. **Plugin ABI v4 → v5** (+ the deliberate-bump pin assert). The parity layout changes `vk_bundle` versus every shipped v4 binary, and `vk_bundle*` crosses the DP-factory boundary — so per ADR-020 this is a negotiate-visible break: mismatched pairings are rejected cleanly (fallback to sim-display) instead of crashing.

## Validated on HW (Suzhou Odyssey box)

- Avatar transparent overlay with **live desktop weave-under**: portal grant once (with leia-plugin's restore-token PR), then **silent re-grant on every relaunch**; `compose-under-bg pipeline initialized`, zero capture warnings
- The skew crash reproduced with a mixed-config pairing and is gone with parity-built binaries

## Release coupling

Runtime **v2.2.0** must ship together with leia-plugin **v2.0.5** (RUNTIME_REF bump + pipewire in its Deb job — plugin PR follows) via bundle v2.0.11. The versions.json ABI gate enforces the pairing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)