### PR TITLE
service(win): gate start_on_login on --autostart; never exit silently (#806)

### DIFF
--- a/installer/DisplayXRInstaller.nsi
+++ b/installer/DisplayXRInstaller.nsi
@@ -824,8 +824,11 @@ Section "DisplayXR Runtime" SecRuntime
 		; Register in HKLM Run key (starts in user session with GPU/tray access).
 		; This section runs in the 64-bit view (SetRegView 64 at section start).
 		DetailPrint "Registering DisplayXR Service for auto-start..."
+		; --autostart lets the service distinguish this logon auto-start from a
+		; manual launch, so the "Start on login" tray toggle only gates the
+		; former (#806).
 		WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Run" \
-			"DisplayXR Service" "$\"$INSTDIR\displayxr-service.exe$\""
+			"DisplayXR Service" "$\"$INSTDIR\displayxr-service.exe$\" --autostart"
 		; Drop any stale 32-bit (WOW6432Node) Run entry from an interim installer
 		; that wrote it before this section used SetRegView 64. Windows fires both
 		; views at logon, so a leftover 32-bit copy double-launches the service.

--- a/src/xrt/targets/service/main.c
+++ b/src/xrt/targets/service/main.c
@@ -103,23 +103,28 @@ WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdS
 	struct service_config cfg;
 	service_config_load(&cfg);
 
-	// If user disabled "Start on login" via the tray menu, exit immediately.
-	// The HKLM Run key still launches us, but we honor the config and bow out
-	// before creating any windows or tray icons. The service can still be
-	// started manually or via IPC auto-launch from an OpenXR app.
-	if (!cfg.start_on_login) {
-		ExitProcess(0);
-	}
-
-	// Parse --workspace for the manual multi-terminal workflow. The
+	// Parse flags. --workspace is the manual multi-terminal workflow (the
 	// orchestrator will also enable workspace mode when it spawns the
-	// workspace controller.
+	// workspace controller). --autostart is appended by the HKLM Run key
+	// registration so we can tell a logon auto-start from a manual launch.
 	bool workspace_mode = false;
+	bool autostart = false;
 	for (int i = 1; i < argc; i++) {
 		if (strcmp(argv[i], "--workspace") == 0) {
 			workspace_mode = true;
-			break;
+		} else if (strcmp(argv[i], "--autostart") == 0) {
+			autostart = true;
 		}
+	}
+
+	// If user disabled "Start on login" via the tray menu, bow out of logon
+	// auto-starts only. Manual launches and IPC auto-launch from an OpenXR
+	// app (neither passes --autostart) always start (#806 — the old
+	// unconditional gate silently killed every launch on any machine where
+	// the toggle had ever been unchecked).
+	if (autostart && !cfg.start_on_login) {
+		U_LOG_W("Start-on-login is disabled in service.json; exiting (logon auto-start).");
+		ExitProcess(0);
 	}
 
 	// Start the system tray icon with orchestrator menu


### PR DESCRIPTION
Fixes #806 — service silently refuses to start on devices where "Start on login" was ever unchecked (Lenovo field report).

## Changes
- `main.c` (WinMain): parse `--autostart`; the `start_on_login=false` early-exit now applies **only** to logon auto-starts. Manual launches and IPC auto-launch always start. The intentional exit logs one WARN line first, so the log never ends silently right after the priority lines.
- `DisplayXRInstaller.nsi`: HKLM Run key now registers `displayxr-service.exe --autostart`.

## Compatibility
- Existing installs keep their old argument-less Run key until the next installer upgrade; with this runtime, that just means the toggle temporarily doesn't suppress logon auto-start (fail-open — strictly better than the current fail-closed silent exit). The upgrade rewrites the key.
- Workaround for stuck devices in the field (no upgrade needed): delete `%LOCALAPPDATA%\DisplayXR\service.json` or set `"start_on_login": true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)