### PR TITLE
runtime(zones,#800): per-zone opt-in cosmetic feather — XrDisplayZoneFeatherDXR

### DIFF
--- a/docs/specs/extensions/XR_DXR_display_zones.md
+++ b/docs/specs/extensions/XR_DXR_display_zones.md
@@ -132,6 +132,30 @@ logs/captures, and as the stable referent for the reserved effective-mask
 readback. There is **no zone handle** — zones are stateless per-frame data,
 like layers; only the mask owns GPU resources and already has a handle.
 
+### 3.3.1 XrDisplayZoneFeatherDXR — per-zone opt-in cosmetic feather (spec v3)
+
+```c
+/*!
+ * OPT-IN cosmetic edge feather for one zone (runtime#800). Chained on
+ * XrDisplayZoneDXR::next at the xrEndFrame chain point; read at submit (a
+ * feather on the locate instance is ignored). Absent = HARD edge — feathering
+ * is a purely cosmetic feature the app must request, never a runtime default.
+ *
+ * radiusPx: inward ramp width in client-window pixels — the zone's weave
+ * fades toward transparent over the first radiusPx inside each zone edge.
+ * 0 / negative / NaN = hard edge. The runtime clamps to half the zone's
+ * shorter side.
+ *
+ * COMPOSITE-only: the published hardware wish stays binary regardless — the
+ * wish is the app's hardware signal and a cosmetic fade never enters it.
+ */
+typedef struct XrDisplayZoneFeatherDXR {
+    XrStructureType          type;     // XR_TYPE_DISPLAY_ZONE_FEATHER_DXR (1004999154)
+    const void* XR_MAY_ALIAS next;
+    float                    radiusPx;
+} XrDisplayZoneFeatherDXR;
+```
+
 ### 3.4 XrDisplayZonesFrameEndInfoDXR — per-frame wish reference
 
 ```c
@@ -139,7 +163,8 @@ like layers; only the mask owns GPU resources and already has a handle.
  * Optional, chained on XrFrameEndInfo::next in a zones frame.
  *
  * Absent, or wishMask == XR_NULL_HANDLE: the wish AUTO-DERIVES as the union
- * of the frame's 3D-zone rects with an implementation-defined feather.
+ * of the frame's 3D-zone rects, BINARY (hard-edged) — cosmetic feathering is
+ * per-zone opt-in via XrDisplayZoneFeatherDXR and never enters the wish.
  *
  * Present with a mask: that mask is the frame's wish verbatim — atomic with
  * the layer set. In zones mode the wish is HARDWARE-ONLY: it does not gate

--- a/src/external/openxr_includes/openxr/XR_DXR_display_zones.h
+++ b/src/external/openxr_includes/openxr/XR_DXR_display_zones.h
@@ -62,7 +62,11 @@ extern "C" {
 // canvas size in pixels (the shell-driven workspace tile this session composites
 // into; follows tile resize). A minimized engine tile (whose OS window/backbuffer
 // can't track the resize) queries this to re-author to the current tile.
-#define XR_DXR_display_zones_SPEC_VERSION 2
+// SPEC_VERSION 3 (runtime#800): + XrDisplayZoneFeatherDXR — per-zone cosmetic
+// edge feather, OPT-IN. Zone edges are HARD by default (and the published
+// hardware wish is always binary/un-feathered regardless of this struct);
+// chain a feather on the zone at xrEndFrame to soften the COMPOSITE only.
+#define XR_DXR_display_zones_SPEC_VERSION 3
 #define XR_DXR_DISPLAY_ZONES_EXTENSION_NAME "XR_DXR_display_zones"
 
 // Extension type-value range (1004999xxx); replace with a Khronos-assigned
@@ -71,6 +75,7 @@ extern "C" {
 #define XR_TYPE_DISPLAY_ZONE_DXR                            ((XrStructureType)1004999151)
 #define XR_TYPE_DISPLAY_ZONES_FRAME_END_INFO_DXR            ((XrStructureType)1004999152)
 #define XR_TYPE_EVENT_DATA_DISPLAY_ZONE_METRICS_CHANGED_DXR ((XrStructureType)1004999153)
+#define XR_TYPE_DISPLAY_ZONE_FEATHER_DXR                    ((XrStructureType)1004999154)
 
 typedef XrFlags64 XrDisplayZonesFrameEndFlagsDXR;
 //! Cross-check zone/locate/mask consistency this frame: zone rects vs wish
@@ -129,11 +134,33 @@ typedef struct XrDisplayZoneDXR {
 } XrDisplayZoneDXR;
 
 /*!
+ * @brief OPT-IN cosmetic edge feather for one zone (spec v3, runtime#800).
+ *
+ * Chained on XrDisplayZoneDXR::next at the xrEndFrame chain point. Absent (the
+ * default), the zone's composite edge is HARD — feathering is a purely
+ * cosmetic feature the app must request, never an implementation default.
+ *
+ * @c radiusPx is the inward ramp width in client-window pixels: the zone's
+ * weave fades toward transparent over the first radiusPx inside each zone
+ * edge. 0 (or a negative/NaN value) = hard edge, identical to not chaining.
+ *
+ * COMPOSITE-only: the published hardware wish stays binary regardless — the
+ * wish is the app's hardware signal and a cosmetic fade never belongs in it.
+ * Read at submit; a feather chained on the locate instance is ignored.
+ */
+typedef struct XrDisplayZoneFeatherDXR {
+    XrStructureType          type;     //!< XR_TYPE_DISPLAY_ZONE_FEATHER_DXR
+    const void* XR_MAY_ALIAS next;
+    float                    radiusPx; //!< inward ramp width, client-window px; 0 = hard
+} XrDisplayZoneFeatherDXR;
+
+/*!
  * @brief Per-frame wish reference. Optional, chained on XrFrameEndInfo::next
  *        in a zones frame.
  *
  * Absent, or wishMask == XR_NULL_HANDLE: the wish AUTO-DERIVES as the union
- * of the frame's 3D-zone rects with an implementation-defined feather.
+ * of the frame's 3D-zone rects, BINARY (hard-edged) — cosmetic feathering is
+ * per-zone opt-in via XrDisplayZoneFeatherDXR and never enters the wish.
  *
  * Present with a mask: that mask is the frame's wish verbatim — atomic with
  * the layer set. In zones mode the wish is HARDWARE-ONLY: it does not gate

--- a/src/xrt/auxiliary/vk/vk_local2d_composite.c
+++ b/src/xrt/auxiliary/vk/vk_local2d_composite.c
@@ -565,6 +565,104 @@ vk_local2d_composite_raster_mask_rings(struct vk_local2d_composite *lc,
 }
 
 void
+vk_local2d_composite_raster_mask_zones(struct vk_local2d_composite *lc,
+                                       struct vk_bundle *vk,
+                                       VkCommandBuffer cmd,
+                                       VkFramebuffer mask_fb,
+                                       uint32_t w,
+                                       uint32_t h,
+                                       const struct xrt_rect *rects,
+                                       const float *feather_px,
+                                       uint32_t rect_count)
+{
+	if (!lc->initialized || mask_fb == VK_NULL_HANDLE || w == 0 || h == 0 || rects == NULL ||
+	    rect_count == 0) {
+		return;
+	}
+
+	// LOAD_OP_CLEAR fills the whole attachment with 0 (outside every zone).
+	VkClearValue clear = {.color = {.float32 = {0.0f, 0.0f, 0.0f, 0.0f}}};
+	VkRenderPassBeginInfo rp_bi = {
+	    .sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO,
+	    .renderPass = lc->mask_rp,
+	    .framebuffer = mask_fb,
+	    .renderArea = {{0, 0}, {w, h}},
+	    .clearValueCount = 1,
+	    .pClearValues = &clear,
+	};
+	vk->vkCmdBeginRenderPass(cmd, &rp_bi, VK_SUBPASS_CONTENTS_INLINE);
+
+	// Per-zone: a hard zone is one full-rect clear at 1.0 (inset 0); a
+	// feathered zone ramps 0->1 over its OWN radius via the rings idiom —
+	// ascending value WITH ascending inset, later (deeper, higher-value)
+	// clears overwriting the inner part of earlier ones so the edge keeps
+	// the low values and the core reaches 1. Per zone so radii can differ.
+	for (uint32_t i = 0; i < rect_count; i++) {
+		const float radius = feather_px != NULL ? feather_px[i] : 0.0f;
+		const bool feathered = radius > 0.0f;
+		int32_t steps = 1;
+		int32_t step_px = 0;
+		if (feathered) {
+			step_px = 2;
+			steps = (int32_t)(radius / (float)step_px + 0.5f);
+			if (steps < 1) {
+				steps = 1;
+			}
+			if (steps > 32) { // beyond a 64px ramp, widen the step instead
+				step_px = (int32_t)(radius / 32.0f + 0.5f);
+				steps = 32;
+			}
+		}
+		for (int32_t s = 1; s <= steps; s++) {
+			const float v = (float)s / (float)steps; // 1.0 for the hard single step
+			// Small zones clamp the inset so the center still reaches 1.
+			int32_t min_ext =
+			    rects[i].extent.w < rects[i].extent.h ? rects[i].extent.w : rects[i].extent.h;
+			int32_t max_inset = (min_ext - 1) / 2;
+			if (max_inset < 0) {
+				max_inset = 0;
+			}
+			int32_t inset = feathered ? s * step_px : 0;
+			if (inset > max_inset) {
+				inset = max_inset;
+			}
+			int32_t left = rects[i].offset.w + inset;
+			int32_t top = rects[i].offset.h + inset;
+			int32_t right = rects[i].offset.w + rects[i].extent.w - inset;
+			int32_t bottom = rects[i].offset.h + rects[i].extent.h - inset;
+			if (left < 0) {
+				left = 0;
+			}
+			if (top < 0) {
+				top = 0;
+			}
+			if (right > (int32_t)w) {
+				right = (int32_t)w;
+			}
+			if (bottom > (int32_t)h) {
+				bottom = (int32_t)h;
+			}
+			if (right <= left || bottom <= top) {
+				continue;
+			}
+			VkClearAttachment ca = {
+			    .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
+			    .colorAttachment = 0,
+			    .clearValue = {.color = {.float32 = {v, 0.0f, 0.0f, 0.0f}}},
+			};
+			VkClearRect cr = {
+			    .rect = {{left, top}, {(uint32_t)(right - left), (uint32_t)(bottom - top)}},
+			    .baseArrayLayer = 0,
+			    .layerCount = 1,
+			};
+			vk->vkCmdClearAttachments(cmd, 1, &ca, 1, &cr);
+		}
+	}
+
+	vk->vkCmdEndRenderPass(cmd);
+}
+
+void
 vk_local2d_composite_flatten_draw(struct vk_local2d_composite *lc,
                                   struct vk_bundle *vk,
                                   VkCommandBuffer cmd,

--- a/src/xrt/auxiliary/vk/vk_local2d_composite.h
+++ b/src/xrt/auxiliary/vk/vk_local2d_composite.h
@@ -155,6 +155,27 @@ vk_local2d_composite_raster_mask_rings(struct vk_local2d_composite *lc,
                                        uint32_t feather_step_px);
 
 /*!
+ * Rasterize the zones COMPOSITE mask with PER-ZONE opt-in feather
+ * (XrDisplayZoneFeatherDXR, runtime#800): LOAD_OP_CLEAR to 0, then each zone
+ * draws hard (one full-rect clear at 1.0, @p feather_px[i] <= 0 — the default)
+ * or with its own inward 0->1 ramp over feather_px[i] window pixels (the rings
+ * idiom, per zone so radii can differ). @p feather_px may be NULL = all hard.
+ * Layout contract identical to vk_local2d_composite_raster_mask.
+ *
+ * @ingroup aux_vk
+ */
+void
+vk_local2d_composite_raster_mask_zones(struct vk_local2d_composite *lc,
+                                       struct vk_bundle *vk,
+                                       VkCommandBuffer cmd,
+                                       VkFramebuffer mask_fb,
+                                       uint32_t w,
+                                       uint32_t h,
+                                       const struct xrt_rect *rects,
+                                       const float *feather_px,
+                                       uint32_t rect_count);
+
+/*!
  * Flatten one Local2D layer into the `twod` scratch (caller clears the scratch
  * transparent once before the first layer, and manages its layout).
  *

--- a/src/xrt/compositor/vk_native/comp_vk_native_compositor.c
+++ b/src/xrt/compositor/vk_native/comp_vk_native_compositor.c
@@ -333,6 +333,16 @@ struct comp_vk_native_compositor
 	VkFramebuffer implicit_mask_fb;
 	uint32_t implicit_mask_w, implicit_mask_h;
 
+	//! Zones COMPOSITE mask with per-zone opt-in feather (runtime#800).
+	//! Allocated only when a frame's zones request feather — the published
+	//! wish must stay binary (implicit_mask above), so a feathered composite
+	//! needs its own image. All-hard frames reuse implicit_mask for both.
+	VkImage feather_mask_tex;
+	VkDeviceMemory feather_mask_mem;
+	VkImageView feather_mask_view;
+	VkFramebuffer feather_mask_fb;
+	uint32_t feather_mask_w, feather_mask_h;
+
 	//! Composite-target framebuffer cache (over the rotating swapchain/shared
 	//! image view, keyed by view — the DP target image rotates per frame).
 	VkFramebuffer composite_target_fb;
@@ -4873,11 +4883,17 @@ vk_composite_local_2d(struct comp_vk_native_compositor *c,
 
 	// XR_DXR_display_zones: the auto wish rasterizes from the ZONE rects.
 	struct xrt_rect zone_rects[XRT_MAX_LAYERS];
+	float zone_feathers[XRT_MAX_LAYERS]; // per-zone opt-in feather (runtime#800)
+	bool any_feather = false;
 	uint32_t zone_rect_count = 0;
 	if (zones_frame) {
 		for (uint32_t i = 0; i < c->layer_accum.layer_count && zone_rect_count < XRT_MAX_LAYERS; i++) {
 			if (c->layer_accum.layers[i].data.type != XRT_LAYER_ZONE_3D) {
 				continue;
+			}
+			zone_feathers[zone_rect_count] = c->layer_accum.layers[i].data.zone_3d.feather_px;
+			if (zone_feathers[zone_rect_count] > 0.0f) {
+				any_feather = true;
 			}
 			zone_rects[zone_rect_count++] = c->layer_accum.layers[i].data.zone_3d.rect;
 		}
@@ -4979,6 +4995,34 @@ vk_composite_local_2d(struct comp_vk_native_compositor *c,
 		                            VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
 		                            VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, k_color_sub);
 		mask_view = c->implicit_mask_view;
+
+		// Per-zone opt-in feather (XrDisplayZoneFeatherDXR, runtime#800):
+		// the COMPOSITE samples a separately-rastered mask with each zone's
+		// requested inward ramp; the binary raster above still publishes as
+		// the hardware wish (cosmetics never enter the wish).
+		if (any_feather) {
+			if (vk_ensure_rt(c, &c->feather_mask_tex, &c->feather_mask_mem, &c->feather_mask_view,
+			                 &c->feather_mask_fb, &c->feather_mask_w, &c->feather_mask_h, region_w,
+			                 region_h, mask_fmt,
+			                 VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT,
+			                 c->local2d.mask_rp, "zone feather mask")) {
+				vk_cmd_image_barrier_locked(
+				    vk, cmd, c->feather_mask_tex, 0, VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+				    VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+				    VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+				    k_color_sub);
+				vk_local2d_composite_raster_mask_zones(&c->local2d, vk, cmd, c->feather_mask_fb,
+				                                       region_w, region_h, zone_rects, zone_feathers,
+				                                       zone_rect_count);
+				vk_cmd_image_barrier_locked(
+				    vk, cmd, c->feather_mask_tex, VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+				    VK_ACCESS_SHADER_READ_BIT, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+				    VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+				    VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+				    VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, k_color_sub);
+				mask_view = c->feather_mask_view;
+			} // ensure failure: fall back to the binary mask — hard edges, never a lost frame
+		}
 	}
 
 	if (zones_frame && c->frame_wish != NULL && c->frame_wish->staged != VK_NULL_HANDLE &&
@@ -5228,6 +5272,8 @@ vk_release_local2d_state(struct comp_vk_native_compositor *c)
 	vk_destroy_rt(c, &c->weave_scratch, &c->weave_scratch_mem, &c->weave_scratch_view, NULL);
 	vk_destroy_rt(c, &c->implicit_mask_tex, &c->implicit_mask_mem, &c->implicit_mask_view,
 	              &c->implicit_mask_fb);
+	vk_destroy_rt(c, &c->feather_mask_tex, &c->feather_mask_mem, &c->feather_mask_view,
+	              &c->feather_mask_fb);
 	if (c->local2d_initialized) {
 		vk_local2d_composite_fini(&c->local2d, vk);
 		c->local2d_initialized = false;

--- a/src/xrt/include/xrt/xrt_compositor.h
+++ b/src/xrt/include/xrt/xrt_compositor.h
@@ -439,6 +439,11 @@ struct xrt_layer_zone_3d_data
 
 	struct xrt_rect rect; //!< Zone placement, client-window pixels
 	uint32_t zone_id;     //!< App-chosen; unique among this frame's zones
+
+	//! Opt-in cosmetic edge feather (XrDisplayZoneFeatherDXR, runtime#800):
+	//! inward ramp width in client-window pixels. 0 = hard edge (the
+	//! default). COMPOSITE-only — the published hardware wish stays binary.
+	float feather_px;
 };
 
 /*!

--- a/src/xrt/state_trackers/oxr/oxr_session_frame_end.c
+++ b/src/xrt/state_trackers/oxr/oxr_session_frame_end.c
@@ -1827,6 +1827,21 @@ submit_zone_3d_layer(struct oxr_session *sess,
 	data.zone_3d.rect.extent.w = zone->rect.extent.width;
 	data.zone_3d.rect.extent.h = zone->rect.extent.height;
 	data.zone_3d.zone_id = zone->zoneId;
+	// Opt-in cosmetic feather (spec v3, runtime#800): chained on the zone at
+	// the SUBMIT chain point. Absent / non-positive / NaN = hard edge. Clamp
+	// the ramp to half the zone's shorter side — a wider request would invert.
+	data.zone_3d.feather_px = 0.0f;
+	{
+		const XrDisplayZoneFeatherDXR *feather =
+		    OXR_GET_INPUT_FROM_CHAIN(zone, XR_TYPE_DISPLAY_ZONE_FEATHER_DXR, XrDisplayZoneFeatherDXR);
+		if (feather != NULL && feather->radiusPx > 0.0f && feather->radiusPx == feather->radiusPx) {
+			float max_ramp = (float)(zone->rect.extent.width < zone->rect.extent.height
+			                             ? zone->rect.extent.width
+			                             : zone->rect.extent.height) *
+			                 0.5f;
+			data.zone_3d.feather_px = feather->radiusPx < max_ramp ? feather->radiusPx : max_ramp;
+		}
+	}
 	fill_in_color_scale_bias(sess, (XrCompositionLayerBaseHeader *)proj, &data);
 	fill_in_y_flip(sess, (XrCompositionLayerBaseHeader *)proj, &data);
 	fill_in_blend_factors(sess, (XrCompositionLayerBaseHeader *)proj, &data);


### PR DESCRIPTION
Closes #800.

Implements the ruling from the #800 discussion: **zone edges are hard by default; feathering is a purely cosmetic feature the app must request, with the radius as a parameter** — and it never enters the published hardware wish.

## What

- **`XR_DXR_display_zones` spec v3**: `XrDisplayZoneFeatherDXR { float radiusPx }`, chained on `XrDisplayZoneDXR::next` at the **submit** chain point (locate-instance chains ignored). Absent / 0 / negative / NaN = hard edge; clamped to half the zone's shorter side.
- `xrt_layer_zone_3d_data` gains `feather_px`; oxr frame-end parses + clamps.
- **VK compositor**: when any zone requests feather, the composite samples a **separately-rastered** mask (`feather_mask_*` RT) built by the new per-zone `vk_local2d_composite_raster_mask_zones` — each zone hard or with its own inward 0→1 ramp (rings idiom, 2 px steps, 64 px ramp cap then wider steps). **The published wish stays the binary raster regardless.** All-hard frames take exactly the pre-change path: no extra image, no behavior change.
- Ensure-RT failure on the feather mask falls back to the binary mask — hard edges, never a lost frame.

## Hardware validation

Exercised live on the Leia display: avatar demo chaining a 24 px feather via `DXR_ZONE_FEATHER_PX` (env-gated exerciser branch), against this runtime + an ABI-v5 dev-built plug-in.

## Scope notes

- **VK native only.** The D3D11-service / D3D11 / D3D12 / Metal zones paths still run the pre-#801 feathered-lerp composite — parity follow-up filed separately so all backends land the #801 composite-mode + this opt-in together.
- No shipped app requests feather yet; `cube_zones_vk_linux` is the natural place to add exercise coverage (follow-up, compile-checked by Linux CI).
- Extension header change auto-syncs to `displayxr-extensions` on merge.